### PR TITLE
feat: add phosphor-protocol library for D-Bus wire types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,7 @@ add_subdirectory(libs/phosphor-shortcuts)   # global shortcut backends + domain-
 add_subdirectory(libs/phosphor-animation)   # motion-runtime primitives (curves, springs, profiles)
 add_subdirectory(libs/phosphor-audio)       # audio spectrum provider (CAVA backend)
 add_subdirectory(libs/phosphor-surfaces)    # managed surface lifecycle (engine, keep-alive, scope gen)
+add_subdirectory(libs/phosphor-protocol)    # D-Bus wire types and service constants
 
 # Source directories
 add_subdirectory(src)

--- a/docs/phosphor-protocol-api-design.md
+++ b/docs/phosphor-protocol-api-design.md
@@ -1,0 +1,298 @@
+# PhosphorProtocol -- API Design Document
+
+## Overview
+
+PhosphorProtocol is the wire-format library for the Phosphor daemon-to-
+compositor protocol. It defines the D-Bus struct types, service
+addressing constants, API versioning, and client-side call helpers that
+both the daemon and every compositor plugin (KWin, Wayfire, future)
+share. The library owns _what_ crosses the wire; it does not own _how_
+(transport selection, connection management, session lifecycle).
+
+Content-agnostic in the transport sense: the structs carry D-Bus
+streaming operators today, but the POD definitions and validation
+methods are transport-independent. A future `phosphor-ipc` library
+providing a native Wayland or Unix-socket transport would depend on
+PhosphorProtocol for its type definitions.
+
+**License:** LGPL-2.1-or-later (pure wire-format PODs, no domain logic)
+**Namespace:** `PhosphorProtocol`
+**Depends on:** Qt6::Core, Qt6::DBus
+**Build artefact:** `libPhosphorProtocol.so` (SHARED)
+
+---
+
+## Motivation
+
+The daemon-to-compositor wire types (`dbus_types.h`, 583 LOC header +
+592 LOC impl), service constants (`dbus_constants.h`, 53 LOC), and
+client helpers (`dbus_helpers.h`, 116 LOC) live in
+`src/compositor-common/` -- a STATIC library with a relationship name,
+not a domain name. Every other reusable piece has already been extracted
+into a `phosphor-*` LGPL shared library.
+
+Problems with the status quo:
+
+1. **GPL license.** The compositor-common files are GPL-3.0. A Wayfire
+   plugin or third-party compositor integration cannot link a GPL
+   library without inheriting GPL. The types are pure PODs -- no domain
+   logic justifies GPL.
+
+2. **PlasmaZones namespace.** The types use `PlasmaZones::*`. Reusable
+   Phosphor libraries use `Phosphor*` namespaces. Third-party consumers
+   should not carry the app name.
+
+3. **No install target.** The static lib is internal; there is no
+   `find_package(PhosphorProtocol)` path for out-of-tree consumers.
+
+4. **Logging ownership.** `dbus_helpers.h` depends on
+   `lcCompositorCommon` from `logging.{h,cpp}` -- a category named
+   after the relationship, not the domain.
+
+---
+
+## Dependency Graph
+
+```
+PhosphorProtocol (wire types, constants, client helpers)
+       |
+       +------ daemon (D-Bus adaptors, services)
+       +------ kwin-effect (PlasmaZonesEffect, handlers)
+       +------ wayfire-plugin [future]
+       +------ third-party plugins [future]
+       +------ phosphor-ipc [future, native transport]
+```
+
+---
+
+## Library Layout
+
+```
+libs/phosphor-protocol/
+  include/PhosphorProtocol/
+    WireTypes.h            -- 21 POD structs, enums, QDBusArgument operators, Q_DECLARE_METATYPE
+    ServiceConstants.h     -- service name, object path, interface names, API version
+    ClientHelpers.h        -- fireAndForget, asyncCall, loadSettingAsync
+    PhosphorProtocol.h     -- umbrella include
+  src/
+    wiretypes.cpp          -- streaming operators, validation, registerDBusTypes()
+    logging.cpp            -- Q_LOGGING_CATEGORY(lcPhosphorProtocol, "phosphor.protocol")
+  tests/
+    test_phosphorprotocol.cpp  -- round-trip marshal/unmarshal, validation
+  CMakeLists.txt
+  PhosphorProtocolConfig.cmake.in
+```
+
+---
+
+## Namespace Migration
+
+All types move from `PlasmaZones::` to `PhosphorProtocol::`.
+
+Clean break -- no compat aliases. All ~50 consumer files are in-tree
+and updated atomically. The `PlasmaZones` namespace continues to exist
+for daemon-internal types (services, controllers, settings) that are not
+part of the wire protocol.
+
+### What moves
+
+| Old (PlasmaZones::) | New (PhosphorProtocol::) |
+|---|---|
+| `WindowGeometryEntry` | `WindowGeometryEntry` |
+| `TileRequestEntry` | `TileRequestEntry` |
+| `SnapAllResultEntry` | `SnapAllResultEntry` |
+| `SnapConfirmationEntry` | `SnapConfirmationEntry` |
+| `WindowOpenedEntry` | `WindowOpenedEntry` |
+| `WindowStateEntry` | `WindowStateEntry` |
+| `UnfloatRestoreResult` | `UnfloatRestoreResult` |
+| `ZoneGeometryRect` | `ZoneGeometryRect` |
+| `EmptyZoneEntry` | `EmptyZoneEntry` |
+| `SnapAssistCandidate` | `SnapAssistCandidate` |
+| `NamedZoneGeometry` | `NamedZoneGeometry` |
+| `AlgorithmInfoEntry` | `AlgorithmInfoEntry` |
+| `BridgeRegistrationResult` | `BridgeRegistrationResult` |
+| `MoveTargetResult` | `MoveTargetResult` |
+| `FocusTargetResult` | `FocusTargetResult` |
+| `CycleTargetResult` | `CycleTargetResult` |
+| `SwapTargetResult` | `SwapTargetResult` |
+| `RestoreTargetResult` | `RestoreTargetResult` |
+| `PreTileGeometryEntry` | `PreTileGeometryEntry` |
+| `DragPolicy` | `DragPolicy` |
+| `DragOutcome` | `DragOutcome` |
+| `DragBypassReason` | `DragBypassReason` |
+| `HasDBusStreaming<T>` | `HasDBusStreaming<T>` |
+| `DBus::ServiceName` etc. | `Service::Name` etc. |
+| `DBus::Interface::*` | `Service::Interface::*` |
+| `DBus::ApiVersion` | `Service::ApiVersion` |
+| `DBusHelpers::*` | `ClientHelpers::*` |
+| All `*List` type aliases | Same names |
+| `registerDBusTypes()` | `registerWireTypes()` |
+
+### What stays in PlasmaZones::
+
+- All daemon services (OverlayService, WindowTrackingService, etc.)
+- All D-Bus adaptors (they USE the types but are daemon-specific)
+- All controllers, settings, config
+- SnapEngine, ZoneDetection, etc.
+
+---
+
+## Header Design
+
+### WireTypes.h
+
+Contains all 21 POD structs, the `DragBypassReason` enum, wire-string
+converters, `HasDBusStreaming<T>` trait, `QDBusArgument` operator
+declarations, `Q_DECLARE_METATYPE` macros, and the `registerWireTypes()`
+entry point.
+
+The `PHOSPHORPROTOCOL_EXPORT` macro is applied to:
+- Free functions (`toWireString`, `bypassReasonFromWireString`, `registerWireTypes`)
+- The struct types themselves (for MSVC dllexport, Linux ignores)
+- QDebug streaming operator
+
+Structs remain POD with inline convenience methods (`toRect()`,
+`fromRect()`, `validationError()`). Validation methods that have
+non-trivial logic are declared in the header and defined in
+`wiretypes.cpp`.
+
+### ServiceConstants.h
+
+Header-only. `inline constexpr` values in `PhosphorProtocol::Service::`.
+
+```cpp
+namespace PhosphorProtocol::Service {
+
+inline constexpr QLatin1String Name("org.plasmazones");
+inline constexpr QLatin1String ObjectPath("/PlasmaZones");
+
+namespace Interface {
+inline constexpr QLatin1String Settings("org.plasmazones.Settings");
+// ... all 9 interface names
+}
+
+inline constexpr int ApiVersion = 2;
+inline constexpr int MinPeerApiVersion = 2;
+inline constexpr int SyncCallTimeoutMs = 500;
+
+}
+```
+
+The D-Bus service name and interface strings do NOT change -- they are
+the on-wire identity. Only the C++ accessor path changes
+(`DBus::ServiceName` -> `Service::Name`).
+
+### ClientHelpers.h
+
+Header-only (inline/template functions). Moves from `DBusHelpers::`
+to `PhosphorProtocol::ClientHelpers::`. The logging category changes
+from `lcCompositorCommon` to `lcPhosphorProtocol`.
+
+Functions:
+- `fireAndForget()` -- fire-and-forget async D-Bus call with error logging
+- `asyncCall()` -- create async call, return pending result
+- `loadSettingAsync()` -- async setting fetch with QDBusVariant unwrap
+
+---
+
+## What Changes for Consumers
+
+### Include paths
+
+```
+#include <dbus_types.h>       ->  #include <PhosphorProtocol/WireTypes.h>
+#include <dbus_constants.h>   ->  #include <PhosphorProtocol/ServiceConstants.h>
+#include <dbus_helpers.h>     ->  #include <PhosphorProtocol/ClientHelpers.h>
+```
+
+### Namespace
+
+```cpp
+// Before:
+PlasmaZones::WindowGeometryEntry e;
+PlasmaZones::DBus::ServiceName;
+PlasmaZones::DBusHelpers::fireAndForget(...);
+
+// After:
+PhosphorProtocol::WindowGeometryEntry e;
+PhosphorProtocol::Service::Name;
+PhosphorProtocol::ClientHelpers::fireAndForget(...);
+```
+
+Consumers that use many types can add `using namespace PhosphorProtocol;`
+in their .cpp files. Header files should use fully-qualified names.
+
+### CMake linkage
+
+```cmake
+# Before:
+target_link_libraries(my_target PRIVATE plasmazones_compositor_common)
+
+# After:
+target_link_libraries(my_target PRIVATE PhosphorProtocol::PhosphorProtocol)
+```
+
+`plasmazones_compositor_common` remains as a static library for the
+non-protocol files (`snap_assist_filter`, `trigger_parser`,
+`compositor_bridge`, `autotile_state`, `floating_cache`,
+`geometry_helpers`). It drops its D-Bus sources and gains a link to
+`PhosphorProtocol::PhosphorProtocol`.
+
+---
+
+## What Stays in compositor-common/
+
+| File | Status |
+|---|---|
+| `compositor_bridge.h` | Stays (ICompositorBridge -- compositor SDK candidate) |
+| `autotile_state.h` | Stays (compositor-plugin POD) |
+| `floating_cache.h` | Stays (compositor-plugin cache) |
+| `geometry_helpers.h` | Stays (inline helper) |
+| `snap_assist_filter.{h,cpp}` | Stays (targeted at phosphor-tiles later) |
+| `trigger_parser.{h,cpp}` | Stays (targeted at phosphor-shortcuts later) |
+| `debounced_action.h` | Stays (unused, can drop separately) |
+| `dbus_types.{h,cpp}` | **Removed** (moved to PhosphorProtocol) |
+| `dbus_constants.h` | **Removed** (moved to PhosphorProtocol) |
+| `dbus_helpers.h` | **Removed** (moved to PhosphorProtocol) |
+| `logging.{h,cpp}` | **Removed** (only consumer was dbus_helpers) |
+
+---
+
+## D-Bus Metatype Registration
+
+`registerWireTypes()` (renamed from `registerDBusTypes()`) registers
+each type under both qualified and unqualified names via
+`qRegisterMetaType<T>()` + `qDBusRegisterMetaType<T>()`. The
+unqualified registration is a defensive measure documented in the
+original code.
+
+Both daemon (`main.cpp`) and compositor plugin (`PlasmaZonesEffect`
+constructor) call `registerWireTypes()` at startup.
+
+---
+
+## Testing
+
+Unit tests (`libs/phosphor-protocol/tests/`):
+
+- **Round-trip marshal/unmarshal** -- each struct type serialized to
+  QDBusArgument and deserialized back, fields compared
+- **Validation methods** -- TileRequestEntry, BridgeRegistrationResult,
+  DragPolicy, DragOutcome edge cases
+- **DragBypassReason wire strings** -- toWireString/fromWireString
+  round-trip, unknown-value fallback
+- **HasDBusStreaming trait** -- static_assert coverage
+
+---
+
+## Migration Sequence
+
+1. Create `libs/phosphor-protocol/` with all headers and sources
+2. Add to root `CMakeLists.txt`
+3. Update `compositor-common/CMakeLists.txt` -- remove D-Bus sources,
+   link PhosphorProtocol
+4. Update all consumer includes and namespaces (~50 files)
+5. Update `kwin-effect/CMakeLists.txt` link
+6. Update `src/CMakeLists.txt` link
+7. Build and test (Docker)
+8. Update `library-extraction-survey.md`

--- a/kwin-effect/CMakeLists.txt
+++ b/kwin-effect/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(kwin_effect_plasmazones PRIVATE
     Qt6::Gui
     Qt6::DBus
     plasmazones_compositor_common
+    PhosphorProtocol::PhosphorProtocol
     # Explicit link: `compositorclock.h` and `windowanimator.h` directly
     # include `<PhosphorAnimation/...>`. The dependency is reachable
     # transitively via `plasmazones_compositor_common`, but depending

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -6,9 +6,9 @@
 #include "windowanimator.h"
 #include "navigationhandler.h"
 
-#include <dbus_constants.h>
-#include <dbus_helpers.h>
-#include <dbus_types.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/ClientHelpers.h>
+#include <PhosphorProtocol/WireTypes.h>
 
 #include <effect/effecthandler.h>
 #include <effect/effectwindow.h>
@@ -259,11 +259,11 @@ bool AutotileHandler::saveAndRecordPreAutotileGeometry(const QString& windowId, 
         // the screenId parameter may already be correct from callers that use
         // getWindowScreenId(), but re-resolve to be safe.
         QString resolvedScreenId = m_effect->getWindowScreenId(m_effect->findWindowById(windowId));
-        DBusHelpers::fireAndForget(m_effect, DBus::Interface::WindowTracking, QStringLiteral("storePreTileGeometry"),
-                                   {windowId, static_cast<int>(frame.x()), static_cast<int>(frame.y()),
-                                    static_cast<int>(frame.width()), static_cast<int>(frame.height()),
-                                    resolvedScreenId.isEmpty() ? screenId : resolvedScreenId, true},
-                                   QStringLiteral("storePreTileGeometry"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(
+            m_effect, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("storePreTileGeometry"),
+            {windowId, static_cast<int>(frame.x()), static_cast<int>(frame.y()), static_cast<int>(frame.width()),
+             static_cast<int>(frame.height()), resolvedScreenId.isEmpty() ? screenId : resolvedScreenId, true},
+            QStringLiteral("storePreTileGeometry"));
     }
     return true;
 }
@@ -376,8 +376,9 @@ void AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
             }
         }
 
-        QDBusMessage msg = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath,
-                                                          DBus::Interface::Autotile, QStringLiteral("windowOpened"));
+        QDBusMessage msg = QDBusMessage::createMethodCall(
+            PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+            PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("windowOpened"));
         msg << windowId;
         msg << screenId;
         msg << minWidth;
@@ -403,7 +404,7 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
 {
     // Collect eligible windows using the same filtering as notifyWindowAdded,
     // then send one batch D-Bus call instead of per-window round-trips.
-    WindowOpenedList batchEntries;
+    PhosphorProtocol::WindowOpenedList batchEntries;
     QStringList batchWindowIds; // for error rollback
 
     for (KWin::EffectWindow* w : windows) {
@@ -450,7 +451,7 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
             }
         }
 
-        WindowOpenedEntry entry;
+        PhosphorProtocol::WindowOpenedEntry entry;
         entry.windowId = windowId;
         entry.screenId = screenId;
         entry.minWidth = minWidth;
@@ -463,8 +464,9 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
         return;
     }
 
-    QDBusMessage msg = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile,
-                                                      QStringLiteral("windowsOpenedBatch"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+        PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("windowsOpenedBatch"));
     msg << QVariant::fromValue(batchEntries);
 
     QDBusPendingCall pending = QDBusConnection::sessionBus().asyncCall(msg);
@@ -578,9 +580,9 @@ void AutotileHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
         const int fallbackW = savedPreAutotileGeo.isValid() ? std::max(0, qRound(savedPreAutotileGeo.width())) : 0;
         const int fallbackH = savedPreAutotileGeo.isValid() ? std::max(0, qRound(savedPreAutotileGeo.height())) : 0;
 
-        QDBusMessage msg =
-            QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
-                                           QStringLiteral("getValidatedPreTileGeometry"));
+        QDBusMessage msg = QDBusMessage::createMethodCall(
+            PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+            PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getValidatedPreTileGeometry"));
         msg << windowId;
         auto* watcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(msg), m_effect);
         connect(watcher, &QDBusPendingCallWatcher::finished, m_effect,
@@ -731,8 +733,9 @@ void AutotileHandler::onWindowClosed(const QString& windowId, const QString& scr
 
     // Notify autotile daemon
     if (m_autotileScreens.contains(screenId)) {
-        DBusHelpers::fireAndForget(m_effect, DBus::Interface::Autotile, QStringLiteral("windowClosed"), {windowId},
-                                   QStringLiteral("windowClosed"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Autotile,
+                                                       QStringLiteral("windowClosed"), {windowId},
+                                                       QStringLiteral("windowClosed"));
         qCDebug(lcEffect) << "Notified autotile: windowClosed" << windowId << "on screen" << screenId;
     }
 }
@@ -909,33 +912,41 @@ void AutotileHandler::connectSignals()
     // rules. Qt's QDBusConnection::connect can register the same handler
     // twice if called twice with identical args, which would cause each
     // signal to invoke the slot N times after N daemon restarts.
-    bus.disconnect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile,
-                   QStringLiteral("windowsTileRequested"), this,
-                   SLOT(slotWindowsTileRequested(PlasmaZones::TileRequestList)));
-    bus.disconnect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile,
-                   QStringLiteral("focusWindowRequested"), this, SLOT(slotFocusWindowRequested(QString)));
-    bus.disconnect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile, QStringLiteral("enabledChanged"),
-                   this, SLOT(slotEnabledChanged(bool)));
-    bus.disconnect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile,
-                   QStringLiteral("autotileScreensChanged"), this, SLOT(slotScreensChanged(QStringList, bool)));
-    bus.disconnect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile,
-                   QStringLiteral("windowFloatingChanged"), this,
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("windowsTileRequested"), this,
+                   SLOT(slotWindowsTileRequested(PhosphorProtocol::TileRequestList)));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("focusWindowRequested"), this,
+                   SLOT(slotFocusWindowRequested(QString)));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("enabledChanged"), this,
+                   SLOT(slotEnabledChanged(bool)));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("autotileScreensChanged"), this,
+                   SLOT(slotScreensChanged(QStringList, bool)));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("windowFloatingChanged"), this,
                    SLOT(slotWindowFloatingChanged(QString, bool, QString)));
 
-    bus.connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile, QStringLiteral("windowsTileRequested"),
-                this, SLOT(slotWindowsTileRequested(PlasmaZones::TileRequestList)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("windowsTileRequested"), this,
+                SLOT(slotWindowsTileRequested(PhosphorProtocol::TileRequestList)));
 
-    bus.connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile, QStringLiteral("focusWindowRequested"),
-                this, SLOT(slotFocusWindowRequested(QString)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("focusWindowRequested"), this,
+                SLOT(slotFocusWindowRequested(QString)));
 
-    bus.connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile, QStringLiteral("enabledChanged"), this,
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("enabledChanged"), this,
                 SLOT(slotEnabledChanged(bool)));
 
-    bus.connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile,
-                QStringLiteral("autotileScreensChanged"), this, SLOT(slotScreensChanged(QStringList, bool)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("autotileScreensChanged"), this,
+                SLOT(slotScreensChanged(QStringList, bool)));
 
-    bus.connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Autotile, QStringLiteral("windowFloatingChanged"),
-                this, SLOT(slotWindowFloatingChanged(QString, bool, QString)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("windowFloatingChanged"), this,
+                SLOT(slotWindowFloatingChanged(QString, bool, QString)));
 
     qCInfo(lcEffect) << "Connected to autotile D-Bus signals";
 }
@@ -943,9 +954,10 @@ void AutotileHandler::connectSignals()
 void AutotileHandler::loadSettings()
 {
     // Query initial autotile screen set from daemon asynchronously.
-    QDBusMessage msg = QDBusMessage::createMethodCall(
-        DBus::ServiceName, DBus::ObjectPath, QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("Get"));
-    msg << DBus::Interface::Autotile << QStringLiteral("autotileScreens");
+    QDBusMessage msg =
+        QDBusMessage::createMethodCall(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                       QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("Get"));
+    msg << PhosphorProtocol::Service::Interface::Autotile << QStringLiteral("autotileScreens");
 
     QDBusPendingCall call = QDBusConnection::sessionBus().asyncCall(msg);
     auto* watcher = new QDBusPendingCallWatcher(call, this);

--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <autotile_state.h>
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 
 #include <QHash>
 #include <QObject>
@@ -237,7 +237,7 @@ public:
 
 public Q_SLOTS:
     // Autotile D-Bus signal handlers
-    void slotWindowsTileRequested(const TileRequestList& tileRequests);
+    void slotWindowsTileRequested(const PhosphorProtocol::TileRequestList& tileRequests);
     void slotFocusWindowRequested(const QString& windowId);
     void slotEnabledChanged(bool enabled);
     void slotScreensChanged(const QStringList& screenIds, bool isDesktopSwitch);

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -7,8 +7,8 @@
 #include "../autotilehandler.h"
 #include "../plasmazoneseffect.h"
 #include "../navigationhandler.h"
-#include <dbus_constants.h>
-#include <dbus_helpers.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/ClientHelpers.h>
 #include <PhosphorIdentity/WindowId.h>
 
 #include <effect/effecthandler.h>
@@ -386,8 +386,9 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                     // frame at the tiled position. If a correct pre-tile entry already
                     // exists, preserve it. If no entry exists, the floating window's
                     // current geometry is the best available fallback.
-                    DBusHelpers::fireAndForget(
-                        m_effect, DBus::Interface::WindowTracking, QStringLiteral("storePreTileGeometry"),
+                    PhosphorProtocol::ClientHelpers::fireAndForget(
+                        m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                        QStringLiteral("storePreTileGeometry"),
                         {windowId, static_cast<int>(frame.x()), static_cast<int>(frame.y()),
                          static_cast<int>(frame.width()), static_cast<int>(frame.height()), screenId, false},
                         QStringLiteral("storePreTileGeometry"));
@@ -406,9 +407,9 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             // Non-blocking: the old synchronous QDBus::Block call (500ms timeout) froze the
             // compositor thread, causing jerky first-retile animations since QElapsedTimer
             // kept advancing while no frames were rendered.
-            QDBusMessage fetchMsg =
-                QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
-                                               QStringLiteral("getPreTileGeometries"));
+            QDBusMessage fetchMsg = QDBusMessage::createMethodCall(
+                PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getPreTileGeometries"));
             auto* watcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(fetchMsg), this);
             // Capture expected screen set for staleness detection — if the user
             // rapidly toggles autotile, a stale reply must not overwrite fresh data.
@@ -416,7 +417,7 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             connect(watcher, &QDBusPendingCallWatcher::finished, this,
                     [this, added, expectedScreens](QDBusPendingCallWatcher* w) {
                         w->deleteLater();
-                        QDBusPendingReply<PlasmaZones::PreTileGeometryList> reply = *w;
+                        QDBusPendingReply<PhosphorProtocol::PreTileGeometryList> reply = *w;
                         if (!reply.isValid()) {
                             return;
                         }
@@ -425,7 +426,7 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                             qCDebug(lcEffect) << "Stale async pre-autotile geometry reply, screen set changed";
                             return;
                         }
-                        const PlasmaZones::PreTileGeometryList entries = reply.value();
+                        const PhosphorProtocol::PreTileGeometryList entries = reply.value();
                         const auto allWindows = KWin::effects->stackingOrder();
                         for (const auto& entry : entries) {
                             const QString stableId = entry.appId;
@@ -607,9 +608,10 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
                              << screenId;
 
             if (m_effect->m_daemonServiceRegistered) {
-                DBusHelpers::fireAndForget(m_effect, DBus::Interface::WindowTracking,
-                                           QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, true},
-                                           QStringLiteral("setWindowFloatingForScreen"));
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                    QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, true},
+                    QStringLiteral("setWindowFloatingForScreen"));
             }
         });
         m_pendingMinimizeFloat.insert(windowId, timer);
@@ -640,9 +642,10 @@ void AutotileHandler::slotWindowMinimizedChanged(KWin::EffectWindow* w)
     qCInfo(lcEffect) << "Autotile: window unminimized, unfloating:" << windowId << "on" << screenId;
 
     if (m_effect->m_daemonServiceRegistered) {
-        DBusHelpers::fireAndForget(m_effect, DBus::Interface::WindowTracking,
-                                   QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, false},
-                                   QStringLiteral("setWindowFloatingForScreen"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("setWindowFloatingForScreen"),
+                                                       {windowId, screenId, false},
+                                                       QStringLiteral("setWindowFloatingForScreen"));
     }
 
     notifyWindowAdded(w);
