### PR TITLE
feat(autotile): drag-insert triggers for live stack reorder

### DIFF
--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -191,9 +191,10 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                         // where the user drops it, not snap back to a stored rect.
                         m_dragFloatedWindowIds.insert(windowId);
                     }
-                    // Stash pending dragStarted info so sendDeferredDragStarted()
-                    // can forward it to the daemon later if the autotile drag-insert
-                    // trigger gets engaged mid-drag (autotileDragInsertHeld path).
+                    // Stash pending dragStarted info so the autotile drag-insert
+                    // forwarding path (dragMoved when autotileDragInsertHeld) can
+                    // send a fresh dragStarted to the daemon if the trigger
+                    // engages mid-drag on this bypassed autotile screen.
                     m_dragStartedSent = false;
                     m_pendingDragWindowId = windowId;
                     m_pendingDragGeometry = geometry;
@@ -326,13 +327,16 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                         sendDragMovedBypassSafe(windowId, cursorPos, m_currentModifiers,
                                                 static_cast<int>(m_currentMouseButtons));
                     } else if (m_autotileDragInsertForwarded) {
-                        // Trigger released mid-drag: keep forwarding dragMoved so the
-                        // daemon sees the trigger state transition and cancels the
-                        // in-progress preview. After this one more tick the daemon
-                        // clears its state and subsequent dragMoveds are no-ops on
-                        // the autotile side.
+                        // Trigger released mid-drag: forward ONE final dragMoved so
+                        // the daemon sees the trigger state transition and cancels
+                        // the in-progress preview, then stop forwarding for the rest
+                        // of the drag to avoid 60Hz D-Bus traffic. The flag is reset
+                        // so we won't keep forwarding — but if the user presses the
+                        // trigger again we'll re-enter the insertHeld branch and
+                        // resume.
                         sendDragMovedBypassSafe(windowId, cursorPos, m_currentModifiers,
                                                 static_cast<int>(m_currentMouseButtons));
+                        m_autotileDragInsertForwarded = false;
                     }
                     return;
                 }

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -988,19 +988,27 @@ void PlasmaZonesEffect::slotMouseChanged(const QPointF& pos, const QPointF& oldp
             // to promote a pending drag to active (first tick with trigger
             // held) and when to hide the overlay (trigger released).
             //
+            // For bypass (autotile) drags, modifier changes must also flow
+            // so the daemon's autotile drag-insert rising-edge detection
+            // (hold and toggle modes) can fire without requiring cursor
+            // motion. Without this, tapping the trigger while stationary
+            // was silently dropped.
+            //
             // The daemon's updateDragCursor is cheap for pending drags
             // (returns early without running dragMoved), so the rapid fire
             // of modifier-change events during a drag no longer causes the
             // overlay destroy/create churn that prompted discussion #310's
             // sibling regression.
-            if (!m_dragBypassedForAutotile) {
-                if (detectActivationAndGrab() || m_cachedZoneSelectorEnabled || !m_triggersLoaded) {
-                    DBusHelpers::fireAndForget(this, DBus::Interface::WindowDrag, QStringLiteral("updateDragCursor"),
-                                               {m_dragTracker->draggedWindowId(), qRound(pos.x()), qRound(pos.y()),
-                                                static_cast<int>(m_currentModifiers),
-                                                static_cast<int>(m_currentMouseButtons)},
-                                               QStringLiteral("updateDragCursor - modifier/button change"));
-                }
+            const bool bypassed =
+                m_currentDragPolicy.bypassReason == QLatin1String("autotile_screen") || m_dragBypassedForAutotile;
+            const bool shouldForward =
+                bypassed || detectActivationAndGrab() || m_cachedZoneSelectorEnabled || !m_triggersLoaded;
+            if (shouldForward) {
+                DBusHelpers::fireAndForget(this, DBus::Interface::WindowDrag, QStringLiteral("updateDragCursor"),
+                                           {m_dragTracker->draggedWindowId(), qRound(pos.x()), qRound(pos.y()),
+                                            static_cast<int>(m_currentModifiers),
+                                            static_cast<int>(m_currentMouseButtons)},
+                                           QStringLiteral("updateDragCursor - modifier/button change"));
             }
         } else {
             // Position-only change: drive cursor tracking through DragTracker's
@@ -1663,6 +1671,9 @@ void PlasmaZonesEffect::loadCachedSettings()
     loadSettingAsync(QStringLiteral("toggleActivation"), [this](const QVariant& v) {
         m_cachedToggleActivation = v.toBool();
     });
+    loadSettingAsync(QStringLiteral("autotileDragInsertToggle"), [this](const QVariant& v) {
+        m_cachedAutotileDragInsertToggle = v.toBool();
+    });
     loadSettingAsync(QStringLiteral("zoneSelectorEnabled"), [this](const QVariant& v) {
         m_cachedZoneSelectorEnabled = v.toBool();
     });
@@ -1743,7 +1754,12 @@ bool PlasmaZonesEffect::detectActivationAndGrab()
     if (m_dragActivationDetected) {
         return true;
     }
-    if (anyLocalTriggerHeld() || m_cachedToggleActivation) {
+    // Autotile drag-insert toggle mode also forces activation so the daemon
+    // receives dragMoved ticks for rising-edge detection even when the drag
+    // started on a non-autotile screen and the user hasn't held any snap
+    // trigger. Without this, the cross-to-autotile policy flip never fires
+    // because the gate below (drag lambda, slotMouseChanged) swallows ticks.
+    if (anyLocalTriggerHeld() || m_cachedToggleActivation || m_cachedAutotileDragInsertToggle) {
         m_dragActivationDetected = true;
         if (!m_keyboardGrabbed) {
             KWin::effects->grabKeyboard(this);

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -191,8 +191,16 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                         // where the user drops it, not snap back to a stored rect.
                         m_dragFloatedWindowIds.insert(windowId);
                     }
+                    // Stash pending dragStarted info so sendDeferredDragStarted()
+                    // can forward it to the daemon later if the autotile drag-insert
+                    // trigger gets engaged mid-drag (autotileDragInsertHeld path).
+                    m_dragStartedSent = false;
+                    m_pendingDragWindowId = windowId;
+                    m_pendingDragGeometry = geometry;
+                    m_autotileDragInsertForwarded = false;
                     return;
                 }
+                m_autotileDragInsertForwarded = false;
                 m_dragBypassedForAutotile = false;
                 m_dragActivationDetected = false;
                 m_dragStartedSent = false;
@@ -280,17 +288,52 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                             m_dragBypassedForAutotile = true;
                             m_dragBypassScreenId = cursorScreenId; // Track the autotile VS we entered
                             m_dragStartedSent = false;
-                            m_pendingDragWindowId.clear();
-                            m_pendingDragGeometry = QRectF();
+                            // Preserve pending drag info so the autotile drag-insert path
+                            // can re-send dragStarted later if the trigger engages here.
+                            // (callCancelSnap cleared the daemon-side drag state, so we
+                            // have to send a fresh dragStarted before any dragMoved.)
+                            if (KWin::EffectWindow* draggedW = m_dragTracker->draggedWindow()) {
+                                m_pendingDragWindowId = windowId;
+                                m_pendingDragGeometry = draggedW->frameGeometry();
+                            } else {
+                                m_pendingDragWindowId.clear();
+                                m_pendingDragGeometry = QRectF();
+                            }
                             m_snapDragStartScreenId.clear();
+                            m_autotileDragInsertForwarded = false;
                             qCInfo(lcEffect)
                                 << "Drag crossed from snap to autotile" << cursorScreenId << "- deactivating zones";
                         }
                     }
                 }
 
-                // In autotile bypass — skip snap zone processing
+                // In autotile bypass — skip snap zone processing, but still
+                // forward dragStarted/dragMoved to the daemon when an autotile
+                // drag-insert trigger is held so the daemon can reorder the
+                // tiling stack live under the cursor.
                 if (m_dragBypassedForAutotile) {
+                    const bool insertHeld = autotileDragInsertHeld();
+                    if (insertHeld) {
+                        // Send dragStarted the first time we forward anything during
+                        // a bypassed drag (callDragStarted has no bypass guard). The
+                        // daemon needs this to populate m_draggedWindowId before
+                        // dragMoved early-returns on the mismatch.
+                        if (!m_dragStartedSent && !m_pendingDragWindowId.isEmpty()) {
+                            callDragStarted(m_pendingDragWindowId, m_pendingDragGeometry);
+                            m_dragStartedSent = true;
+                        }
+                        m_autotileDragInsertForwarded = true;
+                        sendDragMovedBypassSafe(windowId, cursorPos, m_currentModifiers,
+                                                static_cast<int>(m_currentMouseButtons));
+                    } else if (m_autotileDragInsertForwarded) {
+                        // Trigger released mid-drag: keep forwarding dragMoved so the
+                        // daemon sees the trigger state transition and cancels the
+                        // in-progress preview. After this one more tick the daemon
+                        // clears its state and subsequent dragMoveds are no-ops on
+                        // the autotile side.
+                        sendDragMovedBypassSafe(windowId, cursorPos, m_currentModifiers,
+                                                static_cast<int>(m_currentMouseButtons));
+                    }
                     return;
                 }
 
@@ -316,6 +359,22 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                 // Use the captured autotile state from drag start (not live m_autotileScreens)
                 // to ensure consistent behavior even if autotile screens changed mid-drag.
                 if (m_dragBypassedForAutotile) {
+                    // Autotile drag-insert: the daemon owns this drag. Forward
+                    // dragStopped so the daemon's drop.cpp commits the preview
+                    // (final retile places the window at its picked stack slot)
+                    // and skip the effect-side adoption fallbacks below — those
+                    // would fight the daemon's geometry application.
+                    if (m_autotileDragInsertForwarded) {
+                        callDragStopped(w, windowId, /*snapDragStartScreenId=*/{});
+                        m_autotileDragInsertForwarded = false;
+                        m_snapDragStartScreenId.clear();
+                        m_dragBypassedForAutotile = false;
+                        m_dragBypassScreenId.clear();
+                        m_dragStartedSent = false;
+                        m_pendingDragWindowId.clear();
+                        m_pendingDragGeometry = QRectF();
+                        return;
+                    }
                     if (!cancelled) {
                         const QString dropScreenId = w ? getWindowScreenId(w) : m_dragBypassScreenId;
                         const bool windowWasInAutotile = m_autotileHandler->isTrackedWindow(windowId);
@@ -1673,6 +1732,18 @@ void PlasmaZonesEffect::loadCachedSettings()
         });
     }
 
+    // autotileDragInsertTriggers — forwarded to daemon during autotile-bypassed
+    // drags so the stack can be reordered live. Same parsing pipeline as the
+    // snapping triggers above.
+    {
+        DBusHelpers::loadSettingAsync(this, QStringLiteral("autotileDragInsertTriggers"), [this](const QVariant& v) {
+            m_parsedAutotileDragInsertTriggers =
+                TriggerParser::parseTriggers(v, TriggerModifierField, TriggerMouseButtonField);
+            qCDebug(lcEffect) << "Loaded autotileDragInsertTriggers:" << m_parsedAutotileDragInsertTriggers.size()
+                              << "triggers";
+        });
+    }
+
     qCDebug(lcEffect) << "Loading cached settings asynchronously, using defaults until loaded";
 }
 
@@ -2819,14 +2890,28 @@ void PlasmaZonesEffect::callDragMoved(const QString& windowId, const QPointF& cu
     if (m_dragBypassedForAutotile) {
         return;
     }
+    sendDragMovedBypassSafe(windowId, cursorPos, mods, mouseButtons);
+}
 
-    // QDBusMessage::createMethodCall — purely local, no D-Bus introspection.
-    // See callDragStarted() comment for rationale.
+void PlasmaZonesEffect::sendDragMovedBypassSafe(const QString& windowId, const QPointF& cursorPos,
+                                                Qt::KeyboardModifiers mods, int mouseButtons)
+{
+    // Unguarded D-Bus dragMoved — the caller is responsible for deciding whether
+    // the daemon should see this event (e.g. autotile drag-insert path during a
+    // bypassed drag).
     QDBusMessage msg = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
                                                       QStringLiteral("dragMoved"));
     msg << windowId << static_cast<int>(cursorPos.x()) << static_cast<int>(cursorPos.y()) << static_cast<int>(mods)
         << mouseButtons;
     QDBusConnection::sessionBus().asyncCall(msg);
+}
+
+bool PlasmaZonesEffect::autotileDragInsertHeld() const
+{
+    if (m_parsedAutotileDragInsertTriggers.isEmpty()) {
+        return false;
+    }
+    return TriggerParser::anyTriggerHeld(m_parsedAutotileDragInsertTriggers, m_currentModifiers, m_currentMouseButtons);
 }
 
 void PlasmaZonesEffect::callDragStopped(KWin::EffectWindow* window, const QString& windowId,

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -150,6 +150,15 @@ private:
 
     void callDragStarted(const QString& windowId, const QRectF& geometry);
     void callDragMoved(const QString& windowId, const QPointF& cursorPos, Qt::KeyboardModifiers mods, int mouseButtons);
+    // Bypass-safe variant: sends dragMoved over D-Bus without the
+    // m_dragBypassedForAutotile early return in callDragMoved(). Used by the
+    // autotile drag-insert forwarding path so the daemon sees modifier state
+    // transitions while the cursor is on an autotile screen.
+    void sendDragMovedBypassSafe(const QString& windowId, const QPointF& cursorPos, Qt::KeyboardModifiers mods,
+                                 int mouseButtons);
+    // True when the current modifiers/buttons match any configured autotile
+    // drag-insert trigger. Empty list (not yet loaded) returns false.
+    bool autotileDragInsertHeld() const;
     void callDragStopped(KWin::EffectWindow* window, const QString& windowId,
                          const QString& snapDragStartScreenId = {});
     void callCancelSnap();
@@ -452,6 +461,16 @@ private:
     // Once real settings arrive, they override these conservative defaults.
     QVector<ParsedTrigger> m_parsedTriggers; // pre-parsed via TriggerParser::parseTriggers() at load time (avoids
                                              // QVariant unboxing in hot path)
+    // Autotile drag-insert triggers: forwarded to daemon even in autotile-bypass
+    // drags so the daemon can reorder the tiling stack live while the cursor is
+    // on an autotile screen. Populated async from Settings::autotileDragInsertTriggers.
+    QVector<ParsedTrigger> m_parsedAutotileDragInsertTriggers;
+    // True when the effect has started forwarding drag events to the daemon for
+    // an in-progress autotile drag-insert preview. Set when the trigger first
+    // engages during a bypassed drag, cleared on drag end. Used by the drag-end
+    // handler to ensure a matching callDragStopped is sent so the daemon commits
+    // or cancels the preview.
+    bool m_autotileDragInsertForwarded = false;
     bool m_triggersLoaded =
         false; // false until D-Bus reply arrives — permissive default bypasses trigger gating (#175)
     bool m_cachedToggleActivation = false;

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -540,6 +540,7 @@ private:
     bool m_triggersLoaded =
         false; // false until D-Bus reply arrives — permissive default bypasses trigger gating (#175)
     bool m_cachedToggleActivation = false;
+    bool m_cachedAutotileDragInsertToggle = false;
     bool m_cachedZoneSelectorEnabled = true; // true until proven false — ensures dragMoved passes through at startup
     int m_cachedAnimationSequenceMode = 0; // 0=all at once, 1=one by one in zone order
     int m_cachedAnimationDuration = 150; // ms, fallback until loaded from daemon

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -2350,7 +2350,6 @@ bool AutotileEngine::beginDragInsertPreview(const QString& windowId, const QStri
             targetState->setFloating(windowId, false);
             m_overflow.clearOverflow(windowId);
         }
-        preview.lastInsertIndex = targetState->tiledWindowIndex(windowId);
     } else {
         // Cross-screen adoption or fresh adoption: remove from prior state (if any)
         // and append to the target state's tiled list.
@@ -2367,12 +2366,33 @@ bool AutotileEngine::beginDragInsertPreview(const QString& windowId, const QStri
         }
         targetState->addWindow(windowId);
         m_windowToStateKey[windowId] = targetKey;
-        preview.lastInsertIndex = targetState->tiledWindowIndex(windowId);
     }
