### PR TITLE
refactor: engine namespace cleanup and typed interfaces

### DIFF
--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/PlacementEngineBase.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/PlacementEngineBase.h
@@ -121,6 +121,10 @@ Q_SIGNALS:
     /// Emitted when windows are released from engine management.
     void windowsReleased(const QStringList& windowIds, const QSet<QString>& releasedScreenIds);
 
+    /// Emitted when the engine writes tuning values back to the settings
+    /// object and wants the daemon to persist them to disk.
+    void settingsPersistRequested();
+
 private:
     QHash<QString, UnmanagedEntry> m_unmanagedGeometries;
     QHash<QString, WindowState> m_windowStates;

--- a/libs/phosphor-engine-api/include/PhosphorEngineApi/PlacementEngineBase.h
+++ b/libs/phosphor-engine-api/include/PhosphorEngineApi/PlacementEngineBase.h
@@ -121,11 +121,6 @@ Q_SIGNALS:
     /// Emitted when windows are released from engine management.
     void windowsReleased(const QStringList& windowIds, const QSet<QString>& releasedScreenIds);
 
-    /// Emitted when the engine wants to persist changed settings values.
-    /// The QVariantMap contains key-value pairs the daemon should write
-    /// to its settings store (e.g. {"autotileSplitRatio": 0.6}).
-    void settingsWriteBackRequested(const QVariantMap& values);
-
 private:
     QHash<QString, UnmanagedEntry> m_unmanagedGeometries;
     QHash<QString, WindowState> m_windowStates;

--- a/libs/phosphor-snap-engine/CMakeLists.txt
+++ b/libs/phosphor-snap-engine/CMakeLists.txt
@@ -21,7 +21,11 @@ add_library(PhosphorSnapEngine SHARED
     include/PhosphorSnapEngine/SnapEngine.h
     include/PhosphorSnapEngine/SnapState.h
     include/PhosphorSnapEngine/ISnapSettings.h
+    include/PhosphorSnapEngine/INavigationStateProvider.h
+    include/PhosphorSnapEngine/IZoneAdjacencyResolver.h
     include/PhosphorSnapEngine/snapnavigationtargets.h
+    src/INavigationStateProvider.cpp
+    src/IZoneAdjacencyResolver.cpp
     src/SnapEngine.cpp
     src/SnapState.cpp
     src/calculate.cpp

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/INavigationStateProvider.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/INavigationStateProvider.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <phosphorsnapengine_export.h>
+
+#include <QRect>
+#include <QString>
+
+namespace PhosphorSnapEngine {
+
+/**
+ * @brief Narrow read-only interface for compositor-layer state queries.
+ *
+ * SnapEngine's navigation entry points need three string shadows
+ * (last-active window, last-active screen, last-cursor screen) and
+ * one frame-geometry accessor that live on the daemon's
+ * WindowTrackingAdaptor. Rather than holding an opaque QObject* and
+ * calling methods by string via QMetaObject::invokeMethod, the engine
+ * now depends on this typed interface.
+ *
+ * The daemon's WindowTrackingAdaptor must implement (or wrap)
+ * INavigationStateProvider so that setNavigationStateProvider() can
+ * accept a typed pointer. The interface is intentionally minimal —
+ * if a future navigation method needs additional adaptor state, add
+ * a virtual here rather than reaching back into a QObject*.
+ *
+ * Not a QObject — pure data queries with no lifecycle signals.
+ */
+class PHOSPHORSNAPENGINE_EXPORT INavigationStateProvider
+{
+public:
+    INavigationStateProvider() = default;
+    virtual ~INavigationStateProvider();
+
+    /// Screen that most recently contained the mouse cursor.
+    virtual QString lastCursorScreenName() const = 0;
+
+    /// Screen that most recently held the active (focused) window.
+    virtual QString lastActiveScreenName() const = 0;
+
+    /// Window ID that most recently received keyboard focus.
+    virtual QString lastActiveWindowId() const = 0;
+
+    /// Live frame geometry for @p windowId as reported by the compositor.
+    /// Returns an invalid QRect when the window is unknown.
+    virtual QRect frameGeometry(const QString& windowId) const = 0;
+
+protected:
+    INavigationStateProvider(const INavigationStateProvider&) = default;
+    INavigationStateProvider& operator=(const INavigationStateProvider&) = default;
+};
+
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/INavigationStateProvider.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/INavigationStateProvider.h
@@ -47,9 +47,8 @@ public:
     /// Returns an invalid QRect when the window is unknown.
     virtual QRect frameGeometry(const QString& windowId) const = 0;
 
-protected:
-    INavigationStateProvider(const INavigationStateProvider&) = default;
-    INavigationStateProvider& operator=(const INavigationStateProvider&) = default;
+    INavigationStateProvider(const INavigationStateProvider&) = delete;
+    INavigationStateProvider& operator=(const INavigationStateProvider&) = delete;
 };
 
 } // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/IZoneAdjacencyResolver.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/IZoneAdjacencyResolver.h
@@ -54,9 +54,8 @@ public:
      */
     virtual QString getFirstZoneInDirection(const QString& direction, const QString& screenId) const = 0;
 
-protected:
-    IZoneAdjacencyResolver(const IZoneAdjacencyResolver&) = default;
-    IZoneAdjacencyResolver& operator=(const IZoneAdjacencyResolver&) = default;
+    IZoneAdjacencyResolver(const IZoneAdjacencyResolver&) = delete;
+    IZoneAdjacencyResolver& operator=(const IZoneAdjacencyResolver&) = delete;
 };
 
 } // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/IZoneAdjacencyResolver.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/IZoneAdjacencyResolver.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <phosphorsnapengine_export.h>
+
+#include <QString>
+
+namespace PhosphorSnapEngine {
+
+/**
+ * @brief Narrow interface for zone-adjacency queries used by snap navigation.
+ *
+ * SnapNavigationTargetResolver needs two directional zone lookups that
+ * live on the daemon's ZoneDetectionAdaptor:
+ *   - getAdjacentZone   (find the zone next to a given zone in a direction)
+ *   - getFirstZoneInDirection (find the edge zone when no current zone exists)
+ *
+ * Rather than holding an opaque QObject* and dispatching through
+ * QMetaObject::invokeMethod, the resolver now depends on this typed
+ * interface. The daemon's ZoneDetectionAdaptor must implement (or wrap)
+ * IZoneAdjacencyResolver so that the engine receives a typed pointer.
+ *
+ * Not a QObject — pure data queries with no lifecycle signals.
+ */
+class PHOSPHORSNAPENGINE_EXPORT IZoneAdjacencyResolver
+{
+public:
+    IZoneAdjacencyResolver() = default;
+    virtual ~IZoneAdjacencyResolver();
+
+    /**
+     * @brief Find the zone adjacent to @p currentZoneId in @p direction.
+     *
+     * @param currentZoneId  Zone the window is currently snapped to
+     * @param direction      "left", "right", "up", or "down"
+     * @param screenId       Screen context for multi-monitor layouts
+     * @return Zone ID of the adjacent zone, or empty string if none exists
+     */
+    virtual QString getAdjacentZone(const QString& currentZoneId, const QString& direction,
+                                    const QString& screenId) const = 0;
+
+    /**
+     * @brief Find the edge zone in @p direction when no current zone exists.
+     *
+     * Used when a window is not yet snapped and the user presses a
+     * navigation key. Returns the zone at the layout edge in the given
+     * direction (e.g. leftmost zone for "left").
+     *
+     * @param direction  "left", "right", "up", or "down"
+     * @param screenId   Screen context for multi-monitor layouts
+     * @return Zone ID of the edge zone, or empty string if none exists
+     */
+    virtual QString getFirstZoneInDirection(const QString& direction, const QString& screenId) const = 0;
+
+protected:
+    IZoneAdjacencyResolver(const IZoneAdjacencyResolver&) = default;
+    IZoneAdjacencyResolver& operator=(const IZoneAdjacencyResolver&) = default;
+};
+
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -22,32 +22,14 @@
 namespace PhosphorZones {
 class IZoneDetector;
 class LayoutRegistry;
-class SnapState;
 }
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
 
-using NavigationContext = PhosphorEngineApi::NavigationContext;
-using SnapResult = PhosphorEngineApi::SnapResult;
-using SnapIntent = PhosphorEngineApi::SnapIntent;
-using ZoneAssignmentEntry = PhosphorEngineApi::ZoneAssignmentEntry;
-using UnfloatResult = PhosphorEngineApi::UnfloatResult;
-using PendingRestore = PhosphorEngineApi::PendingRestore;
-using ResnapEntry = PhosphorEngineApi::ResnapEntry;
-using StickyWindowHandling = PhosphorEngineApi::StickyWindowHandling;
-
-using PhosphorProtocol::CycleTargetResult;
-using PhosphorProtocol::FocusTargetResult;
-using PhosphorProtocol::MoveTargetResult;
-using PhosphorProtocol::RestoreTargetResult;
-using PhosphorProtocol::SnapAllResultEntry;
-using PhosphorProtocol::SnapAllResultList;
-using PhosphorProtocol::SwapTargetResult;
-using PhosphorProtocol::WindowGeometryEntry;
-using PhosphorProtocol::WindowGeometryList;
-using PhosphorProtocol::WindowStateEntry;
-
+class INavigationStateProvider;
+class IZoneAdjacencyResolver;
 class SnapNavigationTargetResolver;
+class SnapState;
 
 /**
  * @brief Engine for manual zone-based window snapping
@@ -113,16 +95,16 @@ public:
     /**
      * @brief Calculate resnap entries from autotile order WITHOUT emitting signal
      *
-     * Returns the computed ZoneAssignmentEntry vector so the caller can batch entries
+     * Returns the computed PhosphorEngineApi::ZoneAssignmentEntry vector so the caller can batch entries
      * from multiple screens into a single resnapToNewLayoutRequested emission.
      * Falls back to current-assignment entries if autotile order yields nothing.
      *
      * @param autotileWindowOrder Ordered list of window IDs from autotile engine
      * @param screenId Screen to resnap on
-     * @return Vector of ZoneAssignmentEntry (may be empty)
+     * @return Vector of PhosphorEngineApi::ZoneAssignmentEntry (may be empty)
      */
-    QVector<ZoneAssignmentEntry> calculateResnapEntriesFromAutotileOrder(const QStringList& autotileWindowOrder,
-                                                                         const QString& screenId);
+    QVector<PhosphorEngineApi::ZoneAssignmentEntry>
+    calculateResnapEntriesFromAutotileOrder(const QStringList& autotileWindowOrder, const QString& screenId);
 
     /**
      * @brief Calculate snap-all-windows assignments without applying them
@@ -130,7 +112,7 @@ public:
      * @param screenId Screen to snap on
      * @return JSON array of zone assignment entries for KWin effect to apply
      */
-    SnapAllResultList calculateSnapAllWindows(const QStringList& windowIds, const QString& screenId);
+    PhosphorProtocol::SnapAllResultList calculateSnapAllWindows(const QStringList& windowIds, const QString& screenId);
 
     /**
      * @brief Emit a single batched resnapToNewLayoutRequested signal
@@ -139,9 +121,9 @@ public:
      * Used by the daemon to combine entries from multiple screens into
      * one signal, eliminating the per-screen race condition.
      *
-     * @param entries Combined ZoneAssignmentEntry vector from all screens
+     * @param entries Combined PhosphorEngineApi::ZoneAssignmentEntry vector from all screens
      */
-    void emitBatchedResnap(const QVector<ZoneAssignmentEntry>& entries);
+    void emitBatchedResnap(const QVector<PhosphorEngineApi::ZoneAssignmentEntry>& entries);
 
     /**
      * @brief Request the KWin effect to collect and snap all unsnapped windows
@@ -162,15 +144,15 @@ public:
      *   3. Auto-assign to empty zone
      *   4. Snap to last zone (final fallback)
      *
-     * Returns a SnapResult so the D-Bus adaptor can unpack geometry for the
+     * Returns a PhosphorEngineApi::SnapResult so the D-Bus adaptor can unpack geometry for the
      * KWin effect. Also handles floating windows (skips snap, emits feedback).
      *
      * @param windowId Window identifier
      * @param screenId Screen where the window appeared
      * @param sticky Whether the window is on all desktops
-     * @return SnapResult with geometry and zone info, or SnapResult::noSnap()
+     * @return PhosphorEngineApi::SnapResult with geometry and zone info, or PhosphorEngineApi::SnapResult::noSnap()
      */
-    SnapResult resolveWindowRestore(const QString& windowId, const QString& screenId, bool sticky);
+    PhosphorEngineApi::SnapResult resolveWindowRestore(const QString& windowId, const QString& screenId, bool sticky);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Autotile engine reference (for isActiveOnScreen routing)
@@ -186,57 +168,52 @@ public:
      */
     void setAutotileEngine(PhosphorEngineApi::IPlacementEngine* engine);
 
-    PhosphorZones::SnapState* snapState() const
+    SnapState* snapState() const
     {
         return m_snapState;
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // PhosphorZones::Zone detection adaptor (for daemon-driven navigation)
+    // Zone adjacency resolver (for daemon-driven navigation)
     // ═══════════════════════════════════════════════════════════════════════════
 
     /**
-     * @brief Set ZoneDetectionAdaptor for adjacency queries
+     * @brief Set typed zone-adjacency resolver for directional navigation.
      *
-     * @param adaptor ZoneDetectionAdaptor instance (not owned, must outlive SnapEngine)
+     * Replaces the opaque QObject* setZoneDetectionAdaptor() that dispatched
+     * via QMetaObject::invokeMethod. The daemon's ZoneDetectionAdaptor must
+     * implement (or wrap) IZoneAdjacencyResolver.
+     *
+     * @param resolver Non-owning pointer; must outlive SnapEngine.
      */
-    void setZoneDetectionAdaptor(QObject* adaptor);
+    void setZoneAdjacencyResolver(IZoneAdjacencyResolver* resolver);
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // WindowTrackingAdaptor back-reference
+    // Navigation state provider
     // ═══════════════════════════════════════════════════════════════════════════
 
     /**
-     * @brief Wire the shared WindowTrackingAdaptor back-reference.
+     * @brief Wire the typed navigation-state provider.
      *
-     * SnapEngine owns the snap-mode navigation logic (focusInDirection,
-     * moveFocusedInDirection, etc.) but some of the state those methods
-     * consult — the SnapNavigationTargetResolver, the last-active-window
-     * shadow, the frame-geometry shadow, and the snap-bookkeeping helpers
-     * (windowSnapped / windowUnsnapped / storePreTileGeometry / ...) —
-     * is still held on WindowTrackingAdaptor.
-     *
-     * This back-reference lets SnapEngine call into that state without
-     * duplicating it. A future refactor should either move the state to
-     * WindowTrackingService (for cross-cutting pieces like the bookkeeping
-     * helpers) or onto SnapEngine itself (for snap-only pieces like the
-     * target resolver) and retire this back-reference entirely. Until
-     * then it's the honest expression of the coupling.
+     * Replaces the opaque QObject* setWindowTrackingAdaptor() that dispatched
+     * lastActiveWindowId / lastActiveScreenName / lastCursorScreenName /
+     * frameGeometry via QMetaObject::invokeMethod. The daemon's
+     * WindowTrackingAdaptor must implement (or wrap) INavigationStateProvider.
      *
      * Must be set after construction and before any navigation method is
      * called. Not owned; must outlive SnapEngine.
      */
-    void setWindowTrackingAdaptor(QObject* adaptor);
+    void setNavigationStateProvider(INavigationStateProvider* provider);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Navigation (moved out of WindowTrackingAdaptor)
     //
-    // Every method takes a NavigationContext populated by the daemon's
+    // Every method takes a PhosphorEngineApi::NavigationContext populated by the daemon's
     // shortcut handler. The engine uses ctx.windowId directly rather than
     // re-reading it from the WTA shadow, which is a step toward retiring
-    // the SnapEngine → WTA back-reference entirely. When ctx.windowId is
-    // empty, the engine may consult m_wta->lastActiveWindowId() as a
-    // best-effort fallback — but in the normal path the daemon always
+    // the SnapEngine -> WTA back-reference entirely. When ctx.windowId is
+    // empty, the engine may consult m_navState->lastActiveWindowId() as a
+    // best-effort fallback -- but in the normal path the daemon always
     // provides a resolved target.
     // ═══════════════════════════════════════════════════════════════════════════
 
@@ -246,46 +223,46 @@ public:
 
     /// Walk to the adjacent window in @p direction and transfer keyboard focus.
     /// Empty direction is a no-op with feedback.
-    void focusInDirection(const QString& direction, const NavigationContext& ctx) override;
+    void focusInDirection(const QString& direction, const PhosphorEngineApi::NavigationContext& ctx) override;
 
     /// Move the focused window into the adjacent zone in @p direction
     /// (displacing or filling the target). Empty direction is a no-op.
-    void moveFocusedInDirection(const QString& direction, const NavigationContext& ctx) override;
+    void moveFocusedInDirection(const QString& direction, const PhosphorEngineApi::NavigationContext& ctx) override;
 
     /// Swap the focused window with whatever's in the adjacent zone in
     /// @p direction. Empty direction is a no-op.
-    void swapFocusedInDirection(const QString& direction, const NavigationContext& ctx) override;
+    void swapFocusedInDirection(const QString& direction, const PhosphorEngineApi::NavigationContext& ctx) override;
 
     /// Move the focused window to the layout zone with @p zoneNumber
     /// (1-based) on ctx.screenId. PhosphorZones::Zone numbers outside [1,9] are rejected.
-    void moveFocusedToPosition(int zoneNumber, const NavigationContext& ctx) override;
+    void moveFocusedToPosition(int zoneNumber, const PhosphorEngineApi::NavigationContext& ctx) override;
 
     /// Rotate snapped windows through the layout's zone order, dispatched
     /// via IPlacementEngine. Forwards to rotateWindowsInLayout().
-    void rotateWindows(bool clockwise, const NavigationContext& ctx) override;
+    void rotateWindows(bool clockwise, const PhosphorEngineApi::NavigationContext& ctx) override;
 
     /// Re-apply the current layout to all managed windows. Forwards to
     /// resnapToNewLayout().
-    void reapplyLayout(const NavigationContext& ctx) override;
+    void reapplyLayout(const PhosphorEngineApi::NavigationContext& ctx) override;
 
     /// Snap every unmanaged window on the screen. The IPlacementEngine
-    /// override takes NavigationContext; coexists with the existing
+    /// override takes PhosphorEngineApi::NavigationContext; coexists with the existing
     /// snapAllWindows(const QString&) method which it delegates to.
-    void snapAllWindows(const NavigationContext& ctx) override;
+    void snapAllWindows(const PhosphorEngineApi::NavigationContext& ctx) override;
 
     /// Move the focused window to the first empty zone on ctx.screenId.
-    void pushToEmptyZone(const NavigationContext& ctx) override;
+    void pushToEmptyZone(const PhosphorEngineApi::NavigationContext& ctx) override;
 
     /// Restore the focused window to its captured pre-snap size and unsnap.
-    void restoreFocusedWindow(const NavigationContext& ctx) override;
+    void restoreFocusedWindow(const PhosphorEngineApi::NavigationContext& ctx) override;
 
     /// Toggle the focused window between snapped and floating.
-    void toggleFocusedFloat(const NavigationContext& ctx) override;
+    void toggleFocusedFloat(const PhosphorEngineApi::NavigationContext& ctx) override;
 
     /// Cycle keyboard focus forward/backward through managed windows in
     /// the active zone (or the layout cycle order if single-window per
     /// zone).
-    void cycleFocus(bool forward, const NavigationContext& ctx) override;
+    void cycleFocus(bool forward, const PhosphorEngineApi::NavigationContext& ctx) override;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Snap commit orchestration
@@ -296,39 +273,47 @@ public:
     // ═══════════════════════════════════════════════════════════════════════════
 
     void commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId,
-                    SnapIntent intent = SnapIntent::UserInitiated);
+                    PhosphorEngineApi::SnapIntent intent = PhosphorEngineApi::SnapIntent::UserInitiated);
 
     void commitMultiZoneSnap(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
-                             SnapIntent intent = SnapIntent::UserInitiated);
+                             PhosphorEngineApi::SnapIntent intent = PhosphorEngineApi::SnapIntent::UserInitiated);
 
     void uncommitSnap(const QString& windowId);
 
