### PR TITLE
feat: extract engine interfaces into LGPL libraries for physical separation

### DIFF
--- a/libs/phosphor-engine-api/CMakeLists.txt
+++ b/libs/phosphor-engine-api/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CMAKE_AUTOMOC ON)
 add_library(PhosphorEngineApi SHARED
     include/PhosphorEngineApi/PlacementEngineBase.h
     src/PlacementEngineBase.cpp
+    src/GeometryUtils.cpp
 )
 add_library(PhosphorEngineApi::PhosphorEngineApi ALIAS PhosphorEngineApi)
 
@@ -51,6 +52,7 @@ target_compile_features(PhosphorEngineApi PUBLIC cxx_std_20)
 target_link_libraries(PhosphorEngineApi
     PUBLIC
         Qt6::Core
+        Qt6::Gui
 )
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/EngineTypes.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/EngineTypes.h
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <phosphorengineapi_export.h>
+
+#include <QHashFunctions>
+#include <QList>
+#include <QRect>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+
+namespace PhosphorEngineApi {
+
+struct PHOSPHORENGINEAPI_EXPORT TilingStateKey
+{
+    QString screenId;
+    int desktop = 1;
+    QString activity;
+
+    bool operator==(const TilingStateKey& other) const
+    {
+        return screenId == other.screenId && desktop == other.desktop && activity == other.activity;
+    }
+};
+
+inline size_t qHash(const TilingStateKey& key, size_t seed = 0)
+{
+    return qHashMulti(seed, key.screenId, key.desktop, key.activity);
+}
+
+enum class SnapIntent {
+    UserInitiated,
+    AutoRestored,
+};
+
+struct PHOSPHORENGINEAPI_EXPORT ResnapEntry
+{
+    QString windowId;
+    int zonePosition;
+    QList<int> allZonePositions;
+    QString screenId;
+    int virtualDesktop = 0;
+};
+
+struct PHOSPHORENGINEAPI_EXPORT PendingRestore
+{
+    QStringList zoneIds;
+    QString screenId;
+    int virtualDesktop = 0;
+    QString layoutId;
+    QList<int> zoneNumbers;
+};
+
+struct PHOSPHORENGINEAPI_EXPORT SnapResult
+{
+    bool shouldSnap = false;
+    QRect geometry;
+    QString zoneId;
+    QStringList zoneIds;
+    QString screenId;
+
+    bool isValid() const
+    {
+        return shouldSnap && geometry.isValid() && !zoneId.isEmpty();
+    }
+
+    static SnapResult noSnap()
+    {
+        return SnapResult{false, QRect(), QString(), QStringList(), QString()};
+    }
+};
+
+struct PHOSPHORENGINEAPI_EXPORT UnfloatResult
+{
+    bool found = false;
+    QStringList zoneIds;
+    QRect geometry;
+    QString screenId;
+};
+
+struct PHOSPHORENGINEAPI_EXPORT ZoneAssignmentEntry
+{
+    QString windowId{};
+    QString sourceZoneId{};
+    QString targetZoneId{};
+    QStringList targetZoneIds{};
+    QRect targetGeometry{};
+    QString targetScreenId{};
+};
+
+} // namespace PhosphorEngineApi

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/GeometryUtils.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/GeometryUtils.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorEngineApi/EngineTypes.h>
+#include <phosphorengineapi_export.h>
+
+#include <QRect>
+#include <QRectF>
+#include <QSize>
+#include <QString>
+#include <QVector>
+
+class QScreen;
+
+namespace PhosphorEngineApi {
+namespace GeometryUtils {
+
+PHOSPHORENGINEAPI_EXPORT QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, QScreen* screen);
+PHOSPHORENGINEAPI_EXPORT QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, const QRect& overlayGeometry);
+
+PHOSPHORENGINEAPI_EXPORT QRect snapToRect(const QRectF& rf);
+
+PHOSPHORENGINEAPI_EXPORT void enforceWindowMinSizes(QVector<QRect>& zones, const QVector<QSize>& minSizes,
+                                                    int gapThreshold, int innerGap = 0);
+
+PHOSPHORENGINEAPI_EXPORT void removeZoneOverlaps(QVector<QRect>& zones, const QVector<QSize>& minSizes = {},
+                                                 int innerGap = 0);
+
+PHOSPHORENGINEAPI_EXPORT QString rectToJson(const QRect& rect);
+
+PHOSPHORENGINEAPI_EXPORT QString serializeZoneAssignments(const QVector<ZoneAssignmentEntry>& entries);
+
+} // namespace GeometryUtils
+} // namespace PhosphorEngineApi

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/IGeometrySettings.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/IGeometrySettings.h
@@ -4,19 +4,20 @@
 #pragma once
 
 #include <phosphorengineapi_export.h>
+#include <QLatin1String>
 #include <QString>
 #include <QVariantMap>
 
 namespace PhosphorEngineApi {
 
 namespace PerScreenSnappingKey {
-inline constexpr const char ZonePadding[] = "ZonePadding";
-inline constexpr const char OuterGap[] = "OuterGap";
-inline constexpr const char UsePerSideOuterGap[] = "UsePerSideOuterGap";
-inline constexpr const char OuterGapTop[] = "OuterGapTop";
-inline constexpr const char OuterGapBottom[] = "OuterGapBottom";
-inline constexpr const char OuterGapLeft[] = "OuterGapLeft";
-inline constexpr const char OuterGapRight[] = "OuterGapRight";
+inline constexpr QLatin1String ZonePadding{"ZonePadding"};
+inline constexpr QLatin1String OuterGap{"OuterGap"};
+inline constexpr QLatin1String UsePerSideOuterGap{"UsePerSideOuterGap"};
+inline constexpr QLatin1String OuterGapTop{"OuterGapTop"};
+inline constexpr QLatin1String OuterGapBottom{"OuterGapBottom"};
+inline constexpr QLatin1String OuterGapLeft{"OuterGapLeft"};
+inline constexpr QLatin1String OuterGapRight{"OuterGapRight"};
 } // namespace PerScreenSnappingKey
 
 // Library-level fallback defaults. The app-level authority is ConfigDefaults (GPL);

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/IGeometrySettings.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/IGeometrySettings.h
@@ -19,6 +19,8 @@ inline constexpr const char OuterGapLeft[] = "OuterGapLeft";
 inline constexpr const char OuterGapRight[] = "OuterGapRight";
 } // namespace PerScreenSnappingKey
 
+// Library-level fallback defaults. The app-level authority is ConfigDefaults (GPL);
+// these must be kept in sync manually since the LGPL library cannot depend on it.
 namespace GeometryDefaults {
 inline constexpr int ZonePadding = 8;
 inline constexpr int OuterGap = 8;

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/IGeometrySettings.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/IGeometrySettings.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <phosphorengineapi_export.h>
+#include <QString>
+#include <QVariantMap>
+
+namespace PhosphorEngineApi {
+
+namespace PerScreenSnappingKey {
+inline constexpr const char ZonePadding[] = "ZonePadding";
+inline constexpr const char OuterGap[] = "OuterGap";
+inline constexpr const char UsePerSideOuterGap[] = "UsePerSideOuterGap";
+inline constexpr const char OuterGapTop[] = "OuterGapTop";
+inline constexpr const char OuterGapBottom[] = "OuterGapBottom";
+inline constexpr const char OuterGapLeft[] = "OuterGapLeft";
+inline constexpr const char OuterGapRight[] = "OuterGapRight";
+} // namespace PerScreenSnappingKey
+
+namespace GeometryDefaults {
+inline constexpr int ZonePadding = 8;
+inline constexpr int OuterGap = 8;
+} // namespace GeometryDefaults
+
+class PHOSPHORENGINEAPI_EXPORT IGeometrySettings
+{
+public:
+    virtual ~IGeometrySettings() = default;
+
+    virtual int zonePadding() const = 0;
+    virtual int outerGap() const = 0;
+    virtual bool usePerSideOuterGap() const = 0;
+    virtual int outerGapTop() const = 0;
+    virtual int outerGapBottom() const = 0;
+    virtual int outerGapLeft() const = 0;
+    virtual int outerGapRight() const = 0;
+    virtual QVariantMap getPerScreenSnappingSettings(const QString& screenId) const = 0;
+};
+
+} // namespace PhosphorEngineApi

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/IVirtualDesktopManager.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/IVirtualDesktopManager.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <phosphorengineapi_export.h>
+
+namespace PhosphorEngineApi {
+
+class PHOSPHORENGINEAPI_EXPORT IVirtualDesktopManager
+{
+public:
+    virtual ~IVirtualDesktopManager() = default;
+
+    virtual int currentDesktop() const = 0;
+};
+
+} // namespace PhosphorEngineApi

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/IWindowTrackingService.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/IWindowTrackingService.h
@@ -38,6 +38,8 @@ public:
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Screen manager access
+    // Tech debt: returns concrete ScreenManager* — should be an IScreenManager
+    // interface once one exists. Acceptable for now as a stepping stone.
     // ═══════════════════════════════════════════════════════════════════════════
 
     virtual Phosphor::Screens::ScreenManager* screenManager() const = 0;
@@ -118,6 +120,8 @@ public:
     virtual QRect zoneGeometry(const QString& zoneId, const QString& screenId = QString()) const = 0;
     virtual QRect resolveZoneGeometry(const QStringList& zoneIds, const QString& screenId) const = 0;
     virtual QString resolveEffectiveScreenId(const QString& screenId) const = 0;
+    // Tech debt: takes concrete Layout* — should take an opaque layout identifier
+    // once the layout interface is extracted. Acceptable for this extraction phase.
     virtual QString findEmptyZoneInLayout(PhosphorZones::Layout* layout, const QString& screenId,
                                           int desktopFilter = 0) const = 0;
     virtual QSet<QUuid> buildOccupiedZoneSet(const QString& screenFilter = QString(), int desktopFilter = 0) const = 0;

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/IWindowTrackingService.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/IWindowTrackingService.h
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorEngineApi/EngineTypes.h>
+#include <phosphorengineapi_export.h>
+
+#include <QHash>
+#include <QList>
+#include <QRect>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+#include <QUuid>
+#include <QVector>
+
+#include <optional>
+
+class QObject;
+
+namespace PhosphorZones {
+class Layout;
+}
+
+namespace Phosphor::Screens {
+class ScreenManager;
+}
+
+namespace PhosphorEngineApi {
+
+class PHOSPHORENGINEAPI_EXPORT IWindowTrackingService
+{
+public:
+    virtual ~IWindowTrackingService() = default;
+
+    virtual QObject* asQObject() = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Screen manager access
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual Phosphor::Screens::ScreenManager* screenManager() const = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Zone assignment management
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual void assignWindowToZone(const QString& windowId, const QString& zoneId, const QString& screenId,
+                                    int virtualDesktop) = 0;
+    virtual void assignWindowToZones(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
+                                     int virtualDesktop) = 0;
+    virtual void unassignWindow(const QString& windowId) = 0;
+
+    virtual const QHash<QString, QStringList>& zoneAssignments() const = 0;
+    virtual const QHash<QString, QString>& screenAssignments() const = 0;
+    virtual QString zoneForWindow(const QString& windowId) const = 0;
+    virtual QStringList zonesForWindow(const QString& windowId) const = 0;
+    virtual QStringList windowsInZone(const QString& zoneId) const = 0;
+    virtual bool isWindowSnapped(const QString& windowId) const = 0;
+    virtual QString findEmptyZone(const QString& screenId = QString()) const = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Auto-snap
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual void recordSnapIntent(const QString& windowId, bool wasUserInitiated) = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Floating state
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual bool isWindowFloating(const QString& windowId) const = 0;
+    virtual void setWindowFloating(const QString& windowId, bool floating) = 0;
+    virtual void unsnapForFloat(const QString& windowId) = 0;
+    virtual bool clearFloatingForSnap(const QString& windowId) = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Sticky state
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual bool isWindowSticky(const QString& windowId) const = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Pre-float zone/screen restore
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual QStringList preFloatZones(const QString& windowId) const = 0;
+    virtual QString preFloatScreen(const QString& windowId) const = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Auto-snap / pending restore
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual bool clearAutoSnapped(const QString& windowId) = 0;
+    virtual bool consumePendingAssignment(const QString& windowId) = 0;
+    virtual const QHash<QString, QList<PendingRestore>>& pendingRestoreQueues() const = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Last-used zone tracking
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual void updateLastUsedZone(const QString& zoneId, const QString& screenId, const QString& windowClass,
+                                    int virtualDesktop) = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // App identity
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual QString currentAppIdFor(const QString& anyWindowId) const = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Geometry resolution
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual std::optional<QRect> validatedUnmanagedGeometry(const QString& windowId, const QString& screenId,
+                                                            bool exactOnly = false) const = 0;
+    virtual QRect zoneGeometry(const QString& zoneId, const QString& screenId = QString()) const = 0;
+    virtual QRect resolveZoneGeometry(const QStringList& zoneIds, const QString& screenId) const = 0;
+    virtual QString resolveEffectiveScreenId(const QString& screenId) const = 0;
+    virtual QString findEmptyZoneInLayout(PhosphorZones::Layout* layout, const QString& screenId,
+                                          int desktopFilter = 0) const = 0;
+    virtual QSet<QUuid> buildOccupiedZoneSet(const QString& screenFilter = QString(), int desktopFilter = 0) const = 0;
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Resnap buffer
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    virtual QVector<ResnapEntry> takeResnapBuffer() = 0;
+};
+
+} // namespace PhosphorEngineApi

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/PerScreenKeys.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/PerScreenKeys.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <QLatin1String>
+
+namespace PhosphorEngineApi {
+namespace PerScreenKeys {
+
+inline constexpr QLatin1String SplitRatio{"SplitRatio"};
+inline constexpr QLatin1String SplitRatioStep{"SplitRatioStep"};
+inline constexpr QLatin1String MasterCount{"MasterCount"};
+inline constexpr QLatin1String Algorithm{"Algorithm"};
+inline constexpr QLatin1String MaxWindows{"MaxWindows"};
+inline constexpr QLatin1String InnerGap{"InnerGap"};
+inline constexpr QLatin1String OuterGap{"OuterGap"};
+inline constexpr QLatin1String UsePerSideOuterGap{"UsePerSideOuterGap"};
+inline constexpr QLatin1String FocusNewWindows{"FocusNewWindows"};
+inline constexpr QLatin1String SmartGaps{"SmartGaps"};
+inline constexpr QLatin1String InsertPosition{"InsertPosition"};
+inline constexpr QLatin1String FocusFollowsMouse{"FocusFollowsMouse"};
+inline constexpr QLatin1String RespectMinimumSize{"RespectMinimumSize"};
+inline constexpr QLatin1String HideTitleBars{"HideTitleBars"};
+inline constexpr QLatin1String AnimationsEnabled{"AnimationsEnabled"};
+inline constexpr QLatin1String AnimationDuration{"AnimationDuration"};
+inline constexpr QLatin1String AnimationEasingCurve{"AnimationEasingCurve"};
+
+} // namespace PerScreenKeys
+} // namespace PhosphorEngineApi

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/PhosphorEngineApi.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/PhosphorEngineApi.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <PhosphorEngineApi/EngineTypes.h>
 #include <PhosphorEngineApi/IPlacementEngine.h>
 #include <PhosphorEngineApi/IPlacementState.h>
+#include <PhosphorEngineApi/IVirtualDesktopManager.h>
+#include <PhosphorEngineApi/IWindowTrackingService.h>
 #include <PhosphorEngineApi/NavigationContext.h>

--- a/libs/phosphor-engine-api/src/GeometryUtils.cpp
+++ b/libs/phosphor-engine-api/src/GeometryUtils.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorEngineApi/GeometryUtils.h>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QScreen>
+
+#include <algorithm>
+#include <cmath>
+
+namespace PhosphorEngineApi {
+namespace GeometryUtils {
+
+QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, QScreen* screen)
+{
+    if (!screen) {
+        return geometry;
+    }
+    const QRectF screenGeom = screen->geometry();
+    return QRectF(geometry.x() - screenGeom.x(), geometry.y() - screenGeom.y(), geometry.width(), geometry.height());
+}
+
+QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, const QRect& overlayGeometry)
+{
+    return QRectF(geometry.x() - overlayGeometry.x(), geometry.y() - overlayGeometry.y(), geometry.width(),
+                  geometry.height());
+}
+
+QRect snapToRect(const QRectF& rf)
+{
+    const int left = qRound(rf.x());
+    const int top = qRound(rf.y());
+    const int right = qRound(rf.x() + rf.width());
+    const int bottom = qRound(rf.y() + rf.height());
+    return QRect(left, top, std::max(0, right - left), std::max(0, bottom - top));
+}
+
+void enforceWindowMinSizes(QVector<QRect>& zones, const QVector<QSize>& minSizes, int gapThreshold, int innerGap)
+{
+    if (zones.size() != minSizes.size()) {
+        return;
+    }
+    for (int i = 0; i < zones.size(); ++i) {
+        QRect& zone = zones[i];
+        const QSize& minSize = minSizes[i];
+        if (minSize.isEmpty()) {
+            continue;
+        }
+        int needWidth = minSize.width() - zone.width();
+        int needHeight = minSize.height() - zone.height();
+        if (needWidth <= 0 && needHeight <= 0) {
+            continue;
+        }
+        for (int j = 0; j < zones.size(); ++j) {
+            if (i == j)
+                continue;
+            QRect& neighbor = zones[j];
+            bool adjacentH = (std::abs(zone.right() - neighbor.left()) <= gapThreshold
+                              || std::abs(neighbor.right() - zone.left()) <= gapThreshold)
+                && zone.top() < neighbor.bottom() && zone.bottom() > neighbor.top();
+            bool adjacentV = (std::abs(zone.bottom() - neighbor.top()) <= gapThreshold
+                              || std::abs(neighbor.bottom() - zone.top()) <= gapThreshold)
+                && zone.left() < neighbor.right() && zone.right() > neighbor.left();
+
+            if (needWidth > 0 && adjacentH) {
+                int steal = std::min(needWidth, neighbor.width() / 3);
+                if (steal <= 0)
+                    continue;
+                if (zone.right() <= neighbor.left() + gapThreshold) {
+                    zone.setRight(zone.right() + steal);
+                    neighbor.setLeft(neighbor.left() + steal);
+                } else {
+                    zone.setLeft(zone.left() - steal);
+                    neighbor.setRight(neighbor.right() - steal);
+                }
+                needWidth -= steal;
+            }
+            if (needHeight > 0 && adjacentV) {
+                int steal = std::min(needHeight, neighbor.height() / 3);
+                if (steal <= 0)
+                    continue;
+                if (zone.bottom() <= neighbor.top() + gapThreshold) {
+                    zone.setBottom(zone.bottom() + steal);
+                    neighbor.setTop(neighbor.top() + steal);
+                } else {
+                    zone.setTop(zone.top() - steal);
+                    neighbor.setBottom(neighbor.bottom() - steal);
+                }
+                needHeight -= steal;
+            }
+        }
+    }
+    removeZoneOverlaps(zones, minSizes, innerGap);
+}
+
+void removeZoneOverlaps(QVector<QRect>& zones, const QVector<QSize>& minSizes, int innerGap)
+{
+    for (int i = 0; i < zones.size(); ++i) {
+        for (int j = i + 1; j < zones.size(); ++j) {
+            QRect& a = zones[i];
+            QRect& b = zones[j];
+            QRect overlap = a.intersected(b);
+            if (overlap.isEmpty()) {
+                continue;
+            }
+            int surplusA_w = a.width() - (minSizes.size() > i ? minSizes[i].width() : 0);
+            int surplusB_w = b.width() - (minSizes.size() > j ? minSizes[j].width() : 0);
+            int surplusA_h = a.height() - (minSizes.size() > i ? minSizes[i].height() : 0);
+            int surplusB_h = b.height() - (minSizes.size() > j ? minSizes[j].height() : 0);
+
+            if (overlap.width() < overlap.height()) {
+                int mid = overlap.left() + overlap.width() / 2;
+                if (surplusA_w >= surplusB_w) {
+                    a.setRight(mid - innerGap / 2);
+                    b.setLeft(mid + (innerGap + 1) / 2);
+                } else {
+                    b.setRight(mid - innerGap / 2);
+                    a.setLeft(mid + (innerGap + 1) / 2);
+                }
+            } else {
+                int mid = overlap.top() + overlap.height() / 2;
+                if (surplusA_h >= surplusB_h) {
+                    a.setBottom(mid - innerGap / 2);
+                    b.setTop(mid + (innerGap + 1) / 2);
+                } else {
+                    b.setBottom(mid - innerGap / 2);
+                    a.setTop(mid + (innerGap + 1) / 2);
+                }
+            }
+        }
+    }
+}
+
+QString rectToJson(const QRect& rect)
+{
+    QJsonObject obj;
+    obj[QLatin1String("x")] = rect.x();
+    obj[QLatin1String("y")] = rect.y();
+    obj[QLatin1String("width")] = rect.width();
+    obj[QLatin1String("height")] = rect.height();
+    return QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+QString serializeZoneAssignments(const QVector<ZoneAssignmentEntry>& entries)
+{
+    if (entries.isEmpty()) {
+        return QStringLiteral("[]");
+    }
+    QJsonArray array;
+    for (const ZoneAssignmentEntry& entry : entries) {
+        QJsonObject obj;
+        obj[QLatin1String("windowId")] = entry.windowId;
+        obj[QLatin1String("sourceZoneId")] = entry.sourceZoneId;
+        obj[QLatin1String("targetZoneId")] = entry.targetZoneId;
+        if (!entry.targetZoneIds.isEmpty()) {
+            QJsonArray zoneIdsArr;
+            for (const QString& zid : entry.targetZoneIds)
+                zoneIdsArr.append(zid);
+            obj[QLatin1String("targetZoneIds")] = zoneIdsArr;
+        }
+        obj[QLatin1String("x")] = entry.targetGeometry.x();
+        obj[QLatin1String("y")] = entry.targetGeometry.y();
+        obj[QLatin1String("width")] = entry.targetGeometry.width();
+        obj[QLatin1String("height")] = entry.targetGeometry.height();
+        array.append(obj);
+    }
+    return QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact));
+}
+
+} // namespace GeometryUtils
+} // namespace PhosphorEngineApi

--- a/libs/phosphor-screens/include/PhosphorScreens/ScreenIdentity.h
+++ b/libs/phosphor-screens/include/PhosphorScreens/ScreenIdentity.h
@@ -167,7 +167,9 @@ PHOSPHORSCREENS_EXPORT bool screensMatch(const QString& a, const QString& b);
 
 /// Whether @p storedScreenId belongs to the physical screen @p physicalScreenId.
 /// Handles virtual screen IDs: if stored is virtual, extracts its physical parent
