### PR TITLE
refactor(dbus): performance audit — delta persistence, compact signals, async picker

### DIFF
--- a/dbus/org.plasmazones.LayoutManager.xml
+++ b/dbus/org.plasmazones.LayoutManager.xml
@@ -424,9 +424,21 @@
             </arg>
         </signal>
         <signal name="layoutChanged">
-            <annotation name="org.gtk.GDBus.DocString" value="Emitted when the active layout is modified (full layout JSON)."/>
+            <annotation name="org.gtk.GDBus.DocString" value="Emitted on structural layout mutations (editor save, updateLayout, createLayoutFromJson). Carries the full layout JSON payload. Scalar property mutations (hidden, autoAssign, aspectRatioClass) emit layoutPropertyChanged instead to avoid the full serialization."/>
             <arg name="layoutJson" type="s">
                 <annotation name="org.gtk.GDBus.DocString" value="Full layout as JSON."/>
+            </arg>
+        </signal>
+        <signal name="layoutPropertyChanged">
+            <annotation name="org.gtk.GDBus.DocString" value="Compact per-property change notification. Replaces layoutChanged(json) for setLayoutHidden, setLayoutAutoAssign, and setLayoutAspectRatioClass. Subscribers that want the full shape should pull it via getLayout(layoutId) — the adaptor's cache is invalidated before the signal fires."/>
+            <arg name="layoutId" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Layout UUID whose property changed."/>
+            </arg>
+            <arg name="property" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Property name: 'hidden', 'autoAssign', or 'aspectRatioClass'."/>
+            </arg>
+            <arg name="value" type="v">
+                <annotation name="org.gtk.GDBus.DocString" value="New value as a variant (bool or int)."/>
             </arg>
         </signal>
         <signal name="layoutListChanged">

--- a/dbus/org.plasmazones.Settings.xml
+++ b/dbus/org.plasmazones.Settings.xml
@@ -159,7 +159,7 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Map of per-screen setting key -> value."/>
             </arg>
             <arg name="success" type="b" direction="out">
-                <annotation name="org.gtk.GDBus.DocString" value="True if the category was recognized and every setter call returned without erroring."/>
+                <annotation name="org.gtk.GDBus.DocString" value="True if the category was recognized and the batch ran against a concrete Settings backend; false if the category was unknown or no concrete backend was available. Individual per-key failures are logged by the underlying Settings implementation but cannot be surfaced here since the setter methods return void."/>
             </arg>
         </method>
 

--- a/dbus/org.plasmazones.Settings.xml
+++ b/dbus/org.plasmazones.Settings.xml
@@ -163,10 +163,11 @@
             </arg>
         </method>
 
-        <!-- Async window picker flow (preferred). Callers kick off a fetch
-             via requestRunningWindows and bind to runningWindowsAvailable
-             for the reply instead of blocking on the legacy getRunningWindows
-             call path. -->
+        <!-- Async window picker flow. Callers kick off a fetch via
+             requestRunningWindows and bind to runningWindowsAvailable
+             for the reply. No blocking variant exists; the earlier
+             blocking getRunningWindows path was removed in Phase 6 of
+             refactor/dbus-performance. -->
         <method name="requestRunningWindows">
             <annotation name="org.gtk.GDBus.DocString" value="Asynchronously request the running-windows list. The daemon emits runningWindowsRequested to the KWin effect; the reply is delivered via the runningWindowsAvailable signal."/>
         </method>

--- a/dbus/org.plasmazones.Settings.xml
+++ b/dbus/org.plasmazones.Settings.xml
@@ -142,5 +142,19 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Map of uniform names to values (e.g. customParams1_x: 0.5)."/>
             </arg>
         </method>
+
+        <!-- Async window picker flow (preferred). Callers kick off a fetch
+             via requestRunningWindows and bind to runningWindowsAvailable
+             for the reply instead of blocking on the legacy getRunningWindows
+             call path. -->
+        <method name="requestRunningWindows">
+            <annotation name="org.gtk.GDBus.DocString" value="Asynchronously request the running-windows list. The daemon emits runningWindowsRequested to the KWin effect; the reply is delivered via the runningWindowsAvailable signal."/>
+        </method>
+        <signal name="runningWindowsAvailable">
+            <annotation name="org.gtk.GDBus.DocString" value="Emitted when a fresh running-windows list has arrived from the KWin effect."/>
+            <arg name="json" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="JSON array: [{windowClass, appName, caption}, ...]."/>
+            </arg>
+        </signal>
     </interface>
 </node>

--- a/dbus/org.plasmazones.Settings.xml
+++ b/dbus/org.plasmazones.Settings.xml
@@ -143,6 +143,26 @@
             </arg>
         </method>
 
+        <!-- Batch-set multiple per-screen keys in one round-trip (Phase 5
+             of refactor/dbus-performance). Mirrors the global setSettings
+             pattern so the KCM per-monitor page can flush a category in
+             a single D-Bus call. -->
+        <method name="setPerScreenSettings">
+            <annotation name="org.gtk.GDBus.DocString" value="Batch-set multiple per-screen keys in one D-Bus call. Applies every entry to the named category and schedules a single debounced save."/>
+            <arg name="screenId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Virtual or physical screen identifier."/>
+            </arg>
+            <arg name="category" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="'autotile' | 'snapping' | 'zoneSelector'."/>
+            </arg>
+            <arg name="values" type="a{sv}" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Map of per-screen setting key -> value."/>
+            </arg>
+            <arg name="success" type="b" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="True if the category was recognized and every setter call returned without erroring."/>
+            </arg>
+        </method>
+
         <!-- Async window picker flow (preferred). Callers kick off a fetch
              via requestRunningWindows and bind to runningWindowsAvailable
              for the reply instead of blocking on the legacy getRunningWindows

--- a/docs/perf/dbus-baseline.md
+++ b/docs/perf/dbus-baseline.md
@@ -50,16 +50,37 @@ the ratio between runs on the same machine.
   drops the full JSON serialization + marshal of a 5–20KB string. Expected
   60–90% reduction.
 
-## Post-refactor (branch tip)
+## Post-refactor (branch tip after Phase 6)
 
-Filled in after Phase 6.
+Captured on the same reference workstation immediately after the
+Phase 6 cleanup landed. Same CachyOS / GCC 15.2 / Qt 6.11.0 / Unity
+release build.
 
-| Benchmark                                  | Metric    | Value | Δ vs baseline |
-| ------------------------------------------ | --------- | ----- | ------------- |
-| `benchSetSetting_unchanged`                | ns / call | _TBD_ | _TBD_         |
-| `benchSetSetting_changing`                 | ns / call | _TBD_ | _TBD_         |
-| `benchGetSettings_batch` (8 keys)          | ns / call | _TBD_ | _TBD_         |
-| `benchGetSetting_individual` (8 × 1 key)   | ns / call | _TBD_ | _TBD_         |
-| `benchSetLayoutHidden_toggle`              | ns / call | _TBD_ | _TBD_         |
-| `benchSetLayoutHidden_sameValue`           | ns / call | _TBD_ | _TBD_         |
-| `benchGetLayout_cached`                    | ns / call | _TBD_ | _TBD_         |
+| Benchmark                                  | ms / call | Δ vs baseline | Notes |
+| ------------------------------------------ | --------- | ------------- | ----- |
+| `benchSetSetting_unchanged`                | 0.00041   | **−59 %**     | Value-equality guard short-circuits the setter + scheduleSave() restart. |
+| `benchSetSetting_changing`                 | 0.0012    | +20 %         | Extra equality comparison on the changing path. Within noise at 1 µs absolute. |
+| `benchGetSettings_batch` (8 keys)          | 0.0075    | ≈ flat        | Unchanged — already batched pre-refactor. |
+| `benchGetSetting_individual` (8 × 1 key)   | 0.0018    | ≈ flat        | Unchanged baseline. |
+| `benchSetLayoutHidden_toggle`              | 0.055     | **−42 %**     | Compact `layoutPropertyChanged` replaces full-JSON `layoutChanged`; redundant `layoutListChanged` dropped. |
+| `benchSetLayoutHidden_sameValue`           | 0.0012    | **−97 %**     | Layout's internal setter is a no-op for unchanged values, and the only remaining cost is emitting a 3-field compact signal. |
+| `benchGetLayout_cached`                    | 0.00063   | ≈ flat        | Cache path unchanged — the fix was correctness (invalidation on property mutations), not throughput. |
+
+The bench measures in-process adaptor cost only — no D-Bus marshaling.
+Over the wire the wins are larger because each saved signal emission
+also drops 5–20 KB of marshaled JSON per layout mutation and one full
+round-trip per setting write on the unchanged-value path.
+
+WindowTrackingAdaptor delta persistence (Phase 3) has no dedicated
+bench — the optimization gates disk I/O on a per-field dirty bitfield,
+and the win scales with `(#fields not changed) × JSON size`, which
+only shows up in a realistic long-running session. The correctness
+invariant is covered by `tests/unit/core/test_wts_dirty_mask.cpp`.
+
+## How to reproduce
+
+```bash
+cmake --build build --parallel $(nproc) --target bench_dbus_adaptors
+QT_QPA_PLATFORM=offscreen ./build/bin/bench_dbus_adaptors \
+    | grep -A1 RESULT | grep -v '^--$'
+```

--- a/docs/perf/dbus-baseline.md
+++ b/docs/perf/dbus-baseline.md
@@ -1,0 +1,65 @@
+# D-Bus Performance Baseline
+
+Tracks before/after numbers for the refactor on branch `refactor/dbus-performance`.
+
+## Running
+
+```bash
+cmake --build build --parallel $(nproc) --target bench_dbus_adaptors
+./build/tests/unit/bench_dbus_adaptors -tickcounter
+# or
+ctest --test-dir build -R bench_dbus_adaptors --output-on-failure
+```
+
+`-tickcounter` gives cycle-accurate numbers; `-callgrind` writes a callgrind
+profile. `-event` is the default (counts instructions). All three are useful —
+pick whichever is available on the host.
+
+Benchmarks live in `tests/unit/dbus/bench_dbus_adaptors.cpp`. They use
+`StubSettings` + an in-memory `LayoutManager`, so there is no disk I/O in the
+hot path and the numbers reflect pure adaptor + QJson serialization cost.
+
+## Baseline (pre-refactor, branch base = v3 @ a3ee7c44)
+
+Captured on the reference workstation (CachyOS, GCC 15.2, Qt 6.11.0, Unity build,
+release) before any Phase 1 work landed. Numbers vary by host — what matters is
+the ratio between runs on the same machine.
+
+| Benchmark                                  | ms / call | Notes |
+| ------------------------------------------ | --------- | ----- |
+| `benchSetSetting_unchanged`                | 0.0010    | Same cost as changing — setter runs unconditionally |
+| `benchSetSetting_changing`                 | 0.0010    | Reference path |
+| `benchGetSettings_batch` (8 keys)          | 0.0074    | In-process, slower than N calls due to QVariantMap conversion — the batch win is marshal count, not CPU |
+| `benchGetSetting_individual` (8 × 1 key)   | 0.0017    | |
+| `benchSetLayoutHidden_toggle`              | 0.095     | Full layout JSON (~1KB here, 5–20KB in prod) re-serialized each call |
+| `benchSetLayoutHidden_sameValue`           | 0.039     | Still pays full JSON cost — no value-equality guard |
+| `benchGetLayout_cached`                    | 0.00063   | Cached-path baseline (Phase 1.3 must stay within noise) |
+
+## Phase-by-phase expected wins
+
+- **Phase 1.1 (value-equality guard):** `benchSetSetting_unchanged` drops by
+  the cost of the setter lambda + `scheduleSave()` timer restart. Expected
+  50–80% reduction on the unchanged path. The changing path must stay within
+  noise of baseline.
+- **Phase 1.2 (drop layoutListChanged on property mutations):**
+  `benchSetLayoutHidden_toggle` drops one signal emission and one empty-arg
+  marshal. Expected 10–20% reduction.
+- **Phase 1.3 (cache invalidation):** `benchGetLayout_cached` stays flat;
+  correctness change, no throughput impact.
+- **Phase 4 (layoutPropertyChanged delta signal):** `benchSetLayoutHidden_toggle`
+  drops the full JSON serialization + marshal of a 5–20KB string. Expected
+  60–90% reduction.
+
+## Post-refactor (branch tip)
+
+Filled in after Phase 6.
+
+| Benchmark                                  | Metric    | Value | Δ vs baseline |
+| ------------------------------------------ | --------- | ----- | ------------- |
+| `benchSetSetting_unchanged`                | ns / call | _TBD_ | _TBD_         |
+| `benchSetSetting_changing`                 | ns / call | _TBD_ | _TBD_         |
+| `benchGetSettings_batch` (8 keys)          | ns / call | _TBD_ | _TBD_         |
+| `benchGetSetting_individual` (8 × 1 key)   | ns / call | _TBD_ | _TBD_         |
+| `benchSetLayoutHidden_toggle`              | ns / call | _TBD_ | _TBD_         |
+| `benchSetLayoutHidden_sameValue`           | ns / call | _TBD_ | _TBD_         |
+| `benchGetLayout_cached`                    | ns / call | _TBD_ | _TBD_         |

--- a/docs/perf/dbus-baseline.md
+++ b/docs/perf/dbus-baseline.md
@@ -6,7 +6,7 @@ Tracks before/after numbers for the refactor on branch `refactor/dbus-performanc
 
 ```bash
 cmake --build build --parallel $(nproc) --target bench_dbus_adaptors
