### PR TITLE
feat(drag-protocol): daemon-owned drag routing + daemon-local float toggle (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Drag protocol refactor** ([#310](https://github.com/fuddlesworth/PlasmaZones/discussions/310)): the kwin-effect is now a dumb relay for drag events — the daemon owns all drag routing decisions through a new `beginDrag` / `updateDragCursor` / `endDrag` protocol with typed `DragPolicy` and `DragOutcome` structs. The previous effect-side distributed state (`m_dragBypassedForAutotile` / `m_cachedZoneSelectorEnabled` / `m_autotileScreens` local cache) went stale during the asynchronous settings-reload window and produced ~40 seconds of dead drags in the reporter's log on #310. The new protocol makes the daemon the single source of truth at drag start, drag cursor update (30Hz fire-and-forget), and drag end. Cross-VS mid-drag flips are emitted by the daemon via `dragPolicyChanged` and applied locally by the plugin, replacing the effect-side flip loop that walked `KWin::effects->screens()` against a local autotile-screen cache. Pinned against drift by a new 8-state truth table test.
+- **Meta-F float toggle now runs daemon-local** ([#310](https://github.com/fuddlesworth/PlasmaZones/discussions/310)): the keyboard shortcut previously made 4 D-Bus hops across 3 processes (KWin → daemon → effect → daemon → engine → effect), stalling under any D-Bus backpressure and producing the "pressed Meta-F, nothing happened, seconds later it toggled" symptom. It now reads the active window from `WindowTrackingAdaptor::m_lastActiveWindowId`, fresh frame geometry from a 50ms-debounced shadow (`setFrameGeometry`), and dispatches to the engine in-process. One D-Bus hop (the daemon → effect `applyGeometryRequested` paint), targeting sub-50ms latency from keypress to visible toggle. The 100ms debounce on `handleFloat` has been dropped since the in-process path has no D-Bus latency to coalesce.
+- **Settings nesting made compile-time**: `ISettings` gains `isZoneSelectorActive()` and `isSnapAssistActive()` composite accessors that return `snappingEnabled() && <child>Enabled()`. Consumers can no longer forget the parent-gate check when reading a nested `Snapping.*` flag. Raw child accessors remain for KCM settings UI code that genuinely needs the unaffected value.
+
 ## [2.8.5] - 2026-04-10
 
 ### Fixed

--- a/dbus/org.plasmazones.WindowDrag.xml
+++ b/dbus/org.plasmazones.WindowDrag.xml
@@ -25,6 +25,15 @@
             </arg>
         </method>
 
+        <method name="updateDragCursor">
+            <annotation name="org.gtk.GDBus.DocString" value="Phase 3 drag protocol: hot-path cursor update. Replaces dragMoved. Fire-and-forget; throttled ~30Hz by the plugin. For snap-path drags the daemon runs overlay/zone detection; for bypass drags it watches for cursor crossing a virtual-screen boundary and emits dragPolicyChanged when the policy flips (autotile↔snap)."/>
+            <arg name="windowId" type="s" direction="in"/>
+            <arg name="cursorX" type="i" direction="in"/>
+            <arg name="cursorY" type="i" direction="in"/>
+            <arg name="modifiers" type="i" direction="in"/>
+            <arg name="mouseButtons" type="i" direction="in"/>
+        </method>
+
         <method name="endDrag">
             <annotation name="org.gtk.GDBus.DocString" value="Phase 3 drag protocol: daemon-authoritative end. Returns a DragOutcome the plugin applies verbatim — no further decisions on the plugin side. Handles autotile float, snap, drag-out unsnap, snap assist, and cancelled-drag paths through a single dispatch. Replaces dragStopped as the canonical drag-end entry point."/>
             <arg name="windowId" type="s" direction="in">
@@ -181,6 +190,13 @@
             </arg>
             <arg name="height" type="i">
                 <annotation name="org.gtk.GDBus.DocString" value="Pre-snap height (pixels)."/>
+            </arg>
+        </signal>
+        <signal name="dragPolicyChanged">
+            <annotation name="org.gtk.GDBus.DocString" value="Phase 3 drag protocol: daemon detected a policy flip mid-drag (typically because the cursor crossed a virtual-screen boundary that changes autotile↔snap routing). Plugin reacts by applying the transition: entering/exiting autotile bypass, canceling snap overlay, calling handleDragToFloat, etc. Replaces the effect-side cross-VS flip loop that used a stale local cache."/>
+            <arg name="windowId" type="s"/>
+            <arg name="newPolicy" type="(bbbbbss)">
+                <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="PlasmaZones::DragPolicy"/>
             </arg>
         </signal>
     </interface>

--- a/dbus/org.plasmazones.WindowDrag.xml
+++ b/dbus/org.plasmazones.WindowDrag.xml
@@ -4,6 +4,27 @@
     <!-- Window Drag Interface (KWin script -> Daemon) -->
     <interface name="org.plasmazones.WindowDrag">
         <annotation name="org.gtk.GDBus.DocString" value="Window drag handling: KWin script calls dragStarted/dragMoved/dragStopped; daemon returns snap geometry. Uses double for window rect (KWin QML) and int for cursor/modifiers."/>
+        <method name="beginDrag">
+            <annotation name="org.gtk.GDBus.DocString" value="Phase 3 drag protocol: daemon-authoritative begin. Returns a DragPolicy that the compositor plugin uses to decide streaming, keyboard grab, and immediate-float behavior. Replaces dragStarted as the canonical drag-begin entry point. Single source of truth — no effect-side cache to go stale after settings reloads."/>
+            <arg name="windowId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
+            </arg>
+            <arg name="frameX" type="i" direction="in"/>
+            <arg name="frameY" type="i" direction="in"/>
+            <arg name="frameWidth" type="i" direction="in"/>
+            <arg name="frameHeight" type="i" direction="in"/>
+            <arg name="startScreenId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Virtual-screen-aware screen identifier at drag start."/>
+            </arg>
+            <arg name="mouseButtons" type="i" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Qt::MouseButtons flags."/>
+            </arg>
+            <arg name="policy" type="(bbbbbss)" direction="out">
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::DragPolicy"/>
+                <annotation name="org.gtk.GDBus.DocString" value="DragPolicy struct: {streamDragMoved, showOverlay, grabKeyboard, captureGeometry, immediateFloatOnStart, screenId, bypassReason}."/>
+            </arg>
+        </method>
+
         <method name="dragStarted">
             <annotation name="org.gtk.GDBus.DocString" value="Called when a window drag begins. Coordinates are double (KWin QML)."/>
             <arg name="windowId" type="s" direction="in">

--- a/dbus/org.plasmazones.WindowDrag.xml
+++ b/dbus/org.plasmazones.WindowDrag.xml
@@ -25,6 +25,28 @@
             </arg>
         </method>
 
+        <method name="endDrag">
+            <annotation name="org.gtk.GDBus.DocString" value="Phase 3 drag protocol: daemon-authoritative end. Returns a DragOutcome the plugin applies verbatim — no further decisions on the plugin side. Handles autotile float, snap, drag-out unsnap, snap assist, and cancelled-drag paths through a single dispatch. Replaces dragStopped as the canonical drag-end entry point."/>
+            <arg name="windowId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Window identifier (must match the windowId from beginDrag)."/>
+            </arg>
+            <arg name="cursorX" type="i" direction="in"/>
+            <arg name="cursorY" type="i" direction="in"/>
+            <arg name="modifiers" type="i" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Qt::KeyboardModifiers at release."/>
+            </arg>
+            <arg name="mouseButtons" type="i" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Qt::MouseButtons at release."/>
+            </arg>
+            <arg name="cancelled" type="b" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="True if the drag was cancelled (Escape, external cancel). False for normal button release."/>
+            </arg>
+            <arg name="outcome" type="(issiiiisbba(siiiiiibsssdd))" direction="out">
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::DragOutcome"/>
+                <annotation name="org.gtk.GDBus.DocString" value="DragOutcome struct: {action, windowId, targetScreenId, x, y, width, height, zoneId, skipAnimation, requestSnapAssist, emptyZones}."/>
+            </arg>
+        </method>
+
         <method name="dragStarted">
             <annotation name="org.gtk.GDBus.DocString" value="Called when a window drag begins. Coordinates are double (KWin QML)."/>
             <arg name="windowId" type="s" direction="in">

--- a/dbus/org.plasmazones.WindowDrag.xml
+++ b/dbus/org.plasmazones.WindowDrag.xml
@@ -56,98 +56,16 @@
             </arg>
         </method>
 
-        <method name="dragStarted">
-            <annotation name="org.gtk.GDBus.DocString" value="Called when a window drag begins. Coordinates are double (KWin QML)."/>
-            <arg name="windowId" type="s" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
-            </arg>
-            <arg name="x" type="d" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Window X position (double, KWin QML)."/>
-            </arg>
-            <arg name="y" type="d" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Window Y position (double)."/>
-            </arg>
-            <arg name="width" type="d" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Window width (double)."/>
-            </arg>
-            <arg name="height" type="d" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Window height (double)."/>
-            </arg>
-            <arg name="mouseButtons" type="i" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Qt::MouseButtons flags for the button(s) that started the drag (0=None, 2=Right, 4=Middle, 8=Back, 16=Forward, etc.). Used for activation-by-mouse-button."/>
-            </arg>
-        </method>
-
-        <method name="dragMoved">
-            <annotation name="org.gtk.GDBus.DocString" value="Called while the window is being dragged. Cursor position (int), keyboard modifiers and current mouse buttons (Qt flags)."/>
-            <arg name="windowId" type="s" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
-            </arg>
-            <arg name="cursorX" type="i" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Cursor X position."/>
-            </arg>
-            <arg name="cursorY" type="i" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Cursor Y position."/>
-            </arg>
-            <arg name="modifiers" type="i" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Qt::KeyboardModifiers flags."/>
-            </arg>
-            <arg name="mouseButtons" type="i" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Qt::MouseButtons flags currently held (0=None, 2=Right, 4=Middle, etc.). Used to toggle overlay when activation is set to a mouse button (same as modifier: hold button during drag to show zones)."/>
-            </arg>
-        </method>
+        <!-- Legacy dragStarted/dragMoved/dragStopped removed in phase 3f.
+             The canonical drag protocol is beginDrag / updateDragCursor /
+             endDrag. Internal C++ helpers with those names still exist in
+             the adaptor (called from drag_protocol.cpp) but they're no
+             longer exposed to D-Bus. -->
 
         <method name="selectorScrollWheel">
             <annotation name="org.gtk.GDBus.DocString" value="Forward scroll delta to the zone selector during drag. Reserved for future use when KWin exposes pointer axis events to effects."/>
             <arg name="angleDeltaY" type="i" direction="in">
                 <annotation name="org.gtk.GDBus.DocString" value="Vertical scroll delta in 1/8 degree units (positive=up, negative=down). Standard wheel tick is ±120."/>
-            </arg>
-        </method>
-
-        <method name="dragStopped">
-            <annotation name="org.gtk.GDBus.DocString" value="Called when the drag ends. Returns snap rectangle and whether to apply it (shouldSnap). cursorX/Y are the cursor position at release (for release screen detection). modifiers: Qt::KeyboardModifiers at release — used for Snap Assist triggers (when always-on is off)."/>
-            <arg name="windowId" type="s" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
-            </arg>
-            <arg name="cursorX" type="i" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Cursor X at release (global coordinates)."/>
-            </arg>
-            <arg name="cursorY" type="i" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Cursor Y at release (global coordinates)."/>
-            </arg>
-            <arg name="modifiers" type="i" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Qt::KeyboardModifiers at release."/>
-            </arg>
-            <arg name="mouseButtons" type="i" direction="in">
-                <annotation name="org.gtk.GDBus.DocString" value="Qt::MouseButtons at release. With modifiers, used for Snap Assist triggers: when any trigger held, enables Snap Assist for this drop (when always-enabled is off)."/>
-            </arg>
-            <arg name="snapX" type="i" direction="out">
-                <annotation name="org.gtk.GDBus.DocString" value="Snap X position (if shouldSnap)."/>
-            </arg>
-            <arg name="snapY" type="i" direction="out">
-                <annotation name="org.gtk.GDBus.DocString" value="Snap Y position (if shouldSnap)."/>
-            </arg>
-            <arg name="snapWidth" type="i" direction="out">
-                <annotation name="org.gtk.GDBus.DocString" value="Snap width (if shouldSnap)."/>
-            </arg>
-            <arg name="snapHeight" type="i" direction="out">
-                <annotation name="org.gtk.GDBus.DocString" value="Snap height (if shouldSnap)."/>
-            </arg>
-            <arg name="shouldSnap" type="b" direction="out">
-                <annotation name="org.gtk.GDBus.DocString" value="True if KWin should apply the snap geometry."/>
-            </arg>
-            <arg name="releaseScreenName" type="s" direction="out">
-                <annotation name="org.gtk.GDBus.DocString" value="Screen name where the drag was released (cursor position). Use for auto-fill on drop."/>
-            </arg>
-            <arg name="restoreSizeOnly" type="b" direction="out">
-                <annotation name="org.gtk.GDBus.DocString" value="If true with shouldSnap: apply only width/height; keep window at current position (drag-to-unsnap). Float-toggle shortcut restores full x/y/w/h."/>
-            </arg>
-            <arg name="snapAssistRequested" type="b" direction="out">
-                <annotation name="org.gtk.GDBus.DocString" value="If true: effect should call showSnapAssist with candidate windows to fill empty zones."/>
-            </arg>
-            <arg name="emptyZones" type="a(siiiiiibsssdd)" direction="out">
-                <annotation name="org.gtk.GDBus.DocString" value="Array of EmptyZoneEntry structs: (zoneId, x, y, width, height, borderWidth, borderRadius, useCustomColors, highlightColor, inactiveColor, borderColor, activeOpacity, inactiveOpacity). Only set when snapAssistRequested is true."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out8" value="PlasmaZones::EmptyZoneList"/>
             </arg>
         </method>
 

--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -424,12 +424,6 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Zone UUID (or empty if unsnapped)."/>
             </arg>
         </signal>
-        <signal name="toggleWindowFloatRequested">
-            <annotation name="org.gtk.GDBus.DocString" value="Emitted when keyboard shortcut requests float toggle (KWin effect reacts)."/>
-            <arg name="shouldFloat" type="b">
-                <annotation name="org.gtk.GDBus.DocString" value="True to float, false to unfloat."/>
-            </arg>
-        </signal>
         <signal name="navigationFeedback">
             <annotation name="org.gtk.GDBus.DocString" value="Emitted when KWin effect reports navigation result via reportNavigationFeedback (for OSD)."/>
             <arg name="success" type="b">

--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -554,6 +554,16 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Screen where window is located."/>
             </arg>
         </method>
+        <method name="setFrameGeometry">
+            <annotation name="org.gtk.GDBus.DocString" value="Push current frame geometry for a window into the daemon's shadow. Called by the compositor plugin on windowFrameGeometryChanged (debounced). Enables daemon-local shortcut handlers (e.g. float toggle) to read fresh geometry without a cross-process round-trip."/>
+            <arg name="windowId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Window identifier."/>
+            </arg>
+            <arg name="x" type="i" direction="in"/>
+            <arg name="y" type="i" direction="in"/>
+            <arg name="width" type="i" direction="in"/>
+            <arg name="height" type="i" direction="in"/>
+        </method>
         <method name="resnapToNewLayout">
             <annotation name="org.gtk.GDBus.DocString" value="Resnap all windows from the previous layout to the current layout. Maps by zone number (1-&gt;1, 2-&gt;2) with cycling when new layout has fewer zones. Call after switching layouts."/>
         </method>

--- a/docs/architecture/drag-protocol.md
+++ b/docs/architecture/drag-protocol.md
@@ -1,0 +1,159 @@
+# Drag Protocol — v3 design note
+
+**Status**: implemented on `feat/drag-protocol-refactor` branch for v3.
+**Scope**: kwin-effect ↔ daemon drag event routing.
+**Fixes**: discussion [#310](https://github.com/fuddlesworth/PlasmaZones/discussions/310) (post-settings-reload dead-drag window, Meta-F float toggle lag/drop).
+
+## Problem
+
+Before the refactor, drag routing decisions (autotile bypass vs snap path vs dead-on-disabled) were made in the kwin-effect using local state caches:
+
+- `m_autotileScreens` — set updated by async `autotileScreensChanged` D-Bus signal from daemon
+- `m_dragBypassedForAutotile` — bool flag set at drag start from `m_autotileScreens.contains(startScreenId)`
+- `m_cachedZoneSelectorEnabled` — bool shadow of `Snapping.ZoneSelector.Enabled`
+
+Each of these was **eventually consistent** with the daemon's authoritative state. During the ~ms window after a settings reload, the effect's cache could disagree with the daemon. The log forensics on #310 showed **7 consecutive dead drags over ~41 seconds** following a settings reload, with the daemon rejecting each one at the "Snapping disabled in settings" early-return gate — the effect had sent `dragStarted` believing it was a snap-path drag, but the daemon's authoritative state said snap was off. No autotile fallback fired because `m_dragBypassedForAutotile` was set to the wrong value at drag start.
+
+The float-toggle shortcut had a different but related symptom: Meta-F made **4 D-Bus hops across 3 processes** (KWin → daemon → effect → daemon → engine → effect) and stalled under any D-Bus backpressure, producing the "pressed Meta-F, nothing happened, ... seconds later it toggled" user experience.
+
+Both bugs have the same shape: **policy decisions made from local state that should be daemon-owned**.
+
+## Design
+
+The effect becomes a dumb relay. The daemon owns all policy decisions. Two new D-Bus methods (`beginDrag`, `endDrag`), one new fire-and-forget method (`updateDragCursor`), and one new signal (`dragPolicyChanged`) form the new surface. Typed structs `DragPolicy` and `DragOutcome` carry the decisions.
+
+### Wire format
+
+```
+[Plugin → Daemon]   beginDrag(windowId, frameX, frameY, frameW, frameH,
+                              startScreenId, mouseButtons)
+                    → DragPolicy {
+                          streamDragMoved,
+                          showOverlay,
+                          grabKeyboard,
+                          captureGeometry,
+                          immediateFloatOnStart,
+                          screenId,
+                          bypassReason
+                      }
+
+[Plugin → Daemon]   updateDragCursor(windowId, cursorX, cursorY,
+                                     modifiers, mouseButtons)
+                    — fire-and-forget, 30Hz throttled by plugin
+
+[Daemon → Plugin]   dragPolicyChanged(windowId, DragPolicy)
+                    — emitted when daemon detects cursor crossed a
+                      virtual-screen boundary that flips the policy
+
+[Plugin → Daemon]   endDrag(windowId, cursorX, cursorY, modifiers,
+                            mouseButtons, cancelled)
+                    → DragOutcome {
+                          action,  // NoOp / ApplyFloat / ApplySnap /
+                                   // RestoreSize / CancelSnap /
+                                   // NotifyDragOutUnsnap
+                          windowId,
+                          targetScreenId,
+                          x, y, width, height,
+                          zoneId,
+                          skipAnimation,
+                          requestSnapAssist,
+                          emptyZones  // populated only if requestSnapAssist
+                      }
+```
+
+### `computeDragPolicy` — the decision function
+
+A pure static function on `WindowDragAdaptor` that encapsulates the entire routing decision. Inputs: `ISettings*`, `AutotileEngine*`, windowId, screenId, desktop, activity. No side effects. Precedence (first match wins):
+
+1. **`context_disabled`** — activity / desktop / monitor excluded in display settings
+2. **`autotile_screen`** — the autotile engine owns window placement on this screen
+3. **`snapping_disabled`** — top-level `Snapping.Enabled = false` on a non-autotile screen
+4. **Canonical snap path** — everything else
+
+This ordering means a user with `Snapping.Enabled = false` and autotile active on both monitors (exactly the #310 reporter's config) gets the correct `autotile_screen` policy — autotile wins over snap-disabled because it's listed first.
+
+Pinned by an 8-state truth table in `tests/unit/dbus/test_drag_policy.cpp`.
+
+### Cross-VS flip handling
+
+When `updateDragCursor` is called during a drag, the daemon resolves the cursor screen, re-computes the policy at that screen, and compares against the currently-active policy. If the `bypassReason` changes (or the screen changes while both sides are autotile), the daemon emits `dragPolicyChanged` with the new policy.
+
+The plugin's `slotDragPolicyChanged` handler diffs old vs new and applies the compositor-level transition:
+
+- **snap → autotile**: cancel snap overlay, enter autotile bypass, clear pending snap state. Do NOT call `handleDragToFloat` mid-drag — it schedules an `applySnapGeometry` that would race against the drop-time snap (see the comment in the handler for the original debug story).
+- **autotile → snap**: drop bypass flag, call `onWindowClosed` on the old autotile screen to clear tracking state, initialize snap-drag state at the new cursor position, grab keyboard.
+- **autotile → different autotile** (same `bypassReason`, different `screenId`): update tracked bypass screen id. Drop-time `endDrag` will apply `ApplyFloat` to the final screen.
+- **snap → snap**: no-op.
+
+### `endDrag` — the dispatch
+
+Internally calls the legacy `dragStopped` (still present as a private C++ helper) for the snap path to preserve the intricate overlay/zone/snap-assist logic, and packages the nine out-parameters into a `DragOutcome` struct. For bypass paths, composes the outcome directly (autotile → `ApplyFloat`, disabled → `NoOp`).
+
+The plugin's `callEndDrag` helper sends the D-Bus call and applies the returned outcome verbatim via a switch on `DragOutcome::action`:
+
+- `ApplySnap` / `RestoreSize` — paint via `applySnapGeometry` (same as the legacy path)
+- `ApplyFloat` — call `handleDragToFloat` + `setWindowFloatingForScreen` for the drop screen
+- `NoOp` / `CancelSnap` / `NotifyDragOutUnsnap` — nothing to paint; daemon handled its own cleanup
+- `requestSnapAssist` true — show the window picker via `asyncShow`
+
+Auto-fill on empty-zone drop is still done by `tryAsyncSnapCall` when no other action applied and the daemon supplied a release screen.
+
+## What got deleted
+
+From `kwin-effect/plasmazoneseffect.cpp`:
+
+- `callDragStarted` / `sendDeferredDragStarted` — the "defer dragStarted until activation trigger detected" optimization is obsolete. `beginDrag` is unconditional; the daemon always knows about the drag from the moment it begins.
+- `callDragMoved` / `callDragStopped` — replaced by the inline `updateDragCursor` fire-and-forget call in the dragMoved lambda and the `callEndDrag` helper respectively.
+- The effect-side cross-VS flip loop (~80 lines in the dragMoved lambda) — moved to daemon-side detection in `updateDragCursor` + reaction handler `slotDragPolicyChanged`.
+- The autotile special-case branch in the dragStopped lambda (~60 lines of sub-case dispatch for snap→autotile, cross-VS, same-VS) — collapsed into `ApplyFloat` handling inside `callEndDrag`.
+
+From `dbus/org.plasmazones.WindowDrag.xml`:
+
+- `dragStarted` / `dragMoved` / `dragStopped` methods — no longer part of the D-Bus introspection surface. Still exist as private C++ helpers called by `drag_protocol.cpp` internally.
+
+## Related: float toggle (phase 2)
+
+The Meta-F bug from the same #310 report had a different root cause (not drag policy, just the 4-hop D-Bus chain) but was fixed as part of the same branch.
+
+- Phase 1 added a frame-geometry shadow in `WindowTrackingAdaptor`, populated via `setFrameGeometry` D-Bus pushes from the effect on `windowFrameGeometryChanged` (50ms debounced).
+- Phase 2 rewrote `WindowTrackingAdaptor::toggleWindowFloat` to use `m_lastActiveWindowId` + the frame-geometry shadow and dispatch to `toggleFloatForWindow` in-process. The old effect round-trip, the stale `isWindowFloating` local cache read on the effect side, and the 100ms debounce on `Daemon::handleFloat` are all gone.
+- Net change: Meta-F → visible toggle latency drops from "seconds under backpressure" to sub-50ms.
+
+## Invariants
+
+1. **Single source of truth**. The daemon's `computeDragPolicy` is the only place that answers "what kind of drag is this". No effect-side cache shadows it.
+2. **First-match precedence**. `computeDragPolicy` checks disables in a fixed order (context → autotile → snap-disabled → canonical). The resulting `bypassReason` string is stable across coincidental disables.
+3. **Fire-and-forget hot path**. `updateDragCursor` is the only 30Hz call. Daemon replies (signals) flow back async.
+4. **Mid-drag transitions are daemon-driven**. The plugin never diffs its own state to decide when to flip modes; it only reacts to `dragPolicyChanged`.
+5. **Parent gates are compile-time**. `ISettings::isZoneSelectorActive()` and `isSnapAssistActive()` encode `snappingEnabled() && child` so consumers can't forget the parent check.
+
+## Why not sync `beginDrag`?
+
+Early drafts used a synchronous D-Bus call at drag-start so the plugin would have the policy before dispatching the first mouse move. Rejected because:
+
+- Sync D-Bus on the compositor thread risks deadlock if the daemon is mid-callback into the plugin.
+- The ~ms reply window is tolerable: the plugin defaults to a conservative snap-path policy while waiting, and a rare brief overlay flash is much better than a dead drag.
+- If the reply arrives mid-drag with a different policy, `slotDragPolicyChanged` retroactively applies the transition via the same handler as cross-VS flips. Same machinery, same correctness.
+
+## Files
+
+- `src/compositor-common/dbus_types.{h,cpp}` — `DragPolicy` / `DragOutcome` types + QDBusArgument streaming
+- `src/dbus/windowdragadaptor.h` + `src/dbus/windowdragadaptor/drag_protocol.cpp` — `beginDrag` / `endDrag` / `updateDragCursor` / `computeDragPolicy`
+- `dbus/org.plasmazones.WindowDrag.xml` — D-Bus interface
+- `kwin-effect/plasmazoneseffect.{h,cpp}` — plugin-side port (`callEndDrag`, `slotDragPolicyChanged`)
+- `tests/unit/dbus/test_drag_policy.cpp` — 8-state truth table
+- `src/core/interfaces.h` — `isZoneSelectorActive()` / `isSnapAssistActive()` composite accessors
+
+## Commits
+
+`feat/drag-protocol-refactor` on top of `v3`:
+
+- `4330f22c` — phase 1: frame-geometry shadow
+- `b04b1b7c` — phase 2: daemon-local float toggle
+- `992b9e52` — phase 3a: DragPolicy types + beginDrag + truth table test
+- `d97ddfaf` — phase 3b: endDrag + DragOutcome
+- `355a55c9` — phase 3c: effect calls beginDrag
+- `46d92844` — phase 3d: updateDragCursor + dragPolicyChanged signal
+- `cd916b50` — phase 3e: effect port (cross-VS flip deletion, callEndDrag)
+- `0dac0613` — phase 3f: delete legacy dragStarted/dragMoved/dragStopped from D-Bus surface
+- `e8a80896` — phase 4: composite settings accessors

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -177,8 +177,8 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                 qCDebug(lcEffect) << "Window move started -" << w->windowClass()
                                   << "current modifiers:" << static_cast<int>(m_currentModifiers);
 
-                // Phase 3 drag protocol: fire beginDrag async to get a
-                // daemon-authoritative policy. While the reply is pending, we
+                // Fire beginDrag async to get a daemon-authoritative policy.
+                // While the reply is pending, we
                 // default m_currentDragPolicy to a conservative snap-path so
                 // the worst case (stale effect cache would have said autotile
                 // but daemon knows better, or vice-versa) is a brief overlay
@@ -299,7 +299,7 @@ PlasmaZonesEffect::PlasmaZonesEffect()
             });
     connect(
         m_dragTracker.get(), &DragTracker::dragMoved, this, [this](const QString& windowId, const QPointF& cursorPos) {
-            // Phase 3e: cross-VS flip detection is now daemon-owned. The
+            // Cross-VS flip detection is daemon-owned. The
             // daemon's updateDragCursor handler computes policy at the
             // cursor position and emits dragPolicyChanged when it flips.
             // The effect reacts via slotDragPolicyChanged (see below).
@@ -341,7 +341,7 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                     m_keyboardGrabbed = false;
                 }
 
-                // Phase 3e: single entry point for drag-end dispatch. The
+                // Single entry point for drag-end dispatch. The
                 // daemon owns the decision; callEndDrag sends endDrag and
                 // the reply handler applies whatever DragOutcome comes back
                 // (ApplySnap / ApplyFloat / RestoreSize / NoOp / etc.).
@@ -988,7 +988,7 @@ void PlasmaZonesEffect::slotMouseChanged(const QPointF& pos, const QPointF& oldp
             // matching keyboard modifier behavior (hold to show, release to hide,
             // re-press to show again).
             //
-            // Phase 3e: push modifier/button changes through the new
+            // Push modifier/button changes through the
             // updateDragCursor path. The daemon handles cursor-driven
             // cross-VS detection and activation-trigger gating.
             // Effect-side detectActivationAndGrab still maintains the
@@ -1754,10 +1754,9 @@ bool PlasmaZonesEffect::detectActivationAndGrab()
     return false;
 }
 
-// sendDeferredDragStarted removed — phase 3e. beginDrag is now called
-// unconditionally at drag-start; there's no deferred "only send dragStarted
-// when zones activate" path because the daemon always knows about the drag
-// from the moment it begins.
+// beginDrag is called unconditionally at drag-start; there's no deferred
+// "only send dragStarted when zones activate" path because the daemon
+// always knows about the drag from the moment it begins.
 
 void PlasmaZonesEffect::connectNavigationSignals()
 {
@@ -1771,10 +1770,10 @@ void PlasmaZonesEffect::connectNavigationSignals()
                                           QStringLiteral("activateWindowRequested"), this,
                                           SLOT(slotActivateWindowRequested(QString)));
 
-    // Float toggle is now entirely daemon-local (drag-protocol refactor,
-    // phase 2): the daemon reads the active window from its own shadow, calls
-    // toggleFloatForWindow internally, and emits applyGeometryRequested to
-    // paint the outcome. The effect no longer participates in the decision.
+    // Float toggle is entirely daemon-local: the daemon reads the active
+    // window from its own shadow, calls toggleFloatForWindow internally, and
+    // emits applyGeometryRequested to paint the outcome. The effect no longer
+    // participates in the decision.
 
     // Daemon-driven batch operations (rotate, resnap emit applyGeometriesBatch)
     QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
@@ -2807,10 +2806,9 @@ void PlasmaZonesEffect::callResolveWindowRestore(KWin::EffectWindow* window, std
                      /*skipAnimation=*/true, onComplete);
 }
 
-// callDragStarted removed — phase 3e. The kwin-effect no longer calls the
-// legacy dragStarted D-Bus method; beginDrag now sets up snap-path state
-// internally on the daemon side, so there's only one code path into the
-// drag state machine.
+// The kwin-effect no longer calls the legacy dragStarted D-Bus method;
+// beginDrag sets up snap-path state internally on the daemon side, so
+// there's only one code path into the drag state machine.
 bool PlasmaZonesEffect::isWindowSticky(KWin::EffectWindow* w) const
 {
     return w && w->isOnAllDesktops();
@@ -2837,13 +2835,12 @@ void PlasmaZonesEffect::updateWindowStickyState(KWin::EffectWindow* w)
                                {windowId, sticky}, QStringLiteral("setWindowSticky"));
 }
 
-// callDragMoved removed — phase 3e. The dragMoved lambda now sends
-// updateDragCursor directly via DBusHelpers::fireAndForget. Single
-// entry point for hot-path cursor updates.
+// The dragMoved lambda sends updateDragCursor directly via
+// DBusHelpers::fireAndForget. Single entry point for hot-path cursor updates.
 
 void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& windowId, bool cancelled)
 {
-    // Phase 3e drag protocol: single entry point for drag-end dispatch.
+    // Single entry point for drag-end dispatch.
     // Sends endDrag, receives a DragOutcome, and applies exactly the
     // action the daemon decided. Replaces callDragStopped (whose reply
     // shape was a 9-tuple of out-params) with a typed struct.
@@ -3190,7 +3187,7 @@ void PlasmaZonesEffect::slotRestoreSizeDuringDrag(const QString& windowId, int w
 
 void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const DragPolicy& newPolicy)
 {
-    // Phase 3e: daemon-owned cross-VS flip. The daemon's updateDragCursor
+    // Daemon-owned cross-VS flip. The daemon's updateDragCursor
     // handler computed policy at the current cursor position and found it
     // different from the policy in force — tell us so we can apply the
     // compositor-level transition. Replaces the effect-side cross-VS flip

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -176,14 +176,86 @@ PlasmaZonesEffect::PlasmaZonesEffect()
             [this](KWin::EffectWindow* w, const QString& windowId, const QRectF& geometry) {
                 qCDebug(lcEffect) << "Window move started -" << w->windowClass()
                                   << "current modifiers:" << static_cast<int>(m_currentModifiers);
-                // On autotile screens, don't show manual zone overlay or grab keyboard.
-                // The drag proceeds freely; floatWindow is called on drag end.
-                // Capture this decision so dragStopped uses the same state — prevents
-                // a race where m_autotileScreens changes mid-drag (async D-Bus signal)
-                // and leaves the popup visible with no snap.
-                if (m_autotileHandler->isAutotileScreen(getWindowScreenId(w))) {
+
+                // Phase 3 drag protocol: fire beginDrag async to get a
+                // daemon-authoritative policy. While the reply is pending, we
+                // default m_currentDragPolicy to a conservative snap-path so
+                // the worst case (stale effect cache would have said autotile
+                // but daemon knows better, or vice-versa) is a brief overlay
+                // flash rather than a dead drag. The reply handler flips the
+                // bypass flag retroactively a few ms later if the daemon says
+                // this is an autotile drag.
+                //
+                // This replaces the previous stale-cache read of
+                // m_autotileHandler->isAutotileScreen() as the single source
+                // of truth for drag-start routing — root cause of the
+                // post-settings-reload dead-drag window found in #310 log
+                // forensics.
+                m_currentDragPolicy = DragPolicy{};
+                m_currentDragPolicy.streamDragMoved = true;
+                m_currentDragPolicy.showOverlay = true;
+                m_currentDragPolicy.grabKeyboard = true;
+                m_currentDragPolicy.captureGeometry = true;
+
+                const QString startScreenId = getWindowScreenId(w);
+                const QRect frame = geometry.toRect();
+                QDBusMessage beginMsg = QDBusMessage::createMethodCall(
+                    DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag, QStringLiteral("beginDrag"));
+                beginMsg << windowId << frame.x() << frame.y() << frame.width() << frame.height() << startScreenId
+                         << static_cast<int>(m_currentMouseButtons);
+                QDBusPendingCall beginPending = QDBusConnection::sessionBus().asyncCall(beginMsg);
+                auto* beginWatcher = new QDBusPendingCallWatcher(beginPending, this);
+                QPointer<KWin::EffectWindow> safeW = w;
+                const QString capturedWindowId = windowId;
+                const QString capturedScreenId = startScreenId;
+                connect(beginWatcher, &QDBusPendingCallWatcher::finished, this,
+                        [this, safeW, capturedWindowId, capturedScreenId](QDBusPendingCallWatcher* bw) {
+                            bw->deleteLater();
+                            QDBusPendingReply<DragPolicy> reply = *bw;
+                            if (!reply.isValid()) {
+                                qCWarning(lcEffect) << "beginDrag reply invalid:" << reply.error().message();
+                                return;
+                            }
+                            m_currentDragPolicy = reply.value();
+                            qCInfo(lcEffect) << "beginDrag reply:" << capturedWindowId
+                                             << "bypass=" << m_currentDragPolicy.bypassReason
+                                             << "stream=" << m_currentDragPolicy.streamDragMoved
+                                             << "immediateFloat=" << m_currentDragPolicy.immediateFloatOnStart;
+                            // If the daemon confirms autotile, flip the effect
+                            // state to bypass mode. Usually the effect-side
+                            // fast path below already did this synchronously;
+                            // this catches the stale-cache case where the fast
+                            // path missed.
+                            if (m_currentDragPolicy.bypassReason == QLatin1String("autotile_screen")) {
+                                if (!m_dragBypassedForAutotile) {
+                                    m_dragBypassedForAutotile = true;
+                                    m_dragBypassScreenId = capturedScreenId;
+                                    qCInfo(lcEffect)
+                                        << "beginDrag: retroactive autotile bypass for" << capturedWindowId;
+                                }
+                                // Apply immediate float transition if the policy
+                                // says so and the window wasn't already floated
+                                // by the fast path. Using QPointer so we skip
+                                // if the window was destroyed between drag-start
+                                // and reply.
+                                if (safeW && m_currentDragPolicy.immediateFloatOnStart
+                                    && !isWindowFloating(capturedWindowId)
+                                    && !m_dragFloatedWindowIds.contains(capturedWindowId)) {
+                                    m_autotileHandler->handleDragToFloat(safeW, capturedWindowId, capturedScreenId,
+                                                                         /*immediate=*/true);
+                                    m_dragFloatedWindowIds.insert(capturedWindowId);
+                                }
+                            }
+                        });
+
+                // Fast path: the effect-side autotile cache is USUALLY correct.
+                // We still consult it synchronously so the common case runs at
+                // zero latency. The async beginDrag reply above runs as a
+                // correction layer for the cases where the cache is stale
+                // (post-settings-reload — the #310 scenario).
+                if (m_autotileHandler->isAutotileScreen(startScreenId)) {
                     m_dragBypassedForAutotile = true;
-                    m_dragBypassScreenId = getWindowScreenId(w);
+                    m_dragBypassScreenId = startScreenId;
                     // If the window is currently autotile-tiled, restore its
                     // title bar and pre-autotile size NOW (synchronously, during
                     // the interactive move). This mirrors snap mode, where

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -284,15 +284,11 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                 m_pendingDragGeometry = geometry;
                 m_snapDragStartScreenId = getWindowScreenId(w);
 
-                // Check if zones are needed right now. If so, send dragStarted
-                // immediately and grab keyboard. Otherwise defer until activation
-                // is detected mid-drag (or skip entirely if user never activates).
-                //
-                // When triggers haven't loaded yet (!m_triggersLoaded), stay
-                // permissive — send immediately to avoid masking trigger issues (#175).
-                if (detectActivationAndGrab() || m_cachedZoneSelectorEnabled || !m_triggersLoaded) {
-                    sendDeferredDragStarted();
-                }
+                // beginDrag already initialized daemon-side snap-drag state
+                // (called internally from the adaptor). The effect only needs
+                // to decide whether to grab the keyboard for local Escape
+                // handling.
+                detectActivationAndGrab();
                 // Grab keyboard to intercept Escape before KWin's MoveResizeFilter.
                 // Without this, Escape cancels the interactive move AND the overlay.
                 // With the grab, Escape only dismisses the overlay while the drag continues.
@@ -301,95 +297,42 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                     m_keyboardGrabbed = true;
                 }
             });
-    connect(m_dragTracker.get(), &DragTracker::dragMoved, this,
-            [this](const QString& windowId, const QPointF& cursorPos) {
-                // Cross-VS drag mode transitions: when the cursor crosses between
-                // autotile and snap screens mid-drag, switch the drag handling mode
-                // so zone overlay and snap activation match the screen under the cursor.
-                if (!m_virtualScreenDefs.isEmpty()) {
-                    QPoint cursorPt(qRound(cursorPos.x()), qRound(cursorPos.y()));
-                    const KWin::LogicalOutput* cursorOutput = nullptr;
-                    for (const auto* output : KWin::effects->screens()) {
-                        if (output->geometry().contains(cursorPt)) {
-                            cursorOutput = output;
-                            break;
-                        }
-                    }
-                    if (cursorOutput) {
-                        QString cursorScreenId = resolveEffectiveScreenId(cursorPt, cursorOutput);
-                        bool cursorOnAutotile = m_autotileHandler->isAutotileScreen(cursorScreenId);
+    connect(
+        m_dragTracker.get(), &DragTracker::dragMoved, this, [this](const QString& windowId, const QPointF& cursorPos) {
+            // Phase 3e: cross-VS flip detection is now daemon-owned. The
+            // daemon's updateDragCursor handler computes policy at the
+            // cursor position and emits dragPolicyChanged when it flips.
+            // The effect reacts via slotDragPolicyChanged (see below).
+            //
+            // Here we only forward the cursor to the daemon as a
+            // fire-and-forget call. The daemon-side dispatch handles
+            // both the snap-path overlay updates and the cross-VS
+            // detection in a single round trip.
 
-                        if (m_dragBypassedForAutotile && !cursorOnAutotile) {
-                            // Autotile→snap: exit bypass mode and initialize snap-drag
-                            // state as if the drag started on this snap screen.
-                            // Remove the window from autotile tracking NOW so that
-                            // slotWindowFrameGeometryChanged doesn't detect a stale
-                            // VS crossing on every subsequent geometry change (including
-                            // user resize), which would call handleWindowOutputChanged
-                            // and fight the snap geometry.
-                            //
-                            // Deliberately DO NOT call handleDragToFloat here: it runs
-                            // mid-drag, reads the current (mid-drag) frame position, and
-                            // schedules an applySnapGeometry that defers via
-                            // windowFinishUserMovedResized. When the drop eventually
-                            // completes the deferred lambda fires with that stale
-                            // mid-drag position and races against the zone snap applied
-                            // by dragStopped — causing the window to jump and resize
-                            // itself after the user drops. Border/float cleanup at drop
-                            // time is handled by the dragStopped path or by snap-zone
-                            // restore; onWindowClosed alone is sufficient to kill the
-                            // resize-lock this crossover path was added to fix.
-                            KWin::EffectWindow* dragW = m_dragTracker->draggedWindow();
-                            if (dragW) {
-                                m_autotileHandler->onWindowClosed(windowId, m_dragBypassScreenId);
-                            }
-                            m_dragBypassedForAutotile = false;
-                            m_dragActivationDetected = false;
-                            m_dragStartedSent = false;
-                            m_pendingDragWindowId = windowId;
-                            m_pendingDragGeometry = dragW ? dragW->frameGeometry() : QRectF();
-                            m_snapDragStartScreenId = cursorScreenId;
-                            qCInfo(lcEffect) << "Drag crossed from autotile" << m_dragBypassScreenId << "to snap screen"
-                                             << cursorScreenId << "- activating zones";
-                            if (!m_keyboardGrabbed) {
-                                KWin::effects->grabKeyboard(this);
-                                m_keyboardGrabbed = true;
-                            }
-                        } else if (!m_dragBypassedForAutotile && cursorOnAutotile && m_dragStartedSent) {
-                            // Snap→autotile: re-enter bypass mode. Cancel the active
-                            // snap overlay so zones disappear while cursor is on the
-                            // autotile screen. If the user drags back to snap, the
-                            // autotile→snap path above re-initializes snap state.
-                            callCancelSnap();
-                            m_dragBypassedForAutotile = true;
-                            m_dragBypassScreenId = cursorScreenId; // Track the autotile VS we entered
-                            m_dragStartedSent = false;
-                            m_pendingDragWindowId.clear();
-                            m_pendingDragGeometry = QRectF();
-                            m_snapDragStartScreenId.clear();
-                            qCInfo(lcEffect)
-                                << "Drag crossed from snap to autotile" << cursorScreenId << "- deactivating zones";
-                        }
-                    }
-                }
-
-                // In autotile bypass — skip snap zone processing
-                if (m_dragBypassedForAutotile) {
-                    return;
-                }
-
-                // Gate D-Bus calls: if no activation trigger is held, toggle mode is off,
-                // and zone selector is disabled, skip the D-Bus call entirely. This
-                // eliminates 60Hz D-Bus traffic during non-zone drags.
-                //
-                // When triggers haven't loaded yet, stay permissive (#175).
+            // In autotile bypass — skip snap zone processing locally;
+            // the daemon's updateDragCursor still watches for a flip
+            // BACK to snap mode.
+            const bool bypassed =
+                m_currentDragPolicy.bypassReason == QLatin1String("autotile_screen") || m_dragBypassedForAutotile;
+            if (!bypassed) {
+                // Gate D-Bus calls on activation trigger state so a drag
+                // without any intent to use zones doesn't flood the bus
+                // at 30Hz. This is a local input-event optimization; it
+                // isn't policy and doesn't come from the daemon.
                 if (!detectActivationAndGrab() && !m_cachedZoneSelectorEnabled && m_triggersLoaded) {
                     return;
                 }
-                // Ensure dragStarted was sent before any dragMoved
-                sendDeferredDragStarted();
-                callDragMoved(windowId, cursorPos, m_currentModifiers, static_cast<int>(m_currentMouseButtons));
-            });
+            }
+
+            // Forward the cursor to the daemon. For snap drags, this
+            // drives overlay/zone detection. For bypass drags, the
+            // daemon watches the cursor for a cross-VS flip and emits
+            // dragPolicyChanged when the policy changes.
+            DBusHelpers::fireAndForget(this, DBus::Interface::WindowDrag, QStringLiteral("updateDragCursor"),
+                                       {windowId, qRound(cursorPos.x()), qRound(cursorPos.y()),
+                                        static_cast<int>(m_currentModifiers), static_cast<int>(m_currentMouseButtons)},
+                                       QStringLiteral("updateDragCursor"));
+        });
     connect(m_dragTracker.get(), &DragTracker::dragStopped, this,
             [this](KWin::EffectWindow* w, const QString& windowId, bool cancelled) {
                 // Release keyboard grab before handling drag end
@@ -397,118 +340,27 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                     KWin::effects->ungrabKeyboard();
                     m_keyboardGrabbed = false;
                 }
-                // Use the captured autotile state from drag start (not live m_autotileScreens)
-                // to ensure consistent behavior even if autotile screens changed mid-drag.
-                if (m_dragBypassedForAutotile) {
-                    if (!cancelled) {
-                        const QString dropScreenId = w ? getWindowScreenId(w) : m_dragBypassScreenId;
-                        const bool windowWasInAutotile = m_autotileHandler->isTrackedWindow(windowId);
 
-                        if (!windowWasInAutotile) {
-                            // Snap→autotile drag: the window was on a snap screen and
-                            // the cursor crossed to an autotile VS mid-drag. The window
-                            // was never in autotile tracking — just add it now.
-                            const bool dropIsAutotile = m_autotileHandler->isAutotileScreen(dropScreenId);
-                            if (w && dropIsAutotile) {
-                                m_autotileHandler->notifyWindowAdded(w);
-                                qCInfo(lcEffect)
-                                    << "Snap→autotile drag: added" << windowId << "to autotile on" << dropScreenId;
-                            }
-                        } else if (dropScreenId != m_dragBypassScreenId) {
-                            // Autotile drag: virtual screen changed.
-                            qCInfo(lcEffect) << "Autotile drag: virtual screen changed" << m_dragBypassScreenId << "->"
-                                             << dropScreenId;
-                            const bool dropIsAutotile = m_autotileHandler->isAutotileScreen(dropScreenId);
-                            if (dropIsAutotile) {
-                                m_autotileHandler->transferPreAutotileGeometry(windowId, m_dragBypassScreenId,
-                                                                               dropScreenId);
-                            }
+                // Phase 3e: single entry point for drag-end dispatch. The
+                // daemon owns the decision; callEndDrag sends endDrag and
+                // the reply handler applies whatever DragOutcome comes back
+                // (ApplySnap / ApplyFloat / RestoreSize / NoOp / etc.).
+                //
+                // The autotile branch special-casing that used to live here
+                // is gone — cross-VS transitions were applied mid-drag by
+                // slotDragPolicyChanged, and final drop-time actions are
+                // encoded in the DragOutcome.
+                callEndDrag(w, windowId, cancelled);
 
-                            if (!dropIsAutotile) {
-                                m_autotileHandler->handleDragToFloat(w, windowId, m_dragBypassScreenId);
-                            }
-
-                            m_autotileHandler->onWindowClosed(windowId, m_dragBypassScreenId);
-                            if (w && dropIsAutotile) {
-                                m_autotileHandler->notifyWindowAdded(w);
-                                m_autotileHandler->handleDragToFloat(w, windowId, dropScreenId);
-                                m_dragFloatedWindowIds.insert(windowId);
-                                DBusHelpers::fireAndForget(
-                                    this, DBus::Interface::WindowTracking, QStringLiteral("setWindowFloatingForScreen"),
-                                    {windowId, dropScreenId, true},
-                                    QStringLiteral("setWindowFloatingForScreen - cross-VS drag"));
-                                qCInfo(lcEffect) << "Autotile cross-VS drag-to-float:" << windowId
-                                                 << m_dragBypassScreenId << "->" << dropScreenId;
-                            }
-                        } else {
-                            // Same virtual screen — normal drag-to-float behavior.
-                            m_autotileHandler->handleDragToFloat(w, windowId, m_dragBypassScreenId);
-                            m_dragFloatedWindowIds.insert(windowId);
-                            DBusHelpers::fireAndForget(
-                                this, DBus::Interface::WindowTracking, QStringLiteral("setWindowFloatingForScreen"),
-                                {windowId, m_dragBypassScreenId, true}, QStringLiteral("setWindowFloatingForScreen"));
-                            qCInfo(lcEffect) << "Autotile drag-to-float:" << windowId;
-                        }
-                    }
-                    m_snapDragStartScreenId.clear();
-                    m_dragBypassedForAutotile = false;
-                    m_dragBypassScreenId.clear();
-                    return;
-                }
-                m_dragActivationDetected = false;
-
-                // Virtual screen crossing for snap-mode: KWin's outputChanged
-                // doesn't fire when moving between virtual screens on the same
-                // physical monitor, and the frameGeometryChanged handler skips
-                // during drag. Re-resolve now and notify the daemon if changed.
-                if (!cancelled && w && !m_snapDragStartScreenId.isEmpty()) {
-                    const QString dropScreenId = getWindowScreenId(w);
-                    if (dropScreenId != m_snapDragStartScreenId && !dropScreenId.isEmpty()
-                        && VirtualScreenId::samePhysical(dropScreenId, m_snapDragStartScreenId)
-                        && !m_autotileHandler->isAutotileScreen(dropScreenId)) {
-                        // Only send windowScreenChanged for snap-to-snap VS crossings.
-                        // Snap-to-autotile crossings are handled by callDragStopped's callback
-                        // which does notifyWindowAdded + setWindowFloatingForScreen.
-                        qCInfo(lcEffect) << "Snap drag: virtual screen changed" << m_snapDragStartScreenId << "->"
-                                         << dropScreenId;
-                        DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking,
-                                                   QStringLiteral("windowScreenChanged"), {windowId, dropScreenId},
-                                                   QStringLiteral("snap drag VS crossing"));
-                    }
-                }
-                // Capture snap-mode start screen ID BEFORE clearing — callDragStopped's
-                // async callback needs it for cross-VS autotile transfer detection.
-                // m_dragBypassScreenId is only set for autotile-bypass drags, not snap drags,
-                // so without this capture the cross-VS path in callDragStopped is dead code.
-                const QString snapDragStartScreenId = m_snapDragStartScreenId;
+                // Clear drag state for the next session.
+                m_currentDragPolicy = DragPolicy{};
+                m_dragBypassedForAutotile = false;
+                m_dragBypassScreenId.clear();
                 m_snapDragStartScreenId.clear();
-
-                if (!m_dragStartedSent) {
-                    // Drag ended without ever activating zones — no D-Bus state to clean up.
-                    // BUT: if the window was snapped, notify the daemon so it can handle
-                    // unsnap (restore original size, clear zone assignment, mark floating).
-                    // Without this, dragging a snapped window without the activation trigger
-                    // leaves stale zone state that persists across close/reopen.
-                    if (!cancelled && !m_pendingDragWindowId.isEmpty()) {
-                        DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking,
-                                                   QStringLiteral("notifyDragOutUnsnap"), {m_pendingDragWindowId},
-                                                   QStringLiteral("notifyDragOutUnsnap"));
-                    }
-                    m_pendingDragWindowId.clear();
-                    m_pendingDragGeometry = QRectF();
-                    return;
-                }
+                m_dragActivationDetected = false;
                 m_dragStartedSent = false;
                 m_pendingDragWindowId.clear();
                 m_pendingDragGeometry = QRectF();
-
-                if (cancelled) {
-                    // Drag was cancelled externally (e.g. window went fullscreen).
-                    // Tell the daemon to cancel rather than snap to the hovered zone.
-                    callCancelSnap();
-                } else {
-                    callDragStopped(w, windowId, snapDragStartScreenId);
-                }
             });
 
     // Connect to window lifecycle signals
@@ -1136,18 +988,18 @@ void PlasmaZonesEffect::slotMouseChanged(const QPointF& pos, const QPointF& oldp
             // matching keyboard modifier behavior (hold to show, release to hide,
             // re-press to show again).
             //
-            // Skip on autotile screens — no zone overlay to update, and calling
-            // detectActivationAndGrab() would wastefully grab the keyboard and
-            // sendDeferredDragStarted() would send a D-Bus call the daemon can't use.
-            //
-            // Gating: same logic as dragMoved lambda — skip if no activation
-            // detected and no reason to send (avoids D-Bus traffic for non-zone drags).
+            // Phase 3e: push modifier/button changes through the new
+            // updateDragCursor path. The daemon handles cursor-driven
+            // cross-VS detection and activation-trigger gating.
+            // Effect-side detectActivationAndGrab still maintains the
+            // keyboard grab for Escape handling during snap drags.
             if (!m_dragBypassedForAutotile) {
-                // When triggers haven't loaded yet, stay permissive (#175).
                 if (detectActivationAndGrab() || m_cachedZoneSelectorEnabled || !m_triggersLoaded) {
-                    sendDeferredDragStarted();
-                    callDragMoved(m_dragTracker->draggedWindowId(), pos, m_currentModifiers,
-                                  static_cast<int>(m_currentMouseButtons));
+                    DBusHelpers::fireAndForget(this, DBus::Interface::WindowDrag, QStringLiteral("updateDragCursor"),
+                                               {m_dragTracker->draggedWindowId(), qRound(pos.x()), qRound(pos.y()),
+                                                static_cast<int>(m_currentModifiers),
+                                                static_cast<int>(m_currentMouseButtons)},
+                                               QStringLiteral("updateDragCursor - modifier/button change"));
                 }
             }
         } else {
@@ -1902,14 +1754,10 @@ bool PlasmaZonesEffect::detectActivationAndGrab()
     return false;
 }
 
-void PlasmaZonesEffect::sendDeferredDragStarted()
-{
-    if (m_dragStartedSent) {
-        return;
-    }
-    m_dragStartedSent = true;
-    callDragStarted(m_pendingDragWindowId, m_pendingDragGeometry);
-}
+// sendDeferredDragStarted removed — phase 3e. beginDrag is now called
+// unconditionally at drag-start; there's no deferred "only send dragStarted
+// when zones activate" path because the daemon always knows about the drag
+// from the moment it begins.
 
 void PlasmaZonesEffect::connectNavigationSignals()
 {
@@ -1972,6 +1820,14 @@ void PlasmaZonesEffect::connectNavigationSignals()
     QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
                                           QStringLiteral("restoreSizeDuringDragChanged"), this,
                                           SLOT(slotRestoreSizeDuringDrag(QString, int, int)));
+
+    // WindowDrag: cross-VS policy flip. Daemon detects the cursor crossing
+    // a virtual-screen boundary that changes autotile↔snap routing and
+    // emits this signal so the effect can apply the transition locally
+    // (handleDragToFloat, onWindowClosed, overlay cancel, etc.).
+    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
+                                          QStringLiteral("dragPolicyChanged"), this,
+                                          SLOT(slotDragPolicyChanged(QString, PlasmaZones::DragPolicy)));
 
     qCInfo(lcEffect) << "Connected to navigation D-Bus signals";
 }