-/// and compares. If physicalScreenId is itself virtual, returns false (misuse).
+/// and compares via screensMatch() so connector-name / EDID-ID equivalence is
+/// honored (e.g. "DP-2" vs "Dell:U2722D:115107"). If physicalScreenId is itself
+/// virtual, returns false (misuse — the function is "stored belongs to PHYSICAL X").
 PHOSPHORSCREENS_EXPORT bool belongsToPhysicalScreen(const QString& storedScreenId, const QString& physicalScreenId);
 
 } // namespace ScreenIdentity

--- a/libs/phosphor-screens/include/PhosphorScreens/ScreenIdentity.h
+++ b/libs/phosphor-screens/include/PhosphorScreens/ScreenIdentity.h
@@ -165,6 +165,11 @@ PHOSPHORSCREENS_EXPORT QString nameForId(const QString& screenId);
  */
 PHOSPHORSCREENS_EXPORT bool screensMatch(const QString& a, const QString& b);
 
+/// Whether @p storedScreenId belongs to the physical screen @p physicalScreenId.
+/// Handles virtual screen IDs: if stored is virtual, extracts its physical parent
+/// and compares. If physicalScreenId is itself virtual, returns false (misuse).
+PHOSPHORSCREENS_EXPORT bool belongsToPhysicalScreen(const QString& storedScreenId, const QString& physicalScreenId);
+
 } // namespace ScreenIdentity
 
 } // namespace Phosphor::Screens

--- a/libs/phosphor-screens/src/screenidentity.cpp
+++ b/libs/phosphor-screens/src/screenidentity.cpp
@@ -291,4 +291,18 @@ bool screensMatch(const QString& a, const QString& b)
     return sb && sa == sb;
 }
 
+bool belongsToPhysicalScreen(const QString& storedScreenId, const QString& physicalScreenId)
+{
+    if (storedScreenId.isEmpty() || physicalScreenId.isEmpty()) {
+        return false;
+    }
+    if (PhosphorIdentity::VirtualScreenId::isVirtual(physicalScreenId)) {
+        return false;
+    }
+    if (PhosphorIdentity::VirtualScreenId::isVirtual(storedScreenId)) {
+        return screensMatch(PhosphorIdentity::VirtualScreenId::extractPhysicalId(storedScreenId), physicalScreenId);
+    }
+    return screensMatch(storedScreenId, physicalScreenId);
+}
+
 } // namespace Phosphor::Screens::ScreenIdentity

--- a/libs/phosphor-tiles/include/PhosphorTiles/AutotileConstants.h
+++ b/libs/phosphor-tiles/include/PhosphorTiles/AutotileConstants.h
@@ -158,4 +158,14 @@ using AutotileJsonValues::OverflowFloat;
 using AutotileJsonValues::OverflowUnlimited;
 } // namespace AutotileJsonKeys
 
+enum class AutotileOverflowBehavior {
+    Float = 0,
+    Unlimited = 1
+};
+
+enum class AutotileDragBehavior {
+    Float = 0,
+    Reorder = 1
+};
+
 } // namespace PhosphorTiles

--- a/libs/phosphor-zones/CMakeLists.txt
+++ b/libs/phosphor-zones/CMakeLists.txt
@@ -97,6 +97,7 @@ set(phosphorzones_SRCS
     src/layoutregistry_assignments.cpp
     src/layoutregistry_persistence.cpp
     src/snapstate.cpp
+    src/geometryutils.cpp
 )
 
 add_library(PhosphorZones SHARED

--- a/libs/phosphor-zones/include/PhosphorZones/GeometryUtils.h
+++ b/libs/phosphor-zones/include/PhosphorZones/GeometryUtils.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <PhosphorEngineApi/EngineTypes.h>
+#include <PhosphorEngineApi/GeometryUtils.h>
 #include <PhosphorEngineApi/IGeometrySettings.h>
 #include <phosphorzones_export.h>
 
@@ -11,11 +11,8 @@
 
 #include <QRect>
 #include <QRectF>
-#include <QSize>
 #include <QString>
-#include <QVector>
-
-#include <functional>
+#include <QVariantMap>
 
 class QScreen;
 
@@ -31,8 +28,12 @@ class ScreenManager;
 namespace PhosphorZones {
 namespace GeometryUtils {
 
-PHOSPHORZONES_EXPORT QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, QScreen* screen);
-PHOSPHORZONES_EXPORT QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, const QRect& overlayGeometry);
+using PhosphorEngineApi::GeometryUtils::availableAreaToOverlayCoordinates;
+using PhosphorEngineApi::GeometryUtils::enforceWindowMinSizes;
+using PhosphorEngineApi::GeometryUtils::rectToJson;
+using PhosphorEngineApi::GeometryUtils::removeZoneOverlaps;
+using PhosphorEngineApi::GeometryUtils::serializeZoneAssignments;
+using PhosphorEngineApi::GeometryUtils::snapToRect;
 
 PHOSPHORZONES_EXPORT QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
                                                     QScreen* screen, int innerGap,
@@ -58,8 +59,6 @@ PHOSPHORZONES_EXPORT int getEffectiveZonePadding(PhosphorZones::Layout* layout,
                                                  PhosphorEngineApi::IGeometrySettings* settings,
                                                  const QString& screenId = {});
 
-PHOSPHORZONES_EXPORT QRect snapToRect(const QRectF& rf);
-
 PHOSPHORZONES_EXPORT ::PhosphorLayout::EdgeGaps getEffectiveOuterGaps(PhosphorZones::Layout* layout,
                                                                       PhosphorEngineApi::IGeometrySettings* settings,
                                                                       const QString& screenId = {});
@@ -72,16 +71,6 @@ PHOSPHORZONES_EXPORT QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenMan
 
 PHOSPHORZONES_EXPORT QRectF extractZoneGeometry(const QVariantMap& zone);
 PHOSPHORZONES_EXPORT void setZoneGeometry(QVariantMap& zone, const QRectF& rect);
-
-PHOSPHORZONES_EXPORT void enforceWindowMinSizes(QVector<QRect>& zones, const QVector<QSize>& minSizes, int gapThreshold,
-                                                int innerGap = 0);
-
-PHOSPHORZONES_EXPORT void removeZoneOverlaps(QVector<QRect>& zones, const QVector<QSize>& minSizes = {},
-                                             int innerGap = 0);
-
-PHOSPHORZONES_EXPORT QString rectToJson(const QRect& rect);
-
-PHOSPHORZONES_EXPORT QString serializeZoneAssignments(const QVector<PhosphorEngineApi::ZoneAssignmentEntry>& entries);
 
 } // namespace GeometryUtils
 } // namespace PhosphorZones

--- a/libs/phosphor-zones/include/PhosphorZones/GeometryUtils.h
+++ b/libs/phosphor-zones/include/PhosphorZones/GeometryUtils.h
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorEngineApi/EngineTypes.h>
+#include <PhosphorEngineApi/IGeometrySettings.h>
+#include <phosphorzones_export.h>
+
+#include <PhosphorLayoutApi/EdgeGaps.h>
+
+#include <QRect>
+#include <QRectF>
+#include <QSize>
+#include <QString>
+#include <QVector>
+
+#include <functional>
+
+class QScreen;
+
+namespace PhosphorZones {
+class Layout;
+class Zone;
+}
+
+namespace Phosphor::Screens {
+class ScreenManager;
+}
+
+namespace PhosphorZones {
+namespace GeometryUtils {
+
+PHOSPHORZONES_EXPORT QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, QScreen* screen);
+PHOSPHORZONES_EXPORT QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, const QRect& overlayGeometry);
+
+PHOSPHORZONES_EXPORT QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
+                                                    QScreen* screen, int innerGap,
+                                                    const ::PhosphorLayout::EdgeGaps& outerGaps,
+                                                    bool useAvailableGeometry = true, const QString& screenId = {});
+
+PHOSPHORZONES_EXPORT QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
+                                                    const QRect& screenGeometry, const QRect& availableGeometry,
+                                                    int innerGap, const ::PhosphorLayout::EdgeGaps& outerGaps,
+                                                    bool useAvailableGeometry = true, const QString& screenId = {});
+
+PHOSPHORZONES_EXPORT QRect getZoneGeometryForScreen(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
+                                                    QScreen* screen, const QString& screenId,
+                                                    PhosphorZones::Layout* layout,
+                                                    PhosphorEngineApi::IGeometrySettings* settings);
+
+PHOSPHORZONES_EXPORT QRectF getZoneGeometryForScreenF(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
+                                                      QScreen* screen, const QString& screenId,
+                                                      PhosphorZones::Layout* layout,
+                                                      PhosphorEngineApi::IGeometrySettings* settings);
+
+PHOSPHORZONES_EXPORT int getEffectiveZonePadding(PhosphorZones::Layout* layout,
+                                                 PhosphorEngineApi::IGeometrySettings* settings,
+                                                 const QString& screenId = {});
+
+PHOSPHORZONES_EXPORT QRect snapToRect(const QRectF& rf);
+
+PHOSPHORZONES_EXPORT ::PhosphorLayout::EdgeGaps getEffectiveOuterGaps(PhosphorZones::Layout* layout,
+                                                                      PhosphorEngineApi::IGeometrySettings* settings,
+                                                                      const QString& screenId = {});
+
+PHOSPHORZONES_EXPORT QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr,
+                                                    PhosphorZones::Layout* layout, QScreen* screen);
+
+PHOSPHORZONES_EXPORT QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr,
+                                                    PhosphorZones::Layout* layout, const QString& screenId);
+
+PHOSPHORZONES_EXPORT QRectF extractZoneGeometry(const QVariantMap& zone);
+PHOSPHORZONES_EXPORT void setZoneGeometry(QVariantMap& zone, const QRectF& rect);
+
+PHOSPHORZONES_EXPORT void enforceWindowMinSizes(QVector<QRect>& zones, const QVector<QSize>& minSizes, int gapThreshold,
+                                                int innerGap = 0);
+
+PHOSPHORZONES_EXPORT void removeZoneOverlaps(QVector<QRect>& zones, const QVector<QSize>& minSizes = {},
+                                             int innerGap = 0);
+
+PHOSPHORZONES_EXPORT QString rectToJson(const QRect& rect);
+
+PHOSPHORZONES_EXPORT QString serializeZoneAssignments(const QVector<PhosphorEngineApi::ZoneAssignmentEntry>& entries);
+
+} // namespace GeometryUtils
+} // namespace PhosphorZones

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutUtils.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutUtils.h
@@ -5,6 +5,7 @@
 
 #include <phosphorzones_export.h>
 #include <QFlags>
+#include <QHash>
 #include <QJsonObject>
 #include <QList>
 #include <QRectF>
@@ -12,6 +13,7 @@
 #include <QStringList>
 #include <QVariantList>
 #include <QVariantMap>