+
+    // Evict last tiled neighbour if adoption pushed us over the maxWindows cap.
+    // Skipped when the dragged window was already tiled on target (same-screen
+    // reorder with priorFloating=false) because that doesn't grow the count.
+    // setFloating preserves the victim's raw position in m_windowOrder, so cancel
+    // can restore it with a simple unfloat — no index bookkeeping needed.
+    const int maxWindows = m_config ? m_config->maxWindows : 0;
+    if (maxWindows > 0 && targetState->tiledWindowCount() > maxWindows) {
+        const QStringList tiled = targetState->tiledWindows();
+        for (int i = tiled.size() - 1; i >= 0; --i) {
+            if (tiled[i] != windowId) {
+                preview.evictedWindowId = tiled[i];
+                targetState->setFloating(tiled[i], true);
+                break;
+            }
+        }
+    }
+
+    preview.lastInsertIndex = targetState->tiledWindowIndex(windowId);
 
     if (preview.lastInsertIndex < 0) {
         // Something went wrong: window isn't in the tiled list after the setup above.
         // Roll back the prior-state capture so we don't leave the engine in a bad state.
+        if (!preview.evictedWindowId.isEmpty()) {
+            targetState->setFloating(preview.evictedWindowId, false);
+        }
         if (preview.hadPriorState && preview.priorSameScreen) {
             // Same-screen: we only mutated the floating flag (if priorFloating).
             // Re-float to restore the original state.
@@ -2443,6 +2463,7 @@ void AutotileEngine::commitDragInsertPreview()
     }
     const QString targetScreenId = m_dragInsertPreview->targetScreenId;
     const QString windowId = m_dragInsertPreview->windowId;
+    const QString evictedWindowId = m_dragInsertPreview->evictedWindowId;
     const bool crossScreenAdoption = m_dragInsertPreview->hadPriorState && !m_dragInsertPreview->priorSameScreen;
     const bool freshAdoption = !m_dragInsertPreview->hadPriorState;
     // Same-screen reorders that unfloated the window also need the WTS sync
@@ -2462,6 +2483,13 @@ void AutotileEngine::commitDragInsertPreview()
     if (crossScreenAdoption || freshAdoption || sameScreenUnfloat) {
         Q_EMIT windowFloatingStateSynced(windowId, false, targetScreenId);
     }
+    // Evicted neighbour: route through the batch-float path so the daemon
+    // restores its pre-tile geometry in one pass. Without this the victim
+    // would stay stuck in its old tile rect visually while flagged floating
+    // in TilingState.
+    if (!evictedWindowId.isEmpty()) {
+        Q_EMIT windowsBatchFloated(QStringList{evictedWindowId}, targetScreenId);
+    }
 }
 
 void AutotileEngine::cancelDragInsertPreview()
@@ -2473,6 +2501,13 @@ void AutotileEngine::cancelDragInsertPreview()
     m_dragInsertPreview.reset();
 
     TilingState* targetState = stateForScreen(p.targetScreenId);