@@ -2951,21 +2807,10 @@ void PlasmaZonesEffect::callResolveWindowRestore(KWin::EffectWindow* window, std
                      /*skipAnimation=*/true, onComplete);
 }
 
-void PlasmaZonesEffect::callDragStarted(const QString& windowId, const QRectF& geometry)
-{
-    updateWindowStickyState(m_dragTracker->draggedWindow());
-
-    // Use QDBusMessage::createMethodCall instead of QDBusInterface to avoid
-    // synchronous D-Bus introspection. QDBusInterface's constructor blocks the
-    // compositor thread (~25s timeout) if the daemon is registered but not yet
-    // processing messages. QDBusMessage is purely local — no D-Bus communication
-    // until asyncCall, which returns immediately.
-    QDBusMessage msg = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
-                                                      QStringLiteral("dragStarted"));
-    msg << windowId << geometry.x() << geometry.y() << geometry.width() << geometry.height()
-        << static_cast<int>(m_currentMouseButtons);
-    QDBusConnection::sessionBus().asyncCall(msg);
-}
+// callDragStarted removed — phase 3e. The kwin-effect no longer calls the
+// legacy dragStarted D-Bus method; beginDrag now sets up snap-path state
+// internally on the daemon side, so there's only one code path into the
+// drag state machine.
 bool PlasmaZonesEffect::isWindowSticky(KWin::EffectWindow* w) const
 {
     return w && w->isOnAllDesktops();
@@ -2992,162 +2837,140 @@ void PlasmaZonesEffect::updateWindowStickyState(KWin::EffectWindow* w)
                                {windowId, sticky}, QStringLiteral("setWindowSticky"));
 }
 
