### PR TITLE
feat(layout): add per-layout full screen geometry toggle

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -407,6 +407,8 @@ set(plasmazones_editor_SRCS
     editor/undo/commands/UpdateShaderParamsCommand.h
     editor/undo/commands/UpdateGapOverrideCommand.cpp
     editor/undo/commands/UpdateGapOverrideCommand.h
+    editor/undo/commands/UpdateFullScreenGeometryCommand.cpp
+    editor/undo/commands/UpdateFullScreenGeometryCommand.h
     editor/undo/commands/UpdateVisibilityCommand.cpp
     editor/undo/commands/UpdateVisibilityCommand.h
 )

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -154,6 +154,9 @@ inline constexpr QLatin1String TargetScreen{"targetScreen"};
 // Auto-assign keys
 inline constexpr QLatin1String AutoAssign{"autoAssign"};
 
+// Geometry mode keys
+inline constexpr QLatin1String UseFullScreenGeometry{"useFullScreenGeometry"};
+
 // Pywal color file keys
 inline constexpr QLatin1String Colors{"colors"};
 }

--- a/src/core/geometryutils.h
+++ b/src/core/geometryutils.h
@@ -76,6 +76,17 @@ PLASMAZONES_EXPORT int getEffectiveZonePadding(Layout* layout, ISettings* settin
 PLASMAZONES_EXPORT int getEffectiveOuterGap(Layout* layout, ISettings* settings);
 
 /**
+ * @brief Get the effective screen geometry for a layout
+ * @param layout Layout to check (may use full screen geometry)
+ * @param screen Screen to get geometry for
+ * @return Full screen geometry if layout->useFullScreenGeometry(), otherwise available geometry
+ *
+ * Centralizes the decision of whether to use full screen or available (panel-excluded)
+ * geometry based on the layout's useFullScreenGeometry setting.
+ */
+PLASMAZONES_EXPORT QRectF effectiveScreenGeometry(Layout* layout, QScreen* screen);
+
+/**
  * @brief Extract geometry as QRectF from a zone QVariantMap
  * @param zone Zone data map containing x, y, width, height keys
  * @return QRectF with the zone's geometry

--- a/src/core/layout.cpp
+++ b/src/core/layout.cpp
@@ -80,6 +80,7 @@ Layout::Layout(const Layout& other)
     , m_defaultOrder(other.m_defaultOrder)
     , m_appRules(other.m_appRules)
     , m_autoAssign(other.m_autoAssign)
+    , m_useFullScreenGeometry(other.m_useFullScreenGeometry)
     , m_shaderId(other.m_shaderId)
     , m_shaderParams(other.m_shaderParams)
     , m_hiddenFromSelector(other.m_hiddenFromSelector)
@@ -122,6 +123,8 @@ Layout& Layout::operator=(const Layout& other)
         m_appRules = other.m_appRules;
         bool autoAssignDiff = m_autoAssign != other.m_autoAssign;
         m_autoAssign = other.m_autoAssign;
+        bool fullScreenGeomDiff = m_useFullScreenGeometry != other.m_useFullScreenGeometry;
+        m_useFullScreenGeometry = other.m_useFullScreenGeometry;
         m_hiddenFromSelector = other.m_hiddenFromSelector;
         m_allowedScreens = other.m_allowedScreens;
         m_allowedDesktops = other.m_allowedDesktops;
@@ -144,6 +147,7 @@ Layout& Layout::operator=(const Layout& other)
         if (activitiesChanged) Q_EMIT allowedActivitiesChanged();
         if (rulesChanged) Q_EMIT appRulesChanged();
         if (autoAssignDiff) Q_EMIT autoAssignChanged();
+        if (fullScreenGeomDiff) Q_EMIT useFullScreenGeometryChanged();
     }
     return *this;
 }
@@ -161,6 +165,7 @@ LAYOUT_SETTER(const QString&, ShaderId, m_shaderId, shaderIdChanged)
 LAYOUT_SETTER(const QVariantMap&, ShaderParams, m_shaderParams, shaderParamsChanged)
 LAYOUT_SETTER(bool, HiddenFromSelector, m_hiddenFromSelector, hiddenFromSelectorChanged)
 LAYOUT_SETTER(bool, AutoAssign, m_autoAssign, autoAssignChanged)
+LAYOUT_SETTER(bool, UseFullScreenGeometry, m_useFullScreenGeometry, useFullScreenGeometryChanged)
 
 void Layout::setAllowedScreens(const QStringList& screens)
 {
@@ -522,6 +527,11 @@ QJsonObject Layout::toJson() const
         json[JsonKeys::AutoAssign] = true;
     }
 
+    // Full screen geometry mode - only serialize if true
+    if (m_useFullScreenGeometry) {
+        json[JsonKeys::UseFullScreenGeometry] = true;
+    }
+
     // Visibility filtering - only serialize non-default values
     if (m_hiddenFromSelector) {
         json[JsonKeys::HiddenFromSelector] = true;
@@ -569,6 +579,9 @@ Layout* Layout::fromJson(const QJsonObject& json, QObject* parent)
 
     // Auto-assign
     layout->m_autoAssign = json[JsonKeys::AutoAssign].toBool(false);
+
+    // Full screen geometry mode
+    layout->m_useFullScreenGeometry = json[JsonKeys::UseFullScreenGeometry].toBool(false);
 
     // Visibility filtering
     layout->m_hiddenFromSelector = json[JsonKeys::HiddenFromSelector].toBool(false);

--- a/src/core/layout.h
+++ b/src/core/layout.h
@@ -102,6 +102,9 @@ class PLASMAZONES_EXPORT Layout : public QObject
     // Auto-assign: new windows fill first empty zone
     Q_PROPERTY(bool autoAssign READ autoAssign WRITE setAutoAssign NOTIFY autoAssignChanged)
 
+    // Geometry mode: use full screen or available (panel-excluded) geometry
+    Q_PROPERTY(bool useFullScreenGeometry READ useFullScreenGeometry WRITE setUseFullScreenGeometry NOTIFY useFullScreenGeometryChanged)
+
     // Visibility filtering
     Q_PROPERTY(bool hiddenFromSelector READ hiddenFromSelector WRITE setHiddenFromSelector NOTIFY hiddenFromSelectorChanged)
     Q_PROPERTY(QStringList allowedScreens READ allowedScreens WRITE setAllowedScreens NOTIFY allowedScreensChanged)
@@ -224,6 +227,10 @@ public:
     bool autoAssign() const { return m_autoAssign; }
     void setAutoAssign(bool enabled);
 
+    // Geometry mode: when true, zones span the full screen including panel/taskbar areas
+    bool useFullScreenGeometry() const { return m_useFullScreenGeometry; }
+    void setUseFullScreenGeometry(bool enabled);
+
     // Optional load order for "default" layout when defaultLayoutId is not set (lower = first)
     int defaultOrder() const
     {
@@ -286,6 +293,7 @@ Q_SIGNALS:
     void allowedActivitiesChanged();
     void appRulesChanged();
     void autoAssignChanged();
+    void useFullScreenGeometryChanged();
     void zonesChanged();
     void zoneAdded(Zone* zone);
     void zoneRemoved(Zone* zone);
@@ -308,6 +316,9 @@ private:
 
     // Auto-assign: new windows fill first empty zone
     bool m_autoAssign = false;
+
+    // Geometry mode: zones use full screen (true) or available area excluding panels (false)
+    bool m_useFullScreenGeometry = false;
 
     // Shader support
     QString m_shaderId; // Shader effect ID (empty = no shader)

--- a/src/core/windowtrackingservice.cpp
+++ b/src/core/windowtrackingservice.cpp
@@ -916,7 +916,8 @@ QRect WindowTrackingService::zoneGeometry(const QString& zoneId, const QString& 
     // Use the zone's own layout for per-layout gap overrides
     int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
     int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
-    QRectF geoF = GeometryUtils::getZoneGeometryWithGaps(zone, screen, zonePadding, outerGap, true);
+    bool useAvail = !(layout && layout->useFullScreenGeometry());
+    QRectF geoF = GeometryUtils::getZoneGeometryWithGaps(zone, screen, zonePadding, outerGap, useAvail);
 
     return geoF.toRect();
 }
@@ -1047,8 +1048,9 @@ QVector<RotationEntry> WindowTrackingService::calculateRotation(bool clockwise, 
 
             Zone* sourceZone = zones[currentIdx];
             Zone* targetZone = zones[targetIdx];
+            bool useAvail = !(layout && layout->useFullScreenGeometry());
             QRectF geoF = GeometryUtils::getZoneGeometryWithGaps(
-                targetZone, screen, zonePadding, outerGap, true);
+                targetZone, screen, zonePadding, outerGap, useAvail);
             QRect geo = geoF.toRect();
 
             if (geo.isValid()) {
@@ -1170,8 +1172,9 @@ QVector<RotationEntry> WindowTrackingService::calculateSnapAllWindows(const QStr
             break;
         }
 
+        bool useAvail = !(layout && layout->useFullScreenGeometry());
         QRectF geoF = GeometryUtils::getZoneGeometryWithGaps(
-            targetZone, screen, zonePadding, outerGap, true);
+            targetZone, screen, zonePadding, outerGap, useAvail);
         QRect geo = geoF.toRect();
 
         if (geo.isValid()) {

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -1908,12 +1908,13 @@ QVariantMap OverlayService::zoneToVariantMap(Zone* zone, QScreen* screen, Layout
     }
 
     // Calculate zone geometry with gaps applied (matches snap geometry).
-    // useAvailableGeometry=true means zones are calculated within the usable screen area
-    // (excluding panels/taskbars), so windows won't overlap with system UI.
+    // Uses the layout's geometry preference: available area (excluding panels/taskbars)
+    // or full screen geometry depending on useFullScreenGeometry setting.
     // Layout's zonePadding/outerGap takes precedence over global settings
     int zonePadding = GeometryUtils::getEffectiveZonePadding(layout, m_settings);
     int outerGap = GeometryUtils::getEffectiveOuterGap(layout, m_settings);
-    QRectF geom = GeometryUtils::getZoneGeometryWithGaps(zone, screen, zonePadding, outerGap, true);
+    bool useAvail = !(layout && layout->useFullScreenGeometry());
+    QRectF geom = GeometryUtils::getZoneGeometryWithGaps(zone, screen, zonePadding, outerGap, useAvail);
 
     // Convert to overlay window local coordinates
     // The overlay covers the full screen, but zones are positioned within available area
@@ -2023,8 +2024,9 @@ QRect OverlayService::getSelectedZoneGeometry(QScreen* screen) const
             if (zone) {
                 int zonePadding = GeometryUtils::getEffectiveZonePadding(selectedLayout, m_settings);
                 int outerGap = GeometryUtils::getEffectiveOuterGap(selectedLayout, m_settings);
+                bool useAvail = !(selectedLayout && selectedLayout->useFullScreenGeometry());
                 QRectF geom = GeometryUtils::getZoneGeometryWithGaps(
-                    zone, screen, zonePadding, outerGap, /*useAvailableGeometry=*/true);
+                    zone, screen, zonePadding, outerGap, useAvail);
                 return geom.toRect();
             }
         }

