### PR TITLE
fix: overlay follows cursor when dragging to another monitor (#136)

### DIFF
--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -156,6 +156,7 @@ private:
     QString m_currentActivity; // Current KDE activity (empty = all activities)
     bool m_visible = false;
     bool m_zoneSelectorVisible = false;
+    QScreen* m_currentOverlayScreen = nullptr; // Screen overlay is shown on (single-monitor mode only, for #136)
 
     // Zone selector selection tracking
     QString m_selectedLayoutId;

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -157,6 +157,7 @@ private:
     QRect m_currentZoneGeometry;
     bool m_snapCancelled = false;
     bool m_overlayShown = false;
+    QScreen* m_overlayScreen = nullptr; // Screen overlay is shown on (single-monitor mode only)
     bool m_zoneSelectorShown = false;
     int m_lastCursorX = 0;
     int m_lastCursorY = 0;


### PR DESCRIPTION
## Summary

When "show zones on all monitors while dragging" is disabled and the user drags a window to a second monitor with the modifier held, the overlay now automatically switches to the target monitor instead of staying on the original.

## Changes

- **WindowDragAdaptor:** Track overlay screen in single-monitor mode; call `showAtPosition` when cursor moves to a different monitor so the overlay switches.
- **OverlayService:** Make `showAtPosition` handle the already-visible case and switch overlay to the new screen; have `initializeOverlay` hide the old screen overlay before showing on the new one.
- Add null check for `m_settings` in `prepareHandlerContext`.

Closes #136

Made with [Cursor](https://cursor.com)