### PR TITLE
feat: Add per-activity layout assignments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,23 +113,29 @@ find_package(KF6 ${KF_MIN_VERSION} REQUIRED COMPONENTS
     ColorScheme
 )
 
-# KActivities is optional (for activity-based layouts)
-# Note: KActivities may be part of Plasma Workspace, check both package names
-find_package(KF6Activities QUIET COMPONENTS Activities)
-if(NOT KF6Activities_FOUND)
-    # Try older package name (KF5)
+# KActivities/PlasmaActivities is optional (for activity-based layouts)
+# Plasma 6 renamed KActivities to PlasmaActivities
+find_package(PlasmaActivities QUIET)
+if(NOT PlasmaActivities_FOUND)
+    # Try KF6 name (some distros)
+    find_package(KF6Activities QUIET COMPONENTS Activities)
+    if(KF6Activities_FOUND)
+        set(PlasmaActivities_FOUND TRUE)
+    endif()
+endif()
+if(NOT PlasmaActivities_FOUND)
+    # Try older KF5 package name
     find_package(KActivities QUIET)
     if(KActivities_FOUND)
-        set(KF6Activities_FOUND TRUE)
-        set(KF6Activities_Activities_FOUND TRUE)
+        set(PlasmaActivities_FOUND TRUE)
     endif()
 endif()
 
-if(KF6Activities_FOUND)
-    message(STATUS "KActivities found - activity-based layouts enabled")
+if(PlasmaActivities_FOUND)
+    message(STATUS "PlasmaActivities found - activity-based layouts enabled")
     # Don't add global definitions here - set per-target instead
 else()
-    message(STATUS "KActivities not found - activity support disabled")
+    message(STATUS "PlasmaActivities/KActivities not found - activity support disabled")
 endif()
 
 # LayerShellQt for Wayland overlay support (REQUIRED)

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Configure all keyboard shortcuts for layout switching, window navigation, and ed
 - C++20 compiler
 
 Optional:
-- KF6::Activities for activity-based layouts
+- PlasmaActivities (plasma-activities package) for activity-based layouts
 
 ### Building
 

--- a/dbus/org.plasmazones.xml
+++ b/dbus/org.plasmazones.xml
@@ -84,6 +84,65 @@
         <method name="getAllScreenAssignments">
             <arg name="assignmentsJson" type="s" direction="out"/>
         </method>
+        <!-- KDE Activities Support -->
+        <method name="isActivitiesAvailable">
+            <arg name="available" type="b" direction="out"/>
+        </method>
+        <method name="getActivities">
+            <arg name="activityIds" type="as" direction="out"/>
+        </method>
+        <method name="getCurrentActivity">
+            <arg name="activityId" type="s" direction="out"/>
+        </method>
+        <method name="getActivityInfo">
+            <arg name="activityId" type="s" direction="in"/>
+            <arg name="activityJson" type="s" direction="out"/>
+        </method>
+        <method name="getAllActivitiesInfo">
+            <arg name="activitiesJson" type="s" direction="out"/>
+        </method>
+        <!-- Per-activity layout assignments (screen + activity, any desktop) -->
+        <method name="getLayoutForScreenActivity">
+            <arg name="screenName" type="s" direction="in"/>
+            <arg name="activityId" type="s" direction="in"/>
+            <arg name="layoutId" type="s" direction="out"/>
+        </method>
+        <method name="assignLayoutToScreenActivity">
+            <arg name="screenName" type="s" direction="in"/>
+            <arg name="activityId" type="s" direction="in"/>
+            <arg name="layoutId" type="s" direction="in"/>
+        </method>
+        <method name="clearAssignmentForScreenActivity">
+            <arg name="screenName" type="s" direction="in"/>
+            <arg name="activityId" type="s" direction="in"/>
+        </method>
+        <method name="hasExplicitAssignmentForScreenActivity">
+            <arg name="screenName" type="s" direction="in"/>
+            <arg name="activityId" type="s" direction="in"/>
+            <arg name="hasAssignment" type="b" direction="out"/>
+        </method>
+        <!-- Full assignment (screen + desktop + activity) -->
+        <method name="getLayoutForScreenDesktopActivity">
+            <arg name="screenName" type="s" direction="in"/>
+            <arg name="virtualDesktop" type="i" direction="in"/>
+            <arg name="activityId" type="s" direction="in"/>
+            <arg name="layoutId" type="s" direction="out"/>
+        </method>
+        <method name="assignLayoutToScreenDesktopActivity">
+            <arg name="screenName" type="s" direction="in"/>
+            <arg name="virtualDesktop" type="i" direction="in"/>
+            <arg name="activityId" type="s" direction="in"/>
+            <arg name="layoutId" type="s" direction="in"/>
+        </method>
+        <method name="clearAssignmentForScreenDesktopActivity">
+            <arg name="screenName" type="s" direction="in"/>
+            <arg name="virtualDesktop" type="i" direction="in"/>
+            <arg name="activityId" type="s" direction="in"/>
+        </method>
+        <signal name="currentActivityChanged">
+            <arg name="activityId" type="s"/>
+        </signal>
+        <signal name="activitiesChanged"/>
         <signal name="virtualDesktopCountChanged">
             <arg name="count" type="i"/>
         </signal>