-./build/tests/unit/bench_dbus_adaptors -tickcounter
+./build/bin/bench_dbus_adaptors -tickcounter
 # or
 ctest --test-dir build -R bench_dbus_adaptors --output-on-failure
 ```

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -861,25 +861,25 @@ public:
 
     // Per-screen zone selector config (override > global fallback)
     ZoneSelectorConfig resolvedZoneSelectorConfig(const QString& screenIdOrName) const override;
-    Q_INVOKABLE QVariantMap getPerScreenZoneSelectorSettings(const QString& screenIdOrName) const;
+    Q_INVOKABLE QVariantMap getPerScreenZoneSelectorSettings(const QString& screenIdOrName) const override;
     Q_INVOKABLE void setPerScreenZoneSelectorSetting(const QString& screenIdOrName, const QString& key,
-                                                     const QVariant& value);
-    Q_INVOKABLE void clearPerScreenZoneSelectorSettings(const QString& screenIdOrName);
+                                                     const QVariant& value) override;
+    Q_INVOKABLE void clearPerScreenZoneSelectorSettings(const QString& screenIdOrName) override;
     Q_INVOKABLE bool hasPerScreenZoneSelectorSettings(const QString& screenIdOrName) const;
     Q_INVOKABLE QStringList screensWithZoneSelectorOverrides() const;
 
     // Per-screen autotile config (override > global fallback)
-    Q_INVOKABLE QVariantMap getPerScreenAutotileSettings(const QString& screenIdOrName) const;
+    Q_INVOKABLE QVariantMap getPerScreenAutotileSettings(const QString& screenIdOrName) const override;
     Q_INVOKABLE void setPerScreenAutotileSetting(const QString& screenIdOrName, const QString& key,
-                                                 const QVariant& value);
-    Q_INVOKABLE void clearPerScreenAutotileSettings(const QString& screenIdOrName);
+                                                 const QVariant& value) override;
+    Q_INVOKABLE void clearPerScreenAutotileSettings(const QString& screenIdOrName) override;
     Q_INVOKABLE bool hasPerScreenAutotileSettings(const QString& screenIdOrName) const;
 
     // Per-screen snapping config (override > global fallback)
     Q_INVOKABLE QVariantMap getPerScreenSnappingSettings(const QString& screenIdOrName) const override;
     Q_INVOKABLE void setPerScreenSnappingSetting(const QString& screenIdOrName, const QString& key,
-                                                 const QVariant& value);
-    Q_INVOKABLE void clearPerScreenSnappingSettings(const QString& screenIdOrName);
+                                                 const QVariant& value) override;
+    Q_INVOKABLE void clearPerScreenSnappingSettings(const QString& screenIdOrName) override;
     Q_INVOKABLE bool hasPerScreenSnappingSettings(const QString& screenIdOrName) const;
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -865,7 +865,7 @@ public:
     Q_INVOKABLE void setPerScreenZoneSelectorSetting(const QString& screenIdOrName, const QString& key,
                                                      const QVariant& value) override;
     Q_INVOKABLE void clearPerScreenZoneSelectorSettings(const QString& screenIdOrName) override;
-    Q_INVOKABLE bool hasPerScreenZoneSelectorSettings(const QString& screenIdOrName) const;
+    Q_INVOKABLE bool hasPerScreenZoneSelectorSettings(const QString& screenIdOrName) const override;
     Q_INVOKABLE QStringList screensWithZoneSelectorOverrides() const;
 
     // Per-screen autotile config (override > global fallback)
@@ -873,14 +873,14 @@ public:
     Q_INVOKABLE void setPerScreenAutotileSetting(const QString& screenIdOrName, const QString& key,
                                                  const QVariant& value) override;
     Q_INVOKABLE void clearPerScreenAutotileSettings(const QString& screenIdOrName) override;
-    Q_INVOKABLE bool hasPerScreenAutotileSettings(const QString& screenIdOrName) const;
+    Q_INVOKABLE bool hasPerScreenAutotileSettings(const QString& screenIdOrName) const override;
 
     // Per-screen snapping config (override > global fallback)
     Q_INVOKABLE QVariantMap getPerScreenSnappingSettings(const QString& screenIdOrName) const override;
     Q_INVOKABLE void setPerScreenSnappingSetting(const QString& screenIdOrName, const QString& key,
                                                  const QVariant& value) override;
     Q_INVOKABLE void clearPerScreenSnappingSettings(const QString& screenIdOrName) override;
-    Q_INVOKABLE bool hasPerScreenSnappingSettings(const QString& screenIdOrName) const;
+    Q_INVOKABLE bool hasPerScreenSnappingSettings(const QString& screenIdOrName) const override;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Autotiling Settings (ISettings interface)

--- a/src/core/interfaces.h
+++ b/src/core/interfaces.h
@@ -150,6 +150,9 @@ public:
     // interface without implementing these. The concrete Settings class
     // overrides every method; the D-Bus SettingsAdaptor depends only on
     // these virtuals so it doesn't need a qobject_cast<Settings*>.
+    // The has*() query methods are virtual with a "nothing persisted"
+    // default so the SettingsAdaptor can answer existence questions
+    // through the interface too.
     // ═══════════════════════════════════════════════════════════════════════════
     virtual QVariantMap getPerScreenAutotileSettings(const QString& /*screenIdOrName*/) const
     {
@@ -161,6 +164,10 @@ public:
     }
     virtual void clearPerScreenAutotileSettings(const QString& /*screenIdOrName*/)
     {
+    }
+    virtual bool hasPerScreenAutotileSettings(const QString& /*screenIdOrName*/) const
+    {
+        return false;
     }
 
     virtual QVariantMap getPerScreenZoneSelectorSettings(const QString& /*screenIdOrName*/) const
@@ -174,6 +181,10 @@ public:
     virtual void clearPerScreenZoneSelectorSettings(const QString& /*screenIdOrName*/)
     {
     }
+    virtual bool hasPerScreenZoneSelectorSettings(const QString& /*screenIdOrName*/) const
+    {
+        return false;
+    }
 
     virtual void setPerScreenSnappingSetting(const QString& /*screenIdOrName*/, const QString& /*key*/,
                                              const QVariant& /*value*/)
@@ -181,6 +192,10 @@ public:
     }
     virtual void clearPerScreenSnappingSettings(const QString& /*screenIdOrName*/)
     {
+    }
+    virtual bool hasPerScreenSnappingSettings(const QString& /*screenIdOrName*/) const
+    {
+        return false;
     }
 
     // Persistence (unique to ISettings)

--- a/src/core/interfaces.h
+++ b/src/core/interfaces.h
@@ -143,6 +143,46 @@ public:
     virtual QString renderingBackend() const = 0;
     virtual void setRenderingBackend(const QString& backend) = 0;
 
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Per-screen overrides — category-keyed maps of setting key → value that
+    // live alongside the global setting. Defaults are no-op bodies so backends
+    // that don't persist per-screen state (test stubs) can inherit the
+    // interface without implementing these. The concrete Settings class
+    // overrides every method; the D-Bus SettingsAdaptor depends only on
+    // these virtuals so it doesn't need a qobject_cast<Settings*>.
+    // ═══════════════════════════════════════════════════════════════════════════
+    virtual QVariantMap getPerScreenAutotileSettings(const QString& /*screenIdOrName*/) const
+    {
+        return {};
+    }
+    virtual void setPerScreenAutotileSetting(const QString& /*screenIdOrName*/, const QString& /*key*/,
+                                             const QVariant& /*value*/)
+    {
+    }
+    virtual void clearPerScreenAutotileSettings(const QString& /*screenIdOrName*/)
+    {
+    }
+
+    virtual QVariantMap getPerScreenZoneSelectorSettings(const QString& /*screenIdOrName*/) const
+    {
+        return {};
+    }
+    virtual void setPerScreenZoneSelectorSetting(const QString& /*screenIdOrName*/, const QString& /*key*/,
+                                                 const QVariant& /*value*/)
+    {
+    }
+    virtual void clearPerScreenZoneSelectorSettings(const QString& /*screenIdOrName*/)
+    {
+    }
+
+    virtual void setPerScreenSnappingSetting(const QString& /*screenIdOrName*/, const QString& /*key*/,
+                                             const QVariant& /*value*/)
+    {
+    }
+    virtual void clearPerScreenSnappingSettings(const QString& /*screenIdOrName*/)
+    {
+    }
+
     // Persistence (unique to ISettings)
     virtual void load() = 0;
     virtual void save() = 0;

--- a/src/core/interfaces.h
+++ b/src/core/interfaces.h
@@ -186,6 +186,10 @@ public:
         return false;
     }
 
+    virtual QVariantMap getPerScreenSnappingSettings(const QString& /*screenIdOrName*/) const
+    {
+        return {};
+    }
     virtual void setPerScreenSnappingSetting(const QString& /*screenIdOrName*/, const QString& /*key*/,
                                              const QVariant& /*value*/)
     {

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -258,12 +258,9 @@ public:
     virtual void setMinimumZoneSizePx(int size) = 0;
     virtual int minimumZoneDisplaySizePx() const = 0;
     virtual void setMinimumZoneDisplaySizePx(int size) = 0;
-
-    // Per-screen snapping config resolution (override > global fallback)
-    virtual QVariantMap getPerScreenSnappingSettings(const QString& /*screenIdOrName*/) const
-    {
-        return {};
-    }
+    // Per-screen snapping overrides are declared on ISettings alongside the
+    // autotile / zone-selector per-screen APIs so all three share one home.
+    // See PlasmaZones::ISettings in core/interfaces.h.
 };
 
 /**

--- a/src/core/windowtrackingservice.cpp
+++ b/src/core/windowtrackingservice.cpp
@@ -249,6 +249,14 @@ int WindowTrackingService::pruneStaleAssignments(const QSet<QString>& aliveWindo
     removeSetIfNotAlive(m_autoSnappedWindows);
     removeSetIfNotAlive(m_effectReportedWindows);
 
+    // Persist the prune. Without this, delta-persistence short-circuits in
+    // saveState() (takeDirty() == DirtyNone) and stale entries come back as
+    // ghost windows on the next daemon restart — exactly the bug that the
+    // initial pruneStaleWindows fix was written to prevent.
+    if (pruned > 0) {
+        markDirty(DirtyZoneAssignments | DirtyPreTileGeometries | DirtyPreFloatZones | DirtyPreFloatScreens);
+    }
+
     return pruned;
 }
 
@@ -542,6 +550,15 @@ void WindowTrackingService::unsnapForFloat(const QString& windowId)
             m_preFloatScreenAssignments[windowId] = screenId;
         }
         qCInfo(lcCore) << "Saved pre-float zones for" << windowId << "->" << zoneIds << "screen:" << screenId;
+
+        // Mark the pre-float mutations dirty in their own right. Historically
+        // every caller immediately follows up with setWindowFloating(true),
+        // which uses DirtyAll and masks the hole — but that's an implicit
+        // contract between unrelated methods. Marking here makes
+        // unsnapForFloat self-sufficient so a future refactor that separates
+        // the two calls cannot silently lose pre-float restore state.
+        markDirty(DirtyPreFloatZones | DirtyPreFloatScreens);
+
         unassignWindow(windowId);
 
         // Pop one pending-restore entry (FIFO) so this window doesn't get

--- a/src/core/windowtrackingservice.cpp
+++ b/src/core/windowtrackingservice.cpp
@@ -128,7 +128,9 @@ void WindowTrackingService::assignWindowToZones(const QString& windowId, const Q
     if (zoneChanged) {
         Q_EMIT windowZoneChanged(windowId, validZoneIds.first());
     }
-    scheduleSaveState();
+    // Only the zone/screen/desktop maps changed. Narrower than DirtyAll so
+    // the next save rewrites exactly one JSON field instead of all ten.
+    markDirty(DirtyZoneAssignments);
 }
 
 void WindowTrackingService::unassignWindow(const QString& windowId)
@@ -142,20 +144,22 @@ void WindowTrackingService::unassignWindow(const QString& windowId)
     m_windowScreenAssignments.remove(windowId);
     m_windowDesktopAssignments.remove(windowId);
 
-    // Clear last-used zone if we're unsnapping from it
-    // This preserves last-used zone when unsnapping a different window
+    // Clear last-used zone if we're unsnapping from it. Track whether this
+    // branch ran so the dirty mask accurately reflects what changed.
+    bool lastUsedCleared = false;
     if (!m_lastUsedZoneId.isEmpty() && previousZoneIds.contains(m_lastUsedZoneId)) {
         m_lastUsedZoneId.clear();
         m_lastUsedScreenId.clear();
         m_lastUsedZoneClass.clear();
         m_lastUsedDesktop = 0;
+        lastUsedCleared = true;
     }
 
     // Don't remove from pending - keep for session restore
     // (pending is keyed by app ID anyway)
 
     Q_EMIT windowZoneChanged(windowId, QString());
-    scheduleSaveState();
+    markDirty(DirtyZoneAssignments | (lastUsedCleared ? DirtyLastUsedZone : DirtyNone));
 }
 
 QString WindowTrackingService::zoneForWindow(const QString& windowId) const
@@ -316,7 +320,7 @@ void WindowTrackingService::storePreTileGeometry(const QString& windowId, const 
         }
     }
 
-    scheduleSaveState();
+    markDirty(DirtyPreTileGeometries);
 }
 
 std::optional<QRect> WindowTrackingService::preTileGeometry(const QString& windowId) const
@@ -365,7 +369,7 @@ void WindowTrackingService::clearPreTileGeometry(const QString& windowId)
     }
     if (removed) {
         qCDebug(lcCore) << "clearPreTileGeometry:" << windowId;
-        scheduleSaveState();
+        markDirty(DirtyPreTileGeometries);
     }
 }
 

--- a/src/core/windowtrackingservice.h
+++ b/src/core/windowtrackingservice.h
@@ -1017,6 +1017,68 @@ public:
         m_preFloatScreenAssignments = assignments;
     }
 
+public:
+    // ═══════════════════════════════════════════════════════════════════════
+    // Dirty field tracking (Phase 3 of refactor/dbus-performance)
+    //
+    // Replaces "any mutation forces a full re-serialization" with a bitfield
+    // mask of which persisted state has changed since the last successful
+    // save. WindowTrackingAdaptor::saveState() reads this mask to decide
+    // which JSON maps to re-write, and the persistence worker's write-
+    // completed signal clears the committed bits — surviving bits either
+    // represent new mutations that landed during the in-flight write, or
+    // the write itself failed (same treatment in both cases: retry on the
+    // next tick).
+    //
+    // The mask is initialized to All so the first save after a daemon
+    // startup always writes every field. loadState() should clear the mask
+    // immediately after populating in-memory state so the first real save
+    // doesn't redundantly write back what we just loaded.
+    // ═══════════════════════════════════════════════════════════════════════
+    enum DirtyField : uint32_t {
+        DirtyNone = 0,
+        DirtyActiveLayoutId = 1u << 0,
+        DirtyZoneAssignments = 1u << 1, // zones + screens + desktops (always written together)
+        DirtyPendingRestores = 1u << 2,
+        DirtyPreTileGeometries = 1u << 3,
+        DirtyLastUsedZone = 1u << 4,
+        DirtyPreFloatZones = 1u << 5,
+        DirtyPreFloatScreens = 1u << 6,
+        DirtyUserSnapped = 1u << 7,
+        DirtyAutotileOrders = 1u << 8,
+        DirtyAutotilePending = 1u << 9,
+        DirtyAll = 0x3FFu,
+    };
+    using DirtyMask = uint32_t;
+
+    /// OR the given fields into the dirty mask AND emit stateChanged.
+    /// Primary entry point for mutators — replaces direct scheduleSaveState().
+    /// Public because the adaptor also needs to mark dirty from outside,
+    /// e.g. when the active-layout change is observed via LayoutManager.
+    void markDirty(DirtyMask fields);
+
+    /// Return the current dirty mask, clearing it atomically. Used by the
+    /// adaptor's saveState() to snapshot "what needs writing" in one step.
+    DirtyMask takeDirty();
+
+    /// Return the current dirty mask without clearing. Read-only accessor
+    /// for tests and instrumentation.
+    DirtyMask peekDirty() const
+    {
+        return m_dirtyMask;
+    }
+
+    /// OR fields back into the dirty mask. Called by the adaptor when a
+    /// write fails (persistence worker signals writeCompleted(success=false))
+    /// so the next save picks up the bits the failed attempt was supposed
+    /// to cover.
+    void addDirty(DirtyMask fields);
+
+    /// Clear every dirty bit. Called from loadState's end after in-memory
+    /// state mirrors the disk file — nothing is dirty until the next
+    /// mutation lands.
+    void clearDirty();
+
 Q_SIGNALS:
     /**
      * @brief Emitted when a window's zone assignment changes
@@ -1057,7 +1119,15 @@ private:
     static constexpr int MinVisibleHeight = 100;
 
     // Helpers
-    void scheduleSaveState();
+    //
+    // scheduleSaveState() wraps markDirty(DirtyAll). Retained as the
+    // default entry point for mutators that haven't been updated to
+    // declare which specific fields they touch — marking everything dirty
+    // is behaviorally equivalent to the pre-refactor code. Hot-path
+    // mutators (assign/unassign zone, storePreTileGeometry, etc.) should
+    // call markDirty() directly with a narrow mask so the next save
+    // only re-serializes the fields that actually changed.
+    void scheduleSaveState(DirtyMask fields = DirtyAll);
     bool isGeometryOnScreen(const QRect& geometry) const;
     QRect adjustGeometryToScreen(const QRect& geometry) const;
     Zone* findZoneById(const QString& zoneId) const;
@@ -1210,6 +1280,11 @@ private:
         int virtualDesktop = 0;
     };
     QVector<ResnapEntry> m_resnapBuffer;
+
+    // Delta-persistence dirty mask. Initial value DirtyAll forces the first
+    // save after daemon startup to serialize every field. Cleared by
+    // loadState() once in-memory state mirrors the disk file.
+    DirtyMask m_dirtyMask = DirtyAll;
 
     // Note: No save timer - persistence handled by WindowTrackingAdaptor via KConfig
     // Service emits stateChanged() signal when state needs saving

--- a/src/core/windowtrackingservice.h
+++ b/src/core/windowtrackingservice.h
@@ -1017,7 +1017,6 @@ public:
         m_preFloatScreenAssignments = assignments;
     }
 
-public:
     // ═══════════════════════════════════════════════════════════════════════
     // Dirty field tracking (Phase 3 of refactor/dbus-performance)
     //
@@ -1052,9 +1051,12 @@ public:
     using DirtyMask = uint32_t;
 
     /// OR the given fields into the dirty mask AND emit stateChanged.
-    /// Primary entry point for mutators — replaces direct scheduleSaveState().
-    /// Public because the adaptor also needs to mark dirty from outside,
-    /// e.g. when the active-layout change is observed via LayoutManager.
+    /// Primary (and only) entry point for mutators — replaces direct
+    /// scheduleSaveState(). Public because the adaptor also needs to
+    /// mark dirty from outside, e.g. when the active-layout change is
+    /// observed via LayoutManager or when a failed async write needs
+    /// its bits re-marked for retry. Multiple calls are idempotent
+    /// (OR semantics) and cheap (bit OR + one signal emission).
     void markDirty(DirtyMask fields);
 
     /// Return the current dirty mask, clearing it atomically. Used by the
@@ -1067,12 +1069,6 @@ public:
     {
         return m_dirtyMask;
     }
-
-    /// OR fields back into the dirty mask. Called by the adaptor when a
-    /// write fails (persistence worker signals writeCompleted(success=false))
-    /// so the next save picks up the bits the failed attempt was supposed
-    /// to cover.
-    void addDirty(DirtyMask fields);
 
     /// Clear every dirty bit. Called from loadState's end after in-memory
     /// state mirrors the disk file — nothing is dirty until the next

--- a/src/core/windowtrackingservice/lifecycle.cpp
+++ b/src/core/windowtrackingservice/lifecycle.cpp
@@ -783,11 +783,6 @@ WindowTrackingService::DirtyMask WindowTrackingService::takeDirty()
     return current;
 }
 
-void WindowTrackingService::addDirty(DirtyMask fields)
-{
-    m_dirtyMask |= fields;
-}
-
 void WindowTrackingService::clearDirty()
 {
     m_dirtyMask = DirtyNone;

--- a/src/core/windowtrackingservice/lifecycle.cpp
+++ b/src/core/windowtrackingservice/lifecycle.cpp
@@ -756,11 +756,41 @@ void WindowTrackingService::onLayoutChanged()
 // State Management (persistence handled by adaptor via KConfig)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-void WindowTrackingService::scheduleSaveState()
+void WindowTrackingService::scheduleSaveState(DirtyMask fields)
 {
-    // Signal to adaptor that state changed and needs saving
-    // Adaptor handles actual KConfig persistence
+    // Mark the supplied fields dirty and wake the adaptor's save timer.
+    // Default DirtyAll preserves pre-Phase-3 semantics for call sites that
+    // haven't been updated to declare which fields they mutate.
+    markDirty(fields);
+}
+
+void WindowTrackingService::markDirty(DirtyMask fields)
+{
+    // OR into the persistent mask so the next saveState() knows which
+    // JSON maps it needs to rewrite. Always emit stateChanged so the
+    // adaptor's debounced save timer is kicked — even if the caller
+    // passed DirtyNone (e.g. ephemeral state that wants to wake the timer
+    // for indirect reasons), the adaptor does the right thing when the
+    // eventual saveState() sees an empty mask.
+    m_dirtyMask |= fields;
     Q_EMIT stateChanged();
+}
+
+WindowTrackingService::DirtyMask WindowTrackingService::takeDirty()
+{
+    const DirtyMask current = m_dirtyMask;
+    m_dirtyMask = DirtyNone;
+    return current;
+}
+
+void WindowTrackingService::addDirty(DirtyMask fields)
+{
+    m_dirtyMask |= fields;
+}
+
+void WindowTrackingService::clearDirty()
+{
+    m_dirtyMask = DirtyNone;
 }
 
 void WindowTrackingService::setLastUsedZone(const QString& zoneId, const QString& screenId, const QString& zoneClass,

--- a/src/core/windowtrackingservice/snap.cpp
+++ b/src/core/windowtrackingservice/snap.cpp
@@ -453,7 +453,7 @@ void WindowTrackingService::recordSnapIntent(const QString& windowId, bool wasUs
         QString windowClass = currentAppIdFor(windowId);
         if (!windowClass.isEmpty()) {
             m_userSnappedClasses.insert(windowClass);
-            scheduleSaveState();
+            markDirty(DirtyUserSnapped);
         }
     }
 }
@@ -465,7 +465,7 @@ void WindowTrackingService::updateLastUsedZone(const QString& zoneId, const QStr
     m_lastUsedScreenId = screenId;
     m_lastUsedZoneClass = windowClass;
     m_lastUsedDesktop = virtualDesktop;
-    scheduleSaveState();
+    markDirty(DirtyLastUsedZone);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -707,7 +707,7 @@ bool WindowTrackingService::consumePendingAssignment(const QString& windowId)
     }
     qCDebug(lcCore) << "Consumed pending assignment for" << appId
                     << "remaining:" << m_pendingRestoreQueues.value(appId).size();
-    scheduleSaveState();
+    markDirty(DirtyPendingRestores);
     return true;
 }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -495,6 +495,12 @@ bool Daemon::init()
     // Narrower dirty mask than the default DirtyAll — only the two autotile-owned
     // fields can change as a result of a tilingChanged signal, so the next save
     // rewrites just those keys rather than the whole window-tracking blob.
+    //
+    // markDirty() emits WindowTrackingService::stateChanged, which is wired to
+    // WindowTrackingAdaptor::scheduleSaveState in the adaptor's constructor —
+    // that connection is what actually kicks the debounced save timer. If the
+    // stateChanged hookup ever gets severed, autotile state will silently
+    // stop persisting; add an explicit scheduleSaveState() call here if so.
     connect(m_autotileEngine.get(), &AutotileEngine::tilingChanged, m_windowTrackingAdaptor, [this]() {
         if (m_windowTrackingAdaptor && m_windowTrackingAdaptor->service()) {
             m_windowTrackingAdaptor->service()->markDirty(WindowTrackingService::DirtyAutotileOrders

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -491,9 +491,16 @@ bool Daemon::init()
                 engine->deserializePendingRestores(obj);
         });
 
-    // Trigger WTA save on autotile state changes (window order, split ratio, master count)
-    connect(m_autotileEngine.get(), &AutotileEngine::tilingChanged, m_windowTrackingAdaptor,
-            &WindowTrackingAdaptor::scheduleSaveState);
+    // Trigger WTA save on autotile state changes (window order, split ratio, master count).
+    // Narrower dirty mask than the default DirtyAll — only the two autotile-owned
+    // fields can change as a result of a tilingChanged signal, so the next save
+    // rewrites just those keys rather than the whole window-tracking blob.
+    connect(m_autotileEngine.get(), &AutotileEngine::tilingChanged, m_windowTrackingAdaptor, [this]() {
+        if (m_windowTrackingAdaptor && m_windowTrackingAdaptor->service()) {
+            m_windowTrackingAdaptor->service()->markDirty(WindowTrackingService::DirtyAutotileOrders
+                                                          | WindowTrackingService::DirtyAutotilePending);
+        }
+    });
 
     // Create engine D-Bus adaptors — each engine has a dedicated adaptor that
     // connects signals in its constructor (unified pattern for both engines)

--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -314,17 +314,18 @@ void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
     layout->setHiddenFromSelector(hidden);
     // Note: saveLayouts() is triggered automatically via layoutModified signal
 
-    // Invalidate the cached JSON for this layout so getLayout() re-serializes
-    // with the new hidden flag. Without this, subsequent reads would serve a
-    // stale cache entry populated before the mutation.
+    // Invalidate the cached JSON for this layout so a later getLayout()
+    // re-serializes with the new value. Subscribers that want the full
+    // shape after a property mutation pull via getLayout — the signal is
+    // deliberately narrow.
     invalidateLayoutJsonCache(m_cachedLayoutJson, m_cachedActiveLayoutId, m_cachedActiveLayoutJson, layout->id());
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "hidden:" << hidden;
-    // Single property mutation — emit layoutChanged only. layoutListChanged
-    // is reserved for add/delete operations; subscribers (SettingsController)
-    // already connect both signals to the same reload slot, so the extra
-    // emission is pure signal churn.
-    Q_EMIT layoutChanged(QString::fromUtf8(QJsonDocument(layout->toJson()).toJson()));
+    // Phase 4 of refactor/dbus-performance: emit the compact property
+    // signal (3 strings + 1 bool over the wire) instead of layoutChanged
+    // with the full 5–20 KB JSON payload. layoutListChanged is likewise
+    // not emitted — the list didn't change.
+    Q_EMIT layoutPropertyChanged(layoutId, QStringLiteral("hidden"), QDBusVariant(hidden));
 }
 
 void LayoutAdaptor::setLayoutAutoAssign(const QString& layoutId, bool enabled)
@@ -340,8 +341,7 @@ void LayoutAdaptor::setLayoutAutoAssign(const QString& layoutId, bool enabled)
     invalidateLayoutJsonCache(m_cachedLayoutJson, m_cachedActiveLayoutId, m_cachedActiveLayoutJson, layout->id());
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "autoAssign:" << enabled;
-    // See setLayoutHidden for the rationale on not emitting layoutListChanged.
-    Q_EMIT layoutChanged(QString::fromUtf8(QJsonDocument(layout->toJson()).toJson()));
+    Q_EMIT layoutPropertyChanged(layoutId, QStringLiteral("autoAssign"), QDBusVariant(enabled));
 }
 
 void LayoutAdaptor::setLayoutAspectRatioClass(const QString& layoutId, int aspectRatioClass)
@@ -356,8 +356,7 @@ void LayoutAdaptor::setLayoutAspectRatioClass(const QString& layoutId, int aspec
     invalidateLayoutJsonCache(m_cachedLayoutJson, m_cachedActiveLayoutId, m_cachedActiveLayoutJson, layout->id());
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "aspectRatioClass:" << aspectRatioClass;
-    // See setLayoutHidden for the rationale on not emitting layoutListChanged.
-    Q_EMIT layoutChanged(QString::fromUtf8(QJsonDocument(layout->toJson()).toJson()));
+    Q_EMIT layoutPropertyChanged(layoutId, QStringLiteral("aspectRatioClass"), QDBusVariant(aspectRatioClass));
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -288,6 +288,22 @@ QString LayoutAdaptor::getLayout(const QString& id)
 // Visibility Filtering
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// Drop any cached JSON for @p uuid so the next getLayout call
+// re-serializes from the live Layout. Also clears the active-layout
+// cache slot if the modified layout happens to be the active one,
+// otherwise getActiveLayout would keep serving the stale entry.
+// Private helper — used by all per-layout mutation paths to keep
+// cache invalidation centralized.
+static void invalidateLayoutJsonCache(QHash<QUuid, QString>& cache, QUuid& cachedActiveId, QString& cachedActiveJson,
+                                      const QUuid& uuid)
+{
+    cache.remove(uuid);
+    if (cachedActiveId == uuid) {
+        cachedActiveId = QUuid();
+        cachedActiveJson.clear();
+    }
+}
+
 void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
 {
     auto* layout = getValidatedLayout(layoutId, QStringLiteral("set layout hidden"));
@@ -297,6 +313,11 @@ void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
 
     layout->setHiddenFromSelector(hidden);
     // Note: saveLayouts() is triggered automatically via layoutModified signal
+
+    // Invalidate the cached JSON for this layout so getLayout() re-serializes
+    // with the new hidden flag. Without this, subsequent reads would serve a
+    // stale cache entry populated before the mutation.
+    invalidateLayoutJsonCache(m_cachedLayoutJson, m_cachedActiveLayoutId, m_cachedActiveLayoutJson, layout->id());
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "hidden:" << hidden;
     // Single property mutation — emit layoutChanged only. layoutListChanged
@@ -316,6 +337,8 @@ void LayoutAdaptor::setLayoutAutoAssign(const QString& layoutId, bool enabled)
     layout->setAutoAssign(enabled);
     // Note: saveLayouts() is triggered automatically via layoutModified signal
 
+    invalidateLayoutJsonCache(m_cachedLayoutJson, m_cachedActiveLayoutId, m_cachedActiveLayoutJson, layout->id());
+
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "autoAssign:" << enabled;
     // See setLayoutHidden for the rationale on not emitting layoutListChanged.
     Q_EMIT layoutChanged(QString::fromUtf8(QJsonDocument(layout->toJson()).toJson()));
@@ -329,6 +352,8 @@ void LayoutAdaptor::setLayoutAspectRatioClass(const QString& layoutId, int aspec
     }
 
     layout->setAspectRatioClassInt(aspectRatioClass);
+
+    invalidateLayoutJsonCache(m_cachedLayoutJson, m_cachedActiveLayoutId, m_cachedActiveLayoutJson, layout->id());
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "aspectRatioClass:" << aspectRatioClass;
     // See setLayoutHidden for the rationale on not emitting layoutListChanged.

--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -299,8 +299,11 @@ void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
     // Note: saveLayouts() is triggered automatically via layoutModified signal
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "hidden:" << hidden;
+    // Single property mutation — emit layoutChanged only. layoutListChanged
+    // is reserved for add/delete operations; subscribers (SettingsController)
+    // already connect both signals to the same reload slot, so the extra
+    // emission is pure signal churn.
     Q_EMIT layoutChanged(QString::fromUtf8(QJsonDocument(layout->toJson()).toJson()));
-    Q_EMIT layoutListChanged();
 }
 
 void LayoutAdaptor::setLayoutAutoAssign(const QString& layoutId, bool enabled)
@@ -314,8 +317,8 @@ void LayoutAdaptor::setLayoutAutoAssign(const QString& layoutId, bool enabled)
     // Note: saveLayouts() is triggered automatically via layoutModified signal
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "autoAssign:" << enabled;
+    // See setLayoutHidden for the rationale on not emitting layoutListChanged.
     Q_EMIT layoutChanged(QString::fromUtf8(QJsonDocument(layout->toJson()).toJson()));
-    Q_EMIT layoutListChanged();
 }
 
 void LayoutAdaptor::setLayoutAspectRatioClass(const QString& layoutId, int aspectRatioClass)
@@ -328,8 +331,8 @@ void LayoutAdaptor::setLayoutAspectRatioClass(const QString& layoutId, int aspec
     layout->setAspectRatioClassInt(aspectRatioClass);
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "aspectRatioClass:" << aspectRatioClass;
+    // See setLayoutHidden for the rationale on not emitting layoutListChanged.
     Q_EMIT layoutChanged(QString::fromUtf8(QJsonDocument(layout->toJson()).toJson()));
-    Q_EMIT layoutListChanged();
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -288,26 +288,36 @@ QString LayoutAdaptor::getLayout(const QString& id)
 // Visibility Filtering
 // ═══════════════════════════════════════════════════════════════════════════════
 
-// Drop any cached JSON for @p uuid so the next getLayout call
-// re-serializes from the live Layout. Also clears the active-layout
-// cache slot if the modified layout happens to be the active one,
-// otherwise getActiveLayout would keep serving the stale entry.
-// Private helper — used by all per-layout mutation paths to keep
-// cache invalidation centralized.
-static void invalidateLayoutJsonCache(QHash<QUuid, QString>& cache, QUuid& cachedActiveId, QString& cachedActiveJson,
-                                      const QUuid& uuid)
+void LayoutAdaptor::invalidateLayoutJsonCacheFor(const QUuid& uuid)
 {
-    cache.remove(uuid);
-    if (cachedActiveId == uuid) {
-        cachedActiveId = QUuid();
-        cachedActiveJson.clear();
+    m_cachedLayoutJson.remove(uuid);
+    if (m_cachedActiveLayoutId == uuid) {
+        m_cachedActiveLayoutId = QUuid();
+        m_cachedActiveLayoutJson.clear();
     }
 }
+
+// Property-name constants for the compact layoutPropertyChanged signal.
+// Centralizes the wire format so the three mutators and any future
+// subscriber-side dispatcher cannot drift on spelling.
+namespace {
+constexpr QLatin1String kPropHidden{"hidden"};
+constexpr QLatin1String kPropAutoAssign{"autoAssign"};
+constexpr QLatin1String kPropAspectRatioClass{"aspectRatioClass"};
+} // namespace
 
 void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
 {
     auto* layout = getValidatedLayout(layoutId, QStringLiteral("set layout hidden"));
     if (!layout) {
+        return;
+    }
+
+    // Value-equality guard: skip the mutation + cache invalidation +
+    // signal fan-out when the incoming value already matches the current
+    // one. Mirrors the Phase 1.1 guard in SettingsAdaptor::setSetting so
+    // a settled checkbox cannot spam subscribers with no-op reloads.
+    if (layout->hiddenFromSelector() == hidden) {
         return;
     }
 
@@ -318,14 +328,14 @@ void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
     // re-serializes with the new value. Subscribers that want the full
     // shape after a property mutation pull via getLayout — the signal is
     // deliberately narrow.
-    invalidateLayoutJsonCache(m_cachedLayoutJson, m_cachedActiveLayoutId, m_cachedActiveLayoutJson, layout->id());
+    invalidateLayoutJsonCacheFor(layout->id());
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "hidden:" << hidden;
     // Phase 4 of refactor/dbus-performance: emit the compact property
     // signal (3 strings + 1 bool over the wire) instead of layoutChanged
     // with the full 5–20 KB JSON payload. layoutListChanged is likewise
     // not emitted — the list didn't change.
-    Q_EMIT layoutPropertyChanged(layoutId, QStringLiteral("hidden"), QDBusVariant(hidden));
+    Q_EMIT layoutPropertyChanged(layoutId, QString(kPropHidden), QDBusVariant(hidden));
 }
 
 void LayoutAdaptor::setLayoutAutoAssign(const QString& layoutId, bool enabled)
@@ -335,13 +345,17 @@ void LayoutAdaptor::setLayoutAutoAssign(const QString& layoutId, bool enabled)
         return;
     }
 
+    if (layout->autoAssign() == enabled) {
+        return;
+    }
+
     layout->setAutoAssign(enabled);
     // Note: saveLayouts() is triggered automatically via layoutModified signal
 
-    invalidateLayoutJsonCache(m_cachedLayoutJson, m_cachedActiveLayoutId, m_cachedActiveLayoutJson, layout->id());
+    invalidateLayoutJsonCacheFor(layout->id());
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "autoAssign:" << enabled;
-    Q_EMIT layoutPropertyChanged(layoutId, QStringLiteral("autoAssign"), QDBusVariant(enabled));
+    Q_EMIT layoutPropertyChanged(layoutId, QString(kPropAutoAssign), QDBusVariant(enabled));
 }
 
 void LayoutAdaptor::setLayoutAspectRatioClass(const QString& layoutId, int aspectRatioClass)
@@ -351,12 +365,16 @@ void LayoutAdaptor::setLayoutAspectRatioClass(const QString& layoutId, int aspec
         return;
     }
 
+    if (static_cast<int>(layout->aspectRatioClass()) == aspectRatioClass) {
+        return;
+    }
+
     layout->setAspectRatioClassInt(aspectRatioClass);
 
-    invalidateLayoutJsonCache(m_cachedLayoutJson, m_cachedActiveLayoutId, m_cachedActiveLayoutJson, layout->id());
+    invalidateLayoutJsonCacheFor(layout->id());
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "aspectRatioClass:" << aspectRatioClass;
-    Q_EMIT layoutPropertyChanged(layoutId, QStringLiteral("aspectRatioClass"), QDBusVariant(aspectRatioClass));
+    Q_EMIT layoutPropertyChanged(layoutId, QString(kPropAspectRatioClass), QDBusVariant(aspectRatioClass));
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -299,11 +299,13 @@ void LayoutAdaptor::invalidateLayoutJsonCacheFor(const QUuid& uuid)
 
 // Property-name constants for the compact layoutPropertyChanged signal.
 // Centralizes the wire format so the three mutators and any future
-// subscriber-side dispatcher cannot drift on spelling.
+// subscriber-side dispatcher cannot drift on spelling. Stored as
+// `const QString` (via QStringLiteral's static UTF-16 storage) so the
+// emit sites don't allocate a temporary QString on every property change.
 namespace {
-constexpr QLatin1String kPropHidden{"hidden"};
-constexpr QLatin1String kPropAutoAssign{"autoAssign"};
-constexpr QLatin1String kPropAspectRatioClass{"aspectRatioClass"};
+const QString kPropHidden = QStringLiteral("hidden");
+const QString kPropAutoAssign = QStringLiteral("autoAssign");
+const QString kPropAspectRatioClass = QStringLiteral("aspectRatioClass");
 } // namespace
 
 void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
@@ -335,7 +337,7 @@ void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
     // signal (3 strings + 1 bool over the wire) instead of layoutChanged
     // with the full 5–20 KB JSON payload. layoutListChanged is likewise
     // not emitted — the list didn't change.
-    Q_EMIT layoutPropertyChanged(layoutId, QString(kPropHidden), QDBusVariant(hidden));
+    Q_EMIT layoutPropertyChanged(layoutId, kPropHidden, QDBusVariant(hidden));
 }
 
 void LayoutAdaptor::setLayoutAutoAssign(const QString& layoutId, bool enabled)
@@ -355,7 +357,7 @@ void LayoutAdaptor::setLayoutAutoAssign(const QString& layoutId, bool enabled)
     invalidateLayoutJsonCacheFor(layout->id());
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "autoAssign:" << enabled;
-    Q_EMIT layoutPropertyChanged(layoutId, QString(kPropAutoAssign), QDBusVariant(enabled));
+    Q_EMIT layoutPropertyChanged(layoutId, kPropAutoAssign, QDBusVariant(enabled));
 }
 
 void LayoutAdaptor::setLayoutAspectRatioClass(const QString& layoutId, int aspectRatioClass)
@@ -374,7 +376,7 @@ void LayoutAdaptor::setLayoutAspectRatioClass(const QString& layoutId, int aspec
     invalidateLayoutJsonCacheFor(layout->id());
 
     qCInfo(lcDbusLayout) << "Set layout" << layoutId << "aspectRatioClass:" << aspectRatioClass;
-    Q_EMIT layoutPropertyChanged(layoutId, QString(kPropAspectRatioClass), QDBusVariant(aspectRatioClass));
+    Q_EMIT layoutPropertyChanged(layoutId, kPropAspectRatioClass, QDBusVariant(aspectRatioClass));
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/layoutadaptor.h
+++ b/src/dbus/layoutadaptor.h
@@ -6,6 +6,7 @@
 #include "plasmazones_export.h"
 #include <QObject>
 #include <QDBusAbstractAdaptor>
+#include <QDBusVariant>
 #include <QString>
 #include <QStringList>
 #include <QUuid>
@@ -196,7 +197,37 @@ Q_SIGNALS:
      */
     void daemonReady();
 
+    /**
+     * @brief Full-layout change notification.
+     *
+     * Emitted by structural mutations — editor save, createLayoutFromJson,
+     * updateLayout — where the client genuinely needs the whole serialized
+     * layout. Carries the complete JSON payload (5–20 KB in prod).
+     *
+     * Compact property-level mutations (setLayoutHidden / setLayoutAutoAssign /
+     * setLayoutAspectRatioClass) do NOT emit this signal any more — they
+     * emit layoutPropertyChanged instead to avoid the full re-serialization.
+     */
     void layoutChanged(const QString& layoutJson);
+
+    /**
+     * @brief Compact property-level change notification.
+     *
+     * Emitted when a single scalar property on a layout is mutated without
+     * touching zone structure. Subscribers that only need to refresh a flag
+     * (hidden, auto-assign, aspect ratio class) can react to this signal
+     * directly instead of re-parsing the full layout JSON. Clients that
+     * still want the full shape can pull it via getLayout(layoutId) — the
+     * adaptor's cache is invalidated before this signal fires, so that
+     * read reflects the mutation.
+     *
+     * @param layoutId The layout whose property changed
+     * @param property Property name: "hidden", "autoAssign", or "aspectRatioClass"
+     * @param value    New value as a QDBusVariant (bool for hidden/autoAssign,
+     *                 int for aspectRatioClass)
+     */
+    void layoutPropertyChanged(const QString& layoutId, const QString& property, const QDBusVariant& value);
+
     void layoutListChanged();
     void screenLayoutChanged(const QString& screenId, const QString& layoutId, int virtualDesktop);
     void virtualDesktopCountChanged(int count);

--- a/src/dbus/layoutadaptor.h
+++ b/src/dbus/layoutadaptor.h
@@ -345,6 +345,15 @@ private:
      */
     QJsonObject buildActivityInfoJson(const QString& activityId) const;
 
+    /**
+     * @brief Drop any cached JSON for @p uuid so the next getLayout call
+     * re-serializes from the live Layout. Also clears the active-layout
+     * cache slot when the modified layout happens to be the active one,
+     * otherwise getActiveLayout would keep serving the stale entry.
+     * Centralizes cache invalidation for all per-layout mutation paths.
+     */
+    void invalidateLayoutJsonCacheFor(const QUuid& uuid);
+
     LayoutManager* m_layoutManager; // Concrete type for signal connections
     VirtualDesktopManager* m_virtualDesktopManager = nullptr;
     ActivityManager* m_activityManager = nullptr;

--- a/src/dbus/layoutadaptor/editor.cpp
+++ b/src/dbus/layoutadaptor/editor.cpp
@@ -128,8 +128,11 @@ bool LayoutAdaptor::updateLayout(const QString& layoutJson)
             overrides[JsonKeys::OverlayDisplayMode] = obj[JsonKeys::OverlayDisplayMode];
         m_layoutManager->saveAutotileOverrides(algoId, overrides);
         qCInfo(lcDbusLayout) << "Saved autotile overrides for algorithm:" << algoId;
+        // Autotile override save mutates a single autotile preview entry, not
+        // the layout list itself. Emit layoutChanged only; layoutListChanged
+        // stays reserved for add/delete operations. SettingsController wires
+        // both signals to the same reload slot so no visible behavior changes.
         Q_EMIT layoutChanged(layoutJson);
-        Q_EMIT layoutListChanged();
         return true;
     }
 

--- a/src/dbus/screenadaptor.cpp
+++ b/src/dbus/screenadaptor.cpp
@@ -27,6 +27,11 @@ ScreenAdaptor::ScreenAdaptor(QObject* parent)
     connect(qGuiApp, &QGuiApplication::screenAdded, this, [this](QScreen* screen) {
         const QString physId = Utils::screenIdentifier(screen);
 
+        // Any new screen invalidates the cache — a new entry for physId
+        // may need serializing and previously-missing siblings gain an
+        // "isVirtualScreen" field once ScreenManager catches up.
+        invalidateScreenInfoCache();
+
         // When virtual screens exist for this physical screen, emit only the
         // virtual screen IDs — not the physical ID — to avoid phantom entries.
         bool hadVirtual = emitForEffectiveScreens(physId, [this](const QString& id) {
@@ -113,6 +118,7 @@ ScreenAdaptor::ScreenAdaptor(QObject* parent)
     // stale defs until something else triggers fetchAllVirtualScreenConfigs.
     if (auto* mgr = ScreenManager::instance()) {
         auto refreshAndEmit = [this](const QString& physId) {
+            invalidateScreenInfoCache();
             auto* m = ScreenManager::instance();
             if (m && m->hasVirtualScreens(physId)) {
                 m_cachedEffectiveIdsPerScreen[physId] = m->virtualScreenIdsFor(physId);
@@ -131,6 +137,7 @@ ScreenAdaptor::ScreenAdaptor(QObject* parent)
 void ScreenAdaptor::handleScreenGeometryChanged(QScreen* screen, const QString& physId)
 {
     Q_UNUSED(screen)
+    invalidateScreenInfoCache();
     emitForEffectiveScreens(physId, [this](const QString& id) {
         Q_EMIT screenGeometryChanged(id);
     });
@@ -141,6 +148,7 @@ void ScreenAdaptor::handleScreenRemoved(QScreen* removedScreen, QScreen* targetS
     if (removedScreen != targetScreen) {
         return;
     }
+    invalidateScreenInfoCache();
     const QStringList effectiveIds = m_cachedEffectiveIdsPerScreen.take(cachedId);
     if (!effectiveIds.isEmpty()) {
         for (const QString& id : effectiveIds) {
@@ -149,6 +157,11 @@ void ScreenAdaptor::handleScreenRemoved(QScreen* removedScreen, QScreen* targetS
     } else {
         Q_EMIT screenRemoved(cachedId);
     }
+}
+
+void ScreenAdaptor::invalidateScreenInfoCache()
+{
+    m_cachedScreenInfoJson.clear();
 }
 
 bool ScreenAdaptor::emitForEffectiveScreens(const QString& physId, const std::function<void(const QString&)>& emitFn)
@@ -179,6 +192,17 @@ QString ScreenAdaptor::getScreenInfo(const QString& screenId)
     if (screenId.isEmpty()) {
         qCWarning(lcDbus) << "getScreenInfo: empty screen name";
         return QString();
+    }
+
+    // Serve memoized JSON when we have it — KCM and settings-app refreshes
+    // poll getScreenInfo for every monitor on every page render, and the
+    // underlying data only changes on screen topology signals (hot-plug,
+    // geometry change, virtual screen reconfigure), each of which calls
+    // invalidateScreenInfoCache(). The cached string is the fully-formed
+    // D-Bus reply so we skip both the QScreen walk and JSON serialization.
+    auto cachedIt = m_cachedScreenInfoJson.constFind(screenId);
+    if (cachedIt != m_cachedScreenInfoJson.constEnd()) {
+        return cachedIt.value();
     }
 
     // For virtual screens, resolve the backing physical screen for metadata
@@ -232,7 +256,9 @@ QString ScreenAdaptor::getScreenInfo(const QString& screenId)
             }
         }
 
-        return QString::fromUtf8(QJsonDocument(info).toJson());
+        const QString json = QString::fromUtf8(QJsonDocument(info).toJson());
+        m_cachedScreenInfoJson.insert(screenId, json);
+        return json;
     }
 
     qCWarning(lcDbus) << "Screen not found:" << screenId;

--- a/src/dbus/screenadaptor.h
+++ b/src/dbus/screenadaptor.h
@@ -97,6 +97,11 @@ private:
     /// Returns true if virtual screen IDs were emitted, false if physical.
     bool emitForEffectiveScreens(const QString& physId, const std::function<void(const QString&)>& emitFn);
 
+    /// Drop every cached getScreenInfo JSON entry. Called from every
+    /// invalidation edge: geometry change, virtual-screen add/remove,
+    /// region reconfigure, screen add/remove. Cheap — just clears a QHash.
+    void invalidateScreenInfoCache();
+
     QString m_primaryScreenOverride;
     Settings* m_settings = nullptr;
 
@@ -107,6 +112,13 @@ private:
     /// Per-physical-screen cached effective IDs for screenRemoved emission.
     /// Updated when virtualScreensChanged fires so removal signals stay current.
     QHash<QString, QStringList> m_cachedEffectiveIdsPerScreen;
+
+    /// Cache of getScreenInfo(screenId) JSON responses. Populated lazily on
+    /// first request; invalidated globally on any screen topology change
+    /// (geometry, add, remove, virtual screen reconfigure). KCM re-reads
+    /// this info on every monitor page refresh, so memoizing saves a full
+    /// QScreen walk + JSON serialization per query.
+    QHash<QString, QString> m_cachedScreenInfoJson;
 };
 
 } // namespace PlasmaZones

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -667,21 +667,27 @@ bool SettingsAdaptor::setSetting(const QString& key, const QDBusVariant& value)
 
     // Value-equality guard: if the incoming value already matches the
     // currently stored value, skip the setter invocation and the debounced
-    // save-timer restart. Gated on scalar variant types where operator==
-    // is reliable — composite types (QVariantList of QVariantMaps used by
-    // dragActivationTriggers, for example) compare on internal layout
-    // rather than semantic equality and would produce false negatives.
+    // save-timer restart. Covers scalar variant types plus the two Qt
+    // composite types that the settings surface actually uses
+    // (QVariantList and QVariantMap) — both compare structurally via
+    // element-wise recursion in Qt's operator==, so the guard is reliable
+    // for keys like dragActivationTriggers (list-of-maps) that would
+    // otherwise always take the full setter path on every idle UI tick.
+    //
     // The schema map's type string is NOT used as the gate because at
     // least one key (dragActivationTriggers) advertises "stringlist" while
     // actually storing a list-of-maps — the actual QVariant type is the
-    // authoritative source.
+    // authoritative source. Types outside this allow-list (custom QObject
+    // pointers, exotic Q_DECLARE_METATYPE payloads) fall through to the
+    // full setter to avoid false negatives from a non-structural operator==.
     const int typeId = converted.metaType().id();
-    const bool scalarType =
+    const bool comparableType =
         (typeId == QMetaType::Bool || typeId == QMetaType::Int || typeId == QMetaType::UInt
          || typeId == QMetaType::LongLong || typeId == QMetaType::ULongLong || typeId == QMetaType::Double
          || typeId == QMetaType::Float || typeId == QMetaType::QString || typeId == QMetaType::QStringList
-         || typeId == QMetaType::QUrl || typeId == QMetaType::QByteArray || typeId == QMetaType::QChar);
-    if (scalarType) {
+         || typeId == QMetaType::QUrl || typeId == QMetaType::QByteArray || typeId == QMetaType::QChar
+         || typeId == QMetaType::QVariantList || typeId == QMetaType::QVariantMap);
+    if (comparableType) {
         auto getterIt = m_getters.constFind(key);
         if (getterIt != m_getters.constEnd()) {
             const QVariant current = getterIt.value()();
@@ -693,10 +699,10 @@ bool SettingsAdaptor::setSetting(const QString& key, const QDBusVariant& value)
             }
         }
     } else {
-        // Non-scalar fall-through. Debug-log once so a future caller that
-        // tries to optimize same-value writes on a new composite type can
+        // Exotic-type fall-through. Debug-log once so a future caller that
+        // tries to optimize same-value writes on a new custom type can
         // trace back to why their key isn't being short-circuited.
-        qCDebug(lcDbusSettings) << "setSetting: value-equality guard skipped for non-scalar type"
+        qCDebug(lcDbusSettings) << "setSetting: value-equality guard skipped for non-comparable type"
                                 << converted.metaType().name() << "key=" << key;
     }
 

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -32,6 +32,13 @@ SettingsAdaptor::SettingsAdaptor(ISettings* settings, QObject* parent)
 
     // Connect to interface signals (DIP)
     connect(m_settings, &ISettings::settingsChanged, this, &SettingsAdaptor::settingsChanged);
+
+    // Drop shader caches whenever the registry reloads from disk. The
+    // registry is a singleton, but may not yet exist in unit tests that
+    // instantiate SettingsAdaptor without a daemon — guard the connect.
+    if (auto* registry = ShaderRegistry::instance()) {
+        connect(registry, &ShaderRegistry::shadersChanged, this, &SettingsAdaptor::invalidateShaderCaches);
+    }
 }
 
 SettingsAdaptor::~SettingsAdaptor()
@@ -867,20 +874,54 @@ QVariantMap SettingsAdaptor::getPerScreenSettings(const QString& screenId, const
 
 QVariantList SettingsAdaptor::availableShaders()
 {
+    if (m_cachedAvailableShadersValid) {
+        return m_cachedAvailableShaders;
+    }
     auto* registry = ShaderRegistry::instance();
-    return registry ? registry->availableShadersVariant() : QVariantList();
+    if (!registry) {
+        return QVariantList();
+    }
+    m_cachedAvailableShaders = registry->availableShadersVariant();
+    m_cachedAvailableShadersValid = true;
+    return m_cachedAvailableShaders;
 }
 
 QVariantMap SettingsAdaptor::shaderInfo(const QString& shaderId)
 {
+    auto it = m_cachedShaderInfo.constFind(shaderId);
+    if (it != m_cachedShaderInfo.constEnd()) {
+        return it.value();
+    }
     auto* registry = ShaderRegistry::instance();
-    return registry ? registry->shaderInfo(shaderId) : QVariantMap();
+    if (!registry) {
+        return QVariantMap();
+    }
+    const QVariantMap info = registry->shaderInfo(shaderId);
+    m_cachedShaderInfo.insert(shaderId, info);
+    return info;
 }
 
 QVariantMap SettingsAdaptor::defaultShaderParams(const QString& shaderId)
 {
+    auto it = m_cachedShaderDefaults.constFind(shaderId);
+    if (it != m_cachedShaderDefaults.constEnd()) {
+        return it.value();
+    }
     auto* registry = ShaderRegistry::instance();
-    return registry ? registry->defaultParams(shaderId) : QVariantMap();
+    if (!registry) {
+        return QVariantMap();
+    }
+    const QVariantMap defaults = registry->defaultParams(shaderId);
+    m_cachedShaderDefaults.insert(shaderId, defaults);
+    return defaults;
+}
+
+void SettingsAdaptor::invalidateShaderCaches()
+{
+    m_cachedAvailableShaders.clear();
+    m_cachedAvailableShadersValid = false;
+    m_cachedShaderInfo.clear();
+    m_cachedShaderDefaults.clear();
 }
 
 QVariantMap SettingsAdaptor::translateShaderParams(const QString& shaderId, const QVariantMap& params)
@@ -917,6 +958,11 @@ void SettingsAdaptor::openUserShaderDirectory()
 
 void SettingsAdaptor::refreshShaders()
 {
+    // Drop our memoized view before asking the registry to reload — if
+    // the ShaderRegistry::shadersChanged signal isn't connected (e.g. the
+    // singleton was created after this adaptor), we still guarantee the
+    // next D-Bus query hits the fresh registry.
+    invalidateShaderCaches();
     auto* registry = ShaderRegistry::instance();
     if (registry) {
         registry->refresh();

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -639,22 +639,51 @@ bool SettingsAdaptor::setSetting(const QString& key, const QDBusVariant& value)
     }
 
     auto it = m_setters.find(key);
-    if (it != m_setters.end()) {
-        QVariant converted = DBusVariantUtils::convertDbusArgument(value.variant());
-        bool result = it.value()(converted);
-        if (result) {
-            // Use debounced save instead of immediate save (performance optimization)
-            // This batches multiple rapid setting changes into a single disk write
-            scheduleSave();
-            qCInfo(lcDbusSettings) << "Setting" << key << "updated, save scheduled";
-        } else {
-            qCWarning(lcDbusSettings) << "Failed to set setting:" << key;
-        }
-        return result;
+    if (it == m_setters.end()) {
+        qCWarning(lcDbusSettings) << "Setting key not found:" << key;
+        return false;
     }
 
-    qCWarning(lcDbusSettings) << "Setting key not found:" << key;
-    return false;
+    const QVariant converted = DBusVariantUtils::convertDbusArgument(value.variant());
+
+    // Value-equality guard: if the incoming value already matches the
+    // currently stored value, skip the setter invocation and the debounced
+    // save-timer restart. Gated on scalar variant types where operator==
+    // is reliable — composite types (QVariantList of QVariantMaps used by
+    // dragActivationTriggers, for example) compare on internal layout
+    // rather than semantic equality and would produce false negatives.
+    // The schema map's type string is NOT used as the gate because at
+    // least one key (dragActivationTriggers) advertises "stringlist" while
+    // actually storing a list-of-maps — the actual QVariant type is the
+    // authoritative source.
+    const int typeId = converted.metaType().id();
+    const bool scalarType =
+        (typeId == QMetaType::Bool || typeId == QMetaType::Int || typeId == QMetaType::UInt
+         || typeId == QMetaType::LongLong || typeId == QMetaType::ULongLong || typeId == QMetaType::Double
+         || typeId == QMetaType::QString || typeId == QMetaType::QStringList);
+    if (scalarType) {
+        auto getterIt = m_getters.constFind(key);
+        if (getterIt != m_getters.constEnd()) {
+            const QVariant current = getterIt.value()();
+            if (current.isValid() && current == converted) {
+                // Already current — nothing to do. Return true because the
+                // post-condition ("the setting now equals the supplied value")
+                // holds, which is what D-Bus callers rely on.
+                return true;
+            }
+        }
+    }
+
+    const bool result = it.value()(converted);
+    if (result) {
+        // Use debounced save instead of immediate save (performance optimization)
+        // This batches multiple rapid setting changes into a single disk write
+        scheduleSave();
+        qCInfo(lcDbusSettings) << "Setting" << key << "updated, save scheduled";
+    } else {
+        qCWarning(lcDbusSettings) << "Failed to set setting:" << key;
+    }
+    return result;
 }
 
 QVariantMap SettingsAdaptor::getSettings(const QStringList& keys)

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -975,6 +975,9 @@ void SettingsAdaptor::refreshShaders()
 
 QString SettingsAdaptor::getRunningWindows()
 {
+    qCWarning(lcDbusSettings) << "getRunningWindows: DEPRECATED blocking path — callers should switch to "
+                                 "requestRunningWindows() + runningWindowsAvailable signal";
+
     // Guard against reentrant calls (shouldn't happen via D-Bus serialization,
     // but protects against unexpected provideRunningWindows calls)
     if (m_windowListLoop) {
@@ -988,8 +991,8 @@ QString SettingsAdaptor::getRunningWindows()
 
     // Blocking call: waits for KWin effect to respond via provideRunningWindows().
     // The 2s timeout prevents indefinite blocking if the effect is unloaded or
-    // unresponsive. This is called from the KCM settings UI (not the daemon hot
-    // path), so briefly blocking the caller thread is acceptable.
+    // unresponsive. Retained only for backward compatibility with clients that
+    // have not yet migrated to the async flow.
     constexpr int WindowListTimeoutMs = 2000;
     QTimer::singleShot(WindowListTimeoutMs, &loop, &QEventLoop::quit);
 
@@ -1003,12 +1006,29 @@ QString SettingsAdaptor::getRunningWindows()
     return m_pendingWindowList;
 }
 
+void SettingsAdaptor::requestRunningWindows()
+{
+    // Fire-and-forget. Callers receive the reply asynchronously via the
+    // runningWindowsAvailable signal (emitted from provideRunningWindows).
+    // Safe to call while a previous request is still in flight — the
+    // effect side is idempotent, and the last-arriving payload is the
+    // one subscribers see.
+    Q_EMIT runningWindowsRequested();
+}
+
 void SettingsAdaptor::provideRunningWindows(const QString& json)
 {
     m_pendingWindowList = json;
+
+    // Legacy path: unblock any blocking getRunningWindows() caller.
     if (m_windowListLoop && m_windowListLoop->isRunning()) {
         m_windowListLoop->quit();
     }
+
+    // Async path: fan out to subscribers of the new signal. Always emit
+    // even when a legacy blocking caller is present — the subscribers are
+    // disjoint and the broadcast is harmless for the blocking waiter.
+    Q_EMIT runningWindowsAvailable(json);
 }
 
 } // namespace PlasmaZones

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -138,10 +138,10 @@ void SettingsAdaptor::initializeRegistry()
     // The per-screen override API is fully on ISettings — this cast is
     // used only by the REGISTER_CONCRETE_* macros below for dozens of
     // global properties that haven't been hoisted to the segregated
-    // interfaces yet. Test backends that don't supply a concrete Settings
-    // leave `concrete` null; the per-property lambdas capture it by value
-    // and would crash if invoked, but those keys never appear in
-    // stub-driven tests.
+    // interfaces yet. Every REGISTER_CONCRETE_* call site is wrapped in
+    // an `if (concrete)` block, so test backends that don't supply a
+    // concrete Settings simply don't register those keys — setSetting
+    // returns "key not found" instead of dereferencing a null pointer.
     auto* concrete = qobject_cast<Settings*>(m_settings);
 
 // Macros for concrete Settings entries (same pattern as REGISTER_* but captures 'concrete')
@@ -679,7 +679,8 @@ bool SettingsAdaptor::setSetting(const QString& key, const QDBusVariant& value)
     const bool scalarType =
         (typeId == QMetaType::Bool || typeId == QMetaType::Int || typeId == QMetaType::UInt
          || typeId == QMetaType::LongLong || typeId == QMetaType::ULongLong || typeId == QMetaType::Double
-         || typeId == QMetaType::QString || typeId == QMetaType::QStringList);
+         || typeId == QMetaType::Float || typeId == QMetaType::QString || typeId == QMetaType::QStringList
+         || typeId == QMetaType::QUrl || typeId == QMetaType::QByteArray || typeId == QMetaType::QChar);
     if (scalarType) {
         auto getterIt = m_getters.constFind(key);
         if (getterIt != m_getters.constEnd()) {
@@ -691,6 +692,12 @@ bool SettingsAdaptor::setSetting(const QString& key, const QDBusVariant& value)
                 return true;
             }
         }
+    } else {
+        // Non-scalar fall-through. Debug-log once so a future caller that
+        // tries to optimize same-value writes on a new composite type can
+        // trace back to why their key isn't being short-circuited.
+        qCDebug(lcDbusSettings) << "setSetting: value-equality guard skipped for non-scalar type"
+                                << converted.metaType().name() << "key=" << key;
     }
 
     const bool result = it.value()(converted);
@@ -1059,7 +1066,9 @@ void SettingsAdaptor::requestRunningWindows()
 
 void SettingsAdaptor::provideRunningWindows(const QString& json)
 {
-    m_pendingWindowList = json;
+    // Fan out to every client that subscribed to runningWindowsAvailable —
+    // SettingsController caches the last payload on the client side, so
+    // there is no server-side state to keep here.
     Q_EMIT runningWindowsAvailable(json);
 }
 

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -868,6 +868,56 @@ QVariantMap SettingsAdaptor::getPerScreenSettings(const QString& screenId, const
     return {};
 }
 
+bool SettingsAdaptor::setPerScreenSettings(const QString& screenId, const QString& category, const QVariantMap& values)
+{
+    if (values.isEmpty()) {
+        // Empty map is a valid no-op — treat like setSettings batch and
+        // return true so callers don't need to guard for it.
+        return true;
+    }
+    auto* concrete = qobject_cast<Settings*>(m_settings);
+    if (!concrete) {
+        qCWarning(lcDbusSettings) << "setPerScreenSettings: concrete Settings not available";
+        return false;
+    }
+
+    // Single category dispatch outside the loop — each underlying Settings
+    // method is O(1) per call, so the hot path is one hash lookup per key.
+    using PerScreenSetter = std::function<void(const QString&, const QString&, const QVariant&)>;
+    PerScreenSetter setter;
+    if (category == QLatin1String("autotile")) {
+        setter = [concrete](const QString& id, const QString& k, const QVariant& v) {
+            concrete->setPerScreenAutotileSetting(id, k, v);
+        };
+    } else if (category == QLatin1String("snapping")) {
+        setter = [concrete](const QString& id, const QString& k, const QVariant& v) {
+            concrete->setPerScreenSnappingSetting(id, k, v);
+        };
+    } else if (category == QLatin1String("zoneSelector")) {
+        setter = [concrete](const QString& id, const QString& k, const QVariant& v) {
+            concrete->setPerScreenZoneSelectorSetting(id, k, v);
+        };
+    } else {
+        qCWarning(lcDbusSettings) << "setPerScreenSettings: unknown category" << category;
+        return false;
+    }
+
+    for (auto it = values.constBegin(); it != values.constEnd(); ++it) {
+        // Values arriving over the wire can be QDBusArgument-wrapped when
+        // they contain lists or maps; normalize to plain Qt types first —
+        // matches the single-key setPerScreenSetting path exactly.
+        const QVariant converted = DBusVariantUtils::convertDbusArgument(it.value());
+        setter(screenId, it.key(), converted);
+    }
+
+    // One debounced save for the whole batch. The per-screen save path
+    // coalesces multiple category updates into a single disk write.
+    scheduleSave();
+    qCInfo(lcDbusSettings) << "setPerScreenSettings: batch applied" << values.size() << "keys on screen" << screenId
+                           << "category" << category;
+    return true;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Shader Registry D-Bus Methods
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -1023,39 +1023,6 @@ void SettingsAdaptor::refreshShaders()
 // Window Picker D-Bus Methods
 // ═══════════════════════════════════════════════════════════════════════════════
 
-QString SettingsAdaptor::getRunningWindows()
-{
-    qCWarning(lcDbusSettings) << "getRunningWindows: DEPRECATED blocking path — callers should switch to "
-                                 "requestRunningWindows() + runningWindowsAvailable signal";
-
-    // Guard against reentrant calls (shouldn't happen via D-Bus serialization,
-    // but protects against unexpected provideRunningWindows calls)
-    if (m_windowListLoop) {
-        return QStringLiteral("[]");
-    }
-
-    m_pendingWindowList.clear();
-
-    QEventLoop loop;
-    m_windowListLoop = &loop;
-
-    // Blocking call: waits for KWin effect to respond via provideRunningWindows().
-    // The 2s timeout prevents indefinite blocking if the effect is unloaded or
-    // unresponsive. Retained only for backward compatibility with clients that
-    // have not yet migrated to the async flow.
-    constexpr int WindowListTimeoutMs = 2000;
-    QTimer::singleShot(WindowListTimeoutMs, &loop, &QEventLoop::quit);
-
-    // Signal the KWin effect to enumerate windows
-    Q_EMIT runningWindowsRequested();
-
-    // Block until provideRunningWindows() is called or timeout
-    loop.exec();
-
-    m_windowListLoop = nullptr;
-    return m_pendingWindowList;
-}
-
 void SettingsAdaptor::requestRunningWindows()
 {
     // Fire-and-forget. Callers receive the reply asynchronously via the
@@ -1069,15 +1036,6 @@ void SettingsAdaptor::requestRunningWindows()
 void SettingsAdaptor::provideRunningWindows(const QString& json)
 {
     m_pendingWindowList = json;
-
-    // Legacy path: unblock any blocking getRunningWindows() caller.
-    if (m_windowListLoop && m_windowListLoop->isRunning()) {
-        m_windowListLoop->quit();
-    }
-
-    // Async path: fan out to subscribers of the new signal. Always emit
-    // even when a legacy blocking caller is present — the subscribers are
-    // disjoint and the broadcast is harmless for the blocking waiter.
     Q_EMIT runningWindowsAvailable(json);
 }
 

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -11,6 +11,8 @@
 #include <QJsonObject>
 #include <QColor>
 #include <QDBusVariant>
+#include <functional>
+#include <optional>
 
 namespace PlasmaZones {
 
@@ -36,6 +38,9 @@ SettingsAdaptor::SettingsAdaptor(ISettings* settings, QObject* parent)
     // Drop shader caches whenever the registry reloads from disk. The
     // registry is a singleton, but may not yet exist in unit tests that
     // instantiate SettingsAdaptor without a daemon — guard the connect.
+    // ShaderRegistry::refresh() is always invoked from the main thread
+    // (D-Bus refreshShaders slot) so a direct connection is safe; if
+    // that invariant ever changes, switch to Qt::QueuedConnection here.
     if (auto* registry = ShaderRegistry::instance()) {
         connect(registry, &ShaderRegistry::shadersChanged, this, &SettingsAdaptor::invalidateShaderCaches);
     }
@@ -129,7 +134,14 @@ void SettingsAdaptor::initializeRegistry()
     };                                                                                                                 \
     m_schemas[QStringLiteral(name)] = QStringLiteral("stringlist");
 
-    // Concrete Settings pointer for properties not on ISettings interface
+    // Concrete Settings pointer for properties not on ISettings interface.
+    // The per-screen override API is fully on ISettings — this cast is
+    // used only by the REGISTER_CONCRETE_* macros below for dozens of
+    // global properties that haven't been hoisted to the segregated
+    // interfaces yet. Test backends that don't supply a concrete Settings
+    // leave `concrete` null; the per-property lambdas capture it by value
+    // and would crash if invoked, but those keys never appear in
+    // stub-driven tests.
     auto* concrete = qobject_cast<Settings*>(m_settings);
 
 // Macros for concrete Settings entries (same pattern as REGISTER_* but captures 'concrete')
@@ -809,63 +821,96 @@ QString SettingsAdaptor::getAllSettingSchemas()
 // Per-Screen Settings D-Bus Methods
 // ═══════════════════════════════════════════════════════════════════════════════
 
+// Category → {get, set, clear} dispatch table. Closing over @p settings
+// lets every per-screen D-Bus entry point share one dispatch definition
+// instead of re-deriving the if/else ladder per call. Every method is
+// on ISettings with a default no-op body, so backends that don't
+// support per-screen state (test stubs) simply inherit the no-op —
+// no qobject_cast required.
+namespace {
+struct PerScreenDispatch
+{
+    std::function<QVariantMap(const QString&)> get;
+    std::function<void(const QString&, const QString&, const QVariant&)> set;
+    std::function<void(const QString&)> clear;
+};
+
+std::optional<PerScreenDispatch> dispatchFor(ISettings* settings, const QString& category)
+{
+    if (category == QLatin1String("autotile")) {
+        return PerScreenDispatch{
+            [settings](const QString& id) {
+                return settings->getPerScreenAutotileSettings(id);
+            },
+            [settings](const QString& id, const QString& k, const QVariant& v) {
+                settings->setPerScreenAutotileSetting(id, k, v);
+            },
+            [settings](const QString& id) {
+                settings->clearPerScreenAutotileSettings(id);
+            },
+        };
+    }
+    if (category == QLatin1String("snapping")) {
+        return PerScreenDispatch{
+            [settings](const QString& id) {
+                return settings->getPerScreenSnappingSettings(id);
+            },
+            [settings](const QString& id, const QString& k, const QVariant& v) {
+                settings->setPerScreenSnappingSetting(id, k, v);
+            },
+            [settings](const QString& id) {
+                settings->clearPerScreenSnappingSettings(id);
+            },
+        };
+    }
+    if (category == QLatin1String("zoneSelector")) {
+        return PerScreenDispatch{
+            [settings](const QString& id) {
+                return settings->getPerScreenZoneSelectorSettings(id);
+            },
+            [settings](const QString& id, const QString& k, const QVariant& v) {
+                settings->setPerScreenZoneSelectorSetting(id, k, v);
+            },
+            [settings](const QString& id) {
+                settings->clearPerScreenZoneSelectorSettings(id);
+            },
+        };
+    }
+    return std::nullopt;
+}
+} // namespace
+
 void SettingsAdaptor::setPerScreenSetting(const QString& screenId, const QString& category, const QString& key,
                                           const QDBusVariant& value)
 {
-    auto* concrete = qobject_cast<Settings*>(m_settings);
-    if (!concrete) {
-        qCWarning(lcDbusSettings) << "setPerScreenSetting: concrete Settings not available";
-        return;
-    }
-    if (category == QLatin1String("autotile")) {
-        concrete->setPerScreenAutotileSetting(screenId, key, value.variant());
-    } else if (category == QLatin1String("snapping")) {
-        concrete->setPerScreenSnappingSetting(screenId, key, value.variant());
-    } else if (category == QLatin1String("zoneSelector")) {
-        concrete->setPerScreenZoneSelectorSetting(screenId, key, value.variant());
-    } else {
+    auto dispatch = dispatchFor(m_settings, category);
+    if (!dispatch) {
         qCWarning(lcDbusSettings) << "setPerScreenSetting: unknown category" << category;
         return;
     }
+    dispatch->set(screenId, key, value.variant());
     scheduleSave();
 }
 
 void SettingsAdaptor::clearPerScreenSettings(const QString& screenId, const QString& category)
 {
-    auto* concrete = qobject_cast<Settings*>(m_settings);
-    if (!concrete) {
-        qCWarning(lcDbusSettings) << "clearPerScreenSettings: concrete Settings not available";
-        return;
-    }
-    if (category == QLatin1String("autotile")) {
-        concrete->clearPerScreenAutotileSettings(screenId);
-    } else if (category == QLatin1String("snapping")) {
-        concrete->clearPerScreenSnappingSettings(screenId);
-    } else if (category == QLatin1String("zoneSelector")) {
-        concrete->clearPerScreenZoneSelectorSettings(screenId);
-    } else {
+    auto dispatch = dispatchFor(m_settings, category);
+    if (!dispatch) {
         qCWarning(lcDbusSettings) << "clearPerScreenSettings: unknown category" << category;
         return;
     }
+    dispatch->clear(screenId);
     scheduleSave();
 }
 
 QVariantMap SettingsAdaptor::getPerScreenSettings(const QString& screenId, const QString& category)
 {
-    auto* concrete = qobject_cast<Settings*>(m_settings);
-    if (!concrete) {
-        qCWarning(lcDbusSettings) << "getPerScreenSettings: concrete Settings not available";
+    auto dispatch = dispatchFor(m_settings, category);
+    if (!dispatch) {
+        qCWarning(lcDbusSettings) << "getPerScreenSettings: unknown category" << category;
         return {};
     }
-    if (category == QLatin1String("autotile")) {
-        return concrete->getPerScreenAutotileSettings(screenId);
-    } else if (category == QLatin1String("snapping")) {
-        return concrete->getPerScreenSnappingSettings(screenId);
-    } else if (category == QLatin1String("zoneSelector")) {
-        return concrete->getPerScreenZoneSelectorSettings(screenId);
-    }
-    qCWarning(lcDbusSettings) << "getPerScreenSettings: unknown category" << category;
-    return {};
+    return dispatch->get(screenId);
 }
 
 bool SettingsAdaptor::setPerScreenSettings(const QString& screenId, const QString& category, const QVariantMap& values)
@@ -875,29 +920,8 @@ bool SettingsAdaptor::setPerScreenSettings(const QString& screenId, const QStrin
         // return true so callers don't need to guard for it.
         return true;
     }
-    auto* concrete = qobject_cast<Settings*>(m_settings);
-    if (!concrete) {
-        qCWarning(lcDbusSettings) << "setPerScreenSettings: concrete Settings not available";
-        return false;
-    }
-
-    // Single category dispatch outside the loop — each underlying Settings
-    // method is O(1) per call, so the hot path is one hash lookup per key.
-    using PerScreenSetter = std::function<void(const QString&, const QString&, const QVariant&)>;
-    PerScreenSetter setter;
-    if (category == QLatin1String("autotile")) {
-        setter = [concrete](const QString& id, const QString& k, const QVariant& v) {
-            concrete->setPerScreenAutotileSetting(id, k, v);
-        };
-    } else if (category == QLatin1String("snapping")) {
-        setter = [concrete](const QString& id, const QString& k, const QVariant& v) {
-            concrete->setPerScreenSnappingSetting(id, k, v);
-        };
-    } else if (category == QLatin1String("zoneSelector")) {
-        setter = [concrete](const QString& id, const QString& k, const QVariant& v) {
-            concrete->setPerScreenZoneSelectorSetting(id, k, v);
-        };
-    } else {
+    auto dispatch = dispatchFor(m_settings, category);
+    if (!dispatch) {
         qCWarning(lcDbusSettings) << "setPerScreenSettings: unknown category" << category;
         return false;
     }
@@ -907,7 +931,7 @@ bool SettingsAdaptor::setPerScreenSettings(const QString& screenId, const QStrin
         // they contain lists or maps; normalize to plain Qt types first —
         // matches the single-key setPerScreenSetting path exactly.
         const QVariant converted = DBusVariantUtils::convertDbusArgument(it.value());
-        setter(screenId, it.key(), converted);
+        dispatch->set(screenId, it.key(), converted);
     }
 
     // One debounced save for the whole batch. The per-screen save path

--- a/src/dbus/settingsadaptor.h
+++ b/src/dbus/settingsadaptor.h
@@ -184,6 +184,15 @@ private:
      */
     void scheduleSave();
 
+    /**
+     * @brief Drop all cached ShaderRegistry results.
+     *
+     * Called from refreshShaders() and from ShaderRegistry::shadersChanged
+     * so the editor and KCM never see stale shader metadata after a
+     * hot-reload. Cheap — just clears three hashes.
+     */
+    void invalidateShaderCaches();
+
     ISettings* m_settings; // Interface type (DIP)
 
     // Window picker request/response state
@@ -201,6 +210,19 @@ private:
     // Debounced save timer (performance optimization)
     QTimer* m_saveTimer = nullptr;
     static constexpr int SaveDebounceMs = 500; // 500ms debounce
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ShaderRegistry caches
+    //
+    // Memoizes availableShaders() / shaderInfo() / defaultShaderParams() so
+    // repeated editor + KCM queries don't hit ShaderRegistry on every call.
+    // Invalidated on refreshShaders() and on the registry's own shadersChanged
+    // signal. Marked mutable so const-ish read paths can populate them.
+    // ═══════════════════════════════════════════════════════════════════════
+    QVariantList m_cachedAvailableShaders;
+    bool m_cachedAvailableShadersValid = false;
+    QHash<QString, QVariantMap> m_cachedShaderInfo;
+    QHash<QString, QVariantMap> m_cachedShaderDefaults;
 };
 
 } // namespace PlasmaZones

--- a/src/dbus/settingsadaptor.h
+++ b/src/dbus/settingsadaptor.h
@@ -245,12 +245,6 @@ private:
 
     ISettings* m_settings; // Interface type (DIP)
 
-    // Window picker reply cache — last JSON payload received from the
-    // KWin effect via provideRunningWindows(). Re-broadcast on
-    // runningWindowsAvailable; subscribers can also pull it via the
-    // signal with no further D-Bus round-trip.
-    QString m_pendingWindowList;
-
     // Registry pattern
     using Getter = std::function<QVariant()>;
     using Setter = std::function<bool(const QVariant&)>;

--- a/src/dbus/settingsadaptor.h
+++ b/src/dbus/settingsadaptor.h
@@ -84,6 +84,29 @@ public Q_SLOTS:
     QVariantMap getPerScreenSettings(const QString& screenId, const QString& category);
 
     /**
+     * @brief Batch-set multiple per-screen keys in one D-Bus call.
+     *
+     * Applies every (key, value) pair in @p values via the same category
+     * dispatch as setPerScreenSetting, then schedules a single debounced
+     * save. Mirrors the global getSettings/setSettings batch pattern so
+     * the KCM per-monitor page can flush a category in one round-trip
+     * instead of N sequential calls.
+     *
+     * Unknown keys inside @p values are passed through to the underlying
+     * Settings method, which logs a warning and no-ops — consistent with
+     * single-key behavior.
+     *
+     * @param screenId Virtual or physical screen identifier
+     * @param category "autotile" | "snapping" | "zoneSelector"
+     * @param values   Map of key -> value. QDBusArgument-wrapped values
+     *                 from the wire are unwrapped via DBusVariantUtils
+     *                 before reaching the setter.
+     * @return true if the category was recognized and every setter call
+     *         returned without erroring
+     */
+    bool setPerScreenSettings(const QString& screenId, const QString& category, const QVariantMap& values);
+
+    /**
      * @brief Get list of available shader effects
      * @return List of shader metadata (id, name, description, etc.)
      */

--- a/src/dbus/settingsadaptor.h
+++ b/src/dbus/settingsadaptor.h
@@ -7,7 +7,6 @@
 #include <QObject>
 #include <QDBusAbstractAdaptor>
 #include <QDBusVariant>
-#include <QEventLoop>
 #include <QString>
 #include <QVariant>
 #include <QTimer>
@@ -163,29 +162,15 @@ public Q_SLOTS:
     void refreshShaders();
 
     /**
-     * @brief Get list of currently running windows (for exclusion picker)
-     *
-     * DEPRECATED — blocks up to 2 seconds on a QEventLoop waiting for
-     * provideRunningWindows() to fire. Replaced by the fire-and-forget
-     * requestRunningWindows() + runningWindowsAvailable(json) signal
-     * pair, which keeps the settings UI responsive even when the KWin
-     * effect is unloaded or slow to respond. New callers MUST use the
-     * async pair. This method is kept only so in-flight clients on
-     * older daemon versions still work while they migrate; it will be
-     * removed once every caller is on the async flow.
-     *
-     * @return JSON string: [{"windowClass":"...", "appName":"...", "caption":"..."}]
-     */
-    QString getRunningWindows();
-
-    /**
      * @brief Asynchronous window list request (fire-and-forget).
      *
      * Emits runningWindowsRequested() so the KWin effect enumerates its
      * window list and sends it back via provideRunningWindows(). The
      * resulting JSON is then broadcast via the runningWindowsAvailable
      * signal — subscribers update their view when the signal arrives
-     * rather than blocking on the D-Bus call.
+     * rather than blocking on the D-Bus call. This is the only
+     * supported path; the old blocking getRunningWindows() method was
+     * removed in Phase 6 of refactor/dbus-performance.
      *
      * Returns immediately. Safe to call repeatedly from UI — each call
      * triggers at most one KWin round-trip; duplicate requests while a
@@ -257,9 +242,11 @@ private:
 
     ISettings* m_settings; // Interface type (DIP)
 
-    // Window picker request/response state
+    // Window picker reply cache — last JSON payload received from the
+    // KWin effect via provideRunningWindows(). Re-broadcast on
+    // runningWindowsAvailable; subscribers can also pull it via the
+    // signal with no further D-Bus round-trip.
     QString m_pendingWindowList;
-    QEventLoop* m_windowListLoop = nullptr;
 
     // Registry pattern
     using Getter = std::function<QVariant()>;

--- a/src/dbus/settingsadaptor.h
+++ b/src/dbus/settingsadaptor.h
@@ -142,13 +142,33 @@ public Q_SLOTS:
     /**
      * @brief Get list of currently running windows (for exclusion picker)
      *
-     * Requests the KWin effect to enumerate all windows. Returns JSON array
-     * of objects with windowClass and caption fields.
-     * Blocks up to 2 seconds waiting for the KWin effect to respond.
+     * DEPRECATED — blocks up to 2 seconds on a QEventLoop waiting for
+     * provideRunningWindows() to fire. Replaced by the fire-and-forget
+     * requestRunningWindows() + runningWindowsAvailable(json) signal
+     * pair, which keeps the settings UI responsive even when the KWin
+     * effect is unloaded or slow to respond. New callers MUST use the
+     * async pair. This method is kept only so in-flight clients on
+     * older daemon versions still work while they migrate; it will be
+     * removed once every caller is on the async flow.
      *
      * @return JSON string: [{"windowClass":"...", "appName":"...", "caption":"..."}]
      */
     QString getRunningWindows();
+
+    /**
+     * @brief Asynchronous window list request (fire-and-forget).
+     *
+     * Emits runningWindowsRequested() so the KWin effect enumerates its
+     * window list and sends it back via provideRunningWindows(). The
+     * resulting JSON is then broadcast via the runningWindowsAvailable
+     * signal — subscribers update their view when the signal arrives
+     * rather than blocking on the D-Bus call.
+     *
+     * Returns immediately. Safe to call repeatedly from UI — each call
+     * triggers at most one KWin round-trip; duplicate requests while a
+     * previous response is in flight are coalesced by the effect side.
+     */
+    void requestRunningWindows();
 
     /**
      * @brief Receive window list from KWin effect (callback)
@@ -171,7 +191,26 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     void settingsChanged();
+
+    /**
+     * @brief Daemon → KWin effect: please enumerate running windows.
+     *
+     * Emitted by requestRunningWindows() (async path) and by the legacy
+     * blocking getRunningWindows() (migration path). The effect answers
+     * by calling provideRunningWindows().
+     */
     void runningWindowsRequested();
+
+    /**
+     * @brief Daemon → clients: fresh running-windows JSON is available.
+     *
+     * Emitted every time provideRunningWindows() receives a payload from
+     * the KWin effect. Subscribers (SettingsController) cache the value
+     * and present it to the UI without a blocking round-trip.
+     *
+     * @param json JSON array: [{windowClass, appName, caption}, ...]
+     */
+    void runningWindowsAvailable(const QString& json);
 
 private:
     void initializeRegistry();

--- a/src/dbus/settingsadaptor.h
+++ b/src/dbus/settingsadaptor.h
@@ -100,8 +100,11 @@ public Q_SLOTS:
      * @param values   Map of key -> value. QDBusArgument-wrapped values
      *                 from the wire are unwrapped via DBusVariantUtils
      *                 before reaching the setter.
-     * @return true if the category was recognized and every setter call
-     *         returned without erroring
+     * @return true if the category was recognized and the batch ran
+     *         against a concrete Settings backend; false if the category
+     *         was unknown or no concrete Settings was available.
+     *         Per-key failures are logged by the underlying Settings but
+     *         cannot be surfaced here since the setters return void.
      */
     bool setPerScreenSettings(const QString& screenId, const QString& category, const QVariantMap& values);
 
@@ -203,9 +206,9 @@ Q_SIGNALS:
     /**
      * @brief Daemon → KWin effect: please enumerate running windows.
      *
-     * Emitted by requestRunningWindows() (async path) and by the legacy
-     * blocking getRunningWindows() (migration path). The effect answers
-     * by calling provideRunningWindows().
+     * Emitted by requestRunningWindows(). The effect answers by calling
+     * provideRunningWindows(), which then broadcasts runningWindowsAvailable
+     * to all subscribers.
      */
     void runningWindowsRequested();
 

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -74,16 +74,26 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(LayoutManager* layoutManager, IZone
     connect(m_saveTimer, &QTimer::timeout, this, &WindowTrackingAdaptor::saveState);
 
     // Persistence I/O worker — disk writes happen off the main thread.
-    // On a verified-successful write, clear the backend's dirty flag so
-    // the next saveState() can be a no-op. On failure we leave the dirty
-    // flag alone so the next timer tick retries the write.
+    // On a verified-successful write, clear the backend's dirty flag AND
+    // reset the committed-dirty snapshot. On failure, OR the committed
+    // bits back into the service's dirty mask so the next save tick
+    // re-serializes the fields that the failed attempt was supposed to
+    // cover — without touching any bits set by mutations that landed
+    // between takeDirty() and the failure callback (those survive via
+    // the service's own mask).
     m_persistenceWorker = std::make_unique<PersistenceWorker>(nullptr);
     connect(m_persistenceWorker.get(), &PersistenceWorker::writeCompleted, this,
             [this](const QString& filePath, bool success) {
                 if (!success) {
-                    qCWarning(lcDbusWindow) << "session state write failed for" << filePath << "— will retry";
+                    qCWarning(lcDbusWindow) << "session state write failed for" << filePath
+                                            << "— restoring dirty mask and retrying on next tick";
+                    if (m_service) {
+                        m_service->addDirty(m_lastCommittedDirty);
+                        scheduleSaveState();
+                    }
                     return;
                 }
+                m_lastCommittedDirty = WindowTrackingService::DirtyNone;
                 if (auto* json = dynamic_cast<JsonConfigBackend*>(m_sessionBackend.get())) {
                     if (json->filePath() == filePath) {
                         json->clearDirty();
@@ -93,6 +103,16 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(LayoutManager* layoutManager, IZone
 
     // Connect to layout changes for pending restores notification
     connect(m_layoutManager, &LayoutManager::activeLayoutChanged, this, &WindowTrackingAdaptor::onLayoutChanged);
+
+    // The persisted state includes the active layout ID — mark it dirty
+    // whenever the layout manager switches layouts so the next save
+    // captures the new value. Without this, the active layout ID field
+    // would only get rewritten on unrelated DirtyAll paths.
+    connect(m_layoutManager, &LayoutManager::activeLayoutChanged, this, [this]() {
+        if (m_service) {
+            m_service->markDirty(WindowTrackingService::DirtyActiveLayoutId);
+        }
+    });
 
     // Deferred: ScreenManager may not be initialized yet during adaptor construction.
     // If ScreenManager is still unavailable after the first event loop iteration,

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -74,26 +74,34 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(LayoutManager* layoutManager, IZone
     connect(m_saveTimer, &QTimer::timeout, this, &WindowTrackingAdaptor::saveState);
 
     // Persistence I/O worker — disk writes happen off the main thread.
-    // On a verified-successful write, clear the backend's dirty flag AND
-    // reset the committed-dirty snapshot. On failure, OR the committed
-    // bits back into the service's dirty mask so the next save tick
-    // re-serializes the fields that the failed attempt was supposed to
-    // cover — without touching any bits set by mutations that landed
-    // between takeDirty() and the failure callback (those survive via
-    // the service's own mask).
+    // PersistenceIO::processWrite runs on the worker thread via a queued
+    // requestWrite signal, so writes are handled strictly FIFO. The
+    // writeCompleted handler dequeues the head of m_pendingWriteMasks in
+    // the same order: on success we discard the mask (bits made it to
+    // disk); on failure we OR the mask back into the service's dirty
+    // state so the retry picks up exactly the fields the failed write
+    // was supposed to cover, without disturbing any bits set by
+    // mutations that landed after takeDirty() was called for that write.
     m_persistenceWorker = std::make_unique<PersistenceWorker>(nullptr);
     connect(m_persistenceWorker.get(), &PersistenceWorker::writeCompleted, this,
             [this](const QString& filePath, bool success) {
+                // The queue tracks writes we enqueued ourselves. If it's
+                // empty here, the signal came from a write we didn't
+                // originate (shouldn't happen) or from the fallback
+                // synchronous path; either way, there's nothing to retry.
+                const WindowTrackingService::DirtyMask committed =
+                    m_pendingWriteMasks.isEmpty() ? WindowTrackingService::DirtyNone : m_pendingWriteMasks.dequeue();
                 if (!success) {
                     qCWarning(lcDbusWindow) << "session state write failed for" << filePath
                                             << "— restoring dirty mask and retrying on next tick";
-                    if (m_service) {
-                        m_service->addDirty(m_lastCommittedDirty);
-                        scheduleSaveState();
+                    if (m_service && committed != WindowTrackingService::DirtyNone) {
+                        // markDirty emits stateChanged, which is wired to
+                        // scheduleSaveState() above — the retry lands on
+                        // the next debounce tick automatically.
+                        m_service->markDirty(committed);
                     }
                     return;
                 }
-                m_lastCommittedDirty = WindowTrackingService::DirtyNone;
                 if (auto* json = dynamic_cast<JsonConfigBackend*>(m_sessionBackend.get())) {
                     if (json->filePath() == filePath) {
                         json->clearDirty();
@@ -101,17 +109,15 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(LayoutManager* layoutManager, IZone
                 }
             });
 
-    // Connect to layout changes for pending restores notification
-    connect(m_layoutManager, &LayoutManager::activeLayoutChanged, this, &WindowTrackingAdaptor::onLayoutChanged);
-
-    // The persisted state includes the active layout ID — mark it dirty
-    // whenever the layout manager switches layouts so the next save
-    // captures the new value. Without this, the active layout ID field
-    // would only get rewritten on unrelated DirtyAll paths.
+    // Active-layout changes: single handler. onLayoutChanged() covers the
+    // pending-restores notification side; we prepend a dirty-mark for the
+    // DirtyActiveLayoutId field so the next save captures the new value
+    // without needing an unrelated DirtyAll path to drag it along.
     connect(m_layoutManager, &LayoutManager::activeLayoutChanged, this, [this]() {
         if (m_service) {
             m_service->markDirty(WindowTrackingService::DirtyActiveLayoutId);
         }
+        onLayoutChanged();
     });
 
     // Deferred: ScreenManager may not be initialized yet during adaptor construction.

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -85,12 +85,16 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(LayoutManager* layoutManager, IZone
     m_persistenceWorker = std::make_unique<PersistenceWorker>(nullptr);
     connect(m_persistenceWorker.get(), &PersistenceWorker::writeCompleted, this,
             [this](const QString& filePath, bool success) {
-                // The queue tracks writes we enqueued ourselves. If it's
-                // empty here, the signal came from a write we didn't
-                // originate (shouldn't happen) or from the fallback
-                // synchronous path; either way, there's nothing to retry.
-                const WindowTrackingService::DirtyMask committed =
-                    m_pendingWriteMasks.isEmpty() ? WindowTrackingService::DirtyNone : m_pendingWriteMasks.dequeue();
+                // writeCompleted only fires from writes WE enqueued (the
+                // sync-fallback path calls m_sessionBackend->sync() directly
+                // without routing through the worker), so the queue head
+                // must exist. Assert instead of hedging — a disappearing
+                // head would indicate a bug in enqueue/dequeue pairing.
+                Q_ASSERT(!m_pendingWriteMasks.isEmpty());
+                if (m_pendingWriteMasks.isEmpty()) {
+                    return;
+                }
+                const WindowTrackingService::DirtyMask committed = m_pendingWriteMasks.dequeue();
                 if (!success) {
                     qCWarning(lcDbusWindow) << "session state write failed for" << filePath
                                             << "— restoring dirty mask and retrying on next tick";
@@ -102,11 +106,16 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(LayoutManager* layoutManager, IZone
                     }
                     return;
                 }
-                if (auto* json = dynamic_cast<JsonConfigBackend*>(m_sessionBackend.get())) {
-                    if (json->filePath() == filePath) {
-                        json->clearDirty();
-                    }
-                }
+                // Success: intentionally NOT calling JsonConfigBackend::clearDirty()
+                // here. The backend's own m_dirty flag tracks in-memory mutations
+                // since the last inline sync(); a successful async write of an
+                // earlier snapshot does not mean the current in-memory state
+                // matches disk, because the main thread may have mutated m_root
+                // between snapshot and completion. Clearing m_dirty in that
+                // window would cause the shutdown inline sync() to skip a real
+                // pending write. The WTS dirty mask is the authoritative
+                // gate for async writes anyway.
+                Q_UNUSED(filePath);
             });
 
     // Active-layout changes: single handler. onLayoutChanged() covers the

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -1086,6 +1086,15 @@ private:
     QTimer* m_saveTimer = nullptr;
     std::unique_ptr<PersistenceWorker> m_persistenceWorker;
 
+    // Last-committed dirty mask snapshot. saveState() reads the service's
+    // dirty bits via takeDirty() and stores them here before handing the
+    // JSON snapshot to the persistence worker. When writeCompleted arrives
+    // with success=false, the handler ORs these bits back into the
+    // service's mask so the failed save is retried on the next tick.
+    // On success the field is reset so the next successful save starts
+    // with a clean slate.
+    WindowTrackingService::DirtyMask m_lastCommittedDirty = WindowTrackingService::DirtyNone;
+
     // Tiling state serialization delegates (autotile engine → WTA persistence)
     std::function<QJsonArray()> m_serializeTilingStatesFn;
     std::function<void(const QJsonArray&)> m_deserializeTilingStatesFn;

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -1098,6 +1098,12 @@ private:
     // on any newer mutations.
     QQueue<WindowTrackingService::DirtyMask> m_pendingWriteMasks;
 
+    // One-shot warning latch for the test-only synchronous fallback path
+    // in saveState(). Production always uses JsonConfigBackend + the
+    // async worker, so hitting the sync path indicates either a test
+    // harness or an unexpected misconfiguration.
+    bool m_syncFallbackWarned = false;
+
     // Tiling state serialization delegates (autotile engine → WTA persistence)
     std::function<QJsonArray()> m_serializeTilingStatesFn;
     std::function<void(const QJsonArray&)> m_deserializeTilingStatesFn;

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -13,6 +13,7 @@
 #include <QStringList>
 #include <QHash>
 #include <QJsonArray>
+#include <QQueue>
 #include <QRect>
 #include <QTimer>
 #include <QPointer>
@@ -1086,14 +1087,16 @@ private:
     QTimer* m_saveTimer = nullptr;
     std::unique_ptr<PersistenceWorker> m_persistenceWorker;
 
-    // Last-committed dirty mask snapshot. saveState() reads the service's
-    // dirty bits via takeDirty() and stores them here before handing the
-    // JSON snapshot to the persistence worker. When writeCompleted arrives
-    // with success=false, the handler ORs these bits back into the
-    // service's mask so the failed save is retried on the next tick.
-    // On success the field is reset so the next successful save starts
-    // with a clean slate.
-    WindowTrackingService::DirtyMask m_lastCommittedDirty = WindowTrackingService::DirtyNone;
+    // FIFO queue of dirty masks for writes currently in flight on the
+    // persistence worker thread. saveState() enqueues the committed mask
+    // when it hands a write off to the worker; the writeCompleted handler
+    // dequeues the head in the same FIFO order the worker processes
+    // requestWrite signals, so a mask survives even when saveState() is
+    // called again before the previous write lands. On success the head
+    // is dropped; on failure the head bits are OR'd back into the
+    // service's dirty mask so the retry picks them up without stomping
+    // on any newer mutations.
+    QQueue<WindowTrackingService::DirtyMask> m_pendingWriteMasks;
 
     // Tiling state serialization delegates (autotile engine → WTA persistence)
     std::function<QJsonArray()> m_serializeTilingStatesFn;

--- a/src/dbus/windowtrackingadaptor/saveload.cpp
+++ b/src/dbus/windowtrackingadaptor/saveload.cpp
@@ -54,10 +54,21 @@ void WindowTrackingAdaptor::saveState()
     using D = WindowTrackingService;
     // Snapshot the dirty mask — after this call the service is clean
     // from our perspective. If the write fails, the persistence worker's
-    // writeCompleted(success=false) handler addDirty()s the same bits
-    // back so the next tick retries.
+    // writeCompleted(success=false) handler re-marks the same bits on
+    // the service so the next tick retries. The committed mask is
+    // pushed onto m_pendingWriteMasks only at the actual hand-off point,
+    // so a no-op wake (dirty == DirtyNone) never clobbers an in-flight
+    // write's committed snapshot.
     const D::DirtyMask dirty = m_service->takeDirty();
-    m_lastCommittedDirty = dirty;
+
+    // Fast path: no bits dirty means no disk work to do. Returning here
+    // skips both the (unnecessary) group walk and the per-field writes.
+    // Nothing has been pushed onto m_pendingWriteMasks for this call,
+    // so in-flight writes are unaffected.
+    if (dirty == D::DirtyNone) {
+        qCDebug(lcDbusWindow) << "Saved state: no dirty fields, skipping write";
+        return;
+    }
 
     auto tracking = m_sessionBackend->group(ConfigKeys::windowTrackingGroup());
 
@@ -125,11 +136,11 @@ void WindowTrackingAdaptor::saveState()
                               QString::fromUtf8(QJsonDocument(pendingQueuesObj).toJson(QJsonDocument::Compact)));
     }
 
-    // Clean up obsolete keys from old formats. These are cheap no-ops when
-    // the keys don't exist, and we need them to run at least once per
-    // daemon start regardless of the dirty mask — so they sit outside any
-    // gate. On subsequent saves they're already deleted so the calls are
-    // idempotent.
+    // Clean up obsolete keys from old formats. Reached only when at
+    // least one dirty bit is set (the DirtyNone early-return above
+    // skips this path), so we always flush the deletions along with
+    // the rest of the write. On subsequent saves the keys are already
+    // gone so deleteKey is a cheap no-op.
     tracking->deleteKey(ConfigKeys::obsoletePendingWindowScreenAssignmentsKey());
     tracking->deleteKey(ConfigKeys::obsoletePendingWindowDesktopAssignmentsKey());
     tracking->deleteKey(ConfigKeys::obsoletePendingWindowLayoutAssignmentsKey());
@@ -240,27 +251,28 @@ void WindowTrackingAdaptor::saveState()
 
     tracking.reset(); // release group before write
 
-    // If nothing was dirty, skip the write entirely. This can happen when
-    // the scheduler fires against an all-ephemeral-state wake (float
-    // toggles, etc.) — no bytes on disk changed, so there's nothing to
-    // persist. Without this gate we'd rewrite the whole file with the
-    // same content on every debounce tick.
-    if (dirty == D::DirtyNone) {
-        qCDebug(lcDbusWindow) << "Saved state: no dirty fields, skipping write";
-        return;
-    }
-
     // Async I/O: snapshot the in-memory JSON root (COW copy) and hand off
     // to the persistence worker thread. The main thread returns immediately.
     // The dirty flag is cleared asynchronously when the worker's
     // writeCompleted(success=true) signal lands (see ctor wiring) — so a
     // failed write is retried on the next timer tick instead of silently
     // losing state.
+    //
+    // Push the committed mask onto the pending-writes FIFO at the exact
+    // hand-off point: the worker processes requestWrite signals in queued
+    // order, so dequeueing from the head in writeCompleted correctly
+    // matches masks to completions even with multiple writes in flight.
     auto* jsonBackend = dynamic_cast<JsonConfigBackend*>(m_sessionBackend.get());
     if (jsonBackend && m_persistenceWorker) {
+        m_pendingWriteMasks.enqueue(dirty);
         m_persistenceWorker->enqueueWrite(jsonBackend->filePath(), jsonBackend->jsonRootSnapshot());
     } else {
-        m_sessionBackend->sync(); // fallback: synchronous write
+        // Fallback synchronous path: the sync() backend signature is void,
+        // so we can't detect a failed write here. This path is only hit
+        // when the backend is not a JsonConfigBackend (i.e. tests), and
+        // the committed mask is NOT enqueued — the worker's writeCompleted
+        // handler never fires for this path.
+        m_sessionBackend->sync();
     }
     qCInfo(lcDbusWindow) << "Saved state: dirty=" << Qt::hex << dirty << Qt::dec << "zones=" << fullAssignments.size()
                          << "pending=" << pendingQueuesObj.size() << "preTile=" << m_service->preTileGeometries().size()

--- a/src/dbus/windowtrackingadaptor/saveload.cpp
+++ b/src/dbus/windowtrackingadaptor/saveload.cpp
@@ -267,11 +267,26 @@ void WindowTrackingAdaptor::saveState()
         m_pendingWriteMasks.enqueue(dirty);
         m_persistenceWorker->enqueueWrite(jsonBackend->filePath(), jsonBackend->jsonRootSnapshot());
     } else {
-        // Fallback synchronous path: the sync() backend signature is void,
-        // so we can't detect a failed write here. This path is only hit
-        // when the backend is not a JsonConfigBackend (i.e. tests), and
-        // the committed mask is NOT enqueued — the worker's writeCompleted
-        // handler never fires for this path.
+        // Fallback synchronous path.
+        //
+        // This branch is only reachable when m_sessionBackend is not a
+        // JsonConfigBackend — i.e. tests that wire a memory-only backend.
+        // The production daemon always uses JsonConfigBackend, so the
+        // async/retry path above is the only one exercised outside of
+        // the test harness.
+        //
+        // sync() returns void, so we have no way to detect a failed
+        // write and re-mark the committed bits for retry. The mask has
+        // already been taken (above), which means a silent failure here
+        // silently loses the committed bits — same behavior as
+        // pre-Phase-3 code, and acceptable only because this path is
+        // test-only. Log a one-time warning on first hit so any future
+        // production regression is obvious in logs.
+        if (!m_syncFallbackWarned) {
+            qCWarning(lcDbusWindow) << "saveState: using synchronous fallback backend; failed writes cannot be retried "
+                                       "(expected only in unit tests)";
+            m_syncFallbackWarned = true;
+        }
         m_sessionBackend->sync();
     }
     qCInfo(lcDbusWindow) << "Saved state: dirty=" << Qt::hex << dirty << Qt::dec << "zones=" << fullAssignments.size()

--- a/src/dbus/windowtrackingadaptor/saveload.cpp
+++ b/src/dbus/windowtrackingadaptor/saveload.cpp
@@ -51,10 +51,20 @@ static QHash<QString, QStringList> parseZoneListMap(const QString& json)
 
 void WindowTrackingAdaptor::saveState()
 {
+    using D = WindowTrackingService;
+    // Snapshot the dirty mask — after this call the service is clean
+    // from our perspective. If the write fails, the persistence worker's
+    // writeCompleted(success=false) handler addDirty()s the same bits
+    // back so the next tick retries.
+    const D::DirtyMask dirty = m_service->takeDirty();
+    m_lastCommittedDirty = dirty;
+
     auto tracking = m_sessionBackend->group(ConfigKeys::windowTrackingGroup());
 
     // Save active layout ID so we can restore it after daemon restart.
-    if (m_layoutManager && m_layoutManager->activeLayout()) {
+    // Gated on DirtyActiveLayoutId — only rewrites when the layout manager
+    // signal fired since the last save.
+    if ((dirty & D::DirtyActiveLayoutId) && m_layoutManager && m_layoutManager->activeLayout()) {
         tracking->writeString(ConfigKeys::activeLayoutIdKey(), m_layoutManager->activeLayout()->id().toString());
     }
 
@@ -62,56 +72,64 @@ void WindowTrackingAdaptor::saveState()
     // distinction. On daemon-only restart (KWin still running), UUIDs are stable so
     // exact matching prevents restoring the wrong instance of a multi-instance app.
     QJsonArray fullAssignments;
-    for (auto it = m_service->zoneAssignments().constBegin(); it != m_service->zoneAssignments().constEnd(); ++it) {
-        QJsonObject entry;
-        entry[QLatin1String("windowId")] = it.key();
-        entry[QLatin1String("zoneIds")] = toJsonArray(it.value());
-        const QString assignedScreen = m_service->screenAssignments().value(it.key());
-        entry[QLatin1String("screen")] =
-            VirtualScreenId::isVirtual(assignedScreen) ? assignedScreen : Utils::screenIdForName(assignedScreen);
-        entry[QLatin1String("desktop")] = m_service->desktopAssignments().value(it.key(), 0);
-        fullAssignments.append(entry);
+    if (dirty & D::DirtyZoneAssignments) {
+        for (auto it = m_service->zoneAssignments().constBegin(); it != m_service->zoneAssignments().constEnd(); ++it) {
+            QJsonObject entry;
+            entry[QLatin1String("windowId")] = it.key();
+            entry[QLatin1String("zoneIds")] = toJsonArray(it.value());
+            const QString assignedScreen = m_service->screenAssignments().value(it.key());
+            entry[QLatin1String("screen")] =
+                VirtualScreenId::isVirtual(assignedScreen) ? assignedScreen : Utils::screenIdForName(assignedScreen);
+            entry[QLatin1String("desktop")] = m_service->desktopAssignments().value(it.key(), 0);
+            fullAssignments.append(entry);
+        }
+        tracking->writeString(ConfigKeys::windowZoneAssignmentsFullKey(),
+                              QString::fromUtf8(QJsonDocument(fullAssignments).toJson(QJsonDocument::Compact)));
     }
-    tracking->writeString(ConfigKeys::windowZoneAssignmentsFullKey(),
-                          QString::fromUtf8(QJsonDocument(fullAssignments).toJson(QJsonDocument::Compact)));
 
     // Save pending restore queues as JSON: appId -> array of entry objects
     // Each entry: {zoneIds: [...], screen: "...", desktop: N, layout: "...", zoneNumbers: [...]}
     QJsonObject pendingQueuesObj;
-    for (auto it = m_service->pendingRestoreQueues().constBegin(); it != m_service->pendingRestoreQueues().constEnd();
-         ++it) {
-        QJsonArray entryArray;
-        for (const auto& entry : it.value()) {
-            QJsonObject entryObj;
-            entryObj[QLatin1String("zoneIds")] = toJsonArray(entry.zoneIds);
-            if (!entry.screenId.isEmpty()) {
-                entryObj[QLatin1String("screen")] = VirtualScreenId::isVirtual(entry.screenId)
-                    ? entry.screenId
-                    : Utils::screenIdForName(entry.screenId);
-            }
-            if (entry.virtualDesktop > 0) {
-                entryObj[QLatin1String("desktop")] = entry.virtualDesktop;
-            }
-            if (!entry.layoutId.isEmpty()) {
-                entryObj[QLatin1String("layout")] = entry.layoutId;
-            }
-            if (!entry.zoneNumbers.isEmpty()) {
-                QJsonArray numArray;
-                for (int num : entry.zoneNumbers) {
-                    numArray.append(num);
+    if (dirty & D::DirtyPendingRestores) {
+        for (auto it = m_service->pendingRestoreQueues().constBegin();
+             it != m_service->pendingRestoreQueues().constEnd(); ++it) {
+            QJsonArray entryArray;
+            for (const auto& entry : it.value()) {
+                QJsonObject entryObj;
+                entryObj[QLatin1String("zoneIds")] = toJsonArray(entry.zoneIds);
+                if (!entry.screenId.isEmpty()) {
+                    entryObj[QLatin1String("screen")] = VirtualScreenId::isVirtual(entry.screenId)
+                        ? entry.screenId
+                        : Utils::screenIdForName(entry.screenId);
                 }
-                entryObj[QLatin1String("zoneNumbers")] = numArray;
+                if (entry.virtualDesktop > 0) {
+                    entryObj[QLatin1String("desktop")] = entry.virtualDesktop;
+                }
+                if (!entry.layoutId.isEmpty()) {
+                    entryObj[QLatin1String("layout")] = entry.layoutId;
+                }
+                if (!entry.zoneNumbers.isEmpty()) {
+                    QJsonArray numArray;
+                    for (int num : entry.zoneNumbers) {
+                        numArray.append(num);
+                    }
+                    entryObj[QLatin1String("zoneNumbers")] = numArray;
+                }
+                entryArray.append(entryObj);
             }
-            entryArray.append(entryObj);
+            if (!entryArray.isEmpty()) {
+                pendingQueuesObj[it.key()] = entryArray;
+            }
         }
-        if (!entryArray.isEmpty()) {
-            pendingQueuesObj[it.key()] = entryArray;
-        }
+        tracking->writeString(ConfigKeys::pendingRestoreQueuesKey(),
+                              QString::fromUtf8(QJsonDocument(pendingQueuesObj).toJson(QJsonDocument::Compact)));
     }
-    tracking->writeString(ConfigKeys::pendingRestoreQueuesKey(),
-                          QString::fromUtf8(QJsonDocument(pendingQueuesObj).toJson(QJsonDocument::Compact)));
 
-    // Clean up obsolete keys from old formats
+    // Clean up obsolete keys from old formats. These are cheap no-ops when
+    // the keys don't exist, and we need them to run at least once per
+    // daemon start regardless of the dirty mask — so they sit outside any
+    // gate. On subsequent saves they're already deleted so the calls are
+    // idempotent.
     tracking->deleteKey(ConfigKeys::obsoletePendingWindowScreenAssignmentsKey());
     tracking->deleteKey(ConfigKeys::obsoletePendingWindowDesktopAssignmentsKey());
     tracking->deleteKey(ConfigKeys::obsoletePendingWindowLayoutAssignmentsKey());
@@ -124,14 +142,18 @@ void WindowTrackingAdaptor::saveState()
     // even after daemon restart (windows stay at their zone positions across restarts).
     // Save full windowId format for daemon-only restarts (UUIDs stable, multi-instance distinction).
     // Save appId format as fallback for KWin restarts (UUIDs change).
-    tracking->writeString(ConfigKeys::preTileGeometriesFullKey(),
-                          serializeGeometryMapFull(m_service->preTileGeometries()));
-    tracking->writeString(ConfigKeys::preTileGeometriesKey(),
-                          serializeGeometryMap(m_service->preTileGeometries(), m_service));
+    if (dirty & D::DirtyPreTileGeometries) {
+        tracking->writeString(ConfigKeys::preTileGeometriesFullKey(),
+                              serializeGeometryMapFull(m_service->preTileGeometries()));
+        tracking->writeString(ConfigKeys::preTileGeometriesKey(),
+                              serializeGeometryMap(m_service->preTileGeometries(), m_service));
+    }
 
     // Save last used zone info (from service)
-    tracking->writeString(ConfigKeys::lastUsedZoneIdKey(), m_service->lastUsedZoneId());
-    // Note: Other last-used fields would need accessors in service
+    if (dirty & D::DirtyLastUsedZone) {
+        tracking->writeString(ConfigKeys::lastUsedZoneIdKey(), m_service->lastUsedZoneId());
+        // Note: Other last-used fields would need accessors in service
+    }
 
     // Float state is ephemeral (session-only) — do NOT persist across restarts.
     // Clear any stale entry from older versions so restored sessions start clean.
@@ -141,72 +163,92 @@ void WindowTrackingAdaptor::saveState()
     // Runtime keys are full window IDs; convert to the CURRENT app class so
     // that a window which renamed mid-session persists under the live class.
     QJsonObject preFloatZonesObj;
-    for (auto it = m_service->preFloatZoneAssignments().constBegin();
-         it != m_service->preFloatZoneAssignments().constEnd(); ++it) {
-        QString key = m_service->currentAppIdFor(it.key());
-        if (key.isEmpty()) {
-            continue;
+    if (dirty & D::DirtyPreFloatZones) {
+        for (auto it = m_service->preFloatZoneAssignments().constBegin();
+             it != m_service->preFloatZoneAssignments().constEnd(); ++it) {
+            QString key = m_service->currentAppIdFor(it.key());
+            if (key.isEmpty()) {
+                continue;
+            }
+            preFloatZonesObj[key] = toJsonArray(it.value());
         }
-        preFloatZonesObj[key] = toJsonArray(it.value());
+        tracking->writeString(ConfigKeys::preFloatZoneAssignmentsKey(),
+                              QString::fromUtf8(QJsonDocument(preFloatZonesObj).toJson(QJsonDocument::Compact)));
     }
-    tracking->writeString(ConfigKeys::preFloatZoneAssignmentsKey(),
-                          QString::fromUtf8(QJsonDocument(preFloatZonesObj).toJson(QJsonDocument::Compact)));
 
     // Save pre-float screen assignments (for unfloating to correct monitor).
     // Same current-class conversion as above, plus translate to screen IDs.
-    QJsonObject preFloatScreensObj;
-    for (auto it = m_service->preFloatScreenAssignments().constBegin();
-         it != m_service->preFloatScreenAssignments().constEnd(); ++it) {
-        QString key = m_service->currentAppIdFor(it.key());
-        if (key.isEmpty()) {
-            continue;
+    if (dirty & D::DirtyPreFloatScreens) {
+        QJsonObject preFloatScreensObj;
+        for (auto it = m_service->preFloatScreenAssignments().constBegin();
+             it != m_service->preFloatScreenAssignments().constEnd(); ++it) {
+            QString key = m_service->currentAppIdFor(it.key());
+            if (key.isEmpty()) {
+                continue;
+            }
+            preFloatScreensObj[key] =
+                VirtualScreenId::isVirtual(it.value()) ? it.value() : Utils::screenIdForName(it.value());
         }
-        preFloatScreensObj[key] =
-            VirtualScreenId::isVirtual(it.value()) ? it.value() : Utils::screenIdForName(it.value());
+        tracking->writeString(ConfigKeys::preFloatScreenAssignmentsKey(),
+                              QString::fromUtf8(QJsonDocument(preFloatScreensObj).toJson(QJsonDocument::Compact)));
     }
-    tracking->writeString(ConfigKeys::preFloatScreenAssignmentsKey(),
-                          QString::fromUtf8(QJsonDocument(preFloatScreensObj).toJson(QJsonDocument::Compact)));
 
     // Save user-snapped classes
     QJsonArray userSnappedArray;
-    for (const QString& windowClass : m_service->userSnappedClasses()) {
-        userSnappedArray.append(windowClass);
+    if (dirty & D::DirtyUserSnapped) {
+        for (const QString& windowClass : m_service->userSnappedClasses()) {
+            userSnappedArray.append(windowClass);
+        }
+        tracking->writeString(ConfigKeys::userSnappedClassesKey(),
+                              QString::fromUtf8(QJsonDocument(userSnappedArray).toJson(QJsonDocument::Compact)));
     }
-    tracking->writeString(ConfigKeys::userSnappedClassesKey(),
-                          QString::fromUtf8(QJsonDocument(userSnappedArray).toJson(QJsonDocument::Compact)));
 
     // Save autotile per-context window orders (analogous to WindowZoneAssignmentsFull
     // for snap mode). masterCount/splitRatio are NOT saved here — Settings owns those
     // via AutotileScreen:<id> per-screen overrides.
-    if (m_serializeTilingStatesFn) {
-        const QJsonArray autotileOrders = m_serializeTilingStatesFn();
-        if (!autotileOrders.isEmpty()) {
-            tracking->writeString(ConfigKeys::autotileWindowOrdersKey(),
-                                  QString::fromUtf8(QJsonDocument(autotileOrders).toJson(QJsonDocument::Compact)));
+    if (dirty & D::DirtyAutotileOrders) {
+        if (m_serializeTilingStatesFn) {
+            const QJsonArray autotileOrders = m_serializeTilingStatesFn();
+            if (!autotileOrders.isEmpty()) {
+                tracking->writeString(ConfigKeys::autotileWindowOrdersKey(),
+                                      QString::fromUtf8(QJsonDocument(autotileOrders).toJson(QJsonDocument::Compact)));
+            } else {
+                tracking->deleteKey(ConfigKeys::autotileWindowOrdersKey());
+            }
         } else {
+            // No serialize delegate — clean up any stale key from a prior session
+            // where autotile was enabled. Prevents restoring orphaned window orders.
             tracking->deleteKey(ConfigKeys::autotileWindowOrdersKey());
         }
-    } else {
-        // No serialize delegate — clean up any stale key from a prior session
-        // where autotile was enabled. Prevents restoring orphaned window orders.
-        tracking->deleteKey(ConfigKeys::autotileWindowOrdersKey());
     }
 
     // Save autotile pending restore queues (close/reopen window preservation).
     // Separate key from window orders to keep the orders array homogeneous.
-    if (m_serializePendingRestoresFn) {
-        const QJsonObject pendingRestores = m_serializePendingRestoresFn();
-        if (!pendingRestores.isEmpty()) {
-            tracking->writeString(ConfigKeys::autotilePendingRestoresKey(),
-                                  QString::fromUtf8(QJsonDocument(pendingRestores).toJson(QJsonDocument::Compact)));
+    if (dirty & D::DirtyAutotilePending) {
+        if (m_serializePendingRestoresFn) {
+            const QJsonObject pendingRestores = m_serializePendingRestoresFn();
+            if (!pendingRestores.isEmpty()) {
+                tracking->writeString(ConfigKeys::autotilePendingRestoresKey(),
+                                      QString::fromUtf8(QJsonDocument(pendingRestores).toJson(QJsonDocument::Compact)));
+            } else {
+                tracking->deleteKey(ConfigKeys::autotilePendingRestoresKey());
+            }
         } else {
             tracking->deleteKey(ConfigKeys::autotilePendingRestoresKey());
         }
-    } else {
-        tracking->deleteKey(ConfigKeys::autotilePendingRestoresKey());
     }
 
     tracking.reset(); // release group before write
+
+    // If nothing was dirty, skip the write entirely. This can happen when
+    // the scheduler fires against an all-ephemeral-state wake (float
+    // toggles, etc.) — no bytes on disk changed, so there's nothing to
+    // persist. Without this gate we'd rewrite the whole file with the
+    // same content on every debounce tick.
+    if (dirty == D::DirtyNone) {
+        qCDebug(lcDbusWindow) << "Saved state: no dirty fields, skipping write";
+        return;
+    }
 
     // Async I/O: snapshot the in-memory JSON root (COW copy) and hand off
     // to the persistence worker thread. The main thread returns immediately.
@@ -220,9 +262,8 @@ void WindowTrackingAdaptor::saveState()
     } else {
         m_sessionBackend->sync(); // fallback: synchronous write
     }
-    qCInfo(lcDbusWindow) << "Saved state:"
-                         << "zones=" << fullAssignments.size() << "pending=" << pendingQueuesObj.size()
-                         << "preTile=" << m_service->preTileGeometries().size()
+    qCInfo(lcDbusWindow) << "Saved state: dirty=" << Qt::hex << dirty << Qt::dec << "zones=" << fullAssignments.size()
+                         << "pending=" << pendingQueuesObj.size() << "preTile=" << m_service->preTileGeometries().size()
                          << "preFloat=" << preFloatZonesObj.size() << "userSnapped=" << userSnappedArray.size();
 }
 
@@ -659,6 +700,13 @@ void WindowTrackingAdaptor::loadState()
     if (!pendingQueues.isEmpty()) {
         m_hasPendingRestores = true;
         tryEmitPendingRestoresAvailable();
+    }
+
+    // In-memory state now mirrors the disk file — nothing is dirty until
+    // the next mutation lands. Without this clear, the first saveState()
+    // after startup would re-serialize every field we just loaded.
+    if (m_service) {
+        m_service->clearDirty();
     }
 }
 

--- a/src/settings/qml/SnappingBridge.qml
+++ b/src/settings/qml/SnappingBridge.qml
@@ -96,8 +96,18 @@ SharedBridge {
         appRulesRefreshed();
     }
 
-    function getRunningWindows() {
-        return settingsController.getRunningWindows();
+    // Async window picker: kick off a fetch; the reply arrives via the
+    // controller's runningWindowsAvailable signal — QML pickers connect
+    // directly to settingsController, not to this bridge, so a single
+    // in-flight request is delivered to every listening dialog.
+    function requestRunningWindows() {
+        settingsController.requestRunningWindows();
+    }
+
+    // Synchronous accessor for the last-received list (may be stale until
+    // the next runningWindowsAvailable signal fires). Never blocks.
+    function cachedRunningWindows() {
+        return settingsController.cachedRunningWindows();
     }
 
     assignmentViewMode: 0

--- a/src/settings/qml/WindowPickerDialog.qml
+++ b/src/settings/qml/WindowPickerDialog.qml
@@ -55,9 +55,15 @@ Kirigami.Dialog {
         searchField.forceActiveFocus();
     }
 
+    // Async refresh: show whatever we already have cached from a previous
+    // fetch so the list paints instantly, then kick off a fresh request.
+    // The `Connections` block below replaces `windowList` when the
+    // daemon signals runningWindowsAvailable — the dialog never blocks
+    // on the D-Bus call even if the KWin effect is unloaded or slow.
     function refresh() {
         searchField.text = "";
-        windowList = appSettings.getRunningWindows();
+        windowList = appSettings.cachedRunningWindows();
+        appSettings.requestRunningWindows();
     }
 
     title: forApps ? i18n("Pick Application from Running Windows") : i18n("Pick Window Class from Running Windows")
@@ -70,6 +76,14 @@ Kirigami.Dialog {
             onTriggered: dialog.refresh()
         }
     ]
+
+    Connections {
+        function onRunningWindowsAvailable(windows) {
+            dialog.windowList = windows;
+        }
+
+        target: settingsController
+    }
 
     ColumnLayout {
         spacing: Kirigami.Units.smallSpacing

--- a/src/settings/qml/WindowPickerDialog.qml
+++ b/src/settings/qml/WindowPickerDialog.qml
@@ -20,6 +20,10 @@ Kirigami.Dialog {
     required property var appSettings
     property bool forApps: false
     property var windowList: []
+    // Set by the Connections block below when the controller signals a
+    // timeout (KWin effect unloaded / unresponsive). Cleared on every
+    // successful reply. Drives the placeholder-message error state.
+    property bool requestTimedOut: false
 
     signal picked(string value)
 
@@ -60,8 +64,12 @@ Kirigami.Dialog {
     // The `Connections` block below replaces `windowList` when the
     // daemon signals runningWindowsAvailable — the dialog never blocks
     // on the D-Bus call even if the KWin effect is unloaded or slow.
+    // A client-side timeout in SettingsController surfaces
+    // runningWindowsTimedOut() if no reply arrives, which flips
+    // requestTimedOut so the placeholder can switch to an error state.
     function refresh() {
         searchField.text = "";
+        requestTimedOut = false;
         windowList = appSettings.cachedRunningWindows();
         appSettings.requestRunningWindows();
     }
@@ -79,7 +87,12 @@ Kirigami.Dialog {
 
     Connections {
         function onRunningWindowsAvailable(windows) {
+            dialog.requestTimedOut = false;
             dialog.windowList = windows;
+        }
+
+        function onRunningWindowsTimedOut() {
+            dialog.requestTimedOut = true;
         }
 
         target: settingsController
@@ -124,8 +137,8 @@ Kirigami.Dialog {
                 anchors.centerIn: parent
                 width: parent.width - Kirigami.Units.gridUnit * 4
                 visible: windowListView.count === 0
-                text: dialog.windowList.length === 0 ? i18n("No windows found") : i18n("No matching windows")
-                explanation: dialog.windowList.length === 0 ? i18n("Make sure the PlasmaZones daemon and KWin effect are running") : i18n("Try a different search term")
+                text: dialog.requestTimedOut ? i18n("No response from KWin effect") : dialog.windowList.length === 0 ? i18n("No windows found") : i18n("No matching windows")
+                explanation: dialog.requestTimedOut ? i18n("The KWin effect did not respond. Make sure the PlasmaZones daemon is running, then click Refresh.") : dialog.windowList.length === 0 ? i18n("Make sure the PlasmaZones daemon and KWin effect are running") : i18n("Try a different search term")
             }
 
             delegate: ItemDelegate {

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -1992,21 +1992,6 @@ static QVariantList parseRunningWindowsJson(const QString& json)
     return result;
 }
 
-QVariantList SettingsController::getRunningWindows() const
-{
-    // Legacy synchronous path. Retained for QML that has not yet migrated
-    // to the requestRunningWindows + runningWindowsAvailable flow. Issues
-    // a blocking D-Bus call that can freeze the UI for up to 2 seconds
-    // when the KWin effect is unloaded — new callers should use the async
-    // pair instead.
-    QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::Settings), QStringLiteral("getRunningWindows"));
-    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().isEmpty()) {
-        return {};
-    }
-    return parseRunningWindowsJson(reply.arguments().at(0).toString());
-}
-
 void SettingsController::requestRunningWindows()
 {
     // Fire-and-forget: the daemon emits runningWindowsRequested to the

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -1973,9 +1973,10 @@ void SettingsController::loadColorsFromFile(const QString& filePath)
     setNeedsSave(true);
 }
 
-// Shared parser used by both the async reply path and the legacy
-// synchronous getRunningWindows() helper. Keeps the JSON wire format
-// documented in exactly one place.
+// Parses the daemon's running-windows JSON payload into a QVariantList of
+// {windowClass, appName, caption} maps ready for QML consumption. The
+// synchronous getRunningWindows() predecessor was removed in Phase 6 of
+// refactor/dbus-performance; only onRunningWindowsAvailable calls this now.
 static QVariantList parseRunningWindowsJson(const QString& json)
 {
     if (json.isEmpty()) {

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -126,6 +126,14 @@ SettingsController::SettingsController(QObject* parent)
                                           QString(DBus::Interface::Settings), QStringLiteral("settingsChanged"), this,
                                           SLOT(onExternalSettingsChanged()));
 
+    // Async window picker reply channel. Emitted by SettingsAdaptor whenever
+    // the KWin effect answers a runningWindowsRequested call via
+    // provideRunningWindows(). The signal carries the JSON payload directly
+    // so clients don't need a follow-up blocking fetch.
+    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
+                                          QString(DBus::Interface::Settings), QStringLiteral("runningWindowsAvailable"),
+                                          this, SLOT(onRunningWindowsAvailable(QString)));
+
     // Forward daemon running state changes and refresh data when daemon starts
     connect(&m_daemonController, &DaemonController::runningChanged, this, [this]() {
         Q_EMIT daemonRunningChanged();
@@ -1946,40 +1954,65 @@ void SettingsController::loadColorsFromFile(const QString& filePath)
     setNeedsSave(true);
 }
 
-QVariantList SettingsController::getRunningWindows() const
+// Shared parser used by both the async reply path and the legacy
+// synchronous getRunningWindows() helper. Keeps the JSON wire format
+// documented in exactly one place.
+static QVariantList parseRunningWindowsJson(const QString& json)
 {
-    QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::Settings), QStringLiteral("getRunningWindows"));
-    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().isEmpty()) {
-        return {};
-    }
-
-    QString json = reply.arguments().at(0).toString();
     if (json.isEmpty()) {
         return {};
     }
-
     QJsonParseError parseError;
-    QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8(), &parseError);
+    const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8(), &parseError);
     if (parseError.error != QJsonParseError::NoError || !doc.isArray()) {
         return {};
     }
 
     QVariantList result;
     const QJsonArray array = doc.array();
+    result.reserve(array.size());
     for (const QJsonValue& value : array) {
         if (!value.isObject()) {
             continue;
         }
-        QJsonObject obj = value.toObject();
+        const QJsonObject obj = value.toObject();
         QVariantMap item;
         item[QStringLiteral("windowClass")] = obj[QLatin1String("windowClass")].toString();
         item[QStringLiteral("appName")] = obj[QLatin1String("appName")].toString();
         item[QStringLiteral("caption")] = obj[QLatin1String("caption")].toString();
         result.append(item);
     }
-
     return result;
+}
+
+QVariantList SettingsController::getRunningWindows() const
+{
+    // Legacy synchronous path. Retained for QML that has not yet migrated
+    // to the requestRunningWindows + runningWindowsAvailable flow. Issues
+    // a blocking D-Bus call that can freeze the UI for up to 2 seconds
+    // when the KWin effect is unloaded — new callers should use the async
+    // pair instead.
+    QDBusMessage reply =
+        DaemonDBus::callDaemon(QString(DBus::Interface::Settings), QStringLiteral("getRunningWindows"));
+    if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().isEmpty()) {
+        return {};
+    }
+    return parseRunningWindowsJson(reply.arguments().at(0).toString());
+}
+
+void SettingsController::requestRunningWindows()
+{
+    // Fire-and-forget: the daemon emits runningWindowsRequested to the
+    // KWin effect, which answers via provideRunningWindows, which the
+    // daemon fans out on runningWindowsAvailable — caught by our
+    // onRunningWindowsAvailable slot. The UI thread never blocks.
+    DaemonDBus::callDaemon(QString(DBus::Interface::Settings), QStringLiteral("requestRunningWindows"));
+}
+
+void SettingsController::onRunningWindowsAvailable(const QString& json)
+{
+    m_cachedRunningWindows = parseRunningWindowsJson(json);
+    Q_EMIT runningWindowsAvailable(m_cachedRunningWindows);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -201,6 +201,13 @@ SettingsController::SettingsController(QObject* parent)
     QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
                                           QString(DBus::Interface::LayoutManager), QStringLiteral("layoutChanged"),
                                           this, SLOT(loadLayoutsAsync()));
+    // layoutPropertyChanged fires on compact property mutations (hidden, autoAssign,
+    // aspectRatioClass) — Phase 4 of refactor/dbus-performance. The settings UI still
+    // triggers a full reload so the layout list view refreshes, but the daemon side
+    // saved a full JSON serialization per mutation by not emitting layoutChanged.
+    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
+                                          QString(DBus::Interface::LayoutManager),
+                                          QStringLiteral("layoutPropertyChanged"), this, SLOT(loadLayoutsAsync()));
     // layoutListChanged fires when the layout list changes (editor, import, system layout reload)
     QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
                                           QString(DBus::Interface::LayoutManager), QStringLiteral("layoutListChanged"),

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -134,6 +134,18 @@ SettingsController::SettingsController(QObject* parent)
                                           QString(DBus::Interface::Settings), QStringLiteral("runningWindowsAvailable"),
                                           this, SLOT(onRunningWindowsAvailable(QString)));
 
+    // Client-side timeout for the async window picker. If the daemon
+    // never fans out a runningWindowsAvailable signal (KWin effect
+    // unloaded, crashed, or slow), the timer fires runningWindowsTimedOut()
+    // so the UI can switch from a spinner to an error state.
+    m_runningWindowsTimeout.setSingleShot(true);
+    m_runningWindowsTimeout.setInterval(RunningWindowsTimeoutMs);
+    connect(&m_runningWindowsTimeout, &QTimer::timeout, this, [this]() {
+        qCWarning(PlasmaZones::lcCore) << "requestRunningWindows: no reply within" << RunningWindowsTimeoutMs
+                                       << "ms — KWin effect unresponsive?";
+        Q_EMIT runningWindowsTimedOut();
+    });
+
     // Forward daemon running state changes and refresh data when daemon starts
     connect(&m_daemonController, &DaemonController::runningChanged, this, [this]() {
         Q_EMIT daemonRunningChanged();
@@ -1998,11 +2010,19 @@ void SettingsController::requestRunningWindows()
     // KWin effect, which answers via provideRunningWindows, which the
     // daemon fans out on runningWindowsAvailable — caught by our
     // onRunningWindowsAvailable slot. The UI thread never blocks.
+    //
+    // Start (or restart) the client-side timeout guard. Repeated calls
+    // coalesce — the most recent deadline wins, matching the fire-and-
+    // forget semantics on the daemon side.
+    m_runningWindowsTimeout.start();
     DaemonDBus::callDaemon(QString(DBus::Interface::Settings), QStringLiteral("requestRunningWindows"));
 }
 
 void SettingsController::onRunningWindowsAvailable(const QString& json)
 {
+    // Reply arrived — stop the timeout timer so a stale runningWindowsTimedOut()
+    // doesn't fire after we've already served fresh data.
+    m_runningWindowsTimeout.stop();
     m_cachedRunningWindows = parseRunningWindowsJson(json);
     Q_EMIT runningWindowsAvailable(m_cachedRunningWindows);
 }

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -592,10 +592,19 @@ public:
     // repeat opens of the dialog can show the last-seen values immediately
     // while the fresh fetch is in flight. The old synchronous
     // getRunningWindows() was removed in Phase 6 of refactor/dbus-performance.
+    //
+    // A client-side timeout guards against the KWin effect being unloaded:
+    // if no reply arrives within RunningWindowsTimeoutMs, we surface the
+    // last-cached list via runningWindowsTimedOut() so the QML dialog can
+    // show a "no response" state instead of hanging on a spinner forever.
     Q_INVOKABLE void requestRunningWindows();
     Q_INVOKABLE QVariantList cachedRunningWindows() const
     {
         return m_cachedRunningWindows;
+    }
+    Q_INVOKABLE bool runningWindowsPending() const
+    {
+        return m_runningWindowsTimeout.isActive();
     }
 
     // ── Config export/import ────────────────────────────────────────────────
@@ -744,6 +753,18 @@ Q_SIGNALS:
      */
     void runningWindowsAvailable(const QVariantList& windows);
 
+    /**
+     * @brief No reply arrived within RunningWindowsTimeoutMs.
+     *
+     * Emitted by the client-side timeout timer when the KWin effect never
+     * answers a requestRunningWindows() call (effect unloaded, crashed,
+     * or slow). QML dialogs should surface an error state so the user
+     * can distinguish "no windows" from "daemon or effect not responding".
+     * Cached list (possibly stale) is still available via
+     * cachedRunningWindows().
+     */
+    void runningWindowsTimedOut();
+
     // KZones import signals
     void kzonesImportFinished(int count, const QString& message);
     void lockedScreensChanged();
@@ -838,6 +859,14 @@ private:
     // cachedRunningWindows() for the initial paint while a fresh
     // request is in flight.
     QVariantList m_cachedRunningWindows;
+
+    // Client-side timeout for the async window picker. Started on
+    // requestRunningWindows(), stopped when the daemon's
+    // runningWindowsAvailable signal arrives. On expiry, we emit
+    // runningWindowsTimedOut() so the UI can give the user feedback
+    // instead of hanging indefinitely on an unloaded KWin effect.
+    QTimer m_runningWindowsTimeout;
+    static constexpr int RunningWindowsTimeoutMs = 3000;
 
     // Staged assignment changes (applied on save, discarded on load/reset)
     struct StagedAssignment

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -583,7 +583,24 @@ public:
     // ── Color import ─────────────────────────────────────────────────────────
     Q_INVOKABLE void loadColorsFromPywal();
     Q_INVOKABLE void loadColorsFromFile(const QString& filePath);
+
+    // ── Running window picker (async flow) ──────────────────────────────────
+    //
+    // The QML picker dialog calls requestRunningWindows() and binds to
+    // runningWindowsAvailable(list) — no blocking D-Bus round-trip. The
+    // controller caches the most recent list in m_cachedRunningWindows so
+    // repeat opens of the dialog can show the last-seen values immediately
+    // while the fresh fetch is in flight.
+    //
+    // getRunningWindows() remains as a legacy synchronous helper only so
+    // older QML paths keep working during migration; it will be removed
+    // once every caller is on the async flow.
     Q_INVOKABLE QVariantList getRunningWindows() const;
+    Q_INVOKABLE void requestRunningWindows();
+    Q_INVOKABLE QVariantList cachedRunningWindows() const
+    {
+        return m_cachedRunningWindows;
+    }
 
     // ── Config export/import ────────────────────────────────────────────────
     Q_INVOKABLE bool exportAllSettings(const QString& filePath);
@@ -721,6 +738,16 @@ Q_SIGNALS:
     void colorImportError(const QString& error);
     void colorImportSuccess();
 
+    /**
+     * @brief Fresh running-windows list has arrived from the daemon.
+     *
+     * Emitted in response to requestRunningWindows(). The @p windows list
+     * is a QVariantList of {windowClass, appName, caption} maps ready for
+     * QML consumption. Also updates cachedRunningWindows() so later
+     * queries can read the last-seen value synchronously.
+     */
+    void runningWindowsAvailable(const QVariantList& windows);
+
     // KZones import signals
     void kzonesImportFinished(int count, const QString& message);
     void lockedScreensChanged();
@@ -751,6 +778,15 @@ private Q_SLOTS:
     void onVirtualDesktopsChanged();
     void onActivitiesChanged();
     void onScreenLayoutChanged(const QString& screenId, const QString& layoutId, int virtualDesktop);
+
+    /**
+     * @brief Handle SettingsAdaptor::runningWindowsAvailable D-Bus signal.
+     *
+     * Parses the JSON payload into a QVariantList of window maps, stores
+     * it in m_cachedRunningWindows, and emits the QML-facing
+     * runningWindowsAvailable(list) signal.
+     */
+    void onRunningWindowsAvailable(const QString& json);
 
 private:
     /// Resolve saved custom params for the given algorithm from per-algorithm settings
@@ -800,6 +836,12 @@ private:
     bool m_activitiesAvailable = false;
     QVariantList m_activities;
     QString m_currentActivity;
+
+    // Last-received running-windows list (async window picker).
+    // Populated by onRunningWindowsAvailable. QML reads this via
+    // cachedRunningWindows() for the initial paint while a fresh
+    // request is in flight.
+    QVariantList m_cachedRunningWindows;
 
     // Staged assignment changes (applied on save, discarded on load/reset)
     struct StagedAssignment

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -590,12 +590,8 @@ public:
     // runningWindowsAvailable(list) — no blocking D-Bus round-trip. The
     // controller caches the most recent list in m_cachedRunningWindows so
     // repeat opens of the dialog can show the last-seen values immediately
-    // while the fresh fetch is in flight.
-    //
-    // getRunningWindows() remains as a legacy synchronous helper only so
-    // older QML paths keep working during migration; it will be removed
-    // once every caller is on the async flow.
-    Q_INVOKABLE QVariantList getRunningWindows() const;
+    // while the fresh fetch is in flight. The old synchronous
+    // getRunningWindows() was removed in Phase 6 of refactor/dbus-performance.
     Q_INVOKABLE void requestRunningWindows();
     Q_INVOKABLE QVariantList cachedRunningWindows() const
     {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -59,6 +59,11 @@ add_executable(test_wts_registry_integration core/test_wts_registry_integration.
 target_link_libraries(test_wts_registry_integration PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
 add_test(NAME test_wts_registry_integration COMMAND test_wts_registry_integration)
 
+# DirtyMask invariants for delta-persistence (Phase 3 of refactor/dbus-performance).
+add_executable(test_wts_dirty_mask core/test_wts_dirty_mask.cpp)
+target_link_libraries(test_wts_dirty_mask PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
+add_test(NAME test_wts_dirty_mask COMMAND test_wts_dirty_mask)
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # core/ — SnapEngine Tests
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -376,7 +381,7 @@ set(_all_tests
     test_window_identity
     test_window_tracking_snap test_window_tracking_float
     test_session_persistence test_session_persistence_layout
-    test_wts_lifecycle test_wts_session test_wts_queries
+    test_wts_lifecycle test_wts_session test_wts_queries test_wts_dirty_mask
     test_tiling_algo_masterstack test_tiling_algo_spiral_monocle
     test_tiling_algo_grid_threecolumn test_tiling_algo_wide_centered
     test_tiling_algo_cascade_stair_spread

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -363,7 +363,12 @@ add_test(NAME test_layout_adaptor_signals COMMAND test_layout_adaptor_signals)
 add_executable(bench_dbus_adaptors dbus/bench_dbus_adaptors.cpp)
 target_link_libraries(bench_dbus_adaptors PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
 add_test(NAME bench_dbus_adaptors COMMAND bench_dbus_adaptors)
-set_tests_properties(bench_dbus_adaptors PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+# LABELS=bench lets CI skip the verbose benchmark output via
+# `ctest -LE bench` while still letting `ctest -L bench` select it
+# explicitly for the perf-regression run.
+set_tests_properties(bench_dbus_adaptors PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+    LABELS "bench")
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # compositor-common/ — Shared Library Types Tests (D-Bus types, FloatingCache,

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -341,6 +341,18 @@ add_executable(test_dbus_validation dbus/test_dbus_validation.cpp)
 target_link_libraries(test_dbus_validation PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_compositor_common)
 add_test(NAME test_dbus_validation COMMAND test_dbus_validation)
 
+# Micro-benchmarks for D-Bus adaptor hot paths. Drives the
+# refactor/dbus-performance branch (SettingsAdaptor value-equality guard,
+# LayoutAdaptor signal split, JSON cache reuse). Run with
+# `ctest -R bench_dbus_adaptors` to capture numbers against
+# docs/perf/dbus-baseline.md. Not in _all_tests by default because
+# benchmark output is verbose; it is still added via add_test() so
+# `ctest -R bench` can select it.
+add_executable(bench_dbus_adaptors dbus/bench_dbus_adaptors.cpp)
+target_link_libraries(bench_dbus_adaptors PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
+add_test(NAME bench_dbus_adaptors COMMAND bench_dbus_adaptors)
+set_tests_properties(bench_dbus_adaptors PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # compositor-common/ — Shared Library Types Tests (D-Bus types, FloatingCache,
 #                      TriggerParser, WindowIdUtils)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -341,6 +341,13 @@ add_executable(test_dbus_validation dbus/test_dbus_validation.cpp)
 target_link_libraries(test_dbus_validation PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_compositor_common)
 add_test(NAME test_dbus_validation COMMAND test_dbus_validation)
 
+# LayoutAdaptor signal contract test (Phase 1.2 of refactor/dbus-performance).
+# Pins the rule: property mutations emit layoutChanged only, NEVER
+# layoutListChanged — the list hasn't changed.
+add_executable(test_layout_adaptor_signals dbus/test_layout_adaptor_signals.cpp)
+target_link_libraries(test_layout_adaptor_signals PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
+add_test(NAME test_layout_adaptor_signals COMMAND test_layout_adaptor_signals)
+
 # Micro-benchmarks for D-Bus adaptor hot paths. Drives the
 # refactor/dbus-performance branch (SettingsAdaptor value-equality guard,
 # LayoutAdaptor signal split, JSON cache reuse). Run with
@@ -405,6 +412,7 @@ set(_all_tests
     test_autotile_adaptor_panel_gate
     test_drag_policy
     test_dbus_validation
+    test_layout_adaptor_signals
     test_compositor_common
 )
 set_tests_properties(${_all_tests} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/tests/unit/core/test_wts_dirty_mask.cpp
+++ b/tests/unit/core/test_wts_dirty_mask.cpp
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_wts_dirty_mask.cpp
+ * @brief WindowTrackingService::DirtyMask invariants (Phase 3).
+ *
+ * Pins the contract between WTS mutators and the delta-persistence path
+ * in WindowTrackingAdaptor::saveState():
+ *
+ *  1. Zone-assignment mutations set DirtyZoneAssignments (+ DirtyLastUsedZone
+ *     when the last-used-zone tracking is cleared as a side effect).
+ *  2. Pre-tile geometry store/clear sets DirtyPreTileGeometries — not the
+ *     rest of the mask.
+ *  3. updateLastUsedZone sets DirtyLastUsedZone only.
+ *  4. recordSnapIntent(true) sets DirtyUserSnapped only.
+ *  5. consumePendingAssignment sets DirtyPendingRestores only.
+ *  6. takeDirty() returns the current mask and resets to DirtyNone.
+ *  7. addDirty() ORs bits back in (used by the retry-on-failure path).
+ *  8. Initial mask is DirtyAll so first save after construction writes
+ *     every field.
+ *
+ * These invariants are what the saveload.cpp gate relies on. If a mutator
+ * regresses to leaving the mask wider than necessary, the delta win
+ * silently disappears. If a mutator forgets to mark dirty at all, state
+ * is lost on the next save.
+ */
+
+#include <QTest>
+#include <QRect>
+
+#include "core/layout.h"
+#include "core/layoutmanager.h"
+#include "core/virtualdesktopmanager.h"
+#include "core/windowtrackingservice.h"
+#include "core/zone.h"
+#include "../helpers/IsolatedConfigGuard.h"
+#include "../helpers/StubSettings.h"
+#include "../helpers/StubZoneDetector.h"
+
+using namespace PlasmaZones;
+using PlasmaZones::TestHelpers::IsolatedConfigGuard;
+
+class TestWtsDirtyMask : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void init()
+    {
+        m_guard = std::make_unique<IsolatedConfigGuard>();
+        m_parent = new QObject(nullptr);
+        m_layoutManager = new LayoutManager(m_parent);
+        m_virtualDesktopManager = new VirtualDesktopManager(m_layoutManager, m_parent);
+        m_settings = new StubSettings(m_parent);
+        m_zoneDetector = new StubZoneDetector(m_parent);
+
+        m_layout = new Layout(QStringLiteral("TestLayout"));
+        auto* zone1 = new Zone(QRectF(0.0, 0.0, 0.5, 1.0));
+        zone1->setZoneNumber(1);
+        m_layout->addZone(zone1);
+        auto* zone2 = new Zone(QRectF(0.5, 0.0, 0.5, 1.0));
+        zone2->setZoneNumber(2);
+        m_layout->addZone(zone2);
+        m_layoutManager->addLayout(m_layout);
+        m_zone1Id = zone1->id().toString();
+
+        m_service =
+            new WindowTrackingService(m_layoutManager, m_zoneDetector, m_settings, m_virtualDesktopManager, m_parent);
+        // Construction leaves mask = DirtyAll; clear so subsequent mutator
+        // tests start from a known-clean state and only assert on the
+        // bits that the mutator under test is responsible for.
+        m_service->clearDirty();
+    }
+
+    void cleanup()
+    {
+        delete m_parent;
+        m_parent = nullptr;
+        m_layoutManager = nullptr;
+        m_virtualDesktopManager = nullptr;
+        m_settings = nullptr;
+        m_zoneDetector = nullptr;
+        m_layout = nullptr;
+        m_service = nullptr;
+        m_guard.reset();
+    }
+
+    void testInitialMaskIsAll()
+    {
+        // Fresh service (before init's clearDirty call) starts DirtyAll so
+        // the first save after construction writes every field. Build a
+        // second service to verify — m_service has already been cleared.
+        WindowTrackingService fresh(m_layoutManager, m_zoneDetector, m_settings, m_virtualDesktopManager);
+        QCOMPARE(fresh.peekDirty(), static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyAll));
+    }
+
+    void testMarkDirty_orsBits()
+    {
+        m_service->markDirty(WindowTrackingService::DirtyZoneAssignments);
+        QCOMPARE(m_service->peekDirty(),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyZoneAssignments));
+
+        m_service->markDirty(WindowTrackingService::DirtyPreTileGeometries);
+        QCOMPARE(m_service->peekDirty(),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyZoneAssignments
+                                                               | WindowTrackingService::DirtyPreTileGeometries));
+    }
+
+    void testTakeDirty_returnsAndResets()
+    {
+        m_service->markDirty(WindowTrackingService::DirtyLastUsedZone);
+        const auto snapshot = m_service->takeDirty();
+        QCOMPARE(snapshot, static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyLastUsedZone));
+        QCOMPARE(m_service->peekDirty(),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyNone));
+    }
+
+    void testAddDirty_orsWithoutEmittingSignal()
+    {
+        // addDirty() is for retry-on-failure: restore the bits a failed
+        // save attempt was supposed to cover. It must NOT emit stateChanged
+        // (the retry is scheduled manually by the adaptor) — pin that.
+        m_service->clearDirty();
+        int signalCount = 0;
+        connect(m_service, &WindowTrackingService::stateChanged, this, [&]() {
+            ++signalCount;
+        });
+        m_service->addDirty(WindowTrackingService::DirtyPendingRestores);
+        QCOMPARE(m_service->peekDirty(),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyPendingRestores));
+        QCOMPARE(signalCount, 0);
+    }
+
+    void testAssignWindowToZone_marksZoneAssignmentsOnly()
+    {
+        m_service->assignWindowToZone(QStringLiteral("app|abc"), m_zone1Id, QStringLiteral("DP-1"), 1);
+        const auto mask = m_service->peekDirty();
+        // Must include DirtyZoneAssignments.
+        QVERIFY((mask & WindowTrackingService::DirtyZoneAssignments) != 0);
+        // Must NOT include unrelated bits (PreTileGeometries, etc).
+        QCOMPARE((mask & ~WindowTrackingService::DirtyZoneAssignments),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyNone));
+    }
+
+    void testStorePreTileGeometry_marksPreTileOnly()
+    {
+        m_service->storePreTileGeometry(QStringLiteral("app|abc"), QRect(0, 0, 400, 300), QStringLiteral("DP-1"),
+                                        /*overwrite=*/false);
+        const auto mask = m_service->peekDirty();
+        QVERIFY((mask & WindowTrackingService::DirtyPreTileGeometries) != 0);
+        QCOMPARE((mask & ~WindowTrackingService::DirtyPreTileGeometries),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyNone));
+    }
+
+    void testClearPreTileGeometry_marksPreTileOnly()
+    {
+        // First store so the subsequent clear has something to remove.
+        m_service->storePreTileGeometry(QStringLiteral("app|abc"), QRect(0, 0, 400, 300), QStringLiteral("DP-1"),
+                                        false);
+        m_service->clearDirty();
+        m_service->clearPreTileGeometry(QStringLiteral("app|abc"));
+        const auto mask = m_service->peekDirty();
+        QVERIFY((mask & WindowTrackingService::DirtyPreTileGeometries) != 0);
+        QCOMPARE((mask & ~WindowTrackingService::DirtyPreTileGeometries),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyNone));
+    }
+
+    void testUpdateLastUsedZone_marksLastUsedZoneOnly()
+    {
+        m_service->updateLastUsedZone(m_zone1Id, QStringLiteral("DP-1"), QStringLiteral("app"), 1);
+        const auto mask = m_service->peekDirty();
+        QCOMPARE(mask, static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyLastUsedZone));
+    }
+
+    void testRecordSnapIntent_userInitiated_marksUserSnappedOnly()
+    {
+        m_service->recordSnapIntent(QStringLiteral("app|abc"), /*wasUserInitiated=*/true);
+        const auto mask = m_service->peekDirty();
+        QCOMPARE(mask, static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyUserSnapped));
+    }
+
+    void testRecordSnapIntent_autoSnapped_doesNotMarkDirty()
+    {
+        m_service->recordSnapIntent(QStringLiteral("app|abc"), /*wasUserInitiated=*/false);
+        QCOMPARE(m_service->peekDirty(),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyNone));
+    }
+
+    void testUnassignWindow_clearingLastUsed_marksBoth()
+    {
+        // Setup: assign a window to zone1, mark that zone as last-used.
+        m_service->assignWindowToZone(QStringLiteral("app|abc"), m_zone1Id, QStringLiteral("DP-1"), 1);
+        m_service->updateLastUsedZone(m_zone1Id, QStringLiteral("DP-1"), QStringLiteral("app"), 1);
+        m_service->clearDirty();
+
+        // Unassign: should clear last-used-zone tracking AND touch zone map.
+        m_service->unassignWindow(QStringLiteral("app|abc"));
+        const auto mask = m_service->peekDirty();
+        QVERIFY((mask & WindowTrackingService::DirtyZoneAssignments) != 0);
+        QVERIFY((mask & WindowTrackingService::DirtyLastUsedZone) != 0);
+        // And only those two.
+        QCOMPARE((mask & ~(WindowTrackingService::DirtyZoneAssignments | WindowTrackingService::DirtyLastUsedZone)),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyNone));
+    }
+
+    void testScheduleSaveState_defaultArg_marksAll()
+    {
+        // Backward-compat path: old call sites that pass no argument must
+        // still behave as "everything is dirty". Protects the safety net.
+        // Use assignWindowToZone + clearDirty to ensure we test the default.
+        // Private: can't call directly, so we verify via markDirty with DirtyAll
+        // which scheduleSaveState wraps.
+        m_service->markDirty(WindowTrackingService::DirtyAll);
+        QCOMPARE(m_service->peekDirty(),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyAll));
+    }
+
+private:
+    std::unique_ptr<IsolatedConfigGuard> m_guard;
+    QObject* m_parent = nullptr;
+    LayoutManager* m_layoutManager = nullptr;
+    VirtualDesktopManager* m_virtualDesktopManager = nullptr;
+    StubSettings* m_settings = nullptr;
+    StubZoneDetector* m_zoneDetector = nullptr;
+    Layout* m_layout = nullptr;
+    WindowTrackingService* m_service = nullptr;
+    QString m_zone1Id;
+};
+
+QTEST_MAIN(TestWtsDirtyMask)
+#include "test_wts_dirty_mask.moc"

--- a/tests/unit/core/test_wts_dirty_mask.cpp
+++ b/tests/unit/core/test_wts_dirty_mask.cpp
@@ -90,10 +90,20 @@ private Q_SLOTS:
 
     void testInitialMaskIsAll()
     {
-        // Fresh service (before init's clearDirty call) starts DirtyAll so
-        // the first save after construction writes every field. Build a
-        // second service to verify — m_service has already been cleared.
-        WindowTrackingService fresh(m_layoutManager, m_zoneDetector, m_settings, m_virtualDesktopManager);
+        // Fresh service starts DirtyAll so the first save after construction
+        // writes every field. Build a fully-isolated fixture (independent
+        // parent, layout manager, stubs, etc.) so construction / teardown
+        // cannot interfere with the shared m_* fixture used by other
+        // tests in this class.
+        auto guard = std::make_unique<IsolatedConfigGuard>();
+        QObject freshParent;
+        auto* freshLayoutManager = new LayoutManager(&freshParent);
+        auto* freshVirtualDesktopManager = new VirtualDesktopManager(freshLayoutManager, &freshParent);
+        auto* freshSettings = new StubSettings(&freshParent);
+        auto* freshZoneDetector = new StubZoneDetector(&freshParent);
+
+        WindowTrackingService fresh(freshLayoutManager, freshZoneDetector, freshSettings, freshVirtualDesktopManager,
+                                    &freshParent);
         QCOMPARE(fresh.peekDirty(), static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyAll));
     }
 
@@ -220,16 +230,28 @@ private Q_SLOTS:
                  static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyNone));
     }
 
-    void testScheduleSaveState_defaultArg_marksAll()
+    void testMarkDirty_All_setsEveryBit()
     {
-        // Backward-compat path: old call sites that pass no argument must
-        // still behave as "everything is dirty". Protects the safety net.
-        // Use assignWindowToZone + clearDirty to ensure we test the default.
-        // Private: can't call directly, so we verify via markDirty with DirtyAll
-        // which scheduleSaveState wraps.
+        // Phase 3 safety net: the DirtyAll constant covers every declared
+        // DirtyField so a legacy mutator that just calls markDirty(DirtyAll)
+        // (via the scheduleSaveState default-arg wrapper it delegates to)
+        // still flushes the full state on the next save. This test pins
+        // that invariant: DirtyAll must be a strict superset of every
+        // individual bit. scheduleSaveState itself is private and
+        // exercised indirectly — the wrapper just delegates to markDirty.
         m_service->markDirty(WindowTrackingService::DirtyAll);
-        QCOMPARE(m_service->peekDirty(),
-                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyAll));
+        const auto mask = m_service->peekDirty();
+        QCOMPARE(mask, static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyAll));
+        // Every individual field bit must be included in DirtyAll so
+        // adding a new field without extending DirtyAll fails the test.
+        for (const auto bit :
+             {WindowTrackingService::DirtyActiveLayoutId, WindowTrackingService::DirtyZoneAssignments,
+              WindowTrackingService::DirtyPendingRestores, WindowTrackingService::DirtyPreTileGeometries,
+              WindowTrackingService::DirtyLastUsedZone, WindowTrackingService::DirtyPreFloatZones,
+              WindowTrackingService::DirtyPreFloatScreens, WindowTrackingService::DirtyUserSnapped,
+              WindowTrackingService::DirtyAutotileOrders, WindowTrackingService::DirtyAutotilePending}) {
+            QVERIFY2((mask & bit) != 0, "DirtyAll is missing a DirtyField bit — extend DirtyAll in the header");
+        }
     }
 
 private:

--- a/tests/unit/core/test_wts_dirty_mask.cpp
+++ b/tests/unit/core/test_wts_dirty_mask.cpp
@@ -230,6 +230,62 @@ private Q_SLOTS:
                  static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyNone));
     }
 
+    void testPruneStaleAssignments_marksPersistedFieldsDirty()
+    {
+        // Regression pin: pruneStaleAssignments used to mutate maps without
+        // touching the dirty mask. Combined with WTA::pruneStaleWindows
+        // calling WTA::scheduleSaveState (which only kicks the timer, not
+        // the mask), the prune was silently dropped at saveState's DirtyNone
+        // early-return — ghost windows came back on the next daemon restart.
+        m_service->assignWindowToZone(QStringLiteral("app|abc"), m_zone1Id, QStringLiteral("DP-1"), 1);
+        m_service->storePreTileGeometry(QStringLiteral("app|abc"), QRect(0, 0, 400, 300), QStringLiteral("DP-1"),
+                                        /*overwrite=*/false);
+        m_service->clearDirty();
+
+        const int pruned = m_service->pruneStaleAssignments(QSet<QString>{}); // empty alive set — prune everything
+        QCOMPARE(pruned, 1);
+
+        const auto mask = m_service->peekDirty();
+        // Prune touched zone maps and pre-tile geometries; both must appear
+        // in the dirty mask so saveState rewrites their JSON fields.
+        QVERIFY((mask & WindowTrackingService::DirtyZoneAssignments) != 0);
+        QVERIFY((mask & WindowTrackingService::DirtyPreTileGeometries) != 0);
+    }
+
+    void testPruneStaleAssignments_noop_leavesDirtyMaskClean()
+    {
+        // When nothing actually gets pruned (alive set contains all
+        // tracked windows), the mask must stay clean — we don't want to
+        // trigger a disk write for a no-op.
+        m_service->assignWindowToZone(QStringLiteral("app|abc"), m_zone1Id, QStringLiteral("DP-1"), 1);
+        m_service->clearDirty();
+
+        const int pruned = m_service->pruneStaleAssignments(QSet<QString>{QStringLiteral("app|abc")});
+        QCOMPARE(pruned, 0);
+        QCOMPARE(m_service->peekDirty(),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyNone));
+    }
+
+    void testUnsnapForFloat_marksPreFloatDirty()
+    {
+        // Regression pin: unsnapForFloat writes new pre-float zone/screen
+        // entries but previously relied on the caller's immediate
+        // setWindowFloating(true) follow-up (DirtyAll) to persist them.
+        // That implicit contract is fragile — marking here makes the method
+        // self-sufficient.
+        m_service->assignWindowToZone(QStringLiteral("app|abc"), m_zone1Id, QStringLiteral("DP-1"), 1);
+        m_service->clearDirty();
+
+        m_service->unsnapForFloat(QStringLiteral("app|abc"));
+
+        const auto mask = m_service->peekDirty();
+        QVERIFY((mask & WindowTrackingService::DirtyPreFloatZones) != 0);
+        QVERIFY((mask & WindowTrackingService::DirtyPreFloatScreens) != 0);
+        // unassignWindow inside unsnapForFloat also touches DirtyZoneAssignments;
+        // last-used may or may not clear. The critical thing is both pre-float
+        // bits are set — the zone bit is best-effort.
+    }
+
     void testMarkDirty_All_setsEveryBit()
     {
         // Phase 3 safety net: the DirtyAll constant covers every declared

--- a/tests/unit/core/test_wts_dirty_mask.cpp
+++ b/tests/unit/core/test_wts_dirty_mask.cpp
@@ -16,7 +16,8 @@
  *  4. recordSnapIntent(true) sets DirtyUserSnapped only.
  *  5. consumePendingAssignment sets DirtyPendingRestores only.
  *  6. takeDirty() returns the current mask and resets to DirtyNone.
- *  7. addDirty() ORs bits back in (used by the retry-on-failure path).
+ *  7. markDirty() OR-merges bits and emits stateChanged (used by both
+ *     mutators and the retry-on-write-failure path).
  *  8. Initial mask is DirtyAll so first save after construction writes
  *     every field.
  *
@@ -27,6 +28,7 @@
  */
 
 #include <QTest>
+#include <QSignalSpy>
 #include <QRect>
 
 #include "core/layout.h"
@@ -116,20 +118,34 @@ private Q_SLOTS:
                  static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyNone));
     }
 
-    void testAddDirty_orsWithoutEmittingSignal()
+    void testMarkDirty_emitsStateChanged()
     {
-        // addDirty() is for retry-on-failure: restore the bits a failed
-        // save attempt was supposed to cover. It must NOT emit stateChanged
-        // (the retry is scheduled manually by the adaptor) — pin that.
+        // markDirty() is the single entry point for OR'ing bits — it MUST
+        // emit stateChanged so the adaptor's save timer is woken. The
+        // retry-on-write-failure path relies on this: the failure handler
+        // calls markDirty() and expects the stateChanged → scheduleSaveState
+        // chain to schedule the next tick without an explicit call.
         m_service->clearDirty();
-        int signalCount = 0;
-        connect(m_service, &WindowTrackingService::stateChanged, this, [&]() {
-            ++signalCount;
-        });
-        m_service->addDirty(WindowTrackingService::DirtyPendingRestores);
+        QSignalSpy spy(m_service, &WindowTrackingService::stateChanged);
+        m_service->markDirty(WindowTrackingService::DirtyPendingRestores);
         QCOMPARE(m_service->peekDirty(),
                  static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyPendingRestores));
-        QCOMPARE(signalCount, 0);
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void testMarkDirty_retryRestoresCommittedBits()
+    {
+        // Simulates the writeCompleted(success=false) path: a previous
+        // save called takeDirty() (mask == None after) and the worker
+        // came back with failure — the adaptor re-marks the committed
+        // bits, which must OR-merge with any newer mutations without
+        // losing either side.
+        m_service->clearDirty();
+        m_service->markDirty(WindowTrackingService::DirtyZoneAssignments); // new mutation during in-flight write
+        m_service->markDirty(WindowTrackingService::DirtyPendingRestores); // committed-snapshot retry
+        QCOMPARE(m_service->peekDirty(),
+                 static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyZoneAssignments
+                                                               | WindowTrackingService::DirtyPendingRestores));
     }
 
     void testAssignWindowToZone_marksZoneAssignmentsOnly()

--- a/tests/unit/dbus/bench_dbus_adaptors.cpp
+++ b/tests/unit/dbus/bench_dbus_adaptors.cpp
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file bench_dbus_adaptors.cpp
+ * @brief Micro-benchmarks for D-Bus adaptor hot paths.
+ *
+ * These benchmarks drive the D-Bus performance refactor on branch
+ * refactor/dbus-performance. Each benchmark targets a specific phase
+ * of the refactor so before/after numbers can be captured:
+ *
+ *   - SettingsAdaptor::setSetting unchanged-value writes (Phase 1.1)
+ *   - SettingsAdaptor::getSettings batch vs N×getSetting (baseline)
+ *   - LayoutAdaptor::setLayoutHidden signal emission path (Phase 1.2/4)
+ *
+ * Results are captured in docs/perf/dbus-baseline.md. Run with:
+ *
+ *   ctest --test-dir build -R bench_dbus_adaptors --output-on-failure
+ *
+ * or directly:
+ *
+ *   ./build/tests/unit/bench_dbus_adaptors -callgrind
+ *   ./build/tests/unit/bench_dbus_adaptors -tickcounter
+ *
+ * Stored in tests/unit/dbus/ (not a separate bench/ dir) so the
+ * existing headless-QPA fixture and IsolatedConfigGuard can be reused.
+ */
+
+#include <QTest>
+#include <QSignalSpy>
+#include <QVariant>
+#include <QVariantMap>
+#include <QDBusVariant>
+#include <QStringList>
+
+#include "dbus/settingsadaptor.h"
+#include "dbus/layoutadaptor.h"
+#include "core/layout.h"
+#include "core/layoutmanager.h"
+#include "core/zone.h"
+#include "../helpers/StubSettings.h"
+#include "../helpers/IsolatedConfigGuard.h"
+
+using namespace PlasmaZones;
+using PlasmaZones::TestHelpers::IsolatedConfigGuard;
+
+class BenchDBusAdaptors : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void init()
+    {
+        m_guard = std::make_unique<IsolatedConfigGuard>();
+        // m_settings is deliberately parented to nullptr so it outlives the
+        // adaptor's destructor, which calls m_settings->save() during
+        // teardown. See test_settings_adaptor_batch.cpp for the same pattern.
+        m_settings = new StubSettings(nullptr);
+        m_parent = new QObject(nullptr);
+        m_settingsAdaptor = new SettingsAdaptor(m_settings, m_parent);
+
+        m_layoutManager = new LayoutManager(m_parent);
+        auto* layout = new Layout(QStringLiteral("BenchLayout"));
+        for (int i = 0; i < 4; ++i) {
+            auto* zone = new Zone(QRectF(0.25 * i, 0.0, 0.25, 1.0));
+            zone->setZoneNumber(i + 1);
+            layout->addZone(zone);
+        }
+        m_layoutManager->addLayout(layout);
+        m_benchLayoutId = layout->id().toString();
+        m_layoutAdaptor = new LayoutAdaptor(m_layoutManager, m_parent);
+    }
+
+    void cleanup()
+    {
+        delete m_parent;
+        m_parent = nullptr;
+        m_settingsAdaptor = nullptr;
+        m_layoutManager = nullptr;
+        m_layoutAdaptor = nullptr;
+        delete m_settings;
+        m_settings = nullptr;
+        m_guard.reset();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Settings: setSetting with a value that is already current.
+    // Before Phase 1.1 this call still reaches the setter lambda and
+    // schedules a debounced save; after Phase 1.1 it returns early.
+    // ─────────────────────────────────────────────────────────────────
+    void benchSetSetting_unchanged()
+    {
+        const QString key = QStringLiteral("zonePadding");
+        // Prime the value so subsequent writes are no-ops.
+        m_settingsAdaptor->setSetting(key, QDBusVariant(QVariant(5)));
+        const QDBusVariant value(QVariant(5));
+
+        QBENCHMARK {
+            m_settingsAdaptor->setSetting(key, value);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Settings: setSetting with a value that actually changes.
+    // Baseline for "unchanged path must not be slower than changed path".
+    // ─────────────────────────────────────────────────────────────────
+    void benchSetSetting_changing()
+    {
+        const QString key = QStringLiteral("zonePadding");
+        int v = 0;
+
+        QBENCHMARK {
+            ++v;
+            m_settingsAdaptor->setSetting(key, QDBusVariant(QVariant(v)));
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Settings: one batched read for the editor startup key set vs the
+    // old per-key chain. The batched form is already in place — this
+    // bench pins the win so a future refactor can't regress it.
+    // ─────────────────────────────────────────────────────────────────
+    void benchGetSettings_batch()
+    {
+        const QStringList keys{
+            QStringLiteral("zonePadding"),   QStringLiteral("outerGap"),           QStringLiteral("usePerSideOuterGap"),
+            QStringLiteral("outerGapTop"),   QStringLiteral("outerGapBottom"),     QStringLiteral("outerGapLeft"),
+            QStringLiteral("outerGapRight"), QStringLiteral("overlayDisplayMode"),
+        };
+
+        QBENCHMARK {
+            (void)m_settingsAdaptor->getSettings(keys);
+        }
+    }
+
+    void benchGetSetting_individual()
+    {
+        const QStringList keys{
+            QStringLiteral("zonePadding"),   QStringLiteral("outerGap"),           QStringLiteral("usePerSideOuterGap"),
+            QStringLiteral("outerGapTop"),   QStringLiteral("outerGapBottom"),     QStringLiteral("outerGapLeft"),
+            QStringLiteral("outerGapRight"), QStringLiteral("overlayDisplayMode"),
+        };
+
+        QBENCHMARK {
+            for (const QString& k : keys) {
+                (void)m_settingsAdaptor->getSetting(k);
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Layout: setLayoutHidden full emission path.
+    //
+    // Before Phase 1.2/4 this emits layoutChanged (full JSON, 5–20KB)
+    // AND layoutListChanged. After Phase 1.2 layoutListChanged is gone;
+    // after Phase 4 the full-JSON signal is replaced by a compact
+    // layoutPropertyChanged. The bench captures the cost of the
+    // signal path including JSON serialization.
+    // ─────────────────────────────────────────────────────────────────
+    void benchSetLayoutHidden_toggle()
+    {
+        QSignalSpy changedSpy(m_layoutAdaptor, &LayoutAdaptor::layoutChanged);
+        QSignalSpy listSpy(m_layoutAdaptor, &LayoutAdaptor::layoutListChanged);
+        bool hidden = false;
+
+        QBENCHMARK {
+            hidden = !hidden;
+            m_layoutAdaptor->setLayoutHidden(m_benchLayoutId, hidden);
+        }
+        // Keep the spies alive so Qt compiles in the signal delivery cost.
+        Q_UNUSED(changedSpy);
+        Q_UNUSED(listSpy);
+    }
+
+    // Repeated setLayoutHidden with the same value. After Phase 4's
+    // layoutPropertyChanged split we can add a value-equality guard in
+    // the setter; today this exercises the redundant-emit path.
+    void benchSetLayoutHidden_sameValue()
+    {
+        m_layoutAdaptor->setLayoutHidden(m_benchLayoutId, true);
+        QBENCHMARK {
+            m_layoutAdaptor->setLayoutHidden(m_benchLayoutId, true);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Layout: getLayout for a known id. Before Phase 1.3 the JSON
+    // cache is populated but never invalidated after property mutations,
+    // so stale JSON can be served. This bench pins the cached-path cost.
+    // ─────────────────────────────────────────────────────────────────
+    void benchGetLayout_cached()
+    {
+        // Prime the cache.
+        (void)m_layoutAdaptor->getLayout(m_benchLayoutId);
+
+        QBENCHMARK {
+            (void)m_layoutAdaptor->getLayout(m_benchLayoutId);
+        }
+    }
+
+private:
+    std::unique_ptr<IsolatedConfigGuard> m_guard;
+    QObject* m_parent = nullptr;
+    StubSettings* m_settings = nullptr;
+    SettingsAdaptor* m_settingsAdaptor = nullptr;
+    LayoutManager* m_layoutManager = nullptr;
+    LayoutAdaptor* m_layoutAdaptor = nullptr;
+    QString m_benchLayoutId;
+};
+
+QTEST_MAIN(BenchDBusAdaptors)
+#include "bench_dbus_adaptors.moc"

--- a/tests/unit/dbus/bench_dbus_adaptors.cpp
+++ b/tests/unit/dbus/bench_dbus_adaptors.cpp
@@ -86,14 +86,18 @@ private Q_SLOTS:
     // ─────────────────────────────────────────────────────────────────
     // Settings: setSetting with a value that is already current.
     // Before Phase 1.1 this call still reaches the setter lambda and
-    // schedules a debounced save; after Phase 1.1 it returns early.
+    // schedules a debounced save; after Phase 1.1 it returns early
+    // because the getter returns the same value.
+    //
+    // Must use a value that StubSettings actually returns from its
+    // getter — the stub ignores setters, so priming has no effect and
+    // the guard only engages if we supply the stub's default.
+    // See StubSettings::zonePadding() which returns 8.
     // ─────────────────────────────────────────────────────────────────
     void benchSetSetting_unchanged()
     {
         const QString key = QStringLiteral("zonePadding");
-        // Prime the value so subsequent writes are no-ops.
-        m_settingsAdaptor->setSetting(key, QDBusVariant(QVariant(5)));
-        const QDBusVariant value(QVariant(5));
+        const QDBusVariant value(QVariant(8));
 
         QBENCHMARK {
             m_settingsAdaptor->setSetting(key, value);

--- a/tests/unit/dbus/bench_dbus_adaptors.cpp
+++ b/tests/unit/dbus/bench_dbus_adaptors.cpp
@@ -155,25 +155,23 @@ private Q_SLOTS:
     // ─────────────────────────────────────────────────────────────────
     // Layout: setLayoutHidden full emission path.
     //
-    // Before Phase 1.2/4 this emits layoutChanged (full JSON, 5–20KB)
-    // AND layoutListChanged. After Phase 1.2 layoutListChanged is gone;
-    // after Phase 4 the full-JSON signal is replaced by a compact
-    // layoutPropertyChanged. The bench captures the cost of the
+    // Before Phase 1.2 this emitted layoutChanged (full JSON, 5–20KB in
+    // prod) AND layoutListChanged; after Phase 1.2 only layoutChanged
+    // fires. After Phase 4 the full-JSON signal will be replaced by a
+    // compact layoutPropertyChanged. The bench captures the cost of the
     // signal path including JSON serialization.
     // ─────────────────────────────────────────────────────────────────
     void benchSetLayoutHidden_toggle()
     {
         QSignalSpy changedSpy(m_layoutAdaptor, &LayoutAdaptor::layoutChanged);
-        QSignalSpy listSpy(m_layoutAdaptor, &LayoutAdaptor::layoutListChanged);
         bool hidden = false;
 
         QBENCHMARK {
             hidden = !hidden;
             m_layoutAdaptor->setLayoutHidden(m_benchLayoutId, hidden);
         }
-        // Keep the spies alive so Qt compiles in the signal delivery cost.
+        // Keep the spy alive so Qt compiles in the signal delivery cost.
         Q_UNUSED(changedSpy);
-        Q_UNUSED(listSpy);
     }
 
     // Repeated setLayoutHidden with the same value. After Phase 4's

--- a/tests/unit/dbus/bench_dbus_adaptors.cpp
+++ b/tests/unit/dbus/bench_dbus_adaptors.cpp
@@ -107,11 +107,16 @@ private Q_SLOTS:
     // ─────────────────────────────────────────────────────────────────
     // Settings: setSetting with a value that actually changes.
     // Baseline for "unchanged path must not be slower than changed path".
+    //
+    // Seed v outside the StubSettings::zonePadding() default (8) so no
+    // iteration accidentally short-circuits through the Phase 1.1
+    // equality guard. Without this seed, one in every N iterations
+    // collides with the stub default and skews the bench.
     // ─────────────────────────────────────────────────────────────────
     void benchSetSetting_changing()
     {
         const QString key = QStringLiteral("zonePadding");
-        int v = 0;
+        int v = 100;
 
         QBENCHMARK {
             ++v;

--- a/tests/unit/dbus/test_layout_adaptor_signals.cpp
+++ b/tests/unit/dbus/test_layout_adaptor_signals.cpp
@@ -60,39 +60,63 @@ private Q_SLOTS:
     }
 
     // ─────────────────────────────────────────────────────────────────
-    // setLayoutHidden: property change, not a list change.
+    // Phase 4: property mutations emit the compact layoutPropertyChanged
+    // signal, NOT the heavyweight layoutChanged(json) or layoutListChanged.
+    // Payload on the wire is (layoutId, property, value) instead of a
+    // 5–20 KB full-layout JSON blob.
     // ─────────────────────────────────────────────────────────────────
-    void testSetLayoutHidden_emitsLayoutChangedOnly()
+    void testSetLayoutHidden_emitsCompactPropertySignalOnly()
     {
         QSignalSpy changed(m_adaptor, &LayoutAdaptor::layoutChanged);
         QSignalSpy listChanged(m_adaptor, &LayoutAdaptor::layoutListChanged);
+        QSignalSpy propertyChanged(m_adaptor, &LayoutAdaptor::layoutPropertyChanged);
 
         m_adaptor->setLayoutHidden(m_layoutId, true);
 
-        QCOMPARE(changed.count(), 1);
+        QCOMPARE(changed.count(), 0);
         QCOMPARE(listChanged.count(), 0);
+        QCOMPARE(propertyChanged.count(), 1);
+
+        const QList<QVariant> args = propertyChanged.takeFirst();
+        QCOMPARE(args.at(0).toString(), m_layoutId);
+        QCOMPARE(args.at(1).toString(), QStringLiteral("hidden"));
+        // QDBusVariant unwraps via .variant(); in-process connections keep
+        // the variant identity, so args.at(2) is a QVariant holding a
+        // QDBusVariant holding a bool.
+        const QDBusVariant wrapped = args.at(2).value<QDBusVariant>();
+        QCOMPARE(wrapped.variant().toBool(), true);
     }
 
-    void testSetLayoutAutoAssign_emitsLayoutChangedOnly()
+    void testSetLayoutAutoAssign_emitsCompactPropertySignalOnly()
     {
         QSignalSpy changed(m_adaptor, &LayoutAdaptor::layoutChanged);
         QSignalSpy listChanged(m_adaptor, &LayoutAdaptor::layoutListChanged);
+        QSignalSpy propertyChanged(m_adaptor, &LayoutAdaptor::layoutPropertyChanged);
 
         m_adaptor->setLayoutAutoAssign(m_layoutId, true);
 
-        QCOMPARE(changed.count(), 1);
+        QCOMPARE(changed.count(), 0);
         QCOMPARE(listChanged.count(), 0);
+        QCOMPARE(propertyChanged.count(), 1);
+        const QList<QVariant> args = propertyChanged.takeFirst();
+        QCOMPARE(args.at(1).toString(), QStringLiteral("autoAssign"));
+        QCOMPARE(args.at(2).value<QDBusVariant>().variant().toBool(), true);
     }
 
-    void testSetLayoutAspectRatioClass_emitsLayoutChangedOnly()
+    void testSetLayoutAspectRatioClass_emitsCompactPropertySignalOnly()
     {
         QSignalSpy changed(m_adaptor, &LayoutAdaptor::layoutChanged);
         QSignalSpy listChanged(m_adaptor, &LayoutAdaptor::layoutListChanged);
+        QSignalSpy propertyChanged(m_adaptor, &LayoutAdaptor::layoutPropertyChanged);
 
-        m_adaptor->setLayoutAspectRatioClass(m_layoutId, 1);
+        m_adaptor->setLayoutAspectRatioClass(m_layoutId, 2);
 
-        QCOMPARE(changed.count(), 1);
+        QCOMPARE(changed.count(), 0);
         QCOMPARE(listChanged.count(), 0);
+        QCOMPARE(propertyChanged.count(), 1);
+        const QList<QVariant> args = propertyChanged.takeFirst();
+        QCOMPARE(args.at(1).toString(), QStringLiteral("aspectRatioClass"));
+        QCOMPARE(args.at(2).value<QDBusVariant>().variant().toInt(), 2);
     }
 
     // ─────────────────────────────────────────────────────────────────

--- a/tests/unit/dbus/test_layout_adaptor_signals.cpp
+++ b/tests/unit/dbus/test_layout_adaptor_signals.cpp
@@ -183,6 +183,43 @@ private Q_SLOTS:
         QVERIFY(afterJson != beforeJson);
     }
 
+    // ─────────────────────────────────────────────────────────────────
+    // Value-equality guard: calling setLayoutHidden/AutoAssign/AspectRatioClass
+    // with the currently-stored value must short-circuit — no signal
+    // emission, no cache invalidation. Mirrors SettingsAdaptor::setSetting's
+    // Phase 1.1 guard so settled checkboxes don't spam subscribers with
+    // no-op reloads.
+    // ─────────────────────────────────────────────────────────────────
+    void testSetLayoutHidden_sameValue_noSignal()
+    {
+        // Flip to a known state first so the next (same-value) call can
+        // exercise the guard. Both the flip and the guard path must
+        // produce exactly one propertyChanged signal between them.
+        m_adaptor->setLayoutHidden(m_layoutId, true);
+
+        QSignalSpy propertyChanged(m_adaptor, &LayoutAdaptor::layoutPropertyChanged);
+        m_adaptor->setLayoutHidden(m_layoutId, true);
+        QCOMPARE(propertyChanged.count(), 0);
+    }
+
+    void testSetLayoutAutoAssign_sameValue_noSignal()
+    {
+        m_adaptor->setLayoutAutoAssign(m_layoutId, true);
+
+        QSignalSpy propertyChanged(m_adaptor, &LayoutAdaptor::layoutPropertyChanged);
+        m_adaptor->setLayoutAutoAssign(m_layoutId, true);
+        QCOMPARE(propertyChanged.count(), 0);
+    }
+
+    void testSetLayoutAspectRatioClass_sameValue_noSignal()
+    {
+        m_adaptor->setLayoutAspectRatioClass(m_layoutId, 2);
+
+        QSignalSpy propertyChanged(m_adaptor, &LayoutAdaptor::layoutPropertyChanged);
+        m_adaptor->setLayoutAspectRatioClass(m_layoutId, 2);
+        QCOMPARE(propertyChanged.count(), 0);
+    }
+
 private:
     std::unique_ptr<IsolatedConfigGuard> m_guard;
     QObject* m_parent = nullptr;

--- a/tests/unit/dbus/test_layout_adaptor_signals.cpp
+++ b/tests/unit/dbus/test_layout_adaptor_signals.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_layout_adaptor_signals.cpp
+ * @brief LayoutAdaptor signal emission contract tests.
+ *
+ * Pins the rule (Phase 1.2 of refactor/dbus-performance): property
+ * mutations (setLayoutHidden, setLayoutAutoAssign, setLayoutAspectRatioClass)
+ * emit `layoutChanged` but NEVER `layoutListChanged` — the list hasn't
+ * changed. layoutListChanged is reserved for genuine add/delete/reload
+ * operations (onLayoutsChanged, notifyLayoutListChanged).
+ *
+ * Subscribers (SettingsController) wire both signals to the same reload
+ * slot, so dropping the redundant list-changed emission is behavior-
+ * preserving on the client side but shaves one D-Bus marshal + slot
+ * invocation per property mutation.
+ */
+
+#include <QTest>
+#include <QSignalSpy>
+
+#include "dbus/layoutadaptor.h"
+#include "core/layout.h"
+#include "core/layoutmanager.h"
+#include "core/zone.h"
+#include "../helpers/IsolatedConfigGuard.h"
+
+using namespace PlasmaZones;
+using PlasmaZones::TestHelpers::IsolatedConfigGuard;
+
+class TestLayoutAdaptorSignals : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void init()
+    {
+        m_guard = std::make_unique<IsolatedConfigGuard>();
+        m_parent = new QObject(nullptr);
+        m_layoutManager = new LayoutManager(m_parent);
+        auto* layout = new Layout(QStringLiteral("SignalTestLayout"));
+        for (int i = 0; i < 2; ++i) {
+            auto* zone = new Zone(QRectF(0.5 * i, 0.0, 0.5, 1.0));
+            zone->setZoneNumber(i + 1);
+            layout->addZone(zone);
+        }
+        m_layoutManager->addLayout(layout);
+        m_layoutId = layout->id().toString();
+        m_adaptor = new LayoutAdaptor(m_layoutManager, m_parent);
+    }
+
+    void cleanup()
+    {
+        delete m_parent;
+        m_parent = nullptr;
+        m_layoutManager = nullptr;
+        m_adaptor = nullptr;
+        m_guard.reset();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // setLayoutHidden: property change, not a list change.
+    // ─────────────────────────────────────────────────────────────────
+    void testSetLayoutHidden_emitsLayoutChangedOnly()
+    {
+        QSignalSpy changed(m_adaptor, &LayoutAdaptor::layoutChanged);
+        QSignalSpy listChanged(m_adaptor, &LayoutAdaptor::layoutListChanged);
+
+        m_adaptor->setLayoutHidden(m_layoutId, true);
+
+        QCOMPARE(changed.count(), 1);
+        QCOMPARE(listChanged.count(), 0);
+    }
+
+    void testSetLayoutAutoAssign_emitsLayoutChangedOnly()
+    {
+        QSignalSpy changed(m_adaptor, &LayoutAdaptor::layoutChanged);
+        QSignalSpy listChanged(m_adaptor, &LayoutAdaptor::layoutListChanged);
+
+        m_adaptor->setLayoutAutoAssign(m_layoutId, true);
+
+        QCOMPARE(changed.count(), 1);
+        QCOMPARE(listChanged.count(), 0);
+    }
+
+    void testSetLayoutAspectRatioClass_emitsLayoutChangedOnly()
+    {
+        QSignalSpy changed(m_adaptor, &LayoutAdaptor::layoutChanged);
+        QSignalSpy listChanged(m_adaptor, &LayoutAdaptor::layoutListChanged);
+
+        m_adaptor->setLayoutAspectRatioClass(m_layoutId, 1);
+
+        QCOMPARE(changed.count(), 1);
+        QCOMPARE(listChanged.count(), 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // notifyLayoutListChanged: the one path that SHOULD emit
+    // layoutListChanged (daemon calls it after Apply-time reloads).
+    // This is the inverse of the rule above — guards against
+    // over-zealous removal of the emission.
+    // ─────────────────────────────────────────────────────────────────
+    void testNotifyLayoutListChanged_emitsListChanged()
+    {
+        QSignalSpy listChanged(m_adaptor, &LayoutAdaptor::layoutListChanged);
+
+        m_adaptor->notifyLayoutListChanged();
+
+        QCOMPARE(listChanged.count(), 1);
+    }
+
+private:
+    std::unique_ptr<IsolatedConfigGuard> m_guard;
+    QObject* m_parent = nullptr;
+    LayoutManager* m_layoutManager = nullptr;
+    LayoutAdaptor* m_adaptor = nullptr;
+    QString m_layoutId;
+};
+
+QTEST_MAIN(TestLayoutAdaptorSignals)
+#include "test_layout_adaptor_signals.moc"

--- a/tests/unit/dbus/test_layout_adaptor_signals.cpp
+++ b/tests/unit/dbus/test_layout_adaptor_signals.cpp
@@ -110,6 +110,55 @@ private Q_SLOTS:
         QCOMPARE(listChanged.count(), 1);
     }
 
+    // ─────────────────────────────────────────────────────────────────
+    // Phase 1.3: getLayout must never serve stale JSON after a property
+    // mutation. Before the fix, m_cachedLayoutJson was populated on the
+    // first getLayout() call but never invalidated by setLayoutHidden,
+    // setLayoutAutoAssign, or setLayoutAspectRatioClass — so a second
+    // getLayout() call would return the pre-mutation JSON.
+    // ─────────────────────────────────────────────────────────────────
+    void testGetLayout_cacheInvalidated_afterSetLayoutHidden()
+    {
+        // Prime the cache.
+        const QString beforeJson = m_adaptor->getLayout(m_layoutId);
+        QVERIFY(!beforeJson.isEmpty());
+        // Layout::toJson() only serializes the hiddenFromSelector key when
+        // the flag is true, so beforeJson (default false) must not contain it.
+        QVERIFY(!beforeJson.contains(QLatin1String("hiddenFromSelector")));
+
+        m_adaptor->setLayoutHidden(m_layoutId, true);
+
+        // The next read must reflect the new value — no stale cache.
+        const QString afterJson = m_adaptor->getLayout(m_layoutId);
+        QVERIFY(!afterJson.isEmpty());
+        QVERIFY(afterJson.contains(QLatin1String("hiddenFromSelector")));
+        QVERIFY(afterJson != beforeJson);
+    }
+
+    void testGetLayout_cacheInvalidated_afterSetLayoutAutoAssign()
+    {
+        const QString beforeJson = m_adaptor->getLayout(m_layoutId);
+        QVERIFY(!beforeJson.isEmpty());
+        QVERIFY(!beforeJson.contains(QLatin1String("autoAssign")));
+
+        m_adaptor->setLayoutAutoAssign(m_layoutId, true);
+
+        const QString afterJson = m_adaptor->getLayout(m_layoutId);
+        QVERIFY(afterJson.contains(QLatin1String("autoAssign")));
+        QVERIFY(afterJson != beforeJson);
+    }
+
+    void testGetLayout_cacheInvalidated_afterSetLayoutAspectRatioClass()
+    {
+        const QString beforeJson = m_adaptor->getLayout(m_layoutId);
+        QVERIFY(!beforeJson.isEmpty());
+
+        m_adaptor->setLayoutAspectRatioClass(m_layoutId, 2);
+
+        const QString afterJson = m_adaptor->getLayout(m_layoutId);
+        QVERIFY(afterJson != beforeJson);
+    }
+
 private:
     std::unique_ptr<IsolatedConfigGuard> m_guard;
     QObject* m_parent = nullptr;

--- a/tests/unit/dbus/test_settings_adaptor_batch.cpp
+++ b/tests/unit/dbus/test_settings_adaptor_batch.cpp
@@ -187,6 +187,45 @@ private Q_SLOTS:
         QVERIFY(ok);
     }
 
+    // ─────────────────────────────────────────────────────────────────────
+    // Phase 5: setPerScreenSettings batch surface.
+    //
+    // The contract mirrors setSettings (global batch): empty map returns
+    // true as a no-op, unknown category returns false, recognized category
+    // returns true after looping through every key.
+    // The underlying StubSettings does not implement per-screen storage, so
+    // the tests can only verify routing + return value — deep correctness
+    // belongs to test_settings_perscreen which exercises the concrete
+    // Settings type.
+    // ─────────────────────────────────────────────────────────────────────
+    void testSetPerScreenSettings_emptyMap_returnsTrue()
+    {
+        const bool ok = m_adaptor->setPerScreenSettings(QStringLiteral("DP-1"), QStringLiteral("autotile"), {});
+        QVERIFY(ok);
+    }
+
+    void testSetPerScreenSettings_unknownCategory_returnsFalse()
+    {
+        QVariantMap values;
+        values[QStringLiteral("anyKey")] = 1;
+        const bool ok = m_adaptor->setPerScreenSettings(QStringLiteral("DP-1"), QStringLiteral("bogus"), values);
+        QVERIFY(!ok);
+    }
+
+    void testSetPerScreenSettings_recognizedCategory_returnsTrue()
+    {
+        // StubSettings dynamic_cast-fails to concrete Settings, so the
+        // routing path returns false — verify we get the expected result
+        // on the stub and trust test_settings_perscreen for the concrete
+        // path. This pins the adaptor's "concrete required" contract.
+        QVariantMap values;
+        values[QStringLiteral("masterCount")] = 2;
+        const bool ok = m_adaptor->setPerScreenSettings(QStringLiteral("DP-1"), QStringLiteral("autotile"), values);
+        // With StubSettings the qobject_cast<Settings*> fails → returns false.
+        // That's the documented stub-adaptor behavior, pin it here.
+        QVERIFY(!ok);
+    }
+
 private:
     std::unique_ptr<IsolatedConfigGuard> m_guard;
     StubSettings* m_settings = nullptr;

--- a/tests/unit/dbus/test_settings_adaptor_batch.cpp
+++ b/tests/unit/dbus/test_settings_adaptor_batch.cpp
@@ -142,6 +142,51 @@ private Q_SLOTS:
         QVERIFY(result.isEmpty());
     }
 
+    // ─────────────────────────────────────────────────────────────────────
+    // Value-equality guard (Phase 1.1 of refactor/dbus-performance):
+    // setSetting with a value that already matches the current one must
+    // return true without invoking the underlying setter or scheduling a
+    // save. Contract: post-condition "setting now equals value" holds, so
+    // callers that treat true as success stay happy.
+    //
+    // StubSettings::zonePadding() returns 8 — supply 8 and the guard fires.
+    // ─────────────────────────────────────────────────────────────────────
+    void testSetSetting_unchangedScalar_returnsTrueForIdempotentWrite()
+    {
+        const bool ok = m_adaptor->setSetting(QStringLiteral("zonePadding"), QDBusVariant(QVariant(8)));
+        QVERIFY(ok);
+    }
+
+    // Value-equality guard must NOT intercept changing writes.
+    void testSetSetting_changedScalar_invokesSetter()
+    {
+        const bool ok = m_adaptor->setSetting(QStringLiteral("zonePadding"), QDBusVariant(QVariant(42)));
+        QVERIFY(ok);
+    }
+
+    // Empty-string matches StubSettings::defaultLayoutId() default — guard fires.
+    void testSetSetting_unchangedStringScalar_returnsTrue()
+    {
+        const bool ok = m_adaptor->setSetting(QStringLiteral("defaultLayoutId"), QDBusVariant(QVariant(QString())));
+        QVERIFY(ok);
+    }
+
+    // Composite (list-of-map) settings like dragActivationTriggers advertise
+    // schema "stringlist" but actually store QVariantList of QVariantMap.
+    // The guard is gated on the actual variant type (not the schema string),
+    // so list-type writes always fall through to the setter — which must
+    // still return true via the registered setter lambda.
+    void testSetSetting_compositeListType_fallsThroughToSetter()
+    {
+        QVariantList triggers;
+        QVariantMap one;
+        one[QStringLiteral("key")] = QStringLiteral("Meta");
+        triggers.append(one);
+        const bool ok = m_adaptor->setSetting(QStringLiteral("dragActivationTriggers"),
+                                              QDBusVariant(QVariant::fromValue(triggers)));
+        QVERIFY(ok);
+    }
+
 private:
     std::unique_ptr<IsolatedConfigGuard> m_guard;
     StubSettings* m_settings = nullptr;

--- a/tests/unit/dbus/test_settings_adaptor_batch.cpp
+++ b/tests/unit/dbus/test_settings_adaptor_batch.cpp
@@ -26,6 +26,24 @@
 using namespace PlasmaZones;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
+// Counting-stub: overrides one setter so the guard-fires test can
+// distinguish "setter not invoked" (guard hit) from "setter invoked,
+// returned true" (guard missed). StubSettings' getters are hard-coded
+// (setters are no-ops), so this subclass keeps the getter unchanged
+// and only adds a hit counter for setZonePadding.
+class CountingStubSettings : public StubSettings
+{
+public:
+    using StubSettings::StubSettings;
+    void setZonePadding(int v) override
+    {
+        ++setZonePaddingCalls;
+        lastZonePadding = v;
+    }
+    int setZonePaddingCalls = 0;
+    int lastZonePadding = -1;
+};
+
 class TestSettingsAdaptorBatch : public QObject
 {
     Q_OBJECT
@@ -34,7 +52,7 @@ private Q_SLOTS:
     void init()
     {
         m_guard = std::make_unique<IsolatedConfigGuard>();
-        m_settings = new StubSettings(nullptr);
+        m_settings = new CountingStubSettings(nullptr);
         m_parent = new QObject(nullptr);
         m_adaptor = new SettingsAdaptor(m_settings, m_parent);
     }
@@ -145,23 +163,31 @@ private Q_SLOTS:
     // ─────────────────────────────────────────────────────────────────────
     // Value-equality guard (Phase 1.1 of refactor/dbus-performance):
     // setSetting with a value that already matches the current one must
-    // return true without invoking the underlying setter or scheduling a
-    // save. Contract: post-condition "setting now equals value" holds, so
-    // callers that treat true as success stay happy.
+    // return true WITHOUT invoking the underlying setter. The counter on
+    // CountingStubSettings is what actually pins the short-circuit —
+    // return-value-only assertions can't distinguish guard-fires from
+    // setter-runs-and-returns-true.
     //
     // StubSettings::zonePadding() returns 8 — supply 8 and the guard fires.
     // ─────────────────────────────────────────────────────────────────────
-    void testSetSetting_unchangedScalar_returnsTrueForIdempotentWrite()
+    void testSetSetting_unchangedScalar_guardShortCircuits()
     {
+        m_settings->setZonePaddingCalls = 0;
         const bool ok = m_adaptor->setSetting(QStringLiteral("zonePadding"), QDBusVariant(QVariant(8)));
         QVERIFY(ok);
+        QCOMPARE(m_settings->setZonePaddingCalls, 0);
     }
 
-    // Value-equality guard must NOT intercept changing writes.
+    // Value-equality guard must NOT intercept changing writes — setter
+    // must actually run. Counter proves the call path, not just the
+    // return code.
     void testSetSetting_changedScalar_invokesSetter()
     {
+        m_settings->setZonePaddingCalls = 0;
         const bool ok = m_adaptor->setSetting(QStringLiteral("zonePadding"), QDBusVariant(QVariant(42)));
         QVERIFY(ok);
+        QCOMPARE(m_settings->setZonePaddingCalls, 1);
+        QCOMPARE(m_settings->lastZonePadding, 42);
     }
 
     // Empty-string matches StubSettings::defaultLayoutId() default — guard fires.
@@ -192,11 +218,10 @@ private Q_SLOTS:
     //
     // The contract mirrors setSettings (global batch): empty map returns
     // true as a no-op, unknown category returns false, recognized category
-    // returns true after looping through every key.
-    // The underlying StubSettings does not implement per-screen storage, so
-    // the tests can only verify routing + return value — deep correctness
-    // belongs to test_settings_perscreen which exercises the concrete
-    // Settings type.
+    // returns true regardless of backend. The per-screen setters are on
+    // ISettings with default no-op bodies, so stub backends pass through
+    // cleanly — deep correctness belongs to test_settings_perscreen which
+    // exercises the concrete Settings type.
     // ─────────────────────────────────────────────────────────────────────
     void testSetPerScreenSettings_emptyMap_returnsTrue()
     {
@@ -214,21 +239,18 @@ private Q_SLOTS:
 
     void testSetPerScreenSettings_recognizedCategory_returnsTrue()
     {
-        // StubSettings dynamic_cast-fails to concrete Settings, so the
-        // routing path returns false — verify we get the expected result
-        // on the stub and trust test_settings_perscreen for the concrete
-        // path. This pins the adaptor's "concrete required" contract.
+        // Post-DIP fix: the per-screen batch dispatches through ISettings
+        // no-op defaults when the backend is a stub, so recognized
+        // categories succeed even without a concrete Settings.
         QVariantMap values;
         values[QStringLiteral("masterCount")] = 2;
         const bool ok = m_adaptor->setPerScreenSettings(QStringLiteral("DP-1"), QStringLiteral("autotile"), values);
-        // With StubSettings the qobject_cast<Settings*> fails → returns false.
-        // That's the documented stub-adaptor behavior, pin it here.
-        QVERIFY(!ok);
+        QVERIFY(ok);
     }
 
 private:
     std::unique_ptr<IsolatedConfigGuard> m_guard;
-    StubSettings* m_settings = nullptr;
+    CountingStubSettings* m_settings = nullptr;
     QObject* m_parent = nullptr;
     SettingsAdaptor* m_adaptor = nullptr;
 };


### PR DESCRIPTION
Full audit + refactor of the D-Bus surface across daemon ↔ KWin effect ↔ editor ↔ settings-app ↔ KCM, driven by `docs/perf/dbus-baseline.md` numbers captured in Phase 0 and re-captured after Phase 6.

## Summary

- **Delta persistence** for WindowTrackingService via a `DirtyMask` bitfield — `saveState()` only re-serializes the JSON fields that actually changed since the last successful write. Failed writes restore the committed bits so retries don't lose state.
- **Compact property signals** for `LayoutAdaptor` — `setLayoutHidden` / `setLayoutAutoAssign` / `setLayoutAspectRatioClass` now emit a new `layoutPropertyChanged(layoutId, property, value)` signal instead of rebuilding a 5–20 KB full-layout JSON payload per call.
- **Value-equality guard** on `SettingsAdaptor::setSetting` — idempotent writes short-circuit before the setter lambda + debounced save timer.
- **Async window picker** — `requestRunningWindows()` + `runningWindowsAvailable(json)` signal pair replaces the blocking `getRunningWindows()` QEventLoop that could freeze the KCM UI thread for 2 seconds. Blocking variant removed in Phase 6.
- **Metadata caches** — `ShaderRegistry` results and `ScreenAdaptor::getScreenInfo` JSON responses are now memoized with correct invalidation on every topology edge (hot-plug, geometry change, virtual-screen reconfigure, shadersChanged).
- **Batch per-screen API** — new `setPerScreenSettings(screenId, category, QVariantMap)` mirrors the global `setSettings` batch pattern so KCM per-monitor pages can flush a category in one round-trip.
- **Signal churn fixes** — `layoutListChanged` no longer fires from scalar property setters (subscribers wire both `layoutChanged` and `layoutListChanged` to the same reload slot, so the extra emission was pure churn).
- **Cache invalidation correctness** — `LayoutAdaptor`'s `m_cachedLayoutJson` is now invalidated from `setLayoutHidden` / `setLayoutAutoAssign` / `setLayoutAspectRatioClass`, so `getLayout()` never serves pre-mutation JSON.

## Benchmarks

Captured on the reference workstation (CachyOS, GCC 15.2, Qt 6.11.0, Unity release build). Numbers are in-process adaptor cost only — over the wire the wins are larger because marshaling savings aren't reflected.

| Benchmark                                  | Before    | After     | Δ         |
| ------------------------------------------ | --------- | --------- | --------- |
| `benchSetSetting_unchanged`                | 0.0010    | 0.00041   | **−59 %** |
| `benchSetSetting_changing`                 | 0.0010    | 0.0012    | +20 %     |
| `benchGetSettings_batch` (8 keys)          | 0.0074    | 0.0075    | ≈ flat    |
| `benchGetSetting_individual` (8 × 1 key)   | 0.0017    | 0.0018    | ≈ flat    |
| `benchSetLayoutHidden_toggle`              | 0.095     | 0.055     | **−42 %** |
| `benchSetLayoutHidden_sameValue`           | 0.039     | 0.0012    | **−97 %** |
| `benchGetLayout_cached`                    | 0.00063   | 0.00063   | ≈ flat    |

All numbers in ms/iter. See `docs/perf/dbus-baseline.md` for methodology.

WindowTracking delta persistence (Phase 3) has no dedicated bench — the optimization gates disk I/O on a per-field dirty bitfield and the win scales with `(#fields not changed) × JSON size`, which only shows up in realistic long-running sessions. Correctness is pinned by `tests/unit/core/test_wts_dirty_mask.cpp`.

## Commits (phase-by-phase)

1. `5f00d9be` test(bench): add dbus adaptor benchmarks and baseline *(Phase 0)*
2. `5edb7d8a` perf(dbus): guard SettingsAdaptor::setSetting against unchanged writes *(Phase 1.1)*
3. `4d64864e` fix(dbus): drop spurious layoutListChanged on property mutations *(Phase 1.2)*
4. `5f028f8b` fix(dbus): invalidate LayoutAdaptor JSON cache on property mutations *(Phase 1.3)*
5. `95e8b33f` perf(dbus): cache ShaderRegistry metadata in SettingsAdaptor *(Phase 1.4)*
6. `f776c2a8` perf(dbus): cache ScreenAdaptor::getScreenInfo JSON responses *(Phase 1.5)*
7. `50891381` feat(dbus): async window picker *(Phase 2)*
8. `3853f3c5` perf(wts): delta-persistence via DirtyMask *(Phase 3)*
9. `0b213f8a` perf(dbus): add layoutPropertyChanged compact signal *(Phase 4)*
10. `11e6e938` feat(dbus): add setPerScreenSettings batch method *(Phase 5)*
11. `dfcdac4d` refactor(dbus): remove blocking getRunningWindows + final bench refresh *(Phase 6)*

## New Tests

- `tests/unit/dbus/bench_dbus_adaptors.cpp` — 7 QBENCHMARK loops pinning the perf-critical paths.
- `tests/unit/dbus/test_layout_adaptor_signals.cpp` — 9 tests pinning the compact-signal contract and cache-invalidation invariants.
- `tests/unit/core/test_wts_dirty_mask.cpp` — 14 tests pinning `DirtyMask` invariants: initial `DirtyAll`, `markDirty`/`takeDirty`/`addDirty`/`clearDirty` semantics, `addDirty` must NOT emit `stateChanged`, and every hot-path mutator marks only its own bits.
- Four new test cases added to `tests/unit/dbus/test_settings_adaptor_batch.cpp` covering the value-equality guard contract and the batch per-screen setter.

## Test plan

- [x] Full unit test suite (`ctest --test-dir build`): **93/93 pass**
- [x] Build green with `cmake --build build --parallel $(nproc)` (daemon, KWin effect, editor, settings app, KCM)
- [x] Benchmark suite runs under offscreen QPA and produces numbers in `docs/perf/dbus-baseline.md`
- [ ] Manual smoke test: KCM exclusion picker opens instantly even when KWin effect is unloaded
- [ ] Manual smoke test: layout property toggles (hide/autoAssign/aspect ratio) propagate to settings UI
- [ ] Manual smoke test: session state survives daemon restart with windows snapped, floated, and stacked
- [ ] Manual smoke test: long-running session with heavy window churn — observe lower disk write volume on `~/.local/share/plasmazones/session.json`

## Wire compatibility

- No breaking changes to any retained D-Bus method signatures.
- `getRunningWindows()` **removed** — every in-tree caller was migrated to the async flow in Phase 2 before the removal in Phase 6. Out-of-tree clients that still call it will get a D-Bus `UnknownMethod` error; they should migrate to `requestRunningWindows()` + the `runningWindowsAvailable(json)` signal.
- New methods and signals: `requestRunningWindows`, `runningWindowsAvailable`, `layoutPropertyChanged`, `setPerScreenSettings`. All additive.
- XML introspection files updated to match (`dbus/org.plasmazones.Settings.xml`, `dbus/org.plasmazones.LayoutManager.xml`).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)