### PR TITLE
feat(settings): rework Animations → Shaders page UX

### DIFF
--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -172,6 +172,8 @@ qt_add_qml_module(plasmazones-settings
         qml/AnimationsMotionSetsPage.qml
         qml/AnimationsPresetsPage.qml
         qml/AnimationsShadersPage.qml
+        qml/AnimationsShaderCard.qml
+        qml/AnimationsShaderDetailDialog.qml
         qml/CurveEditorDialog.qml
         qml/CurvePresets.qml
         qml/CurveThumbnail.qml

--- a/src/settings/animationspagecontroller.cpp
+++ b/src/settings/animationspagecontroller.cpp
@@ -650,6 +650,11 @@ static QVariantMap effectToMap(const PhosphorAnimationShaders::AnimationShaderEf
     m.insert(QLatin1String("version"), effect.version);
     m.insert(QLatin1String("category"), effect.category);
     m.insert(QLatin1String("isUserEffect"), effect.isUserEffect);
+    // `previewPath` is resolved to an absolute path by the registry's
+    // `parseEffect`, so QML can pass it directly to `Image.source` (with
+    // a `file://` scheme prefix). Empty when the pack didn't ship a
+    // preview — the page renders a placeholder for that case.
+    m.insert(QLatin1String("previewPath"), effect.previewPath);
     QVariantList params;
     params.reserve(effect.parameters.size());
     for (const auto& p : effect.parameters) {
@@ -722,6 +727,90 @@ void AnimationsPageController::openUserShaderDirectory()
 {
     ensureUserShaderDirectory();
     QDesktopServices::openUrl(QUrl::fromLocalFile(userShaderDirectoryPath()));
+}
+
+namespace animations_controller_detail {
+
+/// Copy a directory recursively. Qt has no built-in equivalent; the
+/// stdlib's `std::filesystem::copy` exists but we stick to QDir/QFile
+/// for consistency with the rest of the codebase. Returns false on the
+/// first failure (broken file copy, mkpath fail, etc.) so the caller
+/// can roll back via QDir::removeRecursively.
+static bool copyDirRecursive(const QString& sourcePath, const QString& destPath)
+{
+    QDir sourceDir(sourcePath);
+    if (!sourceDir.exists())
+        return false;
+    if (!QDir().mkpath(destPath))
+        return false;
+
+    const QFileInfoList entries = sourceDir.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
+    for (const QFileInfo& entry : entries) {
+        const QString destEntryPath = destPath + QLatin1Char('/') + entry.fileName();
+        if (entry.isDir()) {
+            if (!copyDirRecursive(entry.absoluteFilePath(), destEntryPath))
+                return false;
+        } else if (entry.isFile()) {
+            // QFile::copy refuses to overwrite — caller's collision check
+            // already guarantees a clean destination, but defend against
+            // a partial failed previous run leaving stale files.
+            if (QFile::exists(destEntryPath))
+                QFile::remove(destEntryPath);
+            if (!QFile::copy(entry.absoluteFilePath(), destEntryPath))
+                return false;
+        }
+        // Symlinks, devices, etc. are intentionally skipped — a shader
+        // pack contains regular files only; anything exotic is suspect.
+    }
+    return true;
+}
+
+} // namespace animations_controller_detail
+
+bool AnimationsPageController::installShaderPack(const QString& sourceUrl)
+{
+    if (sourceUrl.isEmpty())
+        return false;
+
+    // Accept both `file://...` URLs (drag-drop from a file manager) and
+    // bare paths (programmatic callers).
+    QString sourcePath = sourceUrl;
+    if (sourcePath.startsWith(QLatin1String("file://")))
+        sourcePath = QUrl(sourceUrl).toLocalFile();
+
+    const QFileInfo sourceInfo(sourcePath);
+    if (!sourceInfo.exists() || !sourceInfo.isDir()) {
+        qCWarning(lcConfig) << "installShaderPack: source is not an existing directory:" << sourcePath;
+        return false;
+    }
+
+    // Validate metadata.json — without it the registry won't pick up the
+    // pack, so accepting the drop would silently be a no-op.
+    const QString metadataPath = sourceInfo.absoluteFilePath() + QLatin1String("/metadata.json");
+    if (!QFile::exists(metadataPath)) {
+        qCWarning(lcConfig) << "installShaderPack: source has no metadata.json:" << sourcePath;
+        return false;
+    }
+
+    if (!ensureUserShaderDirectory())
+        return false;
+
+    const QString destDir = userShaderDirectoryPath() + QLatin1Char('/') + sourceInfo.fileName();
+    if (QFileInfo::exists(destDir)) {
+        qCWarning(lcConfig) << "installShaderPack: destination already exists, refusing to overwrite:" << destDir;
+        return false;
+    }
+
+    if (!animations_controller_detail::copyDirRecursive(sourceInfo.absoluteFilePath(), destDir)) {
+        qCWarning(lcConfig) << "installShaderPack: copy failed; rolling back:" << destDir;
+        QDir(destDir).removeRecursively();
+        return false;
+    }
+
+    // The registry's filewatcher rescans on its own — no explicit poke
+    // needed. If a poke is ever required, emit `shaderEffectsChanged`
+    // here.
+    return true;
 }
 
 QVariantMap AnimationsPageController::rawShaderProfile(const QString& path) const
@@ -870,6 +959,32 @@ int AnimationsPageController::clearShaderOverrideDescendants(const QString& path
     m_shaderTreeDirty = true;
     Q_EMIT pendingChangesChanged();
     return toClear.size();
+}
+
+QVariantList AnimationsPageController::shaderEffectUsages(const QString& effectId) const
+{
+    using namespace PhosphorAnimationShaders;
+    if (!m_settings || effectId.isEmpty())
+        return {};
+    const ShaderProfileTree tree = m_settings->shaderProfileTree();
+    const QStringList overridden = tree.overriddenPaths();
+    QVariantList out;
+    for (const QString& p : overridden) {
+        const ShaderProfile profile = tree.directOverride(p);
+        if (!profile.effectId || *profile.effectId != effectId)
+            continue;
+        QVariantMap entry;
+        entry.insert(QLatin1String("path"), p);
+        entry.insert(QLatin1String("label"), eventLabel(p));
+        out.append(entry);
+    }
+    // Sort by label for deterministic UI order across runs — the tree's
+    // `overriddenPaths()` iterates a QHash internally so the order is
+    // not stable.
+    std::sort(out.begin(), out.end(), [](const QVariant& a, const QVariant& b) {
+        return a.toMap().value(QLatin1String("label")).toString() < b.toMap().value(QLatin1String("label")).toString();
+    });
+    return out;
 }
 
 } // namespace PlasmaZones

--- a/src/settings/animationspagecontroller.cpp
+++ b/src/settings/animationspagecontroller.cpp
@@ -736,6 +736,14 @@ namespace animations_controller_detail {
 /// for consistency with the rest of the codebase. Returns false on the
 /// first failure (broken file copy, mkpath fail, etc.) so the caller
 /// can roll back via QDir::removeRecursively.
+///
+/// Symlinks (file or dir) are explicitly skipped via `QDir::NoSymLinks`
+/// AND a per-entry `isSymLink()` guard. Without that, a dropped pack
+/// containing `metadata.json -> /etc/shadow` or `assets -> /etc` would
+/// silently follow the link during traversal and the recursive copy
+/// would smuggle arbitrary readable filesystem content into the user
+/// shader dir under deceptive names. A shader pack contains regular
+/// files only; anything exotic is suspect and refused.
 static bool copyDirRecursive(const QString& sourcePath, const QString& destPath)
 {
     QDir sourceDir(sourcePath);
@@ -744,8 +752,17 @@ static bool copyDirRecursive(const QString& sourcePath, const QString& destPath)
     if (!QDir().mkpath(destPath))
         return false;
 
-    const QFileInfoList entries = sourceDir.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoDotAndDotDot);
+    const QFileInfoList entries =
+        sourceDir.entryInfoList(QDir::Files | QDir::Dirs | QDir::NoSymLinks | QDir::NoDotAndDotDot);
     for (const QFileInfo& entry : entries) {
+        // QDir::NoSymLinks already filters at the entryInfoList layer, but
+        // recheck per-entry: filesystem races (the entry being replaced
+        // by a symlink between enumeration and this iteration) and the
+        // historical leniency of QDir::NoSymLinks across Qt versions
+        // both argue for an explicit guard at the copy boundary.
+        if (entry.isSymLink())
+            continue;
+
         const QString destEntryPath = destPath + QLatin1Char('/') + entry.fileName();
         if (entry.isDir()) {
             if (!copyDirRecursive(entry.absoluteFilePath(), destEntryPath))
@@ -759,8 +776,9 @@ static bool copyDirRecursive(const QString& sourcePath, const QString& destPath)
             if (!QFile::copy(entry.absoluteFilePath(), destEntryPath))
                 return false;
         }
-        // Symlinks, devices, etc. are intentionally skipped — a shader
-        // pack contains regular files only; anything exotic is suspect.
+        // Devices, FIFOs, sockets, etc. are not isFile()/isDir() and
+        // therefore fall through silently — same intent as the symlink
+        // skip above.
     }
     return true;
 }
@@ -778,16 +796,31 @@ bool AnimationsPageController::installShaderPack(const QString& sourceUrl)
     if (sourcePath.startsWith(QLatin1String("file://")))
         sourcePath = QUrl(sourceUrl).toLocalFile();
 
+    // Normalise trailing slashes and `.`/`..` components — without this,
+    // a drop URL like `file:///path/to/pack/` produces an empty
+    // `fileName()` below and the destDir collapses onto the user shader
+    // dir itself, surfacing as a confusing "destination already exists"
+    // rather than a clean parse failure.
+    sourcePath = QDir::cleanPath(sourcePath);
+
     const QFileInfo sourceInfo(sourcePath);
-    if (!sourceInfo.exists() || !sourceInfo.isDir()) {
+    if (!sourceInfo.exists() || !sourceInfo.isDir() || sourceInfo.isSymLink()) {
         qCWarning(lcConfig) << "installShaderPack: source is not an existing directory:" << sourcePath;
+        return false;
+    }
+    const QString sourceBasename = sourceInfo.fileName();
+    if (sourceBasename.isEmpty()) {
+        qCWarning(lcConfig) << "installShaderPack: source path has no basename:" << sourcePath;
         return false;
     }
 
     // Validate metadata.json — without it the registry won't pick up the
-    // pack, so accepting the drop would silently be a no-op.
+    // pack, so accepting the drop would silently be a no-op. Reject
+    // symlinked metadata so a malicious pack can't smuggle a non-shader
+    // JSON file's content past the validation gate.
     const QString metadataPath = sourceInfo.absoluteFilePath() + QLatin1String("/metadata.json");
-    if (!QFile::exists(metadataPath)) {
+    const QFileInfo metadataInfo(metadataPath);
+    if (!metadataInfo.exists() || !metadataInfo.isFile() || metadataInfo.isSymLink()) {
         qCWarning(lcConfig) << "installShaderPack: source has no metadata.json:" << sourcePath;
         return false;
     }
@@ -795,7 +828,7 @@ bool AnimationsPageController::installShaderPack(const QString& sourceUrl)
     if (!ensureUserShaderDirectory())
         return false;
 
-    const QString destDir = userShaderDirectoryPath() + QLatin1Char('/') + sourceInfo.fileName();
+    const QString destDir = userShaderDirectoryPath() + QLatin1Char('/') + sourceBasename;
     if (QFileInfo::exists(destDir)) {
         qCWarning(lcConfig) << "installShaderPack: destination already exists, refusing to overwrite:" << destDir;
         return false;

--- a/src/settings/animationspagecontroller.h
+++ b/src/settings/animationspagecontroller.h
@@ -224,7 +224,10 @@ public:
 
     /// XDG-writable user shader directory path (no side effects). Use
     /// `ensureUserShaderDirectory()` if you also need it created on disk.
-    Q_INVOKABLE QString userShaderDirectoryPath() const;
+    /// Internal helper — not exposed to QML; the page surfaces an
+    /// "Open Folder" button that calls `openUserShaderDirectory()`
+    /// directly rather than displaying the path as a label.
+    QString userShaderDirectoryPath() const;
 
     /// Ensure the user shader directory exists; create it if missing.
     /// @return true when the directory exists (newly created or already

--- a/src/settings/animationspagecontroller.h
+++ b/src/settings/animationspagecontroller.h
@@ -238,15 +238,19 @@ public:
     /// creating it first if missing.
     Q_INVOKABLE void openUserShaderDirectory();
 
-    /// Install a shader pack from a dropped folder. @p sourceUrl is a
-    /// `file://` URL pointing at a directory containing a `metadata.json`
-    /// at its root. The directory is copied recursively into
-    /// `userShaderDirectoryPath()/<basename>`; the registry's filewatcher
-    /// detects the new pack and emits `effectsChanged` automatically.
-    /// Validates that the source exists, is a directory, contains a
-    /// `metadata.json`, and that the basename does not collide with an
-    /// existing entry in the user dir (collision returns false rather
-    /// than overwriting). @return true on success.
+    /// Install a shader pack from a dropped folder. @p sourceUrl accepts
+    /// either a `file://` URL (drag-drop from a file manager) or a bare
+    /// absolute path (programmatic callers); both forms are normalised
+    /// via `QDir::cleanPath` before use. The source must be a directory
+    /// containing a `metadata.json` at its root. The directory is copied
+    /// recursively into `userShaderDirectoryPath()/<basename>`; the
+    /// registry's filewatcher detects the new pack and emits
+    /// `effectsChanged` automatically. Validates that the source exists,
+    /// is a non-symlinked directory with a non-symlinked `metadata.json`,
+    /// and that the basename does not collide with an existing entry in
+    /// the user dir (collision returns false rather than overwriting).
+    /// Symlinks anywhere inside the source tree are silently skipped by
+    /// the recursive copy. @return true on success.
     Q_INVOKABLE bool installShaderPack(const QString& sourceUrl);
 
     /// Per-event shader override read.

--- a/src/settings/animationspagecontroller.h
+++ b/src/settings/animationspagecontroller.h
@@ -235,6 +235,17 @@ public:
     /// creating it first if missing.
     Q_INVOKABLE void openUserShaderDirectory();
 
+    /// Install a shader pack from a dropped folder. @p sourceUrl is a
+    /// `file://` URL pointing at a directory containing a `metadata.json`
+    /// at its root. The directory is copied recursively into
+    /// `userShaderDirectoryPath()/<basename>`; the registry's filewatcher
+    /// detects the new pack and emits `effectsChanged` automatically.
+    /// Validates that the source exists, is a directory, contains a
+    /// `metadata.json`, and that the basename does not collide with an
+    /// existing entry in the user dir (collision returns false rather
+    /// than overwriting). @return true on success.
+    Q_INVOKABLE bool installShaderPack(const QString& sourceUrl);
+
     /// Per-event shader override read.
     /// @return `{ effectId: QString, parameters: QVariantMap }` or empty
     /// when no override is set at this exact path.
@@ -276,6 +287,16 @@ public:
     /// Also emits `pendingChangesChanged()`. Used by parent-node
     /// cards' "Clear shadowing children" affordance.
     Q_INVOKABLE int clearShaderOverrideDescendants(const QString& path);
+
+    /// Reverse-lookup: list every event path whose direct shader
+    /// override targets @p effectId. Each entry: `{ path, label }` with
+    /// @c label produced by @c eventLabel(path). Used by the read-only
+    /// shaders browser to surface a "Used in:" line per shader so a
+    /// user can tell at a glance which assignments would be affected if
+    /// they uninstalled or replaced a pack. Inherited / resolved
+    /// references are intentionally NOT included — only direct
+    /// overrides count, mirroring the existing tree-walk semantics.
+    Q_INVOKABLE QVariantList shaderEffectUsages(const QString& effectId) const;
 
     /// Test hook: redirect file I/O to @p dir instead of the XDG default.
     /// Pass an empty string to restore the default. Not Q_INVOKABLE — QML

--- a/src/settings/qml/AnimationsShaderCard.qml
+++ b/src/settings/qml/AnimationsShaderCard.qml
@@ -81,7 +81,11 @@ ItemDelegate {
             Image {
                 anchors.fill: parent
                 anchors.margins: Math.max(1, Math.round(Kirigami.Units.devicePixelRatio))
-                source: parent._hasPreview ? "file://" + root.effect.previewPath : ""
+                // `encodeURI` percent-encodes spaces and unicode while
+                // preserving the path separators, which a raw
+                // `"file://" + path` concat would silently break on
+                // (e.g. a user-installed pack at `~/My Shaders/`).
+                source: parent._hasPreview ? "file://" + encodeURI(root.effect.previewPath) : ""
                 fillMode: Image.PreserveAspectCrop
                 sourceSize.width: width * 2
                 sourceSize.height: height * 2

--- a/src/settings/qml/AnimationsShaderCard.qml
+++ b/src/settings/qml/AnimationsShaderCard.qml
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+/**
+ * @brief Compact shader card for the Animations → Shaders grid.
+ *
+ * Renders one effect as a fixed-width card: preview thumbnail (or a
+ * theme-iconography placeholder when the pack didn't ship one), name
+ * + badges row, two-line description, and a small footer chip showing
+ * parameter count and an event-usage count. Clicking the card emits
+ * `clicked(effect)` so the host can pop the detail dialog.
+ *
+ * Required:
+ *   - `effect`: var — effect map from `availableShaderEffects()`.
+ *
+ * Optional:
+ *   - `usagesRev`: int — host-owned tick that invalidates the
+ *      `shaderEffectUsages(id)` Q_INVOKABLE result on registry /
+ *      override mutations. Forwarded into the binding's dependency set.
+ */
+ItemDelegate {
+    id: root
+
+    required property var effect
+    property int usagesRev: 0
+
+    signal showDetails(var effect)
+
+    // Card geometry — fixed `width` (not `implicitWidth`) so the Flow
+    // host doesn't stretch cards based on enclosing-Layout fillWidth
+    // propagation. Height is content-driven so cards without preview
+    // images don't carry empty placeholder padding.
+    width: Kirigami.Units.gridUnit * 14
+    implicitWidth: width
+    implicitHeight: cardLayout.implicitHeight + topPadding + bottomPadding
+    hoverEnabled: true
+    Accessible.name: effect ? (effect.name || effect.id || "") : ""
+    Accessible.description: effect && effect.description ? effect.description : i18nc("@info:tooltip generic shader card", "Shader effect details")
+    onClicked: {
+        if (effect)
+            root.showDetails(effect);
+
+    }
+
+    background: Rectangle {
+        radius: Kirigami.Units.smallSpacing
+        color: root.hovered ? Kirigami.Theme.hoverColor : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.04)
+        border.width: Math.max(1, Math.round(Kirigami.Units.devicePixelRatio))
+        border.color: root.activeFocus ? Kirigami.Theme.focusColor : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.12)
+    }
+
+    // ItemDelegate's default contentItem is a Label; override with our
+    // own column so we get full control over the card body.
+    contentItem: ColumnLayout {
+        id: cardLayout
+
+        spacing: Kirigami.Units.smallSpacing
+
+        // ── Preview thumbnail (only when the pack ships one) ──────
+        // Skip the preview area entirely for packs without
+        // `previewPath`. A placeholder iconography slot dominates the
+        // card visually for no real information gain — text content
+        // alone is enough when there's nothing to show.
+        Rectangle {
+            readonly property bool _hasPreview: root.effect && root.effect.previewPath && root.effect.previewPath.length > 0
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: width * 9 / 16 // 16:9 aspect
+            visible: _hasPreview
+            radius: Kirigami.Units.smallSpacing
+            color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.08)
+            border.width: Math.max(1, Math.round(Kirigami.Units.devicePixelRatio))
+            border.color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.12)
+            clip: true
+
+            Image {
+                anchors.fill: parent
+                anchors.margins: Math.max(1, Math.round(Kirigami.Units.devicePixelRatio))
+                source: parent._hasPreview ? "file://" + root.effect.previewPath : ""
+                fillMode: Image.PreserveAspectCrop
+                sourceSize.width: width * 2
+                sourceSize.height: height * 2
+                asynchronous: true
+                cache: true
+                visible: status === Image.Ready
+            }
+
+        }
+
+        // ── Name row ──────────────────────────────────────────────
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Kirigami.Units.smallSpacing
+
+            Label {
+                Layout.fillWidth: true
+                text: root.effect ? (root.effect.name || root.effect.id || "") : ""
+                font.weight: Font.DemiBold
+                elide: Text.ElideRight
+            }
+
+            Label {
+                visible: root.effect && root.effect.isUserEffect
+                text: i18nc("@info shader source badge", "User")
+                font: Kirigami.Theme.smallFont
+                color: Kirigami.Theme.positiveTextColor
+            }
+
+        }
+
+        // ── Description (max 2 lines) ─────────────────────────────
+        Label {
+            readonly property string _description: root.effect && typeof root.effect.description === "string" ? root.effect.description : ""
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: visible ? Kirigami.Units.gridUnit * 2 : 0
+            visible: _description.length > 0
+            text: _description
+            color: Kirigami.Theme.disabledTextColor
+            font: Kirigami.Theme.smallFont
+            wrapMode: Text.Wrap
+            maximumLineCount: 2
+            elide: Text.ElideRight
+            verticalAlignment: Text.AlignTop
+        }
+
+        // ── Footer chips: parameter count + Used-in count ─────────
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Kirigami.Units.smallSpacing
+
+            Label {
+                text: i18np("%n parameter", "%n parameters", (root.effect && root.effect.parameters) ? root.effect.parameters.length : 0)
+                font: Kirigami.Theme.smallFont
+                color: Kirigami.Theme.disabledTextColor
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            // "N events" chip — visible only when this shader is
+            // assigned somewhere. Tooltip carries the full label list;
+            // the detail dialog renders them inline. KI18n's `%n` is
+            // the canonical placeholder for the count in plural strings;
+            // `%1` here would render as a literal because the second
+            // count argument doesn't substitute back into the singular/
+            // plural template.
+            Label {
+                readonly property var _usages: {
+                    root.usagesRev; // reactive dep
+                    var id = root.effect ? root.effect.id : "";
+                    if (!id || id.length === 0)
+                        return [];
+
+                    return settingsController.animationsPage.shaderEffectUsages(id);
+                }
+
+                visible: _usages.length > 0
+                text: i18ncp("@info shader usage count", "%n event", "%n events", _usages.length)
+                font: Kirigami.Theme.smallFont
+                // Match the parameter-count's dim treatment — the chip
+                // is a count, not an alert; positiveTextColor was too
+                // attention-grabbing for a passive metadata item.
+                color: Kirigami.Theme.disabledTextColor
+                ToolTip.visible: hovered.hovered && _usages.length > 0
+                ToolTip.text: {
+                    var names = [];
+                    for (var i = 0; i < _usages.length; i++) names.push(_usages[i].label || _usages[i].path)
+                    return names.join(", ");
+                }
+                ToolTip.delay: Kirigami.Units.toolTipDelay
+
+                HoverHandler {
+                    id: hovered
+                }
+
+            }
+
+        }
+
+    }
+
+}

--- a/src/settings/qml/AnimationsShaderDetailDialog.qml
+++ b/src/settings/qml/AnimationsShaderDetailDialog.qml
@@ -115,7 +115,10 @@ Kirigami.Dialog {
             Image {
                 anchors.fill: parent
                 anchors.margins: Math.max(1, Math.round(Kirigami.Units.devicePixelRatio))
-                source: parent._hasPreview ? "file://" + root.effect.previewPath : ""
+                // Encode spaces / unicode in the path before embedding
+                // into the `file://` URL — same rationale as
+                // AnimationsShaderCard.qml's preview Image.
+                source: parent._hasPreview ? "file://" + encodeURI(root.effect.previewPath) : ""
                 fillMode: Image.PreserveAspectFit
                 sourceSize.width: width * 2
                 sourceSize.height: height * 2

--- a/src/settings/qml/AnimationsShaderDetailDialog.qml
+++ b/src/settings/qml/AnimationsShaderDetailDialog.qml
@@ -1,0 +1,349 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
+import org.kde.kirigami as Kirigami
+
+/**
+ * @brief Detail view for a single shader effect.
+ *
+ * Triggered by clicking a card in the shader catalogue. Shows the same
+ * data the card teases (name, badges, description, parameter count,
+ * Used-in count) in full detail — large preview, complete description,
+ * full Used-in list, and the entire parameter list using the same
+ * compact one-line-per-param format the catalogue uses.
+ *
+ * ## Layout
+ *
+ * The dialog is structured as a vertical column of *sections*:
+ *
+ *   1. Optional preview thumbnail (full-width, 16:9).
+ *   2. Header row — category pill, "User" badge, parameter count chip.
+ *   3. Description (full text, no truncation).
+ *   4. Author / version line (italic, dimmed).
+ *   5. "Used in: …" list (only when the shader has direct overrides).
+ *   6. Parameters section — `Kirigami.Heading` + `Kirigami.Separator`
+ *      then one row per parameter.
+ *
+ * Each section is followed by a `Kirigami.Separator` so the visual
+ * groups read as distinct, not as a wall of stacked labels. Sections
+ * with no content (no description, no Used-in, no parameters) are
+ * hidden along with their trailing separator so the dialog tightens
+ * around what's actually shown.
+ *
+ * Required:
+ *   - `effect`: var — set by the host before calling `open()`. The
+ *      dialog reads from this directly; no separate "load" step.
+ *
+ * Optional:
+ *   - `usagesRev`: int — host-owned tick that invalidates the
+ *      `shaderEffectUsages(id)` Q_INVOKABLE result. Without it, the
+ *      Used-in list goes stale after any override mutation.
+ */
+Kirigami.Dialog {
+    // No `parent: root.Window.window.contentItem` reparenting —
+    // `Window.window` only works on Items, not Popups. Kirigami.Dialog
+    // (a Popup) handles its own modal parenting against the application
+    // window automatically.
+
+    id: root
+
+    property var effect: null
+    property int usagesRev: 0
+    readonly property string _description: effect && typeof effect.description === "string" ? effect.description : ""
+    readonly property string _author: effect && effect.author && effect.author.length > 0 ? effect.author : ""
+    readonly property string _version: effect && effect.version && effect.version.length > 0 ? effect.version : ""
+    readonly property var _usages: {
+        usagesRev; // reactive dep
+        var id = effect ? effect.id : "";
+        if (!id || id.length === 0)
+            return [];
+
+        return settingsController.animationsPage.shaderEffectUsages(id);
+    }
+    readonly property bool _hasParameters: effect && effect.parameters && effect.parameters.length > 0
+
+    // Format helper shared between the param-row text segments.
+    function _fmt(v) {
+        if (typeof v === "number")
+            return Number.isInteger(v) ? String(v) : v.toFixed(2);
+
+        if (typeof v === "boolean")
+            return v ? i18nc("@info bool true", "Yes") : i18nc("@info bool false", "No");
+
+        return String(v);
+    }
+
+    title: effect ? (effect.name || effect.id || "") : ""
+    // Both `preferredWidth` AND `preferredHeight` are required —
+    // `Kirigami.Dialog` collapses its content area to zero when either
+    // is unset. Bind preferredHeight to the actual content's implicit
+    // height plus a chrome estimate (title bar + padding + footer)
+    // so the dialog tightens around what's actually shown — capped at
+    // 85% of the host item's height so it never overflows.
+    preferredWidth: Kirigami.Units.gridUnit * 36
+    preferredHeight: {
+        var content = contentColumn.implicitHeight + Kirigami.Units.gridUnit * 6;
+        var hostMax = parent ? parent.height * 0.85 : Kirigami.Units.gridUnit * 32;
+        return Math.min(content, hostMax);
+    }
+    standardButtons: Kirigami.Dialog.Close
+    padding: Kirigami.Units.largeSpacing
+
+    ColumnLayout {
+        id: contentColumn
+
+        Layout.fillWidth: true
+        spacing: Kirigami.Units.largeSpacing
+
+        // ── 1. Preview ──────────────────────────────────────────────
+        Rectangle {
+            readonly property bool _hasPreview: root.effect && root.effect.previewPath && root.effect.previewPath.length > 0
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: width * 9 / 16
+            visible: _hasPreview
+            radius: Kirigami.Units.smallSpacing
+            color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.08)
+            border.width: Math.max(1, Math.round(Kirigami.Units.devicePixelRatio))
+            border.color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.15)
+            clip: true
+
+            Image {
+                anchors.fill: parent
+                anchors.margins: Math.max(1, Math.round(Kirigami.Units.devicePixelRatio))
+                source: parent._hasPreview ? "file://" + root.effect.previewPath : ""
+                fillMode: Image.PreserveAspectFit
+                sourceSize.width: width * 2
+                sourceSize.height: height * 2
+                asynchronous: true
+                cache: true
+                visible: status === Image.Ready
+            }
+
+        }
+
+        // ── 2. Header row: category pill + badges + parameter count ─
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Kirigami.Units.smallSpacing
+
+            // Category pill (matches the card aesthetic). Explicit
+            // Layout.preferredWidth/Height ensures the RowLayout
+            // gives it space — a Rectangle's `implicitWidth` alone
+            // sometimes loses the layout negotiation when siblings
+            // declare `Layout.fillWidth`.
+            Rectangle {
+                visible: root.effect && root.effect.category && root.effect.category.length > 0
+                radius: height / 2
+                color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.18)
+                Layout.preferredWidth: categoryLabel.implicitWidth + Kirigami.Units.largeSpacing
+                Layout.preferredHeight: categoryLabel.implicitHeight + Kirigami.Units.smallSpacing
+                Layout.alignment: Qt.AlignVCenter
+
+                Label {
+                    id: categoryLabel
+
+                    anchors.centerIn: parent
+                    text: root.effect ? (root.effect.category || "") : ""
+                    font: Kirigami.Theme.smallFont
+                    color: Kirigami.Theme.highlightColor
+                }
+
+            }
+
+            Label {
+                visible: root.effect && root.effect.isUserEffect
+                text: i18nc("@info shader source badge", "User")
+                font: Kirigami.Theme.smallFont
+                color: Kirigami.Theme.positiveTextColor
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            Label {
+                visible: root._hasParameters
+                text: i18np("%n parameter", "%n parameters", root.effect ? (root.effect.parameters || []).length : 0)
+                font: Kirigami.Theme.smallFont
+                color: Kirigami.Theme.disabledTextColor
+            }
+
+        }
+
+        // ── 3. Description + author/version ────────────────────────
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: root._description.length > 0 || root._author.length > 0 || root._version.length > 0
+            spacing: Kirigami.Units.smallSpacing
+
+            Label {
+                visible: root._description.length > 0
+                Layout.fillWidth: true
+                text: root._description
+                wrapMode: Text.WordWrap
+            }
+
+            Label {
+                visible: root._author.length > 0 || root._version.length > 0
+                Layout.fillWidth: true
+                text: {
+                    var parts = [];
+                    if (root._author.length > 0)
+                        parts.push(i18nc("@info shader author", "by %1", root._author));
+
+                    if (root._version.length > 0)
+                        parts.push(i18nc("@info shader version", "v%1", root._version));
+
+                    return parts.join(" · ");
+                }
+                color: Kirigami.Theme.disabledTextColor
+                font.italic: true
+                font.pointSize: Kirigami.Theme.smallFont.pointSize
+                elide: Text.ElideRight
+            }
+
+        }
+
+        // ── 4. Used-in section ─────────────────────────────────────
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: root._usages.length > 0
+            spacing: Kirigami.Units.smallSpacing
+
+            Kirigami.Separator {
+                Layout.fillWidth: true
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Kirigami.Units.smallSpacing
+
+                Kirigami.Icon {
+                    source: "checkmark"
+                    implicitWidth: Kirigami.Units.iconSizes.small
+                    implicitHeight: Kirigami.Units.iconSizes.small
+                    color: Kirigami.Theme.positiveTextColor
+                }
+
+                Label {
+                    text: i18ncp("@info shader usage section header", "Used in %n event", "Used in %n events", root._usages.length)
+                    font.weight: Font.DemiBold
+                }
+
+            }
+
+            Label {
+                Layout.fillWidth: true
+                Layout.leftMargin: Kirigami.Units.iconSizes.small + Kirigami.Units.smallSpacing
+                text: {
+                    var labels = [];
+                    for (var i = 0; i < root._usages.length; i++) labels.push(root._usages[i].label || root._usages[i].path)
+                    return labels.join(", ");
+                }
+                color: Kirigami.Theme.disabledTextColor
+                font: Kirigami.Theme.smallFont
+                wrapMode: Text.WordWrap
+            }
+
+        }
+
+        // ── 5. Parameters section ──────────────────────────────────
+        ColumnLayout {
+            Layout.fillWidth: true
+            visible: root._hasParameters
+            spacing: Kirigami.Units.smallSpacing
+
+            Kirigami.Separator {
+                Layout.fillWidth: true
+            }
+
+            Kirigami.Heading {
+                text: i18nc("@title:group shader parameters section", "Parameters")
+                level: 4
+            }
+
+            Repeater {
+                model: root.effect && root.effect.parameters ? root.effect.parameters : []
+
+                // Each row is a Rectangle (the alternating-tint
+                // container) directly under the ColumnLayout, with a
+                // RowLayout anchored inside it. Putting the Rectangle
+                // *as the row* — not as a sibling of the RowLayout —
+                // avoids the "anchors on a layout-managed item" warning
+                // QML flags when an anchored child sits inside a
+                // RowLayout / ColumnLayout.
+                delegate: Rectangle {
+                    id: paramRow
+
+                    required property var modelData
+                    required property int index
+
+                    Layout.fillWidth: true
+                    implicitHeight: rowContent.implicitHeight + Kirigami.Units.smallSpacing
+                    radius: Kirigami.Units.smallSpacing / 2
+                    // Subtle alternating-row tint — improves
+                    // scannability on long parameter lists (e.g.
+                    // hexagon's 13 params) without the heavy striping
+                    // a ListView would impose.
+                    color: index % 2 === 0 ? "transparent" : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.04)
+
+                    RowLayout {
+                        id: rowContent
+
+                        anchors.fill: parent
+                        anchors.leftMargin: Kirigami.Units.smallSpacing
+                        anchors.rightMargin: Kirigami.Units.smallSpacing
+                        spacing: Kirigami.Units.smallSpacing
+
+                        // Fixed-width name column so metadata aligns
+                        // across rows — much more scannable than a
+                        // self-sizing label per row.
+                        Label {
+                            Layout.preferredWidth: Kirigami.Units.gridUnit * 10
+                            Layout.alignment: Qt.AlignVCenter
+                            text: paramRow.modelData ? (paramRow.modelData.name || paramRow.modelData.id || "") : ""
+                            font.weight: Font.Medium
+                            elide: Text.ElideRight
+                        }
+
+                        Label {
+                            Layout.fillWidth: true
+                            Layout.alignment: Qt.AlignVCenter
+                            text: {
+                                var p = paramRow.modelData;
+                                if (!p)
+                                    return "";
+
+                                var parts = [];
+                                if (p.type && p.type.length > 0)
+                                    parts.push(p.type);
+
+                                if (p.min !== undefined && p.max !== undefined)
+                                    parts.push(i18nc("@info parameter range", "[%1 .. %2]", root._fmt(p.min), root._fmt(p.max)));
+
+                                if (p.default !== undefined)
+                                    parts.push(i18nc("@info parameter default value", "default %1", root._fmt(p.default)));
+
+                                return parts.join(" · ");
+                            }
+                            color: Kirigami.Theme.disabledTextColor
+                            font: Kirigami.Theme.smallFont
+                            elide: Text.ElideRight
+                        }
+
+                    }
+
+                }
+
+            }
+
+        }
+
+    }
+
+}

