### PR TITLE
feat(phosphor-wayland): expand Wayland protocol support

### DIFF
--- a/libs/phosphor-wayland/CMakeLists.txt
+++ b/libs/phosphor-wayland/CMakeLists.txt
@@ -71,10 +71,53 @@ add_custom_command(
     COMMENT "PhosphorWayland: generating wlr-layer-shell protocol code"
 )
 
+add_custom_command(
+    OUTPUT ${_ps_gen_dir}/single-pixel-buffer-v1-client-protocol.h
+           ${_ps_gen_dir}/single-pixel-buffer-v1-protocol.c
+    COMMAND ${WAYLAND_SCANNER} client-header
+            ${_ps_proto_dir}/single-pixel-buffer-v1.xml
+            ${_ps_gen_dir}/single-pixel-buffer-v1-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} private-code
+            ${_ps_proto_dir}/single-pixel-buffer-v1.xml
+            ${_ps_gen_dir}/single-pixel-buffer-v1-protocol.c
+    DEPENDS ${_ps_proto_dir}/single-pixel-buffer-v1.xml
+    COMMENT "PhosphorWayland: generating single-pixel-buffer protocol code"
+)
+
+add_custom_command(
+    OUTPUT ${_ps_gen_dir}/ext-idle-notify-v1-client-protocol.h
+           ${_ps_gen_dir}/ext-idle-notify-v1-protocol.c
+    COMMAND ${WAYLAND_SCANNER} client-header
+            ${_ps_proto_dir}/ext-idle-notify-v1.xml
+            ${_ps_gen_dir}/ext-idle-notify-v1-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} private-code
+            ${_ps_proto_dir}/ext-idle-notify-v1.xml
+            ${_ps_gen_dir}/ext-idle-notify-v1-protocol.c
+    DEPENDS ${_ps_proto_dir}/ext-idle-notify-v1.xml
+    COMMENT "PhosphorWayland: generating ext-idle-notify protocol code"
+)
+
+add_custom_command(
+    OUTPUT ${_ps_gen_dir}/xdg-toplevel-drag-v1-client-protocol.h
+           ${_ps_gen_dir}/xdg-toplevel-drag-v1-protocol.c
+    COMMAND ${WAYLAND_SCANNER} client-header
+            ${_ps_proto_dir}/xdg-toplevel-drag-v1.xml
+            ${_ps_gen_dir}/xdg-toplevel-drag-v1-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} private-code
+            ${_ps_proto_dir}/xdg-toplevel-drag-v1.xml
+            ${_ps_gen_dir}/xdg-toplevel-drag-v1-protocol.c
+    DEPENDS ${_ps_proto_dir}/xdg-toplevel-drag-v1.xml
+    COMMENT "PhosphorWayland: generating xdg-toplevel-drag protocol code"
+)
+
 # Generated C code: skip PCH and unity build
 set_source_files_properties(
     ${_ps_gen_dir}/wlr-layer-shell-unstable-v1-protocol.c
+    ${_ps_gen_dir}/single-pixel-buffer-v1-protocol.c
+    ${_ps_gen_dir}/ext-idle-notify-v1-protocol.c
+    ${_ps_gen_dir}/xdg-toplevel-drag-v1-protocol.c
     src/qpa/xdg_popup_stub.c
+    src/qpa/xdg_toplevel_stub.c
     PROPERTIES
         SKIP_PRECOMPILE_HEADERS ON
         SKIP_UNITY_BUILD_INCLUSION ON
@@ -87,17 +130,27 @@ set_source_files_properties(
 # --- Public headers with Q_OBJECT (must be listed for AUTOMOC) ---
 set(phosphorwayland_public_HDRS
     include/PhosphorWayland/LayerSurface.h
+    include/PhosphorWayland/SinglePixelBuffer.h
+    include/PhosphorWayland/IdleNotifier.h
+    include/PhosphorWayland/ToplevelDrag.h
 )
 
 # --- Layer-shell sources ---
 set(phosphorwayland_layershell_SRCS
     src/layersurface.cpp
+    src/singlepixelbuffer.cpp
+    src/idlenotifier.cpp
+    src/topleveldrag.cpp
     src/qpa/layershellintegration.cpp
     src/qpa/layershellintegration.h
     src/qpa/layershellwindow.cpp
     src/qpa/layershellwindow.h
     src/qpa/xdg_popup_stub.c
+    src/qpa/xdg_toplevel_stub.c
     ${_ps_gen_dir}/wlr-layer-shell-unstable-v1-protocol.c
+    ${_ps_gen_dir}/single-pixel-buffer-v1-protocol.c
+    ${_ps_gen_dir}/ext-idle-notify-v1-protocol.c
+    ${_ps_gen_dir}/xdg-toplevel-drag-v1-protocol.c
 )
 
 add_library(PhosphorWayland SHARED

--- a/libs/phosphor-wayland/include/PhosphorWayland/IdleNotifier
+++ b/libs/phosphor-wayland/include/PhosphorWayland/IdleNotifier
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+#include <PhosphorWayland/IdleNotifier.h>

--- a/libs/phosphor-wayland/include/PhosphorWayland/IdleNotifier.h
+++ b/libs/phosphor-wayland/include/PhosphorWayland/IdleNotifier.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <phosphorwayland_export.h>
+
+#include <QObject>
+
+#include <chrono>
+#include <memory>
+
+namespace PhosphorWayland {
+
+class PHOSPHORWAYLAND_EXPORT IdleNotifier : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool idle READ isIdle NOTIFY idleChanged)
+
+public:
+    explicit IdleNotifier(QObject* parent = nullptr);
+    ~IdleNotifier() override;
+
+    void setTimeout(std::chrono::milliseconds timeout);
+    std::chrono::milliseconds timeout() const;
+
+    bool isIdle() const;
+
+    static bool isSupported();
+
+Q_SIGNALS:
+    void timeoutChanged();
+    void idleChanged();
+    void idled();
+    void resumed();
+
+private:
+    class Private;
+    std::unique_ptr<Private> d;
+};
+
+} // namespace PhosphorWayland

--- a/libs/phosphor-wayland/include/PhosphorWayland/LayerSurface.h
+++ b/libs/phosphor-wayland/include/PhosphorWayland/LayerSurface.h
@@ -28,6 +28,7 @@ inline constexpr const char* MarginsLeft = "_ps_margins_left";
 inline constexpr const char* MarginsTop = "_ps_margins_top";
 inline constexpr const char* MarginsRight = "_ps_margins_right";
 inline constexpr const char* MarginsBottom = "_ps_margins_bottom";
+inline constexpr const char* ExclusiveEdge = "_ps_exclusive_edge";
 } // namespace LayerSurfaceProps
 
 /// Wayland layer-shell surface backed by zwlr_layer_shell_v1.
@@ -44,6 +45,7 @@ class PHOSPHORWAYLAND_EXPORT LayerSurface : public QObject
     Q_PROPERTY(QString scope READ scope WRITE setScope NOTIFY scopeChanged)
     Q_PROPERTY(QScreen* screen READ screen WRITE setScreen NOTIFY screenChanged)
     Q_PROPERTY(QMargins margins READ margins WRITE setMargins NOTIFY marginsChanged)
+    Q_PROPERTY(Anchors exclusiveEdge READ exclusiveEdge WRITE setExclusiveEdge NOTIFY exclusiveEdgeChanged)
 
 public:
     ~LayerSurface() override;
@@ -91,6 +93,9 @@ public:
     void setMargins(const QMargins& margins);
     QMargins margins() const;
 
+    void setExclusiveEdge(Anchors edge);
+    Anchors exclusiveEdge() const;
+
     // ── Immutable properties (must set before show()) ────────────────
     void setScope(const QString& scope);
     QString scope() const;
@@ -117,6 +122,7 @@ Q_SIGNALS:
     void keyboardInteractivityChanged();
     void scopeChanged();
     void marginsChanged();
