### PR TITLE
feat: auto-assign windows to first empty zone per layout

### DIFF
--- a/dbus/org.plasmazones.LayoutManager.xml
+++ b/dbus/org.plasmazones.LayoutManager.xml
@@ -85,6 +85,24 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Destination file path."/>
             </arg>
         </method>
+        <method name="setLayoutHidden">
+            <annotation name="org.gtk.GDBus.DocString" value="Set whether a layout is hidden from the zone selector."/>
+            <arg name="layoutId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Layout UUID."/>
+            </arg>
+            <arg name="hidden" type="b" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="True to hide from zone selector."/>
+            </arg>
+        </method>
+        <method name="setLayoutAutoAssign">
+            <annotation name="org.gtk.GDBus.DocString" value="Set whether a layout auto-assigns new windows to empty zones."/>
+            <arg name="layoutId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Layout UUID."/>
+            </arg>
+            <arg name="enabled" type="b" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="True to enable auto-assign."/>
+            </arg>
+        </method>
         <method name="openEditor">
             <annotation name="org.gtk.GDBus.DocString" value="Launch the layout editor for the active layout."/>
         </method>

--- a/dbus/org.plasmazones.WindowDrag.xml
+++ b/dbus/org.plasmazones.WindowDrag.xml
@@ -52,9 +52,15 @@
         </method>
 
         <method name="dragStopped">
-            <annotation name="org.gtk.GDBus.DocString" value="Called when the drag ends. Returns snap rectangle and whether to apply it (shouldSnap)."/>
+            <annotation name="org.gtk.GDBus.DocString" value="Called when the drag ends. Returns snap rectangle and whether to apply it (shouldSnap). cursorX/Y are the cursor position at release (for release screen detection)."/>
             <arg name="windowId" type="s" direction="in">
                 <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
+            </arg>
+            <arg name="cursorX" type="i" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Cursor X at release (global coordinates)."/>
+            </arg>
+            <arg name="cursorY" type="i" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Cursor Y at release (global coordinates)."/>
             </arg>
             <arg name="snapX" type="i" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="Snap X position (if shouldSnap)."/>
@@ -70,6 +76,12 @@
             </arg>
             <arg name="shouldSnap" type="b" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="True if KWin should apply the snap geometry."/>
+            </arg>
+            <arg name="releaseScreenName" type="s" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="Screen name where the drag was released (cursor position). Use for auto-fill on drop."/>
+            </arg>
+            <arg name="restoreSizeOnly" type="b" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="If true with shouldSnap: apply only width/height; keep window at current position (drag-to-unsnap). Float-toggle shortcut restores full x/y/w/h."/>
             </arg>
         </method>
 

--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -262,6 +262,33 @@
                 <annotation name="org.gtk.GDBus.DocString" value="True if caller should apply the geometry."/>
             </arg>
         </method>
+        <method name="snapToEmptyZone">
+            <annotation name="org.gtk.GDBus.DocString" value="Snap window to first empty zone (auto-assign). Only fires if layout has autoAssign enabled."/>
+            <arg name="windowId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Window to snap."/>
+            </arg>
+            <arg name="windowScreenName" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Window's current screen (e.g. DP-1)."/>
+            </arg>
+            <arg name="sticky" type="b" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="True if window is on all desktops."/>
+            </arg>
+            <arg name="snapX" type="i" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="Snap X (if shouldSnap)."/>
+            </arg>
+            <arg name="snapY" type="i" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="Snap Y (if shouldSnap)."/>
+            </arg>
+            <arg name="snapWidth" type="i" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="Snap width (if shouldSnap)."/>
+            </arg>
+            <arg name="snapHeight" type="i" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="Snap height (if shouldSnap)."/>
+            </arg>
+            <arg name="shouldSnap" type="b" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="True if auto-assign matched and window should be snapped."/>
+            </arg>
+        </method>
         <method name="restoreToPersistedZone">
             <annotation name="org.gtk.GDBus.DocString" value="Restore window to its zone from the previous session. Returns geometry and shouldRestore."/>
             <arg name="windowId" type="s" direction="in">

--- a/kcm/kcm_plasmazones.h
+++ b/kcm/kcm_plasmazones.h
@@ -357,6 +357,7 @@ public Q_SLOTS:
     Q_INVOKABLE void editLayout(const QString& layoutId);
     Q_INVOKABLE void openEditor();
     Q_INVOKABLE void setLayoutHidden(const QString& layoutId, bool hidden);