-void PlasmaZonesEffect::callDragMoved(const QString& windowId, const QPointF& cursorPos, Qt::KeyboardModifiers mods,
-                                      int mouseButtons)
-{
-    // Don't send manual zone drag updates when drag was started on an autotile screen.
-    // Use captured flag (not live m_autotileScreens) for consistency with drag start/stop.
-    if (m_dragBypassedForAutotile) {
-        return;
-    }
+// callDragMoved removed — phase 3e. The dragMoved lambda now sends
+// updateDragCursor directly via DBusHelpers::fireAndForget. Single
+// entry point for hot-path cursor updates.
 
-    // QDBusMessage::createMethodCall — purely local, no D-Bus introspection.
-    // See callDragStarted() comment for rationale.
-    QDBusMessage msg = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
-                                                      QStringLiteral("dragMoved"));
-    msg << windowId << static_cast<int>(cursorPos.x()) << static_cast<int>(cursorPos.y()) << static_cast<int>(mods)
-        << mouseButtons;
-    QDBusConnection::sessionBus().asyncCall(msg);
-}
-
-void PlasmaZonesEffect::callDragStopped(KWin::EffectWindow* window, const QString& windowId,
-                                        const QString& snapDragStartScreenId)
+void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& windowId, bool cancelled)
 {
-    // Cursor position at release (from last poll during drag) - daemon uses this for release screen
+    // Phase 3e drag protocol: single entry point for drag-end dispatch.
+    // Sends endDrag, receives a DragOutcome, and applies exactly the
+    // action the daemon decided. Replaces callDragStopped (whose reply
+    // shape was a 9-tuple of out-params) with a typed struct.
     QPointF cursorAtRelease = m_dragTracker->lastCursorPos();
 
-    // Modifiers: m_currentModifiers is updated by slotMouseChanged. When drag ends via forceEnd (LMB
-    // release), modifiers reflect the state at that moment. When drag ends via poll (isUserMove went
-    // false), we use the last slotMouseChanged state; modifier released just before mouse may be stale.
-    // This is acceptable for Snap Assist triggers - best-effort detection.
-
-    // QDBusMessage::createMethodCall — purely local, no D-Bus introspection.
-    // See callDragStarted() comment for rationale.
     QDBusMessage msg = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
-                                                      QStringLiteral("dragStopped"));
+                                                      QStringLiteral("endDrag"));
     msg << windowId << static_cast<int>(cursorAtRelease.x()) << static_cast<int>(cursorAtRelease.y())
-        << static_cast<int>(m_currentModifiers) << static_cast<int>(m_currentMouseButtons);
+        << static_cast<int>(m_currentModifiers) << static_cast<int>(m_currentMouseButtons) << cancelled;
     QDBusPendingCall pendingCall = QDBusConnection::sessionBus().asyncCall(msg);
 
-    // Use QPointer to safely handle window destruction during async call
     QPointer<KWin::EffectWindow> safeWindow = window;
+    auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
+    connect(
+        watcher, &QDBusPendingCallWatcher::finished, this, [this, safeWindow, windowId](QDBusPendingCallWatcher* w) {
+            w->deleteLater();
+            QDBusPendingReply<DragOutcome> reply = *w;
+            if (reply.isError()) {
+                qCWarning(lcEffect) << "endDrag call failed:" << reply.error().message();
+                return;
+            }
+            const DragOutcome outcome = reply.value();
+            qCInfo(lcEffect) << "endDrag outcome:" << windowId << "action=" << outcome.action
+                             << "screen=" << outcome.targetScreenId << "geo=" << outcome.toRect()
+                             << "snapAssist=" << outcome.requestSnapAssist;
 
-    // Create watcher to handle the reply
-    QDBusPendingCallWatcher* watcher = new QDBusPendingCallWatcher(pendingCall, this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this,
-            [this, safeWindow, windowId, snapDragStartScreenId](QDBusPendingCallWatcher* w) {
-                w->deleteLater();
+            switch (outcome.action) {
+            case DragOutcome::NoOp:
+            case DragOutcome::CancelSnap:
+            case DragOutcome::NotifyDragOutUnsnap:
+                // Daemon handled any internal cleanup. Nothing for the
+                // effect to paint.
+                break;
 
-                QDBusPendingReply<int, int, int, int, bool, QString, bool, bool, PlasmaZones::EmptyZoneList> reply = *w;
-                if (reply.isError()) {
-                    qCWarning(lcEffect) << "dragStopped call failed:" << reply.error().message();
-                    return;
+            case DragOutcome::ApplyFloat: {
+                // Autotile bypass drag ended — float the window at its
+                // current screen. The plugin-side compositor work
+                // (handleDragToFloat, setWindowFloatingForScreen) was
+                // previously inlined in the dragStopped lambda; now it
+                // fires here off the daemon's authoritative answer.
+                //
+                // Cross-VS transitions that happened mid-drag were
+                // applied by slotDragPolicyChanged at the moment of
+                // crossing, so by the time we get here the autotile
+                // handler has the right tracking state.
+                if (!safeWindow) {
+                    break;
                 }
+                const QString dropScreenId = getWindowScreenId(safeWindow);
+                if (dropScreenId.isEmpty()) {
+                    break;
+                }
+                m_autotileHandler->handleDragToFloat(safeWindow, windowId, dropScreenId);
+                m_dragFloatedWindowIds.insert(windowId);
+                DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking,
+                                           QStringLiteral("setWindowFloatingForScreen"), {windowId, dropScreenId, true},
+                                           QStringLiteral("setWindowFloatingForScreen - endDrag ApplyFloat"));
+                qCInfo(lcEffect) << "endDrag ApplyFloat:" << windowId << "on" << dropScreenId;
+                break;
+            }
 
-                int snapX = reply.argumentAt<0>();
-                int snapY = reply.argumentAt<1>();
-                int snapWidth = reply.argumentAt<2>();
-                int snapHeight = reply.argumentAt<3>();
-                bool shouldSnap = reply.argumentAt<4>();
-                QString releaseScreenId = reply.argumentAt<5>();
-                bool restoreSizeOnly = reply.argumentAt<6>();
-                bool snapAssistRequested = reply.argumentAt<7>();
-                EmptyZoneList emptyZones = reply.argumentAt<8>();
-
-                qCInfo(lcEffect) << "dragStopped returned shouldSnap=" << shouldSnap
-                                 << "releaseScreenId=" << releaseScreenId << "restoreSizeOnly=" << restoreSizeOnly
-                                 << "geometry=" << QRect(snapX, snapY, snapWidth, snapHeight);
-
-                if (shouldSnap && safeWindow) {
-                    // Final fullscreen check before applying geometry - window could have
-                    // transitioned to fullscreen between drag stop and this point
-                    if (safeWindow->isFullScreen()) {
-                        qCDebug(lcEffect) << "Window is fullscreen at drag stop, skipping snap";
-                    } else {
-                        QRect snapGeometry;
-                        bool shouldApply = true;
-                        if (restoreSizeOnly) {
-                            // Drag-to-unsnap: apply only pre-snap width/height, keep current position
-                            QRectF frame = safeWindow->frameGeometry();
-                            snapGeometry =
-                                QRect(static_cast<int>(frame.x()), static_cast<int>(frame.y()), snapWidth, snapHeight);
-                            // Skip if already restored during drag (slotRestoreSizeDuringDrag) to avoid redundant
-                            // moveResize
-                            if (qAbs(frame.width() - snapWidth) <= 1 && qAbs(frame.height() - snapHeight) <= 1) {
-                                shouldApply = false;
-                                qCDebug(lcEffect)
-                                    << "restore apply: already at correct size from during-drag restore, skipping";
-                            }
-                        } else {
-                            snapGeometry = QRect(snapX, snapY, snapWidth, snapHeight);
-                        }
-                        if (shouldApply) {
-                            // If the window is still in user-move state because only the
-                            // activation mouse button is held (LMB already released),
-                            // cancel KWin's interactive move so we can snap immediately.
-                            // Without this, applySnapGeometry defers (100 ms retry) until
-                            // ALL buttons are released, causing a noticeable delay when
-                            // using a mouse button (e.g. RMB) for zone activation.
-                            if (safeWindow->isUserMove() && !(m_currentMouseButtons & Qt::LeftButton)) {
-                                KWin::Window* kw = safeWindow->window();
-                                if (kw) {
-                                    qCDebug(lcEffect) << "Cancelling interactive move"
-                                                         " (activation button held, LMB released)";
-                                    kw->cancelInteractiveMoveResize();
-                                }
-                            }
-                            applySnapGeometry(safeWindow, snapGeometry);
-                        }
+            case DragOutcome::ApplySnap: {
+                if (!safeWindow || safeWindow->isFullScreen()) {
+                    break;
+                }
+                const QRect snapGeometry = outcome.toRect();
+                // If the window is still in user-move state because only
+                // the activation mouse button is held (LMB already
+                // released), cancel KWin's interactive move so we can
+                // snap immediately. Without this, applySnapGeometry
+                // defers (100ms retry) until ALL buttons are released —
+                // noticeable delay when using a mouse button (RMB) for
+                // zone activation.
+                if (safeWindow->isUserMove() && !(m_currentMouseButtons & Qt::LeftButton)) {
+                    if (KWin::Window* kw = safeWindow->window()) {
+                        kw->cancelInteractiveMoveResize();
                     }
                 }
+                applySnapGeometry(safeWindow, snapGeometry);
+                break;
+            }
 
-                // Auto-fill: if window was dropped without snapping to a zone, try snapping to
-                // the first empty zone on the release screen (where the user released the drag).
-                // Use daemon-provided releaseScreenId (cursor position), not window's current
-                // screen - after cross-screen drag the window may still report the old screen.
-                if (!shouldSnap && safeWindow && !releaseScreenId.isEmpty() && isDaemonReady("auto-fill on drop")) {
-                    bool sticky = isWindowSticky(safeWindow);
-                    auto onSnapSuccess = [this](const QString&, const QString& snappedScreenId) {
-                        m_snapAssistHandler->showContinuationIfNeeded(snappedScreenId);
-                    };
-                    tryAsyncSnapCall(DBus::Interface::WindowTracking, QStringLiteral("snapToEmptyZone"),
-                                     {windowId, releaseScreenId, sticky}, safeWindow, windowId, true, nullptr,
-                                     onSnapSuccess);
+            case DragOutcome::RestoreSize: {
+                if (!safeWindow || safeWindow->isFullScreen()) {
+                    break;
                 }
-
-                // Snap Assist: if daemon requested, build candidates (unsnapped only) and call showSnapAssist.
-                // All D-Bus calls are async to prevent compositor freeze if daemon is busy with
-                // overlay teardown / layout change (see discussion #158).
-                if (snapAssistRequested && !emptyZones.isEmpty() && !releaseScreenId.isEmpty()) {
-                    m_snapAssistHandler->asyncShow(windowId, releaseScreenId, emptyZones);
+                // Drag-to-unsnap: apply pre-snap width/height at current
+                // position. Skip if slotRestoreSizeDuringDrag already
+                // applied during the drag (size within 1px).
+                QRectF frame = safeWindow->frameGeometry();
+                const QRect geo(static_cast<int>(frame.x()), static_cast<int>(frame.y()), outcome.width,
+                                outcome.height);
+                if (qAbs(frame.width() - outcome.width) <= 1 && qAbs(frame.height() - outcome.height) <= 1) {
+                    qCDebug(lcEffect) << "endDrag RestoreSize: already at correct size, skipping";
+                    break;
                 }
-
-                // Cross-VS autotile transfer: if the window was dropped on an autotile
-                // virtual screen from a different VS on the SAME physical monitor,
-                // add it to autotile. KWin's outputChanged won't fire (same physical
-                // monitor), so the autotile handler doesn't see the transfer.
-                // Use m_dragBypassScreenId for autotile-bypass drags, or the captured
-                // snapDragStartScreenId for snap-mode drags (m_snapDragStartScreenId
-                // is already cleared by the time this async callback runs).
-                if (safeWindow && !releaseScreenId.isEmpty() && m_autotileHandler->isAutotileScreen(releaseScreenId)) {
-                    const QString oldScreenId =
-                        !m_dragBypassScreenId.isEmpty() ? m_dragBypassScreenId : snapDragStartScreenId;
-                    if (!oldScreenId.isEmpty() && VirtualScreenId::samePhysical(releaseScreenId, oldScreenId)) {
-                        m_autotileHandler->notifyWindowAdded(safeWindow);
-                        // The window was floating (snap-dragged from a non-autotile VS) —
-                        // keep it floating on the destination. notifyWindowAdded tiles the
-                        // window, so immediately restore its floating state and size.
-                        m_autotileHandler->handleDragToFloat(safeWindow, windowId, releaseScreenId);
-                        m_dragFloatedWindowIds.insert(windowId);
-                        DBusHelpers::fireAndForget(
-                            this, DBus::Interface::WindowTracking, QStringLiteral("setWindowFloatingForScreen"),
-                            {windowId, releaseScreenId, true},
-                            QStringLiteral("setWindowFloatingForScreen - snap→autotile VS crossing"));
-                        qCInfo(lcEffect) << "Snap→autotile cross-VS drag-to-float:" << windowId << oldScreenId << "->"
-                                         << releaseScreenId;
+                if (safeWindow->isUserMove() && !(m_currentMouseButtons & Qt::LeftButton)) {
+                    if (KWin::Window* kw = safeWindow->window()) {
+                        kw->cancelInteractiveMoveResize();
                     }
                 }
-            });
+                applySnapGeometry(safeWindow, geo);
+                break;
+            }
+            }
+
+            // Auto-fill: if window was dropped without snapping to a
+            // zone and wasn't floated, try the first empty zone on the
+            // release screen. Daemon-provided targetScreenId wins over
+            // window's current screen (cross-screen drags).
+            const bool applied = outcome.action == DragOutcome::ApplySnap || outcome.action == DragOutcome::ApplyFloat;
+            if (!applied && safeWindow && !outcome.targetScreenId.isEmpty() && isDaemonReady("auto-fill on drop")) {
+                const bool sticky = isWindowSticky(safeWindow);
+                auto onSnapSuccess = [this](const QString&, const QString& snappedScreenId) {
+                    m_snapAssistHandler->showContinuationIfNeeded(snappedScreenId);
+                };
+                tryAsyncSnapCall(DBus::Interface::WindowTracking, QStringLiteral("snapToEmptyZone"),
+                                 {windowId, outcome.targetScreenId, sticky}, safeWindow, windowId, true, nullptr,
+                                 onSnapSuccess);
+            }
+
+            // Snap Assist: show the window picker if the daemon
+            // requested it. asyncShow is non-blocking.
+            if (outcome.requestSnapAssist && !outcome.emptyZones.isEmpty() && !outcome.targetScreenId.isEmpty()) {
+                m_snapAssistHandler->asyncShow(windowId, outcome.targetScreenId, outcome.emptyZones);
+            }
+        });
 }
 
 void PlasmaZonesEffect::callCancelSnap()
@@ -3363,6 +3186,94 @@ void PlasmaZonesEffect::slotRestoreSizeDuringDrag(const QString& windowId, int w
 
     qCDebug(lcEffect) << "Restoring size during drag:" << windowId << geometry;
     applySnapGeometry(window, geometry, true);
+}
+
+void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const DragPolicy& newPolicy)
+{
+    // Phase 3e: daemon-owned cross-VS flip. The daemon's updateDragCursor
+    // handler computed policy at the current cursor position and found it
+    // different from the policy in force — tell us so we can apply the
+    // compositor-level transition. Replaces the effect-side cross-VS flip
+    // loop in the dragMoved lambda that walked KWin::effects->screens()
+    // with a stale m_autotileScreens cache.
+    //
+    // Guards: this slot only acts if we're actively tracking the drag for
+    // this windowId. Stray signals (daemon restart, out-of-order delivery)
+    // are ignored.
+    if (!m_dragTracker->isDragging() || m_dragTracker->draggedWindowId() != windowId) {
+        qCDebug(lcEffect) << "slotDragPolicyChanged: drag no longer active for" << windowId;
+        return;
+    }
+
+    const QString oldReason = m_currentDragPolicy.bypassReason;
+    const QString newReason = newPolicy.bypassReason;
+    if (oldReason == newReason) {
+        // Same reason but different screenId (autotile→autotile cross-VS):
+        // update the captured screen so endDrag's ApplyFloat uses the right one.
+        m_currentDragPolicy = newPolicy;
+        if (newReason == QLatin1String("autotile_screen")) {
+            m_dragBypassScreenId = newPolicy.screenId;
+        }
+        return;
+    }
+
+    qCInfo(lcEffect) << "slotDragPolicyChanged:" << windowId << oldReason << "->" << newReason
+                     << "screen=" << newPolicy.screenId;
+
+    m_currentDragPolicy = newPolicy;
+
+    KWin::EffectWindow* dragW = m_dragTracker->draggedWindow();
+
+    if (newReason == QLatin1String("autotile_screen")) {
+        // Snap → autotile (or context-disabled → autotile). Cancel any
+        // active snap overlay, enter bypass mode. Mirrors the old
+        // effect-side flip block's "snap→autotile" branch, but driven by
+        // daemon truth rather than an effect-cached screen set.
+        if (!m_dragBypassedForAutotile) {
+            callCancelSnap();
+            m_dragBypassedForAutotile = true;
+            m_dragBypassScreenId = newPolicy.screenId;
+            m_dragStartedSent = false;
+            m_pendingDragWindowId.clear();
+            m_pendingDragGeometry = QRectF();
+            m_snapDragStartScreenId.clear();
+        } else {
+            // Already in bypass but on a different autotile screen — just
+            // update the captured screen id.
+            m_dragBypassScreenId = newPolicy.screenId;
+        }
+        return;
+    }
+
+    if (oldReason == QLatin1String("autotile_screen")) {
+        // Autotile → snap (or autotile → context-disabled). Drop the
+        // bypass flag and initialize snap-drag state as if the drag just
+        // started on this snap screen. Remove the window from autotile
+        // tracking so slotWindowFrameGeometryChanged doesn't fight the
+        // snap geometry on subsequent geometry changes.
+        //
+        // Do NOT call handleDragToFloat here: the mid-drag schedule would
+        // race against the zone snap at drop, making the window jump after
+        // the user lets go. onWindowClosed alone clears the tracking state.
+        if (dragW) {
+            m_autotileHandler->onWindowClosed(windowId, m_dragBypassScreenId);
+        }
+        m_dragBypassedForAutotile = false;
+        m_dragActivationDetected = false;
+        m_dragStartedSent = false;
+        m_pendingDragWindowId = windowId;
+        m_pendingDragGeometry = dragW ? dragW->frameGeometry() : QRectF();
+        m_snapDragStartScreenId = newPolicy.screenId;
+        if (!m_keyboardGrabbed) {
+            KWin::effects->grabKeyboard(this);
+            m_keyboardGrabbed = true;
+        }
+        return;
+    }
+
+    // Other transitions (snap ↔ context_disabled / snapping_disabled):
+    // no compositor-level work needed. The daemon will return a NoOp at
+    // endDrag for disabled paths.
 }
 
 void PlasmaZonesEffect::notifyWindowClosed(KWin::EffectWindow* w)

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -983,16 +983,16 @@ void PlasmaZonesEffect::slotMouseChanged(const QPointF& pos, const QPointF& oldp
             m_dragTracker->forceEnd(pos);
         } else if (modifiersChanged || buttonsChanged) {
             // Push modifier/button changes to daemon during drag immediately.
-            // This includes activation button press/release — the daemon shows/hides
-            // the overlay based on whether the activation trigger is currently held,
-            // matching keyboard modifier behavior (hold to show, release to hide,
-            // re-press to show again).
+            // This includes activation button press/release — the daemon's
+            // lazy snap-drag activation uses these modifiers to decide when
+            // to promote a pending drag to active (first tick with trigger
+            // held) and when to hide the overlay (trigger released).
             //
-            // Push modifier/button changes through the
-            // updateDragCursor path. The daemon handles cursor-driven
-            // cross-VS detection and activation-trigger gating.
-            // Effect-side detectActivationAndGrab still maintains the
-            // keyboard grab for Escape handling during snap drags.
+            // The daemon's updateDragCursor is cheap for pending drags
+            // (returns early without running dragMoved), so the rapid fire
+            // of modifier-change events during a drag no longer causes the
+            // overlay destroy/create churn that prompted discussion #310's
+            // sibling regression.
             if (!m_dragBypassedForAutotile) {
                 if (detectActivationAndGrab() || m_cachedZoneSelectorEnabled || !m_triggersLoaded) {
                     DBusHelpers::fireAndForget(this, DBus::Interface::WindowDrag, QStringLiteral("updateDragCursor"),

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -155,6 +155,18 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     , m_compositorBridge(std::make_unique<KWinCompositorBridge>(this))
 {
     PlasmaZones::registerDBusTypes();
+
+    // Frame-geometry shadow flush timer. Debounces per-window
+    // windowFrameGeometryChanged signals and pushes the latest geometry to
+    // the daemon at ~20Hz so daemon-local shortcut handlers (float toggle,
+    // etc.) have fresh geometry without a round-trip. Single-shot timer
+    // re-armed on each incoming change — the flush fires at most one D-Bus
+    // call per window per 50ms window regardless of how many pixels moved.
+    m_frameGeometryFlushTimer = new QTimer(this);
+    m_frameGeometryFlushTimer->setSingleShot(true);
+    m_frameGeometryFlushTimer->setInterval(50);
+    connect(m_frameGeometryFlushTimer, &QTimer::timeout, this, &PlasmaZonesEffect::flushPendingFrameGeometry);
+
     // Connect DragTracker signals
     //
     // Performance optimization: keyboard grab and D-Bus dragMoved calls are deferred
@@ -981,6 +993,29 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     connect(w, &KWin::EffectWindow::windowFrameGeometryChanged, m_autotileHandler.get(),
             &AutotileHandler::slotWindowFrameGeometryChanged);
 
+    // Frame-geometry shadow: push the latest geometry to the daemon so
+    // daemon-local shortcut handlers (float toggle, etc.) can read fresh
+    // geometry without round-tripping. Debounced at ~50ms per window via
+    // m_frameGeometryFlushTimer so rapid move/resize sequences collapse
+    // into at most one D-Bus push.
+    connect(w, &KWin::EffectWindow::windowFrameGeometryChanged, this, [this, w]() {
+        if (!w || !shouldHandleWindow(w)) {
+            return;
+        }
+        const QString windowId = getWindowId(w);
+        if (windowId.isEmpty()) {
+            return;
+        }
+        const QRect geo = w->frameGeometry().toRect();
+        if (geo.width() <= 0 || geo.height() <= 0) {
+            return;
+        }
+        m_pendingFrameGeometry[windowId] = geo;
+        if (!m_frameGeometryFlushTimer->isActive()) {
+            m_frameGeometryFlushTimer->start();
+        }
+    });
+
     // Autotile: track minimize/unminimize to remove/re-add windows from tiling
     connect(w, &KWin::EffectWindow::minimizedChanged, m_autotileHandler.get(),
             &AutotileHandler::slotWindowMinimizedChanged);
@@ -1495,6 +1530,22 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w)
     // Fire-and-forget — the daemon side is idempotent.
     DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("setWindowMetadata"),
                                {instanceId, appId, desktopFile, title}, QStringLiteral("setWindowMetadata"));
+}
+
+void PlasmaZonesEffect::flushPendingFrameGeometry()
+{
+    if (m_pendingFrameGeometry.isEmpty()) {
+        return;
+    }
+    // Move into a local so reentrancy from D-Bus (or later pushes) can't
+    // disturb the iteration.
+    const auto batch = std::exchange(m_pendingFrameGeometry, {});
+    for (auto it = batch.constBegin(); it != batch.constEnd(); ++it) {
+        const QRect& geo = it.value();
+        DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("setFrameGeometry"),
+                                   {it.key(), geo.x(), geo.y(), geo.width(), geo.height()},
+                                   QStringLiteral("setFrameGeometry"));
+    }
 }
 
 bool PlasmaZonesEffect::isPlasmaShellSurface(const QString& windowClass)

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -1851,10 +1851,10 @@ void PlasmaZonesEffect::connectNavigationSignals()
                                           QStringLiteral("activateWindowRequested"), this,
                                           SLOT(slotActivateWindowRequested(QString)));
 
-    // Float toggle (daemon handles full flow, emits applyGeometryRequested for geometry)
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
-                                          QStringLiteral("toggleWindowFloatRequested"), this,
-                                          SLOT(slotToggleWindowFloatRequested(bool)));
+    // Float toggle is now entirely daemon-local (drag-protocol refactor,
+    // phase 2): the daemon reads the active window from its own shadow, calls
+    // toggleFloatForWindow internally, and emits applyGeometryRequested to
+    // paint the outcome. The effect no longer participates in the decision.
 
     // Daemon-driven batch operations (rotate, resnap emit applyGeometriesBatch)
     QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
@@ -2328,33 +2328,9 @@ void PlasmaZonesEffect::slotMoveSpecificWindowToZoneRequested(const QString& win
     }
 }
 
-void PlasmaZonesEffect::slotToggleWindowFloatRequested(bool shouldFloat)
-{
-    Q_UNUSED(shouldFloat)
-    KWin::EffectWindow* activeWindow = getValidActiveWindowOrFail(QStringLiteral("float"));
-    if (!activeWindow) {
-        return;
-    }
-    QString windowId = getWindowId(activeWindow);
-    QString screenId = getWindowScreenId(activeWindow);
-
-    // Store current geometry before the daemon processes the toggle.
-    // D-Bus calls on the same connection are processed in order.
-    //   - Floating → unfloat: capture floating position (overwrite=true)
-    //   - Snapped/tiled → float: first-only (overwrite=false)
-    QRectF frameGeo = activeWindow->frameGeometry();
-    const bool floating = isWindowFloating(windowId);
-
-    // Daemon handles the full flow: pre-snap geometry, zone bookkeeping,
-    // emits applyGeometryRequested for the geometry change.
-    DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("storePreTileGeometry"),
-                               {windowId, static_cast<int>(frameGeo.x()), static_cast<int>(frameGeo.y()),
-                                static_cast<int>(frameGeo.width()), static_cast<int>(frameGeo.height()), screenId,
-                                floating},
-                               QStringLiteral("storePreTileGeometry"));
-    DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("toggleFloatForWindow"),
-                               {windowId, screenId}, QStringLiteral("toggleFloatForWindow"));
-}
+// slotToggleWindowFloatRequested removed — the daemon now handles float-toggle
+// locally against its active-window + frame-geometry shadow and emits
+// applyGeometryRequested directly. See WindowTrackingAdaptor::toggleWindowFloat.
 
 void PlasmaZonesEffect::slotApplyGeometryRequested(const QString& windowId, int x, int y, int width, int height,
                                                    const QString& zoneId, const QString& screenId, bool sizeOnly)

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -409,6 +409,15 @@ private:
     // round-trip over D-Bus.
     QHash<QString, QString> m_appIdByInstance;
 