@@ -666,9 +669,10 @@ void AutotileHandler::slotWindowMaximizedStateChanged(KWin::EffectWindow* w, boo
     qCInfo(lcEffect) << "Monocle window manually unmaximized:" << windowId << "- floating";
 
     if (m_effect->m_daemonServiceRegistered) {
-        DBusHelpers::fireAndForget(m_effect, DBus::Interface::WindowTracking,
-                                   QStringLiteral("setWindowFloatingForScreen"), {windowId, screenId, true},
-                                   QStringLiteral("setWindowFloatingForScreen"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("setWindowFloatingForScreen"),
+                                                       {windowId, screenId, true},
+                                                       QStringLiteral("setWindowFloatingForScreen"));
     }
 }
 

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -8,9 +8,9 @@
 #include "../dragtracker.h"
 #include "../plasmazoneseffect.h"
 #include "../windowanimator.h"
-#include <dbus_constants.h>
-#include <dbus_helpers.h>
-#include <dbus_types.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/ClientHelpers.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <PhosphorIdentity/WindowId.h>
 
 #include <effect/effecthandler.h>
@@ -24,7 +24,7 @@ namespace PlasmaZones {
 
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
 
-void AutotileHandler::slotWindowsTileRequested(const TileRequestList& tileRequests)
+void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequestList& tileRequests)
 {
     if (tileRequests.isEmpty()) {
         return;
@@ -34,7 +34,7 @@ void AutotileHandler::slotWindowsTileRequested(const TileRequestList& tileReques
     // dropped from the batch; the remaining requests still apply. This avoids
     // one corrupt payload (e.g. zero-size tiled request from a protocol glitch)
     // from either resizing a window to 0×0 or poisoning the whole retile pass.
-    TileRequestList validatedRequests;
+    PhosphorProtocol::TileRequestList validatedRequests;
     validatedRequests.reserve(tileRequests.size());
     for (const auto& req : tileRequests) {
         if (const QString err = req.validationError(); !err.isEmpty()) {
@@ -543,8 +543,9 @@ void AutotileHandler::reportDiscoveredMinSize(const QString& windowId, int minWi
     qCInfo(lcEffect) << "Discovered min size for" << windowId << ":" << minWidth << "x" << minHeight
                      << "- reporting to daemon for future retiles";
 
-    DBusHelpers::fireAndForget(m_effect, DBus::Interface::Autotile, QStringLiteral("windowMinSizeUpdated"),
-                               {windowId, minWidth, minHeight}, QStringLiteral("windowMinSizeUpdated"));
+    PhosphorProtocol::ClientHelpers::fireAndForget(
+        m_effect, PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("windowMinSizeUpdated"),
+        {windowId, minWidth, minHeight}, QStringLiteral("windowMinSizeUpdated"));
 }
 
 } // namespace PlasmaZones

--- a/kwin-effect/navigationhandler.cpp
+++ b/kwin-effect/navigationhandler.cpp
@@ -4,8 +4,8 @@
 #include "navigationhandler.h"
 #include "plasmazoneseffect.h"
 
-#include <dbus_constants.h>
-#include <dbus_helpers.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/ClientHelpers.h>
 
 #include <QDBusPendingCall>
 #include <QDBusPendingCallWatcher>
@@ -32,8 +32,8 @@ void NavigationHandler::syncFloatingWindowsFromDaemon()
         return;
     }
 
-    QDBusPendingCall pendingCall =
-        DBusHelpers::asyncCall(DBus::Interface::WindowTracking, QStringLiteral("getFloatingWindows"));
+    QDBusPendingCall pendingCall = PhosphorProtocol::ClientHelpers::asyncCall(
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getFloatingWindows"));
     auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
 
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
@@ -66,8 +66,8 @@ void NavigationHandler::syncFloatingStateForWindow(const QString& windowId)
         return;
     }
 
-    QDBusPendingCall pendingCall =
-        DBusHelpers::asyncCall(DBus::Interface::WindowTracking, QStringLiteral("queryWindowFloating"), {windowId});
+    QDBusPendingCall pendingCall = PhosphorProtocol::ClientHelpers::asyncCall(
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("queryWindowFloating"), {windowId});
     auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
 
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, windowId](QDBusPendingCallWatcher* w) {

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -7,8 +7,8 @@
 #include <PhosphorAnimation/Easing.h>
 #include <PhosphorAnimation/StaggerTimer.h>
 
-#include <dbus_helpers.h>
-#include <dbus_types.h>
+#include <PhosphorProtocol/ClientHelpers.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <PhosphorIdentity/ScreenId.h>
 #include <PhosphorIdentity/WindowId.h>
 
@@ -49,7 +49,7 @@
 #include "navigationhandler.h"
 #include "windowanimator.h"
 #include "dragtracker.h"
-#include "dbus_constants.h"
+#include <PhosphorProtocol/ServiceConstants.h>
 // QGuiApplication::queryKeyboardModifiers() doesn't work in KWin effects on Wayland
 // because the effect runs inside the compositor process. We use mouseChanged instead.
 
@@ -109,10 +109,11 @@ void PlasmaZonesEffect::ensurePreSnapGeometryStored(KWin::EffectWindow* w, const
     // pre-check: that path matched on appId too, so a stale cross-session entry from
     // a prior window instance (keyed by appId) would block the fresh per-instance
     // capture and freeze float-restore at ancient coordinates.
-    DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("storePreTileGeometry"),
-                               {windowId, static_cast<int>(geom.x()), static_cast<int>(geom.y()),
-                                static_cast<int>(geom.width()), static_cast<int>(geom.height()), screenId, false},
-                               QStringLiteral("storePreTileGeometry"));
+    PhosphorProtocol::ClientHelpers::fireAndForget(
+        this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("storePreTileGeometry"),
+        {windowId, static_cast<int>(geom.x()), static_cast<int>(geom.y()), static_cast<int>(geom.width()),
+         static_cast<int>(geom.height()), screenId, false},
+        QStringLiteral("storePreTileGeometry"));
     qCInfo(lcEffect) << "Stored pre-tile geometry for window" << windowId << "geom=" << geom;
 }
 
@@ -165,7 +166,7 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     , m_dragTracker(std::make_unique<DragTracker>(this))
     , m_compositorBridge(std::make_unique<KWinCompositorBridge>(this))
 {
-    PlasmaZones::registerDBusTypes();
+    PhosphorProtocol::registerWireTypes();
 
     // Populate per-output clocks from the currently-known output set.
     // Subsequent hotplug events land in onScreenAdded / onScreenRemoved.
@@ -231,7 +232,7 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                 // of truth for drag-start routing — root cause of the
                 // post-settings-reload dead-drag window found in #310 log
                 // forensics.
-                m_currentDragPolicy = DragPolicy{};
+                m_currentDragPolicy = PhosphorProtocol::DragPolicy{};
                 m_currentDragPolicy.streamDragMoved = true;
                 m_currentDragPolicy.showOverlay = true;
                 m_currentDragPolicy.grabKeyboard = true;
@@ -240,7 +241,8 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                 const QString startScreenId = getWindowScreenId(w);
                 const QRect frame = geometry.toRect();
                 QDBusMessage beginMsg = QDBusMessage::createMethodCall(
-                    DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag, QStringLiteral("beginDrag"));
+                    PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                    PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("beginDrag"));
                 beginMsg << windowId << frame.x() << frame.y() << frame.width() << frame.height() << startScreenId
                          << static_cast<int>(m_currentMouseButtons);
                 QDBusPendingCall beginPending = QDBusConnection::sessionBus().asyncCall(beginMsg);
@@ -248,52 +250,51 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                 QPointer<KWin::EffectWindow> safeW = w;
                 const QString capturedWindowId = windowId;
                 const QString capturedScreenId = startScreenId;
-                connect(beginWatcher, &QDBusPendingCallWatcher::finished, this,
-                        [this, safeW, capturedWindowId, capturedScreenId](QDBusPendingCallWatcher* bw) {
-                            bw->deleteLater();
-                            QDBusPendingReply<DragPolicy> reply = *bw;
-                            if (!reply.isValid()) {
-                                qCWarning(lcEffect) << "beginDrag reply invalid:" << reply.error().message();
-                                return;
+                connect(
+                    beginWatcher, &QDBusPendingCallWatcher::finished, this,
+                    [this, safeW, capturedWindowId, capturedScreenId](QDBusPendingCallWatcher* bw) {
+                        bw->deleteLater();
+                        QDBusPendingReply<PhosphorProtocol::DragPolicy> reply = *bw;
+                        if (!reply.isValid()) {
+                            qCWarning(lcEffect) << "beginDrag reply invalid:" << reply.error().message();
+                            return;
+                        }
+                        const PhosphorProtocol::DragPolicy policy = reply.value();
+                        if (const QString err = policy.validationError(); !err.isEmpty()) {
+                            qCWarning(lcEffect) << "beginDrag reply rejected:" << err
+                                                << "— keeping conservative snap-path policy for" << capturedWindowId;
+                            return;
+                        }
+                        m_currentDragPolicy = policy;
+                        qCInfo(lcEffect) << "beginDrag reply:" << capturedWindowId
+                                         << "bypass=" << m_currentDragPolicy.bypassReason
+                                         << "stream=" << m_currentDragPolicy.streamDragMoved
+                                         << "immediateFloat=" << m_currentDragPolicy.immediateFloatOnStart;
+                        // If the daemon confirms autotile, flip the effect
+                        // state to bypass mode. Usually the effect-side
+                        // fast path below already did this synchronously;
+                        // this catches the stale-cache case where the fast
+                        // path missed.
+                        if (m_currentDragPolicy.bypassReason == PhosphorProtocol::DragBypassReason::AutotileScreen) {
+                            if (!m_dragBypassedForAutotile) {
+                                m_dragBypassedForAutotile = true;
+                                m_dragBypassScreenId = capturedScreenId;
+                                qCInfo(lcEffect) << "beginDrag: retroactive autotile bypass for" << capturedWindowId;
                             }
-                            const DragPolicy policy = reply.value();
-                            if (const QString err = policy.validationError(); !err.isEmpty()) {
-                                qCWarning(lcEffect)
-                                    << "beginDrag reply rejected:" << err
-                                    << "— keeping conservative snap-path policy for" << capturedWindowId;
-                                return;
+                            // Apply immediate float transition if the policy
+                            // says so and the window wasn't already floated
+                            // by the fast path. Using QPointer so we skip
+                            // if the window was destroyed between drag-start
+                            // and reply.
+                            if (safeW && m_currentDragPolicy.immediateFloatOnStart
+                                && !isWindowFloating(capturedWindowId)
+                                && !m_dragFloatedWindowIds.contains(capturedWindowId)) {
+                                m_autotileHandler->handleDragToFloat(safeW, capturedWindowId, capturedScreenId,
+                                                                     /*immediate=*/true);
+                                m_dragFloatedWindowIds.insert(capturedWindowId);
                             }
-                            m_currentDragPolicy = policy;
-                            qCInfo(lcEffect) << "beginDrag reply:" << capturedWindowId
-                                             << "bypass=" << m_currentDragPolicy.bypassReason
-                                             << "stream=" << m_currentDragPolicy.streamDragMoved
-                                             << "immediateFloat=" << m_currentDragPolicy.immediateFloatOnStart;
-                            // If the daemon confirms autotile, flip the effect
-                            // state to bypass mode. Usually the effect-side
-                            // fast path below already did this synchronously;
-                            // this catches the stale-cache case where the fast
-                            // path missed.
-                            if (m_currentDragPolicy.bypassReason == DragBypassReason::AutotileScreen) {
-                                if (!m_dragBypassedForAutotile) {
-                                    m_dragBypassedForAutotile = true;
-                                    m_dragBypassScreenId = capturedScreenId;
-                                    qCInfo(lcEffect)
-                                        << "beginDrag: retroactive autotile bypass for" << capturedWindowId;
-                                }
-                                // Apply immediate float transition if the policy
-                                // says so and the window wasn't already floated
-                                // by the fast path. Using QPointer so we skip
-                                // if the window was destroyed between drag-start
-                                // and reply.
-                                if (safeW && m_currentDragPolicy.immediateFloatOnStart
-                                    && !isWindowFloating(capturedWindowId)
-                                    && !m_dragFloatedWindowIds.contains(capturedWindowId)) {
-                                    m_autotileHandler->handleDragToFloat(safeW, capturedWindowId, capturedScreenId,
-                                                                         /*immediate=*/true);
-                                    m_dragFloatedWindowIds.insert(capturedWindowId);
-                                }
-                            }
-                        });
+                        }
+                    });
 
                 // Fast path: the effect-side autotile cache is USUALLY correct.
                 // We still consult it synchronously so the common case runs at
@@ -365,8 +366,8 @@ PlasmaZonesEffect::PlasmaZonesEffect()
             // In autotile bypass — skip snap zone processing locally;
             // the daemon's updateDragCursor still watches for a flip
             // BACK to snap mode.
-            const bool bypassed =
-                m_currentDragPolicy.bypassReason == DragBypassReason::AutotileScreen || m_dragBypassedForAutotile;
+            const bool bypassed = m_currentDragPolicy.bypassReason == PhosphorProtocol::DragBypassReason::AutotileScreen
+                || m_dragBypassedForAutotile;
             if (!bypassed) {
                 // Gate D-Bus calls on activation trigger state so a drag
                 // without any intent to use zones doesn't flood the bus
@@ -381,10 +382,11 @@ PlasmaZonesEffect::PlasmaZonesEffect()
             // drives overlay/zone detection. For bypass drags, the
             // daemon watches the cursor for a cross-VS flip and emits
             // dragPolicyChanged when the policy changes.
-            DBusHelpers::fireAndForget(this, DBus::Interface::WindowDrag, QStringLiteral("updateDragCursor"),
-                                       {windowId, qRound(cursorPos.x()), qRound(cursorPos.y()),
-                                        static_cast<int>(m_currentModifiers), static_cast<int>(m_currentMouseButtons)},
-                                       QStringLiteral("updateDragCursor"));
+            PhosphorProtocol::ClientHelpers::fireAndForget(
+                this, PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("updateDragCursor"),
+                {windowId, qRound(cursorPos.x()), qRound(cursorPos.y()), static_cast<int>(m_currentModifiers),
+                 static_cast<int>(m_currentMouseButtons)},
+                QStringLiteral("updateDragCursor"));
         });
     connect(m_dragTracker.get(), &DragTracker::dragStopped, this,
             [this](KWin::EffectWindow* w, const QString& windowId, bool cancelled) {
@@ -410,17 +412,17 @@ PlasmaZonesEffect::PlasmaZonesEffect()
 
                 // Single entry point for drag-end dispatch. The
                 // daemon owns the decision; callEndDrag sends endDrag and
-                // the reply handler applies whatever DragOutcome comes back
+                // the reply handler applies whatever PhosphorProtocol::DragOutcome comes back
                 // (ApplySnap / ApplyFloat / RestoreSize / NoOp / etc.).
                 //
                 // The autotile branch special-casing that used to live here
                 // is gone — cross-VS transitions were applied mid-drag by
                 // slotDragPolicyChanged, and final drop-time actions are
-                // encoded in the DragOutcome.
+                // encoded in the PhosphorProtocol::DragOutcome.
                 callEndDrag(w, windowId, cancelled);
 
                 // Clear drag state for the next session.
-                m_currentDragPolicy = DragPolicy{};
+                m_currentDragPolicy = PhosphorProtocol::DragPolicy{};
                 m_dragBypassedForAutotile = false;
                 m_dragBypassScreenId.clear();
                 m_snapDragStartScreenId.clear();
@@ -458,9 +460,9 @@ PlasmaZonesEffect::PlasmaZonesEffect()
             if (workspace && m_daemonServiceRegistered) {
                 const auto outputs = workspace->outputOrder();
                 if (!outputs.isEmpty()) {
-                    DBusHelpers::fireAndForget(this, DBus::Interface::Screen,
-                                               QStringLiteral("setPrimaryScreenFromKWin"), {outputs.first()->name()},
-                                               QStringLiteral("setPrimaryScreenFromKWin"));
+                    PhosphorProtocol::ClientHelpers::fireAndForget(
+                        this, PhosphorProtocol::Service::Interface::Screen, QStringLiteral("setPrimaryScreenFromKWin"),
+                        {outputs.first()->name()}, QStringLiteral("setPrimaryScreenFromKWin"));
                 }
             }
         });
@@ -483,13 +485,15 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     });
 
     // Connect to daemon's settingsChanged D-Bus signal
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Settings,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::Settings,
                                           QStringLiteral("settingsChanged"), this, SLOT(slotSettingsChanged()));
     qCInfo(lcEffect) << "Connected to daemon settingsChanged D-Bus signal";
 
     // Connect to virtual screen changes — daemon emits this when a physical screen's
     // virtual subdivisions are added, removed, or modified.
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Screen,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::Screen,
                                           QStringLiteral("virtualScreensChanged"), this,
                                           SLOT(onVirtualScreensChanged(QString)));
 
@@ -513,9 +517,9 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     // initializing), the call times out harmlessly and we wait for the
     // daemonReady D-Bus signal instead.
     {
-        QDBusMessage introspect = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath,
-                                                                 QStringLiteral("org.freedesktop.DBus.Introspectable"),
-                                                                 QStringLiteral("Introspect"));
+        QDBusMessage introspect = QDBusMessage::createMethodCall(
+            PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+            QStringLiteral("org.freedesktop.DBus.Introspectable"), QStringLiteral("Introspect"));
         auto* watcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(introspect, 3000), this);
         connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
             w->deleteLater();
@@ -531,7 +535,8 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     // Connect to daemon's daemonReady signal — emitted at the end of Daemon::start()
     // after all initialization is complete and the daemon can process D-Bus messages.
     // This is the safe point to set m_daemonServiceRegistered and create QDBusInterfaces.
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::LayoutRegistry,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::LayoutRegistry,
                                           QStringLiteral("daemonReady"), this, SLOT(slotDaemonReady()));
 
     // Watch for daemon D-Bus service registration and unregistration.
@@ -543,7 +548,7 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     // On Wayland, this watcher uses D-Bus monitoring (not X11 selection),
     // which works reliably across both sessions.
     auto* serviceWatcher = new QDBusServiceWatcher(
-        DBus::ServiceName, QDBusConnection::sessionBus(),
+        PhosphorProtocol::Service::Name, QDBusConnection::sessionBus(),
         QDBusServiceWatcher::WatchForRegistration | QDBusServiceWatcher::WatchForUnregistration, this);
     connect(serviceWatcher, &QDBusServiceWatcher::serviceUnregistered, this, [this]() {
         qCInfo(lcEffect) << "Daemon service unregistered";
@@ -570,9 +575,11 @@ PlasmaZonesEffect::PlasmaZonesEffect()
         // name in match rules, so refresh for the new daemon instance.
         // Disconnect first to prevent duplicate match rules (Qt doesn't deduplicate),
         // which would cause slotDaemonReady to fire twice on the same signal.
-        QDBusConnection::sessionBus().disconnect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::LayoutRegistry,
+        QDBusConnection::sessionBus().disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                                 PhosphorProtocol::Service::Interface::LayoutRegistry,
                                                  QStringLiteral("daemonReady"), this, SLOT(slotDaemonReady()));
-        QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::LayoutRegistry,
+        QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                              PhosphorProtocol::Service::Interface::LayoutRegistry,
                                               QStringLiteral("daemonReady"), this, SLOT(slotDaemonReady()));
     });
 
@@ -895,8 +902,9 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
                 && !m_autotileHandler->isAutotileScreen(newScreenId) && !m_dragTracker->isDragging()
                 && oldScreenStillConnected && !m_screenChangeHandler->isScreenChangeInProgress()) {
                 const QString windowId = getWindowId(safeW);
-                DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("windowScreenChanged"),
-                                           {windowId, newScreenId}, QStringLiteral("cross-screen move"));
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("windowScreenChanged"),
+                    {windowId, newScreenId}, QStringLiteral("cross-screen move"));
             }
         });
         // Virtual screen boundary detection: KWin's outputChanged only fires when
@@ -944,8 +952,9 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
             // For snapping→snapping cross-VS moves: notify the daemon
             if (!m_autotileHandler->isAutotileScreen(oldScreenId) && !m_autotileHandler->isAutotileScreen(newScreenId)
                 && !m_screenChangeHandler->isScreenChangeInProgress()) {
-                DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("windowScreenChanged"),
-                                           {windowId, newScreenId}, QStringLiteral("virtual screen crossing"));
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("windowScreenChanged"),
+                    {windowId, newScreenId}, QStringLiteral("virtual screen crossing"));
             }
         });
 
@@ -1084,16 +1093,16 @@ void PlasmaZonesEffect::slotMouseChanged(const QPointF& pos, const QPointF& oldp
             // of modifier-change events during a drag no longer causes the
             // overlay destroy/create churn that prompted discussion #310's
             // sibling regression.
-            const bool bypassed =
-                m_currentDragPolicy.bypassReason == DragBypassReason::AutotileScreen || m_dragBypassedForAutotile;
+            const bool bypassed = m_currentDragPolicy.bypassReason == PhosphorProtocol::DragBypassReason::AutotileScreen
+                || m_dragBypassedForAutotile;
             const bool shouldForward =
                 bypassed || detectActivationAndGrab() || m_cachedZoneSelectorEnabled || !m_triggersLoaded;
             if (shouldForward) {
-                DBusHelpers::fireAndForget(this, DBus::Interface::WindowDrag, QStringLiteral("updateDragCursor"),
-                                           {m_dragTracker->draggedWindowId(), qRound(pos.x()), qRound(pos.y()),
-                                            static_cast<int>(m_currentModifiers),
-                                            static_cast<int>(m_currentMouseButtons)},
-                                           QStringLiteral("updateDragCursor - modifier/button change"));
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    this, PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("updateDragCursor"),
+                    {m_dragTracker->draggedWindowId(), qRound(pos.x()), qRound(pos.y()),
+                     static_cast<int>(m_currentModifiers), static_cast<int>(m_currentMouseButtons)},
+                    QStringLiteral("updateDragCursor - modifier/button change"));
             }
         } else {
             // Position-only change: drive cursor tracking through DragTracker's
@@ -1121,8 +1130,9 @@ void PlasmaZonesEffect::slotMouseChanged(const QPointF& pos, const QPointF& oldp
             m_lastEffectiveScreenId = effectiveScreenId;
             m_lastCursorOutput = connectorName;
             if (m_daemonServiceRegistered) {
-                DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("cursorScreenChanged"),
-                                           {effectiveScreenId});
+                PhosphorProtocol::ClientHelpers::fireAndForget(
+                    this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("cursorScreenChanged"),
+                    {effectiveScreenId});
             }
         }
     }
@@ -1166,19 +1176,20 @@ void PlasmaZonesEffect::slotDaemonReady()
     // call would either fail noisily or risk silent marshalling mismatches —
     // the very failure mode this PR is designed to prevent.
     QDBusMessage msg = QDBusMessage::createMethodCall(
-        DBus::ServiceName, DBus::ObjectPath, DBus::Interface::CompositorBridge, QStringLiteral("registerBridge"));
-    msg << QStringLiteral("kwin") << QString::number(DBus::ApiVersion)
+        PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+        PhosphorProtocol::Service::Interface::CompositorBridge, QStringLiteral("registerBridge"));
+    msg << QStringLiteral("kwin") << QString::number(PhosphorProtocol::Service::ApiVersion)
         << QStringList{QStringLiteral("borderless"), QStringLiteral("animation")};
     auto* watcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(msg), this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
         w->deleteLater();
-        QDBusPendingReply<PlasmaZones::BridgeRegistrationResult> reply = *w;
+        QDBusPendingReply<PhosphorProtocol::BridgeRegistrationResult> reply = *w;
         if (reply.isError()) {
             qCWarning(lcEffect) << "registerBridge call failed:" << reply.error().message()
                                 << "— effect remains idle until the daemon signals ready again.";
             return;
         }
-        BridgeRegistrationResult result = reply.value();
+        PhosphorProtocol::BridgeRegistrationResult result = reply.value();
         if (const QString err = result.validationError(); !err.isEmpty()) {
             qCWarning(lcEffect) << "registerBridge reply rejected:" << err
                                 << "— effect remains idle until the daemon signals ready again.";
@@ -1186,14 +1197,15 @@ void PlasmaZonesEffect::slotDaemonReady()
         }
         if (result.sessionId == QLatin1String("REJECTED")) {
             qCCritical(lcEffect) << "Daemon REJECTED this effect: daemon apiVersion=" << result.apiVersion
-                                 << "but this effect speaks" << DBus::ApiVersion
+                                 << "but this effect speaks" << PhosphorProtocol::Service::ApiVersion
                                  << "— update the effect to match the daemon.";
             return;
         }
         int daemonVersion = result.apiVersion.toInt();
-        if (daemonVersion < DBus::MinPeerApiVersion) {
+        if (daemonVersion < PhosphorProtocol::Service::MinPeerApiVersion) {
             qCCritical(lcEffect) << "Daemon apiVersion" << daemonVersion << "is below this effect's minimum"
-                                 << DBus::MinPeerApiVersion << "— update the daemon to match the effect.";
+                                 << PhosphorProtocol::Service::MinPeerApiVersion
+                                 << "— update the daemon to match the effect.";
             return;
         }
         qCInfo(lcEffect) << "Bridge registered: daemon apiVersion=" << result.apiVersion
@@ -1214,8 +1226,9 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
     if (ws) {
         const auto outputs = ws->outputOrder();
         if (!outputs.isEmpty()) {
-            DBusHelpers::fireAndForget(this, DBus::Interface::Screen, QStringLiteral("setPrimaryScreenFromKWin"),
-                                       {outputs.first()->name()}, QStringLiteral("setPrimaryScreenFromKWin"));
+            PhosphorProtocol::ClientHelpers::fireAndForget(
+                this, PhosphorProtocol::Service::Interface::Screen, QStringLiteral("setPrimaryScreenFromKWin"),
+                {outputs.first()->name()}, QStringLiteral("setPrimaryScreenFromKWin"));
         }
     }
 
@@ -1225,8 +1238,9 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
     // m_lastEffectiveScreenId was set during the last processCursorPosition() call
     // via resolveEffectiveScreenId(), so it already has the correct virtual ID.
     if (!m_lastEffectiveScreenId.isEmpty()) {
-        DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("cursorScreenChanged"),
-                                   {m_lastEffectiveScreenId}, QStringLiteral("cursorScreenChanged"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("cursorScreenChanged"), {m_lastEffectiveScreenId},
+                                                       QStringLiteral("cursorScreenChanged"));
         qCDebug(lcEffect) << "Re-sent cursor screen:" << m_lastEffectiveScreenId;
     } else if (!m_lastCursorOutput.isEmpty()) {
         // Fallback: no effective ID cached yet (cursor hasn't moved since startup).
@@ -1241,8 +1255,9 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
         if (cursorScreenId.isEmpty()) {
             cursorScreenId = m_lastCursorOutput;
         }
-        DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("cursorScreenChanged"),
-                                   {cursorScreenId}, QStringLiteral("cursorScreenChanged"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("cursorScreenChanged"), {cursorScreenId},
+                                                       QStringLiteral("cursorScreenChanged"));
         qCDebug(lcEffect) << "Re-sent cursor screen (physical fallback):" << cursorScreenId;
     }
 
@@ -1270,7 +1285,8 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
     // for windows that are no longer floating.
     {
         QDBusMessage msg = QDBusMessage::createMethodCall(
-            DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking, QStringLiteral("getFloatingWindows"));
+            PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+            PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getFloatingWindows"));
         auto* watcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(msg), this);
         connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
             w->deleteLater();
@@ -1332,8 +1348,9 @@ void PlasmaZonesEffect::processDaemonReadyWindowState()
                 aliveWindowIds.append(getWindowId(w));
             }
         }
-        DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("pruneStaleWindows"),
-                                   {QVariant::fromValue(aliveWindowIds)}, QStringLiteral("pruneStaleWindows"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(
+            this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("pruneStaleWindows"),
+            {QVariant::fromValue(aliveWindowIds)}, QStringLiteral("pruneStaleWindows"));
     }
 
     // Fetch pre-computed pending restore geometries so slotWindowAdded can
@@ -1341,9 +1358,9 @@ void PlasmaZonesEffect::processDaemonReadyWindowState()
     // Fire-and-forget: the cache is populated asynchronously. Windows that open
     // before the reply arrives fall back to the normal async restore path.
     {
-        QDBusMessage geoMsg =
-            QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
-                                           QStringLiteral("getPendingRestoreGeometries"));
+        QDBusMessage geoMsg = QDBusMessage::createMethodCall(
+            PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+            PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getPendingRestoreGeometries"));
         auto* geoWatcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(geoMsg), this);
         connect(geoWatcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
             w->deleteLater();
@@ -1379,7 +1396,8 @@ void PlasmaZonesEffect::processDaemonReadyWindowState()
     // QDBusMessage (no QDBusInterface) to avoid synchronous introspection.
     {
         QDBusMessage msg = QDBusMessage::createMethodCall(
-            DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
+            PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+            PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
         auto* watcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(msg), this);
         connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
             w->deleteLater();
@@ -1598,8 +1616,9 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w)
     const QString title = w->caption();
 
     // Fire-and-forget — the daemon side is idempotent.
-    DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("setWindowMetadata"),
-                               {instanceId, appId, desktopFile, title}, QStringLiteral("setWindowMetadata"));
+    PhosphorProtocol::ClientHelpers::fireAndForget(
+        this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("setWindowMetadata"),
+        {instanceId, appId, desktopFile, title}, QStringLiteral("setWindowMetadata"));
 }
 
 void PlasmaZonesEffect::flushPendingFrameGeometry()
@@ -1612,9 +1631,9 @@ void PlasmaZonesEffect::flushPendingFrameGeometry()
     const auto batch = std::exchange(m_pendingFrameGeometry, {});
     for (auto it = batch.constBegin(); it != batch.constEnd(); ++it) {
         const QRect& geo = it.value();
-        DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("setFrameGeometry"),
-                                   {it.key(), geo.x(), geo.y(), geo.width(), geo.height()},
-                                   QStringLiteral("setFrameGeometry"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(
+            this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("setFrameGeometry"),
+            {it.key(), geo.x(), geo.y(), geo.width(), geo.height()}, QStringLiteral("setFrameGeometry"));
     }
 }
 
@@ -1759,7 +1778,7 @@ void PlasmaZonesEffect::syncFloatingWindowsFromDaemon()
 template<typename Fn>
 void PlasmaZonesEffect::loadSettingAsync(const QString& name, Fn&& onValue)
 {
-    DBusHelpers::loadSettingAsync(this, name, std::forward<Fn>(onValue));
+    PhosphorProtocol::ClientHelpers::loadSettingAsync(this, name, std::forward<Fn>(onValue));
 }
 
 void PlasmaZonesEffect::loadCachedSettings()
@@ -1854,8 +1873,9 @@ void PlasmaZonesEffect::loadCachedSettings()
             m_autotileHandler->setBorderWidth(bw);
             // Invalidate pending stagger timers that would use the old border width
             m_autotileHandler->invalidateStaggerGeneration();
-            DBusHelpers::fireAndForget(this, DBus::Interface::Autotile, QStringLiteral("retileAllScreens"), {},
-                                       QStringLiteral("border width change retile"));
+            PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::Autotile,
+                                                           QStringLiteral("retileAllScreens"), {},
+                                                           QStringLiteral("border width change retile"));
             updateAllBorders();
         }
     });
@@ -1884,20 +1904,21 @@ void PlasmaZonesEffect::loadCachedSettings()
 
     // dragActivationTriggers — uses shared TriggerParser for QDBusArgument deserialization
     {
-        DBusHelpers::loadSettingAsync(this, QStringLiteral("dragActivationTriggers"), [this](const QVariant& v) {
-            m_parsedTriggers = TriggerParser::parseTriggers(v, TriggerModifierField, TriggerMouseButtonField);
+        PhosphorProtocol::ClientHelpers::loadSettingAsync(
+            this, QStringLiteral("dragActivationTriggers"), [this](const QVariant& v) {
+                m_parsedTriggers = TriggerParser::parseTriggers(v, TriggerModifierField, TriggerMouseButtonField);
 
-            qCDebug(lcEffect) << "Loaded dragActivationTriggers:" << m_parsedTriggers.size() << "triggers";
-            bool anyValid =
-                std::any_of(m_parsedTriggers.cbegin(), m_parsedTriggers.cend(), [](const ParsedTrigger& pt) {
-                    return pt.modifier != 0 || pt.mouseButton != 0;
-                });
-            if (!m_parsedTriggers.isEmpty() && !anyValid) {
-                qCWarning(lcEffect) << "All triggers have modifier=0 mouseButton=0"
-                                    << "- possible deserialization issue";
-            }
-            m_triggersLoaded = true;
-        });
+                qCDebug(lcEffect) << "Loaded dragActivationTriggers:" << m_parsedTriggers.size() << "triggers";
+                bool anyValid =
+                    std::any_of(m_parsedTriggers.cbegin(), m_parsedTriggers.cend(), [](const ParsedTrigger& pt) {
+                        return pt.modifier != 0 || pt.mouseButton != 0;
+                    });
+                if (!m_parsedTriggers.isEmpty() && !anyValid) {
+                    qCWarning(lcEffect) << "All triggers have modifier=0 mouseButton=0"
+                                        << "- possible deserialization issue";
+                }
+                m_triggersLoaded = true;
+            });
     }
 
     qCDebug(lcEffect) << "Loading cached settings asynchronously, using defaults until loaded";
@@ -1937,11 +1958,13 @@ void PlasmaZonesEffect::connectNavigationSignals()
 {
     // Daemon-driven navigation: daemon computes geometry and emits applyGeometryRequested directly
     QDBusConnection::sessionBus().connect(
-        DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking, QStringLiteral("applyGeometryRequested"),
-        this, SLOT(slotApplyGeometryRequested(QString, int, int, int, int, QString, QString, bool)));
+        PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("applyGeometryRequested"), this,
+        SLOT(slotApplyGeometryRequested(QString, int, int, int, int, QString, QString, bool)));
 
     // Daemon-driven focus/cycle: daemon resolves target window and emits activateWindowRequested
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowTracking,
                                           QStringLiteral("activateWindowRequested"), this,
                                           SLOT(slotActivateWindowRequested(QString)));
 
@@ -1951,47 +1974,55 @@ void PlasmaZonesEffect::connectNavigationSignals()
     // participates in the decision.
 
     // Daemon-driven batch operations (rotate, resnap emit applyGeometriesBatch)
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
-                                          QStringLiteral("applyGeometriesBatch"), this,
-                                          SLOT(slotApplyGeometriesBatch(PlasmaZones::WindowGeometryList, QString)));
+    QDBusConnection::sessionBus().connect(
+        PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("applyGeometriesBatch"), this,
+        SLOT(slotApplyGeometriesBatch(PhosphorProtocol::WindowGeometryList, QString)));
 
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowTracking,
                                           QStringLiteral("raiseWindowsRequested"), this,
                                           SLOT(slotRaiseWindowsRequested(QStringList)));
 
     // Snap-all: daemon triggers effect to collect candidates
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowTracking,
                                           QStringLiteral("snapAllWindowsRequested"), this,
                                           SLOT(slotSnapAllWindowsRequested(QString)));
 
     // Move specific window (Snap Assist selection)
     QDBusConnection::sessionBus().connect(
-        DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
-        QStringLiteral("moveSpecificWindowToZoneRequested"), this,
+        PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("moveSpecificWindowToZoneRequested"), this,
         SLOT(slotMoveSpecificWindowToZoneRequested(QString, QString, int, int, int, int)));
 
     // Pending restores on daemon startup
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowTracking,
                                           QStringLiteral("pendingRestoresAvailable"), this,
                                           SLOT(slotPendingRestoresAvailable()));
 
     // Screen geometry reapply
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowTracking,
                                           QStringLiteral("reapplyWindowGeometriesRequested"),
                                           m_screenChangeHandler.get(), SLOT(slotReapplyWindowGeometriesRequested()));
 
     // Floating state sync
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowTracking,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowTracking,
                                           QStringLiteral("windowFloatingChanged"), this,
                                           SLOT(slotWindowFloatingChanged(QString, bool, QString)));
 
     // Settings: window picker for KCM exclusion list
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Settings,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::Settings,
                                           QStringLiteral("runningWindowsRequested"), this,
                                           SLOT(slotRunningWindowsRequested()));
 
     // WindowDrag: during-drag size restore
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowDrag,
                                           QStringLiteral("restoreSizeDuringDragChanged"), this,
                                           SLOT(slotRestoreSizeDuringDrag(QString, int, int)));
 
@@ -1999,16 +2030,18 @@ void PlasmaZonesEffect::connectNavigationSignals()
     // a virtual-screen boundary that changes autotile↔snap routing and
     // emits this signal so the effect can apply the transition locally
     // (handleDragToFloat, onWindowClosed, overlay cancel, etc.).
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowDrag,
                                           QStringLiteral("dragPolicyChanged"), this,
-                                          SLOT(slotDragPolicyChanged(QString, PlasmaZones::DragPolicy)));
+                                          SLOT(slotDragPolicyChanged(QString, PhosphorProtocol::DragPolicy)));
 
     // WindowDrag: snap assist (delivered asynchronously, separate from the
     // fast endDrag reply). The daemon schedules the empty-zone-list compute
     // after endDrag returns, so the compositor is unblocked first.
-    QDBusConnection::sessionBus().connect(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowDrag,
                                           QStringLiteral("snapAssistReady"), this,
-                                          SLOT(slotSnapAssistReady(QString, QString, PlasmaZones::EmptyZoneList)));
+                                          SLOT(slotSnapAssistReady(QString, QString, PhosphorProtocol::EmptyZoneList)));
 
     qCInfo(lcEffect) << "Connected to navigation D-Bus signals";
 }
@@ -2157,8 +2190,9 @@ QString PlasmaZonesEffect::resolveEffectiveScreenId(const QPoint& pos, const KWi
 
 void PlasmaZonesEffect::fetchVirtualScreenConfig(const QString& physicalScreenId, uint64_t generation)
 {
-    QDBusMessage msg = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Screen,
-                                                      QStringLiteral("getVirtualScreenConfig"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+        PhosphorProtocol::Service::Interface::Screen, QStringLiteral("getVirtualScreenConfig"));
     msg << physicalScreenId;
 
     QDBusPendingCall call = QDBusConnection::sessionBus().asyncCall(msg);
@@ -2358,8 +2392,9 @@ void PlasmaZonesEffect::emitNavigationFeedback(bool success, const QString& acti
     if (!isDaemonReady("report navigation feedback")) {
         return;
     }
-    DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("reportNavigationFeedback"),
-                               {success, action, reason, sourceZoneId, targetZoneId, screenId});
+    PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                   QStringLiteral("reportNavigationFeedback"),
+                                                   {success, action, reason, sourceZoneId, targetZoneId, screenId});
 }
 
 void PlasmaZonesEffect::slotActivateWindowRequested(const QString& windowId)
@@ -2422,10 +2457,12 @@ void PlasmaZonesEffect::slotMoveSpecificWindowToZoneRequested(const QString& win
     QString screenId = output ? resolveEffectiveScreenId(geoCenter, output) : getWindowScreenId(targetWindow);
 
     if (isDaemonReady("snap assist windowSnapped")) {
-        DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("windowSnapped"),
-                                   {getWindowId(targetWindow), zoneId, screenId});
-        DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("recordSnapIntent"),
-                                   {getWindowId(targetWindow), true});
+        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("windowSnapped"),
+                                                       {getWindowId(targetWindow), zoneId, screenId});
+        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("recordSnapIntent"),
+                                                       {getWindowId(targetWindow), true});
 
         // Snap Assist continuation: only for manual-mode screens.
         // Autotile screens manage their own window placement; showing snap assist
@@ -2506,7 +2543,8 @@ void PlasmaZonesEffect::slotApplyGeometryRequested(const QString& windowId, int 
     // applyGeometryForFloat), zoneId is empty so no snap confirmation is needed.
 }
 
-void PlasmaZonesEffect::slotApplyGeometriesBatch(const WindowGeometryList& geometries, const QString& action)
+void PlasmaZonesEffect::slotApplyGeometriesBatch(const PhosphorProtocol::WindowGeometryList& geometries,
+                                                 const QString& action)
 {
     qCInfo(lcEffect) << "applyGeometriesBatch:" << action;
 
@@ -2633,8 +2671,8 @@ void PlasmaZonesEffect::slotSnapAllWindowsRequested(const QString& screenId)
     }
 
     // Async fetch all snapped windows to filter already-snapped ones locally
