### PR TITLE
feat: add 5 tiling algorithms for auto-tiling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,16 @@ set(plasmazones_core_SRCS
     core/zone.h
     core/tilingalgorithm.cpp
     core/tilingalgorithm.h
+    core/algorithms/bspalgorithm.cpp
+    core/algorithms/bspalgorithm.h
+    core/algorithms/fibonaccialgorithm.cpp
+    core/algorithms/fibonaccialgorithm.h
+    core/algorithms/masterstackalgorithm.cpp
+    core/algorithms/masterstackalgorithm.h
+    core/algorithms/monoclealgorithm.cpp
+    core/algorithms/monoclealgorithm.h
+    core/algorithms/threecolumnalgorithm.cpp
+    core/algorithms/threecolumnalgorithm.h
     core/layout.cpp
     core/layout.h
     core/layoutmanager.cpp

--- a/src/core/algorithms/bspalgorithm.cpp
+++ b/src/core/algorithms/bspalgorithm.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "bspalgorithm.h"
+
+#include <algorithm>
+#include <QQueue>
+
+namespace PlasmaZones {
+
+QVector<QRectF> BSPTilingAlgorithm::generateZones(int windowCount, const TilingParams& params) const
+{
+    if (windowCount <= 0) {
+        return {};
+    }
+
+    if (windowCount == 1) {
+        return {QRectF(0.0, 0.0, 1.0, 1.0)};
+    }
+
+    const qreal masterRatio = std::clamp(params.masterRatio, 0.1, 0.9);
+
+    struct Region {
+        QRectF rect;
+        int depth;
+        int count;
+    };
+
+    QVector<QRectF> zones;
+    zones.reserve(windowCount);
+
+    QQueue<Region> queue;
+    queue.enqueue({QRectF(0.0, 0.0, 1.0, 1.0), 0, windowCount});
+
+    while (!queue.isEmpty()) {
+        const Region region = queue.dequeue();
+
+        if (region.count == 1) {
+            zones.append(region.rect);
+            continue;
+        }
+
+        const int leftCount = region.count / 2;
+        const int rightCount = region.count - leftCount;
+
+        // Depth 0 uses masterRatio, deeper levels use 50/50
+        const qreal ratio = (region.depth == 0) ? masterRatio : 0.5;
+
+        // Even depth = vertical split, odd depth = horizontal split
+        if (region.depth % 2 == 0) {
+            // Vertical split
+            const qreal splitX = region.rect.x() + region.rect.width() * ratio;
+            const qreal leftWidth = splitX - region.rect.x();
+            const qreal rightWidth = region.rect.right() - splitX;
+
+            queue.enqueue({QRectF(region.rect.x(), region.rect.y(), leftWidth, region.rect.height()),
+                           region.depth + 1, leftCount});
+            queue.enqueue({QRectF(splitX, region.rect.y(), rightWidth, region.rect.height()),
+                           region.depth + 1, rightCount});
+        } else {
+            // Horizontal split
+            const qreal splitY = region.rect.y() + region.rect.height() * ratio;
+            const qreal topHeight = splitY - region.rect.y();
+            const qreal bottomHeight = region.rect.bottom() - splitY;
+
+            queue.enqueue({QRectF(region.rect.x(), region.rect.y(), region.rect.width(), topHeight),
+                           region.depth + 1, leftCount});
+            queue.enqueue({QRectF(region.rect.x(), splitY, region.rect.width(), bottomHeight),
+                           region.depth + 1, rightCount});
+        }
+    }
+
+    return zones;
+}
+
+} // namespace PlasmaZones

--- a/src/core/algorithms/bspalgorithm.h
+++ b/src/core/algorithms/bspalgorithm.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "core/tilingalgorithm.h"
+
+namespace PlasmaZones {
+
+/**
+ * @brief Binary Space Partition — recursive balanced subdivision
+ *
+ * Alternates vertical/horizontal splits, balanced count distribution.
+ * Equivalent to Krohnkite's BTree layout.
+ *
+ * Example with masterRatio=0.55, windowCount=5 (BFS traversal order):
+ * ┌───────────┬─────────┐
+ * │           │         │
+ * │     1     │    3    │
+ * │           │         │
+ * ├───────────┼────┬────┤
+ * │           │    │    │
+ * │     2     │ 4  │ 5  │
+ * │           │    │    │
+ * └───────────┴────┴────┘
+ *
+ * Key: balanced split (count/2 per side), depth 0 uses masterRatio,
+ * deeper levels use 50/50. Even depth = vertical, odd = horizontal.
+ * Zone 0 is the top-left region, not the full left column.
+ */
+class PLASMAZONES_EXPORT BSPTilingAlgorithm : public TilingAlgorithm
+{
+public:
+    QString id() const override { return QStringLiteral("bsp"); }
+    QString name() const override { return QStringLiteral("BSP"); }
+    QString description() const override { return QStringLiteral("Binary Space Partition with balanced recursive subdivision"); }
+    QVector<QRectF> generateZones(int windowCount, const TilingParams& params) const override;
+};
+
+} // namespace PlasmaZones

--- a/src/core/algorithms/fibonaccialgorithm.cpp
+++ b/src/core/algorithms/fibonaccialgorithm.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "fibonaccialgorithm.h"
+
+#include <algorithm>
+
+namespace PlasmaZones {
+
+QVector<QRectF> FibonacciTilingAlgorithm::generateZones(int windowCount, const TilingParams& params) const
+{
+    if (windowCount <= 0) {
+        return {};
+    }
+
+    if (windowCount == 1) {
+        return {QRectF(0.0, 0.0, 1.0, 1.0)};
+    }
+
+    QVector<QRectF> zones;
+    zones.reserve(windowCount);
+
+    // First split: vertical, zone 1 = left masterRatio, remaining = right
+    QRectF remaining(0.0, 0.0, 1.0, 1.0);
+
+    const qreal masterRatio = std::clamp(params.masterRatio, 0.1, 0.9);
+    const qreal masterWidth = remaining.width() * masterRatio;
+    zones.append(QRectF(remaining.x(), remaining.y(), masterWidth, remaining.height()));
+    remaining = QRectF(remaining.x() + masterWidth, remaining.y(),
+                       remaining.width() - masterWidth, remaining.height());
+
+    // Each subsequent split alternates H/V, peeling ONE window
+    for (int i = 1; i < windowCount - 1; ++i) {
+        if (i % 2 == 1) {
+            // Even index in 0-based from second window → horizontal split
+            // Zone takes top half, remaining = bottom
+            const qreal splitHeight = remaining.height() * 0.5;
+            zones.append(QRectF(remaining.x(), remaining.y(),
+                                remaining.width(), splitHeight));
+            remaining = QRectF(remaining.x(), remaining.y() + splitHeight,
+                               remaining.width(), remaining.height() - splitHeight);
+        } else {
+            // Odd index → vertical split
+            // Zone takes left half, remaining = right
+            const qreal splitWidth = remaining.width() * 0.5;
+            zones.append(QRectF(remaining.x(), remaining.y(),
+                                splitWidth, remaining.height()));
+            remaining = QRectF(remaining.x() + splitWidth, remaining.y(),
+                               remaining.width() - splitWidth, remaining.height());
+        }
+    }
+
+    // Last window = remaining area
+    zones.append(remaining);
+
+    return zones;
+}
+
+} // namespace PlasmaZones

--- a/src/core/algorithms/fibonaccialgorithm.h
+++ b/src/core/algorithms/fibonaccialgorithm.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "core/tilingalgorithm.h"
+
+namespace PlasmaZones {
+
+/**
+ * @brief Spiral subdivision — each new window peels off from remaining space
+ *
+ * Equivalent to Krohnkite's Spiral layout.
+ *
+ * Example with masterRatio=0.5, windowCount=5:
+ * ┌──────────┬──────────┐
+ * │          │          │
+ * │    1     │    2     │
+ * │          ├────┬─────┤
+ * │          │    │  4  │
+ * │          │ 3  ├─────┤
+ * │          │    │  5  │
+ * └──────────┴────┴─────┘
+ *
+ * Key difference from BSP: always peels 1 window (greedy), not balanced split,
+ * creating progressively smaller zones in a spiral pattern.
+ */
+class PLASMAZONES_EXPORT FibonacciTilingAlgorithm : public TilingAlgorithm
+{
+public:
+    QString id() const override { return QStringLiteral("fibonacci"); }
+    QString name() const override { return QStringLiteral("Fibonacci"); }
+    QString description() const override { return QStringLiteral("Spiral subdivision with progressively smaller zones"); }
+    QVector<QRectF> generateZones(int windowCount, const TilingParams& params) const override;
+};
+
+} // namespace PlasmaZones

--- a/src/core/algorithms/masterstackalgorithm.cpp
+++ b/src/core/algorithms/masterstackalgorithm.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "masterstackalgorithm.h"
+
+#include <algorithm>
+
+namespace PlasmaZones {
+
+QVector<QRectF> MasterStackTilingAlgorithm::generateZones(int windowCount, const TilingParams& params) const
+{
+    if (windowCount <= 0) {
+        return {};
+    }
+
+    if (windowCount == 1) {
+        return {QRectF(0.0, 0.0, 1.0, 1.0)};
+    }
+
+    const int masterCount = std::max(1, std::min(params.masterCount, windowCount));
+    const qreal masterRatio = std::clamp(params.masterRatio, 0.1, 0.9);
+    const int stackCount = windowCount - masterCount;
+
+    QVector<QRectF> zones;
+    zones.reserve(windowCount);
+
+    if (stackCount == 0) {
+        // All windows in master area — full width, split vertically
+        const qreal height = 1.0 / masterCount;
+        for (int i = 0; i < masterCount; ++i) {
+            const qreal y = i * height;
+            const qreal h = (i == masterCount - 1) ? (1.0 - y) : height;
+            zones.append(QRectF(0.0, y, 1.0, h));
+        }
+    } else {
+        // Master area on left, stack on right
+        const qreal masterWidth = masterRatio;
+        const qreal stackWidth = 1.0 - masterWidth;
+        const qreal masterHeight = 1.0 / masterCount;
+        const qreal stackHeight = 1.0 / stackCount;
+
+        // Master zones
+        for (int i = 0; i < masterCount; ++i) {
+            const qreal y = i * masterHeight;
+            const qreal h = (i == masterCount - 1) ? (1.0 - y) : masterHeight;
+            zones.append(QRectF(0.0, y, masterWidth, h));
+        }
+
+        // Stack zones
+        for (int i = 0; i < stackCount; ++i) {
+            const qreal y = i * stackHeight;
+            const qreal h = (i == stackCount - 1) ? (1.0 - y) : stackHeight;
+            zones.append(QRectF(masterWidth, y, stackWidth, h));
+        }
+    }
+
+    return zones;
+}
+
+} // namespace PlasmaZones

--- a/src/core/algorithms/masterstackalgorithm.h
+++ b/src/core/algorithms/masterstackalgorithm.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "core/tilingalgorithm.h"
+
+namespace PlasmaZones {
+
+/**
+ * @brief Classic dwm-style master-stack layout
+ *
+ * Master area on the left (masterRatio width), stack on the right.
+ * Equivalent to Krohnkite's Tile (default) layout.
+ *
+ * Example with masterRatio=0.55, masterCount=1, windowCount=4:
+ * ┌──────────┬────────┐
+ * │          │   S1   │
+ * │  Master  ├────────┤
+ * │  (55%)   │   S2   │
+ * │          ├────────┤
+ * │          │   S3   │
+ * └──────────┴────────┘
+ */
+class PLASMAZONES_EXPORT MasterStackTilingAlgorithm : public TilingAlgorithm
+{
+public:
+    QString id() const override { return QStringLiteral("master-stack"); }
+    QString name() const override { return QStringLiteral("Master-Stack"); }
+    QString description() const override { return QStringLiteral("Master area on left, stack on right (dwm-style)"); }
+    QVector<QRectF> generateZones(int windowCount, const TilingParams& params) const override;
+};
+
+} // namespace PlasmaZones

--- a/src/core/algorithms/monoclealgorithm.cpp
+++ b/src/core/algorithms/monoclealgorithm.cpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "monoclealgorithm.h"
+
+namespace PlasmaZones {
+
+QVector<QRectF> MonocleTilingAlgorithm::generateZones(int windowCount, const TilingParams& /*params*/) const
+{
+    if (windowCount <= 0) {
+        return {};
+    }
+
+    return {QRectF(0.0, 0.0, 1.0, 1.0)};
+}
+
+} // namespace PlasmaZones

--- a/src/core/algorithms/monoclealgorithm.h
+++ b/src/core/algorithms/monoclealgorithm.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "core/tilingalgorithm.h"
+
+namespace PlasmaZones {
+
+/**
+ * @brief Single fullscreen zone — all windows stack in one zone
+ *
+ * Equivalent to Krohnkite's Monocle layout.
+ * Ignores masterRatio and masterCount entirely.
+ */
+class PLASMAZONES_EXPORT MonocleTilingAlgorithm : public TilingAlgorithm
+{
+public:
+    QString id() const override { return QStringLiteral("monocle"); }
+    QString name() const override { return QStringLiteral("Monocle"); }
+    QString description() const override { return QStringLiteral("Single fullscreen zone (all windows stacked)"); }
+    QVector<QRectF> generateZones(int windowCount, const TilingParams& params) const override;
+};
+
+} // namespace PlasmaZones

--- a/src/core/algorithms/threecolumnalgorithm.cpp
+++ b/src/core/algorithms/threecolumnalgorithm.cpp
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "threecolumnalgorithm.h"
+
+#include <algorithm>
+
+namespace PlasmaZones {
+
+QVector<QRectF> ThreeColumnTilingAlgorithm::generateZones(int windowCount, const TilingParams& params) const
+{
+    if (windowCount <= 0) {
+        return {};
+    }
+
+    if (windowCount == 1) {
+        return {QRectF(0.0, 0.0, 1.0, 1.0)};
+    }
+
+    const int masterCount = std::max(1, std::min(params.masterCount, windowCount));
+    const int stackCount = windowCount - masterCount;
+
+    QVector<QRectF> zones;
+    zones.reserve(windowCount);
+
+    if (stackCount == 0) {
+        // All masters — full width, split into rows
+        const qreal masterHeight = 1.0 / masterCount;
+        for (int i = 0; i < masterCount; ++i) {
+            const qreal y = i * masterHeight;
+            const qreal h = (i == masterCount - 1) ? (1.0 - y) : masterHeight;
+            zones.append(QRectF(0.0, y, 1.0, h));
+        }
+        return zones;
+    }
+
+    // Distribute stacks: right gets ceiling, left gets floor
+    const int rightCount = (stackCount + 1) / 2;
+    const int leftCount = stackCount / 2;
+
+    // Compute column geometry based on whether left column is used
+    const qreal centerWidth = std::clamp(params.masterRatio, 0.1, 0.9);
+    qreal centerX;
+    qreal sideWidth;
+    qreal rightX;
+
+    if (leftCount > 0) {
+        // Three columns: left | center | right
+        sideWidth = (1.0 - centerWidth) / 2.0;
+        centerX = sideWidth;
+        rightX = sideWidth + centerWidth;
+    } else {
+        // Two columns: center | right (no left column)
+        sideWidth = 1.0 - centerWidth;
+        centerX = 0.0;
+        rightX = centerWidth;
+    }
+
+    // Center column (master zones)
+    const qreal masterHeight = 1.0 / masterCount;
+    for (int i = 0; i < masterCount; ++i) {
+        const qreal y = i * masterHeight;
+        const qreal h = (i == masterCount - 1) ? (1.0 - y) : masterHeight;
+        zones.append(QRectF(centerX, y, centerWidth, h));
+    }
+
+    // Right column
+    const qreal rightHeight = 1.0 / rightCount;
+    for (int i = 0; i < rightCount; ++i) {
+        const qreal y = i * rightHeight;
+        const qreal h = (i == rightCount - 1) ? (1.0 - y) : rightHeight;
+        zones.append(QRectF(rightX, y, sideWidth, h));
+    }
+
+    // Left column
+    if (leftCount > 0) {
+        const qreal leftHeight = 1.0 / leftCount;
+        for (int i = 0; i < leftCount; ++i) {
+            const qreal y = i * leftHeight;
+            const qreal h = (i == leftCount - 1) ? (1.0 - y) : leftHeight;
+            zones.append(QRectF(0.0, y, sideWidth, h));
+        }
+    }
+
+    return zones;
+}
+
+} // namespace PlasmaZones

--- a/src/core/algorithms/threecolumnalgorithm.h
+++ b/src/core/algorithms/threecolumnalgorithm.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "core/tilingalgorithm.h"
+
+namespace PlasmaZones {
+
+/**
+ * @brief Master in center, stacks on left and right
+ *
+ * Designed for ultrawide monitors. Equivalent to Krohnkite's Three Column layout.
+ *
+ * Example with masterRatio=0.5, masterCount=1, windowCount=6:
+ * ┌──────┬──────────┬──────┐
+ * │  L1  │          │  R1  │
+ * ├──────┤  Master  ├──────┤
+ * │  L2  │  (50%)   │  R2  │
+ * └──────┴──────────┴──────┘
+ *
+ * Zone order: center (master) first, then right top-to-bottom, then left top-to-bottom.
+ * 2 windows: center + right (no left column).
+ */
+class PLASMAZONES_EXPORT ThreeColumnTilingAlgorithm : public TilingAlgorithm
+{
+public:
+    QString id() const override { return QStringLiteral("three-column"); }
+    QString name() const override { return QStringLiteral("Three Column"); }
+    QString description() const override { return QStringLiteral("Master in center, stacks on left and right (ultrawide)"); }
+    QVector<QRectF> generateZones(int windowCount, const TilingParams& params) const override;
+};
+
+} // namespace PlasmaZones

--- a/src/core/tilingalgorithm.cpp
+++ b/src/core/tilingalgorithm.cpp
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "tilingalgorithm.h"
+#include "algorithms/bspalgorithm.h"
+#include "algorithms/fibonaccialgorithm.h"
+#include "algorithms/masterstackalgorithm.h"
+#include "algorithms/monoclealgorithm.h"
+#include "algorithms/threecolumnalgorithm.h"
 
 namespace PlasmaZones {
 
@@ -17,8 +22,13 @@ TilingAlgorithmRegistry* TilingAlgorithmRegistry::instance()
 
 TilingAlgorithmRegistry::TilingAlgorithmRegistry()
 {
-    // Register built-in algorithms
+    // Register built-in algorithms (alphabetical order)
+    registerAlgorithm(std::make_unique<BSPTilingAlgorithm>());
     registerAlgorithm(std::make_unique<ColumnsTilingAlgorithm>());
+    registerAlgorithm(std::make_unique<FibonacciTilingAlgorithm>());
+    registerAlgorithm(std::make_unique<MasterStackTilingAlgorithm>());
+    registerAlgorithm(std::make_unique<MonocleTilingAlgorithm>());
+    registerAlgorithm(std::make_unique<ThreeColumnTilingAlgorithm>());
 }
 
 void TilingAlgorithmRegistry::registerAlgorithm(std::unique_ptr<TilingAlgorithm> algorithm)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -56,3 +56,21 @@ target_link_libraries(test_session_persistence
 
 add_test(NAME SessionPersistence COMMAND test_session_persistence)
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tiling Algorithm Tests
+# Tests for all built-in tiling algorithms (BSP, Fibonacci, Master-Stack,
+# Monocle, Three Column) plus generic validation
+# ═══════════════════════════════════════════════════════════════════════════════
+add_executable(test_tiling_algorithms
+    test_tiling_algorithms.cpp
+)
+
+target_link_libraries(test_tiling_algorithms
+    PRIVATE
+        Qt6::Test
+        Qt6::Core
+        plasmazones_core
+)
+
+add_test(NAME TilingAlgorithms COMMAND test_tiling_algorithms)
+

--- a/tests/unit/test_tiling_algorithms.cpp
+++ b/tests/unit/test_tiling_algorithms.cpp
@@ -1,0 +1,792 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_tiling_algorithms.cpp
+ * @brief Unit tests for all built-in tiling algorithms
+ *
+ * Tests BSP, Columns, Fibonacci, Master-Stack, Monocle, and Three Column
+ * algorithms plus generic validation (valid rects, no overlap, total area = 1.0).
+ */
+
+#include <QTest>
+#include <QRectF>
+#include <QVector>
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include "core/tilingalgorithm.h"
+#include "core/algorithms/bspalgorithm.h"
+#include "core/algorithms/fibonaccialgorithm.h"
+#include "core/algorithms/masterstackalgorithm.h"
+#include "core/algorithms/monoclealgorithm.h"
+#include "core/algorithms/threecolumnalgorithm.h"
+
+using namespace PlasmaZones;
+
+static constexpr qreal EPSILON = 1e-9;
+
+class TestTilingAlgorithms : public QObject
+{
+    Q_OBJECT
+
+private:
+    static void verifyValidRects(const QVector<QRectF>& zones, const QString& ctx = {})
+    {
+        for (int i = 0; i < zones.size(); ++i) {
+            const auto& z = zones[i];
+            QVERIFY2(z.x() >= -EPSILON,
+                     qPrintable(QStringLiteral("%1 zone %2 x < 0: %3").arg(ctx).arg(i).arg(z.x())));
+            QVERIFY2(z.y() >= -EPSILON,
+                     qPrintable(QStringLiteral("%1 zone %2 y < 0: %3").arg(ctx).arg(i).arg(z.y())));
+            QVERIFY2(z.right() <= 1.0 + EPSILON,
+                     qPrintable(QStringLiteral("%1 zone %2 right > 1: %3").arg(ctx).arg(i).arg(z.right())));
+            QVERIFY2(z.bottom() <= 1.0 + EPSILON,
+                     qPrintable(QStringLiteral("%1 zone %2 bottom > 1: %3").arg(ctx).arg(i).arg(z.bottom())));
+            QVERIFY2(z.width() > EPSILON,
+                     qPrintable(QStringLiteral("%1 zone %2 width too small: %3").arg(ctx).arg(i).arg(z.width())));
+            QVERIFY2(z.height() > EPSILON,
+                     qPrintable(QStringLiteral("%1 zone %2 height too small: %3").arg(ctx).arg(i).arg(z.height())));
+        }
+    }
+
+    static void verifyTotalArea(const QVector<QRectF>& zones, const QString& ctx = {})
+    {
+        qreal totalArea = 0.0;
+        for (const auto& z : zones) {
+            totalArea += z.width() * z.height();
+        }
+        QVERIFY2(std::abs(totalArea - 1.0) < EPSILON,
+                 qPrintable(QStringLiteral("%1 total area = %2, expected 1.0").arg(ctx).arg(totalArea, 0, 'g', 15)));
+    }
+
+    static void verifyNoOverlap(const QVector<QRectF>& zones, const QString& ctx = {})
+    {
+        for (int i = 0; i < zones.size(); ++i) {
+            for (int j = i + 1; j < zones.size(); ++j) {
+                const QRectF overlap = zones[i].intersected(zones[j]);
+                if (overlap.isValid() && overlap.width() > EPSILON && overlap.height() > EPSILON) {
+                    QFAIL(qPrintable(QStringLiteral("%1 zones %2 and %3 overlap (area=%4)")
+                                         .arg(ctx).arg(i).arg(j).arg(overlap.width() * overlap.height())));
+                }
+            }
+        }
+    }
+
+    static void verifyAll(const QVector<QRectF>& zones, const QString& ctx = {})
+    {
+        verifyValidRects(zones, ctx);
+        verifyTotalArea(zones, ctx);
+        verifyNoOverlap(zones, ctx);
+    }
+
+private Q_SLOTS:
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Registry
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testRegistryContainsAllAlgorithms()
+    {
+        auto* reg = TilingAlgorithmRegistry::instance();
+        auto ids = reg->algorithmIds();
+        QVERIFY(ids.contains(QStringLiteral("bsp")));
+        QVERIFY(ids.contains(QStringLiteral("columns")));
+        QVERIFY(ids.contains(QStringLiteral("fibonacci")));
+        QVERIFY(ids.contains(QStringLiteral("master-stack")));
+        QVERIFY(ids.contains(QStringLiteral("monocle")));
+        QVERIFY(ids.contains(QStringLiteral("three-column")));
+        QCOMPARE(ids.size(), 6);
+    }
+
+    void testRegistryUniqueIds()
+    {
+        auto* reg = TilingAlgorithmRegistry::instance();
+        auto ids = reg->algorithmIds();
+        QSet<QString> unique(ids.begin(), ids.end());
+        QCOMPARE(unique.size(), ids.size());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Monocle
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testMonocleEmpty()
+    {
+        MonocleTilingAlgorithm algo;
+        QCOMPARE(algo.generateZones(0, {}), QVector<QRectF>());
+    }
+
+    void testMonocleSingle()
+    {
+        MonocleTilingAlgorithm algo;
+        auto zones = algo.generateZones(1, {});
+        QCOMPARE(zones.size(), 1);
+        QCOMPARE(zones[0], QRectF(0.0, 0.0, 1.0, 1.0));
+    }
+
+    void testMonocleMany()
+    {
+        MonocleTilingAlgorithm algo;
+        for (int n : {2, 5, 10, 100}) {
+            auto zones = algo.generateZones(n, {0.6, 3});
+            QCOMPARE(zones.size(), 1);
+            QCOMPARE(zones[0], QRectF(0.0, 0.0, 1.0, 1.0));
+        }
+    }
+
+    void testMonocleId()
+    {
+        MonocleTilingAlgorithm algo;
+        QCOMPARE(algo.id(), QStringLiteral("monocle"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Master-Stack
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testMasterStackEmpty()
+    {
+        MasterStackTilingAlgorithm algo;
+        QCOMPARE(algo.generateZones(0, {}), QVector<QRectF>());
+    }
+
+    void testMasterStackSingle()
+    {
+        MasterStackTilingAlgorithm algo;
+        auto zones = algo.generateZones(1, {});
+        QCOMPARE(zones.size(), 1);
+        QCOMPARE(zones[0], QRectF(0.0, 0.0, 1.0, 1.0));
+    }
+
+    void testMasterStackStandard()
+    {
+        MasterStackTilingAlgorithm algo;
+        TilingParams params{0.6, 1};
+        auto zones = algo.generateZones(4, params);
+
+        QCOMPARE(zones.size(), 4);
+        verifyAll(zones, QStringLiteral("MasterStack(4,0.6)"));
+
+        // Master zone: left 60%
+        QCOMPARE(zones[0].x(), 0.0);
+        QVERIFY(std::abs(zones[0].width() - 0.6) < EPSILON);
+        QVERIFY(std::abs(zones[0].height() - 1.0) < EPSILON);
+
+        // Stack zones: right 40%, 3 equal rows
+        for (int i = 1; i <= 3; ++i) {
+            QVERIFY(std::abs(zones[i].x() - 0.6) < EPSILON);
+            QVERIFY(std::abs(zones[i].width() - 0.4) < EPSILON);
+        }
+    }
+
+    void testMasterStackMultipleMasters()
+    {
+        MasterStackTilingAlgorithm algo;
+        TilingParams params{0.55, 2};
+        auto zones = algo.generateZones(5, params);
+
+        QCOMPARE(zones.size(), 5);
+        verifyAll(zones, QStringLiteral("MasterStack(5,0.55,2)"));
+
+        // 2 master zones on left
+        QCOMPARE(zones[0].x(), 0.0);
+        QCOMPARE(zones[1].x(), 0.0);
+        QVERIFY(std::abs(zones[0].width() - 0.55) < EPSILON);
+        QVERIFY(std::abs(zones[1].width() - 0.55) < EPSILON);
+
+        // 3 stack zones on right
+        for (int i = 2; i < 5; ++i) {
+            QVERIFY(std::abs(zones[i].x() - 0.55) < EPSILON);
+        }
+    }
+
+    void testMasterStackAllMasters()
+    {
+        MasterStackTilingAlgorithm algo;
+        TilingParams params{0.5, 5};
+        auto zones = algo.generateZones(3, params);
+
+        // masterCount clamped to windowCount=3, stackCount=0, full width
+        QCOMPARE(zones.size(), 3);
+        verifyAll(zones, QStringLiteral("MasterStack(3,allMasters)"));
+        for (const auto& z : zones) {
+            QVERIFY(std::abs(z.width() - 1.0) < EPSILON);
+        }
+    }
+
+    void testMasterStackMasterCountZero()
+    {
+        MasterStackTilingAlgorithm algo;
+        TilingParams params{0.5, 0};
+        auto zones = algo.generateZones(3, params);
+
+        // masterCount=0 clamped to 1 → 1 master + 2 stack
+        QCOMPARE(zones.size(), 3);
+        verifyAll(zones, QStringLiteral("MasterStack(3,mc=0)"));
+        QVERIFY(std::abs(zones[0].width() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[0].height() - 1.0) < EPSILON);
+    }
+
+    void testMasterStackMasterRatioBoundaries()
+    {
+        MasterStackTilingAlgorithm algo;
+
+        // masterRatio at documented min
+        {
+            TilingParams params{0.1, 1};
+            auto zones = algo.generateZones(3, params);
+            QCOMPARE(zones.size(), 3);
+            verifyAll(zones, QStringLiteral("MasterStack(3,mr=0.1)"));
+            QVERIFY(std::abs(zones[0].width() - 0.1) < EPSILON);
+        }
+
+        // masterRatio at documented max
+        {
+            TilingParams params{0.9, 1};
+            auto zones = algo.generateZones(3, params);
+            QCOMPARE(zones.size(), 3);
+            verifyAll(zones, QStringLiteral("MasterStack(3,mr=0.9)"));
+            QVERIFY(std::abs(zones[0].width() - 0.9) < EPSILON);
+        }
+
+        // masterRatio=0.0 clamped to 0.1
+        {
+            TilingParams params{0.0, 1};
+            auto zones = algo.generateZones(3, params);
+            QCOMPARE(zones.size(), 3);
+            verifyAll(zones, QStringLiteral("MasterStack(3,mr=0.0)"));
+            QVERIFY(std::abs(zones[0].width() - 0.1) < EPSILON);
+        }
+
+        // masterRatio=1.0 clamped to 0.9
+        {
+            TilingParams params{1.0, 1};
+            auto zones = algo.generateZones(3, params);
+            QCOMPARE(zones.size(), 3);
+            verifyAll(zones, QStringLiteral("MasterStack(3,mr=1.0)"));
+            QVERIFY(std::abs(zones[0].width() - 0.9) < EPSILON);
+        }
+    }
+
+    void testMasterStackId()
+    {
+        MasterStackTilingAlgorithm algo;
+        QCOMPARE(algo.id(), QStringLiteral("master-stack"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Three Column
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testThreeColumnEmpty()
+    {
+        ThreeColumnTilingAlgorithm algo;
+        QCOMPARE(algo.generateZones(0, {}), QVector<QRectF>());
+    }
+
+    void testThreeColumnSingle()
+    {
+        ThreeColumnTilingAlgorithm algo;
+        auto zones = algo.generateZones(1, {});
+        QCOMPARE(zones.size(), 1);
+        QCOMPARE(zones[0], QRectF(0.0, 0.0, 1.0, 1.0));
+    }
+
+    void testThreeColumnTwo()
+    {
+        ThreeColumnTilingAlgorithm algo;
+        TilingParams params{0.5, 1};
+        auto zones = algo.generateZones(2, params);
+
+        QCOMPARE(zones.size(), 2);
+        verifyAll(zones, QStringLiteral("ThreeColumn(2)"));
+
+        // No left column → center starts at x=0
+        QVERIFY(std::abs(zones[0].x() - 0.0) < EPSILON);
+        QVERIFY(std::abs(zones[0].width() - 0.5) < EPSILON);
+
+        // Right stack fills remaining space
+        QVERIFY(std::abs(zones[1].x() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[1].width() - 0.5) < EPSILON);
+    }
+
+    void testThreeColumnStandard()
+    {
+        ThreeColumnTilingAlgorithm algo;
+        TilingParams params{0.5, 1};
+        auto zones = algo.generateZones(6, params);
+
+        QCOMPARE(zones.size(), 6);
+        verifyAll(zones, QStringLiteral("ThreeColumn(6)"));
+
+        // Zone 0: center master (50% width)
+        QVERIFY(std::abs(zones[0].x() - 0.25) < EPSILON);
+        QVERIFY(std::abs(zones[0].width() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[0].height() - 1.0) < EPSILON);
+
+        // stackCount=5, rightCount=3, leftCount=2
+        // Zones 1-3: right column
+        for (int i = 1; i <= 3; ++i) {
+            QVERIFY(std::abs(zones[i].x() - 0.75) < EPSILON);
+            QVERIFY(std::abs(zones[i].width() - 0.25) < EPSILON);
+        }
+
+        // Zones 4-5: left column
+        for (int i = 4; i <= 5; ++i) {
+            QVERIFY(std::abs(zones[i].x() - 0.0) < EPSILON);
+            QVERIFY(std::abs(zones[i].width() - 0.25) < EPSILON);
+        }
+    }
+
+    void testThreeColumnEvenStack()
+    {
+        ThreeColumnTilingAlgorithm algo;
+        TilingParams params{0.5, 1};
+        auto zones = algo.generateZones(5, params);
+
+        // stackCount=4, rightCount=2, leftCount=2 (symmetric)
+        QCOMPARE(zones.size(), 5);
+        verifyAll(zones, QStringLiteral("ThreeColumn(5,even)"));
+
+        // Center master
+        QVERIFY(std::abs(zones[0].x() - 0.25) < EPSILON);
+        QVERIFY(std::abs(zones[0].width() - 0.5) < EPSILON);
+
+        // Right column: 2 zones
+        for (int i = 1; i <= 2; ++i) {
+            QVERIFY(std::abs(zones[i].x() - 0.75) < EPSILON);
+            QVERIFY(std::abs(zones[i].width() - 0.25) < EPSILON);
+        }
+
+        // Left column: 2 zones (symmetric with right)
+        for (int i = 3; i <= 4; ++i) {
+            QVERIFY(std::abs(zones[i].x() - 0.0) < EPSILON);
+            QVERIFY(std::abs(zones[i].width() - 0.25) < EPSILON);
+        }
+    }
+
+    void testThreeColumnAllMasters()
+    {
+        ThreeColumnTilingAlgorithm algo;
+        TilingParams params{0.5, 10};
+        auto zones = algo.generateZones(3, params);
+
+        // masterCount clamped to 3, stackCount=0, full width rows
+        QCOMPARE(zones.size(), 3);
+        verifyAll(zones, QStringLiteral("ThreeColumn(3,allMasters)"));
+        for (const auto& z : zones) {
+            QVERIFY(std::abs(z.width() - 1.0) < EPSILON);
+        }
+    }
+
+    void testThreeColumnMasterCountZero()
+    {
+        ThreeColumnTilingAlgorithm algo;
+        TilingParams params{0.5, 0};
+        auto zones = algo.generateZones(4, params);
+
+        // masterCount=0 clamped to 1
+        QCOMPARE(zones.size(), 4);
+        verifyAll(zones, QStringLiteral("ThreeColumn(4,mc=0)"));
+    }
+
+    void testThreeColumnId()
+    {
+        ThreeColumnTilingAlgorithm algo;
+        QCOMPARE(algo.id(), QStringLiteral("three-column"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // BSP
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testBspEmpty()
+    {
+        BSPTilingAlgorithm algo;
+        QCOMPARE(algo.generateZones(0, {}), QVector<QRectF>());
+    }
+
+    void testBspSingle()
+    {
+        BSPTilingAlgorithm algo;
+        auto zones = algo.generateZones(1, {});
+        QCOMPARE(zones.size(), 1);
+        QCOMPARE(zones[0], QRectF(0.0, 0.0, 1.0, 1.0));
+    }
+
+    void testBspTwo()
+    {
+        BSPTilingAlgorithm algo;
+        TilingParams params{0.55, 1};
+        auto zones = algo.generateZones(2, params);
+
+        QCOMPARE(zones.size(), 2);
+        verifyAll(zones, QStringLiteral("BSP(2)"));
+
+        // First split at masterRatio=0.55
+        QVERIFY(std::abs(zones[0].width() - 0.55) < EPSILON);
+        QVERIFY(std::abs(zones[1].width() - 0.45) < EPSILON);
+    }
+
+    void testBspFiveStructure()
+    {
+        BSPTilingAlgorithm algo;
+        TilingParams params{0.55, 1};
+        auto zones = algo.generateZones(5, params);
+
+        QCOMPARE(zones.size(), 5);
+        verifyAll(zones, QStringLiteral("BSP(5)"));
+
+        // BFS order:
+        // zone[0] = top-left     (0, 0, 0.55, 0.5)
+        // zone[1] = bottom-left  (0, 0.5, 0.55, 0.5)
+        // zone[2] = top-right    (0.55, 0, 0.45, 0.5)
+        // zone[3] = bottom-mid   (0.55, 0.5, 0.225, 0.5)
+        // zone[4] = bottom-right (0.775, 0.5, 0.225, 0.5)
+        QVERIFY(std::abs(zones[0].x() - 0.0) < EPSILON);
+        QVERIFY(std::abs(zones[0].y() - 0.0) < EPSILON);
+        QVERIFY(std::abs(zones[0].width() - 0.55) < EPSILON);
+        QVERIFY(std::abs(zones[0].height() - 0.5) < EPSILON);
+
+        QVERIFY(std::abs(zones[1].x() - 0.0) < EPSILON);
+        QVERIFY(std::abs(zones[1].y() - 0.5) < EPSILON);
+
+        QVERIFY(std::abs(zones[2].x() - 0.55) < EPSILON);
+        QVERIFY(std::abs(zones[2].y() - 0.0) < EPSILON);
+        QVERIFY(std::abs(zones[2].width() - 0.45) < EPSILON);
+
+        QVERIFY(std::abs(zones[3].x() - 0.55) < EPSILON);
+        QVERIFY(std::abs(zones[3].y() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[3].width() - 0.225) < EPSILON);
+
+        QVERIFY(std::abs(zones[4].x() - 0.775) < EPSILON);
+        QVERIFY(std::abs(zones[4].y() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[4].width() - 0.225) < EPSILON);
+    }
+
+    void testBspBalanced()
+    {
+        BSPTilingAlgorithm algo;
+        TilingParams params{0.5, 1};
+        auto zones = algo.generateZones(4, params);
+
+        QCOMPARE(zones.size(), 4);
+        verifyAll(zones, QStringLiteral("BSP(4)"));
+
+        // With 50/50 ratio, 4 zones should each be 0.25 area
+        for (const auto& z : zones) {
+            QVERIFY(std::abs(z.width() * z.height() - 0.25) < 0.01);
+        }
+    }
+
+    void testBspDeeperLevelsUseEqualSplit()
+    {
+        BSPTilingAlgorithm algo;
+        TilingParams params{0.7, 1};
+        auto zones = algo.generateZones(4, params);
+
+        QCOMPARE(zones.size(), 4);
+        verifyAll(zones, QStringLiteral("BSP(4,mr=0.7)"));
+
+        // Depth 0: vertical split at 0.7 → left 70% (2), right 30% (2)
+        // Depth 1: horizontal split at 0.5 for each
+        // Left zones: 0.7 * 0.5 = 0.35 area each
+        // Right zones: 0.3 * 0.5 = 0.15 area each
+        QVERIFY(std::abs(zones[0].width() * zones[0].height() - 0.35) < 0.01);
+        QVERIFY(std::abs(zones[1].width() * zones[1].height() - 0.35) < 0.01);
+        QVERIFY(std::abs(zones[2].width() * zones[2].height() - 0.15) < 0.01);
+        QVERIFY(std::abs(zones[3].width() * zones[3].height() - 0.15) < 0.01);
+    }
+
+    void testBspMasterRatioBoundaries()
+    {
+        BSPTilingAlgorithm algo;
+
+        // masterRatio=0.0 → clamped to 0.1
+        {
+            TilingParams params{0.0, 1};
+            auto zones = algo.generateZones(2, params);
+            QCOMPARE(zones.size(), 2);
+            verifyAll(zones, QStringLiteral("BSP(2,mr=0.0)"));
+            QVERIFY(std::abs(zones[0].width() - 0.1) < EPSILON);
+        }
+
+        // masterRatio=1.0 → clamped to 0.9
+        {
+            TilingParams params{1.0, 1};
+            auto zones = algo.generateZones(2, params);
+            QCOMPARE(zones.size(), 2);
+            verifyAll(zones, QStringLiteral("BSP(2,mr=1.0)"));
+            QVERIFY(std::abs(zones[0].width() - 0.9) < EPSILON);
+        }
+    }
+
+    void testBspId()
+    {
+        BSPTilingAlgorithm algo;
+        QCOMPARE(algo.id(), QStringLiteral("bsp"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Fibonacci
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testFibonacciEmpty()
+    {
+        FibonacciTilingAlgorithm algo;
+        QCOMPARE(algo.generateZones(0, {}), QVector<QRectF>());
+    }
+
+    void testFibonacciSingle()
+    {
+        FibonacciTilingAlgorithm algo;
+        auto zones = algo.generateZones(1, {});
+        QCOMPARE(zones.size(), 1);
+        QCOMPARE(zones[0], QRectF(0.0, 0.0, 1.0, 1.0));
+    }
+
+    void testFibonacciTwo()
+    {
+        FibonacciTilingAlgorithm algo;
+        TilingParams params{0.5, 1};
+        auto zones = algo.generateZones(2, params);
+
+        QCOMPARE(zones.size(), 2);
+        verifyAll(zones, QStringLiteral("Fibonacci(2)"));
+
+        QVERIFY(std::abs(zones[0].width() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[0].height() - 1.0) < EPSILON);
+        QVERIFY(std::abs(zones[1].x() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[1].width() - 0.5) < EPSILON);
+    }
+
+    void testFibonacciFiveSpiralStructure()
+    {
+        FibonacciTilingAlgorithm algo;
+        TilingParams params{0.5, 1};
+        auto zones = algo.generateZones(5, params);
+
+        QCOMPARE(zones.size(), 5);
+        verifyAll(zones, QStringLiteral("Fibonacci(5)"));
+
+        // Spiral: left → top → left → top → remaining
+        // zone[0]: master left half  (0, 0, 0.5, 1.0)
+        // zone[1]: top-right         (0.5, 0, 0.5, 0.5)
+        // zone[2]: bottom-mid-left   (0.5, 0.5, 0.25, 0.5)
+        // zone[3]: bottom-right-top  (0.75, 0.5, 0.25, 0.25)
+        // zone[4]: bottom-right-bot  (0.75, 0.75, 0.25, 0.25)
+        QVERIFY(std::abs(zones[0].x() - 0.0) < EPSILON);
+        QVERIFY(std::abs(zones[0].y() - 0.0) < EPSILON);
+        QVERIFY(std::abs(zones[0].width() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[0].height() - 1.0) < EPSILON);
+
+        QVERIFY(std::abs(zones[1].x() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[1].y() - 0.0) < EPSILON);
+        QVERIFY(std::abs(zones[1].width() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[1].height() - 0.5) < EPSILON);
+
+        QVERIFY(std::abs(zones[2].x() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[2].y() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[2].width() - 0.25) < EPSILON);
+        QVERIFY(std::abs(zones[2].height() - 0.5) < EPSILON);
+
+        QVERIFY(std::abs(zones[3].x() - 0.75) < EPSILON);
+        QVERIFY(std::abs(zones[3].y() - 0.5) < EPSILON);
+        QVERIFY(std::abs(zones[3].width() - 0.25) < EPSILON);
+        QVERIFY(std::abs(zones[3].height() - 0.25) < EPSILON);
+
+        QVERIFY(std::abs(zones[4].x() - 0.75) < EPSILON);
+        QVERIFY(std::abs(zones[4].y() - 0.75) < EPSILON);
+
+        // Monotonically decreasing areas (including zone[0] vs zone[1])
+        for (int i = 1; i < zones.size(); ++i) {
+            qreal prevArea = zones[i - 1].width() * zones[i - 1].height();
+            qreal currArea = zones[i].width() * zones[i].height();
+            QVERIFY2(currArea <= prevArea + EPSILON,
+                     qPrintable(QStringLiteral("Fibonacci zone %1 area (%2) > zone %3 area (%4)")
+                                    .arg(i).arg(currArea).arg(i - 1).arg(prevArea)));
+        }
+    }
+
+    void testFibonacciMasterRatio()
+    {
+        FibonacciTilingAlgorithm algo;
+        TilingParams params{0.7, 1};
+        auto zones = algo.generateZones(3, params);
+
+        QCOMPARE(zones.size(), 3);
+        verifyAll(zones, QStringLiteral("Fibonacci(3,mr=0.7)"));
+        QVERIFY(std::abs(zones[0].width() - 0.7) < EPSILON);
+    }
+
+    void testFibonacciId()
+    {
+        FibonacciTilingAlgorithm algo;
+        QCOMPARE(algo.id(), QStringLiteral("fibonacci"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Columns
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testColumnsEmpty()
+    {
+        ColumnsTilingAlgorithm algo;
+        QCOMPARE(algo.generateZones(0, {}), QVector<QRectF>());
+    }
+
+    void testColumnsSingle()
+    {
+        ColumnsTilingAlgorithm algo;
+        auto zones = algo.generateZones(1, {});
+        QCOMPARE(zones.size(), 1);
+        QCOMPARE(zones[0], QRectF(0.0, 0.0, 1.0, 1.0));
+    }
+
+    void testColumnsStandard()
+    {
+        ColumnsTilingAlgorithm algo;
+        auto zones = algo.generateZones(4, {});
+
+        QCOMPARE(zones.size(), 4);
+        verifyAll(zones, QStringLiteral("Columns(4)"));
+
+        for (int i = 0; i < 4; ++i) {
+            QVERIFY(std::abs(zones[i].width() - 0.25) < EPSILON);
+            QVERIFY(std::abs(zones[i].height() - 1.0) < EPSILON);
+            QVERIFY(std::abs(zones[i].x() - i * 0.25) < EPSILON);
+        }
+    }
+
+    void testColumnsId()
+    {
+        ColumnsTilingAlgorithm algo;
+        QCOMPARE(algo.id(), QStringLiteral("columns"));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Generic validation across all algorithms
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testAllAlgorithmsGenericValidation()
+    {
+        std::vector<std::unique_ptr<TilingAlgorithm>> algos;
+        algos.push_back(std::make_unique<BSPTilingAlgorithm>());
+        algos.push_back(std::make_unique<ColumnsTilingAlgorithm>());
+        algos.push_back(std::make_unique<FibonacciTilingAlgorithm>());
+        algos.push_back(std::make_unique<MasterStackTilingAlgorithm>());
+        algos.push_back(std::make_unique<MonocleTilingAlgorithm>());
+        algos.push_back(std::make_unique<ThreeColumnTilingAlgorithm>());
+
+        TilingParams params{0.55, 1};
+
+        for (const auto& algo : algos) {
+            const QString id = algo->id();
+
+            // Empty
+            auto empty = algo->generateZones(0, params);
+            QVERIFY2(empty.isEmpty(),
+                     qPrintable(QStringLiteral("%1: expected empty for windowCount=0").arg(id)));
+
+            // Single
+            auto single = algo->generateZones(1, params);
+            QVERIFY2(single.size() == 1,
+                     qPrintable(QStringLiteral("%1: expected 1 zone for windowCount=1, got %2")
+                                    .arg(id).arg(single.size())));
+            QVERIFY2(single[0] == QRectF(0.0, 0.0, 1.0, 1.0),
+                     qPrintable(QStringLiteral("%1: single zone should be fullscreen").arg(id)));
+
+            // Standard cases
+            for (int n : {2, 3, 4, 5, 8}) {
+                const QString ctx = QStringLiteral("%1(%2)").arg(id).arg(n);
+                auto zones = algo->generateZones(n, params);
+                if (id != QStringLiteral("monocle")) {
+                    QVERIFY2(zones.size() == n,
+                             qPrintable(QStringLiteral("%1: expected %2 zones, got %3")
+                                            .arg(ctx).arg(n).arg(zones.size())));
+                } else {
+                    QVERIFY2(zones.size() == 1,
+                             qPrintable(QStringLiteral("%1: monocle should return 1 zone").arg(ctx)));
+                }
+                verifyAll(zones, ctx);
+            }
+        }
+    }
+
+    void testAllAlgorithmsMasterIndex()
+    {
+        std::vector<std::unique_ptr<TilingAlgorithm>> algos;
+        algos.push_back(std::make_unique<BSPTilingAlgorithm>());
+        algos.push_back(std::make_unique<FibonacciTilingAlgorithm>());
+        algos.push_back(std::make_unique<MasterStackTilingAlgorithm>());
+        algos.push_back(std::make_unique<MonocleTilingAlgorithm>());
+        algos.push_back(std::make_unique<ThreeColumnTilingAlgorithm>());
+
+        for (const auto& algo : algos) {
+            QCOMPARE(algo->masterIndex(), 0);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Comparative: BSP (balanced) vs Fibonacci (greedy)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testBspVsFibonacciDistinction()
+    {
+        BSPTilingAlgorithm bsp;
+        FibonacciTilingAlgorithm fib;
+        TilingParams params{0.5, 1};
+
+        auto bspZones = bsp.generateZones(5, params);
+        auto fibZones = fib.generateZones(5, params);
+
+        QCOMPARE(bspZones.size(), 5);
+        QCOMPARE(fibZones.size(), 5);
+
+        // BSP (balanced) should produce more uniform zone areas than Fibonacci (greedy)
+        auto areaRatio = [](const QVector<QRectF>& zones) {
+            qreal minA = 1.0, maxA = 0.0;
+            for (const auto& z : zones) {
+                qreal a = z.width() * z.height();
+                minA = std::min(minA, a);
+                maxA = std::max(maxA, a);
+            }
+            return maxA / minA;
+        };
+
+        qreal bspRatio = areaRatio(bspZones);   // ~2.0
+        qreal fibRatio = areaRatio(fibZones);    // ~8.0
+
+        QVERIFY2(bspRatio < fibRatio,
+                 qPrintable(QStringLiteral("BSP area ratio (%1) should be less than Fibonacci (%2)")
+                                .arg(bspRatio).arg(fibRatio)));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Large window counts
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testLargeWindowCount()
+    {
+        TilingParams params{0.5, 1};
+        BSPTilingAlgorithm bsp;
+        FibonacciTilingAlgorithm fib;
+        MasterStackTilingAlgorithm ms;
+        ThreeColumnTilingAlgorithm tc;
+        ColumnsTilingAlgorithm col;
+
+        for (int n : {20, 50}) {
+            verifyAll(bsp.generateZones(n, params), QStringLiteral("BSP(%1)").arg(n));
+            verifyAll(fib.generateZones(n, params), QStringLiteral("Fibonacci(%1)").arg(n));
+            verifyAll(ms.generateZones(n, params), QStringLiteral("MasterStack(%1)").arg(n));
+            verifyAll(tc.generateZones(n, params), QStringLiteral("ThreeColumn(%1)").arg(n));
+            verifyAll(col.generateZones(n, params), QStringLiteral("Columns(%1)").arg(n));
+        }
+    }
+};
+
+QTEST_MAIN(TestTilingAlgorithms)
+#include "test_tiling_algorithms.moc"


### PR DESCRIPTION
## Summary

- Implements 5 tiling algorithms matching Krohnkite's core layouts (#101 BSP, #102 Master-Stack, #103 Monocle, #104 Fibonacci, #105 Three Column)
- All algorithms are stateless pure functions conforming to the `TilingAlgorithm` interface from Phase 1 (PR #125)
- Registers all 5 in `TilingAlgorithmRegistry` (6 total with existing `columns`)
- Input clamping: `masterRatio` to `[0.1, 0.9]`, `masterCount` to `≥1` — prevents zero-width zones and div-by-zero
- Three Column gracefully degrades: 2 windows → 2-column layout (no empty left gap), all-masters → full-width rows

### Algorithms

| Algorithm | ID | Krohnkite Equivalent | Key Behavior |
|-----------|----|----|---|
| Master-Stack | `master-stack` | Tile (default) | Master left, stack right, dwm-style |
| BSP | `bsp` | BTree | Balanced recursive subdivision (count/2), BFS order |
| Fibonacci | `fibonacci` | Spiral | Greedy spiral peel (1 window at a time) |
| Monocle | `monocle` | Monocle | Single fullscreen zone, ignores all params |
| Three Column | `three-column` | Three Column | Center master, left/right stacks (ultrawide) |

### Files

**New** (`src/core/algorithms/`): 10 files (5 `.h` + 5 `.cpp`)  
**Modified**: `src/core/tilingalgorithm.cpp` (registration), `src/CMakeLists.txt`, `tests/unit/CMakeLists.txt`  
**New test**: `tests/unit/test_tiling_algorithms.cpp` — 46 test cases

## Test plan

- [x] `cmake --build build` — compiles with no errors/warnings
- [x] `ctest --test-dir build -R TilingAlgorithms` — 46/46 pass
- [x] Full test suite (`ctest --test-dir build`) — 5/5 suites pass
- [ ] Spot-check: Master-Stack(4, {0.6, 1}) → 1 master 60% wide, 3 stack 40% wide
- [ ] Spot-check: BSP(5, {0.55, 1}) → 5 non-overlapping zones, first split at 55%
- [ ] Spot-check: Monocle(any N) → always 1 fullscreen zone
- [ ] Spot-check: Three Column(6, {0.5, 1}) → center 50%, 3 right, 2 left
- [ ] Verify registry has 6 algorithms with unique IDs

Closes #101, closes #102, closes #103, closes #104, closes #105

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)