+    // Frame-geometry shadow push state. Effect debounces windowFrameGeometryChanged
+    // signals per-window to ~50ms and pushes the latest geometry to the daemon via
+    // WindowTracking::setFrameGeometry. Populates the daemon's frame-geometry
+    // shadow used by daemon-local shortcut handlers (float toggle, etc.) so they
+    // can read fresh geometry without a round-trip.
+    QHash<QString, QRect> m_pendingFrameGeometry;
+    QTimer* m_frameGeometryFlushTimer = nullptr;
+    void flushPendingFrameGeometry();
+
     void updateWindowBorder(const QString& windowId, KWin::EffectWindow* w);
     void removeWindowBorder(const QString& windowId);
     void updateAllBorders();

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -100,6 +100,14 @@ private Q_SLOTS:
     // Float toggle is entirely daemon-local — no effect-side slot needed.
     // Phase 2 of the drag-protocol refactor.
 
+    // Phase 3e drag protocol: daemon tells the effect the drag routing
+    // has flipped mid-drag (cursor crossed a virtual-screen boundary that
+    // changes autotile↔snap mode). Effect applies the transition:
+    // entering/exiting autotile bypass, canceling snap overlay, etc.
+    // Replaces the effect-side cross-VS flip loop that used a stale local
+    // m_autotileScreens cache.
+    void slotDragPolicyChanged(const QString& windowId, const PlasmaZones::DragPolicy& newPolicy);
+
     // Daemon-driven batch operations (rotate, resnap)
     void slotApplyGeometriesBatch(const WindowGeometryList& geometries, const QString& action);
     void slotRaiseWindowsRequested(const QStringList& windowIds);
@@ -202,10 +210,16 @@ private:
 
     // D-Bus communication
 
-    void callDragStarted(const QString& windowId, const QRectF& geometry);
-    void callDragMoved(const QString& windowId, const QPointF& cursorPos, Qt::KeyboardModifiers mods, int mouseButtons);
-    void callDragStopped(KWin::EffectWindow* window, const QString& windowId,
-                         const QString& snapDragStartScreenId = {});
+    /**
+     * @brief Phase 3 drag protocol — fire endDrag and apply the returned
+     *        DragOutcome. Single entry point for drag-end dispatch,
+     *        regardless of autotile bypass or snap path.
+     *
+     * @param window Dragged window (QPointer-protected in the async reply)
+     * @param windowId Window identifier
+     * @param cancelled True if the drag was cancelled (Escape / external)
+     */
+    void callEndDrag(KWin::EffectWindow* window, const QString& windowId, bool cancelled);
     void callCancelSnap();
     void callResolveWindowRestore(KWin::EffectWindow* window, std::function<void()> onComplete = nullptr);
     void connectNavigationSignals();
@@ -489,14 +503,9 @@ private:
      */
     bool detectActivationAndGrab();
 
-    /**
-     * @brief Send the deferred dragStarted D-Bus call to the daemon
-     *
-     * Called lazily on first activation detection or zone selector need.
-     * Uses stored pending drag info from the DragTracker::dragStarted signal.
-     * No-op if already sent for the current drag.
-     */
-    void sendDeferredDragStarted();
+    // sendDeferredDragStarted removed — phase 3e. beginDrag is now called
+    // unconditionally at drag-start; the deferred-send optimization is
+    // obsolete now that the daemon always knows about the drag.
 
     // User-configured exclusion lists — cached from daemon for shouldHandleWindow() gating.
     // The daemon also enforces these for keyboard navigation, but the effect needs them

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -409,6 +409,13 @@ private:
     // round-trip over D-Bus.
     QHash<QString, QString> m_appIdByInstance;
 
+    // Phase 3 drag protocol: policy returned from the daemon's beginDrag
+    // for the currently-active drag. Async-populated a few ms after the
+    // drag starts; until then, conservative defaults apply (snap-path
+    // with streaming) so the worst-case UX is a brief zone-overlay flash
+    // rather than a dead drag. Cleared at drag end.
+    DragPolicy m_currentDragPolicy;
+
     // Frame-geometry shadow push state. Effect debounces windowFrameGeometryChanged
     // signals per-window to ~50ms and pushes the latest geometry to the daemon via
     // WindowTracking::setFrameGeometry. Populates the daemon's frame-geometry

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -97,8 +97,8 @@ private Q_SLOTS:
                                     const QString& screenId, bool sizeOnly);
     void slotActivateWindowRequested(const QString& windowId);
 
-    // Float toggle: daemon handles full flow via toggleFloatForWindow
-    void slotToggleWindowFloatRequested(bool shouldFloat);
+    // Float toggle is entirely daemon-local — no effect-side slot needed.
+    // Phase 2 of the drag-protocol refactor.
 
     // Daemon-driven batch operations (rotate, resnap)
     void slotApplyGeometriesBatch(const WindowGeometryList& geometries, const QString& action);

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -98,14 +98,11 @@ private Q_SLOTS:
     void slotActivateWindowRequested(const QString& windowId);
 
     // Float toggle is entirely daemon-local — no effect-side slot needed.
-    // Phase 2 of the drag-protocol refactor.
 
-    // Phase 3e drag protocol: daemon tells the effect the drag routing
-    // has flipped mid-drag (cursor crossed a virtual-screen boundary that
-    // changes autotile↔snap mode). Effect applies the transition:
-    // entering/exiting autotile bypass, canceling snap overlay, etc.
-    // Replaces the effect-side cross-VS flip loop that used a stale local
-    // m_autotileScreens cache.
+    // Daemon tells the effect the drag routing has flipped mid-drag (cursor
+    // crossed a virtual-screen boundary that changes autotile↔snap mode).
+    // Effect applies the transition: entering/exiting autotile bypass,
+    // canceling snap overlay, etc.
     void slotDragPolicyChanged(const QString& windowId, const PlasmaZones::DragPolicy& newPolicy);
 
     // Daemon-driven batch operations (rotate, resnap)
@@ -211,8 +208,8 @@ private:
     // D-Bus communication
 
     /**
-     * @brief Phase 3 drag protocol — fire endDrag and apply the returned
-     *        DragOutcome. Single entry point for drag-end dispatch,
+     * @brief Fire endDrag and apply the returned DragOutcome.
+     *        Single entry point for drag-end dispatch,
      *        regardless of autotile bypass or snap path.
      *
      * @param window Dragged window (QPointer-protected in the async reply)
@@ -423,8 +420,8 @@ private:
     // round-trip over D-Bus.
     QHash<QString, QString> m_appIdByInstance;
 
-    // Phase 3 drag protocol: policy returned from the daemon's beginDrag
-    // for the currently-active drag. Async-populated a few ms after the
+    // Policy returned from the daemon's beginDrag for the currently-active
+    // drag. Async-populated a few ms after the
     // drag starts; until then, conservative defaults apply (snap-path
     // with streaming) so the worst-case UX is a brief zone-overlay flash
     // rather than a dead drag. Cleared at drag end.
@@ -503,9 +500,8 @@ private:
      */
     bool detectActivationAndGrab();
 
