### PR TITLE
feat: Implement autotile window geometry with animation (Phase 2.3)

### DIFF
--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -1972,7 +1972,12 @@ void PlasmaZonesEffect::loadAutotileSettings()
     m_autotileAnimationsEnabled = loadDBusSetting<bool>(
         settingsInterface, QStringLiteral("autotileAnimationsEnabled"), true);
 
-    qCDebug(lcEffect) << "Loaded autotile settings: animationsEnabled=" << m_autotileAnimationsEnabled;
+    // Load animation duration setting (default 150ms)
+    m_autotileAnimationDuration = loadDBusSetting<int>(
+        settingsInterface, QStringLiteral("autotileAnimationDuration"), 150);
+
+    qCDebug(lcEffect) << "Loaded autotile settings: animationsEnabled=" << m_autotileAnimationsEnabled
+                      << "animationDuration=" << m_autotileAnimationDuration << "ms";
 }
 
 KWin::EffectWindow* PlasmaZonesEffect::findWindowById(const QString& windowId) const
@@ -2063,6 +2068,7 @@ void PlasmaZonesEffect::applyAutotileGeometry(KWin::EffectWindow* window, const 
         WindowAnimation anim;
         anim.startGeometry = existing.currentGeometry();
         anim.endGeometry = QRectF(geometry);
+        anim.duration = m_autotileAnimationDuration;
         anim.timer.start();
         m_autotileAnimations[window] = anim;
 
@@ -2074,6 +2080,7 @@ void PlasmaZonesEffect::applyAutotileGeometry(KWin::EffectWindow* window, const 
     WindowAnimation anim;
     anim.startGeometry = currentGeometry;
     anim.endGeometry = QRectF(geometry);
+    anim.duration = m_autotileAnimationDuration;
     anim.timer.start();
     m_autotileAnimations[window] = anim;
 

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -225,7 +225,8 @@ private:
 
     // Phase 2.3: Autotile animations for smooth window geometry transitions
     QHash<KWin::EffectWindow*, WindowAnimation> m_autotileAnimations;
-    bool m_autotileAnimationsEnabled = true; ///< Whether to animate autotile geometry changes
+    bool m_autotileAnimationsEnabled = true;   ///< Whether to animate autotile geometry changes
+    qreal m_autotileAnimationDuration = 150.0; ///< Animation duration in milliseconds
 
     // Polling timer for detecting window moves
     QTimer m_pollTimer;


### PR DESCRIPTION
## Summary

Implements Phase 2.3 of the autotiling feature - window geometry application in the KWin effect with smooth animation support.

- Add D-Bus signal handlers for `windowTileRequested` and `focusWindowRequested` from AutotileAdaptor
- Implement 150ms OutQuad easing animation for window geometry transitions
- Add `WindowAnimation` struct with interpolation and progress tracking
- Wire animation setting to daemon configuration

## Changes

### New Features
- **`slotAutotileWindowRequested()`** - Receives tile geometry from daemon, applies with animation
- **`slotAutotileFocusWindowRequested()`** - Receives focus requests, activates window
- **`WindowAnimation` struct** - Tracks start/end geometry with OutQuad easing
- **Animation pipeline** - `prePaintWindow`/`paintWindow`/`postPaintWindow` overrides

### Edge Case Handling
- Skip autotile during user drag/resize operations
- Handle rapid geometry changes (detect duplicates, redirect from interpolated position)
- Float precision guard with 10px minimum dimension threshold
- Timer validity checks for safety
- Null window checks in paint cycle

## Test Plan
- [ ] Enable autotiling, verify windows animate to calculated positions
- [ ] Test focus cycling works via D-Bus signals
- [ ] Verify animation is smooth (150ms, no jitter)
- [ ] Test rapid window operations don't cause visual glitches
- [ ] Test dragging window during autotile doesn't interfere
- [ ] Verify multi-monitor support

## Related Issues
Closes #33

## Dependencies
- #32 (AutotileAdaptor) - must be merged first

---
🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)