### PR TITLE
feat(osd): improve navigation OSD with multi-monitor support and UX fixes

### DIFF
--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -252,6 +252,15 @@
             <arg name="reason" type="s" direction="in">
                 <annotation name="org.gtk.GDBus.DocString" value="Reason string (e.g. no adjacent zone)."/>
             </arg>
+            <arg name="sourceZoneId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Source zone ID for OSD highlighting (optional)."/>
+            </arg>
+            <arg name="targetZoneId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Target zone ID for OSD highlighting (optional)."/>
+            </arg>
+            <arg name="screenName" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Screen name where navigation occurred (for OSD placement)."/>
+            </arg>
         </method>
         <signal name="windowZoneChanged">
             <annotation name="org.gtk.GDBus.DocString" value="Emitted when a window's zone assignment changes."/>
@@ -278,6 +287,15 @@
             </arg>
             <arg name="reason" type="s">
                 <annotation name="org.gtk.GDBus.DocString" value="Reason string (e.g. no adjacent zone)."/>
+            </arg>
+            <arg name="sourceZoneId" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Source zone ID for OSD highlighting."/>
+            </arg>
+            <arg name="targetZoneId" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Target zone ID for OSD highlighting."/>
+            </arg>
+            <arg name="screenName" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Screen name where navigation occurred (for OSD placement)."/>
             </arg>
         </signal>
         <signal name="pendingRestoresAvailable">