+    Q_INVOKABLE void setLayoutAutoAssign(const QString& layoutId, bool enabled);
 
     // App-to-zone rules management
     Q_INVOKABLE QVariantList getAppRulesForLayout(const QString& layoutId) const;
@@ -582,6 +583,10 @@ private:
     // Pending layout visibility changes (staged until Apply)
     // Key: layoutId, Value: hiddenFromSelector state
     QHash<QString, bool> m_pendingHiddenStates;
+
+    // Pending auto-assign changes (staged until Apply)
+    // Key: layoutId, Value: autoAssign state
+    QHash<QString, bool> m_pendingAutoAssignStates;
 
     // Pending app-to-zone rules (staged until Apply)
     // Key: layoutId, Value: rules list (QVariantList of {pattern, zoneNumber})

--- a/kcm/ui/LayoutComboBox.qml
+++ b/kcm/ui/LayoutComboBox.qml
@@ -180,6 +180,7 @@ ComboBox {
                     QFZCommon.CategoryBadge {
                         visible: hasLayout && modelData.category >= 0
                         category: modelData.category
+                        autoAssign: modelData.layout?.autoAssign === true
                     }
                 }
 

--- a/kcm/ui/tabs/LayoutGridDelegate.qml
+++ b/kcm/ui/tabs/LayoutGridDelegate.qml
@@ -140,25 +140,50 @@ Item {
                     }
                 }
 
