### PR TITLE
feat: Add window event signals for autotiling (Phase 2.1)

### DIFF
--- a/dbus/org.plasmazones.xml
+++ b/dbus/org.plasmazones.xml
@@ -1038,5 +1038,64 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Reason string (e.g. no adjacent zone)."/>
             </arg>
         </signal>
+
+        <!-- Phase 2.1: Window Event Methods and Signals for Autotiling -->
+        <method name="windowAdded">
+            <annotation name="org.gtk.GDBus.DocString" value="Notify daemon that a new window was added (for autotiling)."/>
+            <arg name="windowId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
+            </arg>
+            <arg name="screenName" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Screen where window appeared."/>
+            </arg>
+        </method>
+        <method name="windowClosed">
+            <annotation name="org.gtk.GDBus.DocString" value="Notify daemon that a window was closed (for cleanup and autotiling)."/>
+            <arg name="windowId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
+            </arg>
+        </method>
+        <method name="windowActivated">
+            <annotation name="org.gtk.GDBus.DocString" value="Notify daemon that a window was activated/focused (for autotiling focus tracking)."/>
+            <arg name="windowId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
+            </arg>
+            <arg name="screenName" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Screen where window is located."/>
+            </arg>
+        </method>
+        <method name="setWindowSticky">
+            <annotation name="org.gtk.GDBus.DocString" value="Set whether a window is sticky (visible on all virtual desktops)."/>
+            <arg name="windowId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
+            </arg>
+            <arg name="sticky" type="b" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="True if window is on all desktops."/>
+            </arg>
+        </method>
+        <signal name="windowAddedEvent">
+            <annotation name="org.gtk.GDBus.DocString" value="Emitted when a new window is added (for autotiling consumers)."/>
+            <arg name="windowId" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
+            </arg>
+            <arg name="screenName" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Screen where window appeared."/>
+            </arg>
+        </signal>
+        <signal name="windowRemovedEvent">
+            <annotation name="org.gtk.GDBus.DocString" value="Emitted when a window is closed (for autotiling consumers)."/>
+            <arg name="windowId" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
+            </arg>
+        </signal>
+        <signal name="windowActivatedEvent">
+            <annotation name="org.gtk.GDBus.DocString" value="Emitted when a window is activated/focused (for autotiling focus tracking)."/>
+            <arg name="windowId" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
+            </arg>
+            <arg name="screenName" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Screen where window is located."/>
+            </arg>
+        </signal>
     </interface>
 </node>

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -47,6 +47,7 @@ public:
 private Q_SLOTS:
     void slotWindowAdded(KWin::EffectWindow* w);
     void slotWindowClosed(KWin::EffectWindow* w);