-    QDBusPendingCall snapCall =
-        DBusHelpers::asyncCall(DBus::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
+    QDBusPendingCall snapCall = PhosphorProtocol::ClientHelpers::asyncCall(
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
     auto* snapWatcher = new QDBusPendingCallWatcher(snapCall, this);
 
     connect(snapWatcher, &QDBusPendingCallWatcher::finished, this, [this, screenId](QDBusPendingCallWatcher* sw) {
@@ -2705,15 +2743,15 @@ void PlasmaZonesEffect::slotSnapAllWindowsRequested(const QString& screenId)
         }
 
         // Ask daemon to calculate zone assignments
-        QDBusPendingCall calcCall =
-            DBusHelpers::asyncCall(DBus::Interface::WindowTracking, QStringLiteral("calculateSnapAllWindows"),
-                                   {QVariant::fromValue(unsnappedWindowIds), screenId});
+        QDBusPendingCall calcCall = PhosphorProtocol::ClientHelpers::asyncCall(
+            PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("calculateSnapAllWindows"),
+            {QVariant::fromValue(unsnappedWindowIds), screenId});
         auto* calcWatcher = new QDBusPendingCallWatcher(calcCall, this);
 
         connect(calcWatcher, &QDBusPendingCallWatcher::finished, this, [this, screenId](QDBusPendingCallWatcher* cw) {
             cw->deleteLater();
 
-            QDBusPendingReply<SnapAllResultList> calcReply = *cw;
+            QDBusPendingReply<PhosphorProtocol::SnapAllResultList> calcReply = *cw;
             if (calcReply.isError()) {
                 qCWarning(lcEffect) << "calculateSnapAllWindows failed:" << calcReply.error().message();
                 emitNavigationFeedback(false, QStringLiteral("snap_all"), QStringLiteral("calculation_error"),
@@ -2721,10 +2759,10 @@ void PlasmaZonesEffect::slotSnapAllWindowsRequested(const QString& screenId)
                 return;
             }
 
-            SnapAllResultList snapResults = calcReply.value();
+            PhosphorProtocol::SnapAllResultList snapResults = calcReply.value();
 
             // Build WindowGeometryList for the batch geometry path
-            WindowGeometryList snapGeometries;
+            PhosphorProtocol::WindowGeometryList snapGeometries;
             snapGeometries.reserve(snapResults.size());
             for (const auto& r : snapResults) {
                 snapGeometries.append(r.toGeometryEntry());
@@ -2733,9 +2771,9 @@ void PlasmaZonesEffect::slotSnapAllWindowsRequested(const QString& screenId)
 
             // Confirm snap assignments with daemon
             if (isDaemonReady("snap-all confirmation")) {
-                SnapConfirmationList confirmEntries;
+                PhosphorProtocol::SnapConfirmationList confirmEntries;
                 for (const auto& r : snapResults) {
-                    SnapConfirmationEntry entry;
+                    PhosphorProtocol::SnapConfirmationEntry entry;
                     entry.windowId = r.windowId;
                     entry.zoneId = r.targetZoneId;
                     entry.screenId = screenId;
@@ -2743,9 +2781,9 @@ void PlasmaZonesEffect::slotSnapAllWindowsRequested(const QString& screenId)
                     confirmEntries.append(entry);
                 }
                 if (!confirmEntries.isEmpty()) {
-                    QDBusMessage msg = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath,
-                                                                      DBus::Interface::WindowTracking,
-                                                                      QStringLiteral("windowsSnappedBatch"));
+                    QDBusMessage msg = QDBusMessage::createMethodCall(
+                        PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("windowsSnappedBatch"));
                     msg << QVariant::fromValue(confirmEntries);
                     auto* batchWatcher =
                         new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(msg), this);
@@ -2779,8 +2817,8 @@ void PlasmaZonesEffect::slotPendingRestoresAvailable()
     }
 
     // Use ASYNC batch call to get all tracked windows at once
-    QDBusPendingCall pendingCall =
-        DBusHelpers::asyncCall(DBus::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
+    QDBusPendingCall pendingCall = PhosphorProtocol::ClientHelpers::asyncCall(
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
     auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
 
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
@@ -2879,8 +2917,9 @@ void PlasmaZonesEffect::slotWindowMinimizedChanged(KWin::EffectWindow* w)
                      << "on" << screenId;
 
     if (m_daemonServiceRegistered) {
-        DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("setWindowFloatingForScreen"),
-                                   {windowId, screenId, minimized}, QStringLiteral("setWindowFloatingForScreen"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(
+            this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("setWindowFloatingForScreen"),
+            {windowId, screenId, minimized}, QStringLiteral("setWindowFloatingForScreen"));
     }
 }
 
@@ -2941,8 +2980,9 @@ void PlasmaZonesEffect::slotRunningWindowsRequested()
 
     // Send result back to daemon via D-Bus
     if (m_daemonServiceRegistered) {
-        DBusHelpers::fireAndForget(this, DBus::Interface::Settings, QStringLiteral("provideRunningWindows"),
-                                   {jsonString}, QStringLiteral("provideRunningWindows"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::Settings,
+                                                       QStringLiteral("provideRunningWindows"), {jsonString},
+                                                       QStringLiteral("provideRunningWindows"));
     } else {
         qCWarning(lcEffect) << "provideRunningWindows: daemon not ready";
     }
@@ -2983,7 +3023,7 @@ void PlasmaZonesEffect::callResolveWindowRestore(KWin::EffectWindow* window, std
     // daemon restart or from KWin session restore), so its current frameGeometry is the
     // zone geometry — NOT the free-floating geometry. Storing it as pre-tile would cause
     // float toggle to restore to the zone geometry instead of the original free-floating position.
-    tryAsyncSnapCall(DBus::Interface::WindowTracking, QStringLiteral("resolveWindowRestore"),
+    tryAsyncSnapCall(PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("resolveWindowRestore"),
                      {windowId, screenId, sticky}, safeWindow, windowId, false, nullptr, nullptr,
                      /*skipAnimation=*/true, onComplete);
 }
@@ -3013,23 +3053,25 @@ void PlasmaZonesEffect::updateWindowStickyState(KWin::EffectWindow* w)
     // window during login; QDBusInterface creation blocks the compositor thread
     // for ~25s if the daemon hasn't entered app.exec() yet (daemonReady is
     // emitted before the event loop starts).
-    DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("setWindowSticky"),
-                               {windowId, sticky}, QStringLiteral("setWindowSticky"));
+    PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                   QStringLiteral("setWindowSticky"), {windowId, sticky},
+                                                   QStringLiteral("setWindowSticky"));
 }
 
 // The dragMoved lambda sends updateDragCursor directly via
-// DBusHelpers::fireAndForget. Single entry point for hot-path cursor updates.
+// ClientHelpers::fireAndForget. Single entry point for hot-path cursor updates.
 
 void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& windowId, bool cancelled)
 {
     // Single entry point for drag-end dispatch.
-    // Sends endDrag, receives a DragOutcome, and applies exactly the
+    // Sends endDrag, receives a PhosphorProtocol::DragOutcome, and applies exactly the
     // action the daemon decided. Replaces callDragStopped (whose reply
     // shape was a 9-tuple of out-params) with a typed struct.
     QPointF cursorAtRelease = m_dragTracker->lastCursorPos();
 
-    QDBusMessage msg = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
-                                                      QStringLiteral("endDrag"));
+    QDBusMessage msg =
+        QDBusMessage::createMethodCall(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                       PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("endDrag"));
     msg << windowId << static_cast<int>(cursorAtRelease.x()) << static_cast<int>(cursorAtRelease.y())
         << static_cast<int>(m_currentModifiers) << static_cast<int>(m_currentMouseButtons) << cancelled;
     QDBusPendingCall pendingCall = QDBusConnection::sessionBus().asyncCall(msg);
@@ -3059,149 +3101,151 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
     });
     timeoutTimer->start(EndDragTimeoutMs);
 
-    connect(
-        watcher, &QDBusPendingCallWatcher::finished, this,
-        [this, safeWindow, windowId, handled, timeoutTimer](QDBusPendingCallWatcher* w) {
-            w->deleteLater();
-            if (*handled) {
-                // Timeout already fired; this is a late reply — discard.
-                return;
-            }
-            *handled = true;
-            timeoutTimer->stop();
-            timeoutTimer->deleteLater();
-
-            QDBusPendingReply<DragOutcome> reply = *w;
-            if (reply.isError()) {
-                qCWarning(lcEffect) << "endDrag call failed:" << reply.error().message();
-                return;
-            }
-            const DragOutcome outcome = reply.value();
-            if (const QString err = outcome.validationError(); !err.isEmpty()) {
-                // Garbled outcome — refuse to apply any window transform.
-                // Better to leave the window where it is than to float/snap
-                // based on a corrupted payload.
-                qCWarning(lcEffect) << "endDrag outcome rejected:" << err
-                                    << "— dropping without applying any action for" << windowId;
-                return;
-            }
-            qCInfo(lcEffect) << "endDrag outcome:" << windowId << "action=" << outcome.action
-                             << "screen=" << outcome.targetScreenId << "geo=" << outcome.toRect()
-                             << "snapAssist=" << outcome.requestSnapAssist;
-
-            switch (outcome.action) {
-            case DragOutcome::NoOp:
-            case DragOutcome::CancelSnap:
-            case DragOutcome::NotifyDragOutUnsnap:
-                // Daemon handled any internal cleanup. Nothing for the
-                // effect to paint.
-                break;
-
-            case DragOutcome::ApplyFloat: {
-                // Autotile bypass drag ended — float the window at its
-                // current screen. The plugin-side compositor work
-                // (handleDragToFloat, setWindowFloatingForScreen) was
-                // previously inlined in the dragStopped lambda; now it
-                // fires here off the daemon's authoritative answer.
-                //
-                // Cross-VS transitions that happened mid-drag were
-                // applied by slotDragPolicyChanged at the moment of
-                // crossing, so by the time we get here the autotile
-                // handler has the right tracking state.
-                if (!safeWindow) {
-                    break;
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, safeWindow, windowId, handled, timeoutTimer](QDBusPendingCallWatcher* w) {
+                w->deleteLater();
+                if (*handled) {
+                    // Timeout already fired; this is a late reply — discard.
+                    return;
                 }
-                const QString dropScreenId = getWindowScreenId(safeWindow);
-                if (dropScreenId.isEmpty()) {
-                    break;
-                }
-                m_autotileHandler->handleDragToFloat(safeWindow, windowId, dropScreenId);
-                // Note: m_dragFloatedWindowIds is intentionally NOT re-set here.
-                // See dragStopped handler — the marker is cleared at drag end
-                // because the daemon's drag-end float path (setWindowFloat →
-                // windowFloatingStateSynced) never emits applyGeometryForFloat,
-                // so there's nothing for the marker to suppress.
-                DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking,
-                                           QStringLiteral("setWindowFloatingForScreen"), {windowId, dropScreenId, true},
-                                           QStringLiteral("setWindowFloatingForScreen - endDrag ApplyFloat"));
-                qCInfo(lcEffect) << "endDrag ApplyFloat:" << windowId << "on" << dropScreenId;
-                break;
-            }
+                *handled = true;
+                timeoutTimer->stop();
+                timeoutTimer->deleteLater();
 
-            case DragOutcome::ApplySnap: {
-                if (!safeWindow || safeWindow->isFullScreen()) {
-                    break;
+                QDBusPendingReply<PhosphorProtocol::DragOutcome> reply = *w;
+                if (reply.isError()) {
+                    qCWarning(lcEffect) << "endDrag call failed:" << reply.error().message();
+                    return;
                 }
-                const QRect snapGeometry = outcome.toRect();
-                // If the window is still in user-move state because only
-                // the activation mouse button is held (LMB already
-                // released), cancel KWin's interactive move so we can
-                // snap immediately. Without this, applySnapGeometry
-                // defers (100ms retry) until ALL buttons are released —
-                // noticeable delay when using a mouse button (RMB) for
-                // zone activation.
-                if (safeWindow->isUserMove() && !(m_currentMouseButtons & Qt::LeftButton)) {
-                    if (KWin::Window* kw = safeWindow->window()) {
-                        kw->cancelInteractiveMoveResize();
+                const PhosphorProtocol::DragOutcome outcome = reply.value();
+                if (const QString err = outcome.validationError(); !err.isEmpty()) {
+                    // Garbled outcome — refuse to apply any window transform.
+                    // Better to leave the window where it is than to float/snap
+                    // based on a corrupted payload.
+                    qCWarning(lcEffect) << "endDrag outcome rejected:" << err
+                                        << "— dropping without applying any action for" << windowId;
+                    return;
+                }
+                qCInfo(lcEffect) << "endDrag outcome:" << windowId << "action=" << outcome.action
+                                 << "screen=" << outcome.targetScreenId << "geo=" << outcome.toRect()
+                                 << "snapAssist=" << outcome.requestSnapAssist;
+
+                switch (outcome.action) {
+                case PhosphorProtocol::DragOutcome::NoOp:
+                case PhosphorProtocol::DragOutcome::CancelSnap:
+                case PhosphorProtocol::DragOutcome::NotifyDragOutUnsnap:
+                    // Daemon handled any internal cleanup. Nothing for the
+                    // effect to paint.
+                    break;
+
+                case PhosphorProtocol::DragOutcome::ApplyFloat: {
+                    // Autotile bypass drag ended — float the window at its
+                    // current screen. The plugin-side compositor work
+                    // (handleDragToFloat, setWindowFloatingForScreen) was
+                    // previously inlined in the dragStopped lambda; now it
+                    // fires here off the daemon's authoritative answer.
+                    //
+                    // Cross-VS transitions that happened mid-drag were
+                    // applied by slotDragPolicyChanged at the moment of
+                    // crossing, so by the time we get here the autotile
+                    // handler has the right tracking state.
+                    if (!safeWindow) {
+                        break;
                     }
-                }
-                applySnapGeometry(safeWindow, snapGeometry);
-                break;
-            }
-
-            case DragOutcome::RestoreSize: {
-                if (!safeWindow || safeWindow->isFullScreen()) {
-                    break;
-                }
-                // Drag-to-unsnap: apply pre-snap width/height at current
-                // position. Skip if slotRestoreSizeDuringDrag already
-                // applied during the drag (size within 1px).
-                QRectF frame = safeWindow->frameGeometry();
-                const QRect geo(static_cast<int>(frame.x()), static_cast<int>(frame.y()), outcome.width,
-                                outcome.height);
-                if (qAbs(frame.width() - outcome.width) <= 1 && qAbs(frame.height() - outcome.height) <= 1) {
-                    qCDebug(lcEffect) << "endDrag RestoreSize: already at correct size, skipping";
-                    break;
-                }
-                if (safeWindow->isUserMove() && !(m_currentMouseButtons & Qt::LeftButton)) {
-                    if (KWin::Window* kw = safeWindow->window()) {
-                        kw->cancelInteractiveMoveResize();
+                    const QString dropScreenId = getWindowScreenId(safeWindow);
+                    if (dropScreenId.isEmpty()) {
+                        break;
                     }
+                    m_autotileHandler->handleDragToFloat(safeWindow, windowId, dropScreenId);
+                    // Note: m_dragFloatedWindowIds is intentionally NOT re-set here.
+                    // See dragStopped handler — the marker is cleared at drag end
+                    // because the daemon's drag-end float path (setWindowFloat →
+                    // windowFloatingStateSynced) never emits applyGeometryForFloat,
+                    // so there's nothing for the marker to suppress.
+                    PhosphorProtocol::ClientHelpers::fireAndForget(
+                        this, PhosphorProtocol::Service::Interface::WindowTracking,
+                        QStringLiteral("setWindowFloatingForScreen"), {windowId, dropScreenId, true},
+                        QStringLiteral("setWindowFloatingForScreen - endDrag ApplyFloat"));
+                    qCInfo(lcEffect) << "endDrag ApplyFloat:" << windowId << "on" << dropScreenId;
+                    break;
                 }
-                applySnapGeometry(safeWindow, geo);
-                break;
-            }
-            }
 
-            // Auto-fill: if window was dropped without snapping to a
-            // zone and wasn't floated, try the first empty zone on the
-            // release screen. Daemon-provided targetScreenId wins over
-            // window's current screen (cross-screen drags).
-            const bool applied = outcome.action == DragOutcome::ApplySnap || outcome.action == DragOutcome::ApplyFloat;
-            if (!applied && safeWindow && !outcome.targetScreenId.isEmpty() && isDaemonReady("auto-fill on drop")) {
-                const bool sticky = isWindowSticky(safeWindow);
-                auto onSnapSuccess = [this](const QString&, const QString& snappedScreenId) {
-                    m_snapAssistHandler->showContinuationIfNeeded(snappedScreenId);
-                };
-                tryAsyncSnapCall(DBus::Interface::WindowTracking, QStringLiteral("snapToEmptyZone"),
-                                 {windowId, outcome.targetScreenId, sticky}, safeWindow, windowId, true, nullptr,
-                                 onSnapSuccess);
-            }
+                case PhosphorProtocol::DragOutcome::ApplySnap: {
+                    if (!safeWindow || safeWindow->isFullScreen()) {
+                        break;
+                    }
+                    const QRect snapGeometry = outcome.toRect();
+                    // If the window is still in user-move state because only
+                    // the activation mouse button is held (LMB already
+                    // released), cancel KWin's interactive move so we can
+                    // snap immediately. Without this, applySnapGeometry
+                    // defers (100ms retry) until ALL buttons are released —
+                    // noticeable delay when using a mouse button (RMB) for
+                    // zone activation.
+                    if (safeWindow->isUserMove() && !(m_currentMouseButtons & Qt::LeftButton)) {
+                        if (KWin::Window* kw = safeWindow->window()) {
+                            kw->cancelInteractiveMoveResize();
+                        }
+                    }
+                    applySnapGeometry(safeWindow, snapGeometry);
+                    break;
+                }
 
-            // Snap Assist: show the window picker if the daemon
-            // requested it. asyncShow is non-blocking.
-            if (outcome.requestSnapAssist && !outcome.emptyZones.isEmpty() && !outcome.targetScreenId.isEmpty()) {
-                m_snapAssistHandler->asyncShow(windowId, outcome.targetScreenId, outcome.emptyZones);
-            }
-        });
+                case PhosphorProtocol::DragOutcome::RestoreSize: {
+                    if (!safeWindow || safeWindow->isFullScreen()) {
+                        break;
+                    }
+                    // Drag-to-unsnap: apply pre-snap width/height at current
+                    // position. Skip if slotRestoreSizeDuringDrag already
+                    // applied during the drag (size within 1px).
+                    QRectF frame = safeWindow->frameGeometry();
+                    const QRect geo(static_cast<int>(frame.x()), static_cast<int>(frame.y()), outcome.width,
+                                    outcome.height);
+                    if (qAbs(frame.width() - outcome.width) <= 1 && qAbs(frame.height() - outcome.height) <= 1) {
+                        qCDebug(lcEffect) << "endDrag RestoreSize: already at correct size, skipping";
+                        break;
+                    }
+                    if (safeWindow->isUserMove() && !(m_currentMouseButtons & Qt::LeftButton)) {
+                        if (KWin::Window* kw = safeWindow->window()) {
+                            kw->cancelInteractiveMoveResize();
+                        }
+                    }
+                    applySnapGeometry(safeWindow, geo);
+                    break;
+                }
+                }
+
+                // Auto-fill: if window was dropped without snapping to a
+                // zone and wasn't floated, try the first empty zone on the
+                // release screen. Daemon-provided targetScreenId wins over
+                // window's current screen (cross-screen drags).
+                const bool applied = outcome.action == PhosphorProtocol::DragOutcome::ApplySnap
+                    || outcome.action == PhosphorProtocol::DragOutcome::ApplyFloat;
+                if (!applied && safeWindow && !outcome.targetScreenId.isEmpty() && isDaemonReady("auto-fill on drop")) {
+                    const bool sticky = isWindowSticky(safeWindow);
+                    auto onSnapSuccess = [this](const QString&, const QString& snappedScreenId) {
+                        m_snapAssistHandler->showContinuationIfNeeded(snappedScreenId);
+                    };
+                    tryAsyncSnapCall(PhosphorProtocol::Service::Interface::WindowTracking,
+                                     QStringLiteral("snapToEmptyZone"), {windowId, outcome.targetScreenId, sticky},
+                                     safeWindow, windowId, true, nullptr, onSnapSuccess);
+                }
+
+                // Snap Assist: show the window picker if the daemon
+                // requested it. asyncShow is non-blocking.
+                if (outcome.requestSnapAssist && !outcome.emptyZones.isEmpty() && !outcome.targetScreenId.isEmpty()) {
+                    m_snapAssistHandler->asyncShow(windowId, outcome.targetScreenId, outcome.emptyZones);
+                }
+            });
 }
 
 void PlasmaZonesEffect::callCancelSnap()
 {
     qCInfo(lcEffect) << "Calling cancelSnap (drag cancelled by Escape or external event)";
     // QDBusMessage::createMethodCall — purely local, no D-Bus introspection.
-    QDBusMessage msg = QDBusMessage::createMethodCall(DBus::ServiceName, DBus::ObjectPath, DBus::Interface::WindowDrag,
-                                                      QStringLiteral("cancelSnap"));
+    QDBusMessage msg =
+        QDBusMessage::createMethodCall(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                       PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("cancelSnap"));
     QDBusConnection::sessionBus().asyncCall(msg);
 }
 
@@ -3211,7 +3255,7 @@ void PlasmaZonesEffect::tryAsyncSnapCall(const QString& interface, const QString
                                          std::function<void(const QString&, const QString&)> onSnapSuccess,
                                          bool skipAnimation, std::function<void()> onComplete)
 {
-    QDBusPendingCall call = DBusHelpers::asyncCall(interface, method, args);
+    QDBusPendingCall call = PhosphorProtocol::ClientHelpers::asyncCall(interface, method, args);
     auto* watcher = new QDBusPendingCallWatcher(call, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this,
             [this, window, windowId, storePreSnap, method, fallback, onSnapSuccess, args, skipAnimation,
@@ -3439,7 +3483,7 @@ void PlasmaZonesEffect::slotRestoreSizeDuringDrag(const QString& windowId, int w
 }
 
 void PlasmaZonesEffect::slotSnapAssistReady(const QString& windowId, const QString& releaseScreenId,
-                                            const PlasmaZones::EmptyZoneList& emptyZones)
+                                            const PhosphorProtocol::EmptyZoneList& emptyZones)
 {
     // Discard if a new drag has already started — this signal was from a
     // prior drop. The daemon defers the compute to after endDrag returns,
@@ -3454,7 +3498,7 @@ void PlasmaZonesEffect::slotSnapAssistReady(const QString& windowId, const QStri
     m_snapAssistHandler->asyncShow(windowId, releaseScreenId, emptyZones);
 }
 
-void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const DragPolicy& newPolicy)
+void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const PhosphorProtocol::DragPolicy& newPolicy)
 {
     // Daemon-owned cross-VS flip. The daemon's updateDragCursor
     // handler computed policy at the current cursor position and found it
@@ -3479,13 +3523,13 @@ void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const Dra
         return;
     }
 
-    const DragBypassReason oldReason = m_currentDragPolicy.bypassReason;
-    const DragBypassReason newReason = newPolicy.bypassReason;
+    const PhosphorProtocol::DragBypassReason oldReason = m_currentDragPolicy.bypassReason;
+    const PhosphorProtocol::DragBypassReason newReason = newPolicy.bypassReason;
     if (oldReason == newReason) {
         // Same reason but different screenId (autotile→autotile cross-VS):
         // update the captured screen so endDrag's ApplyFloat uses the right one.
         m_currentDragPolicy = newPolicy;
-        if (newReason == DragBypassReason::AutotileScreen) {
+        if (newReason == PhosphorProtocol::DragBypassReason::AutotileScreen) {
             m_dragBypassScreenId = newPolicy.screenId;
         }
         return;
@@ -3498,7 +3542,7 @@ void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const Dra
 
     KWin::EffectWindow* dragW = m_dragTracker->draggedWindow();
 
-    if (newReason == DragBypassReason::AutotileScreen) {
+    if (newReason == PhosphorProtocol::DragBypassReason::AutotileScreen) {
         // Snap → autotile (or context-disabled → autotile). Cancel any
         // active snap overlay, enter bypass mode. Mirrors the old
         // effect-side flip block's "snap→autotile" branch, but driven by
@@ -3519,7 +3563,7 @@ void PlasmaZonesEffect::slotDragPolicyChanged(const QString& windowId, const Dra
         return;
     }
 
-    if (oldReason == DragBypassReason::AutotileScreen) {
+    if (oldReason == PhosphorProtocol::DragBypassReason::AutotileScreen) {
         // Autotile → snap (or autotile → context-disabled). Drop the
         // bypass flag and initialize snap-drag state as if the drag just
         // started on this snap screen. Remove the window from autotile
@@ -3563,7 +3607,8 @@ void PlasmaZonesEffect::notifyWindowClosed(KWin::EffectWindow* w)
     }
 
     qCInfo(lcEffect) << "Notifying daemon: windowClosed" << windowId;
-    DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("windowClosed"), {windowId});
+    PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                   QStringLiteral("windowClosed"), {windowId});
 }
 
 void PlasmaZonesEffect::notifyWindowActivated(KWin::EffectWindow* w)
@@ -3605,13 +3650,14 @@ void PlasmaZonesEffect::notifyWindowActivated(KWin::EffectWindow* w)
     QString screenId = getWindowScreenId(w);
 
     qCDebug(lcEffect) << "Notifying daemon: windowActivated" << windowId << "on screen" << screenId;
-    DBusHelpers::fireAndForget(this, DBus::Interface::WindowTracking, QStringLiteral("windowActivated"),
-                               {windowId, screenId});
+    PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                   QStringLiteral("windowActivated"), {windowId, screenId});
 
     // Notify autotile engine of focus change so m_windowToScreen is updated
     if (m_autotileHandler->isAutotileScreen(screenId)) {
-        DBusHelpers::fireAndForget(this, DBus::Interface::Autotile, QStringLiteral("notifyWindowFocused"),
-                                   {windowId, screenId}, QStringLiteral("notifyWindowFocused"));
+        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::Autotile,
+                                                       QStringLiteral("notifyWindowFocused"), {windowId, screenId},
+                                                       QStringLiteral("notifyWindowFocused"));
     }
 }
 

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -6,7 +6,7 @@
 #include <cstdint>
 
 #include <compositor_bridge.h>
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <trigger_parser.h>
 
 #include <PhosphorAnimation/CurveRegistry.h>
@@ -127,10 +127,10 @@ private Q_SLOTS:
     // crossed a virtual-screen boundary that changes autotile↔snap mode).
     // Effect applies the transition: entering/exiting autotile bypass,
     // canceling snap overlay, etc.
-    void slotDragPolicyChanged(const QString& windowId, const PlasmaZones::DragPolicy& newPolicy);
+    void slotDragPolicyChanged(const QString& windowId, const PhosphorProtocol::DragPolicy& newPolicy);
 
     // Daemon-driven batch operations (rotate, resnap)
-    void slotApplyGeometriesBatch(const WindowGeometryList& geometries, const QString& action);
+    void slotApplyGeometriesBatch(const PhosphorProtocol::WindowGeometryList& geometries, const QString& action);
     void slotRaiseWindowsRequested(const QStringList& windowIds);
 
     // Snap-all (effect collects candidates, daemon computes assignments)
@@ -140,7 +140,7 @@ private Q_SLOTS:
     void slotRunningWindowsRequested();
     void slotRestoreSizeDuringDrag(const QString& windowId, int width, int height);
     void slotSnapAssistReady(const QString& windowId, const QString& releaseScreenId,
-                             const PlasmaZones::EmptyZoneList& emptyZones);
+                             const PhosphorProtocol::EmptyZoneList& emptyZones);
     void slotMoveSpecificWindowToZoneRequested(const QString& windowId, const QString& zoneId, int x, int y, int width,
                                                int height);
 
@@ -440,7 +440,7 @@ private:
     // drag starts; until then, conservative defaults apply (snap-path
     // with streaming) so the worst-case UX is a brief zone-overlay flash
     // rather than a dead drag. Cleared at drag end.
-    DragPolicy m_currentDragPolicy;
+    PhosphorProtocol::DragPolicy m_currentDragPolicy;
 
     // Frame-geometry shadow push state. Effect debounces windowFrameGeometryChanged
     // signals per-window to ~50ms and pushes the latest geometry to the daemon via
@@ -493,7 +493,7 @@ private:
 
     // D-Bus communication uses QDBusMessage::createMethodCall exclusively
     // (no QDBusInterface) to avoid synchronous D-Bus introspection that blocks
-    // the compositor thread. See DBusHelpers::asyncCall() and DBusHelpers::fireAndForget().
+    // the compositor thread. See ClientHelpers::asyncCall() and ClientHelpers::fireAndForget().
 
     // Screen change debouncing and reapply handled by ScreenChangeHandler
 

--- a/kwin-effect/screenchangehandler.cpp
+++ b/kwin-effect/screenchangehandler.cpp
@@ -5,9 +5,9 @@
 #include "autotilehandler.h"
 #include "plasmazoneseffect.h"
 
-#include <dbus_constants.h>
-#include <dbus_helpers.h>
-#include <dbus_types.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/ClientHelpers.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <PhosphorIdentity/WindowId.h>
 
 #include <effect/effecthandler.h>
@@ -125,8 +125,8 @@ void ScreenChangeHandler::fetchAndApplyWindowGeometries()
         return;
     }
     m_reapplyInProgress = true;
-    QDBusPendingCall pendingCall =
-        DBusHelpers::asyncCall(DBus::Interface::WindowTracking, QStringLiteral("getUpdatedWindowGeometries"));
+    QDBusPendingCall pendingCall = PhosphorProtocol::ClientHelpers::asyncCall(
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getUpdatedWindowGeometries"));
     auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
     QPointer<ScreenChangeHandler> self(this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [self](QDBusPendingCallWatcher* w) {
@@ -135,7 +135,7 @@ void ScreenChangeHandler::fetchAndApplyWindowGeometries()
             return;
         }
         self->m_reapplyInProgress = false;
-        QDBusPendingReply<WindowGeometryList> reply = *w;
+        QDBusPendingReply<PhosphorProtocol::WindowGeometryList> reply = *w;
         if (!reply.isValid()) {
             qCDebug(lcScreenChange) << "No window geometries to update";
         } else {
@@ -152,7 +152,7 @@ void ScreenChangeHandler::fetchAndApplyWindowGeometries()
     });
 }
 
-void ScreenChangeHandler::applyWindowGeometries(const WindowGeometryList& geometries)
+void ScreenChangeHandler::applyWindowGeometries(const PhosphorProtocol::WindowGeometryList& geometries)
 {
     if (geometries.isEmpty()) {
         qCDebug(lcScreenChange) << "Empty geometries list from daemon";

--- a/kwin-effect/screenchangehandler.h
+++ b/kwin-effect/screenchangehandler.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
 #include <QPointer>
 #include <QRect>
@@ -52,7 +52,7 @@ public Q_SLOTS:
 private:
     void applyScreenGeometryChange();
     void fetchAndApplyWindowGeometries();
-    void applyWindowGeometries(const WindowGeometryList& geometries);
+    void applyWindowGeometries(const PhosphorProtocol::WindowGeometryList& geometries);
 
     PlasmaZonesEffect* m_effect;
     QTimer m_screenChangeDebounce;

--- a/kwin-effect/snapassisthandler.cpp
+++ b/kwin-effect/snapassisthandler.cpp
@@ -6,9 +6,9 @@
 #include "autotilehandler.h"
 #include "kwin_compositor_bridge.h"
 
-#include <dbus_constants.h>
-#include <dbus_helpers.h>
-#include <dbus_types.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/ClientHelpers.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <snap_assist_filter.h>
 
 #include <effect/effecthandler.h>
@@ -44,12 +44,12 @@ void SnapAssistHandler::showContinuationIfNeeded(const QString& screenId)
         return;
     }
     qCInfo(lcSnapAssist) << "Snap assist continuation: querying empty zones for screen" << screenId;
-    QDBusPendingCall emptyCall =
-        DBusHelpers::asyncCall(DBus::Interface::WindowTracking, QStringLiteral("getEmptyZones"), {screenId});
+    QDBusPendingCall emptyCall = PhosphorProtocol::ClientHelpers::asyncCall(
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getEmptyZones"), {screenId});
     auto* watcher = new QDBusPendingCallWatcher(emptyCall, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, screenId](QDBusPendingCallWatcher* w) {
         w->deleteLater();
-        QDBusPendingReply<EmptyZoneList> reply = *w;
+        QDBusPendingReply<PhosphorProtocol::EmptyZoneList> reply = *w;
         if (!reply.isValid() || reply.value().isEmpty()) {
             qCInfo(lcSnapAssist) << "Snap assist continuation: no empty zones"
                                  << (reply.isValid() ? QStringLiteral("(empty list)")
@@ -61,13 +61,13 @@ void SnapAssistHandler::showContinuationIfNeeded(const QString& screenId)
 }
 
 void SnapAssistHandler::asyncShow(const QString& excludeWindowId, const QString& screenId,
-                                  const EmptyZoneList& emptyZones)
+                                  const PhosphorProtocol::EmptyZoneList& emptyZones)
 {
     if (!m_effect->isDaemonReady("snap assist snapped windows")) {
         return;
     }
-    QDBusPendingCall snapCall =
-        DBusHelpers::asyncCall(DBus::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
+    QDBusPendingCall snapCall = PhosphorProtocol::ClientHelpers::asyncCall(
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
     auto* snapWatcher = new QDBusPendingCallWatcher(snapCall, this);
     connect(snapWatcher, &QDBusPendingCallWatcher::finished, this,
             [this, excludeWindowId, screenId, emptyZones](QDBusPendingCallWatcher* w) {
@@ -79,7 +79,8 @@ void SnapAssistHandler::asyncShow(const QString& excludeWindowId, const QString&
                         snappedWindowIds.insert(id);
                     }
                 }
-                SnapAssistCandidateList candidates = buildCandidates(excludeWindowId, screenId, snappedWindowIds);
+                PhosphorProtocol::SnapAssistCandidateList candidates =
+                    buildCandidates(excludeWindowId, screenId, snappedWindowIds);
                 if (candidates.isEmpty()) {
                     qCInfo(lcSnapAssist) << "Snap assist skipped: no unsnapped candidate windows on" << screenId;
                     return;
@@ -88,7 +89,8 @@ void SnapAssistHandler::asyncShow(const QString& excludeWindowId, const QString&
                     return;
                 }
                 QDBusMessage msg = QDBusMessage::createMethodCall(
-                    DBus::ServiceName, DBus::ObjectPath, DBus::Interface::Overlay, QStringLiteral("showSnapAssist"));
+                    PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                    PhosphorProtocol::Service::Interface::Overlay, QStringLiteral("showSnapAssist"));
                 msg << screenId << QVariant::fromValue(emptyZones) << QVariant::fromValue(candidates);
                 auto* callWatcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(msg), m_effect);
                 connect(callWatcher, &QDBusPendingCallWatcher::finished, m_effect, [](QDBusPendingCallWatcher* cw) {
@@ -101,10 +103,11 @@ void SnapAssistHandler::asyncShow(const QString& excludeWindowId, const QString&
             });
 }
 
-SnapAssistCandidateList SnapAssistHandler::buildCandidates(const QString& excludeWindowId, const QString& screenId,
-                                                           const QSet<QString>& snappedWindowIds) const
+PhosphorProtocol::SnapAssistCandidateList
+SnapAssistHandler::buildCandidates(const QString& excludeWindowId, const QString& screenId,
+                                   const QSet<QString>& snappedWindowIds) const
 {
-    SnapAssistCandidateList candidates =
+    PhosphorProtocol::SnapAssistCandidateList candidates =
         SnapAssistFilter::buildCandidates(m_effect->compositorBridge(), excludeWindowId, screenId, snappedWindowIds);
 
     // KWin-specific: fill compositorHandle (internal UUID) for overlay window identification.

--- a/kwin-effect/snapassisthandler.h
+++ b/kwin-effect/snapassisthandler.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 
 #include <QObject>
 #include <QSet>
@@ -34,7 +34,8 @@ public:
     void showContinuationIfNeeded(const QString& screenId);
 
     /// Full async snap assist: get snapped windows, build candidates, show overlay
-    void asyncShow(const QString& excludeWindowId, const QString& screenId, const EmptyZoneList& emptyZones);
+    void asyncShow(const QString& excludeWindowId, const QString& screenId,
+                   const PhosphorProtocol::EmptyZoneList& emptyZones);
 
     /// Update the enabled flag (from loadCachedSettings)
     void setEnabled(bool enabled)
@@ -47,8 +48,8 @@ public:
     }
 
 private:
-    SnapAssistCandidateList buildCandidates(const QString& excludeWindowId, const QString& screenId,
-                                            const QSet<QString>& snappedWindowIds) const;
+    PhosphorProtocol::SnapAssistCandidateList buildCandidates(const QString& excludeWindowId, const QString& screenId,
+                                                              const QSet<QString>& snappedWindowIds) const;
 
     PlasmaZonesEffect* m_effect;
     bool m_snapAssistEnabled = false;

--- a/libs/phosphor-protocol/CMakeLists.txt
+++ b/libs/phosphor-protocol/CMakeLists.txt
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# PhosphorProtocol — D-Bus wire types and service constants for Phosphor IPC.
+#
+# Provides:
+#   - Wire-format structs for D-Bus marshalling/demarshalling
+#   - Service name and path constants
+#   - Client-side helper utilities
+#
+# Depends on Qt6::Core, Qt6::DBus.
+
+cmake_minimum_required(VERSION 3.16)
+
+set(PHOSPHORPROTOCOL_VERSION "0.1.0")
+
+if(NOT PROJECT_VERSION)
+    project(PhosphorProtocol VERSION ${PHOSPHORPROTOCOL_VERSION} LANGUAGES CXX)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_AUTOMOC ON)
+endif()
+
+include(GenerateExportHeader)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dependencies
+# ═══════════════════════════════════════════════════════════════════════════════
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core DBus)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PhosphorProtocol Library
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set(phosphorprotocol_SRCS
+    src/wiretypes.cpp
+    src/logging.cpp
+)
+
+set(phosphorprotocol_public_HDRS
+    include/PhosphorProtocol/PhosphorProtocol.h
+    include/PhosphorProtocol/WireTypes.h
+    include/PhosphorProtocol/ServiceConstants.h
+    include/PhosphorProtocol/ClientHelpers.h
+)
+
+add_library(PhosphorProtocol SHARED
+    ${phosphorprotocol_public_HDRS}
+    ${phosphorprotocol_SRCS}
+)
+
+add_library(PhosphorProtocol::PhosphorProtocol ALIAS PhosphorProtocol)
+
+generate_export_header(PhosphorProtocol
+    EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/PhosphorProtocol/phosphorprotocol_export.h
+    EXPORT_MACRO_NAME PHOSPHORPROTOCOL_EXPORT
+)
+
+if(NOT DEFINED KDE_INSTALL_INCLUDEDIR)
+    include(GNUInstallDirs)
+    set(KDE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
+    set(KDE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+    set(KDE_INSTALL_BINDIR ${CMAKE_INSTALL_BINDIR})
+endif()
+
+target_include_directories(PhosphorProtocol
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(PhosphorProtocol PUBLIC cxx_std_20)
+
+target_link_libraries(PhosphorProtocol
+    PUBLIC
+        Qt6::Core
+        Qt6::DBus
+)
+
+set_target_properties(PhosphorProtocol PROPERTIES
+    VERSION ${PHOSPHORPROTOCOL_VERSION}
+    SOVERSION 0
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+if(CMAKE_PROJECT_NAME STREQUAL "PhosphorProtocol" OR BUILD_TESTING)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Install
+# ═══════════════════════════════════════════════════════════════════════════════
+
+install(TARGETS PhosphorProtocol
+    EXPORT PhosphorProtocolTargets
+    RUNTIME DESTINATION ${KDE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${KDE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${KDE_INSTALL_LIBDIR}
+)
+
+install(FILES ${phosphorprotocol_public_HDRS}
+    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/PhosphorProtocol
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PhosphorProtocol/phosphorprotocol_export.h
+    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/PhosphorProtocol
+)
+
+install(EXPORT PhosphorProtocolTargets
+    FILE PhosphorProtocolTargets.cmake
+    NAMESPACE PhosphorProtocol::
+    DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorProtocol
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/PhosphorProtocolConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorProtocolConfig.cmake"
+    INSTALL_DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorProtocol
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorProtocolConfigVersion.cmake"
+    VERSION ${PHOSPHORPROTOCOL_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorProtocolConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorProtocolConfigVersion.cmake"
+    DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorProtocol
+)

--- a/libs/phosphor-protocol/PhosphorProtocolConfig.cmake.in
+++ b/libs/phosphor-protocol/PhosphorProtocolConfig.cmake.in
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Qt6 6.6 COMPONENTS Core DBus)
+
+include("${CMAKE_CURRENT_LIST_DIR}/PhosphorProtocolTargets.cmake")
+
+check_required_components(PhosphorProtocol)

--- a/libs/phosphor-protocol/include/PhosphorProtocol/ClientHelpers.h
+++ b/libs/phosphor-protocol/include/PhosphorProtocol/ClientHelpers.h
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/phosphorprotocol_export.h>
+
+#include <QLoggingCategory>
+
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusPendingCall>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+#include <QObject>
+#include <QVariant>
+#include <functional>
+
+namespace PhosphorProtocol {
+PHOSPHORPROTOCOL_EXPORT const QLoggingCategory& lcPhosphorProtocol();
+}
+
+namespace PhosphorProtocol::ClientHelpers {
+
+/**
+ * @brief Compositor-agnostic D-Bus helper utilities
+ *
+ * These functions wrap common D-Bus call patterns used by all compositor plugins
+ * when communicating with the PlasmaZones daemon. They use QDBusMessage::createMethodCall
+ * (not QDBusInterface) to avoid synchronous D-Bus introspection that blocks the
+ * compositor thread.
+ */
+
+/**
+ * @brief Fire-and-forget async D-Bus call with error logging.
+ *
+ * @param parent     QObject parent for the watcher (must outlive the call)
+ * @param interface  D-Bus interface (e.g., DBus::Interface::Autotile)
+ * @param method     D-Bus method name
+ * @param args       Method arguments
+ * @param logContext Human-readable label for the warning log
+ */
+inline void fireAndForget(QObject* parent, const QString& interface, const QString& method, const QVariantList& args,
+                          const QString& logContext = {})
+{
+    if (!parent) {
+        qCWarning(lcPhosphorProtocol) << (logContext.isEmpty() ? method : logContext)
+                                      << "fireAndForget called with null parent, ignoring";
+        return;
+    }
+    QDBusMessage msg = QDBusMessage::createMethodCall(Service::Name, Service::ObjectPath, interface, method);
+    for (const QVariant& arg : args) {
+        msg << arg;
+    }
+    QDBusPendingCall pending = QDBusConnection::sessionBus().asyncCall(msg);
+    auto* watcher = new QDBusPendingCallWatcher(pending, parent);
+    const QString ctx = logContext.isEmpty() ? method : logContext;
+    QObject::connect(watcher, &QDBusPendingCallWatcher::finished, parent, [ctx](QDBusPendingCallWatcher* w) {
+        if (w->isError()) {
+            qCWarning(lcPhosphorProtocol) << ctx << "D-Bus call failed:" << w->error().message();
+        }
+        w->deleteLater();
+    });
+}
+
+/**
+ * @brief Create an async D-Bus method call and return the pending result.
+ *
+ * @param interface  D-Bus interface name
+ * @param method     D-Bus method name
+ * @param args       Method arguments
+ * @return QDBusPendingCall for attaching a watcher
+ */
+inline QDBusPendingCall asyncCall(const QString& interface, const QString& method, const QVariantList& args = {})
+{
+    QDBusMessage msg = QDBusMessage::createMethodCall(Service::Name, Service::ObjectPath, interface, method);
+    for (const QVariant& arg : args) {
+        msg << arg;
+    }
+    return QDBusConnection::sessionBus().asyncCall(msg);
+}
+
+/**
+ * @brief Async helper for loading a single daemon setting.
+ *
+ * Sends getSetting(name) via raw QDBusMessage, unwraps the QDBusVariant,
+ * and calls onValue with the extracted QVariant.
+ *
+ * @param parent   QObject parent for the watcher
+ * @param name     Setting name to load
+ * @param onValue  Callback receiving the unwrapped QVariant value (captured by
+ *                 move into the lambda — callers must pass a fresh rvalue each call)
+ */
+template<typename Fn>
+void loadSettingAsync(QObject* parent, const QString& name, Fn&& onValue)
+{
+    QDBusMessage msg = QDBusMessage::createMethodCall(Service::Name, Service::ObjectPath, Service::Interface::Settings,
+                                                      QStringLiteral("getSetting"));
+    msg << name;
+    auto* watcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(msg), parent);
+    QObject::connect(watcher, &QDBusPendingCallWatcher::finished, parent,
+                     [name, onValue = std::forward<Fn>(onValue)](QDBusPendingCallWatcher* w) {
+                         w->deleteLater();
+                         QDBusPendingReply<QVariant> reply = *w;
+                         if (reply.isValid()) {
+                             QVariant value = reply.value();
+                             if (value.canConvert<QDBusVariant>()) {
+                                 value = value.value<QDBusVariant>().variant();
+                             }
+                             onValue(value);
+                             qCDebug(lcPhosphorProtocol) << "Loaded" << name;
+                         } else {
+                             qCWarning(lcPhosphorProtocol)
+                                 << "loadSettingAsync: failed to load" << name << ":" << reply.error().message();
+                         }
+                     });
+}
+
+} // namespace PhosphorProtocol::ClientHelpers

--- a/libs/phosphor-protocol/include/PhosphorProtocol/PhosphorProtocol.h
+++ b/libs/phosphor-protocol/include/PhosphorProtocol/PhosphorProtocol.h
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorProtocol/WireTypes.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/ClientHelpers.h>

--- a/libs/phosphor-protocol/include/PhosphorProtocol/ServiceConstants.h
+++ b/libs/phosphor-protocol/include/PhosphorProtocol/ServiceConstants.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <QLatin1String>
+
+namespace PhosphorProtocol::Service {
+
+/**
+ * @brief D-Bus service constants shared by all compositor plugins
+ *
+ * Centralized D-Bus interface names to avoid magic strings.
+ * Used by KWin effect, Wayfire plugin, and any future compositor integration.
+ */
+inline constexpr QLatin1String Name("org.plasmazones");
+inline constexpr QLatin1String ObjectPath("/PlasmaZones");
+
+namespace Interface {
+inline constexpr QLatin1String Settings("org.plasmazones.Settings");
+inline constexpr QLatin1String WindowDrag("org.plasmazones.WindowDrag");
+inline constexpr QLatin1String WindowTracking("org.plasmazones.WindowTracking");
+inline constexpr QLatin1String Overlay("org.plasmazones.Overlay");
+inline constexpr QLatin1String Autotile("org.plasmazones.Autotile");
+inline constexpr QLatin1String LayoutRegistry("org.plasmazones.LayoutRegistry");
+inline constexpr QLatin1String Screen("org.plasmazones.Screen");
+inline constexpr QLatin1String ZoneDetection("org.plasmazones.ZoneDetection");
+inline constexpr QLatin1String CompositorBridge("org.plasmazones.CompositorBridge");
+}
+
+// Protocol version. Bumped when the D-Bus method/signal schema changes in a
+// backwards-incompatible way (e.g. dragStopped out-params changed, new
+// required signal). Both sides check the peer's version at bridge registration
+// and reject if below their minimum. The version is a simple integer string
+// ("1", "2", …) to keep comparison trivial.
+//
+//   v1: original protocol (PlasmaZones v3.0–v3.x)
+//   v2: split dragStopped + snapAssistReady signal (Phase C)
+//
+inline constexpr int ApiVersion = 2;
+inline constexpr int MinPeerApiVersion = 2;
+
+// Hard cap on blocking synchronous D-Bus calls from the editor/settings
+// apps to the daemon. Qt's default is 25 seconds, long enough to freeze
+// the UI for tens of seconds if the daemon event loop is busy. Daemon-side
+// settings/shader handlers are all in-memory hash lookups (sub-millisecond
+// in the healthy case), so 500 ms is generous while still degrading
+// gracefully to caller-side defaults when the daemon is unresponsive.
+inline constexpr int SyncCallTimeoutMs = 500;
+
+} // namespace PhosphorProtocol::Service

--- a/libs/phosphor-protocol/include/PhosphorProtocol/WireTypes.h
+++ b/libs/phosphor-protocol/include/PhosphorProtocol/WireTypes.h
@@ -1,0 +1,585 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorProtocol/phosphorprotocol_export.h>
+
+#include <QDBusArgument>
+#include <QDBusMetaType>
+#include <QList>
+#include <QRect>
+#include <QString>
+#include <QStringList>
+
+class QDebug;
+
+namespace PhosphorProtocol {
+
+/// Why a drag was bypassed from the canonical snap pipeline.
+///
+/// The daemon's computeDragPolicy picks exactly one of these based on the
+/// drag's context, and both sides route behavior off the value. Replaces
+/// the free-form `QString bypassReason` that carried `""` / `"autotile_screen"`
+/// / `"snapping_disabled"` / `"context_disabled"` as magic strings.
+///
+/// Wire format: unchanged — serialized as the same legacy string via
+/// toWireString()/fromWireString() inside the DragPolicy marshaller, so no
+/// ApiVersion bump is required. Unknown wire values parse to None (matches
+/// the old behavior where unrecognized strings didn't match the autotile
+/// branch and fell through to the canonical snap path).
+enum class DragBypassReason : int {
+    None = 0, ///< canonical snap path — drag flows through the snap pipeline
+    AutotileScreen = 1, ///< drag started/ended on an autotile screen — engine owns placement
+    SnappingDisabled = 2, ///< snap mode off globally — dead drag
+    ContextDisabled = 3, ///< monitor/desktop/activity excluded in settings — dead drag
+};
+
+/// Convert to the legacy wire-format string. Returns an empty QString for None.
+PHOSPHORPROTOCOL_EXPORT QString toWireString(DragBypassReason r);
+
+/// Parse from the legacy wire-format string. Unknown values map to None.
+PHOSPHORPROTOCOL_EXPORT DragBypassReason bypassReasonFromWireString(const QString& s);
+
+/// QDebug streaming for logging. Prints the enum name (e.g. "AutotileScreen").
+PHOSPHORPROTOCOL_EXPORT QDebug operator<<(QDebug debug, DragBypassReason r);
+
+/**
+ * @brief Compile-time check that a type has QDBusArgument streaming operators.
+ *
+ * Use in adaptor headers to catch missing operator<</>/>> definitions at build
+ * time rather than hitting a runtime "demarshalling function failed" crash.
+ *
+ * @code
+ *   static_assert(HasDBusStreaming<MyEntry>::value,
+ *       "MyEntry needs QDBusArgument operator<< and operator>> — see dbus_types.h");
+ * @endcode
+ */
+template<typename T, typename = void>
+struct HasDBusStreaming : std::false_type
+{
+};
+
+template<typename T>
+struct HasDBusStreaming<T,
+                        std::void_t<decltype(std::declval<QDBusArgument&>() << std::declval<const T&>()),
+                                    decltype(std::declval<const QDBusArgument&>() >> std::declval<T&>())>>
+    : std::true_type
+{
+};
+
+/// D-Bus struct for batch geometry entries: (siiii)
+struct WindowGeometryEntry
+{
+    QString windowId;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+    static WindowGeometryEntry fromRect(const QString& id, const QRect& r)
+    {
+        return {id, r.x(), r.y(), r.width(), r.height()};
+    }
+};
+
+using WindowGeometryList = QList<WindowGeometryEntry>;
+
+/// D-Bus struct for autotile tile requests: (siiiissbb)
+struct PHOSPHORPROTOCOL_EXPORT TileRequestEntry
+{
+    QString windowId;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+    QString zoneId;
+    QString screenId;
+    bool monocle = false;
+    bool floating = false;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+
+    /// Returns empty QString if valid, or a human-readable description of
+    /// the invariant violation. Call at every unmarshal site to detect a
+    /// garbled payload before acting on it.
+    QString validationError() const;
+};
+
+using TileRequestList = QList<TileRequestEntry>;
+
+/// D-Bus struct for snap-all result entries: (sssiiii)
+/// Carries targetZoneId so the plugin can confirm snaps without a second JSON parse.
+struct SnapAllResultEntry
+{
+    QString windowId;
+    QString targetZoneId;
+    QString sourceZoneId;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+    WindowGeometryEntry toGeometryEntry() const
+    {
+        return {windowId, x, y, width, height};
+    }
+};
+
+using SnapAllResultList = QList<SnapAllResultEntry>;
+
+/// D-Bus struct for batch snap confirmation: (sssb)
+struct SnapConfirmationEntry
+{
+    QString windowId;
+    QString zoneId;
+    QString screenId;
+    bool isRestore = false;
+};
+
+using SnapConfirmationList = QList<SnapConfirmationEntry>;
+
+/// D-Bus struct for batch window-opened notification: (ssii)
+struct WindowOpenedEntry
+{
+    QString windowId;
+    QString screenId;
+    int minWidth = 0;
+    int minHeight = 0;
+};
+
+using WindowOpenedList = QList<WindowOpenedEntry>;
+
+/// D-Bus struct for window state: (sssbsasb)
+struct WindowStateEntry
+{
+    QString windowId;
+    QString zoneId;
+    QString screenId;
+    bool isFloating = false;
+    QString changeType; ///< "snapped", "unsnapped", "floated", "unfloated", "screen_changed"
+    QStringList zoneIds; ///< D-Bus type 'as' — all zone IDs for multi-zone span (query only)
+    bool isSticky = false; ///< Whether window is on all virtual desktops (query only)
+};
+
+using WindowStateList = QList<WindowStateEntry>;
+
+/// D-Bus struct for unfloat restore result: (bassiiii).
+/// Intentionally scalar-only — `calculateUnfloatRestore` returns exactly one
+/// result per call. No `QList<UnfloatRestoreResult>` metatype is registered;
+/// if a batch variant is ever added, register the list type alongside it.
+struct UnfloatRestoreResult
+{
+    bool found = false;
+    QStringList zoneIds; ///< D-Bus type 'as'
+    QString screenName;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+};
+
+/// D-Bus struct for zone geometry: (iiii)
+struct ZoneGeometryRect
+{
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+    static ZoneGeometryRect fromRect(const QRect& r)
+    {
+        return {r.x(), r.y(), r.width(), r.height()};
+    }
+};
+
+using ZoneGeometryList = QList<ZoneGeometryRect>;
+
+/// D-Bus struct for empty zone info: (siiiiiibsssdd)
+struct EmptyZoneEntry
+{
+    QString zoneId;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+    int borderWidth = 0;
+    int borderRadius = 0;
+    bool useCustomColors = false;
+    QString highlightColor;
+    QString inactiveColor;
+    QString borderColor;
+    double activeOpacity = 0.5;
+    double inactiveOpacity = 0.3;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+};
+
+using EmptyZoneList = QList<EmptyZoneEntry>;
+
+/// D-Bus struct for snap assist candidate: (ssss)
+struct SnapAssistCandidate
+{
+    QString windowId;
+    QString compositorHandle;
+    QString icon;
+    QString caption;
+};
+
+using SnapAssistCandidateList = QList<SnapAssistCandidate>;
+
+/// D-Bus struct for named zone geometry: (siiii)
+struct NamedZoneGeometry
+{
+    QString zoneId;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+};
+
+using NamedZoneGeometryList = QList<NamedZoneGeometry>;
+
+/// D-Bus struct for algorithm metadata: (sssbbbbdibsbb)
+struct AlgorithmInfoEntry
+{
+    QString id;
+    QString name;
+    QString description;
+    bool supportsMasterCount = false;
+    bool supportsSplitRatio = false;
+    bool centerLayout = false;
+    bool producesOverlappingZones = false;
+    double defaultSplitRatio = 0.5;
+    int defaultMaxWindows = 0;
+    bool isScripted = false;
+    QString zoneNumberDisplay;
+    bool isUserScript = false;
+    bool supportsMemory = false;
+};
+
+using AlgorithmInfoList = QList<AlgorithmInfoEntry>;
+
+/// D-Bus struct for bridge registration result: (sss)
+struct PHOSPHORPROTOCOL_EXPORT BridgeRegistrationResult
+{
+    QString apiVersion;
+    QString bridgeName;
+    QString sessionId;
+
+    /// Returns empty QString if valid, or a human-readable description of
+    /// the invariant violation. "REJECTED" sessionId is a valid sentinel
+    /// signaling version mismatch and is NOT flagged as invalid — callers
+    /// must check for it separately before using the result.
+    QString validationError() const;
+};
+
+/// D-Bus struct for move/push/zone-number navigation result: (bssiiiiss)
+struct MoveTargetResult
+{
+    bool success = false;
+    QString reason;
+    QString zoneId;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+    QString sourceZoneId;
+    QString screenName;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+};
+
+/// D-Bus struct for focus navigation result: (bsssss)
+struct FocusTargetResult
+{
+    bool success = false;
+    QString reason;
+    QString windowIdToActivate;
+    QString sourceZoneId;
+    QString targetZoneId;
+    QString screenName;
+};
+
+/// D-Bus struct for cycle navigation result: (bssss)
+struct CycleTargetResult
+{
+    bool success = false;
+    QString reason;
+    QString windowIdToActivate;
+    QString zoneId;
+    QString screenName;
+};
+
+/// D-Bus struct for swap navigation result: (bssiiiissiiiissss)
+struct SwapTargetResult
+{
+    bool success = false;
+    QString reason;
+    QString windowId1;
+    int x1 = 0;
+    int y1 = 0;
+    int w1 = 0;
+    int h1 = 0;
+    QString zoneId1;
+    QString windowId2;
+    int x2 = 0;
+    int y2 = 0;
+    int w2 = 0;
+    int h2 = 0;
+    QString zoneId2;
+    QString screenName;
+    QString sourceZoneId;
+    QString targetZoneId;
+};
+
+/// Drag policy — daemon-authoritative decision about how a drag should be
+/// handled. Returned from WindowDragAdaptor::beginDrag at drag start and
+/// re-emitted via dragPolicyChanged if the cursor crosses a screen boundary
+/// that flips the mode (autotile↔snap). The compositor plugin uses this to
+/// decide whether to stream dragMoved, grab keyboard, show an overlay, and
+/// whether to apply an immediate float transition for an autotile drag.
+///
+/// Wire: (bbbbbss)  —  5 bools + 2 strings
+///
+/// Single source of truth replaces the effect-side
+/// m_dragBypassedForAutotile / m_cachedZoneSelectorEnabled cache that went
+/// stale after every settings reload.
+struct PHOSPHORPROTOCOL_EXPORT DragPolicy
+{
+    bool streamDragMoved = false; ///< effect should send dragMoved D-Bus ticks
+    bool showOverlay = false; ///< daemon will show zone overlay during this drag
+    bool grabKeyboard = false; ///< effect should grab keyboard (Escape cancel)
+    bool captureGeometry = false; ///< effect should capture pre-drag geometry
+    bool immediateFloatOnStart = false; ///< effect should call handleDragToFloat(immediate) at drag start
+    QString screenId; ///< screen the drag started/currently is on (virtual-screen-aware)
+    DragBypassReason bypassReason = DragBypassReason::None; ///< drag routing (None = canonical snap path)
+
+    /// Returns empty QString if valid, or a human-readable description of
+    /// the invariant violation. Call at every unmarshal site on the effect
+    /// side to catch garbled policies before they perturb drag state.
+    QString validationError() const;
+
+    /// Full structural equality. Used by WindowDragAdaptor::updateDragCursor
+    /// to detect per-screen policy changes during a drag — any field that
+    /// participates in routing (bypass reason, screen id, the behavior
+    /// flags) is compared, so future fields are picked up automatically
+    /// without touching the comparator.
+    bool operator==(const DragPolicy&) const = default;
+};
+
+/// Drag outcome — daemon-authoritative decision about what to apply at drag
+/// end. Returned from WindowDragAdaptor::endDrag. The compositor plugin
+/// executes exactly the action specified; no further decisions on the effect
+/// side. Wire: (issiiiisb)  —  int action + 2 strings + 4 ints + string + bool
+struct PHOSPHORPROTOCOL_EXPORT DragOutcome
+{
+    enum Action : int {
+        NoOp = 0, ///< drag produced no state change (e.g. cancelled with no prior snap)
+        ApplyFloat = 1, ///< autotile path: mark window floating at current position
+        ApplySnap = 2, ///< snap path: apply snap geometry to a zone
+        RestoreSize = 3, ///< drag-out unsnap: restore original size, keep current position
+        CancelSnap = 4, ///< snap cancelled via Escape
+        NotifyDragOutUnsnap = 5 ///< drag ended without activation trigger on a previously-snapped window
+    };
+
+    int action = NoOp;
+    QString windowId;
+    QString targetScreenId;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+    QString zoneId; ///< populated for ApplySnap
+    bool skipAnimation = false;
+    bool requestSnapAssist = false; ///< true → plugin should show snap-assist window picker
+    EmptyZoneList emptyZones; ///< candidate zones for snap assist (empty unless requestSnapAssist)
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+
+    /// Returns empty QString if valid, or a human-readable description of
+    /// the invariant violation. Enforces action enum range and per-action
+    /// cross-field invariants (ApplySnap requires non-empty zoneId + non-
+    /// zero size, ApplyFloat/RestoreSize/NotifyDragOutUnsnap require
+    /// windowId, etc).
+    QString validationError() const;
+};
+
+/// D-Bus struct for restore navigation result: (bbiiii)
+struct RestoreTargetResult
+{
+    bool success = false;
+    bool found = false;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+};
+
+/// D-Bus struct for pre-tile geometry entries: (siiiiis)
+/// Replaces the JSON blob previously returned by getPreTileGeometriesJson.
+struct PreTileGeometryEntry
+{
+    QString appId;
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+    QString screenId;
+
+    QRect toRect() const
+    {
+        return QRect(x, y, width, height);
+    }
+};
+
+using PreTileGeometryList = QList<PreTileGeometryEntry>;
+
+// QDBusArgument streaming operators (implemented in wiretypes.cpp)
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const WindowGeometryEntry& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, WindowGeometryEntry& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const TileRequestEntry& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, TileRequestEntry& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const SnapAllResultEntry& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, SnapAllResultEntry& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const SnapConfirmationEntry& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, SnapConfirmationEntry& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const WindowOpenedEntry& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, WindowOpenedEntry& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const WindowStateEntry& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, WindowStateEntry& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const UnfloatRestoreResult& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, UnfloatRestoreResult& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const ZoneGeometryRect& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, ZoneGeometryRect& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const EmptyZoneEntry& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, EmptyZoneEntry& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const SnapAssistCandidate& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, SnapAssistCandidate& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const NamedZoneGeometry& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, NamedZoneGeometry& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const AlgorithmInfoEntry& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, AlgorithmInfoEntry& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const BridgeRegistrationResult& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, BridgeRegistrationResult& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const MoveTargetResult& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, MoveTargetResult& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const FocusTargetResult& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, FocusTargetResult& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const CycleTargetResult& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, CycleTargetResult& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const SwapTargetResult& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, SwapTargetResult& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const RestoreTargetResult& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, RestoreTargetResult& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const PreTileGeometryEntry& e);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, PreTileGeometryEntry& e);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const DragPolicy& p);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, DragPolicy& p);
+PHOSPHORPROTOCOL_EXPORT QDBusArgument& operator<<(QDBusArgument& arg, const DragOutcome& o);
+PHOSPHORPROTOCOL_EXPORT const QDBusArgument& operator>>(const QDBusArgument& arg, DragOutcome& o);
+
+// Compile-time verification that all D-Bus struct types have streaming operators.
+// If you add a new struct above and forget the operator<</>> declarations, the
+// build will fail here with a clear message instead of crashing at runtime.
+static_assert(HasDBusStreaming<WindowGeometryEntry>::value, "WindowGeometryEntry missing QDBusArgument operators");
+static_assert(HasDBusStreaming<TileRequestEntry>::value, "TileRequestEntry missing QDBusArgument operators");
+static_assert(HasDBusStreaming<SnapAllResultEntry>::value, "SnapAllResultEntry missing QDBusArgument operators");
+static_assert(HasDBusStreaming<SnapConfirmationEntry>::value, "SnapConfirmationEntry missing QDBusArgument operators");
+static_assert(HasDBusStreaming<WindowOpenedEntry>::value, "WindowOpenedEntry missing QDBusArgument operators");
+static_assert(HasDBusStreaming<WindowStateEntry>::value, "WindowStateEntry missing QDBusArgument operators");
+static_assert(HasDBusStreaming<UnfloatRestoreResult>::value, "UnfloatRestoreResult missing QDBusArgument operators");
+static_assert(HasDBusStreaming<ZoneGeometryRect>::value, "ZoneGeometryRect missing QDBusArgument operators");
+static_assert(HasDBusStreaming<EmptyZoneEntry>::value, "EmptyZoneEntry missing QDBusArgument operators");
+static_assert(HasDBusStreaming<SnapAssistCandidate>::value, "SnapAssistCandidate missing QDBusArgument operators");
+static_assert(HasDBusStreaming<NamedZoneGeometry>::value, "NamedZoneGeometry missing QDBusArgument operators");
+static_assert(HasDBusStreaming<AlgorithmInfoEntry>::value, "AlgorithmInfoEntry missing QDBusArgument operators");
+static_assert(HasDBusStreaming<BridgeRegistrationResult>::value,
+              "BridgeRegistrationResult missing QDBusArgument operators");
+static_assert(HasDBusStreaming<MoveTargetResult>::value, "MoveTargetResult missing QDBusArgument operators");
+static_assert(HasDBusStreaming<FocusTargetResult>::value, "FocusTargetResult missing QDBusArgument operators");
+static_assert(HasDBusStreaming<CycleTargetResult>::value, "CycleTargetResult missing QDBusArgument operators");
+static_assert(HasDBusStreaming<SwapTargetResult>::value, "SwapTargetResult missing QDBusArgument operators");
+static_assert(HasDBusStreaming<RestoreTargetResult>::value, "RestoreTargetResult missing QDBusArgument operators");
+static_assert(HasDBusStreaming<PreTileGeometryEntry>::value, "PreTileGeometryEntry missing QDBusArgument operators");
+static_assert(HasDBusStreaming<DragPolicy>::value, "DragPolicy missing QDBusArgument operators");
+static_assert(HasDBusStreaming<DragOutcome>::value, "DragOutcome missing QDBusArgument operators");
+
+/// Call once at startup (daemon and plugin) to register types with Qt D-Bus
+PHOSPHORPROTOCOL_EXPORT void registerWireTypes();
+
+} // namespace PhosphorProtocol
+
+// Must be outside namespace for Qt meta-type system
+Q_DECLARE_METATYPE(PhosphorProtocol::WindowGeometryEntry)
+Q_DECLARE_METATYPE(PhosphorProtocol::WindowGeometryList)
+Q_DECLARE_METATYPE(PhosphorProtocol::TileRequestEntry)
+Q_DECLARE_METATYPE(PhosphorProtocol::TileRequestList)
+Q_DECLARE_METATYPE(PhosphorProtocol::SnapAllResultEntry)
+Q_DECLARE_METATYPE(PhosphorProtocol::SnapAllResultList)
+Q_DECLARE_METATYPE(PhosphorProtocol::SnapConfirmationEntry)
+Q_DECLARE_METATYPE(PhosphorProtocol::SnapConfirmationList)
+Q_DECLARE_METATYPE(PhosphorProtocol::WindowOpenedEntry)
+Q_DECLARE_METATYPE(PhosphorProtocol::WindowOpenedList)
+Q_DECLARE_METATYPE(PhosphorProtocol::WindowStateEntry)
+Q_DECLARE_METATYPE(PhosphorProtocol::WindowStateList)
+Q_DECLARE_METATYPE(PhosphorProtocol::UnfloatRestoreResult)
+Q_DECLARE_METATYPE(PhosphorProtocol::ZoneGeometryRect)
+Q_DECLARE_METATYPE(PhosphorProtocol::ZoneGeometryList)
+Q_DECLARE_METATYPE(PhosphorProtocol::EmptyZoneEntry)
+Q_DECLARE_METATYPE(PhosphorProtocol::EmptyZoneList)
+Q_DECLARE_METATYPE(PhosphorProtocol::SnapAssistCandidate)
+Q_DECLARE_METATYPE(PhosphorProtocol::SnapAssistCandidateList)
+Q_DECLARE_METATYPE(PhosphorProtocol::NamedZoneGeometry)
+Q_DECLARE_METATYPE(PhosphorProtocol::NamedZoneGeometryList)
+Q_DECLARE_METATYPE(PhosphorProtocol::AlgorithmInfoEntry)
+Q_DECLARE_METATYPE(PhosphorProtocol::AlgorithmInfoList)
+Q_DECLARE_METATYPE(PhosphorProtocol::BridgeRegistrationResult)
+Q_DECLARE_METATYPE(PhosphorProtocol::MoveTargetResult)
+Q_DECLARE_METATYPE(PhosphorProtocol::FocusTargetResult)
+Q_DECLARE_METATYPE(PhosphorProtocol::CycleTargetResult)
+Q_DECLARE_METATYPE(PhosphorProtocol::SwapTargetResult)
+Q_DECLARE_METATYPE(PhosphorProtocol::RestoreTargetResult)
+Q_DECLARE_METATYPE(PhosphorProtocol::PreTileGeometryEntry)
+Q_DECLARE_METATYPE(PhosphorProtocol::PreTileGeometryList)
+Q_DECLARE_METATYPE(PhosphorProtocol::DragPolicy)
+Q_DECLARE_METATYPE(PhosphorProtocol::DragOutcome)

--- a/libs/phosphor-protocol/include/PhosphorProtocol/WireTypes.h
+++ b/libs/phosphor-protocol/include/PhosphorProtocol/WireTypes.h
@@ -402,7 +402,7 @@ struct PHOSPHORPROTOCOL_EXPORT DragPolicy
 /// Drag outcome — daemon-authoritative decision about what to apply at drag
 /// end. Returned from WindowDragAdaptor::endDrag. The compositor plugin
 /// executes exactly the action specified; no further decisions on the effect
-/// side. Wire: (issiiiisb)  —  int action + 2 strings + 4 ints + string + bool
+/// side. Wire: (issiiiisbba(...))  —  int + 2 strings + 4 ints + string + 2 bools + EmptyZoneList
 struct PHOSPHORPROTOCOL_EXPORT DragOutcome
 {
     enum Action : int {

--- a/libs/phosphor-protocol/src/logging.cpp
+++ b/libs/phosphor-protocol/src/logging.cpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorProtocol/ClientHelpers.h>
+
+namespace PhosphorProtocol {
+
+static const QLoggingCategory s_category("phosphor.protocol", QtInfoMsg);
+
+const QLoggingCategory& lcPhosphorProtocol()
+{
+    return s_category;
+}
+
+} // namespace PhosphorProtocol

--- a/libs/phosphor-protocol/src/wiretypes.cpp
+++ b/libs/phosphor-protocol/src/wiretypes.cpp
@@ -1,0 +1,592 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorProtocol/WireTypes.h>
+
+#include <QDebug>
+#include <QLatin1String>
+
+namespace PhosphorProtocol {
+
+namespace {
+// Wire-format strings for DragBypassReason. Kept as a single source of truth
+// so toWireString() and bypassReasonFromWireString() can never drift.
+constexpr QLatin1String kBypassAutotileScreen("autotile_screen");
+constexpr QLatin1String kBypassSnappingDisabled("snapping_disabled");
+constexpr QLatin1String kBypassContextDisabled("context_disabled");
+} // namespace
+
+QString toWireString(DragBypassReason r)
+{
+    switch (r) {
+    case DragBypassReason::None:
+        return {};
+    case DragBypassReason::AutotileScreen:
+        return kBypassAutotileScreen;
+    case DragBypassReason::SnappingDisabled:
+        return kBypassSnappingDisabled;
+    case DragBypassReason::ContextDisabled:
+        return kBypassContextDisabled;
+    }
+    return {};
+}
+
+DragBypassReason bypassReasonFromWireString(const QString& s)
+{
+    if (s.isEmpty()) {
+        return DragBypassReason::None;
+    }
+    if (s == kBypassAutotileScreen) {
+        return DragBypassReason::AutotileScreen;
+    }
+    if (s == kBypassSnappingDisabled) {
+        return DragBypassReason::SnappingDisabled;
+    }
+    if (s == kBypassContextDisabled) {
+        return DragBypassReason::ContextDisabled;
+    }
+    qWarning() << "bypassReasonFromWireString: unknown wire value" << s << "— mapping to None";
+    return DragBypassReason::None;
+}
+
+QString TileRequestEntry::validationError() const
+{
+    if (windowId.isEmpty()) {
+        return QStringLiteral("TileRequestEntry: empty windowId");
+    }
+    if (screenId.isEmpty()) {
+        return QStringLiteral("TileRequestEntry: empty screenId (windowId=%1)").arg(windowId);
+    }
+    if (width < 0 || height < 0) {
+        return QStringLiteral("TileRequestEntry: negative size (windowId=%1 w=%2 h=%3)")
+            .arg(windowId)
+            .arg(width)
+            .arg(height);
+    }
+    // Floating tile requests legitimately carry zero size — the plugin
+    // resolves geometry from the current frame. Tiled requests must have
+    // concrete geometry or the plugin has nothing to apply.
+    if (!floating && (width == 0 || height == 0)) {
+        return QStringLiteral("TileRequestEntry: tiled request requires non-zero size (windowId=%1)").arg(windowId);
+    }
+    return {};
+}
+
+QString BridgeRegistrationResult::validationError() const
+{
+    // REJECTED is a legitimate sentinel the daemon sends when peer version
+    // is incompatible. Surface it as valid so the caller can branch on it
+    // before calling any other methods on the result.
+    if (sessionId == QLatin1String("REJECTED")) {
+        return {};
+    }
+    if (apiVersion.isEmpty()) {
+        return QStringLiteral("BridgeRegistrationResult: empty apiVersion");
+    }
+    bool ok = false;
+    apiVersion.toInt(&ok);
+    if (!ok) {
+        return QStringLiteral("BridgeRegistrationResult: apiVersion not an integer: '%1'").arg(apiVersion);
+    }
+    if (bridgeName.isEmpty()) {
+        return QStringLiteral("BridgeRegistrationResult: empty bridgeName");
+    }
+    if (sessionId.isEmpty()) {
+        return QStringLiteral("BridgeRegistrationResult: empty sessionId");
+    }
+    return {};
+}
+
+QString DragPolicy::validationError() const
+{
+    // The only strong invariant: an AutotileScreen bypass must carry the
+    // autotile screen id, because the effect uses it to scope retroactive
+    // bypass state and the post-drag float target. Other bypass reasons
+    // (SnappingDisabled, ContextDisabled) may be emitted with an empty
+    // screenId when beginDrag was called with an empty startScreenId —
+    // the producer code in drag_protocol.cpp deliberately tolerates that.
+    if (bypassReason == DragBypassReason::AutotileScreen && screenId.isEmpty()) {
+        return QStringLiteral("DragPolicy: AutotileScreen bypass requires non-empty screenId");
+    }
+    return {};
+}
+
+QString DragOutcome::validationError() const
+{
+    // action enum range check — catches memory corruption or protocol
+    // drift from a peer built at a different revision.
+    if (action < NoOp || action > NotifyDragOutUnsnap) {
+        return QStringLiteral("DragOutcome: action out of range: %1").arg(action);
+    }
+
+    // windowId is required for every action that does real work.
+    if (action != NoOp && windowId.isEmpty()) {
+        return QStringLiteral("DragOutcome: windowId required for action=%1").arg(action);
+    }
+
+    switch (action) {
+    case NoOp:
+    case CancelSnap:
+        // No further cross-field requirements.
+        break;
+    case ApplyFloat:
+        // ApplyFloat carries cursor position; (0,0) is a legitimate drop
+        // location at top-left. targetScreenId is optional — the plugin
+        // resolves it from the cursor.
+        break;
+    case ApplySnap:
+        if (zoneId.isEmpty()) {
+            return QStringLiteral("DragOutcome: ApplySnap requires non-empty zoneId (windowId=%1)").arg(windowId);
+        }
+        if (width <= 0 || height <= 0) {
+            return QStringLiteral("DragOutcome: ApplySnap requires non-zero size (windowId=%1 w=%2 h=%3)")
+                .arg(windowId)
+                .arg(width)
+                .arg(height);
+        }
+        break;
+    case RestoreSize:
+        if (width <= 0 || height <= 0) {
+            return QStringLiteral("DragOutcome: RestoreSize requires non-zero size (windowId=%1 w=%2 h=%3)")
+                .arg(windowId)
+                .arg(width)
+                .arg(height);
+        }
+        break;
+    case NotifyDragOutUnsnap:
+        // windowId (checked above) is the only requirement.
+        break;
+    }
+    return {};
+}
+
+QDebug operator<<(QDebug debug, DragBypassReason r)
+{
+    QDebugStateSaver saver(debug);
+    debug.nospace();
+    switch (r) {
+    case DragBypassReason::None:
+        debug << "DragBypassReason::None";
+        break;
+    case DragBypassReason::AutotileScreen:
+        debug << "DragBypassReason::AutotileScreen";
+        break;
+    case DragBypassReason::SnappingDisabled:
+        debug << "DragBypassReason::SnappingDisabled";
+        break;
+    case DragBypassReason::ContextDisabled:
+        debug << "DragBypassReason::ContextDisabled";
+        break;
+    }
+    return debug;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const WindowGeometryEntry& e)
+{
+    arg.beginStructure();
+    arg << e.windowId << e.x << e.y << e.width << e.height;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, WindowGeometryEntry& e)
+{
+    arg.beginStructure();
+    arg >> e.windowId >> e.x >> e.y >> e.width >> e.height;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const TileRequestEntry& e)
+{
+    arg.beginStructure();
+    arg << e.windowId << e.x << e.y << e.width << e.height << e.zoneId << e.screenId << e.monocle << e.floating;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, TileRequestEntry& e)
+{
+    arg.beginStructure();
+    arg >> e.windowId >> e.x >> e.y >> e.width >> e.height >> e.zoneId >> e.screenId >> e.monocle >> e.floating;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const SnapAllResultEntry& e)
+{
+    arg.beginStructure();
+    arg << e.windowId << e.targetZoneId << e.sourceZoneId << e.x << e.y << e.width << e.height;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, SnapAllResultEntry& e)
+{
+    arg.beginStructure();
+    arg >> e.windowId >> e.targetZoneId >> e.sourceZoneId >> e.x >> e.y >> e.width >> e.height;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const SnapConfirmationEntry& e)
+{
+    arg.beginStructure();
+    arg << e.windowId << e.zoneId << e.screenId << e.isRestore;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, SnapConfirmationEntry& e)
+{
+    arg.beginStructure();
+    arg >> e.windowId >> e.zoneId >> e.screenId >> e.isRestore;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const WindowOpenedEntry& e)
+{
+    arg.beginStructure();
+    arg << e.windowId << e.screenId << e.minWidth << e.minHeight;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, WindowOpenedEntry& e)
+{
+    arg.beginStructure();
+    arg >> e.windowId >> e.screenId >> e.minWidth >> e.minHeight;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const WindowStateEntry& e)
+{
+    arg.beginStructure();
+    arg << e.windowId << e.zoneId << e.screenId << e.isFloating << e.changeType << e.zoneIds << e.isSticky;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, WindowStateEntry& e)
+{
+    arg.beginStructure();
+    arg >> e.windowId >> e.zoneId >> e.screenId >> e.isFloating >> e.changeType >> e.zoneIds >> e.isSticky;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const UnfloatRestoreResult& e)
+{
+    arg.beginStructure();
+    arg << e.found << e.zoneIds << e.screenName << e.x << e.y << e.width << e.height;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, UnfloatRestoreResult& e)
+{
+    arg.beginStructure();
+    arg >> e.found >> e.zoneIds >> e.screenName >> e.x >> e.y >> e.width >> e.height;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const ZoneGeometryRect& e)
+{
+    arg.beginStructure();
+    arg << e.x << e.y << e.width << e.height;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, ZoneGeometryRect& e)
+{
+    arg.beginStructure();
+    arg >> e.x >> e.y >> e.width >> e.height;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const EmptyZoneEntry& e)
+{
+    arg.beginStructure();
+    arg << e.zoneId << e.x << e.y << e.width << e.height << e.borderWidth << e.borderRadius << e.useCustomColors
+        << e.highlightColor << e.inactiveColor << e.borderColor << e.activeOpacity << e.inactiveOpacity;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, EmptyZoneEntry& e)
+{
+    arg.beginStructure();
+    arg >> e.zoneId >> e.x >> e.y >> e.width >> e.height >> e.borderWidth >> e.borderRadius >> e.useCustomColors
+        >> e.highlightColor >> e.inactiveColor >> e.borderColor >> e.activeOpacity >> e.inactiveOpacity;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const SnapAssistCandidate& e)
+{
+    arg.beginStructure();
+    arg << e.windowId << e.compositorHandle << e.icon << e.caption;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, SnapAssistCandidate& e)
+{
+    arg.beginStructure();
+    arg >> e.windowId >> e.compositorHandle >> e.icon >> e.caption;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const NamedZoneGeometry& e)
+{
+    arg.beginStructure();
+    arg << e.zoneId << e.x << e.y << e.width << e.height;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, NamedZoneGeometry& e)
+{
+    arg.beginStructure();
+    arg >> e.zoneId >> e.x >> e.y >> e.width >> e.height;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const AlgorithmInfoEntry& e)
+{
+    arg.beginStructure();
+    arg << e.id << e.name << e.description << e.supportsMasterCount << e.supportsSplitRatio << e.centerLayout
+        << e.producesOverlappingZones << e.defaultSplitRatio << e.defaultMaxWindows << e.isScripted
+        << e.zoneNumberDisplay << e.isUserScript << e.supportsMemory;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, AlgorithmInfoEntry& e)
+{
+    arg.beginStructure();
+    arg >> e.id >> e.name >> e.description >> e.supportsMasterCount >> e.supportsSplitRatio >> e.centerLayout
+        >> e.producesOverlappingZones >> e.defaultSplitRatio >> e.defaultMaxWindows >> e.isScripted
+        >> e.zoneNumberDisplay >> e.isUserScript >> e.supportsMemory;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const BridgeRegistrationResult& e)
+{
+    arg.beginStructure();
+    arg << e.apiVersion << e.bridgeName << e.sessionId;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, BridgeRegistrationResult& e)
+{
+    arg.beginStructure();
+    arg >> e.apiVersion >> e.bridgeName >> e.sessionId;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const MoveTargetResult& e)
+{
+    arg.beginStructure();
+    arg << e.success << e.reason << e.zoneId << e.x << e.y << e.width << e.height << e.sourceZoneId << e.screenName;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, MoveTargetResult& e)
+{
+    arg.beginStructure();
+    arg >> e.success >> e.reason >> e.zoneId >> e.x >> e.y >> e.width >> e.height >> e.sourceZoneId >> e.screenName;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const FocusTargetResult& e)
+{
+    arg.beginStructure();
+    arg << e.success << e.reason << e.windowIdToActivate << e.sourceZoneId << e.targetZoneId << e.screenName;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, FocusTargetResult& e)
+{
+    arg.beginStructure();
+    arg >> e.success >> e.reason >> e.windowIdToActivate >> e.sourceZoneId >> e.targetZoneId >> e.screenName;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const CycleTargetResult& e)
+{
+    arg.beginStructure();
+    arg << e.success << e.reason << e.windowIdToActivate << e.zoneId << e.screenName;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, CycleTargetResult& e)
+{
+    arg.beginStructure();
+    arg >> e.success >> e.reason >> e.windowIdToActivate >> e.zoneId >> e.screenName;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const SwapTargetResult& e)
+{
+    arg.beginStructure();
+    arg << e.success << e.reason << e.windowId1 << e.x1 << e.y1 << e.w1 << e.h1 << e.zoneId1 << e.windowId2 << e.x2
+        << e.y2 << e.w2 << e.h2 << e.zoneId2 << e.screenName << e.sourceZoneId << e.targetZoneId;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, SwapTargetResult& e)
+{
+    arg.beginStructure();
+    arg >> e.success >> e.reason >> e.windowId1 >> e.x1 >> e.y1 >> e.w1 >> e.h1 >> e.zoneId1 >> e.windowId2 >> e.x2
+        >> e.y2 >> e.w2 >> e.h2 >> e.zoneId2 >> e.screenName >> e.sourceZoneId >> e.targetZoneId;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const RestoreTargetResult& e)
+{
+    arg.beginStructure();
+    arg << e.success << e.found << e.x << e.y << e.width << e.height;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, RestoreTargetResult& e)
+{
+    arg.beginStructure();
+    arg >> e.success >> e.found >> e.x >> e.y >> e.width >> e.height;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const PreTileGeometryEntry& e)
+{
+    arg.beginStructure();
+    arg << e.appId << e.x << e.y << e.width << e.height << e.screenId;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, PreTileGeometryEntry& e)
+{
+    arg.beginStructure();
+    arg >> e.appId >> e.x >> e.y >> e.width >> e.height >> e.screenId;
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const DragPolicy& p)
+{
+    // Wire format kept as `(bbbbbss)` — bypassReason is serialized as its
+    // legacy string representation so effects/daemons built at different
+    // revisions still interoperate within the same ApiVersion.
+    arg.beginStructure();
+    arg << p.streamDragMoved << p.showOverlay << p.grabKeyboard << p.captureGeometry << p.immediateFloatOnStart
+        << p.screenId << toWireString(p.bypassReason);
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, DragPolicy& p)
+{
+    arg.beginStructure();
+    QString bypassWire;
+    arg >> p.streamDragMoved >> p.showOverlay >> p.grabKeyboard >> p.captureGeometry >> p.immediateFloatOnStart
+        >> p.screenId >> bypassWire;
+    p.bypassReason = bypassReasonFromWireString(bypassWire);
+    arg.endStructure();
+    return arg;
+}
+
+QDBusArgument& operator<<(QDBusArgument& arg, const DragOutcome& o)
+{
+    arg.beginStructure();
+    arg << o.action << o.windowId << o.targetScreenId << o.x << o.y << o.width << o.height << o.zoneId
+        << o.skipAnimation << o.requestSnapAssist << o.emptyZones;
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, DragOutcome& o)
+{
+    arg.beginStructure();
+    arg >> o.action >> o.windowId >> o.targetScreenId >> o.x >> o.y >> o.width >> o.height >> o.zoneId
+        >> o.skipAnimation >> o.requestSnapAssist >> o.emptyZones;
+    arg.endStructure();
+    return arg;
+}
+
+void registerWireTypes()
+{
+    // IMPORTANT: register each type under BOTH its qualified and unqualified
+    // names. Q_DECLARE_METATYPE must be at global scope, so it registers under
+    // the fully-qualified name "PlasmaZones::Foo". The authoritative fix is to
+    // fully-qualify the type in every adaptor slot parameter declaration (see
+    // e.g. autotileadaptor.h) so moc records "PlasmaZones::Foo" and matches
+    // the qualified registration. This unqualified-alias registration is a
+    // defensive belt-and-suspenders so that a future adaptor written with
+    // unqualified slot parameters still works rather than crashing D-Bus
+    // dispatch at runtime (see dbus_adaptor_routing integration test for the
+    // failure mode — "Could not find slot ..." / "demarshalling function for
+    // type 'QString' failed" observed in production on 2026-04-10).
+
+#define PZ_REGISTER_DBUS_TYPE(Type)                                                                                    \
+    qRegisterMetaType<Type>(#Type);                                                                                    \
+    qDBusRegisterMetaType<Type>()
+
+    PZ_REGISTER_DBUS_TYPE(WindowGeometryEntry);
+    PZ_REGISTER_DBUS_TYPE(WindowGeometryList);
+    PZ_REGISTER_DBUS_TYPE(TileRequestEntry);
+    PZ_REGISTER_DBUS_TYPE(TileRequestList);
+    PZ_REGISTER_DBUS_TYPE(SnapAllResultEntry);
+    PZ_REGISTER_DBUS_TYPE(SnapAllResultList);
+    PZ_REGISTER_DBUS_TYPE(SnapConfirmationEntry);
+    PZ_REGISTER_DBUS_TYPE(SnapConfirmationList);
+    PZ_REGISTER_DBUS_TYPE(WindowOpenedEntry);
+    PZ_REGISTER_DBUS_TYPE(WindowOpenedList);
+    PZ_REGISTER_DBUS_TYPE(WindowStateEntry);
+    PZ_REGISTER_DBUS_TYPE(WindowStateList);
+    PZ_REGISTER_DBUS_TYPE(UnfloatRestoreResult);
+    PZ_REGISTER_DBUS_TYPE(ZoneGeometryRect);
+    PZ_REGISTER_DBUS_TYPE(ZoneGeometryList);
+    PZ_REGISTER_DBUS_TYPE(EmptyZoneEntry);
+    PZ_REGISTER_DBUS_TYPE(EmptyZoneList);
+    PZ_REGISTER_DBUS_TYPE(SnapAssistCandidate);
+    PZ_REGISTER_DBUS_TYPE(SnapAssistCandidateList);
+    PZ_REGISTER_DBUS_TYPE(NamedZoneGeometry);
+    PZ_REGISTER_DBUS_TYPE(NamedZoneGeometryList);
+    PZ_REGISTER_DBUS_TYPE(AlgorithmInfoEntry);
+    PZ_REGISTER_DBUS_TYPE(AlgorithmInfoList);
+    PZ_REGISTER_DBUS_TYPE(BridgeRegistrationResult);
+    PZ_REGISTER_DBUS_TYPE(MoveTargetResult);
+    PZ_REGISTER_DBUS_TYPE(FocusTargetResult);
+    PZ_REGISTER_DBUS_TYPE(CycleTargetResult);
+    PZ_REGISTER_DBUS_TYPE(SwapTargetResult);
+    PZ_REGISTER_DBUS_TYPE(RestoreTargetResult);
+    PZ_REGISTER_DBUS_TYPE(PreTileGeometryEntry);
+    PZ_REGISTER_DBUS_TYPE(PreTileGeometryList);
+    PZ_REGISTER_DBUS_TYPE(DragPolicy);
+    PZ_REGISTER_DBUS_TYPE(DragOutcome);
+
+#undef PZ_REGISTER_DBUS_TYPE
+}
+
+} // namespace PhosphorProtocol

--- a/libs/phosphor-protocol/tests/CMakeLists.txt
+++ b/libs/phosphor-protocol/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Test)
+
+add_executable(test_phosphorprotocol
+    test_phosphorprotocol.cpp
+)
+
+target_link_libraries(test_phosphorprotocol
+    PRIVATE
+        PhosphorProtocol::PhosphorProtocol
+        Qt6::Test
+)
+
+add_test(NAME test_phosphorprotocol COMMAND test_phosphorprotocol)

--- a/libs/phosphor-protocol/tests/test_phosphorprotocol.cpp
+++ b/libs/phosphor-protocol/tests/test_phosphorprotocol.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorProtocol/WireTypes.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+
+#include <QTest>
+
+using namespace PhosphorProtocol;
+
+class TestPhosphorProtocol : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        registerWireTypes();
+    }
+
+    // D-Bus round-trip tests are in test_compositor_common (requires full message transport).
+
+    void testWindowGeometryToRect()
+    {
+        WindowGeometryEntry e{QStringLiteral("w"), 5, 10, 100, 200};
+        QCOMPARE(e.toRect(), QRect(5, 10, 100, 200));
+    }
+
+    void testWindowGeometryFromRect()
+    {
+        auto e = WindowGeometryEntry::fromRect(QStringLiteral("w"), QRect(1, 2, 3, 4));
+        QCOMPARE(e.windowId, QStringLiteral("w"));
+        QCOMPARE(e.x, 1);
+        QCOMPARE(e.y, 2);
+        QCOMPARE(e.width, 3);
+        QCOMPARE(e.height, 4);
+    }
+
+    // DragPolicy and DragOutcome round-trips are covered by test_compositor_common
+    // (they require full D-Bus message transport for nested types like EmptyZoneList).
+
+    void testBypassReasonWireStringRoundTrip()
+    {
+        QCOMPARE(bypassReasonFromWireString(toWireString(DragBypassReason::None)), DragBypassReason::None);
+        QCOMPARE(bypassReasonFromWireString(toWireString(DragBypassReason::AutotileScreen)),
+                 DragBypassReason::AutotileScreen);
+        QCOMPARE(bypassReasonFromWireString(toWireString(DragBypassReason::SnappingDisabled)),
+                 DragBypassReason::SnappingDisabled);
+        QCOMPARE(bypassReasonFromWireString(toWireString(DragBypassReason::ContextDisabled)),
+                 DragBypassReason::ContextDisabled);
+    }
+
+    void testBypassReasonUnknownFallback()
+    {
+        QCOMPARE(bypassReasonFromWireString(QStringLiteral("bogus")), DragBypassReason::None);
+    }
+
+    void testTileRequestValidationEmpty()
+    {
+        TileRequestEntry e;
+        QVERIFY(!e.validationError().isEmpty());
+    }
+
+    void testTileRequestValidationValid()
+    {
+        TileRequestEntry e;
+        e.windowId = QStringLiteral("w");
+        e.screenId = QStringLiteral("s");
+        e.width = 100;
+        e.height = 100;
+        QVERIFY(e.validationError().isEmpty());
+    }
+
+    void testTileRequestValidationFloatingZeroSize()
+    {
+        TileRequestEntry e;
+        e.windowId = QStringLiteral("w");
+        e.screenId = QStringLiteral("s");
+        e.floating = true;
+        e.width = 0;
+        e.height = 0;
+        QVERIFY(e.validationError().isEmpty());
+    }
+
+    void testDragPolicyValidationAutotileNoScreen()
+    {
+        DragPolicy p;
+        p.bypassReason = DragBypassReason::AutotileScreen;
+        p.screenId.clear();
+        QVERIFY(!p.validationError().isEmpty());
+    }
+
+    void testDragOutcomeValidationApplySnapNoZone()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::ApplySnap;
+        o.windowId = QStringLiteral("w");
+        o.zoneId.clear();
+        QVERIFY(!o.validationError().isEmpty());
+    }
+
+    void testDragOutcomeValidationNoOp()
+    {
+        DragOutcome o;
+        o.action = DragOutcome::NoOp;
+        QVERIFY(o.validationError().isEmpty());
+    }
+
+    void testBridgeRegistrationValidation()
+    {
+        BridgeRegistrationResult r;
+        r.apiVersion = QStringLiteral("2");
+        r.bridgeName = QStringLiteral("kwin");
+        r.sessionId = QStringLiteral("abc");
+        QVERIFY(r.validationError().isEmpty());
+    }
+
+    void testBridgeRegistrationRejected()
+    {
+        BridgeRegistrationResult r;
+        r.sessionId = QStringLiteral("REJECTED");
+        QVERIFY(r.validationError().isEmpty());
+    }
+
+    void testServiceConstants()
+    {
+        QCOMPARE(Service::Name, QLatin1String("org.plasmazones"));
+        QCOMPARE(Service::ObjectPath, QLatin1String("/PlasmaZones"));
+        QCOMPARE(Service::ApiVersion, 2);
+        QCOMPARE(Service::MinPeerApiVersion, 2);
+    }
+
+    // SnapAssistCandidate round-trip is covered by test_compositor_common.
+};
+
+QTEST_GUILESS_MAIN(TestPhosphorProtocol)
+#include "test_phosphorprotocol.moc"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -225,6 +225,7 @@ target_link_libraries(plasmazones_core
         PhosphorConfig::PhosphorConfig
         PhosphorIdentity::PhosphorIdentity
         PhosphorLayoutApi::PhosphorLayoutApi
+        PhosphorProtocol::PhosphorProtocol
         PhosphorScreens::PhosphorScreens
         PhosphorShell::PhosphorShell
         PhosphorTiles::PhosphorTiles

--- a/src/common/daemoncontroller.cpp
+++ b/src/common/daemoncontroller.cpp
@@ -8,6 +8,7 @@
 #include <QTimer>
 #include "../../src/core/constants.h"
 #include "../../src/core/logging.h"
+#include <PhosphorProtocol/ServiceConstants.h>
 
 namespace PlasmaZones {
 
@@ -22,7 +23,7 @@ DaemonController::DaemonController(QObject* parent)
 
     // Set up D-Bus service watcher for immediate daemon start/stop notification
     m_watcher = new QDBusServiceWatcher(
-        QString(DBus::ServiceName), QDBusConnection::sessionBus(),
+        QString(PhosphorProtocol::Service::Name), QDBusConnection::sessionBus(),
         QDBusServiceWatcher::WatchForRegistration | QDBusServiceWatcher::WatchForUnregistration, this);
 
     connect(m_watcher, &QDBusServiceWatcher::serviceRegistered, this, [this]() {
@@ -69,7 +70,7 @@ bool DaemonController::isRunning() const
     if (!iface) {
         return false;
     }
-    return iface->isServiceRegistered(QString(DBus::ServiceName));
+    return iface->isServiceRegistered(QString(PhosphorProtocol::Service::Name));
 }
 
 bool DaemonController::isEnabled() const

--- a/src/compositor-common/CMakeLists.txt
+++ b/src/compositor-common/CMakeLists.txt
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # Compositor-agnostic shared library for PlasmaZones compositor plugins.
-# Contains D-Bus helpers, JSON parsing, trigger marshalling, and other
-# portable code shared by the KWin effect, Wayfire plugin, and future
-# compositor integrations.
+# Contains JSON parsing, trigger marshalling, and other portable code
+# shared by the KWin effect, Wayfire plugin, and future compositor
+# integrations.  D-Bus wire types and service constants moved to
+# PhosphorProtocol.
 #
 # Animation primitives (EasingCurve, WindowAnimation, AnimationConfig,
 # AnimationMath, applyStaggeredOrImmediate) moved to PhosphorAnimation.
@@ -14,8 +15,6 @@
 # NOTE: If this ever becomes a shared (SHARED) library, all public API types
 # (BorderState, WindowInfo, etc.) will need PLASMAZONES_EXPORT macros.
 add_library(plasmazones_compositor_common STATIC
-    logging.cpp
-    logging.h
     snap_assist_filter.cpp
     snap_assist_filter.h
     trigger_parser.cpp
@@ -29,13 +28,13 @@ add_library(plasmazones_compositor_common STATIC
     # Animation primitives moved to libs/phosphor-animation. Consumers
     # include <PhosphorAnimation/{Easing,WindowMotion,AnimationMath,
     # StaggerTimer}.h> directly — no forwarding shim.
+    #
+    # D-Bus wire types (dbus_types), constants (dbus_constants), helpers
+    # (dbus_helpers), and logging moved to libs/phosphor-protocol.
+    # Consumers include <PhosphorProtocol/…> headers directly.
     autotile_state.h
     compositor_bridge.h
-    dbus_types.cpp
-    dbus_constants.h
     debounced_action.h
-    dbus_helpers.h
-    dbus_types.h
     floating_cache.h
     geometry_helpers.h
 )
@@ -47,7 +46,7 @@ target_include_directories(plasmazones_compositor_common PUBLIC
 target_link_libraries(plasmazones_compositor_common PUBLIC
     Qt6::Core
     Qt6::Gui
-    Qt6::DBus
+    PhosphorProtocol::PhosphorProtocol
     PhosphorIdentity::PhosphorIdentity
     PhosphorAnimation::PhosphorAnimation
 )

--- a/src/compositor-common/snap_assist_filter.h
+++ b/src/compositor-common/snap_assist_filter.h
@@ -4,13 +4,16 @@
 #pragma once
 
 #include "compositor_bridge.h"
-#include "dbus_types.h"
 #include <PhosphorIdentity/WindowId.h>
+#include <PhosphorProtocol/WireTypes.h>
 
 #include <QSet>
 #include <QString>
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::SnapAssistCandidate;
+using PhosphorProtocol::SnapAssistCandidateList;
 
 /**
  * @brief Compositor-agnostic snap assist candidate builder

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -9,12 +9,6 @@
 #include <QString>
 #include <limits>
 
-// Pull in the canonical effect↔daemon protocol-version constants
-// (PlasmaZones::DBus::ApiVersion / MinPeerApiVersion). Defined in
-// compositor-common so the KWin effect, which does not link
-// plasmazones_core, shares exactly one definition with the daemon.
-#include <dbus_constants.h>
-
 // Shared shapes (per-side gap struct + aspect-ratio classification) live in
 // libs/phosphor-layout-api so every layout/tile provider can consume them
 // without forcing them to depend on PlasmaZones internals.  Re-aliased into
@@ -221,13 +215,15 @@ inline constexpr QLatin1String ZoneSelectorIdPrefix{"zoneselector-"};
 inline constexpr QLatin1StringView RestoreSentinel("__restore__");
 
 /**
- * @brief D-Bus service constants
+ * @brief D-Bus identity constants for PlasmaZones sub-applications
  *
- * ServiceName, ObjectPath, ApiVersion / MinPeerApiVersion, and the
- * per-interface name table all live in compositor-common/dbus_constants.h
- * (included at the top of this file) — that's the single source of truth
- * shared with the KWin effect, which doesn't link plasmazones_core.
- * This re-opens `namespace DBus` only to add daemon-only constants.
+ * The daemon protocol constants (service name, object path, interfaces,
+ * API version, timeout) live in PhosphorProtocol::Service
+ * (libs/phosphor-protocol). Consumers reference them qualified directly.
+ *
+ * This namespace holds only the app-specific D-Bus identities for the
+ * settings and editor processes (single-instance management, not
+ * daemon protocol).
  */
 namespace DBus {
 

--- a/src/core/geometryutils.h
+++ b/src/core/geometryutils.h
@@ -6,7 +6,7 @@
 #include "constants.h"
 #include "plasmazones_export.h"
 #include "types.h"
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QRectF>
 #include <QScreen>
 #include <QVariantMap>
@@ -26,6 +26,9 @@ class ScreenManager;
 }
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::EmptyZoneEntry;
+using PhosphorProtocol::EmptyZoneList;
 
 class ISettings;
 

--- a/src/core/ioverlayservice.h
+++ b/src/core/ioverlayservice.h
@@ -12,7 +12,7 @@
 
 #include "plasmazones_export.h"
 
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 
 #include <QObject>
 #include <QRect>
@@ -28,6 +28,9 @@ class Zone;
 }
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::EmptyZoneList;
+using PhosphorProtocol::SnapAssistCandidateList;
 
 class ISettings;
 

--- a/src/core/windowtrackingservice.h
+++ b/src/core/windowtrackingservice.h
@@ -5,7 +5,7 @@
 
 #include "plasmazones_export.h"
 #include "types.h"
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
 #include <QString>
 #include <QStringList>
@@ -34,6 +34,12 @@ namespace Phosphor::Screens {
 class ScreenManager;
 }
 namespace PlasmaZones {
+
+using PhosphorProtocol::EmptyZoneList;
+using PhosphorProtocol::WindowGeometryEntry;
+using PhosphorProtocol::WindowGeometryList;
+using PhosphorProtocol::WindowStateEntry;
+
 class VirtualDesktopManager;
 class WindowRegistry;
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -31,6 +31,7 @@
 #include "../core/activitymanager.h"
 #include "../core/constants.h"
 #include "../core/geometryutils.h"
+#include <PhosphorProtocol/ServiceConstants.h>
 #include "../core/logging.h"
 #include "../core/screenmoderouter.h"
 #include "../core/utils.h"
@@ -714,7 +715,7 @@ bool Daemon::init()
     constexpr int baseDelayMs = 100; // 100ms, 200ms, 400ms exponential backoff
     bool serviceRegistered = false;
     for (int attempt = 0; attempt < maxRetries; ++attempt) {
-        if (bus.registerService(QString(DBus::ServiceName))) {
+        if (bus.registerService(QString(PhosphorProtocol::Service::Name))) {
             serviceRegistered = true;
             break;
         }
@@ -732,8 +733,8 @@ bool Daemon::init()
         }
 
         // Non-retryable error or max retries reached
-        qCCritical(lcDaemon) << "Failed to register D-Bus service=" << DBus::ServiceName << "error=" << error.message()
-                             << "type=" << error.type();
+        qCCritical(lcDaemon) << "Failed to register D-Bus service=" << PhosphorProtocol::Service::Name
+                             << "error=" << error.message() << "type=" << error.type();
         return false;
     }
 
@@ -743,15 +744,17 @@ bool Daemon::init()
     }
 
     // Register D-Bus object (no retry needed - service is already registered)
-    if (!bus.registerObject(QString(DBus::ObjectPath), this)) {
+    if (!bus.registerObject(QString(PhosphorProtocol::Service::ObjectPath), this)) {
         QDBusError error = bus.lastError();
-        qCCritical(lcDaemon) << "Failed to register D-Bus object=" << DBus::ObjectPath << "error=" << error.message();
+        qCCritical(lcDaemon) << "Failed to register D-Bus object=" << PhosphorProtocol::Service::ObjectPath
+                             << "error=" << error.message();
         // Cleanup: unregister service if object registration fails
-        bus.unregisterService(QString(DBus::ServiceName));
+        bus.unregisterService(QString(PhosphorProtocol::Service::Name));
         return false;
     }
 
-    qCInfo(lcDaemon) << "D-Bus service registered service=" << DBus::ServiceName << "path=" << DBus::ObjectPath;
+    qCInfo(lcDaemon) << "D-Bus service registered service=" << PhosphorProtocol::Service::Name
+                     << "path=" << PhosphorProtocol::Service::ObjectPath;
 
     // Connect overlay adaptor signals to daemon overlay control
     connect(m_overlayAdaptor, &OverlayAdaptor::overlayVisibilityChanged, this, [this](bool visible) {
@@ -894,8 +897,8 @@ void Daemon::stop()
 
     // Unregister D-Bus object path and service to prevent late calls during shutdown
     QDBusConnection bus = QDBusConnection::sessionBus();
-    bus.unregisterObject(QString(DBus::ObjectPath));
-    bus.unregisterService(QString(DBus::ServiceName));
+    bus.unregisterObject(QString(PhosphorProtocol::Service::ObjectPath));
+    bus.unregisterService(QString(PhosphorProtocol::Service::Name));
 
     // Sever the remaining raw-pointer adaptors from the unique_ptr members
     // they borrow. ~QObject destroys these adaptors AFTER all unique_ptr

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -12,7 +12,8 @@
 #include "version.h"
 #include "rendering/zoneshaderitem.h"
 #include "vulkan_support.h"
-#include <dbus_types.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QGuiApplication>
 #include <QCommandLineParser>
 #include <QDBusConnection>
@@ -94,7 +95,7 @@ int main(int argc, char* argv[])
     PlasmaZones::loadTranslations(&app);
 
     // Register D-Bus struct types for typed signal/method exchange
-    PlasmaZones::registerDBusTypes();
+    PhosphorProtocol::registerWireTypes();
 
     // Register metatype for QVariant storage (LayerSurface stores itself
     // as a QWindow dynamic property via QVariant::fromValue).
@@ -180,7 +181,7 @@ int main(int argc, char* argv[])
     }
 
     // Ensure single instance via D-Bus service name registration
-    const QString serviceName = QString(DBus::ServiceName);
+    const QString serviceName = QString(PhosphorProtocol::Service::Name);
     QDBusConnection bus = QDBusConnection::sessionBus();
 
     if (!bus.registerService(serviceName)) {

--- a/src/dbus/autotileadaptor.cpp
+++ b/src/dbus/autotileadaptor.cpp
@@ -11,7 +11,7 @@
 #include "core/logging.h"
 #include <PhosphorScreens/Manager.h>
 
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>

--- a/src/dbus/autotileadaptor.h
+++ b/src/dbus/autotileadaptor.h
@@ -5,7 +5,7 @@
 
 #include "plasmazones_export.h"
 
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QDBusAbstractAdaptor>
 #include <QObject>
 #include <QRect>
@@ -22,6 +22,12 @@ class ITileAlgorithmRegistry;
 }
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::AlgorithmInfoEntry;
+using PhosphorProtocol::TileRequestEntry;
+using PhosphorProtocol::TileRequestList;
+using PhosphorProtocol::WindowOpenedEntry;
+using PhosphorProtocol::WindowOpenedList;
 
 class AutotileEngine;
 

--- a/src/dbus/compositorbridgeadaptor.cpp
+++ b/src/dbus/compositorbridgeadaptor.cpp
@@ -5,18 +5,19 @@
 #include "../core/constants.h"
 #include "../core/logging.h"
 
-#include <dbus_types.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QUuid>
 
 namespace PlasmaZones {
 
 // Protocol version constants are the single source of truth in
-// compositor-common/dbus_constants.h, re-exported into the DBus namespace
-// via core/constants.h. The effect links compositor-common directly;
-// the daemon pulls the same symbols through core/constants.h.
+// PhosphorProtocol::Service (libs/phosphor-protocol). The effect links
+// compositor-common for its own constants; the daemon includes
+// PhosphorProtocol/ServiceConstants.h directly.
 namespace {
-constexpr int DaemonApiVersion = DBus::ApiVersion;
-constexpr int DaemonMinPeerApiVersion = DBus::MinPeerApiVersion;
+constexpr int DaemonApiVersion = PhosphorProtocol::Service::ApiVersion;
+constexpr int DaemonMinPeerApiVersion = PhosphorProtocol::Service::MinPeerApiVersion;
 } // namespace
 
 CompositorBridgeAdaptor::CompositorBridgeAdaptor(QObject* parent)

--- a/src/dbus/compositorbridgeadaptor.h
+++ b/src/dbus/compositorbridgeadaptor.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
 #include <QDBusAbstractAdaptor>
 #include <QString>
@@ -12,6 +12,9 @@
 #include <QVariantMap>
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::BridgeRegistrationResult;
+using PhosphorProtocol::WindowGeometryList;
 
 /**
  * @brief D-Bus adaptor for the compositor bridge protocol

--- a/src/dbus/overlayadaptor.h
+++ b/src/dbus/overlayadaptor.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
 #include <QDBusAbstractAdaptor>
 #include <QString>
@@ -19,6 +19,10 @@ class IZoneDetector;
 }
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::EmptyZoneEntry;
+using PhosphorProtocol::EmptyZoneList;
+using PhosphorProtocol::SnapAssistCandidateList;
 
 class IOverlayService;
 class ISettings;

--- a/src/dbus/screenadaptor.h
+++ b/src/dbus/screenadaptor.h
@@ -26,7 +26,7 @@ namespace PlasmaZones {
  * Wiring: both the ScreenManager and the IConfigStore are passed through
  * the constructor — no setters, no service-locator intermediary. Interface
  * name must match `dbus/org.plasmazones.Screen.xml` and
- * `DBus::Interface::Screen` for KCM signal connections.
+ * `PhosphorProtocol::Service::Interface::Screen` for KCM signal connections.
  */
 class PLASMAZONES_EXPORT ScreenAdaptor : public Phosphor::Screens::DBusScreenAdaptor
 {

--- a/src/dbus/snapnavigationtargets.h
+++ b/src/dbus/snapnavigationtargets.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 
 #include <QString>
 
@@ -15,6 +15,12 @@ class LayoutRegistry;
 }
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::CycleTargetResult;
+using PhosphorProtocol::FocusTargetResult;
+using PhosphorProtocol::MoveTargetResult;
+using PhosphorProtocol::RestoreTargetResult;
+using PhosphorProtocol::SwapTargetResult;
 
 class ISettings;
 
@@ -45,7 +51,7 @@ class ZoneDetectionAdaptor;
  * This class is deliberately not a QObject — it needs no signals of
  * its own, and the absence of QObject machinery makes it trivially
  * constructable for unit tests. The single dependency on Qt is the
- * shared result-struct types (MoveTargetResult etc. from dbus_types.h).
+ * shared result-struct types (MoveTargetResult etc. from PhosphorProtocol/WireTypes.h).
  *
  * All methods are intended to be called only for screens that the
  * router (ScreenModeRouter) has confirmed are in Snapping mode. The

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QDBusAbstractAdaptor>
 #include <QObject>
 #include <QString>
@@ -32,6 +32,11 @@ class LayoutRegistry;
 }
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::DragBypassReason;
+using PhosphorProtocol::DragOutcome;
+using PhosphorProtocol::DragPolicy;
+using PhosphorProtocol::EmptyZoneList;
 
 class IOverlayService;
 

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -6,7 +6,7 @@
 #include "plasmazones_export.h"
 #include "../core/windowregistry.h"
 #include "../core/windowtrackingservice.h"
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
 #include <QDBusAbstractAdaptor>
 #include <QString>
@@ -30,6 +30,18 @@ class LayoutRegistry;
 }
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::EmptyZoneList;
+using PhosphorProtocol::PreTileGeometryEntry;
+using PhosphorProtocol::PreTileGeometryList;
+using PhosphorProtocol::SnapAllResultList;
+using PhosphorProtocol::SnapConfirmationList;
+using PhosphorProtocol::UnfloatRestoreResult;
+using PhosphorProtocol::WindowGeometryEntry;
+using PhosphorProtocol::WindowGeometryList;
+using PhosphorProtocol::WindowStateEntry;
+using PhosphorProtocol::WindowStateList;
+using PhosphorProtocol::ZoneGeometryRect;
 
 class AutotileEngine;
 class ScreenModeRouter;

--- a/src/dbus/zonedetectionadaptor.h
+++ b/src/dbus/zonedetectionadaptor.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
-#include "../compositor-common/dbus_types.h"
+#include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
 #include <QDBusAbstractAdaptor>
 #include <QString>
@@ -19,6 +19,10 @@ class LayoutRegistry;
 }
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::NamedZoneGeometry;
+using PhosphorProtocol::NamedZoneGeometryList;
+using PhosphorProtocol::ZoneGeometryRect;
 
 class ISettings;
 

--- a/src/editor/EditorController.cpp
+++ b/src/editor/EditorController.cpp
@@ -20,6 +20,7 @@
 #include "../common/layoutpreviewserialize.h"
 #include "../core/constants.h"
 #include "../core/geometryutils.h"
+#include <PhosphorProtocol/ServiceConstants.h>
 #include "../core/layoutworker/layoutcomputeservice.h"
 #include "../core/logging.h"
 #include "../core/utils.h"
@@ -131,9 +132,9 @@ EditorController::EditorController(QObject* parent)
     connect(&m_layoutReloadTimer, &QTimer::timeout, this, &EditorController::reloadLocalLayouts);
 
     auto bus = QDBusConnection::sessionBus();
-    const QString svc = QString::fromLatin1(DBus::ServiceName);
-    const QString path = QString::fromLatin1(DBus::ObjectPath);
-    const QString iface = QString::fromLatin1(DBus::Interface::LayoutRegistry);
+    const QString svc = QString::fromLatin1(PhosphorProtocol::Service::Name);
+    const QString path = QString::fromLatin1(PhosphorProtocol::Service::ObjectPath);
+    const QString iface = QString::fromLatin1(PhosphorProtocol::Service::Interface::LayoutRegistry);
     for (const auto& sig :
          {QStringLiteral("layoutCreated"), QStringLiteral("layoutDeleted"), QStringLiteral("layoutChanged"),
           QStringLiteral("layoutListChanged"), QStringLiteral("layoutPropertyChanged")}) {

--- a/src/editor/EditorController.cpp
+++ b/src/editor/EditorController.cpp
@@ -132,9 +132,9 @@ EditorController::EditorController(QObject* parent)
     connect(&m_layoutReloadTimer, &QTimer::timeout, this, &EditorController::reloadLocalLayouts);
 
     auto bus = QDBusConnection::sessionBus();
-    const QString svc = QString::fromLatin1(PhosphorProtocol::Service::Name);
-    const QString path = QString::fromLatin1(PhosphorProtocol::Service::ObjectPath);
-    const QString iface = QString::fromLatin1(PhosphorProtocol::Service::Interface::LayoutRegistry);
+    const QString svc = QString(PhosphorProtocol::Service::Name);
+    const QString path = QString(PhosphorProtocol::Service::ObjectPath);
+    const QString iface = QString(PhosphorProtocol::Service::Interface::LayoutRegistry);
     for (const auto& sig :
          {QStringLiteral("layoutCreated"), QStringLiteral("layoutDeleted"), QStringLiteral("layoutChanged"),
           QStringLiteral("layoutListChanged"), QStringLiteral("layoutPropertyChanged")}) {

--- a/src/editor/controller/gaps.cpp
+++ b/src/editor/controller/gaps.cpp
@@ -477,14 +477,12 @@ void EditorController::refreshUsableAreaInsets()
     // Query the daemon for both full and available geometry via D-Bus.
     // The daemon's Phosphor::Screens::ScreenManager handles VS IDs natively.
     QDBusMessage geoMsg = QDBusMessage::createMethodCall(
-        QString::fromLatin1(PhosphorProtocol::Service::Name),
-        QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
-        QString::fromLatin1(PhosphorProtocol::Service::Interface::Screen), QStringLiteral("getScreenGeometry"));
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::Screen), QStringLiteral("getScreenGeometry"));
     geoMsg << screenId;
     QDBusMessage availMsg = QDBusMessage::createMethodCall(
-        QString::fromLatin1(PhosphorProtocol::Service::Name),
-        QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
-        QString::fromLatin1(PhosphorProtocol::Service::Interface::Screen), QStringLiteral("getAvailableGeometry"));
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::Screen), QStringLiteral("getAvailableGeometry"));
     availMsg << screenId;
 
     auto* geoWatcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(geoMsg), this);

--- a/src/editor/controller/gaps.cpp
+++ b/src/editor/controller/gaps.cpp
@@ -12,6 +12,7 @@
 #include "../../config/configdefaults.h"
 #include "../../core/constants.h"
 #include "../../core/logging.h"
+#include <PhosphorProtocol/ServiceConstants.h>
 #include "../../core/utils.h"
 #include <PhosphorIdentity/VirtualScreenId.h>
 #include <QDBusConnection>
@@ -476,12 +477,14 @@ void EditorController::refreshUsableAreaInsets()
     // Query the daemon for both full and available geometry via D-Bus.
     // The daemon's Phosphor::Screens::ScreenManager handles VS IDs natively.
     QDBusMessage geoMsg = QDBusMessage::createMethodCall(
-        QString::fromLatin1(DBus::ServiceName), QString::fromLatin1(DBus::ObjectPath),
-        QString::fromLatin1(DBus::Interface::Screen), QStringLiteral("getScreenGeometry"));
+        QString::fromLatin1(PhosphorProtocol::Service::Name),
+        QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
+        QString::fromLatin1(PhosphorProtocol::Service::Interface::Screen), QStringLiteral("getScreenGeometry"));
     geoMsg << screenId;
     QDBusMessage availMsg = QDBusMessage::createMethodCall(
-        QString::fromLatin1(DBus::ServiceName), QString::fromLatin1(DBus::ObjectPath),
-        QString::fromLatin1(DBus::Interface::Screen), QStringLiteral("getAvailableGeometry"));
+        QString::fromLatin1(PhosphorProtocol::Service::Name),
+        QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
+        QString::fromLatin1(PhosphorProtocol::Service::Interface::Screen), QStringLiteral("getAvailableGeometry"));
     availMsg << screenId;
 
     auto* geoWatcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(geoMsg), this);

--- a/src/editor/controller/layout.cpp
+++ b/src/editor/controller/layout.cpp
@@ -7,6 +7,7 @@
 #include "../undo/UndoController.h"
 #include "../helpers/ShaderDbusQueries.h"
 #include "../../core/constants.h"
+#include <PhosphorProtocol/ServiceConstants.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutUtils.h>
 #include "../../core/shaderregistry.h"
@@ -43,9 +44,10 @@ void EditorController::cacheVirtualScreenGeometry(const QString& screenName)
     if (!PhosphorIdentity::VirtualScreenId::isVirtual(screenName)) {
         return;
     }
-    QDBusMessage msg = QDBusMessage::createMethodCall(
-        QString::fromLatin1(DBus::ServiceName), QString::fromLatin1(DBus::ObjectPath),
-        QString::fromLatin1(DBus::Interface::Screen), QStringLiteral("getScreenGeometry"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(QString::fromLatin1(PhosphorProtocol::Service::Name),
+                                                      QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
+                                                      QString::fromLatin1(PhosphorProtocol::Service::Interface::Screen),
+                                                      QStringLiteral("getScreenGeometry"));
     msg << screenName;
     QDBusMessage reply = QDBusConnection::sessionBus().call(msg, QDBus::Block, 2000);
     if (reply.type() == QDBusMessage::ReplyMessage && reply.arguments().size() >= 1) {
@@ -92,8 +94,10 @@ QVariantList EditorController::screenModel() const
             if (vsIndex >= 0) {
                 if (!vsConfigCache.contains(physId)) {
                     QDBusMessage msg = QDBusMessage::createMethodCall(
-                        QString::fromLatin1(DBus::ServiceName), QString::fromLatin1(DBus::ObjectPath),
-                        QString::fromLatin1(DBus::Interface::Screen), QStringLiteral("getVirtualScreenConfig"));
+                        QString::fromLatin1(PhosphorProtocol::Service::Name),
+                        QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
+                        QString::fromLatin1(PhosphorProtocol::Service::Interface::Screen),
+                        QStringLiteral("getVirtualScreenConfig"));
                     msg << physId;
                     QDBusMessage reply = QDBusConnection::sessionBus().call(msg, QDBus::Block, 2000);
                     if (reply.type() == QDBusMessage::ReplyMessage && reply.arguments().size() >= 1) {
@@ -501,8 +505,8 @@ void EditorController::loadLayout(const QString& layoutId)
     m_activitiesAvailable = false;
     m_availableActivities.clear();
     {
-        QDBusInterface iface{QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                             QString(DBus::Interface::LayoutRegistry)};
+        QDBusInterface iface{QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+                             QString(PhosphorProtocol::Service::Interface::LayoutRegistry)};
         if (iface.isValid()) {
             // Screen IDs (stable EDID-based identifiers)
             QDBusReply<QString> screensReply = iface.call(QStringLiteral("getAllScreenAssignments"));
@@ -867,8 +871,10 @@ void EditorController::importLayout(const QString& filePath)
         return;
     }
 
-    QDBusInterface layoutManager(QString::fromLatin1(DBus::ServiceName), QString::fromLatin1(DBus::ObjectPath),
-                                 QString::fromLatin1(DBus::Interface::LayoutRegistry), QDBusConnection::sessionBus());
+    QDBusInterface layoutManager(QString::fromLatin1(PhosphorProtocol::Service::Name),
+                                 QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
+                                 QString::fromLatin1(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                 QDBusConnection::sessionBus());
 
     if (!layoutManager.isValid()) {
         QString error = PzI18n::tr("Cannot connect to PlasmaZones daemon");
@@ -916,8 +922,10 @@ void EditorController::exportLayout(const QString& filePath)
         return;
     }
 
-    QDBusInterface layoutManager(QString::fromLatin1(DBus::ServiceName), QString::fromLatin1(DBus::ObjectPath),
-                                 QString::fromLatin1(DBus::Interface::LayoutRegistry), QDBusConnection::sessionBus());
+    QDBusInterface layoutManager(QString::fromLatin1(PhosphorProtocol::Service::Name),
+                                 QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
+                                 QString::fromLatin1(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                 QDBusConnection::sessionBus());
 
     if (!layoutManager.isValid()) {
         QString error = PzI18n::tr("Cannot connect to PlasmaZones daemon");

--- a/src/editor/controller/layout.cpp
+++ b/src/editor/controller/layout.cpp
@@ -44,10 +44,9 @@ void EditorController::cacheVirtualScreenGeometry(const QString& screenName)
     if (!PhosphorIdentity::VirtualScreenId::isVirtual(screenName)) {
         return;
     }
-    QDBusMessage msg = QDBusMessage::createMethodCall(QString::fromLatin1(PhosphorProtocol::Service::Name),
-                                                      QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
-                                                      QString::fromLatin1(PhosphorProtocol::Service::Interface::Screen),
-                                                      QStringLiteral("getScreenGeometry"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::Screen), QStringLiteral("getScreenGeometry"));
     msg << screenName;
     QDBusMessage reply = QDBusConnection::sessionBus().call(msg, QDBus::Block, 2000);
     if (reply.type() == QDBusMessage::ReplyMessage && reply.arguments().size() >= 1) {
@@ -94,9 +93,8 @@ QVariantList EditorController::screenModel() const
             if (vsIndex >= 0) {
                 if (!vsConfigCache.contains(physId)) {
                     QDBusMessage msg = QDBusMessage::createMethodCall(
-                        QString::fromLatin1(PhosphorProtocol::Service::Name),
-                        QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
-                        QString::fromLatin1(PhosphorProtocol::Service::Interface::Screen),
+                        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+                        QString(PhosphorProtocol::Service::Interface::Screen),
                         QStringLiteral("getVirtualScreenConfig"));
                     msg << physId;
                     QDBusMessage reply = QDBusConnection::sessionBus().call(msg, QDBus::Block, 2000);
@@ -871,10 +869,9 @@ void EditorController::importLayout(const QString& filePath)
         return;
     }
 
-    QDBusInterface layoutManager(QString::fromLatin1(PhosphorProtocol::Service::Name),
-                                 QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
-                                 QString::fromLatin1(PhosphorProtocol::Service::Interface::LayoutRegistry),
-                                 QDBusConnection::sessionBus());
+    QDBusInterface layoutManager(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QDBusConnection::sessionBus());
 
     if (!layoutManager.isValid()) {
         QString error = PzI18n::tr("Cannot connect to PlasmaZones daemon");
@@ -922,10 +919,9 @@ void EditorController::exportLayout(const QString& filePath)
         return;
     }
 
-    QDBusInterface layoutManager(QString::fromLatin1(PhosphorProtocol::Service::Name),
-                                 QString::fromLatin1(PhosphorProtocol::Service::ObjectPath),
-                                 QString::fromLatin1(PhosphorProtocol::Service::Interface::LayoutRegistry),
-                                 QDBusConnection::sessionBus());
+    QDBusInterface layoutManager(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QDBusConnection::sessionBus());
 
     if (!layoutManager.isValid()) {
         QString error = PzI18n::tr("Cannot connect to PlasmaZones daemon");

--- a/src/editor/helpers/DbusHelpers.h
+++ b/src/editor/helpers/DbusHelpers.h
@@ -30,7 +30,7 @@ namespace DbusHelpers {
  *
  * Shared by SettingsDbusQueries.cpp and ShaderDbusQueries.cpp because
  * both target the exact same service/object/interface, and duplicating
- * the three fromLatin1() conversions at every call site invites drift.
+ * the three QLatin1String→QString conversions at every call site invites drift.
  */
 inline QDBusInterface createSettingsInterface()
 {

--- a/src/editor/helpers/DbusHelpers.h
+++ b/src/editor/helpers/DbusHelpers.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "../../compositor-common/dbus_constants.h"
+#include <PhosphorProtocol/ServiceConstants.h>
 
 #include <QDBusConnection>
 #include <QDBusInterface>
@@ -21,7 +21,7 @@ namespace DbusHelpers {
  * prvalue return into the caller's storage correctly.
  *
  * ⚠ CRITICAL: every caller MUST invoke
- *     iface.setTimeout(DBus::SyncCallTimeoutMs);
+ *     iface.setTimeout(PhosphorProtocol::Service::SyncCallTimeoutMs);
  * before dispatching a synchronous .call(). Omitting it reintroduces the
  * editor-startup-freeze failure mode this PR was written to fix (Qt's
  * default is 25 seconds). The timeout cannot be baked into this helper
@@ -34,8 +34,8 @@ namespace DbusHelpers {
  */
 inline QDBusInterface createSettingsInterface()
 {
-    return QDBusInterface(QString::fromLatin1(DBus::ServiceName), QString::fromLatin1(DBus::ObjectPath),
-                          QString::fromLatin1(DBus::Interface::Settings), QDBusConnection::sessionBus());
+    return QDBusInterface(QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+                          QString(PhosphorProtocol::Service::Interface::Settings), QDBusConnection::sessionBus());
 }
 
 } // namespace DbusHelpers

--- a/src/editor/helpers/SettingsDbusQueries.cpp
+++ b/src/editor/helpers/SettingsDbusQueries.cpp
@@ -37,7 +37,7 @@ QVariantMap querySettingsPerKey_NonStringOnly(const QStringList& keys)
     if (!iface.isValid()) {
         return result;
     }
-    iface.setTimeout(DBus::SyncCallTimeoutMs);
+    iface.setTimeout(PhosphorProtocol::Service::SyncCallTimeoutMs);
     for (const QString& key : keys) {
         if (key.isEmpty()) {
             continue;
@@ -73,7 +73,7 @@ QVariantMap querySettingsBatch(const QStringList& keys)
     if (!settingsIface.isValid()) {
         return QVariantMap();
     }
-    settingsIface.setTimeout(DBus::SyncCallTimeoutMs);
+    settingsIface.setTimeout(PhosphorProtocol::Service::SyncCallTimeoutMs);
 
     QDBusReply<QVariantMap> reply = settingsIface.call(QStringLiteral("getSettings"), keys);
     if (reply.isValid()) {
@@ -112,7 +112,7 @@ int queryIntSetting(const QString& settingKey, int defaultValue)
     if (!settingsIface.isValid()) {
         return defaultValue;
     }
-    settingsIface.setTimeout(DBus::SyncCallTimeoutMs);
+    settingsIface.setTimeout(PhosphorProtocol::Service::SyncCallTimeoutMs);
 
     QDBusReply<QDBusVariant> reply = settingsIface.call(QStringLiteral("getSetting"), settingKey);
     if (!reply.isValid()) {
@@ -134,7 +134,7 @@ bool queryBoolSetting(const QString& settingKey, bool defaultValue)
     if (!settingsIface.isValid()) {
         return defaultValue;
     }
-    settingsIface.setTimeout(DBus::SyncCallTimeoutMs);
+    settingsIface.setTimeout(PhosphorProtocol::Service::SyncCallTimeoutMs);
 
     QDBusReply<QDBusVariant> reply = settingsIface.call(QStringLiteral("getSetting"), settingKey);
     if (!reply.isValid()) {

--- a/src/editor/helpers/ShaderDbusQueries.cpp
+++ b/src/editor/helpers/ShaderDbusQueries.cpp
@@ -25,7 +25,7 @@ bool queryShadersEnabled()
         return false;
     }
 
-    settingsIface.setTimeout(DBus::SyncCallTimeoutMs);
+    settingsIface.setTimeout(PhosphorProtocol::Service::SyncCallTimeoutMs);
     QDBusReply<bool> reply = settingsIface.call(QStringLiteral("shadersEnabled"));
     return reply.isValid() && reply.value();
 }
@@ -39,7 +39,7 @@ QVariantList queryAvailableShaders()
         return QVariantList();
     }
 
-    settingsIface.setTimeout(DBus::SyncCallTimeoutMs);
+    settingsIface.setTimeout(PhosphorProtocol::Service::SyncCallTimeoutMs);
     QDBusReply<QVariantList> reply = settingsIface.call(QStringLiteral("availableShaders"));
     if (!reply.isValid()) {
         qCWarning(lcDbus) << "D-Bus availableShaders call failed:" << reply.error().message();
@@ -81,7 +81,7 @@ QVariantMap queryShaderInfo(const QString& shaderId)
         return QVariantMap();
     }
 
-    settingsIface.setTimeout(DBus::SyncCallTimeoutMs);
+    settingsIface.setTimeout(PhosphorProtocol::Service::SyncCallTimeoutMs);
     QDBusReply<QVariantMap> reply = settingsIface.call(QStringLiteral("shaderInfo"), shaderId);
     if (reply.isValid()) {
         // D-Bus may return nested structures as QDBusArgument - convert recursively
@@ -115,7 +115,7 @@ QVariantMap queryTranslateShaderParams(const QString& shaderId, const QVariantMa
         }
     }
 
-    settingsIface.setTimeout(DBus::SyncCallTimeoutMs);
+    settingsIface.setTimeout(PhosphorProtocol::Service::SyncCallTimeoutMs);
     QDBusReply<QVariantMap> reply = settingsIface.call(QStringLiteral("translateShaderParams"), shaderId, safeParams);
     if (reply.isValid()) {
         QVariant converted = DBusVariantUtils::convertDbusArgument(QVariant::fromValue(reply.value()));

--- a/src/editor/services/DBusLayoutService.cpp
+++ b/src/editor/services/DBusLayoutService.cpp
@@ -3,6 +3,7 @@
 
 #include "DBusLayoutService.h"
 #include "../../core/constants.h"
+#include <PhosphorProtocol/ServiceConstants.h>
 
 #include <QDBusConnection>
 #include <QDBusInterface>
@@ -14,9 +15,9 @@ using namespace PlasmaZones;
 
 DBusLayoutService::DBusLayoutService(QObject* parent)
     : ILayoutService(parent)
-    , m_serviceName(QString::fromLatin1(DBus::ServiceName))
-    , m_objectPath(QString::fromLatin1(DBus::ObjectPath))
-    , m_interfaceName(QString::fromLatin1(DBus::Interface::LayoutRegistry))
+    , m_serviceName(QString::fromLatin1(PhosphorProtocol::Service::Name))
+    , m_objectPath(QString::fromLatin1(PhosphorProtocol::Service::ObjectPath))
+    , m_interfaceName(QString::fromLatin1(PhosphorProtocol::Service::Interface::LayoutRegistry))
     , m_interface(nullptr)
 {
 }

--- a/src/editor/services/DBusLayoutService.cpp
+++ b/src/editor/services/DBusLayoutService.cpp
@@ -15,9 +15,9 @@ using namespace PlasmaZones;
 
 DBusLayoutService::DBusLayoutService(QObject* parent)
     : ILayoutService(parent)
-    , m_serviceName(QString::fromLatin1(PhosphorProtocol::Service::Name))
-    , m_objectPath(QString::fromLatin1(PhosphorProtocol::Service::ObjectPath))
-    , m_interfaceName(QString::fromLatin1(PhosphorProtocol::Service::Interface::LayoutRegistry))
+    , m_serviceName(QString(PhosphorProtocol::Service::Name))
+    , m_objectPath(QString(PhosphorProtocol::Service::ObjectPath))
+    , m_interfaceName(QString(PhosphorProtocol::Service::Interface::LayoutRegistry))
     , m_interface(nullptr)
 {
 }

--- a/src/settings/dbusutils.h
+++ b/src/settings/dbusutils.h
@@ -8,6 +8,7 @@
 #include <QDBusMetaType>
 #include <QDBusPendingCall>
 #include "../core/constants.h"
+#include <PhosphorProtocol/ServiceConstants.h>
 
 namespace PlasmaZones::DaemonDBus {
 
@@ -17,8 +18,8 @@ constexpr int TimeoutMs = 3000;
 /// Call a daemon method synchronously and return the reply
 inline QDBusMessage callDaemon(const QString& interface, const QString& method, const QVariantList& args = {})
 {
-    QDBusMessage msg =
-        QDBusMessage::createMethodCall(QString(DBus::ServiceName), QString(DBus::ObjectPath), interface, method);
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath), interface, method);
     if (!args.isEmpty()) {
         msg.setArguments(args);
     }
@@ -33,16 +34,16 @@ inline QDBusMessage callDaemon(const QString& interface, const QString& method, 
 /// load() that reverts just-saved assignments.
 inline void notifyReload()
 {
-    QDBusMessage msg =
-        QDBusMessage::createMethodCall(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                       QString(DBus::Interface::Settings), QStringLiteral("reloadSettings"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::Settings), QStringLiteral("reloadSettings"));
     QDBusConnection::sessionBus().call(msg, QDBus::Block, TimeoutMs);
 }
 
 /// Batch-set settings on the daemon. Synchronous call.
 inline QDBusMessage setDaemonSettings(const QVariantMap& settings)
 {
-    return callDaemon(QString(DBus::Interface::Settings), QStringLiteral("setSettings"),
+    return callDaemon(QString(PhosphorProtocol::Service::Interface::Settings), QStringLiteral("setSettings"),
                       {QVariant::fromValue(settings)});
 }
 
@@ -51,9 +52,9 @@ inline QDBusMessage setDaemonSettings(const QVariantMap& settings)
 inline void setPerScreenDaemonSetting(const QString& screenName, const QString& category, const QString& key,
                                       const QVariant& value)
 {
-    QDBusMessage msg =
-        QDBusMessage::createMethodCall(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                       QString(DBus::Interface::Settings), QStringLiteral("setPerScreenSetting"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::Settings), QStringLiteral("setPerScreenSetting"));
     msg.setArguments({screenName, category, key, QVariant::fromValue(QDBusVariant(value))});
     QDBusConnection::sessionBus().asyncCall(msg);
 }
@@ -61,9 +62,9 @@ inline void setPerScreenDaemonSetting(const QString& screenName, const QString& 
 /// Clear all per-screen settings for a category on the daemon (async).
 inline void clearPerScreenDaemonSettings(const QString& screenName, const QString& category)
 {
-    QDBusMessage msg =
-        QDBusMessage::createMethodCall(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                       QString(DBus::Interface::Settings), QStringLiteral("clearPerScreenSettings"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::Settings), QStringLiteral("clearPerScreenSettings"));
     msg.setArguments({screenName, category});
     QDBusConnection::sessionBus().asyncCall(msg);
 }

--- a/src/settings/screenprovider.cpp
+++ b/src/settings/screenprovider.cpp
@@ -21,14 +21,15 @@ QList<ScreenInfo> fetchScreens()
 
     // Get primary screen name from daemon
     QString primaryScreenName;
-    QDBusMessage primaryReply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::Screen), QStringLiteral("getPrimaryScreen"));
+    QDBusMessage primaryReply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::Screen),
+                                                       QStringLiteral("getPrimaryScreen"));
     if (primaryReply.type() == QDBusMessage::ReplyMessage && !primaryReply.arguments().isEmpty()) {
         primaryScreenName = primaryReply.arguments().first().toString();
     }
 
     // Get screens from daemon via D-Bus
-    QDBusMessage screenReply = DaemonDBus::callDaemon(QString(DBus::Interface::Screen), QStringLiteral("getScreens"));
+    QDBusMessage screenReply =
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::Screen), QStringLiteral("getScreens"));
 
     if (screenReply.type() == QDBusMessage::ReplyMessage && !screenReply.arguments().isEmpty()) {
         const QStringList screenNames = screenReply.arguments().first().toStringList();
@@ -47,8 +48,8 @@ QList<ScreenInfo> fetchScreens()
                 info.isPrimary = (physName == primaryScreenName);
             }
 
-            QDBusMessage infoReply =
-                DaemonDBus::callDaemon(QString(DBus::Interface::Screen), QStringLiteral("getScreenInfo"), {screenName});
+            QDBusMessage infoReply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::Screen),
+                                                            QStringLiteral("getScreenInfo"), {screenName});
 
             if (infoReply.type() == QDBusMessage::ReplyMessage && !infoReply.arguments().isEmpty()) {
                 QString infoJson = infoReply.arguments().first().toString();

--- a/src/settings/screenprovider.h
+++ b/src/settings/screenprovider.h
@@ -9,6 +9,7 @@
 #include <QVariantList>
 #include <functional>
 #include "../../src/core/constants.h"
+#include <PhosphorProtocol/ServiceConstants.h>
 
 namespace PlasmaZones {
 
@@ -72,12 +73,14 @@ void setMonitorDisabledFor(Settings* settings, const QString& screenName, bool d
  */
 inline void connectScreenChangeSignals(QObject* receiver)
 {
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::Screen), QStringLiteral("screenAdded"), receiver,
-                                          SLOT(refreshScreens()));
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::Screen), QStringLiteral("screenRemoved"), receiver,
-                                          SLOT(refreshScreens()));
+    QDBusConnection::sessionBus().connect(QString(PhosphorProtocol::Service::Name),
+                                          QString(PhosphorProtocol::Service::ObjectPath),
+                                          QString(PhosphorProtocol::Service::Interface::Screen),
+                                          QStringLiteral("screenAdded"), receiver, SLOT(refreshScreens()));
+    QDBusConnection::sessionBus().connect(QString(PhosphorProtocol::Service::Name),
+                                          QString(PhosphorProtocol::Service::ObjectPath),
+                                          QString(PhosphorProtocol::Service::Interface::Screen),
+                                          QStringLiteral("screenRemoved"), receiver, SLOT(refreshScreens()));
 }
 
 } // namespace PlasmaZones

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -242,17 +242,19 @@ SettingsController::SettingsController(QObject* parent)
             &SettingsController::layoutsChanged);
 
     // Listen for external settings changes from the daemon
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::Settings), QStringLiteral("settingsChanged"), this,
-                                          SLOT(onExternalSettingsChanged()));
+    QDBusConnection::sessionBus().connect(QString(PhosphorProtocol::Service::Name),
+                                          QString(PhosphorProtocol::Service::ObjectPath),
+                                          QString(PhosphorProtocol::Service::Interface::Settings),
+                                          QStringLiteral("settingsChanged"), this, SLOT(onExternalSettingsChanged()));
 
     // Async window picker reply channel. Emitted by SettingsAdaptor whenever
     // the KWin effect answers a runningWindowsRequested call via
     // provideRunningWindows(). The signal carries the JSON payload directly
     // so clients don't need a follow-up blocking fetch.
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::Settings), QStringLiteral("runningWindowsAvailable"),
-                                          this, SLOT(onRunningWindowsAvailable(QString)));
+    QDBusConnection::sessionBus().connect(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::Settings), QStringLiteral("runningWindowsAvailable"), this,
+        SLOT(onRunningWindowsAvailable(QString)));
 
     // Client-side timeout for the async window picker. If the daemon
     // never fans out a runningWindowsAvailable signal (KWin effect
@@ -328,48 +330,59 @@ SettingsController::SettingsController(QObject* parent)
     // tweak → layoutPropertyChanged + layoutListChanged) coalesces into
     // one loadLayoutsAsync() call instead of recomputing the full preview
     // list + D-Bus round-trip for every hit.
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::LayoutRegistry), QStringLiteral("layoutCreated"),
-                                          this, SLOT(scheduleLayoutLoad()));
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::LayoutRegistry), QStringLiteral("layoutDeleted"),
-                                          this, SLOT(scheduleLayoutLoad()));
+    QDBusConnection::sessionBus().connect(QString(PhosphorProtocol::Service::Name),
+                                          QString(PhosphorProtocol::Service::ObjectPath),
+                                          QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                          QStringLiteral("layoutCreated"), this, SLOT(scheduleLayoutLoad()));
+    QDBusConnection::sessionBus().connect(QString(PhosphorProtocol::Service::Name),
+                                          QString(PhosphorProtocol::Service::ObjectPath),
+                                          QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                          QStringLiteral("layoutDeleted"), this, SLOT(scheduleLayoutLoad()));
     // layoutChanged fires when a layout is modified (editor saves, zone changes, rename)
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::LayoutRegistry), QStringLiteral("layoutChanged"),
-                                          this, SLOT(scheduleLayoutLoad()));
+    QDBusConnection::sessionBus().connect(QString(PhosphorProtocol::Service::Name),
+                                          QString(PhosphorProtocol::Service::ObjectPath),
+                                          QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                          QStringLiteral("layoutChanged"), this, SLOT(scheduleLayoutLoad()));
     // layoutPropertyChanged fires on compact property mutations (hidden, autoAssign,
     // aspectRatioClass) — Phase 4 of refactor/dbus-performance. The settings UI still
     // triggers a full reload so the layout list view refreshes, but the daemon side
     // saved a full JSON serialization per mutation by not emitting layoutChanged.
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::LayoutRegistry),
+    QDBusConnection::sessionBus().connect(QString(PhosphorProtocol::Service::Name),
+                                          QString(PhosphorProtocol::Service::ObjectPath),
+                                          QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                           QStringLiteral("layoutPropertyChanged"), this, SLOT(scheduleLayoutLoad()));
     // layoutListChanged fires when the layout list changes (editor, import, system layout reload)
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::LayoutRegistry), QStringLiteral("layoutListChanged"),
-                                          this, SLOT(scheduleLayoutLoad()));
+    QDBusConnection::sessionBus().connect(QString(PhosphorProtocol::Service::Name),
+                                          QString(PhosphorProtocol::Service::ObjectPath),
+                                          QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                          QStringLiteral("layoutListChanged"), this, SLOT(scheduleLayoutLoad()));
     // screenLayoutChanged(QString,QString,int) fires when assignments change (hotkeys, scripts, toggle)
     QDBusConnection::sessionBus().connect(
-        QString(DBus::ServiceName), QString(DBus::ObjectPath), QString(DBus::Interface::LayoutRegistry),
-        QStringLiteral("screenLayoutChanged"), this, SLOT(onScreenLayoutChanged(QString, QString, int)));
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QStringLiteral("screenLayoutChanged"), this,
+        SLOT(onScreenLayoutChanged(QString, QString, int)));
     // quickLayoutSlotsChanged fires when quick layout slots are modified externally
     QDBusConnection::sessionBus().connect(
-        QString(DBus::ServiceName), QString(DBus::ObjectPath), QString(DBus::Interface::LayoutRegistry),
-        QStringLiteral("quickLayoutSlotsChanged"), this, SIGNAL(quickLayoutSlotsChanged()));
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QStringLiteral("quickLayoutSlotsChanged"), this,
+        SIGNAL(quickLayoutSlotsChanged()));
 
     // Connect virtual desktop / activity D-Bus signals for reactive updates
     QDBusConnection::sessionBus().connect(
-        QString(DBus::ServiceName), QString(DBus::ObjectPath), QString(DBus::Interface::LayoutRegistry),
-        QStringLiteral("virtualDesktopCountChanged"), this, SLOT(onVirtualDesktopsChanged()));
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QStringLiteral("virtualDesktopCountChanged"),
+        this, SLOT(onVirtualDesktopsChanged()));
     QDBusConnection::sessionBus().connect(
-        QString(DBus::ServiceName), QString(DBus::ObjectPath), QString(DBus::Interface::LayoutRegistry),
-        QStringLiteral("virtualDesktopNamesChanged"), this, SLOT(onVirtualDesktopsChanged()));
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::LayoutRegistry), QStringLiteral("activitiesChanged"),
-                                          this, SLOT(onActivitiesChanged()));
-    QDBusConnection::sessionBus().connect(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                          QString(DBus::Interface::LayoutRegistry),
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QStringLiteral("virtualDesktopNamesChanged"),
+        this, SLOT(onVirtualDesktopsChanged()));
+    QDBusConnection::sessionBus().connect(QString(PhosphorProtocol::Service::Name),
+                                          QString(PhosphorProtocol::Service::ObjectPath),
+                                          QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                          QStringLiteral("activitiesChanged"), this, SLOT(onActivitiesChanged()));
+    QDBusConnection::sessionBus().connect(QString(PhosphorProtocol::Service::Name),
+                                          QString(PhosphorProtocol::Service::ObjectPath),
+                                          QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                           QStringLiteral("currentActivityChanged"), this, SLOT(onActivitiesChanged()));
 
     // Connect editor settings signals from Settings to SettingsController for QML forwarding