--- a/po/kcm_plasmazones.pot
+++ b/po/kcm_plasmazones.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PlasmaZones 1.0.0\n"
 "Report-Msgid-Bugs-To: \"https://github.com/plasmazones/plasmazones/issues\"\n"
-"POT-Creation-Date: 2026-01-27 19:39-0600\n"
+"POT-Creation-Date: 2026-01-28 13:54-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English\n"
@@ -126,7 +126,7 @@ msgid "System • %1"
 msgstr ""
 
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:460
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1224
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1428
 msgid "%1 zones"
 msgstr ""
 
@@ -279,6 +279,7 @@ msgid "Default"
 msgstr ""
 
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:881
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1229
 msgid "Clear assignment"
 msgstr ""
 
@@ -317,6 +318,7 @@ msgid "Desktop %1"
 msgstr ""
 
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:972
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1175
 msgid "Use default"
 msgstr ""
 
@@ -338,474 +340,531 @@ msgid ""
 "desktops. Add more desktops in System Settings → Virtual Desktops."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1072
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1075
+msgid "Activity Assignments"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1085
+msgid ""
+"Assign different layouts to KDE Activities. When you switch activities, the "
+"layout will change automatically."
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1136
+msgid "Current"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1246
+msgid "No activities found. Create activities in System Settings → Activities."
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1255
+msgid "No screens detected. Make sure the PlasmaZones daemon is running."
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1266
+msgid ""
+"KDE Activities support is not available. Activity-based layout assignments "
+"require the KDE Activities service to be running."
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1276
 msgid "Quick Layout Shortcuts"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1082
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1286
 msgid "Assign layouts to keyboard shortcuts for instant switching."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1108
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1312
 msgid "Not assigned"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1124
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1328
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/ModifierCheckBoxes.qml:32
 msgid "None"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1224
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1428
 msgid "No shortcut assigned"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1271
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1475
 msgid "Clear shortcut"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1295
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1499
 msgid "Colors"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1300
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1504
 msgid "Color scheme:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1301
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1505
 msgid "Use system accent color"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1307
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1511
 msgid "Highlight:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1326
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1530
 msgid "Inactive:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1345
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1549
 msgid "Border:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1365
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1569
 msgid "Import colors:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1370
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1574
 msgid "From pywal"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1376
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1580
 msgid "From file..."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1385
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1589
 msgid "Opacity"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1389
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1593
 msgid "Active zone:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1408
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1612
 msgid "Inactive zone:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1429
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1633
 msgid "Border"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1433
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1637
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2360
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/PreviewSizeControl.qml:122
 msgid "Width:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1444
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1460
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1609
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1634
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1650
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1648
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1664
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1813
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1838
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1854
 msgid "px"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1449
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1653
 msgid "Radius:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1467
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1671
 msgid "Effects"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1471
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1675
 msgid "Blur:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1472
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1676
 msgid "Enable blur behind zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1478
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1682
 msgid "Shaders:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1479
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1683
 msgid "Enable shader effects"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1485
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1689
 msgid "Shader FPS:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1506
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1710
 msgid "Numbers:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1507
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1711
 msgid "Show zone numbers"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1513
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1717
 msgid "Animation:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1514
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1718
 msgid "Flash zones when switching layouts"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1521
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1725
 msgid "Notifications:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1522
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1726
 msgid "Show OSD when switching layouts"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1528
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1732
 msgid "OSD style:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1535
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1739
 msgid "Text only"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1536
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1740
 msgid "Visual preview"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1559
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1763
 msgid "Activation"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1564
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1768
 msgid "Zone activation modifiers:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1575
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1779
 msgid "Multi-Zone Selection"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1580
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1784
 msgid "Multi-zone modifier:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1583
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1787
 msgid ""
 "Hold this modifier combination while dragging to span windows across "
 "multiple zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1590
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1794
 msgid "Middle click:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1591
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1795
 msgid "Use middle mouse button to select multiple zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1597
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1801
 msgid "Edge threshold:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1613
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1817
 msgid "Distance from zone edge for multi-zone selection"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1619
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1823
 msgid "Zone Settings"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1623
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1827
 msgid "Zone padding:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1639
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1843
 msgid "Edge gap:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1655
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1859
 msgid "Display:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1656
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1860
 msgid "Show zones on all monitors while dragging"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1664
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1868
 msgid "Window Behavior"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1668
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1872
 msgid "Resolution:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1669
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1873
 msgid "Keep windows in zones when resolution changes"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1675
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1879
 msgid "New windows:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1676
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1880
 msgid "Move new windows to their last used zone"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1682
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1886
 msgid "Unsnapping:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1683
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1887
 msgid "Restore original window size when unsnapping"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1690
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1894
 msgid "Sticky windows:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1694
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1898
 msgid "Treat as normal"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1695
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1899
 msgid "Restore only"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1696
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1900
 msgid "Ignore all"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1709
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1913
 msgid ""
 "Sticky windows appear on all desktops. Choose how snapping should behave."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1730
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1934
 msgid ""
 "The zone selector popup appears when dragging windows to screen edges, "
 "allowing quick layout selection."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1737
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1941
 msgid "Enable zone selector popup"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1750
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1954
 msgid "Position"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1768
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1972
 msgid ""
 "Choose where the popup appears on screen. Edges and corners are supported."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1782
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1986
 msgid "Trigger & Layout"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1795
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1999
 msgid "Trigger distance"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1800
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2004
 msgid "How close to the edge before the popup appears"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1838
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2042
 msgid "Arrangement:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1842
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2046
 msgid "Grid"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1843
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2047
 msgid "Horizontal"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1844
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2048
 msgid "Vertical"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1858
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2062
 msgid "Grid columns:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1867
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2071
 msgid "Max visible rows:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1876
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2080
 msgid "Scrolling enabled when more rows exist"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1889
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2093
 msgid "Preview Size"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1980
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2184
 msgid "Auto"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1990
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2194
 #, javascript-format
 msgid "~10%% of screen width (120-280px)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:1994
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2198
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/PreviewSizeControl.qml:31
 msgid "Small"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2006
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2210
 msgid "120px width"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2010
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2214
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/PreviewSizeControl.qml:35
 msgid "Medium"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2022
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2226
 msgid "180px width"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2026
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2230
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/PreviewSizeControl.qml:39
 msgid "Large"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2038
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2242
 msgid "260px width"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2042
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2246
 msgid "Custom"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2052
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2256
 msgid "Custom size with slider"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2065
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2269
 msgid "Size:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2097
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2301
 msgid "Preview size adjusts automatically based on your screen resolution."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2122
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2326
 msgid ""
 "Windows from excluded applications or with excluded window classes will not "
 "snap to zones."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2133
