### PR TITLE
feat(kcm): expose AlwaysActive zone activation in settings UI

### DIFF
--- a/kcm/kcm_plasmazones.h
+++ b/kcm/kcm_plasmazones.h
@@ -45,11 +45,13 @@ class KCMPlasmaZones : public KQuickConfigModule
     // Activation
     Q_PROPERTY(QVariantList dragActivationTriggers READ dragActivationTriggers WRITE setDragActivationTriggers NOTIFY
                    dragActivationTriggersChanged)
+    Q_PROPERTY(bool alwaysActivateOnDrag READ alwaysActivateOnDrag WRITE setAlwaysActivateOnDrag NOTIFY
+                   alwaysActivateOnDragChanged)
+    Q_PROPERTY(bool toggleActivation READ toggleActivation WRITE setToggleActivation NOTIFY
+                   toggleActivationChanged)
     Q_PROPERTY(bool zoneSpanEnabled READ zoneSpanEnabled WRITE setZoneSpanEnabled NOTIFY zoneSpanEnabledChanged)
     Q_PROPERTY(QVariantList zoneSpanTriggers READ zoneSpanTriggers WRITE setZoneSpanTriggers NOTIFY
                    zoneSpanTriggersChanged)
-    Q_PROPERTY(bool toggleActivation READ toggleActivation WRITE setToggleActivation NOTIFY
-                   toggleActivationChanged)
 
     // Display
     Q_PROPERTY(bool showZonesOnAllMonitors READ showZonesOnAllMonitors WRITE setShowZonesOnAllMonitors NOTIFY
@@ -220,9 +222,10 @@ public:
 
     // Property getters
     QVariantList dragActivationTriggers() const;
+    bool alwaysActivateOnDrag() const;
+    bool toggleActivation() const;
     bool zoneSpanEnabled() const;
     QVariantList zoneSpanTriggers() const;
-    bool toggleActivation() const;
     bool showZonesOnAllMonitors() const;
     QStringList disabledMonitors() const;
     bool showZoneNumbers() const;
@@ -330,9 +333,10 @@ public:
 
     // Property setters
     void setDragActivationTriggers(const QVariantList& triggers);
+    void setAlwaysActivateOnDrag(bool enabled);
+    void setToggleActivation(bool enable);
     void setZoneSpanEnabled(bool enabled);
     void setZoneSpanTriggers(const QVariantList& triggers);
-    void setToggleActivation(bool enable);
     void setShowZonesOnAllMonitors(bool show);
     void setShowZoneNumbers(bool show);
     void setFlashZonesOnSwitch(bool flash);
@@ -481,9 +485,10 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void dragActivationTriggersChanged();
+    void alwaysActivateOnDragChanged();
+    void toggleActivationChanged();
     void zoneSpanEnabledChanged();
     void zoneSpanTriggersChanged();
-    void toggleActivationChanged();
     void showZonesOnAllMonitorsChanged();
     void disabledMonitorsChanged();
     void showZoneNumbersChanged();

--- a/kcm/ui/tabs/ZonesTab.qml
+++ b/kcm/ui/tabs/ZonesTab.qml
@@ -452,11 +452,24 @@ ScrollView {
                         Kirigami.FormData.label: i18n("Triggers")
                     }
 
+                    CheckBox {
+                        id: alwaysActivateCheck
+                        Layout.fillWidth: true
+                        Kirigami.FormData.label: i18n("Zone activation:")
+                        text: i18n("Activate on every window drag")
+                        checked: kcm.alwaysActivateOnDrag
+                        onToggled: kcm.alwaysActivateOnDrag = checked
+                        ToolTip.visible: hovered && root.isCurrentTab
+                        ToolTip.text: i18n("When enabled, the zone overlay appears on every window drag without requiring a modifier key or mouse button. Similar to FancyZones and KZones behavior.")
+                    }
+
                     ModifierAndMouseCheckBoxes {
                         id: dragActivationInput
                         Layout.fillWidth: true
                         Layout.preferredWidth: root.constants.sliderPreferredWidth
-                        Kirigami.FormData.label: i18n("Zone activation:")
+                        Kirigami.FormData.label: i18n("Hold to activate:")
+                        enabled: !alwaysActivateCheck.checked
+                        opacity: enabled ? 1 : 0.6
                         allowMultiple: true
                         acceptMode: acceptModeAll
                         triggers: kcm.dragActivationTriggers
@@ -471,6 +484,8 @@ ScrollView {
                     CheckBox {
                         Layout.fillWidth: true
                         Kirigami.FormData.label: i18n("Toggle mode:")
+                        enabled: !alwaysActivateCheck.checked
+                        opacity: enabled ? 1 : 0.6
                         text: i18n("Tap trigger to toggle overlay")
                         checked: kcm.toggleActivation
                         onToggled: kcm.toggleActivation = checked


### PR DESCRIPTION
## Summary
- Adds **"Activate on every window drag"** checkbox to the KCM Activation card, exposing `DragModifier::AlwaysActive` (enum 8) which already existed in the daemon and KWin effect but had no UI to enable it
- Writes the AlwaysActive trigger directly in storage format (`{modifier: 8}`), bypassing the lossy `enum→bitmask→enum` round-trip that silently converted AlwaysActive to None
- Modifier selector and toggle mode controls show as **disabled** (not hidden) when checked, following the existing UX pattern used by zone span and snap assist triggers

Closes #185

## Changes
| File | What |
|------|------|
| `kcm/kcm_plasmazones.h` | `alwaysActivateOnDrag` Q_PROPERTY, getter, setter, signal — grouped with drag activation properties |
| `kcm/kcm_plasmazones.cpp` | Getter scans triggers for `DragModifier::AlwaysActive`; setter writes/clears it directly; guarded signal emission in `setDragActivationTriggers` |
| `kcm/ui/tabs/ZonesTab.qml` | CheckBox before modifier input; `enabled`/`opacity` pattern on dependent controls |

## Test plan
- [ ] Build passes with zero errors and zero new warnings
- [ ] All existing tests pass
- [ ] Check "Activate on every window drag" → modifier selector and toggle mode show disabled at 0.6 opacity
- [ ] Uncheck → modifier selector and toggle mode re-enable, triggers revert to defaults (Alt)
- [ ] With checkbox checked, drag any window → zone overlay appears without holding a modifier
- [ ] Apply → close KCM → reopen → checkbox state persists
- [ ] Reset to Defaults → checkbox unchecks, triggers revert to Alt

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)