-                // Visibility toggle (top-right)
-                ToolButton {
+                // Top-right toggle buttons (autoAssign and hidden are independent:
+                // a layout can be hidden from the zone selector while still auto-assigning
+                // new windows when active via screen/desktop/activity assignment)
+                Row {
                     anchors.top: parent.top
                     anchors.right: parent.right
                     anchors.margins: Kirigami.Units.smallSpacing / 2
-                    width: Kirigami.Units.iconSizes.small + Kirigami.Units.smallSpacing
-                    height: width
-                    padding: 0
-                    visible: root.isHovered || root.modelData.hiddenFromSelector === true
-                    icon.name: root.modelData.hiddenFromSelector ? "view-hidden" : "view-visible"
-                    icon.width: Kirigami.Units.iconSizes.small
-                    icon.height: Kirigami.Units.iconSizes.small
-                    icon.color: root.modelData.hiddenFromSelector ? Kirigami.Theme.disabledTextColor : Kirigami.Theme.textColor
-                    onClicked: root.kcm.setLayoutHidden(root.modelData.id, !root.modelData.hiddenFromSelector)
+                    spacing: 0
 
-                    ToolTip.visible: hovered
-                    ToolTip.text: root.modelData.hiddenFromSelector
-                        ? i18n("Hidden from zone selector. Click to show.")
-                        : i18n("Visible in zone selector. Click to hide.")
+                    // Auto-assign toggle
+                    ToolButton {
+                        width: Kirigami.Units.iconSizes.small + Kirigami.Units.smallSpacing
+                        height: width
+                        padding: 0
+                        visible: root.isHovered || root.modelData.autoAssign === true
+                        icon.name: root.modelData.autoAssign === true ? "window-duplicate" : "window-new"
+                        icon.width: Kirigami.Units.iconSizes.small
+                        icon.height: Kirigami.Units.iconSizes.small
+                        icon.color: root.modelData.autoAssign === true ? Kirigami.Theme.textColor : Kirigami.Theme.disabledTextColor
+                        onClicked: root.kcm.setLayoutAutoAssign(root.modelData.id, !(root.modelData.autoAssign === true))
+
+                        ToolTip.visible: hovered
+                        ToolTip.text: root.modelData.autoAssign === true
+                            ? i18n("Auto-assign enabled: new windows fill empty zones. Click to disable.")
+                            : i18n("Click to auto-assign new windows to empty zones")
+                    }
+
+                    // Visibility toggle
+                    ToolButton {
+                        width: Kirigami.Units.iconSizes.small + Kirigami.Units.smallSpacing
+                        height: width
+                        padding: 0
+                        visible: root.isHovered || root.modelData.hiddenFromSelector === true
+                        icon.name: root.modelData.hiddenFromSelector ? "view-hidden" : "view-visible"
+                        icon.width: Kirigami.Units.iconSizes.small
+                        icon.height: Kirigami.Units.iconSizes.small
+                        icon.color: root.modelData.hiddenFromSelector ? Kirigami.Theme.disabledTextColor : Kirigami.Theme.textColor
+                        onClicked: root.kcm.setLayoutHidden(root.modelData.id, !root.modelData.hiddenFromSelector)
+
+                        ToolTip.visible: hovered
+                        ToolTip.text: root.modelData.hiddenFromSelector
+                            ? i18n("Hidden from zone selector. Click to show.")
+                            : i18n("Visible in zone selector. Click to hide.")
+                    }
                 }
 
                 // Dim thumbnail when hidden
@@ -175,6 +200,7 @@ Item {
                 QFZCommon.CategoryBadge {
                     visible: root.modelData.category !== undefined
                     category: root.modelData.category !== undefined ? root.modelData.category : 0
+                    autoAssign: root.modelData.autoAssign === true
                 }
 
                 Label {

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -13,7 +13,10 @@
 #include <QDBusInterface>
 #include <QHash>
 #include <QPoint>
+#include <QPointer>
 #include <QRect>
+
+#include <functional>
 
 namespace PlasmaZones {
 
@@ -186,6 +189,14 @@ private:
 
     // Apply snap geometry to window
     void applySnapGeometry(KWin::EffectWindow* window, const QRect& geometry);
+
+    // Async D-Bus helper for 5-arg snap replies (x, y, w, h, shouldSnap).
+    // iface must remain valid for the duration of the async call (caller guarantees
+    // ownership via unique_ptr member; the reference is only used to initiate the call,
+    // not captured in the async lambda).
+    void tryAsyncSnapCall(QDBusAbstractInterface& iface, const QString& method, const QList<QVariant>& args,
+                          QPointer<KWin::EffectWindow> window, const QString& windowId,
+                          bool storePreSnap, std::function<void()> fallback);
 
     // Extract stable ID from full window ID (strips pointer address)
     // Stable ID = windowClass:resourceName (without pointer address)

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -149,6 +149,9 @@ inline constexpr QLatin1String Pattern{"pattern"};
 // ZoneNumber is reused from zone keys above
 inline constexpr QLatin1String TargetScreen{"targetScreen"};
 
+// Auto-assign keys
+inline constexpr QLatin1String AutoAssign{"autoAssign"};
+
 // Pywal color file keys
 inline constexpr QLatin1String Colors{"colors"};
 }

--- a/src/core/layout.cpp
+++ b/src/core/layout.cpp
@@ -78,6 +78,7 @@ Layout::Layout(const Layout& other)
     , m_sourcePath() // Copies have no source path (will be saved to user directory)
     , m_defaultOrder(other.m_defaultOrder)
     , m_appRules(other.m_appRules)
+    , m_autoAssign(other.m_autoAssign)
     , m_shaderId(other.m_shaderId)
     , m_shaderParams(other.m_shaderParams)
     , m_hiddenFromSelector(other.m_hiddenFromSelector)
@@ -118,6 +119,8 @@ Layout& Layout::operator=(const Layout& other)
         m_shaderParams = other.m_shaderParams;
         bool rulesChanged = m_appRules != other.m_appRules;
         m_appRules = other.m_appRules;
+        bool autoAssignDiff = m_autoAssign != other.m_autoAssign;
+        m_autoAssign = other.m_autoAssign;
         m_hiddenFromSelector = other.m_hiddenFromSelector;
         m_allowedScreens = other.m_allowedScreens;
         m_allowedDesktops = other.m_allowedDesktops;
@@ -139,6 +142,7 @@ Layout& Layout::operator=(const Layout& other)
         if (desktopsChanged) Q_EMIT allowedDesktopsChanged();
         if (activitiesChanged) Q_EMIT allowedActivitiesChanged();
         if (rulesChanged) Q_EMIT appRulesChanged();
+        if (autoAssignDiff) Q_EMIT autoAssignChanged();
     }
     return *this;
 }
@@ -155,6 +159,7 @@ LAYOUT_SETTER(bool, ShowZoneNumbers, m_showZoneNumbers, showZoneNumbersChanged)
 LAYOUT_SETTER(const QString&, ShaderId, m_shaderId, shaderIdChanged)
 LAYOUT_SETTER(const QVariantMap&, ShaderParams, m_shaderParams, shaderParamsChanged)
 LAYOUT_SETTER(bool, HiddenFromSelector, m_hiddenFromSelector, hiddenFromSelectorChanged)
+LAYOUT_SETTER(bool, AutoAssign, m_autoAssign, autoAssignChanged)
 
 void Layout::setAllowedScreens(const QStringList& screens)
 {
@@ -511,6 +516,11 @@ QJsonObject Layout::toJson() const
         json[JsonKeys::AppRules] = rulesArray;
     }
 
+    // Auto-assign - only serialize if true
+    if (m_autoAssign) {
+        json[JsonKeys::AutoAssign] = true;
+    }
+
     // Visibility filtering - only serialize non-default values
     if (m_hiddenFromSelector) {
         json[JsonKeys::HiddenFromSelector] = true;
@@ -555,6 +565,9 @@ Layout* Layout::fromJson(const QJsonObject& json, QObject* parent)
     if (json.contains(JsonKeys::AppRules)) {
         layout->m_appRules = AppRule::fromJsonArray(json[JsonKeys::AppRules].toArray());
     }
+
+    // Auto-assign
+    layout->m_autoAssign = json[JsonKeys::AutoAssign].toBool(false);
 
     // Visibility filtering
     layout->m_hiddenFromSelector = json[JsonKeys::HiddenFromSelector].toBool(false);

--- a/src/core/layout.h
+++ b/src/core/layout.h
@@ -99,6 +99,9 @@ class PLASMAZONES_EXPORT Layout : public QObject
     // App-to-zone rules
     Q_PROPERTY(QVariantList appRules READ appRulesVariant WRITE setAppRulesVariant NOTIFY appRulesChanged)
 
+    // Auto-assign: new windows fill first empty zone
+    Q_PROPERTY(bool autoAssign READ autoAssign WRITE setAutoAssign NOTIFY autoAssignChanged)
+
     // Visibility filtering
     Q_PROPERTY(bool hiddenFromSelector READ hiddenFromSelector WRITE setHiddenFromSelector NOTIFY hiddenFromSelectorChanged)
     Q_PROPERTY(QStringList allowedScreens READ allowedScreens WRITE setAllowedScreens NOTIFY allowedScreensChanged)
@@ -217,6 +220,10 @@ public:
     void setAppRulesVariant(const QVariantList& rules);
     AppRuleMatch matchAppRule(const QString& windowClass) const;
 
+    // Auto-assign: new windows fill first empty zone
+    bool autoAssign() const { return m_autoAssign; }
+    void setAutoAssign(bool enabled);
+
     // Optional load order for "default" layout when defaultLayoutId is not set (lower = first)
     int defaultOrder() const
     {
@@ -278,6 +285,7 @@ Q_SIGNALS:
     void allowedDesktopsChanged();
     void allowedActivitiesChanged();
     void appRulesChanged();
+    void autoAssignChanged();
     void zonesChanged();
     void zoneAdded(Zone* zone);
     void zoneRemoved(Zone* zone);
@@ -297,6 +305,9 @@ private:
 
     // App-to-zone rules
     QVector<AppRule> m_appRules;
+
+    // Auto-assign: new windows fill first empty zone
+    bool m_autoAssign = false;
 
     // Shader support
     QString m_shaderId; // Shader effect ID (empty = no shader)

--- a/src/core/layoututils.cpp
+++ b/src/core/layoututils.cpp
@@ -104,6 +104,7 @@ QVariantMap layoutToVariantMap(Layout* layout, ZoneFields zoneFields)
     map[ZoneCount] = layout->zoneCount();
     map[Zones] = zonesToVariantList(layout, zoneFields);
     map[Category] = static_cast<int>(LayoutCategory::Manual);
+    map[AutoAssign] = layout->autoAssign();
 
     return map;
 }
@@ -120,6 +121,7 @@ static UnifiedLayoutEntry entryFromLayout(Layout* layout)
     entry.description = layout->description();
     entry.zoneCount = layout->zoneCount();
     entry.zones = zonesToVariantList(layout, ZoneField::Minimal);
+    entry.autoAssign = layout->autoAssign();
     return entry;
 }
 
@@ -208,6 +210,7 @@ QVariantMap toVariantMap(const UnifiedLayoutEntry& entry)
     map[ZoneCount] = entry.zoneCount;
     map[Zones] = entry.zones;
     map[Category] = static_cast<int>(LayoutCategory::Manual);
+    map[AutoAssign] = entry.autoAssign;
 
     return map;
 }