+#include <QVector>
 
 namespace PhosphorZones {
 
@@ -86,6 +88,9 @@ PHOSPHORZONES_EXPORT QVariantList zonesToVariantList(Layout* layout, ZoneFields 
  * whole layout as a single map without going through LayoutPreview.
  */
 PHOSPHORZONES_EXPORT QVariantMap layoutToVariantMap(Layout* layout, ZoneFields zoneFields = ZoneField::Minimal);
+
+PHOSPHORZONES_EXPORT void sortZonesByNumber(QVector<Zone*>& zones);
+PHOSPHORZONES_EXPORT QHash<QString, int> buildZonePositionMap(Layout* layout);
 
 } // namespace LayoutUtils
 

--- a/libs/phosphor-zones/src/geometryutils.cpp
+++ b/libs/phosphor-zones/src/geometryutils.cpp
@@ -11,17 +11,10 @@
 #include <PhosphorZones/ZoneDefaults.h>
 #include <PhosphorZones/ZoneJsonKeys.h>
 
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QScreen>
 #include <QVariantMap>
 
-#include <algorithm>
-#include <cmath>
-
 using PhosphorEngineApi::IGeometrySettings;
-using PhosphorEngineApi::ZoneAssignmentEntry;
 namespace GeometryDefaults = PhosphorEngineApi::GeometryDefaults;
 namespace PerScreenSnappingKey = PhosphorEngineApi::PerScreenSnappingKey;
 
@@ -53,7 +46,7 @@ ScreenGeometries resolveScreenGeometries(Phosphor::Screens::ScreenManager* mgr, 
     return {mgr->screenGeometry(screenId), mgr->screenAvailableGeometry(screenId)};
 }
 
-QRectF calculateZoneGeometry(PhosphorZones::Zone* zone, QScreen* screen)
+QRectF calculateZoneGeometry(Zone* zone, QScreen* screen)
 {
     if (!zone || !screen) {
         return QRectF();
@@ -61,8 +54,7 @@ QRectF calculateZoneGeometry(PhosphorZones::Zone* zone, QScreen* screen)
     return zone->calculateAbsoluteGeometry(QRectF(screen->geometry()));
 }
 
-QRectF calculateZoneGeometryInAvailableArea(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
-                                            QScreen* screen)
+QRectF calculateZoneGeometryInAvailableArea(Phosphor::Screens::ScreenManager* mgr, Zone* zone, QScreen* screen)
 {
     if (!zone || !screen) {
         return QRectF();
@@ -79,7 +71,7 @@ struct EdgeBoundaries
     bool bottom = false;
 };
 
-EdgeBoundaries detectEdgeBoundaries(PhosphorZones::Zone* zone, const QRectF& screenGeom)
+EdgeBoundaries detectEdgeBoundaries(Zone* zone, const QRectF& screenGeom)
 {
     EdgeBoundaries edges;
     if (zone->isFixedGeometry()) {
@@ -100,8 +92,8 @@ EdgeBoundaries detectEdgeBoundaries(PhosphorZones::Zone* zone, const QRectF& scr
     return edges;
 }
 
-QRectF applyGapsToZoneGeometry(const QRectF& zoneGeom, PhosphorZones::Zone* zone, const QRectF& referenceGeom,
-                               int innerGap, const ::PhosphorLayout::EdgeGaps& outerGaps,
+QRectF applyGapsToZoneGeometry(const QRectF& zoneGeom, Zone* zone, const QRectF& referenceGeom, int innerGap,
+                               const ::PhosphorLayout::EdgeGaps& outerGaps,
                                const Phosphor::Screens::VirtualScreenDef::PhysicalEdges& physEdges = {true, true, true,
                                                                                                       true})
 {
@@ -121,23 +113,8 @@ QRectF applyGapsToZoneGeometry(const QRectF& zoneGeom, PhosphorZones::Zone* zone
 }
 } // anonymous namespace
 
-QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, QScreen* screen)
-{
-    if (!screen) {
-        return geometry;
-    }
-    const QRectF screenGeom = screen->geometry();
-    return QRectF(geometry.x() - screenGeom.x(), geometry.y() - screenGeom.y(), geometry.width(), geometry.height());
-}
-
-QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, const QRect& overlayGeometry)
-{
-    return QRectF(geometry.x() - overlayGeometry.x(), geometry.y() - overlayGeometry.y(), geometry.width(),
-                  geometry.height());
-}
-
-QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone, QScreen* screen,
-                               int innerGap, const ::PhosphorLayout::EdgeGaps& outerGaps, bool useAvailableGeometry,
+QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, Zone* zone, QScreen* screen, int innerGap,
+                               const ::PhosphorLayout::EdgeGaps& outerGaps, bool useAvailableGeometry,
                                const QString& screenId)
 {
     if (!zone || !screen) {
@@ -160,8 +137,8 @@ QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZo
     return applyGapsToZoneGeometry(geom, zone, screenGeom, innerGap, outerGaps, physEdges);
 }
 
-QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
-                               const QRect& screenGeometry, const QRect& availableGeometry, int innerGap,
+QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, Zone* zone, const QRect& screenGeometry,
+                               const QRect& availableGeometry, int innerGap,
                                const ::PhosphorLayout::EdgeGaps& outerGaps, bool useAvailableGeometry,
                                const QString& screenId)
 {
@@ -177,8 +154,8 @@ QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZo
     return applyGapsToZoneGeometry(geom, zone, referenceGeom, innerGap, outerGaps);
 }
 
-QRectF getZoneGeometryForScreenF(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone, QScreen* screen,
-                                 const QString& screenId, PhosphorZones::Layout* layout, IGeometrySettings* settings)
+QRectF getZoneGeometryForScreenF(Phosphor::Screens::ScreenManager* mgr, Zone* zone, QScreen* screen,
+                                 const QString& screenId, Layout* layout, IGeometrySettings* settings)
 {
     if (!zone) {
         return QRectF();
@@ -200,14 +177,14 @@ QRectF getZoneGeometryForScreenF(Phosphor::Screens::ScreenManager* mgr, Phosphor
     return QRectF();
 }
 
-QRect getZoneGeometryForScreen(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone, QScreen* screen,
-                               const QString& screenId, PhosphorZones::Layout* layout, IGeometrySettings* settings)
+QRect getZoneGeometryForScreen(Phosphor::Screens::ScreenManager* mgr, Zone* zone, QScreen* screen,
+                               const QString& screenId, Layout* layout, IGeometrySettings* settings)
 {
     QRectF geoF = getZoneGeometryForScreenF(mgr, zone, screen, screenId, layout, settings);
-    return geoF.isValid() ? snapToRect(geoF) : QRect();
+    return geoF.isValid() ? PhosphorEngineApi::GeometryUtils::snapToRect(geoF) : QRect();
 }
 
-int getEffectiveZonePadding(PhosphorZones::Layout* layout, IGeometrySettings* settings, const QString& screenId)
+int getEffectiveZonePadding(Layout* layout, IGeometrySettings* settings, const QString& screenId)
 {
     if (!screenId.isEmpty() && settings) {
         QVariantMap perScreen = getPerScreenSnappingWithFallback(settings, screenId);
@@ -225,17 +202,7 @@ int getEffectiveZonePadding(PhosphorZones::Layout* layout, IGeometrySettings* se
     return GeometryDefaults::ZonePadding;
 }
 
-QRect snapToRect(const QRectF& rf)
-{
-    const int left = qRound(rf.x());
-    const int top = qRound(rf.y());
-    const int right = qRound(rf.x() + rf.width());
-    const int bottom = qRound(rf.y() + rf.height());
-    return QRect(left, top, std::max(0, right - left), std::max(0, bottom - top));
-}
-
-::PhosphorLayout::EdgeGaps getEffectiveOuterGaps(PhosphorZones::Layout* layout, IGeometrySettings* settings,
-                                                 const QString& screenId)
+::PhosphorLayout::EdgeGaps getEffectiveOuterGaps(Layout* layout, IGeometrySettings* settings, const QString& screenId)
 {
     if (!screenId.isEmpty() && settings) {
         QVariantMap perScreen = getPerScreenSnappingWithFallback(settings, screenId);
@@ -300,7 +267,7 @@ QRect snapToRect(const QRectF& rf)
     return ::PhosphorLayout::EdgeGaps::uniform(GeometryDefaults::OuterGap);
 }
 
-QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout, QScreen* screen)
+QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, Layout* layout, QScreen* screen)
 {
     if (!screen) {
         return QRectF();
@@ -311,8 +278,7 @@ QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, PhosphorZo
     return mgr ? mgr->actualAvailableGeometry(screen) : screen->availableGeometry();
 }
 
-QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
-                               const QString& screenId)
+QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, Layout* layout, const QString& screenId)
 {
     auto [geom, availGeom] = resolveScreenGeometries(mgr, screenId);
     if (geom.isValid()) {
@@ -327,150 +293,16 @@ QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, PhosphorZo
 
 QRectF extractZoneGeometry(const QVariantMap& zone)
 {
-    return QRectF(zone.value(::PhosphorZones::ZoneJsonKeys::X).toDouble(),
-                  zone.value(::PhosphorZones::ZoneJsonKeys::Y).toDouble(),
-                  zone.value(::PhosphorZones::ZoneJsonKeys::Width).toDouble(),
-                  zone.value(::PhosphorZones::ZoneJsonKeys::Height).toDouble());
+    return QRectF(zone.value(ZoneJsonKeys::X).toDouble(), zone.value(ZoneJsonKeys::Y).toDouble(),
+                  zone.value(ZoneJsonKeys::Width).toDouble(), zone.value(ZoneJsonKeys::Height).toDouble());
 }
 
 void setZoneGeometry(QVariantMap& zone, const QRectF& rect)
 {
-    zone[::PhosphorZones::ZoneJsonKeys::X] = rect.x();
-    zone[::PhosphorZones::ZoneJsonKeys::Y] = rect.y();
-    zone[::PhosphorZones::ZoneJsonKeys::Width] = rect.width();
-    zone[::PhosphorZones::ZoneJsonKeys::Height] = rect.height();
-}
-
-void enforceWindowMinSizes(QVector<QRect>& zones, const QVector<QSize>& minSizes, int gapThreshold, int innerGap)
-{
-    if (zones.size() != minSizes.size()) {
-        return;
-    }
-    for (int i = 0; i < zones.size(); ++i) {
-        QRect& zone = zones[i];
-        const QSize& minSize = minSizes[i];
-        if (minSize.isEmpty()) {
-            continue;
-        }
-        int needWidth = minSize.width() - zone.width();
-        int needHeight = minSize.height() - zone.height();
-        if (needWidth <= 0 && needHeight <= 0) {
-            continue;
-        }
-        for (int j = 0; j < zones.size(); ++j) {
-            if (i == j)
-                continue;
-            QRect& neighbor = zones[j];
-            bool adjacentH = (std::abs(zone.right() - neighbor.left()) <= gapThreshold
-                              || std::abs(neighbor.right() - zone.left()) <= gapThreshold)
-                && zone.top() < neighbor.bottom() && zone.bottom() > neighbor.top();
-            bool adjacentV = (std::abs(zone.bottom() - neighbor.top()) <= gapThreshold
-                              || std::abs(neighbor.bottom() - zone.top()) <= gapThreshold)
-                && zone.left() < neighbor.right() && zone.right() > neighbor.left();
-
-            if (needWidth > 0 && adjacentH) {
-                int steal = std::min(needWidth, neighbor.width() / 3);
-                if (steal <= 0)
-                    continue;
-                if (zone.right() <= neighbor.left() + gapThreshold) {
-                    zone.setRight(zone.right() + steal);
-                    neighbor.setLeft(neighbor.left() + steal);
-                } else {
-                    zone.setLeft(zone.left() - steal);
-                    neighbor.setRight(neighbor.right() - steal);
-                }
-                needWidth -= steal;
-            }
-            if (needHeight > 0 && adjacentV) {
-                int steal = std::min(needHeight, neighbor.height() / 3);
-                if (steal <= 0)
-                    continue;
-                if (zone.bottom() <= neighbor.top() + gapThreshold) {
-                    zone.setBottom(zone.bottom() + steal);
-                    neighbor.setTop(neighbor.top() + steal);
-                } else {
-                    zone.setTop(zone.top() - steal);
-                    neighbor.setBottom(neighbor.bottom() - steal);
-                }
-                needHeight -= steal;
-            }
-        }
-    }
-    removeZoneOverlaps(zones, minSizes, innerGap);
-}
-
-void removeZoneOverlaps(QVector<QRect>& zones, const QVector<QSize>& minSizes, int innerGap)
-{
-    for (int i = 0; i < zones.size(); ++i) {
-        for (int j = i + 1; j < zones.size(); ++j) {
-            QRect& a = zones[i];
-            QRect& b = zones[j];
-            QRect overlap = a.intersected(b);
-            if (overlap.isEmpty()) {
-                continue;
-            }
-            int surplusA_w = a.width() - (minSizes.size() > i ? minSizes[i].width() : 0);
-            int surplusB_w = b.width() - (minSizes.size() > j ? minSizes[j].width() : 0);
-            int surplusA_h = a.height() - (minSizes.size() > i ? minSizes[i].height() : 0);
-            int surplusB_h = b.height() - (minSizes.size() > j ? minSizes[j].height() : 0);
-
-            if (overlap.width() < overlap.height()) {
-                int mid = overlap.left() + overlap.width() / 2;
-                if (surplusA_w >= surplusB_w) {
-                    a.setRight(mid - innerGap / 2);
-                    b.setLeft(mid + (innerGap + 1) / 2);
-                } else {
-                    b.setRight(mid - innerGap / 2);
-                    a.setLeft(mid + (innerGap + 1) / 2);
-                }
-            } else {
-                int mid = overlap.top() + overlap.height() / 2;
-                if (surplusA_h >= surplusB_h) {
-                    a.setBottom(mid - innerGap / 2);
-                    b.setTop(mid + (innerGap + 1) / 2);
-                } else {
-                    b.setBottom(mid - innerGap / 2);
-                    a.setTop(mid + (innerGap + 1) / 2);
-                }
-            }
-        }
-    }
-}
-
-QString rectToJson(const QRect& rect)
-{
-    QJsonObject obj;
-    obj[::PhosphorZones::ZoneJsonKeys::X] = rect.x();
-    obj[::PhosphorZones::ZoneJsonKeys::Y] = rect.y();
-    obj[::PhosphorZones::ZoneJsonKeys::Width] = rect.width();
-    obj[::PhosphorZones::ZoneJsonKeys::Height] = rect.height();
-    return QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact));
-}
-
-QString serializeZoneAssignments(const QVector<ZoneAssignmentEntry>& entries)
-{
-    if (entries.isEmpty()) {
-        return QStringLiteral("[]");
-    }
-    QJsonArray array;
-    for (const ZoneAssignmentEntry& entry : entries) {
-        QJsonObject obj;
-        obj[QLatin1String("windowId")] = entry.windowId;
-        obj[QLatin1String("sourceZoneId")] = entry.sourceZoneId;
-        obj[QLatin1String("targetZoneId")] = entry.targetZoneId;
-        if (!entry.targetZoneIds.isEmpty()) {
-            QJsonArray zoneIdsArr;
-            for (const QString& zid : entry.targetZoneIds)
-                zoneIdsArr.append(zid);
-            obj[QLatin1String("targetZoneIds")] = zoneIdsArr;
-        }
-        obj[::PhosphorZones::ZoneJsonKeys::X] = entry.targetGeometry.x();
-        obj[::PhosphorZones::ZoneJsonKeys::Y] = entry.targetGeometry.y();
-        obj[::PhosphorZones::ZoneJsonKeys::Width] = entry.targetGeometry.width();
-        obj[::PhosphorZones::ZoneJsonKeys::Height] = entry.targetGeometry.height();
-        array.append(obj);
-    }
-    return QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact));
+    zone[ZoneJsonKeys::X] = rect.x();
+    zone[ZoneJsonKeys::Y] = rect.y();
+    zone[ZoneJsonKeys::Width] = rect.width();
+    zone[ZoneJsonKeys::Height] = rect.height();
 }
 
 } // namespace GeometryUtils

--- a/libs/phosphor-zones/src/geometryutils.cpp
+++ b/libs/phosphor-zones/src/geometryutils.cpp
@@ -1,0 +1,477 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorZones/GeometryUtils.h>
+#include <PhosphorEngineApi/IGeometrySettings.h>
+#include <PhosphorIdentity/VirtualScreenId.h>
+#include <PhosphorScreens/Manager.h>
+#include <PhosphorScreens/ScreenIdentity.h>
+#include <PhosphorZones/Layout.h>
+#include <PhosphorZones/Zone.h>
+#include <PhosphorZones/ZoneDefaults.h>
+#include <PhosphorZones/ZoneJsonKeys.h>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QScreen>
+#include <QVariantMap>
+
+#include <algorithm>
+#include <cmath>
+
+using PhosphorEngineApi::IGeometrySettings;
+using PhosphorEngineApi::ZoneAssignmentEntry;
+namespace GeometryDefaults = PhosphorEngineApi::GeometryDefaults;
+namespace PerScreenSnappingKey = PhosphorEngineApi::PerScreenSnappingKey;
+
+namespace PhosphorZones {
+
+static QVariantMap getPerScreenSnappingWithFallback(IGeometrySettings* settings, const QString& screenId)
+{
+    QVariantMap result = settings->getPerScreenSnappingSettings(screenId);
+    if (result.isEmpty() && PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
+        result = settings->getPerScreenSnappingSettings(PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId));
+    }
+    return result;
+}
+
+namespace GeometryUtils {
+
+namespace {
+struct ScreenGeometries
+{
+    QRect geometry;
+    QRect availableGeometry;
+};
+
+ScreenGeometries resolveScreenGeometries(Phosphor::Screens::ScreenManager* mgr, const QString& screenId)
+{
+    if (!mgr) {
+        return {};
+    }
+    return {mgr->screenGeometry(screenId), mgr->screenAvailableGeometry(screenId)};
+}
+
+QRectF calculateZoneGeometry(PhosphorZones::Zone* zone, QScreen* screen)
+{
+    if (!zone || !screen) {
+        return QRectF();
+    }
+    return zone->calculateAbsoluteGeometry(QRectF(screen->geometry()));
+}
+
+QRectF calculateZoneGeometryInAvailableArea(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
+                                            QScreen* screen)
+{
+    if (!zone || !screen) {
+        return QRectF();
+    }
+    const QRectF availableGeom = mgr ? mgr->actualAvailableGeometry(screen) : screen->availableGeometry();
+    return zone->calculateAbsoluteGeometry(availableGeom);
+}
+
+struct EdgeBoundaries
+{
+    bool left = false;
+    bool top = false;
+    bool right = false;
+    bool bottom = false;
+};
+
+EdgeBoundaries detectEdgeBoundaries(PhosphorZones::Zone* zone, const QRectF& screenGeom)
+{
+    EdgeBoundaries edges;
+    if (zone->isFixedGeometry()) {
+        constexpr qreal pixelTolerance = 5.0;
+        QRectF fixedGeo = zone->fixedGeometry();
+        edges.left = (fixedGeo.left() < pixelTolerance);
+        edges.top = (fixedGeo.top() < pixelTolerance);
+        edges.right = (fixedGeo.right() > (screenGeom.width() - pixelTolerance));
+        edges.bottom = (fixedGeo.bottom() > (screenGeom.height() - pixelTolerance));
+    } else {
+        constexpr qreal edgeTolerance = 0.01;
+        QRectF relGeom = zone->relativeGeometry();
+        edges.left = (relGeom.left() < edgeTolerance);
+        edges.top = (relGeom.top() < edgeTolerance);
+        edges.right = (relGeom.right() > (1.0 - edgeTolerance));
+        edges.bottom = (relGeom.bottom() > (1.0 - edgeTolerance));
+    }
+    return edges;
+}
+
+QRectF applyGapsToZoneGeometry(const QRectF& zoneGeom, PhosphorZones::Zone* zone, const QRectF& referenceGeom,
+                               int innerGap, const ::PhosphorLayout::EdgeGaps& outerGaps,
+                               const Phosphor::Screens::VirtualScreenDef::PhysicalEdges& physEdges = {true, true, true,
+                                                                                                      true})
+{
+    EdgeBoundaries edges = detectEdgeBoundaries(zone, referenceGeom);
+    qreal leftAdj = (edges.left && physEdges.left) ? outerGaps.left : (innerGap / 2.0);
+    qreal topAdj = (edges.top && physEdges.top) ? outerGaps.top : (innerGap / 2.0);
+    qreal rightAdj = (edges.right && physEdges.right) ? outerGaps.right : (innerGap / 2.0);
+    qreal bottomAdj = (edges.bottom && physEdges.bottom) ? outerGaps.bottom : (innerGap / 2.0);
+    QRectF geoF = zoneGeom.adjusted(leftAdj, topAdj, -rightAdj, -bottomAdj);
+    if (geoF.width() < 1.0) {
+        geoF.setWidth(1.0);
+    }
+    if (geoF.height() < 1.0) {
+        geoF.setHeight(1.0);
+    }
+    return geoF;
+}
+} // anonymous namespace
+
+QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, QScreen* screen)
+{
+    if (!screen) {
+        return geometry;
+    }
+    const QRectF screenGeom = screen->geometry();
+    return QRectF(geometry.x() - screenGeom.x(), geometry.y() - screenGeom.y(), geometry.width(), geometry.height());
+}
+
+QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, const QRect& overlayGeometry)
+{
+    return QRectF(geometry.x() - overlayGeometry.x(), geometry.y() - overlayGeometry.y(), geometry.width(),
+                  geometry.height());
+}
+
+QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone, QScreen* screen,
+                               int innerGap, const ::PhosphorLayout::EdgeGaps& outerGaps, bool useAvailableGeometry,
+                               const QString& screenId)
+{
+    if (!zone || !screen) {
+        return QRectF();
+    }
+    QRectF geom;
+    if (useAvailableGeometry) {
+        geom = calculateZoneGeometryInAvailableArea(mgr, zone, screen);
+    } else {
+        geom = calculateZoneGeometry(zone, screen);
+    }
+    QRectF screenGeom = useAvailableGeometry
+        ? (mgr ? mgr->actualAvailableGeometry(screen) : screen->availableGeometry())
+        : screen->geometry();
+    Phosphor::Screens::VirtualScreenDef::PhysicalEdges physEdges{true, true, true, true};
+    if (mgr) {
+        QString resolvedId = screenId.isEmpty() ? Phosphor::Screens::ScreenIdentity::identifierFor(screen) : screenId;
+        physEdges = mgr->physicalEdgesFor(resolvedId);
+    }
+    return applyGapsToZoneGeometry(geom, zone, screenGeom, innerGap, outerGaps, physEdges);
+}
+
+QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
+                               const QRect& screenGeometry, const QRect& availableGeometry, int innerGap,
+                               const ::PhosphorLayout::EdgeGaps& outerGaps, bool useAvailableGeometry,
+                               const QString& screenId)
+{
+    if (!zone) {
+        return QRectF();
+    }
+    QRectF referenceGeom = useAvailableGeometry ? QRectF(availableGeometry) : QRectF(screenGeometry);
+    QRectF geom = zone->calculateAbsoluteGeometry(referenceGeom);
+    if (!screenId.isEmpty() && mgr) {
+        auto pe = mgr->physicalEdgesFor(screenId);
+        return applyGapsToZoneGeometry(geom, zone, referenceGeom, innerGap, outerGaps, pe);
+    }
+    return applyGapsToZoneGeometry(geom, zone, referenceGeom, innerGap, outerGaps);
+}
+
+QRectF getZoneGeometryForScreenF(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone, QScreen* screen,
+                                 const QString& screenId, PhosphorZones::Layout* layout, IGeometrySettings* settings)
+{
+    if (!zone) {
+        return QRectF();
+    }
+    int zonePadding = getEffectiveZonePadding(layout, settings, screenId);
+    ::PhosphorLayout::EdgeGaps outerGaps = getEffectiveOuterGaps(layout, settings, screenId);
+    bool useAvail = !(layout && layout->useFullScreenGeometry());
+    auto [vsGeom, vsAvailGeom] = resolveScreenGeometries(mgr, screenId);
+    if (vsGeom.isValid()) {
+        QRect availGeom = vsAvailGeom.isValid() ? vsAvailGeom : vsGeom;
+        return getZoneGeometryWithGaps(mgr, zone, vsGeom, availGeom, zonePadding, outerGaps, useAvail, screenId);
+    }
+    if (PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
+        return QRectF();
+    }
+    if (screen) {
+        return getZoneGeometryWithGaps(mgr, zone, screen, zonePadding, outerGaps, useAvail, screenId);
+    }
+    return QRectF();
+}
+
+QRect getZoneGeometryForScreen(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone, QScreen* screen,
+                               const QString& screenId, PhosphorZones::Layout* layout, IGeometrySettings* settings)
+{
+    QRectF geoF = getZoneGeometryForScreenF(mgr, zone, screen, screenId, layout, settings);
+    return geoF.isValid() ? snapToRect(geoF) : QRect();
+}
+
+int getEffectiveZonePadding(PhosphorZones::Layout* layout, IGeometrySettings* settings, const QString& screenId)
+{
+    if (!screenId.isEmpty() && settings) {
+        QVariantMap perScreen = getPerScreenSnappingWithFallback(settings, screenId);
+        auto it = perScreen.constFind(QLatin1String(PerScreenSnappingKey::ZonePadding));
+        if (it != perScreen.constEnd()) {
+            return it->toInt();
+        }
+    }
+    if (layout && layout->hasZonePaddingOverride()) {
+        return layout->zonePadding();
+    }
+    if (settings) {
+        return settings->zonePadding();
+    }
+    return GeometryDefaults::ZonePadding;
+}
+
+QRect snapToRect(const QRectF& rf)
+{
+    const int left = qRound(rf.x());
+    const int top = qRound(rf.y());
+    const int right = qRound(rf.x() + rf.width());
+    const int bottom = qRound(rf.y() + rf.height());
+    return QRect(left, top, std::max(0, right - left), std::max(0, bottom - top));
+}
+
+::PhosphorLayout::EdgeGaps getEffectiveOuterGaps(PhosphorZones::Layout* layout, IGeometrySettings* settings,
+                                                 const QString& screenId)
+{
+    if (!screenId.isEmpty() && settings) {
+        QVariantMap perScreen = getPerScreenSnappingWithFallback(settings, screenId);
+        if (!perScreen.isEmpty()) {
+            auto usePerSideIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::UsePerSideOuterGap));
+            bool usePerSide = (usePerSideIt != perScreen.constEnd()) ? usePerSideIt->toBool() : false;
+            if (usePerSide) {
+                auto topIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapTop));
+                auto bottomIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapBottom));
+                auto leftIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapLeft));
+                auto rightIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapRight));
+                if (topIt != perScreen.constEnd() || bottomIt != perScreen.constEnd() || leftIt != perScreen.constEnd()
+                    || rightIt != perScreen.constEnd()) {
+                    auto uniformIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGap));
+                    int fallback = (uniformIt != perScreen.constEnd()) ? uniformIt->toInt() : settings->outerGap();
+                    return {(topIt != perScreen.constEnd()) ? topIt->toInt() : fallback,
+                            (bottomIt != perScreen.constEnd()) ? bottomIt->toInt() : fallback,
+                            (leftIt != perScreen.constEnd()) ? leftIt->toInt() : fallback,
+                            (rightIt != perScreen.constEnd()) ? rightIt->toInt() : fallback};
+                }
+            }
+            auto uniformIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGap));
+            if (uniformIt != perScreen.constEnd()) {
+                return ::PhosphorLayout::EdgeGaps::uniform(uniformIt->toInt());
+            }
+        }
+    }
+    if (layout && layout->usePerSideOuterGap() && layout->hasPerSideOuterGapOverride()) {
+        ::PhosphorLayout::EdgeGaps gaps = layout->rawOuterGaps();
+        if (settings && settings->usePerSideOuterGap()) {
+            if (gaps.top < 0)
+                gaps.top = settings->outerGapTop();
+            if (gaps.bottom < 0)
+                gaps.bottom = settings->outerGapBottom();
+            if (gaps.left < 0)
+                gaps.left = settings->outerGapLeft();
+            if (gaps.right < 0)
+                gaps.right = settings->outerGapRight();
+        } else {
+            int fallback = settings ? settings->outerGap() : GeometryDefaults::OuterGap;
+            if (gaps.top < 0)
+                gaps.top = fallback;
+            if (gaps.bottom < 0)
+                gaps.bottom = fallback;
+            if (gaps.left < 0)
+                gaps.left = fallback;
+            if (gaps.right < 0)
+                gaps.right = fallback;
+        }
+        return gaps;
+    }
+    if (layout && layout->hasOuterGapOverride()) {
+        return ::PhosphorLayout::EdgeGaps::uniform(layout->outerGap());
+    }
+    if (settings) {
+        if (settings->usePerSideOuterGap()) {
+            return {settings->outerGapTop(), settings->outerGapBottom(), settings->outerGapLeft(),
+                    settings->outerGapRight()};
+        }
+        return ::PhosphorLayout::EdgeGaps::uniform(settings->outerGap());
+    }
+    return ::PhosphorLayout::EdgeGaps::uniform(GeometryDefaults::OuterGap);
+}
+
+QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout, QScreen* screen)
+{
+    if (!screen) {
+        return QRectF();
+    }
+    if (layout && layout->useFullScreenGeometry()) {
+        return screen->geometry();
+    }
+    return mgr ? mgr->actualAvailableGeometry(screen) : screen->availableGeometry();
+}
+
+QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
+                               const QString& screenId)
+{
+    auto [geom, availGeom] = resolveScreenGeometries(mgr, screenId);
+    if (geom.isValid()) {
+        if (layout && layout->useFullScreenGeometry()) {
+            return QRectF(geom);
+        }
+        return availGeom.isValid() ? QRectF(availGeom) : QRectF(geom);
+    }
+    QScreen* screen = Phosphor::Screens::ScreenIdentity::findByIdOrName(screenId);
+    return effectiveScreenGeometry(mgr, layout, screen);
+}
+
+QRectF extractZoneGeometry(const QVariantMap& zone)
+{
+    return QRectF(zone.value(::PhosphorZones::ZoneJsonKeys::X).toDouble(),
+                  zone.value(::PhosphorZones::ZoneJsonKeys::Y).toDouble(),
+                  zone.value(::PhosphorZones::ZoneJsonKeys::Width).toDouble(),
+                  zone.value(::PhosphorZones::ZoneJsonKeys::Height).toDouble());
+}
+
+void setZoneGeometry(QVariantMap& zone, const QRectF& rect)
+{
+    zone[::PhosphorZones::ZoneJsonKeys::X] = rect.x();
+    zone[::PhosphorZones::ZoneJsonKeys::Y] = rect.y();
+    zone[::PhosphorZones::ZoneJsonKeys::Width] = rect.width();
+    zone[::PhosphorZones::ZoneJsonKeys::Height] = rect.height();
+}
+
+void enforceWindowMinSizes(QVector<QRect>& zones, const QVector<QSize>& minSizes, int gapThreshold, int innerGap)
+{
+    if (zones.size() != minSizes.size()) {
+        return;
+    }
+    for (int i = 0; i < zones.size(); ++i) {
+        QRect& zone = zones[i];
+        const QSize& minSize = minSizes[i];
+        if (minSize.isEmpty()) {
+            continue;
+        }
+        int needWidth = minSize.width() - zone.width();
+        int needHeight = minSize.height() - zone.height();
+        if (needWidth <= 0 && needHeight <= 0) {
+            continue;
+        }
+        for (int j = 0; j < zones.size(); ++j) {
+            if (i == j)
+                continue;
+            QRect& neighbor = zones[j];
+            bool adjacentH = (std::abs(zone.right() - neighbor.left()) <= gapThreshold
+                              || std::abs(neighbor.right() - zone.left()) <= gapThreshold)
+                && zone.top() < neighbor.bottom() && zone.bottom() > neighbor.top();
+            bool adjacentV = (std::abs(zone.bottom() - neighbor.top()) <= gapThreshold
+                              || std::abs(neighbor.bottom() - zone.top()) <= gapThreshold)
+                && zone.left() < neighbor.right() && zone.right() > neighbor.left();
+
+            if (needWidth > 0 && adjacentH) {
+                int steal = std::min(needWidth, neighbor.width() / 3);
+                if (steal <= 0)
+                    continue;
+                if (zone.right() <= neighbor.left() + gapThreshold) {
+                    zone.setRight(zone.right() + steal);
+                    neighbor.setLeft(neighbor.left() + steal);
+                } else {
+                    zone.setLeft(zone.left() - steal);
+                    neighbor.setRight(neighbor.right() - steal);
+                }
+                needWidth -= steal;
+            }
+            if (needHeight > 0 && adjacentV) {
+                int steal = std::min(needHeight, neighbor.height() / 3);
+                if (steal <= 0)
+                    continue;
+                if (zone.bottom() <= neighbor.top() + gapThreshold) {
+                    zone.setBottom(zone.bottom() + steal);
+                    neighbor.setTop(neighbor.top() + steal);
+                } else {
+                    zone.setTop(zone.top() - steal);
+                    neighbor.setBottom(neighbor.bottom() - steal);
+                }
+                needHeight -= steal;
+            }
+        }
+    }
+    removeZoneOverlaps(zones, minSizes, innerGap);
+}
+
+void removeZoneOverlaps(QVector<QRect>& zones, const QVector<QSize>& minSizes, int innerGap)
+{
+    for (int i = 0; i < zones.size(); ++i) {
+        for (int j = i + 1; j < zones.size(); ++j) {
+            QRect& a = zones[i];
+            QRect& b = zones[j];
+            QRect overlap = a.intersected(b);
+            if (overlap.isEmpty()) {
+                continue;
+            }
+            int surplusA_w = a.width() - (minSizes.size() > i ? minSizes[i].width() : 0);
+            int surplusB_w = b.width() - (minSizes.size() > j ? minSizes[j].width() : 0);
+            int surplusA_h = a.height() - (minSizes.size() > i ? minSizes[i].height() : 0);
+            int surplusB_h = b.height() - (minSizes.size() > j ? minSizes[j].height() : 0);
+
+            if (overlap.width() < overlap.height()) {
+                int mid = overlap.left() + overlap.width() / 2;
+                if (surplusA_w >= surplusB_w) {
+                    a.setRight(mid - innerGap / 2);
+                    b.setLeft(mid + (innerGap + 1) / 2);
+                } else {
+                    b.setRight(mid - innerGap / 2);
+                    a.setLeft(mid + (innerGap + 1) / 2);
+                }
+            } else {
+                int mid = overlap.top() + overlap.height() / 2;
+                if (surplusA_h >= surplusB_h) {
+                    a.setBottom(mid - innerGap / 2);
+                    b.setTop(mid + (innerGap + 1) / 2);
+                } else {
+                    b.setBottom(mid - innerGap / 2);
+                    a.setTop(mid + (innerGap + 1) / 2);
+                }
+            }
+        }
+    }
+}
+
+QString rectToJson(const QRect& rect)
+{
+    QJsonObject obj;
+    obj[::PhosphorZones::ZoneJsonKeys::X] = rect.x();
+    obj[::PhosphorZones::ZoneJsonKeys::Y] = rect.y();
+    obj[::PhosphorZones::ZoneJsonKeys::Width] = rect.width();
+    obj[::PhosphorZones::ZoneJsonKeys::Height] = rect.height();
+    return QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact));
+}
+
+QString serializeZoneAssignments(const QVector<ZoneAssignmentEntry>& entries)
+{
+    if (entries.isEmpty()) {
+        return QStringLiteral("[]");
+    }
+    QJsonArray array;
+    for (const ZoneAssignmentEntry& entry : entries) {
+        QJsonObject obj;
+        obj[QLatin1String("windowId")] = entry.windowId;
+        obj[QLatin1String("sourceZoneId")] = entry.sourceZoneId;
+        obj[QLatin1String("targetZoneId")] = entry.targetZoneId;
+        if (!entry.targetZoneIds.isEmpty()) {
+            QJsonArray zoneIdsArr;
+            for (const QString& zid : entry.targetZoneIds)
+                zoneIdsArr.append(zid);
+            obj[QLatin1String("targetZoneIds")] = zoneIdsArr;
+        }
+        obj[::PhosphorZones::ZoneJsonKeys::X] = entry.targetGeometry.x();
+        obj[::PhosphorZones::ZoneJsonKeys::Y] = entry.targetGeometry.y();
+        obj[::PhosphorZones::ZoneJsonKeys::Width] = entry.targetGeometry.width();
+        obj[::PhosphorZones::ZoneJsonKeys::Height] = entry.targetGeometry.height();
+        array.append(obj);
+    }
+    return QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact));
+}
+
+} // namespace GeometryUtils
+} // namespace PhosphorZones