@@ -605,8 +618,8 @@ void SettingsController::save()
 
     // Flush staged quick layout slots to daemon (D-Bus mutations, after reload)
     for (auto it = m_stagedQuickSlots.constBegin(); it != m_stagedQuickSlots.constEnd(); ++it) {
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("setQuickLayoutSlot"),
-                               {it.key(), it.value()});
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                               QStringLiteral("setQuickLayoutSlot"), {it.key(), it.value()});
     }
     m_stagedQuickSlots.clear();
 
@@ -614,10 +627,13 @@ void SettingsController::save()
     // This must happen AFTER notifyReload so the reload doesn't overwrite
     // the assignment changes.
     if (!m_stagedAssignments.isEmpty()) {
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("setSaveBatchMode"), {true});
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                               QStringLiteral("setSaveBatchMode"), {true});
         flushStagedAssignments();
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("applyAssignmentChanges"));
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("setSaveBatchMode"), {false});
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                               QStringLiteral("applyAssignmentChanges"));
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                               QStringLiteral("setSaveBatchMode"), {false});
     }
 
     // Safe to clear immediately: notifyReload() is synchronous, so the daemon
@@ -776,9 +792,9 @@ void SettingsController::loadLayoutsAsync()
     // that the local composite can't know about. On reply the enriched
     // list replaces m_layouts; if the call errors we keep the local
     // previews from Step 1 visible rather than blanking the page.
