### PR TITLE
feat: per-layout gap overrides with separate edge gap setting

### DIFF
--- a/kcm/kcm_plasmazones.cpp
+++ b/kcm/kcm_plasmazones.cpp
@@ -218,6 +218,10 @@ int KCMPlasmaZones::zonePadding() const
 {
     return m_settings->zonePadding();
 }
+int KCMPlasmaZones::outerGap() const
+{
+    return m_settings->outerGap();
+}
 int KCMPlasmaZones::adjacentThreshold() const
 {
     return m_settings->adjacentThreshold();
@@ -620,6 +624,15 @@ void KCMPlasmaZones::setZonePadding(int padding)
     if (m_settings->zonePadding() != padding) {
         m_settings->setZonePadding(padding);
         Q_EMIT zonePaddingChanged();
+        setNeedsSave(true);
+    }
+}
+
+void KCMPlasmaZones::setOuterGap(int gap)
+{
+    if (m_settings->outerGap() != gap) {
+        m_settings->setOuterGap(gap);
+        Q_EMIT outerGapChanged();
         setNeedsSave(true);
     }
 }
@@ -1120,6 +1133,7 @@ void KCMPlasmaZones::defaults()
     Q_EMIT enableShaderEffectsChanged();
     Q_EMIT shaderFrameRateChanged();
     Q_EMIT zonePaddingChanged();
+    Q_EMIT outerGapChanged();
     Q_EMIT adjacentThresholdChanged();
     Q_EMIT keepWindowsInZonesOnResolutionChangeChanged();
     Q_EMIT moveNewWindowsToLastZoneChanged();
@@ -1682,6 +1696,7 @@ void KCMPlasmaZones::onSettingsChanged()
         Q_EMIT borderRadiusChanged();
         Q_EMIT enableBlurChanged();
         Q_EMIT zonePaddingChanged();
+        Q_EMIT outerGapChanged();
         Q_EMIT adjacentThresholdChanged();
         Q_EMIT keepWindowsInZonesOnResolutionChangeChanged();
         Q_EMIT moveNewWindowsToLastZoneChanged();

--- a/kcm/kcm_plasmazones.h
+++ b/kcm/kcm_plasmazones.h
@@ -78,6 +78,7 @@ class KCMPlasmaZones : public KQuickConfigModule
 
     // Zones
     Q_PROPERTY(int zonePadding READ zonePadding WRITE setZonePadding NOTIFY zonePaddingChanged)
+    Q_PROPERTY(int outerGap READ outerGap WRITE setOuterGap NOTIFY outerGapChanged)
     Q_PROPERTY(int adjacentThreshold READ adjacentThreshold WRITE setAdjacentThreshold NOTIFY adjacentThresholdChanged)
 
     // Behavior
@@ -190,6 +191,7 @@ public:
     bool enableShaderEffects() const;
     int shaderFrameRate() const;
     int zonePadding() const;
+    int outerGap() const;
     int adjacentThreshold() const;
     bool keepWindowsInZonesOnResolutionChange() const;
     bool moveNewWindowsToLastZone() const;
@@ -256,6 +258,7 @@ public:
     void setEnableShaderEffects(bool enable);
     void setShaderFrameRate(int fps);
     void setZonePadding(int padding);
+    void setOuterGap(int gap);
     void setAdjacentThreshold(int threshold);
     void setKeepWindowsInZonesOnResolutionChange(bool keep);
     void setMoveNewWindowsToLastZone(bool move);
@@ -363,6 +366,7 @@ Q_SIGNALS:
     void enableShaderEffectsChanged();
     void shaderFrameRateChanged();
     void zonePaddingChanged();
+    void outerGapChanged();
     void adjacentThresholdChanged();
     void keepWindowsInZonesOnResolutionChangeChanged();
     void moveNewWindowsToLastZoneChanged();

--- a/kcm/ui/LayoutThumbnail.qml
+++ b/kcm/ui/LayoutThumbnail.qml
@@ -56,6 +56,7 @@ Rectangle {
         zones: root.layout && root.layout.zones ? root.layout.zones : []
         isActive: root.isSelected
         zonePadding: 1 // Minimal padding for thumbnail
+        edgeGap: 1     // Minimal edge gap for thumbnail
         minZoneSize: 8
         showZoneNumbers: true
     }

--- a/kcm/ui/main.qml
+++ b/kcm/ui/main.qml
@@ -1606,6 +1606,15 @@ KCM.AbstractKCM {
                 textFromValue: function(value) { return value + " px" }
             }
 
+            SpinBox {
+                Kirigami.FormData.label: i18n("Edge gap:")
+                from: 0
+                to: constants.thresholdMax
+                value: kcm.outerGap
+                onValueModified: kcm.outerGap = value
+                textFromValue: function(value) { return value + " px" }
+            }
+
             CheckBox {
                 Kirigami.FormData.label: i18n("Display:")
                 text: i18n("Show zones on all monitors while dragging")

--- a/src/config/plasmazones.kcfg
+++ b/src/config/plasmazones.kcfg
@@ -129,7 +129,13 @@
        ═══════════════════════════════════════════════════════════════════════════════ -->
   <group name="Zones">
     <entry name="Padding" type="Int">
-      <label>Padding inside zones in pixels</label>
+      <label>Padding between adjacent zones in pixels</label>
+      <default>8</default>
+      <min>0</min>
+      <max>50</max>
+    </entry>
+    <entry name="OuterGap" type="Int">
+      <label>Gap at screen edges in pixels</label>
       <default>8</default>
       <min>0</min>
       <max>50</max>

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -263,6 +263,16 @@ void Settings::setZonePadding(int padding)
     }
 }
 
