### PR TITLE
fix(wallpaper): crop wallpaper per virtual screen before upload

### DIFF
--- a/libs/phosphor-shell/include/PhosphorShell/ShaderRegistry.h
+++ b/libs/phosphor-shell/include/PhosphorShell/ShaderRegistry.h
@@ -131,6 +131,20 @@ public:
 
     static QString wallpaperPath();
     static QImage loadWallpaperImage();
+
+    /// Return the wallpaper image cropped to the portion that a sub-region
+    /// (@p subGeom) occupies on a physical screen (@p physGeom), assuming
+    /// "cover" scaling (aspect-correct fill, centered, overflow cropped) —
+    /// the same placement model the `wallpaperUv` GLSL helper uses.
+    ///
+    /// Returns the full (uncropped) wallpaper when either rect is invalid
+    /// or when @p subGeom covers all of @p physGeom.
+    ///
+    /// Virtual screens that share a physical monitor need this so each VS
+    /// samples the wallpaper portion it occupies on the monitor, instead of
+    /// each getting the center-cropped wallpaper as if it were a full screen.
+    static QImage loadWallpaperImage(const QRect& subGeom, const QRect& physGeom);
+
     static void invalidateWallpaperCache();
 
 Q_SIGNALS:

--- a/libs/phosphor-shell/include/PhosphorShell/ShaderRegistry.h
+++ b/libs/phosphor-shell/include/PhosphorShell/ShaderRegistry.h
@@ -12,10 +12,13 @@
 #include <QMap>
 #include <QMutex>
 #include <QObject>
+#include <QRect>
+#include <QSize>
 #include <QString>
 #include <QTimer>
 #include <QUrl>
 #include <QVariant>
+#include <array>
 #include <memory>
 
 namespace PhosphorShell {
@@ -143,7 +146,19 @@ public:
     /// Virtual screens that share a physical monitor need this so each VS
     /// samples the wallpaper portion it occupies on the monitor, instead of
     /// each getting the center-cropped wallpaper as if it were a full screen.
+    ///
+    /// The result is memoized keyed on (@p subGeom, @p physGeom, wallpaper
+    /// mtime), so repeated calls for the same VS return the same QImage
+    /// (stable cacheKey()) and avoid re-uploading to the GPU each frame.
     static QImage loadWallpaperImage(const QRect& subGeom, const QRect& physGeom);
+
+    /// Pure geometry helper: compute the pixel rect inside a wallpaper of
+    /// size @p wpSize that corresponds to @p subGeom when the wallpaper
+    /// covers @p physGeom under the same "cover" placement used by
+    /// `wallpaperUv`. Returns an invalid rect if inputs are degenerate or
+    /// if @p subGeom fully covers @p physGeom (caller should use the full
+    /// image in that case). Exposed for unit testing.
+    static QRect computeWallpaperCropRect(QSize wpSize, const QRect& physGeom, const QRect& subGeom);
 
     static void invalidateWallpaperCache();
 
@@ -178,6 +193,21 @@ private:
     static QImage s_cachedWallpaperImage;
     static qint64 s_cachedWallpaperMtime;
     static QMutex s_wallpaperCacheMutex;
+
+    // Per-VS crop cache: keeps the same QImage (and cacheKey) for repeated
+    // loadWallpaperImage(sub, phys) calls so downstream cacheKey()-based
+    // short-circuits in ShaderEffect/ShaderNodeRhi keep working and the GPU
+    // doesn't re-upload the wallpaper on every overlay update.
+    struct WallpaperCropEntry
+    {
+        QRect sub;
+        QRect phys;
+        qint64 mtime = 0;
+        QImage img;
+    };
+    static constexpr int CropCacheCapacity = 8;
+    static std::array<WallpaperCropEntry, CropCacheCapacity> s_cachedWallpaperCrops;
+    static int s_cachedWallpaperCropNextSlot;
 
     static constexpr int RefreshDebounceMs = 500;
 };