-    QDBusMessage msg =
-        QDBusMessage::createMethodCall(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                       QString(DBus::Interface::LayoutRegistry), QStringLiteral("getLayoutList"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QStringLiteral("getLayoutList"));
 
     // Gate the local-path layoutsChanged emit (see the ctor-wired lambda
     // on PhosphorZones::LayoutRegistry::layoutsChanged). The reply lambda clears this
@@ -888,16 +904,16 @@ bool SettingsController::createNewLayout(const QString& name, const QString& typ
 
     const QString layoutType = type.isEmpty() ? QStringLiteral("custom") : type;
 
-    QDBusMessage reply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                                 QStringLiteral("createLayout"), {sanitizedName, layoutType});
 
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty()) {
         QString newLayoutId = reply.arguments().first().toString();
         if (!newLayoutId.isEmpty()) {
             if (aspectRatioClass >= 0) {
-                QDBusMessage arReply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
-                                                              QStringLiteral("setLayoutAspectRatioClass"),
-                                                              {newLayoutId, aspectRatioClass});
+                QDBusMessage arReply = DaemonDBus::callDaemon(
+                    QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                    QStringLiteral("setLayoutAspectRatioClass"), {newLayoutId, aspectRatioClass});
                 if (arReply.type() == QDBusMessage::ErrorMessage) {
                     qCWarning(lcCore) << "setLayoutAspectRatioClass failed:" << arReply.errorMessage();
                 }
@@ -927,8 +943,8 @@ bool SettingsController::createNewLayout(const QString& name, const QString& typ
 
 void SettingsController::deleteLayout(const QString& layoutId)
 {
-    QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("deleteLayout"), {layoutId});
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                                QStringLiteral("deleteLayout"), {layoutId});
     if (reply.type() == QDBusMessage::ErrorMessage) {
         qCWarning(lcCore) << "deleteLayout failed:" << reply.errorMessage();
         Q_EMIT layoutOperationFailed(PzI18n::tr("Could not delete layout: %1").arg(reply.errorMessage()));
@@ -938,8 +954,8 @@ void SettingsController::deleteLayout(const QString& layoutId)
 
 void SettingsController::duplicateLayout(const QString& layoutId)
 {
-    QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("duplicateLayout"), {layoutId});
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                                QStringLiteral("duplicateLayout"), {layoutId});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty()) {
         QString newId = reply.arguments().first().toString();
         if (!newId.isEmpty()) {
@@ -965,9 +981,9 @@ QVariantMap SettingsController::physicalScreenResolution(const QString& screenId
 
 void SettingsController::editLayout(const QString& layoutId)
 {
-    QDBusMessage msg = QDBusMessage::createMethodCall(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                                      QString(DBus::Interface::LayoutRegistry),
-                                                      QStringLiteral("openEditorForLayoutOnScreen"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QStringLiteral("openEditorForLayoutOnScreen"));
     msg << layoutId << QString();
     QDBusConnection::sessionBus().asyncCall(msg);
 }
@@ -976,9 +992,9 @@ void SettingsController::editLayoutOnScreen(const QString& layoutId, const QStri
 {
     if (layoutId.isEmpty() || screenId.isEmpty())
         return;
-    QDBusMessage msg = QDBusMessage::createMethodCall(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                                      QString(DBus::Interface::LayoutRegistry),
-                                                      QStringLiteral("openEditorForLayoutOnScreen"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QStringLiteral("openEditorForLayoutOnScreen"));
     msg << layoutId << screenId;
     QDBusConnection::sessionBus().asyncCall(msg);
 }
@@ -998,8 +1014,8 @@ void SettingsController::importLayout(const QString& filePath)
 {
     if (filePath.isEmpty())
         return;
-    QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("importLayout"), {filePath});
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                                QStringLiteral("importLayout"), {filePath});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty()) {
         QString newLayoutId = reply.arguments().first().toString();
         if (!newLayoutId.isEmpty()) {
@@ -1013,9 +1029,9 @@ void SettingsController::exportLayout(const QString& layoutId, const QString& fi
 {
     if (layoutId.isEmpty() || filePath.isEmpty())
         return;
-    QDBusMessage msg =
-        QDBusMessage::createMethodCall(QString(DBus::ServiceName), QString(DBus::ObjectPath),
-                                       QString(DBus::Interface::LayoutRegistry), QStringLiteral("exportLayout"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        QString(PhosphorProtocol::Service::Name), QString(PhosphorProtocol::Service::ObjectPath),
+        QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QStringLiteral("exportLayout"));
     msg << layoutId << filePath;
     QDBusConnection::sessionBus().asyncCall(msg);
 }
@@ -1024,8 +1040,8 @@ void SettingsController::setLayoutHidden(const QString& layoutId, bool hidden)
 {
     if (layoutId.isEmpty())
         return;
-    DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("setLayoutHidden"),
-                           {layoutId, hidden});
+    DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                           QStringLiteral("setLayoutHidden"), {layoutId, hidden});
     scheduleLayoutLoad();
 }
 
@@ -1033,8 +1049,8 @@ void SettingsController::setLayoutAutoAssign(const QString& layoutId, bool enabl
 {
     if (layoutId.isEmpty())
         return;
-    DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("setLayoutAutoAssign"),
-                           {layoutId, enabled});
+    DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                           QStringLiteral("setLayoutAutoAssign"), {layoutId, enabled});
     scheduleLayoutLoad();
 }
 
@@ -1042,8 +1058,8 @@ void SettingsController::setLayoutAspectRatio(const QString& layoutId, int aspec
 {
     if (layoutId.isEmpty())
         return;
-    DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("setLayoutAspectRatioClass"),
-                           {layoutId, aspectRatioClass});
+    DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                           QStringLiteral("setLayoutAspectRatioClass"), {layoutId, aspectRatioClass});
     scheduleLayoutLoad();
 }
 
@@ -1117,15 +1133,15 @@ void SettingsController::flushStagedAssignments()
         // Full clear — clear the entire entry for this context
         if (s.fullCleared) {
             if (isActivity)
-                DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+                DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                        QStringLiteral("clearAssignmentForScreenActivity"), {s.screenId, s.activityId});
             else if (isDesktop)
-                DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+                DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                        QStringLiteral("clearAssignmentForScreenDesktop"),
                                        {s.screenId, s.virtualDesktop});
             else
-                DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("clearAssignment"),
-                                       {s.screenId});
+                DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                       QStringLiteral("clearAssignment"), {s.screenId});
             continue;
         }
 
@@ -1140,7 +1156,8 @@ void SettingsController::flushStagedAssignments()
                        ? PhosphorLayout::LayoutId::extractAlgorithmId(*s.tilingAlgorithmId)
                        : *s.tilingAlgorithmId)
                 : QString();