+void Settings::setOuterGap(int gap)
+{
+    gap = qMax(0, gap);
+    if (m_outerGap != gap) {
+        m_outerGap = gap;
+        Q_EMIT outerGapChanged();
+        Q_EMIT settingsChanged();
+    }
+}
+
 void Settings::setAdjacentThreshold(int threshold)
 {
     threshold = qMax(0, threshold);
@@ -875,6 +885,13 @@ void Settings::load()
     }
     m_zonePadding = zonePadding;
 
+    int outerGap = zones.readEntry("OuterGap", Defaults::OuterGap);
+    if (outerGap < 0) {
+        qCWarning(lcConfig) << "Invalid outer gap:" << outerGap << "using default";
+        outerGap = Defaults::OuterGap;
+    }
+    m_outerGap = outerGap;
+
     int adjacentThreshold = zones.readEntry("AdjacentThreshold", Defaults::AdjacentThreshold);
     if (adjacentThreshold < 0) {
         qCWarning(lcConfig) << "Invalid adjacent threshold:" << adjacentThreshold << "using default";
@@ -1057,6 +1074,7 @@ void Settings::save()
 
     // Zones
     zones.writeEntry("Padding", m_zonePadding);
+    zones.writeEntry("OuterGap", m_outerGap);
     zones.writeEntry("AdjacentThreshold", m_adjacentThreshold);
 
     // Performance and behavior
@@ -1149,6 +1167,7 @@ void Settings::reset()
 
     // Zone settings defaults (DRY)
     m_zonePadding = Defaults::ZonePadding;
+    m_outerGap = Defaults::OuterGap;
     m_adjacentThreshold = Defaults::AdjacentThreshold;
 
     // Performance and behavior defaults (DRY)

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -61,6 +61,7 @@ class PLASMAZONES_EXPORT Settings : public ISettings
 
     // Zone settings
     Q_PROPERTY(int zonePadding READ zonePadding WRITE setZonePadding NOTIFY zonePaddingChanged)
+    Q_PROPERTY(int outerGap READ outerGap WRITE setOuterGap NOTIFY outerGapChanged)
     Q_PROPERTY(int adjacentThreshold READ adjacentThreshold WRITE setAdjacentThreshold NOTIFY adjacentThresholdChanged)
 
     // Performance and behavior (configurable constants)
@@ -323,6 +324,12 @@ public:
         return m_zonePadding;
     }
     void setZonePadding(int padding) override;