--- a/kcm/CMakeLists.txt
+++ b/kcm/CMakeLists.txt
@@ -47,7 +47,7 @@ install(FILES
     ui/tabs/EditorTab.qml
     ui/tabs/AssignmentsTab.qml
     ui/tabs/ZonesTab.qml
-    ui/tabs/ZoneSelectorTab.qml
+    ui/tabs/DisplayTab.qml
     ui/tabs/ExclusionsTab.qml
     ui/tabs/ExclusionListCard.qml
     ui/tabs/MonitorAssignmentsCard.qml

--- a/kcm/ui/main.qml
+++ b/kcm/ui/main.qml
@@ -9,7 +9,7 @@
  * - Editor: Keyboard shortcuts and snapping settings
  * - Assignments: Monitor, activity, and quick layout assignments
  * - Zones: Appearance and behavior settings (merged for consistency)
- * - Zone Selector: Zone selector popup settings
+ * - Display: Zone selector popup and OSD settings
  * - Exclusions: Apps and windows to exclude from snapping
  */
 import QtQuick
@@ -137,7 +137,7 @@ KCM.AbstractKCM {
                 icon.name: "view-split-left-right"
             }
             TabButton {
-                text: i18n("Zone Selector")
+                text: i18n("Display")
                 icon.name: "select-rectangular"
             }
             TabButton {
@@ -238,7 +238,7 @@ KCM.AbstractKCM {
         }
 
         // TAB 5: ZONE SELECTOR
-        ZoneSelectorTab {
+        DisplayTab {
             kcm: root.kcmModule
             constants: constants
             screenAspectRatio: root.screenAspectRatio

--- a/kcm/ui/tabs/DisplayTab.qml
+++ b/kcm/ui/tabs/DisplayTab.qml
@@ -8,7 +8,7 @@ import org.kde.kirigami as Kirigami
 import ".."
 
 /**
- * @brief Zone Selector tab - Configure the zone selector popup appearance and behavior
+ * @brief Display tab - Zone selector popup and OSD settings
  */
 ScrollView {
     id: root
@@ -439,6 +439,59 @@ ScrollView {
                         opacity: 0.6
                         font.pixelSize: Kirigami.Theme.smallFont.pixelSize
                         horizontalAlignment: Text.AlignHCenter
+                    }
+                }
+            }
+        }
+
+        // On-Screen Display card - wrapped in Item for stable sizing
+        Item {
+            Layout.fillWidth: true
+            implicitHeight: osdCard.implicitHeight
+
+            Kirigami.Card {
+                id: osdCard
+                anchors.fill: parent
+
+                header: Kirigami.Heading {
+                    level: 3
+                    text: i18n("On-Screen Display")
+                    padding: Kirigami.Units.smallSpacing
+                }
+
+                contentItem: Kirigami.FormLayout {
+                    CheckBox {
+                        id: showOsdCheckbox
+                        Kirigami.FormData.label: i18n("Layout switch:")
+                        text: i18n("Show OSD when switching layouts")
+                        checked: kcm.showOsdOnLayoutSwitch
+                        onToggled: kcm.showOsdOnLayoutSwitch = checked
+                    }
+
+                    CheckBox {
+                        Kirigami.FormData.label: i18n("Keyboard navigation:")
+                        text: i18n("Show OSD when using keyboard navigation")
+                        checked: kcm.showNavigationOsd
+                        onToggled: kcm.showNavigationOsd = checked
+                    }
+
+                    ComboBox {
+                        id: osdStyleCombo
+                        Kirigami.FormData.label: i18n("OSD style:")
+                        enabled: showOsdCheckbox.checked || kcm.showNavigationOsd
+
+                        readonly property int osdStyleNone: 0
+                        readonly property int osdStyleText: 1
+                        readonly property int osdStylePreview: 2
+
+                        currentIndex: Math.max(0, kcm.osdStyle - osdStyleText)
+                        model: [
+                            i18n("Text only"),
+                            i18n("Visual preview")
+                        ]
+                        onActivated: (index) => {
+                            kcm.osdStyle = index + osdStyleText
+                        }
                     }
                 }
             }

--- a/kcm/ui/tabs/ZonesTab.qml
+++ b/kcm/ui/tabs/ZonesTab.qml
@@ -283,61 +283,6 @@ ScrollView {
         }
 
         // ═══════════════════════════════════════════════════════════════════════
-        // ON-SCREEN DISPLAY CARD
-        // ═══════════════════════════════════════════════════════════════════════
-        Item {
-            Layout.fillWidth: true
-            implicitHeight: osdCard.implicitHeight
-
-            Kirigami.Card {
-                id: osdCard
-                anchors.fill: parent
-
-                header: Kirigami.Heading {
-                    level: 3
-                    text: i18n("On-Screen Display")
-                    padding: Kirigami.Units.smallSpacing
-                }
-
-                contentItem: Kirigami.FormLayout {
-                    CheckBox {
-                        id: showOsdCheckbox
-                        Kirigami.FormData.label: i18n("Layout switch:")
-                        text: i18n("Show OSD when switching layouts")
-                        checked: kcm.showOsdOnLayoutSwitch
-                        onToggled: kcm.showOsdOnLayoutSwitch = checked
-                    }
-
-                    CheckBox {
-                        Kirigami.FormData.label: i18n("Keyboard navigation:")
-                        text: i18n("Show OSD when using keyboard navigation")
-                        checked: kcm.showNavigationOsd
-                        onToggled: kcm.showNavigationOsd = checked
-                    }
-
-                    ComboBox {
-                        id: osdStyleCombo
-                        Kirigami.FormData.label: i18n("OSD style:")
-                        enabled: showOsdCheckbox.checked || kcm.showNavigationOsd
-
-                        readonly property int osdStyleNone: 0
-                        readonly property int osdStyleText: 1
-                        readonly property int osdStylePreview: 2
-
-                        currentIndex: Math.max(0, kcm.osdStyle - osdStyleText)
-                        model: [
-                            i18n("Text only"),
-                            i18n("Visual preview")
-                        ]
-                        onActivated: (index) => {
-                            kcm.osdStyle = index + osdStyleText
-                        }
-                    }
-                }
-            }
-        }
-
-        // ═══════════════════════════════════════════════════════════════════════
         // ACTIVATION CARD
         // ═══════════════════════════════════════════════════════════════════════
         Item {

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -882,13 +882,16 @@ QString PlasmaZonesEffect::getWindowScreenName(KWin::EffectWindow* w) const
     return QString();
 }
 
-void PlasmaZonesEffect::emitNavigationFeedback(bool success, const QString& action, const QString& reason)
+void PlasmaZonesEffect::emitNavigationFeedback(bool success, const QString& action, const QString& reason,
+                                               const QString& sourceZoneId, const QString& targetZoneId,
+                                               const QString& screenName)
 {
     // Call D-Bus method on daemon to report navigation feedback (can't emit signals on another service's interface)
     if (!ensureWindowTrackingReady("report navigation feedback")) {
         return;
     }
-    m_windowTrackingInterface->asyncCall(QStringLiteral("reportNavigationFeedback"), success, action, reason);
+    m_windowTrackingInterface->asyncCall(QStringLiteral("reportNavigationFeedback"), success, action, reason,
+                                         sourceZoneId, targetZoneId, screenName);
 }
 
 void PlasmaZonesEffect::slotMoveWindowToZoneRequested(const QString& targetZoneId, const QString& zoneGeometry)

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -186,8 +186,13 @@ private:
      * @param success Whether the action succeeded
      * @param action The action type (e.g., "move", "focus", "push", "restore", "float")
      * @param reason Failure reason if !success (e.g., "no_window", "no_adjacent_zone")
+     * @param sourceZoneId Optional source zone ID for OSD highlighting
+     * @param targetZoneId Optional target zone ID for OSD highlighting
+     * @param screenName Screen name where navigation occurred (for OSD placement)
      */
-    void emitNavigationFeedback(bool success, const QString& action, const QString& reason = QString());
+    void emitNavigationFeedback(bool success, const QString& action, const QString& reason = QString(),
+                                const QString& sourceZoneId = QString(), const QString& targetZoneId = QString(),
+                                const QString& screenName = QString());
 
     // Apply snap geometry to window
     void applySnapGeometry(KWin::EffectWindow* window, const QRect& geometry);

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -131,6 +131,7 @@ struct PLASMAZONES_EXPORT NavigationCommand
 struct PLASMAZONES_EXPORT RotationEntry
 {
     QString windowId;           ///< Window to move
+    QString sourceZoneId;       ///< Zone window is moving from (for OSD highlighting)
     QString targetZoneId;       ///< Zone to move to
     QRect targetGeometry;       ///< Target geometry in pixels
 };

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -724,10 +724,11 @@ void Daemon::start()
 
     // Connect navigation feedback signal to show OSD (Qt signal from WindowTrackingAdaptor)
     connect(m_windowTrackingAdaptor, &WindowTrackingAdaptor::navigationFeedback, this,
-            [this](bool success, const QString& action, const QString& reason) {
+            [this](bool success, const QString& action, const QString& reason,
+                   const QString& sourceZoneId, const QString& targetZoneId, const QString& screenName) {
                 // Only show OSD if setting is enabled
                 if (m_settings && m_settings->showNavigationOsd()) {
-                    m_overlayService->showNavigationOsd(success, action, reason);
+                    m_overlayService->showNavigationOsd(success, action, reason, sourceZoneId, targetZoneId, screenName);
                 }
             });
 

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -105,7 +105,9 @@ public:
     void showLayoutOsd(const QString& id, const QString& name, const QVariantList& zones, int category);
 
     // Navigation OSD (feedback for keyboard navigation)
-    void showNavigationOsd(bool success, const QString& action, const QString& reason);
+    void showNavigationOsd(bool success, const QString& action, const QString& reason,
+                           const QString& sourceZoneId = QString(), const QString& targetZoneId = QString(),
+                           const QString& screenName = QString());
 
 public Q_SLOTS:
     void hideLayoutOsd();

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -141,10 +141,15 @@ public Q_SLOTS:
      * @param success Whether the navigation succeeded
      * @param action Action attempted (e.g., "move", "focus", "swap")
      * @param reason Failure reason if !success
+     * @param sourceZoneId Source zone ID for OSD highlighting (optional)
+     * @param targetZoneId Target zone ID for OSD highlighting (optional)
+     * @param screenName Screen name where navigation occurred (for OSD placement)
      * @note This method is called by KWin effect to report navigation results.
      *       It emits the Qt navigationFeedback signal which triggers the OSD.
      */
-    void reportNavigationFeedback(bool success, const QString& action, const QString& reason);
+    void reportNavigationFeedback(bool success, const QString& action, const QString& reason,
+                                  const QString& sourceZoneId, const QString& targetZoneId,
+                                  const QString& screenName);
 
     /**
      * Get validated pre-snap geometry, ensuring it's within visible screen bounds
@@ -397,8 +402,13 @@ Q_SIGNALS:
      * @param success Whether the navigation succeeded
      * @param action Action attempted (e.g., "move", "focus", "push", "restore", "float")
      * @param reason Failure reason if !success (e.g., "no_adjacent_zone", "no_empty_zone", "not_snapped")
+     * @param sourceZoneId Source zone ID for OSD highlighting
+     * @param targetZoneId Target zone ID for OSD highlighting
+     * @param screenName Screen name where navigation occurred (for OSD placement)
      */
-    void navigationFeedback(bool success, const QString& action, const QString& reason);
+    void navigationFeedback(bool success, const QString& action, const QString& reason,
+                            const QString& sourceZoneId, const QString& targetZoneId,
+                            const QString& screenName);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Phase 2.1: Window Event Signals for Autotiling


### PR DESCRIPTION
## Summary

- **Multi-monitor OSD placement**: Navigation OSD now appears on the screen where the action occurred, not always on the primary monitor
- **UUID normalization**: Fixed zone ID comparison to handle both formats (with/without braces)
- **Rotate window count**: OSD now shows actual count of rotated windows (e.g., "Rotated 3 windows")
- **Float toggle text**: Changed "Docked" to "Snapped" when unfloating a window
- **KCM reorganization**: Moved OSD settings from "Zones" tab to renamed "Display" tab (was "Zone Selector")
- **Bug fix**: Floating windows no longer auto-snap to last zone when reopened

## Changes

### D-Bus Interface
- Added `screenName` parameter to `reportNavigationFeedback` method and `navigationFeedback` signal

### KWin Effect
- All `emitNavigationFeedback` calls now pass the window's screen name
- Added `sourceZoneId` to rotation entries for proper OSD highlighting

### Daemon
- `showNavigationOsd` uses `screenName` to find the correct screen (falls back to primary)
- Signal connection updated to pass `screenName`

### QML
- `NavigationOsd.qml`: UUID normalization, "Snapped" text fix, dead code removal
- `ZonePreview.qml`: Added `highlightedZoneIds` for zone highlighting by ID
- `ZonesTab.qml`: Removed OSD settings (now in Display tab)
- Renamed `ZoneSelectorTab.qml` → `DisplayTab.qml`
- Renamed tab from "Zone Selector" to "Display"

## Test plan

- [ ] Test navigation OSD appears on correct monitor in multi-monitor setup
- [ ] Test rotate action shows correct window count
- [ ] Test float toggle shows "Floating" / "Snapped" appropriately
- [ ] Test zone highlighting works in navigation OSD
- [ ] Verify KCM "Display" tab contains zone selector and OSD settings
- [ ] Verify "Zones" tab no longer has OSD settings

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)