+    void exclusiveEdgeChanged();
     void screenChanged();
     void propertiesChanged();
 
@@ -170,6 +176,7 @@ private:
     QString m_scope;
     QPointer<QScreen> m_screen;
     QMargins m_margins;
+    Anchors m_exclusiveEdge;
     QMetaObject::Connection m_destroyedConnection;
 };
 

--- a/libs/phosphor-wayland/include/PhosphorWayland/PhosphorWayland.h
+++ b/libs/phosphor-wayland/include/PhosphorWayland/PhosphorWayland.h
@@ -14,4 +14,7 @@
 
 #pragma once
 
+#include <PhosphorWayland/IdleNotifier>
 #include <PhosphorWayland/LayerSurface>
+#include <PhosphorWayland/SinglePixelBuffer>
+#include <PhosphorWayland/ToplevelDrag>

--- a/libs/phosphor-wayland/include/PhosphorWayland/SinglePixelBuffer
+++ b/libs/phosphor-wayland/include/PhosphorWayland/SinglePixelBuffer
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+#include <PhosphorWayland/SinglePixelBuffer.h>

--- a/libs/phosphor-wayland/include/PhosphorWayland/SinglePixelBuffer.h
+++ b/libs/phosphor-wayland/include/PhosphorWayland/SinglePixelBuffer.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <phosphorwayland_export.h>
+
+#include <QColor>
+#include <QObject>
+
+#include <memory>
+
+QT_BEGIN_NAMESPACE
+class QWindow;
+QT_END_NAMESPACE
+
+namespace PhosphorWayland {
+
+class PHOSPHORWAYLAND_EXPORT SinglePixelBuffer : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QColor color READ color WRITE setColor NOTIFY colorChanged)
+
+public:
+    explicit SinglePixelBuffer(const QColor& color, QObject* parent = nullptr);
+    ~SinglePixelBuffer() override;
+
+    QColor color() const;
+    void setColor(const QColor& color);
+
+    bool attachTo(QWindow* window);
+
+    static bool isSupported();
+
+Q_SIGNALS:
+    void colorChanged();
+
+private:
+    class Private;
+    std::unique_ptr<Private> d;
+};
+
+} // namespace PhosphorWayland

--- a/libs/phosphor-wayland/include/PhosphorWayland/ToplevelDrag
+++ b/libs/phosphor-wayland/include/PhosphorWayland/ToplevelDrag
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+#include <PhosphorWayland/ToplevelDrag.h>

--- a/libs/phosphor-wayland/include/PhosphorWayland/ToplevelDrag.h
+++ b/libs/phosphor-wayland/include/PhosphorWayland/ToplevelDrag.h
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <phosphorwayland_export.h>
+
+namespace PhosphorWayland {
+
+PHOSPHORWAYLAND_EXPORT bool isToplevelDragSupported();
+
+} // namespace PhosphorWayland

--- a/libs/phosphor-wayland/protocols/ext-idle-notify-v1.xml
+++ b/libs/phosphor-wayland/protocols/ext-idle-notify-v1.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_idle_notify_v1">
+  <copyright>
+    Copyright © 2015 Martin Gräßlin
+    Copyright © 2022 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="ext_idle_notifier_v1" version="2">
+    <description summary="idle notification manager">
+      This interface allows clients to monitor user idle status.
+
+      After binding to this global, clients can create ext_idle_notification_v1
+      objects to get notified when the user is idle for a given amount of time.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the manager object. All objects created via this interface
+        remain valid.
+      </description>
+    </request>
+
+    <request name="get_idle_notification">
+      <description summary="create a notification object">
+        Create a new idle notification object.
+
+        The notification object has a minimum timeout duration and is tied to a
+        seat. The client will be notified if the seat is inactive for at least
+        the provided timeout. See ext_idle_notification_v1 for more details.
+
+        A zero timeout is valid and means the client wants to be notified as
+        soon as possible when the seat is inactive.
+      </description>
+      <arg name="id" type="new_id" interface="ext_idle_notification_v1"/>
+      <arg name="timeout" type="uint" summary="minimum idle timeout in msec"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+
+    <!-- Version 2 additions -->
+
+    <request name="get_input_idle_notification" since="2">
+      <description summary="create a notification object">
+        Create a new idle notification object to track input from the
+        user, such as keyboard and mouse movement. Because this object is
+        meant to track user input alone, it ignores idle inhibitors.
+
+        The notification object has a minimum timeout duration and is tied to a
+        seat. The client will be notified if the seat is inactive for at least
+        the provided timeout. See ext_idle_notification_v1 for more details.
+
+        A zero timeout is valid and means the client wants to be notified as
+        soon as possible when the seat is inactive.
+      </description>
+      <arg name="id" type="new_id" interface="ext_idle_notification_v1"/>
+      <arg name="timeout" type="uint" summary="minimum idle timeout in msec"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+    
+  </interface>
+
+  <interface name="ext_idle_notification_v1" version="2">
+    <description summary="idle notification">
+      This interface is used by the compositor to send idle notification events
+      to clients.
+
+      Initially the notification object is not idle. The notification object
+      becomes idle when no user activity has happened for at least the timeout
+      duration, starting from the creation of the notification object. User
+      activity may include input events or a presence sensor, but is
+      compositor-specific.
+
+      How this notification responds to idle inhibitors depends on how
+      it was constructed. If constructed from the
+      get_idle_notification request, then if an idle inhibitor is
+      active (e.g. another client has created a zwp_idle_inhibitor_v1
+      on a visible surface), the compositor must not make the
+      notification object idle. However, if constructed from the
+      get_input_idle_notification request, then idle inhibitors are
+      ignored, and only input from the user, e.g. from a keyboard or
+      mouse, counts as activity.
+
+      When the notification object becomes idle, an idled event is sent. When
+      user activity starts again, the notification object stops being idle,
+      a resumed event is sent and the timeout is restarted.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the notification object">
+        Destroy the notification object.
+      </description>
+    </request>
+
+    <event name="idled">
+      <description summary="notification object is idle">
+        This event is sent when the notification object becomes idle.
+
+        It's a compositor protocol error to send this event twice without a
+        resumed event in-between.
+      </description>
+    </event>
+
+    <event name="resumed">
+      <description summary="notification object is no longer idle">
+        This event is sent when the notification object stops being idle.
+
+        It's a compositor protocol error to send this event twice without an
+        idled event in-between. It's a compositor protocol error to send this
+        event prior to any idled event.
+      </description>
+    </event>
+  </interface>
+</protocol>

--- a/libs/phosphor-wayland/protocols/single-pixel-buffer-v1.xml
+++ b/libs/phosphor-wayland/protocols/single-pixel-buffer-v1.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="single_pixel_buffer_v1">
+  <copyright>
+    Copyright © 2022 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="single pixel buffer factory">
+    This protocol extension allows clients to create single-pixel buffers.
+
+    Compositors supporting this protocol extension should also support the
+    viewporter protocol extension. Clients may use viewporter to scale a
+    single-pixel buffer to a desired size.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="wp_single_pixel_buffer_manager_v1" version="1">
+    <description summary="global factory for single-pixel buffers">
+      The wp_single_pixel_buffer_manager_v1 interface is a factory for
+      single-pixel buffers.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the wp_single_pixel_buffer_manager_v1 object.
+
+        The child objects created via this interface are unaffected.
+      </description>
+    </request>
+
+    <request name="create_u32_rgba_buffer">
+      <description summary="create a 1×1 buffer from 32-bit RGBA values">
+        Create a single-pixel buffer from four 32-bit RGBA values.
+
+        Unless specified in another protocol extension, the RGBA values use
+        pre-multiplied alpha.
+
+        The width and height of the buffer are 1.
+
+        The r, g, b and a arguments valid range is from UINT32_MIN (0)
+        to UINT32_MAX (0xffffffff).
+        
+        These arguments should be interpreted as a percentage, i.e.
+        - UINT32_MIN = 0% of the given color component
+        - UINT32_MAX = 100% of the given color component
+      </description>
+      <arg name="id" type="new_id" interface="wl_buffer"/>
+      <arg name="r" type="uint" summary="value of the buffer's red channel"/>
+      <arg name="g" type="uint" summary="value of the buffer's green channel"/>
+      <arg name="b" type="uint" summary="value of the buffer's blue channel"/>
+      <arg name="a" type="uint" summary="value of the buffer's alpha channel"/>
+    </request>
+  </interface>
+</protocol>