+
+    int outerGap() const override
+    {
+        return m_outerGap;
+    }
+    void setOuterGap(int gap) override;
 
     int adjacentThreshold() const override
     {
@@ -638,6 +645,7 @@ private:
 
     // Zone settings (DRY: use constants from Defaults namespace)
     int m_zonePadding = Defaults::ZonePadding;
+    int m_outerGap = Defaults::OuterGap;
     int m_adjacentThreshold = Defaults::AdjacentThreshold;
 
     // Performance and behavior (DRY: use constants from Defaults namespace)

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -30,6 +30,7 @@ constexpr qreal InactiveOpacity = 0.3;
 constexpr int BorderWidth = 2;
 constexpr int BorderRadius = 8;
 constexpr int ZonePadding = 8;
+constexpr int OuterGap = 8;  // Gap at screen edges (separate from zonePadding between zones)
 constexpr int AdjacentThreshold = 20;
 // EdgeThreshold for overlay window detection (pixels, used in WindowTracker/Overlay)
 constexpr qreal EdgeThreshold = 15.0;
@@ -104,6 +105,7 @@ inline constexpr QLatin1String Description{"description"};
 inline constexpr QLatin1String Author{"author"};
 inline constexpr QLatin1String Zones{"zones"};
 inline constexpr QLatin1String ZonePadding{"zonePadding"};
+inline constexpr QLatin1String OuterGap{"outerGap"};
 inline constexpr QLatin1String ShowZoneNumbers{"showZoneNumbers"};
 inline constexpr QLatin1String IsBuiltIn{"isBuiltIn"}; // Legacy, for backward compat when loading
 inline constexpr QLatin1String IsSystem{"isSystem"}; // New: determined by source path

--- a/src/core/geometryutils.h
+++ b/src/core/geometryutils.h
@@ -10,6 +10,7 @@
 namespace PlasmaZones {
 
 class Zone;
+class Layout;
 class ISettings;
 
 /**
@@ -65,7 +66,7 @@ PLASMAZONES_EXPORT QRectF toOverlayCoordinates(const QRectF& geometry, QScreen* 
 PLASMAZONES_EXPORT QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, QScreen* screen);
 
 /**
- * @brief Get zone geometry with explicit spacing applied (uses global setting)
+ * @brief Get zone geometry with explicit spacing applied (uniform spacing)
  * @param zone Zone to get geometry for
  * @param screen Screen to calculate relative to
  * @param spacing Explicit spacing value in pixels (from settings->zonePadding())
@@ -74,6 +75,21 @@ PLASMAZONES_EXPORT QRectF availableAreaToOverlayCoordinates(const QRectF& geomet
  */
 PLASMAZONES_EXPORT QRectF getZoneGeometryWithSpacing(Zone* zone, QScreen* screen, int spacing,
                                                      bool useAvailableGeometry = true);
+
+/**
+ * @brief Get zone geometry with differentiated inner/outer gaps
+ * @param zone Zone to get geometry for
+ * @param screen Screen to calculate relative to
+ * @param innerGap Gap between adjacent zones (zonePadding)
+ * @param outerGap Gap at screen boundaries
+ * @param useAvailableGeometry If true, calculate relative to available area (excluding panels/taskbars)
+ * @return Geometry with appropriate gaps applied
+ *
+ * This version applies outerGap to zone edges that touch screen boundaries
+ * (relative position 0 or 1), and innerGap/2 to edges between zones.
+ */
+PLASMAZONES_EXPORT QRectF getZoneGeometryWithGaps(Zone* zone, QScreen* screen, int innerGap, int outerGap,
+                                                   bool useAvailableGeometry = true);
 
 /**
  * @brief Calculate absolute zone geometry using available screen area
@@ -85,6 +101,32 @@ PLASMAZONES_EXPORT QRectF getZoneGeometryWithSpacing(Zone* zone, QScreen* screen
  * ensuring zones don't overlap with system UI elements.
  */
 PLASMAZONES_EXPORT QRectF calculateZoneGeometryInAvailableArea(Zone* zone, QScreen* screen);
+
+/**
+ * @brief Get effective zone padding for a layout
+ * @param layout Layout to get padding for (may have per-layout override)
+ * @param settings Global settings (used if layout has no override)
+ * @return Effective zone padding in pixels
+ *
+ * Returns layout-specific zonePadding if set (>= 0), otherwise falls back
+ * to global settings->zonePadding(), or default of 8 if settings is null.
+ */
+PLASMAZONES_EXPORT int getEffectiveZonePadding(Layout* layout, ISettings* settings);
+
+/**
+ * @brief Get effective outer gap for a layout
+ * @param layout Layout to get outer gap for (may have per-layout override)
+ * @param settings Global settings (used if layout has no override)
+ * @return Effective outer gap in pixels
+ *
+ * Returns layout-specific outerGap if set (>= 0), otherwise falls back
+ * to global settings->outerGap(), or default of 8.
+ *
+ * Outer gap is applied to zone edges at screen boundaries (positions 0 or 1),
+ * while zonePadding is applied between adjacent zones. Use getZoneGeometryWithGaps()
+ * to apply differentiated gaps.
+ */
+PLASMAZONES_EXPORT int getEffectiveOuterGap(Layout* layout, ISettings* settings);
 
 } // namespace GeometryUtils
 

--- a/src/core/interfaces.h
+++ b/src/core/interfaces.h
@@ -165,6 +165,8 @@ public:
     // Zone settings
     virtual int zonePadding() const = 0;
     virtual void setZonePadding(int padding) = 0;
+    virtual int outerGap() const = 0;
+    virtual void setOuterGap(int gap) = 0;
     virtual int adjacentThreshold() const = 0;
     virtual void setAdjacentThreshold(int threshold) = 0;
 
@@ -263,6 +265,7 @@ Q_SIGNALS:
     void borderRadiusChanged();
     void enableBlurChanged();
     void zonePaddingChanged();
+    void outerGapChanged();
     void adjacentThresholdChanged();
     void pollIntervalMsChanged();
     void minimumZoneSizePxChanged();

--- a/src/core/layout.h
+++ b/src/core/layout.h
@@ -45,6 +45,9 @@ class PLASMAZONES_EXPORT Layout : public QObject
     Q_PROPERTY(QString author READ author WRITE setAuthor NOTIFY authorChanged)
     Q_PROPERTY(QString shortcut READ shortcut WRITE setShortcut NOTIFY shortcutChanged)
     Q_PROPERTY(int zonePadding READ zonePadding WRITE setZonePadding NOTIFY zonePaddingChanged)
+    Q_PROPERTY(int outerGap READ outerGap WRITE setOuterGap NOTIFY outerGapChanged)
+    Q_PROPERTY(bool hasZonePaddingOverride READ hasZonePaddingOverride NOTIFY zonePaddingChanged)
+    Q_PROPERTY(bool hasOuterGapOverride READ hasOuterGapOverride NOTIFY outerGapChanged)
     Q_PROPERTY(bool showZoneNumbers READ showZoneNumbers WRITE setShowZoneNumbers NOTIFY showZoneNumbersChanged)
     Q_PROPERTY(int zoneCount READ zoneCount NOTIFY zonesChanged)
     Q_PROPERTY(QString sourcePath READ sourcePath WRITE setSourcePath NOTIFY sourcePathChanged)
@@ -96,12 +99,28 @@ public:
     }
     void setShortcut(const QString& shortcut);
 
-    // Layout settings
+    // Layout settings (per-layout gap overrides, -1 = use global setting)
     int zonePadding() const
     {
         return m_zonePadding;
     }
     void setZonePadding(int padding);