+    void slotWindowActivated(KWin::EffectWindow* w);
     void pollWindowMoves();
     void slotMouseChanged(const QPointF& pos, const QPointF& oldpos, Qt::MouseButtons buttons,
                           Qt::MouseButtons oldbuttons, Qt::KeyboardModifiers modifiers,
@@ -85,6 +86,19 @@ private:
     void ensureZoneDetectionInterface();
     void connectNavigationSignals();
     void syncFloatingWindowsFromDaemon();
+
+    /**
+     * @brief Ensure WindowTracking D-Bus interface is ready for use
+     * @param methodName Name of the calling method (for debug logging)
+     * @return true if interface is valid and ready, false otherwise
+     * @note DRY helper - consolidates repeated interface validation pattern
+     */
+    bool ensureWindowTrackingReady(const char* methodName);
+
+    // Phase 2.1: Window event notifications for autotiling
+    void notifyWindowAdded(KWin::EffectWindow* w);
+    void notifyWindowClosed(KWin::EffectWindow* w);
+    void notifyWindowActivated(KWin::EffectWindow* w);
 
     // Navigation helpers
     KWin::EffectWindow* getActiveWindow() const;
@@ -137,6 +151,10 @@ private:
 
     // Float tracking (Phase 1 keyboard navigation)
     QSet<QString> m_floatingWindows;
+
+    // Phase 2.1: Track windows notified to daemon via windowAdded
+    // Only send windowClosed for windows in this set (avoids D-Bus calls for untracked windows)
+    QSet<QString> m_notifiedWindows;
 
     // Polling timer for detecting window moves
     QTimer m_pollTimer;

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -110,8 +110,29 @@ public Q_SLOTS:
      * Clean up all tracking data for a closed window
      * @param windowId Window ID that was closed
      * @note Call this when KWin reports a window has been closed to prevent memory leaks
+     * @note This also emits windowRemovedEvent for autotiling consumers
      */
     void windowClosed(const QString& windowId);
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Phase 2.1: Window Event Methods for Autotiling
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Notify daemon that a new window was added (for autotiling)
+     * @param windowId Window identifier from KWin
+     * @param screenName Screen where the window appeared
+     * @note Emits windowAddedEvent signal for autotiling consumers
+     */
+    void windowAdded(const QString& windowId, const QString& screenName);
+
+    /**
+     * Notify daemon that a window was activated/focused (for autotiling focus tracking)
+     * @param windowId Window identifier from KWin
+     * @param screenName Screen where the window is located
+     * @note Emits windowActivatedEvent signal for autotiling consumers
+     */
+    void windowActivated(const QString& windowId, const QString& screenName);
 
     /**
      * Report navigation feedback from KWin effect (D-Bus method)
@@ -361,6 +382,30 @@ Q_SIGNALS:
      * @param reason Failure reason if !success (e.g., "no_adjacent_zone", "no_empty_zone", "not_snapped")
      */
     void navigationFeedback(bool success, const QString& action, const QString& reason);
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Phase 2.1: Window Event Signals for Autotiling
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Emitted when a new window is added (for autotiling consumers)
+     * @param windowId Window identifier from KWin
+     * @param screenName Screen where the window appeared
+     */
+    void windowAddedEvent(const QString& windowId, const QString& screenName);
+
+    /**
+     * @brief Emitted when a window is closed (for autotiling consumers)
+     * @param windowId Window identifier from KWin
+     */
+    void windowRemovedEvent(const QString& windowId);
+
+    /**
+     * @brief Emitted when a window is activated/focused (for autotiling focus tracking)
+     * @param windowId Window identifier from KWin
+     * @param screenName Screen where the window is located
+     */
+    void windowActivatedEvent(const QString& windowId, const QString& screenName);
 
     // Phase 1 Keyboard Navigation signals (for KWin script)
     /**


### PR DESCRIPTION
## Summary

- Implement Phase 2.1: Add Window Event Signals to KWin Effect
- Enable AutotileEngine to receive window lifecycle notifications via D-Bus
- **NEW:** Focus-based "last used zone" tracking for smarter window placement
- Apply DRY and SRP refactoring to eliminate code duplication

## Changes

### New D-Bus Interface
- `windowAdded(windowId, screenName)` - Notify when window is added
- `windowClosed(windowId)` - Notify when window is closed
- `windowActivated(windowId, screenName)` - Notify when window is activated/focused

### New D-Bus Signals
- `windowAddedEvent(windowId, screenName)` - For autotiling consumers
- `windowRemovedEvent(windowId)` - For autotiling consumers
- `windowActivatedEvent(windowId, screenName)` - For autotiling focus tracking

### KWin Effect Updates
- Connect to `EffectsHandler::windowActivated` signal
- Add `notifyWindowAdded()`, `notifyWindowClosed()`, `notifyWindowActivated()` helpers
- Track notified windows via `m_notifiedWindows` set to avoid D-Bus calls for special windows

### Base FancyZones Enhancement
**Focus-based "last used zone" tracking:**
- Focusing a snapped window now updates `m_lastUsedZoneId`
- Makes "move new windows to last zone" more intuitive
- Example: Click Firefox in zone 3 → new Firefox windows snap to zone 3

### Code Quality (DRY/SRP)
- Extract `ensureWindowTrackingReady()` helper - eliminates 13 duplicated boilerplate blocks
- Move `shouldHandleWindow()` filtering into notify methods for consistency
- Simplify slot methods by delegating filtering responsibility

## Signal Flow

```
KWin Effect                    D-Bus                    Daemon
─────────────────────────────────────────────────────────────────
windowAdded signal    →  asyncCall("windowAdded")  →  windowAdded()
                                                      ↓
                                                      Q_EMIT windowAddedEvent

windowClosed signal   →  asyncCall("windowClosed") →  windowClosed()
                                                      ↓
                                                      Q_EMIT windowRemovedEvent

windowActivated signal→  asyncCall("windowActivated")→ windowActivated()
                                                      ↓
                                                      Update lastUsedZone (if snapped)
                                                      ↓
                                                      Q_EMIT windowActivatedEvent
```

## Test plan

- [x] Build succeeds: `make -j$(nproc)`
- [x] All 7 tests pass: `ctest --output-on-failure`
- [ ] Manual test: Verify window events logged in daemon when opening/closing/focusing windows
- [ ] Manual test: Verify no D-Bus calls for tooltips, popups, notifications
- [ ] Manual test: Focus window in zone 3, open new window of same class → should snap to zone 3

## Related Issues

- Closes phase 2.1 from project board
- Future enhancements: #47

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)