--- a/libs/phosphor-wayland/protocols/xdg-toplevel-drag-v1.xml
+++ b/libs/phosphor-wayland/protocols/xdg-toplevel-drag-v1.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_toplevel_drag_v1">
+
+  <copyright>
+    Copyright 2023 David Redondo
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="xdg_toplevel_drag_manager_v1" version="1">
+    <description summary="Move a window during a drag">
+      This protocol enhances normal drag and drop with the ability to move a
+      window at the same time. This allows having detachable parts of a window
+      that when dragged out of it become a new window and can be dragged over
+      an existing window to be reattached.
+
+      A typical workflow would be when the user starts dragging on top of a
+      detachable part of a window, the client would create a wl_data_source and
+      a xdg_toplevel_drag_v1 object and start the drag as normal via
+      wl_data_device.start_drag. Once the client determines that the detachable
+      window contents should be detached from the originating window, it creates
+      a new xdg_toplevel with these contents and issues a
+      xdg_toplevel_drag_v1.attach request before mapping it. From now on the new
+      window is moved by the compositor during the drag as if the client called
+      xdg_toplevel.move.
+
+      Dragging an existing window is similar. The client creates a
+      xdg_toplevel_drag_v1 object and attaches the existing toplevel before
+      starting the drag.
+
+      Clients use the existing drag and drop mechanism to detect when a window
+      can be docked or undocked. If the client wants to snap a window into a
+      parent window it should delete or unmap the dragged top-level. If the
+      contents should be detached again it attaches a new toplevel as described
+      above. If a drag operation is cancelled without being dropped, clients
+      should revert to the previous state, deleting any newly created windows
+      as appropriate. When a drag operation ends as indicated by
+      wl_data_source.dnd_drop_performed the dragged toplevel window's final
+      position is determined as if a xdg_toplevel_move operation ended.
+
+      Warning! The protocol described in this file is currently in the testing
+      phase. Backward compatible changes may be added together with the
+      corresponding interface version bump. Backward incompatible changes can
+      only be done by creating a new major version of the extension.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_source" value="0"
+             summary="data_source already used for toplevel drag"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_toplevel_drag_manager_v1 object">
+        Destroy this xdg_toplevel_drag_manager_v1 object. Other objects,
+        including xdg_toplevel_drag_v1 objects created by this factory, are not
+        affected by this request.
+      </description>
+    </request>
+
+    <request name="get_xdg_toplevel_drag">
+      <description summary="get an xdg_toplevel_drag for a wl_data_source">
+        Create an xdg_toplevel_drag for a drag and drop operation that is going
+        to be started with data_source.
+
+        This request can only be made on sources used in drag-and-drop, so it
+        must be performed before wl_data_device.start_drag. Attempting to use
+        the source other than for drag-and-drop such as in
+        wl_data_device.set_selection will raise an invalid_source error.
+
+        Destroying data_source while a toplevel is attached to the
+        xdg_toplevel_drag is undefined.
+      </description>
+
+      <arg name="id" type="new_id" interface="xdg_toplevel_drag_v1"/>
+      <arg name="data_source" type="object" interface="wl_data_source"/>
+    </request>
+  </interface>
+
+  <interface name="xdg_toplevel_drag_v1" version="1">
+    <description summary="Object representing a toplevel move during a drag">
+    </description>
+
+    <enum name="error">
+      <entry name="toplevel_attached" value="0"
+             summary="valid toplevel already attached"/>
+      <entry name="ongoing_drag" value="1"
+             summary="drag has not ended" />
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy an xdg_toplevel_drag_v1 object">
+        Destroy this xdg_toplevel_drag_v1 object. This request must only be
+        called after the underlying wl_data_source drag has ended, as indicated
+        by the dnd_drop_performed or cancelled events. In any other case an
+        ongoing_drag error is raised.
+      </description>
+    </request>
+
+    <request name="attach">
+      <description summary="Move a toplevel with the drag operation">
+        Request that the window will be moved with the cursor during the drag
+        operation. The offset is a hint to the compositor how the toplevel
+        should be positioned relative to the cursor hotspot in surface local
+        coordinates and relative to the geometry of the toplevel being attached.
+        See xdg_surface.set_window_geometry. For example it might only
+        be used when an unmapped window is attached. The attached window
+        does not participate in the selection of the drag target.
+
+        If the toplevel is unmapped while it is attached, it is automatically
+        detached from the drag. In this case this request has to be called again
+        if the window should be attached after it is remapped.
+
+        This request can be called multiple times but issuing it while a
+        toplevel with an active role is attached raises a toplevel_attached
+        error.
+      </description>
+
+      <arg name="toplevel" type="object" interface="xdg_toplevel"/>
+      <arg name="x_offset" type="int" summary="dragged surface x offset"/>
+      <arg name="y_offset" type="int" summary="dragged surface y offset"/>
+    </request>
+
+  </interface>
+</protocol>
+

--- a/libs/phosphor-wayland/src/idlenotifier.cpp
+++ b/libs/phosphor-wayland/src/idlenotifier.cpp
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorWayland/IdleNotifier.h>
+#include "qpa/layershellintegration.h"
+#include "qpa/idle_notify_protocol.h"
+
+#include <QLoggingCategory>
+#include <QtWaylandClient/private/qwaylanddisplay_p.h>
+#include <QtWaylandClient/private/qwaylandinputdevice_p.h>
+
+#include <limits>
+
+Q_LOGGING_CATEGORY(lcIdleNotifier, "phosphorwayland.idlenotifier")
+
+namespace PhosphorWayland {
+
+class IdleNotifier::Private
+{
+public:
+    IdleNotifier* owner = nullptr;
+    std::chrono::milliseconds timeout{0};
+    bool idle = false;
+    struct ext_idle_notification_v1* notification = nullptr;
+
+    static void handleIdled(void* data, struct ext_idle_notification_v1* notification)
+    {
+        Q_UNUSED(notification)
+        auto* self = static_cast<Private*>(data);
+        if (self->idle)
+            return;
+        self->idle = true;
+        Q_EMIT self->owner->idleChanged();
+        Q_EMIT self->owner->idled();
+    }
+
+    static void handleResumed(void* data, struct ext_idle_notification_v1* notification)
+    {
+        Q_UNUSED(notification)
+        auto* self = static_cast<Private*>(data);
+        if (!self->idle)
+            return;
+        self->idle = false;
+        Q_EMIT self->owner->idleChanged();
+        Q_EMIT self->owner->resumed();
+    }
+
+    void createNotification()
+    {
+        destroyNotification();
+        if (timeout.count() <= 0)
+            return;
+        auto* integration = LayerShellIntegration::instance();
+        if (!integration)
+            return;
+        auto* notifier = integration->idleNotifier();
+        if (!notifier)
+            return;
+        auto* display = integration->display();
+        if (!display)
+            return;
+        auto seats = display->inputDevices();
+        if (seats.isEmpty()) {
+            qCWarning(lcIdleNotifier) << "No input seat available for idle notification";
+            return;
+        }
+        struct wl_seat* seat = seats.first()->wl_seat();
+        if (!seat)
+            return;
+        static const struct ext_idle_notification_v1_listener listener = {
+            .idled = handleIdled,
+            .resumed = handleResumed,
+        };
+        auto ms =
+            static_cast<uint32_t>(qMin(timeout.count(), static_cast<int64_t>(std::numeric_limits<uint32_t>::max())));
+        notification = ext_idle_notifier_v1_get_idle_notification(notifier, ms, seat);
+        if (notification) {
+            ext_idle_notification_v1_add_listener(notification, &listener, this);
+        }
+    }
+
+    void destroyNotification()
+    {
+        if (notification) {
+            ext_idle_notification_v1_destroy(notification);
+            notification = nullptr;
+        }
+        if (idle && owner) {
+            idle = false;
+            Q_EMIT owner->idleChanged();
+            Q_EMIT owner->resumed();
+        }
+        idle = false;
+    }
+};
+
+IdleNotifier::IdleNotifier(QObject* parent)
+    : QObject(parent)
+    , d(std::make_unique<Private>())
+{
+    d->owner = this;
+}
+
+IdleNotifier::~IdleNotifier()
+{
+    d->destroyNotification();
+}
+
+void IdleNotifier::setTimeout(std::chrono::milliseconds timeout)
+{
+    if (timeout.count() < 0)
+        timeout = std::chrono::milliseconds(0);
+    if (d->timeout == timeout)
+        return;
+    d->timeout = timeout;
+    d->createNotification();
+    Q_EMIT timeoutChanged();
+}
+
+std::chrono::milliseconds IdleNotifier::timeout() const
+{
+    return d->timeout;
+}
+
+bool IdleNotifier::isIdle() const
+{
+    return d->idle;
+}
+
+bool IdleNotifier::isSupported()
+{
+    auto* integration = LayerShellIntegration::instance();
+    return integration && integration->idleNotifier();
+}
+
+} // namespace PhosphorWayland

