### PR TITLE
feat: add phosphor-surfaces library for managed surface lifecycle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,7 @@ add_subdirectory(libs/phosphor-layer)       # wlr-layer-shell surface lifecycle 
 add_subdirectory(libs/phosphor-shortcuts)   # global shortcut backends + domain-free Registry
 add_subdirectory(libs/phosphor-animation)   # motion-runtime primitives (curves, springs, profiles)
 add_subdirectory(libs/phosphor-audio)       # audio spectrum provider (CAVA backend)
+add_subdirectory(libs/phosphor-surfaces)    # managed surface lifecycle (engine, keep-alive, scope gen)
 
 # Source directories
 add_subdirectory(src)

--- a/docs/library-extraction-survey.md
+++ b/docs/library-extraction-survey.md
@@ -1,6 +1,6 @@
 # Library Extraction Survey
 
-**Date:** 2026-04-18 (original); revised 2026-04-20 to fold in PR #343 + #345 outcomes; revised 2026-04-21 to add `phosphor-audio` extraction.
+**Date:** 2026-04-18 (original); revised 2026-04-20 to fold in PR #343 + #345 outcomes; revised 2026-04-21 to add `phosphor-audio` + `phosphor-surfaces` extractions.
 **Scope:** Candidate inventory for further `phosphor-*` library extractions, in service of the long-term compositor / WM / shell goal.
 **Status:** Strategic survey — not a migration plan. Each candidate is backed by a focused investigation (see "Investigation provenance" at the end).
 
@@ -8,7 +8,7 @@
 
 ## Context
 
-Significant decoupling work has already landed: `phosphor-animation`, `phosphor-audio`, `phosphor-config`, `phosphor-identity`, `phosphor-layer`, `phosphor-layout-api`, `phosphor-rendering`, `phosphor-screens`, `phosphor-shell`, `phosphor-shortcuts`, `phosphor-tiles`, `phosphor-zones`. This document maps what remains in `src/` (and `kwin-effect/`) to potential additional libraries, ranks them by value × feasibility, and calls out what should **not** be extracted.
+Significant decoupling work has already landed: `phosphor-animation`, `phosphor-audio`, `phosphor-config`, `phosphor-identity`, `phosphor-layer`, `phosphor-layout-api`, `phosphor-rendering`, `phosphor-screens`, `phosphor-shell`, `phosphor-shortcuts`, `phosphor-surfaces`, `phosphor-tiles`, `phosphor-zones`. This document maps what remains in `src/` (and `kwin-effect/`) to potential additional libraries, ranks them by value × feasibility, and calls out what should **not** be extracted.
 
 The core strategic insight: the daemon has **zero** `KWin::` references in `src/`. Compositor-portability is an *extraction problem*, not an architecture problem.
 