-    // sendDeferredDragStarted removed — phase 3e. beginDrag is now called
-    // unconditionally at drag-start; the deferred-send optimization is
-    // obsolete now that the daemon always knows about the drag.
+    // beginDrag is called unconditionally at drag-start; the deferred-send
+    // optimization is obsolete now that the daemon always knows about the drag.
 
     // User-configured exclusion lists — cached from daemon for shouldHandleWindow() gating.
     // The daemon also enforces these for keyboard navigation, but the effect needs them

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,6 +160,7 @@ set(plasmazones_core_SRCS
     dbus/screenadaptor.h
     dbus/windowdragadaptor.cpp
     dbus/windowdragadaptor/drag.cpp
+    dbus/windowdragadaptor/drag_protocol.cpp
     dbus/windowdragadaptor/drop.cpp
     dbus/windowdragadaptor.h
     daemon/shortcutbackend.h
@@ -241,6 +242,7 @@ set_source_files_properties(
     # between AutotileEngine.h (forward-declares Settings) and
     # SettingsBridge.h (uses QPointer<Settings>, needs full definition)
     dbus/windowdragadaptor/drag.cpp
+    dbus/windowdragadaptor/drag_protocol.cpp
     dbus/windowdragadaptor/drop.cpp
     PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON
 )

--- a/src/autotile/AutotileEngine.h
+++ b/src/autotile/AutotileEngine.h
@@ -151,6 +151,18 @@ public:
      */
     bool isAutotileScreen(const QString& screenId) const;
 
+    /**
+     * @brief Check if a window is currently tracked in any autotile state.
+     *
+     * Used by the drag protocol (beginDrag) to decide whether to apply an
+     * immediate free-floating-size restore when a tiled window is picked up.
+     * Reads m_windowToStateKey which is authoritative.
+     */
+    bool isWindowTracked(const QString& windowId) const
+    {
+        return m_windowToStateKey.contains(windowId);
+    }
+
     // IWindowEngine
     bool isActiveOnScreen(const QString& screenId) const override;
 

--- a/src/compositor-common/dbus_types.cpp
+++ b/src/compositor-common/dbus_types.cpp
@@ -301,6 +301,42 @@ const QDBusArgument& operator>>(const QDBusArgument& arg, RestoreTargetResult& e
     return arg;
 }
 
+QDBusArgument& operator<<(QDBusArgument& arg, const DragPolicy& p)
+{
+    arg.beginStructure();
+    arg << p.streamDragMoved << p.showOverlay << p.grabKeyboard << p.captureGeometry << p.immediateFloatOnStart
+        << p.screenId << p.bypassReason;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, DragPolicy& p)
+{
+    arg.beginStructure();
+    arg >> p.streamDragMoved >> p.showOverlay >> p.grabKeyboard >> p.captureGeometry >> p.immediateFloatOnStart
+        >> p.screenId >> p.bypassReason;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const DragOutcome& o)
+{
+    arg.beginStructure();
+    arg << o.action << o.windowId << o.targetScreenId << o.x << o.y << o.width << o.height << o.zoneId
+        << o.skipAnimation;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, DragOutcome& o)
+{
+    arg.beginStructure();
+    arg >> o.action >> o.windowId >> o.targetScreenId >> o.x >> o.y >> o.width >> o.height >> o.zoneId
+        >> o.skipAnimation;
+    arg.endStructure();
+    return arg;
+}
+
 void registerDBusTypes()
 {
     // IMPORTANT: register each type under BOTH its qualified and unqualified
@@ -348,6 +384,8 @@ void registerDBusTypes()
     PZ_REGISTER_DBUS_TYPE(CycleTargetResult);
     PZ_REGISTER_DBUS_TYPE(SwapTargetResult);
     PZ_REGISTER_DBUS_TYPE(RestoreTargetResult);
+    PZ_REGISTER_DBUS_TYPE(DragPolicy);
+    PZ_REGISTER_DBUS_TYPE(DragOutcome);
 
 #undef PZ_REGISTER_DBUS_TYPE
 }

--- a/src/compositor-common/dbus_types.cpp
+++ b/src/compositor-common/dbus_types.cpp
@@ -323,7 +323,7 @@ QDBusArgument& operator<<(QDBusArgument& arg, const DragOutcome& o)
 {
     arg.beginStructure();
     arg << o.action << o.windowId << o.targetScreenId << o.x << o.y << o.width << o.height << o.zoneId
-        << o.skipAnimation;
+        << o.skipAnimation << o.requestSnapAssist << o.emptyZones;
     arg.endStructure();
     return arg;
 }
@@ -332,7 +332,7 @@ const QDBusArgument& operator>>(const QDBusArgument& arg, DragOutcome& o)
 {
     arg.beginStructure();
     arg >> o.action >> o.windowId >> o.targetScreenId >> o.x >> o.y >> o.width >> o.height >> o.zoneId
-        >> o.skipAnimation;
+        >> o.skipAnimation >> o.requestSnapAssist >> o.emptyZones;
     arg.endStructure();
     return arg;
 }

--- a/src/compositor-common/dbus_types.h
+++ b/src/compositor-common/dbus_types.h
@@ -343,6 +343,8 @@ struct DragOutcome
     int height = 0;
     QString zoneId; ///< populated for ApplySnap
     bool skipAnimation = false;
+    bool requestSnapAssist = false; ///< true → plugin should show snap-assist window picker
+    EmptyZoneList emptyZones; ///< candidate zones for snap assist (empty unless requestSnapAssist)
 
     QRect toRect() const
     {

--- a/src/compositor-common/dbus_types.h
+++ b/src/compositor-common/dbus_types.h
@@ -304,10 +304,11 @@ struct SwapTargetResult
 /// decide whether to stream dragMoved, grab keyboard, show an overlay, and
 /// whether to apply an immediate float transition for an autotile drag.
 ///
-/// Wire: (bbbbbss)  —  6 bools + 2 strings
-/// v3 drag-protocol refactor (phase 3). Single source of truth replaces the
-/// effect-side m_dragBypassedForAutotile / m_cachedZoneSelectorEnabled cache
-/// that went stale after every settings reload.
+/// Wire: (bbbbbss)  —  5 bools + 2 strings
+///
+/// Single source of truth replaces the effect-side
+/// m_dragBypassedForAutotile / m_cachedZoneSelectorEnabled cache that went
+/// stale after every settings reload.
 struct DragPolicy
 {
     bool streamDragMoved = false; ///< effect should send dragMoved D-Bus ticks

--- a/src/compositor-common/dbus_types.h
+++ b/src/compositor-common/dbus_types.h
@@ -297,6 +297,59 @@ struct SwapTargetResult
     QString targetZoneId;
 };
 
+/// Drag policy — daemon-authoritative decision about how a drag should be
+/// handled. Returned from WindowDragAdaptor::beginDrag at drag start and
+/// re-emitted via dragPolicyChanged if the cursor crosses a screen boundary
+/// that flips the mode (autotile↔snap). The compositor plugin uses this to
+/// decide whether to stream dragMoved, grab keyboard, show an overlay, and
+/// whether to apply an immediate float transition for an autotile drag.
+///
+/// Wire: (bbbbbss)  —  6 bools + 2 strings
+/// v3 drag-protocol refactor (phase 3). Single source of truth replaces the
+/// effect-side m_dragBypassedForAutotile / m_cachedZoneSelectorEnabled cache
+/// that went stale after every settings reload.
+struct DragPolicy
+{
+    bool streamDragMoved = false; ///< effect should send dragMoved D-Bus ticks
+    bool showOverlay = false; ///< daemon will show zone overlay during this drag
+    bool grabKeyboard = false; ///< effect should grab keyboard (Escape cancel)
+    bool captureGeometry = false; ///< effect should capture pre-drag geometry
+    bool immediateFloatOnStart = false; ///< effect should call handleDragToFloat(immediate) at drag start
+    QString screenId; ///< screen the drag started/currently is on (virtual-screen-aware)
+    QString bypassReason; ///< empty if snap path; "autotile_screen" / "snapping_disabled" / "context_disabled"
+};
+
+/// Drag outcome — daemon-authoritative decision about what to apply at drag
+/// end. Returned from WindowDragAdaptor::endDrag. The compositor plugin
+/// executes exactly the action specified; no further decisions on the effect
+/// side. Wire: (issiiiisb)  —  int action + 2 strings + 4 ints + string + bool
+struct DragOutcome
+{
+    enum Action : int {
+        NoOp = 0, ///< drag produced no state change (e.g. cancelled with no prior snap)
+        ApplyFloat = 1, ///< autotile path: mark window floating at current position
+        ApplySnap = 2, ///< snap path: apply snap geometry to a zone
+        RestoreSize = 3, ///< drag-out unsnap: restore original size, keep current position
+        CancelSnap = 4, ///< snap cancelled via Escape
+        NotifyDragOutUnsnap = 5 ///< drag ended without activation trigger on a previously-snapped window
+    };
+
+    int action = NoOp;
+    QString windowId;
+    QString targetScreenId;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+    QString zoneId; ///< populated for ApplySnap
+    bool skipAnimation = false;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+};
+
 /// D-Bus struct for restore navigation result: (bbiiii)
 struct RestoreTargetResult
 {
@@ -350,6 +403,10 @@ QDBusArgument& operator<<(QDBusArgument& arg, const SwapTargetResult& e);
 const QDBusArgument& operator>>(const QDBusArgument& arg, SwapTargetResult& e);
 QDBusArgument& operator<<(QDBusArgument& arg, const RestoreTargetResult& e);
 const QDBusArgument& operator>>(const QDBusArgument& arg, RestoreTargetResult& e);
+QDBusArgument& operator<<(QDBusArgument& arg, const DragPolicy& p);
+const QDBusArgument& operator>>(const QDBusArgument& arg, DragPolicy& p);
+QDBusArgument& operator<<(QDBusArgument& arg, const DragOutcome& o);
+const QDBusArgument& operator>>(const QDBusArgument& arg, DragOutcome& o);
 
 /// Call once at startup (daemon and plugin) to register types with Qt D-Bus
 void registerDBusTypes();
@@ -386,3 +443,5 @@ Q_DECLARE_METATYPE(PlasmaZones::FocusTargetResult)
 Q_DECLARE_METATYPE(PlasmaZones::CycleTargetResult)
 Q_DECLARE_METATYPE(PlasmaZones::SwapTargetResult)
 Q_DECLARE_METATYPE(PlasmaZones::RestoreTargetResult)
+Q_DECLARE_METATYPE(PlasmaZones::DragPolicy)
+Q_DECLARE_METATYPE(PlasmaZones::DragOutcome)

--- a/src/core/interfaces.h
+++ b/src/core/interfaces.h
@@ -52,15 +52,14 @@ public:
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Composite convenience accessors — implemented inline to enforce the
-    // parent-gate invariant that was previously consumed-side.
+    // parent-gate invariant that was previously consumer-side.
     //
-    // Phase 4 of the v3 drag protocol refactor: nested settings like
-    // zoneSelectorEnabled live under the Snapping.* config tree but were
-    // checked independently by consumers, so a consumer could read
-    // zoneSelectorEnabled=true even with the top-level Snapping.Enabled=false
-    // (exactly the reporter's config in #310 — Snapping.Enabled=false +
-    // Snapping.ZoneSelector.Enabled=true left the effect in a confused
-    // state that the drag path didn't handle).
+    // Nested settings like zoneSelectorEnabled live under the Snapping.*
+    // config tree but were checked independently by consumers, so a consumer
+    // could read zoneSelectorEnabled=true even with the top-level
+    // Snapping.Enabled=false (exactly the reporter's config in #310 —
+    // Snapping.Enabled=false + Snapping.ZoneSelector.Enabled=true left the
+    // effect in a confused state that the drag path didn't handle).
     //
     // These composite methods make the parent gate compile-time: a consumer
     // can't forget to check snappingEnabled() when they read

--- a/src/core/interfaces.h
+++ b/src/core/interfaces.h
@@ -51,6 +51,38 @@ public:
     ~ISettings() override;
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // Composite convenience accessors — implemented inline to enforce the
+    // parent-gate invariant that was previously consumed-side.
+    //
+    // Phase 4 of the v3 drag protocol refactor: nested settings like
+    // zoneSelectorEnabled live under the Snapping.* config tree but were
+    // checked independently by consumers, so a consumer could read
+    // zoneSelectorEnabled=true even with the top-level Snapping.Enabled=false
+    // (exactly the reporter's config in #310 — Snapping.Enabled=false +
+    // Snapping.ZoneSelector.Enabled=true left the effect in a confused
+    // state that the drag path didn't handle).
+    //
+    // These composite methods make the parent gate compile-time: a consumer
+    // can't forget to check snappingEnabled() when they read
+    // isZoneSelectorActive().
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// True only when the zone selector is enabled AND snapping is enabled
+    /// at the top level. Use this in consumers instead of
+    /// zoneSelectorEnabled() unless you need the raw child flag value.
+    bool isZoneSelectorActive() const
+    {
+        return snappingEnabled() && zoneSelectorEnabled();
+    }
+
+    /// True only when snap assist is enabled AND snapping is enabled at
+    /// the top level. Same pattern as isZoneSelectorActive.
+    bool isSnapAssistActive() const
+    {
+        return snappingEnabled() && snapAssistEnabled();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // All settings methods are inherited from the segregated interfaces:
     //   - IZoneActivationSettings: drag modifiers, activation triggers
     //   - IZoneVisualizationSettings: colors, opacity, blur, shader effects

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -62,13 +62,12 @@ void Daemon::handleRotate(bool clockwise)
 
 void Daemon::handleFloat()
 {
-    // Phase 2 of the drag-protocol refactor: toggleWindowFloat() is now
-    // fully daemon-local — reads the active window from the shadow, reads
-    // fresh frame geometry from the phase-1 shadow, and dispatches to the
-    // engine in-process. The prior 100ms debounce was there because the
-    // old path bounced through D-Bus 4 times, where rapid retries could
-    // double-fire. A direct call doesn't need it; rapid Meta-F presses
-    // should act as rapid toggles, not be silently dropped.
+    // toggleWindowFloat() is fully daemon-local — reads the active window
+    // from the shadow, reads fresh frame geometry from the shadow, and
+    // dispatches to the engine in-process. The prior 100ms debounce was
+    // there because the old path bounced through D-Bus 4 times, where rapid
+    // retries could double-fire. A direct call doesn't need it; rapid
+    // Meta-F presses should act as rapid toggles, not be silently dropped.
     if (!m_windowTrackingAdaptor) {
         return;
     }

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -62,15 +62,13 @@ void Daemon::handleRotate(bool clockwise)
 
 void Daemon::handleFloat()
 {
-    if (m_floatDebounce.isValid() && m_floatDebounce.elapsed() < kShortcutDebounceMs) {
-        return;
-    }
-    m_floatDebounce.restart();
-
-    // Delegate to WTA → effect → unified toggleFloatForWindow.
-    // The effect resolves the active KWin window + screen, stores both pre-snap
-    // and pre-autotile geometry, then calls toggleFloatForWindow which the daemon
-    // routes internally to snapping toggle or autotile engine based on screen mode.
+    // Phase 2 of the drag-protocol refactor: toggleWindowFloat() is now
+    // fully daemon-local — reads the active window from the shadow, reads
+    // fresh frame geometry from the phase-1 shadow, and dispatches to the
+    // engine in-process. The prior 100ms debounce was there because the
+    // old path bounced through D-Bus 4 times, where rapid retries could
+    // double-fire. A direct call doesn't need it; rapid Meta-F presses
+    // should act as rapid toggles, not be silently dropped.
     if (!m_windowTrackingAdaptor) {
         return;
     }

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -453,17 +453,31 @@ void OverlayService::showAtPosition(int cursorX, int cursorY)
     const QPoint cursorPos(cursorX, cursorY);
 
     if (m_visible) {
-        // Already visible: when single-monitor mode, switch overlay if cursor moved to different screen (#136)
-        // Use effective (virtual-aware) screen ID to detect cross-virtual-screen movement
+        // Already visible: when single-monitor mode, switch overlay if cursor moved to a different
+        // PHYSICAL monitor (#136). Previously this compared effective screen IDs (virtual-aware),
+        // but Utils::effectiveScreenIdAt can jitter between the physical ID and a virtual variant
+        // ("LG..:115107" ↔ "LG..:115107/vs:0") on successive calls at the same cursor position —
+        // for example when a stale virtual-screen entry is dropped mid-session and subsequent
+        // lookups fall back to the physical ID. Every flicker would fire initializeOverlay →
+        // destroyOverlayWindow(old) → createOverlayWindow(new), paying a full Vulkan RHI
+        // init + wl_surface round-trip each cycle. The destroy/create loop blocked the daemon
+        // main thread long enough to stall endDrag D-Bus delivery by 10+ seconds.
+        //
+        // Comparing extracted physical IDs matches main's QScreen*-pointer comparison in
+        // semantics while staying virtual-screen aware for genuine cross-monitor crossings.
         if (!cursorScreen) {
             cursorScreen = Utils::findScreenAtPosition(cursorPos);
         }
         if (!cursorScreen) {
             return;
         }
-        QString cursorEffectiveId = Utils::effectiveScreenIdAt(QPoint(cursorX, cursorY), cursorScreen);
-        if (!showOnAllMonitors && !cursorEffectiveId.isEmpty() && m_currentOverlayScreenId != cursorEffectiveId) {
-            initializeOverlay(cursorScreen, cursorPos);
+        const QString cursorEffectiveId = Utils::effectiveScreenIdAt(QPoint(cursorX, cursorY), cursorScreen);
+        if (!showOnAllMonitors && !cursorEffectiveId.isEmpty()) {
+            const QString currentPhys = VirtualScreenId::extractPhysicalId(m_currentOverlayScreenId);
+            const QString cursorPhys = VirtualScreenId::extractPhysicalId(cursorEffectiveId);
+            if (currentPhys != cursorPhys) {
+                initializeOverlay(cursorScreen, cursorPos);
+            }
         }
         return;
     }

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -245,7 +245,20 @@ private:
      */
     void createOverlayWindow(const QString& screenId, QScreen* physScreen, const QRect& geometry);
     void destroyOverlayWindow(const QString& screenId);
+    void dismissOverlayWindow(const QString& screenId);
     void updateOverlayWindow(const QString& screenId, QScreen* physScreen);
+
+    // Move a live overlay entry from oldKey to newKey. Used when the effective
+    // screen id for the same physical monitor flips between a virtual variant
+    // ("...:115107/vs:0") and the bare physical id ("...:115107"), so the
+    // existing QQuickWindow + VkSwapchainKHR is reused instead of torn down.
+    // Returns true if a rekey happened.
+    bool rekeyOverlayState(const QString& oldKey, const QString& newKey);
+
+    // Debug-build invariant check: every m_screenStates entry either has a key
+    // present in targetIds or is a distinct physical monitor from every target.
+    // Catches orphan accumulation from effective-id jitter. No-op in release.
+    void validateScreenStateInvariant(const QStringList& targetIds) const;
 
     void updateLabelsTextureForWindow(QQuickWindow* window, const QVariantList& patched, QScreen* screen,
                                       Layout* screenLayout);

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -68,96 +68,143 @@ void OverlayService::initializeOverlay(QScreen* cursorScreen, const QPoint& curs
     // Store the effective screen ID for cross-virtual-screen detection in showAtPosition()
     m_currentOverlayScreenId = showOnAllMonitors ? QString() : cursorEffectiveId;
 
-    // When single-monitor mode, destroy overlay on screens we're switching away from (#136).
-    // Must destroy (not just hide) because on Vulkan, window->hide() destroys the
-    // VkSwapchainKHR but Qt doesn't properly reinitialize it on re-show. Destroying
-    // the window ensures a fresh window is created via createOverlayWindow() below.
-    if (!showOnAllMonitors) {
-        const QStringList screenIds = m_screenStates.keys();
-        for (const QString& screenId : screenIds) {
-            if (screenId != cursorEffectiveId && m_screenStates[screenId].overlayWindow) {
-                destroyOverlayWindow(screenId);
-            }
-        }
-    }
-
-    // Iterate effective screen IDs (includes virtual screens when configured)
+    // Phase 0: build the set of target screen ids — the effective ids that
+    // should have a live overlay window after this call completes. Filters
+    // on single-monitor mode, disabled contexts, autotile exclusion, and
+    // physical-screen resolvability.
     auto* mgr = ScreenManager::instance();
     const QStringList effectiveIds = mgr ? mgr->effectiveScreenIds() : QStringList();
+    const bool haveEffective = mgr && !effectiveIds.isEmpty();
 
-    // Use effective screen IDs if ScreenManager is available, otherwise fall back to physical screens
-    if (mgr && !effectiveIds.isEmpty()) {
+    QStringList targetIds;
+    QHash<QString, QScreen*> targetPhysScreens;
+    QHash<QString, QRect> targetGeometries;
+    if (haveEffective) {
         for (const QString& screenId : effectiveIds) {
             QScreen* physScreen = mgr->physicalQScreenFor(screenId);
             if (!physScreen) {
                 continue;
             }
-            // Skip screens that aren't the cursor's effective screen when single-monitor mode is enabled
             if (!showOnAllMonitors && screenId != cursorEffectiveId) {
                 continue;
             }
-            // Skip monitors/desktops/activities where PlasmaZones is disabled
             if (isContextDisabled(m_settings, screenId, m_currentVirtualDesktop, m_currentActivity)) {
                 continue;
             }
-            // Skip autotile-managed screens (overlay is for manual zone selection)
             if (m_excludedScreens.contains(screenId)) {
                 continue;
             }
-
-            const QRect geom = mgr->screenGeometry(screenId);
-
-            // Destroy and recreate if the window type no longer matches shader settings.
-            destroyIfTypeMismatch(screenId);
-            if (!m_screenStates.contains(screenId) || !m_screenStates[screenId].overlayWindow) {
-                createOverlayWindow(screenId, physScreen, geom);
-            }
-            if (auto* window = m_screenStates.value(screenId).overlayWindow) {
-                const QRect storedGeom =
-                    (m_screenStates.contains(screenId) && m_screenStates[screenId].overlayGeometry.isValid()
-                         ? m_screenStates[screenId].overlayGeometry
-                         : geom);
-                assertWindowOnScreen(window, physScreen, storedGeom);
-                qCDebug(lcOverlay) << "initializeOverlay: screenId=" << screenId << "geom=" << geom << "windowScreen="
-                                   << (window->screen() ? window->screen()->name() : QStringLiteral("null"));
-                updateOverlayWindow(screenId, physScreen);
-                window->show();
-                window->update();
-            }
+            targetIds.append(screenId);
+            targetPhysScreens.insert(screenId, physScreen);
+            targetGeometries.insert(screenId, mgr->screenGeometry(screenId));
         }
     } else {
-        // Fallback: no ScreenManager, use physical screens directly
         for (auto* screen : Utils::allScreens()) {
             if (!showOnAllMonitors && screen != cursorScreen) {
                 continue;
             }
-            if (isContextDisabled(m_settings, Utils::screenIdentifier(screen), m_currentVirtualDesktop,
-                                  m_currentActivity)) {
-                continue;
-            }
-            if (m_excludedScreens.contains(Utils::screenIdentifier(screen))) {
-                continue;
-            }
-
             const QString screenId = Utils::screenIdentifier(screen);
-
-            // Destroy and recreate if the window type no longer matches shader settings.
-            destroyIfTypeMismatch(screenId);
-            if (!m_screenStates.contains(screenId) || !m_screenStates[screenId].overlayWindow) {
-                createOverlayWindow(screen);
+            if (isContextDisabled(m_settings, screenId, m_currentVirtualDesktop, m_currentActivity)) {
+                continue;
             }
-            if (auto* window = m_screenStates.value(screenId).overlayWindow) {
-                assertWindowOnScreen(window, screen);
-                qCDebug(lcOverlay) << "initializeOverlay (physical fallback): screenId=" << screenId
-                                   << "physGeom=" << screen->geometry()
-                                   << "availGeom=" << ScreenManager::actualAvailableGeometry(screen) << "windowScreen="
-                                   << (window->screen() ? window->screen()->name() : QStringLiteral("null"));
-                updateOverlayWindow(screen);
-                window->show();
-                window->update();
+            if (m_excludedScreens.contains(screenId)) {
+                continue;
             }
+            targetIds.append(screenId);
+            targetPhysScreens.insert(screenId, screen);
+            targetGeometries.insert(screenId, screen->geometry());
         }
     }
+
+    const QSet<QString> targetSet(targetIds.cbegin(), targetIds.cend());
+
+    // Phase 1 — REKEY. For every target id that lacks a live overlay window,
+    // look for an existing m_screenStates entry under a different key but with
+    // the SAME physical monitor. Move (rekey) its state to the target id.
+    //
+    // This preserves the live QQuickWindow and its VkSwapchainKHR across
+    // effective-id "flavor flips" — for example when Utils::effectiveScreenIdAt
+    // jitters between "LG..:115107" and "LG..:115107/vs:0" because a VS config
+    // entry was added/removed/re-cached mid-session. Before this fix, each
+    // flip forced a full Vulkan swap-chain teardown + layer-shell surface
+    // reinit, and rapid flips during a drag (via updateDragCursor) stacked
+    // on the daemon main thread long enough to starve D-Bus delivery and
+    // manifest as the runaway overlay-create loop this refactor is fixing.
+    for (const QString& targetId : targetIds) {
+        auto it = m_screenStates.constFind(targetId);
+        if (it != m_screenStates.constEnd() && it->overlayWindow) {
+            continue; // Already correctly keyed with a live window.
+        }
+        const QString targetPhys = VirtualScreenId::extractPhysicalId(targetId);
+        QString donorKey;
+        for (auto sit = m_screenStates.constBegin(); sit != m_screenStates.constEnd(); ++sit) {
+            if (targetSet.contains(sit.key())) {
+                continue; // Another target's entry, leave it alone.
+            }
+            if (!sit.value().overlayWindow) {
+                continue;
+            }
+            if (VirtualScreenId::extractPhysicalId(sit.key()) != targetPhys) {
+                continue;
+            }
+            donorKey = sit.key();
+            break;
+        }
+        if (!donorKey.isEmpty()) {
+            rekeyOverlayState(donorKey, targetId);
+        }
+    }
+
+    // Phase 2 — DISMISS. Every remaining m_screenStates entry whose key is
+    // not in targetSet is either a different physical monitor we're switching
+    // away from, or a leftover from a removed/excluded screen. Hide
+    // non-shader overlays (cheap, no Vulkan churn — mirrors the 9e0cb05f
+    // "hide-not-destroy" policy that dismissOverlayWindow(QScreen*) uses)
+    // and destroy shader overlays (QSGRenderNode pipelines are bound to the
+    // per-window QRhi context, so destroy-on-hide is mandatory there).
+    const QStringList allKeys = m_screenStates.keys();
+    for (const QString& key : allKeys) {
+        if (targetSet.contains(key)) {
+            continue;
+        }
+        dismissOverlayWindow(key);
+    }
+
+    // Phase 3 — CREATE & SHOW. For each target id, create a window if we
+    // still don't have one (rekey phase didn't find a donor), push current
+    // geometry to rekeyed donors, and call show().
+    for (const QString& screenId : targetIds) {
+        QScreen* physScreen = targetPhysScreens.value(screenId);
+        const QRect geom = targetGeometries.value(screenId);
+        if (!physScreen) {
+            continue;
+        }
+
+        destroyIfTypeMismatch(screenId);
+        if (!m_screenStates.contains(screenId) || !m_screenStates[screenId].overlayWindow) {
+            if (haveEffective) {
+                createOverlayWindow(screenId, physScreen, geom);
+            } else {
+                createOverlayWindow(physScreen);
+            }
+        }
+        if (auto* window = m_screenStates.value(screenId).overlayWindow) {
+            m_screenStates[screenId].overlayPhysScreen = physScreen;
+            if (geom.isValid()) {
+                m_screenStates[screenId].overlayGeometry = geom;
+            }
+            const QRect storedGeom =
+                m_screenStates[screenId].overlayGeometry.isValid() ? m_screenStates[screenId].overlayGeometry : geom;
+            assertWindowOnScreen(window, physScreen, storedGeom);
+            qCDebug(lcOverlay) << "initializeOverlay: screenId=" << screenId << "geom=" << geom << "windowScreen="
+                               << (window->screen() ? window->screen()->name() : QStringLiteral("null"));
+            updateOverlayWindow(screenId, physScreen);
+            window->show();
+            window->update();
+        }
+    }
+
+    validateScreenStateInvariant(targetIds);
 
     if (anyScreenUsesShader()) {
         updateZonesForAllWindows(); // Push initial zone data
@@ -493,21 +540,95 @@ void OverlayService::dismissOverlayWindow(QScreen* screen)
     }
 
     for (const QString& screenId : matchingKeys) {
-        auto* window = m_screenStates.value(screenId).overlayWindow;
-        if (!window) {
+        dismissOverlayWindow(screenId);
+    }
+}
+
+void OverlayService::dismissOverlayWindow(const QString& screenId)
+{
+    auto it = m_screenStates.find(screenId);
+    if (it == m_screenStates.end()) {
+        return;
+    }
+    auto* window = it->overlayWindow;
+    if (!window) {
+        return;
+    }
+    // Shader overlays: must destroy — QSGRenderNode Vulkan pipelines are tied
+    // to the per-window QRhi which gets invalidated when hide() tears down the
+    // wl_surface and show() creates a new one.
+    // Non-shader overlays: hide() is safe — standard QML items recover from
+    // scene graph pause/resume, avoiding Vulkan surface create/destroy churn.
+    if (window->property("isShaderOverlay").toBool()) {
+        destroyOverlayWindow(screenId);
+    } else {
+        window->hide();
+    }
+}
+
+bool OverlayService::rekeyOverlayState(const QString& oldKey, const QString& newKey)
+{
+    if (oldKey == newKey) {
+        return false;
+    }
+    auto donor = m_screenStates.find(oldKey);
+    if (donor == m_screenStates.end() || !donor->overlayWindow) {
+        return false;
+    }
+    // If a stale (empty) entry already exists under newKey, drop it so the
+    // move lands cleanly. It has no live window — if it did the caller
+    // should not have selected this donor.
+    auto existing = m_screenStates.find(newKey);
+    if (existing != m_screenStates.end()) {
+        if (existing->overlayWindow) {
+            qCWarning(lcOverlay) << "rekeyOverlayState: refusing to clobber live entry under" << newKey << "with donor"
+                                 << oldKey;
+            return false;
+        }
+        m_screenStates.erase(existing);
+    }
+    PerScreenOverlayState state = std::move(donor.value());
+    m_screenStates.erase(donor);
+    m_screenStates.insert(newKey, std::move(state));
+    qCInfo(lcOverlay) << "rekeyOverlayState: migrated overlay" << oldKey << "->" << newKey
+                      << "(same physical monitor, preserving Vulkan surface)";
+    return true;
+}
+
+void OverlayService::validateScreenStateInvariant(const QStringList& targetIds) const
+{
+#ifndef QT_NO_DEBUG
+    // Invariant: at most one live overlay entry per physical monitor, and
+    // every live entry must either have its key in targetIds or share a
+    // physical monitor with NO target id (meaning it's awaiting dismissal
+    // on the next init). Any violation indicates orphan accumulation from
+    // effective-id jitter and points at a missed rekey/dismiss site.
+    QSet<QString> seenPhys;
+    const QSet<QString> targetSet(targetIds.cbegin(), targetIds.cend());
+    QSet<QString> targetPhys;
+    for (const QString& id : targetIds) {
+        targetPhys.insert(VirtualScreenId::extractPhysicalId(id));
+    }
+    for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
+        if (!it.value().overlayWindow) {
             continue;
         }
-        // Shader overlays: must destroy — QSGRenderNode Vulkan pipelines are tied
-        // to the per-window QRhi which gets invalidated when hide() tears down the
-        // wl_surface and show() creates a new one.
-        // Non-shader overlays: hide() is safe — standard QML items recover from
-        // scene graph pause/resume, avoiding Vulkan surface create/destroy churn.
-        if (window->property("isShaderOverlay").toBool()) {
-            destroyOverlayWindow(screenId);
-        } else {
-            window->hide();
+        const QString physId = VirtualScreenId::extractPhysicalId(it.key());
+        if (seenPhys.contains(physId)) {
+            qCWarning(lcOverlay) << "validateScreenStateInvariant: duplicate live overlay for physical monitor"
+                                 << physId << "key=" << it.key() << "— orphan accumulation detected";
+            Q_ASSERT_X(false, "OverlayService", "duplicate live overlay for one physical monitor");
+        }
+        seenPhys.insert(physId);
+        if (!targetSet.contains(it.key()) && targetPhys.contains(physId)) {
+            qCWarning(lcOverlay) << "validateScreenStateInvariant: live overlay" << it.key()
+                                 << "shares physical monitor with a target id but was not rekeyed";
+            Q_ASSERT_X(false, "OverlayService", "un-rekeyed overlay on a target's physical monitor");
         }
     }
+#else
+    Q_UNUSED(targetIds);
+#endif
 }
 
 void OverlayService::destroyOverlayWindow(QScreen* screen)

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -252,6 +252,14 @@ void WindowDragAdaptor::handleWindowClosed(const QString& windowId)
         m_originalGeometry = QRect();
         m_snapCancelled = false;
         m_wasSnapped = false;
+        m_currentDragBypassReason.clear();
+    }
+
+    // Drop pending snap-drag state if this window was the pending target
+    // (beginDrag ran but activation was never held before close).
+    if (windowId == m_pendingSnapDragWindowId) {
+        clearPendingSnapDragState();
+        m_currentDragBypassReason.clear();
     }
 
     // Delegate tracking cleanup to WindowTrackingAdaptor
@@ -398,8 +406,6 @@ void WindowDragAdaptor::hideOverlayAndSelector()
     if (m_overlayShown && m_overlayService) {
         m_overlayService->hide();
         m_overlayShown = false;
-        m_overlayScreen = nullptr;
-        m_overlayScreenId.clear();
     }
 
     // Hide zone selector and clear selection

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -207,6 +207,17 @@ private:
                      QString& releaseScreenIdOut, bool& restoreSizeOnly, bool& snapAssistRequested,
                      PlasmaZones::EmptyZoneList& emptyZonesOut);
 
+    // Promote the pending snap-path drag (stashed by beginDrag) to an
+    // active drag by running the legacy dragStarted setup. Called from
+    // updateDragCursor once the activation trigger is first held.
+    // Returns true if promotion happened or the drag was already active.
+    bool activateSnapDragIfNeeded(int modifiers, int mouseButtons);
+
+    // Discard any pending snap-path drag state. Called from endDrag and
+    // handleWindowClosed to prevent leftover pending state leaking into
+    // the next drag.
+    void clearPendingSnapDragState();
+
 public:
     /**
      * @brief Pure policy decision — no side effects, static so tests can
@@ -275,6 +286,21 @@ private:
     // and snap path delegates to the legacy dragStopped. Cleared by endDrag.
     QString m_currentDragBypassReason;
     QRect m_originalGeometry;
+
+    // Pending snap-path drag awaiting first activation. Populated by
+    // beginDrag on the snap path instead of immediately running the full
+    // legacy dragStarted setup — that way updateDragCursor ticks before the
+    // user holds the activation trigger are cheap no-ops (no overlay
+    // show/hide cycle). Promoted to m_draggedWindowId on the first tick
+    // where the activation trigger is held, via activateSnapDragIfNeeded().
+    // Restores the lazy drag-state semantics from before the drag-protocol
+    // refactor — there used to be a sendDeferredDragStarted() latch in the
+    // kwin-effect; the refactor made beginDrag unconditional, so the
+    // laziness now lives on the daemon side.
+    QString m_pendingSnapDragWindowId;
+    QRect m_pendingSnapDragGeometry;
+    int m_pendingSnapDragMouseButtons = 0;
+    bool m_pendingSnapDragWasSnapped = false;
     QString m_currentZoneId;
     QRect m_currentZoneGeometry;
     bool m_snapCancelled = false;
@@ -282,8 +308,6 @@ private:
     bool m_activationToggled = false; // Current toggle state (on/off)
     bool m_prevTriggerHeld = false; // Previous frame's trigger state for edge detection
     bool m_overlayShown = false;
-    QScreen* m_overlayScreen = nullptr; // Screen overlay is shown on (single-monitor mode only)
-    QString m_overlayScreenId; // Virtual-aware screen ID for overlay tracking
     bool m_zoneSelectorShown = false;
     int m_lastCursorX = 0;
     int m_lastCursorY = 0;
@@ -308,6 +332,11 @@ private:
     // Last emitted zone geometry (emit only when changed)
     QRect m_lastEmittedZoneGeometry;
     bool m_restoreSizeEmittedDuringDrag = false;
+
+    // Last logged activationActive value — used to emit a log entry only on
+    // true transitions so the drag-overlay churn source can be traced from
+    // journalctl without spamming every tick.
+    bool m_lastLoggedActivationActive = false;
 
     void registerCancelOverlayShortcut();
     void unregisterCancelOverlayShortcut();

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -90,7 +90,6 @@ public Q_SLOTS:
      * snapping-disabled drags, it only stores m_draggedWindowId so later
      * updateDragCursor / endDrag calls match.
      *
-     * Drag protocol v1 (phase 3 of v3 drag refactor).
      */
     PlasmaZones::DragPolicy beginDrag(const QString& windowId, int frameX, int frameY, int frameWidth, int frameHeight,
                                       const QString& startScreenId, int mouseButtons);
@@ -159,8 +158,8 @@ Q_SIGNALS:
     void restoreSizeDuringDragChanged(const QString& windowId, int width, int height);
 
     /**
-     * Phase 3 drag protocol — daemon has detected a policy change for an
-     * active drag (typically because the cursor crossed a virtual-screen
+     * Daemon has detected a policy change for an active drag
+     * (typically because the cursor crossed a virtual-screen
      * boundary that flips autotile↔snap mode). Plugin reacts by applying
      * the transition: entering/exiting autotile bypass, canceling snap
      * overlay, calling handleDragToFloat, etc.
@@ -270,8 +269,8 @@ private:
 
     // Current drag state
     QString m_draggedWindowId;
-    // Phase 3 drag protocol: bypass reason returned from the last beginDrag
-    // call. Read in endDrag to decide which branch to take — autotile bypass
+    // Bypass reason returned from the last beginDrag call.
+    // Read in endDrag to decide which branch to take — autotile bypass
     // gets a synthesized ApplyFloat outcome, context/snap disabled gets NoOp,
     // and snap path delegates to the legacy dragStopped. Cleared by endDrag.
     QString m_currentDragBypassReason;

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -130,47 +130,8 @@ public Q_SLOTS:
      */
     void updateDragCursor(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons);
 
-    /**
-     * Called when window drag starts (legacy; kept alive during the phase 3
-     * transition for the KWin script path that has not been migrated yet).
-     * @note Parameters are double because KWin QML DBusCall sends JS numbers as D-Bus doubles
-     */
-    void dragStarted(const QString& windowId, double x, double y, double width, double height, int mouseButtons);
-
-    /**
-     * Called while window is being dragged (cursor moved)
-     * @param windowId Unique window identifier
-     * @param cursorX Cursor X position (int32 - matches KWin's QPoint)
-     * @param cursorY Cursor Y position (int32 - matches KWin's QPoint)
-     * @param modifiers Qt keyboard modifiers from KWin (int32 - Qt::KeyboardModifiers flags)
-     * @param mouseButtons Qt::MouseButtons currently held (int32). Enables activation-by-mouse: hold this button during
-     * drag to show overlay (same as modifier).
-     */
-    void dragMoved(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons);
-
     /** Forward mouse wheel delta to zone selector for scrolling during drag. */
     void selectorScrollWheel(int angleDeltaY);
-
-    /**
-     * Called when window drag ends
-     * @param windowId Unique window identifier
-     * @param cursorX Cursor X at release (global; used for release screen detection)
-     * @param cursorY Cursor Y at release (global)
-     * @param modifiers Qt::KeyboardModifiers at release.
-     * @param mouseButtons Qt::MouseButtons at release. With modifiers, used for SnapAssistTriggers.
-     * @param snapX Output: X position for window
-     * @param snapY Output: Y position for window
-     * @param snapWidth Output: Width for window
-     * @param snapHeight Output: Height for window
-     * @param shouldApplyGeometry Output: True if KWin should apply the geometry
-     * @param releaseScreenIdOut Output: Screen ID where the drag was released, for auto-fill on drop
-     * @param restoreSizeOnly Output: If true with shouldApplyGeometry, effect applies only width/height at current
-     * position (drag-to-unsnap)
-     */
-    void dragStopped(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons, int& snapX,
-                     int& snapY, int& snapWidth, int& snapHeight, bool& shouldApplyGeometry,
-                     QString& releaseScreenIdOut, bool& restoreSizeOnly, bool& snapAssistRequested,
-                     PlasmaZones::EmptyZoneList& emptyZonesOut);
 
     /**
      * Cancel current snap operation (Escape key)
@@ -231,6 +192,21 @@ private:
     bool anyTriggerHeld(const QVector<ParsedTrigger>& triggers, Qt::KeyboardModifiers mods, int mouseButtons) const;
     // Parse QVariantList triggers into POD structs for repeated use
     static QVector<ParsedTrigger> parseTriggers(const QVariantList& triggers);
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Legacy drag state-machine helpers (formerly public D-Bus slots). Now
+    // called internally by beginDrag / updateDragCursor / endDrag in
+    // drag_protocol.cpp. They stay as regular C++ member functions to
+    // preserve the intricate snap-path overlay/zone logic without having
+    // to rewrite it into the new protocol wrappers. The D-Bus surface no
+    // longer exposes them — external clients go through the new protocol.
+    // ═══════════════════════════════════════════════════════════════════════
+    void dragStarted(const QString& windowId, double x, double y, double width, double height, int mouseButtons);
+    void dragMoved(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons);
+    void dragStopped(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons, int& snapX,
+                     int& snapY, int& snapWidth, int& snapHeight, bool& shouldApplyGeometry,
+                     QString& releaseScreenIdOut, bool& restoreSizeOnly, bool& snapAssistRequested,
+                     PlasmaZones::EmptyZoneList& emptyZonesOut);
 
 public:
     /**

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -75,13 +75,29 @@ public:
 
 public Q_SLOTS:
     /**
-     * Called when window drag starts
-     * @param windowId Unique window identifier
-     * @param x Window X position
-     * @param y Window Y position
-     * @param width Window width
-     * @param height Window height
-     * @param mouseButtons Qt::MouseButtons flags for the button(s) that started the drag (for activation-by-mouse)
+     * Begin a drag session — daemon-authoritative policy decision.
+     *
+     * Replaces dragStarted as the canonical drag-begin entry point. Compositor
+     * plugin calls this synchronously at drag start and uses the returned
+     * DragPolicy to decide whether to stream cursor updates, grab keyboard,
+     * apply an immediate float transition (autotile), etc. Single source of
+     * truth replaces the effect-side m_dragBypassedForAutotile cache that
+     * went stale after every settings reload.
+     *
+     * Internally, for snap-path drags, this also performs the same drag-start
+     * setup as the legacy dragStarted method (original geometry, pre-parsed
+     * triggers, was-snapped check). For autotile-bypass or
+     * snapping-disabled drags, it only stores m_draggedWindowId so later
+     * updateDragCursor / endDrag calls match.
+     *
+     * Drag protocol v1 (phase 3 of v3 drag refactor).
+     */
+    PlasmaZones::DragPolicy beginDrag(const QString& windowId, int frameX, int frameY, int frameWidth, int frameHeight,
+                                      const QString& startScreenId, int mouseButtons);
+
+    /**
+     * Called when window drag starts (legacy; kept alive during the phase 3
+     * transition for the KWin script path that has not been migrated yet).
      * @note Parameters are double because KWin QML DBusCall sends JS numbers as D-Bus doubles
      */
     void dragStarted(const QString& windowId, double x, double y, double width, double height, int mouseButtons);
@@ -169,6 +185,32 @@ private:
     // Parse QVariantList triggers into POD structs for repeated use
     static QVector<ParsedTrigger> parseTriggers(const QVariantList& triggers);
 
+public:
+    /**
+     * @brief Pure policy decision — no side effects, static so tests can
+     *        invoke it without constructing a full adaptor.
+     *
+     * Consulted from daemon-authoritative state. The result is what
+     * beginDrag returns to the compositor plugin and what is emitted on
+     * dragPolicyChanged during cross-VS cursor crossings.
+     *
+     * Precedence: context_disabled → autotile_screen → snapping_disabled →
+     * snap path (canonical). First match wins so the bypassReason string is
+     * stable across coincidental disables.
+     *
+     * @param settings Settings interface (snappingEnabled, zone-span triggers, etc.)
+     * @param autotileEngine May be nullptr in tests that don't exercise autotile
+     * @param windowId Dragged window (used for the isWindowTracked lookup
+     *                 that decides immediateFloatOnStart)
+     * @param screenId Virtual-screen-aware screen ID at drag start
+     * @param curDesktop Current virtual desktop (for context-disabled check)
+     * @param curActivity Current activity (for context-disabled check)
+     */
+    static PlasmaZones::DragPolicy computeDragPolicy(const ISettings* settings, const AutotileEngine* autotileEngine,
+                                                     const QString& windowId, const QString& screenId, int curDesktop,
+                                                     const QString& curActivity);
+
+private:
     // Helper: Find screen containing a point (returns primary screen if not found)
     QScreen* screenAtPoint(int x, int y) const;
 

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -96,6 +96,25 @@ public Q_SLOTS:
                                       const QString& startScreenId, int mouseButtons);
 
     /**
+     * End a drag session — daemon-authoritative action.
+     *
+     * Replaces dragStopped as the canonical drag-end entry point. Returns a
+     * DragOutcome that the compositor plugin applies verbatim — no further
+     * decisions on the plugin side. Covers the full dispatch matrix:
+     *
+     *   - autotile_screen bypass → ApplyFloat at the release cursor
+     *   - snapping_disabled / context_disabled bypass → NoOp
+     *   - snap path → delegates to legacy dragStopped and packages its
+     *     out-params into the outcome (ApplySnap / RestoreSize / NoOp /
+     *     with snap-assist empty zones if requested)
+     *
+     * Must be called after beginDrag for the same windowId. If beginDrag
+     * was never called (or the ids mismatch), returns NoOp.
+     */
+    PlasmaZones::DragOutcome endDrag(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons,
+                                     bool cancelled);
+
+    /**
      * Called when window drag starts (legacy; kept alive during the phase 3
      * transition for the KWin script path that has not been migrated yet).
      * @note Parameters are double because KWin QML DBusCall sends JS numbers as D-Bus doubles
@@ -247,6 +266,11 @@ private:
 
     // Current drag state
     QString m_draggedWindowId;
+    // Phase 3 drag protocol: bypass reason returned from the last beginDrag
+    // call. Read in endDrag to decide which branch to take — autotile bypass
+    // gets a synthesized ApplyFloat outcome, context/snap disabled gets NoOp,
+    // and snap path delegates to the legacy dragStopped. Cleared by endDrag.
+    QString m_currentDragBypassReason;
     QRect m_originalGeometry;
     QString m_currentZoneId;
     QRect m_currentZoneGeometry;

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -115,6 +115,22 @@ public Q_SLOTS:
                                      bool cancelled);
 
     /**
+     * Update drag cursor position — fire-and-forget counterpart to
+     * beginDrag / endDrag. Replaces dragMoved as the canonical hot-path
+     * entry point during a drag. Throttled 30Hz by the compositor plugin.
+     *
+     * For snap-path drags: delegates to legacy dragMoved internally to
+     * keep overlay/zone-detection state current.
+     *
+     * For bypass drags: no-op, but still consulted for cursor screen
+     * detection — if the cursor crosses a virtual-screen boundary that
+     * would change the policy (autotile↔snap), the daemon emits
+     * dragPolicyChanged and the plugin reacts by switching its local
+     * drag mode. This replaces the effect-side cross-VS flip logic.
+     */
+    void updateDragCursor(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons);
+
+    /**
      * Called when window drag starts (legacy; kept alive during the phase 3
      * transition for the KWin script path that has not been migrated yet).
      * @note Parameters are double because KWin QML DBusCall sends JS numbers as D-Bus doubles
@@ -180,6 +196,18 @@ Q_SIGNALS:
      * KWin effect applies pre-snap size immediately (restore-size-only at current position).
      */
     void restoreSizeDuringDragChanged(const QString& windowId, int width, int height);
+
+    /**
+     * Phase 3 drag protocol — daemon has detected a policy change for an
+     * active drag (typically because the cursor crossed a virtual-screen
+     * boundary that flips autotile↔snap mode). Plugin reacts by applying
+     * the transition: entering/exiting autotile bypass, canceling snap
+     * overlay, calling handleDragToFloat, etc.
+     *
+     * Replaces the effect-side cross-VS flip logic that used a local cache
+     * and could go stale after settings reloads.
+     */
+    void dragPolicyChanged(const QString& windowId, const PlasmaZones::DragPolicy& newPolicy);
 
 private:
     // Tolerance constants for geometry matching (fallback detection)

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -66,13 +66,12 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
     m_modifierConflictWarned = false;
     m_lastEmittedZoneGeometry = QRect();
     m_restoreSizeEmittedDuringDrag = false;
+    m_lastLoggedActivationActive = false;
     m_snapCancelled = false;
     m_triggerReleasedAfterCancel = false;
     m_activationToggled = false;
     m_prevTriggerHeld = false;
     m_overlayShown = false;
-    m_overlayScreen = nullptr;
-    m_overlayScreenId.clear();
     m_zoneSelectorShown = false;
     m_lastCursorX = 0;
     m_lastCursorY = 0;
@@ -140,8 +139,6 @@ Layout* WindowDragAdaptor::prepareHandlerContext(int x, int y, QScreen*& outScre
         if (m_overlayShown && m_overlayService) {
             m_overlayService->hide();
             m_overlayShown = false;
-            m_overlayScreen = nullptr;
-            m_overlayScreenId.clear();
         }
         return nullptr;
     }
@@ -151,23 +148,25 @@ Layout* WindowDragAdaptor::prepareHandlerContext(int x, int y, QScreen*& outScre
         if (m_overlayShown && m_overlayService) {
             m_overlayService->hide();
             m_overlayShown = false;
-            m_overlayScreen = nullptr;
-            m_overlayScreenId.clear();
         }
         return nullptr;
     }
 
+    // Call showAtPosition unconditionally on every tick. OverlayService
+    // short-circuits on same-physical-monitor re-shows (compares extracted
+    // physical ids of m_currentOverlayScreenId vs the cursor's effective id),
+    // so rapid drag ticks that stay on one monitor cost only two findScreen
+    // calls and a string extract — no Vulkan churn. The adaptor-side
+    // m_overlayScreenId comparator that used to gate this was fed by the
+    // same jittery effective-id source, and its string mismatches triggered
+    // a second path into initializeOverlay even when the cursor hadn't
+    // left the physical monitor. Dropping the comparator makes
+    // OverlayService the single source of truth for "is a re-init needed".
     if (!m_overlayShown) {
-        m_overlayService->showAtPosition(x, y);
-        m_overlayShown = true;
-        m_overlayScreen = outScreen;
-        m_overlayScreenId = outScreenId;
-    } else if (m_settings && !m_settings->showZonesOnAllMonitors() && m_overlayScreenId != outScreenId) {
-        // Cursor moved to different screen (physical or virtual) - switch overlay to follow (fixes #136)
-        m_overlayService->showAtPosition(x, y);
-        m_overlayScreen = outScreen;
-        m_overlayScreenId = outScreenId;
+        qCInfo(lcDbusWindow) << "prepareHandlerContext: show overlay at" << x << y << "screen=" << outScreenId;
     }
+    m_overlayService->showAtPosition(x, y);
+    m_overlayShown = true;
 
     auto* layout = m_layoutManager->resolveLayoutForScreen(outScreenId);
     if (!layout) {
@@ -207,10 +206,9 @@ void WindowDragAdaptor::hideOverlayAndClearZoneState()
     }
 
     if (m_overlayShown && m_overlayService) {
+        qCInfo(lcDbusWindow) << "hideOverlayAndClearZoneState: hide overlay triggerHeld=false";
         m_overlayService->hide();
         m_overlayShown = false;
-        m_overlayScreen = nullptr;
-        m_overlayScreenId.clear();
     }
     if (m_zoneDetector) {
         m_zoneDetector->clearHighlights();
@@ -432,6 +430,14 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
         activationActive = m_activationToggled;
     } else {
         activationActive = zoneActivationHeld;
+    }
+
+    // Log activation-state transitions so overlay show/hide churn can be traced.
+    if (activationActive != m_lastLoggedActivationActive) {
+        qCInfo(lcDbusWindow) << "dragMoved activationActive" << m_lastLoggedActivationActive << "->" << activationActive
+                             << "mods=" << static_cast<int>(mods) << "buttons=" << mouseButtons
+                             << "triggerHeld=" << triggerHeld << "toggleActivation=" << m_settings->toggleActivation();
+        m_lastLoggedActivationActive = activationActive;
     }
 
     // Check all configured zone span triggers (multi-bind support)

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -84,6 +84,13 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
     qCInfo(lcDbusWindow) << "beginDrag:" << windowId << "screen=" << startScreenId << "bypass=" << policy.bypassReason
                          << "stream=" << policy.streamDragMoved << "immediateFloat=" << policy.immediateFloatOnStart;
 
+    // Stash bypass reason so the matching endDrag can dispatch to the
+    // right branch without re-computing policy (daemon state may have
+    // changed mid-drag, but endDrag should act on the policy that was
+    // in force when the drag started, unless cross-VS flip replaced it
+    // via dragPolicyChanged — sub-commit 3d).
+    m_currentDragBypassReason = policy.bypassReason;
+
     if (!policy.bypassReason.isEmpty()) {
         // Bypass path — record the id so the matching endDrag can find us,
         // but skip the full snap-path setup (overlay, zone state, etc.).
@@ -108,10 +115,118 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
         DragPolicy fallback;
         fallback.screenId = startScreenId;
         fallback.bypassReason = QStringLiteral("snapping_disabled");
+        m_currentDragBypassReason = fallback.bypassReason;
         return fallback;
     }
 
     return policy;
+}
+
+DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int cursorY, int modifiers,
+                                       int mouseButtons, bool cancelled)
+{
+    DragOutcome outcome;
+    outcome.windowId = windowId;
+
+    if (windowId.isEmpty()) {
+        qCWarning(lcDbusWindow) << "endDrag: empty windowId";
+        return outcome;
+    }
+    if (m_draggedWindowId != windowId) {
+        qCWarning(lcDbusWindow) << "endDrag: windowId mismatch — stashed=" << m_draggedWindowId
+                                << "received=" << windowId;
+        return outcome;
+    }
+
+    const QString bypassReason = m_currentDragBypassReason;
+    m_currentDragBypassReason.clear(); // next drag starts fresh
+
+    qCInfo(lcDbusWindow) << "endDrag:" << windowId << "cursor=" << cursorX << cursorY << "cancelled=" << cancelled
+                         << "bypass=" << bypassReason;
+
+    // Cancelled drags on any path: plugin should simply clean up. For
+    // autotile bypass, there's no zone/snap state to unwind. For snap path,
+    // we still delegate to legacy dragStopped so it can reset its own
+    // internal state machine, then emit CancelSnap back.
+    if (cancelled) {
+        if (bypassReason.isEmpty()) {
+            // Snap path cancelled — run dragStopped through the legacy
+            // adaptor so overlay/zone-state cleanup happens, but discard
+            // the geometry outputs.
+            int sx = 0, sy = 0, sw = 0, sh = 0;
+            bool shouldApply = false;
+            bool restoreSizeOnly = false;
+            bool snapAssistRequested = false;
+            QString releaseScreen;
+            EmptyZoneList emptyZones;
+            dragStopped(windowId, cursorX, cursorY, modifiers, mouseButtons, sx, sy, sw, sh, shouldApply, releaseScreen,
+                        restoreSizeOnly, snapAssistRequested, emptyZones);
+        } else {
+            // Bypass paths — no overlay state to clean up; just drop the id.
+            m_draggedWindowId.clear();
+        }
+        outcome.action = DragOutcome::CancelSnap;
+        return outcome;
+    }
+
+    // Autotile bypass — plugin will float the window at the drop location.
+    // Daemon has no placement decision to make; the outcome just carries
+    // the release screen so the plugin can pass it to
+    // setWindowFloatingForScreen.
+    if (bypassReason == QLatin1String("autotile_screen")) {
+        // Release screen is resolved plugin-side from the cursor position,
+        // but we pass the cursor through so the daemon can log it. The
+        // plugin passes its own view of "current screen" to the float call.
+        outcome.action = DragOutcome::ApplyFloat;
+        outcome.targetScreenId.clear(); // plugin resolves from cursor
+        outcome.x = cursorX;
+        outcome.y = cursorY;
+        m_draggedWindowId.clear();
+        return outcome;
+    }
+
+    // Snapping disabled / context disabled — dead drag. No action.
+    if (bypassReason == QLatin1String("snapping_disabled") || bypassReason == QLatin1String("context_disabled")) {
+        outcome.action = DragOutcome::NoOp;
+        m_draggedWindowId.clear();
+        return outcome;
+    }
+
+    // Snap path — delegate to legacy dragStopped and translate its
+    // out-params into a DragOutcome. dragStopped handles the full
+    // dispatch matrix (snap-to-zone, drag-out unsnap, cross-screen
+    // cleanup, zone selector, snap assist).
+    int sx = 0, sy = 0, sw = 0, sh = 0;
+    bool shouldApply = false;
+    bool restoreSizeOnly = false;
+    bool snapAssistRequested = false;
+    QString releaseScreen;
+    EmptyZoneList emptyZones;
+    dragStopped(windowId, cursorX, cursorY, modifiers, mouseButtons, sx, sy, sw, sh, shouldApply, releaseScreen,
+                restoreSizeOnly, snapAssistRequested, emptyZones);
+
+    outcome.targetScreenId = releaseScreen;
+    outcome.x = sx;
+    outcome.y = sy;
+    outcome.width = sw;
+    outcome.height = sh;
+    outcome.requestSnapAssist = snapAssistRequested;
+    outcome.emptyZones = emptyZones;
+
+    if (shouldApply) {
+        outcome.action = restoreSizeOnly ? DragOutcome::RestoreSize : DragOutcome::ApplySnap;
+        // Captured zone id is the primary zone from multi-zone snap or
+        // the single zone for a regular snap. dragStopped cleared its
+        // m_currentZoneId, so we can't read it here — but the plugin
+        // already knows the zone from its own view of daemon-emitted
+        // zoneGeometryDuringDragChanged signals during the drag, and
+        // DragOutcome's zoneId is informational only for painting.
+    } else {
+        outcome.action = DragOutcome::NoOp;
+    }
+
+    m_draggedWindowId.clear();
+    return outcome;
 }
 
 } // namespace PlasmaZones

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Phase 3 of the v3 drag protocol refactor. Replaces the effect-side
+// m_dragBypassedForAutotile / m_cachedZoneSelectorEnabled distributed state
+// with a daemon-authoritative beginDrag / endDrag protocol.
+//
+// The existing dragStarted / dragMoved / dragStopped methods stay alive in
+// parallel while the compositor plugin is being ported over. Once nothing
+// calls them they'll be deleted (sub-commit 3E).
+
+#include "../windowdragadaptor.h"
+#include "../../core/interfaces.h"
+#include "../../core/layoutmanager.h"
+#include "../../core/settings_interfaces.h"
+#include "../../core/logging.h"
+#include "../../autotile/AutotileEngine.h"
+
+namespace PlasmaZones {
+
+DragPolicy WindowDragAdaptor::computeDragPolicy(const ISettings* settings, const AutotileEngine* autotileEngine,
+                                                const QString& windowId, const QString& screenId, int curDesktop,
+                                                const QString& curActivity)
+{
+    DragPolicy policy;
+    policy.screenId = screenId;
+
+    // Order matters — strongest disables checked first so the reason string
+    // is stable regardless of which conditions coincide.
+
+    // 1) Disabled context (activity / desktop / monitor excluded in settings).
+    //    Dead drag: no overlay, no cursor stream, no float transition.
+    if (settings && !screenId.isEmpty() && isContextDisabled(settings, screenId, curDesktop, curActivity)) {
+        policy.bypassReason = QStringLiteral("context_disabled");
+        return policy;
+    }
+
+    // 2) Autotile screen — the autotile engine owns window placement. The
+    //    plugin applies handleDragToFloat immediately if the window is
+    //    currently tiled, so the user sees the free-floating size restored
+    //    during the interactive move (not deferred to drop).
+    if (autotileEngine && !screenId.isEmpty() && autotileEngine->isAutotileScreen(screenId)) {
+        policy.bypassReason = QStringLiteral("autotile_screen");
+        policy.captureGeometry = true; // preserve pre-autotile size for unfloat restore
+        if (!windowId.isEmpty()) {
+            policy.immediateFloatOnStart = autotileEngine->isWindowTracked(windowId);
+        }
+        return policy;
+    }
+
+    // 3) Top-level snapping disabled. Dead drag on any non-autotile screen —
+    //    the user configured the tool with snap mode off. beginDrag still
+    //    returns a policy so endDrag can clean up consistently.
+    if (settings && !settings->snappingEnabled()) {
+        policy.bypassReason = QStringLiteral("snapping_disabled");
+        return policy;
+    }
+
+    // 4) Snap path — canonical case. Plugin streams cursor updates, daemon
+    //    runs overlay / zone detection / snap assist. Activation-trigger
+    //    gating still happens locally in the plugin against the current
+    //    modifier state (input-event optimization, not policy).
+    policy.streamDragMoved = true;
+    policy.showOverlay = true;
+    policy.grabKeyboard = true;
+    policy.captureGeometry = true;
+    policy.bypassReason.clear();
+    return policy;
+}
+
+DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int frameY, int frameWidth,
+                                        int frameHeight, const QString& startScreenId, int mouseButtons)
+{
+    if (windowId.isEmpty()) {
+        qCWarning(lcDbusWindow) << "beginDrag: empty windowId";
+        return DragPolicy{};
+    }
+
+    const int curDesktop = m_layoutManager ? m_layoutManager->currentVirtualDesktop() : 0;
+    const QString curActivity = m_layoutManager ? m_layoutManager->currentActivity() : QString();
+    const DragPolicy policy =
+        computeDragPolicy(m_settings, m_autotileEngine, windowId, startScreenId, curDesktop, curActivity);
+
+    qCInfo(lcDbusWindow) << "beginDrag:" << windowId << "screen=" << startScreenId << "bypass=" << policy.bypassReason
+                         << "stream=" << policy.streamDragMoved << "immediateFloat=" << policy.immediateFloatOnStart;
+
+    if (!policy.bypassReason.isEmpty()) {
+        // Bypass path — record the id so the matching endDrag can find us,
+        // but skip the full snap-path setup (overlay, zone state, etc.).
+        m_draggedWindowId = windowId;
+        m_originalGeometry = QRect(frameX, frameY, frameWidth, frameHeight);
+        m_snapCancelled = false;
+        m_wasSnapped = false;
+        return policy;
+    }
+
+    // Snap path — delegate to the legacy dragStarted to set up the rest of
+    // the state machine (pre-parsed triggers, wasSnapped check, zone state
+    // reset). This wraps the existing logic rather than duplicating it so
+    // the snap path stays behavior-identical during the migration.
+    dragStarted(windowId, static_cast<double>(frameX), static_cast<double>(frameY), static_cast<double>(frameWidth),
+                static_cast<double>(frameHeight), mouseButtons);
+
+    // dragStarted may have cleared m_draggedWindowId if snapping is actually
+    // disabled (guard is inside dragStarted for the legacy path); reflect
+    // that back in the policy so the plugin gets the correct answer.
+    if (m_draggedWindowId != windowId) {
+        DragPolicy fallback;
+        fallback.screenId = startScreenId;
+        fallback.bypassReason = QStringLiteral("snapping_disabled");
+        return fallback;
+    }
+
+    return policy;
+}
+
+} // namespace PlasmaZones

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-// Phase 3 of the v3 drag protocol refactor. Replaces the effect-side
-// m_dragBypassedForAutotile / m_cachedZoneSelectorEnabled distributed state
-// with a daemon-authoritative beginDrag / endDrag protocol.
+// Daemon-authoritative beginDrag / endDrag protocol. Replaces the
+// effect-side m_dragBypassedForAutotile / m_cachedZoneSelectorEnabled
+// distributed state with a single source of truth on the daemon side.
 //
-// The existing dragStarted / dragMoved / dragStopped methods stay alive in
-// parallel while the compositor plugin is being ported over. Once nothing
-// calls them they'll be deleted (sub-commit 3E).
+// The legacy dragStarted / dragMoved / dragStopped methods are kept as
+// internal C++ helpers (called from this file) so the intricate snap-path
+// state machine doesn't need to be rewritten. They're no longer exposed
+// on the D-Bus surface.
 
 #include "../windowdragadaptor.h"
 #include "../../core/interfaces.h"
@@ -196,6 +197,13 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     // out-params into a DragOutcome. dragStopped handles the full
     // dispatch matrix (snap-to-zone, drag-out unsnap, cross-screen
     // cleanup, zone selector, snap assist).
+    //
+    // Snapshot the active zone id BEFORE dragStopped runs — the cleanup
+    // path inside dragStopped clears m_currentZoneId via
+    // hideOverlayAndClearZoneState, and we want that id exposed on the
+    // outcome so the daemon is authoritative for every DragOutcome field.
+    const QString capturedZoneId = m_currentZoneId;
+
     int sx = 0, sy = 0, sw = 0, sh = 0;
     bool shouldApply = false;
     bool restoreSizeOnly = false;
@@ -215,12 +223,11 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
 
     if (shouldApply) {
         outcome.action = restoreSizeOnly ? DragOutcome::RestoreSize : DragOutcome::ApplySnap;
-        // Captured zone id is the primary zone from multi-zone snap or
-        // the single zone for a regular snap. dragStopped cleared its
-        // m_currentZoneId, so we can't read it here — but the plugin
-        // already knows the zone from its own view of daemon-emitted
-        // zoneGeometryDuringDragChanged signals during the drag, and
-        // DragOutcome's zoneId is informational only for painting.
+        // Primary zone captured pre-cleanup. Empty on RestoreSize (drag-out
+        // unsnap has no target zone), populated on ApplySnap.
+        if (!restoreSizeOnly) {
+            outcome.zoneId = capturedZoneId;
+        }
     } else {
         outcome.action = DragOutcome::NoOp;
     }

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -229,4 +229,49 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     return outcome;
 }
 
+void WindowDragAdaptor::updateDragCursor(const QString& windowId, int cursorX, int cursorY, int modifiers,
+                                         int mouseButtons)
+{
+    if (windowId.isEmpty() || windowId != m_draggedWindowId) {
+        return;
+    }
+
+    // Cross-VS flip detection: if the cursor moved to a screen whose policy
+    // differs from the one in force, compute the new policy and emit
+    // dragPolicyChanged. The plugin reacts by calling handleDragToFloat or
+    // re-initializing snap-drag state as needed. This replaces the
+    // effect-side detection loop in the dragMoved lambda that used the
+    // stale m_autotileScreens cache to decide when to flip.
+    auto resolved = resolveScreenAt(QPointF(cursorX, cursorY));
+    const QString cursorScreenId = resolved.screenId;
+    if (!cursorScreenId.isEmpty()) {
+        const int curDesktop = m_layoutManager ? m_layoutManager->currentVirtualDesktop() : 0;
+        const QString curActivity = m_layoutManager ? m_layoutManager->currentActivity() : QString();
+        const DragPolicy candidate =
+            computeDragPolicy(m_settings, m_autotileEngine, windowId, cursorScreenId, curDesktop, curActivity);
+        if (candidate.bypassReason != m_currentDragBypassReason
+            || (candidate.bypassReason == QLatin1String("autotile_screen") && candidate.screenId != cursorScreenId)) {
+            qCInfo(lcDbusWindow) << "updateDragCursor: policy flip" << m_currentDragBypassReason << "->"
+                                 << candidate.bypassReason << "on" << cursorScreenId;
+            m_currentDragBypassReason = candidate.bypassReason;
+            Q_EMIT dragPolicyChanged(windowId, candidate);
+            // After the flip, fall through: if we're now on the snap path
+            // we still want to call legacy dragMoved below for overlay
+            // updates. If we're now bypassed, legacy dragMoved is a
+            // no-op because m_snapCancelled isn't set and dragMoved only
+            // does real work when m_draggedWindowId matches — which it
+            // does — but the overlay/zone state will be hidden by the
+            // effect's reaction handler, so running dragMoved here does
+            // no harm.
+        }
+    }
+
+    // Snap path: forward to legacy dragMoved so overlay/zone-detection
+    // state stays current. Bypass paths: legacy dragMoved is a harmless
+    // no-op because the snap-path state machine isn't initialized (no
+    // m_snapCancelled, no m_draggedWindowId processing for bypass drags
+    // that never called dragStarted internally).
+    dragMoved(windowId, cursorX, cursorY, modifiers, mouseButtons);
+}
+
 } // namespace PlasmaZones

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -11,11 +11,13 @@
 // on the D-Bus surface.
 
 #include "../windowdragadaptor.h"
+#include "../windowtrackingadaptor.h"
 #include "../../core/interfaces.h"
 #include "../../core/layoutmanager.h"
 #include "../../core/settings_interfaces.h"
 #include "../../core/logging.h"
 #include "../../autotile/AutotileEngine.h"
+#include <QGuiApplication>
 
 namespace PlasmaZones {
 
@@ -77,6 +79,10 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
         return DragPolicy{};
     }
 
+    // Any stale pending state from a previous drag that didn't complete
+    // cleanly must not bleed into this one.
+    clearPendingSnapDragState();
+
     const int curDesktop = m_layoutManager ? m_layoutManager->currentVirtualDesktop() : 0;
     const QString curActivity = m_layoutManager ? m_layoutManager->currentActivity() : QString();
     const DragPolicy policy =
@@ -86,10 +92,7 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
                          << "stream=" << policy.streamDragMoved << "immediateFloat=" << policy.immediateFloatOnStart;
 
     // Stash bypass reason so the matching endDrag can dispatch to the
-    // right branch without re-computing policy (daemon state may have
-    // changed mid-drag, but endDrag should act on the policy that was
-    // in force when the drag started, unless cross-VS flip replaced it
-    // via dragPolicyChanged — sub-commit 3d).
+    // right branch without re-computing policy.
     m_currentDragBypassReason = policy.bypassReason;
 
     if (!policy.bypassReason.isEmpty()) {
@@ -102,25 +105,69 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
         return policy;
     }
 
-    // Snap path — delegate to the legacy dragStarted to set up the rest of
-    // the state machine (pre-parsed triggers, wasSnapped check, zone state
-    // reset). This wraps the existing logic rather than duplicating it so
-    // the snap path stays behavior-identical during the migration.
-    dragStarted(windowId, static_cast<double>(frameX), static_cast<double>(frameY), static_cast<double>(frameWidth),
-                static_cast<double>(frameHeight), mouseButtons);
-
-    // dragStarted may have cleared m_draggedWindowId if snapping is actually
-    // disabled (guard is inside dragStarted for the legacy path); reflect
-    // that back in the policy so the plugin gets the correct answer.
-    if (m_draggedWindowId != windowId) {
-        DragPolicy fallback;
-        fallback.screenId = startScreenId;
-        fallback.bypassReason = QStringLiteral("snapping_disabled");
-        m_currentDragBypassReason = fallback.bypassReason;
-        return fallback;
+    // Snap path — do NOT run the legacy dragStarted setup yet. We defer
+    // m_draggedWindowId population until the user first holds an
+    // activation trigger (checked in updateDragCursor via
+    // activateSnapDragIfNeeded). This restores the lazy drag-state
+    // semantics that used to live in the kwin-effect's
+    // sendDeferredDragStarted() latch: if a user drags a window without
+    // ever holding the activation trigger, the daemon never runs the
+    // overlay show/hide cycle and never pays the Vulkan shader-overlay
+    // destroy/create cost. Pre-parsing triggers here (instead of inside
+    // dragStarted) so activateSnapDragIfNeeded can compare modifier state
+    // against them without a chicken-and-egg dependency.
+    if (m_settings) {
+        m_cachedActivationTriggers = parseTriggers(m_settings->dragActivationTriggers());
+        m_cachedZoneSpanTriggers = parseTriggers(m_settings->zoneSpanTriggers());
     }
 
+    m_pendingSnapDragWindowId = windowId;
+    m_pendingSnapDragGeometry = QRect(frameX, frameY, frameWidth, frameHeight);
+    m_pendingSnapDragMouseButtons = mouseButtons;
+    m_pendingSnapDragWasSnapped = m_windowTracking && !m_windowTracking->getZoneForWindow(windowId).isEmpty();
+
     return policy;
+}
+
+bool WindowDragAdaptor::activateSnapDragIfNeeded(int modifiers, int mouseButtons)
+{
+    // Already active? nothing to do.
+    if (!m_draggedWindowId.isEmpty()) {
+        return true;
+    }
+    // No pending drag to activate.
+    if (m_pendingSnapDragWindowId.isEmpty()) {
+        return false;
+    }
+
+    const Qt::KeyboardModifiers mods = static_cast<Qt::KeyboardModifiers>(modifiers);
+    const bool triggerHeld = anyTriggerHeld(m_cachedActivationTriggers, mods, mouseButtons);
+    const bool toggleMode = m_settings && m_settings->toggleActivation();
+    if (!triggerHeld && !toggleMode) {
+        return false;
+    }
+
+    const QString pendingId = m_pendingSnapDragWindowId;
+    const QRect pendingGeo = m_pendingSnapDragGeometry;
+    const int pendingButtons = m_pendingSnapDragMouseButtons;
+    m_pendingSnapDragWindowId.clear();
+    m_pendingSnapDragGeometry = QRect();
+    m_pendingSnapDragMouseButtons = 0;
+    // Keep m_pendingSnapDragWasSnapped — dragStarted re-derives m_wasSnapped
+    // from live tracking state.
+
+    qCInfo(lcDbusWindow) << "activateSnapDragIfNeeded: promoting" << pendingId << "to active drag";
+    dragStarted(pendingId, static_cast<double>(pendingGeo.x()), static_cast<double>(pendingGeo.y()),
+                static_cast<double>(pendingGeo.width()), static_cast<double>(pendingGeo.height()), pendingButtons);
+    return !m_draggedWindowId.isEmpty();
+}
+
+void WindowDragAdaptor::clearPendingSnapDragState()
+{
+    m_pendingSnapDragWindowId.clear();
+    m_pendingSnapDragGeometry = QRect();
+    m_pendingSnapDragMouseButtons = 0;
+    m_pendingSnapDragWasSnapped = false;
 }
 
 DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int cursorY, int modifiers,
@@ -133,6 +180,27 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
         qCWarning(lcDbusWindow) << "endDrag: empty windowId";
         return outcome;
     }
+
+    // Pending snap-path drag that never activated. Mirrors the main-branch
+    // behavior where sendDeferredDragStarted() never latched and
+    // DragTracker::dragStopped short-circuited at `if (!m_dragStartedSent)`.
+    // If the window was snapped at drag start and the user dragged it
+    // without holding the activation trigger, drive notifyDragOutUnsnap
+    // on the window-tracking side so the window unsnaps and floats at
+    // the drop location — otherwise the stale zone assignment persists.
+    if (m_draggedWindowId.isEmpty() && m_pendingSnapDragWindowId == windowId) {
+        const bool wasSnapped = m_pendingSnapDragWasSnapped;
+        qCInfo(lcDbusWindow) << "endDrag: pending snap drag never activated" << windowId << "wasSnapped=" << wasSnapped
+                             << "cancelled=" << cancelled;
+        clearPendingSnapDragState();
+        m_currentDragBypassReason.clear();
+        if (!cancelled && wasSnapped && m_windowTracking) {
+            m_windowTracking->notifyDragOutUnsnap(windowId);
+        }
+        outcome.action = DragOutcome::NoOp;
+        return outcome;
+    }
+
     if (m_draggedWindowId != windowId) {
         qCWarning(lcDbusWindow) << "endDrag: windowId mismatch — stashed=" << m_draggedWindowId
                                 << "received=" << windowId;
@@ -239,7 +307,20 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
 void WindowDragAdaptor::updateDragCursor(const QString& windowId, int cursorX, int cursorY, int modifiers,
                                          int mouseButtons)
 {
-    if (windowId.isEmpty() || windowId != m_draggedWindowId) {
+    if (windowId.isEmpty()) {
+        return;
+    }
+
+    // Pending snap-path drag: try to activate if the trigger is now held.
+    // If it's still pending after the check, return — the daemon does no
+    // overlay work until the user commits to zone selection.
+    if (m_draggedWindowId.isEmpty() && m_pendingSnapDragWindowId == windowId) {
+        if (!activateSnapDragIfNeeded(modifiers, mouseButtons)) {
+            return;
+        }
+    }
+
+    if (windowId != m_draggedWindowId) {
         return;
     }
 

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -388,6 +388,9 @@ void WindowTrackingAdaptor::windowClosed(const QString& windowId)
         m_lastActiveWindowId.clear();
     }
 
+    // Drop frame-geometry shadow entry for this window.
+    m_frameGeometry.remove(windowId);
+
     m_service->windowClosed(windowId);
 
     // Drop registry state last: consumers subscribed to windowDisappeared may
@@ -493,6 +496,19 @@ void WindowTrackingAdaptor::cursorScreenChanged(const QString& screenId)
 
     m_lastCursorScreenId = resolvedId;
     qCDebug(lcDbusWindow) << "Cursor screen changed to" << resolvedId;
+}
+
+void WindowTrackingAdaptor::setFrameGeometry(const QString& windowId, int x, int y, int width, int height)
+{
+    if (windowId.isEmpty() || width <= 0 || height <= 0) {
+        return;
+    }
+    m_frameGeometry[windowId] = QRect(x, y, width, height);
+}
+
+QRect WindowTrackingAdaptor::frameGeometry(const QString& windowId) const
+{
+    return m_frameGeometry.value(windowId);
 }
 
 void WindowTrackingAdaptor::windowActivated(const QString& windowId, const QString& screenId)

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -492,8 +492,12 @@ public Q_SLOTS:
     void restoreWindowSize();
 
     /**
-     * @brief Toggle float state for the focused window
-     * @note Emits toggleWindowFloatRequested for effect to call toggleFloatForWindow
+     * @brief Toggle float state for the focused window (daemon-local)
+     *
+     * Reads the active windowId + screen from m_lastActive*, reads fresh
+     * frame geometry from the shadow (phase 1), stores pre-tile geometry,
+     * and calls toggleFloatForWindow to dispatch to the engine. No kwin-effect
+     * round-trip, no stale local cache reads.
      */
     void toggleWindowFloat();
 
@@ -879,12 +883,6 @@ Q_SIGNALS:
                             const QString& targetZoneId, const QString& screenId);
 
     // Navigation signals (daemon → effect)
-    /**
-     * @brief Request to toggle float state for the focused window
-     * @param shouldFloat true to float (exclude), false to unfloat
-     */
-    void toggleWindowFloatRequested(bool shouldFloat);
-
     /**
      * @brief Request KWin effect to collect unsnapped windows and snap them all
      * @param screenId Screen to operate on

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -495,7 +495,7 @@ public Q_SLOTS:
      * @brief Toggle float state for the focused window (daemon-local)
      *
      * Reads the active windowId + screen from m_lastActive*, reads fresh
-     * frame geometry from the shadow (phase 1), stores pre-tile geometry,
+     * frame geometry from the shadow, stores pre-tile geometry,
      * and calls toggleFloatForWindow to dispatch to the engine. No kwin-effect
      * round-trip, no stale local cache reads.
      */

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -279,6 +279,27 @@ public Q_SLOTS:
     void windowActivated(const QString& windowId, const QString& screenId);
 
     /**
+     * Push current frame geometry for a window into the daemon's shadow.
+     *
+     * Called by the compositor plugin on windowFrameGeometryChanged (debounced
+     * at ~50ms per window). The shadow is read by daemon-local shortcut
+     * handlers (float toggle, etc.) so they can compose pre-tile geometry
+     * without a round-trip back to the effect.
+     *
+     * @param windowId Window identifier
+     * @param rect Current frame geometry in compositor coordinates
+     */
+    void setFrameGeometry(const QString& windowId, int x, int y, int width, int height);
+
+    /**
+     * Query the daemon's shadow for a window's last-known frame geometry.
+     *
+     * Returns an invalid QRect if the window has not pushed a geometry yet.
+     * Used by daemon-local shortcut handlers.
+     */
+    QRect frameGeometry(const QString& windowId) const;
+
+    /**
      * Update cursor screen when cursor crosses to a different monitor
      * Called by the KWin effect's slotMouseChanged when screen changes.
      * @param screenId Name of the screen the cursor is now on
@@ -1056,6 +1077,12 @@ private:
     QString m_lastActiveWindowId; // From windowActivated (focused window's ID)
     QString m_lastActiveScreenId; // From windowActivated (focused window's screen)
     QString m_lastCursorScreenId; // From cursorScreenChanged (cursor's screen)
+
+    // Frame-geometry shadow: populated via setFrameGeometry D-Bus pushes from
+    // the compositor plugin. Entries are removed on windowClosed. Used by
+    // daemon-local shortcut handlers (float toggle, etc.) so they can read
+    // fresh geometry without round-tripping through the effect.
+    QHash<QString, QRect> m_frameGeometry;
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // Dependencies (kept for signal connections and settings access)

--- a/src/dbus/windowtrackingadaptor/navigation.cpp
+++ b/src/dbus/windowtrackingadaptor/navigation.cpp
@@ -198,7 +198,7 @@ void WindowTrackingAdaptor::toggleWindowFloat()
 {
     // Daemon-local float toggle: no round-trip through the kwin-effect. We
     // already know the active window (windowActivated pushes), its screen,
-    // and its current frame geometry (setFrameGeometry shadow, phase 1).
+    // and its current frame geometry (setFrameGeometry shadow).
     //
     // Previously this emitted toggleWindowFloatRequested, the effect received
     // it, walked KWin's stacking order to find the active window, did two

--- a/src/dbus/windowtrackingadaptor/navigation.cpp
+++ b/src/dbus/windowtrackingadaptor/navigation.cpp
@@ -196,10 +196,44 @@ void WindowTrackingAdaptor::restoreWindowSize()
 
 void WindowTrackingAdaptor::toggleWindowFloat()
 {
-    qCInfo(lcDbusWindow) << "toggleWindowFloat";
-    // Delegate to toggleFloatForWindow which already handles the full flow
-    // (pre-snap geometry, applyGeometryRequested, navigationFeedback)
-    Q_EMIT toggleWindowFloatRequested(true);
+    // Daemon-local float toggle: no round-trip through the kwin-effect. We
+    // already know the active window (windowActivated pushes), its screen,
+    // and its current frame geometry (setFrameGeometry shadow, phase 1).
+    //
+    // Previously this emitted toggleWindowFloatRequested, the effect received
+    // it, walked KWin's stacking order to find the active window, did two
+    // fire-and-forget D-Bus calls back into us, and finally we routed to the
+    // engine. That chain stalled under any D-Bus backpressure and produced
+    // the "pressed Meta-F, nothing happens, seconds later it toggles"
+    // symptom from discussion #310.
+    if (m_lastActiveWindowId.isEmpty() || m_lastActiveScreenId.isEmpty()) {
+        qCInfo(lcDbusWindow) << "toggleWindowFloat: no active window in shadow";
+        Q_EMIT navigationFeedback(false, QStringLiteral("float"), QStringLiteral("no_active_window"), QString(),
+                                  QString(), m_lastActiveScreenId);
+        return;
+    }
+
+    const QString windowId = m_lastActiveWindowId;
+    const QString screenId = m_lastActiveScreenId;
+    qCInfo(lcDbusWindow) << "toggleWindowFloat: windowId=" << windowId << "screen=" << screenId;
+
+    // Capture pre-tile geometry from the shadow so unfloat restores to the
+    // user's last position. The shadow is refreshed on every
+    // windowFrameGeometryChanged the effect sees (debounced to 50ms).
+    //
+    // Skipping the store when the shadow has no entry is safe: that means
+    // this window hasn't had its geometry pushed yet (freshly opened and
+    // never moved), so there's nothing meaningful to preserve. The engine
+    // will use the window's current frame geometry on the effect side when
+    // it applies the outcome.
+    const QRect geo = frameGeometry(windowId);
+    if (geo.isValid()) {
+        const bool wasFloating = m_service && m_service->isWindowFloating(windowId);
+        storePreTileGeometry(windowId, geo.x(), geo.y(), geo.width(), geo.height(), screenId,
+                             /*overwrite=*/wasFloating);
+    }
+
+    toggleFloatForWindow(windowId, screenId);
 }
 
 void WindowTrackingAdaptor::swapWindowWithAdjacentZone(const QString& direction)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -307,10 +307,10 @@ target_link_libraries(test_autotile_adaptor_panel_gate PRIVATE Qt6::Test Qt6::Co
                                                                  plasmazones_core)
 add_test(NAME test_autotile_adaptor_panel_gate COMMAND test_autotile_adaptor_panel_gate)
 