+    bool hasZonePaddingOverride() const
+    {
+        return m_zonePadding >= 0;
+    }
+    void clearZonePaddingOverride();
+
+    int outerGap() const
+    {
+        return m_outerGap;
+    }
+    void setOuterGap(int gap);
+    bool hasOuterGapOverride() const
+    {
+        return m_outerGap >= 0;
+    }
+    void clearOuterGapOverride();
 
     bool showZoneNumbers() const
     {
@@ -185,6 +204,7 @@ Q_SIGNALS:
     void authorChanged();
     void shortcutChanged();
     void zonePaddingChanged();
+    void outerGapChanged();
     void showZoneNumbersChanged();
     void sourcePathChanged();
     void shaderIdChanged();
@@ -201,7 +221,8 @@ private:
     QString m_description;
     QString m_author;
     QString m_shortcut;
-    int m_zonePadding = 8;
+    int m_zonePadding = -1;  // -1 = use global setting
+    int m_outerGap = -1;     // -1 = use global setting
     bool m_showZoneNumbers = true;
     QString m_sourcePath; // Path where layout was loaded from (empty for new layouts)
     int m_defaultOrder = 999; // Optional: lower values appear first when choosing default (999 = not set)

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -1781,12 +1781,13 @@ QVariantMap OverlayService::zoneToVariantMap(Zone* zone, QScreen* screen, Layout
         return map;
     }
 
-    // Calculate zone geometry with spacing applied (matches snap geometry).
+    // Calculate zone geometry with gaps applied (matches snap geometry).
     // useAvailableGeometry=true means zones are calculated within the usable screen area
     // (excluding panels/taskbars), so windows won't overlap with system UI.
-    // Layout's zonePadding takes precedence over global settings
-    int spacing = layout ? layout->zonePadding() : (m_settings ? m_settings->zonePadding() : 8);
-    QRectF geom = GeometryUtils::getZoneGeometryWithSpacing(zone, screen, spacing, true);
+    // Layout's zonePadding/outerGap takes precedence over global settings
+    int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
+    int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
+    QRectF geom = GeometryUtils::getZoneGeometryWithGaps(zone, screen, zonePadding, outerGap, true);
 
     // Convert to overlay window local coordinates
     // The overlay covers the full screen, but zones are positioned within available area

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -155,6 +155,7 @@ void SettingsAdaptor::initializeRegistry()
 
     // Zone settings (DRY: using macros)
     REGISTER_INT_SETTING("zonePadding", zonePadding, setZonePadding)
+    REGISTER_INT_SETTING("outerGap", outerGap, setOuterGap)
     REGISTER_INT_SETTING("adjacentThreshold", adjacentThreshold, setAdjacentThreshold)
     REGISTER_INT_SETTING("pollIntervalMs", pollIntervalMs, setPollIntervalMs)
     REGISTER_INT_SETTING("minimumZoneSizePx", minimumZoneSizePx, setMinimumZoneSizePx)

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -139,10 +139,11 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
             }
             if (layout) {
                 layout->recalculateZoneGeometries(ScreenManager::actualAvailableGeometry(screen));
-                int spacing = m_settings ? m_settings->zonePadding() : 8;
+                int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
+                int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
 
                 for (auto* zone : layout->zones()) {
-                    QRectF zoneGeom = GeometryUtils::getZoneGeometryWithSpacing(zone, screen, spacing, true);
+                    QRectF zoneGeom = GeometryUtils::getZoneGeometryWithGaps(zone, screen, zonePadding, outerGap, true);
                     QRect zoneRect = zoneGeom.toRect();
 
                     // Use class constants for tolerances
@@ -241,13 +242,14 @@ void WindowDragAdaptor::handleMultiZoneModifier(int x, int y, Qt::KeyboardModifi
             m_currentAdjacentZoneIds = newAdjacentZoneIds;
             m_isMultiZoneMode = true;
 
-            // Calculate combined geometry with spacing
-            int multiZoneSpacing = m_settings ? m_settings->zonePadding() : 8;
+            // Calculate combined geometry with gaps
+            int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
+            int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
             QRectF combinedGeom =
-                GeometryUtils::getZoneGeometryWithSpacing(result.primaryZone, screen, multiZoneSpacing, true);
+                GeometryUtils::getZoneGeometryWithGaps(result.primaryZone, screen, zonePadding, outerGap, true);
             for (Zone* zone : result.adjacentZones) {
                 if (zone && zone != result.primaryZone) {
-                    QRectF zoneGeom = GeometryUtils::getZoneGeometryWithSpacing(zone, screen, multiZoneSpacing, true);
+                    QRectF zoneGeom = GeometryUtils::getZoneGeometryWithGaps(zone, screen, zonePadding, outerGap, true);
                     combinedGeom = combinedGeom.united(zoneGeom);
                 }
             }
@@ -280,9 +282,10 @@ void WindowDragAdaptor::handleMultiZoneModifier(int x, int y, Qt::KeyboardModifi
             m_zoneDetector->highlightZone(result.primaryZone);
             m_overlayService->highlightZone(zoneId);
 
-            int singleZoneSpacing = m_settings ? m_settings->zonePadding() : 8;
+            int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
+            int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
             QRectF geom =
-                GeometryUtils::getZoneGeometryWithSpacing(result.primaryZone, screen, singleZoneSpacing, true);
+                GeometryUtils::getZoneGeometryWithGaps(result.primaryZone, screen, zonePadding, outerGap, true);
             m_currentZoneGeometry = geom.toRect();
             m_currentMultiZoneGeometry = QRect();
         }
@@ -355,8 +358,9 @@ void WindowDragAdaptor::handleSingleZoneModifier(int x, int y)
             m_zoneDetector->highlightZone(foundZone);
             m_overlayService->highlightZone(zoneId);
 
-            int zoneSpacing = m_settings ? m_settings->zonePadding() : 8;
-            QRectF geom = GeometryUtils::getZoneGeometryWithSpacing(foundZone, screen, zoneSpacing, true);
+            int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
+            int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
+            QRectF geom = GeometryUtils::getZoneGeometryWithGaps(foundZone, screen, zonePadding, outerGap, true);
             m_currentZoneGeometry = geom.toRect();
         }
     } else {

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -688,10 +688,11 @@ void WindowTrackingAdaptor::snapToLastZone(const QString& windowId, const QStrin
     // Recalculate zone geometry for target screen
     layout->recalculateZoneGeometries(ScreenManager::actualAvailableGeometry(targetScreen));
 
-    // Get zone geometry with spacing
-    // Use global zonePadding setting for consistent spacing
-    int spacing = m_settings ? m_settings->zonePadding() : 8;
-    QRectF zoneGeom = GeometryUtils::getZoneGeometryWithSpacing(zone, targetScreen, spacing, true);
+    // Get zone geometry with gaps
+    // Use per-layout zonePadding/outerGap if set, otherwise fall back to global setting
+    int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
+    int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
+    QRectF zoneGeom = GeometryUtils::getZoneGeometryWithGaps(zone, targetScreen, zonePadding, outerGap, true);
     if (!zoneGeom.isValid()) {
         qCWarning(lcDbusWindow) << "Invalid zone geometry";
         return;
@@ -842,9 +843,10 @@ void WindowTrackingAdaptor::restoreToPersistedZone(const QString& windowId, cons
     // Recalculate zone geometry for target screen
     layout->recalculateZoneGeometries(ScreenManager::actualAvailableGeometry(targetScreen));
 
-    // Get zone geometry with spacing
-    int spacing = m_settings ? m_settings->zonePadding() : 8;
-    QRectF zoneGeom = GeometryUtils::getZoneGeometryWithSpacing(zone, targetScreen, spacing, true);
+    // Get zone geometry with gaps
+    int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
+    int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
+    QRectF zoneGeom = GeometryUtils::getZoneGeometryWithGaps(zone, targetScreen, zonePadding, outerGap, true);
     if (!zoneGeom.isValid()) {
         qCWarning(lcDbusWindow) << "Invalid zone geometry for persisted restore";
         return;
@@ -940,9 +942,10 @@ QString WindowTrackingAdaptor::getUpdatedWindowGeometries()
         }
 
         layout->recalculateZoneGeometries(ScreenManager::actualAvailableGeometry(targetScreen));
-        // Use global zonePadding setting for consistent spacing
-        int updateSpacing = m_settings ? m_settings->zonePadding() : 8;
-        QRectF zoneGeom = GeometryUtils::getZoneGeometryWithSpacing(zone, targetScreen, updateSpacing, true);
+        // Use per-layout zonePadding/outerGap if set, otherwise fall back to global setting
+        int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
+        int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
+        QRectF zoneGeom = GeometryUtils::getZoneGeometryWithGaps(zone, targetScreen, zonePadding, outerGap, true);
 
         if (zoneGeom.isValid()) {
             QJsonObject windowObj;
@@ -1179,9 +1182,10 @@ QString WindowTrackingAdaptor::getZoneGeometryForScreen(const QString& zoneId, c
     // Recalculate zone geometry for screen
     layout->recalculateZoneGeometries(ScreenManager::actualAvailableGeometry(targetScreen));
 
-    // Get zone geometry with spacing
-    int spacing = m_settings ? m_settings->zonePadding() : 8;
-    QRectF zoneGeom = GeometryUtils::getZoneGeometryWithSpacing(zone, targetScreen, spacing, true);
+    // Get zone geometry with gaps
+    int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
+    int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
+    QRectF zoneGeom = GeometryUtils::getZoneGeometryWithGaps(zone, targetScreen, zonePadding, outerGap, true);
 
     if (!zoneGeom.isValid()) {
         qCWarning(lcDbusWindow) << "getZoneGeometryForScreen: invalid geometry for zone:" << zoneId;

--- a/src/dbus/zonedetectionadaptor.cpp
+++ b/src/dbus/zonedetectionadaptor.cpp
@@ -132,10 +132,12 @@ QString ZoneDetectionAdaptor::getZoneGeometryForScreen(const QString& zoneId, co
         return QString();
     }
 
-    // Use geometry with spacing (matches snap behavior)
-    // Use global zonePadding setting for consistent spacing
-    int spacing = m_settings ? m_settings->zonePadding() : 8;
-    QRectF geom = GeometryUtils::getZoneGeometryWithSpacing(zone, screen, spacing, true);
+    // Use geometry with gaps (matches snap behavior)
+    // Use per-layout zonePadding/outerGap if set, otherwise fall back to global settings
+    Layout* zoneLayout = qobject_cast<Layout*>(zone->parent());
+    int zonePadding = GeometryUtils::getEffectiveZonePadding(zoneLayout, m_settings);
+    int outerGap = GeometryUtils::getEffectiveOuterGap(zoneLayout, m_settings);
+    QRectF geom = GeometryUtils::getZoneGeometryWithGaps(zone, screen, zonePadding, outerGap, true);
 
     // Return as "x,y,width,height"
     return QStringLiteral("%1,%2,%3,%4")
@@ -402,11 +404,12 @@ QStringList ZoneDetectionAdaptor::getAllZoneGeometries()
         return result;
     }
 
-    // Use global zonePadding setting for consistent spacing
-    int allZonesSpacing = m_settings ? m_settings->zonePadding() : 8;
+    // Use per-layout zonePadding/outerGap if set, otherwise fall back to global settings
+    int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
+    int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
     for (auto* zone : layout->zones()) {
-        // Use geometry with spacing (matches snap behavior)
-        QRectF geom = GeometryUtils::getZoneGeometryWithSpacing(zone, screen, allZonesSpacing, true);
+        // Use geometry with gaps (matches snap behavior)
+        QRectF geom = GeometryUtils::getZoneGeometryWithGaps(zone, screen, zonePadding, outerGap, true);
         // Format: "zoneId:x,y,width,height"
         QString entry = QStringLiteral("%1:%2,%3,%4,%5")
                             .arg(zone->id().toString())

--- a/src/editor/EditorController.h
+++ b/src/editor/EditorController.h
@@ -71,8 +71,13 @@ class EditorController : public QObject
     // Screen
     Q_PROPERTY(QString targetScreen READ targetScreen WRITE setTargetScreen NOTIFY targetScreenChanged)
 
-    // Zone settings (from global settings)
-    Q_PROPERTY(int zonePadding READ zonePadding NOTIFY zonePaddingChanged)
+    // Zone settings (per-layout override or global settings)
+    Q_PROPERTY(int zonePadding READ zonePadding WRITE setZonePadding NOTIFY zonePaddingChanged)
+    Q_PROPERTY(int outerGap READ outerGap WRITE setOuterGap NOTIFY outerGapChanged)
+    Q_PROPERTY(bool hasZonePaddingOverride READ hasZonePaddingOverride NOTIFY zonePaddingChanged)
+    Q_PROPERTY(bool hasOuterGapOverride READ hasOuterGapOverride NOTIFY outerGapChanged)
+    Q_PROPERTY(int globalZonePadding READ globalZonePadding NOTIFY globalZonePaddingChanged)
+    Q_PROPERTY(int globalOuterGap READ globalOuterGap NOTIFY globalOuterGapChanged)
 
     // Shader properties for current layout
     Q_PROPERTY(QString currentShaderId READ currentShaderId WRITE setCurrentShaderId NOTIFY currentShaderIdChanged)
@@ -117,6 +122,11 @@ public:
     int fillOnDropModifier() const;
     QString targetScreen() const;
     int zonePadding() const;
+    int outerGap() const;
+    bool hasZonePaddingOverride() const;
+    bool hasOuterGapOverride() const;
+    int globalZonePadding() const;
+    int globalOuterGap() const;
     bool canPaste() const;
     UndoController* undoController() const;
 
@@ -152,6 +162,12 @@ public:
     void setFillOnDropModifier(int modifier);
     void setTargetScreen(const QString& screenName);
     void setTargetScreenDirect(const QString& screenName); // Sets screen without loading layout (for initialization)
+    void setZonePadding(int padding);
+    void setOuterGap(int gap);
+    Q_INVOKABLE void clearZonePaddingOverride();
+    Q_INVOKABLE void clearOuterGapOverride();
+    Q_INVOKABLE void refreshGlobalZonePadding();
+    Q_INVOKABLE void refreshGlobalOuterGap();
 
     // Shader setters (create undo commands)
     void setCurrentShaderId(const QString& id);
@@ -339,6 +355,9 @@ Q_SIGNALS:
     void fillOnDropModifierChanged();
     void targetScreenChanged();
     void zonePaddingChanged();
+    void outerGapChanged();
+    void globalZonePaddingChanged();
+    void globalOuterGapChanged();
 
     // Shader signals
     void currentShaderIdChanged();
@@ -454,8 +473,11 @@ private:
     QString m_defaultInactiveColor;
     QString m_defaultBorderColor;
 
-    // Zone settings (from global settings)
-    int m_zonePadding = PlasmaZones::Defaults::ZonePadding;
+    // Zone settings (per-layout override, -1 = use global)
+    int m_zonePadding = -1;
+    int m_outerGap = -1;
+    int m_cachedGlobalZonePadding = PlasmaZones::Defaults::ZonePadding; // Cached to avoid D-Bus calls
+    int m_cachedGlobalOuterGap = PlasmaZones::Defaults::OuterGap; // Cached to avoid D-Bus calls
 
     // Clipboard state
     bool m_canPaste = false;

--- a/src/editor/qml/TopBar.qml
+++ b/src/editor/qml/TopBar.qml
@@ -241,6 +241,187 @@ ToolBar {
         }
 
         // ═══════════════════════════════════════════════════════════════
+        // LAYOUT SETTINGS BUTTON (Per-layout gap overrides)
+        // ═══════════════════════════════════════════════════════════════
+        ToolButton {
+            id: layoutSettingsButton
+
+            icon.name: "configure"
+            enabled: editorController !== null && editorController !== undefined
+            onClicked: layoutSettingsPopup.open()
+            ToolTip.text: i18nc("@tooltip", "Layout-specific settings (gaps)")
+            ToolTip.visible: hovered
+            Accessible.name: i18nc("@action", "Layout Settings")
+            Accessible.description: i18nc("@info", "Configure per-layout gap overrides")
+
+            Popup {
+                id: layoutSettingsPopup
+                x: -width + parent.width
+                y: parent.height + Kirigami.Units.smallSpacing
+                width: 320
+                padding: Kirigami.Units.largeSpacing
+
+                // Sync UI state when values change externally (undo/redo, load layout)
+                Connections {
+                    target: editorController
+                    function onZonePaddingChanged() {
+                        zonePaddingOverrideCheck.checked = editorController.hasZonePaddingOverride
+                        if (editorController.hasZonePaddingOverride) {
+                            zonePaddingSpin.value = editorController.zonePadding
+                        } else {
+                            zonePaddingSpin.value = editorController.globalZonePadding
+                        }
+                    }
+                    function onOuterGapChanged() {
+                        outerGapOverrideCheck.checked = editorController.hasOuterGapOverride
+                        if (editorController.hasOuterGapOverride) {
+                            outerGapSpin.value = editorController.outerGap
+                        } else {
+                            outerGapSpin.value = editorController.globalOuterGap
+                        }
+                    }
+                    function onGlobalZonePaddingChanged() {
+                        if (!editorController.hasZonePaddingOverride) {
+                            zonePaddingSpin.value = editorController.globalZonePadding
+                        }
+                    }
+                    function onGlobalOuterGapChanged() {
+                        if (!editorController.hasOuterGapOverride) {
+                            outerGapSpin.value = editorController.globalOuterGap
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    anchors.fill: parent
+                    spacing: Kirigami.Units.mediumSpacing
+
+                    Label {
+                        text: i18nc("@title", "Layout Gap Overrides")
+                        font.bold: true
+                        Layout.fillWidth: true
+                    }
+
+                    Label {
+                        text: i18nc("@info", "Override global settings for this layout only.")
+                        wrapMode: Text.WordWrap
+                        opacity: 0.7
+                        Layout.fillWidth: true
+                        Layout.bottomMargin: Kirigami.Units.smallSpacing
+                    }
+
+                    // Zone Padding override
+                    GridLayout {
+                        columns: 3
+                        columnSpacing: Kirigami.Units.smallSpacing
+                        rowSpacing: Kirigami.Units.smallSpacing
+                        Layout.fillWidth: true
+
+                        CheckBox {
+                            id: zonePaddingOverrideCheck
+                            text: i18nc("@option:check", "Zone Padding")
+                            checked: editorController ? editorController.hasZonePaddingOverride : false
+                            Layout.fillWidth: true
+                            onToggled: {
+                                if (editorController) {
+                                    if (checked) {
+                                        editorController.zonePadding = editorController.globalZonePadding
+                                    } else {
+                                        editorController.clearZonePaddingOverride()
+                                    }
+                                }
+                            }
+                        }
+
+                        SpinBox {
+                            id: zonePaddingSpin
+                            from: 0
+                            to: 100
+                            value: editorController ? editorController.globalZonePadding : 8
+                            enabled: zonePaddingOverrideCheck.checked
+                            Layout.preferredWidth: 90
+                            onValueModified: {
+                                if (editorController && zonePaddingOverrideCheck.checked) {
+                                    editorController.zonePadding = value
+                                }
+                            }
+                            Component.onCompleted: {
+                                if (editorController && editorController.hasZonePaddingOverride) {
+                                    value = editorController.zonePadding
+                                }
+                            }
+                        }
+
+                        Label {
+                            text: zonePaddingOverrideCheck.checked
+                                ? i18nc("@label", "px")
+                                : i18nc("@label showing global default", "px (global)")
+                            opacity: zonePaddingOverrideCheck.checked ? 1.0 : 0.6
+                        }
+
+                        // Outer Gap override
+                        CheckBox {
+                            id: outerGapOverrideCheck
+                            text: i18nc("@option:check", "Edge Gap")
+                            checked: editorController ? editorController.hasOuterGapOverride : false
+                            Layout.fillWidth: true
+                            onToggled: {
+                                if (editorController) {
+                                    if (checked) {
+                                        editorController.outerGap = editorController.globalOuterGap
+                                    } else {
+                                        editorController.clearOuterGapOverride()
+                                    }
+                                }
+                            }
+                        }
+
+                        SpinBox {
+                            id: outerGapSpin
+                            from: 0
+                            to: 100
+                            value: editorController ? editorController.globalOuterGap : 8
+                            enabled: outerGapOverrideCheck.checked
+                            Layout.preferredWidth: 90
+                            onValueModified: {
+                                if (editorController && outerGapOverrideCheck.checked) {
+                                    editorController.outerGap = value
+                                }
+                            }
+                            Component.onCompleted: {
+                                if (editorController && editorController.hasOuterGapOverride) {
+                                    value = editorController.outerGap
+                                }
+                            }
+                        }
+
+                        Label {
+                            text: outerGapOverrideCheck.checked
+                                ? i18nc("@label", "px")
+                                : i18nc("@label showing global default", "px (global)")
+                            opacity: outerGapOverrideCheck.checked ? 1.0 : 0.6
+                        }
+                    }
+
+                    // Info about where to change global settings
+                    Label {
+                        text: i18nc("@info", "Change global defaults in System Settings.")
+                        opacity: 0.5
+                        font.italic: true
+                        Layout.fillWidth: true
+                        Layout.topMargin: Kirigami.Units.smallSpacing
+                    }
+                }
+            }
+        }
+
+        // Visual separator
+        Kirigami.Separator {
+            Layout.fillHeight: true
+            Layout.preferredWidth: 1
+        }
+
+        // ═══════════════════════════════════════════════════════════════
         // SHADER SETTINGS BUTTON
         // ═══════════════════════════════════════════════════════════════
         ToolButton {

--- a/src/shared/ZonePreview.qml
+++ b/src/shared/ZonePreview.qml
@@ -42,8 +42,10 @@ Item {
     property bool isHovered: false
     /// Index of the currently selected zone (-1 for none)
     property int selectedZoneIndex: -1
-    /// Gap between zones in pixels
+    /// Gap between zones in pixels (applied as zonePadding/2 per side between adjacent zones)
     property real zonePadding: 1
+    /// Gap at screen edges in pixels
+    property real edgeGap: 1
     /// Minimum zone size in pixels
     property int minZoneSize: 8
     /// Whether to show zone numbers
@@ -75,8 +77,7 @@ Item {
             required property var modelData
             required property int index
             // Parse relative geometry
-            property var relGeo: modelData.relativeGeometry || {
-            }
+            property var relGeo: modelData.relativeGeometry || {}
             property real relX: relGeo.x || 0
             property real relY: relGeo.y || 0
             property real relWidth: relGeo.width || 0.25
@@ -84,11 +85,18 @@ Item {
             // Check if this zone is selected
             property bool isZoneSelected: root.selectedZoneIndex === index
 
-            // Position and size with gaps
-            x: relX * root.width + root.zonePadding
-            y: relY * root.height + root.zonePadding
-            width: Math.max(root.minZoneSize, relWidth * root.width - root.zonePadding * 2)
-            height: Math.max(root.minZoneSize, relHeight * root.height - root.zonePadding * 2)
+            // Detect screen boundaries (tolerance 0.01)
+            readonly property real edgeTolerance: 0.01
+            readonly property real leftGap: relX < edgeTolerance ? root.edgeGap : root.zonePadding / 2
+            readonly property real topGap: relY < edgeTolerance ? root.edgeGap : root.zonePadding / 2
+            readonly property real rightGap: (relX + relWidth) > (1.0 - edgeTolerance) ? root.edgeGap : root.zonePadding / 2
+            readonly property real bottomGap: (relY + relHeight) > (1.0 - edgeTolerance) ? root.edgeGap : root.zonePadding / 2
+
+            // Position and size with differentiated gaps
+            x: relX * root.width + leftGap
+            y: relY * root.height + topGap
+            width: Math.max(root.minZoneSize, relWidth * root.width - leftGap - rightGap)
+            height: Math.max(root.minZoneSize, relHeight * root.height - topGap - bottomGap)
             // Zone fill color
             color: {
                 var baseColor = Kirigami.Theme.textColor;

--- a/src/ui/LayoutOsd.qml
+++ b/src/ui/LayoutOsd.qml
@@ -191,6 +191,7 @@ Window {
                 isHovered: false
                 isActive: true
                 zonePadding: 2
+                edgeGap: 2
                 minZoneSize: 12
                 showZoneNumbers: true
                 inactiveOpacity: 0.3

--- a/src/ui/LayoutPreview.qml
+++ b/src/ui/LayoutPreview.qml
@@ -80,6 +80,7 @@ Rectangle {
         isHovered: root.isHovered
         isActive: root.isActive
         zonePadding: 1
+        edgeGap: 1
         minZoneSize: 8
         showZoneNumbers: true
         inactiveOpacity: root.inactiveOpacity


### PR DESCRIPTION
## Summary
Implements per-layout gap overrides with separate edge gap (outer gap) setting.

**Closes #10, Closes #2**

## Changes

### New Global Setting: Edge Gap (outerGap)
- Separate `outerGap` setting for gaps at screen boundaries
- Distinct from `zonePadding` which affects gaps between adjacent zones
- Added to KCM Zone Settings section

### Per-Layout Gap Overrides
- Layouts can override global `zonePadding` and `outerGap`
- Value of `-1` means "use global setting"
- Only serialized to JSON when explicitly set (>= 0)

### Differentiated Gap Logic
- New `getZoneGeometryWithGaps()` function in GeometryUtils
- Edge detection: zones at screen boundaries (position 0 or 1) get `outerGap`
- Interior edges between zones get `zonePadding / 2`
- Applied consistently across daemon, editor, and all previews

### Editor UI
- Layout Settings popup in TopBar with gap override controls
- Checkbox + SpinBox pattern with "(global)" indicator
- Syncs with undo/redo system

### Files Changed (26)
- Core: `geometryutils.cpp/h`, `layout.cpp/h`, `constants.h`, `interfaces.h`
- Settings: `settings.cpp/h`, `settingsadaptor.cpp`, `plasmazones.kcfg`
- KCM: `kcm_plasmazones.cpp/h`, `main.qml`, `LayoutThumbnail.qml`
- Editor: `EditorController.cpp/h`, `EditorWindow.qml`, `EditorZone.qml`, `TopBar.qml`
- Shared: `ZonePreview.qml`
- UI: `LayoutOsd.qml`, `LayoutPreview.qml`
- Daemon: `overlayservice.cpp`, `windowdragadaptor.cpp`, `windowtrackingadaptor.cpp`, `zonedetectionadaptor.cpp`

## Test Plan
- [x] Global outerGap setting works in KCM
- [x] Per-layout overrides save/load correctly
- [x] Editor preview shows differentiated gaps
- [x] Zone overlay renders correct gaps during drag
- [x] Thumbnail previews show correct gaps
- [x] Window snapping uses correct geometry

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)