@@ -204,28 +204,30 @@ namespace PhosphorWindows {
 
 ## Tier 2 — Feasible with known tradeoffs
 
-### `phosphor-overlay`
+### `phosphor-surfaces` (was `phosphor-overlay`) — ✅ EXTRACTED (infrastructure layer)
 
-**Status:** Coherent library; coupling score 3/5; extraction is non-trivial.
+**Status:** Landed. The original "phosphor-overlay" extraction was rescoped during design review: the library manages **surface lifecycle** (any layer-shell surface), not overlay content. Renamed to `phosphor-surfaces` to follow the domain-naming convention.
 
-**Scope:** 7 surface types owned by `OverlayService` — zone overlay, zone selector, layout OSD, navigation OSD, snap assist, layout picker, shader preview — plus the Vulkan keep-alive surface.
+**What was extracted (`libs/phosphor-surfaces/`):**
+- `SurfaceManager` — shared `QQmlEngine` with caller-supplied configurator callback, Vulkan keep-alive surface, scope generation counter.
+- Builds on `PhosphorLayer::SurfaceFactory::create()` — no reinvention of the lower layer.
+- Content-agnostic: callers bring their own QML URLs and C++ types via the engine configurator.
 
-**Adjacent but separate:** `WindowThumbnailService` is a pure async D-Bus screenshot client (KWin `ScreenShot2`). Not a surface manager. Belongs in the same package, not the same class.
+**What stays in PlasmaZones:**
+- `ZoneShaderItem` + `ZoneShaderNodeRhi` + `ZoneUniformExtension` — zone-specific `PhosphorRendering::ShaderEffect` subclass with UBO layout matching `common.glsl`. Leaf-node specialization, not a reusable primitive.
+- All 11 QML overlay files (`src/ui/`) — app content, not library API. 10 of 11 have zero C++ deps but all reference zone-specific data shapes.
+- `OverlayService` orchestration policy — decides _when_ and _what_ to show. The library provides the _how_.
 
-**Clean domain separation:**
-- **Zero** references to `ZoneManager`, `SnapEngine`, `AutotileEngine` in `overlayservice/`.
-- Receives `PhosphorZones::Layout*` / `Zone*` as read-only data.
+**Original obstacles — all resolved:**
 
-**Obstacles:**
+1. ~~**PhosphorLayer becomes a transitive public dep.**~~ Accepted: `phosphor-surfaces` depends on `PhosphorLayer::PhosphorLayer` publicly. This is the natural layering — protocol below, managed lifecycle above.
+2. ~~**Per-instance QQmlEngine.**~~ ✅ Resolved via engine configurator callback (`std::function<void(QQmlEngine&)>`). Library creates the engine; caller installs types, i18n, and context properties in the callback. Audit found only 1 context property (`overlayService`) used by 1 QML file, guarded with `typeof` check.
+3. ~~**Vulkan keep-alive surface.**~~ ✅ Resolved. `SurfaceManager` creates and manages the 1×1 background-layer keep-alive internally. Destruction order guaranteed: all caller surfaces first, deferred-delete drain, keep-alive last.
+4. ~~**Interface-cast violation.**~~ ✅ Resolved in PR #345.
+5. ~~**CavaService hardwired.**~~ ✅ Resolved in PR #348.
+6. ~~**ShaderRegistry singleton.**~~ ✅ Resolved in PR #345.
 
-1. **PhosphorLayer becomes a transitive public dep.** All 7 surfaces use `PhosphorLayer::Surface` / `SurfaceFactory` / `Role` / `Anchors` / `ITransportHandle` directly. No insulation layer. Acceptable for a shell-adjacent library; document as public.
-2. **Per-instance QQmlEngine.** OverlayService owns `unique_ptr<QQmlEngine>` with shared context properties. Refactor-intensive to share across instances.
-3. **Vulkan keep-alive surface.** Persistent 1×1 background window prevents Qt from tearing down Vulkan globals. Must outlive all user overlays; complicates library lifecycle contract.
-4. ~~**Interface-cast violation.**~~ ✅ Resolved in PR #345 (`d6f74fc7`). `ILayoutManager` et al. were deleted; `phosphor-zones` exports `IZoneLayoutRegistry` + concrete `LayoutRegistry` directly, and OverlayService now borrows the concrete type — no downcast needed.
-5. ~~**CavaService hardwired.**~~ ✅ Resolved. `CavaService` extracted to `phosphor-audio` as `CavaSpectrumProvider` behind `IAudioSpectrumProvider`. Overlay can now take the interface via constructor injection.
-6. ~~**ShaderRegistry singleton.**~~ ✅ Resolved in PR #345 (`dd126553`). Per-daemon `unique_ptr` threaded through `OverlayService` / `SettingsAdaptor` / `ShaderAdaptor` constructors; `detach()` wired in `Daemon::stop()` for clean teardown of the three raw-Qt-parented adaptors that borrow it.
-
-**QML coupling:** `src/ui/*.qml` loaded via `resources.qrc`; all run in shared `QQmlEngine` with `ZoneShaderItem` from `src/daemon/rendering/`.
+See `docs/phosphor-surfaces-api-design.md` for the full interface design.
 
 ---
 
@@ -283,7 +285,7 @@ Every clean library is named after its **domain**: `phosphor-config`, `phosphor-
 
 `compositor-common` is named after a **relationship** ("code shared between daemon and effect"). If a candidate can't be named after its domain, it probably isn't a library — it's a shim zone waiting to be decomposed.
 
-Applied to new candidates: `phosphor-animation`, `phosphor-audio`, `phosphor-overlay`, `phosphor-screens`, `phosphor-windows` — all domain names. ✓
+Applied to new candidates: `phosphor-animation`, `phosphor-audio`, `phosphor-screens`, `phosphor-surfaces`, `phosphor-windows` — all domain names. ✓ (Original candidate `phosphor-overlay` renamed to `phosphor-surfaces` during design review — "overlay" implies a specific visual pattern; the library manages any layer-shell surface.)
 
 ---
 
@@ -300,7 +302,7 @@ Applied to new candidates: `phosphor-animation`, `phosphor-audio`, `phosphor-ove
 - ~~Move `layoutsourcefactory.{h,cpp}` to `phosphor-layout-api`.~~ ✅ Done (`LayoutSourceBundle` + `ILayoutSourceFactory` live in `phosphor-layout-api`).
 - ~~Fix `overlayservice/settings.cpp:122` `LayoutManager*` cast by extending `ILayoutManager`.~~ ✅ Resolved in PR #345 (`ILayoutManager` deleted; OverlayService uses concrete `PhosphorZones::LayoutRegistry` directly).
 
-**Overlay** sits outside this sequence. Its extraction depends on whether PhosphorLayer-as-public-API is acceptable for a `phosphor-overlay` library. Three of its six obstacles (interface-cast violation, ShaderRegistry singleton, CavaService hardwired) are now resolved — remaining three still apply.
+~~**Overlay**~~ ✅ Extracted as **`phosphor-surfaces`** — rescoped from "overlay content extraction" to "managed surface lifecycle infrastructure." All six original obstacles resolved. OverlayService migration to use `SurfaceManager` is future work.
 
 ---
 
@@ -317,3 +319,4 @@ This survey is synthesized from 8 parallel codebase investigations run 2026-04-1
 7. Shared QML components reusability audit.
 8. Layout-library consolidation audit (overlap matrix across phosphor-layout-api / phosphor-tiles / phosphor-zones).
 9. `phosphor-audio` extraction (2026-04-21): `CavaService` → `IAudioSpectrumProvider` + `CavaSpectrumProvider`. Motivated by shell-ecosystem reuse — audio spectrum is a system service, not an app feature.
+10. `phosphor-surfaces` extraction (2026-04-21): OverlayService surface lifecycle → `SurfaceManager` with engine configurator, Vulkan keep-alive, and scope generation. Rescoped from "phosphor-overlay" (content extraction) to managed surface lifecycle infrastructure after QML dependency audit found 10/11 overlay QML files have zero C++ coupling and all reference zone-specific data shapes — app content, not library API.

--- a/docs/phosphor-surfaces-api-design.md
+++ b/docs/phosphor-surfaces-api-design.md
@@ -1,0 +1,506 @@
+# PhosphorSurfaces -- API Design Document
+
+## Overview
+
+PhosphorSurfaces is a managed Wayland layer-shell surface lifecycle
+library for Phosphor-based shells, compositors, and window managers. It
+handles QML surface creation, warm-up, show/hide, screen hotplug, and
+orderly teardown -- while remaining agnostic to the content displayed in
+those surfaces.
+
+In a shell ecosystem, surface lifecycle management is **infrastructure**.
+Overlays, panels, OSDs, notification popups, desktop effects, and
+third-party plugins all need the same machinery: create a layer-shell
+surface on the right output, load QML into it, show/hide it efficiently,
+handle screen hotplug, and avoid the Wayland+Vulkan teardown pitfalls
+that make naive approaches unreliable. PhosphorSurfaces provides that
+machinery once.
+
+The library does **not** own QML content, zone-specific rendering types,
+or application domain logic. Those are injected by the caller via an
+engine configurator callback and per-surface QML URLs.
+
+**License:** LGPL-2.1-or-later
+**Namespace:** `PhosphorSurfaces`
+**Depends on:** Qt6::Core, Qt6::Quick, PhosphorLayer::PhosphorLayer
+**Build artefact:** `libPhosphorSurfaces.so` (SHARED)
+
+---
+
+## Dependency Graph
+
+```
+PhosphorLayer (layer-shell protocol, surface factory, transport)
+       |
+PhosphorSurfaces (surface lifecycle, hotplug, keep-alive, engine management)
+       |
+       +------ daemon (OverlayService, ZoneShaderItem, zone QML)
+       +------ panel widget [future]
+       +------ lock screen effects [future]
+       +------ third-party plugins [future]
+```
+
+Every consumer constructs a `SurfaceManager`, passes an engine
+configurator to install its domain types, and calls high-level surface
+lifecycle methods. The library handles Wayland/Vulkan concerns internally.
+
+---
+
+## Design Principles
+
+1. **Content-agnostic.** The library creates surfaces and loads QML URLs
+   the caller provides. It never references zones, shaders, layouts, or
+   any PlasmaZones domain type. Application-specific QML types are
+   registered via the engine configurator.
+
+2. **Engine configurator, not engine owner.** The library creates and
+   owns the QQmlEngine internally, but calls a user-supplied
+   `std::function<void(QQmlEngine&)>` once during initialization. The
+   caller uses this callback to register types (`qmlRegisterType`),
+   install i18n (`setContextObject`), and set context properties. The
+   library never inspects what was installed.
+
+3. **Virtual-screen-aware.** Surfaces are keyed by effective screen ID,
+   not physical QScreen pointer. A single physical monitor may host
+   multiple virtual screens, each with its own overlay. The caller
+   provides the mapping; the library manages per-screen state.
+
+4. **Vulkan-safe lifecycle.** On Wayland with Vulkan rendering, hiding a
+   QQuickWindow destroys the wl_surface but Qt does not properly
+   reinitialize VkSwapchainKHR on re-show. The library uses
+   destroy-on-hide + create-on-show for affected surface types, and
+   maintains a 1x1 keep-alive surface to prevent Qt from tearing down
+   global Vulkan/Wayland protocol objects between show cycles.
+
+5. **Warm-up support.** QML compilation on first load takes 100-300ms.
+   The library supports pre-warming surfaces at startup (load QML, create
+   window, keep hidden) so the first show is latency-free. Pre-warmed
+   surfaces are reused across show/hide cycles without destruction.
+
+6. **Screen hotplug as a first-class concern.** Screen add/remove
+   triggers automatic surface creation/destruction for affected screens.
+   The library handles the bookkeeping; the caller receives callbacks to
+   push content into newly created surfaces.
+
+---
+
+## Public API
+
+### `SurfaceManagerConfig`
+
+```cpp
+namespace PhosphorSurfaces {
+
+struct SurfaceManagerConfig
+{
+    PhosphorLayer::SurfaceFactory* surfaceFactory;
+
+    // Called once during construction. Caller registers QML types,
+    // installs i18n context, and sets context properties here.
+    std::function<void(QQmlEngine&)> engineConfigurator;
+
+    // Optional: pipeline cache path for persisting shader compilation.
+    // Empty string disables caching.
+    QString pipelineCachePath;
+};
+
+}
+```
+
+### `SurfaceHandle`
+
+```cpp
+namespace PhosphorSurfaces {
+
+// Opaque handle to a managed surface. Callers use this to push
+// content updates, query state, and request show/hide.
+class PHOSPHORSURFACES_EXPORT SurfaceHandle
+{
+public:
+    QQuickWindow* window() const;
+    bool isVisible() const;
+    bool isWarmedUp() const;
+
+    // Access the layer-shell transport for post-creation mutations
+    // (margins, keyboard interactivity). Returns nullptr if the
+    // compositor recycled the surface.
+    PhosphorLayer::ITransportHandle* transport() const;
+
+    // The effective screen ID this surface is bound to.
+    QString screenId() const;
+};
+
+}
+```
+
+### `SurfaceSpec`
+
+```cpp
+namespace PhosphorSurfaces {
+
+// Describes a surface to create. The caller builds these; the
+// library creates the underlying PhosphorLayer::Surface.
+struct SurfaceSpec
+{
+    QUrl qmlUrl;
+    PhosphorLayer::Role role;
+    QString debugName;
+
+    // If set, override the role's default anchors/margins.
+    // Used for virtual-screen positioning within a physical output.
+    std::optional<PhosphorLayer::Anchors> anchorsOverride;
+    std::optional<QMargins> marginsOverride;
+
+    // Dynamic QML properties to set on the QQuickWindow root object
+    // before the first frame renders.
+    QVariantMap initialProperties;
+};
+
+}
+```
+
+### `ScreenMapping`
+
+```cpp
+namespace PhosphorSurfaces {
+
+// Caller-provided mapping from effective screen IDs to physical
+// QScreen pointers. The library does not compute virtual screens
+// itself -- that is the caller's domain (e.g., ScreenManager).
+struct ScreenTarget
+{
+    QString effectiveScreenId;
+    QScreen* physicalScreen;
+    QRect geometry;  // Effective geometry (may be subset of physical)
+};
+
+}
+```
+
+### `SurfaceManager`
+
+```cpp
+namespace PhosphorSurfaces {
+
+class PHOSPHORSURFACES_EXPORT SurfaceManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit SurfaceManager(const SurfaceManagerConfig& config,
+                            QObject* parent = nullptr);
+    ~SurfaceManager() override;
+
+    // ── Engine access ───────────────────────────────────────────
+    // Read-only access for callers that need to set additional
+    // context properties after construction (e.g., per-show updates).
+    QQmlEngine* engine() const;
+
+    // ── Surface lifecycle ───────────────────────────────────────
+
+    // Create a surface on the given screen. Returns a handle for
+    // subsequent operations. The surface is warmed up (QML loaded)
+    // before returning. Returns nullptr on failure.
+    SurfaceHandle* createSurface(const SurfaceSpec& spec,
+                                 const ScreenTarget& screen);
+
+    // Destroy a surface immediately. Cleans up Wayland resources.
+    // The handle is invalid after this call.
+    void destroySurface(SurfaceHandle* handle);
+
+    // Destroy all surfaces bound to the given effective screen ID.
+    void destroySurfacesForScreen(const QString& effectiveScreenId);
+
+    // ── Show / hide ─────────────────────────────────────────────
+
+    void showSurface(SurfaceHandle* handle);
+    void hideSurface(SurfaceHandle* handle);
+
+    // ── Warm-up (pre-create without showing) ────────────────────
+
+    // Create and warm up a surface but don't show it. Useful for
+    // OSD-style surfaces where first-show latency matters.
+    SurfaceHandle* warmUpSurface(const SurfaceSpec& spec,
+                                 const ScreenTarget& screen);
+
+    // ── Screen hotplug ──────────────────────────────────────────
+
+    // Notify the manager that screens have changed. The manager
+    // destroys surfaces for removed screens and emits
+    // screenAdded() so the caller can create surfaces for new ones.
+    void updateScreens(const QList<ScreenTarget>& currentScreens);
+
+    // ── Scope generation ────────────────────────────────────────
+
+    // Returns a unique scope suffix for layer-shell surface scopes.
+    // Prevents compositor rate-limiting on rapid destroy/recreate.
+    quint64 nextScopeGeneration();
+
+    // ── Keep-alive ──────────────────────────────────────────────
+
+    // The keep-alive surface is created automatically during
+    // construction and destroyed during destruction. No caller
+    // action required. Exposed only for diagnostics.
+    bool keepAliveActive() const;
+
+Q_SIGNALS:
+    // Emitted when a new physical screen is detected during
+    // updateScreens(). The caller should create surfaces for it.
+    void screenAdded(QScreen* screen);
+
+    // Emitted when a screen is removed. All surfaces for this
+    // screen have already been destroyed by the time this fires.
+    void screenRemoved(const QString& effectiveScreenId);
+};
+
+}  // namespace PhosphorSurfaces
+```
+
+---
+
+## What Stays in PlasmaZones
+
+The following are **not** part of the library. They remain in the
+daemon (GPL) because they encode PlasmaZones domain knowledge:
+
+### Zone shader rendering (`src/daemon/rendering/`)
+
+| File | Reason |
+|---|---|
+| `ZoneShaderItem` | Subclass of `PhosphorRendering::ShaderEffect` with zone-specific UBO layout matching `common.glsl`. Other consumers would write their own subclass. |
+| `ZoneShaderNodeRhi` | Zone-specific QSGRenderNode. Tightly coupled to `ZoneShaderUniforms`. |
+| `ZoneUniformExtension` | Writes zone rect/color/params arrays into the UBO. Binary layout matches GLSL. |
+| `ZoneLabelTextureBuilder` | Pre-renders zone number labels. Domain-specific. |
+| `ZoneShaderUniforms` | UBO struct with `BaseUniforms` + zone extension. GLSL-coupled. |
+
+The reusable rendering primitive is `PhosphorRendering::ShaderEffect`
+(already LGPL). `ZoneShaderItem` is a leaf-node specialization.
+
+### QML overlay content (`src/ui/`)
+
+| File | C++ coupling | Why it stays |
+|---|---|---|
+| `ZoneOverlay.qml` | None | Zone-specific data bindings |
+| `RenderNodeOverlay.qml` | `ZoneShaderItem` | Zone shader rendering |
+| `ZoneSelectorWindow.qml` | None | Zone selection UX |
+| `SnapAssistOverlay.qml` | None | Snap-assist candidate grid |
+| `LayoutPickerOverlay.qml` | None | Layout card grid |
+| `LayoutOsd.qml` | None | Layout switch notification |
+| `NavigationOsd.qml` | None | Keyboard nav feedback |
+| `ZoneItem.qml` | None | Zone rectangle component |
+| `ZoneLabel.qml` | None | Zone number label component |
+| `ZoneSelector.qml` | None | Zone selection component |
+| `LayoutPreview.qml` | None | Layout preview component |
+
+10 of 11 files have zero C++ dependencies. All reference zone-specific
+data shapes (zone IDs, highlight states, layout categories). A panel
+widget or lock screen effect would write its own QML -- not reuse these.
+
+### Shared QML components (`src/shared/qml/`)
+
+`ZonePreview`, `LayoutCard`, `PopupFrame`, `CategoryBadge` are pure
+Kirigami QML. `ZoneShaderRenderer` wraps `ZoneShaderItem`. These serve
+the PlasmaZones UI -- they're app components, not library primitives.
+
+### Orchestration logic in OverlayService
+
+`OverlayService` retains the **policy** layer that decides _when_ and
+_what_ to show. PhosphorSurfaces provides the _how_:
+
+| OverlayService concern | Library provides |
+|---|---|
+| "Show zone overlay with these zones on these screens" | `createSurface()` + `showSurface()` |
+| "Zones changed, update overlay windows" | `SurfaceHandle::window()` for property writes |
+| "Shader or standard overlay for this screen?" | Nothing -- caller picks the QML URL |
+| "Pre-warm OSDs at daemon startup" | `warmUpSurface()` |
+| "Virtual screen geometry changed" | `destroySurfacesForScreen()` + `createSurface()` |
+| "Screen hotplug" | `updateScreens()` + `screenAdded` signal |
+| "Idle/un-idle per-VS overlay" | `SurfaceHandle::window()` for transparency toggle |
+| "Rekey overlay from one VS ID to another" | `destroySurfacesForScreen()` + `createSurface()` |
+
+---
+
+## Integration Pattern
+
+### Daemon (OverlayService)
+
+```cpp
+// Construction:
+m_surfaceManager = std::make_unique<PhosphorSurfaces::SurfaceManager>(
+    PhosphorSurfaces::SurfaceManagerConfig{
+        .surfaceFactory = m_surfaceFactory.get(),
+        .engineConfigurator = [this](QQmlEngine& engine) {
+            auto* i18n = new PzLocalizedContext(&engine);
+            engine.rootContext()->setContextObject(i18n);
+            qmlRegisterType<ZoneShaderItem>("PlasmaZones", 1, 0, "ZoneShaderItem");
+        },
+        .pipelineCachePath = pipelineCachePath(),
+    });
+
+connect(m_surfaceManager.get(), &PhosphorSurfaces::SurfaceManager::screenAdded,
+        this, &OverlayService::onScreenAdded);
+
+// Creating a zone overlay:
+PhosphorSurfaces::SurfaceSpec spec{
+    .qmlUrl = useShader ? qrcShaderOverlay : qrcStandardOverlay,
+    .role = PzRoles::Overlay.withScopePrefix(
+        QStringLiteral("plasmazones-overlay-%1-%2")
+            .arg(screenId)
+            .arg(m_surfaceManager->nextScopeGeneration())),
+    .debugName = "overlay",
+};
+
+auto* handle = m_surfaceManager->createSurface(spec, screenTarget);
+if (handle) {
+    pushZoneDataToWindow(handle->window());
+    m_surfaceManager->showSurface(handle);
+}
+
+// Pre-warming an OSD:
+auto* osdHandle = m_surfaceManager->warmUpSurface(osdSpec, screenTarget);
+// Later, on layout switch:
+pushOsdDataToWindow(osdHandle->window());
+m_surfaceManager->showSurface(osdHandle);
+```
+
+### Future: Panel Widget
+
+```cpp
+auto manager = std::make_unique<PhosphorSurfaces::SurfaceManager>(
+    PhosphorSurfaces::SurfaceManagerConfig{
+        .surfaceFactory = panelSurfaceFactory,
+        .engineConfigurator = [](QQmlEngine& engine) {
+            qmlRegisterType<PanelVisualizerItem>("PanelVis", 1, 0, "VisualizerItem");
+            engine.rootContext()->setContextProperty("audioProvider", audioProvider);
+        },
+    });
+
+// Panel creates its own surfaces with its own QML and its own types.
+// Zero PlasmaZones coupling.
+```
+
+---
+
+## Vulkan Keep-Alive Surface
+
+### Problem
+
+When all visible QQuickWindows are destroyed on Wayland with Vulkan
+rendering, Qt tears down global protocol objects (`zwp_linux_dmabuf_v1`,
+`wp_presentation`, `VkInstance`, `VkDevice`). The next surface creation
+fails because `VkSwapchainKHR` cannot be created without a global
+`VkInstance`.
+
+### Solution
+
+`SurfaceManager` creates a persistent 1x1 background-layer surface
+during construction. This surface:
+
+- Is invisible to the user (background layer, 1x1 size, no content)
+- Keeps Qt's Vulkan/Wayland globals alive between show cycles
+- Is destroyed last during `~SurfaceManager()`, after all other surfaces
+
+The keep-alive is an internal implementation detail. Callers never
+interact with it.
+
+### Destruction Order
+
+```
+1. All caller-created surfaces (via destroySurface or ~SurfaceManager)
+2. Deferred-delete drain (processEvents loop, 4-8 passes typical)
+3. Keep-alive surface (final)
+```
+
+This ensures the Vulkan instance outlives all swapchain teardown.
+
+---
+
+## Scope Generation
+
+Wayland compositors may rate-limit `configure` events per layer-shell
+surface scope. Rapid destroy/recreate cycles (e.g., switching virtual
+screens during a drag) can trigger this, causing surfaces to appear at
+stale positions.
+
+`SurfaceManager::nextScopeGeneration()` returns a monotonically
+increasing `quint64`. Callers append it to their scope strings:
+
+```cpp
+auto role = baseRole.withScopePrefix(
+    QStringLiteral("myapp-surface-%1-%2").arg(screenId).arg(mgr->nextScopeGeneration()));
+```
+
+Each surface gets a unique scope, resetting the compositor's rate-limit
+counter.
+
+---
+
+## Screen Hotplug Protocol
+
+```
+updateScreens(currentScreens)
+    |
+    +-- For each screen no longer in list:
+    |       destroySurfacesForScreen(removedId)
+    |       emit screenRemoved(removedId)
+    |
+    +-- For each screen newly in list:
+            emit screenAdded(newScreen)
+            // Caller creates surfaces in response
+```
+
+The caller drives the screen mapping. The library does not enumerate
+screens or compute virtual screen layouts -- it accepts `ScreenTarget`
+structs that the caller builds from its own `ScreenManager` (or
+equivalent).
+
+---
+
+## Migration from OverlayService
+
+| Before (OverlayService internal) | After (PhosphorSurfaces) |
+|---|---|
+| `createLayerSurface()` private method | `SurfaceManager::createSurface()` |
+| `m_engine` owned directly | Engine owned by `SurfaceManager`, configured via callback |
+| `m_keepAliveSurface` managed manually | Automatic in `SurfaceManager` constructor/destructor |
+| `m_scopeGeneration++` inline | `SurfaceManager::nextScopeGeneration()` |
+| `handleScreenAdded()` / `handleScreenRemoved()` | `updateScreens()` + signals |
+| `warmUpLayoutOsd()` / `warmUpNavigationOsd()` | `warmUpSurface()` |
+| `PerScreenOverlayState` internal struct | `SurfaceHandle` per surface (caller groups by screen) |
+| `m_screenStates` QHash | Internal to `SurfaceManager` (opaque) |
+
+---
+
+## Testing
+
+Unit tests (`libs/phosphor-surfaces/tests/`):
+
+- **Construction** -- manager creates keep-alive, engine configurator called once
+- **Surface lifecycle** -- create, warm-up, show, hide, destroy
+- **Screen hotplug** -- add/remove screens, signals emitted, surfaces cleaned up
+- **Scope generation** -- monotonically increasing, unique per call
+- **Destruction order** -- keep-alive outlives all surfaces
+
+Integration tests (require Wayland compositor):
+
+- Surface actually appears on correct output
+- Vulkan rendering survives show/hide/show cycle
+- Screen unplug during visible overlay does not crash
+
+---
+
+## Estimated Scope
+
+| Component | LOC (est.) |
+|---|---|
+| `SurfaceManager` (engine, keep-alive, hotplug) | ~400 |
+| `SurfaceHandle` (window access, transport, state) | ~100 |
+| `SurfaceSpec` / `ScreenTarget` / config structs | ~60 |
+| CMakeLists.txt + package config | ~140 |
+| Unit tests | ~200 |
+| **Total** | **~900** |
+
+The extraction is small because the library provides **lifecycle
+mechanics**, not business logic. The complexity lives in the caller's
+orchestration policy (what to show, when, with what data) -- which stays
+in the application.

--- a/docs/phosphor-surfaces-api-design.md
+++ b/docs/phosphor-surfaces-api-design.md
@@ -89,7 +89,17 @@ lifecycle methods. The library handles Wayland/Vulkan concerns internally.
    The library handles the bookkeeping; the caller receives callbacks to
    push content into newly created surfaces.
 
-7. **LGPL boundary maintained at runtime.** The engine configurator
+7. **Vulkan as a first-class concern.** The library manages
+   `QVulkanInstance` lifecycle transparently. Callers can provide their
+   own instance via `SurfaceManagerConfig::vulkanInstance`, or let the
+   library create and own a fallback when the active Qt graphics API is
+   Vulkan. Every window gets the Vulkan instance assigned automatically.
+   Combined with the keep-alive surface, this makes Vulkan rendering
+   survive show/hide/destroy cycles without caller intervention -- the
+   exact pain point that makes naive Wayland+Vulkan surface management
+   unreliable.
+
+8. **LGPL boundary maintained at runtime.** The engine configurator
    lets GPL callers register GPL-licensed types (e.g. `ZoneShaderItem`)
    into the library-owned `QQmlEngine`. The library never references
    those types -- they enter via a caller-supplied callback and live
@@ -98,30 +108,48 @@ lifecycle methods. The library handles Wayland/Vulkan concerns internally.
 
 ---
 
-## Public API
+## Shipped API (Phase 1)
 
 ### `SurfaceManagerConfig`
 
 ```cpp
 namespace PhosphorSurfaces {
 
-struct SurfaceManagerConfig
+struct PHOSPHORSURFACES_EXPORT SurfaceManagerConfig
 {
-    PhosphorLayer::SurfaceFactory* surfaceFactory;
+    PhosphorLayer::SurfaceFactory* surfaceFactory = nullptr;
 
     // Called once during construction. Caller registers QML types,
     // installs i18n context, and sets context properties here.
     std::function<void(QQmlEngine&)> engineConfigurator;
 
-    // Optional: pipeline cache path for persisting shader compilation.
-    // Empty string disables caching.
+    // Optional: full path for persisting graphics pipeline compilation.
+    // Applied via QQuickGraphicsConfiguration::setPipelineCacheSaveFile()
+    // on every window. Empty string disables caching.
     QString pipelineCachePath;
+
+    // Caller-owned Vulkan instance. When non-null, every window created
+    // by SurfaceManager will have setVulkanInstance() called with this
+    // pointer. When null and the active Qt graphics API is Vulkan,
+    // SurfaceManager creates and owns a fallback instance internally.
+    // This makes Vulkan lifecycle management automatic — callers don't
+    // need to know about VkInstance/VkSwapchainKHR teardown ordering.
+    QVulkanInstance* vulkanInstance = nullptr;
 };
 
 }
 ```
 
-### `SurfaceHandle`
+---
+
+## Planned API (Not Yet Implemented)
+
+> The types below are the **target design** for Phase 2+. They are not
+> shipped in v0.1.0. Current callers use
+> `SurfaceManager::createSurface(PhosphorLayer::SurfaceConfig)` and
+> manage returned `PhosphorLayer::Surface*` pointers directly.
+
+### `SurfaceHandle` [PLANNED]
 
 ```cpp
 namespace PhosphorSurfaces {
@@ -147,7 +175,7 @@ public:
 }
 ```
 
-### `SurfaceSpec`
+### `SurfaceSpec` [PLANNED]
 
 ```cpp
 namespace PhosphorSurfaces {
@@ -173,7 +201,7 @@ struct SurfaceSpec
 }
 ```
 
-### `ScreenMapping`
+### `ScreenMapping` [PLANNED]
 
 ```cpp
 namespace PhosphorSurfaces {
@@ -191,7 +219,11 @@ struct ScreenTarget
 }
 ```
 
-### `SurfaceManager`
+### `SurfaceManager` (shipped + planned)
+
+The shipped Phase 1 methods are marked **[SHIPPED]**. Methods marked
+**[PLANNED]** use the `SurfaceHandle`/`SurfaceSpec`/`ScreenTarget` types
+defined above and are not yet implemented.
 
 ```cpp
 namespace PhosphorSurfaces {
@@ -201,70 +233,50 @@ class PHOSPHORSURFACES_EXPORT SurfaceManager : public QObject
     Q_OBJECT
 
 public:
-    explicit SurfaceManager(const SurfaceManagerConfig& config,
-                            QObject* parent = nullptr);
-    ~SurfaceManager() override;
+    explicit SurfaceManager(SurfaceManagerConfig config,
+                            QObject* parent = nullptr);         // [SHIPPED]
+    ~SurfaceManager() override;                                 // [SHIPPED]
 
     // ── Engine access ───────────────────────────────────────────
-    // Read-only access for callers that need to set additional
-    // context properties after construction (e.g., per-show updates).
-    QQmlEngine* engine() const;
+    QQmlEngine* engine() const;                                 // [SHIPPED]
 
-    // ── Surface lifecycle ───────────────────────────────────────
+    // ── Surface lifecycle (Phase 1) ─────────────────────────────
+    // Phase 1: callers pass a PhosphorLayer::SurfaceConfig directly.
+    // Ownership: surfaceParent (if non-null) or this SurfaceManager.
+    // Vulkan instance + pipeline cache applied automatically.
+    PhosphorLayer::Surface* createSurface(
+        PhosphorLayer::SurfaceConfig cfg,
+        QObject* surfaceParent = nullptr);                      // [SHIPPED]
 
-    // Create a surface on the given screen. Returns a handle for
-    // subsequent operations. The surface is warmed up (QML loaded)
-    // before returning. Returns nullptr on failure.
+    // ── Surface lifecycle (Phase 2 — not yet implemented) ───────
     SurfaceHandle* createSurface(const SurfaceSpec& spec,
-                                 const ScreenTarget& screen);
-
-    // Destroy a surface immediately. Cleans up Wayland resources.
-    // The handle is invalid after this call.
-    void destroySurface(SurfaceHandle* handle);
-
-    // Destroy all surfaces bound to the given effective screen ID.
-    void destroySurfacesForScreen(const QString& effectiveScreenId);
+                                 const ScreenTarget& screen);   // [PLANNED]
+    void destroySurface(SurfaceHandle* handle);                 // [PLANNED]
+    void destroySurfacesForScreen(
+        const QString& effectiveScreenId);                      // [PLANNED]
 
     // ── Show / hide ─────────────────────────────────────────────
-
-    void showSurface(SurfaceHandle* handle);
-    void hideSurface(SurfaceHandle* handle);
+    void showSurface(SurfaceHandle* handle);                    // [PLANNED]
+    void hideSurface(SurfaceHandle* handle);                    // [PLANNED]
 
     // ── Warm-up (pre-create without showing) ────────────────────
-
-    // Create and warm up a surface but don't show it. Useful for
-    // OSD-style surfaces where first-show latency matters.
     SurfaceHandle* warmUpSurface(const SurfaceSpec& spec,
-                                 const ScreenTarget& screen);
+                                 const ScreenTarget& screen);   // [PLANNED]
 
     // ── Screen hotplug ──────────────────────────────────────────
-
-    // Notify the manager that screens have changed. The manager
-    // destroys surfaces for removed screens and emits
-    // screenAdded() so the caller can create surfaces for new ones.
-    void updateScreens(const QList<ScreenTarget>& currentScreens);
+    void updateScreens(
+        const QList<ScreenTarget>& currentScreens);             // [PLANNED]
 
     // ── Scope generation ────────────────────────────────────────
-
-    // Returns a unique scope suffix for layer-shell surface scopes.
-    // Prevents compositor rate-limiting on rapid destroy/recreate.
-    quint64 nextScopeGeneration();
+    quint64 nextScopeGeneration();                              // [SHIPPED]
 
     // ── Keep-alive ──────────────────────────────────────────────
-
-    // The keep-alive surface is created automatically during
-    // construction and destroyed during destruction. No caller
-    // action required. Exposed only for diagnostics.
-    bool keepAliveActive() const;
+    bool keepAliveActive() const;                               // [SHIPPED]
 
 Q_SIGNALS:
-    // Emitted when a new physical screen is detected during
-    // updateScreens(). The caller should create surfaces for it.
-    void screenAdded(QScreen* screen);
-
-    // Emitted when a screen is removed. All surfaces for this
-    // screen have already been destroyed by the time this fires.
-    void screenRemoved(const QString& effectiveScreenId);
+    void keepAliveLost();                                       // [SHIPPED]
+    void screenAdded(QScreen* screen);                          // [PLANNED]
+    void screenRemoved(const QString& effectiveScreenId);       // [PLANNED]
 };
 
 }  // namespace PhosphorSurfaces

--- a/docs/phosphor-surfaces-api-design.md
+++ b/docs/phosphor-surfaces-api-design.md
@@ -25,6 +25,13 @@ engine configurator callback and per-surface QML URLs.
 **Depends on:** Qt6::Core, Qt6::Quick, PhosphorLayer::PhosphorLayer
 **Build artefact:** `libPhosphorSurfaces.so` (SHARED)
 
+> **Implementation Status (Phase 1):** The shipped `v0.1.0` implements
+> engine management, Vulkan keep-alive, and scope generation. The full
+> `SurfaceHandle`/`SurfaceSpec`/`ScreenTarget` API described below is
+> the **target design** -- not yet implemented. Current callers use
+> `SurfaceManager::createSurface(PhosphorLayer::SurfaceConfig)` and
+> manage returned `PhosphorLayer::Surface*` pointers directly.
+
 ---
 
 ## Dependency Graph
@@ -81,6 +88,13 @@ lifecycle methods. The library handles Wayland/Vulkan concerns internally.
    triggers automatic surface creation/destruction for affected screens.
    The library handles the bookkeeping; the caller receives callbacks to
    push content into newly created surfaces.
+
+7. **LGPL boundary maintained at runtime.** The engine configurator
+   lets GPL callers register GPL-licensed types (e.g. `ZoneShaderItem`)
+   into the library-owned `QQmlEngine`. The library never references
+   those types -- they enter via a caller-supplied callback and live
+   only in the engine's type registry. The LGPL/GPL boundary is
+   preserved: the library is dynamically linked and type-agnostic.
 
 ---
 

--- a/libs/phosphor-surfaces/CMakeLists.txt
+++ b/libs/phosphor-surfaces/CMakeLists.txt
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# PhosphorSurfaces — managed Wayland layer-shell surface lifecycle.
+#
+# Builds on PhosphorLayer to provide:
+#   • Shared QQmlEngine with caller-supplied configurator callback
+#   • Vulkan keep-alive surface (prevents Qt global teardown)
+#   • Scope generation counter (prevents compositor rate-limiting)
+#   • Content-agnostic: callers bring their own QML and C++ types
+#
+# Depends on Qt6::Core, Qt6::Quick, PhosphorLayer::PhosphorLayer.
+
+cmake_minimum_required(VERSION 3.16)
+
+set(PHOSPHORSURFACES_VERSION "0.1.0")
+
+if(NOT PROJECT_VERSION)
+    project(PhosphorSurfaces VERSION ${PHOSPHORSURFACES_VERSION} LANGUAGES CXX)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_AUTOMOC ON)
+endif()
+
+include(GenerateExportHeader)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dependencies
+# ═══════════════════════════════════════════════════════════════════════════════
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Quick)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PhosphorSurfaces Library
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set(phosphorsurfaces_SRCS
+    src/surfacemanager.cpp
+)
+
+set(phosphorsurfaces_public_HDRS
+    include/PhosphorSurfaces/PhosphorSurfaces.h
+    include/PhosphorSurfaces/SurfaceManager.h
+    include/PhosphorSurfaces/SurfaceManagerConfig.h
+)
+
+add_library(PhosphorSurfaces SHARED
+    ${phosphorsurfaces_public_HDRS}
+    ${phosphorsurfaces_SRCS}
+)
+
+add_library(PhosphorSurfaces::PhosphorSurfaces ALIAS PhosphorSurfaces)
+
+generate_export_header(PhosphorSurfaces
+    EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/PhosphorSurfaces/phosphorsurfaces_export.h
+    EXPORT_MACRO_NAME PHOSPHORSURFACES_EXPORT
+)
+
+if(NOT DEFINED KDE_INSTALL_INCLUDEDIR)
+    include(GNUInstallDirs)
+    set(KDE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
+    set(KDE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+    set(KDE_INSTALL_BINDIR ${CMAKE_INSTALL_BINDIR})
+endif()
+
+target_include_directories(PhosphorSurfaces
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(PhosphorSurfaces PUBLIC cxx_std_20)
+
+target_link_libraries(PhosphorSurfaces
+    PUBLIC
+        Qt6::Core
+        Qt6::Quick
+        PhosphorLayer::PhosphorLayer
+)
+
+set_target_properties(PhosphorSurfaces PROPERTIES
+    VERSION ${PHOSPHORSURFACES_VERSION}
+    SOVERSION 0
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+if(CMAKE_PROJECT_NAME STREQUAL "PhosphorSurfaces" OR BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Install
+# ═══════════════════════════════════════════════════════════════════════════════
+
+install(TARGETS PhosphorSurfaces
+    EXPORT PhosphorSurfacesTargets
+    RUNTIME DESTINATION ${KDE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${KDE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${KDE_INSTALL_LIBDIR}
+)
+
+install(FILES ${phosphorsurfaces_public_HDRS}
+    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/PhosphorSurfaces
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PhosphorSurfaces/phosphorsurfaces_export.h
+    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/PhosphorSurfaces
+)
+
+install(EXPORT PhosphorSurfacesTargets
+    FILE PhosphorSurfacesTargets.cmake
+    NAMESPACE PhosphorSurfaces::
+    DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorSurfaces
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/PhosphorSurfacesConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorSurfacesConfig.cmake"
+    INSTALL_DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorSurfaces
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorSurfacesConfigVersion.cmake"
+    VERSION ${PHOSPHORSURFACES_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorSurfacesConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorSurfacesConfigVersion.cmake"
+    DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorSurfaces
+)

--- a/libs/phosphor-surfaces/PhosphorSurfacesConfig.cmake.in
+++ b/libs/phosphor-surfaces/PhosphorSurfacesConfig.cmake.in
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Qt6 6.6 COMPONENTS Core Quick)
+find_dependency(PhosphorLayer)
+
+include("${CMAKE_CURRENT_LIST_DIR}/PhosphorSurfacesTargets.cmake")
+
+check_required_components(PhosphorSurfaces)

--- a/libs/phosphor-surfaces/include/PhosphorSurfaces/PhosphorSurfaces.h
+++ b/libs/phosphor-surfaces/include/PhosphorSurfaces/PhosphorSurfaces.h
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorSurfaces/SurfaceManager.h>
+#include <PhosphorSurfaces/SurfaceManagerConfig.h>

--- a/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManager.h
+++ b/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManager.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorSurfaces/SurfaceManagerConfig.h>
+#include <PhosphorSurfaces/phosphorsurfaces_export.h>
+
+#include <PhosphorLayer/SurfaceConfig.h>
+
+#include <QObject>
+
+#include <memory>
+
+QT_BEGIN_NAMESPACE
+class QQmlEngine;
+class QScreen;
+QT_END_NAMESPACE
+
+namespace PhosphorLayer {
+class Surface;
+}
+
+namespace PhosphorSurfaces {
+
+class PHOSPHORSURFACES_EXPORT SurfaceManager : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit SurfaceManager(SurfaceManagerConfig config, QObject* parent = nullptr);
+    ~SurfaceManager() override;
+
+    QQmlEngine* engine() const;
+
+    PhosphorLayer::Surface* createSurface(PhosphorLayer::SurfaceConfig cfg);
+
+    PhosphorLayer::Surface* warmUpSurface(PhosphorLayer::SurfaceConfig cfg);
+
+    quint64 nextScopeGeneration();
+
+    bool keepAliveActive() const;
+
+Q_SIGNALS:
+    void keepAliveLost();
+
+private:
+    void createKeepAlive();
+
+    class Impl;
+    std::unique_ptr<Impl> m_impl;
+};
+
+} // namespace PhosphorSurfaces

--- a/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManager.h
+++ b/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManager.h
@@ -49,6 +49,12 @@ public:
 
     bool keepAliveActive() const;
 
+    // Drain deferred-delete events posted by deleteLater() calls on surfaces.
+    // Call this from your destructor body BEFORE member destructors run, if
+    // surfaces are parented to your object rather than to this SurfaceManager.
+    // Without this, surface destructors may touch your already-destroyed members.
+    void drainDeferredDeletes();
+
 Q_SIGNALS:
     void keepAliveLost();
 

--- a/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManager.h
+++ b/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManager.h
@@ -14,7 +14,6 @@
 
 QT_BEGIN_NAMESPACE
 class QQmlEngine;
-class QScreen;
 QT_END_NAMESPACE
 
 namespace PhosphorLayer {
@@ -33,9 +32,11 @@ public:
 
     QQmlEngine* engine() const;
 
+    // The returned Surface* is parented to this SurfaceManager (QObject
+    // ownership). The caller drives show/hide/destroy; if the caller
+    // does not destroy the surface, ~SurfaceManager will — but only
+    // after the engine is gone, so callers must destroy surfaces first.
     PhosphorLayer::Surface* createSurface(PhosphorLayer::SurfaceConfig cfg);
-
-    PhosphorLayer::Surface* warmUpSurface(PhosphorLayer::SurfaceConfig cfg);
 
     quint64 nextScopeGeneration();
 

--- a/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManager.h
+++ b/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManager.h
@@ -32,11 +32,18 @@ public:
 
     QQmlEngine* engine() const;
 
-    // The returned Surface* is parented to this SurfaceManager (QObject
-    // ownership). The caller drives show/hide/destroy; if the caller
-    // does not destroy the surface, ~SurfaceManager will — but only
-    // after the engine is gone, so callers must destroy surfaces first.
-    PhosphorLayer::Surface* createSurface(PhosphorLayer::SurfaceConfig cfg);
+    // Create a layer-shell surface from the given config. The surface is
+    // warmed up (QML loaded, window created) before return. Returns nullptr
+    // on failure (logged internally). Rejects async QML load paths — callers
+    // must use qrc:/ or file:/ URLs that resolve synchronously.
+    //
+    // Ownership: the returned Surface* is parented to `surfaceParent` if
+    // non-null, otherwise to this SurfaceManager. The caller drives
+    // show/hide/destroy. If the caller does not destroy the surface
+    // explicitly, the QObject parent will — but engine teardown runs in
+    // ~SurfaceManager, so surfaces parented elsewhere must be destroyed
+    // before this SurfaceManager is destroyed.
+    PhosphorLayer::Surface* createSurface(PhosphorLayer::SurfaceConfig cfg, QObject* surfaceParent = nullptr);
 
     quint64 nextScopeGeneration();
 
@@ -47,6 +54,7 @@ Q_SIGNALS:
 
 private:
     void createKeepAlive();
+    void configureWindow(PhosphorLayer::Surface* surface);
 
     class Impl;
     std::unique_ptr<Impl> m_impl;

--- a/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManagerConfig.h
+++ b/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManagerConfig.h
@@ -6,6 +6,7 @@
 #include <PhosphorSurfaces/phosphorsurfaces_export.h>
 
 #include <QString>
+#include <QVersionNumber>
 
 #include <functional>
 
@@ -33,6 +34,10 @@ struct PHOSPHORSURFACES_EXPORT SurfaceManagerConfig
     // When null and the active Qt graphics API is Vulkan, SurfaceManager
     // creates and owns a fallback instance internally.
     QVulkanInstance* vulkanInstance = nullptr;
+
+    // Vulkan API version for the fallback instance (only used when
+    // vulkanInstance is null and the graphics API is Vulkan).
+    QVersionNumber vulkanApiVersion = QVersionNumber(1, 1);
 };
 
 } // namespace PhosphorSurfaces

--- a/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManagerConfig.h
+++ b/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManagerConfig.h
@@ -11,6 +11,7 @@
 
 QT_BEGIN_NAMESPACE
 class QQmlEngine;
+class QQuickWindow;
 QT_END_NAMESPACE
 
 namespace PhosphorLayer {
@@ -26,6 +27,8 @@ struct PHOSPHORSURFACES_EXPORT SurfaceManagerConfig
     std::function<void(QQmlEngine&)> engineConfigurator;
 
     QString pipelineCachePath;
+
+    std::function<void(QQuickWindow&)> windowConfigurator;
 };
 
 } // namespace PhosphorSurfaces

--- a/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManagerConfig.h
+++ b/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManagerConfig.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorSurfaces/phosphorsurfaces_export.h>
+
+#include <QString>
+
+#include <functional>
+
+QT_BEGIN_NAMESPACE
+class QQmlEngine;
+QT_END_NAMESPACE
+
+namespace PhosphorLayer {
+class SurfaceFactory;
+}
+
+namespace PhosphorSurfaces {
+
+struct PHOSPHORSURFACES_EXPORT SurfaceManagerConfig
+{
+    PhosphorLayer::SurfaceFactory* surfaceFactory = nullptr;
+
+    std::function<void(QQmlEngine&)> engineConfigurator;
+
+    QString pipelineCachePath;
+};
+
+} // namespace PhosphorSurfaces

--- a/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManagerConfig.h
+++ b/libs/phosphor-surfaces/include/PhosphorSurfaces/SurfaceManagerConfig.h
@@ -11,7 +11,7 @@
 
 QT_BEGIN_NAMESPACE
 class QQmlEngine;
-class QQuickWindow;
+class QVulkanInstance;
 QT_END_NAMESPACE
 
 namespace PhosphorLayer {
@@ -28,7 +28,11 @@ struct PHOSPHORSURFACES_EXPORT SurfaceManagerConfig
 
     QString pipelineCachePath;
 
-    std::function<void(QQuickWindow&)> windowConfigurator;
+    // Caller-owned Vulkan instance. When non-null, every window created by
+    // SurfaceManager will have setVulkanInstance() called with this pointer.
+    // When null and the active Qt graphics API is Vulkan, SurfaceManager
+    // creates and owns a fallback instance internally.
+    QVulkanInstance* vulkanInstance = nullptr;
 };
 
 } // namespace PhosphorSurfaces

--- a/libs/phosphor-surfaces/src/surfacemanager.cpp
+++ b/libs/phosphor-surfaces/src/surfacemanager.cpp
@@ -9,15 +9,23 @@
 #include <PhosphorLayer/SurfaceFactory.h>
 
 #include <QCoreApplication>
+#include <QDir>
 #include <QEventLoop>
 #include <QGuiApplication>
 #include <QLoggingCategory>
 #include <QPointer>
 #include <QQmlEngine>
+#include <QQuickGraphicsConfiguration>
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QScreen>
+#include <QSGRendererInterface>
+#include <QStandardPaths>
 #include <QTimer>
+
+#if QT_CONFIG(vulkan)
+#include <QVulkanInstance>
+#endif
 
 namespace PhosphorSurfaces {
 
@@ -31,6 +39,13 @@ public:
     PhosphorLayer::Surface* keepAliveSurface = nullptr;
     QPointer<QQuickWindow> keepAliveWindow;
     quint64 scopeGeneration = 0;
+    QMetaObject::Connection screenAddedConnection;
+
+#if QT_CONFIG(vulkan)
+    std::unique_ptr<QVulkanInstance> ownedVulkanInstance;
+#endif
+
+    bool pipelineCacheDirCreated = false;
 
     void configureEngine()
     {
@@ -38,6 +53,30 @@ public:
         if (config.engineConfigurator) {
             config.engineConfigurator(*engine);
         }
+    }
+
+    QVulkanInstance* resolveVulkanInstance()
+    {
+#if QT_CONFIG(vulkan)
+        if (config.vulkanInstance) {
+            return config.vulkanInstance;
+        }
+        if (QQuickWindow::graphicsApi() != QSGRendererInterface::Vulkan) {
+            return nullptr;
+        }
+        if (ownedVulkanInstance) {
+            return ownedVulkanInstance.get();
+        }
+        ownedVulkanInstance = std::make_unique<QVulkanInstance>();
+        ownedVulkanInstance->setApiVersion(QVersionNumber(1, 1));
+        if (ownedVulkanInstance->create()) {
+            qCDebug(lcSurfaces) << "Created fallback QVulkanInstance";
+            return ownedVulkanInstance.get();
+        }
+        qCWarning(lcSurfaces) << "Failed to create fallback QVulkanInstance";
+        ownedVulkanInstance.reset();
+#endif
+        return nullptr;
     }
 };
 
@@ -52,13 +91,17 @@ SurfaceManager::SurfaceManager(SurfaceManagerConfig config, QObject* parent)
 
 SurfaceManager::~SurfaceManager()
 {
+    if (m_impl->screenAddedConnection) {
+        QObject::disconnect(m_impl->screenAddedConnection);
+    }
+
     if (m_impl->keepAliveSurface) {
         m_impl->keepAliveSurface->deleteLater();
         m_impl->keepAliveSurface = nullptr;
     }
     m_impl->keepAliveWindow = nullptr;
 
-    constexpr int kDrainCap = 32;
+    constexpr int kDrainCap = 64;
     QEventLoop drainLoop;
     int passes = 0;
     for (; passes < kDrainCap; ++passes) {
@@ -79,7 +122,7 @@ QQmlEngine* SurfaceManager::engine() const
     return m_impl->engine.get();
 }
 
-PhosphorLayer::Surface* SurfaceManager::createSurface(PhosphorLayer::SurfaceConfig cfg)
+PhosphorLayer::Surface* SurfaceManager::createSurface(PhosphorLayer::SurfaceConfig cfg, QObject* surfaceParent)
 {
     if (!m_impl->config.surfaceFactory) {
         qCWarning(lcSurfaces) << "No SurfaceFactory configured";
@@ -88,7 +131,7 @@ PhosphorLayer::Surface* SurfaceManager::createSurface(PhosphorLayer::SurfaceConf
 
     cfg.sharedEngine = m_impl->engine.get();
 
-    auto* surface = m_impl->config.surfaceFactory->create(std::move(cfg), this);
+    auto* surface = m_impl->config.surfaceFactory->create(std::move(cfg), surfaceParent ? surfaceParent : this);
     if (!surface) {
         qCWarning(lcSurfaces) << "SurfaceFactory::create() returned nullptr";
         return nullptr;
@@ -96,20 +139,21 @@ PhosphorLayer::Surface* SurfaceManager::createSurface(PhosphorLayer::SurfaceConf
 
     surface->warmUp();
 
-    if (surface->state() == PhosphorLayer::Surface::State::Failed) {
+    const auto state = surface->state();
+    if (state == PhosphorLayer::Surface::State::Failed) {
         qCWarning(lcSurfaces) << "Surface warm-up failed:" << surface->config().effectiveDebugName();
-        delete surface;
+        surface->deleteLater();
+        return nullptr;
+    }
+    if (state == PhosphorLayer::Surface::State::Warming) {
+        qCWarning(lcSurfaces) << "Surface still warming after warmUp() —"
+                              << "async QML load paths are not supported by callers that"
+                              << "dereference window() synchronously:" << surface->config().effectiveDebugName();
+        surface->deleteLater();
         return nullptr;
     }
 
-    if (!m_impl->config.pipelineCachePath.isEmpty() && surface->window()) {
-        surface->window()->setProperty("_pipelineCachePath", m_impl->config.pipelineCachePath);
-    }
-
-    if (m_impl->config.windowConfigurator && surface->window()) {
-        m_impl->config.windowConfigurator(*surface->window());
-    }
-
+    configureWindow(surface);
     return surface;
 }
 
@@ -123,15 +167,51 @@ bool SurfaceManager::keepAliveActive() const
     return m_impl->keepAliveWindow && m_impl->keepAliveSurface;
 }
 
+void SurfaceManager::configureWindow(PhosphorLayer::Surface* surface)
+{
+    auto* w = surface->window();
+    if (!w) {
+        return;
+    }
+
+    if (!m_impl->config.pipelineCachePath.isEmpty()) {
+        if (!m_impl->pipelineCacheDirCreated) {
+            const QFileInfo fi(m_impl->config.pipelineCachePath);
+            QDir().mkpath(fi.path());
+            m_impl->pipelineCacheDirCreated = true;
+        }
+        QQuickGraphicsConfiguration gfxCfg = w->graphicsConfiguration();
+        gfxCfg.setPipelineCacheSaveFile(m_impl->config.pipelineCachePath);
+        w->setGraphicsConfiguration(gfxCfg);
+    }
+
+#if QT_CONFIG(vulkan)
+    auto* vi = m_impl->resolveVulkanInstance();
+    if (vi) {
+        w->setVulkanInstance(vi);
+    }
+#endif
+}
+
 void SurfaceManager::createKeepAlive()
 {
+    if (m_impl->keepAliveSurface) {
+        return;
+    }
     if (!m_impl->config.surfaceFactory) {
         return;
     }
 
     QScreen* screen = QGuiApplication::primaryScreen();
     if (!screen) {
-        qCWarning(lcSurfaces) << "Keep-alive: no screen available at creation time";
+        qCWarning(lcSurfaces) << "Keep-alive: no screen available — will retry on screenAdded";
+        if (qGuiApp && !m_impl->screenAddedConnection) {
+            m_impl->screenAddedConnection = connect(qGuiApp, &QGuiApplication::screenAdded, this, [this]() {
+                if (!m_impl->keepAliveSurface) {
+                    createKeepAlive();
+                }
+            });
+        }
         return;
     }
 
@@ -152,19 +232,19 @@ void SurfaceManager::createKeepAlive()
 
     surface->warmUp();
 
-    if (surface->state() == PhosphorLayer::Surface::State::Failed) {
-        qCWarning(lcSurfaces) << "Keep-alive surface warm-up failed";
-        delete surface;
+    const auto keepAliveState = surface->state();
+    if (keepAliveState == PhosphorLayer::Surface::State::Failed
+        || keepAliveState == PhosphorLayer::Surface::State::Warming) {
+        qCWarning(lcSurfaces) << "Keep-alive surface warm-up failed (state:" << static_cast<int>(keepAliveState) << ")";
+        surface->deleteLater();
         return;
     }
 
     if (surface->window()) {
         surface->window()->setWidth(1);
         surface->window()->setHeight(1);
-        if (m_impl->config.windowConfigurator) {
-            m_impl->config.windowConfigurator(*surface->window());
-        }
     }
+    configureWindow(surface);
 
     surface->show();
     m_impl->keepAliveSurface = surface;
@@ -176,6 +256,7 @@ void SurfaceManager::createKeepAlive()
         m_impl->keepAliveWindow = nullptr;
         surface->deleteLater();
         Q_EMIT keepAliveLost();
+        QTimer::singleShot(0, this, &SurfaceManager::createKeepAlive);
     });
 
     qCDebug(lcSurfaces) << "Keep-alive surface created";

--- a/libs/phosphor-surfaces/src/surfacemanager.cpp
+++ b/libs/phosphor-surfaces/src/surfacemanager.cpp
@@ -46,6 +46,7 @@ public:
 #endif
 
     bool pipelineCacheDirCreated = false;
+    bool creatingKeepAlive = false;
 
     void configureEngine()
     {
@@ -68,7 +69,7 @@ public:
             return ownedVulkanInstance.get();
         }
         ownedVulkanInstance = std::make_unique<QVulkanInstance>();
-        ownedVulkanInstance->setApiVersion(QVersionNumber(1, 1));
+        ownedVulkanInstance->setApiVersion(config.vulkanApiVersion);
         if (ownedVulkanInstance->create()) {
             qCDebug(lcSurfaces) << "Created fallback QVulkanInstance";
             return ownedVulkanInstance.get();
@@ -101,6 +102,12 @@ SurfaceManager::~SurfaceManager()
     }
     m_impl->keepAliveWindow = nullptr;
 
+    drainDeferredDeletes();
+    m_impl->engine.reset();
+}
+
+void SurfaceManager::drainDeferredDeletes()
+{
     constexpr int kDrainCap = 64;
     QEventLoop drainLoop;
     int passes = 0;
@@ -113,8 +120,6 @@ SurfaceManager::~SurfaceManager()
     if (passes == kDrainCap) {
         qCWarning(lcSurfaces) << "deferred-delete drain hit safety cap" << kDrainCap;
     }
-
-    m_impl->engine.reset();
 }
 
 QQmlEngine* SurfaceManager::engine() const
@@ -195,16 +200,18 @@ void SurfaceManager::configureWindow(PhosphorLayer::Surface* surface)
 
 void SurfaceManager::createKeepAlive()
 {
-    if (m_impl->keepAliveSurface) {
+    if (m_impl->keepAliveSurface || m_impl->creatingKeepAlive) {
         return;
     }
     if (!m_impl->config.surfaceFactory) {
         return;
     }
+    m_impl->creatingKeepAlive = true;
 
     QScreen* screen = QGuiApplication::primaryScreen();
     if (!screen) {
         qCWarning(lcSurfaces) << "Keep-alive: no screen available — will retry on screenAdded";
+        m_impl->creatingKeepAlive = false;
         if (qGuiApp && !m_impl->screenAddedConnection) {
             m_impl->screenAddedConnection = connect(qGuiApp, &QGuiApplication::screenAdded, this, [this]() {
                 if (!m_impl->keepAliveSurface) {
@@ -227,6 +234,7 @@ void SurfaceManager::createKeepAlive()
     auto* surface = m_impl->config.surfaceFactory->create(std::move(cfg), this);
     if (!surface) {
         qCWarning(lcSurfaces) << "Failed to create keep-alive surface";
+        m_impl->creatingKeepAlive = false;
         return;
     }
 
@@ -237,6 +245,7 @@ void SurfaceManager::createKeepAlive()
         || keepAliveState == PhosphorLayer::Surface::State::Warming) {
         qCWarning(lcSurfaces) << "Keep-alive surface warm-up failed (state:" << static_cast<int>(keepAliveState) << ")";
         surface->deleteLater();
+        m_impl->creatingKeepAlive = false;
         return;
     }
 
@@ -249,6 +258,7 @@ void SurfaceManager::createKeepAlive()
     surface->show();
     m_impl->keepAliveSurface = surface;
     m_impl->keepAliveWindow = surface->window();
+    m_impl->creatingKeepAlive = false;
 
     connect(surface, &PhosphorLayer::Surface::failed, this, [this, surface](const QString& reason) {
         qCWarning(lcSurfaces) << "Keep-alive surface failed:" << reason;

--- a/libs/phosphor-surfaces/src/surfacemanager.cpp
+++ b/libs/phosphor-surfaces/src/surfacemanager.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorSurfaces/SurfaceManager.h>
+
+#include <PhosphorLayer/Role.h>
+#include <PhosphorLayer/Surface.h>
+#include <PhosphorLayer/SurfaceConfig.h>
+#include <PhosphorLayer/SurfaceFactory.h>
+
+#include <QLoggingCategory>
+#include <QPointer>
+#include <QQmlEngine>
+#include <QQuickItem>
+#include <QQuickWindow>
+
+namespace PhosphorSurfaces {
+
+Q_LOGGING_CATEGORY(lcSurfaces, "phosphor.surfaces")
+
+class SurfaceManager::Impl
+{
+public:
+    SurfaceManagerConfig config;
+    std::unique_ptr<QQmlEngine> engine;
+    PhosphorLayer::Surface* keepAliveSurface = nullptr;
+    QPointer<QQuickWindow> keepAliveWindow;
+    quint64 scopeGeneration = 0;
+
+    void configureEngine()
+    {
+        engine = std::make_unique<QQmlEngine>();
+        if (config.engineConfigurator) {
+            config.engineConfigurator(*engine);
+        }
+    }
+};
+
+SurfaceManager::SurfaceManager(SurfaceManagerConfig config, QObject* parent)
+    : QObject(parent)
+    , m_impl(std::make_unique<Impl>())
+{
+    m_impl->config = std::move(config);
+    m_impl->configureEngine();
+    createKeepAlive();
+}
+
+SurfaceManager::~SurfaceManager()
+{
+    if (m_impl->keepAliveSurface) {
+        delete m_impl->keepAliveSurface;
+        m_impl->keepAliveSurface = nullptr;
+    }
+    m_impl->engine.reset();
+}
+
+QQmlEngine* SurfaceManager::engine() const
+{
+    return m_impl->engine.get();
+}
+
+PhosphorLayer::Surface* SurfaceManager::createSurface(PhosphorLayer::SurfaceConfig cfg)
+{
+    if (!m_impl->config.surfaceFactory) {
+        qCWarning(lcSurfaces) << "No SurfaceFactory configured";
+        return nullptr;
+    }
+
+    cfg.sharedEngine = m_impl->engine.get();
+
+    auto* surface = m_impl->config.surfaceFactory->create(std::move(cfg), this);
+    if (!surface) {
+        qCWarning(lcSurfaces) << "SurfaceFactory::create() returned nullptr";
+        return nullptr;
+    }
+
+    surface->warmUp();
+
+    if (surface->state() == PhosphorLayer::Surface::State::Failed) {
+        qCWarning(lcSurfaces) << "Surface warm-up failed:" << surface->config().effectiveDebugName();
+        delete surface;
+        return nullptr;
+    }
+
+    if (!m_impl->config.pipelineCachePath.isEmpty() && surface->window()) {
+        surface->window()->setProperty("_pipelineCachePath", m_impl->config.pipelineCachePath);
+    }
+
+    return surface;
+}
+
+PhosphorLayer::Surface* SurfaceManager::warmUpSurface(PhosphorLayer::SurfaceConfig cfg)
+{
+    return createSurface(std::move(cfg));
+}
+
+quint64 SurfaceManager::nextScopeGeneration()
+{
+    return ++m_impl->scopeGeneration;
+}
+
+bool SurfaceManager::keepAliveActive() const
+{
+    return m_impl->keepAliveWindow && m_impl->keepAliveSurface;
+}
+
+void SurfaceManager::createKeepAlive()
+{
+    if (!m_impl->config.surfaceFactory) {
+        return;
+    }
+
+    PhosphorLayer::SurfaceConfig cfg;
+    cfg.role = PhosphorLayer::Roles::Background.withScopePrefix(QStringLiteral("phosphor-surfaces-keepalive"));
+    cfg.contentItem = std::make_unique<QQuickItem>();
+    cfg.sharedEngine = m_impl->engine.get();
+    cfg.debugName = QStringLiteral("keepalive");
+    cfg.anchorsOverride = PhosphorLayer::AnchorNone;
+    cfg.exclusiveZoneOverride = 0;
+
+    auto* surface = m_impl->config.surfaceFactory->create(std::move(cfg), this);
+    if (!surface) {
+        qCWarning(lcSurfaces) << "Failed to create keep-alive surface";
+        return;
+    }
+
+    surface->warmUp();
+
+    if (surface->state() == PhosphorLayer::Surface::State::Failed) {
+        qCWarning(lcSurfaces) << "Keep-alive surface warm-up failed";
+        delete surface;
+        return;
+    }
+
+    if (surface->window()) {
+        surface->window()->setWidth(1);
+        surface->window()->setHeight(1);
+    }
+
+    surface->show();
+    m_impl->keepAliveSurface = surface;
+    m_impl->keepAliveWindow = surface->window();
+
+    connect(surface, &PhosphorLayer::Surface::failed, this, [this](const QString& reason) {
+        qCWarning(lcSurfaces) << "Keep-alive surface failed:" << reason;
+        m_impl->keepAliveSurface = nullptr;
+        Q_EMIT keepAliveLost();
+    });
+
+    qCDebug(lcSurfaces) << "Keep-alive surface created";
+}
+
+} // namespace PhosphorSurfaces

--- a/libs/phosphor-surfaces/src/surfacemanager.cpp
+++ b/libs/phosphor-surfaces/src/surfacemanager.cpp
@@ -8,11 +8,16 @@
 #include <PhosphorLayer/SurfaceConfig.h>
 #include <PhosphorLayer/SurfaceFactory.h>
 
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QGuiApplication>
 #include <QLoggingCategory>
 #include <QPointer>
 #include <QQmlEngine>
 #include <QQuickItem>
 #include <QQuickWindow>
+#include <QScreen>
+#include <QTimer>
 
 namespace PhosphorSurfaces {
 
@@ -42,15 +47,30 @@ SurfaceManager::SurfaceManager(SurfaceManagerConfig config, QObject* parent)
 {
     m_impl->config = std::move(config);
     m_impl->configureEngine();
-    createKeepAlive();
+    QTimer::singleShot(0, this, &SurfaceManager::createKeepAlive);
 }
 
 SurfaceManager::~SurfaceManager()
 {
     if (m_impl->keepAliveSurface) {
-        delete m_impl->keepAliveSurface;
+        m_impl->keepAliveSurface->deleteLater();
         m_impl->keepAliveSurface = nullptr;
     }
+    m_impl->keepAliveWindow = nullptr;
+
+    constexpr int kDrainCap = 32;
+    QEventLoop drainLoop;
+    int passes = 0;
+    for (; passes < kDrainCap; ++passes) {
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        if (!drainLoop.processEvents(QEventLoop::ExcludeUserInputEvents)) {
+            break;
+        }
+    }
+    if (passes == kDrainCap) {
+        qCWarning(lcSurfaces) << "deferred-delete drain hit safety cap" << kDrainCap;
+    }
+
     m_impl->engine.reset();
 }
 
@@ -86,12 +106,11 @@ PhosphorLayer::Surface* SurfaceManager::createSurface(PhosphorLayer::SurfaceConf
         surface->window()->setProperty("_pipelineCachePath", m_impl->config.pipelineCachePath);
     }
 
-    return surface;
-}
+    if (m_impl->config.windowConfigurator && surface->window()) {
+        m_impl->config.windowConfigurator(*surface->window());
+    }
 
-PhosphorLayer::Surface* SurfaceManager::warmUpSurface(PhosphorLayer::SurfaceConfig cfg)
-{
-    return createSurface(std::move(cfg));
+    return surface;
 }
 
 quint64 SurfaceManager::nextScopeGeneration()
@@ -110,11 +129,18 @@ void SurfaceManager::createKeepAlive()
         return;
     }
 
+    QScreen* screen = QGuiApplication::primaryScreen();
+    if (!screen) {
+        qCWarning(lcSurfaces) << "Keep-alive: no screen available at creation time";
+        return;
+    }
+
     PhosphorLayer::SurfaceConfig cfg;
     cfg.role = PhosphorLayer::Roles::Background.withScopePrefix(QStringLiteral("phosphor-surfaces-keepalive"));
     cfg.contentItem = std::make_unique<QQuickItem>();
     cfg.sharedEngine = m_impl->engine.get();
     cfg.debugName = QStringLiteral("keepalive");
+    cfg.screen = screen;
     cfg.anchorsOverride = PhosphorLayer::AnchorNone;
     cfg.exclusiveZoneOverride = 0;
 
@@ -135,15 +161,20 @@ void SurfaceManager::createKeepAlive()
     if (surface->window()) {
         surface->window()->setWidth(1);
         surface->window()->setHeight(1);
+        if (m_impl->config.windowConfigurator) {
+            m_impl->config.windowConfigurator(*surface->window());
+        }
     }
 
     surface->show();
     m_impl->keepAliveSurface = surface;
     m_impl->keepAliveWindow = surface->window();
 
-    connect(surface, &PhosphorLayer::Surface::failed, this, [this](const QString& reason) {
+    connect(surface, &PhosphorLayer::Surface::failed, this, [this, surface](const QString& reason) {
         qCWarning(lcSurfaces) << "Keep-alive surface failed:" << reason;
         m_impl->keepAliveSurface = nullptr;
+        m_impl->keepAliveWindow = nullptr;
+        surface->deleteLater();
         Q_EMIT keepAliveLost();
     });
 

--- a/libs/phosphor-surfaces/tests/CMakeLists.txt
+++ b/libs/phosphor-surfaces/tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Test)
+
+add_executable(test_phosphorsurfaces
+    test_phosphorsurfaces.cpp
+)
+
+target_link_libraries(test_phosphorsurfaces
+    PRIVATE
+        PhosphorSurfaces::PhosphorSurfaces
+        Qt6::Test
+        Qt6::Gui
+)
+
+add_test(NAME test_phosphorsurfaces COMMAND test_phosphorsurfaces)
+set_tests_properties(test_phosphorsurfaces PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)

--- a/libs/phosphor-surfaces/tests/test_phosphorsurfaces.cpp
+++ b/libs/phosphor-surfaces/tests/test_phosphorsurfaces.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorSurfaces/SurfaceManager.h>
+#include <PhosphorSurfaces/SurfaceManagerConfig.h>
+
+#include <QTest>
+
+class TestPhosphorSurfaces : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void testConstructionWithoutFactory()
+    {
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        QVERIFY(manager.engine() != nullptr);
+        QVERIFY(!manager.keepAliveActive());
+    }
+
+    void testEngineConfiguratorCalled()
+    {
+        bool called = false;
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        config.engineConfigurator = [&called](QQmlEngine&) {
+            called = true;
+        };
+
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        QVERIFY(called);
+        QVERIFY(manager.engine() != nullptr);
+    }
+
+    void testScopeGenerationMonotonic()
+    {
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        const quint64 first = manager.nextScopeGeneration();
+        const quint64 second = manager.nextScopeGeneration();
+        const quint64 third = manager.nextScopeGeneration();
+
+        QCOMPARE(first, 1u);
+        QCOMPARE(second, 2u);
+        QCOMPARE(third, 3u);
+        QVERIFY(first < second);
+        QVERIFY(second < third);
+    }
+
+    void testCreateSurfaceWithoutFactory()
+    {
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        PhosphorLayer::SurfaceConfig surfCfg;
+        surfCfg.role = PhosphorLayer::Roles::FullscreenOverlay;
+        surfCfg.contentUrl = QUrl(QStringLiteral("qrc:/nonexistent.qml"));
+
+        auto* surface = manager.createSurface(std::move(surfCfg));
+        QVERIFY(surface == nullptr);
+    }
+};
+
+#include <QGuiApplication>
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+    TestPhosphorSurfaces tc;
+    return QTest::qExec(&tc, argc, argv);
+}
+
+#include "test_phosphorsurfaces.moc"

--- a/libs/phosphor-surfaces/tests/test_phosphorsurfaces.cpp
+++ b/libs/phosphor-surfaces/tests/test_phosphorsurfaces.cpp
@@ -4,6 +4,7 @@
 #include <PhosphorSurfaces/SurfaceManager.h>
 #include <PhosphorSurfaces/SurfaceManagerConfig.h>
 
+#include <QSignalSpy>
 #include <QTest>
 
 class TestPhosphorSurfaces : public QObject
@@ -34,6 +35,21 @@ private Q_SLOTS:
         QVERIFY(manager.engine() != nullptr);
     }
 
+    void testWindowConfiguratorStored()
+    {
+        bool called = false;
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        config.windowConfigurator = [&called](QQuickWindow&) {
+            called = true;
+        };
+
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        // windowConfigurator is not called during construction (no windows yet),
+        // only when createSurface / createKeepAlive produce a window.
+        QVERIFY(!called);
+    }
+
     void testScopeGenerationMonotonic()
     {
         PhosphorSurfaces::SurfaceManagerConfig config;
@@ -61,6 +77,15 @@ private Q_SLOTS:
 
         auto* surface = manager.createSurface(std::move(surfCfg));
         QVERIFY(surface == nullptr);
+    }
+
+    void testKeepAliveLostSignalExists()
+    {
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        QSignalSpy spy(&manager, &PhosphorSurfaces::SurfaceManager::keepAliveLost);
+        QVERIFY(spy.isValid());
     }
 };
 

--- a/libs/phosphor-surfaces/tests/test_phosphorsurfaces.cpp
+++ b/libs/phosphor-surfaces/tests/test_phosphorsurfaces.cpp
@@ -35,19 +35,19 @@ private Q_SLOTS:
         QVERIFY(manager.engine() != nullptr);
     }
 
-    void testWindowConfiguratorStored()
+    void testEngineConfiguratorCalledExactlyOnce()
     {
-        bool called = false;
+        int callCount = 0;
         PhosphorSurfaces::SurfaceManagerConfig config;
-        config.windowConfigurator = [&called](QQuickWindow&) {
-            called = true;
+        config.engineConfigurator = [&callCount](QQmlEngine&) {
+            ++callCount;
         };
 
         PhosphorSurfaces::SurfaceManager manager(std::move(config));
+        QCOMPARE(callCount, 1);
 
-        // windowConfigurator is not called during construction (no windows yet),
-        // only when createSurface / createKeepAlive produce a window.
-        QVERIFY(!called);
+        manager.createSurface({});
+        QCOMPARE(callCount, 1);
     }
 
     void testScopeGenerationMonotonic()
@@ -66,6 +66,14 @@ private Q_SLOTS:
         QVERIFY(second < third);
     }
 
+    void testScopeGenerationStartsAtOne()
+    {
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        QCOMPARE(manager.nextScopeGeneration(), 1u);
+    }
+
     void testCreateSurfaceWithoutFactory()
     {
         PhosphorSurfaces::SurfaceManagerConfig config;
@@ -79,6 +87,20 @@ private Q_SLOTS:
         QVERIFY(surface == nullptr);
     }
 
+    void testCreateSurfaceWithParent()
+    {
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        QObject customParent;
+        PhosphorLayer::SurfaceConfig surfCfg;
+        surfCfg.role = PhosphorLayer::Roles::FullscreenOverlay;
+        surfCfg.contentUrl = QUrl(QStringLiteral("qrc:/nonexistent.qml"));
+
+        auto* surface = manager.createSurface(std::move(surfCfg), &customParent);
+        QVERIFY(surface == nullptr);
+    }
+
     void testKeepAliveLostSignalExists()
     {
         PhosphorSurfaces::SurfaceManagerConfig config;
@@ -86,6 +108,57 @@ private Q_SLOTS:
 
         QSignalSpy spy(&manager, &PhosphorSurfaces::SurfaceManager::keepAliveLost);
         QVERIFY(spy.isValid());
+    }
+
+    void testKeepAliveNotActiveWithoutFactory()
+    {
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        QCoreApplication::processEvents();
+
+        QVERIFY(!manager.keepAliveActive());
+    }
+
+    void testPipelineCachePathStored()
+    {
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        config.pipelineCachePath = QStringLiteral("/tmp/test-pipeline.cache");
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        QVERIFY(manager.engine() != nullptr);
+    }
+
+    void testVulkanInstanceNullByDefault()
+    {
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        QVERIFY(config.vulkanInstance == nullptr);
+    }
+
+    void testMultipleScopeGenerationsUnique()
+    {
+        PhosphorSurfaces::SurfaceManagerConfig config;
+        PhosphorSurfaces::SurfaceManager manager(std::move(config));
+
+        QSet<quint64> seen;
+        for (int i = 0; i < 1000; ++i) {
+            auto val = manager.nextScopeGeneration();
+            QVERIFY(!seen.contains(val));
+            seen.insert(val);
+        }
+        QCOMPARE(seen.size(), 1000);
+    }
+
+    void testDestructionWithoutCrash()
+    {
+        auto manager = std::make_unique<PhosphorSurfaces::SurfaceManager>(PhosphorSurfaces::SurfaceManagerConfig{});
+
+        QVERIFY(manager->engine() != nullptr);
+
+        auto gen1 = manager->nextScopeGeneration();
+        QVERIFY(gen1 > 0);
+
+        manager.reset();
     }
 };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -424,6 +424,7 @@ target_link_libraries(plasmazonesd
         PhosphorLayer::PhosphorLayer  # wlr-layer-shell surface lifecycle
         PhosphorShortcuts::PhosphorShortcuts  # ShortcutManager / Registry / backends
         PhosphorAudio::PhosphorAudio  # audio spectrum provider (CAVA)
+        PhosphorSurfaces::PhosphorSurfaces  # managed surface lifecycle (engine, keep-alive)
         Qt6::Widgets
         Qt6::Quick
         Qt6::QuickControls2

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -140,12 +140,14 @@ OverlayService::OverlayService(Phosphor::Screens::ScreenManager* screenManager, 
     m_surfaceManager = std::make_unique<PhosphorSurfaces::SurfaceManager>(PhosphorSurfaces::SurfaceManagerConfig{
         .surfaceFactory = m_surfaceFactory.get(),
         .engineConfigurator =
-            [](QQmlEngine& engine) {
+            [this](QQmlEngine& engine) {
                 auto* localizedContext = new PzLocalizedContext(&engine);
                 engine.rootContext()->setContextObject(localizedContext);
+                engine.rootContext()->setContextProperty(QStringLiteral("overlayService"), this);
             },
         .pipelineCachePath = pipelineCachePath,
         .vulkanInstance = externalVulkanInstance,
+        .vulkanApiVersion = PlasmaZones::PzVulkanApiVersion,
     });
 
     // Connect to screen changes (with safety check for early initialization)
@@ -326,10 +328,11 @@ OverlayService::~OverlayService()
         m_shaderPreviewSurface = nullptr;
     }
 
-    // ~m_surfaceManager runs next (member destruction order) and handles:
-    //   1. keep-alive surface teardown
-    //   2. deferred-delete drain loop
-    //   3. engine destruction
+    // Drain deferred-delete events NOW, while all OverlayService members are
+    // still alive. Surface destructors may touch m_screenStates, m_shaderRegistry,
+    // etc. — if we let ~m_surfaceManager's drain run instead, those members could
+    // already be destroyed (C++ member destruction order is reverse declaration).
+    m_surfaceManager->drainDeferredDeletes();
 }
 
 PhosphorLayer::Surface* OverlayService::createLayerSurface(const QUrl& qmlUrl, QScreen* screen,

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -7,6 +7,8 @@
 
 #include <PhosphorAudio/CavaSpectrumProvider.h>
 
+#include <PhosphorSurfaces/SurfaceManager.h>
+#include <PhosphorSurfaces/SurfaceManagerConfig.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorZones/Zone.h>
@@ -119,22 +121,23 @@ void cleanupVirtualScreenStates(QHash<QString, OverlayService::PerScreenOverlayS
 OverlayService::OverlayService(Phosphor::Screens::ScreenManager* screenManager, ShaderRegistry* shaderRegistry,
                                QObject* parent)
     : IOverlayService(parent)
-    , m_engine(std::make_unique<QQmlEngine>()) // No parent - unique_ptr manages lifetime
     , m_screenProvider(std::make_unique<PhosphorLayer::DefaultScreenProvider>())
     , m_transport(std::make_unique<PhosphorLayer::PhosphorShellTransport>())
 {
     m_screenManager = screenManager;
     m_shaderRegistry = shaderRegistry;
-    // Set up i18n for QML (makes i18n() available in QML)
-    auto* localizedContext = new PzLocalizedContext(m_engine.get());
-    m_engine->rootContext()->setContextObject(localizedContext);
 
-    // PhosphorLayer factory. engineProvider is left null so Surfaces get their
-    // own QQmlEngine by default — except when we pass cfg.sharedEngine pointing
-    // at m_engine (which createLayerSurface does below) so all overlays share
-    // the OverlayService's engine + context properties + i18n setup.
     m_surfaceFactory = std::make_unique<PhosphorLayer::SurfaceFactory>(PhosphorLayer::SurfaceFactory::Deps{
         m_transport.get(), m_screenProvider.get(), nullptr, QStringLiteral("plasmazones.overlay")});
+
+    m_surfaceManager = std::make_unique<PhosphorSurfaces::SurfaceManager>(PhosphorSurfaces::SurfaceManagerConfig{
+        .surfaceFactory = m_surfaceFactory.get(),
+        .engineConfigurator =
+            [](QQmlEngine& engine) {
+                auto* localizedContext = new PzLocalizedContext(&engine);
+                engine.rootContext()->setContextObject(localizedContext);
+            },
+    });
 
     // Connect to screen changes (with safety check for early initialization)
     if (qGuiApp) {
@@ -260,52 +263,7 @@ OverlayService::OverlayService(Phosphor::Screens::ScreenManager* screenManager, 
     connect(m_audioProvider.get(), &PhosphorAudio::IAudioSpectrumProvider::spectrumUpdated, this,
             &OverlayService::onAudioSpectrumUpdated);
 
-    // Create a persistent 1x1 keep-alive window to prevent Qt from tearing down
-    // global Wayland/Vulkan protocol objects (zwp_linux_dmabuf_v1, wp_presentation,
-    // etc.) when the last visible QQuickWindow is destroyed. Without this, after
-    // overlay destroy-on-hide, Qt cleans up the Vulkan rendering infrastructure
-    // and no new windows can render buffers.
-    QTimer::singleShot(0, this, [this]() {
-        QScreen* screen = Utils::primaryScreen();
-        if (!screen) {
-            qCWarning(lcOverlay) << "Keep-alive surface: no primary screen at startup — "
-                                    "Wayland/Vulkan globals may churn across overlay destroy cycles";
-            return;
-        }
-        // Keep-alive goes through PhosphorLayer like every other overlay now —
-        // a tiny 1×1 background-layer surface with no anchors, no input, no
-        // content beyond a bare QQuickItem. Its only job is keeping Qt's
-        // Vulkan globals resident across overlay destroy-cycles.
-        PhosphorLayer::SurfaceConfig cfg;
-        cfg.role = PhosphorLayer::Roles::Background.withScopePrefix(QStringLiteral("plasmazones-keepalive"));
-        cfg.contentItem = std::make_unique<QQuickItem>();
-        cfg.screen = screen;
-        cfg.anchorsOverride = PhosphorLayer::AnchorNone;
-        cfg.exclusiveZoneOverride = 0;
-        cfg.debugName = QStringLiteral("keepalive");
-        auto* keepAlive = m_surfaceFactory->create(std::move(cfg), this);
-        if (!keepAlive) {
-            return;
-        }
-        keepAlive->warmUp();
-        if (keepAlive->state() == PhosphorLayer::Surface::State::Failed) {
-            keepAlive->deleteLater();
-            return;
-        }
-        m_keepAliveSurface = keepAlive;
-        m_keepAliveWindow = keepAlive->window();
-        if (m_keepAliveWindow) {
-#if QT_CONFIG(vulkan)
-            auto* vulkanInstance = qApp->property(PlasmaZones::PzVulkanInstanceProperty).value<QVulkanInstance*>();
-            if (vulkanInstance) {
-                m_keepAliveWindow->setVulkanInstance(vulkanInstance);
-            }
-#endif
-            m_keepAliveWindow->setWidth(1);
-            m_keepAliveWindow->setHeight(1);
-        }
-        keepAlive->show();
-    });
+    // Keep-alive is managed by m_surfaceManager (created in its constructor).
 }
 
 bool OverlayService::isVisible() const
@@ -358,10 +316,10 @@ OverlayService::~OverlayService()
     // QObject children of `this`, so the QObject parent-child system would
     // destroy them AFTER our own destructor body runs — i.e. after the
     // deferred-delete drain below, and potentially after member destructors
-    // (m_engine, m_transport, m_surfaceFactory, m_screenProvider) have run.
+    // (m_surfaceManager, m_transport, m_surfaceFactory, m_screenProvider) have run.
     // Schedule their deletion now so the drain loop picks them up in the
-    // right order and they don't touch dead engine/factory pointers during
-    // their own teardown.
+    // right order and they don't touch dead factory pointers during their
+    // own teardown.
     if (m_snapAssistSurface) {
         m_snapAssistSurface->deleteLater();
         m_snapAssistSurface = nullptr;
@@ -375,26 +333,7 @@ OverlayService::~OverlayService()
         m_shaderPreviewSurface = nullptr;
     }
 
-    // Keep-alive surface is released last (after all other overlays), so its
-    // Vulkan instance outlives their teardown and prevents the global
-    // wl_display / VkInstance churn the keep-alive is designed to suppress.
-    if (m_keepAliveSurface) {
-        m_keepAliveSurface->deleteLater();
-        m_keepAliveSurface = nullptr;
-    }
-    m_keepAliveWindow = nullptr;
-
-    // Drain deferred-delete events. One pass is not enough: ~Surface posts
-    // window deleteLater, the window's destruction posts further deleteLater
-    // for QML-owned children, and those children's dtors may post yet more.
-    // Alternate sendPostedEvents(DeferredDelete) + processEvents until a full
-    // pass processes nothing — that's the point where the cascade has
-    // settled. kDrainCap only bounds pathological chains; in practice the
-    // loop exits after ~4–8 passes. 8 was the empirically-observed depth
-    // during shader-overlay teardown with nested QML components; we cap
-    // well above that so future QML-tree changes don't silently leak
-    // deferred-deletes into engine teardown. Hitting the cap logs a warning
-    // so the regression is loud.
+    // Drain deferred-delete events before m_surfaceManager destroys its engine.
     constexpr int kDrainCap = 64;
     QEventLoop drainLoop;
     int passes = 0;
@@ -409,8 +348,7 @@ OverlayService::~OverlayService()
                              << "— a QML teardown chain is deeper than expected";
     }
 
-    // Now m_engine (unique_ptr) will be destroyed safely
-    // since all QML objects have been properly cleaned up
+    // m_surfaceManager destructor destroys keep-alive + engine
 }
 
 PhosphorLayer::Surface* OverlayService::createLayerSurface(const QUrl& qmlUrl, QScreen* screen,
@@ -432,7 +370,7 @@ PhosphorLayer::Surface* OverlayService::createLayerSurface(const QUrl& qmlUrl, Q
     cfg.role = role;
     cfg.contentUrl = qmlUrl;
     cfg.screen = screen;
-    cfg.sharedEngine = m_engine.get(); // keep i18n + context properties unified
+    cfg.sharedEngine = m_surfaceManager->engine();
     cfg.windowProperties = windowProperties;
     cfg.anchorsOverride = anchorsOverride;
     cfg.marginsOverride = marginsOverride;

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -22,12 +22,10 @@
 
 #include <QCoreApplication>
 #include <QCursor>
-#include <QDir>
 #include <QGuiApplication>
 #include <QScreen>
 #include <QQmlEngine>
 #include <QQmlContext>
-#include <QQuickGraphicsConfiguration>
 #include <QQuickWindow>
 #include <QStandardPaths>
 #include <QTimer>
@@ -130,6 +128,15 @@ OverlayService::OverlayService(Phosphor::Screens::ScreenManager* screenManager, 
     m_surfaceFactory = std::make_unique<PhosphorLayer::SurfaceFactory>(PhosphorLayer::SurfaceFactory::Deps{
         m_transport.get(), m_screenProvider.get(), nullptr, QStringLiteral("plasmazones.overlay")});
 
+    const QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    const QString pipelineCachePath =
+        cacheDir.isEmpty() ? QString() : (cacheDir + QStringLiteral("/plasmazones-pipeline.cache"));
+
+    QVulkanInstance* externalVulkanInstance = nullptr;
+#if QT_CONFIG(vulkan)
+    externalVulkanInstance = qApp->property(PlasmaZones::PzVulkanInstanceProperty).value<QVulkanInstance*>();
+#endif
+
     m_surfaceManager = std::make_unique<PhosphorSurfaces::SurfaceManager>(PhosphorSurfaces::SurfaceManagerConfig{
         .surfaceFactory = m_surfaceFactory.get(),
         .engineConfigurator =
@@ -137,17 +144,8 @@ OverlayService::OverlayService(Phosphor::Screens::ScreenManager* screenManager, 
                 auto* localizedContext = new PzLocalizedContext(&engine);
                 engine.rootContext()->setContextObject(localizedContext);
             },
-        .windowConfigurator =
-            [](QQuickWindow& window) {
-#if QT_CONFIG(vulkan)
-                auto* vi = qApp->property(PlasmaZones::PzVulkanInstanceProperty).value<QVulkanInstance*>();
-                if (vi) {
-                    window.setVulkanInstance(vi);
-                }
-#else
-                Q_UNUSED(window)
-#endif
-            },
+        .pipelineCachePath = pipelineCachePath,
+        .vulkanInstance = externalVulkanInstance,
     });
 
     // Connect to screen changes (with safety check for early initialization)
@@ -289,25 +287,12 @@ bool OverlayService::isZoneSelectorVisible() const
 
 OverlayService::~OverlayService()
 {
-    // Clear the Vulkan instance app property before destruction to avoid dangling pointer.
-    // Only needed for the fallback instance we own — when main.cpp provided the instance,
-    // it outlives OverlayService (declared before QGuiApplication), so no cleanup needed.
-#if QT_CONFIG(vulkan)
-    if (m_fallbackVulkanInstance && qGuiApp) {
-        qApp->setProperty(PlasmaZones::PzVulkanInstanceProperty, QVariant());
-    }
-#endif
-
     // Disconnect from QGuiApplication first so we don't get screen-related callbacks
     // while we're destroying windows.
     if (qGuiApp) {
         disconnect(qGuiApp, nullptr, this, nullptr);
     }
 
-    // Mirror the D-Bus PrepareForSleep connect from the constructor. Not
-    // strictly required — QDBusConnection checks receiver-alive before
-    // dispatch — but leaving a dead entry in the system bus's slot table
-    // for the rest of the session is sloppy.
     if (m_prepareForSleepConnected) {
         QDBusConnection::systemBus().disconnect(QStringLiteral("org.freedesktop.login1"),
                                                 QStringLiteral("/org/freedesktop/login1"),
@@ -326,11 +311,8 @@ OverlayService::~OverlayService()
     // Singleton surfaces (snap assist, layout picker, shader preview) are
     // QObject children of `this`, so the QObject parent-child system would
     // destroy them AFTER our own destructor body runs — i.e. after the
-    // deferred-delete drain below, and potentially after member destructors
-    // (m_surfaceManager, m_transport, m_surfaceFactory, m_screenProvider) have run.
-    // Schedule their deletion now so the drain loop picks them up in the
-    // right order and they don't touch dead factory pointers during their
-    // own teardown.
+    // member destructors. Schedule their deletion now so SurfaceManager's
+    // drain loop picks them up before the engine is destroyed.
     if (m_snapAssistSurface) {
         m_snapAssistSurface->deleteLater();
         m_snapAssistSurface = nullptr;
@@ -344,22 +326,10 @@ OverlayService::~OverlayService()
         m_shaderPreviewSurface = nullptr;
     }
 
-    // Drain deferred-delete events before m_surfaceManager destroys its engine.
-    constexpr int kDrainCap = 64;
-    QEventLoop drainLoop;
-    int passes = 0;
-    for (; passes < kDrainCap; ++passes) {
-        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
-        if (!drainLoop.processEvents(QEventLoop::ExcludeUserInputEvents)) {
-            break;
-        }
-    }
-    if (passes == kDrainCap) {
-        qCWarning(lcOverlay) << "deferred-delete drain hit safety cap" << kDrainCap
-                             << "— a QML teardown chain is deeper than expected";
-    }
-
-    // m_surfaceManager destructor destroys keep-alive + engine
+    // ~m_surfaceManager runs next (member destruction order) and handles:
+    //   1. keep-alive surface teardown
+    //   2. deferred-delete drain loop
+    //   3. engine destruction
 }
 
 PhosphorLayer::Surface* OverlayService::createLayerSurface(const QUrl& qmlUrl, QScreen* screen,
@@ -372,90 +342,17 @@ PhosphorLayer::Surface* OverlayService::createLayerSurface(const QUrl& qmlUrl, Q
         qCWarning(lcOverlay) << "createLayerSurface: screen is null for" << windowType;
         return nullptr;
     }
-    if (!m_surfaceFactory) {
-        qCWarning(lcOverlay) << "createLayerSurface: SurfaceFactory not initialised";
-        return nullptr;
-    }
 
     PhosphorLayer::SurfaceConfig cfg;
     cfg.role = role;
     cfg.contentUrl = qmlUrl;
     cfg.screen = screen;
-    cfg.sharedEngine = m_surfaceManager->engine();
     cfg.windowProperties = windowProperties;
     cfg.anchorsOverride = anchorsOverride;
     cfg.marginsOverride = marginsOverride;
     cfg.debugName = QString::fromUtf8(windowType);
 
-    auto* surface = m_surfaceFactory->create(std::move(cfg), this);
-    if (!surface) {
-        qCWarning(lcOverlay) << "createLayerSurface: factory returned nullptr for" << windowType;
-        return nullptr;
-    }
-    // Warm immediately so the QQuickWindow exists before the caller starts
-    // setting properties on it. Mirrors the old createQmlWindow+configureLayerSurface
-    // sequence where the window was live before return.
-    surface->warmUp();
-    const auto st = surface->state();
-    if (st == PhosphorLayer::Surface::State::Failed) {
-        qCWarning(lcOverlay) << "createLayerSurface: warmUp failed for" << windowType;
-        surface->deleteLater();
-        return nullptr;
-    }
-    if (st == PhosphorLayer::Surface::State::Warming) {
-        // QML is still loading asynchronously. Every consumer in this file
-        // uses qrc:/ URLs which load synchronously, so Warming-on-return
-        // means someone introduced an async source path (remote URL, QML
-        // bytecode fetched from file with background imports, etc.) without
-        // updating the caller to listen for Surface::stateChanged. The
-        // callers below assume a live QQuickWindow and deref surface->window()
-        // synchronously — that would segfault. Refuse up-front so the bug
-        // manifests as a clean refusal instead of a crash.
-        qCWarning(lcOverlay)
-            << "createLayerSurface: surface still Warming on return for" << windowType
-            << "— async QML load path is not supported by the current callers. Switch to qrc:/ or refactor"
-            << "the caller to wait on Surface::stateChanged before touching surface->window().";
-        surface->deleteLater();
-        return nullptr;
-    }
-
-    // Pipeline cache: mirror createQmlWindow's behaviour so shader compilation
-    // persists across daemon restarts.
-    if (auto* w = surface->window()) {
-        const QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
-        if (!cacheDir.isEmpty()) {
-            static bool s_cacheDirCreated = false;
-            if (!s_cacheDirCreated) {
-                QDir().mkpath(cacheDir);
-                s_cacheDirCreated = true;
-            }
-            QQuickGraphicsConfiguration config = w->graphicsConfiguration();
-            config.setPipelineCacheSaveFile(cacheDir + QStringLiteral("/plasmazones-pipeline.cache"));
-            w->setGraphicsConfiguration(config);
-        }
-#if QT_CONFIG(vulkan)
-        auto* vulkanInstance = qApp->property(PlasmaZones::PzVulkanInstanceProperty).value<QVulkanInstance*>();
-        if (!vulkanInstance && QQuickWindow::graphicsApi() == QSGRendererInterface::Vulkan) {
-            if (!m_fallbackVulkanInstance) {
-                m_fallbackVulkanInstance = std::make_unique<QVulkanInstance>();
-                m_fallbackVulkanInstance->setApiVersion(PlasmaZones::PzVulkanApiVersion);
-                if (m_fallbackVulkanInstance->create()) {
-                    qApp->setProperty(PlasmaZones::PzVulkanInstanceProperty,
-                                      QVariant::fromValue(m_fallbackVulkanInstance.get()));
-                    vulkanInstance = m_fallbackVulkanInstance.get();
-                } else {
-                    qCCritical(lcOverlay) << "Failed to create fallback QVulkanInstance for" << windowType;
-                    m_fallbackVulkanInstance.reset();
-                }
-            }
-        }
-        if (vulkanInstance) {
-            w->setVulkanInstance(vulkanInstance);
-        }
-#endif
-    }
-
-    return surface;
+    return m_surfaceManager->createSurface(std::move(cfg), this);
 }
 
 void OverlayService::show()

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -137,6 +137,17 @@ OverlayService::OverlayService(Phosphor::Screens::ScreenManager* screenManager, 
                 auto* localizedContext = new PzLocalizedContext(&engine);
                 engine.rootContext()->setContextObject(localizedContext);
             },
+        .windowConfigurator =
+            [](QQuickWindow& window) {
+#if QT_CONFIG(vulkan)
+                auto* vi = qApp->property(PlasmaZones::PzVulkanInstanceProperty).value<QVulkanInstance*>();
+                if (vi) {
+                    window.setVulkanInstance(vi);
+                }
+#else
+                Q_UNUSED(window)
+#endif
+            },
     });
 
     // Connect to screen changes (with safety check for early initialization)

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -19,9 +19,6 @@
 
 #include "../core/interfaces.h"
 #include <PhosphorZones/Layout.h>
-#include "vulkan_support.h"
-
-class QQmlEngine;
 
 namespace PhosphorLayer {
 class ILayerShellTransport;
@@ -628,11 +625,6 @@ private:
 
     // Screens excluded from overlay display (autotile-managed screens)
     QSet<QString> m_excludedScreens;
-
-    // Fallback QVulkanInstance for when 'auto' backend resolves to Vulkan
-#if QT_CONFIG(vulkan)
-    std::unique_ptr<QVulkanInstance> m_fallbackVulkanInstance;
-#endif
 };
 
 } // namespace PlasmaZones

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -47,6 +47,10 @@ namespace PhosphorAudio {
 class IAudioSpectrumProvider;
 }
 
+namespace PhosphorSurfaces {
+class SurfaceManager;
+}
+
 namespace PlasmaZones {
 class WindowThumbnailService;
 class ShaderRegistry;
@@ -402,8 +406,6 @@ private:
     PhosphorZones::Layout* resolveScreenLayout(QScreen* screen) const;
     PhosphorZones::Layout* resolveScreenLayout(const QString& screenId) const;
 
-    std::unique_ptr<QQmlEngine> m_engine;
-
     // PhosphorLayer infrastructure — owns the wlr-layer-shell binding, screen
     // enumeration, and Surface factory for all overlay-style windows. Members
     // ordered so factory is destroyed before provider/transport (factory keeps
@@ -411,6 +413,9 @@ private:
     std::unique_ptr<PhosphorLayer::IScreenProvider> m_screenProvider;
     std::unique_ptr<PhosphorLayer::ILayerShellTransport> m_transport;
     std::unique_ptr<PhosphorLayer::SurfaceFactory> m_surfaceFactory;
+
+    // Managed surface lifecycle: shared QQmlEngine, Vulkan keep-alive, scope generation.
+    std::unique_ptr<PhosphorSurfaces::SurfaceManager> m_surfaceManager;
 
     QHash<QString, PerScreenOverlayState> m_screenStates;
     QPointer<PhosphorZones::Layout> m_layout;
@@ -478,13 +483,7 @@ private:
     bool m_layoutOsdWarmed = false;
     bool m_navigationOsdWarmed = false;
 
-    // Persistent 1x1 keep-alive window that prevents Qt from tearing down
-    // global Wayland/Vulkan protocol objects when all other windows are destroyed.
-    // The Surface owns the QQuickWindow; the cached pointer is a convenience for
-    // property writes only — never destroy the window directly, deleteLater the
-    // Surface and let ~Surface tear the window down.
-    PhosphorLayer::Surface* m_keepAliveSurface = nullptr;
-    QPointer<QQuickWindow> m_keepAliveWindow;
+    // Keep-alive is managed by m_surfaceManager (PhosphorSurfaces::SurfaceManager).
 
     // Remembered so ~OverlayService can disconnect the D-Bus PrepareForSleep
     // subscription explicitly rather than relying on QDBusConnection's
@@ -615,11 +614,7 @@ private:
     bool m_zoneDataDirty = true;
     QString m_pendingShaderError;
 
-    // Monotonic counter for unique layer-shell scope strings.
-    // Appended to each configureLayerSurface() scope so KWin sees every
-    // new surface as unique, avoiding configure rate-limiting after rapid
-    // destroy/recreate cycles on Vulkan.
-    uint64_t m_scopeGeneration = 0;
+    // Scope generation delegated to m_surfaceManager->nextScopeGeneration().
 
     // Audio spectrum provider (CAVA backend via phosphor-audio)
     std::unique_ptr<PhosphorAudio::IAudioSpectrumProvider> m_audioProvider;

--- a/src/daemon/overlayservice/osd.cpp
+++ b/src/daemon/overlayservice/osd.cpp
@@ -3,8 +3,8 @@
 
 #include "internal.h"
 #include "../overlayservice.h"
-#include <PhosphorSurfaces/SurfaceManager.h>
 #include "../../core/logging.h"
+#include <PhosphorSurfaces/SurfaceManager.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutUtils.h>
 #include <PhosphorScreens/Manager.h>

--- a/src/daemon/overlayservice/osd.cpp
+++ b/src/daemon/overlayservice/osd.cpp
@@ -3,6 +3,7 @@
 
 #include "internal.h"
 #include "../overlayservice.h"
+#include <PhosphorSurfaces/SurfaceManager.h>
 #include "../../core/logging.h"
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutUtils.h>
@@ -360,7 +361,7 @@ void OverlayService::createLayoutOsdWindow(const QString& screenId, QScreen* phy
     }
 
     const auto role = PzRoles::LayoutOsd.withScopePrefix(
-        QStringLiteral("plasmazones-layout-osd-%1-%2").arg(screenId).arg(++m_scopeGeneration));
+        QStringLiteral("plasmazones-layout-osd-%1-%2").arg(screenId).arg(m_surfaceManager->nextScopeGeneration()));
 
     auto* surface = createLayerSurface(QUrl(QStringLiteral("qrc:/ui/LayoutOsd.qml")), physScreen, role, "layout OSD");
     if (!surface) {
@@ -560,7 +561,7 @@ void OverlayService::createNavigationOsdWindow(const QString& screenId, QScreen*
     }
 
     const auto role = PzRoles::NavigationOsd.withScopePrefix(
-        QStringLiteral("plasmazones-navigation-osd-%1-%2").arg(screenId).arg(++m_scopeGeneration));
+        QStringLiteral("plasmazones-navigation-osd-%1-%2").arg(screenId).arg(m_surfaceManager->nextScopeGeneration()));
 
     auto* surface =
         createLayerSurface(QUrl(QStringLiteral("qrc:/ui/NavigationOsd.qml")), physScreen, role, "navigation OSD");

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -3,8 +3,8 @@
 
 #include "internal.h"
 #include "../overlayservice.h"
-#include <PhosphorSurfaces/SurfaceManager.h>
 #include "../../core/logging.h"
+#include <PhosphorSurfaces/SurfaceManager.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorZones/Zone.h>

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -17,7 +17,6 @@
 #include <QScreen>
 #include <QQmlEngine>
 #include <QQmlComponent>
-#include <QQmlContext>
 #include <QMutexLocker>
 #include <QPointer>
 
@@ -370,9 +369,6 @@ void OverlayService::createOverlayWindow(const QString& screenId, QScreen* physS
 
     // Choose overlay type based on shader settings for THIS screen's layout
     bool usingShader = useShaderForScreen(screenId);
-
-    // Expose overlayService to QML context for error reporting
-    m_surfaceManager->engine()->rootContext()->setContextProperty(QStringLiteral("overlayService"), this);
 
     // Compute virtual-screen overrides up-front (wlr-layer-shell locks
     // output+anchors at attach).

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -3,6 +3,7 @@
 
 #include "internal.h"
 #include "../overlayservice.h"
+#include <PhosphorSurfaces/SurfaceManager.h>
 #include "../../core/logging.h"
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
@@ -371,7 +372,7 @@ void OverlayService::createOverlayWindow(const QString& screenId, QScreen* physS
     bool usingShader = useShaderForScreen(screenId);
 
     // Expose overlayService to QML context for error reporting
-    m_engine->rootContext()->setContextProperty(QStringLiteral("overlayService"), this);
+    m_surfaceManager->engine()->rootContext()->setContextProperty(QStringLiteral("overlayService"), this);
 
     // Compute virtual-screen overrides up-front (wlr-layer-shell locks
     // output+anchors at attach).
@@ -385,7 +386,7 @@ void OverlayService::createOverlayWindow(const QString& screenId, QScreen* physS
     }
 
     const auto role = PzRoles::Overlay.withScopePrefix(
-        QStringLiteral("plasmazones-overlay-%1-%2").arg(screenId).arg(++m_scopeGeneration));
+        QStringLiteral("plasmazones-overlay-%1-%2").arg(screenId).arg(m_surfaceManager->nextScopeGeneration()));
 
     // Try shader overlay first, fall back to standard overlay if it fails.
     QVariantMap initProps;

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -3,8 +3,8 @@
 
 #include "internal.h"
 #include "../overlayservice.h"
-#include <PhosphorSurfaces/SurfaceManager.h>
 #include "../../core/logging.h"
+#include <PhosphorSurfaces/SurfaceManager.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorZones/Zone.h>

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -3,6 +3,7 @@
 
 #include "internal.h"
 #include "../overlayservice.h"
+#include <PhosphorSurfaces/SurfaceManager.h>
 #include "../../core/logging.h"
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
@@ -359,7 +360,7 @@ void OverlayService::createZoneSelectorWindow(const QString& screenId, QScreen* 
     }
 
     const auto role = PzRoles::ZoneSelector.withScopePrefix(
-        QStringLiteral("plasmazones-selector-%1-%2").arg(screenId).arg(++m_scopeGeneration));
+        QStringLiteral("plasmazones-selector-%1-%2").arg(screenId).arg(m_surfaceManager->nextScopeGeneration()));
 
     auto* surface = createLayerSurface(QUrl(QStringLiteral("qrc:/ui/ZoneSelectorWindow.qml")), physScreen, role,
                                        "zone selector", QVariantMap(), anchorsOverride, marginsOverride);

--- a/src/daemon/overlayservice/shader.cpp
+++ b/src/daemon/overlayservice/shader.cpp
@@ -3,6 +3,7 @@
 
 #include "internal.h"
 #include "../overlayservice.h"
+#include <PhosphorSurfaces/SurfaceManager.h>
 #include <PhosphorAudio/IAudioSpectrumProvider.h>
 #include "../../core/logging.h"
 #include <PhosphorZones/Layout.h>
@@ -449,7 +450,7 @@ void OverlayService::createShaderPreviewWindow(QScreen* screen, const QString& s
         return;
     }
 
-    m_engine->rootContext()->setContextProperty(QStringLiteral("overlayService"), this);
+    m_surfaceManager->engine()->rootContext()->setContextProperty(QStringLiteral("overlayService"), this);
 
     QImage placeholder(1, 1, QImage::Format_ARGB32);
     placeholder.fill(Qt::transparent);
@@ -461,7 +462,7 @@ void OverlayService::createShaderPreviewWindow(QScreen* screen, const QString& s
     // editor rapidly opens/closes the Shader Settings dialog.
     const QString scopeId = screenId.isEmpty() ? Phosphor::Screens::ScreenIdentity::identifierFor(screen) : screenId;
     const auto role = PzRoles::ShaderPreview.withScopePrefix(
-        QStringLiteral("plasmazones-shader-preview-%1-%2").arg(scopeId).arg(++m_scopeGeneration));
+        QStringLiteral("plasmazones-shader-preview-%1-%2").arg(scopeId).arg(m_surfaceManager->nextScopeGeneration()));
 
     auto* surface = createLayerSurface(QUrl(QStringLiteral("qrc:/ui/RenderNodeOverlay.qml")), screen, role,
                                        "shader preview overlay", initProps);

--- a/src/daemon/overlayservice/shader.cpp
+++ b/src/daemon/overlayservice/shader.cpp
@@ -18,7 +18,6 @@
 #include <QQuickWindow>
 #include <QScreen>
 #include <QQmlEngine>
-#include <QQmlContext>
 #include <QMutexLocker>
 #include <QTimer>
 #include <QImage>
@@ -449,8 +448,6 @@ void OverlayService::createShaderPreviewWindow(QScreen* screen, const QString& s
     if (m_shaderPreviewSurface) {
         return;
     }
-
-    m_surfaceManager->engine()->rootContext()->setContextProperty(QStringLiteral("overlayService"), this);
 
     QImage placeholder(1, 1, QImage::Format_ARGB32);
     placeholder.fill(Qt::transparent);

--- a/src/daemon/overlayservice/shader.cpp
+++ b/src/daemon/overlayservice/shader.cpp
@@ -3,8 +3,8 @@
 
 #include "internal.h"
 #include "../overlayservice.h"
-#include <PhosphorSurfaces/SurfaceManager.h>
 #include <PhosphorAudio/IAudioSpectrumProvider.h>
+#include <PhosphorSurfaces/SurfaceManager.h>
 #include "../../core/logging.h"
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/Zone.h>

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -3,6 +3,7 @@
 
 #include "internal.h"
 #include "../overlayservice.h"
+#include <PhosphorSurfaces/SurfaceManager.h>
 #include "../../core/logging.h"
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutUtils.h>
@@ -324,7 +325,7 @@ void OverlayService::createSnapAssistWindowFor(QScreen* physScreen, const QRect&
     const QString scopeId =
         resolvedId.isEmpty() ? Phosphor::Screens::ScreenIdentity::identifierFor(screen) : resolvedId;
     const auto role = PzRoles::SnapAssist.withScopePrefix(
-        QStringLiteral("plasmazones-snap-assist-%1-%2").arg(scopeId).arg(++m_scopeGeneration));
+        QStringLiteral("plasmazones-snap-assist-%1-%2").arg(scopeId).arg(m_surfaceManager->nextScopeGeneration()));
 
     auto* surface = createLayerSurface(QUrl(QStringLiteral("qrc:/ui/SnapAssistOverlay.qml")), screen, role,
                                        "snap assist", QVariantMap(), anchorsOverride, marginsOverride);
@@ -557,7 +558,7 @@ void OverlayService::createLayoutPickerWindowFor(QScreen* physScreen, const QRec
     const QString scopeId =
         resolvedId.isEmpty() ? Phosphor::Screens::ScreenIdentity::identifierFor(screen) : resolvedId;
     const auto role = PzRoles::LayoutPicker.withScopePrefix(
-        QStringLiteral("plasmazones-layout-picker-%1-%2").arg(scopeId).arg(++m_scopeGeneration));
+        QStringLiteral("plasmazones-layout-picker-%1-%2").arg(scopeId).arg(m_surfaceManager->nextScopeGeneration()));
 
     auto* surface = createLayerSurface(QUrl(QStringLiteral("qrc:/ui/LayoutPickerOverlay.qml")), screen, role,
                                        "layout picker", QVariantMap(), anchorsOverride, marginsOverride);

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -3,8 +3,8 @@
 
 #include "internal.h"
 #include "../overlayservice.h"
-#include <PhosphorSurfaces/SurfaceManager.h>
 #include "../../core/logging.h"
+#include <PhosphorSurfaces/SurfaceManager.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutUtils.h>
 #include "../../core/utils.h"


### PR DESCRIPTION
## Summary

- Add `libs/phosphor-surfaces/` — managed Wayland layer-shell surface lifecycle library (LGPL)
- `SurfaceManager` provides shared `QQmlEngine` with caller-supplied configurator callback, Vulkan keep-alive surface, and scope generation counter
- Builds on `PhosphorLayer::SurfaceFactory::create()` — no reinvention of the lower layer
- Content-agnostic: callers bring their own QML URLs and C++ types
- Add `docs/phosphor-surfaces-api-design.md` — full API design doc with interface design, integration patterns, and what stays in PlasmaZones
- Update `docs/library-extraction-survey.md` — record extraction, resolve all 6 original overlay obstacles, rename from phosphor-overlay to phosphor-surfaces

## Motivation

Surface lifecycle management (engine setup, Vulkan keep-alive, scope generation, screen hotplug) is shell infrastructure that panel widgets, lock screen effects, desktop plugins, and other consumers all need. Keeping it embedded in OverlayService forces every consumer to reimplement the Wayland+Vulkan teardown workarounds.

## Key design decisions

- **Renamed from `phosphor-overlay` to `phosphor-surfaces`** — the library manages any layer-shell surface (panels, backgrounds, overlays, modals), not just overlays
- **QML content stays in PlasmaZones** — 10/11 overlay QML files have zero C++ coupling but all reference zone-specific data shapes; app content, not library API
- **ZoneShaderItem stays in daemon** — leaf-node specialization of `PhosphorRendering::ShaderEffect` with UBO layout matching `common.glsl`; reusable primitive is `ShaderEffect` itself (already LGPL)
- **Engine configurator pattern** — library creates engine, calls `std::function<void(QQmlEngine&)>` once; caller registers types and context properties

## Test plan

- [x] Docker build passes (129/129 tests, zero errors)
- [x] `test_phosphorsurfaces` unit tests pass (construction, configurator, scope generation, no-factory graceful failure)
- [ ] Manual: verify daemon overlay visualizer works with library linked

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)