-    UnfloatResult resolveUnfloatGeometry(const QString& windowId, const QString& fallbackScreen) const;
+    PhosphorEngineApi::UnfloatResult resolveUnfloatGeometry(const QString& windowId,
+                                                            const QString& fallbackScreen) const;
 
-    WindowGeometryList applyBatchAssignments(const QVector<ZoneAssignmentEntry>& entries,
-                                             SnapIntent intent = SnapIntent::UserInitiated,
-                                             std::function<QString()> fallbackScreenResolver = {});
+    PhosphorProtocol::WindowGeometryList
+    applyBatchAssignments(const QVector<PhosphorEngineApi::ZoneAssignmentEntry>& entries,
+                          PhosphorEngineApi::SnapIntent intent = PhosphorEngineApi::SnapIntent::UserInitiated,
+                          std::function<QString()> fallbackScreenResolver = {});
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Auto-snap calculations (moved from WTS)
     // ═══════════════════════════════════════════════════════════════════════════
 
-    SnapResult calculateSnapToAppRule(const QString& windowId, const QString& windowScreenName, bool isSticky) const;
-    SnapResult calculateSnapToLastZone(const QString& windowId, const QString& windowScreenId, bool isSticky) const;
-    SnapResult calculateSnapToEmptyZone(const QString& windowId, const QString& windowScreenId, bool isSticky) const;
-    SnapResult calculateRestoreFromSession(const QString& windowId, const QString& screenId, bool isSticky) const;
+    PhosphorEngineApi::SnapResult calculateSnapToAppRule(const QString& windowId, const QString& windowScreenName,
+                                                         bool isSticky) const;
+    PhosphorEngineApi::SnapResult calculateSnapToLastZone(const QString& windowId, const QString& windowScreenId,
+                                                          bool isSticky) const;
+    PhosphorEngineApi::SnapResult calculateSnapToEmptyZone(const QString& windowId, const QString& windowScreenId,
+                                                           bool isSticky) const;
+    PhosphorEngineApi::SnapResult calculateRestoreFromSession(const QString& windowId, const QString& screenId,
+                                                              bool isSticky) const;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Resnap / rotation calculations (moved from WTS)
     // ═══════════════════════════════════════════════════════════════════════════
 
-    QVector<ZoneAssignmentEntry> calculateResnapFromPreviousLayout();
-    QVector<ZoneAssignmentEntry> calculateResnapFromCurrentAssignments(const QString& screenFilter = QString()) const;
-    QVector<ZoneAssignmentEntry> calculateResnapFromAutotileOrder(const QStringList& autotileWindowOrder,
-                                                                  const QString& screenId) const;
-    QVector<ZoneAssignmentEntry> calculateSnapAllWindowEntries(const QStringList& windowIds,
-                                                               const QString& screenId) const;
-    QVector<ZoneAssignmentEntry> calculateRotation(bool clockwise, const QString& screenFilter = QString()) const;
+    QVector<PhosphorEngineApi::ZoneAssignmentEntry> calculateResnapFromPreviousLayout();
+    QVector<PhosphorEngineApi::ZoneAssignmentEntry>
+    calculateResnapFromCurrentAssignments(const QString& screenFilter = QString()) const;
+    QVector<PhosphorEngineApi::ZoneAssignmentEntry>
+    calculateResnapFromAutotileOrder(const QStringList& autotileWindowOrder, const QString& screenId) const;
+    QVector<PhosphorEngineApi::ZoneAssignmentEntry> calculateSnapAllWindowEntries(const QStringList& windowIds,
+                                                                                  const QString& screenId) const;
+    QVector<PhosphorEngineApi::ZoneAssignmentEntry> calculateRotation(bool clockwise,
+                                                                      const QString& screenFilter = QString()) const;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Saved snap-floating windows (mode-transition bookkeeping)
@@ -389,7 +374,7 @@ public:
 
     /// Move the focused window to the first empty zone on ctx.screenId.
     /// The IPlacementEngine override pushToEmptyZone() delegates here.
-    void pushFocusedToEmptyZone(const NavigationContext& ctx);
+    void pushFocusedToEmptyZone(const PhosphorEngineApi::NavigationContext& ctx);
 
     /// Rotate snapped windows through the layout's zone order on @p screenId.
     void rotateWindowsInLayout(bool clockwise, const QString& screenId);
@@ -425,11 +410,11 @@ public:
 
 Q_SIGNALS:
     // ═══════════════════════════════════════════════════════════════════════════
-    // Signals (relayed via SnapAdaptor → WTA → D-Bus → effect)
+    // Signals (relayed via SnapAdaptor -> WTA -> D-Bus -> effect)
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// Snap state changed (commit / uncommit). WTA relays to D-Bus windowStateChanged.
-    void windowSnapStateChanged(const QString& windowId, const WindowStateEntry& entry);
+    void windowSnapStateChanged(const QString& windowId, const PhosphorProtocol::WindowStateEntry& entry);
 
     /// Floating state cleared as part of a commit. WTA relays as windowFloatingChanged(id, false, screen).
     void windowFloatingClearedForSnap(const QString& windowId, const QString& screenId);
@@ -448,7 +433,7 @@ Q_SIGNALS:
     /// single operation (rotate, resnap, snap-all paths). The @p action
     /// label disambiguates the cause downstream ("rotate", "resnap",
     /// "snap_all", "vs_reconfigure"). Relayed to D-Bus via WTA.
-    void applyGeometriesBatch(const PlasmaZones::WindowGeometryList& geometries, const QString& action);
+    void applyGeometriesBatch(const PhosphorProtocol::WindowGeometryList& geometries, const QString& action);
 
 protected:
     void onWindowClaimed(const QString& windowId) override;
@@ -467,23 +452,21 @@ private:
     GapParams resolveGapParams() const;
 
     void commitSnapImpl(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
-                        SnapIntent intent);
+                        PhosphorEngineApi::SnapIntent intent);
 
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;
     PhosphorEngineApi::IWindowTrackingService* m_windowTracker = nullptr;
-    PhosphorZones::SnapState* m_snapState = nullptr;
+    SnapState* m_snapState = nullptr;
     PhosphorZones::IZoneDetector* m_zoneDetector = nullptr;
     PhosphorEngineApi::IVirtualDesktopManager* m_virtualDesktopManager = nullptr;
     QPointer<QObject> m_autotileEngineObj;
     PhosphorEngineApi::IPlacementEngine* m_autotileEngineTyped = nullptr;
-    QPointer<QObject> m_zoneDetectionAdaptor;
-    // Back-reference to WindowTrackingAdaptor for state SnapEngine reads
-    // but doesn't own yet: the last-active-window / last-active-screen /
-    // last-cursor-screen shadows populated via D-Bus windowActivated and
-    // cursorScreenChanged slots, plus the frame-geometry shadow populated
-    // via setFrameGeometry. Not owned. Remaining uses are all read-only
-    // accessors — SnapEngine no longer routes BEHAVIOUR through WTA.
-    QPointer<QObject> m_wta;
+    IZoneAdjacencyResolver* m_zoneAdjacencyResolver = nullptr;
+    // Typed navigation-state provider — replaces the opaque QObject* m_wta
+    // back-reference. Provides read-only access to compositor-layer shadows
+    // (last-active window, last-active screen, last-cursor screen, frame
+    // geometry). Not owned; must outlive SnapEngine.
+    INavigationStateProvider* m_navState = nullptr;
     // Snap-mode navigation target resolver. Owned by SnapEngine — moved
     // here in Phase 5E from WindowTrackingAdaptor. Constructed lazily on
     // first navigation call (so the construction order isn't constrained
@@ -528,4 +511,4 @@ private:
     QString m_lastActiveScreenId;
 };
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
@@ -16,7 +16,7 @@
 
 #include <optional>
 
-namespace PhosphorZones {
+namespace PhosphorSnapEngine {
 
 /// Per-screen snap placement state.
 ///
@@ -298,4 +298,4 @@ private:
     QSet<QString> m_autoSnappedWindows;
 };
 
-} // namespace PhosphorZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/snapnavigationtargets.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/snapnavigationtargets.h
@@ -15,7 +15,7 @@ namespace PhosphorZones {
 class LayoutRegistry;
 }
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
 
 using PhosphorProtocol::CycleTargetResult;
 using PhosphorProtocol::FocusTargetResult;
@@ -24,8 +24,7 @@ using PhosphorProtocol::RestoreTargetResult;
 using PhosphorProtocol::SwapTargetResult;
 
 class ISettings;
-
-class ZoneDetectionAdaptor;
+class IZoneAdjacencyResolver;
 
 /**
  * @brief Pure snap-mode navigation target resolver.
@@ -37,7 +36,7 @@ class ZoneDetectionAdaptor;
  *
  * Separation of concerns:
  * - This class is pure compute. It holds const* references to
- *   WindowTrackingService / PhosphorZones::LayoutRegistry / ZoneDetectionAdaptor and
+ *   WindowTrackingService / PhosphorZones::LayoutRegistry / IZoneAdjacencyResolver and
  *   reads from them. It does not mutate their state.
  * - It never touches D-Bus or Qt signals directly — navigation
  *   feedback (OSD data) is emitted through a std::function callback
@@ -73,17 +72,17 @@ public:
      *
      * @param service            window tracking state store (non-owning)
      * @param layoutManager      layout / zone owner (non-owning)
-     * @param zoneDetector       adjacent/first-in-direction query helper (non-owning)
+     * @param zoneAdjacency      typed adjacency resolver (non-owning; may be nullptr)
      * @param feedback           OSD feedback callback; may be empty (suppresses feedback)
      */
     SnapNavigationTargetResolver(PhosphorEngineApi::IWindowTrackingService* service,
-                                 PhosphorZones::LayoutRegistry* layoutManager, QObject* zoneDetector,
+                                 PhosphorZones::LayoutRegistry* layoutManager, IZoneAdjacencyResolver* zoneAdjacency,
                                  FeedbackFn feedback);
 
-    /// Late setter for the zone detector — it may not be available at
+    /// Late setter for the zone adjacency resolver — it may not be available at
     /// construction time, so we allow nullptr and bind the pointer when
     /// it becomes available.
-    void setZoneDetector(QObject* zoneDetector);
+    void setZoneAdjacencyResolver(IZoneAdjacencyResolver* resolver);
 
     MoveTargetResult getMoveTargetForWindow(const QString& windowId, const QString& direction, const QString& screenId);
 