-msgid "Excluded Applications"
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2336
+msgid "Window Filtering"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2147
-msgid "Application name (e.g., firefox, konsole)"
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2345
+msgid "Exclude transient windows (dialogs, utilities, tooltips)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2158
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2244
-msgid "Add"
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2351
+msgid "Minimum window size for snapping:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2205
-msgid "No excluded applications"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2206
-msgid "Add application names above to exclude them from zone snapping"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2219
-msgid "Excluded Window Classes"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2233
-msgid "Window class (use xprop to find)"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2292
-msgid "No excluded window classes"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2293
-msgid "Use 'xprop | grep WM_CLASS' to find window classes"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2314
-msgid "Choose Highlight Color"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2320
-msgid "Choose Inactive Zone Color"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2326
-msgid "Choose Border Color"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2333
-msgid "Import Layout"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2341
-msgid "Export Layout"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2350
-msgid "Import Colors from File"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2359
-msgid "Delete Layout"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2360
-msgid "Are you sure you want to delete '%1'?"
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2370
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2387
+msgid "Disabled"
 msgstr ""
 
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2377
-msgid "Edit Layout"
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/PreviewSizeControl.qml:199
+msgid "Height:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2390
-msgid "Use the visual editor to create and modify zone layouts."
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2396
-msgid "Open Layout Editor"
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2394
+msgid ""
+"Windows smaller than these dimensions will not snap to zones. Set to 0 to "
+"disable."
 msgstr ""
 
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2410
+msgid "Excluded Applications"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2424
+msgid "Application name (e.g., firefox, konsole)"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2435
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2521
+msgid "Add"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2482
+msgid "No excluded applications"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2483
+msgid "Add application names above to exclude them from zone snapping"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2496
+msgid "Excluded Window Classes"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2510
+msgid "Window class (use xprop to find)"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2569
+msgid "No excluded window classes"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2570
+msgid "Use 'xprop | grep WM_CLASS' to find window classes"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2591
+msgid "Choose Highlight Color"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2597
+msgid "Choose Inactive Zone Color"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2603
+msgid "Choose Border Color"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2610
+msgid "Import Layout"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2618
+msgid "Export Layout"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2627
+msgid "Import Colors from File"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2636
+msgid "Delete Layout"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2637
+msgid "Are you sure you want to delete '%1'?"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2654
+msgid "Edit Layout"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2667
+msgid "Use the visual editor to create and modify zone layouts."
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2673
+msgid "Open Layout Editor"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2687
 msgid "You can also edit layout JSON files directly:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2416
+#: /home/nlavender/Documents/PlasmaZones/kcm/ui/main.qml:2693
 msgid "Open Layouts Folder"
 msgstr ""
 