--- a/libs/phosphor-zones/src/geometryutils.cpp
+++ b/libs/phosphor-zones/src/geometryutils.cpp
@@ -188,7 +188,7 @@ int getEffectiveZonePadding(Layout* layout, IGeometrySettings* settings, const Q
 {
     if (!screenId.isEmpty() && settings) {
         QVariantMap perScreen = getPerScreenSnappingWithFallback(settings, screenId);
-        auto it = perScreen.constFind(QLatin1String(PerScreenSnappingKey::ZonePadding));
+        auto it = perScreen.constFind(PerScreenSnappingKey::ZonePadding);
         if (it != perScreen.constEnd()) {
             return it->toInt();
         }
@@ -207,16 +207,16 @@ int getEffectiveZonePadding(Layout* layout, IGeometrySettings* settings, const Q
     if (!screenId.isEmpty() && settings) {
         QVariantMap perScreen = getPerScreenSnappingWithFallback(settings, screenId);
         if (!perScreen.isEmpty()) {
-            auto usePerSideIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::UsePerSideOuterGap));
+            auto usePerSideIt = perScreen.constFind(PerScreenSnappingKey::UsePerSideOuterGap);
             bool usePerSide = (usePerSideIt != perScreen.constEnd()) ? usePerSideIt->toBool() : false;
             if (usePerSide) {
-                auto topIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapTop));
-                auto bottomIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapBottom));
-                auto leftIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapLeft));
-                auto rightIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapRight));
+                auto topIt = perScreen.constFind(PerScreenSnappingKey::OuterGapTop);
+                auto bottomIt = perScreen.constFind(PerScreenSnappingKey::OuterGapBottom);
+                auto leftIt = perScreen.constFind(PerScreenSnappingKey::OuterGapLeft);
+                auto rightIt = perScreen.constFind(PerScreenSnappingKey::OuterGapRight);
                 if (topIt != perScreen.constEnd() || bottomIt != perScreen.constEnd() || leftIt != perScreen.constEnd()
                     || rightIt != perScreen.constEnd()) {
-                    auto uniformIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGap));
+                    auto uniformIt = perScreen.constFind(PerScreenSnappingKey::OuterGap);
                     int fallback = (uniformIt != perScreen.constEnd()) ? uniformIt->toInt() : settings->outerGap();
                     return {(topIt != perScreen.constEnd()) ? topIt->toInt() : fallback,
                             (bottomIt != perScreen.constEnd()) ? bottomIt->toInt() : fallback,
@@ -224,7 +224,7 @@ int getEffectiveZonePadding(Layout* layout, IGeometrySettings* settings, const Q
                             (rightIt != perScreen.constEnd()) ? rightIt->toInt() : fallback};
                 }
             }
-            auto uniformIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGap));
+            auto uniformIt = perScreen.constFind(PerScreenSnappingKey::OuterGap);
             if (uniformIt != perScreen.constEnd()) {
                 return ::PhosphorLayout::EdgeGaps::uniform(uniformIt->toInt());
             }

--- a/libs/phosphor-zones/src/layoututils.cpp
+++ b/libs/phosphor-zones/src/layoututils.cpp
@@ -8,6 +8,7 @@
 
 #include <QColor>
 #include <QJsonArray>
+#include <algorithm>
 
 namespace PhosphorZones {
 
@@ -183,6 +184,29 @@ void deserializeAllowLists(const QJsonObject& json, QStringList& screens, QList<
             activities.append(v.toString());
         }
     }
+}
+
+void sortZonesByNumber(QVector<Zone*>& zones)
+{
+    std::stable_sort(zones.begin(), zones.end(), [](Zone* a, Zone* b) {
+        if (a->zoneNumber() != b->zoneNumber())
+            return a->zoneNumber() < b->zoneNumber();
+        return a->id() < b->id();
+    });
+}
+
+QHash<QString, int> buildZonePositionMap(Layout* layout)
+{
+    QHash<QString, int> map;
+    if (!layout) {
+        return map;
+    }
+    QVector<Zone*> zones = layout->zones();
+    sortZonesByNumber(zones);
+    for (int i = 0; i < zones.size(); ++i) {
+        map[zones[i]->id().toString()] = i + 1;
+    }
+    return map;
 }
 
 } // namespace LayoutUtils

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -34,7 +34,6 @@
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorScreens/VirtualScreen.h>
 #include "core/windowregistry.h"
-#include "core/windowtrackingservice.h"
 #include <PhosphorZones/Zone.h>
 #include <PhosphorScreens/ScreenIdentity.h>
 
@@ -60,7 +59,8 @@ T* checkedCast(QObject* obj, const char* context)
 
 } // namespace
 
-AutotileEngine::AutotileEngine(PhosphorZones::LayoutRegistry* layoutManager, WindowTrackingService* windowTracker,
+AutotileEngine::AutotileEngine(PhosphorZones::LayoutRegistry* layoutManager,
+                               PhosphorEngineApi::IWindowTrackingService* windowTracker,
                                Phosphor::Screens::ScreenManager* screenManager,
                                PhosphorTiles::ITileAlgorithmRegistry* algorithmRegistry, QObject* parent)
     : PlacementEngineBase(parent)
@@ -156,6 +156,23 @@ int AutotileEngine::pruneStaleWindows(const QSet<QString>& aliveWindowIds)
 // Signal connections
 // ═══════════════════════════════════════════════════════════════════════════════
 
+void AutotileEngine::onWindowZoneChanged(const QString& windowId, const QString& zoneId)
+{
+    if (m_retiling)
+        return;
+    if (zoneId.isEmpty()) {
+        for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
+            if (it.key().desktop != m_currentDesktop || it.key().activity != m_currentActivity) {
+                continue;
+            }
+            if (it.value() && it.value()->isFloating(windowId)) {
+                return;
+            }
+        }
+        onWindowRemoved(windowId);
+    }
+}
+
 void AutotileEngine::connectSignals()
 {
     // Window tracking signals
@@ -164,35 +181,8 @@ void AutotileEngine::connectSignals()
     // WindowTrackingAdaptor signals. This connection also handles zone changes:
     if (m_windowTracker) {
         // Use windowZoneChanged as a proxy until dedicated signals are added
-        connect(m_windowTracker, &WindowTrackingService::windowZoneChanged, this,
-                [this](const QString& windowId, const QString& zoneId) {
-                    if (m_retiling)
-                        return; // Ignore zone changes during retile
-                    if (zoneId.isEmpty()) {
-                        // Don't remove floating windows — clearing their zone assignment
-                        // (e.g., by an external D-Bus caller or legacy code path) would
-                        // cause onWindowRemoved to drop the window from autotile. Since
-                        // floating windows are still managed by autotile, skip removal.
-                        // Note: windowClosed() calls onWindowRemoved() directly and
-                        // bypasses this guard, so closed floating windows are cleaned up.
-                        // Only check current desktop/activity states — a window
-                        // floating on desktop 1 should not block removal on desktop 2.
-                        for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-                            if (it.key().desktop != m_currentDesktop || it.key().activity != m_currentActivity) {
-                                continue;
-                            }
-                            if (it.value() && it.value()->isFloating(windowId)) {
-                                return;
-                            }
-                        }
-                        onWindowRemoved(windowId);
-                    }
-                    // Non-empty zoneId for already-tracked windows: no action needed,
-                    // the zone assignment is handled by the retile path.
-                    // Untracked windows (snap-mode zone assignments from SnapEngine)
-                    // are intentionally ignored — autotile windows are always added via
-                    // windowOpened() which stores m_windowToStateKey before onWindowAdded.
-                });
+        connect(m_windowTracker->asQObject(), SIGNAL(windowZoneChanged(QString, QString)), this,
+                SLOT(onWindowZoneChanged(QString, QString)));
     }
 
     // Screen geometry changes

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -16,7 +16,6 @@
 #include <PhosphorTiles/AlgorithmRegistry.h>
 #include <PhosphorTiles/ITileAlgorithmRegistry.h>
 #include "core/geometryutils.h"
-#include "core/utils.h"
 #include "AutotileConfig.h"
 #include "NavigationController.h"
 #include "PerScreenConfigResolver.h"
@@ -31,6 +30,7 @@
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include "core/logging.h"
+#include <PhosphorIdentity/WindowId.h>
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorScreens/VirtualScreen.h>
 #include "core/windowregistry.h"
@@ -2397,7 +2397,7 @@ bool AutotileEngine::recalculateLayout(const QString& screenId)
         if (qscreen) {
             const QRect geom = qscreen->geometry();
             screenInfo.portrait = geom.height() > geom.width();
-            screenInfo.aspectRatio = Utils::screenAspectRatio(qscreen);
+            screenInfo.aspectRatio = geom.height() > 0 ? static_cast<qreal>(geom.width()) / geom.height() : 0.0;
         } else if (m_screenManager) {
             // Virtual screen IDs have no QScreen — use Phosphor::Screens::ScreenManager geometry
             const QRect geom = m_screenManager->screenGeometry(screenId);

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -187,6 +187,9 @@ void AutotileEngine::connectSignals()
         bool ok = connect(m_windowTracker->asQObject(), SIGNAL(windowZoneChanged(QString, QString)), this,
                           SLOT(onWindowZoneChanged(QString, QString)));
         Q_ASSERT(ok);
+        if (Q_UNLIKELY(!ok)) {
+            qCCritical(lcAutotile) << "Failed to connect windowZoneChanged — autotile will not react to zone changes";
+        }
     }
 
     // Screen geometry changes

--- a/src/autotile/AutotileEngine.cpp
+++ b/src/autotile/AutotileEngine.cpp
@@ -180,9 +180,13 @@ void AutotileEngine::connectSignals()
     // windowOpened(), windowClosed(), windowFocused() - connected by Daemon to
     // WindowTrackingAdaptor signals. This connection also handles zone changes:
     if (m_windowTracker) {
-        // Use windowZoneChanged as a proxy until dedicated signals are added
-        connect(m_windowTracker->asQObject(), SIGNAL(windowZoneChanged(QString, QString)), this,
-                SLOT(onWindowZoneChanged(QString, QString)));
+        // String-based connect is required: m_windowTracker is IWindowTrackingService*
+        // (non-QObject ABC), so PMF syntax is unavailable. The asQObject() escape
+        // hatch is the standard Qt pattern for interface-based signal routing.
+        // Verify the connection succeeds so signal/slot renames are caught at startup.
+        bool ok = connect(m_windowTracker->asQObject(), SIGNAL(windowZoneChanged(QString, QString)), this,
+                          SLOT(onWindowZoneChanged(QString, QString)));
+        Q_ASSERT(ok);
     }
 
     // Screen geometry changes

--- a/src/autotile/AutotileEngine.h
+++ b/src/autotile/AutotileEngine.h
@@ -6,6 +6,7 @@
 #include "plasmazones_export.h"
 #include "core/constants.h"
 #include "core/types.h"
+#include <PhosphorEngineApi/IWindowTrackingService.h>
 #include <PhosphorEngineApi/PlacementEngineBase.h>
 #include <QHash>
 #include <QJsonArray>
@@ -75,7 +76,6 @@ class ISettings;
 class Settings;
 class SettingsBridge;
 class WindowRegistry;
-class WindowTrackingService;
 } // namespace PlasmaZones
 
 namespace PhosphorTiles {
@@ -106,7 +106,8 @@ class PLASMAZONES_EXPORT AutotileEngine : public PhosphorEngineApi::PlacementEng
     friend class SettingsBridge;
 
 public:
-    explicit AutotileEngine(PhosphorZones::LayoutRegistry* layoutManager, WindowTrackingService* windowTracker,
+    explicit AutotileEngine(PhosphorZones::LayoutRegistry* layoutManager,
+                            PhosphorEngineApi::IWindowTrackingService* windowTracker,
                             Phosphor::Screens::ScreenManager* screenManager,
                             PhosphorTiles::ITileAlgorithmRegistry* algorithmRegistry, QObject* parent = nullptr);
     ~AutotileEngine() override;
@@ -1062,6 +1063,7 @@ public:
     int pruneStaleWindows(const QSet<QString>& aliveWindowIds) override;
 
 private Q_SLOTS:
+    void onWindowZoneChanged(const QString& windowId, const QString& zoneId);
     void onWindowAdded(const QString& windowId);
     void onWindowRemoved(const QString& windowId);
     void onWindowFocused(const QString& windowId);
@@ -1300,7 +1302,7 @@ private:
     QSet<QString> m_autotileFloatedWindows;
 
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;
-    WindowTrackingService* m_windowTracker = nullptr;
+    PhosphorEngineApi::IWindowTrackingService* m_windowTracker = nullptr;
     Phosphor::Screens::ScreenManager* m_screenManager = nullptr;
     WindowRegistry* m_windowRegistry = nullptr; ///< Shared registry for class lookups; not owned
     PhosphorTiles::ITileAlgorithmRegistry* m_algorithmRegistry = nullptr; ///< Borrowed; outlives engine

--- a/src/autotile/AutotileEngine.h
+++ b/src/autotile/AutotileEngine.h
@@ -22,7 +22,6 @@
 #include <optional>
 
 #include "OverflowManager.h"
-#include "core/utils.h"
 
 #include <PhosphorScreens/ScreenIdentity.h>
 

--- a/src/autotile/NavigationController.cpp
+++ b/src/autotile/NavigationController.cpp
@@ -9,7 +9,6 @@
 #include <PhosphorTiles/AutotileConstants.h>
 #include "core/logging.h"
 #include <PhosphorScreens/Manager.h>
-#include "core/utils.h"
 
 #include <QScreen>
 #include <algorithm>

--- a/src/core/constants.h
+++ b/src/core/constants.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <PhosphorEngineApi/PerScreenKeys.h>
+
 #include <QColor>
 #include <QLatin1String>
 #include <QMetaType>
@@ -168,33 +170,7 @@ inline constexpr QLatin1String Region{"region"};
 inline constexpr QLatin1String Screens{"screens"};
 }
 
-/**
- * @brief Per-screen override key names (PascalCase — distinct from camelCase JSON keys)
- *
- * These are the keys used in PerScreenConfigResolver's override map and in
- * NavigationController's shortcut handlers. They match the key names written
- * by the per-screen config system in perscreen.cpp (with the "Autotile" prefix
- * stripped during lookup).
- */
-namespace PerScreenKeys {
-inline constexpr QLatin1String SplitRatio{"SplitRatio"};
-inline constexpr QLatin1String SplitRatioStep{"SplitRatioStep"};
-inline constexpr QLatin1String MasterCount{"MasterCount"};
-inline constexpr QLatin1String Algorithm{"Algorithm"};
-inline constexpr QLatin1String MaxWindows{"MaxWindows"};
-inline constexpr QLatin1String InnerGap{"InnerGap"};
-inline constexpr QLatin1String OuterGap{"OuterGap"};
-inline constexpr QLatin1String UsePerSideOuterGap{"UsePerSideOuterGap"};
-inline constexpr QLatin1String FocusNewWindows{"FocusNewWindows"};
-inline constexpr QLatin1String SmartGaps{"SmartGaps"};
-inline constexpr QLatin1String InsertPosition{"InsertPosition"};
-inline constexpr QLatin1String FocusFollowsMouse{"FocusFollowsMouse"};
-inline constexpr QLatin1String RespectMinimumSize{"RespectMinimumSize"};
-inline constexpr QLatin1String HideTitleBars{"HideTitleBars"};
-inline constexpr QLatin1String AnimationsEnabled{"AnimationsEnabled"};
-inline constexpr QLatin1String AnimationDuration{"AnimationDuration"};
-inline constexpr QLatin1String AnimationEasingCurve{"AnimationEasingCurve"};
-}
+namespace PerScreenKeys = PhosphorEngineApi::PerScreenKeys;
 
 /**
  * @brief Synthetic zone ID prefix used by the zone selector overlay

--- a/src/core/enums.h
+++ b/src/core/enums.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <PhosphorTiles/AutotileConstants.h>
+
 namespace PlasmaZones {
 
 /**
@@ -92,37 +94,7 @@ enum class OverlayDisplayMode {
     LayoutPreview = 1 ///< kZones-style: small layout thumbnail per zone
 };
 
-/**
- * @brief Behavior when a user drags a tiled window on an autotile screen.
- *
- * Float (default, PlasmaZones-native): dragging a tile converts it to a free-floating
- * window that restores its pre-tile geometry. Matches snap-mode semantics.
- *
- * Reorder (dwm/Krohnkite-style): dragging a tile keeps it tiled; the daemon tracks the
- * cursor over calculated zones and, on drop, reorders the window to the target slot.
- * Empty-space drops snap back to the original position.
- */
-enum class AutotileDragBehavior {
-    Float = 0, ///< Drag-to-float: converts dragged tile to floating (default)
-    Reorder = 1 ///< Drag-to-reorder: swaps tile position within the layout
-};
-
-/**
- * @brief Behavior when more windows exist than the algorithm's `maxWindows` cap.
- *
- * Float (default, PlasmaZones-native): excess windows are auto-floated by
- * OverflowManager so the layout stays within the cap. New windows past the
- * cap are rejected at onWindowAdded. The cap is algorithm-dependent and
- * defaults to 4–6 on most bundled algorithms.
- *
- * Unlimited (dwm/Krohnkite-style): the cap is ignored. All windows on an
- * autotile screen are tiled regardless of count. The layout algorithm handles
- * arbitrary N — master-stack's stack area just keeps subdividing. Users who
- * dislike very thin stack slices can still set masterCount or switch layouts.
- */
-enum class AutotileOverflowBehavior {
-    Float = 0, ///< Float windows past the maxWindows cap (default)
-    Unlimited = 1 ///< Ignore the cap entirely — every window tiles
-};
+using AutotileDragBehavior = PhosphorTiles::AutotileDragBehavior;
+using AutotileOverflowBehavior = PhosphorTiles::AutotileOverflowBehavior;
 
 } // namespace PlasmaZones

--- a/src/core/geometryutils.cpp
+++ b/src/core/geometryutils.cpp
@@ -3,27 +3,22 @@
 
 #include "geometryutils.h"
 #include <PhosphorZones/Zone.h>
-#include <geometry_helpers.h>
 #include <PhosphorZones/Layout.h>
 #include "layoutworker/layoutcomputeservice.h"
 #include "interfaces.h"
 #include "constants.h"
+#include <PhosphorEngineApi/IGeometrySettings.h>
 #include <PhosphorScreens/Manager.h>
-#include <QScreen>
-#include <QVariantMap>
 #include <PhosphorScreens/ScreenIdentity.h>
 #include <PhosphorZones/ZoneDefaults.h>
