### PR TITLE
fix(engines): explicit cross-engine handoff API + float-toggle routing

### DIFF
--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/IPlacementEngine.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/IPlacementEngine.h
@@ -246,12 +246,89 @@ public:
         return false;
     }
 
-    /// Adopt an untracked window as floating on this engine's screen.
-    /// Used when a window is dragged from one engine's screen to another.
-    virtual void adoptWindowAsFloating(const QString& windowId, const QString& screenId)
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Cross-engine handoff
+    //
+    // When a window crosses screens whose owning engines differ (e.g. a snap
+    // screen → an autotile screen, via drag drop), ownership has to transfer
+    // between two engines. Without an explicit contract, each engine makes
+    // local guesses (autotile's "is this a floating window I should adopt?"
+    // branch, snap's "do I know this window?" early-return) and the daemon
+    // misroutes user intents during the transition window.
+    //
+    // The handoff is a two-step transaction the daemon orchestrates:
+    //   1. fromEngine->handoffRelease(windowId)
+    //   2. toEngine->handoffReceive(ctx)
+    //
+    // Each engine's release is a tracking-only clear (no geometry mutation —
+    // the receiving engine places the window). Each engine's receive applies
+    // its own placement policy (autotile picks an insert slot or floats;
+    // snap picks the nearest zone or floats) using the context fields.
+    //
+    // Engines that don't currently distinguish ownership across screens can
+    // leave both as no-ops; the defaults are safe.
+    //
+    // The verbs are prefixed `handoff*` to keep them distinct from
+    // PlacementEngineBase::releaseWindow (which is part of the base FSM
+    // lifecycle and means "this window is no longer engine-managed at all"
+    // — a different concept from "transferring ownership to another engine").
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    /// Context for a cross-engine window handoff. Populated by the daemon
+    /// from the source engine's state and the drop event before invoking
+    /// handoffReceive on the destination engine.
+    struct HandoffContext
+    {
+        QString windowId;
+        QString fromEngineId; ///< source engine identity ("snap" / "autotile" / "")
+        QString toScreenId; ///< destination screen (must be owned by `to` engine)
+        QPoint dropPos; ///< cursor position at drop, or invalid for non-drag handoffs
+        QRect sourceGeometry; ///< window's frame at handoff time (for size preservation)
+        QStringList sourceZoneIds; ///< zones the window held at source (empty if not snapped)
+        bool wasFloating = false; ///< window was floating in source engine
+    };
+
+    /// Receive ownership of a window from another engine.
+    ///
+    /// Implementations should:
+    /// - Add the window to their own tracking (per-screen/per-state).
+    /// - Decide placement (snap to zone / tile / float) using the context
+    ///   and engine-local policy. Drag drops typically place at dropPos;
+    ///   non-drag handoffs (cross-engine focus changes, programmatic moves)
+    ///   typically respect wasFloating + sourceGeometry.
+    /// - Emit any `windowFloatingChanged` / placement signals their normal
+    ///   placement paths emit, so downstream state stays consistent.
+    ///
+    /// Default is a no-op so engines that don't yet implement the handoff
+    /// don't reject the call — the orchestrator falls back to its legacy path.
+    virtual void handoffReceive(const HandoffContext& ctx)
+    {
+        Q_UNUSED(ctx)
+    }
+
+    /// Release ownership of a window WITHOUT modifying its geometry.
+    ///
+    /// Implementations should:
+    /// - Remove the window from per-screen/per-state tracking.
+    /// - Clear zone assignments (if any) WITHOUT triggering a resnap of
+    ///   neighbours — that's the receiving engine's job once it places the
+    ///   window in its layout.
+    /// - Preserve any pre-tile / pre-float captured geometry that should
+    ///   survive the cross-engine move (the receiving engine may consult
+    ///   it via the HandoffContext for size preservation).
+    ///
+    /// Default is a no-op for the same reason as handoffReceive.
+    virtual void handoffRelease(const QString& windowId)
     {
         Q_UNUSED(windowId)
-        Q_UNUSED(screenId)
+    }
+
+    /// Stable engine identity for HandoffContext.fromEngineId. Conventional
+    /// values: "snap" / "autotile". Empty string means "unidentified" and
+    /// disables receive-side reasoning that depends on the source mode.
+    virtual QString engineId() const
+    {
+        return {};
     }
 
     /// Compute the insert index for a cursor position on a managed screen.

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/IPlacementEngine.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/IPlacementEngine.h
@@ -9,6 +9,7 @@
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QPoint>
+#include <QRect>
 #include <QSet>
 #include <QString>
 #include <QStringList>

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/IPlacementEngine.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/IPlacementEngine.h
@@ -246,6 +246,22 @@ public:
         return false;
     }
 
+    /// Return the screen this engine considers the window to be on, or empty
+    /// if the window isn't tracked by this engine.
+    ///
+    /// The daemon-side shortcut router consults this across engines to resolve
+    /// the active window's current screen for routing decisions (float, focus,
+    /// move). Without it, a cross-engine handoff (e.g. drag-insert from snap
+    /// into autotile) leaves the daemon's screenAssignments lookup empty
+    /// because the source engine has released its tracking, and the next
+    /// shortcut routes to whichever engine the cached focus screen pointed at
+    /// rather than the engine that now owns the window.
+    virtual QString screenForTrackedWindow(const QString& windowId) const
+    {
+        Q_UNUSED(windowId)
+        return {};
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Cross-engine handoff
     //

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -88,6 +88,14 @@ public:
     void saveState() override;
     void loadState() override;
 
+    // Cross-engine handoff
+    QString engineId() const override
+    {
+        return QStringLiteral("snap");
+    }
+    void handoffReceive(const HandoffContext& ctx) override;
+    void handoffRelease(const QString& windowId) override;
+
     /**
      * @brief Resnap windows from previous layout to current layout after layout switch
      *

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -95,6 +95,7 @@ public:
     }
     void handoffReceive(const HandoffContext& ctx) override;
     void handoffRelease(const QString& windowId) override;
+    QString screenForTrackedWindow(const QString& windowId) const override;
 
     /**
      * @brief Resnap windows from previous layout to current layout after layout switch

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -96,6 +96,11 @@ public:
     void handoffReceive(const HandoffContext& ctx) override;
     void handoffRelease(const QString& windowId) override;
     QString screenForTrackedWindow(const QString& windowId) const override;
+    /// Whether this engine considers the window owned (snapped, snap-floated,
+    /// or otherwise carried in SnapState's screen/zone maps). Used by the
+    /// daemon to disambiguate which engine should handle a shortcut and to
+    /// decide whether a cross-engine handoff is needed.
+    bool isWindowTracked(const QString& windowId) const override;
 
     /**
      * @brief Resnap windows from previous layout to current layout after layout switch

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
@@ -107,6 +107,14 @@ public:
 
     void setFloating(const QString& windowId, bool floating);
 
+    /// Mark a window floating AND record its screen+desktop without a zone.
+    /// Used by cross-engine handoff when the snap engine adopts a floating
+    /// window from another engine — the screen entry is what makes the snap
+    /// engine answerable for "where does this window live" lookups
+    /// (screenAssignments / screenForTrackedWindow) so future shortcut
+    /// routing reaches this engine.
+    void setFloatingOnScreen(const QString& windowId, const QString& screenId, int virtualDesktop);
+
     /// Save zone assignment before floating for later restore.
     UnassignResult unsnapForFloat(const QString& windowId);
     QString preFloatZone(const QString& windowId) const;
@@ -267,6 +275,15 @@ Q_SIGNALS:
 
 private:
     bool removeWindowData(const QString& windowId);
+
+    /// Shared body of unassignWindow / unsnapForFloat. Removes the window's
+    /// zone assignment and (optionally) its screen+desktop assignment, clears
+    /// the last-used-zone tracker if it referenced one of the removed zones,
+    /// and emits the windowUnassigned/stateChanged signals.
+    /// `preserveScreenAndDesktop` keeps the screen + desktop assignment maps
+    /// intact — used by unsnapForFloat so the snap engine still knows which
+    /// screen the now-floating window lives on.
+    UnassignResult clearZoneAssignment(const QString& windowId, bool preserveScreenAndDesktop);
 
     QSet<QString> allManagedWindowIds() const
     {

--- a/libs/phosphor-snap-engine/src/SnapState.cpp
+++ b/libs/phosphor-snap-engine/src/SnapState.cpp
@@ -283,7 +283,32 @@ SnapState::UnassignResult SnapState::unsnapForFloat(const QString& windowId)
             m_preFloatScreenAssignments[windowId] = screen;
         }
     }
-    return unassignWindow(windowId);
+
+    // Float-from-snap clears the zone assignment but PRESERVES the screen
+    // (and desktop) assignment. The window is still on that screen — it's
+    // just floating instead of snapped to a zone. Erasing the screen
+    // assignment leaves the daemon's "what screen does this window live on"
+    // lookups (e.g. lastActiveScreenName) with no answer for a window that
+    // unambiguously lives on a known screen, and routing then falls through
+    // to a stale cached value — for the float toggle, that misroutes the
+    // unfloat to whichever engine the cache points at (e.g. autotile on the
+    // source VS) instead of the snap engine that owns this screen.
+    UnassignResult result;
+    QStringList previousZones = m_windowZoneAssignments.value(windowId);
+    if (!m_windowZoneAssignments.remove(windowId)) {
+        return result;
+    }
+    result.wasAssigned = true;
+    if (!m_lastUsedZoneId.isEmpty() && previousZones.contains(m_lastUsedZoneId)) {
+        m_lastUsedZoneId.clear();
+        m_lastUsedScreenId.clear();
+        m_lastUsedZoneClass.clear();
+        m_lastUsedDesktop = 0;
+        result.lastUsedZoneCleared = true;
+    }
+    Q_EMIT windowUnassigned(windowId);
+    Q_EMIT stateChanged();
+    return result;
 }
 
 QString SnapState::preFloatScreen(const QString& windowId) const

--- a/libs/phosphor-snap-engine/src/SnapState.cpp
+++ b/libs/phosphor-snap-engine/src/SnapState.cpp
@@ -184,14 +184,21 @@ void SnapState::assignWindowToZones(const QString& windowId, const QStringList& 
 
 SnapState::UnassignResult SnapState::unassignWindow(const QString& windowId)
 {
+    return clearZoneAssignment(windowId, /*preserveScreenAndDesktop=*/false);
+}
+
+SnapState::UnassignResult SnapState::clearZoneAssignment(const QString& windowId, bool preserveScreenAndDesktop)
+{
     UnassignResult result;
     QStringList previousZones = m_windowZoneAssignments.value(windowId);
     if (!m_windowZoneAssignments.remove(windowId)) {
         return result;
     }
     result.wasAssigned = true;
-    m_windowScreenAssignments.remove(windowId);
-    m_windowDesktopAssignments.remove(windowId);
+    if (!preserveScreenAndDesktop) {
+        m_windowScreenAssignments.remove(windowId);
+        m_windowDesktopAssignments.remove(windowId);
+    }
     if (!m_lastUsedZoneId.isEmpty() && previousZones.contains(m_lastUsedZoneId)) {
         m_lastUsedZoneId.clear();
         m_lastUsedScreenId.clear();
@@ -273,6 +280,30 @@ void SnapState::setFloating(const QString& windowId, bool floating)
     }
 }
 