+
+    // Restore eviction first: setFloating(false) returns the victim to its
+    // original raw-order slot, making the subsequent restoration logic see
+    // the same tiled list the user started with.
+    if (!p.evictedWindowId.isEmpty() && targetState) {
+        targetState->setFloating(p.evictedWindowId, false);
+    }
 
     if (p.hadPriorState && p.priorSameScreen) {
         // Same-screen path: window was already in targetState at begin time.
@@ -2528,21 +2563,23 @@ int AutotileEngine::computeDragInsertIndexAtPoint(const QString& screenId, const
         return 0;
     }
     const QStringList tiled = state->tiledWindows();
-    const QString draggedId = m_dragInsertPreview ? m_dragInsertPreview->windowId : QString();
     // Walk zones in order; return the first zone whose rect contains the cursor.
-    // Skip the dragged window's own zone so pointing at it doesn't match.
+    // Do NOT skip the dragged window's own zone — cursor-over-own-zone must be a
+    // stable identity (return its current index), otherwise we force a shuffle
+    // to some neighbour slot which immediately re-matches under the cursor and
+    // oscillates every dragMoved tick.
     const int limit = std::min(zones.size(), tiled.size());
     for (int i = 0; i < limit; ++i) {
-        if (tiled[i] == draggedId) {
-            continue;
-        }
         if (zones[i].contains(cursorPos)) {
             return i;
         }
     }
-    // Cursor isn't over any zone on this screen — fall back to the last
-    // non-dragged slot. updateDragInsertPreview() clamps to tileCount-1.
-    return tiled.size() > 0 ? tiled.size() - 1 : 0;
+    // Cursor isn't over any zone — hold the preview at its current index to
+    // avoid snapping to an endpoint when the cursor leaves the stack area.
+    if (m_dragInsertPreview && m_dragInsertPreview->lastInsertIndex >= 0) {
+        return m_dragInsertPreview->lastInsertIndex;
+    }
+    return tiled.isEmpty() ? 0 : tiled.size() - 1;
 }
 
 void AutotileEngine::applyTiling(const QString& screenId)

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -2334,14 +2334,29 @@ bool AutotileEngine::beginDragInsertPreview(const QString& windowId, const QStri
     if (preview.lastInsertIndex < 0) {
         // Something went wrong: window isn't in the tiled list after the setup above.
         // Roll back the prior-state capture so we don't leave the engine in a bad state.
-        if (preview.hadPriorState && !preview.priorSameScreen) {
+        if (preview.hadPriorState && preview.priorSameScreen) {
+            // Same-screen: we only mutated the floating flag (if priorFloating).
+            // Re-float to restore the original state.
+            if (preview.priorFloating) {
+                targetState->setFloating(windowId, true);
+            }
+        } else if (preview.hadPriorState) {
+            // Cross-screen: we removed from prior state and added to target.
+            // Undo both.
+            targetState->removeWindow(windowId);
             if (TilingState* priorState = m_screenStates.value(preview.priorKey)) {
                 priorState->addWindow(windowId, preview.priorRawIndex);
                 if (preview.priorFloating) {
                     priorState->setFloating(windowId, true);
                 }
                 m_windowToStateKey[windowId] = preview.priorKey;
+            } else {
+                m_windowToStateKey.remove(windowId);
             }
+        } else {
+            // Fresh adoption: just undo the add.
+            targetState->removeWindow(windowId);
+            m_windowToStateKey.remove(windowId);
         }
         return false;
     }
@@ -2391,17 +2406,21 @@ void AutotileEngine::commitDragInsertPreview()
     const QString windowId = m_dragInsertPreview->windowId;
     const bool crossScreenAdoption = m_dragInsertPreview->hadPriorState && !m_dragInsertPreview->priorSameScreen;
     const bool freshAdoption = !m_dragInsertPreview->hadPriorState;
+    // Same-screen reorders that unfloated the window also need the WTS sync
+    // below so the daemon drops its stale "floating" bookkeeping.
+    const bool sameScreenUnfloat = m_dragInsertPreview->hadPriorState && m_dragInsertPreview->priorSameScreen
+        && m_dragInsertPreview->priorFloating;
     m_dragInsertPreview.reset();
     // Retile target without the filter so the dragged window's geometry is
     // applied on the next windowsTiled emission (KWin's interactive move has
     // ended and will accept the geometry set).
     retileAfterOperation(targetScreenId, /*operationSucceeded=*/true);
-    // For adopted windows (cross-screen or fresh), emit a float-state sync
-    // signal so the daemon's WTS bridge clears any stale snap/float bookkeeping
-    // and records the window as tiled on the target screen. Passing floating=
-    // false routes through the no-restore path (windowFloatingStateSynced),
-    // avoiding the geometry-restore teleport of windowFloatingChanged.
-    if (crossScreenAdoption || freshAdoption) {
+    // Emit a float-state sync signal whenever the window's tiling/floating
+    // state changed as a result of this drag: cross-screen adoption, fresh
+    // adoption, or a same-screen unfloat. Passing floating=false routes
+    // through the no-restore path (windowFloatingStateSynced), avoiding the
+    // geometry-restore teleport of windowFloatingChanged.
+    if (crossScreenAdoption || freshAdoption || sameScreenUnfloat) {
         Q_EMIT windowFloatingStateSynced(windowId, false, targetScreenId);
     }
 }
@@ -2426,14 +2445,22 @@ void AutotileEngine::cancelDragInsertPreview()
             }
         }
     } else {
-        // Cross-screen / fresh adoption path: remove from target state.
-        if (targetState) {
-            targetState->removeWindow(p.windowId);
-        }
-        m_windowToStateKey.remove(p.windowId);
-        // Restore to the prior state if the window came from one.
-        if (p.hadPriorState) {
-            if (TilingState* priorState = m_screenStates.value(p.priorKey)) {
+        // Cross-screen / fresh adoption path. If the window came from another
+        // state that still exists, restore it there. If the prior state was
+        // evicted (desktop/VS reconfigure between begin and cancel) we cannot
+        // restore — in that case leave the window in target rather than
+        // orphaning it, and notify WTS so bookkeeping stays consistent.
+        TilingState* priorState = (p.hadPriorState) ? m_screenStates.value(p.priorKey) : nullptr;
+        if (p.hadPriorState && !priorState) {
+            // m_windowToStateKey already points at target from begin(); leave
+            // it there and let the window live in target state.
+            Q_EMIT windowFloatingStateSynced(p.windowId, false, p.targetScreenId);
+        } else {
+            if (targetState) {
+                targetState->removeWindow(p.windowId);
+            }
+            m_windowToStateKey.remove(p.windowId);
+            if (priorState) {
                 priorState->addWindow(p.windowId, p.priorRawIndex);
                 if (p.priorFloating) {
                     priorState->setFloating(p.windowId, true);
@@ -2465,15 +2492,17 @@ int AutotileEngine::computeDragInsertIndexAtPoint(const QString& screenId, const
     const QString draggedId = m_dragInsertPreview ? m_dragInsertPreview->windowId : QString();
     // Walk zones in order; return the first zone whose rect contains the cursor.
     // Skip the dragged window's own zone so pointing at it doesn't match.
-    for (int i = 0; i < zones.size(); ++i) {
-        if (i < tiled.size() && tiled[i] == draggedId) {
+    const int limit = std::min(zones.size(), tiled.size());
+    for (int i = 0; i < limit; ++i) {
+        if (tiled[i] == draggedId) {
             continue;
         }
         if (zones[i].contains(cursorPos)) {
             return i;
         }
     }
-    // Cursor isn't over any zone on this screen — fall back to end of stack.
+    // Cursor isn't over any zone on this screen — fall back to the last
+    // non-dragged slot. updateDragInsertPreview() clamps to tileCount-1.
     return tiled.size() > 0 ? tiled.size() - 1 : 0;
 }
 

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -2332,12 +2332,16 @@ bool AutotileEngine::beginDragInsertPreview(const QString& windowId, const QStri
     const TilingStateKey targetKey = currentKeyForScreen(screenId);
 
     // Capture prior engine state (if any) for restoration on cancel.
+    // Look up the prior TilingState once and reuse below to avoid a redundant
+    // m_screenStates hash lookup in the cross-screen branch.
+    TilingState* priorState = nullptr;
     auto it = m_windowToStateKey.constFind(windowId);
     if (it != m_windowToStateKey.constEnd()) {
         preview.hadPriorState = true;
         preview.priorKey = it.value();
         preview.priorSameScreen = (preview.priorKey == targetKey);
-        if (TilingState* priorState = m_screenStates.value(preview.priorKey)) {
+        priorState = m_screenStates.value(preview.priorKey);
+        if (priorState) {
             preview.priorRawIndex = priorState->windowOrder().indexOf(windowId);
             preview.priorFloating = priorState->isFloating(windowId);
         }
@@ -2353,10 +2357,8 @@ bool AutotileEngine::beginDragInsertPreview(const QString& windowId, const QStri
     } else {
         // Cross-screen adoption or fresh adoption: remove from prior state (if any)
         // and append to the target state's tiled list.
-        if (preview.hadPriorState) {
-            if (TilingState* priorState = m_screenStates.value(preview.priorKey)) {
-                priorState->removeWindow(windowId);
-            }
+        if (preview.hadPriorState && priorState) {
+            priorState->removeWindow(windowId);
         }
         if (targetState->containsWindow(windowId)) {
             // Defensive: stale m_screenStates entry left the window in the target

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -2268,12 +2268,227 @@ bool AutotileEngine::recalculateLayout(const QString& screenId)
     return true;
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// Drag-insert preview
+// ═══════════════════════════════════════════════════════════════════════════
+
+bool AutotileEngine::beginDragInsertPreview(const QString& windowId, const QString& screenId)
+{
+    if (windowId.isEmpty() || screenId.isEmpty() || !isAutotileScreen(screenId)) {
+        return false;
+    }
+    if (m_dragInsertPreview) {
+        // A preview is already active — cancel it first so we don't leak state.
+        cancelDragInsertPreview();
+    }
+    TilingState* targetState = stateForScreen(screenId);
+    if (!targetState) {
+        return false;
+    }
+
+    DragInsertPreview preview;
+    preview.windowId = windowId;
+    preview.targetScreenId = screenId;
+
+    const TilingStateKey targetKey = currentKeyForScreen(screenId);
+
+    // Capture prior engine state (if any) for restoration on cancel.
+    auto it = m_windowToStateKey.constFind(windowId);
+    if (it != m_windowToStateKey.constEnd()) {
+        preview.hadPriorState = true;
+        preview.priorKey = it.value();
+        preview.priorSameScreen = (preview.priorKey == targetKey);
+        if (TilingState* priorState = m_screenStates.value(preview.priorKey)) {
+            preview.priorRawIndex = priorState->windowOrder().indexOf(windowId);
+            preview.priorFloating = priorState->isFloating(windowId);
+        }
+    }
+
+    if (preview.hadPriorState && preview.priorSameScreen) {
+        // Same-screen reorder: unfloat if it was floating, otherwise leave in place.
+        // The first updateDragInsertPreview() call will reposition within the stack.
+        if (preview.priorFloating) {
+            targetState->setFloating(windowId, false);
+            m_overflow.clearOverflow(windowId);
+        }
+        preview.lastInsertIndex = targetState->tiledWindowIndex(windowId);
+    } else {
+        // Cross-screen adoption or fresh adoption: remove from prior state (if any)
+        // and append to the target state's tiled list.
+        if (preview.hadPriorState) {
+            if (TilingState* priorState = m_screenStates.value(preview.priorKey)) {
+                priorState->removeWindow(windowId);
+            }
+        }
+        if (targetState->containsWindow(windowId)) {
+            // Defensive: stale m_screenStates entry left the window in the target
+            // state without a matching m_windowToStateKey mapping. Remove it first
+            // so addWindow() can place it cleanly at the end.
+            targetState->removeWindow(windowId);
+        }
+        targetState->addWindow(windowId);
+        m_windowToStateKey[windowId] = targetKey;
+        preview.lastInsertIndex = targetState->tiledWindowIndex(windowId);
+    }
+
+    if (preview.lastInsertIndex < 0) {
+        // Something went wrong: window isn't in the tiled list after the setup above.
+        // Roll back the prior-state capture so we don't leave the engine in a bad state.
+        if (preview.hadPriorState && !preview.priorSameScreen) {
+            if (TilingState* priorState = m_screenStates.value(preview.priorKey)) {
+                priorState->addWindow(windowId, preview.priorRawIndex);
+                if (preview.priorFloating) {
+                    priorState->setFloating(windowId, true);
+                }
+                m_windowToStateKey[windowId] = preview.priorKey;
+            }
+        }
+        return false;
+    }
+
+    m_dragInsertPreview = preview;
+    // Retile target (filtered) so the dragged window is skipped in the batch
+    // while neighbours animate into the new layout.
+    retileAfterOperation(screenId, /*operationSucceeded=*/true);
+    // If we removed the window from a different screen, retile that one too so
+    // its remaining windows fill the gap left by the departure.
+    if (preview.hadPriorState && !preview.priorSameScreen) {
+        retileAfterOperation(preview.priorKey.screenId, /*operationSucceeded=*/true);
+    }
+    return true;
+}
+
+void AutotileEngine::updateDragInsertPreview(int insertIndex)
+{
+    if (!m_dragInsertPreview) {
+        return;
+    }
+    TilingState* state = stateForScreen(m_dragInsertPreview->targetScreenId);
+    if (!state) {
+        return;
+    }
+    const int tileCount = state->tiledWindowCount();
+    if (tileCount <= 0) {
+        return;
+    }
+    const int clamped = std::clamp(insertIndex, 0, tileCount - 1);
+    if (clamped == m_dragInsertPreview->lastInsertIndex) {
+        return; // No change — avoid redundant retile.
+    }
+    if (!state->moveToTiledPosition(m_dragInsertPreview->windowId, clamped)) {
+        return;
+    }
+    m_dragInsertPreview->lastInsertIndex = clamped;
+    retileAfterOperation(m_dragInsertPreview->targetScreenId, /*operationSucceeded=*/true);
+}
+
+void AutotileEngine::commitDragInsertPreview()
+{
+    if (!m_dragInsertPreview) {
+        return;
+    }
+    const QString targetScreenId = m_dragInsertPreview->targetScreenId;
+    const QString windowId = m_dragInsertPreview->windowId;
+    const bool crossScreenAdoption = m_dragInsertPreview->hadPriorState && !m_dragInsertPreview->priorSameScreen;
+    const bool freshAdoption = !m_dragInsertPreview->hadPriorState;
+    m_dragInsertPreview.reset();
+    // Retile target without the filter so the dragged window's geometry is
+    // applied on the next windowsTiled emission (KWin's interactive move has
+    // ended and will accept the geometry set).
+    retileAfterOperation(targetScreenId, /*operationSucceeded=*/true);
+    // For adopted windows (cross-screen or fresh), emit a float-state sync
+    // signal so the daemon's WTS bridge clears any stale snap/float bookkeeping
+    // and records the window as tiled on the target screen. Passing floating=
+    // false routes through the no-restore path (windowFloatingStateSynced),
+    // avoiding the geometry-restore teleport of windowFloatingChanged.
+    if (crossScreenAdoption || freshAdoption) {
+        Q_EMIT windowFloatingStateSynced(windowId, false, targetScreenId);
+    }
+}
+
+void AutotileEngine::cancelDragInsertPreview()
+{
+    if (!m_dragInsertPreview) {
+        return;
+    }
+    const DragInsertPreview p = *m_dragInsertPreview;
+    m_dragInsertPreview.reset();
+
+    TilingState* targetState = stateForScreen(p.targetScreenId);
+
+    if (p.hadPriorState && p.priorSameScreen) {
+        // Same-screen path: window was already in targetState at begin time.
+        // Move it back to its original raw index and restore floating flag.
+        if (targetState) {
+            targetState->moveToPosition(p.windowId, p.priorRawIndex);
+            if (p.priorFloating) {
+                targetState->setFloating(p.windowId, true);
+            }
+        }
+    } else {
+        // Cross-screen / fresh adoption path: remove from target state.
+        if (targetState) {
+            targetState->removeWindow(p.windowId);
+        }
+        m_windowToStateKey.remove(p.windowId);
+        // Restore to the prior state if the window came from one.
+        if (p.hadPriorState) {
+            if (TilingState* priorState = m_screenStates.value(p.priorKey)) {
+                priorState->addWindow(p.windowId, p.priorRawIndex);
+                if (p.priorFloating) {
+                    priorState->setFloating(p.windowId, true);
+                }
+                m_windowToStateKey[p.windowId] = p.priorKey;
+            }
+        }
+    }
+
+    retileAfterOperation(p.targetScreenId, /*operationSucceeded=*/true);
+    if (p.hadPriorState && !p.priorSameScreen) {
+        retileAfterOperation(p.priorKey.screenId, /*operationSucceeded=*/true);
+    }
+}
+
+int AutotileEngine::computeDragInsertIndexAtPoint(const QString& screenId, const QPoint& cursorPos) const
+{
+    // Const-correct lookup: avoid stateForScreen() which may create state.
+    auto it = m_screenStates.constFind(currentKeyForScreen(screenId));
+    if (it == m_screenStates.constEnd() || !it.value()) {
+        return -1;
+    }
+    const TilingState* state = it.value();
+    const QVector<QRect> zones = state->calculatedZones();
+    if (zones.isEmpty()) {
+        return 0;
+    }
+    const QStringList tiled = state->tiledWindows();
+    const QString draggedId = m_dragInsertPreview ? m_dragInsertPreview->windowId : QString();
+    // Walk zones in order; return the first zone whose rect contains the cursor.
+    // Skip the dragged window's own zone so pointing at it doesn't match.
+    for (int i = 0; i < zones.size(); ++i) {
+        if (i < tiled.size() && tiled[i] == draggedId) {
+            continue;
+        }
+        if (zones[i].contains(cursorPos)) {
+            return i;
+        }
+    }
+    // Cursor isn't over any zone on this screen — fall back to end of stack.
+    return tiled.size() > 0 ? tiled.size() - 1 : 0;
+}
+
 void AutotileEngine::applyTiling(const QString& screenId)
 {
     TilingState* state = stateForScreen(screenId);
     if (!state) {
         return;
     }
+
+    // Drag-insert preview: skip emitting geometry for the dragged window so
+    // KWin's interactive move isn't fought. Other windows still animate to
+    // their new tile positions, producing the OrderingPage-style shift.
+    const bool filterForPreview = m_dragInsertPreview && m_dragInsertPreview->targetScreenId == screenId;
+    const QString filteredWindowId = filterForPreview ? m_dragInsertPreview->windowId : QString();
 
     const QStringList windows = state->tiledWindows();
     const QVector<QRect> zones = state->calculatedZones();
@@ -2312,6 +2527,9 @@ void AutotileEngine::applyTiling(const QString& screenId)
                                 });
     QJsonArray arr;
     for (int i = 0; i < tileCount; ++i) {
+        if (filterForPreview && windows[i] == filteredWindowId) {
+            continue;
+        }
         const QRect& geo = zones[i];
         QJsonObject obj;
         obj[QLatin1String("windowId")] = windows[i];

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -415,6 +415,19 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
     const QSet<QString> added = screens - m_autotileScreens;
     const QSet<QString> removed = m_autotileScreens - screens;
 
+    // If an active drag-insert preview touches any screen being removed (or
+    // its prior screen), cancel it before states get torn down below. The
+    // cancel path restores the window to its prior location; otherwise the
+    // dangling preview would reference a TilingState about to be deleted.
+    if (m_dragInsertPreview) {
+        const QString targetScreen = m_dragInsertPreview->targetScreenId;
+        const QString priorScreen =
+            m_dragInsertPreview->hadPriorState ? m_dragInsertPreview->priorKey.screenId : QString();
+        if (removed.contains(targetScreen) || (!priorScreen.isEmpty() && removed.contains(priorScreen))) {
+            cancelDragInsertPreview();
+        }
+    }
+
     m_autotileScreens = screens;
 
     // R1 fix: Retile newly-added screens without requiring pre-existing state.
@@ -1695,6 +1708,23 @@ void AutotileEngine::windowClosed(const QString& rawWindowId)
     }
     const QString windowId = canonicalizeWindowId(rawWindowId);
 
+    // Drag-insert preview bookkeeping: if the closed window is involved in
+    // an active preview (as either the dragged window or the evicted
+    // neighbour), we must react before onWindowRemoved tears down state.
+    // Leaving a stale evictedWindowId would later drive setFloating or
+    // windowsBatchFloated on a dead window id.
+    if (m_dragInsertPreview) {
+        if (m_dragInsertPreview->windowId == windowId) {
+            // Dragged window closed mid-preview — drop the preview entirely.
+            // Cannot "restore" or "commit" a gone window; clear and move on.
+            m_dragInsertPreview.reset();
+        } else if (m_dragInsertPreview->evictedWindowId == windowId) {
+            // Evicted neighbour closed mid-preview — forget the eviction so
+            // commit/cancel don't try to operate on it.
+            m_dragInsertPreview->evictedWindowId.clear();
+        }
+    }
+
     // Clean up saved floating state even if window isn't currently tracked
     // (it may have been floating when autotile was disabled on its screen).
     // This must happen before onWindowRemoved because removeWindow() early-returns
@@ -2537,6 +2567,14 @@ void AutotileEngine::cancelDragInsertPreview()
             }
             m_windowToStateKey.remove(p.windowId);
             if (priorState) {
+                // Defensive: if the prior state was torn down and rebuilt
+                // between begin() and cancel(), it may already contain an
+                // entry for this window (e.g. the rebuild re-adopted it from
+                // a pending order). Mirror the begin() guard so addWindow()
+                // can place it at the captured raw index cleanly.
+                if (priorState->containsWindow(p.windowId)) {
+                    priorState->removeWindow(p.windowId);
+                }
                 priorState->addWindow(p.windowId, p.priorRawIndex);
                 if (p.priorFloating) {
                     priorState->setFloating(p.windowId, true);
@@ -2570,14 +2608,24 @@ int AutotileEngine::computeDragInsertIndexAtPoint(const QString& screenId, const
     // stable identity (return its current index), otherwise we force a shuffle
     // to some neighbour slot which immediately re-matches under the cursor and
     // oscillates every dragMoved tick.
+    //
+    // maxWindows may cap the layout so zones.size() < tiled.size(). In that
+    // case, windows past `limit` have no zone and can't be hit-tested. If the
+    // dragged window fell past the cap (e.g. evicted-to-floating in a tight
+    // monocle-style layout), the stable-identity contract can't hold — hold
+    // the preview at its last index instead.
     const int limit = std::min(zones.size(), tiled.size());
-    for (int i = 0; i < limit; ++i) {
-        if (zones[i].contains(cursorPos)) {
-            return i;
+    const int draggedIdx = m_dragInsertPreview ? tiled.indexOf(m_dragInsertPreview->windowId) : -1;
+    const bool draggedBeyondCap = draggedIdx >= 0 && draggedIdx >= limit;
+    if (!draggedBeyondCap) {
+        for (int i = 0; i < limit; ++i) {
+            if (zones[i].contains(cursorPos)) {
+                return i;
+            }
         }
     }
-    // Cursor isn't over any zone — hold the preview at its current index to
-    // avoid snapping to an endpoint when the cursor leaves the stack area.
+    // Cursor isn't over any zone (or the dragged window is past the cap) —
+    // hold the preview at its current index to avoid snapping to an endpoint.
     if (m_dragInsertPreview && m_dragInsertPreview->lastInsertIndex >= 0) {
         return m_dragInsertPreview->lastInsertIndex;
     }

--- a/src/autotile/AutotileEngine.h
+++ b/src/autotile/AutotileEngine.h
@@ -825,8 +825,10 @@ public:
      * @brief Compute the insert index for a cursor position on an autotile screen.
      *
      * Walks the screen's current calculated zones and returns the index of the
-     * zone that contains the cursor, or the tiled window count if the cursor
-     * is beyond all zones. Returns -1 if the screen has no tiling state.
+     * first zone that contains the cursor. Returns the last tiled index as a
+     * fallback when the cursor is beyond all zones, or -1 if the screen has no
+     * tiling state. updateDragInsertPreview() clamps to [0, tiledWindowCount()-1],
+     * so returning the last slot is equivalent to "append".
      *
      * The dragged window (if any active preview) is excluded from the hit test
      * so pointing at its own tile doesn't produce a no-op reinsert.
@@ -847,6 +849,14 @@ public:
     QString dragInsertPreviewWindowId() const
     {
         return m_dragInsertPreview ? m_dragInsertPreview->windowId : QString();
+    }
+
+    /**
+     * @brief Get the target screen ID of the active drag-insert preview, or empty.
+     */
+    QString dragInsertPreviewScreenId() const
+    {
+        return m_dragInsertPreview ? m_dragInsertPreview->targetScreenId : QString();
     }
 
     /**

--- a/src/autotile/AutotileEngine.h
+++ b/src/autotile/AutotileEngine.h
@@ -1361,6 +1361,13 @@ private:
         int priorRawIndex = -1; // Raw index in priorState->windowOrder() at begin
         bool priorFloating = false; // Prior floating flag in priorState
         bool priorSameScreen = false; // priorKey == currentKeyForScreen(targetScreenId)
+
+        // Eviction info (used when the target stack is already at maxWindows
+        // and the dragged window is a new member). The last tiled neighbour
+        // is floated to make room; on cancel the eviction is undone, on
+        // commit the evicted window is sent through the batch-float path so
+        // its pre-tile geometry is restored.
+        QString evictedWindowId;
     };
     std::optional<DragInsertPreview> m_dragInsertPreview;
 

--- a/src/autotile/AutotileEngine.h
+++ b/src/autotile/AutotileEngine.h
@@ -861,8 +861,10 @@ public:
      * tiling state. updateDragInsertPreview() clamps to [0, tiledWindowCount()-1],
      * so returning the last slot is equivalent to "append".
      *
-     * The dragged window (if any active preview) is excluded from the hit test
-     * so pointing at its own tile doesn't produce a no-op reinsert.
+     * The dragged window's zone is intentionally NOT excluded from the hit
+     * test: cursor-over-own-zone returns its current index (stable identity),
+     * preventing an oscillating shuffle where moving to a neighbour slot
+     * immediately re-matches under the cursor every dragMoved tick.
      */
     int computeDragInsertIndexAtPoint(const QString& screenId, const QPoint& cursorPos) const;
 

--- a/src/autotile/AutotileEngine.h
+++ b/src/autotile/AutotileEngine.h
@@ -17,6 +17,7 @@
 #include <QTimer>
 #include <functional>
 #include <memory>
+#include <optional>
 
 #include "OverflowManager.h"
 #include "core/utils.h"
@@ -781,6 +782,73 @@ public:
      */
     void scheduleRetileForScreen(const QString& screenId);
 
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Drag-insert preview (trigger-held window drag reorders autotile stack)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Begin a drag-insert preview for a window already tiled on a screen.
+     *
+     * Captures the window's current position so it can be restored on cancel.
+     * While a preview is active, applyTiling() skips emitting geometry for the
+     * dragged window — KWin's interactive move remains in control — but still
+     * animates the other windows shifting to leave a gap at the preview index.
+     *
+     * @return true if the window is tiled on the screen and preview was started.
+     */
+    bool beginDragInsertPreview(const QString& windowId, const QString& screenId);
+
+    /**
+     * @brief Update the target insert index for the active drag preview.
+     *
+     * Moves the dragged window within TilingState to the new index (clamped
+     * to [0, tiledWindowCount()-1]) and retiles. No-op if the index hasn't
+     * changed from the last update.
+     */
+    void updateDragInsertPreview(int insertIndex);
+
+    /**
+     * @brief Commit the active drag-insert preview.
+     *
+     * Clears preview state and retiles normally so the dragged window's
+     * geometry is applied (KWin is finishing the interactive move and will
+     * accept the geometry set).
+     */
+    void commitDragInsertPreview();
+
+    /**
+     * @brief Cancel the active drag-insert preview, restoring the original order.
+     */
+    void cancelDragInsertPreview();
+
+    /**
+     * @brief Compute the insert index for a cursor position on an autotile screen.
+     *
+     * Walks the screen's current calculated zones and returns the index of the
+     * zone that contains the cursor, or the tiled window count if the cursor
+     * is beyond all zones. Returns -1 if the screen has no tiling state.
+     *
+     * The dragged window (if any active preview) is excluded from the hit test
+     * so pointing at its own tile doesn't produce a no-op reinsert.
+     */
+    int computeDragInsertIndexAtPoint(const QString& screenId, const QPoint& cursorPos) const;
+
+    /**
+     * @brief Query whether a drag-insert preview is currently active.
+     */
+    bool hasDragInsertPreview() const
+    {
+        return m_dragInsertPreview.has_value();
+    }
+
+    /**
+     * @brief Get the window ID of the active drag-insert preview, or empty.
+     */
+    QString dragInsertPreviewWindowId() const
+    {
+        return m_dragInsertPreview ? m_dragInsertPreview->windowId : QString();
+    }
+
     /**
      * @brief Helper to retile a screen after a window operation
      *
@@ -1183,6 +1251,28 @@ private:
     // focus request arrives at KWin AFTER windowsTiled (whose onComplete raises
     // windows in tiling order). Without this, the raise loop buries the new window.
     QString m_pendingFocusWindowId;
+
+    // Drag-insert preview state. When set, applyTiling() filters the dragged
+    // window out of the windowsTiled batch so the KWin interactive move isn't
+    // fought, while the remaining windows animate into their new positions.
+    // Supports three entry modes (captured at begin() time for cancel restoration):
+    //   - Same-screen reorder: window was already tiled/floating on targetScreenId
+    //   - Cross-screen adoption: window was tracked on a different autotile screen
+    //   - Fresh adoption: window was not tracked by the engine at all
+    struct DragInsertPreview
+    {
+        QString windowId;
+        QString targetScreenId;
+        int lastInsertIndex = -1;
+
+        // Prior-state restoration info (used on cancel)
+        bool hadPriorState = false; // True if m_windowToStateKey contained windowId at begin
+        TilingStateKey priorKey; // Key of the prior TilingState (meaningful iff hadPriorState)
+        int priorRawIndex = -1; // Raw index in priorState->windowOrder() at begin
+        bool priorFloating = false; // Prior floating flag in priorState
+        bool priorSameScreen = false; // priorKey == currentKeyForScreen(targetScreenId)
+    };
+    std::optional<DragInsertPreview> m_dragInsertPreview;
 
     /**
      * @brief Process all pending retiles (fires via QueuedConnection)

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -35,13 +35,20 @@ public:
     // Activation Settings
     // ═══════════════════════════════════════════════════════════════════════════
 
+    // Build a single-entry trigger list with the given modifier and mouse
+    // button. Shared by the default accessors below so the canonical
+    // {modifier, mouseButton} shape lives in one place.
+    static QVariantList makeSingleTriggerList(int modifier, int mouseButton = 0)
+    {
+        QVariantMap trigger;
+        trigger[ConfigKeys::triggerModifierField()] = modifier;
+        trigger[ConfigKeys::triggerMouseButtonField()] = mouseButton;
+        return {trigger};
+    }
+
     static QVariantList dragActivationTriggers()
     {
-        // Default: single trigger with Alt modifier, no mouse button
-        QVariantMap trigger;
-        trigger[ConfigKeys::triggerModifierField()] = static_cast<int>(DragModifier::Alt);
-        trigger[ConfigKeys::triggerMouseButtonField()] = 0;
-        return {trigger};
+        return makeSingleTriggerList(static_cast<int>(DragModifier::Alt));
     }
     static bool toggleActivation()
     {
@@ -61,20 +68,13 @@ public:
     }
     static QVariantList zoneSpanTriggers()
     {
-        QVariantMap trigger;
-        trigger[ConfigKeys::triggerModifierField()] = zoneSpanModifier();
-        trigger[ConfigKeys::triggerMouseButtonField()] = 0;
-        return {trigger};
+        return makeSingleTriggerList(zoneSpanModifier());
     }
     static QVariantList autotileDragInsertTriggers()
     {
-        // Default: single trigger with Alt modifier, no mouse button.
         // Held while dragging a window to dynamically insert it into the
         // autotile stack at the cursor position.
-        QVariantMap trigger;
-        trigger[ConfigKeys::triggerModifierField()] = static_cast<int>(DragModifier::Alt);
-        trigger[ConfigKeys::triggerMouseButtonField()] = 0;
-        return {trigger};
+        return makeSingleTriggerList(static_cast<int>(DragModifier::Alt));
     }
     static bool autotileDragInsertToggle()
     {
@@ -428,10 +428,7 @@ public:
     static QVariantList snapAssistTriggers()
     {
         // Default: Middle mouse
-        QVariantMap trigger;
-        trigger[ConfigKeys::triggerModifierField()] = static_cast<int>(DragModifier::Disabled);
-        trigger[ConfigKeys::triggerMouseButtonField()] = static_cast<int>(Qt::MiddleButton);
-        return {trigger};
+        return makeSingleTriggerList(static_cast<int>(DragModifier::Disabled), static_cast<int>(Qt::MiddleButton));
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -76,6 +76,10 @@ public:
         trigger[ConfigKeys::triggerMouseButtonField()] = 0;
         return {trigger};
     }
+    static bool autotileDragInsertToggle()
+    {
+        return false;
+    }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Display Settings

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -66,6 +66,16 @@ public:
         trigger[ConfigKeys::triggerMouseButtonField()] = 0;
         return {trigger};
     }
+    static QVariantList autotileDragInsertTriggers()
+    {
+        // Default: single trigger with Alt modifier, no mouse button.
+        // Held while dragging a window to dynamically insert it into the
+        // autotile stack at the cursor position.
+        QVariantMap trigger;
+        trigger[ConfigKeys::triggerModifierField()] = static_cast<int>(DragModifier::Alt);
+        trigger[ConfigKeys::triggerMouseButtonField()] = 0;
+        return {trigger};
+    }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Display Settings

--- a/src/config/configkeys.h
+++ b/src/config/configkeys.h
@@ -75,6 +75,7 @@ public:
     PZ_CONFIG_GROUP(tilingAppearanceGroup, "Tiling.Appearance")
     PZ_CONFIG_GROUP(tilingAlgorithmGroup, "Tiling.Algorithm")
     PZ_CONFIG_GROUP(tilingBehaviorGroup, "Tiling.Behavior")
+    PZ_CONFIG_GROUP(tilingBehaviorTriggersGroup, "Tiling.Behavior.Triggers")
     PZ_CONFIG_GROUP(tilingAppearanceColorsGroup, "Tiling.Appearance.Colors")
     PZ_CONFIG_GROUP(tilingAppearanceDecorationsGroup, "Tiling.Appearance.Decorations")
     PZ_CONFIG_GROUP(tilingAppearanceBordersGroup, "Tiling.Appearance.Borders")

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -211,6 +211,8 @@ public:
                    autotileInsertPositionChanged)
     Q_PROPERTY(QVariantList autotileDragInsertTriggers READ autotileDragInsertTriggers WRITE
                    setAutotileDragInsertTriggers NOTIFY autotileDragInsertTriggersChanged)
+    Q_PROPERTY(bool autotileDragInsertToggle READ autotileDragInsertToggle WRITE setAutotileDragInsertToggle NOTIFY
+                   autotileDragInsertToggleChanged)
 
     // Animation Settings (applies to both snapping and autotiling geometry changes)
     Q_PROPERTY(bool animationsEnabled READ animationsEnabled WRITE setAnimationsEnabled NOTIFY animationsEnabledChanged)
@@ -982,6 +984,11 @@ public:
         return m_autotileDragInsertTriggers;
     }
     void setAutotileDragInsertTriggers(const QVariantList& triggers) override;
+    bool autotileDragInsertToggle() const override
+    {
+        return m_autotileDragInsertToggle;
+    }
+    void setAutotileDragInsertToggle(bool enable) override;
 
     // Autotile Shortcuts
     QString autotileToggleShortcut() const
@@ -1740,6 +1747,7 @@ private:
     int m_autotileMaxWindows = ConfigDefaults::autotileMaxWindows();
     AutotileInsertPosition m_autotileInsertPosition = AutotileInsertPosition::End;
     QVariantList m_autotileDragInsertTriggers; // [{modifier: int, mouseButton: int}, ...]
+    bool m_autotileDragInsertToggle = ConfigDefaults::autotileDragInsertToggle();
 
     // Animation Settings (applies to both snapping and autotiling geometry changes)
     bool m_animationsEnabled = ConfigDefaults::animationsEnabled();

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -209,6 +209,8 @@ public:
         int autotileMaxWindows READ autotileMaxWindows WRITE setAutotileMaxWindows NOTIFY autotileMaxWindowsChanged)
     Q_PROPERTY(int autotileInsertPosition READ autotileInsertPositionInt WRITE setAutotileInsertPositionInt NOTIFY
                    autotileInsertPositionChanged)
+    Q_PROPERTY(QVariantList autotileDragInsertTriggers READ autotileDragInsertTriggers WRITE
+                   setAutotileDragInsertTriggers NOTIFY autotileDragInsertTriggersChanged)
 
     // Animation Settings (applies to both snapping and autotiling geometry changes)
     Q_PROPERTY(bool animationsEnabled READ animationsEnabled WRITE setAnimationsEnabled NOTIFY animationsEnabledChanged)
@@ -975,6 +977,12 @@ public:
     }
     void setAutotileInsertPositionInt(int position);
 
+    QVariantList autotileDragInsertTriggers() const override
+    {
+        return m_autotileDragInsertTriggers;
+    }
+    void setAutotileDragInsertTriggers(const QVariantList& triggers) override;
+
     // Autotile Shortcuts
     QString autotileToggleShortcut() const
     {
@@ -1731,6 +1739,7 @@ private:
     bool m_autotileSmartGaps = ConfigDefaults::autotileSmartGaps();
     int m_autotileMaxWindows = ConfigDefaults::autotileMaxWindows();
     AutotileInsertPosition m_autotileInsertPosition = AutotileInsertPosition::End;
+    QVariantList m_autotileDragInsertTriggers; // [{modifier: int, mouseButton: int}, ...]
 
     // Animation Settings (applies to both snapping and autotiling geometry changes)
     bool m_animationsEnabled = ConfigDefaults::animationsEnabled();

--- a/src/config/settings/loadsave.cpp
+++ b/src/config/settings/loadsave.cpp
@@ -488,6 +488,8 @@ void Settings::loadAutotilingConfig(IConfigBackend* backend)
         m_autotileDragInsertTriggers =
             parseTriggerListJson(tilingBehaviorTriggers->readString(ConfigDefaults::triggersKey()))
                 .value_or(ConfigDefaults::autotileDragInsertTriggers());
+        m_autotileDragInsertToggle = tilingBehaviorTriggers->readBool(ConfigDefaults::toggleActivationKey(),
+                                                                      ConfigDefaults::autotileDragInsertToggle());
     }
     {
         auto tilingDecorations = backend->group(ConfigDefaults::tilingAppearanceDecorationsGroup());
@@ -895,6 +897,7 @@ void Settings::saveAutotilingConfig(IConfigBackend* backend)
     {
         auto tilingBehaviorTriggers = backend->group(ConfigDefaults::tilingBehaviorTriggersGroup());
         saveTriggerList(*tilingBehaviorTriggers, ConfigDefaults::triggersKey(), m_autotileDragInsertTriggers);
+        tilingBehaviorTriggers->writeBool(ConfigDefaults::toggleActivationKey(), m_autotileDragInsertToggle);
     }
     {
         auto tilingDecorations = backend->group(ConfigDefaults::tilingAppearanceDecorationsGroup());

--- a/src/config/settings/loadsave.cpp
+++ b/src/config/settings/loadsave.cpp
@@ -484,6 +484,12 @@ void Settings::loadAutotilingConfig(IConfigBackend* backend)
         }
     }
     {
+        auto tilingBehaviorTriggers = backend->group(ConfigDefaults::tilingBehaviorTriggersGroup());
+        m_autotileDragInsertTriggers =
+            parseTriggerListJson(tilingBehaviorTriggers->readString(ConfigDefaults::triggersKey()))
+                .value_or(ConfigDefaults::autotileDragInsertTriggers());
+    }
+    {
         auto tilingDecorations = backend->group(ConfigDefaults::tilingAppearanceDecorationsGroup());
         m_autotileHideTitleBars =
             tilingDecorations->readBool(ConfigDefaults::hideTitleBarsKey(), ConfigDefaults::autotileHideTitleBars());
@@ -885,6 +891,10 @@ void Settings::saveAutotilingConfig(IConfigBackend* backend)
         tilingBehavior->writeInt(ConfigDefaults::stickyWindowHandlingKey(),
                                  static_cast<int>(m_autotileStickyWindowHandling));
         tilingBehavior->writeString(ConfigDefaults::lockedScreensKey(), m_lockedScreens.join(QLatin1Char(',')));
+    }
+    {
+        auto tilingBehaviorTriggers = backend->group(ConfigDefaults::tilingBehaviorTriggersGroup());
+        saveTriggerList(*tilingBehaviorTriggers, ConfigDefaults::triggersKey(), m_autotileDragInsertTriggers);
     }
     {
         auto tilingDecorations = backend->group(ConfigDefaults::tilingAppearanceDecorationsGroup());

--- a/src/config/settings/setters.cpp
+++ b/src/config/settings/setters.cpp
@@ -26,6 +26,16 @@ void Settings::setDragActivationTriggers(const QVariantList& triggers)
     }
 }
 
+void Settings::setAutotileDragInsertTriggers(const QVariantList& triggers)
+{
+    QVariantList capped = triggers.mid(0, MaxTriggersPerAction);
+    if (m_autotileDragInsertTriggers != capped) {
+        m_autotileDragInsertTriggers = capped;
+        Q_EMIT autotileDragInsertTriggersChanged();
+        Q_EMIT settingsChanged();
+    }
+}
+
 void Settings::setZoneSpanModifier(DragModifier modifier)
 {
     if (m_zoneSpanModifier != modifier) {

--- a/src/config/settings/setters.cpp
+++ b/src/config/settings/setters.cpp
@@ -36,6 +36,8 @@ void Settings::setAutotileDragInsertTriggers(const QVariantList& triggers)
     }
 }
 
+SETTINGS_SETTER(bool, AutotileDragInsertToggle, m_autotileDragInsertToggle, autotileDragInsertToggleChanged)
+
 void Settings::setZoneSpanModifier(DragModifier modifier)
 {
     if (m_zoneSpanModifier != modifier) {

--- a/src/core/interfaces.h
+++ b/src/core/interfaces.h
@@ -132,6 +132,8 @@ public:
     // re-inserting a dragged window into the autotile stack.
     virtual QVariantList autotileDragInsertTriggers() const = 0;
     virtual void setAutotileDragInsertTriggers(const QVariantList& triggers) = 0;
+    virtual bool autotileDragInsertToggle() const = 0;
+    virtual void setAutotileDragInsertToggle(bool enable) = 0;
 
     // Rendering backend (pipeline-level, not specific to any sub-interface)
     virtual QString renderingBackend() const = 0;
@@ -146,6 +148,7 @@ Q_SIGNALS:
     void settingsChanged();
     void dragActivationTriggersChanged();
     void autotileDragInsertTriggersChanged();
+    void autotileDragInsertToggleChanged();
     void zoneSpanEnabledChanged();
     void zoneSpanModifierChanged();
     void zoneSpanTriggersChanged();

--- a/src/core/interfaces.h
+++ b/src/core/interfaces.h
@@ -97,6 +97,11 @@ public:
     virtual StickyWindowHandling autotileStickyWindowHandling() const = 0;
     virtual void setAutotileStickyWindowHandling(StickyWindowHandling handling) = 0;
 
+    // Autotile drag-insert triggers: hold-to-activate list for live
+    // re-inserting a dragged window into the autotile stack.
+    virtual QVariantList autotileDragInsertTriggers() const = 0;
+    virtual void setAutotileDragInsertTriggers(const QVariantList& triggers) = 0;
+
     // Rendering backend (pipeline-level, not specific to any sub-interface)
     virtual QString renderingBackend() const = 0;
     virtual void setRenderingBackend(const QString& backend) = 0;
@@ -109,6 +114,7 @@ public:
 Q_SIGNALS:
     void settingsChanged();
     void dragActivationTriggersChanged();
+    void autotileDragInsertTriggersChanged();
     void zoneSpanEnabledChanged();
     void zoneSpanModifierChanged();
     void zoneSpanTriggersChanged();

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -163,6 +163,12 @@ void Daemon::connectDesktopActivity()
         if (m_unifiedLayoutController) {
             m_unifiedLayoutController->setCurrentVirtualDesktop(desktop);
         }
+        // Desktop switch invalidates the TilingStateKey context — cancel any
+        // active drag-insert preview before the engine's desktop changes,
+        // otherwise cancel/commit would operate on the wrong TilingState.
+        if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
+            m_autotileEngine->cancelDragInsertPreview();
+        }
         // Pin screens where all autotiled windows are sticky (on all desktops)
         // BEFORE changing the desktop context. This ensures currentKeyForScreen()
         // continues to resolve existing TilingStates for screens managed by the
@@ -281,6 +287,11 @@ void Daemon::connectDesktopActivity()
                     m_layoutManager->setCurrentActivity(activityId);
                     if (m_unifiedLayoutController) {
                         m_unifiedLayoutController->setCurrentActivity(activityId);
+                    }
+                    // Activity switch invalidates the TilingStateKey context — cancel
+                    // any active drag-insert preview before the engine's activity changes.
+                    if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
+                        m_autotileEngine->cancelDragInsertPreview();
                     }
                     // Pin sticky screens before changing activity context
                     if (m_autotileEngine && m_windowTrackingAdaptor) {

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -211,6 +211,7 @@ void SettingsAdaptor::initializeRegistry()
     };
     m_schemas[QStringLiteral("autotileDragInsertTriggers")] = QStringLiteral("stringlist");
 
+    REGISTER_BOOL_SETTING("autotileDragInsertToggle", autotileDragInsertToggle, setAutotileDragInsertToggle)
     REGISTER_BOOL_SETTING("toggleActivation", toggleActivation, setToggleActivation)
     REGISTER_BOOL_SETTING("snappingEnabled", snappingEnabled, setSnappingEnabled)
 

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -199,6 +199,18 @@ void SettingsAdaptor::initializeRegistry()
     };
     m_schemas[QStringLiteral("zoneSpanTriggers")] = QStringLiteral("stringlist");
 
+    // Autotile drag-insert triggers list (multi-bind) — consumed by the KWin
+    // effect so it knows which modifier/mouse-button combos should forward
+    // dragMoved events to the daemon during an autotile-bypassed drag.
+    m_getters[QStringLiteral("autotileDragInsertTriggers")] = [this]() {
+        return QVariant::fromValue(m_settings->autotileDragInsertTriggers());
+    };
+    m_setters[QStringLiteral("autotileDragInsertTriggers")] = [this](const QVariant& v) {
+        m_settings->setAutotileDragInsertTriggers(v.toList());
+        return true;
+    };
+    m_schemas[QStringLiteral("autotileDragInsertTriggers")] = QStringLiteral("stringlist");
+
     REGISTER_BOOL_SETTING("toggleActivation", toggleActivation, setToggleActivation)
     REGISTER_BOOL_SETTING("snappingEnabled", snappingEnabled, setSnappingEnabled)
 

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -205,6 +205,13 @@ QStringList WindowDragAdaptor::zoneIdsToStringList(const QVector<QUuid>& ids)
 
 void WindowDragAdaptor::cancelSnap()
 {
+    // Cancel any active autotile drag-insert preview so neighbours snap back
+    // to their original order instead of sticking at the previewed position.
+    if (m_autotileDragInsertActive && m_autotileEngine) {
+        m_autotileEngine->cancelDragInsertPreview();
+        m_autotileDragInsertActive = false;
+        m_autotileDragInsertScreenId.clear();
+    }
     m_snapCancelled = true;
     m_triggerReleasedAfterCancel = false;
     m_activationToggled = false;
@@ -237,6 +244,11 @@ void WindowDragAdaptor::handleWindowClosed(const QString& windowId)
 
     // If this window was being dragged, clean up drag state
     if (windowId == m_draggedWindowId) {
+        if (m_autotileDragInsertActive && m_autotileEngine) {
+            m_autotileEngine->cancelDragInsertPreview();
+            m_autotileDragInsertActive = false;
+            m_autotileDragInsertScreenId.clear();
+        }
         unregisterCancelOverlayShortcut();
         hideOverlayAndClearZoneState();
 

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -207,10 +207,8 @@ void WindowDragAdaptor::cancelSnap()
 {
     // Cancel any active autotile drag-insert preview so neighbours snap back
     // to their original order instead of sticking at the previewed position.
-    if (m_autotileDragInsertActive && m_autotileEngine) {
+    if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
         m_autotileEngine->cancelDragInsertPreview();
-        m_autotileDragInsertActive = false;
-        m_autotileDragInsertScreenId.clear();
     }
     m_snapCancelled = true;
     m_triggerReleasedAfterCancel = false;
@@ -244,10 +242,8 @@ void WindowDragAdaptor::handleWindowClosed(const QString& windowId)
 
     // If this window was being dragged, clean up drag state
     if (windowId == m_draggedWindowId) {
-        if (m_autotileDragInsertActive && m_autotileEngine) {
+        if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
             m_autotileEngine->cancelDragInsertPreview();
-            m_autotileDragInsertActive = false;
-            m_autotileDragInsertScreenId.clear();
         }
         unregisterCancelOverlayShortcut();
         hideOverlayAndClearZoneState();

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -203,13 +203,18 @@ QStringList WindowDragAdaptor::zoneIdsToStringList(const QVector<QUuid>& ids)
     return result;
 }
 
+void WindowDragAdaptor::cancelDragInsertIfActive()
+{
+    if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
+        m_autotileEngine->cancelDragInsertPreview();
+    }
+}
+
 void WindowDragAdaptor::cancelSnap()
 {
     // Cancel any active autotile drag-insert preview so neighbours snap back
     // to their original order instead of sticking at the previewed position.
-    if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
-        m_autotileEngine->cancelDragInsertPreview();
-    }
+    cancelDragInsertIfActive();
     m_snapCancelled = true;
     m_triggerReleasedAfterCancel = false;
     m_activationToggled = false;
@@ -242,9 +247,7 @@ void WindowDragAdaptor::handleWindowClosed(const QString& windowId)
 
     // If this window was being dragged, clean up drag state
     if (windowId == m_draggedWindowId) {
-        if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
-            m_autotileEngine->cancelDragInsertPreview();
-        }
+        cancelDragInsertIfActive();
         unregisterCancelOverlayShortcut();
         hideOverlayAndClearZoneState();
 

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -307,6 +307,8 @@ private:
     bool m_triggerReleasedAfterCancel = false; // Tracks release→press cycle for retrigger after Escape
     bool m_activationToggled = false; // Current toggle state (on/off)
     bool m_prevTriggerHeld = false; // Previous frame's trigger state for edge detection
+    bool m_autotileDragInsertToggled = false; // Current toggle state for autotile drag-insert
+    bool m_prevAutotileDragInsertHeld = false; // Previous frame's autotile drag-insert trigger state
     bool m_overlayShown = false;
     bool m_zoneSelectorShown = false;
     int m_lastCursorX = 0;

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -235,6 +235,11 @@ private:
     // Pre-parsed trigger caches (populated on dragStarted, used on every dragMoved tick)
     QVector<ParsedTrigger> m_cachedActivationTriggers;
     QVector<ParsedTrigger> m_cachedZoneSpanTriggers;
+    QVector<ParsedTrigger> m_cachedAutotileDragInsertTriggers;
+
+    // Autotile drag-insert preview state (parallel to snapping's overlay state)
+    bool m_autotileDragInsertActive = false; // True while preview is live in the engine
+    QString m_autotileDragInsertScreenId; // Screen the preview is on
 
     // Last emitted zone geometry (emit only when changed)
     QRect m_lastEmittedZoneGeometry;

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -334,6 +334,9 @@ private:
     // (hasDragInsertPreview(), dragInsertPreviewScreenId()). The adaptor
     // queries the engine directly to avoid drift between the two caches.
 
+    // DRY helper: cancel any active autotile drag-insert preview.
+    void cancelDragInsertIfActive();
+
     // Last emitted zone geometry (emit only when changed)
     QRect m_lastEmittedZoneGeometry;
     bool m_restoreSizeEmittedDuringDrag = false;

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -237,9 +237,9 @@ private:
     QVector<ParsedTrigger> m_cachedZoneSpanTriggers;
     QVector<ParsedTrigger> m_cachedAutotileDragInsertTriggers;
 
-    // Autotile drag-insert preview state (parallel to snapping's overlay state)
-    bool m_autotileDragInsertActive = false; // True while preview is live in the engine
-    QString m_autotileDragInsertScreenId; // Screen the preview is on
+    // Autotile drag-insert preview state lives on AutotileEngine
+    // (hasDragInsertPreview(), dragInsertPreviewScreenId()). The adaptor
+    // queries the engine directly to avoid drift between the two caches.
 
     // Last emitted zone geometry (emit only when changed)
     QRect m_lastEmittedZoneGeometry;

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -404,7 +404,7 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
     // would otherwise starve this block for the entire remainder of the drag.
     // Autotile drag-insert lives on an independent trigger list, so it should
     // activate regardless of snap-overlay cancel state.
-    if (m_autotileEngine) {
+    if (m_autotileEngine && m_settings) {
         const bool rawAutotileInsertHeld = anyTriggerHeld(m_cachedAutotileDragInsertTriggers, mods, mouseButtons);
 
         // Toggle mode: detect rising edge (release→press) to flip insert-active state

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -40,8 +40,10 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
     m_cachedActivationTriggers = parseTriggers(m_settings->dragActivationTriggers());
     m_cachedZoneSpanTriggers = parseTriggers(m_settings->zoneSpanTriggers());
     m_cachedAutotileDragInsertTriggers = parseTriggers(m_settings->autotileDragInsertTriggers());
-    m_autotileDragInsertActive = false;
-    m_autotileDragInsertScreenId.clear();
+    // Ensure no stale preview carries over from a prior drag.
+    if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
+        m_autotileEngine->cancelDragInsertPreview();
+    }
 
     // Check if snapping is enabled
     if (!m_settings->snappingEnabled()) {
@@ -407,17 +409,24 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
         const bool onAutotileScreen =
             !autotileScreenId.isEmpty() && m_autotileEngine->isAutotileScreen(autotileScreenId);
 
+        const bool previewActive = m_autotileEngine->hasDragInsertPreview();
+        const QString previewScreenId = m_autotileEngine->dragInsertPreviewScreenId();
+
         if (autotileInsertHeld && onAutotileScreen) {
-            if (!m_autotileDragInsertActive) {
-                const bool began = m_autotileEngine->beginDragInsertPreview(windowId, autotileScreenId);
-                qCInfo(lcDbusWindow) << "autotile drag-insert preview begin:" << windowId << "on" << autotileScreenId
-                                     << "=>" << began;
-                if (began) {
-                    m_autotileDragInsertActive = true;
-                    m_autotileDragInsertScreenId = autotileScreenId;
-                }
+            // Cursor crossed between two autotile screens while the trigger is
+            // held: cancel the old preview before starting a fresh one on the
+            // new screen. Without this the old preview stays stuck on the
+            // departed screen until the trigger is released.
+            if (previewActive && previewScreenId != autotileScreenId) {
+                m_autotileEngine->cancelDragInsertPreview();
             }
-            if (m_autotileDragInsertActive && m_autotileDragInsertScreenId == autotileScreenId) {
+            if (!m_autotileEngine->hasDragInsertPreview()) {
+                const bool began = m_autotileEngine->beginDragInsertPreview(windowId, autotileScreenId);
+                qCDebug(lcDbusWindow) << "autotile drag-insert preview begin:" << windowId << "on" << autotileScreenId
+                                      << "=>" << began;
+            }
+            if (m_autotileEngine->hasDragInsertPreview()
+                && m_autotileEngine->dragInsertPreviewScreenId() == autotileScreenId) {
                 const int targetIdx =
                     m_autotileEngine->computeDragInsertIndexAtPoint(autotileScreenId, QPoint(cursorX, cursorY));
                 if (targetIdx >= 0) {
@@ -427,12 +436,10 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
                 m_lastCursorY = cursorY;
                 return;
             }
-        } else if (m_autotileDragInsertActive) {
+        } else if (previewActive) {
             // Trigger released or cursor left the autotile screen mid-drag —
             // cancel the preview so neighbours snap back to their original order.
             m_autotileEngine->cancelDragInsertPreview();
-            m_autotileDragInsertActive = false;
-            m_autotileDragInsertScreenId.clear();
         }
     }
 

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -39,6 +39,9 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
     // Pre-parse triggers to avoid QVariantMap unboxing on every dragMoved tick
     m_cachedActivationTriggers = parseTriggers(m_settings->dragActivationTriggers());
     m_cachedZoneSpanTriggers = parseTriggers(m_settings->zoneSpanTriggers());
+    m_cachedAutotileDragInsertTriggers = parseTriggers(m_settings->autotileDragInsertTriggers());
+    m_autotileDragInsertActive = false;
+    m_autotileDragInsertScreenId.clear();
 
     // Check if snapping is enabled
     if (!m_settings->snappingEnabled()) {
@@ -390,6 +393,48 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
 
     // Use pre-parsed triggers (cached on dragStarted) to avoid QVariantMap unboxing per tick.
     const bool triggerHeld = anyTriggerHeld(m_cachedActivationTriggers, mods, mouseButtons);
+
+    // ── Autotile drag-insert preview (runs even when m_snapCancelled) ───────
+    // This block is intentionally ABOVE the snap-cancelled early return because
+    // the KWin effect calls callCancelSnap() when the cursor crosses from a snap
+    // screen to an autotile screen mid-drag. That sets m_snapCancelled=true, and
+    // would otherwise starve this block for the entire remainder of the drag.
+    // Autotile drag-insert lives on an independent trigger list, so it should
+    // activate regardless of snap-overlay cancel state.
+    if (m_autotileEngine) {
+        const bool autotileInsertHeld = anyTriggerHeld(m_cachedAutotileDragInsertTriggers, mods, mouseButtons);
+        const QString autotileScreenId = effectiveScreenIdAt(cursorX, cursorY);
+        const bool onAutotileScreen =
+            !autotileScreenId.isEmpty() && m_autotileEngine->isAutotileScreen(autotileScreenId);
+
+        if (autotileInsertHeld && onAutotileScreen) {
+            if (!m_autotileDragInsertActive) {
+                const bool began = m_autotileEngine->beginDragInsertPreview(windowId, autotileScreenId);
+                qCInfo(lcDbusWindow) << "autotile drag-insert preview begin:" << windowId << "on" << autotileScreenId
+                                     << "=>" << began;
+                if (began) {
+                    m_autotileDragInsertActive = true;
+                    m_autotileDragInsertScreenId = autotileScreenId;
+                }
+            }
+            if (m_autotileDragInsertActive && m_autotileDragInsertScreenId == autotileScreenId) {
+                const int targetIdx =
+                    m_autotileEngine->computeDragInsertIndexAtPoint(autotileScreenId, QPoint(cursorX, cursorY));
+                if (targetIdx >= 0) {
+                    m_autotileEngine->updateDragInsertPreview(targetIdx);
+                }
+                m_lastCursorX = cursorX;
+                m_lastCursorY = cursorY;
+                return;
+            }
+        } else if (m_autotileDragInsertActive) {
+            // Trigger released or cursor left the autotile screen mid-drag —
+            // cancel the preview so neighbours snap back to their original order.
+            m_autotileEngine->cancelDragInsertPreview();
+            m_autotileDragInsertActive = false;
+            m_autotileDragInsertScreenId.clear();
+        }
+    }
 
     if (m_snapCancelled) {
         // Allow retriggering the overlay after Escape: the user must release the

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -41,9 +41,7 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
     m_cachedZoneSpanTriggers = parseTriggers(m_settings->zoneSpanTriggers());
     m_cachedAutotileDragInsertTriggers = parseTriggers(m_settings->autotileDragInsertTriggers());
     // Ensure no stale preview carries over from a prior drag.
-    if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
-        m_autotileEngine->cancelDragInsertPreview();
-    }
+    cancelDragInsertIfActive();
 
     // Check if snapping is enabled
     if (!m_settings->snappingEnabled()) {

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -73,7 +73,12 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
     m_snapCancelled = false;
     m_triggerReleasedAfterCancel = false;
     m_activationToggled = false;
-    m_prevTriggerHeld = false;
+    // Seeded true so the first dragMoved tick can't register a spurious
+    // rising edge when the drag was initiated with the activation trigger
+    // already held (e.g. Alt+Click, where Alt is KWin's move-window modifier
+    // and is also commonly the configured snap activation trigger). The user
+    // must perform a real release→press cycle to toggle.
+    m_prevTriggerHeld = true;
     m_overlayShown = false;
     m_zoneSelectorShown = false;
     m_lastCursorX = 0;
@@ -400,7 +405,20 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
     // Autotile drag-insert lives on an independent trigger list, so it should
     // activate regardless of snap-overlay cancel state.
     if (m_autotileEngine) {
-        const bool autotileInsertHeld = anyTriggerHeld(m_cachedAutotileDragInsertTriggers, mods, mouseButtons);
+        const bool rawAutotileInsertHeld = anyTriggerHeld(m_cachedAutotileDragInsertTriggers, mods, mouseButtons);
+
+        // Toggle mode: detect rising edge (release→press) to flip insert-active state
+        bool autotileInsertHeld;
+        if (m_settings->autotileDragInsertToggle()) {
+            if (rawAutotileInsertHeld && !m_prevAutotileDragInsertHeld) {
+                m_autotileDragInsertToggled = !m_autotileDragInsertToggled;
+            }
+            m_prevAutotileDragInsertHeld = rawAutotileInsertHeld;
+            autotileInsertHeld = m_autotileDragInsertToggled;
+        } else {
+            autotileInsertHeld = rawAutotileInsertHeld;
+        }
+
         const QString autotileScreenId = effectiveScreenIdAt(cursorX, cursorY);
         const bool onAutotileScreen =
             !autotileScreenId.isEmpty() && m_autotileEngine->isAutotileScreen(autotileScreenId);

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -83,6 +83,17 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
     // cleanly must not bleed into this one.
     clearPendingSnapDragState();
 
+    // Reset autotile drag-insert toggle state on every drag start. This runs
+    // before branching so it covers both the bypass path (drag starts on an
+    // autotile screen, dragStarted() is never called) and the snap path.
+    // Prev is seeded to true so the first dragMoved tick can't register a
+    // spurious rising edge when the user initiated the drag with the autotile
+    // trigger already held (e.g. Alt+Click, where Alt is KWin's move-window
+    // modifier and also the default drag-insert trigger). The user must
+    // release and re-press to toggle.
+    m_autotileDragInsertToggled = false;
+    m_prevAutotileDragInsertHeld = true;
+
     const int curDesktop = m_layoutManager ? m_layoutManager->currentVirtualDesktop() : 0;
     const QString curActivity = m_layoutManager ? m_layoutManager->currentActivity() : QString();
     const DragPolicy policy =

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -80,7 +80,9 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
     }
 
     // Any stale pending state from a previous drag that didn't complete
-    // cleanly must not bleed into this one.
+    // cleanly must not bleed into this one. clearPendingSnapDragState also
+    // cancels any leftover drag-insert preview so a new drag always starts
+    // from a clean slate.
     clearPendingSnapDragState();
 
     // Reset autotile drag-insert toggle state on every drag start. This runs
@@ -93,6 +95,16 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
     // release and re-press to toggle.
     m_autotileDragInsertToggled = false;
     m_prevAutotileDragInsertHeld = true;
+
+    // Cache autotile drag-insert triggers unconditionally. The snap path may
+    // defer dragStarted (where the cache was historically populated) until
+    // the user first holds a snap activation trigger. If drag-insert fires
+    // before that (e.g. user holds the drag-insert trigger directly, or the
+    // cursor crosses to an autotile screen and the policy flips to bypass),
+    // dragMoved would otherwise read a stale cache from the previous drag.
+    if (m_settings) {
+        m_cachedAutotileDragInsertTriggers = parseTriggers(m_settings->autotileDragInsertTriggers());
+    }
 
     const int curDesktop = m_layoutManager ? m_layoutManager->currentVirtualDesktop() : 0;
     const QString curActivity = m_layoutManager ? m_layoutManager->currentActivity() : QString();
@@ -109,19 +121,12 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
     if (!policy.bypassReason.isEmpty()) {
         // Bypass path — record the id so the matching endDrag can find us,
         // but skip the full snap-path setup (overlay, zone state, etc.).
+        // Trigger cache and stale-preview cleanup both happen above so bypass
+        // and snap paths behave identically.
         m_draggedWindowId = windowId;
         m_originalGeometry = QRect(frameX, frameY, frameWidth, frameHeight);
         m_snapCancelled = false;
         m_wasSnapped = false;
-        // Autotile drag-insert lives on the bypass path (cursor on an
-        // autotile screen). dragMoved's drag-insert preview block reads
-        // m_cachedAutotileDragInsertTriggers, so cache them here — the
-        // legacy dragStarted setup that normally does this never runs for
-        // bypass drags. Any stale preview from a prior drag is cleared too.
-        if (m_settings) {
-            m_cachedAutotileDragInsertTriggers = parseTriggers(m_settings->autotileDragInsertTriggers());
-        }
-        cancelDragInsertIfActive();
         return policy;
     }
 
@@ -188,6 +193,10 @@ void WindowDragAdaptor::clearPendingSnapDragState()
     m_pendingSnapDragGeometry = QRect();
     m_pendingSnapDragMouseButtons = 0;
     m_pendingSnapDragWasSnapped = false;
+    // Any drag-insert preview left over from an incomplete previous drag
+    // (daemon lost track, client disconnect, snapping-disabled flip, etc.)
+    // must be cleared too — its referenced window may no longer exist.
+    cancelDragInsertIfActive();
 }
 
 DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int cursorY, int modifiers,

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -110,9 +110,7 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
         if (m_settings) {
             m_cachedAutotileDragInsertTriggers = parseTriggers(m_settings->autotileDragInsertTriggers());
         }
-        if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
-            m_autotileEngine->cancelDragInsertPreview();
-        }
+        cancelDragInsertIfActive();
         return policy;
     }
 
@@ -245,9 +243,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
             // Bypass paths — no overlay state to clean up; just drop the id.
             // An active autotile drag-insert preview must be cancelled so
             // neighbours snap back to their original order.
-            if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
-                m_autotileEngine->cancelDragInsertPreview();
-            }
+            cancelDragInsertIfActive();
             m_draggedWindowId.clear();
         }
         outcome.action = DragOutcome::CancelSnap;

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -40,6 +40,19 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
         return;
     }
 
+    // ── Autotile drag-insert commit ─────────────────────────────────────────
+    // If a drag-insert preview is live, finalize it: commit the reorder so the
+    // dragged window's final geometry is applied on the next retile. Snapping
+    // logic is skipped entirely — the window's place in the stack IS the drop.
+    if (m_autotileDragInsertActive && m_autotileEngine) {
+        m_autotileEngine->commitDragInsertPreview();
+        m_autotileDragInsertActive = false;
+        m_autotileDragInsertScreenId.clear();
+        hideOverlayAndSelector();
+        resetDragState();
+        return;
+    }
+
     // Release screen: use cursor position passed from effect (at release time), not last dragMoved.
     // Resolve the effective (virtual-aware) screen ID so zones are calculated against
     // virtual screen bounds, not physical screen bounds.
@@ -286,9 +299,10 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
             // Use screen-filtered occupancy — without this, zones occupied on
             // other screens appear occupied here when layouts share zone IDs.
             QSet<QUuid> occupied = m_windowTracking->service()->buildOccupiedZoneSet(releaseScreenId);
-            EmptyZoneList emptyZones = GeometryUtils::buildEmptyZoneList(
-                layout, releaseScreenId, releaseScreen, m_settings,
-                [&occupied](const Zone* z) { return !occupied.contains(z->id()); });
+            EmptyZoneList emptyZones = GeometryUtils::buildEmptyZoneList(layout, releaseScreenId, releaseScreen,
+                                                                         m_settings, [&occupied](const Zone* z) {
+                                                                             return !occupied.contains(z->id());
+                                                                         });
             if (!emptyZones.isEmpty()) {
                 snapAssistRequestedOut = true;
                 emptyZonesOut = emptyZones;

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -44,10 +44,8 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
     // If a drag-insert preview is live, finalize it: commit the reorder so the
     // dragged window's final geometry is applied on the next retile. Snapping
     // logic is skipped entirely — the window's place in the stack IS the drop.
-    if (m_autotileDragInsertActive && m_autotileEngine) {
+    if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
         m_autotileEngine->commitDragInsertPreview();
-        m_autotileDragInsertActive = false;
-        m_autotileDragInsertScreenId.clear();
         hideOverlayAndSelector();
         resetDragState();
         return;

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -45,7 +45,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
     // dragged window's final geometry is applied on the next retile. Snapping
     // logic is skipped entirely — the window's place in the stack IS the drop.
     if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
-        m_autotileEngine->commitDragInsertPreview();
+        m_autotileEngine->commitDragInsertPreview(); // commit, not cancel — drop finalizes the reorder
         hideOverlayAndSelector();
         resetDragState();
         return;

--- a/src/settings/qml/TilingBehaviorPage.qml
+++ b/src/settings/qml/TilingBehaviorPage.qml
@@ -9,6 +9,8 @@ import org.kde.kirigami as Kirigami
 Flickable {
     id: root
 
+    readonly property int triggerPreferredWidth: Kirigami.Units.gridUnit * 16
+
     contentHeight: content.implicitHeight
     clip: true
 
@@ -17,6 +19,39 @@ Flickable {
 
         width: parent.width
         spacing: Kirigami.Units.largeSpacing
+
+        // =================================================================
+        // Triggers Card
+        // =================================================================
+        SettingsCard {
+            Layout.fillWidth: true
+            headerText: i18n("Triggers")
+            collapsible: true
+
+            contentItem: ColumnLayout {
+                spacing: Kirigami.Units.smallSpacing
+
+                SettingsRow {
+                    title: i18n("Hold to re-insert into stack")
+                    description: i18n("Hold a modifier or mouse button while dragging a window to dynamically insert it into the autotile stack at the cursor position")
+
+                    ModifierAndMouseCheckBoxes {
+                        width: Math.min(root.triggerPreferredWidth, Kirigami.Units.gridUnit * 16)
+                        allowMultiple: true
+                        acceptMode: acceptModeAll
+                        triggers: settingsController.autotileDragInsertTriggers
+                        defaultTriggers: settingsController.defaultAutotileDragInsertTriggers
+                        tooltipEnabled: false
+                        onTriggersModified: (triggers) => {
+                            settingsController.autotileDragInsertTriggers = triggers;
+                        }
+                    }
+
+                }
+
+            }
+
+        }
 
         // =================================================================
         // Behavior Card

--- a/src/settings/qml/TilingBehaviorPage.qml
+++ b/src/settings/qml/TilingBehaviorPage.qml
@@ -36,7 +36,7 @@ Flickable {
                     description: i18n("Hold a modifier or mouse button while dragging a window to dynamically insert it into the autotile stack at the cursor position")
 
                     ModifierAndMouseCheckBoxes {
-                        width: Math.min(root.triggerPreferredWidth, Kirigami.Units.gridUnit * 16)
+                        width: root.triggerPreferredWidth
                         allowMultiple: true
                         acceptMode: acceptModeAll
                         triggers: settingsController.autotileDragInsertTriggers

--- a/src/settings/qml/TilingBehaviorPage.qml
+++ b/src/settings/qml/TilingBehaviorPage.qml
@@ -32,8 +32,29 @@ Flickable {
                 spacing: Kirigami.Units.smallSpacing
 
                 SettingsRow {
+                    title: i18n("Always re-insert on drag")
+                    description: i18n("Dynamically insert dragged windows into the autotile stack at the cursor position without requiring a modifier key or mouse button")
+
+                    SettingsSwitch {
+                        id: alwaysReinsertSwitch
+
+                        checked: settingsController.alwaysReinsertIntoStack
+                        accessibleName: i18n("Always re-insert into stack on drag")
+                        onToggled: function(newValue) {
+                            settingsController.alwaysReinsertIntoStack = newValue;
+                        }
+                    }
+
+                }
+
+                SettingsSeparator {
+                }
+
+                SettingsRow {
                     title: i18n("Hold to re-insert into stack")
                     description: i18n("Hold a modifier or mouse button while dragging a window to dynamically insert it into the autotile stack at the cursor position")
+                    enabled: !alwaysReinsertSwitch.checked
+                    opacity: enabled ? 1 : 0.4
 
                     ModifierAndMouseCheckBoxes {
                         width: root.triggerPreferredWidth
@@ -44,6 +65,25 @@ Flickable {
                         tooltipEnabled: false
                         onTriggersModified: (triggers) => {
                             settingsController.autotileDragInsertTriggers = triggers;
+                        }
+                    }
+
+                }
+
+                SettingsSeparator {
+                }
+
+                SettingsRow {
+                    title: i18n("Toggle mode")
+                    description: i18n("Tap the re-insert trigger once to activate the stack preview, tap again to deactivate it")
+                    enabled: !alwaysReinsertSwitch.checked
+                    opacity: enabled ? 1 : 0.4
+
+                    SettingsSwitch {
+                        checked: appSettings.autotileDragInsertToggle
+                        accessibleName: i18n("Toggle mode for re-insert into stack")
+                        onToggled: function(newValue) {
+                            appSettings.autotileDragInsertToggle = newValue;
                         }
                     }
 

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -1731,16 +1731,33 @@ QVariantList SettingsController::convertTriggersForStorage(const QVariantList& t
 // Trigger getters
 // ═══════════════════════════════════════════════════════════════════════════════
 
-bool SettingsController::alwaysActivateOnDrag() const
+static bool hasAlwaysActiveTrigger(const QVariantList& triggers)
 {
     const int alwaysActive = static_cast<int>(DragModifier::AlwaysActive);
-    const auto triggers = m_settings.dragActivationTriggers();
     for (const auto& t : triggers) {
         if (t.toMap().value(ConfigDefaults::triggerModifierField(), 0).toInt() == alwaysActive) {
             return true;
         }
     }
     return false;
+}
+
+static QVariantList makeAlwaysActiveTriggerList()
+{
+    QVariantMap trigger;
+    trigger[ConfigDefaults::triggerModifierField()] = static_cast<int>(DragModifier::AlwaysActive);
+    trigger[ConfigDefaults::triggerMouseButtonField()] = 0;
+    return {trigger};
+}
+
+bool SettingsController::alwaysActivateOnDrag() const
+{
+    return hasAlwaysActiveTrigger(m_settings.dragActivationTriggers());
+}
+
+bool SettingsController::alwaysReinsertIntoStack() const
+{
+    return hasAlwaysActiveTrigger(m_settings.autotileDragInsertTriggers());
 }
 
 QVariantList SettingsController::dragActivationTriggers() const
@@ -1806,16 +1823,8 @@ void SettingsController::setAlwaysActivateOnDrag(bool enabled)
     if (alwaysActivateOnDrag() == enabled) {
         return;
     }
-    if (enabled) {
-        // Single AlwaysActive trigger -- written directly in storage format (DragModifier enum)
-        QVariantMap trigger;
-        trigger[ConfigDefaults::triggerModifierField()] = static_cast<int>(DragModifier::AlwaysActive);
-        trigger[ConfigDefaults::triggerMouseButtonField()] = 0;
-        m_settings.setDragActivationTriggers({trigger});
-    } else {
-        // Revert to default triggers
-        m_settings.setDragActivationTriggers(ConfigDefaults::dragActivationTriggers());
-    }
+    m_settings.setDragActivationTriggers(enabled ? makeAlwaysActiveTriggerList()
+                                                 : ConfigDefaults::dragActivationTriggers());
     Q_EMIT alwaysActivateOnDragChanged();
     Q_EMIT dragActivationTriggersChanged();
     setNeedsSave(true);
@@ -1843,12 +1852,28 @@ void SettingsController::setSnapAssistTriggers(const QVariantList& triggers)
 
 void SettingsController::setAutotileDragInsertTriggers(const QVariantList& triggers)
 {
+    const bool wasAlwaysActive = alwaysReinsertIntoStack();
     const QVariantList converted = convertTriggersForStorage(triggers);
     if (m_settings.autotileDragInsertTriggers() != converted) {
         m_settings.setAutotileDragInsertTriggers(converted);
         Q_EMIT autotileDragInsertTriggersChanged();
+        if (alwaysReinsertIntoStack() != wasAlwaysActive) {
+            Q_EMIT alwaysReinsertIntoStackChanged();
+        }
         setNeedsSave(true);
     }
+}
+
+void SettingsController::setAlwaysReinsertIntoStack(bool enabled)
+{
+    if (alwaysReinsertIntoStack() == enabled) {
+        return;
+    }
+    m_settings.setAutotileDragInsertTriggers(enabled ? makeAlwaysActiveTriggerList()
+                                                     : ConfigDefaults::autotileDragInsertTriggers());
+    Q_EMIT alwaysReinsertIntoStackChanged();
+    Q_EMIT autotileDragInsertTriggersChanged();
+    setNeedsSave(true);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -1773,6 +1773,16 @@ QVariantList SettingsController::defaultSnapAssistTriggers() const
     return convertTriggersForQml(ConfigDefaults::snapAssistTriggers());
 }
 
+QVariantList SettingsController::autotileDragInsertTriggers() const
+{
+    return convertTriggersForQml(m_settings.autotileDragInsertTriggers());
+}
+
+QVariantList SettingsController::defaultAutotileDragInsertTriggers() const
+{
+    return convertTriggersForQml(ConfigDefaults::autotileDragInsertTriggers());
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Trigger setters
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -1827,6 +1837,16 @@ void SettingsController::setSnapAssistTriggers(const QVariantList& triggers)
     if (m_settings.snapAssistTriggers() != converted) {
         m_settings.setSnapAssistTriggers(converted);
         Q_EMIT snapAssistTriggersChanged();
+        setNeedsSave(true);
+    }
+}
+
+void SettingsController::setAutotileDragInsertTriggers(const QVariantList& triggers)
+{
+    const QVariantList converted = convertTriggersForStorage(triggers);
+    if (m_settings.autotileDragInsertTriggers() != converted) {
+        m_settings.setAutotileDragInsertTriggers(converted);
+        Q_EMIT autotileDragInsertTriggersChanged();
         setNeedsSave(true);
     }
 }

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -88,6 +88,9 @@ class SettingsController : public QObject
     Q_PROPERTY(QVariantList snapAssistTriggers READ snapAssistTriggers WRITE setSnapAssistTriggers NOTIFY
                    snapAssistTriggersChanged)
     Q_PROPERTY(QVariantList defaultSnapAssistTriggers READ defaultSnapAssistTriggers CONSTANT)
+    Q_PROPERTY(QVariantList autotileDragInsertTriggers READ autotileDragInsertTriggers WRITE
+                   setAutotileDragInsertTriggers NOTIFY autotileDragInsertTriggersChanged)
+    Q_PROPERTY(QVariantList defaultAutotileDragInsertTriggers READ defaultAutotileDragInsertTriggers CONSTANT)
 
     // Rendering backend info
     Q_PROPERTY(QStringList renderingBackendOptions READ renderingBackendOptions CONSTANT)
@@ -368,11 +371,14 @@ public:
     QVariantList defaultZoneSpanTriggers() const;
     QVariantList snapAssistTriggers() const;
     QVariantList defaultSnapAssistTriggers() const;
+    QVariantList autotileDragInsertTriggers() const;
+    QVariantList defaultAutotileDragInsertTriggers() const;
 
     void setAlwaysActivateOnDrag(bool enabled);
     void setDragActivationTriggers(const QVariantList& triggers);
     void setZoneSpanTriggers(const QVariantList& triggers);
     void setSnapAssistTriggers(const QVariantList& triggers);
+    void setAutotileDragInsertTriggers(const QVariantList& triggers);
 
     // ── Rendering backend ─────────────────────────────────────────────────────
     QStringList renderingBackendOptions() const
@@ -683,6 +689,7 @@ Q_SIGNALS:
     void dragActivationTriggersChanged();
     void zoneSpanTriggersChanged();
     void snapAssistTriggersChanged();
+    void autotileDragInsertTriggersChanged();
 
     // Color import signals
     void colorImportError(const QString& error);

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -88,6 +88,8 @@ class SettingsController : public QObject
     Q_PROPERTY(QVariantList snapAssistTriggers READ snapAssistTriggers WRITE setSnapAssistTriggers NOTIFY
                    snapAssistTriggersChanged)
     Q_PROPERTY(QVariantList defaultSnapAssistTriggers READ defaultSnapAssistTriggers CONSTANT)
+    Q_PROPERTY(bool alwaysReinsertIntoStack READ alwaysReinsertIntoStack WRITE setAlwaysReinsertIntoStack NOTIFY
+                   alwaysReinsertIntoStackChanged)
     Q_PROPERTY(QVariantList autotileDragInsertTriggers READ autotileDragInsertTriggers WRITE
                    setAutotileDragInsertTriggers NOTIFY autotileDragInsertTriggersChanged)
     Q_PROPERTY(QVariantList defaultAutotileDragInsertTriggers READ defaultAutotileDragInsertTriggers CONSTANT)
@@ -365,6 +367,7 @@ public:
 
     // ── Trigger configuration ────────────────────────────────────────────────
     bool alwaysActivateOnDrag() const;
+    bool alwaysReinsertIntoStack() const;
     QVariantList dragActivationTriggers() const;
     QVariantList defaultDragActivationTriggers() const;
     QVariantList zoneSpanTriggers() const;
@@ -375,6 +378,7 @@ public:
     QVariantList defaultAutotileDragInsertTriggers() const;
 
     void setAlwaysActivateOnDrag(bool enabled);
+    void setAlwaysReinsertIntoStack(bool enabled);
     void setDragActivationTriggers(const QVariantList& triggers);
     void setZoneSpanTriggers(const QVariantList& triggers);
     void setSnapAssistTriggers(const QVariantList& triggers);
@@ -686,6 +690,7 @@ Q_SIGNALS:
 
     // Trigger signals
     void alwaysActivateOnDragChanged();
+    void alwaysReinsertIntoStackChanged();
     void dragActivationTriggersChanged();
     void zoneSpanTriggersChanged();
     void snapAssistTriggersChanged();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -114,6 +114,8 @@ pz_add_test(test_autotile_engine_retry autotile/test_autotile_engine_retry.cpp)
 pz_add_test(test_autotile_engine_order_cycling autotile/test_autotile_engine_order_cycling.cpp)
 target_compile_definitions(test_autotile_engine_order_cycling PRIVATE "PZ_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
 pz_add_test(test_autotile_engine_class_mutation autotile/test_autotile_engine_class_mutation.cpp)
+pz_add_test(test_autotile_drag_insert autotile/test_autotile_drag_insert.cpp)
+target_compile_definitions(test_autotile_drag_insert PRIVATE "PZ_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # autotile/ — Autotile + Virtual Screen Integration Tests
@@ -343,6 +345,7 @@ set(_all_tests
     test_autotile_engine_minsize test_autotile_engine_overflow
     test_autotile_engine_retry
     test_autotile_engine_order_cycling
+    test_autotile_drag_insert
     test_autotile_ext_startup_float test_autotile_ext_algoswitch
     test_autotile_ext_overflow
     test_tiling_state_windows test_tiling_state_config test_tiling_state_serial

--- a/tests/unit/autotile/test_autotile_drag_insert.cpp
+++ b/tests/unit/autotile/test_autotile_drag_insert.cpp
@@ -1,0 +1,383 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QTest>
+#include <QCoreApplication>
+#include <QSignalSpy>
+
+#include "autotile/AutotileEngine.h"
+#include "autotile/AutotileConfig.h"
+#include "autotile/TilingState.h"
+#include "autotile/AlgorithmRegistry.h"
+
+#include "../helpers/AutotileTestHelpers.h"
+#include "../helpers/ScriptedAlgoTestSetup.h"
+
+using namespace PlasmaZones;
+
+/**
+ * @brief Tests for the drag-insert preview state machine on AutotileEngine.
+ *
+ * Covers begin/update/commit/cancel across same-screen reorder, cross-screen
+ * adoption, and fresh adoption paths, plus eviction undo on cancel.
+ *
+ * Uses windowOpened() + processEvents() to register windows through the proper
+ * lifecycle (populating m_windowToStateKey), which is required for the engine
+ * to detect same-screen vs cross-screen vs fresh adoption paths.
+ */
+class TestAutotileDragInsert : public QObject
+{
+    Q_OBJECT
+
+private:
+    PlasmaZones::TestHelpers::ScriptedAlgoTestSetup m_scriptSetup;
+
+    static constexpr auto Screen1 = "eDP-1";
+    static constexpr auto Screen2 = "HDMI-1";
+
+    /// Helper: open windows through the engine lifecycle so m_windowToStateKey
+    /// is properly populated (unlike direct TilingState::addWindow).
+    void openWindows(AutotileEngine& engine, const QString& screenId, const QStringList& windowIds)
+    {
+        for (const QString& id : windowIds) {
+            engine.windowOpened(id, screenId);
+        }
+        QCoreApplication::processEvents();
+    }
+
+    /// Helper: add windows directly to TilingState WITHOUT populating
+    /// m_windowToStateKey. Use only for "fresh adoption" tests where the
+    /// window is intentionally untracked by the engine.
+    void addWindowsToState(AutotileEngine& engine, const QString& screenId, const QStringList& windowIds)
+    {
+        TilingState* state = engine.stateForScreen(screenId);
+        Q_ASSERT(state);
+        for (const QString& id : windowIds) {
+            state->addWindow(id);
+        }
+    }
+
+private Q_SLOTS:
+
+    void initTestCase()
+    {
+        QVERIFY(m_scriptSetup.init(QStringLiteral(PZ_SOURCE_DIR)));
+    }
+
+    // =========================================================================
+    // Precondition tests
+    // =========================================================================
+
+    void testBegin_rejectsEmptyWindowId()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        engine.setAutotileScreens({QLatin1String(Screen1)});
+        QVERIFY(!engine.beginDragInsertPreview(QString(), QLatin1String(Screen1)));
+        QVERIFY(!engine.hasDragInsertPreview());
+    }
+
+    void testBegin_rejectsEmptyScreenId()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        engine.setAutotileScreens({QLatin1String(Screen1)});
+        QVERIFY(!engine.beginDragInsertPreview(QStringLiteral("win1"), QString()));
+        QVERIFY(!engine.hasDragInsertPreview());
+    }
+
+    void testBegin_rejectsNonAutotileScreen()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        engine.setAutotileScreens({QLatin1String(Screen1)});
+        QVERIFY(!engine.beginDragInsertPreview(QStringLiteral("win1"), QLatin1String(Screen2)));
+        QVERIFY(!engine.hasDragInsertPreview());
+    }
+
+    // =========================================================================
+    // Same-screen reorder: begin → update → commit
+    // =========================================================================
+
+    void testSameScreen_beginSetsPreview()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        QVERIFY(engine.hasDragInsertPreview());
+        QCOMPARE(engine.dragInsertPreviewWindowId(), QStringLiteral("A"));
+        QCOMPARE(engine.dragInsertPreviewScreenId(), screen);
+    }
+
+    void testSameScreen_updateMovesWindow()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+
+        // Move A from index 0 to index 2
+        engine.updateDragInsertPreview(2);
+
+        TilingState* state = engine.stateForScreen(screen);
+        QVERIFY(state);
+        const QStringList tiled = state->tiledWindows();
+        QCOMPARE(tiled.size(), 3);
+        // A should now be at position 2
+        QCOMPARE(tiled[2], QStringLiteral("A"));
+    }
+
+    void testSameScreen_commitClearsPreview()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        engine.updateDragInsertPreview(2);
+        engine.commitDragInsertPreview();
+
+        QVERIFY(!engine.hasDragInsertPreview());
+        // Order should persist after commit
+        TilingState* state = engine.stateForScreen(screen);
+        QCOMPARE(state->tiledWindows()[2], QStringLiteral("A"));
+    }
+
+    // =========================================================================
+    // Same-screen reorder: cancel restores original order
+    // =========================================================================
+
+    void testSameScreen_cancelRestoresOrder()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        const QStringList originalOrder = engine.stateForScreen(screen)->tiledWindows();
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        engine.updateDragInsertPreview(2);
+        engine.cancelDragInsertPreview();
+
+        QVERIFY(!engine.hasDragInsertPreview());
+        QCOMPARE(engine.stateForScreen(screen)->tiledWindows(), originalOrder);
+    }
+
+    // =========================================================================
+    // Cross-screen adoption: begin → commit
+    // =========================================================================
+
+    void testCrossScreen_adoptionMovesBetweenScreens()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString s1 = QLatin1String(Screen1);
+        const QString s2 = QLatin1String(Screen2);
+        engine.setAutotileScreens({s1, s2});
+        openWindows(engine, s1, {QStringLiteral("A"), QStringLiteral("B")});
+        openWindows(engine, s2, {QStringLiteral("X"), QStringLiteral("Y")});
+
+        // Adopt A from screen1 onto screen2
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), s2));
+        QVERIFY(engine.hasDragInsertPreview());
+
+        // A should be gone from screen1 and present on screen2
+        QVERIFY(!engine.stateForScreen(s1)->tiledWindows().contains(QStringLiteral("A")));
+        QVERIFY(engine.stateForScreen(s2)->tiledWindows().contains(QStringLiteral("A")));
+    }
+
+    void testCrossScreen_cancelRestoresOriginalScreen()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString s1 = QLatin1String(Screen1);
+        const QString s2 = QLatin1String(Screen2);
+        engine.setAutotileScreens({s1, s2});
+        openWindows(engine, s1, {QStringLiteral("A"), QStringLiteral("B")});
+        openWindows(engine, s2, {QStringLiteral("X"), QStringLiteral("Y")});
+
+        const QStringList s1Original = engine.stateForScreen(s1)->tiledWindows();
+        const QStringList s2Original = engine.stateForScreen(s2)->tiledWindows();
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), s2));
+        engine.cancelDragInsertPreview();
+
+        QVERIFY(!engine.hasDragInsertPreview());
+        // A should be back on screen1, screen2 unchanged
+        QCOMPARE(engine.stateForScreen(s1)->tiledWindows(), s1Original);
+        QCOMPARE(engine.stateForScreen(s2)->tiledWindows(), s2Original);
+    }
+
+    // =========================================================================
+    // Fresh adoption: untracked window enters autotile stack
+    // =========================================================================
+
+    void testFreshAdoption_addsWindowToStack()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        addWindowsToState(engine, screen, {QStringLiteral("A"), QStringLiteral("B")});
+
+        // "newcomer" is not tracked by the engine at all
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("newcomer"), screen));
+        QVERIFY(engine.stateForScreen(screen)->tiledWindows().contains(QStringLiteral("newcomer")));
+    }
+
+    void testFreshAdoption_cancelRemovesWindow()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        addWindowsToState(engine, screen, {QStringLiteral("A"), QStringLiteral("B")});
+
+        const QStringList originalOrder = engine.stateForScreen(screen)->tiledWindows();
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("newcomer"), screen));
+        engine.cancelDragInsertPreview();
+
+        QVERIFY(!engine.hasDragInsertPreview());
+        QCOMPARE(engine.stateForScreen(screen)->tiledWindows(), originalOrder);
+    }
+
+    // =========================================================================
+    // Idempotency: double cancel is safe
+    // =========================================================================
+
+    void testDoubleCancel_isIdempotent()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        engine.cancelDragInsertPreview();
+        // Second cancel should be a no-op, not crash
+        engine.cancelDragInsertPreview();
+        QVERIFY(!engine.hasDragInsertPreview());
+    }
+
+    void testDoubleCommit_isIdempotent()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        engine.commitDragInsertPreview();
+        engine.commitDragInsertPreview();
+        QVERIFY(!engine.hasDragInsertPreview());
+    }
+
+    // =========================================================================
+    // Begin replaces existing preview
+    // =========================================================================
+
+    void testBegin_cancelsExistingPreview()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        engine.updateDragInsertPreview(2);
+
+        // Starting a new preview for B should cancel A's preview first
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("B"), screen));
+        QCOMPARE(engine.dragInsertPreviewWindowId(), QStringLiteral("B"));
+    }
+
+    // =========================================================================
+    // Update with no-change index is a no-op
+    // =========================================================================
+
+    void testUpdate_sameIndexNoOp()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        // A starts at index 0, updating to 0 should be a no-op
+        const QStringList before = engine.stateForScreen(screen)->tiledWindows();
+        engine.updateDragInsertPreview(0);
+        QCOMPARE(engine.stateForScreen(screen)->tiledWindows(), before);
+    }
+
+    // =========================================================================
+    // Update clamps out-of-range indices
+    // =========================================================================
+
+    void testUpdate_clampsNegativeIndex()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("C"), screen));
+        // Negative should clamp to 0
+        engine.updateDragInsertPreview(-5);
+        QCOMPARE(engine.stateForScreen(screen)->tiledWindows()[0], QStringLiteral("C"));
+    }
+
+    void testUpdate_clampsOverflowIndex()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        // Index 100 should clamp to last (2)
+        engine.updateDragInsertPreview(100);
+        QCOMPARE(engine.stateForScreen(screen)->tiledWindows()[2], QStringLiteral("A"));
+    }
+
+    // =========================================================================
+    // computeDragInsertIndexAtPoint with no state returns -1
+    // =========================================================================
+
+    void testComputeIndex_noStateReturnsMinus1()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        QCOMPARE(engine.computeDragInsertIndexAtPoint(QStringLiteral("nonexistent"), QPoint(50, 50)), -1);
+    }
+
+    // =========================================================================
+    // Commit emits windowFloatingStateSynced for fresh adoption
+    // =========================================================================
+
+    void testCommit_freshAdoptionEmitsFloatSync()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        addWindowsToState(engine, screen, {QStringLiteral("A")});
+
+        QSignalSpy spy(&engine, &AutotileEngine::windowFloatingStateSynced);
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("newcomer"), screen));
+        engine.commitDragInsertPreview();
+
+        QVERIFY(spy.count() >= 1);
+        // Should emit for "newcomer" with floating=false
+        bool found = false;
+        for (const auto& call : spy) {
+            if (call[0].toString() == QStringLiteral("newcomer") && call[1].toBool() == false) {
+                found = true;
+                break;
+            }
+        }
+        QVERIFY(found);
+    }
+};
+
+QTEST_MAIN(TestAutotileDragInsert)
+#include "test_autotile_drag_insert.moc"

