### PR TITLE
feat: implement Master-Stack tiling algorithm

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,8 @@ set(plasmazones_core_SRCS
     autotile/TilingState.cpp
     autotile/AutotileConfig.h
     autotile/AutotileConfig.cpp
+    autotile/algorithms/MasterStackAlgorithm.h
+    autotile/algorithms/MasterStackAlgorithm.cpp
     dbus/layoutadaptor.cpp
     dbus/layoutadaptor.h
     dbus/settingsadaptor.cpp

--- a/src/autotile/algorithms/MasterStackAlgorithm.cpp
+++ b/src/autotile/algorithms/MasterStackAlgorithm.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "MasterStackAlgorithm.h"
+#include "../TilingState.h"
+#include "core/constants.h"
+#include <algorithm>
+
+namespace PlasmaZones {
+
+using namespace AutotileDefaults;
+
+MasterStackAlgorithm::MasterStackAlgorithm(QObject *parent)
+    : TilingAlgorithm(parent)
+{
+}
+
+QString MasterStackAlgorithm::name() const
+{
+    return QStringLiteral("Master + Stack");
+}
+
+QString MasterStackAlgorithm::description() const
+{
+    return tr("Large master area with stacked secondary windows");
+}
+
+QString MasterStackAlgorithm::icon() const
+{
+    return QStringLiteral("view-split-left-right");
+}
+
+int MasterStackAlgorithm::masterZoneIndex() const
+{
+    return 0; // First zone is always master
+}
+
+bool MasterStackAlgorithm::supportsMasterCount() const
+{
+    return true;
+}
+
+bool MasterStackAlgorithm::supportsSplitRatio() const
+{
+    return true;
+}
+
+qreal MasterStackAlgorithm::defaultSplitRatio() const
+{
+    return DefaultSplitRatio; // 0.6 (60% master)
+}
+
+QVector<QRect> MasterStackAlgorithm::calculateZones(int windowCount, const QRect &screenGeometry,
+                                                    const TilingState &state) const
+{
+    QVector<QRect> zones;
+
+    if (windowCount <= 0 || !screenGeometry.isValid()) {
+        return zones;
+    }
+
+    const int screenX = screenGeometry.x();
+    const int screenY = screenGeometry.y();
+    const int screenWidth = screenGeometry.width();
+    const int screenHeight = screenGeometry.height();
+
+    // Single window takes full screen
+    if (windowCount == 1) {
+        zones.append(screenGeometry);
+        return zones;
+    }
+
+    // Get master count and split ratio from state
+    const int masterCount = std::clamp(state.masterCount(), 1, windowCount);
+    const int stackCount = windowCount - masterCount;
+    const qreal splitRatio = std::clamp(state.splitRatio(), MinSplitRatio, MaxSplitRatio);
+
+    // Calculate master and stack widths
+    int masterWidth;
+    int stackWidth;
+
+    if (stackCount == 0) {
+        // All windows are masters - they take full width
+        masterWidth = screenWidth;
+        stackWidth = 0;
+    } else {
+        masterWidth = static_cast<int>(screenWidth * splitRatio);
+        stackWidth = screenWidth - masterWidth;
+    }
+
+    // Calculate master zone heights (divide evenly)
+    const int masterHeight = screenHeight / masterCount;
+    int masterRemainder = screenHeight % masterCount;
+
+    // Generate master zones (left side, stacked vertically)
+    int currentY = screenY;
+    for (int i = 0; i < masterCount; ++i) {
+        int zoneHeight = masterHeight;
+        // Distribute remainder pixels to first zones
+        if (masterRemainder > 0) {
+            ++zoneHeight;
+            --masterRemainder;
+        }
+
+        zones.append(QRect(screenX, currentY, masterWidth, zoneHeight));
+        currentY += zoneHeight;
+    }
+
+    // Generate stack zones (right side, stacked vertically)
+    if (stackCount > 0) {
+        const int stackHeight = screenHeight / stackCount;
+        int stackRemainder = screenHeight % stackCount;
+        const int stackX = screenX + masterWidth;
+
+        currentY = screenY;
+        for (int i = 0; i < stackCount; ++i) {
+            int zoneHeight = stackHeight;
+            // Distribute remainder pixels to first zones
+            if (stackRemainder > 0) {
+                ++zoneHeight;
+                --stackRemainder;
+            }
+
+            zones.append(QRect(stackX, currentY, stackWidth, zoneHeight));
+            currentY += zoneHeight;
+        }
+    }
+
+    return zones;
+}
+
+} // namespace PlasmaZones

--- a/src/autotile/algorithms/MasterStackAlgorithm.h
+++ b/src/autotile/algorithms/MasterStackAlgorithm.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "../TilingAlgorithm.h"
+
+namespace PlasmaZones {
+
+/**
+ * @brief Master-Stack tiling algorithm
+ *
+ * Classic tiling layout with one or more "master" windows taking a large
+ * portion of the screen (typically left side, 55-60%), with remaining
+ * windows stacked vertically on the right.
+ *
+ * Layout example (1 master, 3 stack):
+ * ```
+ * +------------------+--------+
+ * |                  |   2    |
+ * |     MASTER       |--------|
+ * |     (60%)        |   3    |
+ * |                  |--------|
+ * |                  |   4    |
+ * +------------------+--------+
+ * ```
+ *
+ * Features:
+ * - Adjustable split ratio (master width percentage)
+ * - Multiple masters (stacked vertically in master area)
+ * - Stack windows divide evenly
+ * - Single window uses full screen
+ */
+class PLASMAZONES_EXPORT MasterStackAlgorithm : public TilingAlgorithm
+{
+    Q_OBJECT
+
+public:
+    explicit MasterStackAlgorithm(QObject *parent = nullptr);
+    ~MasterStackAlgorithm() override = default;
+
+    // TilingAlgorithm interface
+    QString name() const override;
+    QString description() const override;
+    QString icon() const override;
+
+    QVector<QRect> calculateZones(int windowCount, const QRect &screenGeometry,
+                                  const TilingState &state) const override;
+
+    int masterZoneIndex() const override;
+    bool supportsMasterCount() const override;
+    bool supportsSplitRatio() const override;
+    qreal defaultSplitRatio() const override;
+};
+
+} // namespace PlasmaZones


### PR DESCRIPTION
## Summary

Implements the classic Master-Stack tiling algorithm, the default layout from Bismuth and dwm.

Closes #27

## Features

- Large master area (configurable via split ratio, default 60%)
- Stack area with remaining windows divided evenly
- Multiple masters supported (stacked vertically)
- Single window uses full screen
- Pixel-perfect zone calculations with remainder distribution

## Layout Example

```
1 master, 3 stack windows:

+------------------+--------+
|                  |   2    |
|     MASTER       |--------|
|     (60%)        |   3    |
|                  |--------|
|                  |   4    |
+------------------+--------+
```

## Files Added

- `src/autotile/algorithms/MasterStackAlgorithm.h`
- `src/autotile/algorithms/MasterStackAlgorithm.cpp`

## Implementation Details

- Uses absolute pixel coordinates (matches KWin API)
- Distributes remainder pixels evenly to first zones
- Respects `masterCount` and `splitRatio` from TilingState
- Returns `supportsMasterCount()` and `supportsSplitRatio()` as true

## Test Plan

- [x] Project builds successfully
- [ ] Single window takes full screen
- [ ] 2 windows split correctly (60/40)
- [ ] Multiple masters stack vertically
- [ ] Stack windows divide evenly

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)