+#include <QScreen>
+
+static_assert(PhosphorEngineApi::GeometryDefaults::ZonePadding == PlasmaZones::Defaults::ZonePadding,
+              "Library and daemon ZonePadding defaults out of sync");
+static_assert(PhosphorEngineApi::GeometryDefaults::OuterGap == PlasmaZones::Defaults::OuterGap,
+              "Library and daemon OuterGap defaults out of sync");
 
 namespace PlasmaZones {
-
-static QVariantMap getPerScreenSnappingWithFallback(ISettings* settings, const QString& screenId)
-{
-    QVariantMap result = settings->getPerScreenSnappingSettings(screenId);
-    if (result.isEmpty() && PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
-        result = settings->getPerScreenSnappingSettings(PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId));
-    }
-    return result;
-}
 
 namespace GeometryUtils {
 
@@ -46,122 +41,24 @@ ScreenGeometries resolveScreenGeometries(Phosphor::Screens::ScreenManager* mgr, 
 QRectF getZoneGeometryForScreenF(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone, QScreen* screen,
                                  const QString& screenId, PhosphorZones::Layout* layout, ISettings* settings)
 {
-    if (!zone) {
-        return QRectF();
-    }
-
-    int zonePadding = getEffectiveZonePadding(layout, settings, screenId);
-    ::PhosphorLayout::EdgeGaps outerGaps = getEffectiveOuterGaps(layout, settings, screenId);
-    bool useAvail = !(layout && layout->useFullScreenGeometry());
-
-    auto [vsGeom, vsAvailGeom] = resolveScreenGeometries(mgr, screenId);
-
-    if (vsGeom.isValid()) {
-        QRect availGeom = vsAvailGeom.isValid() ? vsAvailGeom : vsGeom;
-        return getZoneGeometryWithGaps(mgr, zone, vsGeom, availGeom, zonePadding, outerGaps, useAvail, screenId);
-    }
-    if (PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
-        return QRectF();
-    }
-    if (screen) {
-        return getZoneGeometryWithGaps(mgr, zone, screen, zonePadding, outerGaps, useAvail, screenId);
-    }
-    return QRectF();
+    return ::PhosphorZones::GeometryUtils::getZoneGeometryForScreenF(mgr, zone, screen, screenId, layout, settings);
 }
 
 QRect getZoneGeometryForScreen(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone, QScreen* screen,
                                const QString& screenId, PhosphorZones::Layout* layout, ISettings* settings)
 {
-    QRectF geoF = getZoneGeometryForScreenF(mgr, zone, screen, screenId, layout, settings);
-    return geoF.isValid() ? snapToRect(geoF) : QRect();
+    return ::PhosphorZones::GeometryUtils::getZoneGeometryForScreen(mgr, zone, screen, screenId, layout, settings);
 }
 
 int getEffectiveZonePadding(PhosphorZones::Layout* layout, ISettings* settings, const QString& screenId)
 {
-    if (!screenId.isEmpty() && settings) {
-        QVariantMap perScreen = getPerScreenSnappingWithFallback(settings, screenId);
-        auto it = perScreen.constFind(QLatin1String(PerScreenSnappingKey::ZonePadding));
-        if (it != perScreen.constEnd()) {
-            return it->toInt();
-        }
-    }
-    if (layout && layout->hasZonePaddingOverride()) {
-        return layout->zonePadding();
-    }
-    if (settings) {
-        return settings->zonePadding();
-    }
-    return Defaults::ZonePadding;
+    return ::PhosphorZones::GeometryUtils::getEffectiveZonePadding(layout, settings, screenId);
 }
 
 ::PhosphorLayout::EdgeGaps getEffectiveOuterGaps(PhosphorZones::Layout* layout, ISettings* settings,
                                                  const QString& screenId)
 {
-    if (!screenId.isEmpty() && settings) {
-        QVariantMap perScreen = getPerScreenSnappingWithFallback(settings, screenId);
-        if (!perScreen.isEmpty()) {
-            auto usePerSideIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::UsePerSideOuterGap));
-            bool usePerSide = (usePerSideIt != perScreen.constEnd()) ? usePerSideIt->toBool() : false;
-            if (usePerSide) {
-                auto topIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapTop));
-                auto bottomIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapBottom));
-                auto leftIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapLeft));
-                auto rightIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapRight));
-                if (topIt != perScreen.constEnd() || bottomIt != perScreen.constEnd() || leftIt != perScreen.constEnd()
-                    || rightIt != perScreen.constEnd()) {
-                    auto uniformIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGap));
-                    int fallback = (uniformIt != perScreen.constEnd()) ? uniformIt->toInt() : settings->outerGap();
-                    return {(topIt != perScreen.constEnd()) ? topIt->toInt() : fallback,
-                            (bottomIt != perScreen.constEnd()) ? bottomIt->toInt() : fallback,
-                            (leftIt != perScreen.constEnd()) ? leftIt->toInt() : fallback,
-                            (rightIt != perScreen.constEnd()) ? rightIt->toInt() : fallback};
-                }
-            }
-            auto uniformIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGap));
-            if (uniformIt != perScreen.constEnd()) {
-                return ::PhosphorLayout::EdgeGaps::uniform(uniformIt->toInt());
-            }
-        }
-    }
-
-    if (layout && layout->usePerSideOuterGap() && layout->hasPerSideOuterGapOverride()) {
-        ::PhosphorLayout::EdgeGaps gaps = layout->rawOuterGaps();
-        if (settings && settings->usePerSideOuterGap()) {
-            if (gaps.top < 0)
-                gaps.top = settings->outerGapTop();
-            if (gaps.bottom < 0)
-                gaps.bottom = settings->outerGapBottom();
-            if (gaps.left < 0)
-                gaps.left = settings->outerGapLeft();
-            if (gaps.right < 0)
-                gaps.right = settings->outerGapRight();
-        } else {
-            int fallback = settings ? settings->outerGap() : Defaults::OuterGap;
-            if (gaps.top < 0)
-                gaps.top = fallback;
-            if (gaps.bottom < 0)
-                gaps.bottom = fallback;
-            if (gaps.left < 0)
-                gaps.left = fallback;
-            if (gaps.right < 0)
-                gaps.right = fallback;
-        }
-        return gaps;
-    }
-
-    if (layout && layout->hasOuterGapOverride()) {
-        return ::PhosphorLayout::EdgeGaps::uniform(layout->outerGap());
-    }
-
-    if (settings) {
-        if (settings->usePerSideOuterGap()) {
-            return {settings->outerGapTop(), settings->outerGapBottom(), settings->outerGapLeft(),
-                    settings->outerGapRight()};
-        }
-        return ::PhosphorLayout::EdgeGaps::uniform(settings->outerGap());
-    }
-
-    return ::PhosphorLayout::EdgeGaps::uniform(Defaults::OuterGap);
+    return ::PhosphorZones::GeometryUtils::getEffectiveOuterGaps(layout, settings, screenId);
 }
 
 static EmptyZoneList buildEmptyZoneListImpl(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,

--- a/src/core/geometryutils.cpp
+++ b/src/core/geometryutils.cpp
@@ -4,26 +4,18 @@
 #include "geometryutils.h"
 #include <PhosphorZones/Zone.h>
 #include <geometry_helpers.h>
-#include "logging.h"
 #include <PhosphorZones/Layout.h>
 #include "layoutworker/layoutcomputeservice.h"
 #include "interfaces.h"
 #include "constants.h"
 #include <PhosphorScreens/Manager.h>
-#include "utils.h"
-#include <algorithm>
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QScreen>
 #include <QVariantMap>
 #include <PhosphorScreens/ScreenIdentity.h>
+#include <PhosphorZones/ZoneDefaults.h>
 
 namespace PlasmaZones {
 
-/// Get per-screen snapping settings with virtual screen fallback.
-/// Tries the exact screenId first; if empty and the screenId is a virtual
-/// screen, falls back to the physical parent's overrides.
 static QVariantMap getPerScreenSnappingWithFallback(ISettings* settings, const QString& screenId)
 {
     QVariantMap result = settings->getPerScreenSnappingSettings(screenId);
@@ -51,189 +43,6 @@ ScreenGeometries resolveScreenGeometries(Phosphor::Screens::ScreenManager* mgr, 
 }
 } // anonymous namespace
 
-static QRectF calculateZoneGeometry(PhosphorZones::Zone* zone, QScreen* screen)
-{
-    if (!zone || !screen) {
-        return QRectF();
-    }
-
-    const QRectF screenGeom = screen->geometry();
-    return zone->calculateAbsoluteGeometry(screenGeom);
-}
-
-QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, QScreen* screen)
-{
-    if (!screen) {
-        return geometry;
-    }
-
-    // The overlay window covers the full screen (geometry()).
-    // The geometry parameter is already in absolute screen coordinates
-    // (from available or full-screen geometry), so we just need to convert
-    // to overlay-local coordinates by subtracting the full screen origin.
-    const QRectF screenGeom = screen->geometry();
-    return QRectF(geometry.x() - screenGeom.x(), geometry.y() - screenGeom.y(), geometry.width(), geometry.height());
-}
-
-static QRectF calculateZoneGeometryInAvailableArea(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
-                                                   QScreen* screen)
-{
-    if (!zone || !screen) {
-        return QRectF();
-    }
-
-    // Use ScreenManager's panel-aware available geometry when present; fall
-    // back to Qt's availableGeometry() (no-panel environments, unit tests).
-    const QRectF availableGeom = mgr ? mgr->actualAvailableGeometry(screen) : screen->availableGeometry();
-    return zone->calculateAbsoluteGeometry(availableGeom);
-}
-
-/**
- * @brief Detect whether each edge of a zone lies at a screen boundary
- * @param zone The zone to check
- * @param screenGeom The reference screen geometry (for fixed mode pixel checks)
- * @return Array of 4 bools: [left, top, right, bottom] — true if at boundary
- */
-struct EdgeBoundaries
-{
-    bool left = false;
-    bool top = false;
-    bool right = false;
-    bool bottom = false;
-};
-
-static EdgeBoundaries detectEdgeBoundaries(PhosphorZones::Zone* zone, const QRectF& screenGeom)
-{
-    EdgeBoundaries edges;
-
-    if (zone->isFixedGeometry()) {
-        // Fixed mode: pixel proximity check (within 5px of screen boundary)
-        constexpr qreal pixelTolerance = 5.0;
-        QRectF fixedGeo = zone->fixedGeometry();
-        edges.left = (fixedGeo.left() < pixelTolerance);
-        edges.top = (fixedGeo.top() < pixelTolerance);
-        edges.right = (fixedGeo.right() > (screenGeom.width() - pixelTolerance));
-        edges.bottom = (fixedGeo.bottom() > (screenGeom.height() - pixelTolerance));
-    } else {
-        // Relative mode: existing check (near 0 or 1, tolerance 0.01)
-        constexpr qreal edgeTolerance = 0.01;
-        QRectF relGeom = zone->relativeGeometry();
-        edges.left = (relGeom.left() < edgeTolerance);
-        edges.top = (relGeom.top() < edgeTolerance);
-        edges.right = (relGeom.right() > (1.0 - edgeTolerance));
-        edges.bottom = (relGeom.bottom() > (1.0 - edgeTolerance));
-    }
-
-    return edges;
-}
-
-/**
- * @brief Apply gap adjustments to a zone's absolute geometry
- * @param zoneGeom Absolute zone geometry (already calculated against reference area)
- * @param zone PhosphorZones::Zone for edge boundary detection
- * @param referenceGeom Reference geometry for fixed-mode edge detection
- * @param innerGap Gap between adjacent zones (zonePadding)
- * @param outerGaps Per-side edge gaps
- * @return Geometry with gaps applied
- *
- * Shared helper used by both QScreen* and QRect overloads of getZoneGeometryWithGaps.
- */
-static QRectF applyGapsToZoneGeometry(const QRectF& zoneGeom, PhosphorZones::Zone* zone, const QRectF& referenceGeom,
-                                      int innerGap, const ::PhosphorLayout::EdgeGaps& outerGaps,
-                                      const Phosphor::Screens::VirtualScreenDef::PhysicalEdges& physEdges = {
-                                          true, true, true, true})
-{
-    // Detect which edges are at screen boundaries
-    EdgeBoundaries edges = detectEdgeBoundaries(zone, referenceGeom);
-
-    // Only apply outer gaps on edges that are at the PHYSICAL screen boundary.
-    // Internal edges (shared with another virtual screen) get inner gap to avoid
-    // double gaps.
-    qreal leftAdj = (edges.left && physEdges.left) ? outerGaps.left : (innerGap / 2.0);
-    qreal topAdj = (edges.top && physEdges.top) ? outerGaps.top : (innerGap / 2.0);
-    qreal rightAdj = (edges.right && physEdges.right) ? outerGaps.right : (innerGap / 2.0);
-    qreal bottomAdj = (edges.bottom && physEdges.bottom) ? outerGaps.bottom : (innerGap / 2.0);
-
-    // Apply the adjustments (positive inset from edges)
-    QRectF geoF = zoneGeom.adjusted(leftAdj, topAdj, -rightAdj, -bottomAdj);
-
-    // Ensure gaps don't collapse the zone to negative dimensions
-    if (geoF.width() < 1.0) {
-        geoF.setWidth(1.0);
-    }
-    if (geoF.height() < 1.0) {
-        geoF.setHeight(1.0);
-    }
-
-    return geoF;
-}
-
-QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone, QScreen* screen,
-                               int innerGap, const ::PhosphorLayout::EdgeGaps& outerGaps, bool useAvailableGeometry,
-                               const QString& screenId)
-{
-    if (!zone || !screen) {
-        return QRectF();
-    }
-
-    // Use available geometry (excludes panels/taskbars) or full screen geometry
-    QRectF geom;
-    if (useAvailableGeometry) {
-        geom = calculateZoneGeometryInAvailableArea(mgr, zone, screen);
-    } else {
-        geom = calculateZoneGeometry(zone, screen);
-    }
-
-    // Detect which edges are at screen boundaries
-    QRectF screenGeom = useAvailableGeometry
-        ? (mgr ? mgr->actualAvailableGeometry(screen) : screen->availableGeometry())
-        : screen->geometry();
-
-    // Look up physical edges via Phosphor::Screens::ScreenManager so virtual screen internal edges
-    // get inner gap instead of outer gap, matching the QRect overload behavior.
-    // When the caller provides a virtual screen ID, use it; otherwise fall back
-    // to the physical screen identifier (which yields all-true physical edges).
-    Phosphor::Screens::VirtualScreenDef::PhysicalEdges physEdges{true, true, true, true};
-    if (mgr) {
-        QString resolvedId = screenId.isEmpty() ? Phosphor::Screens::ScreenIdentity::identifierFor(screen) : screenId;
-        physEdges = mgr->physicalEdgesFor(resolvedId);
-    }
-
-    return applyGapsToZoneGeometry(geom, zone, screenGeom, innerGap, outerGaps, physEdges);
-}
-
-QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, const QRect& overlayGeometry)
-{
-    return QRectF(geometry.x() - overlayGeometry.x(), geometry.y() - overlayGeometry.y(), geometry.width(),
-                  geometry.height());
-}
-
-QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
-                               const QRect& screenGeometry, const QRect& availableGeometry, int innerGap,
-                               const ::PhosphorLayout::EdgeGaps& outerGaps, bool useAvailableGeometry,
-                               const QString& screenId)
-{
-    if (!zone) {
-        return QRectF();
-    }
-
-    // Calculate absolute zone geometry against the chosen reference area
-    QRectF referenceGeom = useAvailableGeometry ? QRectF(availableGeometry) : QRectF(screenGeometry);
-    QRectF geom = zone->calculateAbsoluteGeometry(referenceGeom);
-
-    // Determine which edges are at the physical screen boundary.
-    // For virtual screens, internal edges (shared with another virtual screen) get inner
-    // gap instead of outer gap to avoid double gaps at virtual screen boundaries.
-    // For physical screens, physicalEdgesFor() returns all-true (all edges are outer).
-    // When @p mgr is null (unit tests), applies default all-true physEdges.
-    if (!screenId.isEmpty() && mgr) {
-        auto pe = mgr->physicalEdgesFor(screenId);
-        return applyGapsToZoneGeometry(geom, zone, referenceGeom, innerGap, outerGaps, pe);
-    }
-
-    return applyGapsToZoneGeometry(geom, zone, referenceGeom, innerGap, outerGaps);
-}
-
 QRectF getZoneGeometryForScreenF(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone, QScreen* screen,
                                  const QString& screenId, PhosphorZones::Layout* layout, ISettings* settings)
 {
@@ -251,14 +60,6 @@ QRectF getZoneGeometryForScreenF(Phosphor::Screens::ScreenManager* mgr, Phosphor
         QRect availGeom = vsAvailGeom.isValid() ? vsAvailGeom : vsGeom;
         return getZoneGeometryWithGaps(mgr, zone, vsGeom, availGeom, zonePadding, outerGaps, useAvail, screenId);
     }
-    // For virtual screen IDs, do NOT fall back to the parent QScreen* — that
-    // re-projects relative zone coordinates (defined for the VS sub-region)
-    // onto the full physical screen, producing a geometry that lands in a
-    // DIFFERENT virtual screen. processBatchEntries then re-derives the
-    // window's screen from the geometry center, silently overwriting the
-    // stored VS scope and corrupting WindowScreenAssignments. Better to
-    // return an invalid rect so the caller skips the entry; the next resnap
-    // (after VS state is restored) will succeed.
     if (PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
         return QRectF();
     }
@@ -277,7 +78,6 @@ QRect getZoneGeometryForScreen(Phosphor::Screens::ScreenManager* mgr, PhosphorZo
 
 int getEffectiveZonePadding(PhosphorZones::Layout* layout, ISettings* settings, const QString& screenId)
 {
-    // Per-screen snapping override (highest priority), with virtual screen fallback
     if (!screenId.isEmpty() && settings) {
         QVariantMap perScreen = getPerScreenSnappingWithFallback(settings, screenId);
         auto it = perScreen.constFind(QLatin1String(PerScreenSnappingKey::ZonePadding));
@@ -285,27 +85,18 @@ int getEffectiveZonePadding(PhosphorZones::Layout* layout, ISettings* settings, 
             return it->toInt();
         }
     }
-    // Check for layout-specific override
     if (layout && layout->hasZonePaddingOverride()) {
         return layout->zonePadding();
     }
-    // Fall back to global settings
     if (settings) {
         return settings->zonePadding();
     }
-    // Last resort: use default constant
     return Defaults::ZonePadding;
-}
-
-QRect snapToRect(const QRectF& rf)
-{
-    return GeometryHelpers::snapToRect(rf);
 }
 
 ::PhosphorLayout::EdgeGaps getEffectiveOuterGaps(PhosphorZones::Layout* layout, ISettings* settings,
                                                  const QString& screenId)
 {
-    // Per-screen snapping override (highest priority), with virtual screen fallback
     if (!screenId.isEmpty() && settings) {
         QVariantMap perScreen = getPerScreenSnappingWithFallback(settings, screenId);
         if (!perScreen.isEmpty()) {
@@ -316,10 +107,8 @@ QRect snapToRect(const QRectF& rf)
                 auto bottomIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapBottom));
                 auto leftIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapLeft));
                 auto rightIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGapRight));
-                // If any per-side key is present, use per-screen per-side gaps
                 if (topIt != perScreen.constEnd() || bottomIt != perScreen.constEnd() || leftIt != perScreen.constEnd()
                     || rightIt != perScreen.constEnd()) {
-                    // Fall back to per-screen uniform OuterGap, then global for missing sides
                     auto uniformIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGap));
                     int fallback = (uniformIt != perScreen.constEnd()) ? uniformIt->toInt() : settings->outerGap();
                     return {(topIt != perScreen.constEnd()) ? topIt->toInt() : fallback,
@@ -328,8 +117,6 @@ QRect snapToRect(const QRectF& rf)
                             (rightIt != perScreen.constEnd()) ? rightIt->toInt() : fallback};
                 }
             }
-            // UsePerSideOuterGap not set or false — per-side keys ignored if present
-            // Per-screen uniform outer gap
             auto uniformIt = perScreen.constFind(QLatin1String(PerScreenSnappingKey::OuterGap));
             if (uniformIt != perScreen.constEnd()) {
                 return ::PhosphorLayout::EdgeGaps::uniform(uniformIt->toInt());
@@ -337,10 +124,8 @@ QRect snapToRect(const QRectF& rf)
         }
     }
 
-    // Check for layout-specific per-side override first
     if (layout && layout->usePerSideOuterGap() && layout->hasPerSideOuterGapOverride()) {
         ::PhosphorLayout::EdgeGaps gaps = layout->rawOuterGaps();
-        // Fill in -1 sentinel values from global per-side or uniform fallback
         if (settings && settings->usePerSideOuterGap()) {
             if (gaps.top < 0)
                 gaps.top = settings->outerGapTop();
@@ -364,12 +149,10 @@ QRect snapToRect(const QRectF& rf)
         return gaps;
     }
 
-    // Check for layout-specific uniform override
     if (layout && layout->hasOuterGapOverride()) {
         return ::PhosphorLayout::EdgeGaps::uniform(layout->outerGap());
     }
 
-    // Fall back to global settings
     if (settings) {
         if (settings->usePerSideOuterGap()) {
             return {settings->outerGapTop(), settings->outerGapBottom(), settings->outerGapLeft(),
@@ -381,51 +164,6 @@ QRect snapToRect(const QRectF& rf)
     return ::PhosphorLayout::EdgeGaps::uniform(Defaults::OuterGap);
 }
 
-QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout, QScreen* screen)
-{
-    if (!screen) {
-        return QRectF();
-    }
-    if (layout && layout->useFullScreenGeometry()) {
-        return screen->geometry();
-    }
-    return mgr ? mgr->actualAvailableGeometry(screen) : screen->availableGeometry();
-}
-
-QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
-                               const QString& screenId)
-{
-    auto [geom, availGeom] = resolveScreenGeometries(mgr, screenId);
-    if (geom.isValid()) {
-        if (layout && layout->useFullScreenGeometry()) {
-            return QRectF(geom);
-        }
-        return availGeom.isValid() ? QRectF(availGeom) : QRectF(geom);
-    }
-    // Fallback to physical screen
-    QScreen* screen = Phosphor::Screens::ScreenIdentity::findByIdOrName(screenId);
-    return effectiveScreenGeometry(mgr, layout, screen);
-}
-
-QRectF extractZoneGeometry(const QVariantMap& zone)
-{
-    return QRectF(zone.value(::PhosphorZones::ZoneJsonKeys::X).toDouble(),
-                  zone.value(::PhosphorZones::ZoneJsonKeys::Y).toDouble(),
-                  zone.value(::PhosphorZones::ZoneJsonKeys::Width).toDouble(),
-                  zone.value(::PhosphorZones::ZoneJsonKeys::Height).toDouble());
-}
-
-void setZoneGeometry(QVariantMap& zone, const QRectF& rect)
-{
-    zone[::PhosphorZones::ZoneJsonKeys::X] = rect.x();
-    zone[::PhosphorZones::ZoneJsonKeys::Y] = rect.y();
-    zone[::PhosphorZones::ZoneJsonKeys::Width] = rect.width();
-    zone[::PhosphorZones::ZoneJsonKeys::Height] = rect.height();
-}
-
-/// Iterates empty zones and builds EmptyZoneEntry values for the typed D-Bus result.
-/// EmptyZoneEntry values. Accepts either explicit screen geometry (virtual screen path)
-/// or a physical QScreen* (physical screen path).
 static EmptyZoneList buildEmptyZoneListImpl(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
                                             const std::optional<QRect>& screenGeometry, const QRect& availableGeometry,
                                             const QString& screenId, int zonePadding,
@@ -527,42 +265,6 @@ EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr, Phosphor
     }
 
     return physScreen ? buildEmptyZoneList(mgr, layout, physScreen, settings, isZoneEmpty) : EmptyZoneList{};
-}
-
-QString rectToJson(const QRect& rect)
-{
-    QJsonObject obj;
-    obj[::PhosphorZones::ZoneJsonKeys::X] = rect.x();
-    obj[::PhosphorZones::ZoneJsonKeys::Y] = rect.y();
-    obj[::PhosphorZones::ZoneJsonKeys::Width] = rect.width();
-    obj[::PhosphorZones::ZoneJsonKeys::Height] = rect.height();
-    return QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact));
-}
-
-QString serializeZoneAssignments(const QVector<ZoneAssignmentEntry>& entries)
-{
-    if (entries.isEmpty()) {
-        return QStringLiteral("[]");
-    }
-    QJsonArray array;
-    for (const ZoneAssignmentEntry& entry : entries) {
-        QJsonObject obj;
-        obj[JsonKeys::WindowId] = entry.windowId;
-        obj[JsonKeys::SourceZoneId] = entry.sourceZoneId;
-        obj[JsonKeys::TargetZoneId] = entry.targetZoneId;
-        if (!entry.targetZoneIds.isEmpty()) {
-            QJsonArray zoneIdsArr;
-            for (const QString& zid : entry.targetZoneIds)
-                zoneIdsArr.append(zid);
-            obj[JsonKeys::TargetZoneIds] = zoneIdsArr;
-        }
-        obj[::PhosphorZones::ZoneJsonKeys::X] = entry.targetGeometry.x();
-        obj[::PhosphorZones::ZoneJsonKeys::Y] = entry.targetGeometry.y();
-        obj[::PhosphorZones::ZoneJsonKeys::Width] = entry.targetGeometry.width();
-        obj[::PhosphorZones::ZoneJsonKeys::Height] = entry.targetGeometry.height();
-        array.append(obj);
-    }
-    return QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact));
 }
 
 } // namespace GeometryUtils