--- a/tests/unit/autotile/test_autotile_drag_insert.cpp
+++ b/tests/unit/autotile/test_autotile_drag_insert.cpp
@@ -377,6 +377,111 @@ private Q_SLOTS:
         }
         QVERIFY(found);
     }
+
+    // =========================================================================
+    // Eviction path: maxWindows cap forces a neighbour float on adoption
+    // =========================================================================
+
+    void testEviction_cancelRestoresFloatedNeighbour()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        engine.config()->maxWindows = 3;
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B"), QStringLiteral("C")});
+
+        const QStringList originalTiled = engine.stateForScreen(screen)->tiledWindows();
+        QCOMPARE(originalTiled.size(), 3);
+
+        // Fresh adoption pushes count to 4 > maxWindows=3 → last neighbour is floated.
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("newcomer"), screen));
+        QVERIFY(engine.hasDragInsertPreview());
+        QCOMPARE(engine.stateForScreen(screen)->tiledWindowCount(), 3);
+
+        // Cancel must unfloat the evicted neighbour and remove the newcomer.
+        engine.cancelDragInsertPreview();
+        QVERIFY(!engine.hasDragInsertPreview());
+        QCOMPARE(engine.stateForScreen(screen)->tiledWindows(), originalTiled);
+    }
+
+    void testEviction_commitEmitsBatchFloated()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        engine.config()->maxWindows = 2;
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B")});
+
+        QSignalSpy batchSpy(&engine, &AutotileEngine::windowsBatchFloated);
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("newcomer"), screen));
+        engine.commitDragInsertPreview();
+
+        // Evicted neighbour should be routed through the batch-float signal.
+        QVERIFY(batchSpy.count() >= 1);
+    }
+
+    // =========================================================================
+    // Window-close bookkeeping
+    // =========================================================================
+
+    void testWindowClosed_draggedWindowClearsPreview()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("A"), screen));
+        QVERIFY(engine.hasDragInsertPreview());
+
+        // Dragged window closed mid-preview — preview must vanish, not crash.
+        engine.windowClosed(QStringLiteral("A"));
+        QVERIFY(!engine.hasDragInsertPreview());
+    }
+
+    void testWindowClosed_evictedNeighbourClearsEviction()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+        engine.config()->maxWindows = 2;
+        openWindows(engine, screen, {QStringLiteral("A"), QStringLiteral("B")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("newcomer"), screen));
+        QVERIFY(engine.hasDragInsertPreview());
+
+        // The evicted window is B (last in tiled order before adoption).
+        // Close it while the preview is live.
+        engine.windowClosed(QStringLiteral("B"));
+
+        // Preview still live (newcomer is the dragged window, not B) and
+        // commit/cancel must not crash on the vanished eviction id.
+        QVERIFY(engine.hasDragInsertPreview());
+        engine.commitDragInsertPreview(); // should be safe
+        QVERIFY(!engine.hasDragInsertPreview());
+    }
+
+    // =========================================================================
+    // setAutotileScreens cancels preview when target screen is removed
+    // =========================================================================
+
+    void testSetAutotileScreens_cancelsPreviewOnTargetRemoval()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString s1 = QLatin1String(Screen1);
+        const QString s2 = QLatin1String(Screen2);
+        engine.setAutotileScreens({s1, s2});
+        openWindows(engine, s2, {QStringLiteral("X"), QStringLiteral("Y")});
+
+        QVERIFY(engine.beginDragInsertPreview(QStringLiteral("X"), s2));
+        QVERIFY(engine.hasDragInsertPreview());
+
+        // Remove s2 from autotile — preview must be cancelled before its
+        // TilingState gets torn down.
+        engine.setAutotileScreens({s1});
+        QVERIFY(!engine.hasDragInsertPreview());
+    }
 };
 
 QTEST_MAIN(TestAutotileDragInsert)

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -694,6 +694,13 @@ public:
     void setAutotileDragInsertTriggers(const QVariantList&) override
     {
     }