-            DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("setAssignmentEntry"),
+            DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                   QStringLiteral("setAssignmentEntry"),
                                    {s.screenId, s.virtualDesktop, s.activityId, mode, snapping, tiling});
             continue;
         }
@@ -1149,16 +1166,16 @@ void SettingsController::flushStagedAssignments()
         if (s.snappingLayoutId.has_value() && !s.snappingLayoutId->isEmpty()) {
             QDBusMessage reply;
             if (isActivity)
-                reply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+                reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                                QStringLiteral("assignLayoutToScreenActivity"),
                                                {s.screenId, s.activityId, *s.snappingLayoutId});
             else if (isDesktop)
-                reply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+                reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                                QStringLiteral("assignLayoutToScreenDesktop"),
                                                {s.screenId, s.virtualDesktop, *s.snappingLayoutId});
             else
                 reply =
-                    DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+                    DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                            QStringLiteral("assignLayoutToScreen"), {s.screenId, *s.snappingLayoutId});
             if (reply.type() == QDBusMessage::ErrorMessage)
                 qCWarning(PlasmaZones::lcCore) << "  assignLayout FAILED:" << reply.errorMessage();
@@ -1169,14 +1186,16 @@ void SettingsController::flushStagedAssignments()
             const QString algoId = PhosphorLayout::LayoutId::isAutotile(*s.tilingAlgorithmId)
                 ? PhosphorLayout::LayoutId::extractAlgorithmId(*s.tilingAlgorithmId)
                 : *s.tilingAlgorithmId;