@@ -881,10 +940,6 @@ msgstr ""
 
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/PreviewSizeControl.qml:109
 msgid "(Custom)"
-msgstr ""
-
-#: /home/nlavender/Documents/PlasmaZones/kcm/ui/PreviewSizeControl.qml:199
-msgid "Height:"
 msgstr ""
 
 #: /home/nlavender/Documents/PlasmaZones/kcm/ui/PreviewSizeControl.qml:263

--- a/po/plasmazones-editor.pot
+++ b/po/plasmazones-editor.pot
@@ -9,7 +9,7 @@ msgstr ""
 "#-#-#-#-#  plasmazones-editor-cpp.pot (PlasmaZones 1.0.0)  #-#-#-#-#\n"
 "Project-Id-Version: PlasmaZones 1.0.0\n"
 "Report-Msgid-Bugs-To: \"https://github.com/plasmazones/plasmazones/issues\"\n"
-"POT-Creation-Date: 2026-01-27 18:01-0600\n"
+"POT-Creation-Date: 2026-01-28 12:55-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English\n"
@@ -20,7 +20,7 @@ msgstr ""
 "#-#-#-#-#  plasmazones-editor-qml.pot (PlasmaZones 1.0.0)  #-#-#-#-#\n"
 "Project-Id-Version: PlasmaZones 1.0.0\n"
 "Report-Msgid-Bugs-To: \"https://github.com/plasmazones/plasmazones/issues\"\n"
-"POT-Creation-Date: 2026-01-27 18:01-0600\n"
+"POT-Creation-Date: 2026-01-28 12:55-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English\n"
@@ -58,127 +58,127 @@ msgstr ""
 msgid "Create new layout"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:675
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:676
 msgid "New Layout"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:713
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:715
 msgid "Layout ID cannot be empty"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:718
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:720
 msgid "Layout service not initialized"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:730
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:732
 msgid "Invalid layout data format"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:858
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:861
 msgid "Services not initialized"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1073
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1141
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1177
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1259
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1076
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1144
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1180
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1262
 msgctxt "@info"
 msgid "Zone not found"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1126
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1162
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1129
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1165
 msgctxt "@info"
 msgid "Services not initialized"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1421
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1424
 #: /home/nlavender/Documents/PlasmaZones/src/editor/qml/ZoneContextMenu.qml:154
 msgctxt "@action"
 msgid "Bring to Front"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1444
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1447
 #: /home/nlavender/Documents/PlasmaZones/src/editor/qml/ZoneContextMenu.qml:178
 msgctxt "@action"
 msgid "Send to Back"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1467
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1470
 #: /home/nlavender/Documents/PlasmaZones/src/editor/qml/ZoneContextMenu.qml:162
 msgctxt "@action"
 msgid "Bring Forward"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1490
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:1493
 #: /home/nlavender/Documents/PlasmaZones/src/editor/qml/ZoneContextMenu.qml:170
 msgctxt "@action"
 msgid "Send Backward"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2084
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2150
 msgctxt "@action"
 msgid "Delete %1 Zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2117
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2183
 msgctxt "@action"
 msgid "Duplicate %1 Zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2205
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2404
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2271
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2470
 msgctxt "@action"
 msgid "Move %1 Zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2251
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2317
 msgctxt "@action"
 msgid "Resize %1 Zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2527
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2593
 msgid "Zone name cannot exceed 100 characters"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2536
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2602
 msgid "Zone name contains invalid characters: < > \" ' \\"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2548
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2614
 msgid "A zone with this name already exists"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2567
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2633
 msgid "Zone number must be at least 1"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2570
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2636
 msgid "Zone number cannot exceed 99"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2590
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:2656
 msgid "Zone number %1 is already in use"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:3056
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:3134
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:3130
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:3208
 msgctxt "@info"
 msgid "Zone manager not initialized"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:3116
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:3190
 msgctxt "@action"
 msgid "Cut %1 Zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:3202
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:3276
 #: /home/nlavender/Documents/PlasmaZones/src/editor/undo/commands/PasteZonesCommand.cpp:13
 msgctxt "@action"
 msgid "Paste %1 Zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:3330
+#: /home/nlavender/Documents/PlasmaZones/src/editor/EditorController.cpp:3404
 msgctxt "@action"
 msgid "Reset Shader Parameters"
 msgstr ""