+void SnapState::setFloatingOnScreen(const QString& windowId, const QString& screenId, int virtualDesktop)
+{
+    if (windowId.isEmpty() || screenId.isEmpty()) {
+        return;
+    }
+    bool changed = false;
+    if (!m_floatingWindows.contains(windowId)) {
+        m_floatingWindows.insert(windowId);
+        changed = true;
+    }
+    if (m_windowScreenAssignments.value(windowId) != screenId) {
+        m_windowScreenAssignments[windowId] = screenId;
+        changed = true;
+    }
+    if (m_windowDesktopAssignments.value(windowId, -1) != virtualDesktop) {
+        m_windowDesktopAssignments[windowId] = virtualDesktop;
+        changed = true;
+    }
+    if (changed) {
+        Q_EMIT floatingChanged(windowId, true);
+        Q_EMIT stateChanged();
+    }
+}
+
 SnapState::UnassignResult SnapState::unsnapForFloat(const QString& windowId)
 {
     const auto zones = zonesForWindow(windowId);
@@ -293,22 +324,7 @@ SnapState::UnassignResult SnapState::unsnapForFloat(const QString& windowId)
     // to a stale cached value — for the float toggle, that misroutes the
     // unfloat to whichever engine the cache points at (e.g. autotile on the
     // source VS) instead of the snap engine that owns this screen.
-    UnassignResult result;
-    QStringList previousZones = m_windowZoneAssignments.value(windowId);
-    if (!m_windowZoneAssignments.remove(windowId)) {
-        return result;
-    }
-    result.wasAssigned = true;
-    if (!m_lastUsedZoneId.isEmpty() && previousZones.contains(m_lastUsedZoneId)) {
-        m_lastUsedZoneId.clear();
-        m_lastUsedScreenId.clear();
-        m_lastUsedZoneClass.clear();
-        m_lastUsedDesktop = 0;
-        result.lastUsedZoneCleared = true;
-    }
-    Q_EMIT windowUnassigned(windowId);
-    Q_EMIT stateChanged();
-    return result;
+    return clearZoneAssignment(windowId, /*preserveScreenAndDesktop=*/true);
 }
 
 QString SnapState::preFloatScreen(const QString& windowId) const

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -195,10 +195,14 @@ void SnapEngine::handoffReceive(const HandoffContext& ctx)
         }
     }
 
-    // Floating placement: keep the snap state in sync (so future float toggles
-    // route back to this engine via lastActiveScreenName's screenAssignment
-    // lookup) but don't apply geometry here — the dropping caller already
-    // committed the position.
+    // Floating placement: record the window in snap state as floating-on-screen
+    // so future shortcut routing (lastActiveScreenName via screenAssignments
+    // and screenForTrackedWindow) reaches this engine. Don't apply geometry
+    // here — the dropping caller already committed the position.
+    const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    m_snapState->setFloatingOnScreen(ctx.windowId, ctx.toScreenId, currentDesktop);
+    // Mirror floating state into WTS so cross-engine readers (autotile,
+    // adaptors) see a consistent flag.
     m_windowTracker->setWindowFloating(ctx.windowId, true);
     Q_EMIT windowFloatingChanged(ctx.windowId, true, ctx.toScreenId);
 }
@@ -241,6 +245,17 @@ QString SnapEngine::screenForTrackedWindow(const QString& windowId) const
     // screenAssignments map; an empty string means the snap engine doesn't
     // currently track this window at all.
     return m_snapState->screenAssignments().value(windowId);
+}
+
+bool SnapEngine::isWindowTracked(const QString& windowId) const
+{
+    // The snap engine considers a window "tracked" if it appears in any of
+    // the SnapState maps that imply ownership: zone assignment (snapped),
+    // screen assignment (covers snap-floated post-unsnapForFloat), or the
+    // floating set. Any of those means a snap-engine shortcut routes to
+    // this engine and would be a no-op without our intervention.
+    return m_snapState->isWindowSnapped(windowId) || m_snapState->isFloating(windowId)
+        || m_snapState->screenAssignments().contains(windowId);
 }
 
 } // namespace PlasmaZones

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -210,15 +210,27 @@ void SnapEngine::handoffRelease(const QString& windowId)
     }
     qCInfo(PhosphorSnapEngine::lcSnapEngine) << "SnapEngine::handoffRelease:" << windowId;
 
-    // Tracking-only release: drop the zone/screen/desktop entries so the
-    // receiving engine sees a clean slate, but do NOT mutate geometry.
-    // pre-float / pre-tile captures are intentionally preserved — the receive
-    // side may consult them via the HandoffContext for size restoration.
+    // Tracking-only release: drop snap-engine-private state directly without
+    // routing through WindowTrackingService. WTS is the shared coordination
+    // layer that BOTH engines react to via signals — calling its
+    // unassignWindow / setWindowFloating from here would propagate state
+    // changes back into the autotile engine that just took ownership,
+    // causing it to drop the freshly-adopted window mid-handoff (the
+    // drag-insert-from-snap-to-autotile bug).
+    //
+    // The daemon orchestrator owns the shared WTS-side floating-flag
+    // transitions during a cross-engine handoff (see Daemon::
+    // syncAutotileFloatStatePassive); this method only clears what's
+    // private to the snap engine.
+    //
+    // pre-float / pre-tile captures are intentionally preserved — the
+    // receive side may consult them via the HandoffContext for size
+    // restoration on a future handoff back.
     if (m_snapState->isWindowSnapped(windowId)) {
-        m_windowTracker->unassignWindow(windowId);
+        m_snapState->unassignWindow(windowId);
     }
     if (m_snapState->isFloating(windowId)) {
-        m_windowTracker->setWindowFloating(windowId, false);
+        m_snapState->setFloating(windowId, false);
     }
 }
 

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -159,4 +159,67 @@ UnfloatResult SnapEngine::resolveUnfloatGeometry(const QString& windowId, const 
     return result;
 }
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// Cross-engine handoff (see IPlacementEngine.h for contract)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+void SnapEngine::handoffReceive(const HandoffContext& ctx)
+{
+    if (ctx.windowId.isEmpty() || ctx.toScreenId.isEmpty()) {
+        return;
+    }
+    qCInfo(PhosphorSnapEngine::lcSnapEngine) << "SnapEngine::handoffReceive:" << ctx.windowId << "to" << ctx.toScreenId
+                                             << "from" << ctx.fromEngineId << "wasFloating=" << ctx.wasFloating;
+
+    // Snap-engine policy on receive:
+    //  - If the source had a snap zone (sourceZoneIds non-empty) AND this
+    //    engine knows that zone in the destination screen's layout, restore
+    //    the snap. Useful for same-mode cross-screen moves where the layouts
+    //    happen to share a zone id.
+    //  - Otherwise, treat as floating on the destination screen — preserves
+    //    the user's geometry (sourceGeometry) and lets them drop-snap or use
+    //    the float toggle to land in a zone explicitly. This intentionally
+    //    matches the "drop on snap screen with no zone hit" behaviour rather
+    //    than auto-snapping to a guessed zone.
+    if (!ctx.sourceZoneIds.isEmpty()) {
+        QRect zoneGeo = m_windowTracker->resolveZoneGeometry(ctx.sourceZoneIds, ctx.toScreenId);
+        if (zoneGeo.isValid()) {
+            if (ctx.sourceZoneIds.size() > 1) {
+                commitMultiZoneSnap(ctx.windowId, ctx.sourceZoneIds, ctx.toScreenId, SnapIntent::UserInitiated);
+            } else {
+                commitSnap(ctx.windowId, ctx.sourceZoneIds.first(), ctx.toScreenId, SnapIntent::UserInitiated);
+            }
+            Q_EMIT applyGeometryRequested(ctx.windowId, zoneGeo.x(), zoneGeo.y(), zoneGeo.width(), zoneGeo.height(),
+                                          QString(), ctx.toScreenId, false);
+            return;
+        }
+    }
+
+    // Floating placement: keep the snap state in sync (so future float toggles
+    // route back to this engine via lastActiveScreenName's screenAssignment
+    // lookup) but don't apply geometry here — the dropping caller already
+    // committed the position.
+    m_windowTracker->setWindowFloating(ctx.windowId, true);
+    Q_EMIT windowFloatingChanged(ctx.windowId, true, ctx.toScreenId);
+}
+
+void SnapEngine::handoffRelease(const QString& windowId)
+{
+    if (windowId.isEmpty()) {
+        return;
+    }
+    qCInfo(PhosphorSnapEngine::lcSnapEngine) << "SnapEngine::handoffRelease:" << windowId;
+
+    // Tracking-only release: drop the zone/screen/desktop entries so the
+    // receiving engine sees a clean slate, but do NOT mutate geometry.
+    // pre-float / pre-tile captures are intentionally preserved — the receive
+    // side may consult them via the HandoffContext for size restoration.
+    if (m_snapState->isWindowSnapped(windowId)) {
+        m_windowTracker->unassignWindow(windowId);
+    }
+    if (m_snapState->isFloating(windowId)) {
+        m_windowTracker->setWindowFloating(windowId, false);
+    }
+}
+
 } // namespace PlasmaZones

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -234,4 +234,13 @@ void SnapEngine::handoffRelease(const QString& windowId)
     }
 }
 
+QString SnapEngine::screenForTrackedWindow(const QString& windowId) const
+{
+    // SnapState stores the screen for both snapped and (post-prior-fix)
+    // floating windows that originated as snaps. Either populates the
+    // screenAssignments map; an empty string means the snap engine doesn't
+    // currently track this window at all.
+    return m_snapState->screenAssignments().value(windowId);
+}
+
 } // namespace PlasmaZones

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -432,15 +432,13 @@ public:
         m_isWindowFloatingFn = std::move(fn);
     }
 