@@ -236,6 +239,9 @@ QJsonObject toJson(const UnifiedLayoutEntry& entry)
     json[IsSystem] = false;
     json[Type] = 0;
     json[Category] = static_cast<int>(LayoutCategory::Manual);
+    if (entry.autoAssign) {
+        json[AutoAssign] = true;
+    }
     // hiddenFromSelector is added by callers that have access to the Layout*
 
     // Convert zones to JSON array

--- a/src/core/layoututils.h
+++ b/src/core/layoututils.h
@@ -46,6 +46,7 @@ struct PLASMAZONES_EXPORT UnifiedLayoutEntry {
     QString description; ///< Optional description
     int zoneCount;       ///< Number of zones
     QVariantList zones;  ///< Zone data for preview rendering
+    bool autoAssign = false; ///< Auto-assign: new windows fill first empty zone
 
     bool operator==(const UnifiedLayoutEntry& other) const { return id == other.id; }
     bool operator!=(const UnifiedLayoutEntry& other) const { return id != other.id; }

--- a/src/core/windowtrackingservice.h
+++ b/src/core/windowtrackingservice.h
@@ -244,6 +244,16 @@ public:
                                         bool isSticky) const;
 
     /**
+     * @brief Calculate snap result for new window to first empty zone (auto-assign)
+     * @param windowId Full window ID
+     * @param windowScreenName Screen where window currently is
+     * @param isSticky Whether window is on all desktops
+     * @return SnapResult with geometry and zone info
+     */
+    SnapResult calculateSnapToEmptyZone(const QString& windowId, const QString& windowScreenName,
+                                         bool isSticky) const;
+
+    /**
      * @brief Calculate snap result to restore from persisted session
      * @param windowId Full window ID
      * @param screenName Screen for geometry calculation
@@ -452,6 +462,11 @@ public:
     const QHash<QString, QString>& pendingLayoutAssignments() const { return m_pendingZoneLayouts; }
 
     /**
+     * @brief Get pending zone numbers (for zone-number fallback on session restore)
+     */
+    const QHash<QString, QList<int>>& pendingZoneNumbers() const { return m_pendingZoneNumbers; }
+
+    /**
      * @brief Get user-snapped classes
      */
     const QSet<QString>& userSnappedClasses() const { return m_userSnappedClasses; }