@@ -649,152 +649,152 @@ msgctxt "@action:button"
 msgid "Dismiss notification"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:161
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:148
 msgctxt "@title"
 msgid "Layout Editor"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:549
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:536
 msgid "Exit Fullscreen (F11)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:576
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:563
 msgctxt "@title:window"
 msgid "Unsaved Changes"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:577
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:564
 msgctxt "@info"
 msgid "You have unsaved changes. What would you like to do?"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:595
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:582
 msgctxt "@title:window"
 msgid "Import Layout"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:596
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:610
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:583
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:597
 msgctxt "@item:inlistbox"
 msgid "JSON files (*.json)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:596
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:583
 msgctxt "@item:inlistbox"
 msgid "All files (*)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:609
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:596
 msgctxt "@title:window"
 msgid "Export Layout"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:639
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:626
 msgctxt "@title:window"
 msgid "Layout Editor Help"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:656
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:643
 msgctxt "@title:window"
 msgid "Shader Effect"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:755
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:742
 msgctxt "@action:button"
 msgid "Defaults"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:763
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:750
 msgctxt "@action:button"
 msgid "Apply"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:819
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:806
 msgctxt "@title:group"
 msgid "General"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:861
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:848
 msgctxt "@label"
 msgid "Enable effect:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:864
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:851
 msgctxt "@label"
 msgid "Enable shader effect"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:865
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:852
 msgctxt "@info"
 msgid "Turn the shader effect on or off for zone overlays"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:887
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:874
 msgctxt "@info"
 msgid "The shader effect is disabled for this layout."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:899
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:886
 msgctxt "@label:listbox"
 msgid "Effect:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:905
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:892
 msgctxt "@label:listbox"
 msgid "Shader effect"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:906
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:893
 msgctxt "@info"
 msgid "Select a visual effect for zone overlays"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:961
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:948
 msgctxt "@info shader author"
 msgid "by %1"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:962
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:949
 msgctxt "@info shader version"
 msgid "v%1"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:963
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:950
 msgctxt "@info user-installed shader"
 msgid "(User shader)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:989
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:976
 msgctxt "@title:group"
 msgid "Parameters"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1001
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:988
 msgctxt "@info"
 msgid "This effect has no configurable parameters."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1181
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1168
 msgctxt "@label"
 msgid "%1 color"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1278
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1265
 msgctxt "@title:window"
 msgid "Choose %1"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1293
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1280
 msgctxt "@info"
 msgid "Layout saved successfully"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1298
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1285
 msgctxt "@info"
 msgid "Failed to load layout: %1"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1303
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/EditorWindow.qml:1290
 msgctxt "@info"
 msgid "Failed to save layout: %1"
 msgstr ""