-    /**
-     * @brief Adopt an untracked window as floating on an autotile screen
-     *
-     * Used when a window is dragged from a snap screen to an autotile screen.
-     * Adds the window to the PhosphorTiles::TilingState as floating so subsequent
-     * toggleWindowFloat/setWindowFloat calls can find and manage it.
-     * No-op if the window is already tracked or the screen isn't autotile.
-     */
-    void adoptWindowAsFloating(const QString& windowId, const QString& screenId) override;
+    // Cross-engine handoff (see PhosphorEngineApi/IPlacementEngine.h for contract)
+    QString engineId() const override
+    {
+        return QStringLiteral("autotile");
+    }
+    void handoffReceive(const HandoffContext& ctx) override;
+    void handoffRelease(const QString& windowId) override;
 
     /**
      * @brief Serialize per-context autotile window orders to JSON

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -439,6 +439,11 @@ public:
     }
     void handoffReceive(const HandoffContext& ctx) override;
     void handoffRelease(const QString& windowId) override;
+    QString screenForTrackedWindow(const QString& windowId) const override
+    {
+        const auto it = m_windowToStateKey.constFind(canonicalizeForLookup(windowId));
+        return it == m_windowToStateKey.constEnd() ? QString() : it.value().screenId;
+    }
 
     /**
      * @brief Serialize per-context autotile window orders to JSON

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/NavigationController.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/NavigationController.h
@@ -48,9 +48,15 @@ public:
 
     void swapFocusedWithMaster();
     void rotateWindowOrder(bool clockwise);
-    void swapFocusedInDirection(const QString& direction, const QString& action);
-    void focusInDirection(const QString& direction, const QString& action);
-    void moveFocusedToPosition(int position);
+    /// `explicitWindowId` (when non-empty) overrides the state's internal
+    /// focusedWindow() for the operation. The IPlacementEngine virtual-method
+    /// overrides on AutotileEngine pass `ctx.windowId` here so navigation
+    /// follows the daemon's authoritative focus tracking even when the
+    /// engine's per-state focusedWindow tracker is stale.
+    void swapFocusedInDirection(const QString& direction, const QString& action,
+                                const QString& explicitWindowId = QString());
+    void focusInDirection(const QString& direction, const QString& action, const QString& explicitWindowId = QString());
+    void moveFocusedToPosition(int position, const QString& explicitWindowId = QString());
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Split ratio adjustment
@@ -90,9 +96,15 @@ private:
     void emitFocusRequestAtIndex(int indexOffset, bool useFirst = false);
 
     /**
-     * @brief Helper to get tiled windows and state for focus operations
+     * @brief Helper to get tiled windows and state for focus operations.
+     *
+     * When `explicitWindowId` is non-empty, locate the state that contains
+     * that window first — the daemon may know the true focused window even
+     * when the engine's per-state focusedWindow() tracker is stale. Falls
+     * through to the focused-screen lookup if the window isn't in any state.
      */
-    QStringList tiledWindowsForFocusedScreen(QString& outScreenId, PhosphorTiles::TilingState*& outState);
+    QStringList tiledWindowsForFocusedScreen(QString& outScreenId, PhosphorTiles::TilingState*& outState,
+                                             const QString& explicitWindowId = QString());
 
     /**
      * @brief Helper to apply an operation to all screen states

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -1888,29 +1888,23 @@ void AutotileEngine::toggleWindowFloat(const QString& rawWindowId, const QString
     }
 
     if (!state) {
-        // Window not tracked by autotile — if it's floating (daemon-side) on an autotile
-        // screen, adopt it into the tiling layout. This handles the flow:
-        // float on snap screen → move to autotile screen → toggle float to tile.
-        // The windowFloating flag is checked via the callback to avoid coupling to WTS.
-        if (isAutotileScreen(screenId) && m_isWindowFloatingFn && m_isWindowFloatingFn(windowId)) {
-            state = tilingStateForScreen(screenId);
-            if (state && !state->containsWindow(windowId)) {
-                state->addWindow(windowId);
-                state->setFloating(windowId, true);
-                m_windowToStateKey[windowId] = currentKeyForScreen(screenId);
-                resolvedScreen = screenId;
-                qCInfo(PhosphorTileEngine::lcTileEngine)
-                    << "toggleWindowFloat: adopted floating window" << windowId << "into autotile on" << screenId;
-                // Fall through to performToggleFloat which will unfloat it
-            }
-        }
-        if (!state) {
-            qCWarning(PhosphorTileEngine::lcTileEngine)
-                << "toggleWindowFloat: window" << windowId << "not found in any autotile state";
-            Q_EMIT navigationFeedback(false, QStringLiteral("float"), QStringLiteral("window_not_tracked"), QString(),
-                                      QString(), screenId);
-            return;
-        }
+        // Window not tracked by autotile. The opportunistic "is this a
+        // floating window I should adopt?" branch that used to live here
+        // was the second-order accomplice in a class of cross-engine
+        // misroute bugs: if the daemon's lastActiveScreen pointed at an
+        // autotile screen while the window actually lived on a snap screen
+        // (because snap had cleared its tracking on float), this branch
+        // would silently grab the floating window and tile it on the wrong
+        // screen.
+        //
+        // Cross-engine handoff now goes through the explicit
+        // receiveWindow/releaseWindow contract orchestrated by the daemon
+        // — this path is purely "no-op when the window isn't ours".
+        qCWarning(PhosphorTileEngine::lcTileEngine)
+            << "toggleWindowFloat: window" << windowId << "not found in any autotile state";
+        Q_EMIT navigationFeedback(false, QStringLiteral("float"), QStringLiteral("window_not_tracked"), QString(),
+                                  QString(), screenId);
+        return;
     }
 
     performToggleFloat(state, windowId, resolvedScreen);
@@ -1929,23 +1923,69 @@ void AutotileEngine::performToggleFloat(PhosphorTiles::TilingState* state, const
     Q_EMIT windowFloatingChanged(windowId, isNowFloating, screenId);
 }
 
-void AutotileEngine::adoptWindowAsFloating(const QString& windowId, const QString& screenId)
+// ═══════════════════════════════════════════════════════════════════════════════
+// Cross-engine handoff (see IPlacementEngine.h for contract)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+void AutotileEngine::handoffReceive(const HandoffContext& ctx)
 {
-    if (windowId.isEmpty() || screenId.isEmpty() || !isAutotileScreen(screenId)) {
+    if (ctx.windowId.isEmpty() || ctx.toScreenId.isEmpty() || !isAutotileScreen(ctx.toScreenId)) {
         return;
     }
-    // Already tracked — nothing to adopt
-    if (m_windowToStateKey.contains(windowId)) {
+    qCInfo(PhosphorTileEngine::lcTileEngine)
+        << "AutotileEngine::handoffReceive:" << ctx.windowId << "to" << ctx.toScreenId << "from" << ctx.fromEngineId
+        << "wasFloating=" << ctx.wasFloating;
+
+    const QString windowId = canonicalizeWindowId(ctx.windowId);
+
+    PhosphorTiles::TilingState* state = tilingStateForScreen(ctx.toScreenId);
+    if (!state) {
         return;
     }
-    PhosphorTiles::TilingState* state = tilingStateForScreen(screenId);
-    if (!state || state->containsWindow(windowId)) {
+
+    // Already tracked — nothing to adopt; the float toggle path is what the
+    // caller probably wants instead.
+    if (m_windowToStateKey.contains(windowId) && state->containsWindow(windowId)) {
         return;
     }
+
     state->addWindow(windowId);
-    state->setFloating(windowId, true);
-    m_windowToStateKey[windowId] = currentKeyForScreen(screenId);
-    qCInfo(PhosphorTileEngine::lcTileEngine) << "adoptWindowAsFloating:" << windowId << "on" << screenId;
+    // Autotile-engine policy on receive: a window arriving as "floating in
+    // the source" stays floating here too — drag-from-snap typically falls
+    // into this branch, and the user's drop position is where they want it.
+    // A non-floating arrival gets tiled (the layout engine picks the slot)
+    // — drag-from-another-autotile-screen typically falls here.
+    state->setFloating(windowId, ctx.wasFloating);
+    m_windowToStateKey[windowId] = currentKeyForScreen(ctx.toScreenId);
+
+    // Trigger a retile so a non-floating arrival actually lands in a tile;
+    // floating arrivals retile too because their displacement may free a
+    // slot for the remaining tiled set.
+    retileAfterOperation(ctx.toScreenId, true);
+}
+
+void AutotileEngine::handoffRelease(const QString& windowId)
+{
+    if (windowId.isEmpty()) {
+        return;
+    }
+    const QString canonical = canonicalizeWindowId(windowId);
+    qCInfo(PhosphorTileEngine::lcTileEngine) << "AutotileEngine::handoffRelease:" << canonical;
+
+    auto it = m_windowToStateKey.constFind(canonical);
+    if (it == m_windowToStateKey.constEnd()) {
+        return; // Not ours; nothing to release.
+    }
+    const auto key = it.value();
+    auto stateIt = m_screenStates.find(key);
+    if (stateIt != m_screenStates.end() && stateIt.value()) {
+        // Tracking-only release: drop from layout, drop from floating set.
+        // No retile of the rest is requested here — the orchestrator will
+        // call receiveWindow on the destination engine which (if also
+        // autotile) will retile its own state.
+        stateIt.value()->removeWindow(canonical);
+    }
+    m_windowToStateKey.remove(canonical);
 }
 
 void AutotileEngine::setWindowFloat(const QString& rawWindowId, bool shouldFloat)
@@ -3748,8 +3788,22 @@ void AutotileEngine::snapAllWindows(const NavigationContext& ctx)
     retile(ctx.screenId);
 }
 
-void AutotileEngine::toggleFocusedFloat(const NavigationContext& /*ctx*/)
+void AutotileEngine::toggleFocusedFloat(const NavigationContext& ctx)
 {
+    // Prefer the daemon-provided windowId from KWin's authoritative focus
+    // tracking. The legacy toggleFocusedWindowFloat() uses state->focusedWindow()
+    // which is updated only when KWin emits windowActivated for an
+    // autotile-tracked window — focus moves through floating, snapped, or
+    // never-tracked windows leave it stale, and the next float shortcut then
+    // toggles the wrong window.
+    //
+    // Fall back to the legacy "find a focused state" lookup only when ctx
+    // doesn't carry a windowId (some test paths and direct invocations).
+    if (!ctx.windowId.isEmpty()) {
+        const QString screenId = ctx.screenId.isEmpty() ? m_activeScreen : ctx.screenId;
+        toggleWindowFloat(ctx.windowId, screenId);
+        return;
+    }
     toggleFocusedWindowFloat();
 }
 

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -1898,7 +1898,7 @@ void AutotileEngine::toggleWindowFloat(const QString& rawWindowId, const QString
         // screen.
         //
         // Cross-engine handoff now goes through the explicit
-        // receiveWindow/releaseWindow contract orchestrated by the daemon
+        // handoffReceive/handoffRelease contract orchestrated by the daemon
         // — this path is purely "no-op when the window isn't ours".
         qCWarning(PhosphorTileEngine::lcTileEngine)
             << "toggleWindowFloat: window" << windowId << "not found in any autotile state";
@@ -1943,10 +1943,21 @@ void AutotileEngine::handoffReceive(const HandoffContext& ctx)
         return;
     }
 