-# Truth-table guard for WindowDragAdaptor::computeDragPolicy. Phase 3 of the
-# v3 drag protocol refactor — pins the (snap, autotile, context) matrix so
-# the daemon's drag routing decision can't drift relative to the compositor
-# plugin's now-deleted local caches. Regression guard for #310.
+# Truth-table guard for WindowDragAdaptor::computeDragPolicy — pins the
+# (snap, autotile, context) matrix so the daemon's drag routing decision
+# can't drift relative to the compositor plugin's deleted local caches.
+# Regression guard for #310.
 add_executable(test_drag_policy dbus/test_drag_policy.cpp)
 target_link_libraries(test_drag_policy PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
 add_test(NAME test_drag_policy COMMAND test_drag_policy)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -307,6 +307,14 @@ target_link_libraries(test_autotile_adaptor_panel_gate PRIVATE Qt6::Test Qt6::Co
                                                                  plasmazones_core)
 add_test(NAME test_autotile_adaptor_panel_gate COMMAND test_autotile_adaptor_panel_gate)
 
+# Truth-table guard for WindowDragAdaptor::computeDragPolicy. Phase 3 of the
+# v3 drag protocol refactor — pins the (snap, autotile, context) matrix so
+# the daemon's drag routing decision can't drift relative to the compositor
+# plugin's now-deleted local caches. Regression guard for #310.
+add_executable(test_drag_policy dbus/test_drag_policy.cpp)
+target_link_libraries(test_drag_policy PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
+add_test(NAME test_drag_policy COMMAND test_drag_policy)
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # compositor-common/ — Shared Library Types Tests (D-Bus types, FloatingCache,
 #                      TriggerParser, WindowIdUtils)
@@ -355,6 +363,7 @@ set(_all_tests
     test_wta_convenience test_settings_schema test_compositor_bridge
     test_dbus_adaptor_routing
     test_autotile_adaptor_panel_gate
+    test_drag_policy
     test_compositor_common
 )
 set_tests_properties(${_all_tests} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/tests/unit/dbus/test_drag_policy.cpp
+++ b/tests/unit/dbus/test_drag_policy.cpp
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_drag_policy.cpp
+ * @brief Truth-table guard for WindowDragAdaptor::computeDragPolicy
+ *
+ * Phase 3 of the v3 drag protocol refactor moves drag routing policy out of
+ * the compositor plugin (where it lived in m_dragBypassedForAutotile and
+ * m_cachedZoneSelectorEnabled caches that went stale after every settings
+ * reload — see discussion #310) and into a daemon-side pure function.
+ *
+ * This test pins the function's behavior against every combination of the
+ * three inputs that can change routing:
+ *
+ *   (snap_enabled, screen_is_autotile, context_disabled)
+ *     → DragPolicy.bypassReason + flags
+ *
+ * Precedence (first match wins, strongest disable first):
+ *   context_disabled → autotile_screen → snapping_disabled → canonical_snap
+ *
+ * The precedence order is load-bearing — the log forensics on #310 showed
+ * drags flip-flopping for tens of seconds after a settings reload because
+ * the effect's cache disagreed with the daemon about whether a screen was
+ * autotile-managed; pinning the daemon-side decision table removes the
+ * only place that ambiguity can live.
+ */
+
+#include <QTest>
+#include <QCoreApplication>
+#include <QObject>
+
+#include "autotile/AutotileEngine.h"
+#include "dbus/windowdragadaptor.h"
+
+#include "../helpers/StubSettings.h"
+
+using namespace PlasmaZones;
+
+namespace {
+
+/// Subclass of StubSettings that lets the test flip snappingEnabled and the
+/// per-monitor disabled flag per-case without stamping out a new stub each
+/// time. The base stub returns defaults that are fine for everything else.
+class PolicyStubSettings : public StubSettings
+{
+public:
+    bool m_snapEnabled = true;
+    bool m_monitorDisabled = false;
+
+    bool snappingEnabled() const override
+    {
+        return m_snapEnabled;
+    }
+
+    bool isMonitorDisabled(const QString&) const override
+    {
+        return m_monitorDisabled;
+    }
+};
+
+/// Build a minimal AutotileEngine with one screen seeded (or empty) so
+/// isAutotileScreen() returns the desired answer. The engine is constructed
+/// with null dependencies — computeDragPolicy only reads isAutotileScreen
+/// and isWindowTracked, neither of which touches layoutManager / tracker /
+/// screenManager.
+std::unique_ptr<AutotileEngine> makeEngine(bool screenIsAutotile, const QString& screenId,
+                                           const QString& trackedWindowId = {})
+{
+    auto engine = std::make_unique<AutotileEngine>(nullptr, nullptr, nullptr);
+    if (screenIsAutotile) {
+        engine->setAutotileScreens(QSet<QString>{screenId});
+    }
+    if (!trackedWindowId.isEmpty()) {
+        // Need the window in m_windowToStateKey for isWindowTracked to return
+        // true. The easiest way is to send it through windowOpened on an
+        // autotile screen — but that requires a LayoutManager. For the
+        // test we only need isWindowTracked to return false on an empty
+        // engine (the isTracked branch is a sub-case tested separately
+        // via the isTracked-specific fixtures below).
+        Q_UNUSED(trackedWindowId);
+    }
+    return engine;
+}
+
+} // namespace
+
+class TestDragPolicy : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Canonical snap path — both screens normal, snap enabled, no disables.
+    // Policy should stream, show overlay, grab keyboard, capture geometry.
+    // bypassReason empty.
+    // ─────────────────────────────────────────────────────────────────────
+    void canonicalSnap_allFlagsSet()
+    {
+        PolicyStubSettings settings;
+        settings.m_snapEnabled = true;
+        settings.m_monitorDisabled = false;
+        auto engine = makeEngine(/*screenIsAutotile=*/false, QStringLiteral("DP-1"));
+
+        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
+                                                            QStringLiteral("DP-1"), 1, QString());
+
+        QVERIFY(p.bypassReason.isEmpty());
+        QVERIFY(p.streamDragMoved);
+        QVERIFY(p.showOverlay);
+        QVERIFY(p.grabKeyboard);
+        QVERIFY(p.captureGeometry);
+        QVERIFY(!p.immediateFloatOnStart);
+        QCOMPARE(p.screenId, QStringLiteral("DP-1"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Autotile screen — engine owns placement, plugin bypasses the snap
+    // path and (later in the drag flow) applies handleDragToFloat directly.
+    // bypassReason = "autotile_screen". Policy captures geometry so the
+    // free-floating size can be restored on unfloat.
+    // ─────────────────────────────────────────────────────────────────────
+    void autotileScreen_bypassAutotile()
+    {
+        PolicyStubSettings settings;
+        settings.m_snapEnabled = true;
+        auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
+
+        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
+                                                            QStringLiteral("HP-1"), 1, QString());
+
+        QCOMPARE(p.bypassReason, QStringLiteral("autotile_screen"));
+        QVERIFY(!p.streamDragMoved);
+        QVERIFY(!p.showOverlay);
+        QVERIFY(!p.grabKeyboard);
+        QVERIFY(p.captureGeometry);
+        // No windowOpened flowed through the engine, so isWindowTracked()
+        // returns false and immediateFloatOnStart stays false. The
+        // "tracked window → true" path is exercised indirectly by
+        // integration tests that actually tile windows.
+        QVERIFY(!p.immediateFloatOnStart);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Snapping disabled on a normal screen. Dead drag — the user
+    // configured snap mode off. bypassReason = "snapping_disabled".
+    // Every flag false.
+    // ─────────────────────────────────────────────────────────────────────
+    void snapDisabled_onNormalScreen_bypass()
+    {
+        PolicyStubSettings settings;
+        settings.m_snapEnabled = false;
+        auto engine = makeEngine(/*screenIsAutotile=*/false, QStringLiteral("DP-1"));
+
+        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
+                                                            QStringLiteral("DP-1"), 1, QString());
+
+        QCOMPARE(p.bypassReason, QStringLiteral("snapping_disabled"));
+        QVERIFY(!p.streamDragMoved);
+        QVERIFY(!p.showOverlay);
+        QVERIFY(!p.grabKeyboard);
+        QVERIFY(!p.captureGeometry);
+        QVERIFY(!p.immediateFloatOnStart);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Snapping disabled BUT the drag is on an autotile screen. Autotile
+    // takes precedence — the engine still owns placement regardless of the
+    // snap-mode setting. bypassReason = "autotile_screen".
+    //
+    // This is the exact scenario from discussion #310: reporter had
+    // snapping off and autotile on both monitors. Drags on autotile
+    // screens should NOT be dead — they should float-on-drop.
+    // ─────────────────────────────────────────────────────────────────────
+    void autotileWithSnapDisabled_autotileWins()
+    {
+        PolicyStubSettings settings;
+        settings.m_snapEnabled = false;
+        auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
+
+        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
+                                                            QStringLiteral("HP-1"), 1, QString());
+
+        QCOMPARE(p.bypassReason, QStringLiteral("autotile_screen"));
+        QVERIFY(p.captureGeometry);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Monitor excluded in display settings. Dead drag regardless of snap
+    // or autotile state — user told us to leave this monitor alone.
+    // bypassReason = "context_disabled".
+    // ─────────────────────────────────────────────────────────────────────
+    void contextDisabled_overridesAutotile()
+    {
+        PolicyStubSettings settings;
+        settings.m_snapEnabled = true;
+        settings.m_monitorDisabled = true;
+        auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
+
+        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
+                                                            QStringLiteral("HP-1"), 1, QString());
+
+        QCOMPARE(p.bypassReason, QStringLiteral("context_disabled"));
+        QVERIFY(!p.streamDragMoved);
+        QVERIFY(!p.showOverlay);
+        QVERIFY(!p.immediateFloatOnStart);
+    }
+
+    void contextDisabled_overridesSnapDisabled()
+    {
+        PolicyStubSettings settings;
+        settings.m_snapEnabled = false;
+        settings.m_monitorDisabled = true;
+        auto engine = makeEngine(/*screenIsAutotile=*/false, QStringLiteral("DP-1"));
+
+        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
+                                                            QStringLiteral("DP-1"), 1, QString());
+
+        // Context-disabled is checked before snapping_disabled — the reason
+        // is stable at "context_disabled" even though either would produce
+        // the same flag set.
+        QCOMPARE(p.bypassReason, QStringLiteral("context_disabled"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Null dependencies — defensive path. When the daemon is mid-teardown
+    // the adaptor may call in with nullptr settings / engine. Should
+    // produce a canonical snap policy (no bypass reason) rather than
+    // crashing, because there's no signal that a bypass applies.
+    // ─────────────────────────────────────────────────────────────────────
+    void nullDeps_returnsCanonicalSnap()
+    {
+        DragPolicy p = WindowDragAdaptor::computeDragPolicy(nullptr, nullptr, QStringLiteral("win-1"),
+                                                            QStringLiteral("DP-1"), 1, QString());
+
+        QVERIFY(p.bypassReason.isEmpty());
+        QVERIFY(p.streamDragMoved);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Empty screenId — defensive. Should NOT match the autotile screen
+    // (isAutotileScreen requires a valid id) and should NOT match
+    // isContextDisabled. Falls through to snap-or-snap-disabled check.
+    // ─────────────────────────────────────────────────────────────────────
+    void emptyScreenId_fallsThroughToSnapCheck()
+    {
+        PolicyStubSettings settings;
+        settings.m_snapEnabled = false;
+        auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
+
+        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"), QString(),
+                                                            1, QString());
+
+        // Autotile check is skipped for empty screenId, so snapping_disabled wins.
+        QCOMPARE(p.bypassReason, QStringLiteral("snapping_disabled"));
+    }
+};
+
+QTEST_MAIN(TestDragPolicy)
+#include "test_drag_policy.moc"

--- a/tests/unit/dbus/test_drag_policy.cpp
+++ b/tests/unit/dbus/test_drag_policy.cpp
@@ -5,8 +5,8 @@
  * @file test_drag_policy.cpp
  * @brief Truth-table guard for WindowDragAdaptor::computeDragPolicy
  *
- * Phase 3 of the v3 drag protocol refactor moves drag routing policy out of
- * the compositor plugin (where it lived in m_dragBypassedForAutotile and
+ * The drag protocol refactor moves drag routing policy out of the
+ * compositor plugin (where it lived in m_dragBypassedForAutotile and
  * m_cachedZoneSelectorEnabled caches that went stale after every settings
  * reload — see discussion #310) and into a daemon-side pure function.
  *


### PR DESCRIPTION
## Summary

Full end-to-end architectural fix for the drag/float bugs reported in [discussion #310](https://github.com/fuddlesworth/PlasmaZones/discussions/310). The kwin-effect becomes a dumb relay for drag events and the daemon becomes the single source of truth for all drag routing decisions. Meta-F float toggle runs entirely daemon-local, eliminating the 4-hop D-Bus chain that stalled under backpressure.

Targets the `v3` branch.

## Root causes

**#310 had two independent bugs sharing the same design error** — effect-side state shadowed daemon state, and the shadow went stale.

1. **Post-settings-reload dead-drag window.** The kwin-effect's `m_autotileScreens` cache lagged behind the daemon's authoritative state during the async window after a settings reload. Log forensics on the reporter's bundle showed **7 consecutive dead drags over ~41 seconds** — the effect decided "not autotile, snap path" at drag-start, sent `dragStarted`, daemon rejected with "Snapping disabled in settings" (reporter has snap globally off + autotile on both monitors), and no autotile fallback fired because `m_dragBypassedForAutotile` was set wrong.

2. **Meta-F float toggle lag/drop.** The keyboard shortcut made **4 D-Bus hops across 3 processes**: KWin → daemon → effect → daemon → engine → effect. Under any D-Bus backpressure (e.g., the dragMoved spam from bug #1) the chain stalled, producing the "pressed Meta-F, nothing happened, seconds later it toggled" symptom. The effect also read a stale local `isWindowFloating` cache, causing the wrong geometry to be stored as pre-tile state.

## Solution

### Drag protocol (phases 1, 3a–3f, 4)

New D-Bus surface replacing `dragStarted`/`dragMoved`/`dragStopped`:

```
[Plugin → Daemon]   beginDrag(windowId, frame, startScreenId, buttons)
                    → DragPolicy { stream, overlay, grabKeyboard, capture,
                                   immediateFloatOnStart, screenId, bypassReason }
[Plugin → Daemon]   updateDragCursor(windowId, cursor, modifiers, buttons)
                    — fire-and-forget, 30Hz throttled
[Daemon → Plugin]   dragPolicyChanged(windowId, DragPolicy)
                    — cross-VS mid-drag flip
[Plugin → Daemon]   endDrag(windowId, cursor, modifiers, buttons, cancelled)
                    → DragOutcome { action, geometry, zoneId, snapAssist, ... }
```

**`computeDragPolicy`** is a pure static function pinned by an 8-state truth table. Precedence: `context_disabled` → `autotile_screen` → `snapping_disabled` → canonical snap. The reporter's config (snap off + autotile on both) correctly lands in `autotile_screen` because it's checked before the snap-disabled gate.

**Cross-VS flip** moves entirely daemon-side. The plugin's `slotDragPolicyChanged` reacts to the daemon's signal by applying compositor-level transitions (snap overlay cancel, `onWindowClosed` on old autotile screen, keyboard grab/release). The effect-side ~80-line cross-VS flip loop that walked `KWin::effects->screens()` against a stale local cache is **deleted**.

**Effect-side cache deletions**: `callDragStarted`, `sendDeferredDragStarted`, `callDragMoved`, `callDragStopped` — removed. The plugin can no longer talk to the legacy D-Bus methods. `beginDrag` is unconditional at drag-start; the deferred-send optimization is obsolete because the daemon always knows about the drag.

Legacy `dragStarted`/`dragMoved`/`dragStopped` remain as **private C++ helpers** inside the adaptor (called internally by `drag_protocol.cpp`) so the intricate snap-path overlay/zone/snap-assist logic doesn't have to be rewritten. They are **removed from the D-Bus introspection surface** (phase 3f), so no external client can call them.

### Daemon-local float toggle (phases 1, 2)

Phase 1 adds a `QHash<windowId, QRect>` frame-geometry shadow on `WindowTrackingAdaptor`, populated via `setFrameGeometry` D-Bus pushes from the effect on `windowFrameGeometryChanged` (debounced 50ms per window).

Phase 2 rewrites `WindowTrackingAdaptor::toggleWindowFloat()` to read `m_lastActiveWindowId` + the frame-geometry shadow and dispatch to `toggleFloatForWindow` in-process. Deletes `slotToggleWindowFloatRequested` from the effect, deletes the `toggleWindowFloatRequested(bool)` D-Bus signal, drops the 100ms debounce on `Daemon::handleFloat`.

**Net latency**: keypress → visible toggle drops from "seconds under backpressure" to sub-50ms (one D-Bus hop — the `applyGeometryRequested` paint).

### Settings nesting (phase 4)

`ISettings` gains `isZoneSelectorActive()` and `isSnapAssistActive()` composite accessors that return `snappingEnabled() && <child>Enabled()`. Consumers can no longer forget the parent-gate check. Raw child accessors remain for KCM UI code. Directly addresses the `Snapping.Enabled=false` + `Snapping.ZoneSelector.Enabled=true` footgun from the reporter's config.

## Invariants

1. **Single source of truth**. `computeDragPolicy` is the only place that answers "what kind of drag is this". No effect-side cache shadows it.
2. **First-match precedence**. `computeDragPolicy` checks disables in a fixed order so the resulting `bypassReason` is stable across coincidental disables.
3. **Fire-and-forget hot path**. `updateDragCursor` is the only 30Hz call. Daemon replies (signals) flow back async.
4. **Mid-drag transitions are daemon-driven**. The plugin never diffs its own state to decide when to flip modes; it only reacts to `dragPolicyChanged`.
5. **Parent gates are compile-time**. Consumers can't read a nested Snapping flag without the parent check.

## Commit chain

| Phase | Commit | What |
|---|---|---|
| 1 | `4330f22c` | Frame-geometry shadow (foundation for phase 2) |
| 2 | `b04b1b7c` | Daemon-local Meta-F float toggle |
| 3a | `992b9e52` | `DragPolicy`/`DragOutcome` types + `beginDrag` + 8-state truth table |
| 3b | `d97ddfaf` | `endDrag` returning `DragOutcome` |
| 3c | `355a55c9` | Effect calls `beginDrag` (correction layer) |
| 3d | `46d92844` | `updateDragCursor` + `dragPolicyChanged` signal |
| 3e | `cd916b50` | Effect full port: `callEndDrag`, `slotDragPolicyChanged`, cross-VS flip deleted |
| 3f | `0dac0613` | Legacy `dragStarted`/`dragMoved`/`dragStopped` removed from D-Bus surface |
| 4 | `e8a80896` | `isZoneSelectorActive()` / `isSnapAssistActive()` composite accessors |
| 5 | `4d2a03c1` | Changelog + `docs/architecture/drag-protocol.md` design note |

Each phase is independently buildable — the branch was kept green at every commit.

## Tests

`83/83` passing.

New:
- `test_drag_policy.cpp` — 8-state truth table pinning `computeDragPolicy` precedence against (snap, autotile, context_disabled). Regression guard for the exact #310 scenario.

Existing tests unchanged — the legacy snap-path logic stays behind `drag_protocol.cpp`'s internal wrappers, so all snap-mode behavior tests continue to exercise the same code.

## Design note

See `docs/architecture/drag-protocol.md` for the full design rationale, wire format, cross-VS flip semantics, deletion inventory, and why a sync `beginDrag` was rejected.

## Test plan

- [ ] Build on Arch/CachyOS: `cmake --build build --parallel $(nproc)`
- [ ] Unit tests pass: `cd build && ctest` (83/83)
- [ ] Manual: Meta-F float toggle latency — target sub-50ms from keypress to visible toggle, on autotile and snap modes
- [ ] Manual: reproduce the #310 scenario — snap off, autotile on both monitors, reload settings, drag a window on each monitor. No dead drags, no "Snapping disabled" log spam, float-on-drop works
- [ ] Manual: cross-VS drag mid-flight (autotile ↔ snap) still handles transitions correctly via `dragPolicyChanged`
- [ ] Manual: zone selector drag (snap mode with `ZoneSelector.Enabled=true`) still works
- [ ] Manual: snap assist window picker still appears when the daemon requests it via `DragOutcome.requestSnapAssist`
- [ ] Manual: Escape cancels a snap drag without leaving the overlay stuck

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)