--- a/src/core/geometryutils.h
+++ b/src/core/geometryutils.h
@@ -41,60 +41,11 @@ class ISettings;
  */
 namespace GeometryUtils {
 
-/**
- * @brief Convert available-area zone geometry to overlay window local coordinates
- * @param geometry Absolute geometry in available screen coordinates
- * @param screen Screen the overlay window is on
- * @return Geometry in overlay window local coordinates
- *
- * The overlay window covers the full screen, but zones calculated against
- * availableGeometry need to be offset to account for panels/taskbars.
- */
-PLASMAZONES_EXPORT QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, QScreen* screen);
+using ::PhosphorZones::GeometryUtils::availableAreaToOverlayCoordinates;
 
-/**
- * @brief Get zone geometry with per-side outer gaps
- * @param zone PhosphorZones::Zone to get geometry for
- * @param screen Screen to calculate relative to
- * @param innerGap Gap between adjacent zones (zonePadding)
- * @param outerGaps Per-side edge gaps
- * @param useAvailableGeometry If true, calculate relative to available area (excluding panels/taskbars)
- * @param screenId Optional virtual screen ID for physical-edge lookup.
- *        When non-empty, used for physicalEdgesFor() so that internal virtual
- *        screen edges get inner gap instead of outer gap. When empty, falls
- *        back to Phosphor::Screens::ScreenIdentity::identifierFor(screen) (physical ID, all edges outer).
- * @return Geometry with appropriate gaps applied
- */
-PLASMAZONES_EXPORT QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
-                                                  QScreen* screen, int innerGap,
-                                                  const ::PhosphorLayout::EdgeGaps& outerGaps,
-                                                  bool useAvailableGeometry = true, const QString& screenId = {});
+using ::PhosphorZones::GeometryUtils::getZoneGeometryWithGaps;
 
-/**
- * @brief Convert zone geometry to overlay-local coordinates using explicit geometry
- * @param geometry Absolute geometry in screen coordinates
- * @param overlayGeometry The overlay window's full geometry (origin + size)
- * @return Geometry in overlay window local coordinates
- *
- * For virtual screens, the overlay covers the virtual screen bounds,
- * so we subtract the virtual screen origin to get overlay-local coords.
- */
-PLASMAZONES_EXPORT QRectF availableAreaToOverlayCoordinates(const QRectF& geometry, const QRect& overlayGeometry);
-
-/**
- * @brief Get zone geometry with gaps, using explicit screen geometry
- * @param zone PhosphorZones::Zone to get geometry for
- * @param screenGeometry Screen (or virtual screen) geometry in absolute pixels
- * @param availableGeometry Available area within the screen (excluding panels)
- * @param innerGap Gap between adjacent zones (zonePadding)
- * @param outerGaps Per-side edge gaps
- * @param useAvailableGeometry If true, calculate relative to available area
- * @return Geometry with appropriate gaps applied
- */
-PLASMAZONES_EXPORT QRectF getZoneGeometryWithGaps(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Zone* zone,
-                                                  const QRect& screenGeometry, const QRect& availableGeometry,
-                                                  int innerGap, const ::PhosphorLayout::EdgeGaps& outerGaps,
-                                                  bool useAvailableGeometry = true, const QString& screenId = {});
+// getZoneGeometryWithGaps (QRect overload) imported via using above
 
 /**
  * @brief Get zone geometry with gaps, auto-resolving virtual screen geometry
@@ -145,18 +96,7 @@ PLASMAZONES_EXPORT QRectF getZoneGeometryForScreenF(Phosphor::Screens::ScreenMan
 PLASMAZONES_EXPORT int getEffectiveZonePadding(PhosphorZones::Layout* layout, ISettings* settings,
                                                const QString& screenId = {});
 
-/**
- * @brief Convert QRectF to QRect with edge-consistent rounding
- * @param rf Source floating-point rectangle
- * @return Integer rectangle with consistent edge rounding
- *
- * Unlike QRectF::toRect() which rounds x, y, width, height independently,
- * this rounds the edges (left, top, right, bottom) and derives width/height
- * from the rounded edges. This ensures adjacent zones sharing an edge always
- * produce exactly the configured gap between them, even when fractional
- * scaling (e.g. 1.2x) produces non-integer zone boundaries.
- */
-PLASMAZONES_EXPORT QRect snapToRect(const QRectF& rf);
+using ::PhosphorZones::GeometryUtils::snapToRect;
 
 /**
  * @brief Get effective per-side outer gaps for a layout
@@ -171,48 +111,10 @@ PLASMAZONES_EXPORT QRect snapToRect(const QRectF& rf);
 PLASMAZONES_EXPORT ::PhosphorLayout::EdgeGaps getEffectiveOuterGaps(PhosphorZones::Layout* layout, ISettings* settings,
                                                                     const QString& screenId = {});
 
-/**
- * @brief Get the effective screen geometry for a layout
- * @param layout PhosphorZones::Layout to check (may use full screen geometry)
- * @param screen Screen to get geometry for
- * @return Full screen geometry if layout->useFullScreenGeometry(), otherwise available geometry
- *
- * Centralizes the decision of whether to use full screen or available (panel-excluded)
- * geometry based on the layout's useFullScreenGeometry setting.
- */
-PLASMAZONES_EXPORT QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
-                                                  QScreen* screen);
+using ::PhosphorZones::GeometryUtils::effectiveScreenGeometry;
 
-/**
- * @brief Get the effective screen geometry for a layout using a screen ID
- * @param layout PhosphorZones::Layout to check (may use full screen geometry)
- * @param screenId Screen identifier (physical or virtual, e.g. "physicalId/vs:N")
- * @return Virtual screen geometry if available, otherwise falls back to physical screen geometry
- *
- * Virtual-screen-aware overload: resolves geometry via Phosphor::Screens::ScreenManager first,
- * then falls back to finding the physical QScreen by ID.
- */
-PLASMAZONES_EXPORT QRectF effectiveScreenGeometry(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
-                                                  const QString& screenId);
-
-/**
- * @brief Extract geometry as QRectF from a zone QVariantMap
- * @param zone PhosphorZones::Zone data map containing x, y, width, height keys
- * @return QRectF with the zone's geometry
- *
- * Used by EditorController and serialization code to avoid repeating
- * the x/y/width/height extraction pattern.
- */
-PLASMAZONES_EXPORT QRectF extractZoneGeometry(const QVariantMap& zone);
-
-/**
- * @brief Set geometry fields in a zone QVariantMap from a QRectF
- * @param zone PhosphorZones::Zone data map to modify
- * @param rect Geometry to set
- *
- * Sets x, y, width, height keys in the zone map.
- */
-PLASMAZONES_EXPORT void setZoneGeometry(QVariantMap& zone, const QRectF& rect);
+using ::PhosphorZones::GeometryUtils::extractZoneGeometry;
+using ::PhosphorZones::GeometryUtils::setZoneGeometry;
 
 /**
  * @brief Build typed list of empty zones for Snap Assist
@@ -240,55 +142,14 @@ PLASMAZONES_EXPORT EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenMan
                                                     QScreen* physScreen, ISettings* settings,
                                                     const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty);
 
-/**
- * @brief Enforce minimum size constraints on zones by borrowing space from neighbors
- * @param zones List of zone geometries to adjust (in-place)
- * @param minSizes List of minimum sizes for each zone (same index as zones)
- * @param gapThreshold Threshold for considering zones effectively adjacent
- * @param innerGap Desired gap between adjacent zones (preserved during overlap resolution)
- *
- * Checks if any zone is smaller than its minimum size. If so, attempts to
- * expand it by shrinking adjacent neighbors proportionally. When multiple
- * windows have minimum size, overlaps can occur; a final pass removes them.
- */
 PLASMAZONES_EXPORT void enforceWindowMinSizes(QVector<QRect>& zones, const QVector<QSize>& minSizes, int gapThreshold,
                                               int innerGap = 0);
 
-/**
- * @brief Remove overlapping zone rectangles so no two zones intersect
- * @param zones List of zone geometries to adjust (in-place)
- * @param minSizes Per-zone minimum sizes (optional); when resolving overlaps,
- *        prefer shrinking the zone with more surplus above its minimum
- * @param innerGap Desired gap between adjacent zones; when resolving overlaps,
- *        the boundary is offset so zones maintain this gap instead of being flush
- *
- * When multiple zones have minimum size constraints, steal logic can leave
- * boundaries inconsistent. This fixes horizontal and vertical overlaps by
- * shifting the shared edge toward the zone with more surplus, respecting
- * minimum sizes so enforcement is not undone.
- */
 PLASMAZONES_EXPORT void removeZoneOverlaps(QVector<QRect>& zones, const QVector<QSize>& minSizes = {},
                                            int innerGap = 0);
 
-/**
- * @brief Convert QRect to compact JSON string {x, y, width, height}
- * @param rect Rectangle to serialize
- * @return JSON string suitable for D-Bus geometry exchange
- *
- * Shared utility for all components that need to serialize zone/window
- * geometry for D-Bus signals (SnapEngine, WindowTrackingAdaptor, etc.).
- */
-PLASMAZONES_EXPORT QString rectToJson(const QRect& rect);
-
-/**
- * @brief Serialize zone assignment entries to compact JSON array
- * @param entries Vector of zone assignment entries (window moves with source/target zones)
- * @return JSON array string suitable for D-Bus signals
- *
- * Shared by SnapEngine navigation (rotate, resnap) and any future code
- * that needs to serialize ZoneAssignmentEntry vectors for D-Bus exchange.
- */
-PLASMAZONES_EXPORT QString serializeZoneAssignments(const QVector<ZoneAssignmentEntry>& entries);
+using ::PhosphorZones::GeometryUtils::rectToJson;
+using ::PhosphorZones::GeometryUtils::serializeZoneAssignments;
 
 } // namespace GeometryUtils
 

--- a/src/core/geometryutils.h
+++ b/src/core/geometryutils.h
@@ -6,6 +6,7 @@
 #include "constants.h"
 #include "plasmazones_export.h"
 #include "types.h"
+#include <PhosphorZones/GeometryUtils.h>
 #include <PhosphorProtocol/WireTypes.h>
 #include <QRectF>
 #include <QScreen>

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -184,7 +184,7 @@ public:
         return false;
     }
 
-    virtual QVariantMap getPerScreenSnappingSettings(const QString& /*screenIdOrName*/) const
+    QVariantMap getPerScreenSnappingSettings(const QString& /*screenIdOrName*/) const override
     {
         return {};
     }

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -5,6 +5,7 @@
 
 #include "plasmazones_export.h"
 #include "enums.h"
+#include <PhosphorEngineApi/IGeometrySettings.h>
 #include <QString>
 #include <QStringList>
 #include <QSet>
@@ -231,24 +232,17 @@ public:
  * - Settings: values are clamped to [0, INT_MAX]; -1 is not valid (global config always has a value)
  * - PhosphorZones::Layout: -1 sentinel means "use global setting"; >= 0 is a per-layout override
  */
-class PLASMAZONES_EXPORT IZoneGeometrySettings
+class PLASMAZONES_EXPORT IZoneGeometrySettings : public PhosphorEngineApi::IGeometrySettings
 {
 public:
-    virtual ~IZoneGeometrySettings() = default;
+    ~IZoneGeometrySettings() override = default;
 
-    virtual int zonePadding() const = 0;
     virtual void setZonePadding(int padding) = 0;
-    virtual int outerGap() const = 0;
     virtual void setOuterGap(int gap) = 0;
-    virtual bool usePerSideOuterGap() const = 0;
     virtual void setUsePerSideOuterGap(bool enabled) = 0;
-    virtual int outerGapTop() const = 0;
     virtual void setOuterGapTop(int gap) = 0;
-    virtual int outerGapBottom() const = 0;
     virtual void setOuterGapBottom(int gap) = 0;
-    virtual int outerGapLeft() const = 0;
     virtual void setOuterGapLeft(int gap) = 0;
-    virtual int outerGapRight() const = 0;
     virtual void setOuterGapRight(int gap) = 0;
     virtual int adjacentThreshold() const = 0;
     virtual void setAdjacentThreshold(int threshold) = 0;
@@ -258,9 +252,6 @@ public:
     virtual void setMinimumZoneSizePx(int size) = 0;
     virtual int minimumZoneDisplaySizePx() const = 0;
     virtual void setMinimumZoneDisplaySizePx(int size) = 0;
-    // Per-screen snapping overrides are declared on ISettings alongside the
-    // autotile / zone-selector per-screen APIs so all three share one home.
-    // See PlasmaZones::ISettings in core/interfaces.h.
 };
 
 /**

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -83,10 +83,16 @@ inline constexpr const char AnimationDuration[] = "AnimationDuration";
 inline constexpr const char AnimationEasingCurve[] = "AnimationEasingCurve";
 } // namespace PerScreenAutotileKey
 
-/**
- * Per-screen snapping override key constants.
- */
 namespace PerScreenSnappingKey {
+
+using PhosphorEngineApi::PerScreenSnappingKey::OuterGap;
+using PhosphorEngineApi::PerScreenSnappingKey::OuterGapBottom;
+using PhosphorEngineApi::PerScreenSnappingKey::OuterGapLeft;
+using PhosphorEngineApi::PerScreenSnappingKey::OuterGapRight;
+using PhosphorEngineApi::PerScreenSnappingKey::OuterGapTop;
+using PhosphorEngineApi::PerScreenSnappingKey::UsePerSideOuterGap;
+using PhosphorEngineApi::PerScreenSnappingKey::ZonePadding;
+
 inline constexpr const char SnapAssistEnabled[] = "SnapAssistEnabled";
 inline constexpr const char ZoneSelectorEnabled[] = "ZoneSelectorEnabled";
 inline constexpr const char ZoneSelectorTriggerDistance[] = "ZoneSelectorTriggerDistance";
@@ -96,14 +102,6 @@ inline constexpr const char ZoneSelectorSizeMode[] = "ZoneSelectorSizeMode";
 inline constexpr const char ZoneSelectorMaxRows[] = "ZoneSelectorMaxRows";
 inline constexpr const char ZoneSelectorPreviewWidth[] = "ZoneSelectorPreviewWidth";
 inline constexpr const char ZoneSelectorPreviewHeight[] = "ZoneSelectorPreviewHeight";
-// Geometry override keys
-inline constexpr const char ZonePadding[] = "ZonePadding";
-inline constexpr const char OuterGap[] = "OuterGap";
-inline constexpr const char UsePerSideOuterGap[] = "UsePerSideOuterGap";
-inline constexpr const char OuterGapTop[] = "OuterGapTop";
-inline constexpr const char OuterGapBottom[] = "OuterGapBottom";
-inline constexpr const char OuterGapLeft[] = "OuterGapLeft";
-inline constexpr const char OuterGapRight[] = "OuterGapRight";
 } // namespace PerScreenSnappingKey
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/core/types.h
+++ b/src/core/types.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
+#include <PhosphorEngineApi/EngineTypes.h>
 #include <PhosphorEngineApi/NavigationContext.h>
 #include <QHashFunctions>
 #include <QList>
@@ -16,240 +17,65 @@ namespace PlasmaZones {
 
 using NavigationContext = PhosphorEngineApi::NavigationContext;
 
-/**
- * @brief Composite key for per-desktop/activity tiling state lookup
- *
- * desktop=1 (matching m_currentDesktop default) and empty activity represent
- * the initial desktop/activity context. Always uses explicit desktop numbers.
- */
-struct TilingStateKey
-{
-    QString screenId;
-    int desktop = 1;
-    QString activity;
+using TilingStateKey = PhosphorEngineApi::TilingStateKey;
+using PhosphorEngineApi::qHash;
 
-    bool operator==(const TilingStateKey& other) const
-    {
-        return screenId == other.screenId && desktop == other.desktop && activity == other.activity;
-    }
-};
+using SnapIntent = PhosphorEngineApi::SnapIntent;
+using ResnapEntry = PhosphorEngineApi::ResnapEntry;
+using PendingRestore = PhosphorEngineApi::PendingRestore;
+using SnapResult = PhosphorEngineApi::SnapResult;
+using UnfloatResult = PhosphorEngineApi::UnfloatResult;
+using ZoneAssignmentEntry = PhosphorEngineApi::ZoneAssignmentEntry;
 
-inline size_t qHash(const TilingStateKey& key, size_t seed = 0)
-{
-    return qHashMulti(seed, key.screenId, key.desktop, key.activity);
-}
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// Shared Types - Parameter Objects for Complex Method Signatures
-// ═══════════════════════════════════════════════════════════════════════════════
-// These types reduce the number of output parameters in D-Bus methods and
-// provide clear semantic grouping of related data.
-// ═══════════════════════════════════════════════════════════════════════════════
-
-/**
- * @brief Whether a snap was user-initiated or auto-restored.
- *
- * commitSnap's side effects depend on WHY the snap is happening:
- *
- *   UserInitiated (default):
- *     - Clears any stale auto-snapped flag (so a subsequent
- *       windowActivated's last-used-zone gate sees "user-initiated")
- *     - Consumes one pending-restore entry (so the session entry can't
- *       drag the window back on next close/reopen)
- *     - Updates last-used-zone tracking
- *
- *   AutoRestored:
- *     - Does NOT touch the auto-snapped flag — the caller sets it
- *       BEFORE commit and the flag persists until windowClosed/pruneStale
- *     - Does NOT consume pending-restore — the resolve path already did
- *     - Does NOT update last-used-zone
- *
- * Floating-state clear (+ windowFloatingClearedForSnap emit) and the
- * windowSnapStateChanged emit fire for both intents.
- */
-enum class SnapIntent {
-    UserInitiated, ///< Explicit user action (shortcut, D-Bus call, float-toggle)
-    AutoRestored, ///< Auto-snap on open, session restore, app-rule match
-};
-
-struct PLASMAZONES_EXPORT ResnapEntry
-{
-    QString windowId;
-    int zonePosition; ///< Primary zone: 1-based position in sorted-by-zoneNumber order
-    QList<int> allZonePositions; ///< All zones (for multi-zone windows); empty = single-zone
-    QString screenId; ///< Stable EDID-based screen identifier (or connector name fallback)
-    int virtualDesktop = 0;
-};
-
-/**
- * @brief Result of a snap calculation
- *
- * Used by WindowTrackingService and D-Bus adaptor to communicate
- * snap decisions and geometry in a clean, single-object format.
- */
-struct PLASMAZONES_EXPORT SnapResult
-{
-    bool shouldSnap = false; ///< Whether the window should be snapped
-    QRect geometry; ///< Target geometry for snapping (x, y, width, height)
-    QString zoneId; ///< UUID of primary target zone (backward compat)
-    QStringList zoneIds; ///< All zone UUIDs (for multi-zone snap)
-    QString screenId; ///< Screen where the zone is located
-
-    /**
-     * @brief Check if this result represents a valid snap operation
-     * @return true if shouldSnap is true and geometry is valid
-     */
-    bool isValid() const
-    {
-        return shouldSnap && geometry.isValid() && !zoneId.isEmpty();
-    }
-
-    /**
-     * @brief Create an empty/no-snap result
-     */
-    static SnapResult noSnap()
-    {
-        return SnapResult{false, QRect(), QString(), QStringList(), QString()};
-    }
-};
-
-/**
- * @brief Result of an unfloat geometry resolution
- *
- * Used by SnapEngine and WindowTrackingAdaptor to resolve the geometry
- * a floating window should return to when unfloated. Encapsulates the
- * shared screen-validation + zone-geometry resolution sequence.
- */
-struct PLASMAZONES_EXPORT UnfloatResult
-{
-    bool found = false; ///< Whether a valid restore target was found
-    QStringList zoneIds; ///< PhosphorZones::Zone UUIDs to restore to
-    QRect geometry; ///< Target geometry for the window
-    QString screenId; ///< Screen where the zones are located
-};
-
-/**
- * @brief Information about a window being dragged
- *
- * Groups window identification and context data that's commonly
- * passed together during drag operations.
- */
 struct PLASMAZONES_EXPORT DragInfo
 {
-    QString windowId; ///< Full window ID (class:resource:pointer)
-    QRect geometry; ///< Current window geometry
-    QString appName; ///< Application name (for exclusion checks)
-    QString windowClass; ///< Window class (for pattern matching)
-    QString screenId; ///< Screen where window is located
-    bool isSticky = false; ///< Whether window is on all desktops
-    int virtualDesktop = 0; ///< Current virtual desktop (0 = all)
+    QString windowId;
+    QRect geometry;
+    QString appName;
+    QString windowClass;
+    QString screenId;
+    bool isSticky = false;
+    int virtualDesktop = 0;
 
-    /**
-     * @brief Check if drag info has required fields
-     */
     bool isValid() const
     {
         return !windowId.isEmpty();
     }
-
-    // Note: use WindowTrackingService::currentAppIdFor(dragInfo.windowId) or
-    // AutotileEngine::currentAppIdFor() to get the live app class on the
-    // daemon side (both query WindowRegistry). On the effect side, live
-    // class reads go through PlasmaZonesEffect::getWindowAppId() directly.
-    // The windowId field carries the frozen "appId|instanceId" composite
-    // used as a stable daemon-side key — don't parse the prefix expecting
-    // a current class.
 };
 
-/**
- * @brief Navigation command for keyboard zone movement
- *
- * Encapsulates the parameters for zone navigation operations.
- */
 struct PLASMAZONES_EXPORT NavigationCommand
 {
     enum class Type {
-        MoveToZone, ///< Move window to a specific zone
-        FocusZone, ///< Focus window in a zone
-        SwapWindows, ///< Swap two windows between zones
-        PushToEmpty, ///< Push window to first empty zone
-        Restore, ///< Restore window to original size
-        ToggleFloat, ///< Toggle window floating state
-        SnapToNumber, ///< Snap to zone by number
-        Rotate ///< Rotate windows in layout
+        MoveToZone,
+        FocusZone,
+        SwapWindows,
+        PushToEmpty,
+        Restore,
+        ToggleFloat,
+        SnapToNumber,
+        Rotate
     };
 
     Type type = Type::MoveToZone;
     QString targetZoneId;
     QString targetWindowId;
-    QString zoneGeometry; ///< JSON geometry for D-Bus
-    bool clockwise = true; ///< For rotation commands
+    QString zoneGeometry;
+    bool clockwise = true;
 
-    /**
-     * @brief Create a move-to-zone command
-     */
     static NavigationCommand moveToZone(const QString& zoneId, const QString& geometry)
     {
         return NavigationCommand{Type::MoveToZone, zoneId, QString(), geometry, true};
     }
 
-    /**
-     * @brief Create a focus-zone command
-     */
     static NavigationCommand focusZone(const QString& zoneId, const QString& windowId)
     {
         return NavigationCommand{Type::FocusZone, zoneId, windowId, QString(), true};
     }
 
-    /**
-     * @brief Create a swap-windows command
-     */
     static NavigationCommand swapWindows(const QString& zoneId, const QString& windowId, const QString& geometry)
     {
         return NavigationCommand{Type::SwapWindows, zoneId, windowId, geometry, true};
     }
-};
-
-/**
- * @brief PhosphorZones::Zone assignment entry for window movement operations
- *
- * Describes a single window movement in a rotation, resnap, or snap-all operation.
- */
-struct PLASMAZONES_EXPORT ZoneAssignmentEntry
-{
-    QString windowId{}; ///< Window to move
-    QString sourceZoneId{}; ///< PhosphorZones::Zone window is moving from (for OSD highlighting)
-    QString targetZoneId{}; ///< Primary zone to move to
-    QStringList targetZoneIds{}; ///< All zones (for multi-zone spans; empty = single zone)
-    QRect targetGeometry{}; ///< Target geometry in pixels
-    /// Authoritative target screen ID (physical or virtual). Set by callers
-    /// that know the intended destination screen — typically resnap-from-stored
-    /// paths where the screen is read from m_windowScreenAssignments and the
-    /// geometry is derived from that screen's layout. When non-empty,
-    /// processBatchEntries trusts this value and does NOT re-derive from
-    /// targetGeometry.center(). Empty means "ask effectiveScreenAt" (the
-    /// legacy path; correct for fresh user drops where the target screen is
-    /// unknown a priori, but corrupting on resnap-from-stored where a stale
-    /// geometry could re-derive into the wrong virtual screen).
-    QString targetScreenId{};
-};
-
-/**
- * @brief Pending restore entry for a single window instance
- *
- * Stores all data needed to restore a window to its previous zone.
- * Multiple entries per appId support multi-instance apps (e.g. 3 Konsole windows).
- *
- * Produced by WindowTrackingService::windowClosed() (cross-mode), consumed by
- * SnapEngine paths via WindowTrackingService::consumePendingAssignment().
- */
-struct PLASMAZONES_EXPORT PendingRestore
-{
-    QStringList zoneIds;
-    QString screenId;
-    int virtualDesktop = 0;
-    QString layoutId;
-    QList<int> zoneNumbers;
 };
 
 } // namespace PlasmaZones