--- a/libs/phosphor-wayland/src/layersurface.cpp
+++ b/libs/phosphor-wayland/src/layersurface.cpp
@@ -32,6 +32,7 @@ LayerSurface::LayerSurface(QWindow* window)
     window->setProperty(LayerSurfaceProps::MarginsTop, 0);
     window->setProperty(LayerSurfaceProps::MarginsRight, 0);
     window->setProperty(LayerSurfaceProps::MarginsBottom, 0);
+    window->setProperty(LayerSurfaceProps::ExclusiveEdge, static_cast<int>(m_exclusiveEdge));
 
     QWindow* rawWindow = window;
     m_destroyedConnection = connect(window, &QObject::destroyed, this, [rawWindow]() {
@@ -244,6 +245,28 @@ void LayerSurface::setMargins(const QMargins& margins)
 QMargins LayerSurface::margins() const
 {
     return m_margins;
+}
+
+void LayerSurface::setExclusiveEdge(Anchors edge)
+{
+    int bits = static_cast<int>(edge);
+    if (bits != 0 && bits != AnchorTop && bits != AnchorBottom && bits != AnchorLeft && bits != AnchorRight) {
+        qCWarning(lcLayerSurface) << "setExclusiveEdge() called with invalid value" << Qt::hex << bits
+                                  << "— must be a single anchor or AnchorNone";
+        return;
+    }
+    if (m_exclusiveEdge == edge)
+        return;
+    m_exclusiveEdge = edge;
+    if (m_window)
+        m_window->setProperty(LayerSurfaceProps::ExclusiveEdge, static_cast<int>(edge));
+    Q_EMIT exclusiveEdgeChanged();
+    emitPropertiesChanged();
+}
+
+LayerSurface::Anchors LayerSurface::exclusiveEdge() const
+{
+    return m_exclusiveEdge;
 }
 
 std::pair<uint32_t, uint32_t> LayerSurface::computeLayerSize(Anchors anchors, const QSize& windowSize)

--- a/libs/phosphor-wayland/src/qpa/idle_notify_protocol.h
+++ b/libs/phosphor-wayland/src/qpa/idle_notify_protocol.h
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+extern "C" {
+#include "ext-idle-notify-v1-client-protocol.h"
+}

--- a/libs/phosphor-wayland/src/qpa/layershellintegration.cpp
+++ b/libs/phosphor-wayland/src/qpa/layershellintegration.cpp
@@ -28,6 +28,15 @@ LayerShellIntegration::LayerShellIntegration() = default;
 
 LayerShellIntegration::~LayerShellIntegration()
 {
+    if (m_toplevelDragManager) {
+        xdg_toplevel_drag_manager_v1_destroy(m_toplevelDragManager);
+    }
+    if (m_idleNotifier) {
+        ext_idle_notifier_v1_destroy(m_idleNotifier);
+    }
+    if (m_singlePixelBufferManager) {
+        wp_single_pixel_buffer_manager_v1_destroy(m_singlePixelBufferManager);
+    }
     if (m_layerShell) {
         if (m_boundVersion >= 3) {
             // Protocol-level destroy request (added in v3)
@@ -127,11 +136,9 @@ void LayerShellIntegration::registryHandler(void* data, struct wl_registry* regi
         //   v1: base protocol
         //   v2: set_layer (runtime layer changes)
         //   v3: destroy request
-        //   v4: on_demand keyboard interactivity — we use this
-        //   v5: set_exclusive_edge — we do NOT use this
-        // Capping at v4 avoids negotiation issues with older compositors
-        // while supporting all features PhosphorWayland needs.
-        static constexpr uint32_t kMaxBindVersion = 4;
+        //   v4: on_demand keyboard interactivity
+        //   v5: set_exclusive_edge
+        static constexpr uint32_t kMaxBindVersion = 5;
         uint32_t bindVersion = qMin(version, kMaxBindVersion);
         self->m_layerShell = static_cast<struct zwlr_layer_shell_v1*>(
             wl_registry_bind(registry, id, &zwlr_layer_shell_v1_interface, bindVersion));
@@ -139,6 +146,36 @@ void LayerShellIntegration::registryHandler(void* data, struct wl_registry* regi
         self->m_boundVersion = bindVersion;
         self->m_globalAvailable = true;
         qCDebug(lcLayerShellIntegration).nospace() << "Bound zwlr_layer_shell_v1 v" << bindVersion;
+    } else if (strcmp(interface, wp_single_pixel_buffer_manager_v1_interface.name) == 0) {
+        if (self->m_singlePixelBufferManager)
+            return;
+        static constexpr uint32_t kMaxVersion = 1;
+        uint32_t bindVersion = qMin(version, kMaxVersion);
+        self->m_singlePixelBufferManager = static_cast<struct wp_single_pixel_buffer_manager_v1*>(
+            wl_registry_bind(registry, id, &wp_single_pixel_buffer_manager_v1_interface, bindVersion));
+        self->m_singlePixelBufferManagerId = id;
+        self->m_singlePixelBufferAvailable = true;
+        qCDebug(lcLayerShellIntegration).nospace() << "Bound wp_single_pixel_buffer_manager_v1 v" << bindVersion;
+    } else if (strcmp(interface, ext_idle_notifier_v1_interface.name) == 0) {
+        if (self->m_idleNotifier)
+            return;
+        static constexpr uint32_t kMaxVersion = 1;
+        uint32_t bindVersion = qMin(version, kMaxVersion);
+        self->m_idleNotifier = static_cast<struct ext_idle_notifier_v1*>(
+            wl_registry_bind(registry, id, &ext_idle_notifier_v1_interface, bindVersion));
+        self->m_idleNotifierId = id;
+        self->m_idleNotifierAvailable = true;
+        qCDebug(lcLayerShellIntegration).nospace() << "Bound ext_idle_notifier_v1 v" << bindVersion;
+    } else if (strcmp(interface, xdg_toplevel_drag_manager_v1_interface.name) == 0) {
+        if (self->m_toplevelDragManager)
+            return;
+        static constexpr uint32_t kMaxVersion = 1;
+        uint32_t bindVersion = qMin(version, kMaxVersion);
+        self->m_toplevelDragManager = static_cast<struct xdg_toplevel_drag_manager_v1*>(
+            wl_registry_bind(registry, id, &xdg_toplevel_drag_manager_v1_interface, bindVersion));
+        self->m_toplevelDragManagerId = id;
+        self->m_toplevelDragManagerAvailable = true;
+        qCDebug(lcLayerShellIntegration).nospace() << "Bound xdg_toplevel_drag_manager_v1 v" << bindVersion;
     }
 }
 
@@ -146,7 +183,19 @@ void LayerShellIntegration::registryRemoveHandler(void* data, struct wl_registry
 {
     Q_UNUSED(registry)
     auto* self = static_cast<LayerShellIntegration*>(data);
-    if (id == self->m_layerShellId) {
+    if (id == self->m_singlePixelBufferManagerId) {
+        self->m_singlePixelBufferAvailable = false;
+        self->m_singlePixelBufferManagerId = 0;
+        qCDebug(lcLayerShellIntegration) << "wp_single_pixel_buffer_manager_v1 global removed";
+    } else if (id == self->m_idleNotifierId) {
+        self->m_idleNotifierAvailable = false;
+        self->m_idleNotifierId = 0;
+        qCDebug(lcLayerShellIntegration) << "ext_idle_notifier_v1 global removed";
+    } else if (id == self->m_toplevelDragManagerId) {
+        self->m_toplevelDragManagerAvailable = false;
+        self->m_toplevelDragManagerId = 0;
+        qCDebug(lcLayerShellIntegration) << "xdg_toplevel_drag_manager_v1 global removed";
+    } else if (id == self->m_layerShellId) {
         qCWarning(lcLayerShellIntegration) << "zwlr_layer_shell_v1 global removed (id" << id << ") —"
                                            << "new layer surface creation will fail."
                                            << "Existing layer surfaces may become invalid."

--- a/libs/phosphor-wayland/src/qpa/layershellintegration.h
+++ b/libs/phosphor-wayland/src/qpa/layershellintegration.h
@@ -12,6 +12,9 @@
 #include <QtWaylandClient/private/qwaylandshellintegration_p.h>
 #include <phosphorwayland_export.h>
 #include "wlr_layer_shell_protocol.h"
+#include "single_pixel_buffer_protocol.h"
+#include "idle_notify_protocol.h"
+#include "xdg_toplevel_drag_protocol.h"
 
 namespace PhosphorWayland {
 
@@ -35,11 +38,12 @@ public:
         return m_globalAvailable ? m_layerShell : nullptr;
     }
 
-    /// The protocol version we negotiated with the compositor (1-4).
+    /// The protocol version we negotiated with the compositor (1-5).
     /// Callers should check this before using version-gated features:
     ///   v2: set_layer (runtime layer changes)
     ///   v3: destroy request
     ///   v4: on_demand keyboard interactivity
+    ///   v5: set_exclusive_edge
     uint32_t boundVersion() const
     {
         return m_boundVersion;
@@ -70,6 +74,21 @@ public:
     CallbackId addGlobalRemovedCallback(GlobalRemovedCallback cb);
     void removeGlobalRemovedCallback(CallbackId id);
 
+    struct wp_single_pixel_buffer_manager_v1* singlePixelBufferManager() const
+    {
+        return m_singlePixelBufferAvailable ? m_singlePixelBufferManager : nullptr;
+    }
+
+    struct ext_idle_notifier_v1* idleNotifier() const
+    {
+        return m_idleNotifierAvailable ? m_idleNotifier : nullptr;
+    }
+
+    struct xdg_toplevel_drag_manager_v1* toplevelDragManager() const
+    {
+        return m_toplevelDragManagerAvailable ? m_toplevelDragManager : nullptr;
+    }
+
     /// Access the Wayland display for explicit flushing after surface creation.
     QtWaylandClient::QWaylandDisplay* display() const
     {
@@ -86,11 +105,19 @@ private:
     struct wl_registry* m_registry = nullptr;
     uint32_t m_layerShellId = 0;
     uint32_t m_boundVersion = 0;
-    // Tracks whether the compositor's global is still advertised.
-    // When false, layerShell() returns nullptr to prevent new surface creation,
-    // but m_layerShell is kept non-null for proper cleanup in the destructor
-    // (avoids leaking the wl_proxy when the global is removed at runtime).
     bool m_globalAvailable = false;
+
+    struct wp_single_pixel_buffer_manager_v1* m_singlePixelBufferManager = nullptr;
+    uint32_t m_singlePixelBufferManagerId = 0;
+    bool m_singlePixelBufferAvailable = false;
+
+    struct ext_idle_notifier_v1* m_idleNotifier = nullptr;
+    uint32_t m_idleNotifierId = 0;
+    bool m_idleNotifierAvailable = false;
+
+    struct xdg_toplevel_drag_manager_v1* m_toplevelDragManager = nullptr;
+    uint32_t m_toplevelDragManagerId = 0;
+    bool m_toplevelDragManagerAvailable = false;
 
     std::vector<std::pair<CallbackId, GlobalRemovedCallback>> m_globalRemovedCallbacks;
     CallbackId m_nextCallbackId = 1;

--- a/libs/phosphor-wayland/src/qpa/layershellwindow.cpp
+++ b/libs/phosphor-wayland/src/qpa/layershellwindow.cpp
@@ -230,6 +230,11 @@ void LayerShellWindow::applyProperties()
     // Size — use 0 for axes anchored to both edges; clamp to avoid uint32_t wrap on negative
     auto [w, h] = LayerSurface::computeLayerSize(LayerSurface::Anchors::fromInt(anchors), qwindow->size());
     zwlr_layer_surface_v1_set_size(m_layerSurface, w, h);
+
+    if (m_integration && m_integration->boundVersion() >= 5) {
+        int exclusiveEdge = qwindow->property(LayerSurfaceProps::ExclusiveEdge).toInt();
+        zwlr_layer_surface_v1_set_exclusive_edge(m_layerSurface, static_cast<uint32_t>(exclusiveEdge));
+    }
 }
 
 QSize LayerShellWindow::computeConfigureSize(uint32_t width, uint32_t height) const

--- a/libs/phosphor-wayland/src/qpa/single_pixel_buffer_protocol.h
+++ b/libs/phosphor-wayland/src/qpa/single_pixel_buffer_protocol.h
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+extern "C" {
+#include "single-pixel-buffer-v1-client-protocol.h"
+}

--- a/libs/phosphor-wayland/src/qpa/xdg_toplevel_drag_protocol.h
+++ b/libs/phosphor-wayland/src/qpa/xdg_toplevel_drag_protocol.h
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+extern "C" {
+#include "xdg-toplevel-drag-v1-client-protocol.h"
+}

--- a/libs/phosphor-wayland/src/qpa/xdg_toplevel_stub.c
+++ b/libs/phosphor-wayland/src/qpa/xdg_toplevel_stub.c
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <wayland-util.h>
+
+// Minimal stub — the generated xdg-toplevel-drag protocol code references
+// xdg_toplevel_interface for the attach request, but PhosphorWayland never
+// calls attach (capability query only). See xdg_popup_stub.c for the same
+// pattern.
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((weak))
+#endif
+const struct wl_interface xdg_toplevel_interface = {
+    "xdg_toplevel", 1, 0, NULL, 0, NULL,
+};

--- a/libs/phosphor-wayland/src/singlepixelbuffer.cpp
+++ b/libs/phosphor-wayland/src/singlepixelbuffer.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorWayland/SinglePixelBuffer.h>
+#include "qpa/layershellintegration.h"
+#include "qpa/single_pixel_buffer_protocol.h"
+
+#include <QLoggingCategory>
+#include <QWindow>
+#include <QtWaylandClient/private/qwaylandwindow_p.h>
+
+#include <limits>
+
+Q_LOGGING_CATEGORY(lcSinglePixelBuffer, "phosphorwayland.singlepixelbuffer")
+
+namespace PhosphorWayland {
+
+static uint32_t colorComponentToU32(qreal v)
+{
+    v = qBound(0.0, v, 1.0);
+    return static_cast<uint32_t>(v * std::numeric_limits<uint32_t>::max());
+}
+
+class SinglePixelBuffer::Private
+{
+public:
+    QColor color;
+    struct wl_buffer* buffer = nullptr;
+
+    void recreateBuffer()
+    {
+        destroyBuffer();
+        auto* integration = LayerShellIntegration::instance();
+        if (!integration)
+            return;
+        auto* manager = integration->singlePixelBufferManager();
+        if (!manager)
+            return;
+        buffer = wp_single_pixel_buffer_manager_v1_create_u32_rgba_buffer(
+            manager, colorComponentToU32(color.redF()), colorComponentToU32(color.greenF()),
+            colorComponentToU32(color.blueF()), colorComponentToU32(color.alphaF()));
+    }
+
+    void destroyBuffer()
+    {
+        if (buffer) {
+            wl_buffer_destroy(buffer);
+            buffer = nullptr;
+        }
+    }
+};
+
+SinglePixelBuffer::SinglePixelBuffer(const QColor& color, QObject* parent)
+    : QObject(parent)
+    , d(std::make_unique<Private>())
+{
+    d->color = color;
+    d->recreateBuffer();
+}
+
+SinglePixelBuffer::~SinglePixelBuffer()
+{
+    d->destroyBuffer();
+}
+
+QColor SinglePixelBuffer::color() const
+{
+    return d->color;
+}
+
+void SinglePixelBuffer::setColor(const QColor& color)
+{
+    if (d->color == color)
+        return;
+    d->color = color;
+    d->recreateBuffer();
+    Q_EMIT colorChanged();
+}
+
+bool SinglePixelBuffer::attachTo(QWindow* window)
+{
+    if (!window || !d->buffer) {
+        qCWarning(lcSinglePixelBuffer) << "Cannot attach: window or buffer is null";
+        return false;
+    }
+    auto* waylandWindow = dynamic_cast<QtWaylandClient::QWaylandWindow*>(window->handle());
+    if (!waylandWindow) {
+        qCWarning(lcSinglePixelBuffer) << "Cannot attach: window has no Wayland platform handle";
+        return false;
+    }
+    struct wl_surface* surface = QtWaylandClient::QWaylandShellIntegration::wlSurfaceForWindow(waylandWindow);
+    if (!surface) {
+        qCWarning(lcSinglePixelBuffer) << "Cannot attach: no wl_surface for window";
+        return false;
+    }
+    wl_surface_attach(surface, d->buffer, 0, 0);
+    return true;
+}
+
+bool SinglePixelBuffer::isSupported()
+{
+    auto* integration = LayerShellIntegration::instance();
+    return integration && integration->singlePixelBufferManager();
+}
+
+} // namespace PhosphorWayland

--- a/libs/phosphor-wayland/src/topleveldrag.cpp
+++ b/libs/phosphor-wayland/src/topleveldrag.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorWayland/ToplevelDrag.h>
+#include "qpa/layershellintegration.h"
+#include "qpa/xdg_toplevel_drag_protocol.h"
+
+namespace PhosphorWayland {
+
+bool isToplevelDragSupported()
+{
+    auto* integration = LayerShellIntegration::instance();
+    return integration && integration->toplevelDragManager();
+}
+
+} // namespace PhosphorWayland

--- a/src/core/protocols/ext-idle-notify-v1.xml
+++ b/src/core/protocols/ext-idle-notify-v1.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_idle_notify_v1">
+  <copyright>
+    Copyright © 2015 Martin Gräßlin
+    Copyright © 2022 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="ext_idle_notifier_v1" version="2">
+    <description summary="idle notification manager">
+      This interface allows clients to monitor user idle status.
+
+      After binding to this global, clients can create ext_idle_notification_v1
+      objects to get notified when the user is idle for a given amount of time.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the manager object. All objects created via this interface
+        remain valid.
+      </description>
+    </request>
+
+    <request name="get_idle_notification">
+      <description summary="create a notification object">
+        Create a new idle notification object.
+
+        The notification object has a minimum timeout duration and is tied to a
+        seat. The client will be notified if the seat is inactive for at least
+        the provided timeout. See ext_idle_notification_v1 for more details.
+
+        A zero timeout is valid and means the client wants to be notified as
+        soon as possible when the seat is inactive.
+      </description>
+      <arg name="id" type="new_id" interface="ext_idle_notification_v1"/>
+      <arg name="timeout" type="uint" summary="minimum idle timeout in msec"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+
+    <!-- Version 2 additions -->
+
+    <request name="get_input_idle_notification" since="2">
+      <description summary="create a notification object">
+        Create a new idle notification object to track input from the
+        user, such as keyboard and mouse movement. Because this object is
+        meant to track user input alone, it ignores idle inhibitors.
+
+        The notification object has a minimum timeout duration and is tied to a
+        seat. The client will be notified if the seat is inactive for at least
+        the provided timeout. See ext_idle_notification_v1 for more details.
+
+        A zero timeout is valid and means the client wants to be notified as
+        soon as possible when the seat is inactive.
+      </description>
+      <arg name="id" type="new_id" interface="ext_idle_notification_v1"/>
+      <arg name="timeout" type="uint" summary="minimum idle timeout in msec"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+    
+  </interface>
+
+  <interface name="ext_idle_notification_v1" version="2">
+    <description summary="idle notification">
+      This interface is used by the compositor to send idle notification events
+      to clients.
+
+      Initially the notification object is not idle. The notification object
+      becomes idle when no user activity has happened for at least the timeout
+      duration, starting from the creation of the notification object. User
+      activity may include input events or a presence sensor, but is
+      compositor-specific.
+
+      How this notification responds to idle inhibitors depends on how
+      it was constructed. If constructed from the
+      get_idle_notification request, then if an idle inhibitor is
+      active (e.g. another client has created a zwp_idle_inhibitor_v1
+      on a visible surface), the compositor must not make the
+      notification object idle. However, if constructed from the
+      get_input_idle_notification request, then idle inhibitors are
+      ignored, and only input from the user, e.g. from a keyboard or
+      mouse, counts as activity.
+
+      When the notification object becomes idle, an idled event is sent. When
+      user activity starts again, the notification object stops being idle,
+      a resumed event is sent and the timeout is restarted.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the notification object">
+        Destroy the notification object.
+      </description>
+    </request>
+
+    <event name="idled">
+      <description summary="notification object is idle">
+        This event is sent when the notification object becomes idle.
+
+        It's a compositor protocol error to send this event twice without a
+        resumed event in-between.
+      </description>
+    </event>
+
+    <event name="resumed">
+      <description summary="notification object is no longer idle">
+        This event is sent when the notification object stops being idle.
+
+        It's a compositor protocol error to send this event twice without an
+        idled event in-between. It's a compositor protocol error to send this
+        event prior to any idled event.
+      </description>
+    </event>
+  </interface>
+</protocol>

--- a/src/core/protocols/single-pixel-buffer-v1.xml
+++ b/src/core/protocols/single-pixel-buffer-v1.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="single_pixel_buffer_v1">
+  <copyright>
+    Copyright © 2022 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="single pixel buffer factory">
+    This protocol extension allows clients to create single-pixel buffers.
+
+    Compositors supporting this protocol extension should also support the
+    viewporter protocol extension. Clients may use viewporter to scale a
+    single-pixel buffer to a desired size.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward compatible changes may be added together with the
+    corresponding interface version bump. Backward incompatible changes can
+    only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="wp_single_pixel_buffer_manager_v1" version="1">
+    <description summary="global factory for single-pixel buffers">
+      The wp_single_pixel_buffer_manager_v1 interface is a factory for
+      single-pixel buffers.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the wp_single_pixel_buffer_manager_v1 object.
+
+        The child objects created via this interface are unaffected.
+      </description>
+    </request>
+
+    <request name="create_u32_rgba_buffer">
+      <description summary="create a 1×1 buffer from 32-bit RGBA values">
+        Create a single-pixel buffer from four 32-bit RGBA values.
+
+        Unless specified in another protocol extension, the RGBA values use
+        pre-multiplied alpha.
+
+        The width and height of the buffer are 1.
+
+        The r, g, b and a arguments valid range is from UINT32_MIN (0)
+        to UINT32_MAX (0xffffffff).
+        
+        These arguments should be interpreted as a percentage, i.e.
+        - UINT32_MIN = 0% of the given color component
+        - UINT32_MAX = 100% of the given color component
+      </description>
+      <arg name="id" type="new_id" interface="wl_buffer"/>
+      <arg name="r" type="uint" summary="value of the buffer's red channel"/>
+      <arg name="g" type="uint" summary="value of the buffer's green channel"/>
+      <arg name="b" type="uint" summary="value of the buffer's blue channel"/>
+      <arg name="a" type="uint" summary="value of the buffer's alpha channel"/>
+    </request>
+  </interface>
+</protocol>

--- a/src/core/protocols/xdg-toplevel-drag-v1.xml
+++ b/src/core/protocols/xdg-toplevel-drag-v1.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_toplevel_drag_v1">
+
+  <copyright>
+    Copyright 2023 David Redondo
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="xdg_toplevel_drag_manager_v1" version="1">
+    <description summary="Move a window during a drag">
+      This protocol enhances normal drag and drop with the ability to move a
+      window at the same time. This allows having detachable parts of a window
+      that when dragged out of it become a new window and can be dragged over
+      an existing window to be reattached.
+
+      A typical workflow would be when the user starts dragging on top of a
+      detachable part of a window, the client would create a wl_data_source and
+      a xdg_toplevel_drag_v1 object and start the drag as normal via
+      wl_data_device.start_drag. Once the client determines that the detachable
+      window contents should be detached from the originating window, it creates
+      a new xdg_toplevel with these contents and issues a
+      xdg_toplevel_drag_v1.attach request before mapping it. From now on the new
+      window is moved by the compositor during the drag as if the client called
+      xdg_toplevel.move.
+
+      Dragging an existing window is similar. The client creates a
+      xdg_toplevel_drag_v1 object and attaches the existing toplevel before
+      starting the drag.
+
+      Clients use the existing drag and drop mechanism to detect when a window
+      can be docked or undocked. If the client wants to snap a window into a
+      parent window it should delete or unmap the dragged top-level. If the
+      contents should be detached again it attaches a new toplevel as described
+      above. If a drag operation is cancelled without being dropped, clients
+      should revert to the previous state, deleting any newly created windows
+      as appropriate. When a drag operation ends as indicated by
+      wl_data_source.dnd_drop_performed the dragged toplevel window's final
+      position is determined as if a xdg_toplevel_move operation ended.
+
+      Warning! The protocol described in this file is currently in the testing
+      phase. Backward compatible changes may be added together with the
+      corresponding interface version bump. Backward incompatible changes can
+      only be done by creating a new major version of the extension.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_source" value="0"
+             summary="data_source already used for toplevel drag"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_toplevel_drag_manager_v1 object">
+        Destroy this xdg_toplevel_drag_manager_v1 object. Other objects,
+        including xdg_toplevel_drag_v1 objects created by this factory, are not
+        affected by this request.
+      </description>
+    </request>
+
+    <request name="get_xdg_toplevel_drag">
+      <description summary="get an xdg_toplevel_drag for a wl_data_source">
+        Create an xdg_toplevel_drag for a drag and drop operation that is going
+        to be started with data_source.
+
+        This request can only be made on sources used in drag-and-drop, so it
+        must be performed before wl_data_device.start_drag. Attempting to use
+        the source other than for drag-and-drop such as in
+        wl_data_device.set_selection will raise an invalid_source error.
+
+        Destroying data_source while a toplevel is attached to the
+        xdg_toplevel_drag is undefined.
+      </description>
+
+      <arg name="id" type="new_id" interface="xdg_toplevel_drag_v1"/>
+      <arg name="data_source" type="object" interface="wl_data_source"/>
+    </request>
+  </interface>
+
+  <interface name="xdg_toplevel_drag_v1" version="1">
+    <description summary="Object representing a toplevel move during a drag">
+    </description>
+
+    <enum name="error">
+      <entry name="toplevel_attached" value="0"
+             summary="valid toplevel already attached"/>
+      <entry name="ongoing_drag" value="1"
+             summary="drag has not ended" />
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy an xdg_toplevel_drag_v1 object">
+        Destroy this xdg_toplevel_drag_v1 object. This request must only be
+        called after the underlying wl_data_source drag has ended, as indicated
+        by the dnd_drop_performed or cancelled events. In any other case an
+        ongoing_drag error is raised.
+      </description>
+    </request>
+
+    <request name="attach">
+      <description summary="Move a toplevel with the drag operation">
+        Request that the window will be moved with the cursor during the drag
+        operation. The offset is a hint to the compositor how the toplevel
+        should be positioned relative to the cursor hotspot in surface local
+        coordinates and relative to the geometry of the toplevel being attached.
+        See xdg_surface.set_window_geometry. For example it might only
+        be used when an unmapped window is attached. The attached window
+        does not participate in the selection of the drag target.
+
+        If the toplevel is unmapped while it is attached, it is automatically
+        detached from the drag. In this case this request has to be called again
+        if the window should be attached after it is remapped.
+
+        This request can be called multiple times but issuing it while a
+        toplevel with an active role is attached raises a toplevel_attached
+        error.
+      </description>
+
+      <arg name="toplevel" type="object" interface="xdg_toplevel"/>
+      <arg name="x_offset" type="int" summary="dragged surface x offset"/>
+      <arg name="y_offset" type="int" summary="dragged surface y offset"/>
+    </request>
+
+  </interface>
+</protocol>
+

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -311,6 +311,27 @@ target_include_directories(test_layersurface PRIVATE
 add_test(NAME test_layersurface COMMAND test_layersurface)
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# core/ — SinglePixelBuffer Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+add_executable(test_singlepixelbuffer core/test_singlepixelbuffer.cpp)
+target_link_libraries(test_singlepixelbuffer PRIVATE Qt6::Test Qt6::Core Qt6::Gui PhosphorWayland::PhosphorWayland)
+add_test(NAME test_singlepixelbuffer COMMAND test_singlepixelbuffer)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# core/ — IdleNotifier Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+add_executable(test_idlenotifier core/test_idlenotifier.cpp)
+target_link_libraries(test_idlenotifier PRIVATE Qt6::Test Qt6::Core Qt6::Gui PhosphorWayland::PhosphorWayland)
+add_test(NAME test_idlenotifier COMMAND test_idlenotifier)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# core/ — ToplevelDrag Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+add_executable(test_topleveldrag core/test_topleveldrag.cpp)
+target_link_libraries(test_topleveldrag PRIVATE Qt6::Test Qt6::Core Qt6::Gui PhosphorWayland::PhosphorWayland)
+add_test(NAME test_topleveldrag COMMAND test_topleveldrag)
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # core/ — Support Report Tests (redaction, generation)
 # ═══════════════════════════════════════════════════════════════════════════════
 pz_add_test(test_support_report core/test_support_report.cpp)

--- a/tests/unit/core/test_idlenotifier.cpp
+++ b/tests/unit/core/test_idlenotifier.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <PhosphorWayland/IdleNotifier.h>
+
+#include <QTest>
+#include <QSignalSpy>
+#include <QGuiApplication>
+
+using namespace PhosphorWayland;
+
+class TestIdleNotifier : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    void testIsSupported_offscreen_returnsFalse()
+    {
+        QVERIFY(!IdleNotifier::isSupported());
+    }
+
+    void testDefaultTimeout_isZero()
+    {
+        IdleNotifier notifier;
+        QCOMPARE(notifier.timeout(), std::chrono::milliseconds(0));
+    }
+
+    void testDefaultIdle_isFalse()
+    {
+        IdleNotifier notifier;
+        QVERIFY(!notifier.isIdle());
+    }
+
+    void testSetTimeout_emitsOnChange()
+    {
+        IdleNotifier notifier;
+        QSignalSpy spy(&notifier, &IdleNotifier::timeoutChanged);
+
+        notifier.setTimeout(std::chrono::milliseconds(5000));
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(notifier.timeout(), std::chrono::milliseconds(5000));
+
+        notifier.setTimeout(std::chrono::milliseconds(5000));
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void testSetTimeout_zero_emitsAndResets()
+    {
+        IdleNotifier notifier;
+        notifier.setTimeout(std::chrono::milliseconds(5000));
+
+        QSignalSpy spy(&notifier, &IdleNotifier::timeoutChanged);
+        notifier.setTimeout(std::chrono::milliseconds(0));
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(notifier.timeout(), std::chrono::milliseconds(0));
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+    TestIdleNotifier tc;
+    return QTest::qExec(&tc, argc, argv);
+}
+
+#include "test_idlenotifier.moc"

--- a/tests/unit/core/test_layersurface.cpp
+++ b/tests/unit/core/test_layersurface.cpp
@@ -113,6 +113,7 @@ private Q_SLOTS:
         QCOMPARE(surface->scope(), QStringLiteral("phosphorwayland"));
         QCOMPARE(surface->screen(), nullptr);
         QCOMPARE(surface->margins(), QMargins());
+        QCOMPARE(surface->exclusiveEdge(), LayerSurface::Anchors());
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -192,6 +193,35 @@ private Q_SLOTS:
 
         surface->setScope(QStringLiteral("test-scope"));
         QCOMPARE(spy.count(), 1);
+    }
+
+    void testSetExclusiveEdge_emitsOnChange()
+    {
+        QWindow window;
+        SurfaceGuard guard(window);
+        auto* surface = LayerSurface::get(&window);
+        QSignalSpy spy(surface, &LayerSurface::exclusiveEdgeChanged);
+
+        surface->setExclusiveEdge(LayerSurface::AnchorTop);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(surface->exclusiveEdge(), LayerSurface::Anchors(LayerSurface::AnchorTop));
+
+        surface->setExclusiveEdge(LayerSurface::AnchorTop);
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void testSetExclusiveEdge_invalidValue_ignored()
+    {
+        QWindow window;
+        SurfaceGuard guard(window);
+        auto* surface = LayerSurface::get(&window);
+        QSignalSpy spy(surface, &LayerSurface::exclusiveEdgeChanged);
+
+        QTest::ignoreMessage(QtWarningMsg,
+                             QRegularExpression(QStringLiteral("setExclusiveEdge\\(\\) called with invalid value")));
+        surface->setExclusiveEdge(LayerSurface::AnchorTop | LayerSurface::AnchorLeft);
+        QCOMPARE(spy.count(), 0);
+        QCOMPARE(surface->exclusiveEdge(), LayerSurface::Anchors());
     }
 
     void testSetMargins_emitsOnChange()
@@ -396,6 +426,7 @@ private Q_SLOTS:
         QCOMPARE(window.property(LayerSurfaceProps::MarginsTop).toInt(), 0);
         QCOMPARE(window.property(LayerSurfaceProps::MarginsRight).toInt(), 0);
         QCOMPARE(window.property(LayerSurfaceProps::MarginsBottom).toInt(), 0);
+        QCOMPARE(window.property(LayerSurfaceProps::ExclusiveEdge).toInt(), 0);
     }
 
     void testPropertiesPropagateToWindow()
@@ -424,6 +455,9 @@ private Q_SLOTS:
         QCOMPARE(window.property(LayerSurfaceProps::MarginsTop).toInt(), 2);
         QCOMPARE(window.property(LayerSurfaceProps::MarginsRight).toInt(), 3);
         QCOMPARE(window.property(LayerSurfaceProps::MarginsBottom).toInt(), 4);
+
+        surface->setExclusiveEdge(LayerSurface::AnchorBottom);
+        QCOMPARE(window.property(LayerSurfaceProps::ExclusiveEdge).toInt(), 2); // AnchorBottom
     }
 
     void testIsLayerShellProperty()

--- a/tests/unit/core/test_singlepixelbuffer.cpp
+++ b/tests/unit/core/test_singlepixelbuffer.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <PhosphorWayland/SinglePixelBuffer.h>
+
+#include <QTest>
+#include <QSignalSpy>
+#include <QGuiApplication>
+
+using namespace PhosphorWayland;
+
+class TestSinglePixelBuffer : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    void testIsSupported_offscreen_returnsFalse()
+    {
+        QVERIFY(!SinglePixelBuffer::isSupported());
+    }
+
+    void testConstruction_setsColor()
+    {
+        SinglePixelBuffer buffer(QColor(255, 0, 0));
+        QCOMPARE(buffer.color(), QColor(255, 0, 0));
+    }
+
+    void testSetColor_emitsOnChange()
+    {
+        SinglePixelBuffer buffer(QColor(255, 0, 0));
+        QSignalSpy spy(&buffer, &SinglePixelBuffer::colorChanged);
+
+        buffer.setColor(QColor(0, 255, 0));
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(buffer.color(), QColor(0, 255, 0));
+
+        buffer.setColor(QColor(0, 255, 0));
+        QCOMPARE(spy.count(), 1);
+    }
+
+    void testAttachTo_noCompositor_returnsFalse()
+    {
+        SinglePixelBuffer buffer(QColor(255, 0, 0));
+        QWindow window;
+        QVERIFY(!buffer.attachTo(&window));
+    }
+
+    void testAttachTo_null_returnsFalse()
+    {
+        SinglePixelBuffer buffer(QColor(255, 0, 0));
+        QVERIFY(!buffer.attachTo(nullptr));
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+    TestSinglePixelBuffer tc;
+    return QTest::qExec(&tc, argc, argv);
+}
+
+#include "test_singlepixelbuffer.moc"

--- a/tests/unit/core/test_topleveldrag.cpp
+++ b/tests/unit/core/test_topleveldrag.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include <PhosphorWayland/ToplevelDrag.h>
+
+#include <QTest>
+#include <QGuiApplication>
+
+class TestToplevelDrag : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    void testIsSupported_offscreen_returnsFalse()
+    {
+        QVERIFY(!PhosphorWayland::isToplevelDragSupported());
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+    TestToplevelDrag tc;
+    return QTest::qExec(&tc, argc, argv);
+}
+
+#include "test_topleveldrag.moc"


### PR DESCRIPTION
## Summary
- Bump wlr-layer-shell binding from v4 → v5, exposing `set_exclusive_edge` via new `LayerSurface::setExclusiveEdge()` API
- Add **wp-single-pixel-buffer-v1** — `SinglePixelBuffer` class for cheap solid-color surfaces (zone edge indicators, separator lines)
- Add **ext-idle-notify-v1** — `IdleNotifier` class with idle/resumed signals for overlay suspension during user idle
- Add **xdg-toplevel-drag-v1** — `isToplevelDragSupported()` capability query for future drag-to-zone UX

All protocols follow the established phosphor-wayland pattern: vendored XML, wayland-scanner code generation, C++ wrapper headers, registry binding in `LayerShellIntegration`, and pure-Qt public API with zero Wayland type leaks in public headers.

## Test plan
- [ ] Verify Docker build passes: `docker run --rm -v "$PWD":/src plasmazones-build ctest --output-on-failure`
- [ ] Existing `test_layersurface` tests pass with new `exclusiveEdge` tests
- [ ] New `test_singlepixelbuffer` passes (offscreen: isSupported=false, color change signals, null attach)
- [ ] New `test_idlenotifier` passes (offscreen: isSupported=false, timeout signals, zero timeout)
- [ ] New `test_topleveldrag` passes (offscreen: isSupported=false)
- [ ] `grep -r "wl_\|zwlr_\|ext_\|wp_" include/PhosphorWayland/*.h` returns zero struct type references

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)