### PR TITLE
Build against KWin < 6.6 and Qt < 6.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,8 +305,11 @@ include_directories("${CMAKE_BINARY_DIR}/generated")
 
 # Source directories
 add_subdirectory(src)
+option(BUILD_KWIN_EFFECT "Build KWin C++ effect plugin (needs KWin 6.6+)" ON)
 if(USE_KDE_FRAMEWORKS)
-    add_subdirectory(kwin-effect)  # KWin C++ Effect (KDE-only)
+    if(BUILD_KWIN_EFFECT)
+        add_subdirectory(kwin-effect)  # KWin C++ Effect (KDE-only)
+    endif()
     add_subdirectory(kcm)          # KDE System Settings modules (KDE-only)
 endif()
 

--- a/src/core/qpa/layershellwindow.cpp
+++ b/src/core/qpa/layershellwindow.cpp
@@ -6,6 +6,7 @@
 #include "../layersurface.h"
 
 #include <QLoggingCategory>
+#include <qpa/qwindowsysteminterface.h>
 #include <QtWaylandClient/private/qwaylanddisplay_p.h>
 #include <QtWaylandClient/private/qwaylandscreen_p.h>
 #include <QtWaylandClient/private/qwaylandshellintegration_p.h>
@@ -381,7 +382,13 @@ void LayerShellWindow::handleConfigure(void* data, struct zwlr_layer_surface_v1*
     // and sends the expose event that starts Qt's rendering pipeline.
     // Without this call, the layer surface exists at the Wayland level but Qt
     // never paints it — mExposed stays false and isExposed() returns false.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
     self->m_waylandWindow->updateExposure();
+#else
+    if (qwindow) {
+        QWindowSystemInterface::handleExposeEvent(qwindow, QRegion(QRect(QPoint(0, 0), qwindow->size())));
+    }
+#endif
 
     qCDebug(lcLayerShellWindow) << "Configured:" << width << "x" << height
                                 << (qwindow ? qwindow->objectName() : QStringLiteral("(unknown)"));


### PR DESCRIPTION
## Summary

Two small portability fixes that let PlasmaZones build on distros shipping slightly older Qt/KWin than upstream targets — specifically Debian 13 (Qt 6.8.2, KF 6.13, KWin 6.3.6), but the same will apply to Ubuntu 24.04/24.10 and Fedora 40.

### 1. `BUILD_KWIN_EFFECT` option (default `ON`)

The root `CMakeLists.txt` unconditionally adds the `kwin-effect` subdirectory when `USE_KDE_FRAMEWORKS=ON`, and that subdir hard-requires `find_package(KWin 6.6 REQUIRED)`. On KWin 6.3.x this aborts the whole configure step even though the daemon, editor, KCM, settings app, and QPA plugin build and work fine.

This PR wraps the `kwin-effect` subdir in a `BUILD_KWIN_EFFECT` option. Default is `ON` so existing users see no change; packagers on older KWin can pass `-DBUILD_KWIN_EFFECT=OFF` and get everything else. The KCM still builds either way.

### 2. `QWaylandWindow::updateExposure()` Qt 6.9 guard

`layershellwindow.cpp` calls `m_waylandWindow->updateExposure()` after the initial `configure` event to flip `mExposed` and kick off Qt's render pipeline. That method is new in Qt 6.9 — on Qt 6.8 it fails to compile (`'class QtWaylandClient::QWaylandWindow' has no member named 'updateExposure'`).

For Qt < 6.9 this PR falls back to `QWindowSystemInterface::handleExposeEvent(qwindow, QRegion(...))`, which is the underlying public QPA mechanism `updateExposure()` eventually routes through. Same visible effect: mExposed transitions, expose event gets delivered, Qt starts painting.

## Test plan

- [x] Debian 13 / Qt 6.8.2 / KF 6.13 / KWin 6.3.6: configure, build, install, enable `plasmazones.service`, daemon comes up and stays running
- [x] Editor launches, settings app launches
- [ ] Qt 6.9+ / KWin 6.6+: existing build path unchanged (the new code is behind `#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)` and `BUILD_KWIN_EFFECT` defaults to `ON`) — would appreciate a CI run or maintainer check on a current Plasma 6.6/6.7 box

## Notes

Left untouched on purpose:
- The `Qt6GuiPrivate` / `Qt6ShaderToolsPrivate` / `Qt6WaylandClientPrivate` `find_package` calls. Debian ships the private headers (`qt6-base-private-dev`, `qt6-wayland-private-dev`) but not the CMake config packages; that's a distro packaging gap, not something to paper over in this repo.