--- a/src/core/utils.cpp
+++ b/src/core/utils.cpp
@@ -19,30 +19,7 @@ namespace Utils {
 
 bool belongsToPhysicalScreen(const QString& storedScreenId, const QString& physicalScreenId)
 {
-    if (storedScreenId.isEmpty() || physicalScreenId.isEmpty()) {
-        return false;
-    }
-    // A virtual ID passed as the physical filter is a misuse — the function
-    // is "stored belongs to PHYSICAL screen X". Return false rather than
-    // silently mis-matching.
-    if (PhosphorIdentity::VirtualScreenId::isVirtual(physicalScreenId)) {
-        return false;
-    }
-
-    // Stored ID is virtual: extract its physical parent and compare via
-    // screensMatch so connector-name ↔ EDID-ID equivalence is honored. A
-    // raw `==` would miss legitimate matches when one side is a connector
-    // name (e.g. "DP-2") and the other an EDID-based ID (e.g.
-    // "Dell:U2722D:115107"); both forms can appear in stored window state
-    // depending on which code path produced the ID.
-    if (PhosphorIdentity::VirtualScreenId::isVirtual(storedScreenId)) {
-        return Phosphor::Screens::ScreenIdentity::screensMatch(
-            PhosphorIdentity::VirtualScreenId::extractPhysicalId(storedScreenId), physicalScreenId);
-    }
-
-    // Stored ID is physical (or a connector name): defer to screensMatch
-    // which handles connector-name ↔ screen-ID equivalence via QScreen lookup.
-    return Phosphor::Screens::ScreenIdentity::screensMatch(storedScreenId, physicalScreenId);
+    return Phosphor::Screens::ScreenIdentity::belongsToPhysicalScreen(storedScreenId, physicalScreenId);
 }
 
 void warnDuplicateScreenIds()

--- a/src/core/virtualdesktopmanager.h
+++ b/src/core/virtualdesktopmanager.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
+#include <PhosphorEngineApi/IVirtualDesktopManager.h>
 #include <QObject>
 #include <QStringList>
 
@@ -22,7 +23,7 @@ namespace PlasmaZones {
  * Handles virtual desktop changes and automatically switches layouts
  * based on assignments.
  */
-class PLASMAZONES_EXPORT VirtualDesktopManager : public QObject
+class PLASMAZONES_EXPORT VirtualDesktopManager : public QObject, public PhosphorEngineApi::IVirtualDesktopManager
 {
     Q_OBJECT
 
@@ -50,7 +51,7 @@ public:
      * @brief Get current virtual desktop number
      * @return Desktop number (1-based), or 0 if unable to determine
      */
-    int currentDesktop() const;
+    int currentDesktop() const override;
 
     /**
      * @brief Switch to a specific virtual desktop

--- a/src/core/windowtrackingservice.cpp
+++ b/src/core/windowtrackingservice.cpp
@@ -10,7 +10,6 @@
 #include <PhosphorScreens/VirtualScreen.h>
 #include <PhosphorZones/Zone.h>
 #include <PhosphorZones/LayoutRegistry.h>
-#include <PhosphorZones/LayoutUtils.h>
 #include "virtualdesktopmanager.h"
 #include "utils.h"
 #include "logging.h"
@@ -433,15 +432,8 @@ bool WindowTrackingService::isWindowSticky(const QString& windowId) const
 // Shared Helpers
 // ═══════════════════════════════════════════════════════════════════════════════
 
-void WindowTrackingService::sortZonesByNumber(QVector<PhosphorZones::Zone*>& zones)
-{
-    PhosphorZones::LayoutUtils::sortZonesByNumber(zones);
-}
-
-QHash<QString, int> WindowTrackingService::buildZonePositionMap(PhosphorZones::Layout* layout)
-{
-    return PhosphorZones::LayoutUtils::buildZonePositionMap(layout);
-}
+// sortZonesByNumber / buildZonePositionMap removed — callers should use
+// PhosphorZones::LayoutUtils directly.
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Out-of-line accessors delegating to SnapState

--- a/src/core/windowtrackingservice.cpp
+++ b/src/core/windowtrackingservice.cpp
@@ -10,6 +10,7 @@
 #include <PhosphorScreens/VirtualScreen.h>
 #include <PhosphorZones/Zone.h>
 #include <PhosphorZones/LayoutRegistry.h>
+#include <PhosphorZones/LayoutUtils.h>
 #include "virtualdesktopmanager.h"
 #include "utils.h"
 #include "logging.h"
@@ -434,25 +435,12 @@ bool WindowTrackingService::isWindowSticky(const QString& windowId) const
 
 void WindowTrackingService::sortZonesByNumber(QVector<PhosphorZones::Zone*>& zones)
 {
-    std::stable_sort(zones.begin(), zones.end(), [](PhosphorZones::Zone* a, PhosphorZones::Zone* b) {
-        if (a->zoneNumber() != b->zoneNumber())
-            return a->zoneNumber() < b->zoneNumber();
-        return a->id() < b->id();
-    });
+    PhosphorZones::LayoutUtils::sortZonesByNumber(zones);
 }
 
 QHash<QString, int> WindowTrackingService::buildZonePositionMap(PhosphorZones::Layout* layout)
 {
-    QHash<QString, int> map;
-    if (!layout) {
-        return map;
-    }
-    QVector<PhosphorZones::Zone*> zones = layout->zones();
-    sortZonesByNumber(zones);
-    for (int i = 0; i < zones.size(); ++i) {
-        map[zones[i]->id().toString()] = i + 1;
-    }
-    return map;
+    return PhosphorZones::LayoutUtils::buildZonePositionMap(layout);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/core/windowtrackingservice.h
+++ b/src/core/windowtrackingservice.h
@@ -5,6 +5,7 @@
 
 #include "plasmazones_export.h"
 #include "types.h"
+#include <PhosphorEngineApi/IWindowTrackingService.h>
 #include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
 #include <QString>
@@ -67,7 +68,7 @@ class WindowRegistry;
  * - Maintainable: Clear separation of concerns
  * - Debuggable: Easier to trace logic flow
  */
-class PLASMAZONES_EXPORT WindowTrackingService : public QObject
+class PLASMAZONES_EXPORT WindowTrackingService : public QObject, public PhosphorEngineApi::IWindowTrackingService
 {
     Q_OBJECT
 
@@ -76,6 +77,11 @@ public:
                                    PhosphorZones::IZoneDetector* zoneDetector,
                                    Phosphor::Screens::ScreenManager* screenManager, ISettings* settings,
                                    VirtualDesktopManager* vdm, QObject* parent = nullptr);
+
+    QObject* asQObject() override
+    {
+        return this;
+    }
     ~WindowTrackingService() override;
 
     /**
@@ -124,7 +130,7 @@ public:
         return m_windowRegistry;
     }
 
-    Phosphor::Screens::ScreenManager* screenManager() const
+    Phosphor::Screens::ScreenManager* screenManager() const override
     {
         return m_screenManager;
     }
@@ -141,7 +147,7 @@ public:
      * @param virtualDesktop Virtual desktop number (1-based, 0 = all)
      */
     void assignWindowToZone(const QString& windowId, const QString& zoneId, const QString& screenId,
-                            int virtualDesktop);
+                            int virtualDesktop) override;
 
     /**
      * @brief Assign a window to multiple zones (multi-zone snap)
@@ -151,34 +157,34 @@ public:
      * @param virtualDesktop Virtual desktop number (1-based, 0 = all)
      */
     void assignWindowToZones(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
-                             int virtualDesktop);
+                             int virtualDesktop) override;
 
     /**
      * @brief Remove window from its assigned zone
      * @param windowId Full window ID
      */
-    void unassignWindow(const QString& windowId);
+    void unassignWindow(const QString& windowId) override;
 
     /**
      * @brief Get the primary zone ID for a window
      * @param windowId Full window ID
      * @return PhosphorZones::Zone ID or empty string if not assigned
      */
-    QString zoneForWindow(const QString& windowId) const;
+    QString zoneForWindow(const QString& windowId) const override;
 
     /**
      * @brief Get all zone IDs for a window (multi-zone support)
      * @param windowId Full window ID
      * @return List of zone IDs (empty if not assigned)
      */
-    QStringList zonesForWindow(const QString& windowId) const;
+    QStringList zonesForWindow(const QString& windowId) const override;
 
     /**
      * @brief Get all windows in a specific zone
      * @param zoneId PhosphorZones::Zone UUID string
      * @return List of window IDs
      */
-    QStringList windowsInZone(const QString& zoneId) const;
+    QStringList windowsInZone(const QString& zoneId) const override;
 
     /**
      * @brief Get all snapped windows
@@ -193,7 +199,7 @@ public:
     /**
      * @brief Check if a window is assigned to any zone
      */
-    bool isWindowSnapped(const QString& windowId) const;
+    bool isWindowSnapped(const QString& windowId) const override;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Geometry Validation Utility
@@ -228,7 +234,7 @@ public:
      * @param exactOnly       If true, skip the appId fallback (strict per-instance lookup)
      */
     std::optional<QRect> validatedUnmanagedGeometry(const QString& windowId, const QString& screenId,
-                                                    bool exactOnly = false) const;
+                                                    bool exactOnly = false) const override;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Floating Window State
@@ -237,14 +243,14 @@ public:
     /**
      * @brief Check if a window is floating (excluded from snapping)
      */
-    bool isWindowFloating(const QString& windowId) const;
+    bool isWindowFloating(const QString& windowId) const override;
 
     /**
      * @brief Set window floating state
      * @param windowId Full window ID
      * @param floating true to float, false to unfloat
      */
-    void setWindowFloating(const QString& windowId, bool floating);
+    void setWindowFloating(const QString& windowId, bool floating) override;
 
     /**
      * @brief Get all floating window IDs
@@ -255,7 +261,7 @@ public:
      * @brief Unsnap window for floating (saves zone for later restore)
      * @param windowId Full window ID
      */
-    void unsnapForFloat(const QString& windowId);
+    void unsnapForFloat(const QString& windowId) override;
 
     /**
      * @brief Get primary zone to restore to when unfloating
@@ -269,14 +275,14 @@ public:
      * @param windowId Full window ID
      * @return List of zone IDs (empty if none)
      */
-    QStringList preFloatZones(const QString& windowId) const;
+    QStringList preFloatZones(const QString& windowId) const override;
 
     /**
      * @brief Get the screen name where the window was snapped before floating
      * @param windowId Full window ID
      * @return Screen name or empty string if unknown
      */
-    QString preFloatScreen(const QString& windowId) const;
+    QString preFloatScreen(const QString& windowId) const override;
 
     /**
      * @brief Clear pre-float zone after restore (both windowId and appId keys)
@@ -300,7 +306,7 @@ public:
      * @param windowId Window identifier
      * @return true if the window was floating (caller should emit windowFloatingChanged)
      */
-    bool clearFloatingForSnap(const QString& windowId);
+    bool clearFloatingForSnap(const QString& windowId) override;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Sticky Window Handling
@@ -314,7 +320,7 @@ public:
     /**
      * @brief Check if window is sticky
      */
-    bool isWindowSticky(const QString& windowId) const;
+    bool isWindowSticky(const QString& windowId) const override;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Auto-Snap Logic
@@ -325,7 +331,7 @@ public:
      * @param windowId Full window ID to extract class from
      * @param wasUserInitiated true if user-initiated snap
      */
-    void recordSnapIntent(const QString& windowId, bool wasUserInitiated);
+    void recordSnapIntent(const QString& windowId, bool wasUserInitiated) override;
 
     /**
      * @brief Get last used zone ID
@@ -354,7 +360,7 @@ public:
      * @brief Update last used zone tracking
      */
     void updateLastUsedZone(const QString& zoneId, const QString& screenId, const QString& windowClass,
-                            int virtualDesktop);
+                            int virtualDesktop) override;
 
     /**
      * @brief Mark a window as auto-snapped
@@ -379,7 +385,7 @@ public:
      * @param windowId Full window ID
      * @return true if the window had the auto-snapped flag
      */
-    bool clearAutoSnapped(const QString& windowId);
+    bool clearAutoSnapped(const QString& windowId) override;
 
     /**
      * @brief Pop the oldest pending restore entry for this window's appId.
@@ -410,7 +416,7 @@ public:
      * @return true if an entry was popped, false if the queue was empty.
      *         Callers that don't care about the result may ignore it.
      */
-    bool consumePendingAssignment(const QString& windowId);
+    bool consumePendingAssignment(const QString& windowId) override;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Navigation Helpers
@@ -421,7 +427,7 @@ public:
      * @param screenId Screen to find layout for (empty = active layout)
      * @return PhosphorZones::Zone ID or empty string if all occupied
      */
-    QString findEmptyZone(const QString& screenId = QString()) const;
+    QString findEmptyZone(const QString& screenId = QString()) const override;
 
     /**
      * @brief Get typed list of all empty zones for Snap Assist continuation
@@ -436,7 +442,7 @@ public:
      * @param screenId Screen identifier (empty = primary)
      * @return PhosphorZones::Zone geometry in pixels, or invalid QRect if not found
      */
-    QRect zoneGeometry(const QString& zoneId, const QString& screenId = QString()) const;
+    QRect zoneGeometry(const QString& zoneId, const QString& screenId = QString()) const override;
 
     /**
      * @brief Get combined geometry for multiple zones on a specific screen
@@ -587,12 +593,12 @@ public:
      * @brief Get all zone assignments for persistence
      * @return Map of windowId -> zoneIds (list of zone UUIDs)
      */
-    const QHash<QString, QStringList>& zoneAssignments() const;
+    const QHash<QString, QStringList>& zoneAssignments() const override;
 
     /**
      * @brief Get all screen assignments for persistence
      */
-    const QHash<QString, QString>& screenAssignments() const;
+    const QHash<QString, QString>& screenAssignments() const override;
 
     /**
      * @brief Get all desktop assignments for persistence
@@ -605,12 +611,12 @@ public:
     /**
      * @brief Get pending restore queues (consumption queue: appId -> list of pending restores)
      */
-    const QHash<QString, QList<PendingRestore>>& pendingRestoreQueues() const
+    const QHash<QString, QList<PendingRestore>>& pendingRestoreQueues() const override
     {
         return m_pendingRestoreQueues;
     }
 
-    QVector<ResnapEntry> takeResnapBuffer()
+    QVector<ResnapEntry> takeResnapBuffer() override
     {
         return std::exchange(m_resnapBuffer, {});
     }
@@ -783,13 +789,14 @@ private:
 public:
     /// Resolve a screen ID to an effective screen ID, falling back to the physical
     /// screen ID if a virtual screen no longer exists in the current configuration.
-    QString resolveEffectiveScreenId(const QString& screenId) const;
+    QString resolveEffectiveScreenId(const QString& screenId) const override;
 
     /// Resolve zone geometry: combined geometry for multi-zone, single for single zone.
     /// Avoids repeating the (size>1) ? multiZoneGeometry : zoneGeometry ternary.
-    QRect resolveZoneGeometry(const QStringList& zoneIds, const QString& screenId) const;
+    QRect resolveZoneGeometry(const QStringList& zoneIds, const QString& screenId) const override;
 
-    QString findEmptyZoneInLayout(PhosphorZones::Layout* layout, const QString& screenId, int desktopFilter = 0) const;
+    QString findEmptyZoneInLayout(PhosphorZones::Layout* layout, const QString& screenId,
+                                  int desktopFilter = 0) const override;
 
     /// Sort zones by zone number ascending, with UUID tie-breaker for determinism
     /// when multiple zones share the same number.
@@ -808,7 +815,7 @@ public:
     ///   do not make zones appear occupied — this mirrors the filtering done by
     ///   SnapAssistHandler::buildCandidates() in the KWin effect, keeping the
     ///   "occupied" and "candidate" definitions symmetric.
-    QSet<QUuid> buildOccupiedZoneSet(const QString& screenFilter = QString(), int desktopFilter = 0) const;
+    QSet<QUuid> buildOccupiedZoneSet(const QString& screenFilter = QString(), int desktopFilter = 0) const override;
 
     /**
      * @brief Current app class for a windowId, preferring the live registry.
@@ -818,7 +825,7 @@ public:
      * matching against a freshly-renamed window (Electron/CEF) sees the
      * current class.
      */
-    QString currentAppIdFor(const QString& anyWindowId) const;
+    QString currentAppIdFor(const QString& anyWindowId) const override;
 
     /**
      * @brief Canonicalize for read-only callers (no map mutation).

--- a/src/core/windowtrackingservice.h
+++ b/src/core/windowtrackingservice.h
@@ -798,12 +798,8 @@ public:
     QString findEmptyZoneInLayout(PhosphorZones::Layout* layout, const QString& screenId,
                                   int desktopFilter = 0) const override;
 
-    /// Sort zones by zone number ascending, with UUID tie-breaker for determinism
-    /// when multiple zones share the same number.
-    static void sortZonesByNumber(QVector<PhosphorZones::Zone*>& zones);
-
-    /// Build a map from zone ID (toString) to 1-based position in sorted-by-zoneNumber order.
-    static QHash<QString, int> buildZonePositionMap(PhosphorZones::Layout* layout);
+    // Zone sort / position-map helpers now live in PhosphorZones::LayoutUtils.
+    // Call PhosphorZones::LayoutUtils::sortZonesByNumber / buildZonePositionMap directly.
 
     /// Build set of occupied zone UUIDs, optionally filtered by screen and virtual desktop.
     ///

--- a/src/core/windowtrackingservice/lifecycle.cpp
+++ b/src/core/windowtrackingservice/lifecycle.cpp
@@ -7,6 +7,7 @@
 #include "../windowtrackingservice.h"
 #include "../constants.h"
 #include <PhosphorZones/Layout.h>
+#include <PhosphorZones/LayoutUtils.h>
 #include <PhosphorZones/SnapState.h>
 #include <PhosphorZones/Zone.h>
 #include <PhosphorZones/LayoutRegistry.h>
@@ -576,7 +577,7 @@ void WindowTrackingService::onLayoutChanged()
     {
         QVector<ResnapEntry> newBuffer;
 
-        QHash<QString, int> globalZoneIdToPosition = buildZonePositionMap(prevLayout);
+        QHash<QString, int> globalZoneIdToPosition = PhosphorZones::LayoutUtils::buildZonePositionMap(prevLayout);
         int globalPrevZoneCount = prevLayout->zones().size();
 
         // Cache per-screen position maps for screens with per-screen layouts
@@ -608,7 +609,8 @@ void WindowTrackingService::onLayoutChanged()
                 if (screenLayout && screenLayout != prevLayout) {
                     auto cacheIt = perLayoutPositionMaps.constFind(screenLayout);
                     if (cacheIt == perLayoutPositionMaps.constEnd()) {
-                        cacheIt = perLayoutPositionMaps.insert(screenLayout, buildZonePositionMap(screenLayout));
+                        cacheIt = perLayoutPositionMaps.insert(
+                            screenLayout, PhosphorZones::LayoutUtils::buildZonePositionMap(screenLayout));
                     }
                     posMap = &cacheIt.value();
                     prevZoneCount = screenLayout->zones().size();

--- a/src/core/windowtrackingservice/navigation.cpp
+++ b/src/core/windowtrackingservice/navigation.cpp
@@ -8,6 +8,7 @@
 #include "../constants.h"
 #include "../geometryutils.h"
 #include <PhosphorZones/Layout.h>
+#include <PhosphorZones/LayoutUtils.h>
 #include <PhosphorZones/SnapState.h>
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorZones/Zone.h>
@@ -81,7 +82,7 @@ QString WindowTrackingService::findEmptyZoneInLayout(PhosphorZones::Layout* layo
 
     // Sort by zone number so "first empty" is the lowest-numbered empty zone
     QVector<PhosphorZones::Zone*> sortedZones = layout->zones();
-    sortZonesByNumber(sortedZones);
+    PhosphorZones::LayoutUtils::sortZonesByNumber(sortedZones);
 
     for (PhosphorZones::Zone* zone : sortedZones) {
         if (!occupiedZoneIds.contains(zone->id())) {

--- a/src/core/windowtrackingservice/resnap.cpp
+++ b/src/core/windowtrackingservice/resnap.cpp
@@ -7,6 +7,7 @@
 #include "../windowtrackingservice.h"
 #include "../geometryutils.h"
 #include <PhosphorZones/Layout.h>
+#include <PhosphorZones/LayoutUtils.h>
 #include <PhosphorZones/SnapState.h>
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorZones/Zone.h>
@@ -43,7 +44,7 @@ void WindowTrackingService::populateResnapBufferForAllScreens(const QSet<QString
     // Build a global zoneId → (layoutId, position) map from all layouts
     QHash<QString, int> globalZoneIdToPosition;
     for (PhosphorZones::Layout* layout : m_layoutManager->layouts()) {
-        QHash<QString, int> layoutMap = buildZonePositionMap(layout);
+        QHash<QString, int> layoutMap = PhosphorZones::LayoutUtils::buildZonePositionMap(layout);
         for (auto it = layoutMap.constBegin(); it != layoutMap.constEnd(); ++it) {
             globalZoneIdToPosition[it.key()] = it.value();
         }

--- a/src/dbus/snapadaptor.h
+++ b/src/dbus/snapadaptor.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
+#include "core/types.h"
 #include <PhosphorProtocol/WireTypes.h>
 #include <QDBusAbstractAdaptor>
 #include <QObject>
@@ -18,7 +19,6 @@ using PhosphorProtocol::SnapConfirmationList;
 using PhosphorProtocol::UnfloatRestoreResult;
 using PhosphorProtocol::WindowGeometryList;
 
-struct SnapResult;
 class SnapEngine;
 class ScreenModeRouter;
 class WindowTrackingAdaptor;

--- a/src/dbus/snapnavigationtargets.cpp
+++ b/src/dbus/snapnavigationtargets.cpp
@@ -11,7 +11,6 @@
 #include <PhosphorScreens/Manager.h>
 #include "../core/utils.h"
 #include <PhosphorScreens/VirtualScreen.h>
-#include "../core/windowtrackingservice.h"
 #include <PhosphorZones/Zone.h>
 
 #include <QRect>
@@ -98,7 +97,7 @@ bool checkDirection(const QString& direction)
 // Construction
 // ═══════════════════════════════════════════════════════════════════════════
 
-SnapNavigationTargetResolver::SnapNavigationTargetResolver(WindowTrackingService* service,
+SnapNavigationTargetResolver::SnapNavigationTargetResolver(PhosphorEngineApi::IWindowTrackingService* service,
                                                            PhosphorZones::LayoutRegistry* layoutManager,
                                                            ZoneDetectionAdaptor* zoneDetector, FeedbackFn feedback)
     : m_service(service)

--- a/src/dbus/snapnavigationtargets.h
+++ b/src/dbus/snapnavigationtargets.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
+#include <PhosphorEngineApi/IWindowTrackingService.h>
 #include <PhosphorProtocol/WireTypes.h>
 
 #include <QString>
@@ -24,7 +25,6 @@ using PhosphorProtocol::SwapTargetResult;
 
 class ISettings;
 
-class WindowTrackingService;
 class ZoneDetectionAdaptor;
 
 /**
@@ -76,8 +76,9 @@ public:
      * @param zoneDetector       adjacent/first-in-direction query helper (non-owning)
      * @param feedback           OSD feedback callback; may be empty (suppresses feedback)
      */