--- a/libs/phosphor-shell/src/shaderregistry.cpp
+++ b/libs/phosphor-shell/src/shaderregistry.cpp
@@ -780,6 +780,9 @@ QString ShaderRegistry::s_cachedWallpaperPath;
 QImage ShaderRegistry::s_cachedWallpaperImage;
 qint64 ShaderRegistry::s_cachedWallpaperMtime = 0;
 QMutex ShaderRegistry::s_wallpaperCacheMutex;
+std::array<ShaderRegistry::WallpaperCropEntry, ShaderRegistry::CropCacheCapacity>
+    ShaderRegistry::s_cachedWallpaperCrops;
+int ShaderRegistry::s_cachedWallpaperCropNextSlot = 0;
 
 QString ShaderRegistry::wallpaperPath()
 {
@@ -829,25 +832,24 @@ QImage ShaderRegistry::loadWallpaperImage()
     return s_cachedWallpaperImage;
 }
 
-QImage ShaderRegistry::loadWallpaperImage(const QRect& subGeom, const QRect& physGeom)
+QRect ShaderRegistry::computeWallpaperCropRect(QSize wpSize, const QRect& physGeom, const QRect& subGeom)
 {
-    QImage full = loadWallpaperImage();
-    if (full.isNull() || !subGeom.isValid() || !physGeom.isValid() || subGeom == physGeom) {
-        return full;
+    if (wpSize.isEmpty() || !subGeom.isValid() || !physGeom.isValid() || subGeom == physGeom) {
+        return {};
     }
-    // Only crop when the sub-region is strictly inside the physical screen.
+    // Only crop when the sub-region actually lies inside the physical screen.
     const QRect clamped = subGeom.intersected(physGeom);
     if (!clamped.isValid() || clamped == physGeom) {
-        return full;
+        return {};
     }
 
-    // "Cover" placement of the wallpaper on the physical screen:
-    // aspect-correct fill centered, overflow cropped. This matches the math
-    // in shaders/wallpaper.glsl::wallpaperUv so the cropped image sampled with
-    // aspect == subGeom reproduces the same portion of the wallpaper that
-    // would appear in subGeom if the full physical screen were drawn.
-    const qreal wpW = full.width();
-    const qreal wpH = full.height();
+    // "Cover" placement of the wallpaper on the physical screen: aspect-correct
+    // fill centered, overflow cropped. Mirrors shaders/wallpaper.glsl::wallpaperUv
+    // so the cropped image sampled with aspect == subGeom reproduces the same
+    // portion of the wallpaper that would appear inside subGeom if the whole
+    // physical screen were drawn with the full wallpaper.
+    const qreal wpW = wpSize.width();
+    const qreal wpH = wpSize.height();
     const qreal physW = physGeom.width();
     const qreal physH = physGeom.height();
     const qreal wpAspect = wpW / qMax<qreal>(wpH, 1.0);
@@ -861,24 +863,79 @@ QImage ShaderRegistry::loadWallpaperImage(const QRect& subGeom, const QRect& phy
         coverY = 0.0;
     } else {
         coverW = wpW;
-        coverH = wpW / qMax<qreal>(physAspect, 1e-6);
+        coverH = wpW / qMax<qreal>(physAspect, 1.0);
         coverX = 0.0;
         coverY = (wpH - coverH) * 0.5;
     }
 
-    const qreal fracX = (clamped.x() - physGeom.x()) / physW;
-    const qreal fracY = (clamped.y() - physGeom.y()) / physH;
-    const qreal fracW = clamped.width() / physW;
-    const qreal fracH = clamped.height() / physH;
+    // Compute edges (left/top/right/bottom) independently so adjacent VSes
+    // tile the wallpaper seam-free: VS-A's right edge equals VS-B's left edge
+    // because both are derived from the same coverX + frac*coverW expression
+    // on the shared boundary. Deriving width from (right - left) then keeps
+    // them tight regardless of how qRound breaks the tie.
+    const qreal fracL = (clamped.x() - physGeom.x()) / physW;
+    const qreal fracT = (clamped.y() - physGeom.y()) / physH;
+    const qreal fracR = (clamped.x() + clamped.width() - physGeom.x()) / physW;
+    const qreal fracB = (clamped.y() + clamped.height() - physGeom.y()) / physH;
 
-    const QRect cropRect(qRound(coverX + fracX * coverW), qRound(coverY + fracY * coverH),
-                         qMax(1, qRound(fracW * coverW)), qMax(1, qRound(fracH * coverH)));
+    const int left = qRound(coverX + fracL * coverW);
+    const int top = qRound(coverY + fracT * coverH);
+    const int right = qRound(coverX + fracR * coverW);
+    const int bottom = qRound(coverY + fracB * coverH);
 
-    const QRect safe = cropRect.intersected(full.rect());
+    const QRect cropRect(left, top, qMax(1, right - left), qMax(1, bottom - top));
+    const QRect safe = cropRect.intersected(QRect(QPoint(0, 0), wpSize));
     if (!safe.isValid() || safe.width() < 1 || safe.height() < 1) {
+        return {};
+    }
+    return safe;
+}
+
+QImage ShaderRegistry::loadWallpaperImage(const QRect& subGeom, const QRect& physGeom)
+{
+    QImage full = loadWallpaperImage();
+    if (full.isNull() || !subGeom.isValid() || !physGeom.isValid() || subGeom == physGeom) {
         return full;
     }
-    return full.copy(safe);
+
+    QMutexLocker lock(&s_wallpaperCacheMutex);
+    // Crops are only valid while the full wallpaper behind them is unchanged.
+    // Snapshot the mtime and verify cacheKey() matches the currently-cached
+    // full image — if another thread reloaded the wallpaper between our
+    // loadWallpaperImage() return and this lock, our `full` is stale relative
+    // to s_cachedWallpaperMtime and we must neither read from nor write to
+    // the crop cache under that mtime.
+    const qint64 mtime = s_cachedWallpaperMtime;
+    const bool cacheConsistent = (full.cacheKey() == s_cachedWallpaperImage.cacheKey());
+
+    if (cacheConsistent) {
+        // Cache hit: return the stored QImage (stable cacheKey() so downstream
+        // setWallpaperTexture equality checks short-circuit correctly).
+        for (const auto& entry : s_cachedWallpaperCrops) {
+            if (entry.mtime == mtime && !entry.img.isNull() && entry.sub == subGeom && entry.phys == physGeom) {
+                return entry.img;
+            }
+        }
+    }
+
+    const QRect safe = computeWallpaperCropRect(full.size(), physGeom, subGeom);
+    if (!safe.isValid()) {
+        return full;
+    }
+
+    QImage cropped = full.copy(safe);
+    if (cropped.isNull()) {
+        return full;
+    }
+
+    if (cacheConsistent) {
+        // Insert into the ring-buffer cache. Small fixed capacity — typical
+        // systems have at most a handful of VSes so an LRU isn't worth the
+        // bookkeeping; oldest entry is overwritten.
+        s_cachedWallpaperCrops[s_cachedWallpaperCropNextSlot] = {subGeom, physGeom, mtime, cropped};
+        s_cachedWallpaperCropNextSlot = (s_cachedWallpaperCropNextSlot + 1) % CropCacheCapacity;
+    }
+    return cropped;
 }
 
 void ShaderRegistry::invalidateWallpaperCache()
@@ -887,6 +944,10 @@ void ShaderRegistry::invalidateWallpaperCache()
     s_cachedWallpaperPath.clear();
     s_cachedWallpaperImage = QImage();
     s_cachedWallpaperMtime = 0;
+    for (auto& entry : s_cachedWallpaperCrops) {
+        entry = {};
+    }
+    s_cachedWallpaperCropNextSlot = 0;
     s_wallpaperProvider.reset(); // force re-detection on next call
 }
 