@@ -115,8 +114,8 @@ private:
 
     PhosphorEngineApi::IWindowTrackingService* m_service = nullptr;
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;
-    QObject* m_zoneDetector = nullptr;
+    IZoneAdjacencyResolver* m_zoneAdjacency = nullptr;
     FeedbackFn m_feedback;
 };
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/INavigationStateProvider.cpp
+++ b/libs/phosphor-snap-engine/src/INavigationStateProvider.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorSnapEngine/INavigationStateProvider.h>
+
+namespace PhosphorSnapEngine {
+
+INavigationStateProvider::~INavigationStateProvider() = default;
+
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/IZoneAdjacencyResolver.cpp
+++ b/libs/phosphor-snap-engine/src/IZoneAdjacencyResolver.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorSnapEngine/IZoneAdjacencyResolver.h>
+
+namespace PhosphorSnapEngine {
+
+IZoneAdjacencyResolver::~IZoneAdjacencyResolver() = default;
+
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/SnapEngine.cpp
+++ b/libs/phosphor-snap-engine/src/SnapEngine.cpp
@@ -4,12 +4,16 @@
 #include <PhosphorSnapEngine/SnapEngine.h>
 #include <PhosphorSnapEngine/SnapState.h>
 #include <PhosphorSnapEngine/snapnavigationtargets.h>
+#include <PhosphorSnapEngine/INavigationStateProvider.h>
+#include <PhosphorSnapEngine/IZoneAdjacencyResolver.h>
 #include <PhosphorSnapEngine/ISnapSettings.h>
 #include <PhosphorEngineApi/IGeometrySettings.h>
 #include <PhosphorLayoutApi/EdgeGaps.h>
 #include "snapenginelogging.h"
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
+
+using PhosphorEngineApi::NavigationContext;
 
 // In production (Daemon::start) all dependencies are non-null. Headless unit
 // tests deliberately pass nullptr to construct an engine with minimal parents
@@ -22,7 +26,7 @@ SnapEngine::SnapEngine(PhosphorZones::LayoutRegistry* layoutManager,
     : PlacementEngineBase(parent)
     , m_layoutManager(layoutManager)
     , m_windowTracker(windowTracker)
-    , m_snapState(new PhosphorZones::SnapState(QString(), this))
+    , m_snapState(new SnapState(QString(), this))
     , m_zoneDetector(zoneDetector)
     , m_virtualDesktopManager(vdm)
 {
@@ -131,26 +135,15 @@ void SnapEngine::setAutotileEngine(PhosphorEngineApi::IPlacementEngine* engine)
     }
 }
 
-void SnapEngine::setZoneDetectionAdaptor(QObject* adaptor)
+void SnapEngine::setZoneAdjacencyResolver(IZoneAdjacencyResolver* resolver)
 {
-    m_zoneDetectionAdaptor = adaptor;
-    // Push the zone detector into the target resolver if it exists yet.
-    // The resolver constructs lazily on first navigation call; if that
-    // hasn't happened yet, ensureTargetResolver() will pick up the adaptor
-    // from m_zoneDetectionAdaptor when it first runs.
+    m_zoneAdjacencyResolver = resolver;
+    // Push the resolver into the target resolver if it exists yet.
+    // The target resolver constructs lazily on first navigation call;
+    // if that hasn't happened yet, ensureTargetResolver() will pick up
+    // m_zoneAdjacencyResolver when it first runs.
     if (m_targetResolver) {
-        m_targetResolver->setZoneDetector(adaptor);
-    }
-    // Sever the resolver's raw pointer when the adaptor is destroyed
-    // out-of-band. Production always destroys the adaptor before the
-    // engine, but tests and shutdown orderings can diverge; without this
-    // the resolver would hold a dangling ZoneDetectionAdaptor*.
-    if (adaptor) {
-        connect(adaptor, &QObject::destroyed, this, [this]() {
-            if (m_targetResolver) {
-                m_targetResolver->setZoneDetector(nullptr);
-            }
-        });
+        m_targetResolver->setZoneAdjacencyResolver(resolver);
     }
 }
 
@@ -178,7 +171,7 @@ SnapNavigationTargetResolver* SnapEngine::ensureTargetResolver(const QString& ac
     // navigationFeedback signal, so external consumers see the same
     // wire format as when the resolver lived on WTA.
     m_targetResolver = std::make_unique<SnapNavigationTargetResolver>(
-        m_windowTracker, m_layoutManager, m_zoneDetectionAdaptor.data(),
+        m_windowTracker, m_layoutManager, m_zoneAdjacencyResolver,
         [this](bool success, const QString& action, const QString& reason, const QString& sourceZoneId,
                const QString& targetZoneId, const QString& screenId) {
             Q_EMIT navigationFeedback(success, action, reason, sourceZoneId, targetZoneId, screenId);
@@ -186,9 +179,9 @@ SnapNavigationTargetResolver* SnapEngine::ensureTargetResolver(const QString& ac
     return m_targetResolver.get();
 }
 
-void SnapEngine::setWindowTrackingAdaptor(QObject* adaptor)
+void SnapEngine::setNavigationStateProvider(INavigationStateProvider* provider)
 {
-    m_wta = adaptor;
+    m_navState = provider;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -224,8 +217,8 @@ void SnapEngine::windowFocused(const QString& windowId, const QString& screenId)
 // restoreFocusedWindow, toggleFocusedFloat, cycleFocus,
 // rotateWindowsInLayout, resnapCurrentAssignments, resnapToNewLayout)
 // live in snapengine/navigation_actions.cpp and call back into
-// WindowTrackingAdaptor via m_wta for target resolution and shared
-// bookkeeping helpers. The resnap-by-layout-switch pipeline
+// INavigationStateProvider (m_navState) for fallback target resolution
+// and compositor-layer state. The resnap-by-layout-switch pipeline
 // (calculateResnapEntriesFromAutotileOrder, snapAllWindows etc.) lives
 // in snapengine/navigation.cpp unchanged.
 
@@ -295,4 +288,4 @@ const PhosphorEngineApi::IPlacementState* SnapEngine::stateForScreen(const QStri
     return m_snapState;
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/SnapEngine.cpp
+++ b/libs/phosphor-snap-engine/src/SnapEngine.cpp
@@ -145,6 +145,18 @@ void SnapEngine::setZoneAdjacencyResolver(IZoneAdjacencyResolver* resolver)
     if (m_targetResolver) {
         m_targetResolver->setZoneAdjacencyResolver(resolver);
     }
+    // Guard against out-of-order destruction: null the raw pointer if the
+    // underlying QObject is destroyed before SnapEngine. The interface is
+    // not a QObject, but every production implementor (ZoneDetectionAdaptor)
+    // is — dynamic_cast recovers the QObject identity for the connection.
+    if (auto* qobj = dynamic_cast<QObject*>(resolver)) {
+        connect(qobj, &QObject::destroyed, this, [this]() {
+            m_zoneAdjacencyResolver = nullptr;
+            if (m_targetResolver) {
+                m_targetResolver->setZoneAdjacencyResolver(nullptr);
+            }
+        });
+    }
 }
 
 SnapNavigationTargetResolver* SnapEngine::ensureTargetResolver(const QString& action)
@@ -182,6 +194,13 @@ SnapNavigationTargetResolver* SnapEngine::ensureTargetResolver(const QString& ac
 void SnapEngine::setNavigationStateProvider(INavigationStateProvider* provider)
 {
     m_navState = provider;
+    // Guard against out-of-order destruction: null the raw pointer if the
+    // underlying QObject is destroyed before SnapEngine.
+    if (auto* qobj = dynamic_cast<QObject*>(provider)) {
+        connect(qobj, &QObject::destroyed, this, [this]() {
+            m_navState = nullptr;
+        });
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/libs/phosphor-snap-engine/src/SnapState.cpp
+++ b/libs/phosphor-snap-engine/src/SnapState.cpp
@@ -5,7 +5,7 @@
 
 #include <QJsonArray>
 
-namespace PhosphorZones {
+namespace PhosphorSnapEngine {
 
 SnapState::SnapState(const QString& screenId, QObject* parent)
     : QObject(parent)
@@ -648,4 +648,4 @@ SnapState* SnapState::fromJson(const QJsonObject& json, QObject* parent)
     return state;
 }
 
-} // namespace PhosphorZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -19,7 +19,11 @@
 #include <QScreen>
 #include <QUuid>
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
+
+using PhosphorEngineApi::PendingRestore;
+using PhosphorEngineApi::SnapResult;
+using PhosphorEngineApi::StickyWindowHandling;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Auto-Snap Logic
@@ -461,4 +465,4 @@ SnapResult SnapEngine::calculateRestoreFromSession(const QString& windowId, cons
     return result;
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/commit.cpp
+++ b/libs/phosphor-snap-engine/src/commit.cpp
@@ -9,7 +9,13 @@
 #include <QGuiApplication>
 #include <QScreen>
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
+
+using PhosphorEngineApi::SnapIntent;
+using PhosphorEngineApi::ZoneAssignmentEntry;
+using PhosphorProtocol::WindowGeometryEntry;
+using PhosphorProtocol::WindowGeometryList;
+using PhosphorProtocol::WindowStateEntry;
 
 void SnapEngine::commitSnapImpl(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
                                 SnapIntent intent)
@@ -146,4 +152,4 @@ WindowGeometryList SnapEngine::applyBatchAssignments(const QVector<ZoneAssignmen
     return geometries;
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -7,7 +7,10 @@
 #include <PhosphorScreens/ScreenIdentity.h>
 #include "snapenginelogging.h"
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
+
+using PhosphorEngineApi::SnapIntent;
+using PhosphorEngineApi::UnfloatResult;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Float toggle / set
@@ -159,4 +162,4 @@ UnfloatResult SnapEngine::resolveUnfloatGeometry(const QString& windowId, const 
     return result;
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -9,7 +9,11 @@
 #include <PhosphorZones/LayoutRegistry.h>
 #include "snapenginelogging.h"
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
+
+using PhosphorEngineApi::PendingRestore;
+using PhosphorEngineApi::SnapIntent;
+using PhosphorEngineApi::SnapResult;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // windowOpened — delegates to resolveWindowRestore() and applies the result
@@ -206,4 +210,4 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     return SnapResult::noSnap();
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/navigation.cpp
+++ b/libs/phosphor-snap-engine/src/navigation.cpp
@@ -10,7 +10,11 @@
 #include <PhosphorEngineTypes/EngineTypes.h>
 #include <PhosphorZones/Zone.h>
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
+
+using PhosphorEngineApi::ZoneAssignmentEntry;
+using PhosphorProtocol::SnapAllResultEntry;
+using PhosphorProtocol::SnapAllResultList;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Snap-mode resnap coordination
@@ -138,4 +142,4 @@ void SnapEngine::snapAllWindows(const QString& screenId)
     Q_EMIT snapAllWindowsRequested(screenId);
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/navigation_actions.cpp
+++ b/libs/phosphor-snap-engine/src/navigation_actions.cpp
@@ -14,10 +14,9 @@
  * Navigation is now SnapEngine's concern. Every entry point takes an
  * explicit NavigationContext {windowId, screenId} from the daemon's
  * shortcut handler, so the engine no longer reaches into the WTA shadow
- * store on every call. The back-reference to WTA is retained for last-
- * resort fallback (when the daemon can't resolve a target), for the
- * frame-geometry shadow used by the float pre-tile capture, and for
- * the resnap fallback-screen helper in applyBatchAssignments.
+ * store on every call. Compositor-layer fallbacks (last-active window,
+ * last-cursor screen, frame geometry) are now accessed through the typed
+ * INavigationStateProvider interface rather than opaque QObject* invoke.
  *
  * Signals emitted by these methods are SnapEngine signals; SnapAdaptor
  * relays them to WindowTrackingAdaptor, which exposes them on D-Bus.
@@ -26,6 +25,7 @@
 #include <PhosphorSnapEngine/SnapEngine.h>
 #include <PhosphorSnapEngine/SnapState.h>
 
+#include <PhosphorSnapEngine/INavigationStateProvider.h>
 #include <PhosphorSnapEngine/ISnapSettings.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
@@ -36,26 +36,24 @@
 #include <PhosphorIdentity/VirtualScreenId.h>
 #include <PhosphorIdentity/WindowId.h>
 #include <PhosphorScreens/ScreenIdentity.h>
-#include <QMetaObject>
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
+
+using PhosphorEngineApi::NavigationContext;
+using PhosphorEngineApi::SnapIntent;
+using PhosphorEngineApi::ZoneAssignmentEntry;
+using PhosphorProtocol::CycleTargetResult;
+using PhosphorProtocol::FocusTargetResult;
+using PhosphorProtocol::MoveTargetResult;
+using PhosphorProtocol::RestoreTargetResult;
+using PhosphorProtocol::SwapTargetResult;
+using PhosphorProtocol::WindowGeometryList;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Private helpers
 // ═══════════════════════════════════════════════════════════════════════════════
 
 namespace {
-
-QString invokeStringGetter(QObject* obj, const char* method)
-{
-    QString r;
-    if (obj) {
-        bool ok = QMetaObject::invokeMethod(obj, method, Q_RETURN_ARG(QString, r));
-        if (Q_UNLIKELY(!ok))
-            qCWarning(PhosphorSnapEngine::lcSnapEngine) << "invokeStringGetter: method" << method << "failed on" << obj;
-    }
-    return r;
-}
 
 /// Resolve the screen to use for a navigation operation on @p windowId.
 ///
@@ -64,9 +62,9 @@ QString invokeStringGetter(QObject* obj, const char* method)
 ///      This keeps the operation on the monitor the user originally chose,
 ///      rather than the one KWin happens to think the window is on.
 ///   2. An explicit @p preferredScreen from the NavigationContext.
-///   3. The WTA cursor / last-active screen shadows.
-QString resolveNavScreen(QObject* wta, const QString& windowId, PhosphorEngineApi::IWindowTrackingService* service,
-                         const QString& preferredScreen = QString())
+///   3. The INavigationStateProvider cursor / last-active screen values.
+QString resolveNavScreen(INavigationStateProvider* navState, const QString& windowId,
+                         PhosphorEngineApi::IWindowTrackingService* service, const QString& preferredScreen = QString())
 {
     if (service && !windowId.isEmpty()) {
         const QString zoneId = service->zoneForWindow(windowId);
@@ -91,35 +89,35 @@ QString resolveNavScreen(QObject* wta, const QString& windowId, PhosphorEngineAp
     if (!preferredScreen.isEmpty()) {
         return preferredScreen;
     }
-    if (!wta) {
+    if (!navState) {
         return QString();
     }
-    QString screen = invokeStringGetter(wta, "lastCursorScreenName");
+    QString screen = navState->lastCursorScreenName();
     if (screen.isEmpty()) {
-        screen = invokeStringGetter(wta, "lastActiveScreenName");
+        screen = navState->lastActiveScreenName();
     }
     return screen;
 }
 
 /// Pick the effective window id: the explicit one from NavigationContext
-/// if set, otherwise the last-active shadow on WTA. Returns empty when
-/// neither is available — caller emits "no_window" feedback.
-QString effectiveWindowId(const NavigationContext& ctx, QObject* wta)
+/// if set, otherwise the last-active window from INavigationStateProvider.
+/// Returns empty when neither is available — caller emits "no_window" feedback.
+QString effectiveWindowId(const NavigationContext& ctx, INavigationStateProvider* navState)
 {
     if (!ctx.windowId.isEmpty()) {
         return ctx.windowId;
     }
-    return invokeStringGetter(wta, "lastActiveWindowId");
+    return navState ? navState->lastActiveWindowId() : QString();
 }
 
 /// Pick the effective screen id: the explicit one from NavigationContext
-/// if set, otherwise the last-active screen shadow on WTA.
-QString effectiveScreenId(const NavigationContext& ctx, QObject* wta)
+/// if set, otherwise the last-active screen from INavigationStateProvider.
+QString effectiveScreenId(const NavigationContext& ctx, INavigationStateProvider* navState)
 {
     if (!ctx.screenId.isEmpty()) {
         return ctx.screenId;
     }
-    return invokeStringGetter(wta, "lastActiveScreenName");
+    return navState ? navState->lastActiveScreenName() : QString();
 }
 
 } // namespace
@@ -171,13 +169,13 @@ void SnapEngine::focusInDirection(const QString& direction, const NavigationCont
     if (!resolver) {
         return; // ensureTargetResolver emitted feedback
     }
-    const QString windowId = effectiveWindowId(ctx, m_wta);
+    const QString windowId = effectiveWindowId(ctx, m_navState);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("focus"), QStringLiteral("no_window"), QString(), QString(),
                                   ctx.screenId);
         return;
     }
-    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
+    const QString screenId = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
     FocusTargetResult result = resolver->getFocusTargetForWindow(windowId, direction, screenId);
     if (!result.success) {
         return; // resolver already emitted feedback via its callback
@@ -204,7 +202,7 @@ void SnapEngine::moveFocusedInDirection(const QString& direction, const Navigati
     if (!resolver) {
         return;
     }
-    const QString windowId = effectiveWindowId(ctx, m_wta);
+    const QString windowId = effectiveWindowId(ctx, m_navState);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("move"), QStringLiteral("no_window"), QString(), QString(),
                                   ctx.screenId);
@@ -213,7 +211,7 @@ void SnapEngine::moveFocusedInDirection(const QString& direction, const Navigati
     if (isWindowExcludedForAction(windowId, QStringLiteral("move"), ctx.screenId)) {
         return;
     }
-    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
+    const QString screenId = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
     MoveTargetResult result = resolver->getMoveTargetForWindow(windowId, direction, screenId);
     if (!result.success) {
         return;
@@ -247,7 +245,7 @@ void SnapEngine::swapFocusedInDirection(const QString& direction, const Navigati
     if (!resolver) {
         return;
     }
-    const QString windowId = effectiveWindowId(ctx, m_wta);
+    const QString windowId = effectiveWindowId(ctx, m_navState);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("swap"), QStringLiteral("no_window"), QString(), QString(),
                                   ctx.screenId);
@@ -256,7 +254,7 @@ void SnapEngine::swapFocusedInDirection(const QString& direction, const Navigati
     if (isWindowExcludedForAction(windowId, QStringLiteral("swap"), ctx.screenId)) {
         return;
     }
-    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
+    const QString screenId = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
     SwapTargetResult result = resolver->getSwapTargetForWindow(windowId, direction, screenId);
     if (!result.success) {
         return;
@@ -298,16 +296,16 @@ void SnapEngine::moveFocusedToPosition(int zoneNumber, const NavigationContext& 
     if (!resolver) {
         return;
     }
-    const QString windowId = effectiveWindowId(ctx, m_wta);
+    const QString windowId = effectiveWindowId(ctx, m_navState);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("snap"), QStringLiteral("no_window"), QString(), QString(),
-                                  effectiveScreenId(ctx, m_wta));
+                                  effectiveScreenId(ctx, m_navState));
         return;
     }
     if (isWindowExcludedForAction(windowId, QStringLiteral("snap"), ctx.screenId)) {
         return;
     }
-    const QString effectiveScreen = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
+    const QString effectiveScreen = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
     MoveTargetResult result = resolver->getSnapToZoneByNumberTarget(windowId, zoneNumber, effectiveScreen);
     if (!result.success) {
         return;
@@ -336,16 +334,16 @@ void SnapEngine::pushFocusedToEmptyZone(const NavigationContext& ctx)
     if (!resolver) {
         return;
     }
-    const QString windowId = effectiveWindowId(ctx, m_wta);
+    const QString windowId = effectiveWindowId(ctx, m_navState);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("push"), QStringLiteral("no_window"), QString(), QString(),
-                                  effectiveScreenId(ctx, m_wta));
+                                  effectiveScreenId(ctx, m_navState));
         return;
     }
     if (isWindowExcludedForAction(windowId, QStringLiteral("push"), ctx.screenId)) {
         return;
     }
-    const QString effectiveScreen = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
+    const QString effectiveScreen = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
     MoveTargetResult result = resolver->getPushTargetForWindow(windowId, effectiveScreen);
     if (!result.success) {
         return;
@@ -374,13 +372,13 @@ void SnapEngine::restoreFocusedWindow(const NavigationContext& ctx)
     if (!resolver) {
         return;
     }
-    const QString windowId = effectiveWindowId(ctx, m_wta);
+    const QString windowId = effectiveWindowId(ctx, m_navState);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("restore"), QStringLiteral("no_window"), QString(), QString(),
-                                  effectiveScreenId(ctx, m_wta));
+                                  effectiveScreenId(ctx, m_navState));
         return;
     }
-    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
+    const QString screenId = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
     RestoreTargetResult result = resolver->getRestoreForWindow(windowId, screenId);
     if (!result.success) {
         return;
@@ -399,8 +397,8 @@ void SnapEngine::toggleFocusedFloat(const NavigationContext& ctx)
                                   QString(), ctx.screenId);
         return;
     }
-    const QString windowId = effectiveWindowId(ctx, m_wta);
-    const QString screenId = effectiveScreenId(ctx, m_wta);
+    const QString windowId = effectiveWindowId(ctx, m_navState);
+    const QString screenId = effectiveScreenId(ctx, m_navState);
     if (windowId.isEmpty() || screenId.isEmpty()) {
         qCInfo(PhosphorSnapEngine::lcSnapEngine) << "toggleFocusedFloat: no active window in context";
         Q_EMIT navigationFeedback(false, QStringLiteral("float"), QStringLiteral("no_active_window"), QString(),
@@ -415,13 +413,8 @@ void SnapEngine::toggleFocusedFloat(const NavigationContext& ctx)
     // window is snapped/tiled, the live shadow holds the zone rect — storing
     // it would poison the pre-tile entry with tile coordinates, so we leave
     // whatever's already stored untouched.
-    //
-    // The frame-geometry shadow is the one compositor-layer piece of state
-    // still living on WTA. Reading it here is the last remaining behavior
-    // coupling to the adaptor in this file.
-    if (m_wta && m_snapState->isFloating(windowId)) {
-        QRect geo;
-        QMetaObject::invokeMethod(m_wta, "frameGeometry", Q_RETURN_ARG(QRect, geo), Q_ARG(QString, windowId));
+    if (m_navState && m_snapState->isFloating(windowId)) {
+        QRect geo = m_navState->frameGeometry(windowId);
         if (geo.isValid()) {
             storeUnmanagedGeometry(windowId, geo, screenId, /*overwrite=*/true);
         }
@@ -445,13 +438,13 @@ void SnapEngine::cycleFocus(bool forward, const NavigationContext& ctx)
     if (!resolver) {
         return;
     }
-    const QString windowId = effectiveWindowId(ctx, m_wta);
+    const QString windowId = effectiveWindowId(ctx, m_navState);
     if (windowId.isEmpty()) {
         Q_EMIT navigationFeedback(false, QStringLiteral("cycle"), QStringLiteral("no_window"), QString(), QString(),
-                                  effectiveScreenId(ctx, m_wta));
+                                  effectiveScreenId(ctx, m_navState));
         return;
     }
-    const QString screenId = resolveNavScreen(m_wta, windowId, m_windowTracker, ctx.screenId);
+    const QString screenId = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
     CycleTargetResult result = resolver->getCycleTargetForWindow(windowId, forward, screenId);
     if (!result.success) {
         return;
@@ -487,16 +480,19 @@ void SnapEngine::rotateWindowsInLayout(bool clockwise, const QString& screenId)
     }
 
     // Apply the batch through WTS's unified helper. UserInitiated intent
-    // preserves historical rotate semantics (each windows snap updates
-    // last-used-zone). The fallback resolver is the compositor-layer
-    // cursor/active-window shadow on WTA — only used when none of the
-    // built-in strategies (targetScreenId / geometry.center() /
-    // QGuiApplication::screens()) yield a screen.
-    const QPointer<QObject> wta = m_wta;
-    WindowGeometryList geometries = applyBatchAssignments(entries, SnapIntent::UserInitiated, [wta]() -> QString {
-        QString cursor = invokeStringGetter(wta.data(), "lastCursorScreenName");
+    // preserves historical rotate semantics (each window's snap updates
+    // last-used-zone). The fallback resolver queries the compositor-layer
+    // cursor/active-screen shadows via INavigationStateProvider — only
+    // used when none of the built-in strategies (targetScreenId /
+    // geometry.center() / QGuiApplication::screens()) yield a screen.
+    INavigationStateProvider* navState = m_navState;
+    WindowGeometryList geometries = applyBatchAssignments(entries, SnapIntent::UserInitiated, [navState]() -> QString {
+        if (!navState) {
+            return QString();
+        }
+        QString cursor = navState->lastCursorScreenName();
         if (cursor.isEmpty()) {
-            cursor = invokeStringGetter(wta.data(), "lastActiveScreenName");
+            cursor = navState->lastActiveScreenName();
         }
         return cursor;
     });
@@ -515,4 +511,4 @@ void SnapEngine::rotateWindowsInLayout(bool clockwise, const QString& screenId)
 // the emitBatchedResnap → resnapToNewLayoutRequested → WTA::handleBatchedResnap
 // pipeline, which remains the canonical batch-resnap path.
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/navigation_actions.cpp
+++ b/libs/phosphor-snap-engine/src/navigation_actions.cpp
@@ -485,14 +485,13 @@ void SnapEngine::rotateWindowsInLayout(bool clockwise, const QString& screenId)
     // cursor/active-screen shadows via INavigationStateProvider — only
     // used when none of the built-in strategies (targetScreenId /
     // geometry.center() / QGuiApplication::screens()) yield a screen.
-    INavigationStateProvider* navState = m_navState;
-    WindowGeometryList geometries = applyBatchAssignments(entries, SnapIntent::UserInitiated, [navState]() -> QString {
-        if (!navState) {
+    WindowGeometryList geometries = applyBatchAssignments(entries, SnapIntent::UserInitiated, [this]() -> QString {
+        if (!m_navState) {
             return QString();
         }
-        QString cursor = navState->lastCursorScreenName();
+        QString cursor = m_navState->lastCursorScreenName();
         if (cursor.isEmpty()) {
-            cursor = navState->lastActiveScreenName();
+            cursor = m_navState->lastActiveScreenName();
         }
         return cursor;
     });

--- a/libs/phosphor-snap-engine/src/resnap_calc.cpp
+++ b/libs/phosphor-snap-engine/src/resnap_calc.cpp
@@ -24,7 +24,10 @@
 #include <algorithm>
 #include <tuple>
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
+
+using PhosphorEngineApi::ResnapEntry;
+using PhosphorEngineApi::ZoneAssignmentEntry;
 
 QVector<ZoneAssignmentEntry> SnapEngine::calculateResnapFromPreviousLayout()
 {
@@ -524,4 +527,4 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateRotation(bool clockwise, const
     return result;
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/snapnavigationtargets.cpp
+++ b/libs/phosphor-snap-engine/src/snapnavigationtargets.cpp
@@ -3,44 +3,21 @@
 
 #include <PhosphorSnapEngine/snapnavigationtargets.h>
 
+#include <PhosphorSnapEngine/IZoneAdjacencyResolver.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include "snapenginelogging.h"
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorScreens/VirtualScreen.h>
-#include <QMetaObject>
 #include <PhosphorZones/Zone.h>
 
 #include <QRect>
 #include <QStringList>
 #include <PhosphorScreens/ScreenIdentity.h>
 
-namespace PlasmaZones {
+namespace PhosphorSnapEngine {
 
 namespace {
-
-// ═══════════════════════════════════════════════════════════════════════════
-// Zone detector invoke helpers
-// ═══════════════════════════════════════════════════════════════════════════
-
-QString invokeGetAdjacentZone(QObject* detector, const QString& currentZoneId, const QString& direction,
-                              const QString& screenId)
-{
-    QString r;
-    if (detector)
-        QMetaObject::invokeMethod(detector, "getAdjacentZone", Q_RETURN_ARG(QString, r), Q_ARG(QString, currentZoneId),
-                                  Q_ARG(QString, direction), Q_ARG(QString, screenId));
-    return r;
-}
-
-QString invokeGetFirstZoneInDirection(QObject* detector, const QString& direction, const QString& screenId)
-{
-    QString r;
-    if (detector)
-        QMetaObject::invokeMethod(detector, "getFirstZoneInDirection", Q_RETURN_ARG(QString, r),
-                                  Q_ARG(QString, direction), Q_ARG(QString, screenId));
-    return r;
-}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Result builders
@@ -120,19 +97,19 @@ bool checkDirection(const QString& direction)
 
 SnapNavigationTargetResolver::SnapNavigationTargetResolver(PhosphorEngineApi::IWindowTrackingService* service,
                                                            PhosphorZones::LayoutRegistry* layoutManager,
-                                                           QObject* zoneDetector, FeedbackFn feedback)
+                                                           IZoneAdjacencyResolver* zoneAdjacency, FeedbackFn feedback)
     : m_service(service)
     , m_layoutManager(layoutManager)
-    , m_zoneDetector(zoneDetector)
+    , m_zoneAdjacency(zoneAdjacency)
     , m_feedback(std::move(feedback))
 {
     Q_ASSERT(service);
     Q_ASSERT(layoutManager);
 }
 
-void SnapNavigationTargetResolver::setZoneDetector(QObject* zoneDetector)
+void SnapNavigationTargetResolver::setZoneAdjacencyResolver(IZoneAdjacencyResolver* resolver)
 {
-    m_zoneDetector = zoneDetector;
+    m_zoneAdjacency = resolver;
 }
 
 // Feedback callback emission goes through SnapNavigationTargetResolver::emitFeedback
@@ -159,7 +136,7 @@ MoveTargetResult SnapNavigationTargetResolver::getMoveTargetForWindow(const QStr
                      screenId);
         return moveResult(false, QStringLiteral("invalid_direction"), QString(), QRect(), QString(), screenId);
     }
-    if (!m_zoneDetector) {
+    if (!m_zoneAdjacency) {
         return moveResult(false, QStringLiteral("no_zone_detection"), QString(), QRect(), QString(), screenId);
     }
 
@@ -188,14 +165,14 @@ MoveTargetResult SnapNavigationTargetResolver::getMoveTargetForWindow(const QStr
 
     QString targetZoneId;
     if (currentZoneId.isEmpty()) {
-        targetZoneId = invokeGetFirstZoneInDirection(m_zoneDetector, direction, effectiveScreenId);
+        targetZoneId = m_zoneAdjacency->getFirstZoneInDirection(direction, effectiveScreenId);
         if (targetZoneId.isEmpty()) {
             emitFeedback(false, QStringLiteral("move"), QStringLiteral("no_zones"), QString(), QString(),
                          effectiveScreenId);
             return moveResult(false, QStringLiteral("no_zones"), QString(), QRect(), QString(), effectiveScreenId);
         }
     } else {
-        targetZoneId = invokeGetAdjacentZone(m_zoneDetector, currentZoneId, direction, effectiveScreenId);
+        targetZoneId = m_zoneAdjacency->getAdjacentZone(currentZoneId, direction, effectiveScreenId);
         if (targetZoneId.isEmpty()) {
             emitFeedback(false, QStringLiteral("move"), QStringLiteral("no_adjacent_zone"), currentZoneId, QString(),
                          effectiveScreenId);
@@ -231,7 +208,7 @@ FocusTargetResult SnapNavigationTargetResolver::getFocusTargetForWindow(const QS
                      screenId);
         return focusResult(false, QStringLiteral("invalid_direction"), QString(), QString(), QString(), screenId);
     }
-    if (!m_zoneDetector) {
+    if (!m_zoneAdjacency) {
         return focusResult(false, QStringLiteral("no_zone_detection"), QString(), QString(), QString(), screenId);
     }
 
@@ -250,7 +227,7 @@ FocusTargetResult SnapNavigationTargetResolver::getFocusTargetForWindow(const QS
         }
     }
 
-    QString targetZoneId = invokeGetAdjacentZone(m_zoneDetector, currentZoneId, direction, effectiveScreenId);
+    QString targetZoneId = m_zoneAdjacency->getAdjacentZone(currentZoneId, direction, effectiveScreenId);
     if (targetZoneId.isEmpty()) {
         emitFeedback(false, QStringLiteral("focus"), QStringLiteral("no_adjacent_zone"), currentZoneId, QString(),
                      effectiveScreenId);
@@ -357,7 +334,7 @@ SwapTargetResult SnapNavigationTargetResolver::getSwapTargetForWindow(const QStr
         return swapResult(false, QStringLiteral("invalid_direction"), QString(), 0, 0, 0, 0, QString(), QString(), 0, 0,
                           0, 0, QString(), screenId, QString(), QString());
     }
-    if (!m_zoneDetector) {
+    if (!m_zoneAdjacency) {
         return swapResult(false, QStringLiteral("no_zone_detection"), QString(), 0, 0, 0, 0, QString(), QString(), 0, 0,
                           0, 0, QString(), screenId, QString(), QString());
     }
@@ -378,7 +355,7 @@ SwapTargetResult SnapNavigationTargetResolver::getSwapTargetForWindow(const QStr
         }
     }
 
-    QString targetZoneId = invokeGetAdjacentZone(m_zoneDetector, currentZoneId, direction, effectiveScreenId);
+    QString targetZoneId = m_zoneAdjacency->getAdjacentZone(currentZoneId, direction, effectiveScreenId);
     if (targetZoneId.isEmpty()) {
         emitFeedback(false, QStringLiteral("swap"), QStringLiteral("no_adjacent_zone"), currentZoneId, QString(),
                      effectiveScreenId);
@@ -480,4 +457,4 @@ MoveTargetResult SnapNavigationTargetResolver::getSnapToZoneByNumberTarget(const
     return moveResult(true, QString(), zoneId, geo, QString(), screenId);
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileConfig.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileConfig.h
@@ -11,7 +11,7 @@
 #include <QString>
 #include <QVariantMap>
 
-namespace PlasmaZones {
+namespace PhosphorTileEngine {
 
 /**
  * @brief Per-algorithm saved settings (split ratio + master count)
@@ -258,8 +258,8 @@ struct PHOSPHORTILEENGINE_EXPORT AutotileConfig
     static AutotileConfig defaults();
 };
 
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine
 
 // Enable use with QVariant
-Q_DECLARE_METATYPE(PlasmaZones::AutotileConfig)
-Q_DECLARE_METATYPE(PlasmaZones::AutotileConfig::InsertPosition)
+Q_DECLARE_METATYPE(PhosphorTileEngine::AutotileConfig)
+Q_DECLARE_METATYPE(PhosphorTileEngine::AutotileConfig::InsertPosition)

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -31,11 +31,7 @@ class Layout;
 class LayoutRegistry;
 }
 
-namespace PlasmaZones {
-
-using NavigationContext = PhosphorEngineApi::NavigationContext;
-using TilingStateKey = PhosphorEngineApi::TilingStateKey;
-namespace PerScreenKeys = PhosphorEngineApi::PerScreenKeys;
+namespace PhosphorTileEngine {
 
 /**
  * @brief Saved position for a window removed from autotile, keyed by appId.
@@ -47,7 +43,7 @@ namespace PerScreenKeys = PhosphorEngineApi::PerScreenKeys;
 struct PendingAutotileRestore
 {
     PendingAutotileRestore() = default;
-    PendingAutotileRestore(int pos, TilingStateKey ctx, bool floating)
+    PendingAutotileRestore(int pos, PhosphorEngineApi::TilingStateKey ctx, bool floating)
         : position(pos)
         , context(std::move(ctx))
         , wasFloating(floating)
@@ -55,7 +51,7 @@ struct PendingAutotileRestore
     }
 
     int position = -1; ///< Index in window order at time of removal
-    TilingStateKey context; ///< Screen/desktop/activity where the window was tiled
+    PhosphorEngineApi::TilingStateKey context; ///< Screen/desktop/activity where the window was tiled
     bool wasFloating = false; ///< Whether the window was floating when removed
 };
 
@@ -67,12 +63,10 @@ class AutotileConfig;
 class NavigationController;
 class PerScreenConfigResolver;
 // Phosphor::Screens::ScreenManager moved to libs/phosphor-screens (Phosphor::Screens::ScreenManager).
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine
 namespace Phosphor::Screens {
 class ScreenManager;
 }
-namespace PlasmaZones {
-} // namespace PlasmaZones
 
 namespace PhosphorTiles {
 class ITileAlgorithmRegistry;
@@ -80,7 +74,7 @@ class TilingAlgorithm;
 class TilingState;
 }
 
-namespace PlasmaZones {
+namespace PhosphorTileEngine {
 
 /**
  * @brief Core engine for automatic window tiling.
@@ -478,7 +472,7 @@ public:
     // ═══════════════════════════════════════════════════════════════════════════
 
     PhosphorEngineApi::IAutotileSettings* autotileSettings() const;
-    QVariantMap buildTuningWriteBack() const;
+    void writeBackTuning();
     void refreshConfigFromSettings() override;
 
     // Per-screen config — forwarded to PerScreenConfigResolver (IPlacementEngine overrides)
@@ -733,17 +727,17 @@ public:
     // concrete AutotileEngine method with the right parameters.
     // ═══════════════════════════════════════════════════════════════════════════
 
-    void focusInDirection(const QString& direction, const NavigationContext& ctx) override;
-    void moveFocusedInDirection(const QString& direction, const NavigationContext& ctx) override;
-    void swapFocusedInDirection(const QString& direction, const NavigationContext& ctx) override;
-    void moveFocusedToPosition(int position, const NavigationContext& ctx) override;
-    void rotateWindows(bool clockwise, const NavigationContext& ctx) override;
-    void reapplyLayout(const NavigationContext& ctx) override;
-    void snapAllWindows(const NavigationContext& ctx) override;
-    void toggleFocusedFloat(const NavigationContext& ctx) override;
-    void cycleFocus(bool forward, const NavigationContext& ctx) override;
-    void pushToEmptyZone(const NavigationContext& ctx) override;
-    void restoreFocusedWindow(const NavigationContext& ctx) override;
+    void focusInDirection(const QString& direction, const PhosphorEngineApi::NavigationContext& ctx) override;
+    void moveFocusedInDirection(const QString& direction, const PhosphorEngineApi::NavigationContext& ctx) override;
+    void swapFocusedInDirection(const QString& direction, const PhosphorEngineApi::NavigationContext& ctx) override;
+    void moveFocusedToPosition(int position, const PhosphorEngineApi::NavigationContext& ctx) override;
+    void rotateWindows(bool clockwise, const PhosphorEngineApi::NavigationContext& ctx) override;
+    void reapplyLayout(const PhosphorEngineApi::NavigationContext& ctx) override;
+    void snapAllWindows(const PhosphorEngineApi::NavigationContext& ctx) override;
+    void toggleFocusedFloat(const PhosphorEngineApi::NavigationContext& ctx) override;
+    void cycleFocus(bool forward, const PhosphorEngineApi::NavigationContext& ctx) override;
+    void pushToEmptyZone(const PhosphorEngineApi::NavigationContext& ctx) override;
+    void restoreFocusedWindow(const PhosphorEngineApi::NavigationContext& ctx) override;
 
     // Autotile-specific navigation. Callable directly on the concrete
     // AutotileEngine pointer from internal callers.
@@ -1076,11 +1070,11 @@ private:
      * from creating orphan TilingStates when the KWin script
      * "virtualdesktopsonlyonprimary" pins secondary-screen windows.
      */
-    TilingStateKey currentKeyForScreen(const QString& screenId) const
+    PhosphorEngineApi::TilingStateKey currentKeyForScreen(const QString& screenId) const
     {
         auto it = m_screenDesktopOverride.constFind(screenId);
         int desktop = (it != m_screenDesktopOverride.constEnd()) ? it.value() : m_currentDesktop;
-        return TilingStateKey{screenId, desktop, m_currentActivity};
+        return PhosphorEngineApi::TilingStateKey{screenId, desktop, m_currentActivity};
     }
 
     /**
@@ -1090,7 +1084,7 @@ private:
      * for arbitrary desktop/activity combinations without temporarily mutating
      * m_currentDesktop/m_currentActivity.
      */
-    PhosphorTiles::TilingState* stateForKey(const TilingStateKey& key);
+    PhosphorTiles::TilingState* stateForKey(const PhosphorEngineApi::TilingStateKey& key);
 
     /**
      * @brief Reset maxWindows when switching algorithms (DRY helper)
@@ -1295,9 +1289,9 @@ private:
     QString m_algorithmId;
     bool m_algorithmEverSet = false; ///< True after first successful setAlgorithm() call
     QString m_activeScreen; // Last-focused screen (updated by onWindowFocused)
-    QHash<TilingStateKey, PhosphorTiles::TilingState*> m_screenStates; // Owned via Qt parent (this)
+    QHash<PhosphorEngineApi::TilingStateKey, PhosphorTiles::TilingState*> m_screenStates; // Owned via Qt parent (this)
 
-    QHash<QString, TilingStateKey> m_windowToStateKey; // windowId -> owning state key
+    QHash<QString, PhosphorEngineApi::TilingStateKey> m_windowToStateKey; // windowId -> owning state key
     QHash<QString, QSize> m_windowMinSizes; // windowId -> minimum size from KWin
 
     // Instance id → first-seen canonical windowId.
@@ -1330,7 +1324,7 @@ private:
     // Floating window IDs preserved across mode switches, per desktop/activity.
     // When autotile is deactivated, floated windows are saved here so that
     // re-enabling autotile restores them as floating regardless of screen.
-    QHash<TilingStateKey, QSet<QString>> m_savedFloatingWindows;
+    QHash<PhosphorEngineApi::TilingStateKey, QSet<QString>> m_savedFloatingWindows;
 
     // Pre-seeded window order for snapping → autotile transitions.
     // Keyed by stable EDID-based screen ID (Phosphor::Screens::ScreenIdentity::identifierFor).
@@ -1343,7 +1337,7 @@ private:
     // On desktop/activity switch, orders for the new context are promoted into
     // m_pendingInitialOrders so windows arriving on the new desktop get their
     // saved ordering. Consumed once per context (removed after promotion).
-    QHash<TilingStateKey, QStringList> m_savedWindowOrders;
+    QHash<PhosphorEngineApi::TilingStateKey, QStringList> m_savedWindowOrders;
 
     // Pending restore queue for windows removed from autotile (close/reopen).
     // Keyed by appId (stable across KWin restarts). Multiple entries per appId
@@ -1400,7 +1394,8 @@ private:
 
         // Prior-state restoration info (used on cancel)
         bool hadPriorState = false; // True if m_windowToStateKey contained windowId at begin
-        TilingStateKey priorKey; // Key of the prior PhosphorTiles::TilingState (meaningful iff hadPriorState)
+        PhosphorEngineApi::TilingStateKey
+            priorKey; // Key of the prior PhosphorTiles::TilingState (meaningful iff hadPriorState)
         int priorRawIndex = -1; // Raw index in priorState->windowOrder() at begin
         bool priorFloating = false; // Prior floating flag in priorState
         bool priorSameScreen = false; // priorKey == currentKeyForScreen(targetScreenId)
@@ -1423,4 +1418,4 @@ private:
     void processPendingRetiles();
 };
 
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/IAutotileSettings.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/IAutotileSettings.h
@@ -44,6 +44,13 @@ public:
     virtual PhosphorEngineApi::StickyWindowHandling autotileStickyWindowHandling() const = 0;
 
     virtual QVariantMap autotilePerAlgorithmSettings() const = 0;
+
+    virtual void setDefaultAutotileAlgorithm(const QString& algorithmId) = 0;
+    virtual void setAutotileSplitRatio(qreal ratio) = 0;
+    virtual void setAutotileMasterCount(int count) = 0;
+    virtual void setAutotileMaxWindows(int max) = 0;
+    virtual void setAutotilePerAlgorithmSettings(const QVariantMap& settings) = 0;
+    virtual void clearPerScreenAutotileSettings(const QString& screenId) = 0;
 };
 
 } // namespace PhosphorEngineApi

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/NavigationController.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/NavigationController.h
@@ -12,7 +12,7 @@ namespace PhosphorTiles {
 class TilingState;
 }
 
-namespace PlasmaZones {
+namespace PhosphorTileEngine {
 
 class AutotileEngine;
 
@@ -102,4 +102,4 @@ private:
     AutotileEngine* m_engine = nullptr;
 };
 
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/OverflowManager.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/OverflowManager.h
@@ -15,7 +15,7 @@
 // C++ headers
 #include <functional>
 
-namespace PlasmaZones {
+namespace PhosphorTileEngine {
 
 /**
  * @brief Per-screen overflow window tracking (pure tracking — no PhosphorTiles::TilingState mutation)
@@ -129,4 +129,4 @@ private:
     QHash<QString, QString> m_windowToScreen; // windowId -> screenId (reverse index)
 };
 
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
@@ -14,7 +14,7 @@ namespace PhosphorTiles {
 class TilingAlgorithm;
 }
 
-namespace PlasmaZones {
+namespace PhosphorTileEngine {
 
 namespace PerScreenKeys = PhosphorEngineApi::PerScreenKeys;
 
@@ -109,4 +109,4 @@ private:
     QHash<QString, QVariantMap> m_perScreenOverrides;
 };
 
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine

--- a/libs/phosphor-tile-engine/src/AutotileConfig.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileConfig.cpp
@@ -9,7 +9,7 @@
 #include <QRegularExpression>
 #include <QtMath>
 
-namespace PlasmaZones {
+namespace PhosphorTileEngine {
 
 // Use shared JSON keys and defaults from constants.h
 using namespace PhosphorTiles::AutotileJsonKeys;
@@ -243,4 +243,4 @@ AutotileConfig AutotileConfig::defaults()
     return AutotileConfig();
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -288,6 +288,7 @@ void AutotileEngine::connectSignals()
                             for (const QString& orphanId : orphanedVsIds)
                                 s->clearPerScreenAutotileSettings(orphanId);
                         }
+                        Q_EMIT settingsPersistRequested();
                     }
 
                     // Clean up desktop overrides for removed virtual screens on this physical screen.

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -798,11 +798,9 @@ void AutotileEngine::setAlgorithm(const QString& algorithmId)
     // setAlgorithm with stale KCM algo).
     {
         m_writeBackGuardTimer.start();
+        writeBackTuning();
         if (auto* s = autotileSettings()) {
             s->setDefaultAutotileAlgorithm(newId);
-            s->setAutotileSplitRatio(m_config->splitRatio);
-            s->setAutotileMasterCount(m_config->masterCount);
-            s->setAutotilePerAlgorithmSettings(AutotileConfig::perAlgoToVariantMap(m_config->savedAlgorithmSettings));
             if (m_config->maxWindows != oldMaxWindows)
                 s->setAutotileMaxWindows(m_config->maxWindows);
         }
@@ -1756,11 +1754,7 @@ void AutotileEngine::syncShortcutAdjustmentToSettings()
 
     {
         m_writeBackGuardTimer.start();
-        if (auto* s = autotileSettings()) {
-            s->setAutotileSplitRatio(m_config->splitRatio);
-            s->setAutotileMasterCount(m_config->masterCount);
-            s->setAutotilePerAlgorithmSettings(AutotileConfig::perAlgoToVariantMap(m_config->savedAlgorithmSettings));
-        }
+        writeBackTuning();
     }
 }
 

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -34,8 +34,10 @@
 #include <PhosphorZones/Zone.h>
 #include <PhosphorScreens/ScreenIdentity.h>
 
-namespace PlasmaZones {
+namespace PhosphorTileEngine {
 
+using NavigationContext = PhosphorEngineApi::NavigationContext;
+using TilingStateKey = PhosphorEngineApi::TilingStateKey;
 namespace PerScreenKeys = PhosphorEngineApi::PerScreenKeys;
 
 namespace {
@@ -229,82 +231,82 @@ void AutotileEngine::connectSignals()
 
         // Virtual screen reconfiguration — retile new virtual screens and
         // clean up orphaned PhosphorTiles::TilingState entries for virtual screens that no longer exist.
-        connect(
-            m_screenManager, &Phosphor::Screens::ScreenManager::virtualScreensChanged, this,
-            [this](const QString& physicalScreenId) {
-                const QStringList newVsIds = m_screenManager->virtualScreenIdsFor(physicalScreenId);
-                const QSet<QString> newVsSet(newVsIds.begin(), newVsIds.end());
+        connect(m_screenManager, &Phosphor::Screens::ScreenManager::virtualScreensChanged, this,
+                [this](const QString& physicalScreenId) {
+                    const QStringList newVsIds = m_screenManager->virtualScreenIdsFor(physicalScreenId);
+                    const QSet<QString> newVsSet(newVsIds.begin(), newVsIds.end());
 
-                // Find and release orphaned virtual screen states for this physical screen
-                QStringList releasedWindows;
-                QSet<QString> orphanedVsIds;
-                QMutableHashIterator<TilingStateKey, PhosphorTiles::TilingState*> it(m_screenStates);
-                while (it.hasNext()) {
-                    it.next();
-                    const QString& sid = it.key().screenId;
-                    if (!PhosphorIdentity::VirtualScreenId::isVirtual(sid)) {
-                        continue;
+                    // Find and release orphaned virtual screen states for this physical screen
+                    QStringList releasedWindows;
+                    QSet<QString> orphanedVsIds;
+                    QMutableHashIterator<TilingStateKey, PhosphorTiles::TilingState*> it(m_screenStates);
+                    while (it.hasNext()) {
+                        it.next();
+                        const QString& sid = it.key().screenId;
+                        if (!PhosphorIdentity::VirtualScreenId::isVirtual(sid)) {
+                            continue;
+                        }
+                        if (PhosphorIdentity::VirtualScreenId::extractPhysicalId(sid) != physicalScreenId) {
+                            continue;
+                        }
+                        if (newVsSet.contains(sid)) {
+                            continue;
+                        }
+                        // This virtual screen no longer exists — release its windows.
+                        // Save user-floated windows (excluding overflow) so they stay
+                        // floating if autotile is re-enabled on a new VS config — mirrors
+                        // the preservation logic in setAutotileScreens.
+                        orphanedVsIds.insert(sid);
+                        QSet<QString> screenOverflow = m_overflow.takeForScreen(sid);
+                        const QStringList floated = it.value()->floatingWindows();
+                        for (const QString& fid : floated) {
+                            if (!screenOverflow.contains(fid)) {
+                                m_savedFloatingWindows[it.key()].insert(fid);
+                            }
+                        }
+                        releasedWindows.append(it.value()->tiledWindows());
+                        releasedWindows.append(floated);
+                        m_pendingInitialOrders.remove(sid);
+                        m_pendingOrderGeneration.remove(sid);
+                        it.value()->deleteLater();
+                        it.remove();
                     }
-                    if (PhosphorIdentity::VirtualScreenId::extractPhysicalId(sid) != physicalScreenId) {
-                        continue;
+                    for (const QString& windowId : std::as_const(releasedWindows)) {
+                        m_windowToStateKey.remove(windowId);
                     }
-                    if (newVsSet.contains(sid)) {
-                        continue;
+                    if (!releasedWindows.isEmpty()) {
+                        Q_EMIT windowsReleased(releasedWindows, orphanedVsIds);
                     }
-                    // This virtual screen no longer exists — release its windows.
-                    // Save user-floated windows (excluding overflow) so they stay
-                    // floating if autotile is re-enabled on a new VS config — mirrors
-                    // the preservation logic in setAutotileScreens.
-                    orphanedVsIds.insert(sid);
-                    QSet<QString> screenOverflow = m_overflow.takeForScreen(sid);
-                    const QStringList floated = it.value()->floatingWindows();
-                    for (const QString& fid : floated) {
-                        if (!screenOverflow.contains(fid)) {
-                            m_savedFloatingWindows[it.key()].insert(fid);
+
+                    // Clean up per-screen autotile settings for removed virtual screens.
+                    // Orphaned AutotileScreen: groups would otherwise accumulate indefinitely
+                    // as virtual screen IDs are never reused after reconfiguration.
+                    if (!orphanedVsIds.isEmpty()) {
+                        if (auto* s = autotileSettings()) {
+                            for (const QString& orphanId : orphanedVsIds)
+                                s->clearPerScreenAutotileSettings(orphanId);
                         }
                     }
-                    releasedWindows.append(it.value()->tiledWindows());
-                    releasedWindows.append(floated);
-                    m_pendingInitialOrders.remove(sid);
-                    m_pendingOrderGeneration.remove(sid);
-                    it.value()->deleteLater();
-                    it.remove();
-                }
-                for (const QString& windowId : std::as_const(releasedWindows)) {
-                    m_windowToStateKey.remove(windowId);
-                }
-                if (!releasedWindows.isEmpty()) {
-                    Q_EMIT windowsReleased(releasedWindows, orphanedVsIds);
-                }
 
-                // Clean up per-screen autotile settings for removed virtual screens.
-                // Orphaned AutotileScreen: groups would otherwise accumulate indefinitely
-                // as virtual screen IDs are never reused after reconfiguration.
-                if (!orphanedVsIds.isEmpty()) {
-                    QVariantMap wb;
-                    QStringList orphanList(orphanedVsIds.constBegin(), orphanedVsIds.constEnd());
-                    wb[PhosphorTiles::WriteBackKeys::ClearPerScreenAutotileSettings] = QVariant::fromValue(orphanList);
-                    Q_EMIT settingsWriteBackRequested(wb);
-                }
+                    // Clean up desktop overrides for removed virtual screens on this physical screen.
+                    // Use newVsSet (freshly-computed from Phosphor::Screens::ScreenManager) rather than
+                    // m_autotileScreens which reflects mode assignments and may not yet be updated for the new config.
+                    auto overrideIt = m_screenDesktopOverride.begin();
+                    while (overrideIt != m_screenDesktopOverride.end()) {
+                        if (PhosphorIdentity::VirtualScreenId::isVirtual(overrideIt.key())
+                            && PhosphorIdentity::VirtualScreenId::extractPhysicalId(overrideIt.key())
+                                == physicalScreenId
+                            && !newVsSet.contains(overrideIt.key()))
+                            overrideIt = m_screenDesktopOverride.erase(overrideIt);
+                        else
+                            ++overrideIt;
+                    }
 
-                // Clean up desktop overrides for removed virtual screens on this physical screen.
-                // Use newVsSet (freshly-computed from Phosphor::Screens::ScreenManager) rather than
-                // m_autotileScreens which reflects mode assignments and may not yet be updated for the new config.
-                auto overrideIt = m_screenDesktopOverride.begin();
-                while (overrideIt != m_screenDesktopOverride.end()) {
-                    if (PhosphorIdentity::VirtualScreenId::isVirtual(overrideIt.key())
-                        && PhosphorIdentity::VirtualScreenId::extractPhysicalId(overrideIt.key()) == physicalScreenId
-                        && !newVsSet.contains(overrideIt.key()))
-                        overrideIt = m_screenDesktopOverride.erase(overrideIt);
-                    else
-                        ++overrideIt;
-                }
-
-                // Retile the new virtual screens
-                for (const QString& vsId : newVsIds) {
-                    onScreenGeometryChanged(vsId);
-                }
-            });
+                    // Retile the new virtual screens
+                    for (const QString& vsId : newVsIds) {
+                        onScreenGeometryChanged(vsId);
+                    }
+                });
 
         // Regions-only changes (VS swap/rotate/boundary resize) — skip the
         // orphan cleanup (no VSs removed/added) and just retile each VS with
@@ -796,12 +798,14 @@ void AutotileEngine::setAlgorithm(const QString& algorithmId)
     // setAlgorithm with stale KCM algo).
     {
         m_writeBackGuardTimer.start();
-        QVariantMap wb = buildTuningWriteBack();
-        wb[PhosphorTiles::WriteBackKeys::DefaultAutotileAlgorithm] = newId;
-        if (m_config->maxWindows != oldMaxWindows) {
-            wb[PhosphorTiles::WriteBackKeys::AutotileMaxWindows] = m_config->maxWindows;
+        if (auto* s = autotileSettings()) {
+            s->setDefaultAutotileAlgorithm(newId);
+            s->setAutotileSplitRatio(m_config->splitRatio);
+            s->setAutotileMasterCount(m_config->masterCount);
+            s->setAutotilePerAlgorithmSettings(AutotileConfig::perAlgoToVariantMap(m_config->savedAlgorithmSettings));
+            if (m_config->maxWindows != oldMaxWindows)
+                s->setAutotileMaxWindows(m_config->maxWindows);
         }
-        Q_EMIT settingsWriteBackRequested(wb);
     }
 
     m_algorithmEverSet = true;
@@ -1115,14 +1119,13 @@ PhosphorEngineApi::IAutotileSettings* AutotileEngine::autotileSettings() const
     return qobject_cast<PhosphorEngineApi::IAutotileSettings*>(engineSettings());
 }
 
-QVariantMap AutotileEngine::buildTuningWriteBack() const
+void AutotileEngine::writeBackTuning()
 {
-    QVariantMap wb;
-    wb[PhosphorTiles::WriteBackKeys::AutotileSplitRatio] = m_config->splitRatio;
-    wb[PhosphorTiles::WriteBackKeys::AutotileMasterCount] = m_config->masterCount;
-    wb[PhosphorTiles::WriteBackKeys::AutotilePerAlgorithmSettings] =
-        AutotileConfig::perAlgoToVariantMap(m_config->savedAlgorithmSettings);
-    return wb;
+    if (auto* s = autotileSettings()) {
+        s->setAutotileSplitRatio(m_config->splitRatio);
+        s->setAutotileMasterCount(m_config->masterCount);
+        s->setAutotilePerAlgorithmSettings(AutotileConfig::perAlgoToVariantMap(m_config->savedAlgorithmSettings));
+    }
 }
 
 void AutotileEngine::refreshConfigFromSettings()
@@ -1751,10 +1754,13 @@ void AutotileEngine::syncShortcutAdjustmentToSettings()
         entry.masterCount = m_config->masterCount;
     }
 
-    // Write to Settings (signal-blocked) so refreshConfigFromSettings() won't revert
     {
         m_writeBackGuardTimer.start();
-        Q_EMIT settingsWriteBackRequested(buildTuningWriteBack());
+        if (auto* s = autotileSettings()) {
+            s->setAutotileSplitRatio(m_config->splitRatio);
+            s->setAutotileMasterCount(m_config->masterCount);
+            s->setAutotilePerAlgorithmSettings(AutotileConfig::perAlgoToVariantMap(m_config->savedAlgorithmSettings));
+        }
     }
 }
 
@@ -3791,4 +3797,4 @@ const PhosphorEngineApi::IPlacementState* AutotileEngine::stateForScreen(const Q
     return m_screenStates.value(key, nullptr);
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -86,6 +86,7 @@ AutotileEngine::AutotileEngine(PhosphorZones::LayoutRegistry* layoutManager,
     // keep the guard alive until the burst settles.
     m_writeBackGuardTimer.setSingleShot(true);
     m_writeBackGuardTimer.setInterval(500);
+    connect(&m_writeBackGuardTimer, &QTimer::timeout, this, &AutotileEngine::settingsPersistRequested);
 
     m_settingsRetileTimer.setSingleShot(true);
     m_settingsRetileTimer.setInterval(100);
@@ -282,6 +283,7 @@ void AutotileEngine::connectSignals()
                     // Orphaned AutotileScreen: groups would otherwise accumulate indefinitely
                     // as virtual screen IDs are never reused after reconfiguration.
                     if (!orphanedVsIds.isEmpty()) {
+                        const QSignalBlocker blocker(engineSettings());
                         if (auto* s = autotileSettings()) {
                             for (const QString& orphanId : orphanedVsIds)
                                 s->clearPerScreenAutotileSettings(orphanId);
@@ -798,6 +800,7 @@ void AutotileEngine::setAlgorithm(const QString& algorithmId)
     // setAlgorithm with stale KCM algo).
     {
         m_writeBackGuardTimer.start();
+        const QSignalBlocker blocker(engineSettings());
         writeBackTuning();
         if (auto* s = autotileSettings()) {
             s->setDefaultAutotileAlgorithm(newId);
@@ -1119,6 +1122,11 @@ PhosphorEngineApi::IAutotileSettings* AutotileEngine::autotileSettings() const
 
 void AutotileEngine::writeBackTuning()
 {
+    auto* settings = engineSettings();
+    if (!settings) {
+        return;
+    }
+    const QSignalBlocker blocker(settings);
     if (auto* s = autotileSettings()) {
         s->setAutotileSplitRatio(m_config->splitRatio);
         s->setAutotileMasterCount(m_config->masterCount);

--- a/libs/phosphor-tile-engine/src/NavigationController.cpp
+++ b/libs/phosphor-tile-engine/src/NavigationController.cpp
@@ -14,7 +14,7 @@
 #include <algorithm>
 #include <PhosphorScreens/ScreenIdentity.h>
 
-namespace PlasmaZones {
+namespace PhosphorTileEngine {
 
 namespace PerScreenKeys = PhosphorEngineApi::PerScreenKeys;
 
@@ -434,4 +434,4 @@ void NavigationController::applyToAllStates(const std::function<void(PhosphorTil
     }
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine

--- a/libs/phosphor-tile-engine/src/OverflowManager.cpp
+++ b/libs/phosphor-tile-engine/src/OverflowManager.cpp
@@ -7,7 +7,7 @@
 // KDE/Qt logging
 #include "tileenginelogging.h"
 
-namespace PlasmaZones {
+namespace PhosphorTileEngine {
 
 void OverflowManager::markOverflow(const QString& windowId, const QString& screenId)
 {
@@ -184,4 +184,4 @@ bool OverflowManager::isEmpty() const
     return m_windowToScreen.isEmpty();
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -12,7 +12,7 @@
 #include <PhosphorTiles/AutotileConstants.h>
 #include "tileenginelogging.h"
 
-namespace PlasmaZones {
+namespace PhosphorTileEngine {
 
 namespace PerScreenKeys = PhosphorEngineApi::PerScreenKeys;
 
@@ -287,4 +287,4 @@ PhosphorTiles::TilingAlgorithm* PerScreenConfigResolver::effectiveAlgorithm(cons
     return m_engine->algorithmRegistry()->algorithm(effectiveAlgorithmId(screenId));
 }
 
-} // namespace PlasmaZones
+} // namespace PhosphorTileEngine

--- a/libs/phosphor-tiles/include/PhosphorTiles/AutotileConstants.h
+++ b/libs/phosphor-tiles/include/PhosphorTiles/AutotileConstants.h
@@ -151,15 +151,6 @@ inline constexpr QLatin1String InsertAfterFocused{"afterFocused"};
 inline constexpr QLatin1String InsertAsMaster{"asMaster"};
 } // namespace AutotileJsonValues
 
-namespace WriteBackKeys {
-inline constexpr QLatin1String DefaultAutotileAlgorithm{"defaultAutotileAlgorithm"};
-inline constexpr QLatin1String AutotileSplitRatio{"autotileSplitRatio"};
-inline constexpr QLatin1String AutotileMasterCount{"autotileMasterCount"};
-inline constexpr QLatin1String AutotileMaxWindows{"autotileMaxWindows"};
-inline constexpr QLatin1String AutotilePerAlgorithmSettings{"autotilePerAlgorithmSettings"};
-inline constexpr QLatin1String ClearPerScreenAutotileSettings{"clearPerScreenAutotileSettings"};
-} // namespace WriteBackKeys
-
 /**
  * @brief Backwards-compat re-exports so existing `using namespace AutotileJsonKeys`
  *        sites (e.g. `src/autotile/AutotileConfig.cpp`) resolve the value names

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -1438,7 +1438,8 @@ void Settings::setAutotilePerAlgorithmSettings(const QVariantMap& value)
     // form (the schema validator would canonicalise on both sides anyway,
     // but avoiding the redundant write keeps the settingsChanged signal
     // from firing when a caller writes a semantically equal unsorted map).
-    const QVariantMap sanitized = AutotileConfig::perAlgoToVariantMap(AutotileConfig::perAlgoFromVariantMap(value));
+    const QVariantMap sanitized = PhosphorTileEngine::AutotileConfig::perAlgoToVariantMap(
+        PhosphorTileEngine::AutotileConfig::perAlgoFromVariantMap(value));
     if (autotilePerAlgorithmSettings() == sanitized) {
         return;
     }

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -645,15 +645,15 @@ public:
     bool autotileEnabled() const;
     void setAutotileEnabled(bool enabled);
     QString defaultAutotileAlgorithm() const override;
-    void setDefaultAutotileAlgorithm(const QString& algorithm);
+    void setDefaultAutotileAlgorithm(const QString& algorithm) override;
     qreal autotileSplitRatio() const override;
-    void setAutotileSplitRatio(qreal ratio);
+    void setAutotileSplitRatio(qreal ratio) override;
     qreal autotileSplitRatioStep() const override;
     void setAutotileSplitRatioStep(qreal step);
     int autotileMasterCount() const override;
-    void setAutotileMasterCount(int count);
+    void setAutotileMasterCount(int count) override;
     QVariantMap autotilePerAlgorithmSettings() const override;
-    void setAutotilePerAlgorithmSettings(const QVariantMap& settings);
+    void setAutotilePerAlgorithmSettings(const QVariantMap& settings) override;
     int autotileInnerGap() const override;
     void setAutotileInnerGap(int gap);
     int autotileOuterGap() const override;
@@ -673,7 +673,7 @@ public:
     bool autotileSmartGaps() const override;
     void setAutotileSmartGaps(bool smart);
     int autotileMaxWindows() const override;
-    void setAutotileMaxWindows(int count);
+    void setAutotileMaxWindows(int count) override;
 
     using AutotileInsertPosition = PhosphorTiles::AutotileInsertPosition;
     PhosphorTiles::AutotileInsertPosition autotileInsertPosition() const override;

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -136,7 +136,8 @@ QVariant canonicalTriggerList(const QVariant& v)
 /// @c perAlgoToVariantMap(perAlgoFromVariantMap(x)) == perAlgoToVariantMap(perAlgoFromVariantMap(it)).
 QVariant sanitizePerAlgorithmSettings(const QVariant& v)
 {
-    return QVariant(AutotileConfig::perAlgoToVariantMap(AutotileConfig::perAlgoFromVariantMap(v.toMap())));
+    return QVariant(PhosphorTileEngine::AutotileConfig::perAlgoToVariantMap(
+        PhosphorTileEngine::AutotileConfig::perAlgoFromVariantMap(v.toMap())));
 }
 } // namespace
 

--- a/src/core/windowtrackingservice.h
+++ b/src/core/windowtrackingservice.h
@@ -24,17 +24,17 @@ namespace PhosphorZones {
 class IZoneDetector;
 class Layout;
 class LayoutRegistry;
-class SnapState;
 class Zone;
 }
 
-namespace PlasmaZones {
-class ISettings;
-// Phosphor::Screens::ScreenManager moved to libs/phosphor-screens (Phosphor::Screens::ScreenManager).
-} // namespace PlasmaZones
+namespace PhosphorSnapEngine {
+class SnapState;
+}
+
 namespace Phosphor::Screens {
 class ScreenManager;
 }
+
 namespace PlasmaZones {
 
 using PhosphorProtocol::EmptyZoneList;
@@ -42,6 +42,7 @@ using PhosphorProtocol::WindowGeometryEntry;
 using PhosphorProtocol::WindowGeometryList;
 using PhosphorProtocol::WindowStateEntry;
 
+class ISettings;
 class VirtualDesktopManager;
 class WindowRegistry;
 
@@ -98,7 +99,7 @@ public:
         m_windowRegistry = registry;
     }
 
-    void setSnapState(PhosphorZones::SnapState* state)
+    void setSnapState(PhosphorSnapEngine::SnapState* state)
     {
         m_snapState = state;
     }
@@ -835,7 +836,7 @@ private:
     // Dependencies
     PhosphorZones::LayoutRegistry* m_layoutManager;
     PhosphorZones::IZoneDetector* m_zoneDetector;
-    PhosphorZones::SnapState* m_snapState = nullptr;
+    PhosphorSnapEngine::SnapState* m_snapState = nullptr;
     ISettings* m_settings;
     VirtualDesktopManager* m_virtualDesktopManager;
     // Shared registry for current-class queries and canonical key translation.

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -516,42 +516,6 @@ bool Daemon::init()
     m_snapEngine = std::move(engines.snap);
     m_screenModeRouter = std::move(engines.router);
 
-    m_writeBackSaveTimer.setSingleShot(true);
-    m_writeBackSaveTimer.setInterval(500);
-    connect(&m_writeBackSaveTimer, &QTimer::timeout, this, [this]() {
-        if (m_settings) {
-            m_settings->save();
-        }
-    });
-
-    connect(autotileEngine, &PhosphorEngineApi::PlacementEngineBase::settingsWriteBackRequested, this,
-            [this](const QVariantMap& values) {
-                namespace WBK = PhosphorTiles::WriteBackKeys;
-                if (!m_settings)
-                    return;
-                const QSignalBlocker blocker(m_settings.get());
-                for (auto it = values.constBegin(); it != values.constEnd(); ++it) {
-                    const QString& key = it.key();
-                    if (key == WBK::DefaultAutotileAlgorithm)
-                        m_settings->setDefaultAutotileAlgorithm(it.value().toString());
-                    else if (key == WBK::AutotileSplitRatio)
-                        m_settings->setAutotileSplitRatio(it.value().toDouble());
-                    else if (key == WBK::AutotileMasterCount)
-                        m_settings->setAutotileMasterCount(it.value().toInt());
-                    else if (key == WBK::AutotileMaxWindows)
-                        m_settings->setAutotileMaxWindows(it.value().toInt());
-                    else if (key == WBK::AutotilePerAlgorithmSettings)
-                        m_settings->setAutotilePerAlgorithmSettings(it.value().toMap());
-                    else if (key == WBK::ClearPerScreenAutotileSettings) {
-                        const QStringList orphans = it.value().toStringList();
-                        for (const QString& orphanId : orphans)
-                            m_settings->clearPerScreenAutotileSettings(orphanId);
-                    } else
-                        qCWarning(lcDaemon) << "settingsWriteBack: unknown key" << key;
-                }
-                m_writeBackSaveTimer.start();
-            });
-
     autotileEngine->refreshConfigFromSettings();
 
     // Give the window drag adaptor access to the autotile engine for per-screen
@@ -587,14 +551,14 @@ bool Daemon::init()
     // bookkeeping helpers (windowSnapped, windowUnsnapped, recordSnapIntent,
     // clearPreTileGeometry). A future refactor should move that state onto
     // SnapEngine or WindowTrackingService and retire the back-reference.
-    snapEngine->setWindowTrackingAdaptor(m_windowTrackingAdaptor);
+    snapEngine->setNavigationStateProvider(m_windowTrackingAdaptor);
 
     // Clear stale autotile-floated flag when a window is snapped. A window
     // dragged from an autotile VS to a snap VS retains its autotileFloated
     // marker; without this, a subsequent mode change on the autotile VS
     // incorrectly processes the already-snapped window as autotile-managed.
     // Wired here (daemon) because engines must not know about each other.
-    connect(snapEngine, &SnapEngine::windowSnapStateChanged, this,
+    connect(snapEngine, &PhosphorSnapEngine::SnapEngine::windowSnapStateChanged, this,
             [this](const QString& windowId, const WindowStateEntry&) {
                 if (m_autotileEngine) {
                     m_autotileEngine->clearModeSpecificFloatMarker(windowId);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -516,6 +516,12 @@ bool Daemon::init()
     m_snapEngine = std::move(engines.snap);
     m_screenModeRouter = std::move(engines.router);
 
+    connect(autotileEngine, &PhosphorEngineApi::PlacementEngineBase::settingsPersistRequested, this, [this]() {
+        if (m_settings) {
+            m_settings->save();
+        }
+    });
+
     autotileEngine->refreshConfigFromSettings();
 
     // Give the window drag adaptor access to the autotile engine for per-screen

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -558,7 +558,6 @@ private:
     bool m_prevAutotileEnabled = false;
 
     QTimer m_previewNotifyTimer;
-    QTimer m_writeBackSaveTimer;
     PhosphorTiles::AlgorithmPreviewParams m_preRetilePreviewParams;
 
     // Single-threaded pool for shader baking — QShaderBaker/glslang is not

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -292,7 +292,7 @@ void Daemon::initializeAutotile()
             // to share the same screen, producing wrong results.
             // Windows that were autotile-only (never zone-snapped) get their
             // pre-autotile floating geometry restored by restoreAutotileOnlyGeometries.
-            auto* concreteSnap = qobject_cast<SnapEngine*>(m_snapEngine.get());
+            auto* concreteSnap = qobject_cast<PhosphorSnapEngine::SnapEngine*>(m_snapEngine.get());
             if (applied && wasAutotile && !concreteSnap) {
                 if (m_snapEngine) {
                     qCWarning(lcDaemon) << "Snap engine is not a SnapEngine — autotile→snap resnap skipped";

--- a/src/daemon/enginefactory.cpp
+++ b/src/daemon/enginefactory.cpp
@@ -17,13 +17,14 @@ EngineSet createEngines(PhosphorZones::LayoutRegistry* layoutManager, WindowTrac
                         WindowRegistry* windowRegistry, QObject* parent)
 {
     // --- AutotileEngine ---
-    auto autotile =
-        std::make_unique<AutotileEngine>(layoutManager, windowTracker, screenManager, algorithmRegistry, parent);
+    auto autotile = std::make_unique<PhosphorTileEngine::AutotileEngine>(layoutManager, windowTracker, screenManager,
+                                                                         algorithmRegistry, parent);
     autotile->setWindowRegistry(windowRegistry);
     autotile->setEngineSettings(settings);
 
     // --- SnapEngine ---
-    auto snap = std::make_unique<SnapEngine>(layoutManager, windowTracker, zoneDetector, vdm, parent);
+    auto snap =
+        std::make_unique<PhosphorSnapEngine::SnapEngine>(layoutManager, windowTracker, zoneDetector, vdm, parent);
     snap->setEngineSettings(settings);
 
     // Cross-wire: SnapEngine needs a reference to AutotileEngine for

--- a/src/daemon/enginefactory.h
+++ b/src/daemon/enginefactory.h
@@ -20,27 +20,26 @@ namespace PhosphorTiles {
 class ITileAlgorithmRegistry;
 }
 
+namespace PhosphorTileEngine {
+class AutotileEngine;
+}
+
+namespace PhosphorSnapEngine {
+class SnapEngine;
+}
+
 namespace PlasmaZones {
 
-class AutotileEngine;
 class ISettings;
 class ScreenModeRouter;
-class SnapEngine;
 class VirtualDesktopManager;
 class WindowRegistry;
 class WindowTrackingService;
 
-/**
- * @brief Grouped result of createEngines().
- *
- * Returns concrete engine types so the daemon can wire adaptor construction
- * and engine-specific setup without immediately downcasting. The daemon
- * stores these as PlacementEngineBase* members for all subsequent code paths.
- */
 struct EngineSet
 {
-    std::unique_ptr<AutotileEngine> autotile;
-    std::unique_ptr<SnapEngine> snap;
+    std::unique_ptr<PhosphorTileEngine::AutotileEngine> autotile;
+    std::unique_ptr<PhosphorSnapEngine::SnapEngine> snap;
     std::unique_ptr<ScreenModeRouter> router;
 };
 

--- a/src/dbus/autotileadaptor.cpp
+++ b/src/dbus/autotileadaptor.cpp
@@ -18,7 +18,8 @@
 
 namespace PlasmaZones {
 
-AutotileAdaptor::AutotileAdaptor(AutotileEngine* engine, Phosphor::Screens::ScreenManager* screenManager,
+AutotileAdaptor::AutotileAdaptor(PhosphorTileEngine::AutotileEngine* engine,
+                                 Phosphor::Screens::ScreenManager* screenManager,
                                  PhosphorTiles::ITileAlgorithmRegistry* algorithmRegistry, QObject* parent)
     : QDBusAbstractAdaptor(parent)
     , m_engine(engine)
@@ -36,14 +37,15 @@ AutotileAdaptor::AutotileAdaptor(AutotileEngine* engine, Phosphor::Screens::Scre
     }
 
     // Connect engine signals to D-Bus signals
-    connect(m_engine, &AutotileEngine::enabledChanged, this, &AutotileAdaptor::enabledChanged);
-    connect(m_engine, &AutotileEngine::autotileScreensChanged, this, &AutotileAdaptor::autotileScreensChanged);
+    connect(m_engine, &PhosphorTileEngine::AutotileEngine::enabledChanged, this, &AutotileAdaptor::enabledChanged);
+    connect(m_engine, &PhosphorTileEngine::AutotileEngine::autotileScreensChanged, this,
+            &AutotileAdaptor::autotileScreensChanged);
     connect(m_engine, &PhosphorEngineApi::PlacementEngineBase::algorithmChanged, this,
             &AutotileAdaptor::algorithmChanged);
     // Internal signal is placementChanged (engine-generic); D-Bus name stays tilingChanged
     // for backward compatibility with existing KWin effect / third-party consumers.
     connect(m_engine, &PhosphorEngineApi::PlacementEngineBase::placementChanged, this, &AutotileAdaptor::tilingChanged);
-    connect(m_engine, &AutotileEngine::windowsTiled, this, &AutotileAdaptor::onWindowsTiled);
+    connect(m_engine, &PhosphorTileEngine::AutotileEngine::windowsTiled, this, &AutotileAdaptor::onWindowsTiled);
     connect(m_engine, &PhosphorEngineApi::PlacementEngineBase::activateWindowRequested, this,
             &AutotileAdaptor::focusWindowRequested);
     // The in-process engine signal has a 2nd QSet<QString> argument for

--- a/src/dbus/autotileadaptor.h
+++ b/src/dbus/autotileadaptor.h
@@ -21,6 +21,10 @@ namespace PhosphorTiles {
 class ITileAlgorithmRegistry;
 }
 
+namespace PhosphorTileEngine {
+class AutotileEngine;
+}
+
 namespace PlasmaZones {
 
 using PhosphorProtocol::AlgorithmInfoEntry;
@@ -28,8 +32,6 @@ using PhosphorProtocol::TileRequestEntry;
 using PhosphorProtocol::TileRequestList;
 using PhosphorProtocol::WindowOpenedEntry;
 using PhosphorProtocol::WindowOpenedList;
-
-class AutotileEngine;
 
 /**
  * @brief D-Bus adaptor for autotiling control
@@ -82,7 +84,8 @@ public:
      *        registry divergence doesn't silently re-route D-Bus queries.
      * @param parent Parent QObject (typically the daemon)
      */
-    explicit AutotileAdaptor(AutotileEngine* engine, Phosphor::Screens::ScreenManager* screenManager,
+    explicit AutotileAdaptor(PhosphorTileEngine::AutotileEngine* engine,
+                             Phosphor::Screens::ScreenManager* screenManager,
                              PhosphorTiles::ITileAlgorithmRegistry* algorithmRegistry, QObject* parent = nullptr);
     ~AutotileAdaptor() override = default;
 
@@ -413,7 +416,7 @@ private:
      */
     bool deferUntilPanelReady();
 
-    AutotileEngine* m_engine = nullptr;
+    PhosphorTileEngine::AutotileEngine* m_engine = nullptr;
     Phosphor::Screens::ScreenManager* m_screenManager = nullptr;
     PhosphorTiles::ITileAlgorithmRegistry* m_algorithmRegistry = nullptr; ///< Borrowed; outlives adaptor
 

--- a/src/dbus/snapadaptor.cpp
+++ b/src/dbus/snapadaptor.cpp
@@ -8,7 +8,8 @@
 
 namespace PlasmaZones {
 
-SnapAdaptor::SnapAdaptor(SnapEngine* engine, WindowTrackingAdaptor* adaptor, ISettings* settings, QObject* parent)
+SnapAdaptor::SnapAdaptor(PhosphorSnapEngine::SnapEngine* engine, WindowTrackingAdaptor* adaptor, ISettings* settings,
+                         QObject* parent)
     : QDBusAbstractAdaptor(parent)
     , m_engine(engine)
     , m_adaptor(adaptor)
@@ -34,36 +35,36 @@ SnapAdaptor::SnapAdaptor(SnapEngine* engine, WindowTrackingAdaptor* adaptor, ISe
     m_connections.reserve(7);
 
     // Navigation feedback (shared OSD path — both engines use the same signal)
-    m_connections.append(
-        connect(m_engine, &SnapEngine::navigationFeedback, adaptor, &WindowTrackingAdaptor::navigationFeedback));
+    m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::navigationFeedback, adaptor,
+                                 &WindowTrackingAdaptor::navigationFeedback));
 
     // Float state changes
-    m_connections.append(
-        connect(m_engine, &SnapEngine::windowFloatingChanged, adaptor, &WindowTrackingAdaptor::windowFloatingChanged));
+    m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::windowFloatingChanged, adaptor,
+                                 &WindowTrackingAdaptor::windowFloatingChanged));
 
     // Daemon-driven geometry application (used by autotile float restore via SnapEngine)
-    m_connections.append(connect(m_engine, &SnapEngine::applyGeometryRequested, adaptor,
+    m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::applyGeometryRequested, adaptor,
                                  &WindowTrackingAdaptor::applyGeometryRequested));
 
     // Snap-all-windows (effect collects candidates, daemon calculates)
-    m_connections.append(connect(m_engine, &SnapEngine::snapAllWindowsRequested, adaptor,
+    m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::snapAllWindowsRequested, adaptor,
                                  &WindowTrackingAdaptor::snapAllWindowsRequested));
 
     // Batched resnap: emitBatchedResnap is called from the Daemon layer (autotile→snap
     // transition) which bypasses WTA navigation methods. Route through handleBatchedResnap
     // for proper bookkeeping (windowSnapped per entry) + applyGeometriesBatch emission.
-    m_connections.append(
-        connect(m_engine, &SnapEngine::resnapToNewLayoutRequested, this, &SnapAdaptor::handleBatchedResnap));
+    m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::resnapToNewLayoutRequested, this,
+                                 &SnapAdaptor::handleBatchedResnap));
 
     // Batched geometry application: rotate / resnap / snap-all paths build
     // a WindowGeometryList and emit it here. WTA's applyGeometriesBatch
     // signal is the D-Bus surface.
-    m_connections.append(
-        connect(m_engine, &SnapEngine::applyGeometriesBatch, adaptor, &WindowTrackingAdaptor::applyGeometriesBatch));
+    m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::applyGeometriesBatch, adaptor,
+                                 &WindowTrackingAdaptor::applyGeometriesBatch));
 
     // Window activation: focus-in-direction and cycle operations resolve a
     // target window and ask the KWin effect to raise/focus it.
-    m_connections.append(connect(m_engine, &SnapEngine::activateWindowRequested, adaptor,
+    m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::activateWindowRequested, adaptor,
                                  &WindowTrackingAdaptor::activateWindowRequested));
 
     qCDebug(lcDbusWindow) << "SnapAdaptor initialized with" << m_connections.size() << "signal connections";
@@ -90,7 +91,7 @@ void SnapAdaptor::setScreenModeRouter(ScreenModeRouter* router)
     m_screenModeRouter = router;
 }
 
-SnapEngine* SnapAdaptor::engine() const
+PhosphorSnapEngine::SnapEngine* SnapAdaptor::engine() const
 {
     return m_engine;
 }

--- a/src/dbus/snapadaptor.h
+++ b/src/dbus/snapadaptor.h
@@ -12,6 +12,10 @@
 #include <QStringList>
 #include <QVector>
 
+namespace PhosphorSnapEngine {
+class SnapEngine;
+}
+
 namespace PlasmaZones {
 
 using PhosphorProtocol::SnapAllResultList;
@@ -19,7 +23,6 @@ using PhosphorProtocol::SnapConfirmationList;
 using PhosphorProtocol::UnfloatRestoreResult;
 using PhosphorProtocol::WindowGeometryList;
 
-class SnapEngine;
 class ScreenModeRouter;
 class WindowTrackingAdaptor;
 class ISettings;
@@ -60,7 +63,7 @@ public:
      * @param settings ISettings for restore-on-login gate (not owned)
      * @param parent Parent QObject (must be the D-Bus-registered daemon)
      */
-    explicit SnapAdaptor(SnapEngine* engine, WindowTrackingAdaptor* adaptor, ISettings* settings,
+    explicit SnapAdaptor(PhosphorSnapEngine::SnapEngine* engine, WindowTrackingAdaptor* adaptor, ISettings* settings,
                          QObject* parent = nullptr);
     ~SnapAdaptor() override = default;
 
@@ -85,7 +88,7 @@ public:
     /**
      * @brief Access the underlying SnapEngine (for daemon-side callers)
      */
-    SnapEngine* engine() const;
+    PhosphorSnapEngine::SnapEngine* engine() const;
 
 public Q_SLOTS:
     // ═══════════════════════════════════════════════════════════════════════════
@@ -318,7 +321,7 @@ private:
     void applySnapResult(const SnapResult& result, const QString& windowId, int& snapX, int& snapY, int& snapWidth,
                          int& snapHeight, bool& shouldSnap);
 
-    SnapEngine* m_engine = nullptr;
+    PhosphorSnapEngine::SnapEngine* m_engine = nullptr;
     WindowTrackingAdaptor* m_adaptor = nullptr;
     ISettings* m_settings = nullptr;
     ScreenModeRouter* m_screenModeRouter = nullptr;

--- a/src/dbus/snapadaptor/navigation.cpp
+++ b/src/dbus/snapadaptor/navigation.cpp
@@ -83,7 +83,7 @@ void SnapAdaptor::cycleWindowsInZone(bool forward)
 // handleBatchedResnap). Thin wrapper over
 // SnapEngine::applyBatchAssignments.
 // ═══════════════════════════════════════════════════════════════════════════════
-static bool processBatchEntries(WindowTrackingAdaptor* wta, SnapEngine* engine,
+static bool processBatchEntries(WindowTrackingAdaptor* wta, PhosphorSnapEngine::SnapEngine* engine,
                                 const QVector<ZoneAssignmentEntry>& entries, const QString& action)
 {
     if (!engine || !wta) {

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -164,7 +164,7 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(PhosphorZones::LayoutRegistry* layo
 // unit that includes this header.
 WindowTrackingAdaptor::~WindowTrackingAdaptor() = default;
 
-SnapEngine* WindowTrackingAdaptor::snapEngine() const
+PhosphorSnapEngine::SnapEngine* WindowTrackingAdaptor::snapEngine() const
 {
     return m_cachedSnapEngine;
 }
@@ -186,7 +186,7 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngineApi::PlacementEngineBase* s
 
     m_snapEngine = snapEngine;
     m_autotileEngine = autotileEngine;
-    m_cachedSnapEngine = qobject_cast<SnapEngine*>(snapEngine);
+    m_cachedSnapEngine = qobject_cast<PhosphorSnapEngine::SnapEngine*>(snapEngine);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Cross-engine references — SnapEngine needs AutotileEngine for
@@ -194,16 +194,17 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngineApi::PlacementEngineBase* s
     // When clearing (nullptr, nullptr), we also clear stale cross-references
     // to prevent dangling pointer access.
     // ═══════════════════════════════════════════════════════════════════════════
-    if (auto* snap = qobject_cast<SnapEngine*>(snapEngine)) {
-        snap->setZoneDetectionAdaptor(m_zoneDetectionAdaptor);
-        if (auto* autotile = qobject_cast<AutotileEngine*>(autotileEngine)) {
+    if (auto* snap = qobject_cast<PhosphorSnapEngine::SnapEngine*>(snapEngine)) {
+        snap->setZoneAdjacencyResolver(m_zoneDetectionAdaptor);
+        if (auto* autotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(autotileEngine)) {
             snap->setAutotileEngine(autotile);
         }
 
         // Snap-specific signal: carries WindowStateEntry which is snap-mode-only.
         // Connected via qobject_cast since the member type is PlacementEngineBase.
-        connect(snap, &SnapEngine::windowSnapStateChanged, this, &WindowTrackingAdaptor::windowStateChanged);
-        connect(snap, &SnapEngine::windowFloatingClearedForSnap, this,
+        connect(snap, &PhosphorSnapEngine::SnapEngine::windowSnapStateChanged, this,
+                &WindowTrackingAdaptor::windowStateChanged);
+        connect(snap, &PhosphorSnapEngine::SnapEngine::windowFloatingClearedForSnap, this,
                 [this](const QString& windowId, const QString& screenId) {
                     Q_EMIT windowFloatingChanged(windowId, false, screenId);
                 });

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -7,6 +7,7 @@
 #include "../core/windowregistry.h"
 #include "../core/windowtrackingservice.h"
 #include <PhosphorEngineApi/PlacementEngineBase.h>
+#include <PhosphorSnapEngine/INavigationStateProvider.h>
 #include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
 #include <QDBusAbstractAdaptor>
@@ -30,6 +31,15 @@ class Zone;
 class LayoutRegistry;
 }
 
+namespace PhosphorTileEngine {
+class AutotileEngine;
+}
+
+namespace PhosphorSnapEngine {
+class SnapEngine;
+class SnapNavigationTargetResolver;
+}
+
 namespace PlasmaZones {
 
 using PhosphorProtocol::EmptyZoneList;
@@ -41,13 +51,10 @@ using PhosphorProtocol::WindowStateEntry;
 using PhosphorProtocol::WindowStateList;
 using PhosphorProtocol::ZoneGeometryRect;
 
-class AutotileEngine;
 class ScreenModeRouter;
-class SnapNavigationTargetResolver;
 
 class PersistenceWorker;
 class ISettings;
-class SnapEngine;
 class VirtualDesktopManager;
 class ZoneDetectionAdaptor;
 
@@ -57,7 +64,8 @@ class ZoneDetectionAdaptor;
  * Provides D-Bus interface: org.plasmazones.WindowTracking
  *  Window-zone assignment tracking
  */
-class PLASMAZONES_EXPORT WindowTrackingAdaptor : public QDBusAbstractAdaptor
+class PLASMAZONES_EXPORT WindowTrackingAdaptor : public QDBusAbstractAdaptor,
+                                                 public PhosphorSnapEngine::INavigationStateProvider
 {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.plasmazones.WindowTracking")
@@ -75,7 +83,7 @@ public:
      * The KWin effect has reliable screen info on both X11 and Wayland.
      * Use this as a fallback when cursor screen is unavailable.
      */
-    Q_INVOKABLE QString lastActiveScreenName() const
+    Q_INVOKABLE QString lastActiveScreenName() const override
     {
         return m_lastActiveScreenId;
     }
@@ -87,7 +95,7 @@ public:
      * This is the primary source for shortcut screen detection on Wayland,
      * since QCursor::pos() is unreliable for background daemons.
      */
-    Q_INVOKABLE QString lastCursorScreenName() const
+    Q_INVOKABLE QString lastCursorScreenName() const override
     {
         return m_lastCursorScreenId;
     }
@@ -95,7 +103,7 @@ public:
     /**
      * @brief Get the last activated window's ID
      */
-    Q_INVOKABLE QString lastActiveWindowId() const
+    Q_INVOKABLE QString lastActiveWindowId() const override
     {
         return m_lastActiveWindowId;
     }
@@ -138,7 +146,7 @@ public:
     void setEngines(PhosphorEngineApi::PlacementEngineBase* snapEngine,
                     PhosphorEngineApi::PlacementEngineBase* autotileEngine);
 
-    SnapEngine* snapEngine() const;
+    PhosphorSnapEngine::SnapEngine* snapEngine() const;
 
     /**
      * @brief Wire the daemon's central ScreenModeRouter.
@@ -316,7 +324,7 @@ public Q_SLOTS:
      * Returns an invalid QRect if the window has not pushed a geometry yet.
      * Used by daemon-local shortcut handlers.
      */
-    Q_INVOKABLE QRect frameGeometry(const QString& windowId) const;
+    Q_INVOKABLE QRect frameGeometry(const QString& windowId) const override;
 
     /**
      * Update cursor screen when cursor crosses to a different monitor
@@ -807,7 +815,7 @@ private:
     // QPointer auto-nulls on engine destruction, guarding against late D-Bus calls
     QPointer<PhosphorEngineApi::PlacementEngineBase> m_snapEngine;
     QPointer<PhosphorEngineApi::PlacementEngineBase> m_autotileEngine;
-    QPointer<SnapEngine> m_cachedSnapEngine; // Cached qobject_cast result from setEngines()
+    QPointer<PhosphorSnapEngine::SnapEngine> m_cachedSnapEngine;
 
     // Central dispatcher: adaptor methods route lifecycle / resnap /
     // restore calls through this instead of direct engine pointer checks.

--- a/src/dbus/zonedetectionadaptor.cpp
+++ b/src/dbus/zonedetectionadaptor.cpp
@@ -197,7 +197,7 @@ QStringList ZoneDetectionAdaptor::detectMultiZoneAtPosition(int x, int y)
 }
 
 QString ZoneDetectionAdaptor::getAdjacentZone(const QString& currentZoneId, const QString& direction,
-                                              const QString& screenId)
+                                              const QString& screenId) const
 {
     if (!DbusHelpers::validateNonEmpty(direction, QStringLiteral("direction"), QStringLiteral("get adjacent zone"))) {
         return QString();
@@ -243,7 +243,7 @@ QString ZoneDetectionAdaptor::getAdjacentZone(const QString& currentZoneId, cons
     return zones.at(bestIndex)->id().toString();
 }
 
-QString ZoneDetectionAdaptor::getFirstZoneInDirection(const QString& direction, const QString& screenId)
+QString ZoneDetectionAdaptor::getFirstZoneInDirection(const QString& direction, const QString& screenId) const
 {
     if (!DbusHelpers::validateNonEmpty(direction, QStringLiteral("direction"), QStringLiteral("get first zone"))) {
         return QString();

--- a/src/dbus/zonedetectionadaptor.h
+++ b/src/dbus/zonedetectionadaptor.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "plasmazones_export.h"
+#include <PhosphorSnapEngine/IZoneAdjacencyResolver.h>
 #include <PhosphorProtocol/WireTypes.h>
 #include <QObject>
 #include <QDBusAbstractAdaptor>
@@ -34,7 +35,8 @@ class ISettings;
  *
  * Uses interface types for loose coupling
  */
-class PLASMAZONES_EXPORT ZoneDetectionAdaptor : public QDBusAbstractAdaptor
+class PLASMAZONES_EXPORT ZoneDetectionAdaptor : public QDBusAbstractAdaptor,
+                                                public PhosphorSnapEngine::IZoneAdjacencyResolver
 {
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.plasmazones.ZoneDetection")
@@ -56,7 +58,7 @@ public Q_SLOTS:
     // PhosphorZones::Zone navigation - get adjacent zone in a direction
     // direction: "left", "right", "up", "down"
     Q_INVOKABLE QString getAdjacentZone(const QString& currentZoneId, const QString& direction,
-                                        const QString& screenId = QString());
+                                        const QString& screenId = QString()) const override;
 
     /**
      * @brief Get the first (edge) zone in a given direction
@@ -71,7 +73,8 @@ public Q_SLOTS:
      * @param direction Direction string ("left", "right", "up", "down")
      * @return PhosphorZones::Zone ID of the edge zone, or empty string if no zones available
      */
-    Q_INVOKABLE QString getFirstZoneInDirection(const QString& direction, const QString& screenId = QString());
+    Q_INVOKABLE QString getFirstZoneInDirection(const QString& direction,
+                                                const QString& screenId = QString()) const override;
 
     // Get zone info by zone number (1-indexed), optionally for a specific screen
     QString getZoneByNumber(int zoneNumber, const QString& screenId = QString());

--- a/tests/unit/autotile/test_autotile_drag_insert.cpp
+++ b/tests/unit/autotile/test_autotile_drag_insert.cpp
@@ -14,6 +14,7 @@
 #include "../helpers/ScriptedAlgoTestSetup.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief Tests for the drag-insert preview state machine on AutotileEngine.

--- a/tests/unit/autotile/test_autotile_engine_class_mutation.cpp
+++ b/tests/unit/autotile/test_autotile_engine_class_mutation.cpp
@@ -28,6 +28,7 @@
 #include "core/windowregistry.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 namespace {
 

--- a/tests/unit/autotile/test_autotile_engine_core.cpp
+++ b/tests/unit/autotile/test_autotile_engine_core.cpp
@@ -20,6 +20,7 @@
 #include <QJsonObject>
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief Core AutotileEngine tests: construction, enable/disable, algorithm

--- a/tests/unit/autotile/test_autotile_engine_master.cpp
+++ b/tests/unit/autotile/test_autotile_engine_master.cpp
@@ -19,6 +19,7 @@
 #include <QJsonObject>
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief AutotileEngine tests for master ratio/count adjustments,

--- a/tests/unit/autotile/test_autotile_engine_minsize.cpp
+++ b/tests/unit/autotile/test_autotile_engine_minsize.cpp
@@ -13,6 +13,7 @@
 #include "core/constants.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief AutotileEngine tests for windowMinSizeUpdated behavior

--- a/tests/unit/autotile/test_autotile_engine_order_cycling.cpp
+++ b/tests/unit/autotile/test_autotile_engine_order_cycling.cpp
@@ -13,6 +13,7 @@
 #include "../helpers/ScriptedAlgoTestSetup.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief Tests that window order is preserved across autotile screen removal

--- a/tests/unit/autotile/test_autotile_engine_overflow.cpp
+++ b/tests/unit/autotile/test_autotile_engine_overflow.cpp
@@ -13,6 +13,7 @@
 #include "core/constants.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief AutotileEngine tests for overflow window management

--- a/tests/unit/autotile/test_autotile_engine_retry.cpp
+++ b/tests/unit/autotile/test_autotile_engine_retry.cpp
@@ -14,6 +14,7 @@
 #include "core/constants.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief AutotileEngine tests for bounded retile retry, recalculateLayout bool

--- a/tests/unit/autotile/test_autotile_ext_algoswitch.cpp
+++ b/tests/unit/autotile/test_autotile_ext_algoswitch.cpp
@@ -16,6 +16,7 @@
 #include "../helpers/ScriptedAlgoTestSetup.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief Extended tests for algorithm switch behaviors

--- a/tests/unit/autotile/test_autotile_ext_overflow.cpp
+++ b/tests/unit/autotile/test_autotile_ext_overflow.cpp
@@ -13,6 +13,7 @@
 #include "core/constants.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief Extended tests for minimize tracking, mode transition,

--- a/tests/unit/autotile/test_autotile_ext_startup_float.cpp
+++ b/tests/unit/autotile/test_autotile_ext_startup_float.cpp
@@ -13,6 +13,7 @@
 #include "core/constants.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief Extended tests for startup/init and float/unfloat behaviors

--- a/tests/unit/autotile/test_autotile_tile_request_validation.cpp
+++ b/tests/unit/autotile/test_autotile_tile_request_validation.cpp
@@ -39,6 +39,7 @@
 #include <PhosphorProtocol/WireTypes.h>
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 using namespace PhosphorProtocol;
 
 namespace {

--- a/tests/unit/autotile/test_autotile_virtual.cpp
+++ b/tests/unit/autotile/test_autotile_virtual.cpp
@@ -29,6 +29,7 @@
 #include "../helpers/VirtualScreenTestHelpers.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 using PlasmaZones::TestHelpers::makeSplitConfig;
 using PlasmaZones::TestHelpers::makeThreeWayConfig;
 

--- a/tests/unit/autotile/test_engine_settings.cpp
+++ b/tests/unit/autotile/test_engine_settings.cpp
@@ -25,6 +25,7 @@
 #include <QJsonObject>
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 class TestEngineSettings : public QObject
@@ -652,13 +653,11 @@ private Q_SLOTS:
         engine.windowOpened(QStringLiteral("win2"), screen, 0, 0);
         QCoreApplication::processEvents();
 
-        QSignalSpy writeBackSpy(&engine, &PhosphorEngineApi::PlacementEngineBase::settingsWriteBackRequested);
+        const qreal ratioBefore = settings.autotileSplitRatio();
         engine.windowFocused(QStringLiteral("win1"), screen);
         engine.increaseMasterRatio(0.1);
 
-        QVERIFY(writeBackSpy.count() > 0);
-        const QVariantMap wb = writeBackSpy.last().at(0).toMap();
-        QVERIFY(wb.contains(QLatin1String("autotileSplitRatio")));
+        QVERIFY(settings.autotileSplitRatio() != ratioBefore);
     }
 };
 

--- a/tests/unit/autotile/test_navigation_controller.cpp
+++ b/tests/unit/autotile/test_navigation_controller.cpp
@@ -13,6 +13,7 @@
 #include "../helpers/AutotileTestHelpers.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief Unit tests for NavigationController (via AutotileEngine forwarding)

--- a/tests/unit/autotile/test_overflow_manager.cpp
+++ b/tests/unit/autotile/test_overflow_manager.cpp
@@ -7,7 +7,7 @@
 // Project headers
 #include <PhosphorTileEngine/OverflowManager.h>
 
-using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 static const QString kScreen1 = QStringLiteral("Screen1");
 static const QString kScreen2 = QStringLiteral("Screen2");

--- a/tests/unit/autotile/test_per_screen_config.cpp
+++ b/tests/unit/autotile/test_per_screen_config.cpp
@@ -15,6 +15,7 @@
 #include "../helpers/ScriptedAlgoTestSetup.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 /**
  * @brief Unit tests for PerScreenConfigResolver

--- a/tests/unit/core/test_screen_mode_router.cpp
+++ b/tests/unit/core/test_screen_mode_router.cpp
@@ -29,6 +29,8 @@
 #include <PhosphorSnapEngine/SnapEngine.h>
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
+using namespace PhosphorSnapEngine;
 
 class TestScreenModeRouter : public QObject
 {

--- a/tests/unit/core/test_snap_assist_virtual.cpp
+++ b/tests/unit/core/test_snap_assist_virtual.cpp
@@ -41,6 +41,7 @@
 #include "../helpers/StubZoneDetector.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 // Type alias — shared StubSettings with snap assist enabled for this test file
@@ -65,7 +66,7 @@ private Q_SLOTS:
         m_settings->setSnapAssistEnabled(true);
         m_zoneDetector = new StubZoneDetector(nullptr);
         m_service = new WindowTrackingService(m_layoutManager, m_zoneDetector, nullptr, m_settings, nullptr, nullptr);
-        m_snapState = new PhosphorZones::SnapState(QString(), nullptr);
+        m_snapState = new PhosphorSnapEngine::SnapState(QString(), nullptr);
         m_service->setSnapState(m_snapState);
 
         m_testLayout = createTestLayout(3, m_layoutManager);
@@ -485,7 +486,7 @@ private:
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;
     StubSettingsSnapAssist* m_settings = nullptr;
     StubZoneDetector* m_zoneDetector = nullptr;
-    PhosphorZones::SnapState* m_snapState = nullptr;
+    PhosphorSnapEngine::SnapState* m_snapState = nullptr;
     WindowTrackingService* m_service = nullptr;
     PhosphorZones::Layout* m_testLayout = nullptr;
     QStringList m_zoneIds;

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -12,6 +12,7 @@
 #include "core/interfaces.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 
 // =========================================================================
 // Minimal stubs for WTS constructor assertions
@@ -84,7 +85,7 @@ private:
     StubSettingsSnap* m_settings = nullptr;
     StubZoneDetectorSnap* m_zoneDetector = nullptr;
     WindowTrackingService* m_wts = nullptr;
-    PhosphorZones::SnapState* m_snapState = nullptr;
+    PhosphorSnapEngine::SnapState* m_snapState = nullptr;
 
 private Q_SLOTS:
 
@@ -95,7 +96,7 @@ private Q_SLOTS:
         m_settings = new StubSettingsSnap(nullptr);
         m_zoneDetector = new StubZoneDetectorSnap(nullptr);
         m_wts = new WindowTrackingService(m_layoutManager, m_zoneDetector, nullptr, m_settings, nullptr, nullptr);
-        m_snapState = new PhosphorZones::SnapState(QString(), nullptr);
+        m_snapState = new PhosphorSnapEngine::SnapState(QString(), nullptr);
         m_wts->setSnapState(m_snapState);
     }
 

--- a/tests/unit/core/test_wts_clearfloat.cpp
+++ b/tests/unit/core/test_wts_clearfloat.cpp
@@ -35,6 +35,7 @@
 #include "../helpers/IsolatedConfigGuard.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 // =========================================================================

--- a/tests/unit/core/test_wts_crossmode_float.cpp
+++ b/tests/unit/core/test_wts_crossmode_float.cpp
@@ -42,6 +42,7 @@
 #include "../helpers/StubZoneDetector.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 using StubSettingsCrossModeFloat = StubSettings;

--- a/tests/unit/core/test_wts_dirty_mask.cpp
+++ b/tests/unit/core/test_wts_dirty_mask.cpp
@@ -43,6 +43,7 @@
 #include "../helpers/StubZoneDetector.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 class TestWtsDirtyMask : public QObject
@@ -72,7 +73,7 @@ private Q_SLOTS:
 
         m_service = new WindowTrackingService(m_layoutManager, m_zoneDetector, nullptr, m_settings,
                                               m_virtualDesktopManager, m_parent);
-        m_snapState = new PhosphorZones::SnapState(QString(), nullptr);
+        m_snapState = new PhosphorSnapEngine::SnapState(QString(), nullptr);
         m_service->setSnapState(m_snapState);
         // Construction leaves mask = DirtyAll; clear so subsequent mutator
         // tests start from a known-clean state and only assert on the
@@ -115,7 +116,7 @@ private Q_SLOTS:
 
         WindowTrackingService fresh(freshLayoutManager, freshZoneDetector, nullptr, freshSettings,
                                     freshVirtualDesktopManager, &freshParent);
-        PhosphorZones::SnapState freshSnapState(QString(), nullptr);
+        PhosphorSnapEngine::SnapState freshSnapState(QString(), nullptr);
         fresh.setSnapState(&freshSnapState);
         QCOMPARE(fresh.peekDirty(), static_cast<WindowTrackingService::DirtyMask>(WindowTrackingService::DirtyAll));
         fresh.setSnapState(nullptr);
@@ -303,7 +304,7 @@ private:
     VirtualDesktopManager* m_virtualDesktopManager = nullptr;
     StubSettings* m_settings = nullptr;
     StubZoneDetector* m_zoneDetector = nullptr;
-    PhosphorZones::SnapState* m_snapState = nullptr;
+    PhosphorSnapEngine::SnapState* m_snapState = nullptr;
     PhosphorZones::Layout* m_layout = nullptr;
     WindowTrackingService* m_service = nullptr;
     QString m_zone1Id;

--- a/tests/unit/core/test_wts_lifecycle.cpp
+++ b/tests/unit/core/test_wts_lifecycle.cpp
@@ -47,6 +47,7 @@
 #include "../helpers/StubZoneDetector.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 using StubSettingsLifecycle = StubSettings;

--- a/tests/unit/core/test_wts_queries.cpp
+++ b/tests/unit/core/test_wts_queries.cpp
@@ -39,6 +39,7 @@
 #include "../helpers/IsolatedConfigGuard.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 // =========================================================================

--- a/tests/unit/core/test_wts_registry_integration.cpp
+++ b/tests/unit/core/test_wts_registry_integration.cpp
@@ -39,6 +39,7 @@
 #include "../helpers/StubSettings.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 class StubZoneDetectorRegIntegration : public PhosphorZones::IZoneDetector
@@ -119,7 +120,7 @@ private Q_SLOTS:
         m_zoneDetector = new StubZoneDetectorRegIntegration(nullptr);
         m_registry = new WindowRegistry(nullptr);
         m_service = new WindowTrackingService(m_layoutManager, m_zoneDetector, nullptr, m_settings, nullptr, nullptr);
-        m_snapState = new PhosphorZones::SnapState(QString(), nullptr);
+        m_snapState = new PhosphorSnapEngine::SnapState(QString(), nullptr);
         m_service->setSnapState(m_snapState);
         m_service->setWindowRegistry(m_registry);
 
@@ -247,7 +248,7 @@ private:
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;
     StubSettings* m_settings = nullptr;
     StubZoneDetectorRegIntegration* m_zoneDetector = nullptr;
-    PhosphorZones::SnapState* m_snapState = nullptr;
+    PhosphorSnapEngine::SnapState* m_snapState = nullptr;
     WindowRegistry* m_registry = nullptr;
     WindowTrackingService* m_service = nullptr;
     PhosphorZones::Layout* m_testLayout = nullptr;

--- a/tests/unit/core/test_wts_session.cpp
+++ b/tests/unit/core/test_wts_session.cpp
@@ -44,6 +44,7 @@
 #include "../helpers/IsolatedConfigGuard.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 // =========================================================================

--- a/tests/unit/core/test_wts_virtual_migration.cpp
+++ b/tests/unit/core/test_wts_virtual_migration.cpp
@@ -36,6 +36,7 @@
 #include "../helpers/StubZoneDetector.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 using StubSettingsMigration = StubSettings;
@@ -57,7 +58,7 @@ private Q_SLOTS:
         m_settings = new StubSettingsMigration(nullptr);
         m_zoneDetector = new StubZoneDetector(nullptr);
         m_service = new WindowTrackingService(m_layoutManager, m_zoneDetector, nullptr, m_settings, nullptr, nullptr);
-        m_snapState = new PhosphorZones::SnapState(QString(), nullptr);
+        m_snapState = new PhosphorSnapEngine::SnapState(QString(), nullptr);
         m_service->setSnapState(m_snapState);
 
         m_testLayout = createTestLayout(3, m_layoutManager);
@@ -396,7 +397,7 @@ private:
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;
     StubSettingsMigration* m_settings = nullptr;
     StubZoneDetector* m_zoneDetector = nullptr;
-    PhosphorZones::SnapState* m_snapState = nullptr;
+    PhosphorSnapEngine::SnapState* m_snapState = nullptr;
     WindowTrackingService* m_service = nullptr;
     PhosphorZones::Layout* m_testLayout = nullptr;
     QStringList m_zoneIds;

--- a/tests/unit/core/test_zone_detection_service.cpp
+++ b/tests/unit/core/test_zone_detection_service.cpp
@@ -29,6 +29,7 @@
 #include "../helpers/IsolatedConfigGuard.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/unit/dbus/test_autotile_adaptor_panel_gate.cpp
+++ b/tests/unit/dbus/test_autotile_adaptor_panel_gate.cpp
@@ -24,6 +24,7 @@
 #include "dbus/autotileadaptor.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 namespace {
 /// Fire Phosphor::Screens::ScreenManager::panelGeometryReady directly on the instance. The signal

--- a/tests/unit/dbus/test_compositor_bridge.cpp
+++ b/tests/unit/dbus/test_compositor_bridge.cpp
@@ -32,6 +32,7 @@
 #include "../helpers/IsolatedConfigGuard.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 // =========================================================================

--- a/tests/unit/dbus/test_drag_policy.cpp
+++ b/tests/unit/dbus/test_drag_policy.cpp
@@ -37,6 +37,7 @@
 #include "../helpers/StubSettings.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
 
 namespace {
 

--- a/tests/unit/dbus/test_wta_convenience.cpp
+++ b/tests/unit/dbus/test_wta_convenience.cpp
@@ -29,6 +29,7 @@
 #include "../helpers/IsolatedConfigGuard.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 // =========================================================================

--- a/tests/unit/dbus/test_wta_reactive_metadata.cpp
+++ b/tests/unit/dbus/test_wta_reactive_metadata.cpp
@@ -40,6 +40,7 @@
 #include "../helpers/StubSettings.h"
 
 using namespace PlasmaZones;
+using namespace PhosphorSnapEngine;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/tests/unit/helpers/AutotileTestHelpers.h
+++ b/tests/unit/helpers/AutotileTestHelpers.h
@@ -64,10 +64,10 @@ inline std::unique_ptr<PhosphorTiles::AlgorithmRegistry> scopedRegistry()
  * @param focusedWindow  Optional window ID to focus after all windows are opened.
  * @return Heap-allocated AutotileEngine (caller owns the pointer).
  */
-inline AutotileEngine* createEngineWithWindows(const QString& screen, int count,
-                                               const QString& focusedWindow = QString())
+inline PhosphorTileEngine::AutotileEngine* createEngineWithWindows(const QString& screen, int count,
+                                                                   const QString& focusedWindow = QString())
 {
-    auto* engine = new AutotileEngine(nullptr, nullptr, nullptr, testRegistry());
+    auto* engine = new PhosphorTileEngine::AutotileEngine(nullptr, nullptr, nullptr, testRegistry());
     engine->setAutotileScreens({screen});
 
     for (int i = 1; i <= count; ++i) {


### PR DESCRIPTION
## Summary

- Engine libraries use their own namespaces (`PhosphorTileEngine`, `PhosphorSnapEngine`) instead of the daemon's `PlasmaZones` — eliminates namespace pollution for standalone consumers
- Removed 20 using-aliases from public engine headers; all types fully qualified in API signatures
- Replaced 4 `QMetaObject::invokeMethod` string-dispatch calls with typed interfaces (`INavigationStateProvider`, `IZoneAdjacencyResolver`)
- Eliminated `settingsWriteBackRequested` signal + `WriteBackKeys` string-dispatch by adding write methods to `IAutotileSettings` — engine writes through the settings interface directly
- WTA implements `INavigationStateProvider`, ZoneDetectionAdaptor implements `IZoneAdjacencyResolver`
- SnapState namespace moved from `PhosphorZones` to `PhosphorSnapEngine` (matches its library)

84 files changed, 667 insertions, 541 deletions. Resolves all HIGH and MEDIUM issues from the library architecture audit.

## Test plan

- [x] 131/131 tests pass in Docker build
- [ ] Verify snap navigation (focus/move/swap in direction) works end-to-end
- [ ] Verify autotile keyboard tuning (master ratio, algorithm switch) persists to config
- [ ] Verify zone detection adjacency queries work for snap navigation

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)