-    SnapNavigationTargetResolver(WindowTrackingService* service, PhosphorZones::LayoutRegistry* layoutManager,
-                                 ZoneDetectionAdaptor* zoneDetector, FeedbackFn feedback);
+    SnapNavigationTargetResolver(PhosphorEngineApi::IWindowTrackingService* service,
+                                 PhosphorZones::LayoutRegistry* layoutManager, ZoneDetectionAdaptor* zoneDetector,
+                                 FeedbackFn feedback);
 
     /// Late setter for the zone detector — it is wired after adaptor
     /// construction, so we allow nullptr at construction time and bind
@@ -112,7 +113,7 @@ private:
         }
     }
 
-    WindowTrackingService* m_service = nullptr;
+    PhosphorEngineApi::IWindowTrackingService* m_service = nullptr;
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;
     ZoneDetectionAdaptor* m_zoneDetector = nullptr;
     FeedbackFn m_feedback;

--- a/src/snap/SnapEngine.cpp
+++ b/src/snap/SnapEngine.cpp
@@ -7,8 +7,6 @@
 #include "dbus/snapnavigationtargets.h"
 #include "dbus/windowtrackingadaptor.h"
 #include "dbus/zonedetectionadaptor.h"
-#include "core/virtualdesktopmanager.h"
-#include "core/windowtrackingservice.h"
 #include "core/logging.h"
 
 namespace PlasmaZones {
@@ -17,9 +15,10 @@ namespace PlasmaZones {
 // tests deliberately pass nullptr to construct an engine with minimal parents
 // for testing peripheral classes (adaptors, bridges) — every method that
 // dereferences a dependency guards it locally. Do not Q_ASSERT here.
-SnapEngine::SnapEngine(PhosphorZones::LayoutRegistry* layoutManager, WindowTrackingService* windowTracker,
-                       PhosphorZones::IZoneDetector* zoneDetector, ISettings* settings, VirtualDesktopManager* vdm,
-                       QObject* parent)
+SnapEngine::SnapEngine(PhosphorZones::LayoutRegistry* layoutManager,
+                       PhosphorEngineApi::IWindowTrackingService* windowTracker,
+                       PhosphorZones::IZoneDetector* zoneDetector, ISettings* settings,
+                       PhosphorEngineApi::IVirtualDesktopManager* vdm, QObject* parent)
     : PlacementEngineBase(parent)
     , m_layoutManager(layoutManager)
     , m_windowTracker(windowTracker)

--- a/src/snap/SnapEngine.h
+++ b/src/snap/SnapEngine.h
@@ -5,6 +5,8 @@
 
 #include "plasmazones_export.h"
 #include "core/types.h"
+#include <PhosphorEngineApi/IVirtualDesktopManager.h>
+#include <PhosphorEngineApi/IWindowTrackingService.h>
 #include <PhosphorEngineApi/PlacementEngineBase.h>
 #include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
@@ -37,9 +39,7 @@ class AutotileEngine;
 class ISettings;
 
 class SnapNavigationTargetResolver;
-class VirtualDesktopManager;
 class WindowTrackingAdaptor;
-class WindowTrackingService;
 class ZoneDetectionAdaptor;
 
 /**
@@ -61,9 +61,10 @@ class PLASMAZONES_EXPORT SnapEngine : public PhosphorEngineApi::PlacementEngineB
     Q_OBJECT
 
 public:
-    explicit SnapEngine(PhosphorZones::LayoutRegistry* layoutManager, WindowTrackingService* windowTracker,
-                        PhosphorZones::IZoneDetector* zoneDetector, ISettings* settings, VirtualDesktopManager* vdm,
-                        QObject* parent = nullptr);
+    explicit SnapEngine(PhosphorZones::LayoutRegistry* layoutManager,
+                        PhosphorEngineApi::IWindowTrackingService* windowTracker,
+                        PhosphorZones::IZoneDetector* zoneDetector, ISettings* settings,
+                        PhosphorEngineApi::IVirtualDesktopManager* vdm, QObject* parent = nullptr);
     ~SnapEngine() override;
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -453,11 +454,11 @@ private:
                         SnapIntent intent);
 
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;
-    WindowTrackingService* m_windowTracker = nullptr;
+    PhosphorEngineApi::IWindowTrackingService* m_windowTracker = nullptr;
     PhosphorZones::SnapState* m_snapState = nullptr;
     PhosphorZones::IZoneDetector* m_zoneDetector = nullptr;
     ISettings* m_settings = nullptr;
-    VirtualDesktopManager* m_virtualDesktopManager = nullptr;
+    PhosphorEngineApi::IVirtualDesktopManager* m_virtualDesktopManager = nullptr;
     QPointer<AutotileEngine> m_autotileEngine;
     QPointer<ZoneDetectionAdaptor> m_zoneDetectionAdaptor;
     // Back-reference to WindowTrackingAdaptor for state SnapEngine reads

--- a/src/snap/snapengine/calculate.cpp
+++ b/src/snap/snapengine/calculate.cpp
@@ -16,8 +16,6 @@
 #include "core/interfaces.h"
 #include "core/logging.h"
 #include "core/utils.h"
-#include "core/virtualdesktopmanager.h"
-#include "core/windowtrackingservice.h"
 #include <QGuiApplication>
 #include <QScreen>
 #include <QUuid>

--- a/src/snap/snapengine/calculate.cpp
+++ b/src/snap/snapengine/calculate.cpp
@@ -15,7 +15,6 @@
 #include <PhosphorScreens/VirtualScreen.h>
 #include "core/interfaces.h"
 #include "core/logging.h"
-#include "core/utils.h"
 #include <QGuiApplication>
 #include <QScreen>
 #include <QUuid>
@@ -60,8 +59,8 @@ SnapResult SnapEngine::calculateSnapToAppRule(const QString& windowId, const QSt
 
         // Validate that the target screen exists. Use Phosphor::Screens::ScreenManager::resolvePhysicalScreen
         // which properly handles virtual screen IDs (resolving to backing QScreen*).
-        QScreen* screen = (screenManager ? screenManager->physicalQScreenFor(effectiveScreen)
-                                         : Utils::findScreenAtPosition(QPoint(0, 0)));
+        QScreen* screen =
+            (screenManager ? screenManager->physicalQScreenFor(effectiveScreen) : QGuiApplication::primaryScreen());
         if (!screen) {
             qCInfo(lcCore) << "App rule: screen" << effectiveScreen << "not found for" << windowClass
                            << (match.targetScreen.isEmpty() ? "(current screen)" : "(target screen)") << ", skipping";
@@ -128,7 +127,7 @@ SnapResult SnapEngine::calculateSnapToAppRule(const QString& windowId, const QSt
     if (screenManager) {
         screenIds = screenManager->effectiveScreenIds();
     } else {
-        const auto screens = Utils::allScreens();
+        const auto screens = QGuiApplication::screens();
         for (auto* s : screens) {
             screenIds.append(Phosphor::Screens::ScreenIdentity::identifierFor(s));
         }

--- a/src/snap/snapengine/calculate.cpp
+++ b/src/snap/snapengine/calculate.cpp
@@ -13,7 +13,7 @@
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorScreens/ScreenIdentity.h>
 #include <PhosphorScreens/VirtualScreen.h>
-#include "core/interfaces.h"
+#include "core/isettings.h"
 #include "core/logging.h"
 #include <QGuiApplication>
 #include <QScreen>

--- a/src/snap/snapengine/commit.cpp
+++ b/src/snap/snapengine/commit.cpp
@@ -5,8 +5,6 @@
 #include <PhosphorZones/SnapState.h>
 #include <PhosphorScreens/ScreenIdentity.h>
 #include "core/logging.h"
-#include "core/virtualdesktopmanager.h"
-#include "core/windowtrackingservice.h"
 
 #include <QGuiApplication>
 #include <QScreen>

--- a/src/snap/snapengine/float.cpp
+++ b/src/snap/snapengine/float.cpp
@@ -6,8 +6,6 @@
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorScreens/ScreenIdentity.h>
 #include "core/logging.h"
-#include "core/virtualdesktopmanager.h"
-#include "core/windowtrackingservice.h"
 
 namespace PlasmaZones {
 

--- a/src/snap/snapengine/lifecycle.cpp
+++ b/src/snap/snapengine/lifecycle.cpp
@@ -8,8 +8,6 @@
 #include <PhosphorZones/LayoutRegistry.h>
 #include "core/logging.h"
 #include "core/utils.h"
-#include "core/virtualdesktopmanager.h"
-#include "core/windowtrackingservice.h"
 
 namespace PlasmaZones {
 

--- a/src/snap/snapengine/lifecycle.cpp
+++ b/src/snap/snapengine/lifecycle.cpp
@@ -4,7 +4,7 @@
 #include "../SnapEngine.h"
 #include <PhosphorZones/SnapState.h>
 #include <PhosphorZones/AssignmentEntry.h>
-#include "core/interfaces.h"
+#include "core/isettings.h"
 #include <PhosphorIdentity/WindowId.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include "core/logging.h"

--- a/src/snap/snapengine/lifecycle.cpp
+++ b/src/snap/snapengine/lifecycle.cpp
@@ -5,9 +5,9 @@
 #include <PhosphorZones/SnapState.h>
 #include <PhosphorZones/AssignmentEntry.h>
 #include "core/interfaces.h"
+#include <PhosphorIdentity/WindowId.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include "core/logging.h"
-#include "core/utils.h"
 
 namespace PlasmaZones {
 

--- a/src/snap/snapengine/navigation.cpp
+++ b/src/snap/snapengine/navigation.cpp
@@ -8,7 +8,6 @@
 #include "core/logging.h"
 #include "core/types.h"
 #include "core/utils.h"
-#include "core/windowtrackingservice.h"
 #include <PhosphorZones/Zone.h>
 
 namespace PlasmaZones {

--- a/src/snap/snapengine/navigation.cpp
+++ b/src/snap/snapengine/navigation.cpp
@@ -7,7 +7,6 @@
 #include <PhosphorZones/LayoutRegistry.h>
 #include "core/logging.h"
 #include "core/types.h"
-#include "core/utils.h"
 #include <PhosphorZones/Zone.h>
 
 namespace PlasmaZones {

--- a/src/snap/snapengine/navigation_actions.cpp
+++ b/src/snap/snapengine/navigation_actions.cpp
@@ -27,7 +27,7 @@
 #include <PhosphorZones/SnapState.h>
 
 #include "../../config/settings.h"
-#include "../../core/interfaces.h"
+#include "../../core/isettings.h"
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include "../../core/logging.h"

--- a/src/snap/snapengine/navigation_actions.cpp
+++ b/src/snap/snapengine/navigation_actions.cpp
@@ -32,11 +32,11 @@
 #include <PhosphorZones/LayoutRegistry.h>
 #include "../../core/logging.h"
 #include <PhosphorScreens/Manager.h>
-#include "../../core/utils.h"
 #include <PhosphorScreens/VirtualScreen.h>
 #include "../../dbus/snapnavigationtargets.h"
 #include "../../dbus/windowtrackingadaptor.h"
 #include <PhosphorIdentity/VirtualScreenId.h>
+#include <PhosphorIdentity/WindowId.h>
 #include <PhosphorScreens/ScreenIdentity.h>
 
 namespace PlasmaZones {

--- a/src/snap/snapengine/navigation_actions.cpp
+++ b/src/snap/snapengine/navigation_actions.cpp
@@ -33,9 +33,7 @@
 #include "../../core/logging.h"
 #include <PhosphorScreens/Manager.h>
 #include "../../core/utils.h"
-#include "../../core/virtualdesktopmanager.h"
 #include <PhosphorScreens/VirtualScreen.h>
-#include "../../core/windowtrackingservice.h"
 #include "../../dbus/snapnavigationtargets.h"
 #include "../../dbus/windowtrackingadaptor.h"
 #include <PhosphorIdentity/VirtualScreenId.h>
@@ -57,8 +55,8 @@ namespace {
 ///      rather than the one KWin happens to think the window is on.
 ///   2. An explicit @p preferredScreen from the NavigationContext.
 ///   3. The WTA cursor / last-active screen shadows.
-QString resolveNavScreen(const WindowTrackingAdaptor* wta, const QString& windowId, WindowTrackingService* service,
-                         const QString& preferredScreen = QString())
+QString resolveNavScreen(const WindowTrackingAdaptor* wta, const QString& windowId,
+                         PhosphorEngineApi::IWindowTrackingService* service, const QString& preferredScreen = QString())
 {
     if (service && !windowId.isEmpty()) {
         const QString zoneId = service->zoneForWindow(windowId);

--- a/src/snap/snapengine/resnap_calc.cpp
+++ b/src/snap/snapengine/resnap_calc.cpp
@@ -13,13 +13,12 @@
 #include <PhosphorScreens/ScreenIdentity.h>
 #include <PhosphorScreens/VirtualScreen.h>
 #include <PhosphorIdentity/VirtualScreenId.h>
+#include "core/windowtrackingservice.h"
 #include "core/constants.h"
 #include "core/geometryutils.h"
 #include "core/interfaces.h"
 #include "core/logging.h"
 #include "core/utils.h"
-#include "core/virtualdesktopmanager.h"
-#include "core/windowtrackingservice.h"
 #include <QGuiApplication>
 #include <QScreen>
 #include <QUuid>

--- a/src/snap/snapengine/resnap_calc.cpp
+++ b/src/snap/snapengine/resnap_calc.cpp
@@ -18,7 +18,6 @@
 #include "core/geometryutils.h"
 #include "core/interfaces.h"
 #include "core/logging.h"
-#include "core/utils.h"
 #include <QGuiApplication>
 #include <QScreen>
 #include <QUuid>
@@ -165,7 +164,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateResnapFromCurrentAssignments(c
             // virtual children — belongsToPhysicalScreen handles both cases.
             const bool match = PhosphorIdentity::VirtualScreenId::isVirtual(screenFilter)
                 ? Phosphor::Screens::ScreenIdentity::screensMatch(screenId, screenFilter)
-                : Utils::belongsToPhysicalScreen(screenId, screenFilter);
+                : Phosphor::Screens::ScreenIdentity::belongsToPhysicalScreen(screenId, screenFilter);
             if (!match) {
                 continue;
             }
@@ -202,7 +201,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateResnapFromCurrentAssignments(c
                 return true;
             return PhosphorIdentity::VirtualScreenId::isVirtual(screenFilter)
                 ? Phosphor::Screens::ScreenIdentity::screensMatch(screen, screenFilter)
-                : Utils::belongsToPhysicalScreen(screen, screenFilter);
+                : Phosphor::Screens::ScreenIdentity::belongsToPhysicalScreen(screen, screenFilter);
         };
         for (auto it = zoneAssignments.constBegin(); it != zoneAssignments.constEnd(); ++it) {
             QString screen = screenAssignments.value(it.key());
@@ -363,8 +362,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateSnapAllWindowEntries(const QSt
 
     // Resolve physical screen for zone geometry calculation
     auto* screenManager = m_windowTracker->screenManager();
-    QScreen* screen =
-        (screenManager ? screenManager->physicalQScreenFor(screenId) : Utils::findScreenAtPosition(QPoint(0, 0)));
+    QScreen* screen = (screenManager ? screenManager->physicalQScreenFor(screenId) : QGuiApplication::primaryScreen());
     if (!screen) {
         return result;
     }
@@ -486,7 +484,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateRotation(bool clockwise, const
         // Resolve physical screen for zone geometry calculation
         auto* screenManager = m_windowTracker->screenManager();
         QScreen* screen =
-            (screenManager ? screenManager->physicalQScreenFor(screenId) : Utils::findScreenAtPosition(QPoint(0, 0)));
+            (screenManager ? screenManager->physicalQScreenFor(screenId) : QGuiApplication::primaryScreen());
         if (!screen) {
             continue;
         }

--- a/src/snap/snapengine/resnap_calc.cpp
+++ b/src/snap/snapengine/resnap_calc.cpp
@@ -13,10 +13,10 @@
 #include <PhosphorScreens/ScreenIdentity.h>
 #include <PhosphorScreens/VirtualScreen.h>
 #include <PhosphorIdentity/VirtualScreenId.h>
-#include "core/windowtrackingservice.h"
+#include <PhosphorZones/LayoutUtils.h>
 #include "core/constants.h"
 #include "core/geometryutils.h"
-#include "core/interfaces.h"
+#include "core/isettings.h"
 #include "core/logging.h"
 #include <QGuiApplication>
 #include <QScreen>
@@ -70,7 +70,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateResnapFromPreviousLayout()
         }
 
         QVector<PhosphorZones::Zone*> newZones = newLayout->zones();
-        WindowTrackingService::sortZonesByNumber(newZones);
+        PhosphorZones::LayoutUtils::sortZonesByNumber(newZones);
         const int newZoneCount = newZones.size();
 
         for (const ResnapEntry* entry : screenIt.value()) {
@@ -231,7 +231,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateResnapFromAutotileOrder(const 
     }
 
     QVector<PhosphorZones::Zone*> zones = layout->zones();
-    WindowTrackingService::sortZonesByNumber(zones);
+    PhosphorZones::LayoutUtils::sortZonesByNumber(zones);
 
     const int zoneCount = zones.size();
     const int windowCount = autotileWindowOrder.size();
@@ -353,7 +353,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateSnapAllWindowEntries(const QSt
     }
 
     QVector<PhosphorZones::Zone*> zones = layout->zones();
-    WindowTrackingService::sortZonesByNumber(zones);
+    PhosphorZones::LayoutUtils::sortZonesByNumber(zones);
 
     // Filter occupancy by the current virtual desktop so windows parked on other
     // desktops don't make zones appear occupied on the current-desktop batch snap.
@@ -442,7 +442,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateRotation(bool clockwise, const
 
         // Get zones sorted by zone number
         QVector<PhosphorZones::Zone*> zones = layout->zones();
-        WindowTrackingService::sortZonesByNumber(zones);
+        PhosphorZones::LayoutUtils::sortZonesByNumber(zones);
 
         // Build zone ID -> index map (with and without braces for format-agnostic matching)
         QHash<QString, int> zoneIdToIndex;


### PR DESCRIPTION
## Summary

- Extract `IWindowTrackingService` (30+ methods) and `IVirtualDesktopManager` interfaces into phosphor-engine-api so both engines depend on LGPL contracts instead of concrete GPL daemon classes
- Move shared POD types (`SnapResult`, `ResnapEntry`, `PendingRestore`, `TilingStateKey`, etc.) to `PhosphorEngineApi::EngineTypes` (LGPL)
- Move `GeometryUtils` (13 functions, 477 LOC) to phosphor-zones library with new `IGeometrySettings` contract
- Move `sortZonesByNumber` / `buildZonePositionMap` to `PhosphorZones::LayoutUtils`
- Move `PerScreenKeys` to phosphor-engine-api, autotile enums to phosphor-tiles, `belongsToPhysicalScreen` to phosphor-screens
- Sever `core/utils.h`, `core/windowtrackingservice.h`, `core/virtualdesktopmanager.h` from both engine source trees entirely
- Replace umbrella `core/interfaces.h` with narrow `core/isettings.h` in snap engine

This is the interface extraction phase of PR 7 (physical engine separation). Both engines now store interface pointers (`IWindowTrackingService*`, `IVirtualDesktopManager*`) instead of concrete daemon types. Zero behavioral changes — all 131 tests pass.

## Test plan

- [x] All 131 unit tests pass (Docker build)
- [x] Build succeeds with no errors or new warnings
- [x] Pre-commit hooks (clang-format, conventional-commit) pass on all commits
- [x] No concrete `WindowTrackingService` or `VirtualDesktopManager` includes remain in either engine source tree
- [ ] Manual smoke test: daemon starts, snap/autotile/navigation work as before

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)