-    // Already tracked — nothing to adopt; the float toggle path is what the
-    // caller probably wants instead.
-    if (m_windowToStateKey.contains(windowId) && state->containsWindow(windowId)) {
+    // Already tracked on the destination screen — nothing to adopt; the float
+    // toggle path is what the caller probably wants instead.
+    const auto destKey = currentKeyForScreen(ctx.toScreenId);
+    const auto trackedKeyIt = m_windowToStateKey.constFind(windowId);
+    if (trackedKeyIt != m_windowToStateKey.constEnd() && trackedKeyIt.value() == destKey
+        && state->containsWindow(windowId)) {
         return;
+    }
+    // Already tracked but on a DIFFERENT autotile state (cross-screen
+    // handoff inside the same engine, or stale tracking after an aborted
+    // prior handoff). Release the previous state first to avoid orphaning
+    // the entry — handoffRelease is the correct primitive for "drop
+    // tracking without mutating geometry" within this engine too.
+    if (trackedKeyIt != m_windowToStateKey.constEnd() && trackedKeyIt.value() != destKey) {
+        handoffRelease(windowId);
     }
 
     state->addWindow(windowId);
@@ -3748,27 +3759,31 @@ void AutotileEngine::setFocusNewWindows(bool enabled)
 // concrete AutotileEngine method with the right parameters.
 // ═══════════════════════════════════════════════════════════════════════════════
 
-void AutotileEngine::focusInDirection(const QString& direction, const NavigationContext& /*ctx*/)
+void AutotileEngine::focusInDirection(const QString& direction, const NavigationContext& ctx)
 {
-    focusInDirection(direction, QStringLiteral("focus"));
+    // Daemon-authoritative windowId overrides the per-state focusedWindow()
+    // tracker, which can drift when focus moves through floating, snapped, or
+    // never-tracked windows that don't update it (same root cause as the
+    // toggleFocusedFloat fix).
+    m_navigation->focusInDirection(direction, QStringLiteral("focus"), canonicalizeForLookup(ctx.windowId));
 }
 
-void AutotileEngine::moveFocusedInDirection(const QString& direction, const NavigationContext& /*ctx*/)
+void AutotileEngine::moveFocusedInDirection(const QString& direction, const NavigationContext& ctx)
 {
     // In autotile, "move in direction" is implemented as swap-with-neighbour
     // in the tiling order — the only way to move is to trade places with
     // the neighbour. OSD label "move" keeps the user-facing wording.
-    swapFocusedInDirection(direction, QStringLiteral("move"));
+    m_navigation->swapFocusedInDirection(direction, QStringLiteral("move"), canonicalizeForLookup(ctx.windowId));
 }
 
-void AutotileEngine::swapFocusedInDirection(const QString& direction, const NavigationContext& /*ctx*/)
+void AutotileEngine::swapFocusedInDirection(const QString& direction, const NavigationContext& ctx)
 {
-    swapFocusedInDirection(direction, QStringLiteral("swap"));
+    m_navigation->swapFocusedInDirection(direction, QStringLiteral("swap"), canonicalizeForLookup(ctx.windowId));
 }
 
-void AutotileEngine::moveFocusedToPosition(int position, const NavigationContext& /*ctx*/)
+void AutotileEngine::moveFocusedToPosition(int position, const NavigationContext& ctx)
 {
-    moveFocusedToPosition(position);
+    m_navigation->moveFocusedToPosition(position, canonicalizeForLookup(ctx.windowId));
 }
 
 void AutotileEngine::rotateWindows(bool clockwise, const NavigationContext& ctx)
@@ -3807,10 +3822,10 @@ void AutotileEngine::toggleFocusedFloat(const NavigationContext& ctx)
     toggleFocusedWindowFloat();
 }
 
-void AutotileEngine::cycleFocus(bool forward, const NavigationContext& /*ctx*/)
+void AutotileEngine::cycleFocus(bool forward, const NavigationContext& ctx)
 {
     const QString dir = forward ? QStringLiteral("right") : QStringLiteral("left");
-    focusInDirection(dir, QStringLiteral("cycle"));
+    m_navigation->focusInDirection(dir, QStringLiteral("cycle"), canonicalizeForLookup(ctx.windowId));
 }
 
 void AutotileEngine::pushToEmptyZone(const NavigationContext& /*ctx*/)
@@ -3820,10 +3835,17 @@ void AutotileEngine::pushToEmptyZone(const NavigationContext& /*ctx*/)
     // becomes a harmless press in autotile mode.
 }
 
-void AutotileEngine::restoreFocusedWindow(const NavigationContext& /*ctx*/)
+void AutotileEngine::restoreFocusedWindow(const NavigationContext& ctx)
 {
     // "Restore" in autotile means pulling the focused window out of the
     // tiling layout — toggling its float state achieves exactly that.
+    // Same daemon-authoritative routing as toggleFocusedFloat: prefer
+    // ctx.windowId over the engine's per-state focusedWindow() tracker.
+    if (!ctx.windowId.isEmpty()) {
+        const QString screenId = ctx.screenId.isEmpty() ? m_activeScreen : ctx.screenId;
+        toggleWindowFloat(ctx.windowId, screenId);
+        return;
+    }
     toggleFocusedWindowFloat();
 }
 

--- a/libs/phosphor-tile-engine/src/NavigationController.cpp
+++ b/libs/phosphor-tile-engine/src/NavigationController.cpp
@@ -116,13 +116,14 @@ void NavigationController::rotateWindowOrder(bool clockwise)
     qCInfo(PhosphorTileEngine::lcTileEngine) << "Rotated windows" << (clockwise ? "clockwise" : "counterclockwise");
 }
 