--- a/libs/phosphor-shell/src/shaderregistry.cpp
+++ b/libs/phosphor-shell/src/shaderregistry.cpp
@@ -829,6 +829,58 @@ QImage ShaderRegistry::loadWallpaperImage()
     return s_cachedWallpaperImage;
 }
 
+QImage ShaderRegistry::loadWallpaperImage(const QRect& subGeom, const QRect& physGeom)
+{
+    QImage full = loadWallpaperImage();
+    if (full.isNull() || !subGeom.isValid() || !physGeom.isValid() || subGeom == physGeom) {
+        return full;
+    }
+    // Only crop when the sub-region is strictly inside the physical screen.
+    const QRect clamped = subGeom.intersected(physGeom);
+    if (!clamped.isValid() || clamped == physGeom) {
+        return full;
+    }
+
+    // "Cover" placement of the wallpaper on the physical screen:
+    // aspect-correct fill centered, overflow cropped. This matches the math
+    // in shaders/wallpaper.glsl::wallpaperUv so the cropped image sampled with
+    // aspect == subGeom reproduces the same portion of the wallpaper that
+    // would appear in subGeom if the full physical screen were drawn.
+    const qreal wpW = full.width();
+    const qreal wpH = full.height();
+    const qreal physW = physGeom.width();
+    const qreal physH = physGeom.height();
+    const qreal wpAspect = wpW / qMax<qreal>(wpH, 1.0);
+    const qreal physAspect = physW / qMax<qreal>(physH, 1.0);
+
+    qreal coverX, coverY, coverW, coverH;
+    if (wpAspect > physAspect) {
+        coverH = wpH;
+        coverW = wpH * physAspect;
+        coverX = (wpW - coverW) * 0.5;
+        coverY = 0.0;
+    } else {
+        coverW = wpW;
+        coverH = wpW / qMax<qreal>(physAspect, 1e-6);
+        coverX = 0.0;
+        coverY = (wpH - coverH) * 0.5;
+    }
+
+    const qreal fracX = (clamped.x() - physGeom.x()) / physW;
+    const qreal fracY = (clamped.y() - physGeom.y()) / physH;
+    const qreal fracW = clamped.width() / physW;
+    const qreal fracH = clamped.height() / physH;
+
+    const QRect cropRect(qRound(coverX + fracX * coverW), qRound(coverY + fracY * coverH),
+                         qMax(1, qRound(fracW * coverW)), qMax(1, qRound(fracH * coverH)));
+
+    const QRect safe = cropRect.intersected(full.rect());
+    if (!safe.isValid() || safe.width() < 1 || safe.height() < 1) {
+        return full;
+    }
+    return full.copy(safe);
+}
+
 void ShaderRegistry::invalidateWallpaperCache()
 {
     QMutexLocker lock(&s_wallpaperCacheMutex);

--- a/src/daemon/overlayservice/internal.h
+++ b/src/daemon/overlayservice/internal.h
@@ -187,7 +187,14 @@ inline QRect resolveScreenGeometry(const QString& screenId)
 // Write shader properties (shaderSource, bufferShaderPath, bufferShaderPaths,
 // bufferFeedback, bufferScale, bufferWrap, shaderParams) from ShaderInfo to a QML window.
 // Replaces 3 occurrences of the shader-info-to-window property push pattern.
-inline void applyShaderInfoToWindow(QObject* window, const ShaderRegistry::ShaderInfo& info, const QVariantMap& params)
+//
+// @p vsGeom / @p physGeom identify the target screen. When they differ (i.e.
+// the overlay covers a virtual screen that is a sub-rect of the physical
+// screen), the wallpaper is cropped to the VS's portion so each VS samples
+// its own slice of the physical monitor's wallpaper instead of each getting
+// an aspect-centered full wallpaper. Pass empty rects for full-screen overlays.
+inline void applyShaderInfoToWindow(QObject* window, const ShaderRegistry::ShaderInfo& info, const QVariantMap& params,
+                                    const QRect& vsGeom = QRect(), const QRect& physGeom = QRect())
 {
     if (!window) {
         return;
@@ -213,7 +220,7 @@ inline void applyShaderInfoToWindow(QObject* window, const ShaderRegistry::Shade
     // Desktop wallpaper subscription
     writeQmlProperty(window, QStringLiteral("useWallpaper"), info.useWallpaper);
     if (info.useWallpaper) {
-        const QImage wp = ShaderRegistry::loadWallpaperImage();
+        const QImage wp = ShaderRegistry::loadWallpaperImage(vsGeom, physGeom);
         if (!wp.isNull()) {
             writeQmlProperty(window, QStringLiteral("wallpaperTexture"), QVariant::fromValue(wp));
         }

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -436,7 +436,7 @@ void OverlayService::createOverlayWindow(const QString& screenId, QScreen* physS
             qCDebug(lcOverlay) << "Overlay shader=" << shaderId << "multipass=" << info.isMultipass
                                << "bufferPaths=" << info.bufferShaderPaths.size();
             QVariantMap translatedParams = registry->translateParamsToUniforms(shaderId, screenLayout->shaderParams());
-            applyShaderInfoToWindow(window, info, translatedParams);
+            applyShaderInfoToWindow(window, info, translatedParams, geometry, physScreenGeom);
         }
     }
 
@@ -785,7 +785,9 @@ void OverlayService::updateOverlayWindow(const QString& screenId, QScreen* physS
             const QString shaderId = screenLayout->shaderId();
             const ShaderRegistry::ShaderInfo info = registry->shader(shaderId);
             QVariantMap translatedParams = registry->translateParamsToUniforms(shaderId, screenLayout->shaderParams());
-            applyShaderInfoToWindow(window, info, translatedParams);
+            const QRect vsGeom = resolveScreenGeometry(screenId);
+            const QRect physGeom = physScreen ? physScreen->geometry() : vsGeom;
+            applyShaderInfoToWindow(window, info, translatedParams, vsGeom, physGeom);
         }
     } else if (windowIsShader && !screenUsesShader) {
         // Clear shader properties if window is shader type but shaders are now disabled

--- a/src/daemon/overlayservice/shader.cpp
+++ b/src/daemon/overlayservice/shader.cpp
@@ -381,8 +381,14 @@ void OverlayService::showShaderPreview(int x, int y, int width, int height, cons
     const QImage labelsImage = buildLabelsImageForPreviewZones(zones, size, m_settings);
     writeQmlProperty(m_shaderPreviewWindow, QStringLiteral("labelsTexture"), QVariant::fromValue(labelsImage));
 
-    // applyShaderInfoToWindow sets shaderSource LAST (triggers statusChanged cascade)
-    applyShaderInfoToWindow(m_shaderPreviewWindow, info, shaderParams);
+    // applyShaderInfoToWindow sets shaderSource LAST (triggers statusChanged cascade).
+    // Pass the preview's sub-rect + the containing physical screen so a
+    // wallpaper-consuming shader samples the portion of the wallpaper that
+    // actually sits behind the preview rect — mirrors the VS-cropping path
+    // in overlay.cpp so preview and live overlay agree pixel-for-pixel.
+    const QRect previewSubGeom(x, y, width, height);
+    const QRect previewPhysGeom = screen->geometry();
+    applyShaderInfoToWindow(m_shaderPreviewWindow, info, shaderParams, previewSubGeom, previewPhysGeom);
 
     // Start iTime animation for preview (shared timer with main overlay)
     // Must start m_shaderTimer - updateShaderUniforms() uses it and returns early if invalid

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -288,6 +288,13 @@ add_executable(test_zone_uniform_extension ui/test_zone_uniform_extension.cpp)
 target_link_libraries(test_zone_uniform_extension PRIVATE Qt6::Test Qt6::Core plasmazones_rendering)
 add_test(NAME test_zone_uniform_extension COMMAND test_zone_uniform_extension)
 
+# Pure-geometry test for per-VS wallpaper cropping (PR #333). Pins the C++
+# cover-fit math against hand-worked expected rects so it can't silently
+# drift from the GLSL wallpaperUv helper it mirrors.
+add_executable(test_wallpaper_crop ui/test_wallpaper_crop.cpp)
+target_link_libraries(test_wallpaper_crop PRIVATE Qt6::Test Qt6::Core Qt6::Gui PhosphorShell::PhosphorShell)
+add_test(NAME test_wallpaper_crop COMMAND test_wallpaper_crop)
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # ui/ — Overlay Helpers Tests — need Qt6::Quick + QGuiApplication
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/unit/ui/test_wallpaper_crop.cpp
+++ b/tests/unit/ui/test_wallpaper_crop.cpp
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <PhosphorShell/ShaderRegistry.h>
+
+#include <QRect>
+#include <QSize>
+#include <QtTest/QtTest>
+
+using PhosphorShell::ShaderRegistry;
+
+// Unit tests for ShaderRegistry::computeWallpaperCropRect.
+//
+// This is the pure geometry of the per-VS wallpaper crop introduced in
+// PR #333 — it mirrors the "cover" placement used by shaders/wallpaper.glsl
+// ::wallpaperUv so a virtual screen that is a sub-rect of its physical screen
+// samples its correct slice instead of the center-cropped whole wallpaper.
+//
+// The crop math is duplicated between GLSL and C++; this test pins the C++
+// half against hand-worked expected values to catch silent drift.
+class WallpaperCropTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    // ── Degenerate inputs ─────────────────────────────────────────────────
+
+    void degenerateWallpaperSize()
+    {
+        // Empty wallpaper size → invalid crop (caller falls back to full image).
+        const QRect phys(0, 0, 1920, 1080);
+        const QRect sub(0, 0, 960, 1080);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(QSize(), phys, sub), QRect());
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(QSize(0, 0), phys, sub), QRect());
+    }
+
+    void invalidRects()
+    {
+        const QSize wp(3840, 2160);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, QRect(), QRect(0, 0, 960, 1080)), QRect());
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, QRect(0, 0, 1920, 1080), QRect()), QRect());
+    }
+
+    void subEqualsPhys()
+    {
+        // subGeom == physGeom → caller should use full wallpaper, not a crop.
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 1920, 1080);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, phys, phys), QRect());
+    }
+
+    void subOutsidePhys()
+    {
+        // Sub fully outside phys → intersection invalid → full image used.
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 1920, 1080);
+        const QRect sub(5000, 5000, 100, 100);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, phys, sub), QRect());
+    }
+
+    void subClampedCoversPhys()
+    {
+        // Sub fully contains phys (clamped intersection == phys) → no crop.
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 1920, 1080);
+        const QRect sub(-100, -100, 2200, 1300);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, phys, sub), QRect());
+    }
+
+    // ── Same-aspect wallpaper and screen (no cover letterbox) ─────────────
+
+    void sameAspect_leftHalf()
+    {
+        // 3840x2160 (16:9) wallpaper, 1920x1080 (16:9) screen, left-half VS.
+        // Cover rect is the whole wallpaper. Left half maps to [0..1920, 0..2160].
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 1920, 1080);
+        const QRect sub(0, 0, 960, 1080);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, phys, sub), QRect(0, 0, 1920, 2160));
+    }
+
+    void sameAspect_rightHalf()
+    {
+        // Right-half VS on a 16:9 screen + 16:9 wallpaper.
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 1920, 1080);
+        const QRect sub(960, 0, 960, 1080);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, phys, sub), QRect(1920, 0, 1920, 2160));
+    }
+
+    // ── Wide wallpaper, narrow screen (horizontal letterbox of wallpaper) ─
+
+    void wallpaperWiderThanScreen_rightVS()
+    {
+        // 3840x2160 (16:9, 1.777) wallpaper, 5120x1440 (ultrawide 3.555) screen.
+        // wpAspect < physAspect → vertical-strip branch.
+        // coverW = wpW = 3840, coverH = wpW / physAspect = 3840 / (5120/1440)
+        //        = 3840 * 1440 / 5120 = 1080.
+        // coverY = (2160 - 1080)/2 = 540.
+        // Right VS: fracX=0.5 → left = 1920, right = 3840. width = 1920.
+        //           fracY=0, fracB=1 → top = 540, bottom = 1620. height = 1080.
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 5120, 1440);
+        const QRect subRight(2560, 0, 2560, 1440);
+        const QRect expected(1920, 540, 1920, 1080);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, phys, subRight), expected);
+    }
+
+    void wallpaperWiderThanScreen_leftVS()
+    {
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 5120, 1440);
+        const QRect subLeft(0, 0, 2560, 1440);
+        const QRect expected(0, 540, 1920, 1080);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, phys, subLeft), expected);
+    }
+
+    // ── Tall wallpaper, wide screen (vertical letterbox of wallpaper) ─────
+
+    void wallpaperTallerThanScreen_rightVS()
+    {
+        // 2000x2000 (1:1, square) wallpaper, 4000x1000 (4:1) physical screen.
+        // wpAspect = 1.0 < physAspect = 4.0 → coverW = 2000, coverH = 2000/4 = 500.
+        // coverY = (2000 - 500)/2 = 750.
+        // Right VS at [2000, 0, 2000, 1000]: fracX=0.5, fracR=1.0
+        //   → left=1000, right=2000, width=1000.
+        //   fracY=0, fracB=1 → top=750, bottom=1250, height=500.
+        const QSize wp(2000, 2000);
+        const QRect phys(0, 0, 4000, 1000);
+        const QRect subRight(2000, 0, 2000, 1000);
+        const QRect expected(1000, 750, 1000, 500);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, phys, subRight), expected);
+    }
+
+    // ── Non-(0,0) physical origin (multi-monitor compositor coords) ───────
+
+    void physOffsetFromOrigin()
+    {
+        // Second monitor starts at (1920, 0). VS is its right half.
+        // physGeom = (1920, 0, 1920, 1080), subGeom = (2880, 0, 960, 1080).
+        // Same aspect (16:9 wallpaper): cover rect is full wallpaper.
+        // fracX = (2880-1920)/1920 = 0.5 → left = 1920. right = 3840. width=1920.
+        const QSize wp(3840, 2160);
+        const QRect phys(1920, 0, 1920, 1080);
+        const QRect sub(2880, 0, 960, 1080);
+        QCOMPARE(ShaderRegistry::computeWallpaperCropRect(wp, phys, sub), QRect(1920, 0, 1920, 2160));
+    }
+
+    // ── Tiling/seam guarantee: adjacent VSes must abut exactly ────────────
+
+    void adjacentVSesTileSeamlessly_evenSplit()
+    {
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 1920, 1080);
+        const QRect left(0, 0, 960, 1080);
+        const QRect right(960, 0, 960, 1080);
+        const QRect cL = ShaderRegistry::computeWallpaperCropRect(wp, phys, left);
+        const QRect cR = ShaderRegistry::computeWallpaperCropRect(wp, phys, right);
+        QVERIFY(cL.isValid());
+        QVERIFY(cR.isValid());
+        // Left crop's right edge must equal right crop's left edge — no gap,
+        // no overlap — so the wallpaper tiles across the boundary.
+        QCOMPARE(cL.x() + cL.width(), cR.x());
+        // And together they span the full cover rect (here: whole wallpaper).
+        QCOMPARE(cL.x(), 0);
+        QCOMPARE(cR.x() + cR.width(), wp.width());
+    }
+
+    void adjacentVSesTileSeamlessly_oddSplit()
+    {
+        // Asymmetric split that exercises rounding: 1920 split at x=641.
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 1920, 1080);
+        const QRect left(0, 0, 641, 1080);
+        const QRect right(641, 0, 1279, 1080);
+        const QRect cL = ShaderRegistry::computeWallpaperCropRect(wp, phys, left);
+        const QRect cR = ShaderRegistry::computeWallpaperCropRect(wp, phys, right);
+        QVERIFY(cL.isValid());
+        QVERIFY(cR.isValid());
+        QCOMPARE(cL.x() + cL.width(), cR.x());
+    }
+
+    void adjacentVSesTileSeamlessly_threeWaySplit()
+    {
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 1920, 1080);
+        const QRect a(0, 0, 640, 1080);
+        const QRect b(640, 0, 640, 1080);
+        const QRect c(1280, 0, 640, 1080);
+        const QRect cA = ShaderRegistry::computeWallpaperCropRect(wp, phys, a);
+        const QRect cB = ShaderRegistry::computeWallpaperCropRect(wp, phys, b);
+        const QRect cC = ShaderRegistry::computeWallpaperCropRect(wp, phys, c);
+        QVERIFY(cA.isValid() && cB.isValid() && cC.isValid());
+        QCOMPARE(cA.x() + cA.width(), cB.x());
+        QCOMPARE(cB.x() + cB.width(), cC.x());
+    }
+
+    // ── Cropped aspect matches VS aspect (invariant the shader relies on) ─
+
+    void croppedAspectMatchesSubAspect()
+    {
+        // The in-shader aspect correction becomes a no-op only when the
+        // cropped image's aspect equals the sub rect's aspect. Verify across
+        // a spread of configurations (± a couple of pixels for rounding).
+        struct Case
+        {
+            QSize wp;
+            QRect phys;
+            QRect sub;
+        };
+        const Case cases[] = {
+            {{3840, 2160}, {0, 0, 5120, 1440}, {0, 0, 2560, 1440}},
+            {{3840, 2160}, {0, 0, 5120, 1440}, {2560, 0, 2560, 1440}},
+            {{2000, 2000}, {0, 0, 4000, 1000}, {0, 0, 1000, 1000}},
+            {{3840, 2160}, {0, 0, 1920, 1080}, {100, 100, 800, 600}},
+        };
+        for (const Case& c : cases) {
+            const QRect crop = ShaderRegistry::computeWallpaperCropRect(c.wp, c.phys, c.sub);
+            QVERIFY2(crop.isValid(),
+                     qPrintable(QStringLiteral("invalid crop for sub=%1").arg(QDebug::toString(c.sub))));
+            const double cropAspect = static_cast<double>(crop.width()) / crop.height();
+            const double subAspect = static_cast<double>(c.sub.width()) / c.sub.height();
+            // Allow small slack for integer rounding on the crop rect.
+            QVERIFY2(std::abs(cropAspect - subAspect) < 0.01,
+                     qPrintable(QStringLiteral("aspect mismatch: crop=%1 sub=%2").arg(cropAspect).arg(subAspect)));
+        }
+    }
+
+    // ── Crop stays inside the wallpaper (no out-of-bounds sampling) ───────
+
+    void cropStaysInsideWallpaper()
+    {
+        const QSize wp(3840, 2160);
+        const QRect phys(0, 0, 5120, 1440);
+        // Sweep sub positions covering every corner and the middle.
+        const QVector<QRect> subs = {
+            QRect(0, 0, 2560, 1440), QRect(2560, 0, 2560, 1440), QRect(1000, 0, 2000, 1440),
+            QRect(0, 0, 500, 1440),  QRect(4620, 0, 500, 1440),
+        };
+        const QRect wpBounds(QPoint(0, 0), wp);
+        for (const QRect& sub : subs) {
+            const QRect crop = ShaderRegistry::computeWallpaperCropRect(wp, phys, sub);
+            QVERIFY(crop.isValid());
+            QVERIFY(wpBounds.contains(crop));
+        }
+    }
+};
+
+QTEST_MAIN(WallpaperCropTest)
+#include "test_wallpaper_crop.moc"


### PR DESCRIPTION
## Summary
- Wallpaper-consuming shaders (e.g. `liquid-canvas`) on virtual screens received the full desktop wallpaper and relied on `wallpaperUv` to aspect-fit it to `iResolution`. Since `iResolution` is the VS size, each VS got the wallpaper center-cropped to its own aspect instead of the slice of the monitor it occupies.
- Added `ShaderRegistry::loadWallpaperImage(subGeom, physGeom)` that mirrors the `wallpaperUv` cover-fit math to extract the portion of the wallpaper that would appear inside the VS when the wallpaper covers the whole physical screen.
- Plumbed VS + physical geometry through `applyShaderInfoToWindow` in both overlay create and update paths. Cropped aspect matches VS aspect, so the in-shader aspect correction becomes a no-op and the VS samples its correct slice.

## Test plan
- [x] `cmake --build build --parallel` — succeeds
- [x] `ctest --output-on-failure` — 105/105 passing
- [ ] Manual: dual-VS layout, liquid-canvas on the right VS, confirm wallpaper portion matches monitor position (not center-cropped)
- [ ] Manual: single-screen full-monitor shader still renders the full wallpaper unchanged
- [ ] Manual: swap wallpaper at runtime and confirm VS crop updates on next overlay refresh

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)