@@ -475,6 +490,11 @@ public:
      * @brief Set pending layout assignments (loaded from KConfig by adaptor)
      */
     void setPendingLayoutAssignments(const QHash<QString, QString>& assignments) { m_pendingZoneLayouts = assignments; }
+
+    /**
+     * @brief Set pending zone numbers (loaded from KConfig by adaptor)
+     */
+    void setPendingZoneNumbers(const QHash<QString, QList<int>>& numbers) { m_pendingZoneNumbers = numbers; }
 
     /**
      * @brief Set pre-snap geometries (loaded from KConfig by adaptor)
@@ -530,6 +550,7 @@ private:
     bool isGeometryOnScreen(const QRect& geometry) const;
     QRect adjustGeometryToScreen(const QRect& geometry) const;
     Zone* findZoneById(const QString& zoneId) const;
+    QString findEmptyZoneInLayout(Layout* layout, const QString& screenName) const;
     QSet<QUuid> buildOccupiedZoneSet(const QString& screenFilter = QString()) const;
 
     // Dependencies
@@ -562,6 +583,7 @@ private:
     QHash<QString, QString> m_pendingZoneScreens;      // stableId -> screenName
     QHash<QString, int> m_pendingZoneDesktops;         // stableId -> desktop
     QHash<QString, QString> m_pendingZoneLayouts;      // stableId -> layoutId (for layout validation on restore)
+    QHash<QString, QList<int>> m_pendingZoneNumbers;  // stableId -> zone numbers (fallback when UUIDs change)
 
     // Pre-float zone and screen (for unfloat restore to correct monitor)
     QHash<QString, QStringList> m_preFloatZoneAssignments;

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -101,7 +101,7 @@ public:
     // screenName: target screen (empty = screen under cursor, fallback to primary)
     void showLayoutOsd(Layout* layout, const QString& screenName = QString());
     void showLayoutOsd(const QString& id, const QString& name, const QVariantList& zones, int category,
-                       const QString& screenName = QString());
+                       bool autoAssign = false, const QString& screenName = QString());
 
     // Navigation OSD (feedback for keyboard navigation)
     void showNavigationOsd(bool success, const QString& action, const QString& reason,

--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -286,6 +286,21 @@ void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
     Q_EMIT layoutListChanged();
 }
 
+void LayoutAdaptor::setLayoutAutoAssign(const QString& layoutId, bool enabled)
+{
+    auto* layout = getValidatedLayout(layoutId, QStringLiteral("set layout auto-assign"));
+    if (!layout) {
+        return;
+    }
+
+    layout->setAutoAssign(enabled);
+    // Note: saveLayouts() is triggered automatically via layoutModified signal
+
+    qCDebug(lcDbusLayout) << "Set layout" << layoutId << "autoAssign:" << enabled;
+    Q_EMIT layoutChanged(QString::fromUtf8(QJsonDocument(layout->toJson()).toJson()));
+    Q_EMIT layoutListChanged();
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Layout Management
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/layoutadaptor.h
+++ b/src/dbus/layoutadaptor.h
@@ -58,6 +58,9 @@ public Q_SLOTS:
     // Visibility filtering
     void setLayoutHidden(const QString& layoutId, bool hidden);
 
+    // Auto-assign
+    void setLayoutAutoAssign(const QString& layoutId, bool enabled);
+
     // Editor support
     bool updateLayout(const QString& layoutJson);
     QString createLayoutFromJson(const QString& layoutJson);

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -74,14 +74,18 @@ public Q_SLOTS:
     /**
      * Called when window drag ends
      * @param windowId Unique window identifier
+     * @param cursorX Cursor X at release (global; used for release screen detection)
+     * @param cursorY Cursor Y at release (global)
      * @param snapX Output: X position for window
      * @param snapY Output: Y position for window
      * @param snapWidth Output: Width for window
      * @param snapHeight Output: Height for window
      * @param shouldApplyGeometry Output: True if KWin should apply the geometry
+     * @param releaseScreenName Output: Screen name where the drag was released, for auto-fill on drop
+     * @param restoreSizeOnly Output: If true with shouldApplyGeometry, effect applies only width/height at current position (drag-to-unsnap)
      */