@@ -1016,412 +1016,412 @@ msgid ""
 "controls are keyboard accessible."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:172
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:157
 msgctxt "@title"
 msgid "Zone Properties"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:172
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:157
 msgctxt "@title"
 msgid "1 Zone Selected"
 msgid_plural "%1 Zones Selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:186
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:171
 msgctxt "@tooltip"
 msgid "Close panel"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:188
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:173
 msgctxt "@info:accessibility"
 msgid "Close properties panel"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:216
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:201
 msgctxt "@title"
 msgid "Appearance (All Selected)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:224
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:658
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:209
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:643
 msgctxt "@label"
 msgid "Custom colors:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:225
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:210
 msgctxt "@option:check"
 msgid "Enable for all selected"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:228
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:213
 msgctxt "@info:accessibility"
 msgid "Enable custom colors for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:229
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:214
 msgctxt "@info"
 msgid "Enable custom color settings for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:230
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:215
 msgctxt "@info:tooltip"
 msgid "Enable custom colors for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:240
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:676
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:225
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:661
 msgctxt "@label"
 msgid "Highlight:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:254
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:239
 msgctxt "@label"
 msgid "Highlight color picker for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:255
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:240
 msgctxt "@info:tooltip"
 msgid "Choose highlight color for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:269
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:307
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:344
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:254
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:292
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:329
 msgctxt "@info"
 msgid "Click to set for all"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:278
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:798
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:263
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:764
 msgctxt "@label"
 msgid "Inactive:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:292
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:277
 msgctxt "@label"
 msgid "Inactive color picker for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:293
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:278
 msgctxt "@info:tooltip"
 msgid "Choose inactive color for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:316
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:920
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:301
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:867
 msgctxt "@label"
 msgid "Border:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:329
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:314
 msgctxt "@label"
 msgid "Border color picker for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:330
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:315
 msgctxt "@info:tooltip"
 msgid "Choose border color for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:353
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1046
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:338
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:966
 msgctxt "@label"
 msgid "Active opacity:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:366
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:351
 msgctxt "@label"
 msgid "Active opacity for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:367
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:352
 msgctxt "@info:tooltip"
 msgid "Set active opacity for all selected zones (0-100%)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:389
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1086
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:374
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1006
 msgctxt "@label"
 msgid "Inactive opacity:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:402
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:387
 msgctxt "@label"
 msgid "Inactive opacity for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:403
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:388
 msgctxt "@info:tooltip"
 msgid "Set inactive opacity for all selected zones (0-100%)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:427
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1128
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:412
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1048
 msgctxt "@label"
 msgid "Border width:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:433
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:418
 msgctxt "@label"
 msgid "Border width for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:434
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:419
 msgctxt "@info:tooltip"
 msgid "Set border width for all selected zones (0-20)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:446
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1149
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:431
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1069
 msgctxt "@label"
 msgid "Border radius:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:452
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:437
 msgctxt "@label"
 msgid "Border radius for all selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:453
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:438
 msgctxt "@info:tooltip"
 msgid "Set corner radius for all selected zones (0-50)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:467
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1172
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:452
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1092
 msgctxt "@title"
 msgid "Actions"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:473
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:458
 msgctxt "@info"
 msgid "Actions will apply to all selected zones."
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:482
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:467
 msgctxt "@action:button"
 msgid "Delete Selected Zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:486
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:471
 msgctxt "@info"
 msgid "Delete 1 selected zone"
 msgid_plural "Delete %1 selected zones"
 msgstr[0] ""
 msgstr[1] ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:505
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:490
 msgctxt "@label"
 msgid "Name:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:508
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:493
 msgctxt "@label"
 msgid "Zone name"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:509
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:494
 msgctxt "@info"
 msgid "Enter name for the zone"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:607
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:592
 msgctxt "@label"
 msgid "Number:"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:612
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:597
 msgctxt "@label"
 msgid "Zone number"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:613
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:598
 msgctxt "@info"
 msgid "Zone number (1-99)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:650
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:635
 msgctxt "@title"
 msgid "Appearance"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:659
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:644
 msgctxt "@option:check"
 msgid "Use custom colors"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:663
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:648
 msgctxt "@info:accessibility"
 msgid "Enable custom colors for this zone"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:664
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:649
 msgctxt "@info"
 msgid "Enable custom color settings for this zone"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:665
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:650
 msgctxt "@info:tooltip"
 msgid "Enable custom colors, opacity, and border settings"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:712
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:689
 msgctxt "@label"
 msgid "Highlight color picker"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:713
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:690
 msgctxt "@info"
 msgid "Click to choose highlight color"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:714
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:691
 msgctxt "@info:tooltip"
 msgid "Choose color for highlighted/active zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:791
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:757
 msgctxt "@info:accessibility"
 msgid "Highlight color hex code"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:834
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:792
 msgctxt "@label"
 msgid "Inactive color picker"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:835
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:793
 msgctxt "@info"
 msgid "Click to choose inactive zone color"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:836
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:794
 msgctxt "@info:tooltip"
 msgid "Choose color for non-selected zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:913
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:860
 msgctxt "@info:accessibility"
 msgid "Inactive color hex code"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:953
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:891
 msgctxt "@label"
 msgid "Border color picker"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:954
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:892
 msgctxt "@info"
 msgid "Click to choose border color"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:955
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:893
 msgctxt "@info:tooltip"
 msgid "Choose color for zone borders"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1039
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:959
 msgctxt "@info:accessibility"
 msgid "Border color hex code"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1060
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:980
 msgctxt "@label"
 msgid "Zone active opacity"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1061
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:981
 msgctxt "@info"
 msgid "Active/highlighted opacity percentage (0-100%)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1062
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:982
 msgctxt "@info:tooltip"
 msgid "Adjust zone opacity when highlighted (0-100%)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1100
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1020
 msgctxt "@label"
 msgid "Zone inactive opacity"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1101
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1021
 msgctxt "@info"
 msgid "Inactive/non-highlighted opacity percentage (0-100%)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1102
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1022
 msgctxt "@info:tooltip"
 msgid "Adjust zone opacity when not highlighted (0-100%)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1135
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1055
 msgctxt "@label"
 msgid "Border width in pixels"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1136
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1056
 msgctxt "@info"
 msgid "Zone border width (0-20 pixels)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1137
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1057
 msgctxt "@info:tooltip"
 msgid "Set zone border width in pixels (0-20)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1156
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1076
 msgctxt "@label"
 msgid "Border radius in pixels"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1157
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1077
 msgctxt "@info"
 msgid "Zone corner radius (0-50 pixels)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1158
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1078
 msgctxt "@info:tooltip"
 msgid "Set zone corner radius in pixels (0-50)"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1179
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1099
 msgctxt "@action:button"
 msgid "Delete Zone"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1183
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1103
 msgctxt "@info"
 msgid "Delete the selected zone"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1248
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1168
 msgctxt "@title:window"
 msgid "Zone Highlight Color"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1278
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1198
 msgctxt "@title:window"
 msgid "Zone Inactive Color"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1308
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1228
 msgctxt "@title:window"
 msgid "Zone Border Color"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1336
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1256
 msgctxt "@title:window"
 msgid "Highlight Color for All Selected Zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1351
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1271
 msgctxt "@title:window"
 msgid "Inactive Color for All Selected Zones"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1366
+#: /home/nlavender/Documents/PlasmaZones/src/editor/qml/PropertyPanel.qml:1286
 msgctxt "@title:window"
 msgid "Border Color for All Selected Zones"
 msgstr ""