-            DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("setAssignmentEntry"),
+            DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                   QStringLiteral("setAssignmentEntry"),
                                    {s.screenId, s.virtualDesktop, s.activityId, 1, QString(), algoId});
         }
 
         // Tiling-only clear — clearing the algorithm reverts to snapping mode (mode=0).
         // The daemon clamps mode via qBound(0, mode, 1).
         if (s.tilingAlgorithmId.has_value() && s.tilingAlgorithmId->isEmpty() && !s.fullCleared) {
-            DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("setAssignmentEntry"),
+            DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                   QStringLiteral("setAssignmentEntry"),
                                    {s.screenId, s.virtualDesktop, s.activityId, 0, QString(), QString()});
         }
     }
@@ -1362,7 +1381,7 @@ QString SettingsController::getLayoutForScreen(const QString& screenName) const
     QString staged;
     if (stagedSnappingLayout(screenName, 0, QString(), staged))
         return staged;
-    QDBusMessage reply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                                 QStringLiteral("getLayoutForScreen"), {screenName});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty())
         return reply.arguments().first().toString();
@@ -1374,7 +1393,7 @@ QString SettingsController::getTilingLayoutForScreen(const QString& screenName) 
     QString staged;
     if (stagedTilingLayout(screenName, 0, QString(), staged))
         return staged;
-    QDBusMessage reply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                                 QStringLiteral("getTilingAlgorithmForScreenDesktop"), {screenName, 0});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty())
         return reply.arguments().first().toString();
@@ -1387,8 +1406,8 @@ QString SettingsController::getLayoutForScreenDesktop(const QString& screenName,
     if (stagedSnappingLayout(screenName, virtualDesktop, QString(), staged))
         return staged;
     QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("getLayoutForScreenDesktop"),
-                               {screenName, virtualDesktop});
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                               QStringLiteral("getLayoutForScreenDesktop"), {screenName, virtualDesktop});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty())
         return reply.arguments().first().toString();
     return {};
@@ -1400,7 +1419,7 @@ QString SettingsController::getSnappingLayoutForScreenDesktop(const QString& scr
     if (stagedSnappingLayout(screenName, virtualDesktop, QString(), staged))
         return staged;
     QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                QStringLiteral("getSnappingLayoutForScreenDesktop"), {screenName, virtualDesktop});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty())
         return reply.arguments().first().toString();
@@ -1422,7 +1441,7 @@ bool SettingsController::hasExplicitAssignmentForScreenDesktop(const QString& sc
             return false;
     }
     QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                QStringLiteral("hasExplicitAssignmentForScreenDesktop"), {screenName, virtualDesktop});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty())
         return reply.arguments().first().toBool();
@@ -1435,7 +1454,7 @@ QString SettingsController::getTilingLayoutForScreenDesktop(const QString& scree
     if (stagedTilingLayout(screenName, virtualDesktop, QString(), staged))
         return staged;
     QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                QStringLiteral("getTilingAlgorithmForScreenDesktop"), {screenName, virtualDesktop});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty()) {
         QString algo = reply.arguments().first().toString();
@@ -1452,7 +1471,7 @@ bool SettingsController::hasExplicitTilingAssignmentForScreenDesktop(const QStri
     if (stagedTilingLayout(screenName, virtualDesktop, QString(), staged))
         return !staged.isEmpty();
     QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                QStringLiteral("getTilingAlgorithmForScreenDesktop"), {screenName, virtualDesktop});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty())
         return !reply.arguments().first().toString().isEmpty();
@@ -1464,7 +1483,7 @@ QString SettingsController::getLayoutForScreenActivity(const QString& screenName
     QString staged;
     if (stagedSnappingLayout(screenName, 0, activityId, staged))
         return staged;
-    QDBusMessage reply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                                 QStringLiteral("getLayoutForScreenActivity"), {screenName, activityId});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty())
         return reply.arguments().first().toString();
@@ -1477,7 +1496,7 @@ QString SettingsController::getSnappingLayoutForScreenActivity(const QString& sc
     QString staged;
     if (stagedSnappingLayout(screenName, 0, activityId, staged))
         return staged;
-    QDBusMessage reply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                                 QStringLiteral("getLayoutForScreenActivity"), {screenName, activityId});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty()) {
         QString layoutId = reply.arguments().first().toString();
@@ -1500,7 +1519,7 @@ bool SettingsController::hasExplicitAssignmentForScreenActivity(const QString& s
             return false;
     }
     QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                QStringLiteral("hasExplicitAssignmentForScreenActivity"), {screenName, activityId});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty())
         return reply.arguments().first().toBool();
@@ -1512,7 +1531,7 @@ QString SettingsController::getTilingLayoutForScreenActivity(const QString& scre
     QString staged;
     if (stagedTilingLayout(screenName, 0, activityId, staged))
         return staged;
-    QDBusMessage reply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                                 QStringLiteral("getLayoutForScreenActivity"), {screenName, activityId});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty()) {
         QString layoutId = reply.arguments().first().toString();
@@ -1541,7 +1560,7 @@ QString SettingsController::getQuickLayoutSlot(int slotNumber) const
     auto it = m_stagedQuickSlots.constFind(slotNumber);
     if (it != m_stagedQuickSlots.constEnd())
         return it.value();
-    QDBusMessage reply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                                 QStringLiteral("getQuickLayoutSlot"), {slotNumber});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty())
         return reply.arguments().first().toString();
@@ -1590,8 +1609,8 @@ void SettingsController::setTilingQuickLayoutSlot(int slotNumber, const QString&
 
 QVariantList SettingsController::getAppRulesForLayout(const QString& layoutId) const
 {
-    QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("getLayout"), {layoutId});
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                                QStringLiteral("getLayout"), {layoutId});
     if (reply.type() != QDBusMessage::ReplyMessage || reply.arguments().isEmpty())
         return {};
 
@@ -1755,14 +1774,14 @@ void SettingsController::setActivityDisabled(const QString& screenName, const QS
 
 void SettingsController::refreshVirtualDesktops()
 {
-    QDBusMessage countReply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("getVirtualDesktopCount"));
+    QDBusMessage countReply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                                     QStringLiteral("getVirtualDesktopCount"));
     if (countReply.type() == QDBusMessage::ReplyMessage && !countReply.arguments().isEmpty()) {
         m_virtualDesktopCount = countReply.arguments().first().toInt();
     }
 
-    QDBusMessage namesReply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("getVirtualDesktopNames"));
+    QDBusMessage namesReply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                                     QStringLiteral("getVirtualDesktopNames"));
     if (namesReply.type() == QDBusMessage::ReplyMessage && !namesReply.arguments().isEmpty()) {
         m_virtualDesktopNames = namesReply.arguments().first().toStringList();
     }
@@ -1770,15 +1789,15 @@ void SettingsController::refreshVirtualDesktops()
 
 void SettingsController::refreshActivities()
 {
-    QDBusMessage availReply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("isActivitiesAvailable"));
+    QDBusMessage availReply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                                     QStringLiteral("isActivitiesAvailable"));
     if (availReply.type() == QDBusMessage::ReplyMessage && !availReply.arguments().isEmpty()) {
         m_activitiesAvailable = availReply.arguments().first().toBool();
     }
 
     if (m_activitiesAvailable) {
-        QDBusMessage infoReply =
-            DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("getAllActivitiesInfo"));
+        QDBusMessage infoReply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                                        QStringLiteral("getAllActivitiesInfo"));
         if (infoReply.type() == QDBusMessage::ReplyMessage && !infoReply.arguments().isEmpty()) {
             QString json = infoReply.arguments().first().toString();
             QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
@@ -1790,8 +1809,8 @@ void SettingsController::refreshActivities()
             }
         }
 
-        QDBusMessage currentReply =
-            DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("getCurrentActivity"));
+        QDBusMessage currentReply = DaemonDBus::callDaemon(
+            QString(PhosphorProtocol::Service::Interface::LayoutRegistry), QStringLiteral("getCurrentActivity"));
         if (currentReply.type() == QDBusMessage::ReplyMessage && !currentReply.arguments().isEmpty()) {
             m_currentActivity = currentReply.arguments().first().toString();
         }
@@ -2220,7 +2239,8 @@ void SettingsController::requestRunningWindows()
     // coalesce — the most recent deadline wins, matching the fire-and-
     // forget semantics on the daemon side.
     m_runningWindowsTimeout.start();
-    DaemonDBus::callDaemon(QString(DBus::Interface::Settings), QStringLiteral("requestRunningWindows"));
+    DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::Settings),
+                           QStringLiteral("requestRunningWindows"));
 }
 
 void SettingsController::onRunningWindowsAvailable(const QString& json)
@@ -2357,8 +2377,8 @@ bool SettingsController::importAllSettings(const QString& filePath)
 
 QVariantList SettingsController::getScreenStates() const
 {
-    QDBusMessage reply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("getScreenStates"));
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                                QStringLiteral("getScreenStates"));
     if (reply.type() == QDBusMessage::ErrorMessage || reply.arguments().isEmpty())
         return {};
 
@@ -3233,8 +3253,8 @@ bool SettingsController::hasPerScreenZoneSelectorSettings(const QString& screenN
 void SettingsController::saveAppRulesToDaemon(const QString& layoutId, const QVariantList& rules)
 {
     // Get the current layout JSON, update the appRules field, and send back via updateLayout
-    QDBusMessage getReply =
-        DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("getLayout"), {layoutId});
+    QDBusMessage getReply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                                                   QStringLiteral("getLayout"), {layoutId});
     if (getReply.type() != QDBusMessage::ReplyMessage || getReply.arguments().isEmpty())
         return;
 
@@ -3256,7 +3276,8 @@ void SettingsController::saveAppRulesToDaemon(const QString& layoutId, const QVa
     obj[QLatin1String("appRules")] = rulesArray;
 
     QString updatedJson = QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact));
-    DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry), QStringLiteral("updateLayout"), {updatedJson});
+    DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
+                           QStringLiteral("updateLayout"), {updatedJson});
     scheduleLayoutLoad();
 }
 
@@ -3495,7 +3516,7 @@ int SettingsController::importKZonesLayouts(const QJsonArray& kzonesArray)
 
         // Send to daemon via createLayoutFromJson D-Bus method
         QString layoutJson = QString::fromUtf8(QJsonDocument(pzLayout).toJson(QJsonDocument::Compact));
