### PR TITLE
fix(autotile): isolate tiling per virtual desktop and activity

### DIFF
--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -9,6 +9,7 @@
 
 #include <effect/effecthandler.h>
 #include <effect/effectwindow.h>
+#include <virtualdesktops.h>
 #include <window.h>
 #include <workspace.h>
 
@@ -300,6 +301,16 @@ void AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
         return;
     }
 
+    // Skip windows not on the current virtual desktop or activity.
+    // Without this, windows on other desktops/activities are added to the
+    // tiling engine and affect the layout of the current desktop's windows.
+    if (!w->isOnCurrentDesktop() && !w->isOnAllDesktops()) {
+        return;
+    }
+    if (!w->isOnCurrentActivity()) {
+        return;
+    }
+
     const QString windowId = m_effect->getWindowId(w);
 
     // Window was already closed before we could notify open — skip (D-Bus ordering race)
@@ -354,20 +365,10 @@ void AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
     }
 }
 
-void AutotileHandler::onWindowClosed(const QString& windowId, const QString& screenName)
+void AutotileHandler::cleanupWindowTracking(const QString& windowId, const QString& screenName)
 {
-    // If we haven't notified the daemon about this window yet, record the close
-    // so we can suppress the open if it arrives late (D-Bus ordering race)
-    if (!m_notifiedWindows.contains(windowId) && m_autotileScreens.contains(screenName)) {
-        m_pendingCloses.insert(windowId);
-    }
-
-    // Remove from autotile tracking sets so re-opened windows get re-notified.
     m_notifiedWindows.remove(windowId);
     m_minimizeFloatedWindows.remove(windowId);
-
-    // Clean up borderless, monocle-maximize, deferred-centering, border zone, focus-follows-mouse,
-    // and pre-autotile tracking
     m_border.borderlessWindows.remove(windowId);
     m_border.zoneGeometries.remove(windowId);
     m_monocleMaximizedWindows.remove(windowId);
@@ -379,13 +380,23 @@ void AutotileHandler::onWindowClosed(const QString& windowId, const QString& scr
     if (m_preAutotileGeometries.contains(screenName)) {
         m_preAutotileGeometries[screenName].remove(windowId);
     }
-    // Remove from saved stacking orders so stale IDs don't accumulate
     if (m_savedSnapStackingOrder.contains(screenName)) {
         m_savedSnapStackingOrder[screenName].removeAll(windowId);
     }
     if (m_savedAutotileStackingOrder.contains(screenName)) {
         m_savedAutotileStackingOrder[screenName].removeAll(windowId);
     }
+}
+
+void AutotileHandler::onWindowClosed(const QString& windowId, const QString& screenName)
+{
+    // If we haven't notified the daemon about this window yet, record the close
+    // so we can suppress the open if it arrives late (D-Bus ordering race)
+    if (!m_notifiedWindows.contains(windowId) && m_autotileScreens.contains(screenName)) {
+        m_pendingCloses.insert(windowId);
+    }
+
+    cleanupWindowTracking(windowId, screenName);
 
     // Notify autotile daemon
     if (m_autotileScreens.contains(screenName)) {
@@ -449,6 +460,11 @@ void AutotileHandler::loadSettings()
             const QSet<QString> added(screens.begin(), screens.end());
             m_autotileScreens = added;
             qCInfo(lcEffect) << "Loaded autotile screens:" << m_autotileScreens;
+
+            // Initialize context key so first desktop/activity switch saves order
+            if (!added.isEmpty() && m_lastContextKey.isEmpty()) {
+                m_lastContextKey = currentContextKey();
+            }
 
             if (!added.isEmpty()) {
                 const auto windows = KWin::effects->stackingOrder();

--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -44,6 +44,9 @@ public:
 
     void notifyWindowAdded(KWin::EffectWindow* w);
     void onWindowClosed(const QString& windowId, const QString& screenName);
+    void onWindowDesktopsChanged(KWin::EffectWindow* w);
+    void onDesktopChanged();
+    void onActivityChanged();
     void onDaemonReady();
 
     // D-Bus signal connections and settings
@@ -134,6 +137,9 @@ private:
     // Utility methods
     // ═══════════════════════════════════════════════════════════════════
 
+    void refreshAutotileWindowSet();
+    void cleanupWindowTracking(const QString& windowId, const QString& screenName);
+    QString currentContextKey() const;
     void setWindowBorderless(KWin::EffectWindow* w, const QString& windowId, bool borderless);
     void unmaximizeMonocleWindow(const QString& windowId);
     bool saveAndRecordPreAutotileGeometry(const QString& windowId, const QString& screenName, const QRectF& frame);
@@ -173,6 +179,13 @@ private:
     QPointer<KWin::EffectWindow> m_pendingReactivateWindow; ///< re-activate after raise loop (daemon restart)
     QSet<QString> m_monocleMaximizedWindows;
     int m_suppressMaximizeChanged = 0;
+    // ── Virtual desktop/activity context tracking ──
+    // Tiled window order per screen, updated from slotWindowsTileRequested JSON.
+    // Used to preserve window positions across desktop/activity switches.
+    QHash<QString, QStringList> m_currentTiledOrder; ///< screenName → ordered windowIds
+    // Saved tiled orders per context key (desktopId|activityId → screen → order)
+    QHash<QString, QHash<QString, QStringList>> m_savedContextOrders;
+    QString m_lastContextKey; ///< Last desktop|activity context key
     // ── Focus follows mouse ──
     bool m_focusFollowsMouse = false;
     QString m_lastFocusFollowsMouseWindowId;

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -11,6 +11,7 @@
 
 #include <effect/effecthandler.h>
 #include <effect/effectwindow.h>
+#include <virtualdesktops.h>
 #include <window.h>
 #include <workspace.h>
 
@@ -40,6 +41,156 @@ void AutotileHandler::slotEnabledChanged(bool enabled)
         m_savedSnapStackingOrder.clear();
         m_savedAutotileStackingOrder.clear();
     }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Virtual desktop change handlers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+void AutotileHandler::onWindowDesktopsChanged(KWin::EffectWindow* w)
+{
+    if (!w || !m_effect->shouldHandleWindow(w) || !m_effect->isTileableWindow(w)) {
+        return;
+    }
+
+    const QString windowId = m_effect->getWindowId(w);
+    const QString screenName = m_effect->getWindowScreenName(w);
+    if (!m_autotileScreens.contains(screenName)) {
+        return;
+    }
+
+    const bool visibleNow = w->isOnCurrentDesktop() || w->isOnAllDesktops();
+    const bool wasNotified = m_notifiedWindows.contains(windowId);
+
+    if (wasNotified && !visibleNow) {
+        // Window moved away from current desktop — remove from autotile
+        qCInfo(lcEffect) << "Autotile: window moved to different desktop, removing:" << windowId;
+        onWindowClosed(windowId, screenName);
+    } else if (!wasNotified && visibleNow && !w->isMinimized()) {
+        // Window moved to current desktop — add to autotile
+        qCInfo(lcEffect) << "Autotile: window moved to current desktop, adding:" << windowId;
+        notifyWindowAdded(w);
+    }
+}
+
+void AutotileHandler::onDesktopChanged()
+{
+    qCInfo(lcEffect) << "Virtual desktop changed — refreshing autotile windows";
+    refreshAutotileWindowSet();
+}
+
+void AutotileHandler::onActivityChanged()
+{
+    qCInfo(lcEffect) << "Activity changed — refreshing autotile windows";
+    refreshAutotileWindowSet();
+}
+
+QString AutotileHandler::currentContextKey() const
+{
+    QString desktopId;
+    KWin::VirtualDesktop* desktop = KWin::effects->currentDesktop();
+    if (desktop) {
+        desktopId = desktop->id();
+    }
+    const QString activityId = KWin::effects->currentActivity();
+    return desktopId + QLatin1Char('|') + activityId;
+}
+
+void AutotileHandler::refreshAutotileWindowSet()
+{
+    if (m_autotileScreens.isEmpty()) {
+        return;
+    }
+
+    const QString newContextKey = currentContextKey();
+    const auto windows = KWin::effects->stackingOrder();
+
+    // ── Save outgoing context's tiled order ──
+    if (!m_lastContextKey.isEmpty() && m_lastContextKey != newContextKey) {
+        // Save current tiled orders for the context we're leaving
+        if (!m_currentTiledOrder.isEmpty()) {
+            m_savedContextOrders[m_lastContextKey] = m_currentTiledOrder;
+            qCDebug(lcEffect) << "Saved tiled order for context" << m_lastContextKey;
+        }
+    }
+
+    // ── Pass 1: Batch-remove windows no longer visible ──
+    QStringList toRemove;
+    for (KWin::EffectWindow* w : windows) {
+        if (!w || !m_effect->shouldHandleWindow(w)) {
+            continue;
+        }
+        const QString windowId = m_effect->getWindowId(w);
+        if (!m_notifiedWindows.contains(windowId)) {
+            continue;
+        }
+        const bool onDesktop = w->isOnCurrentDesktop() || w->isOnAllDesktops();
+        const bool onActivity = w->isOnCurrentActivity();
+        if (onDesktop && onActivity) {
+            continue;
+        }
+        const QString screenName = m_effect->getWindowScreenName(w);
+        if (m_autotileScreens.contains(screenName)) {
+            qCDebug(lcEffect) << "Context switch: removing" << windowId << "from autotile";
+            cleanupWindowTracking(windowId, screenName);
+            toRemove.append(windowId);
+        }
+    }
+
+    // Single D-Bus batch-close (daemon removes all, retiles each screen once)
+    if (!toRemove.isEmpty() && m_effect->m_daemonServiceRegistered) {
+        m_effect->fireAndForgetDBusCall(DBus::Interface::Autotile, QStringLiteral("windowsClosedBatch"),
+                                        {QVariant::fromValue(toRemove)}, QStringLiteral("windowsClosedBatch"));
+    }
+
+    // Clear local tiled order (all windows removed from outgoing context)
+    m_currentTiledOrder.clear();
+
+    // ── Restore saved window order for incoming context ──
+    const auto savedIt = m_savedContextOrders.constFind(newContextKey);
+    if (savedIt != m_savedContextOrders.constEnd()) {
+        // Send pre-seeded window orders to daemon before adding windows
+        const QHash<QString, QStringList>& savedOrders = savedIt.value();
+        if (m_effect->m_daemonServiceRegistered) {
+            for (auto oit = savedOrders.constBegin(); oit != savedOrders.constEnd(); ++oit) {
+                if (!oit.value().isEmpty() && m_autotileScreens.contains(oit.key())) {
+                    m_effect->fireAndForgetDBusCall(DBus::Interface::Autotile, QStringLiteral("setInitialWindowOrder"),
+                                                    {oit.key(), QVariant::fromValue(oit.value())},
+                                                    QStringLiteral("setInitialWindowOrder"));
+                    qCDebug(lcEffect) << "Restored tiled order for" << oit.key() << "context" << newContextKey << ":"
+                                      << oit.value().size() << "windows";
+                }
+            }
+        }
+    }
+
+    // ── Pass 2: Add windows now visible on current desktop + activity ──
+    for (KWin::EffectWindow* w : windows) {
+        if (!w || !m_effect->shouldHandleWindow(w) || !m_effect->isTileableWindow(w)) {
+            continue;
+        }
+        if (w->isMinimized()) {
+            continue;
+        }
+        if (!w->isOnCurrentDesktop() && !w->isOnAllDesktops()) {
+            continue;
+        }
+        if (!w->isOnCurrentActivity()) {
+            continue;
+        }
+        const QString windowId = m_effect->getWindowId(w);
+        if (m_notifiedWindows.contains(windowId)) {
+            continue; // Already in tiling (sticky window)
+        }
+        const QString screenName = m_effect->getWindowScreenName(w);
+        if (m_autotileScreens.contains(screenName)) {
+            qCDebug(lcEffect) << "Context switch: adding" << windowId << "to autotile";
+            saveAndRecordPreAutotileGeometry(windowId, screenName, w->frameGeometry());
+            notifyWindowAdded(w);
+        }
+    }
+
+    m_lastContextKey = newContextKey;
 }
 
 void AutotileHandler::slotScreensChanged(const QStringList& screenNames)

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -159,6 +159,16 @@ void AutotileHandler::slotWindowsTileRequested(const QString& tileRequestsJson)
         toApply.append({QPointer<KWin::EffectWindow>(e.window), e.geometry, e.windowId, screenName, e.isMonocle});
     }
 
+    // Update per-screen tiled window order cache for desktop/activity switch preservation.
+    // Group windowIds by screen in the order they appear (which is tiling order from daemon).
+    QHash<QString, QStringList> orderByScreen;
+    for (const TileSnap& snap : std::as_const(toApply)) {
+        orderByScreen[snap.screenName].append(snap.windowId);
+    }
+    for (auto it = orderByScreen.constBegin(); it != orderByScreen.constEnd(); ++it) {
+        m_currentTiledOrder[it.key()] = it.value();
+    }
+
     const uint64_t gen = m_autotileStaggerGeneration;
 
     auto onComplete = [this, toApply, tiledWindowIds, tileScreenNames, savedGlobalStack, gen]() {

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -347,6 +347,16 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     connect(KWin::effects, &KWin::EffectsHandler::virtualScreenGeometryChanged, m_screenChangeHandler.get(),
             &ScreenChangeHandler::slotScreenGeometryChanged);
 
+    // Refresh autotile windows on virtual desktop or activity switch so each
+    // context tiles independently (only windows on the active desktop/activity participate).
+    connect(KWin::effects, &KWin::EffectsHandler::desktopChanged, this,
+            [this](KWin::VirtualDesktop*, KWin::VirtualDesktop*, KWin::EffectWindow*) {
+                m_autotileHandler->onDesktopChanged();
+            });
+    connect(KWin::effects, &KWin::EffectsHandler::currentActivityChanged, this, [this](const QString&) {
+        m_autotileHandler->onActivityChanged();
+    });
+
     // Connect to daemon's settingsChanged D-Bus signal
     QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Settings,
                                           QStringLiteral("settingsChanged"), this, SLOT(slotSettingsChanged()));
@@ -611,6 +621,7 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
 
     connect(w, &KWin::EffectWindow::windowDesktopsChanged, this, [this](KWin::EffectWindow* window) {
         updateWindowStickyState(window);
+        m_autotileHandler->onWindowDesktopsChanged(window);
     });
 
     // Detect drag start/end via KWin's per-window signals instead of polling.

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -955,6 +955,15 @@ void AutotileEngine::windowClosed(const QString& windowId)
     onWindowRemoved(windowId);
 }
 
+void AutotileEngine::removeWindowOnly(const QString& windowId)
+{
+    if (!warnIfEmptyWindowId(windowId, "removeWindowOnly")) {
+        return;
+    }
+    m_savedFloatingWindows.remove(windowId);
+    removeWindow(windowId);
+}
+
 void AutotileEngine::windowFocused(const QString& windowId, const QString& screenName)
 {
     if (!warnIfEmptyWindowId(windowId, "windowFocused")) {

--- a/src/autotile/AutotileEngine.h
+++ b/src/autotile/AutotileEngine.h
@@ -534,6 +534,23 @@ public:
     void windowClosed(const QString& windowId) override;
 
     /**
+     * @brief Remove a window from tracking without triggering a retile
+     *
+     * Used by windowsClosedBatch() to remove multiple windows in one pass,
+     * deferring the retile until all removals are complete.
+     *
+     * @param windowId Window identifier from KWin
+     */
+    void removeWindowOnly(const QString& windowId);
+
+    /**
+     * @brief Get the screen name for a tracked window
+     * @param windowId Window identifier
+     * @return Screen name, or empty if not tracked
+     */
+    QString screenForWindow(const QString& windowId) const;
+
+    /**
      * @brief Notify the engine that a window was focused
      *
      * Called by Daemon when KWin reports window activation. Updates focus
@@ -661,7 +678,6 @@ private:
     void recalculateLayout(const QString& screenName);
     void applyTiling(const QString& screenName);
     bool shouldTileWindow(const QString& windowId) const;
-    QString screenForWindow(const QString& windowId) const;
     QRect screenGeometry(const QString& screenName) const;
 
     /**

--- a/src/dbus/autotileadaptor.cpp
+++ b/src/dbus/autotileadaptor.cpp
@@ -221,6 +221,44 @@ void AutotileAdaptor::windowClosed(const QString& windowId)
     m_engine->windowClosed(windowId);
 }
 
+void AutotileAdaptor::windowsClosedBatch(const QStringList& windowIds)
+{
+    if (!ensureEngine("windowsClosedBatch")) {
+        return;
+    }
+    if (windowIds.isEmpty()) {
+        return;
+    }
+    qCDebug(lcDbusAutotile) << "windowsClosedBatch: count=" << windowIds.size();
+
+    // Collect affected screens before removal (removeWindow clears m_windowToScreen)
+    QSet<QString> affectedScreens;
+    for (const QString& windowId : windowIds) {
+        const QString screen = m_engine->screenForWindow(windowId);
+        if (!screen.isEmpty()) {
+            affectedScreens.insert(screen);
+        }
+        m_engine->removeWindowOnly(windowId);
+    }
+
+    // Retile each affected screen exactly once
+    for (const QString& screen : std::as_const(affectedScreens)) {
+        m_engine->retileAfterOperation(screen, true);
+    }
+}
+
+void AutotileAdaptor::setInitialWindowOrder(const QString& screenName, const QStringList& windowIds)
+{
+    if (!ensureEngine("setInitialWindowOrder")) {
+        return;
+    }
+    if (screenName.isEmpty() || windowIds.isEmpty()) {
+        return;
+    }
+    qCDebug(lcDbusAutotile) << "setInitialWindowOrder: screen=" << screenName << "count=" << windowIds.size();
+    m_engine->setInitialWindowOrder(screenName, windowIds);
+}
+
 void AutotileAdaptor::notifyWindowFocused(const QString& windowId, const QString& screenName)
 {
     if (!ensureEngine("notifyWindowFocused")) {

--- a/src/dbus/autotileadaptor.h
+++ b/src/dbus/autotileadaptor.h
@@ -183,6 +183,29 @@ public Q_SLOTS:
     void windowClosed(const QString& windowId);
 
     /**
+     * @brief Batch-remove multiple windows without intermediate retiles
+     *
+     * Called by KWin effect on virtual desktop/activity switch to remove all
+     * windows leaving the current context in one operation. Retiles each
+     * affected screen exactly once after all removals complete.
+     *
+     * @param windowIds List of window IDs to remove
+     */
+    void windowsClosedBatch(const QStringList& windowIds);
+
+    /**
+     * @brief Pre-seed window insertion order for a screen
+     *
+     * When switching virtual desktops, the KWin effect saves the tiled window
+     * order before removing windows. On return, it sends the saved order so
+     * windows are re-inserted in their previous positions (master stays master).
+     *
+     * @param screenName Screen to set order for
+     * @param windowIds Window IDs in desired tiling order
+     */
+    void setInitialWindowOrder(const QString& screenName, const QStringList& windowIds);
+
+    /**
      * @brief Notify the daemon that a window has been focused
      *
      * Called by KWin effect when a window gains focus. This allows the


### PR DESCRIPTION
## Summary
- **Fixes autotile with multiple virtual desktops/activities** — windows on other desktops no longer corrupt the current desktop's tiling layout (#212)
- **Batch window removal** eliminates retile storm on desktop switch (N windows → 1 retile per screen instead of N retiles)
- **Window order preservation** across desktop switches — master/stack positions restored when returning to a previously-visited desktop

## Changes

### KWin Effect (filtering layer)
- `notifyWindowAdded()` now gates on `isOnCurrentDesktop()` + `isOnCurrentActivity()`, matching snapping behavior
- New `onDesktopChanged()` / `onActivityChanged()` → `refreshAutotileWindowSet()` handles full context transitions
- New `onWindowDesktopsChanged()` handles per-window desktop moves (e.g., "Send to Desktop 2")
- `slotWindowsTileRequested` caches tiled order per screen for order preservation
- Extracted `cleanupWindowTracking()` helper (DRY — shared by `onWindowClosed` and batch removal)

### Daemon (AutotileEngine + D-Bus adaptor)
- New `windowsClosedBatch(QStringList)` D-Bus method — removes all windows, retiles each affected screen once
- New `removeWindowOnly()` — removal without per-window retile (used by batch)
- New `setInitialWindowOrder(screenName, windowIds)` D-Bus method — pre-seeds window insertion order for desktop switch restoration
- `screenForWindow()` promoted from private to public (needed by batch adaptor)

## Test plan
- [ ] Open 3 windows on Desktop 1 with autotile enabled — verify they tile correctly
- [ ] Switch to Desktop 2, open 2 different windows — verify they tile independently (Desktop 1 windows unaffected)
- [ ] Switch back to Desktop 1 — verify original 3 windows restore to their previous tiling positions (master stays master)
- [ ] Move a window from Desktop 1 to Desktop 2 via right-click → verify it's removed from D1 tiling and added to D2
- [ ] Test with sticky (all desktops) window — verify it remains tiled across desktop switches
- [ ] Test with KDE Activities if available — verify same isolation behavior
- [ ] Verify 49/49 unit tests pass

Closes #212

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)