--- a/src/settings/qml/AnimationsShadersPage.qml
+++ b/src/settings/qml/AnimationsShadersPage.qml
@@ -513,13 +513,14 @@ Flickable {
                         // Effects in this section. Cards in a Flow wrap
                         // to next row when they run out of horizontal
                         // space — gives 3-4 cards per row at typical
-                        // settings-window widths. AnimationsShaderCard
-                        // declares `required property var modelData`
-                        // (which it aliases to `effect`) so the Repeater's
-                        // auto-injection wires the per-effect map directly
-                        // — without that, the outer group delegate's
+                        // settings-window widths. The inner delegate
+                        // wrapper below declares its own `required
+                        // property var modelData` and pipes it to the
+                        // card's `effect` slot. Without that explicit
+                        // declaration, the outer group delegate's
                         // identically-named `modelData` would shadow the
-                        // inner Repeater's auto-inject.
+                        // Repeater's auto-injection and every card would
+                        // bind to the parent group instead of its row.
                         Flow {
                             Layout.fillWidth: true
                             Layout.leftMargin: Kirigami.Units.smallSpacing

--- a/src/settings/qml/AnimationsShadersPage.qml
+++ b/src/settings/qml/AnimationsShadersPage.qml
@@ -32,7 +32,6 @@ Flickable {
     // AnimationEventCard (Q_INVOKABLE results aren't reactive across the
     // QML binding boundary).
     property var effectList: settingsController.animationsPage.availableShaderEffects()
-    readonly property string _userShaderDir: settingsController.animationsPage.userShaderDirectoryPath()
     // ── Filter state ────────────────────────────────────────────────────
     property string filterText: ""
     /// Map of `{ categoryName: true }`. Empty = show all categories.
@@ -291,19 +290,21 @@ Flickable {
 
                 }
 
+                // "Open Folder" — matches the layouts / autotile-algorithms
+                // toolbar pattern (see LayoutToolbar.qml). Path display is
+                // intentionally omitted: the file manager surfaces the
+                // location far better than an elided path string ever does.
                 RowLayout {
                     Layout.fillWidth: true
 
-                    Label {
+                    Item {
                         Layout.fillWidth: true
-                        text: root._userShaderDir
-                        elide: Text.ElideMiddle
-                        font: Kirigami.Theme.smallFont
                     }
 
                     Button {
-                        text: i18n("Open Directory")
+                        text: i18n("Open Folder")
                         icon.name: "folder-open"
+                        flat: true
                         Accessible.name: i18n("Open user shader directory")
                         onClicked: settingsController.animationsPage.openUserShaderDirectory()
                     }

--- a/src/settings/qml/AnimationsShadersPage.qml
+++ b/src/settings/qml/AnimationsShadersPage.qml
@@ -13,22 +13,135 @@ import org.kde.kirigami as Kirigami
  * card (AnimationEventCard's shader picker section); this page exists
  * so users can survey what's installed, see parameter metadata, and
  * jump to the user shader directory to drop in their own packs.
+ *
+ * ## Layout
+ *
+ *   • User shaders card — directory path + "Open Directory" button.
+ *   • Filter bar — text search + per-category multi-select pills +
+ *     built-in / user toggles.
+ *   • Installed shaders card — packs grouped by category, each section
+ *     headed with the category name and the (filtered / total) count.
+ *     Each row shows the optional preview thumbnail, name, badges,
+ *     description, and an expandable parameter list.
  */
 Flickable {
     id: root
 
-    // Loaded from a Q_INVOKABLE; the Connections block below manually
-    // refreshes it on shaderEffectsChanged. See AnimationEventCard.qml's
-    // shaderPicker for the same pattern (Q_INVOKABLE results aren't
-    // reactive across the QML binding boundary).
+    // Loaded from a Q_INVOKABLE; Connections below manually refreshes it
+    // on `shaderEffectsChanged`. Mirrors the picker pattern in
+    // AnimationEventCard (Q_INVOKABLE results aren't reactive across the
+    // QML binding boundary).
     property var effectList: settingsController.animationsPage.availableShaderEffects()
-    // QVariantList from C++
-    // Cached at component creation so the binding doesn't re-invoke
-    // userShaderDirectoryPath() on every paint. Pure path accessor (no
-    // mkpath side effect; see ensureUserShaderDirectory() / the Open
-    // Directory button below for the create-if-missing path). The
-    // directory is stable for the process lifetime.
     readonly property string _userShaderDir: settingsController.animationsPage.userShaderDirectoryPath()
+    // ── Filter state ────────────────────────────────────────────────────
+    property string filterText: ""
+    /// Map of `{ categoryName: true }`. Empty = show all categories.
+    /// Toggling any pill makes the map non-empty and switches into "show
+    /// only the explicitly-selected categories" mode.
+    property var selectedCategories: ({
+    })
+    property bool showBuiltIn: true
+    property bool showUser: true
+    readonly property bool _hasActiveFilters: filterText.length > 0 || Object.keys(selectedCategories).length > 0 || !showBuiltIn || !showUser
+    // ── Derived: category index (sorted, with counts) ───────────────────
+    readonly property var _allCategories: {
+        var counts = {
+        };
+        for (var i = 0; i < effectList.length; i++) {
+            var cat = (effectList[i] && effectList[i].category) ? effectList[i].category : "";
+            if (cat.length === 0)
+                continue;
+
+            counts[cat] = (counts[cat] || 0) + 1;
+        }
+        var keys = Object.keys(counts);
+        keys.sort(function(a, b) {
+            return a.localeCompare(b);
+        });
+        var result = [];
+        for (var k = 0; k < keys.length; k++) result.push({
+            "name": keys[k],
+            "count": counts[keys[k]]
+        })
+        return result;
+    }
+    // ── Derived: filtered + grouped effects ─────────────────────────────
+    readonly property var _filteredEffects: {
+        var needle = root.filterText.trim().toLowerCase();
+        var anyCategorySelected = Object.keys(root.selectedCategories).length > 0;
+        var out = [];
+        for (var i = 0; i < effectList.length; i++) {
+            var e = effectList[i];
+            if (!e)
+                continue;
+
+            // Built-in / user gate.
+            var isUser = !!e.isUserEffect;
+            if (isUser && !root.showUser)
+                continue;
+
+            if (!isUser && !root.showBuiltIn)
+                continue;
+
+            // Category gate — only when at least one pill is active.
+            if (anyCategorySelected) {
+                var cat = e.category || "";
+                if (!root.selectedCategories[cat])
+                    continue;
+
+            }
+            // Text search across name / id / description / category / author.
+            if (needle.length > 0) {
+                var hay = (String(e.name || "") + " " + String(e.id || "") + " " + String(e.description || "") + " " + String(e.category || "") + " " + String(e.author || "")).toLowerCase();
+                if (hay.indexOf(needle) === -1)
+                    continue;
+
+            }
+            out.push(e);
+        }
+        return out;
+    }
+    /// `[{category, effects}]` sorted alphabetically by category. Effects
+    /// inside each group keep their controller-emitted order.
+    readonly property var _groupedEffects: {
+        var groups = {
+        };
+        var order = [];
+        // Use a sentinel for uncategorised effects so they cluster
+        // together rather than spreading across the catalogue.
+        var uncategorisedKey = i18nc("@title:group fallback for shaders without a category", "Uncategorised");
+        for (var i = 0; i < _filteredEffects.length; i++) {
+            var e = _filteredEffects[i];
+            var cat = (e.category && e.category.length > 0) ? e.category : uncategorisedKey;
+            if (!groups[cat]) {
+                groups[cat] = [];
+                order.push(cat);
+            }
+            groups[cat].push(e);
+        }
+        order.sort(function(a, b) {
+            // Always sort the uncategorised bucket last so the named
+            // categories take visual precedence.
+            if (a === uncategorisedKey)
+                return 1;
+
+            if (b === uncategorisedKey)
+                return -1;
+
+            return a.localeCompare(b);
+        });
+        var result = [];
+        for (var k = 0; k < order.length; k++) result.push({
+            "category": order[k],
+            "effects": groups[order[k]]
+        })
+        return result;
+    }
+    // Per-row "Used in:" labels resolve via Q_INVOKABLE
+    // `shaderEffectUsages(id)`. QML can't observe the result of an
+    // invokable across mutations, so each row re-evaluates against this
+    // tick whenever any shader override changes anywhere in the tree.
+    property int _usagesRev: 0
 
     contentHeight: content.implicitHeight
     clip: true
@@ -38,7 +151,18 @@ Flickable {
             root.effectList = settingsController.animationsPage.availableShaderEffects();
         }
 
+        function onShaderProfileChanged(path) {
+            ++root._usagesRev;
+        }
+
         target: settingsController.animationsPage
+    }
+
+    Timer {
+        id: searchDebounce
+
+        interval: 150
+        onTriggered: root.filterText = searchField.text
     }
 
     ColumnLayout {
@@ -68,6 +192,105 @@ Flickable {
                     color: Kirigami.Theme.disabledTextColor
                 }
 
+                // ── Drop target ───────────────────────────────────────
+                // Visible affordance for the drag-folder import the copy
+                // above describes. Hover-state highlight + icon, success/
+                // failure feedback via a transient Kirigami.InlineMessage.
+                Rectangle {
+                    id: dropZone
+
+                    readonly property bool _highlight: dropArea.containsDrag
+
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: Kirigami.Units.gridUnit * 5
+                    radius: Kirigami.Units.smallSpacing
+                    color: _highlight ? Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.12) : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.04)
+                    border.width: Math.max(1, Math.round(Kirigami.Units.devicePixelRatio))
+                    // Dashed-look approximation via dimmed border colour
+                    // when idle, theme highlight when active.
+                    border.color: _highlight ? Kirigami.Theme.highlightColor : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.25)
+
+                    RowLayout {
+                        anchors.centerIn: parent
+                        spacing: Kirigami.Units.largeSpacing
+
+                        Kirigami.Icon {
+                            source: dropZone._highlight ? "folder-add" : "folder-download"
+                            implicitWidth: Kirigami.Units.iconSizes.large
+                            implicitHeight: Kirigami.Units.iconSizes.large
+                            color: dropZone._highlight ? Kirigami.Theme.highlightColor : Kirigami.Theme.disabledTextColor
+                        }
+
+                        Label {
+                            text: dropZone._highlight ? i18nc("@info drop-zone hover label", "Release to install shader pack") : i18nc("@info drop-zone idle label", "Drop a shader pack folder here")
+                            color: dropZone._highlight ? Kirigami.Theme.highlightColor : Kirigami.Theme.disabledTextColor
+                            font.italic: !dropZone._highlight
+                        }
+
+                    }
+
+                    DropArea {
+                        id: dropArea
+
+                        anchors.fill: parent
+                        // Accept folder drops from file managers (text/uri-list
+                        // is the standard MIME type for file/folder URLs).
+                        keys: ["text/uri-list"]
+                        onDropped: function(drop) {
+                            // Multi-folder drops aren't useful here — install
+                            // the first folder URL and ignore the rest. The
+                            // controller validates that each URL is actually
+                            // a directory containing metadata.json.
+                            var urls = drop.urls;
+                            if (!urls || urls.length === 0) {
+                                drop.accepted = false;
+                                return ;
+                            }
+                            var ok = settingsController.animationsPage.installShaderPack(String(urls[0]));
+                            installResult.show(ok, urls[0]);
+                            drop.accepted = true;
+                        }
+                    }
+
+                }
+
+                // Transient success/failure banner under the drop zone.
+                // Hidden by default; populated by `installResult.show(ok, url)`.
+                Kirigami.InlineMessage {
+                    id: installResult
+
+                    function show(ok, url) {
+                        var basename = String(url).split("/").pop();
+                        if (basename.length === 0)
+                            basename = String(url);
+
+                        if (ok) {
+                            type = Kirigami.MessageType.Positive;
+                            text = i18nc("@info shader install success", "Installed shader pack “%1”.", basename);
+                        } else {
+                            type = Kirigami.MessageType.Error;
+                            // Keep the message generic — the controller logs
+                            // the specific reason (missing metadata.json,
+                            // collision, copy failure) to journalctl.
+                            text = i18nc("@info shader install failure", "Could not install “%1”. The folder must contain a metadata.json and not collide with an existing pack.", basename);
+                        }
+                        visible = true;
+                        autoHideTimer.restart();
+                    }
+
+                    Layout.fillWidth: true
+                    visible: false
+                    showCloseButton: true
+
+                    Timer {
+                        id: autoHideTimer
+
+                        interval: 6000
+                        onTriggered: installResult.visible = false
+                    }
+
+                }
+
                 RowLayout {
                     Layout.fillWidth: true
 
@@ -91,176 +314,226 @@ Flickable {
 
         }
 
+        // ── Filter bar ──────────────────────────────────────────────────
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Kirigami.Units.smallSpacing
+
+            TextField {
+                id: searchField
+
+                Layout.preferredWidth: Kirigami.Units.gridUnit * 14
+                placeholderText: i18nc("@info:placeholder shader search", "Search shaders…")
+                inputMethodHints: Qt.ImhNoPredictiveText
+                rightPadding: clearSearchButton.visible ? clearSearchButton.width + Kirigami.Units.smallSpacing : Kirigami.Units.smallSpacing
+                Accessible.name: i18n("Search shaders")
+                onTextChanged: searchDebounce.restart()
+
+                ToolButton {
+                    id: clearSearchButton
+
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    visible: searchField.text.length > 0
+                    icon.name: "edit-clear"
+                    icon.width: Kirigami.Units.iconSizes.small
+                    icon.height: Kirigami.Units.iconSizes.small
+                    Accessible.name: i18nc("@action:button", "Clear search")
+                    onClicked: {
+                        searchField.clear();
+                        searchDebounce.stop();
+                        root.filterText = "";
+                    }
+                }
+
+            }
+
+            // Category pill row — one ToolButton per known category.
+            // Click toggles inclusion; a non-empty selection switches
+            // into "show only selected" mode (any-of, not all-of).
+            Flow {
+                Layout.fillWidth: true
+                spacing: Kirigami.Units.smallSpacing
+
+                Repeater {
+                    model: root._allCategories
+
+                    delegate: ToolButton {
+                        required property var modelData
+                        readonly property bool isActive: root.selectedCategories[modelData.name] === true
+
+                        text: i18nc("@action:button category filter pill", "%1 (%2)", modelData.name, modelData.count)
+                        checkable: true
+                        checked: isActive
+                        Accessible.name: isActive ? i18nc("@action:button", "Hide %1 shaders", modelData.name) : i18nc("@action:button", "Show only %1 shaders", modelData.name)
+                        onClicked: {
+                            // Replace-the-map mutation pattern — QML reactivity
+                            // requires a new map identity, not in-place edits.
+                            var next = Object.assign({
+                            }, root.selectedCategories);
+                            if (next[modelData.name])
+                                delete next[modelData.name];
+                            else
+                                next[modelData.name] = true;
+                            root.selectedCategories = next;
+                        }
+                    }
+
+                }
+
+            }
+
+            // Built-in / User toggle — single ToolButton with a popup so
+            // it doesn't dominate the bar at narrow widths.
+            ToolButton {
+                id: sourceFilterButton
+
+                icon.name: "view-filter"
+                checkable: false
+                checked: !root.showBuiltIn || !root.showUser
+                Accessible.name: (root.showBuiltIn && root.showUser) ? i18nc("@action:button", "Source filter") : i18nc("@action:button", "Source filter (active)")
+                ToolTip.text: Accessible.name
+                ToolTip.visible: hovered
+                ToolTip.delay: Kirigami.Units.toolTipDelay
+                onClicked: sourceFilterMenu.popup()
+
+                Menu {
+                    id: sourceFilterMenu
+
+                    title: i18nc("@title:menu", "Source")
+
+                    MenuItem {
+                        text: i18nc("@option:check", "Built-in")
+                        checkable: true
+                        checked: root.showBuiltIn
+                        onToggled: root.showBuiltIn = checked
+                    }
+
+                    MenuItem {
+                        text: i18nc("@option:check", "User-installed")
+                        checkable: true
+                        checked: root.showUser
+                        onToggled: root.showUser = checked
+                    }
+
+                }
+
+            }
+
+            // Reset — only enabled when something to reset.
+            ToolButton {
+                icon.name: "edit-reset"
+                enabled: root._hasActiveFilters
+                Accessible.name: i18nc("@action:button", "Reset filters")
+                ToolTip.text: Accessible.name
+                ToolTip.visible: hovered
+                ToolTip.delay: Kirigami.Units.toolTipDelay
+                onClicked: {
+                    searchField.clear();
+                    searchDebounce.stop();
+                    root.filterText = "";
+                    root.selectedCategories = ({
+                    });
+                    root.showBuiltIn = true;
+                    root.showUser = true;
+                }
+            }
+
+        }
+
         SettingsCard {
             Layout.fillWidth: true
-            headerText: i18n("Installed shaders (%1)", root.effectList.length)
+            headerText: root._hasActiveFilters ? i18nc("@title:group filtered shader catalogue", "Installed shaders (%1 of %2)", root._filteredEffects.length, root.effectList.length) : i18nc("@title:group full shader catalogue", "Installed shaders (%1)", root.effectList.length)
 
             contentItem: ColumnLayout {
                 spacing: Kirigami.Units.smallSpacing
 
                 Label {
+                    Layout.fillWidth: true
                     visible: root.effectList.length === 0
                     text: i18n("No shader effects installed.")
                     color: Kirigami.Theme.disabledTextColor
                     font.italic: true
-                    Layout.fillWidth: true
                 }
 
+                Label {
+                    Layout.fillWidth: true
+                    visible: root.effectList.length > 0 && root._filteredEffects.length === 0
+                    text: i18n("No shaders match the current filter.")
+                    color: Kirigami.Theme.disabledTextColor
+                    font.italic: true
+                }
+
+                // ── Grouped sections ──────────────────────────────────
                 Repeater {
-                    model: root.effectList
+                    model: root._groupedEffects
 
-                    delegate: Item {
-                        id: shaderRow
-
+                    delegate: ColumnLayout {
                         required property var modelData
-                        property bool expanded: false
 
                         Layout.fillWidth: true
-                        implicitHeight: rowColumn.implicitHeight
+                        // Bump vertical spacing between successive
+                        // sections so the headers visually separate
+                        // their card grids — `largeSpacing` topMargin
+                        // gives a clearer "new category" cue than the
+                        // previous tight `smallSpacing`.
+                        Layout.topMargin: Kirigami.Units.largeSpacing
+                        spacing: Math.round(Kirigami.Units.smallSpacing / 2)
 
-                        ColumnLayout {
-                            id: rowColumn
-
-                            anchors.left: parent.left
-                            anchors.right: parent.right
+                        // Section header
+                        RowLayout {
+                            Layout.fillWidth: true
                             spacing: Kirigami.Units.smallSpacing
 
-                            RowLayout {
-                                Layout.fillWidth: true
-                                spacing: Kirigami.Units.smallSpacing
-
-                                ColumnLayout {
-                                    Layout.fillWidth: true
-                                    spacing: 0
-
-                                    RowLayout {
-                                        Layout.fillWidth: true
-                                        spacing: Kirigami.Units.smallSpacing
-
-                                        Label {
-                                            text: shaderRow.modelData.name || shaderRow.modelData.id
-                                            font.weight: Font.DemiBold
-                                        }
-
-                                        Label {
-                                            visible: shaderRow.modelData.isUserEffect
-                                            text: i18n("User")
-                                            font: Kirigami.Theme.smallFont
-                                            color: Kirigami.Theme.positiveTextColor
-                                        }
-
-                                        Label {
-                                            visible: shaderRow.modelData.category && shaderRow.modelData.category.length > 0
-                                            text: shaderRow.modelData.category
-                                            font: Kirigami.Theme.smallFont
-                                            color: Kirigami.Theme.disabledTextColor
-                                        }
-
-                                        Item {
-                                            Layout.fillWidth: true
-                                        }
-
-                                        Label {
-                                            text: i18np("%n parameter", "%n parameters", (shaderRow.modelData.parameters || []).length)
-                                            font: Kirigami.Theme.smallFont
-                                            color: Kirigami.Theme.disabledTextColor
-                                        }
-
-                                    }
-
-                                    Label {
-                                        visible: shaderRow.modelData.description && shaderRow.modelData.description.length > 0
-                                        Layout.fillWidth: true
-                                        text: shaderRow.modelData.description
-                                        wrapMode: Text.WordWrap
-                                        color: Kirigami.Theme.disabledTextColor
-                                        font: Kirigami.Theme.smallFont
-                                    }
-
-                                }
-
-                                ToolButton {
-                                    visible: (shaderRow.modelData.parameters || []).length > 0
-                                    icon.name: shaderRow.expanded ? "go-up" : "go-down"
-                                    Accessible.name: shaderRow.expanded ? i18n("Hide parameters") : i18n("Show parameters")
-                                    onClicked: shaderRow.expanded = !shaderRow.expanded
-                                }
-
+                            Label {
+                                text: modelData.category
+                                font.weight: Font.DemiBold
                             }
 
-                            // Expanded parameter list (read-only metadata)
-                            ColumnLayout {
-                                visible: shaderRow.expanded
+                            Label {
+                                text: i18np("%n shader", "%n shaders", modelData.effects.length)
+                                font: Kirigami.Theme.smallFont
+                                color: Kirigami.Theme.disabledTextColor
+                            }
+
+                            // Hairline divider that fills the rest of the row.
+                            Rectangle {
                                 Layout.fillWidth: true
-                                Layout.leftMargin: Kirigami.Units.gridUnit
-                                spacing: Math.round(Kirigami.Units.smallSpacing / 2)
+                                Layout.alignment: Qt.AlignVCenter
+                                height: Math.max(1, Math.round(Kirigami.Units.devicePixelRatio))
+                                color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.15)
+                            }
 
-                                Repeater {
-                                    model: shaderRow.modelData.parameters || []
+                        }
 
-                                    delegate: RowLayout {
-                                        required property var modelData
+                        // Effects in this section. Cards in a Flow wrap
+                        // to next row when they run out of horizontal
+                        // space — gives 3-4 cards per row at typical
+                        // settings-window widths. AnimationsShaderCard
+                        // declares `required property var modelData`
+                        // (which it aliases to `effect`) so the Repeater's
+                        // auto-injection wires the per-effect map directly
+                        // — without that, the outer group delegate's
+                        // identically-named `modelData` would shadow the
+                        // inner Repeater's auto-inject.
+                        Flow {
+                            Layout.fillWidth: true
+                            Layout.leftMargin: Kirigami.Units.smallSpacing
+                            Layout.topMargin: Math.round(Kirigami.Units.smallSpacing / 2)
+                            spacing: Kirigami.Units.smallSpacing
 
-                                        spacing: Kirigami.Units.smallSpacing
+                            Repeater {
+                                model: modelData.effects
 
-                                        Label {
-                                            text: modelData.name || modelData.id
-                                            Layout.preferredWidth: Kirigami.Units.gridUnit * 8
-                                            elide: Text.ElideRight
-                                        }
+                                delegate: AnimationsShaderCard {
+                                    required property var modelData
 
-                                        Label {
-                                            text: modelData.type
-                                            color: Kirigami.Theme.disabledTextColor
-                                            font: Kirigami.Theme.smallFont
-                                            Layout.preferredWidth: Kirigami.Units.gridUnit * 4
-                                        }
-
-                                        Label {
-                                            // Format floats to 2 decimals so a default like
-                                            // 0.123456789 doesn't render with 9 digits in
-                                            // the per-shader range display. Hoisted out of
-                                            // the binding so it isn't re-allocated per re-eval.
-                                            function fmt(v) {
-                                                if (typeof v === "number")
-                                                    return Number.isInteger(v) ? String(v) : v.toFixed(2);
-
-                                                return String(v);
-                                            }
-
-                                            text: {
-                                                if (modelData.min !== undefined && modelData.max !== undefined)
-                                                    return i18n("[%1 .. %2]", fmt(modelData.min), fmt(modelData.max));
-
-                                                return "";
-                                            }
-                                            color: Kirigami.Theme.disabledTextColor
-                                            font: Kirigami.Theme.smallFont
-                                            Layout.preferredWidth: Kirigami.Units.gridUnit * 8
-                                        }
-
-                                        Label {
-                                            // Reuse the sibling's formatter so a numeric default
-                                            // (like 0.85) doesn't render at full JS precision
-                                            // when the range above is rounded to 2dp.
-                                            function fmt(v) {
-                                                if (typeof v === "number")
-                                                    return Number.isInteger(v) ? String(v) : v.toFixed(2);
-
-                                                if (typeof v === "boolean")
-                                                    return v ? i18nc("@info bool true", "Yes") : i18nc("@info bool false", "No");
-
-                                                return String(v);
-                                            }
-
-                                            text: i18n("default: %1", modelData.default !== undefined ? fmt(modelData.default) : "")
-                                            color: Kirigami.Theme.disabledTextColor
-                                            font: Kirigami.Theme.smallFont
-                                            Layout.fillWidth: true
-                                        }
-
+                                    effect: modelData
+                                    usagesRev: root._usagesRev
+                                    onShowDetails: function(e) {
+                                        detailDialog.effect = e;
+                                        detailDialog.open();
                                     }
-
                                 }
 
                             }
@@ -275,6 +548,13 @@ Flickable {
 
         }
 
+    }
+
+    // ── Detail dialog (single instance; populated on card click) ────────
+    AnimationsShaderDetailDialog {
+        id: detailDialog
+
+        usagesRev: root._usagesRev
     }
 
 }

--- a/src/settings/qml/AnimationsShadersPage.qml
+++ b/src/settings/qml/AnimationsShadersPage.qml
@@ -16,13 +16,16 @@ import org.kde.kirigami as Kirigami
  *
  * ## Layout
  *
- *   • User shaders card — directory path + "Open Directory" button.
+ *   • User shaders card — drop zone for installing user shader packs +
+ *     "Open Folder" button (matches the layouts / autotile-algorithms
+ *     toolbar pattern; no path label — the file manager surfaces the
+ *     location far better than a truncated string).
  *   • Filter bar — text search + per-category multi-select pills +
  *     built-in / user toggles.
- *   • Installed shaders card — packs grouped by category, each section
- *     headed with the category name and the (filtered / total) count.
- *     Each row shows the optional preview thumbnail, name, badges,
- *     description, and an expandable parameter list.
+ *   • Installed shaders card — packs grouped by category as a card grid;
+ *     each section headed with the category name and the count.
+ *     Card click opens AnimationsShaderDetailDialog for the full view
+ *     (preview, description, "Used in:" reverse-lookup, parameter list).
  */
 Flickable {
     id: root


### PR DESCRIPTION
## Summary

Rebuilds the **Animations → Shaders** page from a flat list into a proper catalogue UI, and harmonises the user-shader directory affordance with the rest of the settings app.

### What's new

- **Filter bar** — text search across name/id/description/category/author, per-category multi-select pills, and built-in / user toggles. Search is debounced (150 ms) and has a clear button.
- **Grouped card grid** — shaders cluster by category in a responsive `Flow` of fixed-width cards. Each card shows preview thumbnail (when the pack ships one), name, "User" badge, two-line description, parameter count, and a "Used in N events" chip. Click → opens a detail dialog.
- **Detail dialog** (`AnimationsShaderDetailDialog.qml`) — large preview, full description, author/version, complete "Used in:" reverse-lookup list, and a scannable parameter table with alternating row tint.
- **Drop zone** — drag-and-drop install of user shader packs straight into `~/.local/share/plasmazones/animations`, with success/failure feedback via a transient `Kirigami.InlineMessage`.
- **Card extraction** (`AnimationsShaderCard.qml`) — kept under the 800-line cap and reusable.
- **Reverse-lookup API** — new `shaderEffectUsages(effectId)` walks the shader-tree's `overriddenPaths()` to surface every event currently using each shader. A revision-counter pattern (`_usagesRev` / `_shaderRegistryRev`) keeps Q_INVOKABLE results fresh across mutations.
- **User-shaders card cleanup** (followup commit) — drops the elided-path label and adopts the same flat \`Open Folder\` button used by `LayoutToolbar.qml` for layouts and autotile algorithms. The file manager surfaces the directory location far better than a truncated text string did, and the three "open my user data folder" affordances now match.

### Commits

- \`c8c3803a\` — feat(settings): rework Animations → Shaders page UX
- \`657d40f2\` — refactor(settings): match Open Folder pattern in user shaders card

## Test plan

- [ ] Filter bar: text search narrows results across all metadata fields; category pills toggle; built-in/user toggles work; clear button resets state
- [ ] Cards group by category alphabetically with "Uncategorised" sorted last
- [ ] Card → detail dialog opens; close button dismisses; dialog tightens around content (no empty whitespace for shaders without preview/description/usages)
- [ ] "Used in N events" chip appears only when the shader is assigned somewhere; tooltip lists the event labels
- [ ] Used-in count updates live when shader assignments change on other Animations sub-pages
- [ ] Drop a folder onto the drop zone — installs if it contains \`metadata.json\` and the basename doesn't collide; transient success banner appears; registry filewatcher detects the new pack
- [ ] Drop an invalid folder — error banner appears; specific reason logged to journalctl
- [ ] "Open Folder" button opens the user shader directory in the system file manager
- [ ] Visual consistency: User-shaders \`Open Folder\` button matches the layouts and autotile-algorithms toolbar buttons in label, icon, and flat styling

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)