+    bool autotileDragInsertToggle() const override
+    {
+        return false;
+    }
+    void setAutotileDragInsertToggle(bool) override
+    {
+    }
     QStringList lockedScreens() const override
     {
         return {};

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -687,6 +687,13 @@ public:
     void setAutotileStickyWindowHandling(StickyWindowHandling) override
     {
     }
+    QVariantList autotileDragInsertTriggers() const override
+    {
+        return {};
+    }
+    void setAutotileDragInsertTriggers(const QVariantList&) override
+    {
+    }
     QStringList lockedScreens() const override
     {
         return {};

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -689,7 +689,7 @@ public:
     }
     QVariantList autotileDragInsertTriggers() const override
     {
-        return {};
+        return ConfigDefaults::autotileDragInsertTriggers();
     }
     void setAutotileDragInsertTriggers(const QVariantList&) override
     {


### PR DESCRIPTION
## Summary
- Adds a **Triggers** section to Autotiling Behavior settings (mirrors snapping's hold-to-activate). Holding the configured trigger (Alt by default) while dragging a window over an autotile screen dynamically inserts it into the tiling stack at the cursor position.
- Neighbours animate-shift into their new slots via the normal retile path; the dragged window is filtered from the \`windowsTiled\` batch during the preview so KWin's interactive move stays in control of its geometry.
- Supports three entry modes with cancel restoration: same-screen reorder (tiled or floating), cross-screen adoption from another autotile screen, and fresh adoption of a snap-managed / floating window.

## Implementation notes
- New config group \`Tiling.Behavior.Triggers\` with \`autotileDragInsertTriggers\` (default: Alt, no mouse button). Plumbed through \`ConfigDefaults\`, \`ISettings\`, \`Settings\`, \`SettingsController\`, \`StubSettings\`.
- New \`AutotileEngine::beginDragInsertPreview\` / \`updateDragInsertPreview\` / \`commitDragInsertPreview\` / \`cancelDragInsertPreview\` / \`computeDragInsertIndexAtPoint\`. \`applyTiling\` filters the dragged window's entry out of the emitted batch while a preview is active.
- KWin effect's autotile-bypass drag path now forwards \`dragStarted\` / \`dragMoved\` / \`dragStopped\` to the daemon when the drag-insert trigger engages (previously it early-returned for all bypassed drags, which is why nothing happened on autotile screens). Adds \`sendDragMovedBypassSafe\` and \`autotileDragInsertHeld\` helpers.
- Daemon's \`dragMoved\` autotile block runs above the \`m_snapCancelled\` early return so the effect's \`callCancelSnap()\` on snap→autotile crossings doesn't starve it for the rest of the drag.

## Settings UI
New Triggers card at the top of the Autotiling Behavior page, reusing \`ModifierAndMouseCheckBoxes\` so the UX matches snapping's Hold-to-Activate.

## Test plan
- [ ] Build daemon + kwin-effect, reinstall both, restart kwin
- [ ] Open settings → Autotiling → Behavior; verify "Triggers" card shows Alt as default
- [ ] Autotile stack with 3+ windows on a VS; drag one window, hold Alt, move cursor up/down → neighbours animate-shift, preview index follows cursor
- [ ] Release Alt mid-drag → stack reverts to original order
- [ ] Release with Alt held → window commits to new position
- [ ] Drag a window from a snap VS to an autotile VS while holding Alt → window adopts into the autotile stack at the cursor position
- [ ] Drag a window between two autotile VSes with Alt held → cross-screen move, both screens retile
- [ ] \`ctest --test-dir build\` → 78/78 pass

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)