-void NavigationController::swapFocusedInDirection(const QString& direction, const QString& action)
+void NavigationController::swapFocusedInDirection(const QString& direction, const QString& action,
+                                                  const QString& explicitWindowId)
 {
     const bool forward = (direction == QLatin1String("right") || direction == QLatin1String("down"));
 
     QString screenId;
     PhosphorTiles::TilingState* state = nullptr;
-    const QStringList windows = tiledWindowsForFocusedScreen(screenId, state);
+    const QStringList windows = tiledWindowsForFocusedScreen(screenId, state, explicitWindowId);
 
     if (windows.size() < 2 || !state) {
         Q_EMIT m_engine->navigationFeedback(false, action, QStringLiteral("nothing_to_swap"), QString(), QString(),
@@ -130,7 +131,7 @@ void NavigationController::swapFocusedInDirection(const QString& direction, cons
         return;
     }
 
-    const QString focused = state->focusedWindow();
+    const QString focused = !explicitWindowId.isEmpty() ? explicitWindowId : state->focusedWindow();
     if (focused.isEmpty()) {
         Q_EMIT m_engine->navigationFeedback(false, action, QStringLiteral("no_focus"), QString(), QString(), screenId);
         return;
@@ -157,13 +158,14 @@ void NavigationController::swapFocusedInDirection(const QString& direction, cons
     Q_EMIT m_engine->navigationFeedback(swapped, action, direction, QString(), QString(), screenId);
 }
 
-void NavigationController::focusInDirection(const QString& direction, const QString& action)
+void NavigationController::focusInDirection(const QString& direction, const QString& action,
+                                            const QString& explicitWindowId)
 {
     const bool forward = (direction == QLatin1String("right") || direction == QLatin1String("down"));
 
     QString screenId;
     PhosphorTiles::TilingState* state = nullptr;
-    const QStringList windows = tiledWindowsForFocusedScreen(screenId, state);
+    const QStringList windows = tiledWindowsForFocusedScreen(screenId, state, explicitWindowId);
 
     if (windows.isEmpty() || !state) {
         Q_EMIT m_engine->navigationFeedback(false, action, QStringLiteral("no_windows"), QString(), QString(),
@@ -171,7 +173,7 @@ void NavigationController::focusInDirection(const QString& direction, const QStr
         return;
     }
 
-    const QString focused = state->focusedWindow();
+    const QString focused = !explicitWindowId.isEmpty() ? explicitWindowId : state->focusedWindow();
     const int currentIndex = qMax(0, windows.indexOf(focused));
     const int targetIndex = (currentIndex + (forward ? 1 : -1) + windows.size()) % windows.size();
 
@@ -179,11 +181,11 @@ void NavigationController::focusInDirection(const QString& direction, const QStr
     Q_EMIT m_engine->navigationFeedback(true, action, direction, QString(), QString(), screenId);
 }
 
-void NavigationController::moveFocusedToPosition(int position)
+void NavigationController::moveFocusedToPosition(int position, const QString& explicitWindowId)
 {
     QString screenId;
     PhosphorTiles::TilingState* state = nullptr;
-    const QStringList windows = tiledWindowsForFocusedScreen(screenId, state);
+    const QStringList windows = tiledWindowsForFocusedScreen(screenId, state, explicitWindowId);
 
     if (windows.isEmpty() || !state) {
         Q_EMIT m_engine->navigationFeedback(false, QStringLiteral("snap"), QStringLiteral("no_windows"), QString(),
@@ -191,7 +193,7 @@ void NavigationController::moveFocusedToPosition(int position)
         return;
     }
 
-    const QString focused = state->focusedWindow();
+    const QString focused = !explicitWindowId.isEmpty() ? explicitWindowId : state->focusedWindow();
     if (focused.isEmpty()) {
         Q_EMIT m_engine->navigationFeedback(false, QStringLiteral("snap"), QStringLiteral("no_focus"), QString(),
                                             QString(), screenId);
@@ -368,9 +370,31 @@ void NavigationController::emitFocusRequestAtIndex(int indexOffset, bool useFirs
 }
 
 QStringList NavigationController::tiledWindowsForFocusedScreen(QString& outScreenId,
-                                                               PhosphorTiles::TilingState*& outState)
+                                                               PhosphorTiles::TilingState*& outState,
+                                                               const QString& explicitWindowId)
 {
     outState = nullptr;
+
+    // Authoritative path: when the daemon supplied a windowId (KWin's live
+    // focus), find the state that actually contains that window. The engine's
+    // per-state focusedWindow() tracker may be stale because focus moved
+    // through floating, snapped, or never-tracked windows that don't update
+    // it — using the daemon's value avoids operating on the wrong window.
+    if (!explicitWindowId.isEmpty()) {
+        for (auto it = m_engine->m_screenStates.constBegin(); it != m_engine->m_screenStates.constEnd(); ++it) {
+            if (it.key().desktop != m_engine->m_currentDesktop || it.key().activity != m_engine->m_currentActivity) {
+                continue;
+            }
+            PhosphorTiles::TilingState* state = it.value();
+            if (state && state->containsWindow(explicitWindowId)) {
+                outScreenId = it.key().screenId;
+                outState = state;
+                return state->tiledWindows();
+            }
+        }
+        // Fall through to focused-screen lookup if the explicit window isn't
+        // tracked by autotile — caller will surface no_focus / no_windows.
+    }
 
     // Use the tracked active screen (set by onWindowFocused) to avoid
     // non-deterministic QHash iteration when multiple screens have focused windows

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -734,22 +734,15 @@ void Daemon::syncAutotileFloatStatePassive(const QString& windowId, bool floatin
     }
     WindowTrackingService* wts = m_windowTrackingAdaptor->service();
     // Cross-engine handoff: this signal fires when autotile has just taken
-    // ownership of a window that may still be tracked by snap. If snap still
-    // has zone/screen assignments for the window, releasing them here is the
-    // missing half of the handoff — without it, the daemon's float router
-    // (lastActiveScreenName via screenAssignments) would still resolve to
-    // snap on the source screen, and the next float toggle would float the
-    // window back to its old snap zone instead of operating on its new
-    // autotile placement. Drag-drop from snap → autotile is the canonical
-    // case; the cancellation paths (handoffRelease is no-op when the engine
-    // doesn't track the window) make this safe to call unconditionally.
-    if (m_snapEngine && (wts->isWindowSnapped(windowId) || wts->isWindowFloating(windowId))) {
-        const QString snapScreen = wts->screenAssignments().value(windowId);
-        if (!snapScreen.isEmpty() && snapScreen != screenId) {
-            qCInfo(lcDaemon) << "Cross-engine handoff: releasing snap state for" << windowId << "(snap screen"
-                             << snapScreen << "→ autotile screen" << screenId << ")";
-            m_snapEngine->handoffRelease(windowId);
-        }
+    // ownership of a window that may still be tracked by snap. handoffRelease
+    // is a no-op when the engine doesn't track the window, so we can call it
+    // unconditionally — that closes the loophole where snap thought the
+    // window was on the same screen ID as the autotile target (stale state
+    // mid-mode-switch) and the previous gated path skipped cleanup.
+    if (m_snapEngine && m_snapEngine->isWindowTracked(windowId)) {
+        qCInfo(lcDaemon) << "Cross-engine handoff: releasing snap state for" << windowId << "(autotile screen"
+                         << screenId << ")";
+        m_snapEngine->handoffRelease(windowId);
     }
     if (floating) {
         m_windowTrackingAdaptor->setWindowFloating(windowId, true);

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -733,6 +733,24 @@ void Daemon::syncAutotileFloatStatePassive(const QString& windowId, bool floatin
         return;
     }
     WindowTrackingService* wts = m_windowTrackingAdaptor->service();
+    // Cross-engine handoff: this signal fires when autotile has just taken
+    // ownership of a window that may still be tracked by snap. If snap still
+    // has zone/screen assignments for the window, releasing them here is the
+    // missing half of the handoff — without it, the daemon's float router
+    // (lastActiveScreenName via screenAssignments) would still resolve to
+    // snap on the source screen, and the next float toggle would float the
+    // window back to its old snap zone instead of operating on its new
+    // autotile placement. Drag-drop from snap → autotile is the canonical
+    // case; the cancellation paths (handoffRelease is no-op when the engine
+    // doesn't track the window) make this safe to call unconditionally.
+    if (m_snapEngine && (wts->isWindowSnapped(windowId) || wts->isWindowFloating(windowId))) {
+        const QString snapScreen = wts->screenAssignments().value(windowId);
+        if (!snapScreen.isEmpty() && snapScreen != screenId) {
+            qCInfo(lcDaemon) << "Cross-engine handoff: releasing snap state for" << windowId << "(snap screen"
+                             << snapScreen << "→ autotile screen" << screenId << ")";
+            m_snapEngine->handoffRelease(windowId);
+        }
+    }
     if (floating) {
         m_windowTrackingAdaptor->setWindowFloating(windowId, true);
         m_autotileEngine->markModeSpecificFloated(windowId);

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -100,21 +100,64 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
         useOverlayZone = false;
     }
 
-    // Cross-screen drag: if the window was snapped on a different screen, clear
-    // its snap/float state NOW — before any new zone detection or snap logic runs.
-    // During drag, outputChanged's windowScreenChanged is skipped (drag owns state).
-    // This is the single point where cross-screen state cleanup happens.
-    if (capturedWasSnapped && m_windowTracking && releaseScreen) {
-        QString storedScreen = m_windowTracking->service()->screenAssignments().value(windowId);
-        if (!storedScreen.isEmpty() && storedScreen != releaseScreenId) {
-            m_windowTracking->snapEngine()->uncommitSnap(windowId);
-            // Preserve pre-tile geometry: it holds the correct free-floating dimensions
-            // from the original snap. Clearing it would cause tryStorePreSnapGeometry to
-            // store zone geometry (capturedOriginalGeometry is zone-sized for snapped windows).
-            // The existing entry's screen context may be stale, but validatedPreTileGeometry
-            // handles cross-screen adjustment (clamp + center) when restoring.
-            qCInfo(lcDbusWindow) << "Cross-screen drag: cleared snap state for" << windowId << "from" << storedScreen
-                                 << "to" << releaseScreenId;
+    // Cross-screen drag: when the window's owning engine differs from the
+    // engine that owns the release screen, run the IPlacementEngine handoff
+    // contract NOW — before any destination-side snap/tile logic runs.
+    // During drag, outputChanged's windowScreenChanged is skipped (drag owns
+    // state), so this is the single point where cross-screen ownership
+    // transfer happens.
+    //
+    // The release uses the contract so both source modes (snap zone, autotile
+    // tile) drop tracking via the same call; the receive only fires when the
+    // destination engine type differs from the source — same-mode cross-screen
+    // (snap→snap, autotile→autotile) is already handled by the receiving
+    // engine's normal commit / drag-insert paths below.
+    //
+    // Pre-tile / pre-float geometry captures are preserved by handoffRelease
+    // for the receiving side to consult on a future return handoff.
+    if (releaseScreen && m_windowTracking) {
+        auto* snapEngine = m_windowTracking->snapEngine();
+        const QString snapScreen = snapEngine ? snapEngine->screenForTrackedWindow(windowId) : QString();
+        const QString autotileScreen =
+            m_autotileEngine ? m_autotileEngine->screenForTrackedWindow(windowId) : QString();
+        PhosphorEngineApi::IPlacementEngine* sourceEngine = nullptr;
+        QString sourceScreen;
+        if (!snapScreen.isEmpty() && snapScreen != releaseScreenId) {
+            sourceEngine = snapEngine;
+            sourceScreen = snapScreen;
+        } else if (!autotileScreen.isEmpty() && autotileScreen != releaseScreenId) {
+            sourceEngine = m_autotileEngine;
+            sourceScreen = autotileScreen;
+        }
+        if (sourceEngine) {
+            const bool destIsAutotile = m_autotileEngine && m_autotileEngine->isActiveOnScreen(releaseScreenId);
+            PhosphorEngineApi::IPlacementEngine* destEngine = destIsAutotile ? m_autotileEngine : snapEngine;
+            const bool engineTypeChanged = destEngine && destEngine != sourceEngine;
+
+            sourceEngine->handoffRelease(windowId);
+            qCInfo(lcDbusWindow) << "Cross-screen drag: released" << sourceEngine->engineId() << "state for" << windowId
+                                 << "from" << sourceScreen << "to" << releaseScreenId;
+
+            // Engine-type change: hand off to the destination so it can
+            // adopt the window. The committing snap/tile path below may
+            // still finalize the placement — handoffReceive only sets up
+            // tracking with the right floating disposition.
+            if (engineTypeChanged) {
+                PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+                ctx.windowId = windowId;
+                ctx.toScreenId = releaseScreenId;
+                ctx.fromEngineId = sourceEngine->engineId();
+                ctx.dropPos = QPoint(cursorX, cursorY);
+                ctx.sourceGeometry = capturedOriginalGeometry;
+                ctx.wasFloating = m_windowTracking->service()->isWindowFloating(windowId);
+                if (capturedWasSnapped && !ctx.wasFloating && !capturedZoneId.isEmpty()) {
+                    // sourceZoneIds is informational for receiving engines —
+                    // populated from the pre-drop captured zone since
+                    // handoffRelease has already cleared live tracking.
+                    ctx.sourceZoneIds = QStringList{capturedZoneId};
+                }
+                destEngine->handoffReceive(ctx);
+            }
         }
     }
 

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -517,17 +517,33 @@ QRect WindowTrackingAdaptor::frameGeometry(const QString& windowId) const
 
 QString WindowTrackingAdaptor::lastActiveScreenName() const
 {
-    // Prefer the active window's live screen assignment over the cached
-    // m_lastActiveScreenId. KWin only fires windowActivated on focus
-    // changes, so a window dragged/snapped to a different VS without
-    // losing focus leaves the cache pointing at the source screen — and
-    // the shortcut router would then dispatch (e.g. float, navigate) to
-    // the wrong engine. Reading the screenAssignment closes that gap
-    // without depending on the effect to re-fire windowActivated.
-    if (!m_lastActiveWindowId.isEmpty() && m_service) {
-        const QString tracked = m_service->screenAssignments().value(m_lastActiveWindowId);
-        if (!tracked.isEmpty()) {
-            return tracked;
+    // Prefer the active window's live screen tracking from either engine
+    // over the cached m_lastActiveScreenId. KWin only fires windowActivated
+    // on focus changes, so a window dragged/snapped/tiled to a different
+    // VS without losing focus leaves the cache pointing at the source
+    // screen — and the shortcut router would then dispatch (float,
+    // navigate, etc.) to the wrong engine.
+    //
+    // Lookup order:
+    //   1. snap-side screenAssignments (covers snap-mode windows including
+    //      snap-floated ones whose screen we now preserve through float)
+    //   2. autotile-side per-window screen tracking (covers windows that
+    //      crossed engines via drag-insert handoff — snap released its
+    //      tracking, autotile took ownership)
+    //   3. cached m_lastActiveScreenId (windows neither engine tracks —
+    //      brand-new windows pre-tile, dialogs, etc.)
+    if (!m_lastActiveWindowId.isEmpty()) {
+        if (m_service) {
+            const QString tracked = m_service->screenAssignments().value(m_lastActiveWindowId);
+            if (!tracked.isEmpty()) {
+                return tracked;
+            }
+        }
+        if (m_autotileEngine) {
+            const QString tracked = m_autotileEngine->screenForTrackedWindow(m_lastActiveWindowId);
+            if (!tracked.isEmpty()) {
+                return tracked;
+            }
         }
     }
     return m_lastActiveScreenId;

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -515,6 +515,24 @@ QRect WindowTrackingAdaptor::frameGeometry(const QString& windowId) const
     return m_frameGeometry.value(windowId);
 }
 
+QString WindowTrackingAdaptor::lastActiveScreenName() const
+{
+    // Prefer the active window's live screen assignment over the cached
+    // m_lastActiveScreenId. KWin only fires windowActivated on focus
+    // changes, so a window dragged/snapped to a different VS without
+    // losing focus leaves the cache pointing at the source screen — and
+    // the shortcut router would then dispatch (e.g. float, navigate) to
+    // the wrong engine. Reading the screenAssignment closes that gap
+    // without depending on the effect to re-fire windowActivated.
+    if (!m_lastActiveWindowId.isEmpty() && m_service) {
+        const QString tracked = m_service->screenAssignments().value(m_lastActiveWindowId);
+        if (!tracked.isEmpty()) {
+            return tracked;
+        }
+    }
+    return m_lastActiveScreenId;
+}
+
 void WindowTrackingAdaptor::windowActivated(const QString& windowId, const QString& screenId)
 {
     if (!validateWindowId(windowId, QStringLiteral("process windowActivated"))) {

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -5,6 +5,7 @@
 #include <PhosphorSnapEngine/snapnavigationtargets.h>
 #include "windowtrackingadaptor/persistenceworker.h"
 #include "zonedetectionadaptor.h"
+#include <PhosphorEngineApi/IPlacementEngine.h>
 #include <PhosphorTileEngine/AutotileEngine.h>
 #include <PhosphorSnapEngine/SnapEngine.h>
 #include "../config/configbackends.h"
@@ -304,9 +305,47 @@ void WindowTrackingAdaptor::windowScreenChanged(const QString& windowId, const Q
         return;
     }
 
-    // Check if the window is snapped — if not, nothing to do
+    // Floating window with a tracked screen: refresh the engine's
+    // screen-tracking via the cross-engine handoff contract so subsequent
+    // shortcut routing (lastActiveScreenName) finds the new screen instead of
+    // the stale one. Without this, a snap-floated window dragged to another
+    // screen leaves screenAssignments pointing at the source forever — the
+    // float toggle then unfloats it back to the source-screen zone.
     QString currentZoneId = m_service->zoneForWindow(windowId);
     if (currentZoneId.isEmpty()) {
+        if (!m_service->isWindowFloating(windowId)) {
+            return;
+        }
+        const QString trackedSnap = m_snapEngine ? m_snapEngine->screenForTrackedWindow(windowId) : QString();
+        const QString trackedAutotile =
+            m_autotileEngine ? m_autotileEngine->screenForTrackedWindow(windowId) : QString();
+        const QString trackedScreen = !trackedSnap.isEmpty() ? trackedSnap : trackedAutotile;
+        if (trackedScreen.isEmpty() || Phosphor::Screens::ScreenIdentity::screensMatch(trackedScreen, newScreenId)) {
+            return;
+        }
+        PhosphorEngineApi::PlacementEngineBase* source =
+            !trackedSnap.isEmpty() ? m_snapEngine.data() : m_autotileEngine.data();
+        PhosphorEngineApi::PlacementEngineBase* dest = nullptr;
+        if (m_autotileEngine && m_autotileEngine->isActiveOnScreen(newScreenId)) {
+            dest = m_autotileEngine.data();
+        } else if (m_snapEngine) {
+            dest = m_snapEngine.data();
+        }
+        if (!dest) {
+            return;
+        }
+        PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+        ctx.windowId = windowId;
+        ctx.toScreenId = newScreenId;
+        ctx.fromEngineId = source ? source->engineId() : QString();
+        ctx.wasFloating = true;
+        ctx.sourceGeometry = m_frameGeometry.value(windowId);
+        if (source && source != dest) {
+            source->handoffRelease(windowId);
+        }
+        dest->handoffReceive(ctx);
+        qCInfo(lcDbusWindow) << "windowScreenChanged: floating window" << windowId << "moved from" << trackedScreen
+                             << "to" << newScreenId << "- handoff complete";
         return;
     }
 
@@ -525,16 +564,17 @@ QString WindowTrackingAdaptor::lastActiveScreenName() const
     // navigate, etc.) to the wrong engine.
     //
     // Lookup order:
-    //   1. snap-side screenAssignments (covers snap-mode windows including
-    //      snap-floated ones whose screen we now preserve through float)
-    //   2. autotile-side per-window screen tracking (covers windows that
+    //   1. snap-side screenForTrackedWindow (covers snap-mode windows
+    //      including snap-floated ones whose screen we now preserve through
+    //      float, and floating windows received via cross-engine handoff)
+    //   2. autotile-side screenForTrackedWindow (covers windows that
     //      crossed engines via drag-insert handoff — snap released its
     //      tracking, autotile took ownership)
     //   3. cached m_lastActiveScreenId (windows neither engine tracks —
     //      brand-new windows pre-tile, dialogs, etc.)
     if (!m_lastActiveWindowId.isEmpty()) {
-        if (m_service) {
-            const QString tracked = m_service->screenAssignments().value(m_lastActiveWindowId);
+        if (m_snapEngine) {
+            const QString tracked = m_snapEngine->screenForTrackedWindow(m_lastActiveWindowId);
             if (!tracked.isEmpty()) {
                 return tracked;
             }

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -74,11 +74,18 @@ public:
      *
      * The KWin effect has reliable screen info on both X11 and Wayland.
      * Use this as a fallback when cursor screen is unavailable.
+     *
+     * Implementation: prefers the active window's current daemon-tracked
+     * screen assignment over the cached value. KWin only fires
+     * `windowActivated` on focus changes, so a window that gets dragged or
+     * snapped to a different VS without losing focus leaves
+     * `m_lastActiveScreenId` pointing at the OLD screen — which then
+     * misroutes shortcut handlers (e.g. the float shortcut going to the
+     * autotile engine for the source VS instead of the snap engine for the
+     * destination VS). Reading the live screenAssignment closes that gap
+     * without requiring a separate signal/cache invalidation path.
      */
-    Q_INVOKABLE QString lastActiveScreenName() const
-    {
-        return m_lastActiveScreenId;
-    }
+    Q_INVOKABLE QString lastActiveScreenName() const;
 
     /**
      * @brief Last screen the cursor was on, reported by the KWin effect

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -157,28 +157,38 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
     qCInfo(lcDbusWindow) << "setWindowFloatingForScreen: windowId=" << windowId << "floating=" << floating
                          << "screen=" << screenId;
 
-    // Route to the correct engine based on screen mode
+    // Route to the correct engine based on screen mode. Both directions go
+    // through the explicit cross-engine handoff contract when the window
+    // isn't yet tracked by the destination engine.
+    PhosphorEngineApi::PlacementEngineBase* dest = nullptr;
+    PhosphorEngineApi::PlacementEngineBase* source = nullptr;
     if (m_autotileEngine && m_autotileEngine->isActiveOnScreen(screenId)) {
-        // If the window isn't tracked by autotile yet (e.g., dragged from a snap
-        // screen), hand off ownership via the explicit cross-engine contract.
-        // SnapEngine::handoffRelease drops its tracking;
-        // AutotileEngine::handoffReceive adds the window to the destination
-        // state with the requested floating disposition. Virtual dispatch
-        // handles each engine's policy.
-        if (floating && !m_autotileEngine->isWindowTracked(windowId)) {
-            PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
-            ctx.windowId = windowId;
-            ctx.toScreenId = screenId;
-            ctx.fromEngineId = m_snapEngine ? m_snapEngine->engineId() : QString();
-            ctx.wasFloating = true;
-            if (m_snapEngine) {
-                m_snapEngine->handoffRelease(windowId);
-            }
-            m_autotileEngine->handoffReceive(ctx);
-        }
-        m_autotileEngine->setWindowFloat(windowId, floating);
+        dest = m_autotileEngine.data();
+        source = m_snapEngine.data();
     } else if (m_snapEngine) {
-        m_snapEngine->setWindowFloat(windowId, floating);
+        dest = m_snapEngine.data();
+        source = m_autotileEngine.data();
+    }
+
+    if (dest && floating && !dest->isWindowTracked(windowId)) {
+        // Build the HandoffContext from whichever engine actually claims the
+        // window — fromEngineId stays empty when neither side tracks it (e.g.
+        // a brand-new floating dialog), so receive-side reasoning that depends
+        // on the source mode correctly degrades.
+        PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+        ctx.windowId = windowId;
+        ctx.toScreenId = screenId;
+        ctx.wasFloating = true;
+        if (source && source->isWindowTracked(windowId)) {
+            ctx.fromEngineId = source->engineId();
+            ctx.sourceGeometry = m_frameGeometry.value(windowId);
+            source->handoffRelease(windowId);
+        }
+        dest->handoffReceive(ctx);
+    }
+
+    if (dest) {
+        dest->setWindowFloat(windowId, floating);
     }
 }
 

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -13,6 +13,7 @@
 #include "../../core/interfaces.h"
 #include "../../core/logging.h"
 #include "../../core/utils.h"
+#include <PhosphorEngineApi/IPlacementEngine.h>
 #include <PhosphorEngineApi/PlacementEngineBase.h>
 
 namespace PlasmaZones {
@@ -158,11 +159,22 @@ void WindowTrackingAdaptor::setWindowFloatingForScreen(const QString& windowId, 
 
     // Route to the correct engine based on screen mode
     if (m_autotileEngine && m_autotileEngine->isActiveOnScreen(screenId)) {
-        // If the window isn't tracked by autotile yet (e.g., dragged from a snap screen),
-        // adopt it as floating before setting state. Virtual dispatch handles the
-        // engine-specific logic (AutotileEngine overrides; SnapEngine no-ops).
-        if (floating) {
-            m_autotileEngine->adoptWindowAsFloating(windowId, screenId);
+        // If the window isn't tracked by autotile yet (e.g., dragged from a snap
+        // screen), hand off ownership via the explicit cross-engine contract.
+        // SnapEngine::handoffRelease drops its tracking;
+        // AutotileEngine::handoffReceive adds the window to the destination
+        // state with the requested floating disposition. Virtual dispatch
+        // handles each engine's policy.
+        if (floating && !m_autotileEngine->isWindowTracked(windowId)) {
+            PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+            ctx.windowId = windowId;
+            ctx.toScreenId = screenId;
+            ctx.fromEngineId = m_snapEngine ? m_snapEngine->engineId() : QString();
+            ctx.wasFloating = true;
+            if (m_snapEngine) {
+                m_snapEngine->handoffRelease(windowId);
+            }
+            m_autotileEngine->handoffReceive(ctx);
         }
         m_autotileEngine->setWindowFloat(windowId, floating);
     } else if (m_snapEngine) {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -138,6 +138,8 @@ target_compile_definitions(test_autotile_engine_order_cycling PRIVATE "PZ_SOURCE
 pz_add_test(test_autotile_engine_class_mutation autotile/test_autotile_engine_class_mutation.cpp)
 pz_add_test(test_autotile_drag_insert autotile/test_autotile_drag_insert.cpp)
 target_compile_definitions(test_autotile_drag_insert PRIVATE "PZ_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
+pz_add_test(test_autotile_handoff autotile/test_autotile_handoff.cpp)
+target_compile_definitions(test_autotile_handoff PRIVATE "PZ_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
 # Producer-side validator guard — ensures the JSON emitted by
 # AutotileEngine::applyTiling round-trips through TileRequestEntry
 # parsing and passes validationError(). Would have caught PR #326 C1.

--- a/tests/unit/autotile/test_autotile_handoff.cpp
+++ b/tests/unit/autotile/test_autotile_handoff.cpp
@@ -1,0 +1,245 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <QTest>
+#include <QCoreApplication>
+#include <QSignalSpy>
+
+#include <PhosphorEngineApi/IPlacementEngine.h>
+#include <PhosphorTileEngine/AutotileEngine.h>
+#include <PhosphorTiles/TilingState.h>
+
+#include "../helpers/AutotileTestHelpers.h"
+#include "../helpers/ScriptedAlgoTestSetup.h"
+
+using namespace PlasmaZones;
+
+/**
+ * @brief Tests for the IPlacementEngine cross-engine handoff contract on
+ *        AutotileEngine: handoffReceive / handoffRelease / screenForTrackedWindow.
+ *
+ * The handoff API replaces the opportunistic adopt branch in toggleWindowFloat
+ * (PR #366) with an explicit two-step transaction the daemon orchestrates.
+ * These tests pin the engine-local invariants the daemon depends on:
+ *  - receive populates per-state tracking + m_windowToStateKey
+ *  - release drops tracking without mutating geometry
+ *  - cross-screen receive on the same engine releases prior tracking first
+ *  - screenForTrackedWindow follows ownership transfers
+ */
+class TestAutotileHandoff : public QObject
+{
+    Q_OBJECT
+
+private:
+    PlasmaZones::TestHelpers::ScriptedAlgoTestSetup m_scriptSetup;
+    static constexpr auto Screen1 = "eDP-1";
+    static constexpr auto Screen2 = "HDMI-1";
+
+private Q_SLOTS:
+
+    void initTestCase()
+    {
+        QVERIFY(m_scriptSetup.init(QStringLiteral(PZ_SOURCE_DIR)));
+    }
+
+    // =========================================================================
+    // handoffReceive — adoption + initial state
+    // =========================================================================
+
+    void testHandoffReceive_addsWindowAsFloating()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+
+        const QString windowId = QStringLiteral("win-floating");
+        PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+        ctx.windowId = windowId;
+        ctx.toScreenId = screen;
+        ctx.fromEngineId = QStringLiteral("snap");
+        ctx.wasFloating = true;
+        engine.handoffReceive(ctx);
+        QCoreApplication::processEvents();
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        QVERIFY(state->containsWindow(windowId));
+        QVERIFY(state->isFloating(windowId));
+        QCOMPARE(engine.screenForTrackedWindow(windowId), screen);
+    }
+
+    void testHandoffReceive_addsWindowAsTiled()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+
+        const QString windowId = QStringLiteral("win-tiled");
+        PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+        ctx.windowId = windowId;
+        ctx.toScreenId = screen;
+        ctx.fromEngineId = QStringLiteral("autotile");
+        ctx.wasFloating = false;
+        engine.handoffReceive(ctx);
+        QCoreApplication::processEvents();
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        QVERIFY(state->containsWindow(windowId));
+        QVERIFY(!state->isFloating(windowId));
+        QCOMPARE(engine.screenForTrackedWindow(windowId), screen);
+    }
+
+    void testHandoffReceive_rejectsNonAutotileScreen()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        engine.setAutotileScreens({QLatin1String(Screen1)});
+
+        PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+        ctx.windowId = QStringLiteral("win-x");
+        ctx.toScreenId = QLatin1String(Screen2); // not an autotile screen
+        ctx.wasFloating = true;
+        engine.handoffReceive(ctx);
+
+        QCOMPARE(engine.screenForTrackedWindow(QStringLiteral("win-x")), QString());
+    }
+
+    void testHandoffReceive_emptyArgsIsNoop()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        engine.setAutotileScreens({QLatin1String(Screen1)});
+
+        PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+        ctx.windowId = QString();
+        ctx.toScreenId = QLatin1String(Screen1);
+        engine.handoffReceive(ctx);
+
+        ctx.windowId = QStringLiteral("win-x");
+        ctx.toScreenId = QString();
+        engine.handoffReceive(ctx);
+
+        QCOMPARE(engine.screenForTrackedWindow(QStringLiteral("win-x")), QString());
+    }
+
+    // =========================================================================
+    // handoffReceive — already-tracked / cross-screen edge cases
+    // =========================================================================
+
+    void testHandoffReceive_alreadyTrackedSameScreenIsNoop()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+
+        const QString windowId = QStringLiteral("win-existing");
+        engine.windowOpened(windowId, screen);
+        QCoreApplication::processEvents();
+
+        // Idempotent receive: floating disposition shouldn't overwrite the
+        // existing tiled state.
+        PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+        ctx.windowId = windowId;
+        ctx.toScreenId = screen;
+        ctx.wasFloating = true;
+        engine.handoffReceive(ctx);
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        QVERIFY(state->containsWindow(windowId));
+        QVERIFY(!state->isFloating(windowId));
+    }
+
+    void testHandoffReceive_crossScreenReleasesPreviousState()
+    {
+        // The PR review identified an orphaned-state bug: receiving a
+        // window that's already tracked on a DIFFERENT autotile screen
+        // would overwrite m_windowToStateKey to point at the new screen
+        // while leaving the old screen's PhosphorTiles::TilingState holding the
+        // window. Fix: release the previous state first.
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString s1 = QLatin1String(Screen1);
+        const QString s2 = QLatin1String(Screen2);
+        engine.setAutotileScreens({s1, s2});
+
+        const QString windowId = QStringLiteral("win-cross");
+        engine.windowOpened(windowId, s1);
+        QCoreApplication::processEvents();
+
+        // Hand off to the OTHER autotile screen.
+        PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+        ctx.windowId = windowId;
+        ctx.toScreenId = s2;
+        ctx.wasFloating = false;
+        engine.handoffReceive(ctx);
+        QCoreApplication::processEvents();
+
+        // s2 has it.
+        PhosphorTiles::TilingState* state2 = engine.tilingStateForScreen(s2);
+        QVERIFY(state2);
+        QVERIFY(state2->containsWindow(windowId));
+        // s1 must NOT have it — that's the orphan we're guarding against.
+        PhosphorTiles::TilingState* state1 = engine.tilingStateForScreen(s1);
+        QVERIFY(state1);
+        QVERIFY(!state1->containsWindow(windowId));
+        QCOMPARE(engine.screenForTrackedWindow(windowId), s2);
+    }
+
+    // =========================================================================
+    // handoffRelease — drops tracking without mutating geometry
+    // =========================================================================
+
+    void testHandoffRelease_clearsTracking()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QLatin1String(Screen1);
+        engine.setAutotileScreens({screen});
+
+        const QString windowId = QStringLiteral("win-rel");
+        engine.windowOpened(windowId, screen);
+        QCoreApplication::processEvents();
+        QCOMPARE(engine.screenForTrackedWindow(windowId), screen);
+
+        engine.handoffRelease(windowId);
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        QVERIFY(!state->containsWindow(windowId));
+        QCOMPARE(engine.screenForTrackedWindow(windowId), QString());
+        QVERIFY(!engine.isWindowTracked(windowId));
+    }
+
+    void testHandoffRelease_untrackedWindowIsNoop()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        engine.setAutotileScreens({QLatin1String(Screen1)});
+
+        engine.handoffRelease(QStringLiteral("never-tracked"));
+        engine.handoffRelease(QString());
+        // Did not crash; nothing tracked.
+        QVERIFY(!engine.isWindowTracked(QStringLiteral("never-tracked")));
+    }
+
+    // =========================================================================
+    // engineId — stable identity used in HandoffContext.fromEngineId
+    // =========================================================================
+
+    void testEngineId_returnsAutotile()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        QCOMPARE(engine.engineId(), QStringLiteral("autotile"));
+    }
+
+    // =========================================================================
+    // screenForTrackedWindow — symmetry with snap-side
+    // =========================================================================
+
+    void testScreenForTrackedWindow_returnsEmptyForUnknown()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        engine.setAutotileScreens({QLatin1String(Screen1)});
+        QCOMPARE(engine.screenForTrackedWindow(QStringLiteral("never-seen")), QString());
+    }
+};
+
+QTEST_MAIN(TestAutotileHandoff)
+#include "test_autotile_handoff.moc"

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -484,6 +484,243 @@ private Q_SLOTS:
         QCOMPARE(saveCount, 2);
         QCOMPARE(loadCount, 1);
     }
+
+    // =========================================================================
+    // Float-state screen preservation (PR #366 regression pin)
+    //
+    // unsnapForFloat now preserves the window's screen assignment so that the
+    // daemon can still answer "what screen does this floating window live on"
+    // — that's what makes the float-toggle router send the unfloat shortcut
+    // back to this engine. Erasing the screen would route to whatever the
+    // focus cache pointed at, which is exactly the bug the PR fixes.
+    // =========================================================================
+
+    void testUnsnapForFloat_preservesScreenAssignment()
+    {
+        const QString windowId = QStringLiteral("app|uuid-screen-preserve");
+        const QString screen = QStringLiteral("DP-3");
+
+        m_snapState->assignWindowToZone(windowId, QStringLiteral("zone-1"), screen, 4);
+        QCOMPARE(m_snapState->screenAssignments().value(windowId), screen);
+
+        m_snapState->unsnapForFloat(windowId);
+
+        // Zone gone, but screen + desktop preserved.
+        QVERIFY(!m_snapState->isWindowSnapped(windowId));
+        QCOMPARE(m_snapState->screenAssignments().value(windowId), screen);
+        QCOMPARE(m_snapState->desktopForWindow(windowId), 4);
+    }
+
+    void testUnassignWindow_clearsScreenAssignment()
+    {
+        // Sister test confirming the non-float path still clears the screen
+        // — the DRY refactor of clearZoneAssignment must keep the two paths
+        // distinct.
+        const QString windowId = QStringLiteral("app|uuid-screen-clear");
+        const QString screen = QStringLiteral("DP-3");
+
+        m_snapState->assignWindowToZone(windowId, QStringLiteral("zone-1"), screen, 4);
+        m_snapState->unassignWindow(windowId);
+
+        QVERIFY(!m_snapState->isWindowSnapped(windowId));
+        QVERIFY(m_snapState->screenAssignments().value(windowId).isEmpty());
+        QCOMPARE(m_snapState->desktopForWindow(windowId), 0);
+    }
+
+    // =========================================================================
+    // setFloatingOnScreen — used by SnapEngine::handoffReceive when adopting
+    // a floating window from another engine. Must populate the screen and
+    // desktop assignments so subsequent screenForTrackedWindow lookups
+    // resolve, and so isWindowTracked returns true.
+    // =========================================================================
+
+    void testSetFloatingOnScreen_populatesScreenDesktopAndFloating()
+    {
+        const QString windowId = QStringLiteral("app|uuid-handoff-recv");
+        const QString screen = QStringLiteral("HDMI-1");
+
+        m_snapState->setFloatingOnScreen(windowId, screen, 2);
+
+        QVERIFY(m_snapState->isFloating(windowId));
+        QCOMPARE(m_snapState->screenAssignments().value(windowId), screen);
+        QCOMPARE(m_snapState->desktopForWindow(windowId), 2);
+        QVERIFY(!m_snapState->isWindowSnapped(windowId));
+    }
+
+    void testSetFloatingOnScreen_emptyArgsIsNoop()
+    {
+        m_snapState->setFloatingOnScreen(QString(), QStringLiteral("DP-1"), 0);
+        m_snapState->setFloatingOnScreen(QStringLiteral("app|uuid"), QString(), 0);
+        QVERIFY(m_snapState->isEmpty());
+    }
+
+    // =========================================================================
+    // SnapEngine::handoffRelease — drops snap-private tracking only. Must
+    // NOT route through WindowTrackingService (which fires shared signals
+    // that the autotile engine listens to). Pre-float capture is preserved.
+    // =========================================================================
+
+    void testHandoffRelease_clearsZoneAssignment()
+    {
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+        m_wts->setSnapState(engine.snapState());
+
+        const QString windowId = QStringLiteral("app|uuid-release-zone");
+        const QString screen = QStringLiteral("DP-2");
+        engine.snapState()->assignWindowToZone(windowId, QStringLiteral("zone-3"), screen, 1);
+        QVERIFY(engine.snapState()->isWindowSnapped(windowId));
+
+        engine.handoffRelease(windowId);
+
+        QVERIFY(!engine.snapState()->isWindowSnapped(windowId));
+        QVERIFY(engine.snapState()->screenAssignments().value(windowId).isEmpty());
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testHandoffRelease_clearsFloatingTracking()
+    {
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+        m_wts->setSnapState(engine.snapState());
+
+        const QString windowId = QStringLiteral("app|uuid-release-float");
+        const QString screen = QStringLiteral("DP-2");
+        engine.snapState()->setFloatingOnScreen(windowId, screen, 0);
+        QVERIFY(engine.snapState()->isFloating(windowId));
+
+        engine.handoffRelease(windowId);
+
+        QVERIFY(!engine.snapState()->isFloating(windowId));
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testHandoffRelease_doesNotEmitWtsZoneSignal()
+    {
+        // Routing release through WTS would fire windowZoneChanged, which
+        // the autotile engine listens to — and would interpret as "drop
+        // this window from your state mid-handoff" (the bug commit
+        // 56146efc fixed). Guard the regression by spying for the WTS
+        // signal during a handoffRelease.
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+        m_wts->setSnapState(engine.snapState());
+
+        const QString windowId = QStringLiteral("app|uuid-release-no-signal");
+        engine.snapState()->assignWindowToZone(windowId, QStringLiteral("zone-1"), QStringLiteral("DP-1"), 0);
+
+        QSignalSpy zoneSpy(m_wts, &WindowTrackingService::windowZoneChanged);
+
+        engine.handoffRelease(windowId);
+
+        QCOMPARE(zoneSpy.count(), 0);
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testHandoffRelease_preservesPreFloatCapture()
+    {
+        // The receiving engine may consult HandoffContext for size restoration
+        // on a future return handoff — pre-float capture must survive.
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+        m_wts->setSnapState(engine.snapState());
+
+        const QString windowId = QStringLiteral("app|uuid-release-prefloat");
+        const QString screen = QStringLiteral("DP-2");
+        engine.snapState()->assignWindowToZone(windowId, QStringLiteral("zone-2"), screen, 0);
+        engine.snapState()->unsnapForFloat(windowId); // populates pre-float capture
+        QVERIFY(!engine.snapState()->preFloatZone(windowId).isEmpty());
+
+        engine.handoffRelease(windowId);
+
+        QVERIFY(!engine.snapState()->preFloatZone(windowId).isEmpty());
+        m_wts->setSnapState(nullptr);
+    }
+
+    // =========================================================================
+    // SnapEngine::handoffReceive — floating arrival populates screen so
+    // subsequent screenForTrackedWindow / lastActiveScreenName resolve.
+    // =========================================================================
+
+    void testHandoffReceive_floatingArrivalPopulatesScreen()
+    {
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+        m_wts->setSnapState(engine.snapState());
+
+        const QString windowId = QStringLiteral("app|uuid-recv-float");
+        const QString screen = QStringLiteral("DP-1");
+
+        PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+        ctx.windowId = windowId;
+        ctx.toScreenId = screen;
+        ctx.fromEngineId = QStringLiteral("autotile");
+        ctx.wasFloating = true;
+        engine.handoffReceive(ctx);
+
+        QCOMPARE(engine.screenForTrackedWindow(windowId), screen);
+        QVERIFY(engine.isWindowTracked(windowId));
+        QVERIFY(engine.snapState()->isFloating(windowId));
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testHandoffReceive_emptyArgsIsNoop()
+    {
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+        m_wts->setSnapState(engine.snapState());
+
+        PhosphorEngineApi::IPlacementEngine::HandoffContext ctx;
+        ctx.windowId = QString();
+        ctx.toScreenId = QStringLiteral("DP-1");
+        engine.handoffReceive(ctx);
+
+        ctx.windowId = QStringLiteral("app|uuid");
+        ctx.toScreenId = QString();
+        engine.handoffReceive(ctx);
+
+        QVERIFY(engine.snapState()->isEmpty());
+        m_wts->setSnapState(nullptr);
+    }
+
+    // =========================================================================
+    // screenForTrackedWindow / isWindowTracked — used by the daemon's
+    // shortcut router (lastActiveScreenName) to resolve the right engine.
+    // =========================================================================
+
+    void testScreenForTrackedWindow_returnsEmptyWhenUntracked()
+    {
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+        m_wts->setSnapState(engine.snapState());
+        QCOMPARE(engine.screenForTrackedWindow(QStringLiteral("app|uuid-not-tracked")), QString());
+        QVERIFY(!engine.isWindowTracked(QStringLiteral("app|uuid-not-tracked")));
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testScreenForTrackedWindow_followsSnapAssignment()
+    {
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+        m_wts->setSnapState(engine.snapState());
+
+        const QString windowId = QStringLiteral("app|uuid-tracked-snap");
+        const QString screen = QStringLiteral("DP-2");
+        engine.snapState()->assignWindowToZone(windowId, QStringLiteral("zone-1"), screen, 0);
+
+        QCOMPARE(engine.screenForTrackedWindow(windowId), screen);
+        QVERIFY(engine.isWindowTracked(windowId));
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testScreenForTrackedWindow_followsFloatedSnap()
+    {
+        // After unsnapForFloat the screen is preserved — so the snap engine
+        // must still claim ownership of the window for routing purposes.
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+        m_wts->setSnapState(engine.snapState());
+
+        const QString windowId = QStringLiteral("app|uuid-tracked-floated");
+        const QString screen = QStringLiteral("DP-2");
+        engine.snapState()->assignWindowToZone(windowId, QStringLiteral("zone-1"), screen, 0);
+        engine.snapState()->unsnapForFloat(windowId);
+
+        QCOMPARE(engine.screenForTrackedWindow(windowId), screen);
+        QVERIFY(engine.isWindowTracked(windowId));
+        m_wts->setSnapState(nullptr);
+    }
 };
 
 QTEST_GUILESS_MAIN(TestSnapEngine)


### PR DESCRIPTION
## Summary
- Three concrete bugs fixed around float toggle / cross-VS drags
- New explicit cross-engine handoff API on `IPlacementEngine`
- Removes the opportunistic adopt branch in `AutotileEngine::toggleWindowFloat`

## Bugs fixed

### 1. Float misroute after cross-VS drag → wrong engine
`WindowTrackingAdaptor::lastActiveScreenName()` returned the cached `m_lastActiveScreenId`, which only updates on KWin focus changes. A window dragged across VSs without losing focus left the cache pointing at the source screen, so the shortcut router dispatched float to the wrong engine.

**Fix**: `lastActiveScreenName()` now prefers the active window's live `screenAssignments` lookup over the cache. `screenAssignments` updates synchronously in `commitSnap`, so the answer follows the window even when focus stayed put.

### 2. Wrong-window float in autotile
`AutotileEngine::toggleFocusedFloat` ignored the daemon-provided `ctx` and used `state->focusedWindow()` — autotile's *internal* focus tracker. That tracker only updates when KWin emits `windowActivated` for an autotile-tracked window, so focus moving through floating, snapped, or never-tracked windows left it stale; the next float shortcut then toggled the wrong window (e.g. ghostty when settings was visually focused).

**Fix**: route through `toggleWindowFloat(ctx.windowId, ctx.screenId)` when `ctx` carries a windowId. Legacy `state->focusedWindow()` path stays as the empty-ctx fallback for tests/direct invocations.

### 3. Unfloat back to wrong VS after drag-snap-float-unfloat
`SnapEngine` cleared the window's screen assignment on float (via `unassignWindow`), leaving the daemon with no answer for "what screen does this floating window live on". Unfloat shortcut hit the stale cache, routed to the source-VS engine, and `AutotileEngine`'s opportunistic adopt branch grabbed it and tiled it on the wrong screen.

**Fix**: `SnapState::unsnapForFloat` preserves the screen (and desktop) assignment — only the zone is cleared. Float is now symmetric with autotile, where `m_windowToStateKey` survives the float toggle. Iterators that walk `zoneAssignments` already skip floating windows, so screen-only entries are harmless to existing readers.

## Architectural cleanup

New cross-engine handoff contract on `IPlacementEngine`:
- `handoffReceive(HandoffContext ctx)` — destination engine takes ownership
- `handoffRelease(windowId)` — source engine drops tracking without mutating geometry
- `engineId()` — stable identifier (`"snap"` / `"autotile"`)
- `HandoffContext` carries source mode, source zones, source geometry, drop position, floating disposition

Both engines implement it. The legacy `adoptWindowAsFloating` and its sole caller migrate to the new API. The opportunistic adopt branch in `AutotileEngine::toggleWindowFloat` (the second-order accomplice in bug 3) is removed — cross-engine ownership transfer now goes through the explicit contract instead of being implicitly inferred from "I see a floating window on my screen".

`handoff*` verbs are prefixed to stay distinct from `PlacementEngineBase::releaseWindow`, which is part of the base FSM lifecycle ("this window is no longer engine-managed at all" — a different concept from "transferring ownership to another engine").

## Out of scope (future cleanup)
Drag-drop wiring continues using its existing per-screen orchestration in `windowdragadaptor/drop.cpp`. Migrating that to the handoff contract would unify the cross-screen state cleanup currently scattered across the drop path — separate PR.

Other autotile navigation methods (`focusInDirection`, `moveFocusedInDirection`, `swapFocusedInDirection`, `moveFocusedToPosition`, `cycleFocus`, `restoreFocusedWindow`) still ignore `ctx` and use `state->focusedWindow()`. Same root cause as bug 2 — left for a follow-up since only the float symptom was reported.

## Test plan
- [ ] All 133 unit tests pass
- [ ] Drag window from autotile VS → snap VS, snap to a zone, press float, press float again → window unfloats back to its zone on the snap VS (was: window jumped back to the source autotile VS)
- [ ] Focus a tiled window in autotile, press float → that window floats (was: a different tile floated when the autotile state's `focusedWindow` was stale)
- [ ] Drag a floating window from a snap VS onto an autotile screen, press float → window tiles on the autotile screen (handoff path still works via the new API)
- [ ] Float toggle works on a snapped window in snap mode (regression check)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)