--- a/po/plasmazonesd.pot
+++ b/po/plasmazonesd.pot
@@ -9,7 +9,7 @@ msgstr ""
 "#-#-#-#-#  plasmazonesd-cpp.pot (PlasmaZones 1.0.0)  #-#-#-#-#\n"
 "Project-Id-Version: PlasmaZones 1.0.0\n"
 "Report-Msgid-Bugs-To: \"https://github.com/plasmazones/plasmazones/issues\"\n"
-"POT-Creation-Date: 2026-01-27 18:48-0600\n"
+"POT-Creation-Date: 2026-01-28 13:34-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: English\n"
@@ -49,72 +49,96 @@ msgstr ""
 msgid "Replace existing daemon instance"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/daemon.cpp:531
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/daemon.cpp:563
 msgid "Zone Layout: %1"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:242
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:287
 msgid "Open Zone Editor"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:255
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:300
 msgid "Previous Layout"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:260
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:305
 msgid "Next Layout"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:274
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:319
 msgid "Apply Layout %1"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:323
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:368
 msgid "Move Window Left"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:330
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:375
 msgid "Move Window Right"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:337
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:382
 msgid "Move Window Up"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:344
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:389
 msgid "Move Window Down"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:352
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:397
 msgid "Focus Zone Left"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:359
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:404
 msgid "Focus Zone Right"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:366
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:411
 msgid "Focus Zone Up"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:373
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:418
 msgid "Focus Zone Down"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:381
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:426
 msgid "Push to Empty Zone"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:388
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:433
 msgid "Restore Window Size"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:396
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:441
 msgid "Toggle Window Float"
 msgstr ""
 
-#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:562
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:602
+msgid "Swap Window Left"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:609
+msgid "Swap Window Right"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:616
+msgid "Swap Window Up"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:623
+msgid "Swap Window Down"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:695
 msgid "Snap to Zone %1"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:729
+msgid "Rotate Windows Clockwise"
+msgstr ""
+
+#: /home/nlavender/Documents/PlasmaZones/src/daemon/shortcutmanager.cpp:737
+msgid "Rotate Windows Counterclockwise"
 msgstr ""
 
 #: /home/nlavender/Documents/PlasmaZones/src/ui/LayoutPreview.qml:59

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,23 +99,37 @@ target_link_libraries(plasmazones_core
         KF6::ColorScheme
 )
 
-# Conditionally link KActivities if available
-# Try KF6::Activities first, fallback to KActivities
-if(KF6Activities_FOUND)
-    target_link_libraries(plasmazones_core
-        PUBLIC
-            KF6::Activities
-    )
-    target_compile_definitions(plasmazones_core PRIVATE HAVE_KACTIVITIES)
-elseif(KActivities_FOUND)
-    # KActivities might be found but need different linking approach
-    find_library(KACTIVITIES_LIBRARY KActivities)
-    if(KACTIVITIES_LIBRARY)
+# Conditionally link PlasmaActivities/KActivities if available
+# Plasma 6 uses Plasma::Activities, KF6 uses KF6::Activities, KF5 uses KActivities
+if(PlasmaActivities_FOUND)
+    # Check for Plasma 6 target first
+    if(TARGET Plasma::Activities)
         target_link_libraries(plasmazones_core
             PUBLIC
-                ${KACTIVITIES_LIBRARY}
+                Plasma::Activities
         )
         target_compile_definitions(plasmazones_core PRIVATE HAVE_KACTIVITIES)
+        message(STATUS "Linking PlasmaActivities via Plasma::Activities target")
+    elseif(TARGET KF6::Activities)
+        target_link_libraries(plasmazones_core
+            PUBLIC
+                KF6::Activities
+        )
+        target_compile_definitions(plasmazones_core PRIVATE HAVE_KACTIVITIES)
+        message(STATUS "Linking PlasmaActivities via KF6::Activities target")
+    else()
+        # Fallback to library name lookup
+        find_library(PLASMA_ACTIVITIES_LIBRARY NAMES PlasmaActivities KActivities)
+        if(PLASMA_ACTIVITIES_LIBRARY)
+            target_link_libraries(plasmazones_core
+                PUBLIC
+                    ${PLASMA_ACTIVITIES_LIBRARY}
+            )
+            target_compile_definitions(plasmazones_core PRIVATE HAVE_KACTIVITIES)
+            message(STATUS "Linking PlasmaActivities via library: ${PLASMA_ACTIVITIES_LIBRARY}")
+        else()
+            message(WARNING "PlasmaActivities found but no linkable target/library available")
+        endif()
     endif()
 endif()
 

--- a/src/core/activitymanager.h
+++ b/src/core/activitymanager.h
@@ -6,10 +6,12 @@
 #include "plasmazones_export.h"
 #include <QObject>
 #include <QString>
