### PR TITLE
refactor: architecture cleanup — Phase 1-5 (navigation polymorphism + WTA facade)

### DIFF
--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -30,6 +30,24 @@ void AutotileHandler::slotWindowsTileRequested(const TileRequestList& tileReques
         return;
     }
 
+    // Validate every request up-front. A single malformed entry is logged and
+    // dropped from the batch; the remaining requests still apply. This avoids
+    // one corrupt payload (e.g. zero-size tiled request from a protocol glitch)
+    // from either resizing a window to 0×0 or poisoning the whole retile pass.
+    TileRequestList validatedRequests;
+    validatedRequests.reserve(tileRequests.size());
+    for (const auto& req : tileRequests) {
+        if (const QString err = req.validationError(); !err.isEmpty()) {
+            qCWarning(lcEffect) << "slotWindowsTileRequested: dropping invalid entry:" << err;
+            continue;
+        }
+        validatedRequests.append(req);
+    }
+    if (validatedRequests.isEmpty()) {
+        qCWarning(lcEffect) << "slotWindowsTileRequested: all" << tileRequests.size() << "entries invalid — aborting";
+        return;
+    }
+
     ++m_autotileStaggerGeneration;
     // NOTE: m_autotileTargetZones and m_centeredWaylandZones are intentionally
     // NOT cleared globally here. Each retile fires for a single screen at a
@@ -61,7 +79,7 @@ void AutotileHandler::slotWindowsTileRequested(const TileRequestList& tileReques
     };
     QVector<Entry> entries;
 
-    for (const auto& req : tileRequests) {
+    for (const auto& req : validatedRequests) {
         const QString& windowId = req.windowId;
 
         // Float entries: overflow windows that should be restored to pre-autotile geometry.

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -744,10 +744,6 @@ void PlasmaZonesEffect::slotWindowClosed(KWin::EffectWindow* w)
     // but clean up our tracking hash to avoid stale entries).
     removeWindowBorder(closedWindowId);
 
-    // Drop the effect-local app-id cache entry. closedWindowId is the bare
-    // instance id under the new wire format, which is exactly the cache key.
-    m_appIdByInstance.remove(closedWindowId);
-
     // Notify general daemon for cleanup
     notifyWindowClosed(w);
 
@@ -1475,16 +1471,16 @@ QString PlasmaZonesEffect::getWindowId(KWin::EffectWindow* w) const
     // their WM_CLASS after the surface is mapped.
     //
     // App class is looked up separately — via getWindowAppId() here in the
-    // effect, and via WindowRegistry in the daemon. Both read the live
+    // effect, and via WindowRegistry in the daemon after pushWindowMetadata
+    // updates the registry on KWin's class-change signals. Both read the live
     // value rather than trusting a frozen first-seen string.
-    //
-    // Populates m_appIdByInstance as a side-effect so appIdForInstance()
-    // can answer later D-Bus calls without walking the stacking order.
     if (!w) {
         return QString();
     }
 
-    // Cache hit: window IDs never change during a window's lifetime
+    // Cache hit: the composite is frozen at first observation for the
+    // window's lifetime so daemon maps keyed by windowId stay stable even
+    // when an Electron/CEF app mutates its class mid-session.
     auto cacheIt = m_windowIdCache.constFind(w);
     if (cacheIt != m_windowIdCache.constEnd()) {
         return cacheIt.value();
@@ -1496,9 +1492,6 @@ QString PlasmaZonesEffect::getWindowId(KWin::EffectWindow* w) const
     }
     const QString instanceId = window->internalId().toString(QUuid::WithoutBraces);
     const QString appId = getWindowAppId(w);
-    if (!appId.isEmpty()) {
-        const_cast<PlasmaZonesEffect*>(this)->m_appIdByInstance.insert(instanceId, appId);
-    }
     const QString result = appId + QLatin1Char('|') + instanceId;
     m_windowIdCache.insert(w, result);
     m_windowIdReverse.insert(result, const_cast<KWin::EffectWindow*>(w));

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -213,7 +213,14 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                                 qCWarning(lcEffect) << "beginDrag reply invalid:" << reply.error().message();
                                 return;
                             }
-                            m_currentDragPolicy = reply.value();
+                            const DragPolicy policy = reply.value();
+                            if (const QString err = policy.validationError(); !err.isEmpty()) {
+                                qCWarning(lcEffect)
+                                    << "beginDrag reply rejected:" << err
+                                    << "— keeping conservative snap-path policy for" << capturedWindowId;
+                                return;
+                            }
+                            m_currentDragPolicy = policy;
                             qCInfo(lcEffect) << "beginDrag reply:" << capturedWindowId
                                              << "bypass=" << m_currentDragPolicy.bypassReason
                                              << "stream=" << m_currentDragPolicy.streamDragMoved
@@ -1126,6 +1133,11 @@ void PlasmaZonesEffect::slotDaemonReady()
             return;
         }
         BridgeRegistrationResult result = reply.value();
+        if (const QString err = result.validationError(); !err.isEmpty()) {
+            qCWarning(lcEffect) << "registerBridge reply rejected:" << err
+                                << "— effect remains idle until the daemon signals ready again.";
+            return;
+        }
         if (result.sessionId == QLatin1String("REJECTED")) {
             qCCritical(lcEffect) << "Daemon REJECTED this effect: daemon apiVersion=" << result.apiVersion
                                  << "but this effect speaks" << DBus::ApiVersion
@@ -3019,6 +3031,14 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
                 return;
             }
             const DragOutcome outcome = reply.value();
+            if (const QString err = outcome.validationError(); !err.isEmpty()) {
+                // Garbled outcome — refuse to apply any window transform.
+                // Better to leave the window where it is than to float/snap
+                // based on a corrupted payload.
+                qCWarning(lcEffect) << "endDrag outcome rejected:" << err
+                                    << "— dropping without applying any action for" << windowId;
+                return;
+            }
             qCInfo(lcEffect) << "endDrag outcome:" << windowId << "action=" << outcome.action
                              << "screen=" << outcome.targetScreenId << "geo=" << outcome.toRect()
                              << "snapAssist=" << outcome.requestSnapAssist;
@@ -3375,6 +3395,14 @@ void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const Dra
     // are ignored.
     if (!m_dragTracker->isDragging() || m_dragTracker->draggedWindowId() != windowId) {
         qCDebug(lcEffect) << "slotDragPolicyChanged: drag no longer active for" << windowId;
+        return;
+    }
+
+    if (const QString err = newPolicy.validationError(); !err.isEmpty()) {
+        // Garbled policy change — keep current state rather than transitioning
+        // to a corrupted one. The daemon will re-emit on the next cursor tick
+        // if this was transient.
+        qCWarning(lcEffect) << "slotDragPolicyChanged rejected:" << err << "for" << windowId;
         return;
     }
 

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -223,7 +223,7 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                             // fast path below already did this synchronously;
                             // this catches the stale-cache case where the fast
                             // path missed.
-                            if (m_currentDragPolicy.bypassReason == QLatin1String("autotile_screen")) {
+                            if (m_currentDragPolicy.bypassReason == DragBypassReason::AutotileScreen) {
                                 if (!m_dragBypassedForAutotile) {
                                     m_dragBypassedForAutotile = true;
                                     m_dragBypassScreenId = capturedScreenId;
@@ -316,7 +316,7 @@ PlasmaZonesEffect::PlasmaZonesEffect()
             // the daemon's updateDragCursor still watches for a flip
             // BACK to snap mode.
             const bool bypassed =
-                m_currentDragPolicy.bypassReason == QLatin1String("autotile_screen") || m_dragBypassedForAutotile;
+                m_currentDragPolicy.bypassReason == DragBypassReason::AutotileScreen || m_dragBypassedForAutotile;
             if (!bypassed) {
                 // Gate D-Bus calls on activation trigger state so a drag
                 // without any intent to use zones doesn't flood the bus
@@ -1039,7 +1039,7 @@ void PlasmaZonesEffect::slotMouseChanged(const QPointF& pos, const QPointF& oldp
             // overlay destroy/create churn that prompted discussion #310's
             // sibling regression.
             const bool bypassed =
-                m_currentDragPolicy.bypassReason == QLatin1String("autotile_screen") || m_dragBypassedForAutotile;
+                m_currentDragPolicy.bypassReason == DragBypassReason::AutotileScreen || m_dragBypassedForAutotile;
             const bool shouldForward =
                 bypassed || detectActivationAndGrab() || m_cachedZoneSelectorEnabled || !m_triggersLoaded;
             if (shouldForward) {
@@ -3378,13 +3378,13 @@ void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const Dra
         return;
     }
 
-    const QString oldReason = m_currentDragPolicy.bypassReason;
-    const QString newReason = newPolicy.bypassReason;
+    const DragBypassReason oldReason = m_currentDragPolicy.bypassReason;
+    const DragBypassReason newReason = newPolicy.bypassReason;
     if (oldReason == newReason) {
         // Same reason but different screenId (autotile→autotile cross-VS):
         // update the captured screen so endDrag's ApplyFloat uses the right one.
         m_currentDragPolicy = newPolicy;
-        if (newReason == QLatin1String("autotile_screen")) {
+        if (newReason == DragBypassReason::AutotileScreen) {
             m_dragBypassScreenId = newPolicy.screenId;
         }
         return;
@@ -3397,7 +3397,7 @@ void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const Dra
 
     KWin::EffectWindow* dragW = m_dragTracker->draggedWindow();
 
-    if (newReason == QLatin1String("autotile_screen")) {
+    if (newReason == DragBypassReason::AutotileScreen) {
         // Snap → autotile (or context-disabled → autotile). Cancel any
         // active snap overlay, enter bypass mode. Mirrors the old
         // effect-side flip block's "snap→autotile" branch, but driven by
@@ -3418,7 +3418,7 @@ void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const Dra
         return;
     }
 
-    if (oldReason == QLatin1String("autotile_screen")) {
+    if (oldReason == DragBypassReason::AutotileScreen) {
         // Autotile → snap (or autotile → context-disabled). Drop the
         // bypass flag and initialize snap-drag state as if the drag just
         // started on this snap screen. Remove the window from autotile

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -150,21 +150,31 @@ private:
 
 public:
     /**
-     * @brief Window identification — returns the opaque instance id.
+     * @brief Compose the window's composite runtime identifier.
      *
-     * This is KWin's internalId() as a UUID string, which the daemon uses
-     * as its runtime primary key. Populates m_appIdByInstance as a
-     * side-effect so appIdForInstance() can answer quickly for subsequent
-     * callers.
+     * Returns the "appId|instanceId" composite that every daemon-side
+     * service uses as its primary key. `appId` is the live app class read
+     * from KWin at first observation; `instanceId` is KWin's internalId()
+     * UUID string and is stable for the window's lifetime.
+     *
+     * The composite is cached per EffectWindow* in m_windowIdCache and
+     * returned unchanged for the rest of the window's lifetime — even if
+     * KWin subsequently emits windowClassChanged for an Electron/CEF app
+     * that swaps its class. The stable key semantic is load-bearing:
+     * daemon maps keyed by windowId must not shift under mid-session class
+     * mutations. Live class lookups happen separately via getWindowAppId()
+     * on the effect side, and via WindowRegistry::appIdFor() on the daemon
+     * side after pushWindowMetadata() updates the registry.
      */
     QString getWindowId(KWin::EffectWindow* w) const;
 
     /**
      * @brief Extract the compositor-supplied stable instance token.
      *
-     * Alias for getWindowId() — kept so callers that want to be explicit
-     * about wanting the instance id can say so. Both return the same bare
-     * UUID string.
+     * Returns only KWin's internalId() UUID string, without the appId
+     * prefix. Use when a caller specifically needs the raw instance token
+     * (e.g. pushWindowMetadata feeds it to the daemon's WindowRegistry as
+     * the primary key), not the composite key used by the daemon services.
      */
     QString getWindowInstanceId(KWin::EffectWindow* w) const;
 
@@ -176,24 +186,6 @@ public:
      * updates (Electron/CEF apps).
      */
     QString getWindowAppId(KWin::EffectWindow* w) const;
-
-    /**
-     * @brief Current app class for a windowId string (instance id).
-     *
-     * Accepts either a bare instance id or a legacy "appId|uuid" composite —
-     * normalized via effectExtractInstanceId.
-     *
-     * Resolution order:
-     *   1. Cached class for this instance id (m_appIdByInstance, populated
-     *      by getWindowId()).
-     *   2. Walk the stacking order to find a live EffectWindow with that
-     *      internalId(), then call getWindowAppId(). Result is cached.
-     *   3. Return empty if the window isn't currently known.
-     *
-     * A mid-session class mutation (Electron/CEF apps) returns the latest
-     * value instead of a frozen first-seen parse.
-     */
-    QString appIdForInstance(const QString& windowId);
 
 private:
     // Window management
@@ -433,16 +425,6 @@ private:
         KWin::BorderRadius savedSurfaceRadius;
     };
     QHash<QString, WindowBorder> m_windowBorders; // windowId → border
-
-    // instance id → last observed appId. Populated lazily by getWindowId()
-    // and pushWindowMetadata() so appIdForInstance() can answer without
-    // walking the stacking order. Entries are removed in slotWindowClosed().
-    //
-    // This mirrors (but is independent of) the daemon's WindowRegistry — the
-    // effect needs its own local view because appIdForInstance() is called
-    // on hot paths (findWindowById, drag/snap decision logic) and shouldn't
-    // round-trip over D-Bus.
-    QHash<QString, QString> m_appIdByInstance;
 
     // Policy returned from the daemon's beginDrag for the currently-active
     // drag. Async-populated a few ms after the

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -232,6 +232,7 @@ set(plasmazones_core_SRCS
     snap/snapengine/float.cpp
     snap/snapengine/lifecycle.cpp
     snap/snapengine/navigation.cpp
+    snap/snapengine/navigation_actions.cpp
 )
 
 # Create core library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,6 +54,7 @@ set(plasmazones_core_SRCS
     core/enums.h
     core/interfaces.h
     core/interfaces.cpp
+    core/inavigationactions.h
     core/iwindowengine.h
     core/settings_interfaces.h
     core/types.h
@@ -202,6 +203,8 @@ set(plasmazones_core_SRCS
     autotile/AutotileConfig.h
     autotile/AutotileEngine.cpp
     autotile/AutotileEngine.h
+    autotile/autotilenavigationadapter.cpp
+    autotile/autotilenavigationadapter.h
     autotile/PerScreenConfigResolver.cpp
     autotile/PerScreenConfigResolver.h
     autotile/NavigationController.cpp
@@ -224,6 +227,8 @@ set(plasmazones_core_SRCS
     autotile/algorithms/ScriptedAlgorithmSandbox.h
     snap/SnapEngine.cpp
     snap/SnapEngine.h
+    snap/snapnavigationadapter.cpp
+    snap/snapnavigationadapter.h
     snap/snapengine/float.cpp
     snap/snapengine/lifecycle.cpp
     snap/snapengine/navigation.cpp

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -801,6 +801,16 @@ TilingState* AutotileEngine::stateForKey(const TilingStateKey& key)
     return state;
 }
 
+QSet<int> AutotileEngine::desktopsWithActiveState() const
+{
+    QSet<int> out;
+    out.reserve(m_screenStates.size());
+    for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
+        out.insert(it.key().desktop);
+    }
+    return out;
+}
+
 void AutotileEngine::pruneStatesForDesktop(int removedDesktop)
 {
     QMutableHashIterator<TilingStateKey, TilingState*> it(m_screenStates);

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -2739,6 +2739,7 @@ void AutotileEngine::applyTiling(const QString& screenId)
         const QRect& geo = zones[i];
         QJsonObject obj;
         obj[QLatin1String("windowId")] = windows[i];
+        obj[QLatin1String("screenId")] = screenId;
         obj[QLatin1String("x")] = geo.x();
         obj[QLatin1String("y")] = geo.y();
         obj[QLatin1String("width")] = geo.width();

--- a/src/autotile/AutotileEngine.h
+++ b/src/autotile/AutotileEngine.h
@@ -139,11 +139,26 @@ public:
      */
     bool isEnabled() const noexcept;
 
-    /// @brief Read-only access to per-screen tiling states (used by daemon for state persistence)
-    const QHash<TilingStateKey, TilingState*>& screenStates() const
-    {
-        return m_screenStates;
-    }
+    /**
+     * @brief Return the set of virtual-desktop numbers that currently have
+     *        any tiling state.
+     *
+     * Used by the daemon's desktop-count-changed handler to find stale
+     * desktops (states on desktop > newCount) so they can be pruned via
+     * pruneStatesForDesktop(). Replaces an older screenStates() accessor
+     * that returned a const-ref to a QHash<TilingStateKey, TilingState*>
+     * — that accessor leaked mutable TilingState pointers via the
+     * const-reference loophole (const on the hash doesn't propagate to the
+     * pointed-to values), for a single caller that only needed desktop
+     * numbers.
+     *
+     * Callers that need the raw state map should add a purpose-built
+     * query method rather than iterating private state. The intent here
+     * is that external consumers can't iterate or mutate TilingState
+     * objects through any public accessor — that's why screenStates()
+     * is private.
+     */
+    QSet<int> desktopsWithActiveState() const;
 
     /**
      * @brief Check if a specific screen uses autotile

--- a/src/autotile/autotilenavigationadapter.cpp
+++ b/src/autotile/autotilenavigationadapter.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "autotilenavigationadapter.h"
+
+#include "AutotileEngine.h"
+
+namespace PlasmaZones {
+
+AutotileNavigationAdapter::AutotileNavigationAdapter(AutotileEngine* engine)
+    : m_engine(engine)
+{
+}
+
+void AutotileNavigationAdapter::focusInDirection(const QString& direction, const QString& /*screenId*/)
+{
+    if (m_engine) {
+        m_engine->focusInDirection(direction, QStringLiteral("focus"));
+    }
+}
+
+void AutotileNavigationAdapter::moveFocusedInDirection(const QString& direction, const QString& /*screenId*/)
+{
+    // In autotile, "move in direction" is implemented as swap-with-neighbour
+    // in the tiling order — the only way to move is to trade places with
+    // the neighbour. OSD label "move" keeps the user-facing wording.
+    if (m_engine) {
+        m_engine->swapFocusedInDirection(direction, QStringLiteral("move"));
+    }
+}
+
+void AutotileNavigationAdapter::swapFocusedInDirection(const QString& direction, const QString& /*screenId*/)
+{
+    if (m_engine) {
+        m_engine->swapFocusedInDirection(direction, QStringLiteral("swap"));
+    }
+}
+
+void AutotileNavigationAdapter::moveFocusedToPosition(int position, const QString& /*screenId*/)
+{
+    if (m_engine) {
+        m_engine->moveFocusedToPosition(position);
+    }
+}
+
+void AutotileNavigationAdapter::rotateWindows(bool clockwise, const QString& screenId)
+{
+    if (m_engine) {
+        m_engine->rotateWindows(clockwise, screenId);
+    }
+}
+
+void AutotileNavigationAdapter::reapplyLayout(const QString& screenId)
+{
+    if (m_engine) {
+        m_engine->retile(screenId);
+    }
+}
+
+void AutotileNavigationAdapter::snapAllWindows(const QString& screenId)
+{
+    // Autotile has no distinct "snap all" — retile picks up every window
+    // the engine is tracking and inserts any new ones into the layout.
+    if (m_engine) {
+        m_engine->retile(screenId);
+    }
+}
+
+void AutotileNavigationAdapter::toggleFocusedFloat(const QString& /*screenId*/)
+{
+    if (m_engine) {
+        m_engine->toggleFocusedWindowFloat();
+    }
+}
+
+void AutotileNavigationAdapter::cycleFocus(bool forward, const QString& /*screenId*/)
+{
+    if (m_engine) {
+        const QString dir = forward ? QStringLiteral("right") : QStringLiteral("left");
+        m_engine->focusInDirection(dir, QStringLiteral("cycle"));
+    }
+}
+
+void AutotileNavigationAdapter::pushToEmptyZone(const QString& /*screenId*/)
+{
+    // Autotile has no concept of empty zones — every tracked window is
+    // placed by the layout algorithm. Deliberate no-op so the shortcut
+    // becomes a harmless press in autotile mode rather than the daemon
+    // having to branch on mode at the entry point.
+}
+
+void AutotileNavigationAdapter::restoreFocusedWindow(const QString& /*screenId*/)
+{
+    // "Restore" in autotile means pulling the focused window out of the
+    // tiling layout — toggling its float state achieves exactly that.
+    if (m_engine) {
+        m_engine->toggleFocusedWindowFloat();
+    }
+}
+
+} // namespace PlasmaZones

--- a/src/autotile/autotilenavigationadapter.cpp
+++ b/src/autotile/autotilenavigationadapter.cpp
@@ -12,14 +12,14 @@ AutotileNavigationAdapter::AutotileNavigationAdapter(AutotileEngine* engine)
 {
 }
 
-void AutotileNavigationAdapter::focusInDirection(const QString& direction, const QString& /*screenId*/)
+void AutotileNavigationAdapter::focusInDirection(const QString& direction, const NavigationContext& /*ctx*/)
 {
     if (m_engine) {
         m_engine->focusInDirection(direction, QStringLiteral("focus"));
     }
 }
 
-void AutotileNavigationAdapter::moveFocusedInDirection(const QString& direction, const QString& /*screenId*/)
+void AutotileNavigationAdapter::moveFocusedInDirection(const QString& direction, const NavigationContext& /*ctx*/)
 {
     // In autotile, "move in direction" is implemented as swap-with-neighbour
     // in the tiling order — the only way to move is to trade places with
@@ -29,51 +29,51 @@ void AutotileNavigationAdapter::moveFocusedInDirection(const QString& direction,
     }
 }
 
-void AutotileNavigationAdapter::swapFocusedInDirection(const QString& direction, const QString& /*screenId*/)
+void AutotileNavigationAdapter::swapFocusedInDirection(const QString& direction, const NavigationContext& /*ctx*/)
 {
     if (m_engine) {
         m_engine->swapFocusedInDirection(direction, QStringLiteral("swap"));
     }
 }
 
-void AutotileNavigationAdapter::moveFocusedToPosition(int position, const QString& /*screenId*/)
+void AutotileNavigationAdapter::moveFocusedToPosition(int position, const NavigationContext& /*ctx*/)
 {
     if (m_engine) {
         m_engine->moveFocusedToPosition(position);
     }
 }
 
-void AutotileNavigationAdapter::rotateWindows(bool clockwise, const QString& screenId)
+void AutotileNavigationAdapter::rotateWindows(bool clockwise, const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->rotateWindows(clockwise, screenId);
+        m_engine->rotateWindows(clockwise, ctx.screenId);
     }
 }
 
-void AutotileNavigationAdapter::reapplyLayout(const QString& screenId)
+void AutotileNavigationAdapter::reapplyLayout(const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->retile(screenId);
+        m_engine->retile(ctx.screenId);
     }
 }
 
-void AutotileNavigationAdapter::snapAllWindows(const QString& screenId)
+void AutotileNavigationAdapter::snapAllWindows(const NavigationContext& ctx)
 {
     // Autotile has no distinct "snap all" — retile picks up every window
     // the engine is tracking and inserts any new ones into the layout.
     if (m_engine) {
-        m_engine->retile(screenId);
+        m_engine->retile(ctx.screenId);
     }
 }
 
-void AutotileNavigationAdapter::toggleFocusedFloat(const QString& /*screenId*/)
+void AutotileNavigationAdapter::toggleFocusedFloat(const NavigationContext& /*ctx*/)
 {
     if (m_engine) {
         m_engine->toggleFocusedWindowFloat();
     }
 }
 
-void AutotileNavigationAdapter::cycleFocus(bool forward, const QString& /*screenId*/)
+void AutotileNavigationAdapter::cycleFocus(bool forward, const NavigationContext& /*ctx*/)
 {
     if (m_engine) {
         const QString dir = forward ? QStringLiteral("right") : QStringLiteral("left");
@@ -81,7 +81,7 @@ void AutotileNavigationAdapter::cycleFocus(bool forward, const QString& /*screen
     }
 }
 
-void AutotileNavigationAdapter::pushToEmptyZone(const QString& /*screenId*/)
+void AutotileNavigationAdapter::pushToEmptyZone(const NavigationContext& /*ctx*/)
 {
     // Autotile has no concept of empty zones — every tracked window is
     // placed by the layout algorithm. Deliberate no-op so the shortcut
@@ -89,7 +89,7 @@ void AutotileNavigationAdapter::pushToEmptyZone(const QString& /*screenId*/)
     // having to branch on mode at the entry point.
 }
 
-void AutotileNavigationAdapter::restoreFocusedWindow(const QString& /*screenId*/)
+void AutotileNavigationAdapter::restoreFocusedWindow(const NavigationContext& /*ctx*/)
 {
     // "Restore" in autotile means pulling the focused window out of the
     // tiling layout — toggling its float state achieves exactly that.

--- a/src/autotile/autotilenavigationadapter.h
+++ b/src/autotile/autotilenavigationadapter.h
@@ -5,6 +5,7 @@
 
 #include "core/inavigationactions.h"
 #include "plasmazones_export.h"
+#include <QPointer>
 #include <QString>
 
 namespace PlasmaZones {
@@ -18,31 +19,26 @@ class AutotileEngine;
  * existing concrete methods so ScreenModeRouter can dispatch through a
  * common interface without the daemon branching on mode.
  *
- * Parameter mapping:
- *   - `focusInDirection(dir, screen)` →
- *       engine->focusInDirection(dir, "focus")
- *   - `moveFocusedInDirection(dir, screen)` →
- *       engine->swapFocusedInDirection(dir, "move")
- *       (autotile's "move" IS swap-with-neighbour in the tiling order)
- *   - `swapFocusedInDirection(dir, screen)` →
- *       engine->swapFocusedInDirection(dir, "swap")
- *   - `moveFocusedToPosition(pos, screen)` →
- *       engine->moveFocusedToPosition(pos)
- *   - `rotateWindows(cw, screen)` →
- *       engine->rotateWindows(cw, screen)
- *   - `reapplyLayout(screen)` →
- *       engine->retile(screen)
- *   - `toggleFocusedFloat(screen)` →
- *       engine->toggleFocusedWindowFloat()
- *   - `cycleFocus(forward, screen)` →
- *       engine->focusInDirection(forward ? "right" : "left", "cycle")
+ * Autotile semantics note: most adapter methods ignore the windowId field
+ * of the NavigationContext. Autotile's internal focus tracking is the
+ * authoritative target — by the time the daemon invokes a shortcut, the
+ * engine already knows which window is focused, and the adapter forwards
+ * calls like focusInDirection("left") without naming the window. Methods
+ * that legitimately scope by screen (rotateWindows, retile) use the
+ * screenId field.
  *
- * The `screen` parameter is intentionally ignored for autotile-side calls
- * that rely on the engine's internal focus tracking — by the time the
- * daemon invokes a navigation shortcut, the active screen has already
- * been resolved and the engine's focus state is the authoritative target.
- * Methods that legitimately scope by screen (rotateWindows, retile)
- * forward it through unchanged.
+ * Parameter mapping:
+ *   - focusInDirection        → engine->focusInDirection(dir, "focus")
+ *   - moveFocusedInDirection  → engine->swapFocusedInDirection(dir, "move")
+ *     (autotile's "move" IS swap-with-neighbour in the tiling order)
+ *   - swapFocusedInDirection  → engine->swapFocusedInDirection(dir, "swap")
+ *   - moveFocusedToPosition   → engine->moveFocusedToPosition(pos)
+ *   - rotateWindows           → engine->rotateWindows(cw, ctx.screenId)
+ *   - reapplyLayout           → engine->retile(ctx.screenId)
+ *   - toggleFocusedFloat      → engine->toggleFocusedWindowFloat()
+ *   - cycleFocus              → engine->focusInDirection(dir, "cycle")
+ *   - pushToEmptyZone         → no-op (no empty zones in autotile)
+ *   - restoreFocusedWindow    → engine->toggleFocusedWindowFloat()
  */
 class PLASMAZONES_EXPORT AutotileNavigationAdapter : public INavigationActions
 {
@@ -50,20 +46,25 @@ public:
     explicit AutotileNavigationAdapter(AutotileEngine* engine);
     ~AutotileNavigationAdapter() override = default;
 
-    void focusInDirection(const QString& direction, const QString& screenId) override;
-    void moveFocusedInDirection(const QString& direction, const QString& screenId) override;
-    void swapFocusedInDirection(const QString& direction, const QString& screenId) override;
-    void moveFocusedToPosition(int position, const QString& screenId) override;
-    void rotateWindows(bool clockwise, const QString& screenId) override;
-    void reapplyLayout(const QString& screenId) override;
-    void snapAllWindows(const QString& screenId) override;
-    void toggleFocusedFloat(const QString& screenId) override;
-    void cycleFocus(bool forward, const QString& screenId) override;
-    void pushToEmptyZone(const QString& screenId) override;
-    void restoreFocusedWindow(const QString& screenId) override;
+    void focusInDirection(const QString& direction, const NavigationContext& ctx) override;
+    void moveFocusedInDirection(const QString& direction, const NavigationContext& ctx) override;
+    void swapFocusedInDirection(const QString& direction, const NavigationContext& ctx) override;
+    void moveFocusedToPosition(int position, const NavigationContext& ctx) override;
+    void rotateWindows(bool clockwise, const NavigationContext& ctx) override;
+    void reapplyLayout(const NavigationContext& ctx) override;
+    void snapAllWindows(const NavigationContext& ctx) override;
+    void toggleFocusedFloat(const NavigationContext& ctx) override;
+    void cycleFocus(bool forward, const NavigationContext& ctx) override;
+    void pushToEmptyZone(const NavigationContext& ctx) override;
+    void restoreFocusedWindow(const NavigationContext& ctx) override;
 
 private:
-    AutotileEngine* m_engine; // not owned
+    // QPointer — not owned, but auto-nulls if the engine is destroyed during
+    // daemon shutdown before the adapter is torn down. Every method checks
+    // the pointer before dispatching, so a dangling engine pointer becomes
+    // a silent no-op instead of a use-after-free crash. Mirrors
+    // SnapEngine::m_wta's pattern.
+    QPointer<AutotileEngine> m_engine;
 };
 
 } // namespace PlasmaZones

--- a/src/autotile/autotilenavigationadapter.h
+++ b/src/autotile/autotilenavigationadapter.h
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "core/inavigationactions.h"
+#include "plasmazones_export.h"
+#include <QString>
+
+namespace PlasmaZones {
+
+class AutotileEngine;
+
+/**
+ * @brief Thin INavigationActions adapter for AutotileEngine.
+ *
+ * Maps the user-intent-shaped INavigationActions calls to AutotileEngine's
+ * existing concrete methods so ScreenModeRouter can dispatch through a
+ * common interface without the daemon branching on mode.
+ *
+ * Parameter mapping:
+ *   - `focusInDirection(dir, screen)` →
+ *       engine->focusInDirection(dir, "focus")
+ *   - `moveFocusedInDirection(dir, screen)` →
+ *       engine->swapFocusedInDirection(dir, "move")
+ *       (autotile's "move" IS swap-with-neighbour in the tiling order)
+ *   - `swapFocusedInDirection(dir, screen)` →
+ *       engine->swapFocusedInDirection(dir, "swap")
+ *   - `moveFocusedToPosition(pos, screen)` →
+ *       engine->moveFocusedToPosition(pos)
+ *   - `rotateWindows(cw, screen)` →
+ *       engine->rotateWindows(cw, screen)
+ *   - `reapplyLayout(screen)` →
+ *       engine->retile(screen)
+ *   - `toggleFocusedFloat(screen)` →
+ *       engine->toggleFocusedWindowFloat()
+ *   - `cycleFocus(forward, screen)` →
+ *       engine->focusInDirection(forward ? "right" : "left", "cycle")
+ *
+ * The `screen` parameter is intentionally ignored for autotile-side calls
+ * that rely on the engine's internal focus tracking — by the time the
+ * daemon invokes a navigation shortcut, the active screen has already
+ * been resolved and the engine's focus state is the authoritative target.
+ * Methods that legitimately scope by screen (rotateWindows, retile)
+ * forward it through unchanged.
+ */
+class PLASMAZONES_EXPORT AutotileNavigationAdapter : public INavigationActions
+{
+public:
+    explicit AutotileNavigationAdapter(AutotileEngine* engine);
+    ~AutotileNavigationAdapter() override = default;
+
+    void focusInDirection(const QString& direction, const QString& screenId) override;
+    void moveFocusedInDirection(const QString& direction, const QString& screenId) override;
+    void swapFocusedInDirection(const QString& direction, const QString& screenId) override;
+    void moveFocusedToPosition(int position, const QString& screenId) override;
+    void rotateWindows(bool clockwise, const QString& screenId) override;
+    void reapplyLayout(const QString& screenId) override;
+    void snapAllWindows(const QString& screenId) override;
+    void toggleFocusedFloat(const QString& screenId) override;
+    void cycleFocus(bool forward, const QString& screenId) override;
+    void pushToEmptyZone(const QString& screenId) override;
+    void restoreFocusedWindow(const QString& screenId) override;
+
+private:
+    AutotileEngine* m_engine; // not owned
+};
+
+} // namespace PlasmaZones

--- a/src/compositor-common/dbus_types.cpp
+++ b/src/compositor-common/dbus_types.cpp
@@ -3,7 +3,72 @@
 
 #include "dbus_types.h"
 
+#include <QDebug>
+#include <QLatin1String>
+
 namespace PlasmaZones {
+
+namespace {
+// Wire-format strings for DragBypassReason. Kept as a single source of truth
+// so toWireString() and bypassReasonFromWireString() can never drift.
+constexpr QLatin1String kBypassAutotileScreen("autotile_screen");
+constexpr QLatin1String kBypassSnappingDisabled("snapping_disabled");
+constexpr QLatin1String kBypassContextDisabled("context_disabled");
+} // namespace
+
+QString toWireString(DragBypassReason r)
+{
+    switch (r) {
+    case DragBypassReason::None:
+        return {};
+    case DragBypassReason::AutotileScreen:
+        return kBypassAutotileScreen;
+    case DragBypassReason::SnappingDisabled:
+        return kBypassSnappingDisabled;
+    case DragBypassReason::ContextDisabled:
+        return kBypassContextDisabled;
+    }
+    return {};
+}
+
+DragBypassReason bypassReasonFromWireString(const QString& s)
+{
+    if (s.isEmpty()) {
+        return DragBypassReason::None;
+    }
+    if (s == kBypassAutotileScreen) {
+        return DragBypassReason::AutotileScreen;
+    }
+    if (s == kBypassSnappingDisabled) {
+        return DragBypassReason::SnappingDisabled;
+    }
+    if (s == kBypassContextDisabled) {
+        return DragBypassReason::ContextDisabled;
+    }
+    qWarning() << "bypassReasonFromWireString: unknown wire value" << s << "— mapping to None";
+    return DragBypassReason::None;
+}
+
+QDebug operator<<(QDebug debug, DragBypassReason r)
+{
+    QDebugStateSaver saver(debug);
+    debug.nospace();
+    switch (r) {
+    case DragBypassReason::None:
+        debug << "DragBypassReason::None";
+        break;
+    case DragBypassReason::AutotileScreen:
+        debug << "DragBypassReason::AutotileScreen";
+        break;
+    case DragBypassReason::SnappingDisabled:
+        debug << "DragBypassReason::SnappingDisabled";
+        break;
+    case DragBypassReason::ContextDisabled:
+        debug << "DragBypassReason::ContextDisabled";
+        break;
+    }
+    return debug;
+}
 
 QDBusArgument& operator<<(QDBusArgument& arg, const WindowGeometryEntry& e)
 {
@@ -319,9 +384,12 @@ const QDBusArgument& operator>>(const QDBusArgument& arg, PreTileGeometryEntry& 
 
 QDBusArgument& operator<<(QDBusArgument& arg, const DragPolicy& p)
 {
+    // Wire format kept as `(bbbbbss)` — bypassReason is serialized as its
+    // legacy string representation so effects/daemons built at different
+    // revisions still interoperate within the same ApiVersion.
     arg.beginStructure();
     arg << p.streamDragMoved << p.showOverlay << p.grabKeyboard << p.captureGeometry << p.immediateFloatOnStart
-        << p.screenId << p.bypassReason;
+        << p.screenId << toWireString(p.bypassReason);
     arg.endStructure();
     return arg;
 }
@@ -329,8 +397,10 @@ QDBusArgument& operator<<(QDBusArgument& arg, const DragPolicy& p)
 const QDBusArgument& operator>>(const QDBusArgument& arg, DragPolicy& p)
 {
     arg.beginStructure();
+    QString bypassWire;
     arg >> p.streamDragMoved >> p.showOverlay >> p.grabKeyboard >> p.captureGeometry >> p.immediateFloatOnStart
-        >> p.screenId >> p.bypassReason;
+        >> p.screenId >> bypassWire;
+    p.bypassReason = bypassReasonFromWireString(bypassWire);
     arg.endStructure();
     return arg;
 }

--- a/src/compositor-common/dbus_types.cpp
+++ b/src/compositor-common/dbus_types.cpp
@@ -49,6 +49,117 @@ DragBypassReason bypassReasonFromWireString(const QString& s)
     return DragBypassReason::None;
 }
 
+QString TileRequestEntry::validationError() const
+{
+    if (windowId.isEmpty()) {
+        return QStringLiteral("TileRequestEntry: empty windowId");
+    }
+    if (screenId.isEmpty()) {
+        return QStringLiteral("TileRequestEntry: empty screenId (windowId=%1)").arg(windowId);
+    }
+    if (width < 0 || height < 0) {
+        return QStringLiteral("TileRequestEntry: negative size (windowId=%1 w=%2 h=%3)")
+            .arg(windowId)
+            .arg(width)
+            .arg(height);
+    }
+    // Floating tile requests legitimately carry zero size — the plugin
+    // resolves geometry from the current frame. Tiled requests must have
+    // concrete geometry or the plugin has nothing to apply.
+    if (!floating && (width == 0 || height == 0)) {
+        return QStringLiteral("TileRequestEntry: tiled request requires non-zero size (windowId=%1)").arg(windowId);
+    }
+    return {};
+}
+
+QString BridgeRegistrationResult::validationError() const
+{
+    // REJECTED is a legitimate sentinel the daemon sends when peer version
+    // is incompatible. Surface it as valid so the caller can branch on it
+    // before calling any other methods on the result.
+    if (sessionId == QLatin1String("REJECTED")) {
+        return {};
+    }
+    if (apiVersion.isEmpty()) {
+        return QStringLiteral("BridgeRegistrationResult: empty apiVersion");
+    }
+    bool ok = false;
+    apiVersion.toInt(&ok);
+    if (!ok) {
+        return QStringLiteral("BridgeRegistrationResult: apiVersion not an integer: '%1'").arg(apiVersion);
+    }
+    if (bridgeName.isEmpty()) {
+        return QStringLiteral("BridgeRegistrationResult: empty bridgeName");
+    }
+    if (sessionId.isEmpty()) {
+        return QStringLiteral("BridgeRegistrationResult: empty sessionId");
+    }
+    return {};
+}
+
+QString DragPolicy::validationError() const
+{
+    // The only strong invariant: an AutotileScreen bypass must carry the
+    // autotile screen id, because the effect uses it to scope retroactive
+    // bypass state and the post-drag float target. Other bypass reasons
+    // (SnappingDisabled, ContextDisabled) may be emitted with an empty
+    // screenId when beginDrag was called with an empty startScreenId —
+    // the producer code in drag_protocol.cpp deliberately tolerates that.
+    if (bypassReason == DragBypassReason::AutotileScreen && screenId.isEmpty()) {
+        return QStringLiteral("DragPolicy: AutotileScreen bypass requires non-empty screenId");
+    }
+    return {};
+}
+
+QString DragOutcome::validationError() const
+{
+    // action enum range check — catches memory corruption or protocol
+    // drift from a peer built at a different revision.
+    if (action < NoOp || action > NotifyDragOutUnsnap) {
+        return QStringLiteral("DragOutcome: action out of range: %1").arg(action);
+    }
+
+    // windowId is required for every action that does real work.
+    if (action != NoOp && windowId.isEmpty()) {
+        return QStringLiteral("DragOutcome: windowId required for action=%1").arg(action);
+    }
+
+    switch (action) {
+    case NoOp:
+    case CancelSnap:
+        // No further cross-field requirements.
+        break;
+    case ApplyFloat:
+        // ApplyFloat carries cursor position; (0,0) is a legitimate drop
+        // location at top-left. targetScreenId is optional — the plugin
+        // resolves it from the cursor.
+        break;
+    case ApplySnap:
+        if (zoneId.isEmpty()) {
+            return QStringLiteral("DragOutcome: ApplySnap requires non-empty zoneId (windowId=%1)").arg(windowId);
+        }
+        if (width <= 0 || height <= 0) {
+            return QStringLiteral("DragOutcome: ApplySnap requires non-zero size (windowId=%1 w=%2 h=%3)")
+                .arg(windowId)
+                .arg(width)
+                .arg(height);
+        }
+        break;
+    case RestoreSize:
+        if (width <= 0 || height <= 0) {
+            return QStringLiteral("DragOutcome: RestoreSize requires non-zero size (windowId=%1 w=%2 h=%3)")
+                .arg(windowId)
+                .arg(width)
+                .arg(height);
+        }
+        break;
+    case NotifyDragOutUnsnap:
+        // windowId (checked above) is the only requirement.
+        break;
+    }
+    return {};
+}
+
 QDebug operator<<(QDebug debug, DragBypassReason r)
 {
     QDebugStateSaver saver(debug);

--- a/src/compositor-common/dbus_types.h
+++ b/src/compositor-common/dbus_types.h
@@ -104,6 +104,11 @@ struct TileRequestEntry
     {
         return QRect(x, y, width, height);
     }
+
+    /// Returns empty QString if valid, or a human-readable description of
+    /// the invariant violation. Call at every unmarshal site to detect a
+    /// garbled payload before acting on it.
+    QString validationError() const;
 };
 
 using TileRequestList = QList<TileRequestEntry>;
@@ -287,6 +292,12 @@ struct BridgeRegistrationResult
     QString apiVersion;
     QString bridgeName;
     QString sessionId;
+
+    /// Returns empty QString if valid, or a human-readable description of
+    /// the invariant violation. "REJECTED" sessionId is a valid sentinel
+    /// signaling version mismatch and is NOT flagged as invalid — callers
+    /// must check for it separately before using the result.
+    QString validationError() const;
 };
 
 /// D-Bus struct for move/push/zone-number navigation result: (bssiiiiss)
@@ -372,6 +383,11 @@ struct DragPolicy
     bool immediateFloatOnStart = false; ///< effect should call handleDragToFloat(immediate) at drag start
     QString screenId; ///< screen the drag started/currently is on (virtual-screen-aware)
     DragBypassReason bypassReason = DragBypassReason::None; ///< drag routing (None = canonical snap path)
+
+    /// Returns empty QString if valid, or a human-readable description of
+    /// the invariant violation. Call at every unmarshal site on the effect
+    /// side to catch garbled policies before they perturb drag state.
+    QString validationError() const;
 };
 
 /// Drag outcome — daemon-authoritative decision about what to apply at drag
@@ -405,6 +421,13 @@ struct DragOutcome
     {
         return QRect(x, y, width, height);
     }
+
+    /// Returns empty QString if valid, or a human-readable description of
+    /// the invariant violation. Enforces action enum range and per-action
+    /// cross-field invariants (ApplySnap requires non-empty zoneId + non-
+    /// zero size, ApplyFloat/RestoreSize/NotifyDragOutUnsnap require
+    /// windowId, etc).
+    QString validationError() const;
 };
 
 /// D-Bus struct for restore navigation result: (bbiiii)

--- a/src/compositor-common/dbus_types.h
+++ b/src/compositor-common/dbus_types.h
@@ -10,7 +10,37 @@
 #include <QString>
 #include <QStringList>
 
+class QDebug;
+
 namespace PlasmaZones {
+
+/// Why a drag was bypassed from the canonical snap pipeline.
+///
+/// The daemon's computeDragPolicy picks exactly one of these based on the
+/// drag's context, and both sides route behavior off the value. Replaces
+/// the free-form `QString bypassReason` that carried `""` / `"autotile_screen"`
+/// / `"snapping_disabled"` / `"context_disabled"` as magic strings.
+///
+/// Wire format: unchanged — serialized as the same legacy string via
+/// toWireString()/fromWireString() inside the DragPolicy marshaller, so no
+/// ApiVersion bump is required. Unknown wire values parse to None (matches
+/// the old behavior where unrecognized strings didn't match the autotile
+/// branch and fell through to the canonical snap path).
+enum class DragBypassReason : int {
+    None = 0, ///< canonical snap path — drag flows through the snap pipeline
+    AutotileScreen = 1, ///< drag started/ended on an autotile screen — engine owns placement
+    SnappingDisabled = 2, ///< snap mode off globally — dead drag
+    ContextDisabled = 3, ///< monitor/desktop/activity excluded in settings — dead drag
+};
+
+/// Convert to the legacy wire-format string. Returns an empty QString for None.
+QString toWireString(DragBypassReason r);
+
+/// Parse from the legacy wire-format string. Unknown values map to None.
+DragBypassReason bypassReasonFromWireString(const QString& s);
+
+/// QDebug streaming for logging. Prints the enum name (e.g. "AutotileScreen").
+QDebug operator<<(QDebug debug, DragBypassReason r);
 
 /**
  * @brief Compile-time check that a type has QDBusArgument streaming operators.
@@ -341,7 +371,7 @@ struct DragPolicy
     bool captureGeometry = false; ///< effect should capture pre-drag geometry
     bool immediateFloatOnStart = false; ///< effect should call handleDragToFloat(immediate) at drag start
     QString screenId; ///< screen the drag started/currently is on (virtual-screen-aware)
-    QString bypassReason; ///< empty if snap path; "autotile_screen" / "snapping_disabled" / "context_disabled"
+    DragBypassReason bypassReason = DragBypassReason::None; ///< drag routing (None = canonical snap path)
 };
 
 /// Drag outcome — daemon-authoritative decision about what to apply at drag

--- a/src/core/inavigationactions.h
+++ b/src/core/inavigationactions.h
@@ -9,15 +9,44 @@
 namespace PlasmaZones {
 
 /**
+ * @brief Navigation target context: the window and screen the user is acting on.
+ *
+ * Populated by the daemon's navigation shortcut handlers from compositor
+ * shadow state (windowActivated / cursorScreenChanged pushes) before
+ * dispatching through ScreenModeRouter::navigatorFor().
+ *
+ * Making the target explicit at the interface level (rather than letting
+ * each engine re-read a global "last active window" shadow) has two
+ * architectural benefits:
+ *
+ *   1. The engines stop reaching into WindowTrackingAdaptor's
+ *      compositor-layer shadows on every navigation call, which is a
+ *      step toward retiring the SnapEngine → WTA back-reference entirely.
+ *   2. Tests can invoke navigation methods with an explicit context
+ *      without needing to stub a compositor shadow.
+ *
+ * @note Both fields may be empty — for example on very-early-startup
+ *       shortcuts or when no window is focused. Each method documents
+ *       its behaviour when the fields are empty; the general pattern
+ *       is "emit navigationFeedback with a 'no_window' / 'no_screen'
+ *       reason and return without acting".
+ */
+struct PLASMAZONES_EXPORT NavigationContext
+{
+    QString windowId; ///< The window the operation should act on (typically the focused window).
+    QString screenId; ///< The screen the operation applies to (already resolved by the daemon).
+};
+
+/**
  * @brief Polymorphic dispatch for window-navigation user intents.
  *
- * Both AutotileEngine and SnapEngine implement this interface so
- * ScreenModeRouter can look up the right engine for a given screen and
- * dispatch user-facing navigation commands without the caller branching
- * on mode. The daemon's navigation shortcut handlers (see
- * src/daemon/daemon/navigation.cpp) collapse from ~20 copies of
+ * Both AutotileEngine and SnapEngine implement this interface (via thin
+ * adapter classes) so ScreenModeRouter can look up the right engine for a
+ * given screen and dispatch user-facing navigation commands without the
+ * caller branching on mode. The daemon's navigation shortcut handlers
+ * (see src/daemon/daemon/navigation.cpp) collapse from ~20 copies of
  * `if (isAutotileScreen) { autotile->foo() } else { wta->bar() }` into
- * single-line calls like `router->navigatorFor(screenId)->foo(...)`.
+ * single-line calls like `router->navigatorFor(ctx.screenId)->foo(ctx)`.
  *
  * Semantic contract: each method represents a USER INTENT, not a
  * mode-specific implementation step. "Move focused window left" has
@@ -50,9 +79,9 @@ public:
      * Snap: queries zone adjacency from the target resolver.
      *
      * @param direction "left" / "right" / "up" / "down"
-     * @param screenId Effective screen ID where the operation applies
+     * @param ctx       Target window + screen
      */
-    virtual void focusInDirection(const QString& direction, const QString& screenId) = 0;
+    virtual void focusInDirection(const QString& direction, const NavigationContext& ctx) = 0;
 
     /**
      * @brief Move the focused window to the adjacent slot in the given direction.
@@ -63,9 +92,9 @@ public:
      *   depending on the target's occupancy.
      *
      * @param direction "left" / "right" / "up" / "down"
-     * @param screenId Effective screen ID
+     * @param ctx       Target window + screen
      */
-    virtual void moveFocusedInDirection(const QString& direction, const QString& screenId) = 0;
+    virtual void moveFocusedInDirection(const QString& direction, const NavigationContext& ctx) = 0;
 
     /**
      * @brief Swap the focused window with the adjacent window in the given direction.
@@ -77,9 +106,9 @@ public:
      *   current occupant — both windows change zones simultaneously.
      *
      * @param direction "left" / "right" / "up" / "down"
-     * @param screenId Effective screen ID
+     * @param ctx       Target window + screen
      */
-    virtual void swapFocusedInDirection(const QString& direction, const QString& screenId) = 0;
+    virtual void swapFocusedInDirection(const QString& direction, const NavigationContext& ctx) = 0;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Positional operations
@@ -92,9 +121,9 @@ public:
      * Snap: Nth zone on the screen (by sorted zone number).
      *
      * @param position 1-based position; implementations clamp to valid range
-     * @param screenId Effective screen ID
+     * @param ctx      Target window + screen
      */
-    virtual void moveFocusedToPosition(int position, const QString& screenId) = 0;
+    virtual void moveFocusedToPosition(int position, const NavigationContext& ctx) = 0;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Multi-window operations
@@ -107,9 +136,9 @@ public:
      * Snap: rotates zone assignments through the current layout's zones.
      *
      * @param clockwise Rotation direction
-     * @param screenId Effective screen ID
+     * @param ctx       Target screen (windowId unused)
      */
-    virtual void rotateWindows(bool clockwise, const QString& screenId) = 0;
+    virtual void rotateWindows(bool clockwise, const NavigationContext& ctx) = 0;
 
     /**
      * @brief Re-apply the current layout to all managed windows on the screen.
@@ -121,9 +150,9 @@ public:
      * Idempotent when the layout hasn't changed — safe to call after
      * configuration updates.
      *
-     * @param screenId Effective screen ID
+     * @param ctx Target screen (windowId unused)
      */
-    virtual void reapplyLayout(const QString& screenId) = 0;
+    virtual void reapplyLayout(const NavigationContext& ctx) = 0;
 
     /**
      * @brief Snap every un-managed window on the screen to the current layout.
@@ -137,9 +166,9 @@ public:
      * the grid" user action triggered by an explicit shortcut, whereas
      * reapplyLayout is the post-layout-change refresh.
      *
-     * @param screenId Effective screen ID
+     * @param ctx Target screen (windowId unused)
      */
-    virtual void snapAllWindows(const QString& screenId) = 0;
+    virtual void snapAllWindows(const NavigationContext& ctx) = 0;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Float state
@@ -151,9 +180,9 @@ public:
      * Autotile: excludes from / reinserts into the tiling layout.
      * Snap: stores/restores zone assignments via WindowTrackingService.
      *
-     * @param screenId Effective screen ID where the focused window lives
+     * @param ctx Target window + screen
      */
-    virtual void toggleFocusedFloat(const QString& screenId) = 0;
+    virtual void toggleFocusedFloat(const NavigationContext& ctx) = 0;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Cycle operations
@@ -168,9 +197,9 @@ public:
      *   next/previous zone if only one window per zone.
      *
      * @param forward true = next, false = previous
-     * @param screenId Effective screen ID
+     * @param ctx     Target window + screen
      */
-    virtual void cycleFocus(bool forward, const QString& screenId) = 0;
+    virtual void cycleFocus(bool forward, const NavigationContext& ctx) = 0;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Mode-asymmetric operations
@@ -186,9 +215,9 @@ public:
      * Snap: finds the first unoccupied zone in the layout and moves the
      *   focused window into it.
      *
-     * @param screenId Effective screen ID
+     * @param ctx Target window + screen
      */
-    virtual void pushToEmptyZone(const QString& screenId) = 0;
+    virtual void pushToEmptyZone(const NavigationContext& ctx) = 0;
 
     /**
      * @brief "Restore" the focused window out of its managed state.
@@ -201,9 +230,9 @@ public:
      * Same user intent ("un-manage this window"), different mechanics in
      * each mode.
      *
-     * @param screenId Effective screen ID
+     * @param ctx Target window + screen
      */
-    virtual void restoreFocusedWindow(const QString& screenId) = 0;
+    virtual void restoreFocusedWindow(const NavigationContext& ctx) = 0;
 };
 
 } // namespace PlasmaZones

--- a/src/core/inavigationactions.h
+++ b/src/core/inavigationactions.h
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "plasmazones_export.h"
+#include <QString>
+
+namespace PlasmaZones {
+
+/**
+ * @brief Polymorphic dispatch for window-navigation user intents.
+ *
+ * Both AutotileEngine and SnapEngine implement this interface so
+ * ScreenModeRouter can look up the right engine for a given screen and
+ * dispatch user-facing navigation commands without the caller branching
+ * on mode. The daemon's navigation shortcut handlers (see
+ * src/daemon/daemon/navigation.cpp) collapse from ~20 copies of
+ * `if (isAutotileScreen) { autotile->foo() } else { wta->bar() }` into
+ * single-line calls like `router->navigatorFor(screenId)->foo(...)`.
+ *
+ * Semantic contract: each method represents a USER INTENT, not a
+ * mode-specific implementation step. "Move focused window left" has
+ * different internal meaning in tile-swap mode vs. zone-snap mode, but
+ * the user's request is the same — the interface names the request and
+ * each engine fulfills it in its own terms.
+ *
+ * All methods are idempotent with respect to "no focused window" — each
+ * implementation emits navigation feedback with a sensible reason code
+ * when there's nothing to act on, rather than erroring out. Callers do
+ * NOT need to guard against empty focus state.
+ *
+ * @see ScreenModeRouter::navigatorFor
+ * @see IEngineLifecycle for the complementary lifecycle interface
+ *      (windowOpened / windowClosed / saveState / etc.)
+ */
+class PLASMAZONES_EXPORT INavigationActions
+{
+public:
+    virtual ~INavigationActions() = default;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Directional operations on the focused window
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Move keyboard focus to the adjacent window in the given direction.
+     *
+     * Autotile: walks the tiling-order neighbour list.
+     * Snap: queries zone adjacency from the target resolver.
+     *
+     * @param direction "left" / "right" / "up" / "down"
+     * @param screenId Effective screen ID where the operation applies
+     */
+    virtual void focusInDirection(const QString& direction, const QString& screenId) = 0;
+
+    /**
+     * @brief Move the focused window to the adjacent slot in the given direction.
+     *
+     * Autotile: swaps with the next window in the tiling order (the window
+     *   takes the neighbour's position; the neighbour shifts).
+     * Snap: moves the window into the adjacent zone — displacing or filling
+     *   depending on the target's occupancy.
+     *
+     * @param direction "left" / "right" / "up" / "down"
+     * @param screenId Effective screen ID
+     */
+    virtual void moveFocusedInDirection(const QString& direction, const QString& screenId) = 0;
+
+    /**
+     * @brief Swap the focused window with the adjacent window in the given direction.
+     *
+     * Autotile: identical to moveFocusedInDirection at the implementation
+     *   level (tiling-order swap IS the move), but carries a distinct OSD
+     *   feedback label.
+     * Snap: exchanges the focused window's zone with the adjacent zone's
+     *   current occupant — both windows change zones simultaneously.
+     *
+     * @param direction "left" / "right" / "up" / "down"
+     * @param screenId Effective screen ID
+     */
+    virtual void swapFocusedInDirection(const QString& direction, const QString& screenId) = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Positional operations
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Move the focused window to the Nth position on the screen.
+     *
+     * Autotile: Nth slot in tiling order (1 = master).
+     * Snap: Nth zone on the screen (by sorted zone number).
+     *
+     * @param position 1-based position; implementations clamp to valid range
+     * @param screenId Effective screen ID
+     */
+    virtual void moveFocusedToPosition(int position, const QString& screenId) = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Multi-window operations
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Rotate all tiled / snapped windows on the screen.
+     *
+     * Autotile: rotates positions in the tiling order.
+     * Snap: rotates zone assignments through the current layout's zones.
+     *
+     * @param clockwise Rotation direction
+     * @param screenId Effective screen ID
+     */
+    virtual void rotateWindows(bool clockwise, const QString& screenId) = 0;
+
+    /**
+     * @brief Re-apply the current layout to all managed windows on the screen.
+     *
+     * Autotile: `retile(screenId)` — recomputes and applies tiling.
+     * Snap: `resnapToNewLayout` — re-snaps windows by zone number after a
+     *   layout switch (previous zone N → new zone N).
+     *
+     * Idempotent when the layout hasn't changed — safe to call after
+     * configuration updates.
+     *
+     * @param screenId Effective screen ID
+     */
+    virtual void reapplyLayout(const QString& screenId) = 0;
+
+    /**
+     * @brief Snap every un-managed window on the screen to the current layout.
+     *
+     * Autotile: `retile(screenId)` — picks up any windows the engine isn't
+     *   tracking yet and inserts them into the tiling order.
+     * Snap: `snapAllWindows` — walks the KWin window list and snaps each
+     *   currently-unsnapped window to a zone.
+     *
+     * Differs from reapplyLayout in that this is the "snap everything to
+     * the grid" user action triggered by an explicit shortcut, whereas
+     * reapplyLayout is the post-layout-change refresh.
+     *
+     * @param screenId Effective screen ID
+     */
+    virtual void snapAllWindows(const QString& screenId) = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Float state
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Toggle the focused window between managed and floating states.
+     *
+     * Autotile: excludes from / reinserts into the tiling layout.
+     * Snap: stores/restores zone assignments via WindowTrackingService.
+     *
+     * @param screenId Effective screen ID where the focused window lives
+     */
+    virtual void toggleFocusedFloat(const QString& screenId) = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Cycle operations
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Cycle keyboard focus through managed windows on the screen.
+     *
+     * Autotile: cycles through the tiling order (forward = right in the
+     *   linear layout, wrapping).
+     * Snap: cycles through windows stacked in the same zone, or to the
+     *   next/previous zone if only one window per zone.
+     *
+     * @param forward true = next, false = previous
+     * @param screenId Effective screen ID
+     */
+    virtual void cycleFocus(bool forward, const QString& screenId) = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Mode-asymmetric operations
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Move the focused window to the first empty zone on the screen.
+     *
+     * Autotile: no-op. Autotile mode has no concept of "empty zones" —
+     *   every window participates in the layout, and the engine ignores
+     *   this call. Exists on the interface so the daemon doesn't have to
+     *   branch on mode at the shortcut entry point.
+     * Snap: finds the first unoccupied zone in the layout and moves the
+     *   focused window into it.
+     *
+     * @param screenId Effective screen ID
+     */
+    virtual void pushToEmptyZone(const QString& screenId) = 0;
+
+    /**
+     * @brief "Restore" the focused window out of its managed state.
+     *
+     * Autotile: toggle-float. Pulling a window out of the tiling layout
+     *   is what "restore to original state" means in tile mode.
+     * Snap: restore the window to its pre-snap size (as captured in
+     *   pre-tile geometry) at its current position, and unsnap.
+     *
+     * Same user intent ("un-manage this window"), different mechanics in
+     * each mode.
+     *
+     * @param screenId Effective screen ID
+     */
+    virtual void restoreFocusedWindow(const QString& screenId) = 0;
+};
+
+} // namespace PlasmaZones

--- a/src/core/inavigationactions.h
+++ b/src/core/inavigationactions.h
@@ -30,6 +30,18 @@ namespace PlasmaZones {
  *       its behaviour when the fields are empty; the general pattern
  *       is "emit navigationFeedback with a 'no_window' / 'no_screen'
  *       reason and return without acting".
+ *
+ * @note Adapter asymmetry: SnapNavigationAdapter threads @c ctx through
+ *       to SnapEngine on every call — SnapEngine honours the explicit
+ *       target and only falls back to WTA shadows when both fields are
+ *       empty. AutotileNavigationAdapter passes @c ctx.screenId through
+ *       on the screen-keyed methods (rotate / reapply / snapAllWindows)
+ *       but lets the other methods use AutotileEngine's internal
+ *       focused-screen state. That's intentional: the autotile engine
+ *       already tracks focused window + focused screen per-state, so
+ *       duplicating the target at the call site would only create a
+ *       split-brain risk. The interface contract is therefore "ctx is
+ *       authoritative for snap; advisory for autotile".
  */
 struct PLASMAZONES_EXPORT NavigationContext
 {

--- a/src/core/screenmoderouter.cpp
+++ b/src/core/screenmoderouter.cpp
@@ -5,6 +5,7 @@
 
 #include "../autotile/AutotileEngine.h"
 #include "../snap/SnapEngine.h"
+#include "inavigationactions.h"
 #include "iwindowengine.h"
 #include "layoutmanager.h"
 
@@ -55,6 +56,24 @@ IEngineLifecycle* ScreenModeRouter::engineFor(const QString& screenId) const
     // no `default:` case so that adding a new enum value triggers -Wswitch
     // at compile time instead of silently falling through to nullptr at
     // runtime. Q_UNREACHABLE + nullptr is the safe fallback if that happens.
+    Q_UNREACHABLE();
+    return nullptr;
+}
+
+void ScreenModeRouter::setNavigationAdapters(INavigationActions* snapNavigator, INavigationActions* autotileNavigator)
+{
+    m_snapNavigator = snapNavigator;
+    m_autotileNavigator = autotileNavigator;
+}
+
+INavigationActions* ScreenModeRouter::navigatorFor(const QString& screenId) const
+{
+    switch (modeFor(screenId)) {
+    case AssignmentEntry::Autotile:
+        return m_autotileNavigator;
+    case AssignmentEntry::Snapping:
+        return m_snapNavigator;
+    }
     Q_UNREACHABLE();
     return nullptr;
 }

--- a/src/core/screenmoderouter.h
+++ b/src/core/screenmoderouter.h
@@ -13,6 +13,7 @@ namespace PlasmaZones {
 
 class AutotileEngine;
 class IEngineLifecycle;
+class INavigationActions;
 class LayoutManager;
 class SnapEngine;
 
@@ -47,6 +48,12 @@ public:
     /// passing nullptr for any dependency is a programming error.
     ScreenModeRouter(LayoutManager* layoutManager, SnapEngine* snapEngine, AutotileEngine* autotileEngine);
 
+    /// Wire navigation action adapters. Must be called once at daemon startup
+    /// after the adapters are constructed (which requires the engines and
+    /// WindowTrackingAdaptor to exist). Calling navigatorFor() before this
+    /// returns nullptr for all screens. Adapters are not owned.
+    void setNavigationAdapters(INavigationActions* snapNavigator, INavigationActions* autotileNavigator);
+
     /// Current mode for @p screenId. Consults the autotile engine's
     /// live set first (mode is derived from assignment + context) and
     /// falls back to the layout manager's cascade for unknown screens.
@@ -60,6 +67,19 @@ public:
     /// behaviour for that screen — they must not reach into a specific
     /// engine directly.
     IEngineLifecycle* engineFor(const QString& screenId) const;
+
+    /// Navigation action dispatcher for @p screenId. Returns the adapter
+    /// for whichever engine owns placement on that screen, or nullptr if
+    /// setNavigationAdapters() hasn't been called yet (early daemon
+    /// startup). Callers should use this as the single dispatch point for
+    /// user-facing navigation shortcuts instead of branching on
+    /// isAutotileMode / isSnapMode and calling engine methods ad hoc.
+    ///
+    /// Replaces the ~20 ad-hoc
+    ///   `if (isAutotileScreen(screenId)) { autotile->foo(...) }
+    ///    else { windowTrackingAdaptor->bar(...) }`
+    /// branches that previously lived in daemon/navigation.cpp.
+    INavigationActions* navigatorFor(const QString& screenId) const;
 
     /// Convenience predicates. @see modeFor for the fallback semantics.
     bool isSnapMode(const QString& screenId) const;
@@ -80,6 +100,8 @@ private:
     LayoutManager* m_layoutManager;
     SnapEngine* m_snapEngine;
     AutotileEngine* m_autotileEngine;
+    INavigationActions* m_snapNavigator = nullptr;
+    INavigationActions* m_autotileNavigator = nullptr;
 };
 
 } // namespace PlasmaZones

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -88,9 +88,13 @@ struct PLASMAZONES_EXPORT DragInfo
         return !windowId.isEmpty();
     }
 
-    // Note: Use WindowTrackingService::currentAppIdFor(dragInfo.windowId) or
-    // PlasmaZonesEffect::appIdForInstance() to get the live app class.
-    // windowId is the opaque compositor instance id — never parse it.
+    // Note: use WindowTrackingService::currentAppIdFor(dragInfo.windowId) or
+    // AutotileEngine::currentAppIdFor() to get the live app class on the
+    // daemon side (both query WindowRegistry). On the effect side, live
+    // class reads go through PlasmaZonesEffect::getWindowAppId() directly.
+    // The windowId field carries the frozen "appId|instanceId" composite
+    // used as a stable daemon-side key — don't parse the prefix expecting
+    // a current class.
 };
 
 /**

--- a/src/core/utils.h
+++ b/src/core/utils.h
@@ -197,9 +197,11 @@ inline QString extractAppId(const QString& windowId)
 
 // extractWindowClass() was removed — it was an alias for extractAppId() that
 // only made call sites read "windowClass" instead of "appId". Runtime class
-// lookups now go through WindowTrackingService::currentAppIdFor or
-// PlasmaZonesEffect::appIdForInstance so they hit the live registry instead
-// of parsing a composite string that no longer exists on the wire.
+// lookups go through WindowTrackingService::currentAppIdFor or
+// AutotileEngine::currentAppIdFor on the daemon side, which hit the live
+// WindowRegistry instead of parsing the frozen composite key. On the effect
+// side, the live class is read directly via getWindowAppId() — there is no
+// effect-local app-id cache.
 
 /**
  * @brief Extract the stable KWin instance identifier (UUID) from a full window ID.

--- a/src/core/windowtrackingservice.cpp
+++ b/src/core/windowtrackingservice.cpp
@@ -540,10 +540,11 @@ void WindowTrackingService::unsnapForFloat(const QString& windowId)
         qCInfo(lcCore) << "Saved pre-float zones for" << windowId << "->" << zoneIds << "screen:" << screenId;
         unassignWindow(windowId);
 
-        // Consume one pending restore entry so this window doesn't get re-snapped
-        // to the old zone when closed and reopened. Uses consumePendingAssignment
-        // (not clearStalePendingAssignment) to preserve entries for other instances
-        // of the same app — e.g. unsnapping one Konsole shouldn't affect the other two.
+        // Pop one pending-restore entry (FIFO) so this window doesn't get
+        // re-snapped to the old zone when closed and reopened. The queue is
+        // per-appId, so popping one entry leaves any remaining entries for
+        // other instances of the same app intact — unsnapping one Konsole
+        // doesn't disturb restore entries for the other two.
         consumePendingAssignment(windowId);
     }
     // Note: If window not in assignments, it's already unsnapped - no action needed

--- a/src/core/windowtrackingservice.h
+++ b/src/core/windowtrackingservice.h
@@ -447,6 +447,58 @@ public:
                             int virtualDesktop);
 
     /**
+     * @brief Commit a snap: full orchestration of a "window is now in this zone".
+     *
+     * Encapsulates the sequence that used to live in
+     * WindowTrackingAdaptor::windowSnapped, which was the biggest chunk of
+     * snap-engine business logic masquerading as a D-Bus adaptor method:
+     *
+     *   1. Clear any pre-existing floating state (emits floating-cleared signal)
+     *   2. Clear auto-snapped flag; capture wasAutoSnapped
+     *   3. If !wasAutoSnapped, consume one pending-restore entry
+     *   4. Assign the window to @p zoneId on @p screenId at the current desktop
+     *   5. If this wasn't an auto-snap and @p zoneId isn't a zone-selector
+     *      special ID, update the last-used-zone tracking
+     *   6. Emit windowSnapStateChanged(windowId, WindowStateEntry{...})
+     *
+     * Callers (SnapEngine navigation methods, WTA's D-Bus slot forwarder,
+     * WTA internal paths) pass the resolved screen — WTS does no screen
+     * resolution of its own since cursor/active-window shadows are
+     * compositor-layer state held by WTA.
+     *
+     * @param windowId  Full window id
+     * @param zoneId    Target zone UUID (or "zoneselector-*" sentinel)
+     * @param screenId  Already-resolved effective screen id
+     */
+    void commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId);
+
+    /**
+     * @brief Multi-zone variant of commitSnap for zone-spanning windows.
+     *
+     * Same orchestration, but calls assignWindowToZones for the whole
+     * list and updates last-used-zone tracking based on the primary
+     * (first) zone id.
+     *
+     * @param windowId  Full window id
+     * @param zoneIds   Target zone UUIDs — must be non-empty; first is primary
+     * @param screenId  Already-resolved effective screen id
+     */
+    void commitMultiZoneSnap(const QString& windowId, const QStringList& zoneIds, const QString& screenId);
+
+    /**
+     * @brief Uncommit a snap: unsnap the window and clean up pending state.
+     *
+     *   1. Bail if the window isn't currently snapped (no-op)
+     *   2. Consume one pending-restore entry so a stale session entry
+     *      can't drag the window back on next close/reopen
+     *   3. Unassign from its zone
+     *   4. Emit windowSnapStateChanged with an "unsnapped" WindowStateEntry
+     *
+     * Replaces WindowTrackingAdaptor::windowUnsnapped's body.
+     */
+    void uncommitSnap(const QString& windowId);
+
+    /**
      * @brief Mark a window as reported by the effect (confirmed live)
      *
      * Called when the effect reports a window via windowOpened/resolveWindowRestore.
@@ -891,6 +943,29 @@ Q_SIGNALS:
      * @brief Emitted when state needs to be saved
      */
     void stateChanged();
+
+    /**
+     * @brief Emitted by commitSnap / commitMultiZoneSnap / uncommitSnap.
+     *
+     * Carries a WindowStateEntry describing the new snap state. WTA
+     * subscribes to this signal in its constructor and re-emits as its
+     * own windowStateChanged D-Bus signal so external consumers (the
+     * KWin effect) see exactly what they did before the bookkeeping
+     * orchestration moved from WTA into WTS.
+     *
+     * The changeType field is "snapped" for commit methods and
+     * "unsnapped" for uncommit.
+     */
+    void windowSnapStateChanged(const QString& windowId, const WindowStateEntry& entry);
+
+    /**
+     * @brief Emitted by commitSnap when it had to clear a pre-existing
+     * floating state before committing.
+     *
+     * WTA relays this to windowFloatingChanged(windowId, false, screenId)
+     * so the effect drops the floating flag on its side too.
+     */
+    void windowFloatingClearedForSnap(const QString& windowId, const QString& screenId);
 
 private:
     // Minimum visible area for geometry validation

--- a/src/core/windowtrackingservice.h
+++ b/src/core/windowtrackingservice.h
@@ -447,18 +447,6 @@ public:
                             int virtualDesktop);
 
     /**
-     * @brief Clear stale pending assignment for a window
-     *
-     * When a user explicitly snaps a window, this clears any stale pending
-     * assignment from a previous session. This prevents the window from
-     * restoring to the wrong zone if it's closed and reopened.
-     *
-     * @param windowId Full window ID
-     * @return true if a stale pending assignment was cleared
-     */
-    bool clearStalePendingAssignment(const QString& windowId);
-
-    /**
      * @brief Mark a window as reported by the effect (confirmed live)
      *
      * Called when the effect reports a window via windowOpened/resolveWindowRestore.
@@ -493,16 +481,35 @@ public:
     bool clearAutoSnapped(const QString& windowId);
 
     /**
-     * @brief Consume pending zone assignment after successful restore
+     * @brief Pop the oldest pending restore entry for this window's appId.
      *
-     * After a window is successfully restored to its persisted zone, the pending
-     * assignment should be removed so that:
-     * 1. The same window won't be restored again if reopened
-     * 2. Other windows of the same class won't incorrectly restore to this zone
+     * The pending-restore queue is keyed by appId (FIFO), mirroring KWin's
+     * takeSessionInfo pattern. Every call to this method consumes at most
+     * one entry — the oldest one — and erases the queue entry entirely once
+     * it's emptied. Call sites:
      *
-     * @param windowId Full window ID
+     *   1. After a successful session restore — so the same window isn't
+     *      restored again if reopened, and so other instances of the same
+     *      app class don't incorrectly restore onto this window's zone.
+     *   2. After a user-initiated snap or unsnap — so a stale entry from a
+     *      previous session doesn't drag the window back to a different zone
+     *      on its next close/reopen cycle.
+     *
+     * There is no "stale" vs "fresh" distinction inside the queue: every
+     * entry is a FIFO head, and this method pops the head regardless of
+     * provenance. Earlier versions split this into two methods
+     * (consumePendingAssignment / clearStalePendingAssignment) that were
+     * implementation-identical but named as if they did different things;
+     * the duplication has been removed.
+     *
+     * @param windowId Full window ID — the appId is resolved via
+     *                 currentAppIdFor() so the queue lookup sees the live
+     *                 class (Electron/CEF apps that mutate their class
+     *                 mid-session still hit the right queue).
+     * @return true if an entry was popped, false if the queue was empty.
+     *         Callers that don't care about the result may ignore it.
      */
-    void consumePendingAssignment(const QString& windowId);
+    bool consumePendingAssignment(const QString& windowId);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Navigation Helpers

--- a/src/core/windowtrackingservice.h
+++ b/src/core/windowtrackingservice.h
@@ -12,6 +12,7 @@
 #include <QHash>
 #include <QSet>
 #include <QRect>
+#include <functional>
 #include <optional>
 
 namespace PlasmaZones {
@@ -447,43 +448,126 @@ public:
                             int virtualDesktop);
 
     /**
-     * @brief Commit a snap: full orchestration of a "window is now in this zone".
+     * @brief Snap-commit intent — distinguishes user-initiated from auto-restored snaps.
+     *
+     * commitSnap's side effects depend on WHY the snap is happening. The
+     * two intents select different branches inside the orchestration:
+     *
+     *   UserInitiated (default):
+     *     - Captures and clears any stale auto-snapped flag (so a subsequent
+     *       windowActivated's last-used-zone gate sees "user-initiated")
+     *     - Consumes one pending-restore entry (so the session entry can't
+     *       drag the window back on next close/reopen)
+     *     - Updates last-used-zone tracking
+     *   AutoRestored:
+     *     - Does NOT touch the auto-snapped flag. The caller (lifecycle
+     *       auto-snap path) sets it BEFORE commit, and the flag is
+     *       expected to persist until windowClosed or pruneStale so
+     *       the initial windowActivated can read it and skip the
+     *       last-used-zone update.
+     *     - Does NOT consume pending-restore. The resolve path that
+     *       produced this snap already consumed its entry.
+     *     - Does NOT update last-used-zone. Auto-restores shouldn't
+     *       drag the last-used marker around.
+     *
+     * Floating-state clear (+ windowFloatingClearedForSnap emit) and the
+     * windowSnapStateChanged emit fire for both intents.
+     *
+     * See callers for which intent they pass:
+     *   - SnapEngine navigation methods: UserInitiated (default)
+     *   - WindowTrackingAdaptor::windowSnapped D-Bus slot: UserInitiated
+     *   - SnapEngine::windowOpened auto-snap path: AutoRestored
+     *   - SnapEngine::unfloatToZone: UserInitiated (user toggled float)
+     */
+    enum class SnapIntent {
+        UserInitiated, ///< Explicit user action (shortcut, D-Bus call, float-toggle)
+        AutoRestored, ///< Auto-snap on open, session restore, app-rule match
+    };
+
+    /**
+     * @brief Commit a snap: full orchestration of "window is now in this zone".
      *
      * Encapsulates the sequence that used to live in
-     * WindowTrackingAdaptor::windowSnapped, which was the biggest chunk of
-     * snap-engine business logic masquerading as a D-Bus adaptor method:
+     * WindowTrackingAdaptor::windowSnapped (pre-Phase-5C):
      *
      *   1. Clear any pre-existing floating state (emits floating-cleared signal)
-     *   2. Clear auto-snapped flag; capture wasAutoSnapped
-     *   3. If !wasAutoSnapped, consume one pending-restore entry
+     *   2. If UserInitiated: clear auto-snapped flag; capture wasAutoSnapped
+     *   3. If UserInitiated && !wasAutoSnapped: consume pending-restore entry
      *   4. Assign the window to @p zoneId on @p screenId at the current desktop
-     *   5. If this wasn't an auto-snap and @p zoneId isn't a zone-selector
-     *      special ID, update the last-used-zone tracking
+     *   5. If UserInitiated && !wasAutoSnapped && zoneId isn't a zone-selector
+     *      sentinel: update last-used-zone tracking
      *   6. Emit windowSnapStateChanged(windowId, WindowStateEntry{...})
      *
-     * Callers (SnapEngine navigation methods, WTA's D-Bus slot forwarder,
-     * WTA internal paths) pass the resolved screen — WTS does no screen
-     * resolution of its own since cursor/active-window shadows are
-     * compositor-layer state held by WTA.
+     * Callers pass the resolved screen — WTS does no screen resolution of
+     * its own since cursor/active-window shadows are compositor-layer
+     * state held by WTA.
      *
      * @param windowId  Full window id
      * @param zoneId    Target zone UUID (or "zoneselector-*" sentinel)
      * @param screenId  Already-resolved effective screen id
+     * @param intent    Whether this snap was user-initiated or auto-restored
      */
-    void commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId);
+    void commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId,
+                    SnapIntent intent = SnapIntent::UserInitiated);
 
     /**
      * @brief Multi-zone variant of commitSnap for zone-spanning windows.
      *
-     * Same orchestration, but calls assignWindowToZones for the whole
-     * list and updates last-used-zone tracking based on the primary
-     * (first) zone id.
+     * Same orchestration as commitSnap, but calls assignWindowToZones for
+     * the whole list and updates last-used-zone tracking based on the
+     * primary (first) zone id.
      *
      * @param windowId  Full window id
      * @param zoneIds   Target zone UUIDs — must be non-empty; first is primary
      * @param screenId  Already-resolved effective screen id
+     * @param intent    Whether this snap was user-initiated or auto-restored
      */
-    void commitMultiZoneSnap(const QString& windowId, const QStringList& zoneIds, const QString& screenId);
+    void commitMultiZoneSnap(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
+                             SnapIntent intent = SnapIntent::UserInitiated);
+
+    /**
+     * @brief Apply a batch of zone-assignment changes.
+     *
+     * Used by rotate / resnap / vs_reconfigure / snap-all pipelines to
+     * process a pre-computed vector of ZoneAssignmentEntry items in one
+     * pass. Replaces two nearly-identical `processBatchEntries` copies
+     * that used to live in WindowTrackingAdaptor/navigation.cpp and
+     * snapengine/navigation_actions.cpp — the bookkeeping loop belongs
+     * on WTS, and each caller now emits its own applyGeometriesBatch
+     * signal on the returned geometry list.
+     *
+     * Per-entry semantics:
+     *   - targetZoneId == "__restore__": uncommitSnap + clearPreTileGeometry
+     *   - multi-zone (targetZoneIds.size() > 1): commitMultiZoneSnap(intent)
+     *   - single-zone: commitSnap(intent)
+     *
+     * Screen resolution per entry (first non-empty wins):
+     *   1. entry.targetScreenId — caller stamped an authoritative target
+     *   2. ScreenManager::effectiveScreenAt(geometry.center()) — VS-aware
+     *      point lookup
+     *   3. QGuiApplication::screens() linear walk — physical fallback for
+     *      early startup when ScreenManager isn't initialised yet
+     *   4. fallbackScreenResolver() — caller-supplied last-resort, typically
+     *      a compositor-layer cursor/active shadow read from
+     *      WindowTrackingAdaptor
+     *
+     * @param entries                 Pre-computed assignments (may be empty)
+     * @param intent                  SnapIntent for commit methods. Defaults
+     *                                to UserInitiated to preserve historical
+     *                                rotate/resnap semantics (each window's
+     *                                snap updates last-used-zone).
+     * @param fallbackScreenResolver  Optional callable for the last-resort
+     *                                screen. Invoked at most once per entry,
+     *                                only when all built-in strategies return
+     *                                empty. May itself return empty — commit
+     *                                proceeds with an empty screen in that
+     *                                case, preserving legacy behaviour.
+     * @return WindowGeometryList sized to @p entries (one rect per entry in
+     *         input order). Empty if @p entries is empty.
+     */
+    WindowGeometryList applyBatchAssignments(const QVector<ZoneAssignmentEntry>& entries,
+                                             SnapIntent intent = SnapIntent::UserInitiated,
+                                             std::function<QString()> fallbackScreenResolver = {});
 
     /**
      * @brief Uncommit a snap: unsnap the window and clean up pending state.

--- a/src/core/windowtrackingservice/snap.cpp
+++ b/src/core/windowtrackingservice/snap.cpp
@@ -467,26 +467,6 @@ void WindowTrackingService::updateLastUsedZone(const QString& zoneId, const QStr
     scheduleSaveState();
 }
 
-bool WindowTrackingService::clearStalePendingAssignment(const QString& windowId)
-{
-    // When a user explicitly snaps a window, clear ONE stale pending assignment
-    // from a previous session (FIFO, mirroring consumePendingAssignment). Only the
-    // first entry is removed so multi-instance apps retain entries for other windows.
-    QString appId = currentAppIdFor(windowId);
-    auto it = m_pendingRestoreQueues.find(appId);
-    if (it == m_pendingRestoreQueues.end() || it->isEmpty()) {
-        return false;
-    }
-    it->removeFirst();
-    if (it->isEmpty()) {
-        m_pendingRestoreQueues.erase(it);
-    }
-    qCDebug(lcCore) << "Cleared one stale pending assignment for" << appId
-                    << "remaining:" << m_pendingRestoreQueues.value(appId).size();
-    scheduleSaveState();
-    return true;
-}
-
 void WindowTrackingService::markWindowReported(const QString& windowId)
 {
     if (!windowId.isEmpty()) {
@@ -511,19 +491,25 @@ bool WindowTrackingService::clearAutoSnapped(const QString& windowId)
     return m_autoSnappedWindows.remove(windowId);
 }
 
-void WindowTrackingService::consumePendingAssignment(const QString& windowId)
+bool WindowTrackingService::consumePendingAssignment(const QString& windowId)
 {
-    QString appId = currentAppIdFor(windowId);
+    // Pop the oldest pending-restore entry for this window's live appId.
+    // Single authoritative implementation — see header for why earlier
+    // consumePendingAssignment / clearStalePendingAssignment twins were
+    // merged. Callers that don't care about the result ignore the bool.
+    const QString appId = currentAppIdFor(windowId);
     auto it = m_pendingRestoreQueues.find(appId);
-    if (it != m_pendingRestoreQueues.end() && !it->isEmpty()) {
-        it->removeFirst();
-        if (it->isEmpty()) {
-            m_pendingRestoreQueues.erase(it);
-        }
-        qCDebug(lcCore) << "Consumed pending assignment for" << appId
-                        << "remaining:" << m_pendingRestoreQueues.value(appId).size();
-        scheduleSaveState();
+    if (it == m_pendingRestoreQueues.end() || it->isEmpty()) {
+        return false;
     }
+    it->removeFirst();
+    if (it->isEmpty()) {
+        m_pendingRestoreQueues.erase(it);
+    }
+    qCDebug(lcCore) << "Consumed pending assignment for" << appId
+                    << "remaining:" << m_pendingRestoreQueues.value(appId).size();
+    scheduleSaveState();
+    return true;
 }
 
 } // namespace PlasmaZones

--- a/src/core/windowtrackingservice/snap.cpp
+++ b/src/core/windowtrackingservice/snap.cpp
@@ -467,6 +467,123 @@ void WindowTrackingService::updateLastUsedZone(const QString& zoneId, const QStr
     scheduleSaveState();
 }
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// Snap commit orchestration — moved out of WindowTrackingAdaptor.
+//
+// These methods used to live in WindowTrackingAdaptor::windowSnapped /
+// windowSnappedMultiZone / windowUnsnapped, where they orchestrated a
+// sequence of WTS primitive calls plus a D-Bus signal emit. That made
+// WTA a partial snap engine rather than a thin facade. The orchestration
+// is pure state-management work that belongs on WTS; WTA retains its
+// D-Bus slot entry points but forwards to these methods and relays the
+// WTS signals to its own D-Bus signals at connection wiring time.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+void WindowTrackingService::commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId)
+{
+    if (windowId.isEmpty() || zoneId.isEmpty()) {
+        qCWarning(lcCore) << "commitSnap: empty windowId or zoneId";
+        return;
+    }
+
+    // 1. Clear pre-existing floating state so the snap is authoritative.
+    if (clearFloatingForSnap(windowId)) {
+        Q_EMIT windowFloatingClearedForSnap(windowId, screenId);
+    }
+
+    // 2. Auto-snap flag: clearAutoSnapped returns true if the flag was set.
+    //    When it was, skip "consume pending" and "update last-used zone" — an
+    //    auto-snap shouldn't disturb either.
+    const bool wasAutoSnapped = clearAutoSnapped(windowId);
+
+    // 3. Consume one pending-restore entry (FIFO) for user-initiated snaps so
+    //    a stale session entry can't drag the window back on next close/reopen.
+    if (!wasAutoSnapped) {
+        consumePendingAssignment(windowId);
+    }
+
+    // 4. Actually assign the window to the zone on the resolved screen.
+    const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    assignWindowToZone(windowId, zoneId, screenId, currentDesktop);
+
+    // 5. Update last-used-zone tracking unless this is a zone-selector sentinel
+    //    or an auto-snap. The sentinel bail-out matches the historical WTA
+    //    behaviour — zoneselector-* IDs represent ephemeral selection state,
+    //    not real zones the user wants to remember.
+    if (!zoneId.startsWith(QStringLiteral("zoneselector-")) && !wasAutoSnapped) {
+        const QString windowClass = currentAppIdFor(windowId);
+        updateLastUsedZone(zoneId, screenId, windowClass, currentDesktop);
+    }
+
+    qCInfo(lcCore) << "commitSnap:" << windowId << "zone=" << zoneId << "screen=" << screenId;
+
+    // 6. Notify subscribers (WTA re-emits as the D-Bus windowStateChanged).
+    Q_EMIT windowSnapStateChanged(
+        windowId, WindowStateEntry{windowId, zoneId, screenId, false, QStringLiteral("snapped"), QStringList{}, false});
+}
+
+void WindowTrackingService::commitMultiZoneSnap(const QString& windowId, const QStringList& zoneIds,
+                                                const QString& screenId)
+{
+    if (windowId.isEmpty() || zoneIds.isEmpty() || zoneIds.first().isEmpty()) {
+        qCWarning(lcCore) << "commitMultiZoneSnap: empty windowId or zoneIds";
+        return;
+    }
+
+    if (clearFloatingForSnap(windowId)) {
+        Q_EMIT windowFloatingClearedForSnap(windowId, screenId);
+    }
+
+    const bool wasAutoSnapped = clearAutoSnapped(windowId);
+    if (!wasAutoSnapped) {
+        consumePendingAssignment(windowId);
+    }
+
+    const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    assignWindowToZones(windowId, zoneIds, screenId, currentDesktop);
+
+    // Last-used tracking keys off the primary (first) zone.
+    const QString& primaryZoneId = zoneIds.first();
+    if (!primaryZoneId.startsWith(QStringLiteral("zoneselector-")) && !wasAutoSnapped) {
+        const QString windowClass = currentAppIdFor(windowId);
+        updateLastUsedZone(primaryZoneId, screenId, windowClass, currentDesktop);
+    }
+
+    qCInfo(lcCore) << "commitMultiZoneSnap:" << windowId << "zones=" << zoneIds << "screen=" << screenId;
+
+    Q_EMIT windowSnapStateChanged(
+        windowId,
+        WindowStateEntry{windowId, primaryZoneId, screenId, false, QStringLiteral("snapped"), zoneIds, false});
+}
+
+void WindowTrackingService::uncommitSnap(const QString& windowId)
+{
+    if (windowId.isEmpty()) {
+        return;
+    }
+
+    // Only act if the window is actually snapped — callers may blind-call
+    // this on any window, and uncommitting a never-snapped window is both
+    // pointless and noisy.
+    const QString previousZoneId = zoneForWindow(windowId);
+    if (previousZoneId.isEmpty()) {
+        qCDebug(lcCore) << "uncommitSnap: window not in any zone:" << windowId;
+        return;
+    }
+
+    // Clear any queued pending-restore entry so an explicit unsnap stays
+    // sticky across the window's next close/reopen cycle.
+    consumePendingAssignment(windowId);
+
+    unassignWindow(windowId);
+
+    qCInfo(lcCore) << "uncommitSnap:" << windowId << "from zone" << previousZoneId;
+
+    Q_EMIT windowSnapStateChanged(
+        windowId,
+        WindowStateEntry{windowId, QString(), QString(), false, QStringLiteral("unsnapped"), QStringList{}, false});
+}
+
 void WindowTrackingService::markWindowReported(const QString& windowId)
 {
     if (!windowId.isEmpty()) {

--- a/src/core/windowtrackingservice/snap.cpp
+++ b/src/core/windowtrackingservice/snap.cpp
@@ -14,6 +14,7 @@
 #include "../utils.h"
 #include "../screenmanager.h"
 #include "../logging.h"
+#include <QGuiApplication>
 #include <QScreen>
 #include <QSet>
 #include <QUuid>
@@ -479,7 +480,8 @@ void WindowTrackingService::updateLastUsedZone(const QString& zoneId, const QStr
 // WTS signals to its own D-Bus signals at connection wiring time.
 // ═══════════════════════════════════════════════════════════════════════════════
 
-void WindowTrackingService::commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId)
+void WindowTrackingService::commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId,
+                                       SnapIntent intent)
 {
     if (windowId.isEmpty() || zoneId.isEmpty()) {
         qCWarning(lcCore) << "commitSnap: empty windowId or zoneId";
@@ -487,35 +489,47 @@ void WindowTrackingService::commitSnap(const QString& windowId, const QString& z
     }
 
     // 1. Clear pre-existing floating state so the snap is authoritative.
+    //    Runs for both intents — an auto-snap still needs to take a
+    //    previously-floating window out of the floating set.
     if (clearFloatingForSnap(windowId)) {
         Q_EMIT windowFloatingClearedForSnap(windowId, screenId);
     }
 
-    // 2. Auto-snap flag: clearAutoSnapped returns true if the flag was set.
-    //    When it was, skip "consume pending" and "update last-used zone" — an
-    //    auto-snap shouldn't disturb either.
-    const bool wasAutoSnapped = clearAutoSnapped(windowId);
+    // 2. Auto-snap flag handling. For UserInitiated commits, we capture and
+    //    clear any leftover flag so windowActivated's last-used-zone gate
+    //    sees "user-initiated" on the next focus event. For AutoRestored,
+    //    we leave the flag untouched — the caller (lifecycle auto-snap
+    //    path) already set it and expects it to persist until the window
+    //    is explicitly acted on.
+    bool wasAutoSnapped = false;
+    if (intent == SnapIntent::UserInitiated) {
+        wasAutoSnapped = clearAutoSnapped(windowId);
 
-    // 3. Consume one pending-restore entry (FIFO) for user-initiated snaps so
-    //    a stale session entry can't drag the window back on next close/reopen.
-    if (!wasAutoSnapped) {
-        consumePendingAssignment(windowId);
+        // 3. Consume one pending-restore entry (FIFO) so a stale session
+        //    entry can't drag the window back on next close/reopen.
+        //    Skipped for the auto-snap path because resolveWindowRestore
+        //    already consumed its entry when it produced the result.
+        //    Also skipped when we just cleared a prior auto-snap marker
+        //    (preserves the historical WTA::windowSnapped behaviour).
+        if (!wasAutoSnapped) {
+            consumePendingAssignment(windowId);
+        }
     }
 
     // 4. Actually assign the window to the zone on the resolved screen.
     const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
     assignWindowToZone(windowId, zoneId, screenId, currentDesktop);
 
-    // 5. Update last-used-zone tracking unless this is a zone-selector sentinel
-    //    or an auto-snap. The sentinel bail-out matches the historical WTA
-    //    behaviour — zoneselector-* IDs represent ephemeral selection state,
-    //    not real zones the user wants to remember.
-    if (!zoneId.startsWith(QStringLiteral("zoneselector-")) && !wasAutoSnapped) {
+    // 5. Update last-used-zone tracking. Only when the user initiated this,
+    //    the zone isn't a zone-selector sentinel, and the window wasn't
+    //    carrying a stale auto-snap marker from an earlier restore.
+    if (intent == SnapIntent::UserInitiated && !wasAutoSnapped && !zoneId.startsWith(QStringLiteral("zoneselector-"))) {
         const QString windowClass = currentAppIdFor(windowId);
         updateLastUsedZone(zoneId, screenId, windowClass, currentDesktop);
     }
 
-    qCInfo(lcCore) << "commitSnap:" << windowId << "zone=" << zoneId << "screen=" << screenId;
+    qCInfo(lcCore) << "commitSnap:" << windowId << "zone=" << zoneId << "screen=" << screenId
+                   << "intent=" << (intent == SnapIntent::UserInitiated ? "user" : "auto");
 
     // 6. Notify subscribers (WTA re-emits as the D-Bus windowStateChanged).
     Q_EMIT windowSnapStateChanged(
@@ -523,7 +537,7 @@ void WindowTrackingService::commitSnap(const QString& windowId, const QString& z
 }
 
 void WindowTrackingService::commitMultiZoneSnap(const QString& windowId, const QStringList& zoneIds,
-                                                const QString& screenId)
+                                                const QString& screenId, SnapIntent intent)
 {
     if (windowId.isEmpty() || zoneIds.isEmpty() || zoneIds.first().isEmpty()) {
         qCWarning(lcCore) << "commitMultiZoneSnap: empty windowId or zoneIds";
@@ -534,9 +548,12 @@ void WindowTrackingService::commitMultiZoneSnap(const QString& windowId, const Q
         Q_EMIT windowFloatingClearedForSnap(windowId, screenId);
     }
 
-    const bool wasAutoSnapped = clearAutoSnapped(windowId);
-    if (!wasAutoSnapped) {
-        consumePendingAssignment(windowId);
+    bool wasAutoSnapped = false;
+    if (intent == SnapIntent::UserInitiated) {
+        wasAutoSnapped = clearAutoSnapped(windowId);
+        if (!wasAutoSnapped) {
+            consumePendingAssignment(windowId);
+        }
     }
 
     const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
@@ -544,16 +561,81 @@ void WindowTrackingService::commitMultiZoneSnap(const QString& windowId, const Q
 
     // Last-used tracking keys off the primary (first) zone.
     const QString& primaryZoneId = zoneIds.first();
-    if (!primaryZoneId.startsWith(QStringLiteral("zoneselector-")) && !wasAutoSnapped) {
+    if (intent == SnapIntent::UserInitiated && !wasAutoSnapped
+        && !primaryZoneId.startsWith(QStringLiteral("zoneselector-"))) {
         const QString windowClass = currentAppIdFor(windowId);
         updateLastUsedZone(primaryZoneId, screenId, windowClass, currentDesktop);
     }
 
-    qCInfo(lcCore) << "commitMultiZoneSnap:" << windowId << "zones=" << zoneIds << "screen=" << screenId;
+    qCInfo(lcCore) << "commitMultiZoneSnap:" << windowId << "zones=" << zoneIds << "screen=" << screenId
+                   << "intent=" << (intent == SnapIntent::UserInitiated ? "user" : "auto");
 
     Q_EMIT windowSnapStateChanged(
         windowId,
         WindowStateEntry{windowId, primaryZoneId, screenId, false, QStringLiteral("snapped"), zoneIds, false});
+}
+
+WindowGeometryList WindowTrackingService::applyBatchAssignments(const QVector<ZoneAssignmentEntry>& entries,
+                                                                SnapIntent intent,
+                                                                std::function<QString()> fallbackScreenResolver)
+{
+    WindowGeometryList geometries;
+    if (entries.isEmpty()) {
+        return geometries;
+    }
+
+    auto* mgr = ScreenManager::instance();
+
+    for (const auto& entry : entries) {
+        if (entry.targetZoneId == QLatin1String("__restore__")) {
+            // "__restore__" sentinel: the window's previous zone no
+            // longer exists in the new layout. Unsnap it cleanly and
+            // drop any captured pre-tile geometry.
+            uncommitSnap(entry.windowId);
+            clearPreTileGeometry(entry.windowId);
+            continue;
+        }
+
+        // Resolve the effective screen with the full fallback chain.
+        QString screenId = entry.targetScreenId;
+        const QPoint center = entry.targetGeometry.center();
+        if (screenId.isEmpty() && mgr) {
+            screenId = mgr->effectiveScreenAt(center);
+        }
+        if (screenId.isEmpty()) {
+            // Physical fallback for early startup when ScreenManager
+            // isn't initialised yet. effectiveScreenAt above handles
+            // VS-aware resolution, so this pass only needs to cover
+            // the "ScreenManager::instance() == nullptr" edge case.
+            for (QScreen* screen : QGuiApplication::screens()) {
+                if (screen->geometry().contains(center)) {
+                    screenId = Utils::screenIdentifier(screen);
+                    break;
+                }
+            }
+        }
+        if (screenId.isEmpty() && fallbackScreenResolver) {
+            // Compositor-layer shadow as last resort (cursor/active
+            // window from WindowTrackingAdaptor). May still return
+            // empty; commit proceeds regardless to preserve legacy
+            // behaviour.
+            screenId = fallbackScreenResolver();
+        }
+
+        if (entry.targetZoneIds.size() > 1) {
+            commitMultiZoneSnap(entry.windowId, entry.targetZoneIds, screenId, intent);
+        } else {
+            commitSnap(entry.windowId, entry.targetZoneId, screenId, intent);
+        }
+    }
+
+    // Build the geometry list in input order. Callers emit this on
+    // their own applyGeometriesBatch signal with an action label.
+    geometries.reserve(entries.size());
+    for (const auto& entry : entries) {
+        geometries.append(WindowGeometryEntry::fromRect(entry.windowId, entry.targetGeometry));
+    }
+    return geometries;
 }
 
 void WindowTrackingService::uncommitSnap(const QString& windowId)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -737,6 +737,18 @@ void Daemon::stop()
         m_windowTrackingAdaptor->setEngines(nullptr, nullptr);
     }
 
+    // Clear navigation adapters from the router and tear them down BEFORE
+    // destroying the engines they point at. The adapters hold QPointers to
+    // the engines (so a stray call would no-op rather than crash), but we
+    // still prefer to sever the reference chain explicitly to match the
+    // SnapAdaptor/AutotileAdaptor teardown pattern and keep the router from
+    // handing out about-to-be-invalid navigators during the shutdown window.
+    if (m_screenModeRouter) {
+        m_screenModeRouter->setNavigationAdapters(nullptr, nullptr);
+    }
+    m_snapNavigationAdapter.reset();
+    m_autotileNavigationAdapter.reset();
+
     // Destroy engines now (during stop(), before Qt child destruction order).
     m_snapEngine.reset();
     m_autotileEngine.reset();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -47,9 +47,11 @@
 #include "../dbus/screenadaptor.h"
 #include "../dbus/controladaptor.h"
 #include "../autotile/AutotileEngine.h"
+#include "../autotile/autotilenavigationadapter.h"
 #include "../autotile/algorithms/ScriptedAlgorithmLoader.h"
 #include "../autotile/AlgorithmRegistry.h"
 #include "../snap/SnapEngine.h"
+#include "../snap/snapnavigationadapter.h"
 
 namespace PlasmaZones {
 
@@ -421,6 +423,18 @@ bool Daemon::init()
     m_screenModeRouter =
         std::make_unique<ScreenModeRouter>(m_layoutManager.get(), m_snapEngine.get(), m_autotileEngine.get());
     m_windowTrackingAdaptor->setScreenModeRouter(m_screenModeRouter.get());
+
+    // Navigation-intent dispatch: create thin INavigationActions adapters
+    // and wire them through the router so daemon/navigation.cpp shortcut
+    // handlers can call navigatorFor(screenId)->foo() instead of branching
+    // on mode. The snap adapter forwards to WindowTrackingAdaptor because
+    // that's where the snap navigation logic lives today — a future
+    // refactor should lift the logic into SnapEngine and this adapter's
+    // impl would flip to forwarding to SnapEngine instead, invisible to
+    // the router and callers.
+    m_autotileNavigationAdapter = std::make_unique<AutotileNavigationAdapter>(m_autotileEngine.get());
+    m_snapNavigationAdapter = std::make_unique<SnapNavigationAdapter>(m_windowTrackingAdaptor);
+    m_screenModeRouter->setNavigationAdapters(m_snapNavigationAdapter.get(), m_autotileNavigationAdapter.get());
 
     // Stateless façade for VS swap/rotate. Held here so navigation handlers
     // and any future consumer share one instance instead of constructing

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -413,8 +413,18 @@ bool Daemon::init()
                 wta->loadState();
         });
 
-    // Wire engine cross-references (SnapEngine ↔ AutotileEngine, zone detection)
+    // Wire engine cross-references (SnapEngine ↔ AutotileEngine, zone detection).
     m_windowTrackingAdaptor->setEngines(m_snapEngine.get(), m_autotileEngine.get());
+
+    // Wire SnapEngine's back-reference to the window tracking adaptor.
+    // SnapEngine's navigation methods (focusInDirection, moveFocusedInDirection, …)
+    // were moved out of WindowTrackingAdaptor and need to reach back into the
+    // adaptor for shared state that hasn't been migrated yet: the target
+    // resolver, the last-active window/screen shadow, and the snap-
+    // bookkeeping helpers (windowSnapped, windowUnsnapped, recordSnapIntent,
+    // clearPreTileGeometry). A future refactor should move that state onto
+    // SnapEngine or WindowTrackingService and retire the back-reference.
+    m_snapEngine->setWindowTrackingAdaptor(m_windowTrackingAdaptor);
 
     // Central routing table: single source of truth for "which engine owns
     // screen X". Every window-lifecycle / resnap / restore entry point in the
@@ -424,16 +434,14 @@ bool Daemon::init()
         std::make_unique<ScreenModeRouter>(m_layoutManager.get(), m_snapEngine.get(), m_autotileEngine.get());
     m_windowTrackingAdaptor->setScreenModeRouter(m_screenModeRouter.get());
 
-    // Navigation-intent dispatch: create thin INavigationActions adapters
-    // and wire them through the router so daemon/navigation.cpp shortcut
-    // handlers can call navigatorFor(screenId)->foo() instead of branching
-    // on mode. The snap adapter forwards to WindowTrackingAdaptor because
-    // that's where the snap navigation logic lives today — a future
-    // refactor should lift the logic into SnapEngine and this adapter's
-    // impl would flip to forwarding to SnapEngine instead, invisible to
-    // the router and callers.
+    // Navigation-intent dispatch: thin INavigationActions adapters wired
+    // through the router so daemon/navigation.cpp shortcut handlers dispatch
+    // via router->navigatorFor(screenId)->foo() instead of branching on mode.
+    // Both adapters forward to their respective engine — SnapEngine now
+    // owns the snap-mode navigation methods that used to live on
+    // WindowTrackingAdaptor (see src/snap/snapengine/navigation_actions.cpp).
     m_autotileNavigationAdapter = std::make_unique<AutotileNavigationAdapter>(m_autotileEngine.get());
-    m_snapNavigationAdapter = std::make_unique<SnapNavigationAdapter>(m_windowTrackingAdaptor);
+    m_snapNavigationAdapter = std::make_unique<SnapNavigationAdapter>(m_snapEngine.get());
     m_screenModeRouter->setNavigationAdapters(m_snapNavigationAdapter.get(), m_autotileNavigationAdapter.get());
 
     // Stateless façade for VS swap/rotate. Held here so navigation handlers

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -43,7 +43,9 @@ class AutotileAdaptor;
 class AutotileEngine;
 class IEngineLifecycle;
 class IConfigBackend;
+class AutotileNavigationAdapter;
 class ScreenModeRouter;
+class SnapNavigationAdapter;
 class VirtualScreenSwapper;
 class ScriptedAlgorithmLoader;
 class SnapAdaptor;
@@ -367,6 +369,15 @@ private:
     /// dispatch paths. Owns no state of its own — just delegates to the
     /// layout manager and engine pointers it was constructed with.
     std::unique_ptr<ScreenModeRouter> m_screenModeRouter;
+    /// Thin INavigationActions adapters presented via
+    /// ScreenModeRouter::navigatorFor() so daemon/navigation.cpp shortcut
+    /// handlers dispatch user intents through a common interface instead
+    /// of branching on mode and calling engine methods ad hoc. The snap
+    /// adapter currently forwards to WindowTrackingAdaptor (where the
+    /// snap navigation logic lives today); the autotile adapter forwards
+    /// to AutotileEngine.
+    std::unique_ptr<AutotileNavigationAdapter> m_autotileNavigationAdapter;
+    std::unique_ptr<SnapNavigationAdapter> m_snapNavigationAdapter;
     /// Stateless façade over m_settings for VS swap/rotate. Held as a
     /// member rather than reconstructed per-call so navigation handlers
     /// don't need to know about its dependencies.

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -372,10 +372,10 @@ private:
     /// Thin INavigationActions adapters presented via
     /// ScreenModeRouter::navigatorFor() so daemon/navigation.cpp shortcut
     /// handlers dispatch user intents through a common interface instead
-    /// of branching on mode and calling engine methods ad hoc. The snap
-    /// adapter currently forwards to WindowTrackingAdaptor (where the
-    /// snap navigation logic lives today); the autotile adapter forwards
-    /// to AutotileEngine.
+    /// of branching on mode and calling engine methods ad hoc. Both
+    /// adapters forward to their respective engine — SnapEngine owns the
+    /// snap-mode navigation methods (see src/snap/snapengine/navigation_actions.cpp)
+    /// and AutotileEngine owns the autotile ones.
     std::unique_ptr<AutotileNavigationAdapter> m_autotileNavigationAdapter;
     std::unique_ptr<SnapNavigationAdapter> m_snapNavigationAdapter;
     /// Stateless façade over m_settings for VS swap/rotate. Held as a

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -67,21 +67,27 @@ bool Daemon::isAutotileScreen(const QString& screenId) const
 // vs. snap-specific behaviour lives inside each adapter.
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// Local helper: resolve the active screen and fetch the navigation adapter
-// for it. Returns nullptr if either step fails. Centralises the "no screen
-// info" early return so individual handlers stay short.
+// Local helper: build the navigation context for a shortcut handler.
+// Resolves the active screen and active window from WTA's compositor-layer
+// shadow, then fetches the navigation adapter for that screen from the
+// router. Returns nullptr if either step fails. Centralises the "no screen
+// info" early return and the context population so individual handlers
+// stay short and all shortcut dispatches use the same resolution logic.
 static INavigationActions* navigatorForShortcut(ScreenModeRouter* router, WindowTrackingAdaptor* wta,
-                                                QString& outScreenId, const char* shortcutName)
+                                                NavigationContext& outCtx, const char* shortcutName)
 {
-    outScreenId = resolveShortcutScreenId(wta);
-    if (outScreenId.isEmpty()) {
+    outCtx.screenId = resolveShortcutScreenId(wta);
+    if (outCtx.screenId.isEmpty()) {
         qCDebug(lcDaemon) << shortcutName << "shortcut: no screen info";
         return nullptr;
+    }
+    if (wta) {
+        outCtx.windowId = wta->lastActiveWindowId();
     }
     if (!router) {
         return nullptr;
     }
-    return router->navigatorFor(outScreenId);
+    return router->navigatorFor(outCtx.screenId);
 }
 
 void Daemon::handleRotate(bool clockwise)
@@ -91,30 +97,28 @@ void Daemon::handleRotate(bool clockwise)
     }
     m_rotateDebounce.restart();
 
-    QString screenId;
-    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Rotate")) {
-        nav->rotateWindows(clockwise, screenId);
+    NavigationContext ctx;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "Rotate")) {
+        nav->rotateWindows(clockwise, ctx);
     }
 }
 
 void Daemon::handleFloat()
 {
     // Float toggles the active window regardless of which screen it's on.
-    // We could look up the screen and dispatch through the router, but the
-    // active window's screen is whatever the shadow reports — and the
-    // navigator call would resolve the same answer. The router dispatch is
-    // still preferable to a direct WTA call because it routes through the
-    // adapter layer so each engine owns its own "toggle float" semantics.
-    QString screenId;
-    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Float")) {
-        nav->toggleFocusedFloat(screenId);
+    // The navigatorForShortcut helper pulls both windowId and screenId
+    // from the WTA shadow, so the engine call is fully resolved without
+    // reaching back into WTA state.
+    NavigationContext ctx;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "Float")) {
+        nav->toggleFocusedFloat(ctx);
     }
 }
 
 void Daemon::handleMove(NavigationDirection direction)
 {
-    QString screenId;
-    auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Move");
+    NavigationContext ctx;
+    auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "Move");
     if (!nav) {
         return;
     }
@@ -123,13 +127,13 @@ void Daemon::handleMove(NavigationDirection direction)
         qCWarning(lcDaemon) << "Unknown move navigation direction:" << static_cast<int>(direction);
         return;
     }
-    nav->moveFocusedInDirection(dirStr, screenId);
+    nav->moveFocusedInDirection(dirStr, ctx);
 }
 
 void Daemon::handleFocus(NavigationDirection direction)
 {
-    QString screenId;
-    auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Focus");
+    NavigationContext ctx;
+    auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "Focus");
     if (!nav) {
         return;
     }
@@ -138,35 +142,34 @@ void Daemon::handleFocus(NavigationDirection direction)
         qCWarning(lcDaemon) << "Unknown focus navigation direction:" << static_cast<int>(direction);
         return;
     }
-    nav->focusInDirection(dirStr, screenId);
+    nav->focusInDirection(dirStr, ctx);
 }
 
 void Daemon::handlePush()
 {
-    QString screenId;
-    if (auto* nav =
-            navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "PushToEmptyZone")) {
+    NavigationContext ctx;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "PushToEmptyZone")) {
         // Autotile adapter's impl is a deliberate no-op — empty zones don't
         // exist in autotile mode — so this shortcut is harmlessly absorbed
         // on autotile screens instead of the daemon branching at entry.
-        nav->pushToEmptyZone(screenId);
+        nav->pushToEmptyZone(ctx);
     }
 }
 
 void Daemon::handleRestore()
 {
-    QString screenId;
-    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Restore")) {
+    NavigationContext ctx;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "Restore")) {
         // Autotile: toggle float (restore out of layout).
         // Snap: restore to captured pre-snap geometry.
-        nav->restoreFocusedWindow(screenId);
+        nav->restoreFocusedWindow(ctx);
     }
 }
 
 void Daemon::handleSwap(NavigationDirection direction)
 {
-    QString screenId;
-    auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Swap");
+    NavigationContext ctx;
+    auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "Swap");
     if (!nav) {
         return;
     }
@@ -175,39 +178,38 @@ void Daemon::handleSwap(NavigationDirection direction)
         qCWarning(lcDaemon) << "Unknown swap navigation direction:" << static_cast<int>(direction);
         return;
     }
-    nav->swapFocusedInDirection(dirStr, screenId);
+    nav->swapFocusedInDirection(dirStr, ctx);
 }
 
 void Daemon::handleSnap(int zoneNumber)
 {
-    QString screenId;
-    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "SnapToZone")) {
-        nav->moveFocusedToPosition(zoneNumber, screenId);
+    NavigationContext ctx;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "SnapToZone")) {
+        nav->moveFocusedToPosition(zoneNumber, ctx);
     }
 }
 
 void Daemon::handleCycle(bool forward)
 {
-    QString screenId;
-    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Cycle")) {
-        nav->cycleFocus(forward, screenId);
+    NavigationContext ctx;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "Cycle")) {
+        nav->cycleFocus(forward, ctx);
     }
 }
 
 void Daemon::handleResnap()
 {
-    QString screenId;
-    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Resnap")) {
-        nav->reapplyLayout(screenId);
+    NavigationContext ctx;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "Resnap")) {
+        nav->reapplyLayout(ctx);
     }
 }
 
 void Daemon::handleSnapAll()
 {
-    QString screenId;
-    if (auto* nav =
-            navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "SnapAllWindows")) {
-        nav->snapAllWindows(screenId);
+    NavigationContext ctx;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "SnapAllWindows")) {
+        nav->snapAllWindows(ctx);
     }
 }
 

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -7,6 +7,7 @@
 #include "../overlayservice.h"
 #include "../unifiedlayoutcontroller.h"
 #include "../../config/settings.h"
+#include "../../core/inavigationactions.h"
 #include "../../core/logging.h"
 #include "../../core/screenmoderouter.h"
 #include "../../core/utils.h"
@@ -59,9 +60,29 @@ bool Daemon::isAutotileScreen(const QString& screenId) const
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Navigation handlers — single code path per operation (DRY/SOLID)
-// Resolve screen → check mode (autotile vs zones) → delegate → OSD from backend
+// Navigation handlers — single code path per operation, dispatched through
+// ScreenModeRouter::navigatorFor() so there's no mode-branching in the daemon
+// itself. Each handler resolves the target screen, looks up the engine's
+// INavigationActions adapter, and forwards the user-intent call. Autotile
+// vs. snap-specific behaviour lives inside each adapter.
 // ═══════════════════════════════════════════════════════════════════════════════
+
+// Local helper: resolve the active screen and fetch the navigation adapter
+// for it. Returns nullptr if either step fails. Centralises the "no screen
+// info" early return so individual handlers stay short.
+static INavigationActions* navigatorForShortcut(ScreenModeRouter* router, WindowTrackingAdaptor* wta,
+                                                QString& outScreenId, const char* shortcutName)
+{
+    outScreenId = resolveShortcutScreenId(wta);
+    if (outScreenId.isEmpty()) {
+        qCDebug(lcDaemon) << shortcutName << "shortcut: no screen info";
+        return nullptr;
+    }
+    if (!router) {
+        return nullptr;
+    }
+    return router->navigatorFor(outScreenId);
+}
 
 void Daemon::handleRotate(bool clockwise)
 {
@@ -70,171 +91,123 @@ void Daemon::handleRotate(bool clockwise)
     }
     m_rotateDebounce.restart();
 
-    const QString screenId = resolveShortcutScreenId(m_windowTrackingAdaptor);
-    if (screenId.isEmpty()) {
-        qCDebug(lcDaemon) << "Rotate shortcut: no screen info";
-        return;
-    }
-    if (isAutotileScreen(screenId)) {
-        m_autotileEngine->rotateWindows(clockwise, screenId);
-    } else if (m_windowTrackingAdaptor) {
-        // Route through WTA for daemon-driven geometry computation + applyGeometriesBatch
-        m_windowTrackingAdaptor->rotateWindowsInLayout(clockwise, screenId);
+    QString screenId;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Rotate")) {
+        nav->rotateWindows(clockwise, screenId);
     }
 }
 
 void Daemon::handleFloat()
 {
-    // toggleWindowFloat() is fully daemon-local — reads the active window
-    // from the shadow, reads fresh frame geometry from the shadow, and
-    // dispatches to the engine in-process. The prior 100ms debounce was
-    // there because the old path bounced through D-Bus 4 times, where rapid
-    // retries could double-fire. A direct call doesn't need it; rapid
-    // Meta-F presses should act as rapid toggles, not be silently dropped.
-    if (!m_windowTrackingAdaptor) {
-        return;
+    // Float toggles the active window regardless of which screen it's on.
+    // We could look up the screen and dispatch through the router, but the
+    // active window's screen is whatever the shadow reports — and the
+    // navigator call would resolve the same answer. The router dispatch is
+    // still preferable to a direct WTA call because it routes through the
+    // adapter layer so each engine owns its own "toggle float" semantics.
+    QString screenId;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Float")) {
+        nav->toggleFocusedFloat(screenId);
     }
-    m_windowTrackingAdaptor->toggleWindowFloat();
 }
 
 void Daemon::handleMove(NavigationDirection direction)
 {
-    const QString screenId = resolveShortcutScreenId(m_windowTrackingAdaptor);
-    if (screenId.isEmpty()) {
+    QString screenId;
+    auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Move");
+    if (!nav) {
         return;
     }
-    QString dirStr = navigationDirectionToString(direction);
+    const QString dirStr = navigationDirectionToString(direction);
     if (dirStr.isEmpty()) {
         qCWarning(lcDaemon) << "Unknown move navigation direction:" << static_cast<int>(direction);
         return;
     }
-    if (isAutotileScreen(screenId)) {
-        m_autotileEngine->swapFocusedInDirection(dirStr);
-    } else if (m_windowTrackingAdaptor) {
-        // Route through WTA for daemon-driven geometry computation + applyGeometryRequested
-        m_windowTrackingAdaptor->moveWindowToAdjacentZone(dirStr);
-    }
+    nav->moveFocusedInDirection(dirStr, screenId);
 }
 
 void Daemon::handleFocus(NavigationDirection direction)
 {
-    const QString screenId = resolveShortcutScreenId(m_windowTrackingAdaptor);
-    if (screenId.isEmpty()) {
+    QString screenId;
+    auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Focus");
+    if (!nav) {
         return;
     }
-    QString dirStr = navigationDirectionToString(direction);
+    const QString dirStr = navigationDirectionToString(direction);
     if (dirStr.isEmpty()) {
         qCWarning(lcDaemon) << "Unknown focus navigation direction:" << static_cast<int>(direction);
         return;
     }
-    if (isAutotileScreen(screenId)) {
-        m_autotileEngine->focusInDirection(dirStr, QStringLiteral("focus"));
-    } else if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->focusAdjacentZone(dirStr);
-    }
+    nav->focusInDirection(dirStr, screenId);
 }
 
 void Daemon::handlePush()
 {
-    const QString screenId = resolveShortcutScreenId(m_windowTrackingAdaptor);
-    if (screenId.isEmpty()) {
-        qCDebug(lcDaemon) << "PushToEmptyZone shortcut: no screen info";
-        return;
-    }
-    if (isAutotileScreen(screenId)) {
-        return;
-    }
-    if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->pushToEmptyZone(screenId);
+    QString screenId;
+    if (auto* nav =
+            navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "PushToEmptyZone")) {
+        // Autotile adapter's impl is a deliberate no-op — empty zones don't
+        // exist in autotile mode — so this shortcut is harmlessly absorbed
+        // on autotile screens instead of the daemon branching at entry.
+        nav->pushToEmptyZone(screenId);
     }
 }
 
 void Daemon::handleRestore()
 {
-    const QString screenId = resolveShortcutScreenId(m_windowTrackingAdaptor);
-    if (screenId.isEmpty()) {
-        return;
-    }
-    if (isAutotileScreen(screenId)) {
-        // In autotile mode, "restore" floats the window (equivalent to unsnapping)
-        m_autotileEngine->toggleFocusedWindowFloat();
-        return;
-    }
-    if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->restoreWindowSize();
+    QString screenId;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Restore")) {
+        // Autotile: toggle float (restore out of layout).
+        // Snap: restore to captured pre-snap geometry.
+        nav->restoreFocusedWindow(screenId);
     }
 }
 
 void Daemon::handleSwap(NavigationDirection direction)
 {
-    const QString screenId = resolveShortcutScreenId(m_windowTrackingAdaptor);
-    if (screenId.isEmpty()) {
+    QString screenId;
+    auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Swap");
+    if (!nav) {
         return;
     }
-    QString dirStr = navigationDirectionToString(direction);
+    const QString dirStr = navigationDirectionToString(direction);
     if (dirStr.isEmpty()) {
         qCWarning(lcDaemon) << "Unknown swap navigation direction:" << static_cast<int>(direction);
         return;
     }
-    if (isAutotileScreen(screenId)) {
-        m_autotileEngine->swapInDirection(dirStr, QStringLiteral("swap"));
-    } else if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->swapWindowWithAdjacentZone(dirStr);
-    }
+    nav->swapFocusedInDirection(dirStr, screenId);
 }
 
 void Daemon::handleSnap(int zoneNumber)
 {
-    const QString screenId = resolveShortcutScreenId(m_windowTrackingAdaptor);
-    if (screenId.isEmpty()) {
-        qCDebug(lcDaemon) << "SnapToZone shortcut: no screen info";
-        return;
-    }
-    if (isAutotileScreen(screenId)) {
-        m_autotileEngine->moveToPosition(QString(), zoneNumber, screenId);
-    } else if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->snapToZoneByNumber(zoneNumber, screenId);
+    QString screenId;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "SnapToZone")) {
+        nav->moveFocusedToPosition(zoneNumber, screenId);
     }
 }
 
 void Daemon::handleCycle(bool forward)
 {
-    const QString screenId = resolveShortcutScreenId(m_windowTrackingAdaptor);
-    if (screenId.isEmpty()) {
-        return;
-    }
-    if (isAutotileScreen(screenId)) {
-        QString dirStr = forward ? QStringLiteral("right") : QStringLiteral("left");
-        m_autotileEngine->focusInDirection(dirStr, QStringLiteral("cycle"));
-    } else if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->cycleWindowsInZone(forward);
+    QString screenId;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Cycle")) {
+        nav->cycleFocus(forward, screenId);
     }
 }
 
 void Daemon::handleResnap()
 {
-    const QString screenId = resolveShortcutScreenId(m_windowTrackingAdaptor);
-    if (screenId.isEmpty()) {
-        return;
-    }
-    if (isAutotileScreen(screenId)) {
-        m_autotileEngine->retile(screenId);
-    } else if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->resnapToNewLayout();
+    QString screenId;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "Resnap")) {
+        nav->reapplyLayout(screenId);
     }
 }
 
 void Daemon::handleSnapAll()
 {
-    const QString screenId = resolveShortcutScreenId(m_windowTrackingAdaptor);
-    if (screenId.isEmpty()) {
-        qCDebug(lcDaemon) << "SnapAllWindows shortcut: no screen info";
-        return;
-    }
-    if (isAutotileScreen(screenId)) {
-        m_autotileEngine->retile(screenId);
-    } else if (m_windowTrackingAdaptor) {
-        m_windowTrackingAdaptor->snapAllWindows(screenId);
+    QString screenId;
+    if (auto* nav =
+            navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, screenId, "SnapAllWindows")) {
+        nav->snapAllWindows(screenId);
     }
 }
 

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -219,18 +219,16 @@ void Daemon::connectDesktopActivity()
         }
 
         if (m_autotileEngine) {
-            // Desktop numbers are 1-based. Any state with desktop > newCount is stale.
-            // Iterate the engine's own state map to find stale desktops (avoids
-            // the arbitrary upper bound of the old newCount+20 sweep).
-            QSet<int> staleDesktops;
-            for (auto it = m_autotileEngine->screenStates().constBegin();
-                 it != m_autotileEngine->screenStates().constEnd(); ++it) {
-                if (it.key().desktop > newCount) {
-                    staleDesktops.insert(it.key().desktop);
+            // Desktop numbers are 1-based. Any state with desktop > newCount
+            // is stale. desktopsWithActiveState() returns the set of desktops
+            // currently holding tiling state — we filter that for anything
+            // past the new count and prune, avoiding the arbitrary upper
+            // bound of the old newCount+20 sweep.
+            const QSet<int> active = m_autotileEngine->desktopsWithActiveState();
+            for (int d : active) {
+                if (d > newCount) {
+                    m_autotileEngine->pruneStatesForDesktop(d);
                 }
-            }
-            for (int d : staleDesktops) {
-                m_autotileEngine->pruneStatesForDesktop(d);
             }
         }
         // Prune fallback assignment maps

--- a/src/dbus/snapadaptor.cpp
+++ b/src/dbus/snapadaptor.cpp
@@ -43,7 +43,16 @@ SnapAdaptor::SnapAdaptor(SnapEngine* engine, WindowTrackingAdaptor* adaptor, QOb
     // for proper bookkeeping (windowSnapped per entry) + applyGeometriesBatch emission.
     connect(m_engine, &SnapEngine::resnapToNewLayoutRequested, adaptor, &WindowTrackingAdaptor::handleBatchedResnap);
 
-    qCDebug(lcDbusWindow) << "SnapAdaptor initialized with 5 signal connections";
+    // Batched geometry application: rotate / resnap / snap-all paths build
+    // a WindowGeometryList and emit it here. WTA's applyGeometriesBatch
+    // signal is the D-Bus surface.
+    connect(m_engine, &SnapEngine::applyGeometriesBatch, adaptor, &WindowTrackingAdaptor::applyGeometriesBatch);
+
+    // Window activation: focus-in-direction and cycle operations resolve a
+    // target window and ask the KWin effect to raise/focus it.
+    connect(m_engine, &SnapEngine::activateWindowRequested, adaptor, &WindowTrackingAdaptor::activateWindowRequested);
+
+    qCDebug(lcDbusWindow) << "SnapAdaptor initialized with 7 signal connections";
 }
 
 void SnapAdaptor::clearEngine()

--- a/src/dbus/snapadaptor.cpp
+++ b/src/dbus/snapadaptor.cpp
@@ -21,47 +21,63 @@ SnapAdaptor::SnapAdaptor(SnapEngine* engine, WindowTrackingAdaptor* adaptor, QOb
     // ═══════════════════════════════════════════════════════════════════════════
     // Signal relay: SnapEngine → WindowTrackingAdaptor D-Bus signals
     //
-    // Mirrors AutotileAdaptor's constructor pattern (10 signal connections).
+    // Each connection handle is stored in m_connections so clearEngine()
+    // can disconnect exactly what this class wired — not a broad
+    // disconnect(sender, receiver) that could nuke connections set up
+    // elsewhere (e.g. a future direct WTA→SnapEngine observer).
+    //
     // All snap navigation signals relay through org.plasmazones.WindowTracking
     // because the KWin effect listens for them on that D-Bus interface.
     // ═══════════════════════════════════════════════════════════════════════════
 
+    m_connections.reserve(7);
+
     // Navigation feedback (shared OSD path — both engines use the same signal)
-    connect(m_engine, &SnapEngine::navigationFeedback, adaptor, &WindowTrackingAdaptor::navigationFeedback);
+    m_connections.append(
+        connect(m_engine, &SnapEngine::navigationFeedback, adaptor, &WindowTrackingAdaptor::navigationFeedback));
 
     // Float state changes
-    connect(m_engine, &SnapEngine::windowFloatingChanged, adaptor, &WindowTrackingAdaptor::windowFloatingChanged);
+    m_connections.append(
+        connect(m_engine, &SnapEngine::windowFloatingChanged, adaptor, &WindowTrackingAdaptor::windowFloatingChanged));
 
     // Daemon-driven geometry application (used by autotile float restore via SnapEngine)
-    connect(m_engine, &SnapEngine::applyGeometryRequested, adaptor, &WindowTrackingAdaptor::applyGeometryRequested);
+    m_connections.append(connect(m_engine, &SnapEngine::applyGeometryRequested, adaptor,
+                                 &WindowTrackingAdaptor::applyGeometryRequested));
 
     // Snap-all-windows (effect collects candidates, daemon calculates)
-    connect(m_engine, &SnapEngine::snapAllWindowsRequested, adaptor, &WindowTrackingAdaptor::snapAllWindowsRequested);
+    m_connections.append(connect(m_engine, &SnapEngine::snapAllWindowsRequested, adaptor,
+                                 &WindowTrackingAdaptor::snapAllWindowsRequested));
 
     // Batched resnap: emitBatchedResnap is called from the Daemon layer (autotile→snap
     // transition) which bypasses WTA navigation methods. Route through handleBatchedResnap
     // for proper bookkeeping (windowSnapped per entry) + applyGeometriesBatch emission.
-    connect(m_engine, &SnapEngine::resnapToNewLayoutRequested, adaptor, &WindowTrackingAdaptor::handleBatchedResnap);
+    m_connections.append(connect(m_engine, &SnapEngine::resnapToNewLayoutRequested, adaptor,
+                                 &WindowTrackingAdaptor::handleBatchedResnap));
 
     // Batched geometry application: rotate / resnap / snap-all paths build
     // a WindowGeometryList and emit it here. WTA's applyGeometriesBatch
     // signal is the D-Bus surface.
-    connect(m_engine, &SnapEngine::applyGeometriesBatch, adaptor, &WindowTrackingAdaptor::applyGeometriesBatch);
+    m_connections.append(
+        connect(m_engine, &SnapEngine::applyGeometriesBatch, adaptor, &WindowTrackingAdaptor::applyGeometriesBatch));
 
     // Window activation: focus-in-direction and cycle operations resolve a
     // target window and ask the KWin effect to raise/focus it.
-    connect(m_engine, &SnapEngine::activateWindowRequested, adaptor, &WindowTrackingAdaptor::activateWindowRequested);
+    m_connections.append(connect(m_engine, &SnapEngine::activateWindowRequested, adaptor,
+                                 &WindowTrackingAdaptor::activateWindowRequested));
 
-    qCDebug(lcDbusWindow) << "SnapAdaptor initialized with 7 signal connections";
+    qCDebug(lcDbusWindow) << "SnapAdaptor initialized with" << m_connections.size() << "signal connections";
 }
 
 void SnapAdaptor::clearEngine()
 {
-    if (m_engine && m_adaptor) {
-        // All connections are m_engine → m_adaptor (not m_engine → this),
-        // so we must disconnect from the actual receiver.
-        disconnect(m_engine, nullptr, m_adaptor, nullptr);
+    // Targeted disconnects — removes only the connections this class
+    // wired in the constructor. Safe to call even if engine/adaptor
+    // are already destroyed; QMetaObject::Connection handles invalid
+    // connections gracefully.
+    for (const auto& conn : std::as_const(m_connections)) {
+        QObject::disconnect(conn);
     }
+    m_connections.clear();
     m_engine = nullptr;
     m_adaptor = nullptr;
 }

--- a/src/dbus/snapadaptor.h
+++ b/src/dbus/snapadaptor.h
@@ -5,6 +5,7 @@
 
 #include "plasmazones_export.h"
 #include <QObject>
+#include <QVector>
 
 namespace PlasmaZones {
 
@@ -55,6 +56,14 @@ public:
 private:
     SnapEngine* m_engine = nullptr;
     WindowTrackingAdaptor* m_adaptor = nullptr;
+
+    // Stored handles for the signal relays wired in the constructor so
+    // clearEngine() can disconnect exactly the connections this class
+    // made. A broad disconnect(m_engine, nullptr, m_adaptor, nullptr)
+    // would also remove any connection another class happens to make
+    // between the same sender/receiver pair — a latent footgun the
+    // targeted approach avoids.
+    QVector<QMetaObject::Connection> m_connections;
 };
 
 } // namespace PlasmaZones

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -263,14 +263,14 @@ void WindowDragAdaptor::handleWindowClosed(const QString& windowId)
         m_originalGeometry = QRect();
         m_snapCancelled = false;
         m_wasSnapped = false;
-        m_currentDragBypassReason.clear();
+        m_currentDragBypassReason = DragBypassReason::None;
     }
 
     // Drop pending snap-drag state if this window was the pending target
     // (beginDrag ran but activation was never held before close).
     if (windowId == m_pendingSnapDragWindowId) {
         clearPendingSnapDragState();
-        m_currentDragBypassReason.clear();
+        m_currentDragBypassReason = DragBypassReason::None;
     }
 
     // Delegate tracking cleanup to WindowTrackingAdaptor

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -225,7 +225,7 @@ private:
     void dragStopped(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons, int& snapX,
                      int& snapY, int& snapWidth, int& snapHeight, bool& shouldApplyGeometry,
                      QString& releaseScreenIdOut, bool& restoreSizeOnly, bool& snapAssistRequested,
-                     PlasmaZones::EmptyZoneList& emptyZonesOut);
+                     PlasmaZones::EmptyZoneList& emptyZonesOut, QString& resolvedZoneIdOut);
 
     // Promote the pending snap-path drag (stashed by beginDrag) to an
     // active drag by running the legacy dragStarted setup. Called from

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -316,8 +316,8 @@ private:
     // Bypass reason returned from the last beginDrag call.
     // Read in endDrag to decide which branch to take — autotile bypass
     // gets a synthesized ApplyFloat outcome, context/snap disabled gets NoOp,
-    // and snap path delegates to the legacy dragStopped. Cleared by endDrag.
-    QString m_currentDragBypassReason;
+    // and snap path delegates to the legacy dragStopped. Reset to None by endDrag.
+    DragBypassReason m_currentDragBypassReason = DragBypassReason::None;
     QRect m_originalGeometry;
 
     // Pending snap-path drag awaiting first activation. Populated by

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -305,8 +305,9 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
             bool snapAssistRequested = false;
             QString releaseScreen;
             EmptyZoneList emptyZones;
+            QString resolvedZoneId;
             dragStopped(windowId, cursorX, cursorY, modifiers, mouseButtons, sx, sy, sw, sh, shouldApply, releaseScreen,
-                        restoreSizeOnly, snapAssistRequested, emptyZones);
+                        restoreSizeOnly, snapAssistRequested, emptyZones, resolvedZoneId);
         } else {
             // Bypass paths — no overlay state to clean up; just drop the id.
             // An active autotile drag-insert preview must be cancelled so
@@ -355,11 +356,14 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     // dispatch matrix (snap-to-zone, drag-out unsnap, cross-screen
     // cleanup, zone selector, snap assist).
     //
-    // Snapshot the active zone id BEFORE dragStopped runs — the cleanup
-    // path inside dragStopped clears m_currentZoneId via
-    // hideOverlayAndClearZoneState, and we want that id exposed on the
-    // outcome so the daemon is authoritative for every DragOutcome field.
-    const QString capturedZoneId = m_currentZoneId;
+    // The primary zone id is returned via a dedicated out-parameter
+    // (resolvedZoneId) populated by each snap-success branch inside
+    // drop.cpp — hover detection, zone selector, and multi-zone modifier
+    // all write it explicitly. This replaces the earlier pattern of
+    // snapshotting m_currentZoneId before the call, which missed the
+    // zone-selector path (that branch never wrote m_currentZoneId and
+    // left an empty zoneId on the outcome — rejected post-Phase-1B by
+    // DragOutcome::validationError).
 
     int sx = 0, sy = 0, sw = 0, sh = 0;
     bool shouldApply = false;
@@ -367,8 +371,9 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     bool snapAssistRequested = false;
     QString releaseScreen;
     EmptyZoneList emptyZones;
+    QString resolvedZoneId;
     dragStopped(windowId, cursorX, cursorY, modifiers, mouseButtons, sx, sy, sw, sh, shouldApply, releaseScreen,
-                restoreSizeOnly, snapAssistRequested, emptyZones);
+                restoreSizeOnly, snapAssistRequested, emptyZones, resolvedZoneId);
 
     outcome.targetScreenId = releaseScreen;
     outcome.x = sx;
@@ -385,10 +390,10 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
 
     if (shouldApply) {
         outcome.action = restoreSizeOnly ? DragOutcome::RestoreSize : DragOutcome::ApplySnap;
-        // Primary zone captured pre-cleanup. Empty on RestoreSize (drag-out
-        // unsnap has no target zone), populated on ApplySnap.
+        // Only ApplySnap carries a target zone. RestoreSize is drag-out
+        // unsnap (no target zone by definition).
         if (!restoreSizeOnly) {
-            outcome.zoneId = capturedZoneId;
+            outcome.zoneId = resolvedZoneId;
         }
     } else {
         outcome.action = DragOutcome::NoOp;

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -35,7 +35,7 @@ DragPolicy WindowDragAdaptor::computeDragPolicy(const ISettings* settings, const
     // 1) Disabled context (activity / desktop / monitor excluded in settings).
     //    Dead drag: no overlay, no cursor stream, no float transition.
     if (settings && !screenId.isEmpty() && isContextDisabled(settings, screenId, curDesktop, curActivity)) {
-        policy.bypassReason = QStringLiteral("context_disabled");
+        policy.bypassReason = DragBypassReason::ContextDisabled;
         return policy;
     }
 
@@ -51,7 +51,7 @@ DragPolicy WindowDragAdaptor::computeDragPolicy(const ISettings* settings, const
     //    so both the effect fast path and its async reply handler skip the
     //    handleDragToFloat call.
     if (autotileEngine && !screenId.isEmpty() && autotileEngine->isAutotileScreen(screenId)) {
-        policy.bypassReason = QStringLiteral("autotile_screen");
+        policy.bypassReason = DragBypassReason::AutotileScreen;
         policy.captureGeometry = true; // preserve pre-autotile size for unfloat restore
         const bool reorderMode = settings && settings->autotileDragBehavior() == AutotileDragBehavior::Reorder;
         if (!windowId.isEmpty() && !reorderMode) {
@@ -64,7 +64,7 @@ DragPolicy WindowDragAdaptor::computeDragPolicy(const ISettings* settings, const
     //    the user configured the tool with snap mode off. beginDrag still
     //    returns a policy so endDrag can clean up consistently.
     if (settings && !settings->snappingEnabled()) {
-        policy.bypassReason = QStringLiteral("snapping_disabled");
+        policy.bypassReason = DragBypassReason::SnappingDisabled;
         return policy;
     }
 
@@ -76,7 +76,7 @@ DragPolicy WindowDragAdaptor::computeDragPolicy(const ISettings* settings, const
     policy.showOverlay = true;
     policy.grabKeyboard = true;
     policy.captureGeometry = true;
-    policy.bypassReason.clear();
+    policy.bypassReason = DragBypassReason::None;
     return policy;
 }
 
@@ -132,7 +132,7 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
     // right branch without re-computing policy.
     m_currentDragBypassReason = effectivePolicy.bypassReason;
 
-    if (!effectivePolicy.bypassReason.isEmpty()) {
+    if (effectivePolicy.bypassReason != DragBypassReason::None) {
         // Bypass path — record the id so the matching endDrag can find us,
         // but skip the full snap-path setup (overlay, zone state, etc.).
         // Trigger cache and stale-preview cleanup both happen above so bypass
@@ -159,7 +159,7 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
         // during the drag and a sudden float on drop. Restore the
         // legacy float-on-start behavior here so the UX matches the Float
         // mode default for the rest of this drag.
-        if (effectivePolicy.bypassReason == QLatin1String("autotile_screen") && m_autotileEngine && m_settings
+        if (effectivePolicy.bypassReason == DragBypassReason::AutotileScreen && m_autotileEngine && m_settings
             && m_settings->autotileDragBehavior() == AutotileDragBehavior::Reorder
             && m_autotileEngine->isWindowTiled(windowId)) {
             if (m_autotileEngine->beginDragInsertPreview(windowId, startScreenId)) {
@@ -267,7 +267,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
         qCInfo(lcDbusWindow) << "endDrag: pending snap drag never activated" << windowId << "wasSnapped=" << wasSnapped
                              << "cancelled=" << cancelled;
         clearPendingSnapDragState();
-        m_currentDragBypassReason.clear();
+        m_currentDragBypassReason = DragBypassReason::None;
         if (!cancelled && wasSnapped && m_windowTracking) {
             m_windowTracking->notifyDragOutUnsnap(windowId);
         }
@@ -281,8 +281,8 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
         return outcome;
     }
 
-    const QString bypassReason = m_currentDragBypassReason;
-    m_currentDragBypassReason.clear(); // next drag starts fresh
+    const DragBypassReason bypassReason = m_currentDragBypassReason;
+    m_currentDragBypassReason = DragBypassReason::None; // next drag starts fresh
     // m_dragReorderActive lives for one drag only. Reset here (before the
     // various early-return branches below) so no branch has to remember.
     m_dragReorderActive = false;
@@ -295,7 +295,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     // we still delegate to legacy dragStopped so it can reset its own
     // internal state machine, then emit CancelSnap back.
     if (cancelled) {
-        if (bypassReason.isEmpty()) {
+        if (bypassReason == DragBypassReason::None) {
             // Snap path cancelled — run dragStopped through the legacy
             // adaptor so overlay/zone-state cleanup happens, but discard
             // the geometry outputs.
@@ -322,7 +322,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     // Daemon has no placement decision to make; the outcome just carries
     // the release screen so the plugin can pass it to
     // setWindowFloatingForScreen.
-    if (bypassReason == QLatin1String("autotile_screen")) {
+    if (bypassReason == DragBypassReason::AutotileScreen) {
         // Autotile drag-insert: if a preview is live, commit it so the
         // window takes its picked slot in the stack on the next retile.
         // The autotile engine owns final geometry; no float outcome needed.
@@ -344,7 +344,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     }
 
     // Snapping disabled / context disabled — dead drag. No action.
-    if (bypassReason == QLatin1String("snapping_disabled") || bypassReason == QLatin1String("context_disabled")) {
+    if (bypassReason == DragBypassReason::SnappingDisabled || bypassReason == DragBypassReason::ContextDisabled) {
         outcome.action = DragOutcome::NoOp;
         m_draggedWindowId.clear();
         return outcome;
@@ -441,7 +441,7 @@ void WindowDragAdaptor::updateDragCursor(const QString& windowId, int cursorX, i
         const DragPolicy candidate =
             computeDragPolicy(m_settings, m_autotileEngine, windowId, cursorScreenId, curDesktop, curActivity);
         if (candidate.bypassReason != m_currentDragBypassReason
-            || (candidate.bypassReason == QLatin1String("autotile_screen") && candidate.screenId != cursorScreenId)) {
+            || (candidate.bypassReason == DragBypassReason::AutotileScreen && candidate.screenId != cursorScreenId)) {
             qCInfo(lcDbusWindow) << "updateDragCursor: policy flip" << m_currentDragBypassReason << "->"
                                  << candidate.bypassReason << "on" << cursorScreenId;
             m_currentDragBypassReason = candidate.bypassReason;

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -22,12 +22,16 @@ namespace PlasmaZones {
 void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons,
                                     int& snapX, int& snapY, int& snapWidth, int& snapHeight, bool& shouldApplyGeometry,
                                     QString& releaseScreenIdOut, bool& restoreSizeOnlyOut, bool& snapAssistRequestedOut,
-                                    EmptyZoneList& emptyZonesOut)
+                                    EmptyZoneList& emptyZonesOut, QString& resolvedZoneIdOut)
 {
     // Initialize output parameters
     // shouldApplyGeometry: true = KWin should set window to (snapX, snapY, snapWidth, snapHeight)
     // restoreSizeOnly: when true with shouldApplyGeometry, effect uses current position + returned size
     // (drag-to-unsnap)
+    // resolvedZoneIdOut: the primary zone ID the window snapped to, across every snap
+    //   path (hover-detect, zone selector, modifier multi-zone). Empty when no snap
+    //   happened. The caller uses this for DragOutcome.zoneId, which the post-Phase-1B
+    //   validator requires on ApplySnap — see drag_protocol.cpp.
     snapX = 0;
     snapY = 0;
     snapWidth = 0;
@@ -37,6 +41,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
     restoreSizeOnlyOut = false;
     snapAssistRequestedOut = false;
     emptyZonesOut.clear();
+    resolvedZoneIdOut.clear();
 
     if (windowId != m_draggedWindowId) {
         return;
@@ -165,6 +170,12 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
                         // Fallback to synthetic format (navigation won't work, but tracking still happens)
                         zoneUuid = QStringLiteral("zoneselector-%1-%2").arg(selectedLayoutId).arg(selectedZoneIndex);
                     }
+                    // Publish the resolved id so drag_protocol.cpp can populate
+                    // DragOutcome.zoneId. Without this, the zone-selector path
+                    // would still surface m_currentZoneId (which is never written
+                    // by this branch) and the post-Phase-1B validator would drop
+                    // the ApplySnap outcome for an empty zoneId.
+                    resolvedZoneIdOut = zoneUuid;
                     m_windowTracking->windowSnapped(windowId, zoneUuid, releaseScreenId);
                     // Record user-initiated snap (not auto-snap)
                     // This prevents auto-snapping windows that were never manually snapped by user
@@ -216,6 +227,10 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
             snapWidth = capturedMultiZoneGeometry.width();
             snapHeight = capturedMultiZoneGeometry.height();
             shouldApplyGeometry = true;
+            // Publish primary zone id — identical reason to the zone-selector
+            // branch above. capturedZoneId is the primary zone of the
+            // multi-zone snap as resolved by dragMoved.
+            resolvedZoneIdOut = capturedZoneId;
             tryStorePreSnapGeometry(windowId, capturedWasSnapped, capturedOriginalGeometry);
             if (m_windowTracking) {
                 // Pass ALL zone IDs for multi-zone snap (not just primary)
@@ -236,6 +251,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
             snapWidth = capturedZoneGeometry.width();
             snapHeight = capturedZoneGeometry.height();
             shouldApplyGeometry = true;
+            resolvedZoneIdOut = capturedZoneId;
             tryStorePreSnapGeometry(windowId, capturedWasSnapped, capturedOriginalGeometry);
             if (m_windowTracking) {
                 m_windowTracking->windowSnapped(windowId, capturedZoneId, releaseScreenId);
@@ -264,7 +280,11 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
         // captured on another screen may fail isGeometryOnScreen and not restore).
         if (m_settings && m_settings->restoreOriginalSizeOnUnsnap() && m_windowTracking) {
             auto geo = m_windowTracking->service()->validatedPreTileGeometry(windowId, releaseScreenId);
-            if (geo) {
+            // Require strictly-positive dimensions: a degenerate stored
+            // rect would produce a RestoreSize outcome that validates to
+            // "requires non-zero size" and gets dropped effect-side, so
+            // the window would never actually restore.
+            if (geo && geo->width() > 0 && geo->height() > 0) {
                 snapWidth = geo->width();
                 snapHeight = geo->height();
                 shouldApplyGeometry = true;
@@ -275,7 +295,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
                 m_windowTracking->clearPreTileGeometry(windowId);
                 qCInfo(lcDbusWindow) << "Drag-out unsnap: restoring size" << geo->width() << "x" << geo->height();
             } else {
-                qCInfo(lcDbusWindow) << "Drag-out unsnap: no pre-tile geometry found for" << windowId;
+                qCInfo(lcDbusWindow) << "Drag-out unsnap: no valid pre-tile geometry for" << windowId;
             }
         }
     }

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -224,11 +224,11 @@ void WindowTrackingAdaptor::windowSnapped(const QString& windowId, const QString
     // and clear the flag. Auto-snapped windows don't update last-used zone tracking.
     bool wasAutoSnapped = m_service->clearAutoSnapped(windowId);
 
-    // If NOT auto-snapped (user explicitly snapped), clear any stale pending
-    // assignment from a previous session. This prevents the window from restoring
-    // to the wrong zone if it's closed and reopened.
+    // If NOT auto-snapped (user explicitly snapped), consume one pending-restore
+    // entry so a stale entry from a previous session can't drag the window back
+    // to a different zone on its next close/reopen cycle.
     if (!wasAutoSnapped) {
-        m_service->clearStalePendingAssignment(windowId);
+        m_service->consumePendingAssignment(windowId);
     }
 
     // Use caller-provided screen name if available, otherwise auto-detect,
@@ -271,7 +271,7 @@ void WindowTrackingAdaptor::windowSnappedMultiZone(const QString& windowId, cons
     bool wasAutoSnapped = m_service->clearAutoSnapped(windowId);
 
     if (!wasAutoSnapped) {
-        m_service->clearStalePendingAssignment(windowId);
+        m_service->consumePendingAssignment(windowId);
     }
 
     // Use caller-provided screen name if available, otherwise auto-detect,
@@ -310,8 +310,10 @@ void WindowTrackingAdaptor::windowUnsnapped(const QString& windowId)
         return;
     }
 
-    // Clear pending assignment so window won't be auto-restored on next focus/reopen
-    m_service->clearStalePendingAssignment(windowId);
+    // Consume any queued pending-restore entry for this appId so the window
+    // isn't auto-restored to the old zone on its next focus/reopen after the
+    // explicit unsnap.
+    m_service->consumePendingAssignment(windowId);
 
     // Delegate to service
     m_service->unassignWindow(windowId);
@@ -404,7 +406,7 @@ void WindowTrackingAdaptor::windowScreenChanged(const QString& windowId, const Q
 
     qCInfo(lcDbusWindow) << "windowScreenChanged:" << windowId << "moved from" << storedScreen << "to"
                          << resolvedNewScreen << "- unsnapping";
-    m_service->clearStalePendingAssignment(windowId);
+    m_service->consumePendingAssignment(windowId);
     m_service->unassignWindow(windowId);
 
     // Emit unified state change for screen-change-triggered unsnap

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -56,6 +56,18 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(LayoutManager* layoutManager, IZone
     // Forward service signals to D-Bus
     connect(m_service, &WindowTrackingService::windowZoneChanged, this, &WindowTrackingAdaptor::windowZoneChanged);
 
+    // Relay WTS snap-commit signals (emitted by commitSnap / commitMultiZoneSnap
+    // / uncommitSnap orchestration methods) to WTA's D-Bus surface. These
+    // signals replaced the D-Bus emissions that used to happen inline inside
+    // WTA::windowSnapped — the business logic moved to WTS, but the D-Bus
+    // contract is unchanged.
+    connect(m_service, &WindowTrackingService::windowSnapStateChanged, this,
+            &WindowTrackingAdaptor::windowStateChanged);
+    connect(m_service, &WindowTrackingService::windowFloatingClearedForSnap, this,
+            [this](const QString& windowId, const QString& screenId) {
+                Q_EMIT windowFloatingChanged(windowId, false, screenId);
+            });
+
     // Connect service state changes to persistence
     connect(m_service, &WindowTrackingService::stateChanged, this, &WindowTrackingAdaptor::scheduleSaveState);
 
@@ -207,51 +219,38 @@ void WindowTrackingAdaptor::setTilingPendingRestoreDelegates(std::function<QJson
 // Window Snapping - Delegate to Service
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// Snap-commit D-Bus slots — thin forwarders over WindowTrackingService.
+//
+// The full orchestration (clear floating, clear auto-snapped flag, consume
+// pending restore, assign to zone, update last-used tracking, emit state-
+// change signal) moved to WindowTrackingService::commitSnap /
+// commitMultiZoneSnap / uncommitSnap in Phase 5C. These D-Bus entry points
+// survive as the external contract, but their bodies do only two things:
+//
+//   1. Validate and resolve the screen id (cursor/active shadows live on WTA)
+//   2. Forward to the service
+//
+// The WTS signals (windowSnapStateChanged, windowFloatingClearedForSnap) are
+// wired to WTA's D-Bus signals (windowStateChanged, windowFloatingChanged)
+// in the constructor — external consumers see the same wire format as
+// before, just sourced from the service instead of inline-emitted here.
+// ═══════════════════════════════════════════════════════════════════════════════
+
 void WindowTrackingAdaptor::windowSnapped(const QString& windowId, const QString& zoneId, const QString& screenId)
 {
     if (!validateWindowId(windowId, QStringLiteral("track window snap"))) {
         return;
     }
-
     if (zoneId.isEmpty()) {
         qCWarning(lcDbusWindow) << "Window snap: cannot track, empty zone ID";
         return;
     }
-
-    clearFloatingStateForSnap(windowId, screenId);
-
-    // Check if this was an auto-snap (restore from session or snap to last zone)
-    // and clear the flag. Auto-snapped windows don't update last-used zone tracking.
-    bool wasAutoSnapped = m_service->clearAutoSnapped(windowId);
-
-    // If NOT auto-snapped (user explicitly snapped), consume one pending-restore
-    // entry so a stale entry from a previous session can't drag the window back
-    // to a different zone on its next close/reopen cycle.
-    if (!wasAutoSnapped) {
-        m_service->consumePendingAssignment(windowId);
-    }
-
-    // Use caller-provided screen name if available, otherwise auto-detect,
-    // then fall back to cursor/active screen as tertiary fallback
-    QString resolvedScreen = resolveScreenForSnap(screenId, zoneId);
-
-    int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
-
-    // Delegate to service
-    m_service->assignWindowToZone(windowId, zoneId, resolvedScreen, currentDesktop);
-
-    // Update last used zone (skip zone selector special IDs and auto-snapped windows)
-    if (!zoneId.startsWith(QStringLiteral("zoneselector-")) && !wasAutoSnapped) {
-        QString windowClass = m_service->currentAppIdFor(windowId);
-        m_service->updateLastUsedZone(zoneId, resolvedScreen, windowClass, currentDesktop);
-    }
-
-    qCInfo(lcDbusWindow) << "Window" << windowId << "snapped to zone" << zoneId << "on screen" << resolvedScreen;
-
-    // Emit unified state change
-    Q_EMIT windowStateChanged(
-        windowId,
-        WindowStateEntry{windowId, zoneId, resolvedScreen, false, QStringLiteral("snapped"), QStringList{}, false});
+    // Resolve the effective screen using WTA's cursor/active-window shadows
+    // before handing off to WTS — the service has no compositor-layer
+    // cursor tracking and takes an already-resolved screen.
+    const QString resolvedScreen = resolveScreenForSnap(screenId, zoneId);
+    m_service->commitSnap(windowId, zoneId, resolvedScreen);
 }
 
 void WindowTrackingAdaptor::windowSnappedMultiZone(const QString& windowId, const QStringList& zoneIds,
@@ -260,42 +259,12 @@ void WindowTrackingAdaptor::windowSnappedMultiZone(const QString& windowId, cons
     if (!validateWindowId(windowId, QStringLiteral("track multi-zone window snap"))) {
         return;
     }
-
     if (zoneIds.isEmpty() || zoneIds.first().isEmpty()) {
         qCWarning(lcDbusWindow) << "Multi-zone window snap: cannot track, empty zone IDs";
         return;
     }
-
-    clearFloatingStateForSnap(windowId, screenId);
-
-    bool wasAutoSnapped = m_service->clearAutoSnapped(windowId);
-
-    if (!wasAutoSnapped) {
-        m_service->consumePendingAssignment(windowId);
-    }
-
-    // Use caller-provided screen name if available, otherwise auto-detect,
-    // then fall back to cursor/active screen as tertiary fallback
-    QString primaryZoneId = zoneIds.first();
-    QString resolvedScreen = resolveScreenForSnap(screenId, primaryZoneId);
-
-    int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
-
-    // Delegate to service with all zone IDs
-    m_service->assignWindowToZones(windowId, zoneIds, resolvedScreen, currentDesktop);
-
-    // Update last used zone with primary (skip zone selector special IDs and auto-snapped)
-    if (!primaryZoneId.startsWith(QStringLiteral("zoneselector-")) && !wasAutoSnapped) {
-        QString windowClass = m_service->currentAppIdFor(windowId);
-        m_service->updateLastUsedZone(primaryZoneId, resolvedScreen, windowClass, currentDesktop);
-    }
-
-    qCInfo(lcDbusWindow) << "Window" << windowId << "snapped to multi-zone:" << zoneIds << "on screen"
-                         << resolvedScreen;
-
-    Q_EMIT windowStateChanged(
-        windowId,
-        WindowStateEntry{windowId, primaryZoneId, resolvedScreen, false, QStringLiteral("snapped"), zoneIds, false});
+    const QString resolvedScreen = resolveScreenForSnap(screenId, zoneIds.first());
+    m_service->commitMultiZoneSnap(windowId, zoneIds, resolvedScreen);
 }
 
 void WindowTrackingAdaptor::windowUnsnapped(const QString& windowId)
@@ -303,27 +272,7 @@ void WindowTrackingAdaptor::windowUnsnapped(const QString& windowId)
     if (!validateWindowId(windowId, QStringLiteral("untrack window"))) {
         return;
     }
-
-    QString previousZoneId = m_service->zoneForWindow(windowId);
-    if (previousZoneId.isEmpty()) {
-        qCWarning(lcDbusWindow) << "Window not found for unsnap:" << windowId;
-        return;
-    }
-
-    // Consume any queued pending-restore entry for this appId so the window
-    // isn't auto-restored to the old zone on its next focus/reopen after the
-    // explicit unsnap.
-    m_service->consumePendingAssignment(windowId);
-
-    // Delegate to service
-    m_service->unassignWindow(windowId);
-
-    qCInfo(lcDbusWindow) << "Window" << windowId << "unsnapped from zone" << previousZoneId;
-
-    // Emit unified state change
-    Q_EMIT windowStateChanged(
-        windowId,
-        WindowStateEntry{windowId, QString(), QString(), false, QStringLiteral("unsnapped"), QStringList{}, false});
+    m_service->uncommitSnap(windowId);
 }
 
 void WindowTrackingAdaptor::windowsSnappedBatch(const SnapConfirmationList& entries)

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -43,15 +43,11 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(LayoutManager* layoutManager, IZone
     // Create business logic service
     m_service = new WindowTrackingService(layoutManager, zoneDetector, settings, virtualDesktopManager, this);
 
-    // Snap-mode navigation target resolver — pure compute, owned here, fed
-    // via a lambda that forwards into this adaptor's navigationFeedback
-    // signal. The ZoneDetectionAdaptor is wired later via setZoneDetectionAdaptor.
-    m_targetResolver = std::make_unique<SnapNavigationTargetResolver>(
-        m_service, m_layoutManager, /*zoneDetector=*/nullptr,
-        [this](bool success, const QString& action, const QString& reason, const QString& sourceZoneId,
-               const QString& targetZoneId, const QString& screenId) {
-            Q_EMIT navigationFeedback(success, action, reason, sourceZoneId, targetZoneId, screenId);
-        });
+    // Snap-mode navigation target resolver moved to SnapEngine in Phase 5E.
+    // SnapEngine::ensureTargetResolver() lazy-constructs the resolver on
+    // first navigation call; setZoneDetectionAdaptor is forwarded to
+    // SnapEngine alongside WTA's own copy, so the late-wired zone detector
+    // still reaches the resolver.
 
     // Forward service signals to D-Bus
     connect(m_service, &WindowTrackingService::windowZoneChanged, this, &WindowTrackingAdaptor::windowZoneChanged);
@@ -131,10 +127,10 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(LayoutManager* layoutManager, IZone
     }
 }
 
-// Out-of-line so unique_ptr<SnapNavigationTargetResolver> can destroy the
-// resolver here where snapnavigationtargets.h is included and the type is
-// complete. Declaring `= default` in the header would require the full type
-// at every include site.
+// Out-of-line destructor. The unique_ptr<SnapNavigationTargetResolver>
+// that originally required this has moved to SnapEngine (Phase 5E), but
+// the destructor is kept out-of-line to avoid churning every translation
+// unit that includes this header.
 WindowTrackingAdaptor::~WindowTrackingAdaptor() = default;
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -196,9 +192,10 @@ void WindowTrackingAdaptor::setScreenModeRouter(ScreenModeRouter* router)
 void WindowTrackingAdaptor::setZoneDetectionAdaptor(ZoneDetectionAdaptor* adaptor)
 {
     m_zoneDetectionAdaptor = adaptor;
-    if (m_targetResolver) {
-        m_targetResolver->setZoneDetector(adaptor);
-    }
+    // Target resolver ownership moved to SnapEngine (Phase 5E). SnapEngine's
+    // own setZoneDetectionAdaptor wiring pushes the adaptor into its
+    // resolver when late-wired; this setter no longer has anything to do
+    // except record the pointer for any WTA-side consumers.
 }
 
 void WindowTrackingAdaptor::setTilingStateDelegates(std::function<QJsonArray()> serializeFn,

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -146,6 +146,22 @@ public:
     }
 
     /**
+     * @brief Access the shared snap-navigation target resolver.
+     *
+     * Used by SnapEngine's navigation methods (focusInDirection,
+     * moveFocusedInDirection, etc.) which were moved out of this adaptor
+     * but still need to consult the resolver that the adaptor constructs
+     * and owns. Returns nullptr if the adaptor hasn't finished constructing
+     * yet — callers must null-check.
+     *
+     * @see SnapEngine::setWindowTrackingAdaptor for the coupling rationale.
+     */
+    SnapNavigationTargetResolver* targetResolver() const
+    {
+        return m_targetResolver.get();
+    }
+
+    /**
      * @brief Same as resnapCurrentAssignments but tags the batch with a
      *        non-"resnap" action so the kwin-effect skips its snap-assist
      *        continuation. Used by the virtual-screen reconfigure path
@@ -954,6 +970,14 @@ private Q_SLOTS:
      */
     void onPanelGeometryReady();
 
+public:
+    /// Resolve a resnap filter (empty / physical / virtual screen id) into
+    /// the concrete list of snap-mode screens the resnap should touch.
+    /// Consults the shared ScreenModeRouter to drop autotile screens from
+    /// the candidate set — the router lives on WTA so this helper is
+    /// exposed publicly so SnapEngine's navigation methods can reuse it.
+    QStringList resolveSnapModeScreensForResnap(const QString& screenFilter) const;
+
 private:
     // ═══════════════════════════════════════════════════════════════════════════════
     // Constants
@@ -967,12 +991,6 @@ private:
     // ═══════════════════════════════════════════════════════════════════════════════
     // Helper Methods - Private
     // ═══════════════════════════════════════════════════════════════════════════════
-
-    /// Resolve a resnap filter (empty / physical / virtual screen id) into
-    /// the concrete list of snap-mode screens this resnap should touch.
-    /// Used by resnapCurrentAssignments and resnapForVirtualScreenReconfigure
-    /// so the service-level resnap helper can stay pure and per-screen.
-    QStringList resolveSnapModeScreensForResnap(const QString& screenFilter) const;
 
     /**
      * @brief Validate window ID and log warning if empty

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -49,9 +49,6 @@ class PLASMAZONES_EXPORT WindowTrackingAdaptor : public QDBusAbstractAdaptor
 public:
     explicit WindowTrackingAdaptor(LayoutManager* layoutManager, IZoneDetector* zoneDetector, ISettings* settings,
                                    VirtualDesktopManager* virtualDesktopManager, QObject* parent = nullptr);
-    /// Out-of-line so unique_ptr<SnapNavigationTargetResolver> can destroy
-    /// the resolver in the .cpp where its type is complete — avoids
-    /// dragging snapnavigationtargets.h into every adaptor include site.
     ~WindowTrackingAdaptor() override;
 
     /**
@@ -145,21 +142,11 @@ public:
         return m_service;
     }
 
-    /**
-     * @brief Access the shared snap-navigation target resolver.
-     *
-     * Used by SnapEngine's navigation methods (focusInDirection,
-     * moveFocusedInDirection, etc.) which were moved out of this adaptor
-     * but still need to consult the resolver that the adaptor constructs
-     * and owns. Returns nullptr if the adaptor hasn't finished constructing
-     * yet — callers must null-check.
-     *
-     * @see SnapEngine::setWindowTrackingAdaptor for the coupling rationale.
-     */
-    SnapNavigationTargetResolver* targetResolver() const
-    {
-        return m_targetResolver.get();
-    }
+    // Note: targetResolver() accessor was deleted in Phase 5E. The
+    // SnapNavigationTargetResolver instance now lives on SnapEngine,
+    // lazy-constructed via SnapEngine::ensureTargetResolver(). Consumers
+    // previously using m_wta->targetResolver() go through SnapEngine
+    // directly.
 
     /**
      * @brief Same as resnapCurrentAssignments but tags the batch with a
@@ -615,15 +602,13 @@ public Q_SLOTS:
      */
     PlasmaZones::SnapAllResultList calculateSnapAllWindows(const QStringList& windowIds, const QString& screenId);
 
-    // Snap-mode navigation target computation lives in
-    // src/dbus/snapnavigationtargets.{h,cpp} — see SnapNavigationTargetResolver.
-    // The resolver is a pure-compute helper owned by this adaptor via
-    // m_targetResolver; the D-Bus navigation slots (moveWindowToAdjacentZone,
+    // Note: the snap-mode navigation D-Bus slots (moveWindowToAdjacentZone,
     // focusAdjacentZone, swapWindowWithAdjacentZone, pushToEmptyZone,
-    // snapToZoneByNumber, cycleWindowsInZone, restoreWindowSize) delegate to
-    // it and then emit applyGeometryRequested based on the returned result.
-    // None of those helpers are D-Bus-exposed anymore — there are no external
-    // callers and keeping them in public Q_SLOTS was accidental surface.
+    // snapToZoneByNumber, cycleWindowsInZone, restoreWindowSize) still
+    // exist below as thin forwarders to SnapEngine. Their bodies moved to
+    // src/snap/snapengine/navigation_actions.cpp in Phase 5B and the
+    // SnapNavigationTargetResolver they consulted moved to SnapEngine in
+    // Phase 5E (SnapEngine::ensureTargetResolver).
 
     /**
      * @brief Trigger snap-all-windows from daemon shortcut
@@ -1100,7 +1085,8 @@ private:
     // into the adaptor's navigationFeedback signal. The zone detector is
     // wired late via setZoneDetectionAdaptor which also pushes it into
     // the resolver. Engine pure: never emits Qt signals directly.
-    std::unique_ptr<SnapNavigationTargetResolver> m_targetResolver;
+    // Note: SnapNavigationTargetResolver ownership moved to SnapEngine in
+    // Phase 5E — see SnapEngine::ensureTargetResolver.
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // Business logic service

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -985,22 +985,6 @@ private:
     bool validateWindowId(const QString& windowId, const QString& operation) const;
 
     /**
-     * @brief Validate direction parameter and emit feedback if invalid
-     * @param direction Direction string to validate
-     * @param action Action name for feedback signal
-     * @return true if direction is valid, false if empty
-     */
-    bool validateDirection(const QString& direction, const QString& action);
-
-    /**
-     * @brief Check if a window is excluded from keyboard shortcut operations
-     * @param windowId Full window ID to check
-     * @param action Action name for feedback signal (e.g. "move", "swap")
-     * @return true if window is excluded (caller should abort), false to proceed
-     */
-    bool isWindowExcluded(const QString& windowId, const QString& action);
-
-    /**
      * @brief Detect which screen a zone is on by finding where its center falls
      * @param zoneId Zone UUID string
      * @return Screen name, or empty string if not determinable

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -535,15 +535,14 @@ public Q_SLOTS:
      */
     void restoreWindowSize();
 
-    /**
-     * @brief Toggle float state for the focused window (daemon-local)
-     *
-     * Reads the active windowId + screen from m_lastActive*, reads fresh
-     * frame geometry from the shadow, stores pre-tile geometry,
-     * and calls toggleFloatForWindow to dispatch to the engine. No kwin-effect
-     * round-trip, no stale local cache reads.
-     */
-    void toggleWindowFloat();
+    // Note: toggleWindowFloat() was moved to SnapEngine::toggleFocusedFloat
+    // in Phase 5D — the shortcut-driven float toggle is dispatched through
+    // ScreenModeRouter::navigatorFor() now, and the snap-side adapter
+    // forwards to SnapEngine which owns the pre-tile capture + engine
+    // dispatch. WTA still holds the frame-geometry shadow
+    // (setFrameGeometry / frameGeometry accessors) because it's the
+    // D-Bus-facing shadow store, but the toggle orchestration itself
+    // has moved.
 
     /**
      * @brief Swap the focused window with the window in an adjacent zone (daemon-driven)

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -1040,12 +1040,10 @@ private:
     QJsonObject buildStateObject(const QString& windowId, const QString& zoneId, const QJsonArray& zoneIds,
                                  const QString& screenId, bool isFloating, const QString& changeType) const;
 
-    /**
-     * @brief Clear floating state when a window is being snapped
-     * @param windowId Window ID being snapped
-     * @param screenId Screen where the snap is occurring (for windowFloatingChanged signal)
-     */
-    void clearFloatingStateForSnap(const QString& windowId, const QString& screenId);
+    // clearFloatingStateForSnap was removed — WindowTrackingService::commitSnap
+    // now handles floating-state clearing internally (and emits
+    // windowFloatingClearedForSnap which the adaptor relays to its own
+    // windowFloatingChanged D-Bus signal).
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // Screen tracking (from KWin effect's D-Bus calls)

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -192,13 +192,11 @@ bool WindowTrackingAdaptor::applyGeometryForFloat(const QString& windowId, const
     return false;
 }
 
-void WindowTrackingAdaptor::clearFloatingStateForSnap(const QString& windowId, const QString& screenId)
-{
-    if (m_service->clearFloatingForSnap(windowId)) {
-        qCDebug(lcDbusWindow) << "Window" << windowId << "was floating, clearing floating state for snap";
-        Q_EMIT windowFloatingChanged(windowId, false, screenId);
-    }
-}
+// WindowTrackingAdaptor::clearFloatingStateForSnap was removed — all
+// snap-commit paths now route through WindowTrackingService::commitSnap
+// which handles clearing the floating state internally and emits
+// windowFloatingClearedForSnap, which this adaptor relays to its own
+// windowFloatingChanged D-Bus signal in the constructor wiring.
 
 void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, const QString& screenId, bool floating)
 {

--- a/src/dbus/windowtrackingadaptor/navigation.cpp
+++ b/src/dbus/windowtrackingadaptor/navigation.cpp
@@ -65,57 +65,19 @@ void WindowTrackingAdaptor::restoreWindowSize()
     }
 }
 
-void WindowTrackingAdaptor::toggleWindowFloat()
-{
-    // Daemon-local float toggle: no round-trip through the kwin-effect. We
-    // already know the active window (windowActivated pushes), its screen,
-    // and its current frame geometry (setFrameGeometry shadow).
-    //
-    // Previously this emitted toggleWindowFloatRequested, the effect received
-    // it, walked KWin's stacking order to find the active window, did two
-    // fire-and-forget D-Bus calls back into us, and finally we routed to the
-    // engine. That chain stalled under any D-Bus backpressure and produced
-    // the "pressed Meta-F, nothing happens, seconds later it toggles"
-    // symptom from discussion #310.
-    if (m_lastActiveWindowId.isEmpty() || m_lastActiveScreenId.isEmpty()) {
-        qCInfo(lcDbusWindow) << "toggleWindowFloat: no active window in shadow";
-        Q_EMIT navigationFeedback(false, QStringLiteral("float"), QStringLiteral("no_active_window"), QString(),
-                                  QString(), m_lastActiveScreenId);
-        return;
-    }
-
-    const QString windowId = m_lastActiveWindowId;
-    const QString screenId = m_lastActiveScreenId;
-    qCInfo(lcDbusWindow) << "toggleWindowFloat: windowId=" << windowId << "screen=" << screenId;
-
-    // Capture pre-tile geometry from the shadow ONLY when the window is
-    // currently floating. The shadow is refreshed on every
-    // windowFrameGeometryChanged the effect sees (debounced to 50ms).
-    //
-    // wasFloating=true → window is at a free-float position; capturing
-    //   (and overwriting any prior entry) lets the next un-float restore
-    //   to the user's most recent floated location.
-    //
-    // wasFloating=false → window is tiled/snapped; the shadow holds the
-    //   zone rect, NOT a meaningful pre-float position. Storing it would
-    //   poison the pre-tile entry with tile coordinates — a subsequent
-    //   float-restore would "restore" the window right back to the zone
-    //   it was already in. Leave the existing entry (if any) untouched.
-    //
-    // Skipping the store when the shadow has no entry is safe: the engine
-    // will use the window's current frame geometry on the effect side
-    // when it applies the outcome.
-    const bool wasFloating = m_service && m_service->isWindowFloating(windowId);
-    if (wasFloating) {
-        const QRect geo = frameGeometry(windowId);
-        if (geo.isValid()) {
-            storePreTileGeometry(windowId, geo.x(), geo.y(), geo.width(), geo.height(), screenId,
-                                 /*overwrite=*/true);
-        }
-    }
-
-    toggleFloatForWindow(windowId, screenId);
-}
+// Note: WindowTrackingAdaptor::toggleWindowFloat() (zero-arg shortcut
+// handler) used to live here. It was the daemon-local "Meta-F" float-
+// toggle path — read active window from the shadow, capture pre-tile
+// from the frame-geometry shadow when already floating, route to the
+// correct engine via toggleFloatForWindow.
+//
+// That logic now lives in SnapEngine::toggleFocusedFloat (in
+// snapengine/navigation_actions.cpp). The shortcut handler in
+// daemon/navigation.cpp::handleFloat dispatches through
+// ScreenModeRouter::navigatorFor(screenId) → INavigationActions →
+// toggleFocusedFloat(), which routes to either the autotile engine's
+// toggleFocusedWindowFloat() or SnapEngine's toggleFocusedFloat() via
+// the adapters. No circular bounce through WTA any more.
 
 void WindowTrackingAdaptor::swapWindowWithAdjacentZone(const QString& direction)
 {

--- a/src/dbus/windowtrackingadaptor/navigation.cpp
+++ b/src/dbus/windowtrackingadaptor/navigation.cpp
@@ -21,178 +21,48 @@
 namespace PlasmaZones {
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Daemon-driven navigation: compute geometry internally and emit
-// applyGeometryRequested / activateWindowRequested. The effect just applies.
+// Navigation forwarders.
+//
+// Every method in this range used to contain its own target-resolve +
+// bookkeeping + signal-emission logic. The logic has moved into SnapEngine
+// (src/snap/snapengine/navigation_actions.cpp) — this adaptor now acts as
+// the thin D-Bus facade it was always supposed to be, forwarding
+// shortcut-driven navigation requests to the engine that owns the
+// behaviour.
+//
+// Methods that still contain real logic here are the ones tied to
+// WindowTrackingAdaptor-specific state (toggleWindowFloat reads the
+// frame-geometry shadow), JSON deserialization (handleBatchedResnap),
+// or pure signal passthroughs (requestMoveSpecificWindowToZone,
+// reportNavigationFeedback).
 // ═══════════════════════════════════════════════════════════════════════════════
-
-/**
- * @brief Resolve the screen to use for navigation.
- *
- * For snapped windows, trusts the stored screen assignment (avoids
- * same-model multi-monitor mismatch). Otherwise uses cursor screen
- * with active-window fallback.
- */
-static QString resolveNavScreen(const WindowTrackingAdaptor* adaptor, const QString& windowId,
-                                WindowTrackingService* service)
-{
-    // If window is snapped, use stored screen (authoritative)
-    QString zoneId = service->zoneForWindow(windowId);
-    if (!zoneId.isEmpty()) {
-        QString storedScreen = service->screenAssignments().value(windowId);
-        if (!storedScreen.isEmpty()) {
-            // For virtual screen IDs, verify the backing physical screen exists
-            if (VirtualScreenId::isVirtual(storedScreen)) {
-                QString physId = VirtualScreenId::extractPhysicalId(storedScreen);
-                QScreen* physScreen = Utils::findScreenByIdOrName(physId);
-                if (physScreen) {
-                    // Physical screen exists — verify the virtual screen itself still
-                    // exists (VS config may have changed, e.g. 3 VS → 2 VS)
-                    auto* mgr = ScreenManager::instance();
-                    if (mgr && mgr->effectiveScreenIds().contains(storedScreen)) {
-                        return storedScreen; // Virtual screen is valid, return as-is
-                    }
-                    // Virtual screen gone (config changed), fall through
-                }
-                // Physical screen gone, fall through to cursor-based resolution
-            } else if (Utils::findScreenByIdOrName(storedScreen)) {
-                return storedScreen;
-            }
-        }
-    }
-    // Cursor screen (primary), active-window screen (fallback)
-    QString screen = adaptor->lastCursorScreenName();
-    if (screen.isEmpty()) {
-        screen = adaptor->lastActiveScreenName();
-    }
-    return screen;
-}
 
 void WindowTrackingAdaptor::moveWindowToAdjacentZone(const QString& direction)
 {
-    qCInfo(lcDbusWindow) << "moveWindowToAdjacentZone: direction=" << direction;
-
-    if (!validateDirection(direction, QStringLiteral("move"))) {
-        return;
+    if (m_snapEngine) {
+        m_snapEngine->moveFocusedInDirection(direction);
     }
-
-    if (m_lastActiveWindowId.isEmpty()) {
-        Q_EMIT navigationFeedback(false, QStringLiteral("move"), QStringLiteral("no_window"), QString(), QString(),
-                                  m_lastActiveScreenId);
-        return;
-    }
-
-    if (isWindowExcluded(m_lastActiveWindowId, QStringLiteral("move"))) {
-        return;
-    }
-
-    QString screenId = resolveNavScreen(this, m_lastActiveWindowId, m_service);
-    MoveTargetResult result = m_targetResolver->getMoveTargetForWindow(m_lastActiveWindowId, direction, screenId);
-
-    // getMoveTargetForWindow already emits navigationFeedback on failure
-    if (!result.success) {
-        return;
-    }
-
-    QRect geo = result.toRect();
-    if (!geo.isValid()) {
-        qCWarning(lcDbusWindow) << "moveWindowToAdjacentZone: invalid geometry from nav result";
-        return;
-    }
-
-    // Handle snap bookkeeping internally (pre-snap geometry is stored by the
-    // effect in slotApplyGeometryRequested via ensurePreSnapGeometryStored)
-    windowSnapped(m_lastActiveWindowId, result.zoneId, result.screenName);
-    recordSnapIntent(m_lastActiveWindowId, true);
-
-    // Tell effect to apply the geometry
-    Q_EMIT applyGeometryRequested(m_lastActiveWindowId, geo.x(), geo.y(), geo.width(), geo.height(), result.zoneId,
-                                  result.screenName, false);
 }
 
 void WindowTrackingAdaptor::focusAdjacentZone(const QString& direction)
 {
-    qCInfo(lcDbusWindow) << "focusAdjacentZone: direction=" << direction;
-
-    if (!validateDirection(direction, QStringLiteral("focus"))) {
-        return;
-    }
-
-    if (m_lastActiveWindowId.isEmpty()) {
-        Q_EMIT navigationFeedback(false, QStringLiteral("focus"), QStringLiteral("no_window"), QString(), QString(),
-                                  m_lastActiveScreenId);
-        return;
-    }
-
-    QString screenId = resolveNavScreen(this, m_lastActiveWindowId, m_service);
-    FocusTargetResult result = m_targetResolver->getFocusTargetForWindow(m_lastActiveWindowId, direction, screenId);
-
-    if (!result.success) {
-        return; // getFocusTargetForWindow already emitted feedback
-    }
-
-    if (!result.windowIdToActivate.isEmpty()) {
-        Q_EMIT activateWindowRequested(result.windowIdToActivate);
+    if (m_snapEngine) {
+        m_snapEngine->focusInDirection(direction);
     }
 }
 
 void WindowTrackingAdaptor::pushToEmptyZone(const QString& screenId)
 {
-    qCInfo(lcDbusWindow) << "pushToEmptyZone: screen=" << screenId;
-
-    if (m_lastActiveWindowId.isEmpty()) {
-        Q_EMIT navigationFeedback(false, QStringLiteral("push"), QStringLiteral("no_window"), QString(), QString(),
-                                  screenId.isEmpty() ? m_lastActiveScreenId : screenId);
-        return;
+    if (m_snapEngine) {
+        m_snapEngine->pushFocusedToEmptyZone(screenId);
     }
-
-    if (isWindowExcluded(m_lastActiveWindowId, QStringLiteral("push"))) {
-        return;
-    }
-
-    QString effectiveScreen = screenId.isEmpty() ? resolveNavScreen(this, m_lastActiveWindowId, m_service) : screenId;
-    MoveTargetResult result = m_targetResolver->getPushTargetForWindow(m_lastActiveWindowId, effectiveScreen);
-
-    if (!result.success) {
-        return; // getPushTargetForWindow already emitted feedback
-    }
-
-    QRect geo = result.toRect();
-    if (!geo.isValid()) {
-        qCWarning(lcDbusWindow) << "pushToEmptyZone: invalid geometry from nav result";
-        return;
-    }
-
-    windowSnapped(m_lastActiveWindowId, result.zoneId, effectiveScreen);
-    recordSnapIntent(m_lastActiveWindowId, true);
-
-    Q_EMIT applyGeometryRequested(m_lastActiveWindowId, geo.x(), geo.y(), geo.width(), geo.height(), result.zoneId,
-                                  effectiveScreen, false);
 }
 
 void WindowTrackingAdaptor::restoreWindowSize()
 {
-    qCInfo(lcDbusWindow) << "restoreWindowSize";
-
-    if (m_lastActiveWindowId.isEmpty()) {
-        Q_EMIT navigationFeedback(false, QStringLiteral("restore"), QStringLiteral("no_window"), QString(), QString(),
-                                  m_lastActiveScreenId);
-        return;
+    if (m_snapEngine) {
+        m_snapEngine->restoreFocusedWindow();
     }
-
-    QString screenId = resolveNavScreen(this, m_lastActiveWindowId, m_service);
-    RestoreTargetResult result = m_targetResolver->getRestoreForWindow(m_lastActiveWindowId, screenId);
-
-    if (!result.success) {
-        return; // getRestoreForWindow already emitted feedback
-    }
-
-    // Unsnap the window and clear pre-tile geometry
-    windowUnsnapped(m_lastActiveWindowId);
-    clearPreTileGeometry(m_lastActiveWindowId);
-
-    // Emit with empty zoneId = restore (no snap)
-    Q_EMIT applyGeometryRequested(m_lastActiveWindowId, result.x, result.y, result.width, result.height, QString(),
-                                  screenId, false);
 }
 
 void WindowTrackingAdaptor::toggleWindowFloat()
@@ -249,125 +119,58 @@ void WindowTrackingAdaptor::toggleWindowFloat()
 
 void WindowTrackingAdaptor::swapWindowWithAdjacentZone(const QString& direction)
 {
-    qCInfo(lcDbusWindow) << "swapWindowWithAdjacentZone: direction=" << direction;
-
-    if (!validateDirection(direction, QStringLiteral("swap"))) {
-        return;
-    }
-
-    if (m_lastActiveWindowId.isEmpty()) {
-        Q_EMIT navigationFeedback(false, QStringLiteral("swap"), QStringLiteral("no_window"), QString(), QString(),
-                                  m_lastActiveScreenId);
-        return;
-    }
-
-    if (isWindowExcluded(m_lastActiveWindowId, QStringLiteral("swap"))) {
-        return;
-    }
-
-    QString screenId = resolveNavScreen(this, m_lastActiveWindowId, m_service);
-    SwapTargetResult result = m_targetResolver->getSwapTargetForWindow(m_lastActiveWindowId, direction, screenId);
-
-    if (!result.success) {
-        return; // getSwapTargetForWindow already emitted feedback
-    }
-
-    // Move window 1 to target zone
-    windowSnapped(result.windowId1, result.zoneId1, result.screenName);
-    recordSnapIntent(result.windowId1, true);
-    Q_EMIT applyGeometryRequested(result.windowId1, result.x1, result.y1, result.w1, result.h1, result.zoneId1,
-                                  result.screenName, false);
-
-    // If there's a second window (swap, not move-to-empty), move it to the source zone.
-    // Prefer window2's stored screen assignment, not window1's screen, so cross-VS swaps
-    // assign each window to the correct virtual screen.
-    if (!result.windowId2.isEmpty()) {
-        QString screen2 = m_service->screenAssignments().value(result.windowId2);
-        if (screen2.isEmpty()) {
-            screen2 = result.screenName;
-        }
-
-        windowSnapped(result.windowId2, result.zoneId2, screen2);
-        recordSnapIntent(result.windowId2, true);
-        Q_EMIT applyGeometryRequested(result.windowId2, result.x2, result.y2, result.w2, result.h2, result.zoneId2,
-                                      screen2, false);
+    if (m_snapEngine) {
+        m_snapEngine->swapFocusedInDirection(direction);
     }
 }
 
 void WindowTrackingAdaptor::snapToZoneByNumber(int zoneNumber, const QString& screenId)
 {
-    qCInfo(lcDbusWindow) << "snapToZoneByNumber: zoneNumber=" << zoneNumber << "screen=" << screenId;
-
-    if (zoneNumber < 1 || zoneNumber > 9) {
-        qCWarning(lcDbusWindow) << "Invalid zone number:" << zoneNumber << "(must be 1-9)";
-        Q_EMIT navigationFeedback(false, QStringLiteral("snap"), QStringLiteral("invalid_zone_number"), QString(),
-                                  QString(), QString());
-        return;
+    if (m_snapEngine) {
+        m_snapEngine->moveFocusedToPosition(zoneNumber, screenId);
     }
-
-    if (m_lastActiveWindowId.isEmpty()) {
-        Q_EMIT navigationFeedback(false, QStringLiteral("snap"), QStringLiteral("no_window"), QString(), QString(),
-                                  screenId.isEmpty() ? m_lastActiveScreenId : screenId);
-        return;
-    }
-
-    if (isWindowExcluded(m_lastActiveWindowId, QStringLiteral("snap"))) {
-        return;
-    }
-
-    QString effectiveScreen = screenId.isEmpty() ? resolveNavScreen(this, m_lastActiveWindowId, m_service) : screenId;
-    MoveTargetResult result =
-        m_targetResolver->getSnapToZoneByNumberTarget(m_lastActiveWindowId, zoneNumber, effectiveScreen);
-
-    if (!result.success) {
-        return; // getSnapToZoneByNumberTarget already emitted feedback
-    }
-
-    QRect geo = result.toRect();
-    if (!geo.isValid()) {
-        qCWarning(lcDbusWindow) << "snapToZoneByNumber: invalid geometry from nav result";
-        return;
-    }
-
-    windowSnapped(m_lastActiveWindowId, result.zoneId, effectiveScreen);
-    recordSnapIntent(m_lastActiveWindowId, true);
-
-    Q_EMIT applyGeometryRequested(m_lastActiveWindowId, geo.x(), geo.y(), geo.width(), geo.height(), result.zoneId,
-                                  effectiveScreen, false);
 }
 
-/**
- * @brief Process a vector of ZoneAssignmentEntry: call windowSnapped for each, emit applyGeometriesBatch.
- *
- * Shared by rotate, resnap, and snap-all. Handles bookkeeping (zone assignment,
- * floating state clear, snap intent recording) on the daemon side so the effect
- * only needs to apply geometries.
- *
- * @param entries Zone assignment entries to process
- * @param action Action name for the applyGeometriesBatch signal ("rotate", "resnap", "snap_all")
- * @return true if entries were processed and signal emitted
- */
+void WindowTrackingAdaptor::rotateWindowsInLayout(bool clockwise, const QString& screenId)
+{
+    if (m_snapEngine) {
+        m_snapEngine->rotateWindowsInLayout(clockwise, screenId);
+    }
+}
+
+void WindowTrackingAdaptor::cycleWindowsInZone(bool forward)
+{
+    if (m_snapEngine) {
+        m_snapEngine->cycleFocus(forward);
+    }
+}
+
+void WindowTrackingAdaptor::resnapToNewLayout()
+{
+    if (m_snapEngine) {
+        m_snapEngine->resnapToNewLayout();
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Helper used by the remaining in-adaptor methods (resnapForVirtualScreenReconfigure
+// and handleBatchedResnap) that operate on pre-built ZoneAssignmentEntry vectors
+// and still own their own D-Bus signal emission. SnapEngine's navigation_actions.cpp
+// has an equivalent helper in an anonymous namespace for the engine-owned methods.
+// A future refactor can unify them behind a SnapEngine::applyResnapEntries public
+// method; for now the duplication is bounded to these two call sites.
+// ═══════════════════════════════════════════════════════════════════════════════
 static bool processBatchEntries(WindowTrackingAdaptor* adaptor, const QVector<ZoneAssignmentEntry>& entries,
                                 const QString& action)
 {
     if (entries.isEmpty()) {
         return false;
     }
-
-    // Process bookkeeping for each entry
     for (const auto& entry : entries) {
         if (entry.targetZoneId == QLatin1String("__restore__")) {
             adaptor->windowUnsnapped(entry.windowId);
             adaptor->clearPreTileGeometry(entry.windowId);
         } else {
-            // If the caller stamped an authoritative target screen, trust it.
-            // This is the safe path for resnap-from-stored callers, where
-            // re-deriving from geometry.center() risks landing in a sibling
-            // virtual screen if the layout geometry resolved against a stale
-            // or fallback rect. Empty means "no caller-known target" — legacy
-            // callers like rotate / snap-all that compute geometry without
-            // knowing the target screen — and falls through to the geometry-
-            // based resolution below.
             QString screenId = entry.targetScreenId;
             QPoint center = entry.targetGeometry.center();
             auto* mgr = ScreenManager::instance();
@@ -375,14 +178,6 @@ static bool processBatchEntries(WindowTrackingAdaptor* adaptor, const QVector<Zo
                 screenId = mgr->effectiveScreenAt(center);
             }
             if (screenId.isEmpty()) {
-                // Final fallback: walk QGuiApplication's screens manually.
-                // This path is hit only when both targetScreenId and
-                // effectiveScreenAt(center) returned empty — typically when
-                // ScreenManager hasn't been initialized yet (very early in
-                // daemon lifecycle) or when the geometry's center falls
-                // outside all known screens. effectiveScreenAt above already
-                // covers the VS-aware case, so we just need a physical fall-
-                // through here — no need to re-attempt VS resolution.
                 for (QScreen* screen : QGuiApplication::screens()) {
                     if (screen->geometry().contains(center)) {
                         screenId = Utils::screenIdentifier(screen);
@@ -390,8 +185,6 @@ static bool processBatchEntries(WindowTrackingAdaptor* adaptor, const QVector<Zo
                     }
                 }
             }
-            // Fallback: use cursor/active screen if geometry doesn't resolve to a screen
-            // (possible if zone geometries reference a disconnected monitor)
             if (screenId.isEmpty()) {
                 screenId = adaptor->lastCursorScreenName();
                 if (screenId.isEmpty()) {
@@ -405,8 +198,6 @@ static bool processBatchEntries(WindowTrackingAdaptor* adaptor, const QVector<Zo
             }
         }
     }
-
-    // Build struct list and emit batch for effect to apply geometries
     WindowGeometryList geometries;
     geometries.reserve(entries.size());
     for (const ZoneAssignmentEntry& entry : entries) {
@@ -414,83 +205,6 @@ static bool processBatchEntries(WindowTrackingAdaptor* adaptor, const QVector<Zo
     }
     Q_EMIT adaptor->applyGeometriesBatch(geometries, action);
     return true;
-}
-
-void WindowTrackingAdaptor::rotateWindowsInLayout(bool clockwise, const QString& screenId)
-{
-    qCDebug(lcDbusWindow) << "rotateWindowsInLayout: clockwise=" << clockwise << "screen=" << screenId;
-
-    QVector<ZoneAssignmentEntry> entries = m_service->calculateRotation(clockwise, screenId);
-
-    if (entries.isEmpty()) {
-        // Emit feedback for empty rotation (mirrors SnapEngine::rotateWindows logic)
-        auto* layout = m_layoutManager->resolveLayoutForScreen(screenId);
-        if (!layout) {
-            Q_EMIT navigationFeedback(false, QStringLiteral("rotate"), QStringLiteral("no_active_layout"), QString(),
-                                      QString(), screenId);
-        } else if (layout->zoneCount() < 2) {
-            Q_EMIT navigationFeedback(false, QStringLiteral("rotate"), QStringLiteral("single_zone"), QString(),
-                                      QString(), screenId);
-        } else {
-            Q_EMIT navigationFeedback(false, QStringLiteral("rotate"), QStringLiteral("no_snapped_windows"), QString(),
-                                      QString(), screenId);
-        }
-        return;
-    }
-
-    processBatchEntries(this, entries, QStringLiteral("rotate"));
-
-    QString direction = clockwise ? QStringLiteral("clockwise") : QStringLiteral("counterclockwise");
-    QString reason = QStringLiteral("%1:%2").arg(direction).arg(entries.size());
-    Q_EMIT navigationFeedback(true, QStringLiteral("rotate"), reason, entries.first().sourceZoneId,
-                              entries.first().targetZoneId, screenId);
-}
-
-void WindowTrackingAdaptor::cycleWindowsInZone(bool forward)
-{
-    qCDebug(lcDbusWindow) << "cycleWindowsInZone: forward=" << forward;
-
-    if (m_lastActiveWindowId.isEmpty()) {
-        Q_EMIT navigationFeedback(false, QStringLiteral("cycle"), QStringLiteral("no_window"), QString(), QString(),
-                                  m_lastActiveScreenId);
-        return;
-    }
-
-    QString screenId = resolveNavScreen(this, m_lastActiveWindowId, m_service);
-    CycleTargetResult result = m_targetResolver->getCycleTargetForWindow(m_lastActiveWindowId, forward, screenId);
-
-    if (!result.success) {
-        return; // getCycleTargetForWindow already emitted feedback
-    }
-
-    if (!result.windowIdToActivate.isEmpty()) {
-        Q_EMIT activateWindowRequested(result.windowIdToActivate);
-    }
-}
-
-void WindowTrackingAdaptor::resnapToNewLayout()
-{
-    qCDebug(lcDbusWindow) << "resnapToNewLayout";
-
-    QVector<ZoneAssignmentEntry> entries = m_service->calculateResnapFromPreviousLayout();
-
-    if (entries.isEmpty()) {
-        auto* layout = m_layoutManager->activeLayout();
-        if (!layout) {
-            Q_EMIT navigationFeedback(false, QStringLiteral("resnap"), QStringLiteral("no_active_layout"), QString(),
-                                      QString(), m_lastActiveScreenId);
-        } else {
-            Q_EMIT navigationFeedback(false, QStringLiteral("resnap"), QStringLiteral("no_windows_to_resnap"),
-                                      QString(), QString(), m_lastActiveScreenId);
-        }
-        return;
-    }
-
-    processBatchEntries(this, entries, QStringLiteral("resnap"));
-
-    QString reason = QStringLiteral("resnap:%1").arg(entries.size());
-    Q_EMIT navigationFeedback(true, QStringLiteral("resnap"), reason, QString(), entries.first().targetZoneId,
-                              m_lastActiveScreenId);
 }
 
 // Build the effective list of snap-mode screens this resnap should target.
@@ -523,22 +237,9 @@ QStringList WindowTrackingAdaptor::resolveSnapModeScreensForResnap(const QString
 
 void WindowTrackingAdaptor::resnapCurrentAssignments(const QString& screenFilter)
 {
-    qCDebug(lcDbusWindow) << "resnapCurrentAssignments: screen="
-                          << (screenFilter.isEmpty() ? QStringLiteral("all") : screenFilter);
-
-    const QStringList snapScreens = resolveSnapModeScreensForResnap(screenFilter);
-    QVector<ZoneAssignmentEntry> entries;
-    for (const QString& sid : snapScreens) {
-        entries.append(m_service->calculateResnapFromCurrentAssignments(sid));
+    if (m_snapEngine) {
+        m_snapEngine->resnapCurrentAssignments(screenFilter);
     }
-
-    if (entries.isEmpty()) {
-        Q_EMIT navigationFeedback(false, QStringLiteral("resnap"), QStringLiteral("no_windows_to_resnap"), QString(),
-                                  QString(), screenFilter.isEmpty() ? m_lastActiveScreenId : screenFilter);
-        return;
-    }
-
-    processBatchEntries(this, entries, QStringLiteral("resnap"));
 }
 
 void WindowTrackingAdaptor::resnapForVirtualScreenReconfigure(const QString& physicalScreenId)

--- a/src/dbus/windowtrackingadaptor/navigation.cpp
+++ b/src/dbus/windowtrackingadaptor/navigation.cpp
@@ -2,21 +2,20 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "../windowtrackingadaptor.h"
-#include "../snapnavigationtargets.h"
-#include "internal.h"
-#include "../../snap/SnapEngine.h"
+#include "../../config/settings.h"
+#include "../../core/inavigationactions.h"
 #include "../../core/logging.h"
 #include "../../core/layoutmanager.h"
-#include "../../core/layout.h"
 #include "../../core/screenmanager.h"
+#include "../../core/screenmoderouter.h"
 #include "../../core/utils.h"
 #include "../../core/virtualscreen.h"
+#include "../../core/windowtrackingservice.h"
+#include "../../snap/SnapEngine.h"
 
-#include <QGuiApplication>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QScreen>
 
 namespace PlasmaZones {
 
@@ -37,31 +36,37 @@ namespace PlasmaZones {
 // reportNavigationFeedback).
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// D-Bus entry points: external callers (typically the KWin effect) invoke
+// these without an explicit NavigationContext. The engine methods take a
+// NavigationContext and fall back to WTA's last-active shadow when both
+// fields are empty — matching the historical behaviour where these slots
+// read the shadow directly.
+
 void WindowTrackingAdaptor::moveWindowToAdjacentZone(const QString& direction)
 {
     if (m_snapEngine) {
-        m_snapEngine->moveFocusedInDirection(direction);
+        m_snapEngine->moveFocusedInDirection(direction, NavigationContext{});
     }
 }
 
 void WindowTrackingAdaptor::focusAdjacentZone(const QString& direction)
 {
     if (m_snapEngine) {
-        m_snapEngine->focusInDirection(direction);
+        m_snapEngine->focusInDirection(direction, NavigationContext{});
     }
 }
 
 void WindowTrackingAdaptor::pushToEmptyZone(const QString& screenId)
 {
     if (m_snapEngine) {
-        m_snapEngine->pushFocusedToEmptyZone(screenId);
+        m_snapEngine->pushFocusedToEmptyZone(NavigationContext{QString(), screenId});
     }
 }
 
 void WindowTrackingAdaptor::restoreWindowSize()
 {
     if (m_snapEngine) {
-        m_snapEngine->restoreFocusedWindow();
+        m_snapEngine->restoreFocusedWindow(NavigationContext{});
     }
 }
 
@@ -82,14 +87,14 @@ void WindowTrackingAdaptor::restoreWindowSize()
 void WindowTrackingAdaptor::swapWindowWithAdjacentZone(const QString& direction)
 {
     if (m_snapEngine) {
-        m_snapEngine->swapFocusedInDirection(direction);
+        m_snapEngine->swapFocusedInDirection(direction, NavigationContext{});
     }
 }
 
 void WindowTrackingAdaptor::snapToZoneByNumber(int zoneNumber, const QString& screenId)
 {
     if (m_snapEngine) {
-        m_snapEngine->moveFocusedToPosition(zoneNumber, screenId);
+        m_snapEngine->moveFocusedToPosition(zoneNumber, NavigationContext{QString(), screenId});
     }
 }
 
@@ -103,7 +108,7 @@ void WindowTrackingAdaptor::rotateWindowsInLayout(bool clockwise, const QString&
 void WindowTrackingAdaptor::cycleWindowsInZone(bool forward)
 {
     if (m_snapEngine) {
-        m_snapEngine->cycleFocus(forward);
+        m_snapEngine->cycleFocus(forward, NavigationContext{});
     }
 }
 
@@ -115,55 +120,29 @@ void WindowTrackingAdaptor::resnapToNewLayout()
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Helper used by the remaining in-adaptor methods (resnapForVirtualScreenReconfigure
-// and handleBatchedResnap) that operate on pre-built ZoneAssignmentEntry vectors
-// and still own their own D-Bus signal emission. SnapEngine's navigation_actions.cpp
-// has an equivalent helper in an anonymous namespace for the engine-owned methods.
-// A future refactor can unify them behind a SnapEngine::applyResnapEntries public
-// method; for now the duplication is bounded to these two call sites.
+// Batch helper used by in-adaptor methods that operate on pre-built
+// ZoneAssignmentEntry vectors (resnapForVirtualScreenReconfigure,
+// handleBatchedResnap). Thin wrapper over
+// WindowTrackingService::applyBatchAssignments — the loop and per-entry
+// screen-resolution logic live there, and SnapEngine's navigation_actions.cpp
+// uses the same WTS method, eliminating the historical two-copy duplication.
 // ═══════════════════════════════════════════════════════════════════════════════
 static bool processBatchEntries(WindowTrackingAdaptor* adaptor, const QVector<ZoneAssignmentEntry>& entries,
                                 const QString& action)
 {
-    if (entries.isEmpty()) {
+    WindowTrackingService* service = adaptor ? adaptor->service() : nullptr;
+    if (!service) {
         return false;
     }
-    for (const auto& entry : entries) {
-        if (entry.targetZoneId == QLatin1String("__restore__")) {
-            adaptor->windowUnsnapped(entry.windowId);
-            adaptor->clearPreTileGeometry(entry.windowId);
-        } else {
-            QString screenId = entry.targetScreenId;
-            QPoint center = entry.targetGeometry.center();
-            auto* mgr = ScreenManager::instance();
-            if (screenId.isEmpty() && mgr) {
-                screenId = mgr->effectiveScreenAt(center);
-            }
-            if (screenId.isEmpty()) {
-                for (QScreen* screen : QGuiApplication::screens()) {
-                    if (screen->geometry().contains(center)) {
-                        screenId = Utils::screenIdentifier(screen);
-                        break;
-                    }
-                }
-            }
-            if (screenId.isEmpty()) {
-                screenId = adaptor->lastCursorScreenName();
-                if (screenId.isEmpty()) {
-                    screenId = adaptor->lastActiveScreenName();
-                }
-            }
-            if (entry.targetZoneIds.size() > 1) {
-                adaptor->windowSnappedMultiZone(entry.windowId, entry.targetZoneIds, screenId);
-            } else {
-                adaptor->windowSnapped(entry.windowId, entry.targetZoneId, screenId);
-            }
-        }
-    }
-    WindowGeometryList geometries;
-    geometries.reserve(entries.size());
-    for (const ZoneAssignmentEntry& entry : entries) {
-        geometries.append(WindowGeometryEntry::fromRect(entry.windowId, entry.targetGeometry));
+
+    WindowGeometryList geometries = service->applyBatchAssignments(
+        entries, WindowTrackingService::SnapIntent::UserInitiated, [adaptor]() -> QString {
+            const QString cursor = adaptor->lastCursorScreenName();
+            return cursor.isEmpty() ? adaptor->lastActiveScreenName() : cursor;
+        });
+
+    if (geometries.isEmpty()) {
+        return false;
     }
     Q_EMIT adaptor->applyGeometriesBatch(geometries, action);
     return true;

--- a/src/dbus/windowtrackingadaptor/navigation.cpp
+++ b/src/dbus/windowtrackingadaptor/navigation.cpp
@@ -288,45 +288,4 @@ void WindowTrackingAdaptor::reportNavigationFeedback(bool success, const QString
     Q_EMIT navigationFeedback(success, action, reason, sourceZoneId, targetZoneId, screenId);
 }
 
-bool WindowTrackingAdaptor::validateDirection(const QString& direction, const QString& action)
-{
-    if (direction.isEmpty()) {
-        qCWarning(lcDbusWindow) << "Cannot" << action << "- empty direction";
-        Q_EMIT navigationFeedback(false, action, QStringLiteral("invalid_direction"), QString(), QString(), QString());
-        return false;
-    }
-    return true;
-}
-
-bool WindowTrackingAdaptor::isWindowExcluded(const QString& windowId, const QString& action)
-{
-    if (!m_settings) {
-        return false;
-    }
-
-    // Current class, not first-seen — matches rules against the window's
-    // live appId so mid-session mutations don't bypass exclusions on fresh
-    // operations. (Per feedback_class_change_exclusion.md, existing snapped
-    // state is NOT re-evaluated — only new decision points, like this one.)
-    // m_service is constructed in the adaptor ctor and is never null here.
-    const QString appId = m_service->currentAppIdFor(windowId);
-    for (const QString& excluded : m_settings->excludedApplications()) {
-        if (Utils::appIdMatches(appId, excluded)) {
-            qCInfo(lcDbusWindow) << action << ":" << windowId << "excluded by app rule:" << excluded;
-            Q_EMIT navigationFeedback(false, action, QStringLiteral("excluded"), appId, QString(),
-                                      m_lastActiveScreenId);
-            return true;
-        }
-    }
-    for (const QString& excluded : m_settings->excludedWindowClasses()) {
-        if (Utils::appIdMatches(appId, excluded)) {
-            qCInfo(lcDbusWindow) << action << ":" << windowId << "excluded by class rule:" << excluded;
-            Q_EMIT navigationFeedback(false, action, QStringLiteral("excluded"), appId, QString(),
-                                      m_lastActiveScreenId);
-            return true;
-        }
-    }
-    return false;
-}
-
 } // namespace PlasmaZones

--- a/src/dbus/windowtrackingadaptor/snaprestore.cpp
+++ b/src/dbus/windowtrackingadaptor/snaprestore.cpp
@@ -229,14 +229,23 @@ void WindowTrackingAdaptor::applySnapResult(const SnapResult& result, const QStr
     snapHeight = result.geometry.height();
     shouldSnap = true;
 
+    // Mark auto-snapped first so the flag persists through commitSnap
+    // (AutoRestored leaves it alone). commitSnap runs the full
+    // orchestration — clears any pre-existing floating state (emits
+    // windowFloatingClearedForSnap which this adaptor relays as
+    // windowFloatingChanged), assigns to zone(s), emits state change.
+    // No last-used-zone update (this is an auto-restore, not a user
+    // action) and no pending-consume (the individual snapXxx() paths
+    // already consumed where needed — see restoreToPersistedZone's
+    // explicit consumePendingAssignment after applySnapResult).
     m_service->markAsAutoSnapped(windowId);
-    clearFloatingStateForSnap(windowId, result.screenId);
-
-    int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
-    if (result.zoneIds.size() > 1) {
-        m_service->assignWindowToZones(windowId, result.zoneIds, result.screenId, currentDesktop);
+    const QStringList zoneIds = result.zoneIds.isEmpty() ? QStringList{result.zoneId} : result.zoneIds;
+    if (zoneIds.size() > 1) {
+        m_service->commitMultiZoneSnap(windowId, zoneIds, result.screenId,
+                                       WindowTrackingService::SnapIntent::AutoRestored);
     } else {
-        m_service->assignWindowToZone(windowId, result.zoneId, result.screenId, currentDesktop);
+        m_service->commitSnap(windowId, zoneIds.first(), result.screenId,
+                              WindowTrackingService::SnapIntent::AutoRestored);
     }
 }
 

--- a/src/snap/SnapEngine.cpp
+++ b/src/snap/SnapEngine.cpp
@@ -3,6 +3,7 @@
 
 #include "SnapEngine.h"
 #include "autotile/AutotileEngine.h"
+#include "dbus/snapnavigationtargets.h"
 #include "dbus/zonedetectionadaptor.h"
 #include "core/virtualdesktopmanager.h"
 #include "core/windowtrackingservice.h"
@@ -25,6 +26,9 @@ SnapEngine::SnapEngine(LayoutManager* layoutManager, WindowTrackingService* wind
 {
 }
 
+// Out-of-line so unique_ptr<SnapNavigationTargetResolver> can destroy the
+// pimpl-style owned resolver without its full type being visible in the
+// header (forward-declared in SnapEngine.h).
 SnapEngine::~SnapEngine() = default;
 
 void SnapEngine::setAutotileEngine(AutotileEngine* engine)
@@ -35,6 +39,37 @@ void SnapEngine::setAutotileEngine(AutotileEngine* engine)
 void SnapEngine::setZoneDetectionAdaptor(ZoneDetectionAdaptor* adaptor)
 {
     m_zoneDetectionAdaptor = adaptor;
+    // Push the zone detector into the target resolver if it exists yet.
+    // The resolver constructs lazily on first navigation call; if that
+    // hasn't happened yet, ensureTargetResolver() will pick up the adaptor
+    // from m_zoneDetectionAdaptor when it first runs.
+    if (m_targetResolver) {
+        m_targetResolver->setZoneDetector(adaptor);
+    }
+}
+
+SnapNavigationTargetResolver* SnapEngine::ensureTargetResolver()
+{
+    if (m_targetResolver) {
+        return m_targetResolver.get();
+    }
+    if (!m_windowTracker || !m_layoutManager) {
+        qCWarning(lcCore) << "ensureTargetResolver: missing deps "
+                          << "windowTracker=" << static_cast<void*>(m_windowTracker)
+                          << "layoutManager=" << static_cast<void*>(m_layoutManager);
+        return nullptr;
+    }
+    // Feedback callback forwards into SnapEngine's own navigationFeedback
+    // signal — SnapAdaptor relays that to WindowTrackingAdaptor's D-Bus
+    // navigationFeedback signal, so external consumers see the same
+    // wire format as when the resolver lived on WTA.
+    m_targetResolver = std::make_unique<SnapNavigationTargetResolver>(
+        m_windowTracker, m_layoutManager, m_zoneDetectionAdaptor.data(),
+        [this](bool success, const QString& action, const QString& reason, const QString& sourceZoneId,
+               const QString& targetZoneId, const QString& screenId) {
+            Q_EMIT navigationFeedback(success, action, reason, sourceZoneId, targetZoneId, screenId);
+        });
+    return m_targetResolver.get();
 }
 
 void SnapEngine::setWindowTrackingAdaptor(WindowTrackingAdaptor* adaptor)

--- a/src/snap/SnapEngine.cpp
+++ b/src/snap/SnapEngine.cpp
@@ -46,6 +46,17 @@ void SnapEngine::setZoneDetectionAdaptor(ZoneDetectionAdaptor* adaptor)
     if (m_targetResolver) {
         m_targetResolver->setZoneDetector(adaptor);
     }
+    // Sever the resolver's raw pointer when the adaptor is destroyed
+    // out-of-band. Production always destroys the adaptor before the
+    // engine, but tests and shutdown orderings can diverge; without this
+    // the resolver would hold a dangling ZoneDetectionAdaptor*.
+    if (adaptor) {
+        connect(adaptor, &QObject::destroyed, this, [this]() {
+            if (m_targetResolver) {
+                m_targetResolver->setZoneDetector(nullptr);
+            }
+        });
+    }
 }
 
 SnapNavigationTargetResolver* SnapEngine::ensureTargetResolver(const QString& action)

--- a/src/snap/SnapEngine.cpp
+++ b/src/snap/SnapEngine.cpp
@@ -37,6 +37,11 @@ void SnapEngine::setZoneDetectionAdaptor(ZoneDetectionAdaptor* adaptor)
     m_zoneDetectionAdaptor = adaptor;
 }
 
+void SnapEngine::setWindowTrackingAdaptor(WindowTrackingAdaptor* adaptor)
+{
+    m_wta = adaptor;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // IEngineLifecycle implementation
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -68,7 +73,15 @@ void SnapEngine::windowFocused(const QString& windowId, const QString& screenId)
 }
 
 // toggleWindowFloat and setWindowFloat are implemented in snapengine/float.cpp
-// focusInDirection, swapInDirection, rotateWindows, moveToPosition are in snapengine/navigation.cpp
+// Navigation entry points (focusInDirection, moveFocusedInDirection,
+// swapFocusedInDirection, moveFocusedToPosition, pushFocusedToEmptyZone,
+// restoreFocusedWindow, toggleFocusedFloat, cycleFocus,
+// rotateWindowsInLayout, resnapCurrentAssignments, resnapToNewLayout)
+// live in snapengine/navigation_actions.cpp and call back into
+// WindowTrackingAdaptor via m_wta for target resolution and shared
+// bookkeeping helpers. The resnap-by-layout-switch pipeline
+// (calculateResnapEntriesFromAutotileOrder, snapAllWindows etc.) lives
+// in snapengine/navigation.cpp unchanged.
 
 void SnapEngine::assignToZones(const QString& windowId, const QStringList& zoneIds, const QString& screenId)
 {

--- a/src/snap/SnapEngine.cpp
+++ b/src/snap/SnapEngine.cpp
@@ -48,7 +48,7 @@ void SnapEngine::setZoneDetectionAdaptor(ZoneDetectionAdaptor* adaptor)
     }
 }
 
-SnapNavigationTargetResolver* SnapEngine::ensureTargetResolver()
+SnapNavigationTargetResolver* SnapEngine::ensureTargetResolver(const QString& action)
 {
     if (m_targetResolver) {
         return m_targetResolver.get();
@@ -57,6 +57,14 @@ SnapNavigationTargetResolver* SnapEngine::ensureTargetResolver()
         qCWarning(lcCore) << "ensureTargetResolver: missing deps "
                           << "windowTracker=" << static_cast<void*>(m_windowTracker)
                           << "layoutManager=" << static_cast<void*>(m_layoutManager);
+        if (!action.isEmpty()) {
+            // Surface a specific reason so the OSD doesn't silently swallow
+            // the shortcut. engine_unavailable is the canonical tag for
+            // "engine couldn't be built" — distinct from no_window /
+            // invalid_direction / excluded etc.
+            Q_EMIT navigationFeedback(false, action, QStringLiteral("engine_unavailable"), QString(), QString(),
+                                      QString());
+        }
         return nullptr;
     }
     // Feedback callback forwards into SnapEngine's own navigationFeedback
@@ -118,19 +126,12 @@ void SnapEngine::windowFocused(const QString& windowId, const QString& screenId)
 // (calculateResnapEntriesFromAutotileOrder, snapAllWindows etc.) lives
 // in snapengine/navigation.cpp unchanged.
 
-void SnapEngine::assignToZones(const QString& windowId, const QStringList& zoneIds, const QString& screenId)
-{
-    if (zoneIds.isEmpty()) {
-        qCWarning(lcCore) << "assignToZones: empty zoneIds for" << windowId << "- skipping";
-        return;
-    }
-    int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
-    if (zoneIds.size() > 1) {
-        m_windowTracker->assignWindowToZones(windowId, zoneIds, screenId, currentDesktop);
-    } else {
-        m_windowTracker->assignWindowToZone(windowId, zoneIds.first(), screenId, currentDesktop);
-    }
-}
+// SnapEngine::assignToZones was removed — its two callers (windowOpened
+// in lifecycle.cpp, unfloatToZone in float.cpp) now go through
+// WindowTrackingService::commitSnap / commitMultiZoneSnap which run the
+// full snap orchestration (clear floating, assign zone, emit state
+// change). The raw-assign path was the last thin wrapper that bypassed
+// the orchestration layer.
 
 void SnapEngine::saveState()
 {

--- a/src/snap/SnapEngine.h
+++ b/src/snap/SnapEngine.h
@@ -365,6 +365,12 @@ private:
     /// handle the null case themselves).
     SnapNavigationTargetResolver* ensureTargetResolver(const QString& action = QString());
 
+    /// Check whether the window is excluded from the given navigation
+    /// action by the user's excluded-apps / excluded-classes rules.
+    /// Emits navigationFeedback(false, action, "excluded", ...) and returns
+    /// true when excluded so callers can early-return. False otherwise.
+    bool isWindowExcludedForAction(const QString& windowId, const QString& action, const QString& screenId);
+
     // Persistence delegates (KConfig stays in adaptor layer)
     std::function<void()> m_saveFn;
     std::function<void()> m_loadFn;

--- a/src/snap/SnapEngine.h
+++ b/src/snap/SnapEngine.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
+#include "core/inavigationactions.h"
 #include "core/iwindowengine.h"
 #include "core/types.h"
 #include <dbus_types.h>
@@ -208,39 +209,45 @@ public:
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Navigation (moved out of WindowTrackingAdaptor)
+    //
+    // Every method takes a NavigationContext populated by the daemon's
+    // shortcut handler. The engine uses ctx.windowId directly rather than
+    // re-reading it from the WTA shadow, which is a step toward retiring
+    // the SnapEngine → WTA back-reference entirely. When ctx.windowId is
+    // empty, the engine may consult m_wta->lastActiveWindowId() as a
+    // best-effort fallback — but in the normal path the daemon always
+    // provides a resolved target.
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// Walk to the adjacent window in @p direction and transfer keyboard focus.
     /// Empty direction is a no-op with feedback.
-    void focusInDirection(const QString& direction);
+    void focusInDirection(const QString& direction, const NavigationContext& ctx);
 
     /// Move the focused window into the adjacent zone in @p direction
     /// (displacing or filling the target). Empty direction is a no-op.
-    void moveFocusedInDirection(const QString& direction);
+    void moveFocusedInDirection(const QString& direction, const NavigationContext& ctx);
 
     /// Swap the focused window with whatever's in the adjacent zone in
     /// @p direction. Empty direction is a no-op.
-    void swapFocusedInDirection(const QString& direction);
+    void swapFocusedInDirection(const QString& direction, const NavigationContext& ctx);
 
     /// Move the focused window to the layout zone with @p zoneNumber
-    /// (1-based) on @p screenId. Zone numbers outside [1,9] are rejected.
-    void moveFocusedToPosition(int zoneNumber, const QString& screenId);
+    /// (1-based) on ctx.screenId. Zone numbers outside [1,9] are rejected.
+    void moveFocusedToPosition(int zoneNumber, const NavigationContext& ctx);
 
-    /// Move the focused window to the first empty zone on @p screenId.
-    /// Empty screen id resolves from the active window.
-    void pushFocusedToEmptyZone(const QString& screenId);
+    /// Move the focused window to the first empty zone on ctx.screenId.
+    void pushFocusedToEmptyZone(const NavigationContext& ctx);
 
     /// Restore the focused window to its captured pre-snap size and unsnap.
-    void restoreFocusedWindow();
+    void restoreFocusedWindow(const NavigationContext& ctx);
 
     /// Toggle the focused window between snapped and floating.
-    /// Reads the active window from the WTA shadow.
-    void toggleFocusedFloat();
+    void toggleFocusedFloat(const NavigationContext& ctx);
 
     /// Cycle keyboard focus forward/backward through managed windows in
     /// the active zone (or the layout cycle order if single-window per
     /// zone).
-    void cycleFocus(bool forward);
+    void cycleFocus(bool forward, const NavigationContext& ctx);
 
     /// Rotate snapped windows through the layout's zone order on @p screenId.
     void rotateWindowsInLayout(bool clockwise, const QString& screenId);
@@ -338,16 +345,25 @@ private:
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Float helpers (snapengine/float.cpp)
+    //
+    // The historical clearFloatingStateForSnap / assignToZones pair was
+    // removed — all snap commits now route through
+    // WindowTrackingService::commitSnap / commitMultiZoneSnap.
     // ═══════════════════════════════════════════════════════════════════════════
 
     bool unfloatToZone(const QString& windowId, const QString& screenId);
     bool applyGeometryForFloat(const QString& windowId, const QString& screenId);
-    void clearFloatingStateForSnap(const QString& windowId, const QString& screenId);
-    void assignToZones(const QString& windowId, const QStringList& zoneIds, const QString& screenId);
 
     /// Lazy-constructs m_targetResolver on first call. Returns nullptr if
-    /// the service or layout manager is missing (tests with stub deps).
-    SnapNavigationTargetResolver* ensureTargetResolver();
+    /// the service or layout manager is missing (unit tests with stub
+    /// deps, or shutdown race where WTS/LayoutManager are already gone).
+    ///
+    /// When @p action is non-empty and the resolver can't be built, emits
+    /// navigationFeedback(false, action, "engine_unavailable", ...) so the
+    /// OSD shows a specific reason instead of a silent no-op. Pass an
+    /// empty @p action to skip the emit (for call sites that want to
+    /// handle the null case themselves).
+    SnapNavigationTargetResolver* ensureTargetResolver(const QString& action = QString());
 
     // Persistence delegates (KConfig stays in adaptor layer)
     std::function<void()> m_saveFn;

--- a/src/snap/SnapEngine.h
+++ b/src/snap/SnapEngine.h
@@ -13,6 +13,7 @@
 #include <QString>
 #include <QStringList>
 #include <functional>
+#include <memory>
 
 namespace PlasmaZones {
 
@@ -20,6 +21,7 @@ class AutotileEngine;
 class ISettings;
 class IZoneDetector;
 class LayoutManager;
+class SnapNavigationTargetResolver;
 class VirtualDesktopManager;
 class WindowTrackingAdaptor;
 class WindowTrackingService;
@@ -320,10 +322,19 @@ private:
     VirtualDesktopManager* m_virtualDesktopManager = nullptr;
     QPointer<AutotileEngine> m_autotileEngine;
     QPointer<ZoneDetectionAdaptor> m_zoneDetectionAdaptor;
-    // Back-reference to WindowTrackingAdaptor for shared-state access
-    // (target resolver, last-active shadow, bookkeeping helpers). Not
-    // owned. See setWindowTrackingAdaptor docstring for rationale.
+    // Back-reference to WindowTrackingAdaptor for state SnapEngine reads
+    // but doesn't own yet: the last-active-window / last-active-screen /
+    // last-cursor-screen shadows populated via D-Bus windowActivated and
+    // cursorScreenChanged slots, plus the frame-geometry shadow populated
+    // via setFrameGeometry. Not owned. Remaining uses are all read-only
+    // accessors — SnapEngine no longer routes BEHAVIOUR through WTA.
     QPointer<WindowTrackingAdaptor> m_wta;
+    // Snap-mode navigation target resolver. Owned by SnapEngine — moved
+    // here in Phase 5E from WindowTrackingAdaptor. Constructed lazily on
+    // first navigation call (so the construction order isn't constrained
+    // by the fact that SnapEngine has to exist before a resolver that
+    // takes WTS + LayoutManager can be built).
+    std::unique_ptr<SnapNavigationTargetResolver> m_targetResolver;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Float helpers (snapengine/float.cpp)
@@ -333,6 +344,10 @@ private:
     bool applyGeometryForFloat(const QString& windowId, const QString& screenId);
     void clearFloatingStateForSnap(const QString& windowId, const QString& screenId);
     void assignToZones(const QString& windowId, const QStringList& zoneIds, const QString& screenId);
+
+    /// Lazy-constructs m_targetResolver on first call. Returns nullptr if
+    /// the service or layout manager is missing (tests with stub deps).
+    SnapNavigationTargetResolver* ensureTargetResolver();
 
     // Persistence delegates (KConfig stays in adaptor layer)
     std::function<void()> m_saveFn;

--- a/src/snap/SnapEngine.h
+++ b/src/snap/SnapEngine.h
@@ -21,6 +21,7 @@ class ISettings;
 class IZoneDetector;
 class LayoutManager;
 class VirtualDesktopManager;
+class WindowTrackingAdaptor;
 class WindowTrackingService;
 class ZoneDetectionAdaptor;
 
@@ -178,6 +179,78 @@ public:
     void setZoneDetectionAdaptor(ZoneDetectionAdaptor* adaptor);
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // WindowTrackingAdaptor back-reference
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /**
+     * @brief Wire the shared WindowTrackingAdaptor back-reference.
+     *
+     * SnapEngine owns the snap-mode navigation logic (focusInDirection,
+     * moveFocusedInDirection, etc.) but some of the state those methods
+     * consult — the SnapNavigationTargetResolver, the last-active-window
+     * shadow, the frame-geometry shadow, and the snap-bookkeeping helpers
+     * (windowSnapped / windowUnsnapped / storePreTileGeometry / ...) —
+     * is still held on WindowTrackingAdaptor.
+     *
+     * This back-reference lets SnapEngine call into that state without
+     * duplicating it. A future refactor should either move the state to
+     * WindowTrackingService (for cross-cutting pieces like the bookkeeping
+     * helpers) or onto SnapEngine itself (for snap-only pieces like the
+     * target resolver) and retire this back-reference entirely. Until
+     * then it's the honest expression of the coupling.
+     *
+     * Must be set after construction and before any navigation method is
+     * called. Not owned; must outlive SnapEngine.
+     */
+    void setWindowTrackingAdaptor(WindowTrackingAdaptor* adaptor);
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Navigation (moved out of WindowTrackingAdaptor)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// Walk to the adjacent window in @p direction and transfer keyboard focus.
+    /// Empty direction is a no-op with feedback.
+    void focusInDirection(const QString& direction);
+
+    /// Move the focused window into the adjacent zone in @p direction
+    /// (displacing or filling the target). Empty direction is a no-op.
+    void moveFocusedInDirection(const QString& direction);
+
+    /// Swap the focused window with whatever's in the adjacent zone in
+    /// @p direction. Empty direction is a no-op.
+    void swapFocusedInDirection(const QString& direction);
+
+    /// Move the focused window to the layout zone with @p zoneNumber
+    /// (1-based) on @p screenId. Zone numbers outside [1,9] are rejected.
+    void moveFocusedToPosition(int zoneNumber, const QString& screenId);
+
+    /// Move the focused window to the first empty zone on @p screenId.
+    /// Empty screen id resolves from the active window.
+    void pushFocusedToEmptyZone(const QString& screenId);
+
+    /// Restore the focused window to its captured pre-snap size and unsnap.
+    void restoreFocusedWindow();
+
+    /// Toggle the focused window between snapped and floating.
+    /// Reads the active window from the WTA shadow.
+    void toggleFocusedFloat();
+
+    /// Cycle keyboard focus forward/backward through managed windows in
+    /// the active zone (or the layout cycle order if single-window per
+    /// zone).
+    void cycleFocus(bool forward);
+
+    /// Rotate snapped windows through the layout's zone order on @p screenId.
+    void rotateWindowsInLayout(bool clockwise, const QString& screenId);
+
+    // Note: resnapToNewLayout() and resnapCurrentAssignments(const QString&)
+    // already exist above — they live in snapengine/navigation.cpp and go
+    // through the emitBatchedResnap → resnapToNewLayoutRequested signal
+    // relay, which WTA's handleBatchedResnap consumes. The navigation-from-
+    // shortcuts entry points in daemon/navigation.cpp forward to those
+    // existing methods via SnapNavigationAdapter::reapplyLayout().
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // Persistence delegate
     // ═══════════════════════════════════════════════════════════════════════════
 
@@ -228,6 +301,17 @@ Q_SIGNALS:
     /// Request KWin effect to collect unsnapped windows and snap them all
     void snapAllWindowsRequested(const QString& screenId);
 
+    /// Batch of window-geometry updates, applied by the KWin effect in a
+    /// single operation (rotate, resnap, snap-all paths). The @p action
+    /// label disambiguates the cause downstream ("rotate", "resnap",
+    /// "snap_all", "vs_reconfigure"). Relayed to D-Bus via WTA.
+    void applyGeometriesBatch(const PlasmaZones::WindowGeometryList& geometries, const QString& action);
+
+    /// Request KWin effect to activate (raise + focus) @p windowId.
+    /// Used by focus-in-direction and cycle operations. Relayed to D-Bus
+    /// via WTA.
+    void activateWindowRequested(const QString& windowId);
+
 private:
     LayoutManager* m_layoutManager = nullptr;
     WindowTrackingService* m_windowTracker = nullptr;
@@ -236,6 +320,10 @@ private:
     VirtualDesktopManager* m_virtualDesktopManager = nullptr;
     QPointer<AutotileEngine> m_autotileEngine;
     QPointer<ZoneDetectionAdaptor> m_zoneDetectionAdaptor;
+    // Back-reference to WindowTrackingAdaptor for shared-state access
+    // (target resolver, last-active shadow, bookkeeping helpers). Not
+    // owned. See setWindowTrackingAdaptor docstring for rationale.
+    QPointer<WindowTrackingAdaptor> m_wta;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Float helpers (snapengine/float.cpp)

--- a/src/snap/snapengine/float.cpp
+++ b/src/snap/snapengine/float.cpp
@@ -79,14 +79,25 @@ bool SnapEngine::unfloatToZone(const QString& windowId, const QString& screenId)
         return false;
     }
 
-    m_windowTracker->setWindowFloating(windowId, false);
-    m_windowTracker->clearPreFloatZone(windowId);
-    // Consume any saved snap-float entry — the window is being explicitly zone-snapped,
-    // so it should not be restored as floating during a future mode transition.
+    // Consume any saved snap-float entry — the window is being explicitly
+    // zone-snapped, so it should not be restored as floating during a
+    // future mode transition. This is a float-specific side effect that
+    // doesn't belong in commitSnap's generic orchestration.
     m_windowTracker->restoreSnapFloating(windowId); // consumes and discards
-    assignToZones(windowId, unfloat.zoneIds, unfloat.screenId);
 
-    Q_EMIT windowFloatingChanged(windowId, false, unfloat.screenId);
+    // Commit the snap via the unified orchestration. User-initiated because
+    // the user just toggled float off — they want this snap to update the
+    // last-used-zone tracking. commitSnap handles clearing floating state
+    // (and emits windowFloatingClearedForSnap which WTA relays as
+    // windowFloatingChanged), plus the zone assignment.
+    if (unfloat.zoneIds.size() > 1) {
+        m_windowTracker->commitMultiZoneSnap(windowId, unfloat.zoneIds, unfloat.screenId,
+                                             WindowTrackingService::SnapIntent::UserInitiated);
+    } else {
+        m_windowTracker->commitSnap(windowId, unfloat.zoneIds.first(), unfloat.screenId,
+                                    WindowTrackingService::SnapIntent::UserInitiated);
+    }
+
     Q_EMIT applyGeometryRequested(windowId, unfloat.geometry.x(), unfloat.geometry.y(), unfloat.geometry.width(),
                                   unfloat.geometry.height(), QString(), unfloat.screenId, false);
     return true;
@@ -105,11 +116,11 @@ bool SnapEngine::applyGeometryForFloat(const QString& windowId, const QString& s
     return false;
 }
 
-void SnapEngine::clearFloatingStateForSnap(const QString& windowId, const QString& screenId)
-{
-    if (m_windowTracker->clearFloatingForSnap(windowId)) {
-        Q_EMIT windowFloatingChanged(windowId, false, screenId);
-    }
-}
+// SnapEngine::clearFloatingStateForSnap was removed — its two callers
+// (windowOpened in lifecycle.cpp, unfloatToZone above) now go through
+// WindowTrackingService::commitSnap which handles clearing floating
+// state as step 1 of its orchestration. The D-Bus-visible behaviour is
+// identical: commitSnap emits windowFloatingClearedForSnap, WTA relays
+// it as windowFloatingChanged on the same D-Bus interface.
 
 } // namespace PlasmaZones

--- a/src/snap/snapengine/lifecycle.cpp
+++ b/src/snap/snapengine/lifecycle.cpp
@@ -46,10 +46,23 @@ void SnapEngine::windowOpened(const QString& windowId, const QString& screenId, 
         return;
     }
 
-    // Apply: mark auto-snapped, clear floating state, assign to zone(s)
+    // Apply: mark as auto-snapped first so the flag persists through
+    // commitSnap (AutoRestored intent leaves it alone). Then commit via
+    // the unified orchestration — clear floating, assign to zone(s),
+    // emit windowSnapStateChanged / windowFloatingClearedForSnap as
+    // appropriate. consumePendingAssignment is NOT called here because
+    // resolveWindowRestore already consumed its entry (see
+    // calculateRestoreFromSession + the explicit consume on line 147
+    // above). Last-used-zone update is skipped by AutoRestored intent.
     m_windowTracker->markAsAutoSnapped(windowId);
-    clearFloatingStateForSnap(windowId, result.screenId);
-    assignToZones(windowId, result.zoneIds.isEmpty() ? QStringList{result.zoneId} : result.zoneIds, result.screenId);
+    const QStringList zoneIds = result.zoneIds.isEmpty() ? QStringList{result.zoneId} : result.zoneIds;
+    if (zoneIds.size() > 1) {
+        m_windowTracker->commitMultiZoneSnap(windowId, zoneIds, result.screenId,
+                                             WindowTrackingService::SnapIntent::AutoRestored);
+    } else {
+        m_windowTracker->commitSnap(windowId, zoneIds.first(), result.screenId,
+                                    WindowTrackingService::SnapIntent::AutoRestored);
+    }
 
     // Emit geometry for KWin effect to apply
     Q_EMIT applyGeometryRequested(windowId, result.geometry.x(), result.geometry.y(), result.geometry.width(),

--- a/src/snap/snapengine/navigation_actions.cpp
+++ b/src/snap/snapengine/navigation_actions.cpp
@@ -11,15 +11,13 @@
  * facade class. That violated "the adaptor is a thin facade" and made
  * the daemon branch on mode at every shortcut handler.
  *
- * Navigation is now SnapEngine's concern. The body of each method is
- * essentially the same as the WTA version — it still calls into the
- * SnapNavigationTargetResolver, the WindowTrackingService, and the
- * snap-mode bookkeeping helpers — but those are now accessed through
- * the WTA back-reference (m_wta) for state that hasn't been migrated
- * yet (target resolver, last-active shadow, frame-geometry shadow,
- * bookkeeping helpers). Future refactors should continue moving state
- * into either SnapEngine or WindowTrackingService and retire the
- * back-reference.
+ * Navigation is now SnapEngine's concern. Every entry point takes an
+ * explicit NavigationContext {windowId, screenId} from the daemon's
+ * shortcut handler, so the engine no longer reaches into the WTA shadow
+ * store on every call. The back-reference to WTA is retained for last-
+ * resort fallback (when the daemon can't resolve a target), for the
+ * frame-geometry shadow used by the float pre-tile capture, and for
+ * the resnap fallback-screen helper in applyBatchAssignments.
  *
  * Signals emitted by these methods are SnapEngine signals; SnapAdaptor
  * relays them to WindowTrackingAdaptor, which exposes them on D-Bus.
@@ -41,9 +39,6 @@
 #include "../../dbus/windowtrackingadaptor.h"
 #include "shared/virtualscreenid.h"
 
-#include <QGuiApplication>
-#include <QScreen>
-
 namespace PlasmaZones {
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -53,30 +48,41 @@ namespace PlasmaZones {
 namespace {
 
 /// Resolve the screen to use for a navigation operation on @p windowId.
-/// Prefers the stored screen assignment for snapped windows (so the
-/// operation stays on the monitor the user originally chose, rather than
-/// the one KWin happens to think the window is on). Falls back to the
-/// active cursor/focus screen from the WTA shadow.
-QString resolveNavScreen(const WindowTrackingAdaptor* wta, const QString& windowId, WindowTrackingService* service)
+///
+/// Prefers (in order):
+///   1. The stored screen assignment for the window (if currently snapped).
+///      This keeps the operation on the monitor the user originally chose,
+///      rather than the one KWin happens to think the window is on.
+///   2. An explicit @p preferredScreen from the NavigationContext.
+///   3. The WTA cursor / last-active screen shadows.
+QString resolveNavScreen(const WindowTrackingAdaptor* wta, const QString& windowId, WindowTrackingService* service,
+                         const QString& preferredScreen = QString())
 {
-    // Snapped window — trust the stored screen when it's still reachable.
-    const QString zoneId = service->zoneForWindow(windowId);
-    if (!zoneId.isEmpty()) {
-        const QString storedScreen = service->screenAssignments().value(windowId);
-        if (!storedScreen.isEmpty()) {
-            if (VirtualScreenId::isVirtual(storedScreen)) {
-                const QString physId = VirtualScreenId::extractPhysicalId(storedScreen);
-                QScreen* physScreen = Utils::findScreenByIdOrName(physId);
-                if (physScreen) {
-                    auto* mgr = ScreenManager::instance();
-                    if (mgr && mgr->effectiveScreenIds().contains(storedScreen)) {
-                        return storedScreen;
+    if (service && !windowId.isEmpty()) {
+        const QString zoneId = service->zoneForWindow(windowId);
+        if (!zoneId.isEmpty()) {
+            const QString storedScreen = service->screenAssignments().value(windowId);
+            if (!storedScreen.isEmpty()) {
+                if (VirtualScreenId::isVirtual(storedScreen)) {
+                    const QString physId = VirtualScreenId::extractPhysicalId(storedScreen);
+                    QScreen* physScreen = Utils::findScreenByIdOrName(physId);
+                    if (physScreen) {
+                        auto* mgr = ScreenManager::instance();
+                        if (mgr && mgr->effectiveScreenIds().contains(storedScreen)) {
+                            return storedScreen;
+                        }
                     }
+                } else if (Utils::findScreenByIdOrName(storedScreen)) {
+                    return storedScreen;
                 }
-            } else if (Utils::findScreenByIdOrName(storedScreen)) {
-                return storedScreen;
             }
         }
+    }
+    if (!preferredScreen.isEmpty()) {
+        return preferredScreen;
+    }
+    if (!wta) {
+        return QString();
     }
     QString screen = wta->lastCursorScreenName();
     if (screen.isEmpty()) {
@@ -85,57 +91,25 @@ QString resolveNavScreen(const WindowTrackingAdaptor* wta, const QString& window
     return screen;
 }
 
-/// Apply a vector of ZoneAssignmentEntry: do snap bookkeeping per entry,
-/// build a batch geometry list, and emit it via @p engine's
-/// applyGeometriesBatch signal. Shared by rotate, resnap, and
-/// resnap-current paths.
-bool processBatchEntries(SnapEngine* engine, WindowTrackingService* service, WindowTrackingAdaptor* wta,
-                         const QVector<ZoneAssignmentEntry>& entries, const QString& action)
+/// Pick the effective window id: the explicit one from NavigationContext
+/// if set, otherwise the last-active shadow on WTA. Returns empty when
+/// neither is available — caller emits "no_window" feedback.
+QString effectiveWindowId(const NavigationContext& ctx, const WindowTrackingAdaptor* wta)
 {
-    if (entries.isEmpty()) {
-        return false;
+    if (!ctx.windowId.isEmpty()) {
+        return ctx.windowId;
     }
+    return wta ? wta->lastActiveWindowId() : QString();
+}
 
-    for (const auto& entry : entries) {
-        if (entry.targetZoneId == QLatin1String("__restore__")) {
-            service->uncommitSnap(entry.windowId);
-            service->clearPreTileGeometry(entry.windowId);
-        } else {
-            QString screenId = entry.targetScreenId;
-            QPoint center = entry.targetGeometry.center();
-            auto* mgr = ScreenManager::instance();
-            if (screenId.isEmpty() && mgr) {
-                screenId = mgr->effectiveScreenAt(center);
-            }
-            if (screenId.isEmpty()) {
-                for (QScreen* screen : QGuiApplication::screens()) {
-                    if (screen->geometry().contains(center)) {
-                        screenId = Utils::screenIdentifier(screen);
-                        break;
-                    }
-                }
-            }
-            if (screenId.isEmpty()) {
-                screenId = wta->lastCursorScreenName();
-                if (screenId.isEmpty()) {
-                    screenId = wta->lastActiveScreenName();
-                }
-            }
-            if (entry.targetZoneIds.size() > 1) {
-                service->commitMultiZoneSnap(entry.windowId, entry.targetZoneIds, screenId);
-            } else {
-                service->commitSnap(entry.windowId, entry.targetZoneId, screenId);
-            }
-        }
+/// Pick the effective screen id: the explicit one from NavigationContext
+/// if set, otherwise the last-active screen shadow on WTA.
+QString effectiveScreenId(const NavigationContext& ctx, const WindowTrackingAdaptor* wta)
+{
+    if (!ctx.screenId.isEmpty()) {
+        return ctx.screenId;
     }
-
-    WindowGeometryList geometries;
-    geometries.reserve(entries.size());
-    for (const ZoneAssignmentEntry& entry : entries) {
-        geometries.append(WindowGeometryEntry::fromRect(entry.windowId, entry.targetGeometry));
-    }
-    Q_EMIT engine->applyGeometriesBatch(geometries, action);
-    return true;
+    return wta ? wta->lastActiveScreenName() : QString();
 }
 
 bool isWindowExcludedForAction(const ISettings* settings, WindowTrackingService* service, const QString& windowId,
@@ -170,28 +144,30 @@ bool isWindowExcludedForAction(const ISettings* settings, WindowTrackingService*
 // Navigation entry points
 // ═══════════════════════════════════════════════════════════════════════════════
 
-void SnapEngine::focusInDirection(const QString& direction)
+void SnapEngine::focusInDirection(const QString& direction, const NavigationContext& ctx)
 {
     qCInfo(lcCore) << "SnapEngine::focusInDirection:" << direction;
-    if (!m_wta || !m_windowTracker) {
-        return;
-    }
-    auto* resolver = ensureTargetResolver();
-    if (!resolver) {
+    if (!m_windowTracker) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("focus"), QStringLiteral("engine_unavailable"), QString(),
+                                  QString(), ctx.screenId);
         return;
     }
     if (direction.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("focus"), QStringLiteral("invalid_direction"), QString(),
-                                  QString(), QString());
+                                  QString(), ctx.screenId);
         return;
     }
-    const QString windowId = m_wta->lastActiveWindowId();
+    auto* resolver = ensureTargetResolver(QStringLiteral("focus"));
+    if (!resolver) {
+        return; // ensureTargetResolver emitted feedback
+    }
+    const QString windowId = effectiveWindowId(ctx, m_wta);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("focus"), QStringLiteral("no_window"), QString(), QString(),
-                                  m_wta->lastActiveScreenName());
+                                  ctx.screenId);
         return;
     }
-    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker);
+    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
     FocusTargetResult result = resolver->getFocusTargetForWindow(windowId, direction, screenId);
     if (!result.success) {
         return; // resolver already emitted feedback via its callback
@@ -201,32 +177,33 @@ void SnapEngine::focusInDirection(const QString& direction)
     }
 }
 
-void SnapEngine::moveFocusedInDirection(const QString& direction)
+void SnapEngine::moveFocusedInDirection(const QString& direction, const NavigationContext& ctx)
 {
     qCInfo(lcCore) << "SnapEngine::moveFocusedInDirection:" << direction;
-    if (!m_wta || !m_windowTracker) {
-        return;
-    }
-    auto* resolver = ensureTargetResolver();
-    if (!resolver) {
+    if (!m_windowTracker) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("move"), QStringLiteral("engine_unavailable"), QString(),
+                                  QString(), ctx.screenId);
         return;
     }
     if (direction.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("move"), QStringLiteral("invalid_direction"), QString(),
-                                  QString(), QString());
+                                  QString(), ctx.screenId);
         return;
     }
-    const QString windowId = m_wta->lastActiveWindowId();
+    auto* resolver = ensureTargetResolver(QStringLiteral("move"));
+    if (!resolver) {
+        return;
+    }
+    const QString windowId = effectiveWindowId(ctx, m_wta);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("move"), QStringLiteral("no_window"), QString(), QString(),
-                                  m_wta->lastActiveScreenName());
+                                  ctx.screenId);
         return;
     }
-    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("move"), this,
-                                  m_wta->lastActiveScreenName())) {
+    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("move"), this, ctx.screenId)) {
         return;
     }
-    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker);
+    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
     MoveTargetResult result = resolver->getMoveTargetForWindow(windowId, direction, screenId);
     if (!result.success) {
         return;
@@ -242,32 +219,33 @@ void SnapEngine::moveFocusedInDirection(const QString& direction)
                                   result.screenName, false);
 }
 
-void SnapEngine::swapFocusedInDirection(const QString& direction)
+void SnapEngine::swapFocusedInDirection(const QString& direction, const NavigationContext& ctx)
 {
     qCInfo(lcCore) << "SnapEngine::swapFocusedInDirection:" << direction;
-    if (!m_wta || !m_windowTracker) {
-        return;
-    }
-    auto* resolver = ensureTargetResolver();
-    if (!resolver) {
+    if (!m_windowTracker) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("swap"), QStringLiteral("engine_unavailable"), QString(),
+                                  QString(), ctx.screenId);
         return;
     }
     if (direction.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("swap"), QStringLiteral("invalid_direction"), QString(),
-                                  QString(), QString());
+                                  QString(), ctx.screenId);
         return;
     }
-    const QString windowId = m_wta->lastActiveWindowId();
+    auto* resolver = ensureTargetResolver(QStringLiteral("swap"));
+    if (!resolver) {
+        return;
+    }
+    const QString windowId = effectiveWindowId(ctx, m_wta);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("swap"), QStringLiteral("no_window"), QString(), QString(),
-                                  m_wta->lastActiveScreenName());
+                                  ctx.screenId);
         return;
     }
-    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("swap"), this,
-                                  m_wta->lastActiveScreenName())) {
+    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("swap"), this, ctx.screenId)) {
         return;
     }
-    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker);
+    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
     SwapTargetResult result = resolver->getSwapTargetForWindow(windowId, direction, screenId);
     if (!result.success) {
         return;
@@ -289,33 +267,34 @@ void SnapEngine::swapFocusedInDirection(const QString& direction)
     }
 }
 
-void SnapEngine::moveFocusedToPosition(int zoneNumber, const QString& screenId)
+void SnapEngine::moveFocusedToPosition(int zoneNumber, const NavigationContext& ctx)
 {
-    qCInfo(lcCore) << "SnapEngine::moveFocusedToPosition: zone" << zoneNumber << "screen" << screenId;
-    if (!m_wta || !m_windowTracker) {
-        return;
-    }
-    auto* resolver = ensureTargetResolver();
-    if (!resolver) {
+    qCInfo(lcCore) << "SnapEngine::moveFocusedToPosition: zone" << zoneNumber << "screen" << ctx.screenId;
+    if (!m_windowTracker) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("snap"), QStringLiteral("engine_unavailable"), QString(),
+                                  QString(), ctx.screenId);
         return;
     }
     if (zoneNumber < 1 || zoneNumber > 9) {
         qCWarning(lcCore) << "SnapEngine::moveFocusedToPosition: invalid zone number" << zoneNumber;
         Q_EMIT navigationFeedback(false, QStringLiteral("snap"), QStringLiteral("invalid_zone_number"), QString(),
-                                  QString(), QString());
+                                  QString(), ctx.screenId);
         return;
     }
-    const QString windowId = m_wta->lastActiveWindowId();
+    auto* resolver = ensureTargetResolver(QStringLiteral("snap"));
+    if (!resolver) {
+        return;
+    }
+    const QString windowId = effectiveWindowId(ctx, m_wta);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("snap"), QStringLiteral("no_window"), QString(), QString(),
-                                  screenId.isEmpty() ? m_wta->lastActiveScreenName() : screenId);
+                                  effectiveScreenId(ctx, m_wta));
         return;
     }
-    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("snap"), this,
-                                  m_wta->lastActiveScreenName())) {
+    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("snap"), this, ctx.screenId)) {
         return;
     }
-    const QString effectiveScreen = screenId.isEmpty() ? resolveNavScreen(m_wta, windowId, m_windowTracker) : screenId;
+    const QString effectiveScreen = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
     MoveTargetResult result = resolver->getSnapToZoneByNumberTarget(windowId, zoneNumber, effectiveScreen);
     if (!result.success) {
         return;
@@ -331,27 +310,28 @@ void SnapEngine::moveFocusedToPosition(int zoneNumber, const QString& screenId)
                                   false);
 }
 
-void SnapEngine::pushFocusedToEmptyZone(const QString& screenId)
+void SnapEngine::pushFocusedToEmptyZone(const NavigationContext& ctx)
 {
-    qCInfo(lcCore) << "SnapEngine::pushFocusedToEmptyZone: screen" << screenId;
-    if (!m_wta || !m_windowTracker) {
+    qCInfo(lcCore) << "SnapEngine::pushFocusedToEmptyZone: screen" << ctx.screenId;
+    if (!m_windowTracker) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("push"), QStringLiteral("engine_unavailable"), QString(),
+                                  QString(), ctx.screenId);
         return;
     }
-    auto* resolver = ensureTargetResolver();
+    auto* resolver = ensureTargetResolver(QStringLiteral("push"));
     if (!resolver) {
         return;
     }
-    const QString windowId = m_wta->lastActiveWindowId();
+    const QString windowId = effectiveWindowId(ctx, m_wta);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("push"), QStringLiteral("no_window"), QString(), QString(),
-                                  screenId.isEmpty() ? m_wta->lastActiveScreenName() : screenId);
+                                  effectiveScreenId(ctx, m_wta));
         return;
     }
-    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("push"), this,
-                                  m_wta->lastActiveScreenName())) {
+    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("push"), this, ctx.screenId)) {
         return;
     }
-    const QString effectiveScreen = screenId.isEmpty() ? resolveNavScreen(m_wta, windowId, m_windowTracker) : screenId;
+    const QString effectiveScreen = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
     MoveTargetResult result = resolver->getPushTargetForWindow(windowId, effectiveScreen);
     if (!result.success) {
         return;
@@ -367,23 +347,25 @@ void SnapEngine::pushFocusedToEmptyZone(const QString& screenId)
                                   false);
 }
 
-void SnapEngine::restoreFocusedWindow()
+void SnapEngine::restoreFocusedWindow(const NavigationContext& ctx)
 {
     qCInfo(lcCore) << "SnapEngine::restoreFocusedWindow";
-    if (!m_wta || !m_windowTracker) {
+    if (!m_windowTracker) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("restore"), QStringLiteral("engine_unavailable"), QString(),
+                                  QString(), ctx.screenId);
         return;
     }
-    auto* resolver = ensureTargetResolver();
+    auto* resolver = ensureTargetResolver(QStringLiteral("restore"));
     if (!resolver) {
         return;
     }
-    const QString windowId = m_wta->lastActiveWindowId();
+    const QString windowId = effectiveWindowId(ctx, m_wta);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("restore"), QStringLiteral("no_window"), QString(), QString(),
-                                  m_wta->lastActiveScreenName());
+                                  effectiveScreenId(ctx, m_wta));
         return;
     }
-    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker);
+    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
     RestoreTargetResult result = resolver->getRestoreForWindow(windowId, screenId);
     if (!result.success) {
         return;
@@ -394,16 +376,18 @@ void SnapEngine::restoreFocusedWindow()
                                   false);
 }
 
-void SnapEngine::toggleFocusedFloat()
+void SnapEngine::toggleFocusedFloat(const NavigationContext& ctx)
 {
     qCInfo(lcCore) << "SnapEngine::toggleFocusedFloat";
-    if (!m_wta || !m_windowTracker) {
+    if (!m_windowTracker) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("float"), QStringLiteral("engine_unavailable"), QString(),
+                                  QString(), ctx.screenId);
         return;
     }
-    const QString windowId = m_wta->lastActiveWindowId();
-    const QString screenId = m_wta->lastActiveScreenName();
+    const QString windowId = effectiveWindowId(ctx, m_wta);
+    const QString screenId = effectiveScreenId(ctx, m_wta);
     if (windowId.isEmpty() || screenId.isEmpty()) {
-        qCInfo(lcCore) << "toggleFocusedFloat: no active window in shadow";
+        qCInfo(lcCore) << "toggleFocusedFloat: no active window in context";
         Q_EMIT navigationFeedback(false, QStringLiteral("float"), QStringLiteral("no_active_window"), QString(),
                                   QString(), screenId);
         return;
@@ -416,7 +400,11 @@ void SnapEngine::toggleFocusedFloat()
     // window is snapped/tiled, the live shadow holds the zone rect — storing
     // it would poison the pre-tile entry with tile coordinates, so we leave
     // whatever's already stored untouched.
-    if (m_windowTracker->isWindowFloating(windowId)) {
+    //
+    // The frame-geometry shadow is the one compositor-layer piece of state
+    // still living on WTA. Reading it here is the last remaining behavior
+    // coupling to the adaptor in this file.
+    if (m_wta && m_windowTracker->isWindowFloating(windowId)) {
         const QRect geo = m_wta->frameGeometry(windowId);
         if (geo.isValid()) {
             m_windowTracker->storePreTileGeometry(windowId, geo, screenId, /*overwrite=*/true);
@@ -425,28 +413,29 @@ void SnapEngine::toggleFocusedFloat()
 
     // Dispatch to the IEngineLifecycle toggle path (SnapEngine::toggleWindowFloat
     // lives in snapengine/float.cpp). No need to route through WTA —
-    // the screen has already been selected by the caller (router dispatched
-    // to us because this is a snap-mode screen).
+    // the router already ensured this screen is snap-mode.
     toggleWindowFloat(windowId, screenId);
 }
 
-void SnapEngine::cycleFocus(bool forward)
+void SnapEngine::cycleFocus(bool forward, const NavigationContext& ctx)
 {
     qCInfo(lcCore) << "SnapEngine::cycleFocus: forward=" << forward;
-    if (!m_wta || !m_windowTracker) {
+    if (!m_windowTracker) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("cycle"), QStringLiteral("engine_unavailable"), QString(),
+                                  QString(), ctx.screenId);
         return;
     }
-    auto* resolver = ensureTargetResolver();
+    auto* resolver = ensureTargetResolver(QStringLiteral("cycle"));
     if (!resolver) {
         return;
     }
-    const QString windowId = m_wta->lastActiveWindowId();
+    const QString windowId = effectiveWindowId(ctx, m_wta);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("cycle"), QStringLiteral("no_window"), QString(), QString(),
-                                  m_wta->lastActiveScreenName());
+                                  effectiveScreenId(ctx, m_wta));
         return;
     }
-    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker);
+    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
     CycleTargetResult result = resolver->getCycleTargetForWindow(windowId, forward, screenId);
     if (!result.success) {
         return;
@@ -459,7 +448,9 @@ void SnapEngine::cycleFocus(bool forward)
 void SnapEngine::rotateWindowsInLayout(bool clockwise, const QString& screenId)
 {
     qCDebug(lcCore) << "SnapEngine::rotateWindowsInLayout: clockwise=" << clockwise << "screen=" << screenId;
-    if (!m_wta || !m_windowTracker || !m_layoutManager) {
+    if (!m_windowTracker || !m_layoutManager) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("rotate"), QStringLiteral("engine_unavailable"), QString(),
+                                  QString(), screenId);
         return;
     }
     QVector<ZoneAssignmentEntry> entries = m_windowTracker->calculateRotation(clockwise, screenId);
@@ -477,7 +468,26 @@ void SnapEngine::rotateWindowsInLayout(bool clockwise, const QString& screenId)
         }
         return;
     }
-    processBatchEntries(this, m_windowTracker, m_wta, entries, QStringLiteral("rotate"));
+
+    // Apply the batch through WTS's unified helper. UserInitiated intent
+    // preserves historical rotate semantics (each windows snap updates
+    // last-used-zone). The fallback resolver is the compositor-layer
+    // cursor/active-window shadow on WTA — only used when none of the
+    // built-in strategies (targetScreenId / geometry.center() /
+    // QGuiApplication::screens()) yield a screen.
+    const QPointer<WindowTrackingAdaptor> wta = m_wta;
+    WindowGeometryList geometries = m_windowTracker->applyBatchAssignments(
+        entries, WindowTrackingService::SnapIntent::UserInitiated, [wta]() -> QString {
+            if (!wta) {
+                return QString();
+            }
+            const QString cursor = wta->lastCursorScreenName();
+            return cursor.isEmpty() ? wta->lastActiveScreenName() : cursor;
+        });
+    if (!geometries.isEmpty()) {
+        Q_EMIT applyGeometriesBatch(geometries, QStringLiteral("rotate"));
+    }
+
     const QString direction = clockwise ? QStringLiteral("clockwise") : QStringLiteral("counterclockwise");
     const QString reason = QStringLiteral("%1:%2").arg(direction).arg(entries.size());
     Q_EMIT navigationFeedback(true, QStringLiteral("rotate"), reason, entries.first().sourceZoneId,

--- a/src/snap/snapengine/navigation_actions.cpp
+++ b/src/snap/snapengine/navigation_actions.cpp
@@ -112,33 +112,30 @@ QString effectiveScreenId(const NavigationContext& ctx, const WindowTrackingAdap
     return wta ? wta->lastActiveScreenName() : QString();
 }
 
-bool isWindowExcludedForAction(const ISettings* settings, WindowTrackingService* service, const QString& windowId,
-                               const QString& action, SnapEngine* engine, const QString& lastActiveScreenId)
+} // namespace
+
+bool SnapEngine::isWindowExcludedForAction(const QString& windowId, const QString& action, const QString& screenId)
 {
-    if (!settings) {
+    if (!m_settings || !m_windowTracker) {
         return false;
     }
-    const QString appId = service->currentAppIdFor(windowId);
-    for (const QString& excluded : settings->excludedApplications()) {
+    const QString appId = m_windowTracker->currentAppIdFor(windowId);
+    for (const QString& excluded : m_settings->excludedApplications()) {
         if (Utils::appIdMatches(appId, excluded)) {
             qCInfo(lcCore) << action << ":" << windowId << "excluded by app rule:" << excluded;
-            Q_EMIT engine->navigationFeedback(false, action, QStringLiteral("excluded"), appId, QString(),
-                                              lastActiveScreenId);
+            Q_EMIT navigationFeedback(false, action, QStringLiteral("excluded"), appId, QString(), screenId);
             return true;
         }
     }
-    for (const QString& excluded : settings->excludedWindowClasses()) {
+    for (const QString& excluded : m_settings->excludedWindowClasses()) {
         if (Utils::appIdMatches(appId, excluded)) {
             qCInfo(lcCore) << action << ":" << windowId << "excluded by class rule:" << excluded;
-            Q_EMIT engine->navigationFeedback(false, action, QStringLiteral("excluded"), appId, QString(),
-                                              lastActiveScreenId);
+            Q_EMIT navigationFeedback(false, action, QStringLiteral("excluded"), appId, QString(), screenId);
             return true;
         }
     }
     return false;
 }
-
-} // namespace
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Navigation entry points
@@ -200,7 +197,7 @@ void SnapEngine::moveFocusedInDirection(const QString& direction, const Navigati
                                   ctx.screenId);
         return;
     }
-    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("move"), this, ctx.screenId)) {
+    if (isWindowExcludedForAction(windowId, QStringLiteral("move"), ctx.screenId)) {
         return;
     }
     const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
@@ -242,7 +239,7 @@ void SnapEngine::swapFocusedInDirection(const QString& direction, const Navigati
                                   ctx.screenId);
         return;
     }
-    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("swap"), this, ctx.screenId)) {
+    if (isWindowExcludedForAction(windowId, QStringLiteral("swap"), ctx.screenId)) {
         return;
     }
     const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
@@ -291,7 +288,7 @@ void SnapEngine::moveFocusedToPosition(int zoneNumber, const NavigationContext& 
                                   effectiveScreenId(ctx, m_wta));
         return;
     }
-    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("snap"), this, ctx.screenId)) {
+    if (isWindowExcludedForAction(windowId, QStringLiteral("snap"), ctx.screenId)) {
         return;
     }
     const QString effectiveScreen = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
@@ -328,7 +325,7 @@ void SnapEngine::pushFocusedToEmptyZone(const NavigationContext& ctx)
                                   effectiveScreenId(ctx, m_wta));
         return;
     }
-    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("push"), this, ctx.screenId)) {
+    if (isWindowExcludedForAction(windowId, QStringLiteral("push"), ctx.screenId)) {
         return;
     }
     const QString effectiveScreen = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);

--- a/src/snap/snapengine/navigation_actions.cpp
+++ b/src/snap/snapengine/navigation_actions.cpp
@@ -397,15 +397,37 @@ void SnapEngine::restoreFocusedWindow()
 void SnapEngine::toggleFocusedFloat()
 {
     qCInfo(lcCore) << "SnapEngine::toggleFocusedFloat";
-    if (!m_wta) {
+    if (!m_wta || !m_windowTracker) {
         return;
     }
-    // Delegates to the WTA-side toggleWindowFloat which owns the frame-
-    // geometry shadow and the pre-tile geometry capture logic for the
-    // "currently floating" branch. Moving that state surgery into SnapEngine
-    // is a follow-up; for now the entry point lives here so the navigator
-    // dispatch stays uniform.
-    m_wta->toggleWindowFloat();
+    const QString windowId = m_wta->lastActiveWindowId();
+    const QString screenId = m_wta->lastActiveScreenName();
+    if (windowId.isEmpty() || screenId.isEmpty()) {
+        qCInfo(lcCore) << "toggleFocusedFloat: no active window in shadow";
+        Q_EMIT navigationFeedback(false, QStringLiteral("float"), QStringLiteral("no_active_window"), QString(),
+                                  QString(), screenId);
+        return;
+    }
+
+    // Pre-tile capture semantics (from the historical WTA::toggleWindowFloat
+    // implementation): when the window is CURRENTLY floating, its live frame
+    // geometry is a valid free-float position and we capture it so the next
+    // un-float restores to the user's most recent floated location. When the
+    // window is snapped/tiled, the live shadow holds the zone rect — storing
+    // it would poison the pre-tile entry with tile coordinates, so we leave
+    // whatever's already stored untouched.
+    if (m_windowTracker->isWindowFloating(windowId)) {
+        const QRect geo = m_wta->frameGeometry(windowId);
+        if (geo.isValid()) {
+            m_windowTracker->storePreTileGeometry(windowId, geo, screenId, /*overwrite=*/true);
+        }
+    }
+
+    // Dispatch to the IEngineLifecycle toggle path (SnapEngine::toggleWindowFloat
+    // lives in snapengine/float.cpp). No need to route through WTA —
+    // the screen has already been selected by the caller (router dispatched
+    // to us because this is a snap-mode screen).
+    toggleWindowFloat(windowId, screenId);
 }
 
 void SnapEngine::cycleFocus(bool forward)

--- a/src/snap/snapengine/navigation_actions.cpp
+++ b/src/snap/snapengine/navigation_actions.cpp
@@ -176,7 +176,7 @@ void SnapEngine::focusInDirection(const QString& direction)
     if (!m_wta || !m_windowTracker) {
         return;
     }
-    auto* resolver = m_wta->targetResolver();
+    auto* resolver = ensureTargetResolver();
     if (!resolver) {
         return;
     }
@@ -207,7 +207,7 @@ void SnapEngine::moveFocusedInDirection(const QString& direction)
     if (!m_wta || !m_windowTracker) {
         return;
     }
-    auto* resolver = m_wta->targetResolver();
+    auto* resolver = ensureTargetResolver();
     if (!resolver) {
         return;
     }
@@ -248,7 +248,7 @@ void SnapEngine::swapFocusedInDirection(const QString& direction)
     if (!m_wta || !m_windowTracker) {
         return;
     }
-    auto* resolver = m_wta->targetResolver();
+    auto* resolver = ensureTargetResolver();
     if (!resolver) {
         return;
     }
@@ -295,7 +295,7 @@ void SnapEngine::moveFocusedToPosition(int zoneNumber, const QString& screenId)
     if (!m_wta || !m_windowTracker) {
         return;
     }
-    auto* resolver = m_wta->targetResolver();
+    auto* resolver = ensureTargetResolver();
     if (!resolver) {
         return;
     }
@@ -337,7 +337,7 @@ void SnapEngine::pushFocusedToEmptyZone(const QString& screenId)
     if (!m_wta || !m_windowTracker) {
         return;
     }
-    auto* resolver = m_wta->targetResolver();
+    auto* resolver = ensureTargetResolver();
     if (!resolver) {
         return;
     }
@@ -373,7 +373,7 @@ void SnapEngine::restoreFocusedWindow()
     if (!m_wta || !m_windowTracker) {
         return;
     }
-    auto* resolver = m_wta->targetResolver();
+    auto* resolver = ensureTargetResolver();
     if (!resolver) {
         return;
     }
@@ -436,7 +436,7 @@ void SnapEngine::cycleFocus(bool forward)
     if (!m_wta || !m_windowTracker) {
         return;
     }
-    auto* resolver = m_wta->targetResolver();
+    auto* resolver = ensureTargetResolver();
     if (!resolver) {
         return;
     }

--- a/src/snap/snapengine/navigation_actions.cpp
+++ b/src/snap/snapengine/navigation_actions.cpp
@@ -1,0 +1,469 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file navigation_actions.cpp
+ * @brief Snap-mode navigation entry points moved out of WindowTrackingAdaptor.
+ *
+ * Before the Phase 5 cleanup these methods lived on WindowTrackingAdaptor,
+ * which had grown into a partial engine: target resolution, feedback
+ * emission, bookkeeping, and zone-routing logic all sat in the D-Bus
+ * facade class. That violated "the adaptor is a thin facade" and made
+ * the daemon branch on mode at every shortcut handler.
+ *
+ * Navigation is now SnapEngine's concern. The body of each method is
+ * essentially the same as the WTA version — it still calls into the
+ * SnapNavigationTargetResolver, the WindowTrackingService, and the
+ * snap-mode bookkeeping helpers — but those are now accessed through
+ * the WTA back-reference (m_wta) for state that hasn't been migrated
+ * yet (target resolver, last-active shadow, frame-geometry shadow,
+ * bookkeeping helpers). Future refactors should continue moving state
+ * into either SnapEngine or WindowTrackingService and retire the
+ * back-reference.
+ *
+ * Signals emitted by these methods are SnapEngine signals; SnapAdaptor
+ * relays them to WindowTrackingAdaptor, which exposes them on D-Bus.
+ */
+
+#include "../SnapEngine.h"
+
+#include "../../config/settings.h"
+#include "../../core/interfaces.h"
+#include "../../core/layout.h"
+#include "../../core/layoutmanager.h"
+#include "../../core/logging.h"
+#include "../../core/screenmanager.h"
+#include "../../core/utils.h"
+#include "../../core/virtualdesktopmanager.h"
+#include "../../core/virtualscreen.h"
+#include "../../core/windowtrackingservice.h"
+#include "../../dbus/snapnavigationtargets.h"
+#include "../../dbus/windowtrackingadaptor.h"
+#include "shared/virtualscreenid.h"
+
+#include <QGuiApplication>
+#include <QScreen>
+
+namespace PlasmaZones {
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Private helpers
+// ═══════════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+/// Resolve the screen to use for a navigation operation on @p windowId.
+/// Prefers the stored screen assignment for snapped windows (so the
+/// operation stays on the monitor the user originally chose, rather than
+/// the one KWin happens to think the window is on). Falls back to the
+/// active cursor/focus screen from the WTA shadow.
+QString resolveNavScreen(const WindowTrackingAdaptor* wta, const QString& windowId, WindowTrackingService* service)
+{
+    // Snapped window — trust the stored screen when it's still reachable.
+    const QString zoneId = service->zoneForWindow(windowId);
+    if (!zoneId.isEmpty()) {
+        const QString storedScreen = service->screenAssignments().value(windowId);
+        if (!storedScreen.isEmpty()) {
+            if (VirtualScreenId::isVirtual(storedScreen)) {
+                const QString physId = VirtualScreenId::extractPhysicalId(storedScreen);
+                QScreen* physScreen = Utils::findScreenByIdOrName(physId);
+                if (physScreen) {
+                    auto* mgr = ScreenManager::instance();
+                    if (mgr && mgr->effectiveScreenIds().contains(storedScreen)) {
+                        return storedScreen;
+                    }
+                }
+            } else if (Utils::findScreenByIdOrName(storedScreen)) {
+                return storedScreen;
+            }
+        }
+    }
+    QString screen = wta->lastCursorScreenName();
+    if (screen.isEmpty()) {
+        screen = wta->lastActiveScreenName();
+    }
+    return screen;
+}
+
+/// Apply a vector of ZoneAssignmentEntry: do snap bookkeeping per entry,
+/// build a batch geometry list, and emit it via @p emitBatch. Shared by
+/// rotate, resnap, and resnap-current paths.
+bool processBatchEntries(SnapEngine* engine, WindowTrackingAdaptor* wta, const QVector<ZoneAssignmentEntry>& entries,
+                         const QString& action)
+{
+    if (entries.isEmpty()) {
+        return false;
+    }
+
+    for (const auto& entry : entries) {
+        if (entry.targetZoneId == QLatin1String("__restore__")) {
+            wta->windowUnsnapped(entry.windowId);
+            wta->clearPreTileGeometry(entry.windowId);
+        } else {
+            QString screenId = entry.targetScreenId;
+            QPoint center = entry.targetGeometry.center();
+            auto* mgr = ScreenManager::instance();
+            if (screenId.isEmpty() && mgr) {
+                screenId = mgr->effectiveScreenAt(center);
+            }
+            if (screenId.isEmpty()) {
+                for (QScreen* screen : QGuiApplication::screens()) {
+                    if (screen->geometry().contains(center)) {
+                        screenId = Utils::screenIdentifier(screen);
+                        break;
+                    }
+                }
+            }
+            if (screenId.isEmpty()) {
+                screenId = wta->lastCursorScreenName();
+                if (screenId.isEmpty()) {
+                    screenId = wta->lastActiveScreenName();
+                }
+            }
+            if (entry.targetZoneIds.size() > 1) {
+                wta->windowSnappedMultiZone(entry.windowId, entry.targetZoneIds, screenId);
+            } else {
+                wta->windowSnapped(entry.windowId, entry.targetZoneId, screenId);
+            }
+        }
+    }
+
+    WindowGeometryList geometries;
+    geometries.reserve(entries.size());
+    for (const ZoneAssignmentEntry& entry : entries) {
+        geometries.append(WindowGeometryEntry::fromRect(entry.windowId, entry.targetGeometry));
+    }
+    Q_EMIT engine->applyGeometriesBatch(geometries, action);
+    return true;
+}
+
+bool isWindowExcludedForAction(const ISettings* settings, WindowTrackingService* service, const QString& windowId,
+                               const QString& action, SnapEngine* engine, const QString& lastActiveScreenId)
+{
+    if (!settings) {
+        return false;
+    }
+    const QString appId = service->currentAppIdFor(windowId);
+    for (const QString& excluded : settings->excludedApplications()) {
+        if (Utils::appIdMatches(appId, excluded)) {
+            qCInfo(lcCore) << action << ":" << windowId << "excluded by app rule:" << excluded;
+            Q_EMIT engine->navigationFeedback(false, action, QStringLiteral("excluded"), appId, QString(),
+                                              lastActiveScreenId);
+            return true;
+        }
+    }
+    for (const QString& excluded : settings->excludedWindowClasses()) {
+        if (Utils::appIdMatches(appId, excluded)) {
+            qCInfo(lcCore) << action << ":" << windowId << "excluded by class rule:" << excluded;
+            Q_EMIT engine->navigationFeedback(false, action, QStringLiteral("excluded"), appId, QString(),
+                                              lastActiveScreenId);
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Navigation entry points
+// ═══════════════════════════════════════════════════════════════════════════════
+
+void SnapEngine::focusInDirection(const QString& direction)
+{
+    qCInfo(lcCore) << "SnapEngine::focusInDirection:" << direction;
+    if (!m_wta || !m_windowTracker) {
+        return;
+    }
+    auto* resolver = m_wta->targetResolver();
+    if (!resolver) {
+        return;
+    }
+    if (direction.isEmpty()) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("focus"), QStringLiteral("invalid_direction"), QString(),
+                                  QString(), QString());
+        return;
+    }
+    const QString windowId = m_wta->lastActiveWindowId();
+    if (windowId.isEmpty()) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("focus"), QStringLiteral("no_window"), QString(), QString(),
+                                  m_wta->lastActiveScreenName());
+        return;
+    }
+    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker);
+    FocusTargetResult result = resolver->getFocusTargetForWindow(windowId, direction, screenId);
+    if (!result.success) {
+        return; // resolver already emitted feedback via its callback
+    }
+    if (!result.windowIdToActivate.isEmpty()) {
+        Q_EMIT activateWindowRequested(result.windowIdToActivate);
+    }
+}
+
+void SnapEngine::moveFocusedInDirection(const QString& direction)
+{
+    qCInfo(lcCore) << "SnapEngine::moveFocusedInDirection:" << direction;
+    if (!m_wta || !m_windowTracker) {
+        return;
+    }
+    auto* resolver = m_wta->targetResolver();
+    if (!resolver) {
+        return;
+    }
+    if (direction.isEmpty()) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("move"), QStringLiteral("invalid_direction"), QString(),
+                                  QString(), QString());
+        return;
+    }
+    const QString windowId = m_wta->lastActiveWindowId();
+    if (windowId.isEmpty()) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("move"), QStringLiteral("no_window"), QString(), QString(),
+                                  m_wta->lastActiveScreenName());
+        return;
+    }
+    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("move"), this,
+                                  m_wta->lastActiveScreenName())) {
+        return;
+    }
+    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker);
+    MoveTargetResult result = resolver->getMoveTargetForWindow(windowId, direction, screenId);
+    if (!result.success) {
+        return;
+    }
+    const QRect geo = result.toRect();
+    if (!geo.isValid()) {
+        qCWarning(lcCore) << "SnapEngine::moveFocusedInDirection: invalid geometry from nav result";
+        return;
+    }
+    m_wta->windowSnapped(windowId, result.zoneId, result.screenName);
+    m_wta->recordSnapIntent(windowId, true);
+    Q_EMIT applyGeometryRequested(windowId, geo.x(), geo.y(), geo.width(), geo.height(), result.zoneId,
+                                  result.screenName, false);
+}
+
+void SnapEngine::swapFocusedInDirection(const QString& direction)
+{
+    qCInfo(lcCore) << "SnapEngine::swapFocusedInDirection:" << direction;
+    if (!m_wta || !m_windowTracker) {
+        return;
+    }
+    auto* resolver = m_wta->targetResolver();
+    if (!resolver) {
+        return;
+    }
+    if (direction.isEmpty()) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("swap"), QStringLiteral("invalid_direction"), QString(),
+                                  QString(), QString());
+        return;
+    }
+    const QString windowId = m_wta->lastActiveWindowId();
+    if (windowId.isEmpty()) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("swap"), QStringLiteral("no_window"), QString(), QString(),
+                                  m_wta->lastActiveScreenName());
+        return;
+    }
+    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("swap"), this,
+                                  m_wta->lastActiveScreenName())) {
+        return;
+    }
+    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker);
+    SwapTargetResult result = resolver->getSwapTargetForWindow(windowId, direction, screenId);
+    if (!result.success) {
+        return;
+    }
+    m_wta->windowSnapped(result.windowId1, result.zoneId1, result.screenName);
+    m_wta->recordSnapIntent(result.windowId1, true);
+    Q_EMIT applyGeometryRequested(result.windowId1, result.x1, result.y1, result.w1, result.h1, result.zoneId1,
+                                  result.screenName, false);
+
+    if (!result.windowId2.isEmpty()) {
+        QString screen2 = m_windowTracker->screenAssignments().value(result.windowId2);
+        if (screen2.isEmpty()) {
+            screen2 = result.screenName;
+        }
+        m_wta->windowSnapped(result.windowId2, result.zoneId2, screen2);
+        m_wta->recordSnapIntent(result.windowId2, true);
+        Q_EMIT applyGeometryRequested(result.windowId2, result.x2, result.y2, result.w2, result.h2, result.zoneId2,
+                                      screen2, false);
+    }
+}
+
+void SnapEngine::moveFocusedToPosition(int zoneNumber, const QString& screenId)
+{
+    qCInfo(lcCore) << "SnapEngine::moveFocusedToPosition: zone" << zoneNumber << "screen" << screenId;
+    if (!m_wta || !m_windowTracker) {
+        return;
+    }
+    auto* resolver = m_wta->targetResolver();
+    if (!resolver) {
+        return;
+    }
+    if (zoneNumber < 1 || zoneNumber > 9) {
+        qCWarning(lcCore) << "SnapEngine::moveFocusedToPosition: invalid zone number" << zoneNumber;
+        Q_EMIT navigationFeedback(false, QStringLiteral("snap"), QStringLiteral("invalid_zone_number"), QString(),
+                                  QString(), QString());
+        return;
+    }
+    const QString windowId = m_wta->lastActiveWindowId();
+    if (windowId.isEmpty()) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("snap"), QStringLiteral("no_window"), QString(), QString(),
+                                  screenId.isEmpty() ? m_wta->lastActiveScreenName() : screenId);
+        return;
+    }
+    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("snap"), this,
+                                  m_wta->lastActiveScreenName())) {
+        return;
+    }
+    const QString effectiveScreen = screenId.isEmpty() ? resolveNavScreen(m_wta, windowId, m_windowTracker) : screenId;
+    MoveTargetResult result = resolver->getSnapToZoneByNumberTarget(windowId, zoneNumber, effectiveScreen);
+    if (!result.success) {
+        return;
+    }
+    const QRect geo = result.toRect();
+    if (!geo.isValid()) {
+        qCWarning(lcCore) << "SnapEngine::moveFocusedToPosition: invalid geometry from nav result";
+        return;
+    }
+    m_wta->windowSnapped(windowId, result.zoneId, effectiveScreen);
+    m_wta->recordSnapIntent(windowId, true);
+    Q_EMIT applyGeometryRequested(windowId, geo.x(), geo.y(), geo.width(), geo.height(), result.zoneId, effectiveScreen,
+                                  false);
+}
+
+void SnapEngine::pushFocusedToEmptyZone(const QString& screenId)
+{
+    qCInfo(lcCore) << "SnapEngine::pushFocusedToEmptyZone: screen" << screenId;
+    if (!m_wta || !m_windowTracker) {
+        return;
+    }
+    auto* resolver = m_wta->targetResolver();
+    if (!resolver) {
+        return;
+    }
+    const QString windowId = m_wta->lastActiveWindowId();
+    if (windowId.isEmpty()) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("push"), QStringLiteral("no_window"), QString(), QString(),
+                                  screenId.isEmpty() ? m_wta->lastActiveScreenName() : screenId);
+        return;
+    }
+    if (isWindowExcludedForAction(m_settings, m_windowTracker, windowId, QStringLiteral("push"), this,
+                                  m_wta->lastActiveScreenName())) {
+        return;
+    }
+    const QString effectiveScreen = screenId.isEmpty() ? resolveNavScreen(m_wta, windowId, m_windowTracker) : screenId;
+    MoveTargetResult result = resolver->getPushTargetForWindow(windowId, effectiveScreen);
+    if (!result.success) {
+        return;
+    }
+    const QRect geo = result.toRect();
+    if (!geo.isValid()) {
+        qCWarning(lcCore) << "SnapEngine::pushFocusedToEmptyZone: invalid geometry from nav result";
+        return;
+    }
+    m_wta->windowSnapped(windowId, result.zoneId, effectiveScreen);
+    m_wta->recordSnapIntent(windowId, true);
+    Q_EMIT applyGeometryRequested(windowId, geo.x(), geo.y(), geo.width(), geo.height(), result.zoneId, effectiveScreen,
+                                  false);
+}
+
+void SnapEngine::restoreFocusedWindow()
+{
+    qCInfo(lcCore) << "SnapEngine::restoreFocusedWindow";
+    if (!m_wta || !m_windowTracker) {
+        return;
+    }
+    auto* resolver = m_wta->targetResolver();
+    if (!resolver) {
+        return;
+    }
+    const QString windowId = m_wta->lastActiveWindowId();
+    if (windowId.isEmpty()) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("restore"), QStringLiteral("no_window"), QString(), QString(),
+                                  m_wta->lastActiveScreenName());
+        return;
+    }
+    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker);
+    RestoreTargetResult result = resolver->getRestoreForWindow(windowId, screenId);
+    if (!result.success) {
+        return;
+    }
+    m_wta->windowUnsnapped(windowId);
+    m_wta->clearPreTileGeometry(windowId);
+    Q_EMIT applyGeometryRequested(windowId, result.x, result.y, result.width, result.height, QString(), screenId,
+                                  false);
+}
+
+void SnapEngine::toggleFocusedFloat()
+{
+    qCInfo(lcCore) << "SnapEngine::toggleFocusedFloat";
+    if (!m_wta) {
+        return;
+    }
+    // Delegates to the WTA-side toggleWindowFloat which owns the frame-
+    // geometry shadow and the pre-tile geometry capture logic for the
+    // "currently floating" branch. Moving that state surgery into SnapEngine
+    // is a follow-up; for now the entry point lives here so the navigator
+    // dispatch stays uniform.
+    m_wta->toggleWindowFloat();
+}
+
+void SnapEngine::cycleFocus(bool forward)
+{
+    qCInfo(lcCore) << "SnapEngine::cycleFocus: forward=" << forward;
+    if (!m_wta || !m_windowTracker) {
+        return;
+    }
+    auto* resolver = m_wta->targetResolver();
+    if (!resolver) {
+        return;
+    }
+    const QString windowId = m_wta->lastActiveWindowId();
+    if (windowId.isEmpty()) {
+        Q_EMIT navigationFeedback(false, QStringLiteral("cycle"), QStringLiteral("no_window"), QString(), QString(),
+                                  m_wta->lastActiveScreenName());
+        return;
+    }
+    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker);
+    CycleTargetResult result = resolver->getCycleTargetForWindow(windowId, forward, screenId);
+    if (!result.success) {
+        return;
+    }
+    if (!result.windowIdToActivate.isEmpty()) {
+        Q_EMIT activateWindowRequested(result.windowIdToActivate);
+    }
+}
+
+void SnapEngine::rotateWindowsInLayout(bool clockwise, const QString& screenId)
+{
+    qCDebug(lcCore) << "SnapEngine::rotateWindowsInLayout: clockwise=" << clockwise << "screen=" << screenId;
+    if (!m_wta || !m_windowTracker || !m_layoutManager) {
+        return;
+    }
+    QVector<ZoneAssignmentEntry> entries = m_windowTracker->calculateRotation(clockwise, screenId);
+    if (entries.isEmpty()) {
+        auto* layout = m_layoutManager->resolveLayoutForScreen(screenId);
+        if (!layout) {
+            Q_EMIT navigationFeedback(false, QStringLiteral("rotate"), QStringLiteral("no_active_layout"), QString(),
+                                      QString(), screenId);
+        } else if (layout->zoneCount() < 2) {
+            Q_EMIT navigationFeedback(false, QStringLiteral("rotate"), QStringLiteral("single_zone"), QString(),
+                                      QString(), screenId);
+        } else {
+            Q_EMIT navigationFeedback(false, QStringLiteral("rotate"), QStringLiteral("no_snapped_windows"), QString(),
+                                      QString(), screenId);
+        }
+        return;
+    }
+    processBatchEntries(this, m_wta, entries, QStringLiteral("rotate"));
+    const QString direction = clockwise ? QStringLiteral("clockwise") : QStringLiteral("counterclockwise");
+    const QString reason = QStringLiteral("%1:%2").arg(direction).arg(entries.size());
+    Q_EMIT navigationFeedback(true, QStringLiteral("rotate"), reason, entries.first().sourceZoneId,
+                              entries.first().targetZoneId, screenId);
+}
+
+// Note: resnapToNewLayout() and resnapCurrentAssignments(const QString&)
+// live in snapengine/navigation.cpp. They existed before this file and use
+// the emitBatchedResnap → resnapToNewLayoutRequested → WTA::handleBatchedResnap
+// pipeline, which remains the canonical batch-resnap path.
+
+} // namespace PlasmaZones

--- a/src/snap/snapengine/navigation_actions.cpp
+++ b/src/snap/snapengine/navigation_actions.cpp
@@ -86,10 +86,11 @@ QString resolveNavScreen(const WindowTrackingAdaptor* wta, const QString& window
 }
 
 /// Apply a vector of ZoneAssignmentEntry: do snap bookkeeping per entry,
-/// build a batch geometry list, and emit it via @p emitBatch. Shared by
-/// rotate, resnap, and resnap-current paths.
-bool processBatchEntries(SnapEngine* engine, WindowTrackingAdaptor* wta, const QVector<ZoneAssignmentEntry>& entries,
-                         const QString& action)
+/// build a batch geometry list, and emit it via @p engine's
+/// applyGeometriesBatch signal. Shared by rotate, resnap, and
+/// resnap-current paths.
+bool processBatchEntries(SnapEngine* engine, WindowTrackingService* service, WindowTrackingAdaptor* wta,
+                         const QVector<ZoneAssignmentEntry>& entries, const QString& action)
 {
     if (entries.isEmpty()) {
         return false;
@@ -97,8 +98,8 @@ bool processBatchEntries(SnapEngine* engine, WindowTrackingAdaptor* wta, const Q
 
     for (const auto& entry : entries) {
         if (entry.targetZoneId == QLatin1String("__restore__")) {
-            wta->windowUnsnapped(entry.windowId);
-            wta->clearPreTileGeometry(entry.windowId);
+            service->uncommitSnap(entry.windowId);
+            service->clearPreTileGeometry(entry.windowId);
         } else {
             QString screenId = entry.targetScreenId;
             QPoint center = entry.targetGeometry.center();
@@ -121,9 +122,9 @@ bool processBatchEntries(SnapEngine* engine, WindowTrackingAdaptor* wta, const Q
                 }
             }
             if (entry.targetZoneIds.size() > 1) {
-                wta->windowSnappedMultiZone(entry.windowId, entry.targetZoneIds, screenId);
+                service->commitMultiZoneSnap(entry.windowId, entry.targetZoneIds, screenId);
             } else {
-                wta->windowSnapped(entry.windowId, entry.targetZoneId, screenId);
+                service->commitSnap(entry.windowId, entry.targetZoneId, screenId);
             }
         }
     }
@@ -235,8 +236,8 @@ void SnapEngine::moveFocusedInDirection(const QString& direction)
         qCWarning(lcCore) << "SnapEngine::moveFocusedInDirection: invalid geometry from nav result";
         return;
     }
-    m_wta->windowSnapped(windowId, result.zoneId, result.screenName);
-    m_wta->recordSnapIntent(windowId, true);
+    m_windowTracker->commitSnap(windowId, result.zoneId, result.screenName);
+    m_windowTracker->recordSnapIntent(windowId, true);
     Q_EMIT applyGeometryRequested(windowId, geo.x(), geo.y(), geo.width(), geo.height(), result.zoneId,
                                   result.screenName, false);
 }
@@ -271,8 +272,8 @@ void SnapEngine::swapFocusedInDirection(const QString& direction)
     if (!result.success) {
         return;
     }
-    m_wta->windowSnapped(result.windowId1, result.zoneId1, result.screenName);
-    m_wta->recordSnapIntent(result.windowId1, true);
+    m_windowTracker->commitSnap(result.windowId1, result.zoneId1, result.screenName);
+    m_windowTracker->recordSnapIntent(result.windowId1, true);
     Q_EMIT applyGeometryRequested(result.windowId1, result.x1, result.y1, result.w1, result.h1, result.zoneId1,
                                   result.screenName, false);
 
@@ -281,8 +282,8 @@ void SnapEngine::swapFocusedInDirection(const QString& direction)
         if (screen2.isEmpty()) {
             screen2 = result.screenName;
         }
-        m_wta->windowSnapped(result.windowId2, result.zoneId2, screen2);
-        m_wta->recordSnapIntent(result.windowId2, true);
+        m_windowTracker->commitSnap(result.windowId2, result.zoneId2, screen2);
+        m_windowTracker->recordSnapIntent(result.windowId2, true);
         Q_EMIT applyGeometryRequested(result.windowId2, result.x2, result.y2, result.w2, result.h2, result.zoneId2,
                                       screen2, false);
     }
@@ -324,8 +325,8 @@ void SnapEngine::moveFocusedToPosition(int zoneNumber, const QString& screenId)
         qCWarning(lcCore) << "SnapEngine::moveFocusedToPosition: invalid geometry from nav result";
         return;
     }
-    m_wta->windowSnapped(windowId, result.zoneId, effectiveScreen);
-    m_wta->recordSnapIntent(windowId, true);
+    m_windowTracker->commitSnap(windowId, result.zoneId, effectiveScreen);
+    m_windowTracker->recordSnapIntent(windowId, true);
     Q_EMIT applyGeometryRequested(windowId, geo.x(), geo.y(), geo.width(), geo.height(), result.zoneId, effectiveScreen,
                                   false);
 }
@@ -360,8 +361,8 @@ void SnapEngine::pushFocusedToEmptyZone(const QString& screenId)
         qCWarning(lcCore) << "SnapEngine::pushFocusedToEmptyZone: invalid geometry from nav result";
         return;
     }
-    m_wta->windowSnapped(windowId, result.zoneId, effectiveScreen);
-    m_wta->recordSnapIntent(windowId, true);
+    m_windowTracker->commitSnap(windowId, result.zoneId, effectiveScreen);
+    m_windowTracker->recordSnapIntent(windowId, true);
     Q_EMIT applyGeometryRequested(windowId, geo.x(), geo.y(), geo.width(), geo.height(), result.zoneId, effectiveScreen,
                                   false);
 }
@@ -387,8 +388,8 @@ void SnapEngine::restoreFocusedWindow()
     if (!result.success) {
         return;
     }
-    m_wta->windowUnsnapped(windowId);
-    m_wta->clearPreTileGeometry(windowId);
+    m_windowTracker->uncommitSnap(windowId);
+    m_windowTracker->clearPreTileGeometry(windowId);
     Q_EMIT applyGeometryRequested(windowId, result.x, result.y, result.width, result.height, QString(), screenId,
                                   false);
 }
@@ -454,7 +455,7 @@ void SnapEngine::rotateWindowsInLayout(bool clockwise, const QString& screenId)
         }
         return;
     }
-    processBatchEntries(this, m_wta, entries, QStringLiteral("rotate"));
+    processBatchEntries(this, m_windowTracker, m_wta, entries, QStringLiteral("rotate"));
     const QString direction = clockwise ? QStringLiteral("clockwise") : QStringLiteral("counterclockwise");
     const QString reason = QStringLiteral("%1:%2").arg(direction).arg(entries.size());
     Q_EMIT navigationFeedback(true, QStringLiteral("rotate"), reason, entries.first().sourceZoneId,

--- a/src/snap/snapnavigationadapter.cpp
+++ b/src/snap/snapnavigationadapter.cpp
@@ -3,89 +3,89 @@
 
 #include "snapnavigationadapter.h"
 
-#include "../dbus/windowtrackingadaptor.h"
+#include "SnapEngine.h"
 
 namespace PlasmaZones {
 
-SnapNavigationAdapter::SnapNavigationAdapter(WindowTrackingAdaptor* adaptor)
-    : m_adaptor(adaptor)
+SnapNavigationAdapter::SnapNavigationAdapter(SnapEngine* engine)
+    : m_engine(engine)
 {
 }
 
 void SnapNavigationAdapter::focusInDirection(const QString& direction, const QString& /*screenId*/)
 {
-    if (m_adaptor) {
-        m_adaptor->focusAdjacentZone(direction);
+    if (m_engine) {
+        m_engine->focusInDirection(direction);
     }
 }
 
 void SnapNavigationAdapter::moveFocusedInDirection(const QString& direction, const QString& /*screenId*/)
 {
-    if (m_adaptor) {
-        m_adaptor->moveWindowToAdjacentZone(direction);
+    if (m_engine) {
+        m_engine->moveFocusedInDirection(direction);
     }
 }
 
 void SnapNavigationAdapter::swapFocusedInDirection(const QString& direction, const QString& /*screenId*/)
 {
-    if (m_adaptor) {
-        m_adaptor->swapWindowWithAdjacentZone(direction);
+    if (m_engine) {
+        m_engine->swapFocusedInDirection(direction);
     }
 }
 
 void SnapNavigationAdapter::moveFocusedToPosition(int position, const QString& screenId)
 {
-    if (m_adaptor) {
-        m_adaptor->snapToZoneByNumber(position, screenId);
+    if (m_engine) {
+        m_engine->moveFocusedToPosition(position, screenId);
     }
 }
 
 void SnapNavigationAdapter::rotateWindows(bool clockwise, const QString& screenId)
 {
-    if (m_adaptor) {
-        m_adaptor->rotateWindowsInLayout(clockwise, screenId);
+    if (m_engine) {
+        m_engine->rotateWindowsInLayout(clockwise, screenId);
     }
 }
 
 void SnapNavigationAdapter::reapplyLayout(const QString& /*screenId*/)
 {
-    if (m_adaptor) {
-        m_adaptor->resnapToNewLayout();
+    if (m_engine) {
+        m_engine->resnapToNewLayout();
     }
 }
 
 void SnapNavigationAdapter::snapAllWindows(const QString& screenId)
 {
-    if (m_adaptor) {
-        m_adaptor->snapAllWindows(screenId);
+    if (m_engine) {
+        m_engine->snapAllWindows(screenId);
     }
 }
 
 void SnapNavigationAdapter::toggleFocusedFloat(const QString& /*screenId*/)
 {
-    if (m_adaptor) {
-        m_adaptor->toggleWindowFloat();
+    if (m_engine) {
+        m_engine->toggleFocusedFloat();
     }
 }
 
 void SnapNavigationAdapter::cycleFocus(bool forward, const QString& /*screenId*/)
 {
-    if (m_adaptor) {
-        m_adaptor->cycleWindowsInZone(forward);
+    if (m_engine) {
+        m_engine->cycleFocus(forward);
     }
 }
 
 void SnapNavigationAdapter::pushToEmptyZone(const QString& screenId)
 {
-    if (m_adaptor) {
-        m_adaptor->pushToEmptyZone(screenId);
+    if (m_engine) {
+        m_engine->pushFocusedToEmptyZone(screenId);
     }
 }
 
 void SnapNavigationAdapter::restoreFocusedWindow(const QString& /*screenId*/)
 {
-    if (m_adaptor) {
-        m_adaptor->restoreWindowSize();
+    if (m_engine) {
+        m_engine->restoreFocusedWindow();
     }
 }
 

--- a/src/snap/snapnavigationadapter.cpp
+++ b/src/snap/snapnavigationadapter.cpp
@@ -12,80 +12,80 @@ SnapNavigationAdapter::SnapNavigationAdapter(SnapEngine* engine)
 {
 }
 
-void SnapNavigationAdapter::focusInDirection(const QString& direction, const QString& /*screenId*/)
+void SnapNavigationAdapter::focusInDirection(const QString& direction, const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->focusInDirection(direction);
+        m_engine->focusInDirection(direction, ctx);
     }
 }
 
-void SnapNavigationAdapter::moveFocusedInDirection(const QString& direction, const QString& /*screenId*/)
+void SnapNavigationAdapter::moveFocusedInDirection(const QString& direction, const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->moveFocusedInDirection(direction);
+        m_engine->moveFocusedInDirection(direction, ctx);
     }
 }
 
-void SnapNavigationAdapter::swapFocusedInDirection(const QString& direction, const QString& /*screenId*/)
+void SnapNavigationAdapter::swapFocusedInDirection(const QString& direction, const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->swapFocusedInDirection(direction);
+        m_engine->swapFocusedInDirection(direction, ctx);
     }
 }
 
-void SnapNavigationAdapter::moveFocusedToPosition(int position, const QString& screenId)
+void SnapNavigationAdapter::moveFocusedToPosition(int position, const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->moveFocusedToPosition(position, screenId);
+        m_engine->moveFocusedToPosition(position, ctx);
     }
 }
 
-void SnapNavigationAdapter::rotateWindows(bool clockwise, const QString& screenId)
+void SnapNavigationAdapter::rotateWindows(bool clockwise, const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->rotateWindowsInLayout(clockwise, screenId);
+        m_engine->rotateWindowsInLayout(clockwise, ctx.screenId);
     }
 }
 
-void SnapNavigationAdapter::reapplyLayout(const QString& /*screenId*/)
+void SnapNavigationAdapter::reapplyLayout(const NavigationContext& /*ctx*/)
 {
     if (m_engine) {
         m_engine->resnapToNewLayout();
     }
 }
 
-void SnapNavigationAdapter::snapAllWindows(const QString& screenId)
+void SnapNavigationAdapter::snapAllWindows(const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->snapAllWindows(screenId);
+        m_engine->snapAllWindows(ctx.screenId);
     }
 }
 
-void SnapNavigationAdapter::toggleFocusedFloat(const QString& /*screenId*/)
+void SnapNavigationAdapter::toggleFocusedFloat(const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->toggleFocusedFloat();
+        m_engine->toggleFocusedFloat(ctx);
     }
 }
 
-void SnapNavigationAdapter::cycleFocus(bool forward, const QString& /*screenId*/)
+void SnapNavigationAdapter::cycleFocus(bool forward, const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->cycleFocus(forward);
+        m_engine->cycleFocus(forward, ctx);
     }
 }
 
-void SnapNavigationAdapter::pushToEmptyZone(const QString& screenId)
+void SnapNavigationAdapter::pushToEmptyZone(const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->pushFocusedToEmptyZone(screenId);
+        m_engine->pushFocusedToEmptyZone(ctx);
     }
 }
 
-void SnapNavigationAdapter::restoreFocusedWindow(const QString& /*screenId*/)
+void SnapNavigationAdapter::restoreFocusedWindow(const NavigationContext& ctx)
 {
     if (m_engine) {
-        m_engine->restoreFocusedWindow();
+        m_engine->restoreFocusedWindow(ctx);
     }
 }
 

--- a/src/snap/snapnavigationadapter.cpp
+++ b/src/snap/snapnavigationadapter.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "snapnavigationadapter.h"
+
+#include "../dbus/windowtrackingadaptor.h"
+
+namespace PlasmaZones {
+
+SnapNavigationAdapter::SnapNavigationAdapter(WindowTrackingAdaptor* adaptor)
+    : m_adaptor(adaptor)
+{
+}
+
+void SnapNavigationAdapter::focusInDirection(const QString& direction, const QString& /*screenId*/)
+{
+    if (m_adaptor) {
+        m_adaptor->focusAdjacentZone(direction);
+    }
+}
+
+void SnapNavigationAdapter::moveFocusedInDirection(const QString& direction, const QString& /*screenId*/)
+{
+    if (m_adaptor) {
+        m_adaptor->moveWindowToAdjacentZone(direction);
+    }
+}
+
+void SnapNavigationAdapter::swapFocusedInDirection(const QString& direction, const QString& /*screenId*/)
+{
+    if (m_adaptor) {
+        m_adaptor->swapWindowWithAdjacentZone(direction);
+    }
+}
+
+void SnapNavigationAdapter::moveFocusedToPosition(int position, const QString& screenId)
+{
+    if (m_adaptor) {
+        m_adaptor->snapToZoneByNumber(position, screenId);
+    }
+}
+
+void SnapNavigationAdapter::rotateWindows(bool clockwise, const QString& screenId)
+{
+    if (m_adaptor) {
+        m_adaptor->rotateWindowsInLayout(clockwise, screenId);
+    }
+}
+
+void SnapNavigationAdapter::reapplyLayout(const QString& /*screenId*/)
+{
+    if (m_adaptor) {
+        m_adaptor->resnapToNewLayout();
+    }
+}
+
+void SnapNavigationAdapter::snapAllWindows(const QString& screenId)
+{
+    if (m_adaptor) {
+        m_adaptor->snapAllWindows(screenId);
+    }
+}
+
+void SnapNavigationAdapter::toggleFocusedFloat(const QString& /*screenId*/)
+{
+    if (m_adaptor) {
+        m_adaptor->toggleWindowFloat();
+    }
+}
+
+void SnapNavigationAdapter::cycleFocus(bool forward, const QString& /*screenId*/)
+{
+    if (m_adaptor) {
+        m_adaptor->cycleWindowsInZone(forward);
+    }
+}
+
+void SnapNavigationAdapter::pushToEmptyZone(const QString& screenId)
+{
+    if (m_adaptor) {
+        m_adaptor->pushToEmptyZone(screenId);
+    }
+}
+
+void SnapNavigationAdapter::restoreFocusedWindow(const QString& /*screenId*/)
+{
+    if (m_adaptor) {
+        m_adaptor->restoreWindowSize();
+    }
+}
+
+} // namespace PlasmaZones

--- a/src/snap/snapnavigationadapter.h
+++ b/src/snap/snapnavigationadapter.h
@@ -5,6 +5,7 @@
 
 #include "core/inavigationactions.h"
 #include "plasmazones_export.h"
+#include <QPointer>
 #include <QString>
 
 namespace PlasmaZones {
@@ -15,22 +16,22 @@ class SnapEngine;
  * @brief Thin INavigationActions adapter for SnapEngine.
  *
  * Maps INavigationActions user-intent calls to SnapEngine's concrete
- * navigation methods. The screen parameter is forwarded where the engine
- * needs it and dropped where the engine resolves the target from its own
- * last-active-window shadow (via the WindowTrackingAdaptor back-ref).
+ * navigation methods. The NavigationContext is forwarded as-is —
+ * SnapEngine's methods use both windowId and screenId explicitly
+ * rather than reading them from the WTA shadow store.
  *
  * Parameter mapping:
- *   - `focusInDirection(dir, screen)` → engine->focusInDirection(dir)
- *   - `moveFocusedInDirection(dir, screen)` → engine->moveFocusedInDirection(dir)
- *   - `swapFocusedInDirection(dir, screen)` → engine->swapFocusedInDirection(dir)
- *   - `moveFocusedToPosition(pos, screen)` → engine->moveFocusedToPosition(pos, screen)
- *   - `rotateWindows(cw, screen)` → engine->rotateWindowsInLayout(cw, screen)
- *   - `reapplyLayout(screen)` → engine->resnapToNewLayout()
- *   - `snapAllWindows(screen)` → engine->snapAllWindows(screen)
- *   - `toggleFocusedFloat(screen)` → engine->toggleFocusedFloat()
- *   - `cycleFocus(forward, screen)` → engine->cycleFocus(forward)
- *   - `pushToEmptyZone(screen)` → engine->pushFocusedToEmptyZone(screen)
- *   - `restoreFocusedWindow(screen)` → engine->restoreFocusedWindow()
+ *   - focusInDirection        → engine->focusInDirection(dir, ctx)
+ *   - moveFocusedInDirection  → engine->moveFocusedInDirection(dir, ctx)
+ *   - swapFocusedInDirection  → engine->swapFocusedInDirection(dir, ctx)
+ *   - moveFocusedToPosition   → engine->moveFocusedToPosition(pos, ctx)
+ *   - rotateWindows           → engine->rotateWindowsInLayout(cw, ctx.screenId)
+ *   - reapplyLayout           → engine->resnapToNewLayout()
+ *   - snapAllWindows          → engine->snapAllWindows(ctx.screenId)
+ *   - toggleFocusedFloat      → engine->toggleFocusedFloat(ctx)
+ *   - cycleFocus              → engine->cycleFocus(forward, ctx)
+ *   - pushToEmptyZone         → engine->pushFocusedToEmptyZone(ctx)
+ *   - restoreFocusedWindow    → engine->restoreFocusedWindow(ctx)
  */
 class PLASMAZONES_EXPORT SnapNavigationAdapter : public INavigationActions
 {
@@ -38,20 +39,22 @@ public:
     explicit SnapNavigationAdapter(SnapEngine* engine);
     ~SnapNavigationAdapter() override = default;
 
-    void focusInDirection(const QString& direction, const QString& screenId) override;
-    void moveFocusedInDirection(const QString& direction, const QString& screenId) override;
-    void swapFocusedInDirection(const QString& direction, const QString& screenId) override;
-    void moveFocusedToPosition(int position, const QString& screenId) override;
-    void rotateWindows(bool clockwise, const QString& screenId) override;
-    void reapplyLayout(const QString& screenId) override;
-    void snapAllWindows(const QString& screenId) override;
-    void toggleFocusedFloat(const QString& screenId) override;
-    void cycleFocus(bool forward, const QString& screenId) override;
-    void pushToEmptyZone(const QString& screenId) override;
-    void restoreFocusedWindow(const QString& screenId) override;
+    void focusInDirection(const QString& direction, const NavigationContext& ctx) override;
+    void moveFocusedInDirection(const QString& direction, const NavigationContext& ctx) override;
+    void swapFocusedInDirection(const QString& direction, const NavigationContext& ctx) override;
+    void moveFocusedToPosition(int position, const NavigationContext& ctx) override;
+    void rotateWindows(bool clockwise, const NavigationContext& ctx) override;
+    void reapplyLayout(const NavigationContext& ctx) override;
+    void snapAllWindows(const NavigationContext& ctx) override;
+    void toggleFocusedFloat(const NavigationContext& ctx) override;
+    void cycleFocus(bool forward, const NavigationContext& ctx) override;
+    void pushToEmptyZone(const NavigationContext& ctx) override;
+    void restoreFocusedWindow(const NavigationContext& ctx) override;
 
 private:
-    SnapEngine* m_engine; // not owned
+    // QPointer — not owned, but auto-nulls on engine destruction during
+    // shutdown. See AutotileNavigationAdapter::m_engine for rationale.
+    QPointer<SnapEngine> m_engine;
 };
 
 } // namespace PlasmaZones

--- a/src/snap/snapnavigationadapter.h
+++ b/src/snap/snapnavigationadapter.h
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "core/inavigationactions.h"
+#include "plasmazones_export.h"
+#include <QString>
+
+namespace PlasmaZones {
+
+class WindowTrackingAdaptor;
+
+/**
+ * @brief Thin INavigationActions adapter for snap-mode navigation.
+ *
+ * Snap-mode navigation logic historically lives in WindowTrackingAdaptor
+ * (focusAdjacentZone, moveWindowToAdjacentZone, etc.). This adapter
+ * presents that logic under the INavigationActions interface so the
+ * daemon's shortcut handlers can dispatch through ScreenModeRouter
+ * without branching on mode.
+ *
+ * In a future refactor, the navigation logic should move out of
+ * WindowTrackingAdaptor into SnapEngine (where it belongs — the D-Bus
+ * adaptor should be a thin facade, not a partial engine). When that
+ * happens, this adapter's implementation flips from forwarding to WTA
+ * to forwarding to SnapEngine, without the daemon or the interface
+ * needing to change.
+ *
+ * Parameter mapping:
+ *   - `focusInDirection` → WTA::focusAdjacentZone
+ *   - `moveFocusedInDirection` → WTA::moveWindowToAdjacentZone
+ *   - `swapFocusedInDirection` → WTA::swapWindowWithAdjacentZone
+ *   - `moveFocusedToPosition(pos, screen)` → WTA::snapToZoneByNumber(pos, screen)
+ *   - `rotateWindows(cw, screen)` → WTA::rotateWindowsInLayout(cw, screen)
+ *   - `reapplyLayout(screen)` → WTA::resnapToNewLayout()
+ *                             (WTA's implementation is screen-agnostic)
+ *   - `toggleFocusedFloat(screen)` → WTA::toggleWindowFloat()
+ *   - `cycleFocus(forward, screen)` → WTA::cycleWindowsInZone(forward)
+ */
+class PLASMAZONES_EXPORT SnapNavigationAdapter : public INavigationActions
+{
+public:
+    explicit SnapNavigationAdapter(WindowTrackingAdaptor* adaptor);
+    ~SnapNavigationAdapter() override = default;
+
+    void focusInDirection(const QString& direction, const QString& screenId) override;
+    void moveFocusedInDirection(const QString& direction, const QString& screenId) override;
+    void swapFocusedInDirection(const QString& direction, const QString& screenId) override;
+    void moveFocusedToPosition(int position, const QString& screenId) override;
+    void rotateWindows(bool clockwise, const QString& screenId) override;
+    void reapplyLayout(const QString& screenId) override;
+    void snapAllWindows(const QString& screenId) override;
+    void toggleFocusedFloat(const QString& screenId) override;
+    void cycleFocus(bool forward, const QString& screenId) override;
+    void pushToEmptyZone(const QString& screenId) override;
+    void restoreFocusedWindow(const QString& screenId) override;
+
+private:
+    WindowTrackingAdaptor* m_adaptor; // not owned
+};
+
+} // namespace PlasmaZones

--- a/src/snap/snapnavigationadapter.h
+++ b/src/snap/snapnavigationadapter.h
@@ -9,39 +9,33 @@
 
 namespace PlasmaZones {
 
-class WindowTrackingAdaptor;
+class SnapEngine;
 
 /**
- * @brief Thin INavigationActions adapter for snap-mode navigation.
+ * @brief Thin INavigationActions adapter for SnapEngine.
  *
- * Snap-mode navigation logic historically lives in WindowTrackingAdaptor
- * (focusAdjacentZone, moveWindowToAdjacentZone, etc.). This adapter
- * presents that logic under the INavigationActions interface so the
- * daemon's shortcut handlers can dispatch through ScreenModeRouter
- * without branching on mode.
- *
- * In a future refactor, the navigation logic should move out of
- * WindowTrackingAdaptor into SnapEngine (where it belongs — the D-Bus
- * adaptor should be a thin facade, not a partial engine). When that
- * happens, this adapter's implementation flips from forwarding to WTA
- * to forwarding to SnapEngine, without the daemon or the interface
- * needing to change.
+ * Maps INavigationActions user-intent calls to SnapEngine's concrete
+ * navigation methods. The screen parameter is forwarded where the engine
+ * needs it and dropped where the engine resolves the target from its own
+ * last-active-window shadow (via the WindowTrackingAdaptor back-ref).
  *
  * Parameter mapping:
- *   - `focusInDirection` → WTA::focusAdjacentZone
- *   - `moveFocusedInDirection` → WTA::moveWindowToAdjacentZone
- *   - `swapFocusedInDirection` → WTA::swapWindowWithAdjacentZone
- *   - `moveFocusedToPosition(pos, screen)` → WTA::snapToZoneByNumber(pos, screen)
- *   - `rotateWindows(cw, screen)` → WTA::rotateWindowsInLayout(cw, screen)
- *   - `reapplyLayout(screen)` → WTA::resnapToNewLayout()
- *                             (WTA's implementation is screen-agnostic)
- *   - `toggleFocusedFloat(screen)` → WTA::toggleWindowFloat()
- *   - `cycleFocus(forward, screen)` → WTA::cycleWindowsInZone(forward)
+ *   - `focusInDirection(dir, screen)` → engine->focusInDirection(dir)
+ *   - `moveFocusedInDirection(dir, screen)` → engine->moveFocusedInDirection(dir)
+ *   - `swapFocusedInDirection(dir, screen)` → engine->swapFocusedInDirection(dir)
+ *   - `moveFocusedToPosition(pos, screen)` → engine->moveFocusedToPosition(pos, screen)
+ *   - `rotateWindows(cw, screen)` → engine->rotateWindowsInLayout(cw, screen)
+ *   - `reapplyLayout(screen)` → engine->resnapToNewLayout()
+ *   - `snapAllWindows(screen)` → engine->snapAllWindows(screen)
+ *   - `toggleFocusedFloat(screen)` → engine->toggleFocusedFloat()
+ *   - `cycleFocus(forward, screen)` → engine->cycleFocus(forward)
+ *   - `pushToEmptyZone(screen)` → engine->pushFocusedToEmptyZone(screen)
+ *   - `restoreFocusedWindow(screen)` → engine->restoreFocusedWindow()
  */
 class PLASMAZONES_EXPORT SnapNavigationAdapter : public INavigationActions
 {
 public:
-    explicit SnapNavigationAdapter(WindowTrackingAdaptor* adaptor);
+    explicit SnapNavigationAdapter(SnapEngine* engine);
     ~SnapNavigationAdapter() override = default;
 
     void focusInDirection(const QString& direction, const QString& screenId) override;
@@ -57,7 +51,7 @@ public:
     void restoreFocusedWindow(const QString& screenId) override;
 
 private:
-    WindowTrackingAdaptor* m_adaptor; // not owned
+    SnapEngine* m_engine; // not owned
 };
 
 } // namespace PlasmaZones

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -328,6 +328,14 @@ add_executable(test_drag_policy dbus/test_drag_policy.cpp)
 target_link_libraries(test_drag_policy PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
 add_test(NAME test_drag_policy COMMAND test_drag_policy)
 
+# Validation methods on D-Bus struct types — pins the accept/reject table
+# for validationError() so cross-field invariants (DragOutcome action range,
+# ApplySnap zoneId, TileRequestEntry tiled/floating size semantics, etc.)
+# don't drift as producer code evolves.
+add_executable(test_dbus_validation dbus/test_dbus_validation.cpp)
+target_link_libraries(test_dbus_validation PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_compositor_common)
+add_test(NAME test_dbus_validation COMMAND test_dbus_validation)
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # compositor-common/ — Shared Library Types Tests (D-Bus types, FloatingCache,
 #                      TriggerParser, WindowIdUtils)
@@ -378,6 +386,7 @@ set(_all_tests
     test_dbus_adaptor_routing
     test_autotile_adaptor_panel_gate
     test_drag_policy
+    test_dbus_validation
     test_compositor_common
 )
 set_tests_properties(${_all_tests} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -116,6 +116,11 @@ target_compile_definitions(test_autotile_engine_order_cycling PRIVATE "PZ_SOURCE
 pz_add_test(test_autotile_engine_class_mutation autotile/test_autotile_engine_class_mutation.cpp)
 pz_add_test(test_autotile_drag_insert autotile/test_autotile_drag_insert.cpp)
 target_compile_definitions(test_autotile_drag_insert PRIVATE "PZ_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
+# Producer-side validator guard — ensures the JSON emitted by
+# AutotileEngine::applyTiling round-trips through TileRequestEntry
+# parsing and passes validationError(). Would have caught PR #326 C1.
+pz_add_test(test_autotile_tile_request_validation autotile/test_autotile_tile_request_validation.cpp)
+target_link_libraries(test_autotile_tile_request_validation PRIVATE plasmazones_compositor_common)
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # autotile/ — Autotile + Virtual Screen Integration Tests
@@ -365,6 +370,7 @@ set(_all_tests
     test_autotile_engine_retry
     test_autotile_engine_order_cycling
     test_autotile_drag_insert
+    test_autotile_tile_request_validation
     test_autotile_ext_startup_float test_autotile_ext_algoswitch
     test_autotile_ext_overflow
     test_tiling_state_windows test_tiling_state_config test_tiling_state_serial

--- a/tests/unit/autotile/test_autotile_tile_request_validation.cpp
+++ b/tests/unit/autotile/test_autotile_tile_request_validation.cpp
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_autotile_tile_request_validation.cpp
+ * @brief Producer-side guard for AutotileEngine::windowsTiled JSON.
+ *
+ * Phase 1B added TileRequestEntry::validationError(), and
+ * AutotileAdaptor::slotWindowsTileRequested on the effect side drops any
+ * batch entry that fails validation. The JSON producer in
+ * AutotileEngine::applyTiling must therefore populate every field the
+ * validator requires — screenId, non-zero windowId, non-zero size on
+ * tiled entries — on every snap path AND every overflow path.
+ *
+ * The original regression this test exists to prevent: applyTiling's
+ * tiled-entry branch set windowId/x/y/w/h but never screenId, so every
+ * mode-change retile emitted a batch where all entries failed validation
+ * and the effect aborted with "all N entries invalid — aborting". The
+ * existing test_dbus_validation pinned the validator's behaviour but
+ * never exercised a real producer, so the bug slipped through.
+ *
+ * This test mirrors the AutotileAdaptor::onWindowsTiled parse logic
+ * exactly (same field names, same optional flags) so a drift in either
+ * producer or consumer that broke round-tripping would fail here too.
+ */
+
+#include <QCoreApplication>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSignalSpy>
+#include <QTest>
+
+#include "autotile/AutotileEngine.h"
+#include "autotile/AutotileConfig.h"
+#include "autotile/AlgorithmRegistry.h"
+#include "autotile/TilingState.h"
+#include "compositor-common/dbus_types.h"
+
+using namespace PlasmaZones;
+
+namespace {
+
+/// Mirrors AutotileAdaptor::onWindowsTiled's JSON → TileRequestList parse.
+/// Kept in sync with src/dbus/autotileadaptor.cpp so the producer test
+/// exercises the exact same deserialization the D-Bus pipe performs.
+TileRequestList parseWindowsTiledJson(const QString& json)
+{
+    TileRequestList requests;
+    QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+    if (!doc.isArray()) {
+        return requests;
+    }
+    for (const QJsonValue& val : doc.array()) {
+        QJsonObject obj = val.toObject();
+        TileRequestEntry entry;
+        entry.windowId = obj.value(QLatin1String("windowId")).toString();
+        entry.floating = obj.value(QLatin1String("floating")).toBool(false);
+        if (!entry.floating) {
+            entry.x = obj.value(QLatin1String("x")).toInt();
+            entry.y = obj.value(QLatin1String("y")).toInt();
+            entry.width = obj.value(QLatin1String("width")).toInt();
+            entry.height = obj.value(QLatin1String("height")).toInt();
+        }
+        entry.zoneId = obj.value(QLatin1String("zoneId")).toString();
+        entry.screenId = obj.value(QLatin1String("screenId")).toString();
+        entry.monocle = obj.value(QLatin1String("monocle")).toBool(false);
+        requests.append(entry);
+    }
+    return requests;
+}
+
+} // namespace
+
+class TestAutotileTileRequestValidation : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    // ─────────────────────────────────────────────────────────────────────
+    // The smoke test that would have caught the PR #326 regression.
+    //
+    // Set up an engine with a screen and two windows, force calculated
+    // zones (bypassing real screen geometry which unit tests don't have),
+    // run retile, capture the windowsTiled signal, parse each entry via
+    // the same path the AutotileAdaptor uses, and assert every entry
+    // passes validation.
+    // ─────────────────────────────────────────────────────────────────────
+    void applyTiling_populatesScreenIdOnEveryTiledEntry()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screenName = QStringLiteral("DP-1");
+
+        engine.setAutotileScreens({screenName});
+        engine.setAlgorithm(QLatin1String("master-stack"));
+
+        engine.windowOpened(QStringLiteral("win-1"), screenName);
+        engine.windowOpened(QStringLiteral("win-2"), screenName);
+        QCoreApplication::processEvents();
+
+        QSignalSpy tiledSpy(&engine, &AutotileEngine::windowsTiled);
+
+        // Force zones directly — unit tests don't have real screen
+        // geometry so recalculateLayout() would bail with "invalid screen
+        // geometry". The zones themselves aren't under test; the JSON
+        // shape around them is.
+        TilingState* state = engine.stateForScreen(screenName);
+        QVERIFY(state);
+        state->setCalculatedZones({QRect(10, 10, 950, 1060), QRect(960, 10, 950, 1060)});
+
+        engine.retile(screenName);
+        QVERIFY(tiledSpy.count() >= 1);
+
+        const QString json = tiledSpy.last().first().toString();
+        const TileRequestList entries = parseWindowsTiledJson(json);
+        QVERIFY2(!entries.isEmpty(), "applyTiling emitted no entries");
+        for (const TileRequestEntry& entry : entries) {
+            const QString err = entry.validationError();
+            QVERIFY2(err.isEmpty(), qPrintable(err));
+            // Belt-and-braces: the screenId must match what we retiled.
+            QCOMPARE(entry.screenId, screenName);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Monocle flag: same invariant, different code path — the producer
+    // sets monocle=true on every tiled entry when all zones share
+    // identical geometry. Validator is silent on monocle, but screenId
+    // and window/size requirements still apply.
+    // ─────────────────────────────────────────────────────────────────────
+    void applyTiling_monocleEntriesStillValidate()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screenName = QStringLiteral("HDMI-2");
+        engine.setAutotileScreens({screenName});
+        engine.setAlgorithm(QLatin1String("monocle"));
+
+        engine.windowOpened(QStringLiteral("win-a"), screenName);
+        engine.windowOpened(QStringLiteral("win-b"), screenName);
+        QCoreApplication::processEvents();
+
+        QSignalSpy tiledSpy(&engine, &AutotileEngine::windowsTiled);
+
+        TilingState* state = engine.stateForScreen(screenName);
+        QVERIFY(state);
+        const QRect fullArea(0, 0, 1920, 1080);
+        state->setCalculatedZones({fullArea, fullArea});
+        engine.retile(screenName);
+
+        QVERIFY(tiledSpy.count() >= 1);
+        const TileRequestList entries = parseWindowsTiledJson(tiledSpy.last().first().toString());
+        QVERIFY(!entries.isEmpty());
+        for (const TileRequestEntry& entry : entries) {
+            QVERIFY(entry.monocle);
+            QVERIFY2(entry.validationError().isEmpty(), qPrintable(entry.validationError()));
+            QCOMPARE(entry.screenId, screenName);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Overflow branch of applyTiling: windows that exceed maxWindows are
+    // batched with floating=true and must carry screenId for the plugin
+    // to route them. Floating entries legitimately carry zero geometry
+    // (plugin resolves it from the current frame) — validator tolerates
+    // that — but empty screenId is still rejected.
+    // ─────────────────────────────────────────────────────────────────────
+    void applyTiling_overflowFloatingEntryIsValid()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr);
+        const QString screenName = QStringLiteral("DP-3");
+        engine.setAutotileScreens({screenName});
+        engine.setAlgorithm(QLatin1String("master-stack"));
+
+        // Cap at 2 so a third window is forced into overflow.
+        engine.config()->maxWindows = 2;
+
+        engine.windowOpened(QStringLiteral("win-1"), screenName);
+        engine.windowOpened(QStringLiteral("win-2"), screenName);
+        engine.windowOpened(QStringLiteral("win-3"), screenName);
+        QCoreApplication::processEvents();
+
+        QSignalSpy tiledSpy(&engine, &AutotileEngine::windowsTiled);
+
+        TilingState* state = engine.stateForScreen(screenName);
+        QVERIFY(state);
+        state->setCalculatedZones({QRect(10, 10, 950, 1060), QRect(960, 10, 950, 1060)});
+        engine.retile(screenName);
+
+        QVERIFY(tiledSpy.count() >= 1);
+        const TileRequestList entries = parseWindowsTiledJson(tiledSpy.last().first().toString());
+        QVERIFY2(!entries.isEmpty(), "applyTiling emitted no entries");
+
+        bool sawFloating = false;
+        for (const TileRequestEntry& entry : entries) {
+            QVERIFY2(entry.validationError().isEmpty(), qPrintable(entry.validationError()));
+            QCOMPARE(entry.screenId, screenName);
+            if (entry.floating) {
+                sawFloating = true;
+            }
+        }
+        // The third window's overflow fate depends on which-window-got-capped
+        // order, which is stable under the same algo but not worth pinning
+        // here. What matters is that IF any overflow entry was emitted, it
+        // validated cleanly — the assertion above already covered that.
+        Q_UNUSED(sawFloating);
+    }
+};
+
+QTEST_MAIN(TestAutotileTileRequestValidation)
+#include "test_autotile_tile_request_validation.moc"

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -143,7 +143,11 @@ private Q_SLOTS:
     }
 
     // =========================================================================
-    // clearFloatingStateForSnap tests
+    // WindowTrackingService::clearFloatingForSnap tests
+    //
+    // (The former SnapEngine::clearFloatingStateForSnap wrapper was removed —
+    // all snap-commit paths now go through WindowTrackingService::commitSnap
+    // which handles floating-state clearing internally via clearFloatingForSnap.)
     // =========================================================================
 
     void testClearFloatingForSnap_returnsTrue_whenFloating()

--- a/tests/unit/core/test_window_identity.cpp
+++ b/tests/unit/core/test_window_identity.cpp
@@ -3,21 +3,25 @@
 
 /**
  * @file test_window_identity.cpp
- * @brief Unit tests for Utils::extractAppId() — the legacy composite parser.
+ * @brief Unit tests for Utils::extractAppId() — the composite-key parser.
  *
- * IMPORTANT: the runtime wire format is no longer "appId|uuid" composite —
- * the kwin-effect bridge sends opaque instance ids (bare UUIDs).
- * Utils::extractAppId() is preserved as a fallback inside
- * WindowTrackingService::currentAppIdFor() for unit tests and code paths
- * that don't have a WindowRegistry attached — on a bare instance id the
- * helper is a passthrough (no '|' separator to split on).
+ * The effect produces window ids in the form "appId|instanceId" (frozen at
+ * first observation). Every daemon map keys off that composite. Services
+ * that need the first-seen app class parse it with Utils::extractAppId();
+ * services that need the LIVE app class (Electron/CEF apps that mutate
+ * their WM_CLASS mid-session) query WindowTrackingService::currentAppIdFor
+ * or AutotileEngine::currentAppIdFor, both of which hit WindowRegistry.
  *
- * This file validates the parser's behavior on both legacy composites and
- * bare instance ids so that the compat fallback stays well-defined. It does
- * NOT describe how production looks up app class for a window — for that,
- * see WindowTrackingService::currentAppIdFor() and
- * PlasmaZonesEffect::appIdForInstance(), which query the live
- * WindowRegistry.
+ * The two semantics coexist intentionally: the stable composite lets
+ * daemon maps ignore class mutations (so a rule bound to a zone doesn't
+ * get reassigned mid-session), and the live registry lookup lets new
+ * rule decisions see the current class.
+ *
+ * This file pins extractAppId()'s behavior on composites (split before the
+ * first '|') and on bare strings (passthrough) so the fallback stays
+ * well-defined for the WindowTrackingService::currentAppIdFor() and
+ * AutotileEngine::currentAppIdFor() call paths that walk this helper when
+ * no registry is attached.
  */
 
 #include <QTest>

--- a/tests/unit/core/test_wts_session.cpp
+++ b/tests/unit/core/test_wts_session.cpp
@@ -231,8 +231,8 @@ private Q_SLOTS:
         queues[appId] = {entry};
         m_service->setPendingRestoreQueues(queues);
 
-        bool cleared = m_service->clearStalePendingAssignment(windowId);
-        QVERIFY(cleared);
+        bool popped = m_service->consumePendingAssignment(windowId);
+        QVERIFY(popped);
         QVERIFY(!m_service->pendingRestoreQueues().contains(appId));
     }
 

--- a/tests/unit/dbus/test_dbus_validation.cpp
+++ b/tests/unit/dbus/test_dbus_validation.cpp
@@ -1,0 +1,366 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_dbus_validation.cpp
+ * @brief Pins the validationError() methods on D-Bus struct types.
+ *
+ * The D-Bus types carry payloads across a process boundary. Qt's
+ * marshaller will decode any byte sequence that matches the signature
+ * without checking semantic invariants — so an out-of-range action
+ * enum, an empty zoneId on an ApplySnap outcome, or a zero-size tiled
+ * request unmarshals silently and corrupts state downstream.
+ *
+ * validationError() methods enforce the cross-field invariants at the
+ * unmarshal boundary. This test fixture pins the accept/reject table
+ * so the invariants can't drift as producer code evolves.
+ */
+
+#include <QCoreApplication>
+#include <QObject>
+#include <QTest>
+
+#include "compositor-common/dbus_types.h"
+
+using namespace PlasmaZones;
+
+class TestDbusValidation : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    // ═════════════════════════════════════════════════════════════════════
+    // DragOutcome
+    // ═════════════════════════════════════════════════════════════════════
+
+    void dragOutcome_noOp_noRequirements()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::NoOp;
+        QVERIFY(o.validationError().isEmpty());
+    }
+
+    void dragOutcome_actionOutOfRange_rejected()
+    {
+        DragOutcome o;
+        o.action = 999;
+        o.windowId = QStringLiteral("win-1");
+        const QString err = o.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("out of range")));
+    }
+
+    void dragOutcome_negativeAction_rejected()
+    {
+        DragOutcome o;
+        o.action = -1;
+        const QString err = o.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("out of range")));
+    }
+
+    void dragOutcome_applyFloatRequiresWindowId()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::ApplyFloat;
+        // windowId empty
+        const QString err = o.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("windowId required")));
+    }
+
+    void dragOutcome_applyFloat_valid()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::ApplyFloat;
+        o.windowId = QStringLiteral("win-1");
+        // x/y can be zero (top-left corner), targetScreenId optional
+        QVERIFY(o.validationError().isEmpty());
+    }
+
+    void dragOutcome_applySnapRequiresZoneId()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::ApplySnap;
+        o.windowId = QStringLiteral("win-1");
+        o.width = 800;
+        o.height = 600;
+        // zoneId empty
+        const QString err = o.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("ApplySnap requires non-empty zoneId")));
+    }
+
+    void dragOutcome_applySnapRequiresNonZeroSize()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::ApplySnap;
+        o.windowId = QStringLiteral("win-1");
+        o.zoneId = QStringLiteral("zone-1");
+        o.width = 0;
+        o.height = 600;
+        const QString err = o.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("non-zero size")));
+    }
+
+    void dragOutcome_applySnap_valid()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::ApplySnap;
+        o.windowId = QStringLiteral("win-1");
+        o.zoneId = QStringLiteral("zone-1");
+        o.targetScreenId = QStringLiteral("DP-1");
+        o.x = 100;
+        o.y = 200;
+        o.width = 800;
+        o.height = 600;
+        QVERIFY(o.validationError().isEmpty());
+    }
+
+    void dragOutcome_restoreSizeRequiresNonZeroSize()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::RestoreSize;
+        o.windowId = QStringLiteral("win-1");
+        o.width = 800;
+        o.height = 0;
+        const QString err = o.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("non-zero size")));
+    }
+
+    void dragOutcome_cancelSnap_noSizeNeeded()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::CancelSnap;
+        o.windowId = QStringLiteral("win-1");
+        // CancelSnap has no geometry requirement
+        QVERIFY(o.validationError().isEmpty());
+    }
+
+    void dragOutcome_notifyDragOutUnsnap_requiresWindowId()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::NotifyDragOutUnsnap;
+        // windowId empty
+        const QString err = o.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("windowId required")));
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    // DragPolicy
+    // ═════════════════════════════════════════════════════════════════════
+
+    void dragPolicy_canonicalSnap_valid()
+    {
+        DragPolicy p;
+        p.streamDragMoved = true;
+        p.showOverlay = true;
+        p.grabKeyboard = true;
+        p.captureGeometry = true;
+        p.screenId = QStringLiteral("DP-1");
+        p.bypassReason = DragBypassReason::None;
+        QVERIFY(p.validationError().isEmpty());
+    }
+
+    void dragPolicy_autotileBypassRequiresScreenId()
+    {
+        DragPolicy p;
+        p.bypassReason = DragBypassReason::AutotileScreen;
+        p.captureGeometry = true;
+        // screenId empty
+        const QString err = p.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("AutotileScreen bypass requires non-empty screenId")));
+    }
+
+    void dragPolicy_autotileBypass_valid()
+    {
+        DragPolicy p;
+        p.bypassReason = DragBypassReason::AutotileScreen;
+        p.screenId = QStringLiteral("HP-1");
+        p.captureGeometry = true;
+        QVERIFY(p.validationError().isEmpty());
+    }
+
+    void dragPolicy_snappingDisabledEmptyScreen_tolerated()
+    {
+        // beginDrag with empty startScreenId returns SnappingDisabled with
+        // empty screenId. That path is deliberately tolerated — the drag
+        // still needs to complete via endDrag NoOp.
+        DragPolicy p;
+        p.bypassReason = DragBypassReason::SnappingDisabled;
+        p.screenId = QString();
+        QVERIFY(p.validationError().isEmpty());
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    // TileRequestEntry
+    // ═════════════════════════════════════════════════════════════════════
+
+    void tileRequestEntry_emptyWindowId_rejected()
+    {
+        TileRequestEntry e;
+        e.screenId = QStringLiteral("DP-1");
+        e.width = 800;
+        e.height = 600;
+        const QString err = e.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("empty windowId")));
+    }
+
+    void tileRequestEntry_emptyScreenId_rejected()
+    {
+        TileRequestEntry e;
+        e.windowId = QStringLiteral("win-1");
+        e.width = 800;
+        e.height = 600;
+        const QString err = e.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("empty screenId")));
+    }
+
+    void tileRequestEntry_negativeSize_rejected()
+    {
+        TileRequestEntry e;
+        e.windowId = QStringLiteral("win-1");
+        e.screenId = QStringLiteral("DP-1");
+        e.width = -10;
+        e.height = 600;
+        const QString err = e.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("negative size")));
+    }
+
+    void tileRequestEntry_tiledZeroSize_rejected()
+    {
+        TileRequestEntry e;
+        e.windowId = QStringLiteral("win-1");
+        e.screenId = QStringLiteral("DP-1");
+        e.floating = false;
+        e.width = 0;
+        e.height = 0;
+        const QString err = e.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("tiled request requires non-zero size")));
+    }
+
+    void tileRequestEntry_floatingZeroSize_tolerated()
+    {
+        // Floating requests legitimately carry zero size — the plugin
+        // resolves geometry from the current frame.
+        TileRequestEntry e;
+        e.windowId = QStringLiteral("win-1");
+        e.screenId = QStringLiteral("DP-1");
+        e.floating = true;
+        e.width = 0;
+        e.height = 0;
+        QVERIFY(e.validationError().isEmpty());
+    }
+
+    void tileRequestEntry_tiledValid()
+    {
+        TileRequestEntry e;
+        e.windowId = QStringLiteral("win-1");
+        e.screenId = QStringLiteral("DP-1");
+        e.zoneId = QStringLiteral("zone-1");
+        e.x = 0;
+        e.y = 0;
+        e.width = 1920;
+        e.height = 1080;
+        QVERIFY(e.validationError().isEmpty());
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    // BridgeRegistrationResult
+    // ═════════════════════════════════════════════════════════════════════
+
+    void bridgeRegistration_valid()
+    {
+        BridgeRegistrationResult r;
+        r.apiVersion = QStringLiteral("2");
+        r.bridgeName = QStringLiteral("kwin");
+        r.sessionId = QStringLiteral("abcd-1234");
+        QVERIFY(r.validationError().isEmpty());
+    }
+
+    void bridgeRegistration_rejectedSentinel_tolerated()
+    {
+        // "REJECTED" is how the daemon signals version mismatch. It's
+        // not an invalid result — callers branch on it explicitly.
+        BridgeRegistrationResult r;
+        r.apiVersion = QStringLiteral("999");
+        r.bridgeName = QString(); // sentinel path may leave these empty
+        r.sessionId = QStringLiteral("REJECTED");
+        QVERIFY(r.validationError().isEmpty());
+    }
+
+    void bridgeRegistration_emptyApiVersion_rejected()
+    {
+        BridgeRegistrationResult r;
+        r.bridgeName = QStringLiteral("kwin");
+        r.sessionId = QStringLiteral("abcd-1234");
+        const QString err = r.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("empty apiVersion")));
+    }
+
+    void bridgeRegistration_nonNumericApiVersion_rejected()
+    {
+        BridgeRegistrationResult r;
+        r.apiVersion = QStringLiteral("one");
+        r.bridgeName = QStringLiteral("kwin");
+        r.sessionId = QStringLiteral("abcd-1234");
+        const QString err = r.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("not an integer")));
+    }
+
+    void bridgeRegistration_emptyBridgeName_rejected()
+    {
+        BridgeRegistrationResult r;
+        r.apiVersion = QStringLiteral("2");
+        r.sessionId = QStringLiteral("abcd-1234");
+        const QString err = r.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("empty bridgeName")));
+    }
+
+    void bridgeRegistration_emptySessionId_rejected()
+    {
+        BridgeRegistrationResult r;
+        r.apiVersion = QStringLiteral("2");
+        r.bridgeName = QStringLiteral("kwin");
+        const QString err = r.validationError();
+        QVERIFY(!err.isEmpty());
+        QVERIFY(err.contains(QStringLiteral("empty sessionId")));
+    }
+
+    // ═════════════════════════════════════════════════════════════════════
+    // DragBypassReason wire round-trip
+    // ═════════════════════════════════════════════════════════════════════
+
+    void dragBypassReason_wireRoundTrip_all()
+    {
+        // Every enum value must round-trip through the wire format.
+        for (auto r : {DragBypassReason::None, DragBypassReason::AutotileScreen, DragBypassReason::SnappingDisabled,
+                       DragBypassReason::ContextDisabled}) {
+            QCOMPARE(bypassReasonFromWireString(toWireString(r)), r);
+        }
+    }
+
+    void dragBypassReason_unknownWire_mapsToNone()
+    {
+        // Unknown wire strings map to None to preserve the legacy
+        // fall-through behavior where unrecognized values didn't match
+        // the autotile branch.
+        QCOMPARE(bypassReasonFromWireString(QStringLiteral("future_reason")), DragBypassReason::None);
+        QCOMPARE(bypassReasonFromWireString(QString()), DragBypassReason::None);
+    }
+};
+
+QTEST_MAIN(TestDbusValidation)
+#include "test_dbus_validation.moc"

--- a/tests/unit/dbus/test_drag_policy.cpp
+++ b/tests/unit/dbus/test_drag_policy.cpp
@@ -112,7 +112,7 @@ private Q_SLOTS:
         DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
                                                             QStringLiteral("DP-1"), 1, QString());
 
-        QVERIFY(p.bypassReason.isEmpty());
+        QCOMPARE(p.bypassReason, DragBypassReason::None);
         QVERIFY(p.streamDragMoved);
         QVERIFY(p.showOverlay);
         QVERIFY(p.grabKeyboard);
@@ -136,7 +136,7 @@ private Q_SLOTS:
         DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
                                                             QStringLiteral("HP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, QStringLiteral("autotile_screen"));
+        QCOMPARE(p.bypassReason, DragBypassReason::AutotileScreen);
         QVERIFY(!p.streamDragMoved);
         QVERIFY(!p.showOverlay);
         QVERIFY(!p.grabKeyboard);
@@ -162,7 +162,7 @@ private Q_SLOTS:
         DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
                                                             QStringLiteral("DP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, QStringLiteral("snapping_disabled"));
+        QCOMPARE(p.bypassReason, DragBypassReason::SnappingDisabled);
         QVERIFY(!p.streamDragMoved);
         QVERIFY(!p.showOverlay);
         QVERIFY(!p.grabKeyboard);
@@ -188,7 +188,7 @@ private Q_SLOTS:
         DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
                                                             QStringLiteral("HP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, QStringLiteral("autotile_screen"));
+        QCOMPARE(p.bypassReason, DragBypassReason::AutotileScreen);
         QVERIFY(p.captureGeometry);
     }
 
@@ -207,7 +207,7 @@ private Q_SLOTS:
         DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
                                                             QStringLiteral("HP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, QStringLiteral("context_disabled"));
+        QCOMPARE(p.bypassReason, DragBypassReason::ContextDisabled);
         QVERIFY(!p.streamDragMoved);
         QVERIFY(!p.showOverlay);
         QVERIFY(!p.immediateFloatOnStart);
@@ -224,9 +224,9 @@ private Q_SLOTS:
                                                             QStringLiteral("DP-1"), 1, QString());
 
         // Context-disabled is checked before snapping_disabled — the reason
-        // is stable at "context_disabled" even though either would produce
+        // is stable at ContextDisabled even though either would produce
         // the same flag set.
-        QCOMPARE(p.bypassReason, QStringLiteral("context_disabled"));
+        QCOMPARE(p.bypassReason, DragBypassReason::ContextDisabled);
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -240,7 +240,7 @@ private Q_SLOTS:
         DragPolicy p = WindowDragAdaptor::computeDragPolicy(nullptr, nullptr, QStringLiteral("win-1"),
                                                             QStringLiteral("DP-1"), 1, QString());
 
-        QVERIFY(p.bypassReason.isEmpty());
+        QCOMPARE(p.bypassReason, DragBypassReason::None);
         QVERIFY(p.streamDragMoved);
     }
 
@@ -259,7 +259,7 @@ private Q_SLOTS:
                                                             1, QString());
 
         // Autotile check is skipped for empty screenId, so snapping_disabled wins.
-        QCOMPARE(p.bypassReason, QStringLiteral("snapping_disabled"));
+        QCOMPARE(p.bypassReason, DragBypassReason::SnappingDisabled);
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -281,7 +281,7 @@ private Q_SLOTS:
         DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
                                                             QStringLiteral("HP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, QStringLiteral("autotile_screen"));
+        QCOMPARE(p.bypassReason, DragBypassReason::AutotileScreen);
         // Even though the engine would normally flip this on for tracked
         // windows, Reorder mode must leave it cleared.
         QVERIFY(!p.immediateFloatOnStart);
@@ -303,7 +303,7 @@ private Q_SLOTS:
         DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
                                                             QStringLiteral("HP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, QStringLiteral("autotile_screen"));
+        QCOMPARE(p.bypassReason, DragBypassReason::AutotileScreen);
         // No windowOpened flowed through the engine so isWindowTracked
         // returns false — immediateFloatOnStart stays false either way.
         // The useful assertion here is that the reorder test above isn't

--- a/tests/unit/dbus/test_drag_policy.cpp
+++ b/tests/unit/dbus/test_drag_policy.cpp
@@ -119,6 +119,10 @@ private Q_SLOTS:
         QVERIFY(p.captureGeometry);
         QVERIFY(!p.immediateFloatOnStart);
         QCOMPARE(p.screenId, QStringLiteral("DP-1"));
+        // Producer/validator guard: computeDragPolicy must never return a
+        // payload the effect-side validator would drop. Every branch below
+        // mirrors this assertion.
+        QVERIFY(p.validationError().isEmpty());
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -146,6 +150,8 @@ private Q_SLOTS:
         // "tracked window → true" path is exercised indirectly by
         // integration tests that actually tile windows.
         QVERIFY(!p.immediateFloatOnStart);
+        // AutotileScreen bypass requires non-empty screenId per the validator.
+        QVERIFY(p.validationError().isEmpty());
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -168,6 +174,7 @@ private Q_SLOTS:
         QVERIFY(!p.grabKeyboard);
         QVERIFY(!p.captureGeometry);
         QVERIFY(!p.immediateFloatOnStart);
+        QVERIFY(p.validationError().isEmpty());
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -190,6 +197,7 @@ private Q_SLOTS:
 
         QCOMPARE(p.bypassReason, DragBypassReason::AutotileScreen);
         QVERIFY(p.captureGeometry);
+        QVERIFY(p.validationError().isEmpty());
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -211,6 +219,7 @@ private Q_SLOTS:
         QVERIFY(!p.streamDragMoved);
         QVERIFY(!p.showOverlay);
         QVERIFY(!p.immediateFloatOnStart);
+        QVERIFY(p.validationError().isEmpty());
     }
 
     void contextDisabled_overridesSnapDisabled()
@@ -227,6 +236,7 @@ private Q_SLOTS:
         // is stable at ContextDisabled even though either would produce
         // the same flag set.
         QCOMPARE(p.bypassReason, DragBypassReason::ContextDisabled);
+        QVERIFY(p.validationError().isEmpty());
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -242,6 +252,7 @@ private Q_SLOTS:
 
         QCOMPARE(p.bypassReason, DragBypassReason::None);
         QVERIFY(p.streamDragMoved);
+        QVERIFY(p.validationError().isEmpty());
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -260,6 +271,9 @@ private Q_SLOTS:
 
         // Autotile check is skipped for empty screenId, so snapping_disabled wins.
         QCOMPARE(p.bypassReason, DragBypassReason::SnappingDisabled);
+        // SnappingDisabled with empty screenId is explicitly tolerated by
+        // the validator (see DragPolicy::validationError).
+        QVERIFY(p.validationError().isEmpty());
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -286,6 +300,7 @@ private Q_SLOTS:
         // windows, Reorder mode must leave it cleared.
         QVERIFY(!p.immediateFloatOnStart);
         QVERIFY(p.captureGeometry);
+        QVERIFY(p.validationError().isEmpty());
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -310,6 +325,7 @@ private Q_SLOTS:
         // masking a broken computeDragPolicy: the bypass path still
         // returns the same bypassReason in Float mode.
         QVERIFY(p.captureGeometry);
+        QVERIFY(p.validationError().isEmpty());
     }
 };
 


### PR DESCRIPTION
## Summary

Ten-commit architecture cleanup driven by a fresh review. Two main wins:

1. **Daemon no longer branches on mode.** Every user-facing navigation shortcut (~12 handlers in `daemon/navigation.cpp`) dispatched through ad-hoc `if (isAutotileScreen) { autotile->foo() } else { wta->bar() }` pairs. They now go through a single `ScreenModeRouter::navigatorFor()` call that returns an `INavigationActions*` — each engine implements the interface via a thin adapter. The daemon shortcut handlers are now 4-line dispatches with zero mode branching.

2. **`WindowTrackingAdaptor` is finally a thin facade.** Snap-mode navigation logic (`focusAdjacentZone`, `moveWindowToAdjacentZone`, `swapWindowWithAdjacentZone`, etc.) moved from WTA into `SnapEngine`. Snap-commit orchestration (`windowSnapped` / `windowSnappedMultiZone` / `windowUnsnapped` bodies) moved from WTA into `WindowTrackingService`. The `SnapNavigationTargetResolver` ownership moved from WTA to `SnapEngine`. `toggleWindowFloat`'s circular bounce back into WTA was eliminated. WTA is now a thin D-Bus facade plus shadow state custodian (last-active window, cursor, frame-geometry) populated by D-Bus slots.

Each commit is independently reviewable and the tree is green at every commit (89/89 tests pass).

### Commits

| # | Phase | Commit | Summary |
|---|---|---|---|
| 1 | 1   | `2de8aac8` | `DragBypassReason` enum replaces free-form `bypassReason` string on `DragPolicy` |
| 2 | 1B  | `4cc5b241` | `validationError()` methods + effect-side unmarshal wiring for D-Bus struct types |
| 3 | 2   | `982c4bf1` | Delete dead `m_appIdByInstance` cache + orphan `appIdForInstance()` declaration |
| 4 | 3   | `105f49c1` | Unify `clearStalePendingAssignment` into `consumePendingAssignment` |
| 5 | 5A  | `4213bed3` | `INavigationActions` interface + `ScreenModeRouter::navigatorFor()` dispatch |
| 6 | 5B  | `38216c95` | Snap navigation logic moved from WTA into SnapEngine |
| 7 | 5C  | `14593475` | Snap-commit orchestration moved from WTA to WindowTrackingService |
| 8 | 5D  | `08f4880a` | `toggleWindowFloat` circular bounce eliminated (pre-tile capture → SnapEngine) |
| 9 | 5E  | `3c482d1d` | `SnapNavigationTargetResolver` ownership moved from WTA to SnapEngine |
| 10 | 5F | `25dbd494` | `AutotileEngine::screenStates()` leak replaced with `desktopsWithActiveState()` query |

### Architecture in the final state

| Component | Role |
|---|---|
| `WindowTrackingAdaptor` | D-Bus facade + compositor-layer shadow store (last-active window, cursor, frame-geometry). Thin forwarders for snap D-Bus slots. Signal relay from engines/WTS to D-Bus. |
| `WindowTrackingService` | State store + snap-commit orchestration (`commitSnap` / `commitMultiZoneSnap` / `uncommitSnap`). Emits `windowSnapStateChanged` / `windowFloatingClearedForSnap`. |
| `SnapEngine` | Snap-mode engine. Owns `SnapNavigationTargetResolver`. Implements snap navigation in `src/snap/snapengine/navigation_actions.cpp`. |
| `AutotileEngine` | Autotile-mode engine. Unchanged by this PR. |
| `INavigationActions` | Polymorphic navigation interface (`src/core/inavigationactions.h`). Both engines implement via adapters. |
| `ScreenModeRouter::navigatorFor()` | Single dispatch point for user navigation intents. |
| `daemon/navigation.cpp` | Thin shortcut handlers. 4 lines each. Zero mode-branching. |

### Back-reference coupling (intentional)

`SnapEngine → WTA` back-reference still exists but is read-only and shadow-data-only: `lastActiveWindowId()`, `lastActiveScreenName()`, `lastCursorScreenName()`, `frameGeometry()`. These are populated by WTA's D-Bus slots (`windowActivated`, `cursorScreenChanged`, `setFrameGeometry`) and are legitimately compositor-layer shadow state. No behaviour calls back into WTA — every snap-mode action either talks to WTS directly or stays within SnapEngine.

### Phases NOT done (deliberate)

- **Phase 4** (PlasmaZonesEffect split) — audit verified the decomposition already happened: six handler classes (`DragTracker`, `AutotileHandler`, `WindowAnimator`, `SnapAssistHandler`, `NavigationHandler`, `ScreenChangeHandler`) already own their concerns. The effect is the irreducible KWin integration kernel (8 virtual overrides, 19 D-Bus slots must register on this `QObject`). A split would redistribute state coupling via friends, not eliminate it.
- **AutotileEngine split + friend removal** — 12 private members shared across 3 friend classes (`NavigationController`, `PerScreenConfigResolver`, `SettingsBridge`). Clean removal structurally impossible without exposing 12 new public getters or ~20 wrapper methods — both increase coupling rather than reduce it.
- **Shadow state move off WTA** — `lastActiveWindowId` / cursor / frame-geometry shadows stay on WTA. Legitimately D-Bus-facing shadow data populated by D-Bus slots.

### Notable line count deltas

| File | Baseline | Now | Δ |
|---|---:|---:|---:|
| `dbus/windowtrackingadaptor/navigation.cpp` | 691 | 353 | **−338** |
| `dbus/windowtrackingadaptor.cpp` | ~780 | 663 | −117 |
| `core/windowtrackingservice.h` | 1,052 | 1,134 | +82 (commit methods + signals + docs) |
| `snap/snapengine/navigation_actions.cpp` | — | 492 | new (extracted from WTA) |
| `core/inavigationactions.h` + adapters | — | ~280 | new |

## Test plan

- [ ] Build clean (`cmake --build build --parallel`)
- [ ] Full test suite passes (`ctest --test-dir build --output-on-failure`) — 89/89 green on the branch tip
- [ ] Manual regression: every directional navigation shortcut on an autotile screen (focus, move, swap)
- [ ] Manual regression: every directional navigation shortcut on a snap-mode screen
- [ ] Manual regression: snap to zone by number (1–9) on both modes
- [ ] Manual regression: drag + snap to zone on snap-mode screen
- [ ] Manual regression: drag on autotile screen → float transition at drop
- [ ] Manual regression: Meta-F float toggle on both modes
- [ ] Manual regression: session restore after daemon restart
- [ ] Manual regression: layout switch → resnap
- [ ] Manual regression: cross-VS drag → policy flip
- [ ] Manual regression: rotate windows on both modes
- [ ] Manual regression: cycle focus on both modes

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)