-    void dragStopped(const QString& windowId, int& snapX, int& snapY, int& snapWidth, int& snapHeight,
-                     bool& shouldApplyGeometry);
+    void dragStopped(const QString& windowId, int cursorX, int cursorY, int& snapX, int& snapY, int& snapWidth,
+                     int& snapHeight, bool& shouldApplyGeometry, QString& releaseScreenName, bool& restoreSizeOnly);
 
     /**
      * Cancel current snap operation (Escape key)

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -249,6 +249,9 @@ public Q_SLOTS:
     void snapToAppRule(const QString& windowId, const QString& windowScreenName, bool sticky,
                        int& snapX, int& snapY, int& snapWidth, int& snapHeight, bool& shouldSnap);
 
+    void snapToEmptyZone(const QString& windowId, const QString& windowScreenName, bool sticky,
+                         int& snapX, int& snapY, int& snapWidth, int& snapHeight, bool& shouldSnap);
+
     /**
      * Restore a window to its persisted zone from the previous session
      * This uses stable window identifiers (windowClass:resourceName) to match

--- a/src/shared/CategoryBadge.qml
+++ b/src/shared/CategoryBadge.qml
@@ -6,12 +6,16 @@ import QtQuick.Controls
 import org.kde.kirigami as Kirigami
 
 /**
- * Category badge for layout type (Manual zone-based layouts)
+ * Category badge for layout type (Manual/Auto zone-based layouts).
+ * The label switches between "Auto" and "Manual" based on the autoAssign flag.
+ * The category property is retained for future extension (e.g. different badge
+ * styles per category) but currently does not affect rendering.
  */
 Rectangle {
     id: root
 
-    property int category: 0  // 0=Manual (matches LayoutCategory in C++)
+    property int category: 0  // 0=Manual (matches LayoutCategory in C++); reserved for future styling
+    property bool autoAssign: false
 
     readonly property real heightScale: 0.9
     readonly property real manualBackgroundOpacity: 0.15
@@ -28,7 +32,7 @@ Rectangle {
         id: categoryLabel
 
         anchors.centerIn: parent
-        text: i18nc("@label:badge", "Manual")
+        text: root.autoAssign ? i18nc("@label:badge", "Auto") : i18nc("@label:badge", "Manual")
         font.pixelSize: Kirigami.Theme.smallFont.pixelSize * root.fontScale
         font.weight: Font.Medium
         color: Kirigami.Theme.textColor

--- a/src/ui/LayoutOsd.qml
+++ b/src/ui/LayoutOsd.qml
@@ -22,6 +22,7 @@ Window {
     property var zones: []
     // Layout category: 0=Manual (matches LayoutCategory in C++)
     property int category: 0
+    property bool autoAssign: false
 
     // Screen info for aspect ratio (bounded to prevent layout issues)
     property real screenAspectRatio: 16 / 9
@@ -228,6 +229,7 @@ Window {
 
                 anchors.verticalCenter: parent.verticalCenter
                 category: root.category
+                autoAssign: root.autoAssign === true
             }
 
             Label {

--- a/src/ui/LayoutPreview.qml
+++ b/src/ui/LayoutPreview.qml
@@ -19,6 +19,7 @@ Rectangle {
     property string layoutName: ""
     property var zones: [] // Array of zone objects with relativeGeometry
     property int category: 0  // 0=Manual (matches LayoutCategory in C++)
+    property bool autoAssign: false
     // State
     property bool isActive: false
     property bool isHovered: false
@@ -120,6 +121,7 @@ Rectangle {
 
                 anchors.verticalCenter: parent.verticalCenter
                 category: root.category
+                autoAssign: root.autoAssign === true
             }
 
             Label {

--- a/src/ui/ZoneSelectorWindow.qml
+++ b/src/ui/ZoneSelectorWindow.qml
@@ -611,6 +611,7 @@ Window {
 
                                 anchors.verticalCenter: parent.verticalCenter
                                 category: indicator.layoutCategory
+                                autoAssign: indicator.modelData.autoAssign === true
                             }
 
                             Label {


### PR DESCRIPTION
## Summary

- Add per-layout **autoAssign** toggle that automatically snaps new windows to the lowest-numbered empty zone on their screen
- Integrate auto-assign into the snap priority chain: App Rules → Session Restore → **Auto-assign** → Last Zone
- Fire auto-assign on drag-to-drop when a window lands outside any zone on an auto-assign screen
- Refactor `callSnapToLastZone` into a generic `tryAsyncSnapCall` helper, eliminating deeply nested async callbacks
- Improve drag-to-unsnap: `dragStopped` now receives cursor position for release-screen detection and returns `restoreSizeOnly` (keeps drop position, restores only pre-snap width/height)
- Add zone-number fallback for session restore when zone UUIDs regenerate after layout edits
- Fix navigation OSD assertWindowOnScreen / sizing order

## Details

### Auto-assign feature
- `Layout.autoAssign` property with JSON serialization, D-Bus exposure, KCM save/load/defaults
- New `snapToEmptyZone` D-Bus method on WindowTracking interface
- `WindowTrackingService::calculateSnapToEmptyZone()` checks autoAssign flag, sticky handling, and finds the first empty zone (sorted by zone number)
- KCM: toggle button in layout grid delegate (top-right, next to visibility toggle)
- CategoryBadge shows "Auto" vs "Manual" label throughout OSD, preview, zone selector, and layout combo box

### Drag-to-unsnap improvements
- `dragStopped` D-Bus signature extended: receives `cursorX`/`cursorY` (release position), returns `releaseScreenName` and `restoreSizeOnly`
- On drag-to-unsnap: saves float state via `windowUnsnappedForFloat` + `setWindowFloating` (so unfloat/snap-back works)
- `restoreSizeOnly=true`: effect applies only width/height at current position instead of teleporting to pre-snap x/y

### Session restore robustness
- Persist zone numbers alongside zone UUIDs in KConfig (`PendingWindowZoneNumbers`)
- On restore, if UUID lookup fails, fall back to zone-number matching against the current layout

## Test plan

- [ ] Enable autoAssign on a layout, open new windows → they should fill zones in order (lowest number first)
- [ ] Disable autoAssign → new windows should not auto-snap
- [ ] Drag a window out of a zone on an auto-assign screen → it should keep drop position with restored pre-snap size
- [ ] Drag a window to an auto-assign screen and drop outside zones → it should auto-fill the first empty zone
- [ ] Edit a layout (zone UUIDs regenerate), restart an app → session restore should fall back to zone numbers
- [ ] Verify KCM save/load/defaults round-trips the autoAssign flag
- [ ] Verify badge shows "Auto"/"Manual" in all surfaces (grid, combo, OSD, zone selector)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)