--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -461,6 +461,9 @@ bool LayoutAdaptor::updateLayout(const QString& layoutJson)
         layout->clearOuterGapOverride();
     }
 
+    // Update full screen geometry mode
+    layout->setUseFullScreenGeometry(obj[JsonKeys::UseFullScreenGeometry].toBool(false));
+
     // Update shader settings
     layout->setShaderId(obj[JsonKeys::ShaderId].toString());
     if (obj.contains(JsonKeys::ShaderParams)) {

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -1571,9 +1571,9 @@ QString WindowTrackingAdaptor::detectScreenForZone(const QString& zoneId) const
     }
     QRectF relGeom = zone->relativeGeometry();
     for (QScreen* screen : Utils::allScreens()) {
-        QRect availGeom = ScreenManager::actualAvailableGeometry(screen);
-        QPoint zoneCenter(availGeom.x() + static_cast<int>(relGeom.center().x() * availGeom.width()),
-                          availGeom.y() + static_cast<int>(relGeom.center().y() * availGeom.height()));
+        QRectF refGeom = GeometryUtils::effectiveScreenGeometry(layout, screen);
+        QPoint zoneCenter(refGeom.x() + static_cast<int>(relGeom.center().x() * refGeom.width()),
+                          refGeom.y() + static_cast<int>(relGeom.center().y() * refGeom.height()));
         if (screen->geometry().contains(zoneCenter)) {
             return screen->name();
         }

--- a/src/editor/EditorController.h
+++ b/src/editor/EditorController.h
@@ -86,6 +86,9 @@ class EditorController : public QObject
     Q_PROPERTY(int globalZonePadding READ globalZonePadding NOTIFY globalZonePaddingChanged)
     Q_PROPERTY(int globalOuterGap READ globalOuterGap NOTIFY globalOuterGapChanged)
 
+    // Full screen geometry mode
+    Q_PROPERTY(bool useFullScreenGeometry READ useFullScreenGeometry WRITE setUseFullScreenGeometry NOTIFY useFullScreenGeometryChanged)
+
     // Label font settings (read-only from global Appearance config)
     Q_PROPERTY(QString labelFontFamily READ labelFontFamily CONSTANT)
     Q_PROPERTY(qreal labelFontSizeScale READ labelFontSizeScale CONSTANT)
@@ -154,6 +157,7 @@ public:
     bool hasOuterGapOverride() const;
     int globalZonePadding() const;
     int globalOuterGap() const;
+    bool useFullScreenGeometry() const;
     bool canPaste() const;
     UndoController* undoController() const;
 
@@ -228,6 +232,7 @@ public:
     Q_INVOKABLE void clearOuterGapOverride();
     Q_INVOKABLE void refreshGlobalZonePadding();
     Q_INVOKABLE void refreshGlobalOuterGap();
+    void setUseFullScreenGeometry(bool enabled);
 
     // Shader setters (create undo commands)
     void setCurrentShaderId(const QString& id);
@@ -236,6 +241,7 @@ public:
     // Gap override setters - Direct (for undo/redo, bypass command creation)
     void setZonePaddingDirect(int padding);
     void setOuterGapDirect(int gap);
+    void setUseFullScreenGeometryDirect(bool enabled);
 
     // Shader setters - Direct (for undo/redo, bypass command creation)
     void setCurrentShaderIdDirect(const QString& id);
@@ -520,6 +526,7 @@ Q_SIGNALS:
     void outerGapChanged();
     void globalZonePaddingChanged();
     void globalOuterGapChanged();
+    void useFullScreenGeometryChanged();
 
     // Shader signals
     void currentShaderIdChanged();
@@ -684,6 +691,7 @@ private:
     // Zone settings (per-layout override, -1 = use global)
     int m_zonePadding = -1;
     int m_outerGap = -1;
+    bool m_useFullScreenGeometry = false;
     int m_cachedGlobalZonePadding = PlasmaZones::Defaults::ZonePadding; // Cached to avoid D-Bus calls
     int m_cachedGlobalOuterGap = PlasmaZones::Defaults::OuterGap; // Cached to avoid D-Bus calls
 

--- a/src/editor/qml/LayoutSettingsDialog.qml
+++ b/src/editor/qml/LayoutSettingsDialog.qml
@@ -53,6 +53,7 @@ Kirigami.Dialog {
         outerGapSpin.value = root.editorController.hasOuterGapOverride
             ? root.editorController.outerGap
             : root.editorController.globalOuterGap
+        fullScreenGeomCheck.checked = root.editorController.useFullScreenGeometry
     }
 
     // Sync UI state when values change externally (undo/redo, load layout)
@@ -80,6 +81,9 @@ Kirigami.Dialog {
             if (!root.editorController.hasOuterGapOverride)
                 outerGapSpin.value = root.editorController.globalOuterGap
         }
+        function onUseFullScreenGeometryChanged() {
+            fullScreenGeomCheck.checked = root.editorController.useFullScreenGeometry
+        }
     }
 
     ColumnLayout {
@@ -87,7 +91,7 @@ Kirigami.Dialog {
 
         // Description
         Label {
-            text: i18nc("@info", "Override global gap settings for this layout only. Uncheck to use the global defaults from System Settings.")
+            text: i18nc("@info", "Per-layout overrides for this layout only.")
             wrapMode: Text.WordWrap
             opacity: 0.7
             Layout.fillWidth: true
@@ -107,6 +111,15 @@ Kirigami.Dialog {
             SectionHeader {
                 title: i18nc("@title:group", "Spacing")
                 icon: "format-indent-more"
+            }
+
+            Label {
+                text: i18nc("@info", "Override global gap defaults from System Settings.")
+                wrapMode: Text.WordWrap
+                opacity: 0.7
+                Layout.fillWidth: true
+                Layout.leftMargin: Kirigami.Units.largeSpacing
+                Layout.maximumWidth: root.preferredWidth - root.padding * 2 - Kirigami.Units.largeSpacing
             }
 
             GridLayout {
@@ -192,6 +205,41 @@ Kirigami.Dialog {
                         : i18nc("@label showing global default", "px (global)")
                     opacity: outerGapOverrideCheck.checked ? 1.0 : 0.6
                     Layout.preferredWidth: implicitWidth
+                }
+            }
+        }
+
+        Kirigami.Separator {
+            Layout.fillWidth: true
+        }
+
+        // ─── Geometry section ────────────────────────────────
+        ColumnLayout {
+            spacing: Kirigami.Units.smallSpacing
+            Layout.fillWidth: true
+
+            SectionHeader {
+                title: i18nc("@title:group", "Geometry")
+                icon: "view-fullscreen"
+            }
+
+            Label {
+                text: i18nc("@info", "Control which screen area zones occupy.")
+                wrapMode: Text.WordWrap
+                opacity: 0.7
+                Layout.fillWidth: true
+                Layout.leftMargin: Kirigami.Units.largeSpacing
+                Layout.maximumWidth: root.preferredWidth - root.padding * 2 - Kirigami.Units.largeSpacing
+            }
+
+            CheckBox {
+                id: fullScreenGeomCheck
+                text: i18nc("@option:check", "Include area behind panels and taskbars")
+                checked: root.editorController ? root.editorController.useFullScreenGeometry : false
+                Layout.leftMargin: Kirigami.Units.largeSpacing
+                onToggled: {
+                    if (root.editorController)
+                        root.editorController.useFullScreenGeometry = checked
                 }
             }
         }

--- a/src/editor/undo/commands/UpdateFullScreenGeometryCommand.cpp
+++ b/src/editor/undo/commands/UpdateFullScreenGeometryCommand.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "UpdateFullScreenGeometryCommand.h"
+
+#include <KLocalizedString>
+
+#include "../../EditorController.h"
+
+using namespace PlasmaZones;
+
+UpdateFullScreenGeometryCommand::UpdateFullScreenGeometryCommand(QPointer<EditorController> editorController,
+                                                                   bool oldValue, bool newValue,
+                                                                   const QString& text, QUndoCommand* parent)
+    : QUndoCommand(text.isEmpty() ? i18nc("@action", "Toggle Full Screen Geometry") : text, parent)
+    , m_editorController(editorController)
+    , m_oldValue(oldValue)
+    , m_newValue(newValue)
+{
+}
+
+void UpdateFullScreenGeometryCommand::undo()
+{
+    if (!m_editorController) {
+        return;
+    }
+    m_editorController->setUseFullScreenGeometryDirect(m_oldValue);
+}
+
+void UpdateFullScreenGeometryCommand::redo()
+{
+    if (!m_editorController) {
+        return;
+    }
+    m_editorController->setUseFullScreenGeometryDirect(m_newValue);
+}

--- a/src/editor/undo/commands/UpdateFullScreenGeometryCommand.h
+++ b/src/editor/undo/commands/UpdateFullScreenGeometryCommand.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QPointer>
+#include <QUndoCommand>
+
+namespace PlasmaZones {
+
+class EditorController;
+
+/**
+ * @brief Command for toggling per-layout full screen geometry mode
+ *
+ * Enables undo/redo for the useFullScreenGeometry setting.
+ * When enabled, zones span the entire screen including areas behind
+ * panels and taskbars.
+ */
+class UpdateFullScreenGeometryCommand : public QUndoCommand
+{
+public:
+    explicit UpdateFullScreenGeometryCommand(QPointer<EditorController> editorController,
+                                              bool oldValue, bool newValue,
+                                              const QString& text = QString(),
+                                              QUndoCommand* parent = nullptr);
+
+    void undo() override;
+    void redo() override;
+
+private:
+    QPointer<EditorController> m_editorController;
+    bool m_oldValue;
+    bool m_newValue;
+};
+
+} // namespace PlasmaZones


### PR DESCRIPTION
## Summary

- Adds a per-layout `useFullScreenGeometry` toggle so zones can span the entire screen including areas behind panels and taskbars
- Targets ultrawide monitor setups with split taskbars where users need zones to occupy the full screen height
- New "Geometry" section in Layout Settings dialog with an "Include area behind panels and taskbars" checkbox

## Implementation

- `useFullScreenGeometry` property on `Layout` with JSON serialization (only persisted when `true`)
- `effectiveScreenGeometry()` helper in `GeometryUtils` centralizes the full-screen vs available-area decision
- All ~15 `getZoneGeometryWithGaps` call sites updated across daemon, D-Bus adaptors, overlay service, and window tracking
- Undo/redo support via `UpdateFullScreenGeometryCommand`
- D-Bus `layoutadaptor::updateLayout()` updated to persist the property
- Default is `false` — existing layouts are completely unaffected

## Changed files (18)

| Area | Files | Changes |
|------|-------|---------|
| Core | `layout.h/cpp`, `constants.h`, `geometryutils.h/cpp` | Property, serialization, helper |
| Daemon | `daemon.cpp`, `overlayservice.cpp` | Geometry resolution |
| D-Bus | `layoutadaptor.cpp`, `windowdragadaptor.cpp`, `windowtrackingadaptor.cpp`, `zonedetectionadaptor.cpp` | All call sites |
| Services | `windowtrackingservice.cpp` | Snap/rotation geometry |
| Editor | `EditorController.h/cpp`, `LayoutSettingsDialog.qml` | UI + undo/redo |
| Undo | `UpdateFullScreenGeometryCommand.h/cpp` | New command |
| Build | `CMakeLists.txt` | New files |

## Test plan

- [x] Build passes (zero errors)
- [x] All 4 existing tests pass
- [ ] Create layout, enable "Include area behind panels and taskbars" → zones extend behind panels
- [ ] Disable the toggle → zones snap back to usable area
- [ ] Undo/redo the toggle → state reverts correctly
- [ ] Save and reload layout → setting persists
- [ ] Switch between layouts with different settings → geometry updates correctly
- [ ] Verify existing layouts without the setting behave identically to before

Closes #179

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)