### PR TITLE
fix: persist zone padding and outer gap in layout settings (fixes #145)

### DIFF
--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -445,6 +445,18 @@ bool LayoutAdaptor::updateLayout(const QString& layoutJson)
     // Update basic properties
     layout->setName(obj[JsonKeys::Name].toString());
 
+    // Update per-layout gap overrides (-1 = use global setting)
+    if (obj.contains(JsonKeys::ZonePadding)) {
+        layout->setZonePadding(obj[JsonKeys::ZonePadding].toInt(-1));
+    } else {
+        layout->clearZonePaddingOverride();
+    }
+    if (obj.contains(JsonKeys::OuterGap)) {
+        layout->setOuterGap(obj[JsonKeys::OuterGap].toInt(-1));
+    } else {
+        layout->clearOuterGapOverride();
+    }
+
     // Update shader settings
     layout->setShaderId(obj[JsonKeys::ShaderId].toString());
     if (obj.contains(JsonKeys::ShaderParams)) {


### PR DESCRIPTION
## Description

Fixes #145

Zone padding and outer gap changes in individual layout settings were not persisting after save. When a user unchecked the zone padding override or changed the value in layout settings, then clicked Apply and Save, the old value (e.g. 8px) would reappear when reopening the layout editor.

## Root cause

`LayoutAdaptor::updateLayout()` was not applying zone padding and outer gap from the editor's JSON when saving. The layout object kept its original values from when it was first loaded, so `layout->toJson()` in `saveLayouts()` wrote the stale values.

## Solution

Apply per-layout gap overrides from the incoming JSON in `updateLayout()`:
- If `zonePadding`/`outerGap` key is present: set the value (including 0 to disable)
- If key is absent: clear the override so the layout uses the global setting (-1)

## Testing

- Edit a default layout (e.g. Columns 2) that has zone padding set to 8px
- Open layout settings, uncheck zone padding (or change the value)
- Click Apply, then Save
- Close and reopen the layout editor
- Zone padding should now show the updated value (unchecked = use global)

Made with [Cursor](https://cursor.com)