-        QDBusMessage reply = DaemonDBus::callDaemon(QString(DBus::Interface::LayoutRegistry),
+        QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::LayoutRegistry),
                                                     QStringLiteral("createLayoutFromJson"), {layoutJson});
 
         if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty()) {
@@ -3516,7 +3537,8 @@ int SettingsController::importKZonesLayouts(const QJsonArray& kzonesArray)
 
 QStringList SettingsController::getPhysicalScreens() const
 {
-    QDBusMessage reply = DaemonDBus::callDaemon(QString(DBus::Interface::Screen), QStringLiteral("getPhysicalScreens"));
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::Screen),
+                                                QStringLiteral("getPhysicalScreens"));
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty()) {
         return reply.arguments().first().toStringList();
     }
@@ -3525,7 +3547,7 @@ QStringList SettingsController::getPhysicalScreens() const
 
 QVariantList SettingsController::getVirtualScreenConfig(const QString& physicalScreenId) const
 {
-    QDBusMessage reply = DaemonDBus::callDaemon(QString(DBus::Interface::Screen),
+    QDBusMessage reply = DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::Screen),
                                                 QStringLiteral("getVirtualScreenConfig"), {physicalScreenId});
     if (reply.type() == QDBusMessage::ReplyMessage && !reply.arguments().isEmpty()) {
         QString json = reply.arguments().first().toString();
@@ -3577,8 +3599,8 @@ void SettingsController::applyVirtualScreenConfig(const QString& physicalScreenI
     root[QLatin1String("screens")] = screensArr;
 
     QString json = QString::fromUtf8(QJsonDocument(root).toJson(QJsonDocument::Compact));
-    DaemonDBus::callDaemon(QString(DBus::Interface::Screen), QStringLiteral("setVirtualScreenConfig"),
-                           {physicalScreenId, json});
+    DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::Screen),
+                           QStringLiteral("setVirtualScreenConfig"), {physicalScreenId, json});
 }
 
 void SettingsController::removeVirtualScreenConfig(const QString& physicalScreenId)

--- a/src/snap/SnapEngine.h
+++ b/src/snap/SnapEngine.h
@@ -7,7 +7,7 @@
 #include "core/inavigationactions.h"
 #include "core/iwindowengine.h"
 #include "core/types.h"
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
 #include <QPointer>
 #include <QRect>
@@ -22,6 +22,15 @@ class LayoutRegistry;
 }
 
 namespace PlasmaZones {
+
+using PhosphorProtocol::CycleTargetResult;
+using PhosphorProtocol::FocusTargetResult;
+using PhosphorProtocol::MoveTargetResult;
+using PhosphorProtocol::RestoreTargetResult;
+using PhosphorProtocol::SnapAllResultEntry;
+using PhosphorProtocol::SnapAllResultList;
+using PhosphorProtocol::SwapTargetResult;
+using PhosphorProtocol::WindowGeometryList;
 
 class AutotileEngine;
 class ISettings;

--- a/tests/unit/autotile/test_autotile_tile_request_validation.cpp
+++ b/tests/unit/autotile/test_autotile_tile_request_validation.cpp
@@ -36,9 +36,10 @@
 #include "autotile/AutotileConfig.h"
 #include <PhosphorTiles/AlgorithmRegistry.h>
 #include <PhosphorTiles/TilingState.h>
-#include "compositor-common/dbus_types.h"
+#include <PhosphorProtocol/WireTypes.h>
 
 using namespace PlasmaZones;
+using namespace PhosphorProtocol;
 
 namespace {
 

--- a/tests/unit/compositor-common/test_compositor_common.cpp
+++ b/tests/unit/compositor-common/test_compositor_common.cpp
@@ -12,7 +12,7 @@
 #include <QTest>
 
 #include "compositor-common/autotile_state.h"
-#include "compositor-common/dbus_types.h"
+#include <PhosphorProtocol/WireTypes.h>
 #include "compositor-common/floating_cache.h"
 #include "compositor-common/trigger_parser.h"
 #include <PhosphorIdentity/WindowId.h>
@@ -66,15 +66,15 @@ private Q_SLOTS:
 
     void testWindowGeometryEntryRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::WindowGeometryEntry entry{QStringLiteral("firefox|42"), 100, 200, 800, 600};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::WindowGeometryEntry entry{QStringLiteral("firefox|42"), 100, 200, 800, 600};
 
         // Verify D-Bus signature: (siiii) = struct of string + 4 ints
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(siiii)"));
 
         // Verify metatype is registered (needed for QVariant D-Bus transport)
-        const int typeId = qMetaTypeId<PlasmaZones::WindowGeometryEntry>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::WindowGeometryEntry>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         // Verify aggregate construction preserves all fields
@@ -85,7 +85,7 @@ private Q_SLOTS:
         QCOMPARE(entry.height, 600);
 
         // Verify default construction
-        PlasmaZones::WindowGeometryEntry defaultEntry;
+        PhosphorProtocol::WindowGeometryEntry defaultEntry;
         QVERIFY(defaultEntry.windowId.isEmpty());
         QCOMPARE(defaultEntry.x, 0);
         QCOMPARE(defaultEntry.y, 0);
@@ -99,8 +99,8 @@ private Q_SLOTS:
 
     void testTileRequestEntryRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::TileRequestEntry entry{
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::TileRequestEntry entry{
             QStringLiteral("konsole|7"), 50,   100,  640, 480, QStringLiteral("{zone-uuid}"),
             QStringLiteral("screen-0"),  true, false};
 
@@ -109,7 +109,7 @@ private Q_SLOTS:
         QCOMPARE(sig, QStringLiteral("(siiiissbb)"));
 
         // Verify metatype registration
-        const int typeId = qMetaTypeId<PlasmaZones::TileRequestEntry>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::TileRequestEntry>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         // Verify aggregate construction preserves all fields
@@ -124,7 +124,7 @@ private Q_SLOTS:
         QCOMPARE(entry.floating, false);
 
         // Verify default construction
-        PlasmaZones::TileRequestEntry defaultEntry;
+        PhosphorProtocol::TileRequestEntry defaultEntry;
         QVERIFY(defaultEntry.windowId.isEmpty());
         QCOMPARE(defaultEntry.monocle, false);
         QCOMPARE(defaultEntry.floating, false);
@@ -136,21 +136,21 @@ private Q_SLOTS:
 
     void testSnapAllResultEntryRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::SnapAllResultEntry entry{QStringLiteral("dolphin|3"),
-                                              QStringLiteral("{target-zone}"),
-                                              QStringLiteral("{source-zone}"),
-                                              10,
-                                              20,
-                                              500,
-                                              400};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::SnapAllResultEntry entry{QStringLiteral("dolphin|3"),
+                                                   QStringLiteral("{target-zone}"),
+                                                   QStringLiteral("{source-zone}"),
+                                                   10,
+                                                   20,
+                                                   500,
+                                                   400};
 
         // Verify D-Bus signature: (sssiiii) = 3 strings + 4 ints
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(sssiiii)"));
 
         // Verify metatype registration
-        const int typeId = qMetaTypeId<PlasmaZones::SnapAllResultEntry>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::SnapAllResultEntry>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         // Verify aggregate construction preserves all fields
@@ -163,7 +163,7 @@ private Q_SLOTS:
         QCOMPARE(entry.height, 400);
 
         // Verify default construction
-        PlasmaZones::SnapAllResultEntry defaultEntry;
+        PhosphorProtocol::SnapAllResultEntry defaultEntry;
         QVERIFY(defaultEntry.windowId.isEmpty());
         QVERIFY(defaultEntry.targetZoneId.isEmpty());
         QVERIFY(defaultEntry.sourceZoneId.isEmpty());
@@ -175,7 +175,7 @@ private Q_SLOTS:
 
     void testWindowGeometryToRect()
     {
-        PlasmaZones::WindowGeometryEntry entry{QStringLiteral("win|1"), 10, 20, 300, 400};
+        PhosphorProtocol::WindowGeometryEntry entry{QStringLiteral("win|1"), 10, 20, 300, 400};
         QRect rect = entry.toRect();
         QCOMPARE(rect, QRect(10, 20, 300, 400));
     }
@@ -183,7 +183,7 @@ private Q_SLOTS:
     void testWindowGeometryFromRect()
     {
         QRect rect(50, 60, 700, 500);
-        auto entry = PlasmaZones::WindowGeometryEntry::fromRect(QStringLiteral("app|2"), rect);
+        auto entry = PhosphorProtocol::WindowGeometryEntry::fromRect(QStringLiteral("app|2"), rect);
         QCOMPARE(entry.windowId, QStringLiteral("app|2"));
         QCOMPARE(entry.toRect(), rect);
     }
@@ -194,8 +194,8 @@ private Q_SLOTS:
 
     void testTileRequestToRect()
     {
-        PlasmaZones::TileRequestEntry entry{QStringLiteral("app|5"), 15,    25,   640, 480, QStringLiteral("{z}"),
-                                            QStringLiteral("s0"),    false, false};
+        PhosphorProtocol::TileRequestEntry entry{QStringLiteral("app|5"), 15,    25,   640, 480, QStringLiteral("{z}"),
+                                                 QStringLiteral("s0"),    false, false};
         QCOMPARE(entry.toRect(), QRect(15, 25, 640, 480));
     }
 
@@ -205,10 +205,10 @@ private Q_SLOTS:
 
     void testSnapAllResultToGeometryEntry()
     {
-        PlasmaZones::SnapAllResultEntry snap{
+        PhosphorProtocol::SnapAllResultEntry snap{
             QStringLiteral("kate|9"), QStringLiteral("{target}"), QStringLiteral("{source}"), 30, 40, 1024, 768};
 
-        PlasmaZones::WindowGeometryEntry geo = snap.toGeometryEntry();
+        PhosphorProtocol::WindowGeometryEntry geo = snap.toGeometryEntry();
         QCOMPARE(geo.windowId, QStringLiteral("kate|9"));
         QCOMPARE(geo.x, 30);
         QCOMPARE(geo.y, 40);
@@ -218,7 +218,7 @@ private Q_SLOTS:
 
     void testSnapAllResultToRect()
     {
-        PlasmaZones::SnapAllResultEntry snap{
+        PhosphorProtocol::SnapAllResultEntry snap{
             QStringLiteral("app|1"), QStringLiteral("{t}"), QStringLiteral("{s}"), 5, 10, 200, 150};
         QCOMPARE(snap.toRect(), QRect(5, 10, 200, 150));
     }
@@ -229,8 +229,8 @@ private Q_SLOTS:
 
     void testWindowStateEntryRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::WindowStateEntry entry;
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::WindowStateEntry entry;
         entry.windowId = QStringLiteral("firefox|42");
         entry.zoneId = QStringLiteral("{zone-1}");
         entry.screenId = QStringLiteral("screen-0");
@@ -242,7 +242,7 @@ private Q_SLOTS:
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(sssbsasb)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::WindowStateEntry>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::WindowStateEntry>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.windowId, QStringLiteral("firefox|42"));
@@ -253,7 +253,7 @@ private Q_SLOTS:
         QCOMPARE(entry.isSticky, true);
         QCOMPARE(entry.changeType, QStringLiteral("snapped"));
 
-        PlasmaZones::WindowStateEntry defaultEntry;
+        PhosphorProtocol::WindowStateEntry defaultEntry;
         QVERIFY(defaultEntry.windowId.isEmpty());
         QCOMPARE(defaultEntry.isFloating, false);
         QVERIFY(defaultEntry.changeType.isEmpty());
@@ -265,14 +265,14 @@ private Q_SLOTS:
 
     void testUnfloatRestoreResultRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::UnfloatRestoreResult entry{
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::UnfloatRestoreResult entry{
             true, {QStringLiteral("{z1}"), QStringLiteral("{z2}")}, QStringLiteral("screen-0"), 10, 20, 800, 600};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(bassiiii)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::UnfloatRestoreResult>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::UnfloatRestoreResult>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.found, true);
@@ -282,7 +282,7 @@ private Q_SLOTS:
         QCOMPARE(entry.screenName, QStringLiteral("screen-0"));
         QCOMPARE(entry.toRect(), QRect(10, 20, 800, 600));
 
-        PlasmaZones::UnfloatRestoreResult defaultEntry;
+        PhosphorProtocol::UnfloatRestoreResult defaultEntry;
         QCOMPARE(defaultEntry.found, false);
         QVERIFY(defaultEntry.zoneIds.isEmpty());
     }
@@ -293,13 +293,13 @@ private Q_SLOTS:
 
     void testZoneGeometryRectRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::ZoneGeometryRect entry{50, 100, 1920, 1080};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::ZoneGeometryRect entry{50, 100, 1920, 1080};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(iiii)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::ZoneGeometryRect>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::ZoneGeometryRect>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.x, 50);
@@ -309,7 +309,7 @@ private Q_SLOTS:
         QCOMPARE(entry.toRect(), QRect(50, 100, 1920, 1080));
 
         QRect rect(200, 300, 640, 480);
-        auto fromRect = PlasmaZones::ZoneGeometryRect::fromRect(rect);
+        auto fromRect = PhosphorProtocol::ZoneGeometryRect::fromRect(rect);
         QCOMPARE(fromRect.toRect(), rect);
     }
 
@@ -319,8 +319,8 @@ private Q_SLOTS:
 
     void testEmptyZoneEntryRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::EmptyZoneEntry entry;
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::EmptyZoneEntry entry;
         entry.zoneId = QStringLiteral("{zone-abc}");
         entry.x = 10;
         entry.y = 20;
@@ -338,7 +338,7 @@ private Q_SLOTS:
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(siiiiiibsssdd)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::EmptyZoneEntry>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::EmptyZoneEntry>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.zoneId, QStringLiteral("{zone-abc}"));
@@ -350,7 +350,7 @@ private Q_SLOTS:
         QCOMPARE(entry.activeOpacity, 0.7);
         QCOMPARE(entry.inactiveOpacity, 0.2);
 
-        PlasmaZones::EmptyZoneEntry defaultEntry;
+        PhosphorProtocol::EmptyZoneEntry defaultEntry;
         QCOMPARE(defaultEntry.borderWidth, 0);
         QCOMPARE(defaultEntry.borderRadius, 0);
         QCOMPARE(defaultEntry.useCustomColors, false);
@@ -364,15 +364,15 @@ private Q_SLOTS:
 
     void testSnapAssistCandidateRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::SnapAssistCandidate entry{QStringLiteral("konsole|7"), QStringLiteral("kwin-handle-42"),
-                                               QStringLiteral("utilities-terminal"),
-                                               QStringLiteral("Konsole - Terminal")};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::SnapAssistCandidate entry{QStringLiteral("konsole|7"), QStringLiteral("kwin-handle-42"),
+                                                    QStringLiteral("utilities-terminal"),
+                                                    QStringLiteral("Konsole - Terminal")};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(ssss)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::SnapAssistCandidate>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::SnapAssistCandidate>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.windowId, QStringLiteral("konsole|7"));
@@ -387,13 +387,13 @@ private Q_SLOTS:
 
     void testNamedZoneGeometryRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::NamedZoneGeometry entry{QStringLiteral("{zone-left}"), 0, 0, 960, 1080};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::NamedZoneGeometry entry{QStringLiteral("{zone-left}"), 0, 0, 960, 1080};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(siiii)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::NamedZoneGeometry>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::NamedZoneGeometry>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.zoneId, QStringLiteral("{zone-left}"));
@@ -406,25 +406,25 @@ private Q_SLOTS:
 
     void testAlgorithmInfoEntryRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::AlgorithmInfoEntry entry{QStringLiteral("master-stack"),
-                                              QStringLiteral("Master-Stack"),
-                                              QStringLiteral("A tiling algorithm"),
-                                              true,
-                                              true,
-                                              false,
-                                              false,
-                                              0.65,
-                                              8,
-                                              false,
-                                              QStringLiteral("sequential"),
-                                              false,
-                                              true};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::AlgorithmInfoEntry entry{QStringLiteral("master-stack"),
+                                                   QStringLiteral("Master-Stack"),
+                                                   QStringLiteral("A tiling algorithm"),
+                                                   true,
+                                                   true,
+                                                   false,
+                                                   false,
+                                                   0.65,
+                                                   8,
+                                                   false,
+                                                   QStringLiteral("sequential"),
+                                                   false,
+                                                   true};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(sssbbbbdibsbb)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::AlgorithmInfoEntry>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::AlgorithmInfoEntry>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.id, QStringLiteral("master-stack"));
@@ -448,14 +448,14 @@ private Q_SLOTS:
 
     void testBridgeRegistrationResultRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::BridgeRegistrationResult entry{QStringLiteral("1"), QStringLiteral("kwin"),
-                                                    QStringLiteral("abc-123")};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::BridgeRegistrationResult entry{QStringLiteral("1"), QStringLiteral("kwin"),
+                                                         QStringLiteral("abc-123")};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(sss)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::BridgeRegistrationResult>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::BridgeRegistrationResult>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.apiVersion, QStringLiteral("1"));
@@ -469,21 +469,21 @@ private Q_SLOTS:
 
     void testMoveTargetResultRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::MoveTargetResult entry{true,
-                                            QString(),
-                                            QStringLiteral("{zone-right}"),
-                                            100,
-                                            200,
-                                            960,
-                                            1080,
-                                            QStringLiteral("{zone-left}"),
-                                            QStringLiteral("screen-0")};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::MoveTargetResult entry{true,
+                                                 QString(),
+                                                 QStringLiteral("{zone-right}"),
+                                                 100,
+                                                 200,
+                                                 960,
+                                                 1080,
+                                                 QStringLiteral("{zone-left}"),
+                                                 QStringLiteral("screen-0")};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(bssiiiiss)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::MoveTargetResult>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::MoveTargetResult>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.success, true);
@@ -500,18 +500,18 @@ private Q_SLOTS:
 
     void testFocusTargetResultRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::FocusTargetResult entry{true,
-                                             QString(),
-                                             QStringLiteral("dolphin|3"),
-                                             QStringLiteral("{zone-left}"),
-                                             QStringLiteral("{zone-right}"),
-                                             QStringLiteral("screen-0")};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::FocusTargetResult entry{true,
+                                                  QString(),
+                                                  QStringLiteral("dolphin|3"),
+                                                  QStringLiteral("{zone-left}"),
+                                                  QStringLiteral("{zone-right}"),
+                                                  QStringLiteral("screen-0")};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(bsssss)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::FocusTargetResult>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::FocusTargetResult>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.success, true);
@@ -527,14 +527,14 @@ private Q_SLOTS:
 
     void testCycleTargetResultRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::CycleTargetResult entry{true, QString(), QStringLiteral("kate|5"), QStringLiteral("{zone-center}"),
-                                             QStringLiteral("screen-1")};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::CycleTargetResult entry{true, QString(), QStringLiteral("kate|5"),
+                                                  QStringLiteral("{zone-center}"), QStringLiteral("screen-1")};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(bssss)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::CycleTargetResult>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::CycleTargetResult>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.success, true);
@@ -549,29 +549,29 @@ private Q_SLOTS:
 
     void testSwapTargetResultRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::SwapTargetResult entry{true,
-                                            QString(),
-                                            QStringLiteral("firefox|1"),
-                                            0,
-                                            0,
-                                            960,
-                                            1080,
-                                            QStringLiteral("{zone-left}"),
-                                            QStringLiteral("konsole|2"),
-                                            960,
-                                            0,
-                                            960,
-                                            1080,
-                                            QStringLiteral("{zone-right}"),
-                                            QStringLiteral("screen-0"),
-                                            QStringLiteral("{zone-left}"),
-                                            QStringLiteral("{zone-right}")};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::SwapTargetResult entry{true,
+                                                 QString(),
+                                                 QStringLiteral("firefox|1"),
+                                                 0,
+                                                 0,
+                                                 960,
+                                                 1080,
+                                                 QStringLiteral("{zone-left}"),
+                                                 QStringLiteral("konsole|2"),
+                                                 960,
+                                                 0,
+                                                 960,
+                                                 1080,
+                                                 QStringLiteral("{zone-right}"),
+                                                 QStringLiteral("screen-0"),
+                                                 QStringLiteral("{zone-left}"),
+                                                 QStringLiteral("{zone-right}")};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(bssiiiissiiiissss)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::SwapTargetResult>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::SwapTargetResult>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.success, true);
@@ -598,20 +598,20 @@ private Q_SLOTS:
 
     void testRestoreTargetResultRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::RestoreTargetResult entry{true, true, 50, 75, 1024, 768};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::RestoreTargetResult entry{true, true, 50, 75, 1024, 768};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(bbiiii)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::RestoreTargetResult>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::RestoreTargetResult>();
         QVERIFY(typeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.success, true);
         QCOMPARE(entry.found, true);
         QCOMPARE(entry.toRect(), QRect(50, 75, 1024, 768));
 
-        PlasmaZones::RestoreTargetResult defaultEntry;
+        PhosphorProtocol::RestoreTargetResult defaultEntry;
         QCOMPARE(defaultEntry.success, false);
         QCOMPARE(defaultEntry.found, false);
         QCOMPARE(defaultEntry.toRect(), QRect(0, 0, 0, 0));
@@ -865,15 +865,15 @@ private Q_SLOTS:
 
     void testWindowOpenedEntryRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::WindowOpenedEntry entry{QStringLiteral("firefox|42"), QStringLiteral("screen-0"), 320, 240};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::WindowOpenedEntry entry{QStringLiteral("firefox|42"), QStringLiteral("screen-0"), 320, 240};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(ssii)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::WindowOpenedEntry>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::WindowOpenedEntry>();
         QVERIFY(typeId != QMetaType::UnknownType);
-        const int listTypeId = qMetaTypeId<PlasmaZones::WindowOpenedList>();
+        const int listTypeId = qMetaTypeId<PhosphorProtocol::WindowOpenedList>();
         QVERIFY(listTypeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.windowId, QStringLiteral("firefox|42"));
@@ -881,7 +881,7 @@ private Q_SLOTS:
         QCOMPARE(entry.minWidth, 320);
         QCOMPARE(entry.minHeight, 240);
 
-        PlasmaZones::WindowOpenedEntry defaultEntry;
+        PhosphorProtocol::WindowOpenedEntry defaultEntry;
         QVERIFY(defaultEntry.windowId.isEmpty());
         QVERIFY(defaultEntry.screenId.isEmpty());
         QCOMPARE(defaultEntry.minWidth, 0);
@@ -894,16 +894,16 @@ private Q_SLOTS:
 
     void testSnapConfirmationEntryRoundtrip()
     {
-        PlasmaZones::registerDBusTypes();
-        PlasmaZones::SnapConfirmationEntry entry{QStringLiteral("kate|7"), QStringLiteral("{zone-1}"),
-                                                 QStringLiteral("screen-0"), true};
+        PhosphorProtocol::registerWireTypes();
+        PhosphorProtocol::SnapConfirmationEntry entry{QStringLiteral("kate|7"), QStringLiteral("{zone-1}"),
+                                                      QStringLiteral("screen-0"), true};
 
         const QString sig = dbusSignature(entry);
         QCOMPARE(sig, QStringLiteral("(sssb)"));
 
-        const int typeId = qMetaTypeId<PlasmaZones::SnapConfirmationEntry>();
+        const int typeId = qMetaTypeId<PhosphorProtocol::SnapConfirmationEntry>();
         QVERIFY(typeId != QMetaType::UnknownType);
-        const int listTypeId = qMetaTypeId<PlasmaZones::SnapConfirmationList>();
+        const int listTypeId = qMetaTypeId<PhosphorProtocol::SnapConfirmationList>();
         QVERIFY(listTypeId != QMetaType::UnknownType);
 
         QCOMPARE(entry.windowId, QStringLiteral("kate|7"));
@@ -911,7 +911,7 @@ private Q_SLOTS:
         QCOMPARE(entry.screenId, QStringLiteral("screen-0"));
         QCOMPARE(entry.isRestore, true);
 
-        PlasmaZones::SnapConfirmationEntry defaultEntry;
+        PhosphorProtocol::SnapConfirmationEntry defaultEntry;
         QVERIFY(defaultEntry.windowId.isEmpty());
         QCOMPARE(defaultEntry.isRestore, false);
     }

--- a/tests/unit/dbus/test_autotile_adaptor_panel_gate.cpp
+++ b/tests/unit/dbus/test_autotile_adaptor_panel_gate.cpp
@@ -16,7 +16,7 @@
 #include <QScopeGuard>
 #include <QSignalSpy>
 
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 
 #include "autotile/AutotileEngine.h"
 #include "../helpers/AutotileTestHelpers.h"

--- a/tests/unit/dbus/test_dbus_adaptor_routing.cpp
+++ b/tests/unit/dbus/test_dbus_adaptor_routing.cpp
@@ -8,14 +8,14 @@
  * Regression guard for the 2026-04-10 resnap crash. Root cause: slots written
  * as `void slot(const WindowOpenedList&)` inside `namespace PlasmaZones` were
  * recorded by moc with the unqualified type name "WindowOpenedList", but the
- * metatype was registered via `Q_DECLARE_METATYPE(PlasmaZones::WindowOpenedList)`
- * under the qualified name "PlasmaZones::WindowOpenedList". QDBusAbstractAdaptor
+ * metatype was registered via `Q_DECLARE_METATYPE(PhosphorProtocol::WindowOpenedList)`
+ * under the qualified name "PhosphorProtocol::WindowOpenedList". QDBusAbstractAdaptor
  * dispatch couldn't resolve the type → "Could not find slot ..." at runtime →
  * kwin_wayland downstream crash with "demarshalling function for type 'QString'
  * failed".
  *
  * The structural fix is that every typed-struct slot parameter in the adaptor
- * headers is now fully-qualified (e.g. `const PlasmaZones::WindowOpenedList&`).
+ * headers is now fully-qualified (e.g. `const PhosphorProtocol::WindowOpenedList&`).
  * This test registers an adaptor on a private QDBusConnection and verifies
  * that a method call with a typed-struct payload is actually dispatched to
  * the slot. If a future adaptor regresses by using an unqualified slot
@@ -37,9 +37,9 @@
 #include <QUuid>
 #include <QVariant>
 
-#include <dbus_types.h>
+#include <PhosphorProtocol/WireTypes.h>
 
-using namespace PlasmaZones;
+using namespace PhosphorProtocol;
 
 // =========================================================================
 // Minimal owner object that hosts an adaptor on a private connection.
@@ -62,7 +62,7 @@ public:
     // are expected to declare them. If someone later writes these without
     // the `PlasmaZones::` prefix, the test will start failing.
 public Q_SLOTS:
-    void takeWindowOpenedList(const PlasmaZones::WindowOpenedList& entries)
+    void takeWindowOpenedList(const PhosphorProtocol::WindowOpenedList& entries)
     {
         m_lastReceivedCount = entries.size();
         if (!entries.isEmpty()) {
@@ -72,9 +72,9 @@ public Q_SLOTS:
         Q_EMIT received();
     }
 
-    PlasmaZones::MoveTargetResult produceMoveTarget()
+    PhosphorProtocol::MoveTargetResult produceMoveTarget()
     {
-        PlasmaZones::MoveTargetResult r;
+        PhosphorProtocol::MoveTargetResult r;
         r.success = true;
         r.reason = QStringLiteral("ok");
         r.zoneId = QStringLiteral("{zone-uuid}");
@@ -108,7 +108,7 @@ private Q_SLOTS:
     void initTestCase()
     {
         // Must be called before any adaptors are constructed.
-        PlasmaZones::registerDBusTypes();
+        PhosphorProtocol::registerWireTypes();
 
         // Each test run gets its own bus name on the session bus so tests
         // can run in parallel without stepping on each other. We use a UUID
@@ -154,9 +154,9 @@ private Q_SLOTS:
     {
         QVERIFY(m_bus.isConnected());
 
-        PlasmaZones::WindowOpenedList entries;
-        PlasmaZones::WindowOpenedEntry e1{QStringLiteral("firefox|abc"), QStringLiteral("screen-0"), 640, 480};
-        PlasmaZones::WindowOpenedEntry e2{QStringLiteral("konsole|def"), QStringLiteral("screen-0"), 320, 200};
+        PhosphorProtocol::WindowOpenedList entries;
+        PhosphorProtocol::WindowOpenedEntry e1{QStringLiteral("firefox|abc"), QStringLiteral("screen-0"), 640, 480};
+        PhosphorProtocol::WindowOpenedEntry e2{QStringLiteral("konsole|def"), QStringLiteral("screen-0"), 320, 200};
         entries << e1 << e2;
 
         QDBusMessage msg = QDBusMessage::createMethodCall(m_serviceName, m_objectPath,
@@ -204,10 +204,10 @@ private Q_SLOTS:
         QVERIFY2(watcher.isFinished(), "D-Bus call did not complete within 2s");
         QVERIFY2(!watcher.isError(), qPrintable(watcher.error().message()));
 
-        QDBusPendingReply<PlasmaZones::MoveTargetResult> reply(pending);
+        QDBusPendingReply<PhosphorProtocol::MoveTargetResult> reply(pending);
         QVERIFY2(reply.isValid(), qPrintable(reply.error().message()));
 
-        const PlasmaZones::MoveTargetResult r = reply.value();
+        const PhosphorProtocol::MoveTargetResult r = reply.value();
         QCOMPARE(r.success, true);
         QCOMPARE(r.reason, QStringLiteral("ok"));
         QCOMPARE(r.zoneId, QStringLiteral("{zone-uuid}"));
@@ -228,15 +228,15 @@ private Q_SLOTS:
     // ─────────────────────────────────────────────────────────────────────
     void metatypesAreRegisteredUnderBothNames()
     {
-        QVERIFY(QMetaType::fromName("PlasmaZones::WindowOpenedList").isValid());
+        QVERIFY(QMetaType::fromName("PhosphorProtocol::WindowOpenedList").isValid());
         QVERIFY(QMetaType::fromName("WindowOpenedList").isValid());
-        QCOMPARE(QMetaType::fromName("PlasmaZones::WindowOpenedList").id(),
+        QCOMPARE(QMetaType::fromName("PhosphorProtocol::WindowOpenedList").id(),
                  QMetaType::fromName("WindowOpenedList").id());
 
-        QVERIFY(QMetaType::fromName("PlasmaZones::MoveTargetResult").isValid());
+        QVERIFY(QMetaType::fromName("PhosphorProtocol::MoveTargetResult").isValid());
         QVERIFY(QMetaType::fromName("MoveTargetResult").isValid());
 
-        QVERIFY(QMetaType::fromName("PlasmaZones::WindowStateEntry").isValid());
+        QVERIFY(QMetaType::fromName("PhosphorProtocol::WindowStateEntry").isValid());
         QVERIFY(QMetaType::fromName("WindowStateEntry").isValid());
     }
 

--- a/tests/unit/dbus/test_dbus_validation.cpp
+++ b/tests/unit/dbus/test_dbus_validation.cpp
@@ -20,9 +20,9 @@
 #include <QObject>
 #include <QTest>
 
-#include "compositor-common/dbus_types.h"
+#include <PhosphorProtocol/WireTypes.h>
 
-using namespace PlasmaZones;
+using namespace PhosphorProtocol;
 
 class TestDbusValidation : public QObject
 {


### PR DESCRIPTION
## Summary

- Add `libs/phosphor-protocol/` — LGPL shared library for the daemon-to-compositor wire protocol
- `WireTypes.h`: 21 POD structs, `DragBypassReason` enum, QDBusArgument streaming operators, validation methods, metatype registrations
- `ServiceConstants.h`: D-Bus service name, object path, 9 interface names, API version, timeout constant
- `ClientHelpers.h`: `fireAndForget()`, `asyncCall()`, `loadSettingAsync()` async D-Bus wrappers
- Namespace: `PhosphorProtocol` (clean break from `PlasmaZones::`, no compat aliases)
- All ~50 consumer files migrated atomically (daemon, settings, editor, kwin-effect, tests)
- `compositor-common/` drops D-Bus sources, links PhosphorProtocol transitively
- Add `docs/phosphor-protocol-api-design.md` — full API design doc
- Update `library-extraction-survey.md` is future work (deferred to keep this PR focused)

## Motivation

The D-Bus wire types, service constants, and client helpers lived in `src/compositor-common/` — a GPL static library named after a relationship, not a domain. Third-party compositor plugins (Wayfire, future) cannot link GPL. The types are pure wire-format PODs with no domain logic — LGPL is appropriate.

## Key design decisions

- **`phosphor-protocol`** not `phosphor-ipc` — reserves `phosphor-ipc` for a future native transport layer; this library owns *what* crosses the wire, not *how*
- **Header naming**: `WireTypes.h`, `ServiceConstants.h`, `ClientHelpers.h` — specific enough to coexist with future transport code in the same library
- **Clean namespace break** — no `using namespace` aliases or forwarding headers; all consumers updated in one atomic commit
- **Export macros** on structs with out-of-line methods (`DragPolicy`, `DragOutcome`, `TileRequestEntry`, `BridgeRegistrationResult`) and all QDBusArgument operators — required for `-fvisibility=hidden` shared libraries

## Test plan

- [x] Docker build passes (130/130 tests, zero errors)
- [x] `test_phosphorprotocol` unit tests pass (validation, constants, wire string round-trips)
- [x] Existing `test_compositor_common` D-Bus round-trip tests pass with new namespace
- [x] `test_dbus_validation` passes with PhosphorProtocol types
- [x] `test_dbus_adaptor_routing` passes with PhosphorProtocol metatype names
- [x] KWin effect module builds and links successfully

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)