+#include <QStringList>
 
 namespace PlasmaZones {
 
 class LayoutManager;
+class VirtualDesktopManager;
 
 /**
  * @brief Manages KDE Activities integration for activity-based layouts (SRP)
@@ -27,6 +29,12 @@ class PLASMAZONES_EXPORT ActivityManager : public QObject
 public:
     explicit ActivityManager(LayoutManager* layoutManager, QObject* parent = nullptr);
     ~ActivityManager() override;
+
+    /**
+     * @brief Set the VirtualDesktopManager for desktop coordination
+     * @param vdm Pointer to VirtualDesktopManager (not owned)
+     */
+    void setVirtualDesktopManager(VirtualDesktopManager* vdm);
 
     /**
      * @brief Initialize activity monitoring
@@ -56,6 +64,33 @@ public:
      */
     static bool isAvailable();
 
+    /**
+     * @brief Get list of all activity IDs
+     * @return List of activity UUIDs, empty if KActivities unavailable
+     */
+    QStringList activities() const;
+
+    /**
+     * @brief Get the human-readable name of an activity
+     * @param activityId Activity UUID
+     * @return Activity name, or empty string if not found
+     */
+    QString activityName(const QString& activityId) const;
+
+    /**
+     * @brief Get icon name for an activity
+     * @param activityId Activity UUID
+     * @return Icon name (Breeze icon naming), or empty string if not found
+     */
+    QString activityIcon(const QString& activityId) const;
+
+public Q_SLOTS:
+    /**
+     * @brief Re-evaluate and update the active layout based on current activity/desktop
+     * Called when activity assignments change to refresh the layout
+     */
+    void updateActiveLayout();
+
 Q_SIGNALS:
     /**
      * @brief Emitted when activity changes
@@ -63,15 +98,23 @@ Q_SIGNALS:
      */
     void currentActivityChanged(const QString& activityId);
 
+    /**
+     * @brief Emitted when the list of activities changes
+     */
+    void activitiesChanged();
+
 private Q_SLOTS:
     void onCurrentActivityChanged(const QString& activityId);
+    void onActivityAdded(const QString& activityId);
+    void onActivityRemoved(const QString& activityId);
 
 private:
     void connectSignals();
     void disconnectSignals();
-    void updateActiveLayout();
 
     LayoutManager* m_layoutManager = nullptr;
+    VirtualDesktopManager* m_virtualDesktopManager = nullptr;
+    QObject* m_controller = nullptr; // KActivities::Controller*, stored as QObject* for optional dependency
     bool m_running = false;
     QString m_currentActivity;
     bool m_activitiesAvailable = false;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -141,6 +141,7 @@ bool Daemon::init()
     // Each adaptor has a single responsibility and its own D-Bus interface
     // D-Bus adaptors use raw new; Qt parent-child manages their lifetime.
     m_layoutAdaptor = new LayoutAdaptor(m_layoutManager.get(), m_virtualDesktopManager.get(), this);
+    m_layoutAdaptor->setActivityManager(m_activityManager.get());
     m_settingsAdaptor = new SettingsAdaptor(m_settings.get(), this);
 
     // Overlay adaptor - overlay visibility and highlighting (SRP - kept for backward compatibility)
@@ -265,6 +266,8 @@ void Daemon::start()
     m_overlayService->setCurrentVirtualDesktop(m_virtualDesktopManager->currentDesktop());
 
     // Initialize and start activity manager (SRP: activity handling)
+    // Connect to VirtualDesktopManager for desktop+activity coordinate lookup
+    m_activityManager->setVirtualDesktopManager(m_virtualDesktopManager.get());
     m_activityManager->init();
     if (ActivityManager::isAvailable()) {
         m_activityManager->start();


### PR DESCRIPTION
## Summary

Implements KDE Activity support for PlasmaZones (Issue #9), allowing users to assign different layouts to different KDE Activities. When switching activities, the assigned layout is automatically applied.

**Key Features:**
- Activity Assignments UI in System Settings (KCM) - consistent with Monitor Assignments section
- Per-screen layout assignments for each activity
- Automatic layout switching when activity changes
- Full D-Bus API for programmatic activity management
- Optional feature - works without plasma-activities installed

**Technical Changes:**
- PlasmaActivities/KActivities CMake detection (Plasma 6 first, fallback to KF6/KF5)
- Async ActivityManager initialization for proper service synchronization
- 11 new D-Bus methods + 2 signals in LayoutAdaptor
- KCM backend with pending assignment caching (Apply/Cancel pattern)

## Test Plan

- [ ] Install plasma-activities package if not present
- [ ] Create multiple KDE Activities in System Settings → Activities
- [ ] Open PlasmaZones settings → Assignments tab
- [ ] Verify Activity Assignments section appears with all activities listed
- [ ] Assign different layouts to different activities
- [ ] Click Apply
- [ ] Switch between activities and verify layout changes automatically
- [ ] Verify "Current" badge shows on active activity
- [ ] Test without plasma-activities installed - should show "not available" message

Closes #9