### PR TITLE
refactor(settings): share shader-param lock + randomize with editor

### DIFF
--- a/src/editor/qml/ShaderSettingsDialog.qml
+++ b/src/editor/qml/ShaderSettingsDialog.qml
@@ -207,27 +207,11 @@ Kirigami.Dialog {
     }
 
     function setParamLocked(paramId, locked) {
-        var next = Object.assign({
-        }, lockedParams || {
-        });
-        if (locked)
-            next[paramId] = true;
-        else
-            delete next[paramId];
-        lockedParams = next;
+        lockedParams = paramEditor.lockedAfterToggle(paramId, locked);
     }
 
     function toggleAllLocks(locked) {
-        var copy = {
-        };
-        if (locked && shaderParams) {
-            for (var i = 0; i < shaderParams.length; i++) {
-                if (shaderParams[i] && shaderParams[i].id !== undefined)
-                    copy[shaderParams[i].id] = true;
-
-            }
-        }
-        lockedParams = copy;
+        lockedParams = paramEditor.lockedAfterAllToggle(locked);
     }
 
     function applyChanges() {
@@ -264,57 +248,7 @@ Kirigami.Dialog {
         if (!editorController || shaderParams.length === 0)
             return ;
 
-        var randomized = {
-        };
-        for (var i = 0; i < shaderParams.length; i++) {
-            var param = shaderParams[i];
-            if (!param || param.id === undefined)
-                continue;
-
-            // Skip locked parameters — preserve their current value.
-            if (lockedParams && lockedParams[param.id] === true) {
-                randomized[param.id] = (pendingParams && pendingParams[param.id] !== undefined) ? pendingParams[param.id] : param.default;
-                continue;
-            }
-            var value;
-            switch (param.type) {
-            case "float":
-                var minF = param.min !== undefined ? param.min : 0;
-                var maxF = param.max !== undefined ? param.max : 1;
-                value = minF + Math.random() * (maxF - minF);
-                if (param.step !== undefined && param.step > 0)
-                    value = Math.round(value / param.step) * param.step;
-
-                break;
-            case "int":
-                var minI = param.min !== undefined ? param.min : 0;
-                var maxI = param.max !== undefined ? param.max : 100;
-                value = Math.floor(minI + Math.random() * (maxI - minI + 1));
-                break;
-            case "bool":
-                value = Math.random() < 0.5;
-                break;
-            case "color":
-                var r = Math.floor(Math.random() * 256);
-                var g = Math.floor(Math.random() * 256);
-                var b = Math.floor(Math.random() * 256);
-                value = "#" + r.toString(16).padStart(2, "0") + g.toString(16).padStart(2, "0") + b.toString(16).padStart(2, "0");
-                break;
-            case "image":
-                // Preserve the current path for image params — randomizing a
-                // file path would just erase the user's pick. Same fallback
-                // chain as the lock-skip branch above.
-                value = (pendingParams && pendingParams[param.id] !== undefined) ? pendingParams[param.id] : param.default;
-                break;
-            default:
-                value = param.default;
-                break;
-            }
-            if (value !== undefined)
-                randomized[param.id] = value;
-
-        }
-        pendingParams = randomized;
+        pendingParams = paramEditor.computeRandomized();
     }
 
     function extractDefaults(params) {
@@ -602,6 +536,8 @@ Kirigami.Dialog {
 
             // ── Parameters editor (toolbar + flat/grouped rows) ───────
             PZCommon.ShaderParameterEditor {
+                id: paramEditor
+
                 Layout.fillWidth: true
                 visible: root.hasShaderEffect
                 parameters: root.shaderParams

--- a/src/settings/qml/AnimationEventCard.qml
+++ b/src/settings/qml/AnimationEventCard.qml
@@ -112,7 +112,8 @@ Item {
     // `ShaderProfileTree::resolve` and shadows the parent's value at
     // runtime. Surfaced via the warning banner below with a one-click
     // "Clear shadowing children" button. Refreshed on any
-    // shaderProfileChanged signal (see Connections at line 222+).
+    // shaderProfileChanged signal — see `onShaderProfileChanged` in the
+    // `target: settingsController.animationsPage` Connections block below.
     property int _shadowingChildrenCount: 0
     // Bumped on every `shaderEffectsChanged` so any binding that reads
     // a shader-registry Q_INVOKABLE (`availableShaderEffects()`,

--- a/src/settings/qml/AnimationEventCard.qml
+++ b/src/settings/qml/AnimationEventCard.qml
@@ -65,13 +65,10 @@ Item {
     // shaderProfileChanged via the Connections block at the bottom.
     property var currentShaderParams: ({
     })
-    /// Per-card lock state for the parameter editor's lock-all /
-    /// randomize toolbar. Keyed by param id; values are `true` for
-    /// locked. Local to the card — not persisted (locking is a UI
-    /// affordance for shaping the next randomize roll, not a property
-    /// of the saved override). Cleared whenever the assigned shader
-    /// effect changes so a stale lock from the previous shader's
-    /// schema can't shadow the new shader's same-id param.
+    /// Per-card lock state for the parameter editor's lock + randomize
+    /// toolbar. UI affordance only — not persisted. Cleared on shader
+    /// switch in `refreshShaderFromTree` (same-named ids in different
+    /// shader schemas are unrelated).
     property var lockedShaderParams: ({
     })
     readonly property string currentCurveString: {
@@ -200,16 +197,11 @@ Item {
         settingsController.animationsPage.setShaderOverride(root.eventPath, effectId, next);
     }
 
-    /// Replace every parameter in one write. Used by the randomize
-    /// affordance so N rolled values land as a single override push
-    /// (and a single daemon round-trip) rather than N sequential
-    /// `setShaderOverride` calls each reading the previous map back.
-    /// Same stale-effect guard as `_writeShaderParam`.
+    /// Batch write — randomize rolls N values that should land as one
+    /// `setShaderOverride` round-trip. Same stale-effect guard as
+    /// `_writeShaderParam`.
     function _writeAllShaderParams(effectId, allParams) {
-        if (!effectId)
-            return ;
-
-        if (effectId !== root.currentShaderEffectId)
+        if (!effectId || effectId !== root.currentShaderEffectId)
             return ;
 
         root.currentShaderParams = allParams;
@@ -219,10 +211,8 @@ Item {
     function refreshShaderFromTree() {
         var resolved = settingsController.animationsPage.resolvedShaderProfile(root.eventPath);
         var nextEffectId = (resolved && resolved.effectId) ? resolved.effectId : "";
-        // Drop stale locks whenever the effect changes — keeping a
-        // lock keyed by `seedX` from one shader's schema could pin a
-        // same-named-but-unrelated param in a different shader's
-        // schema across a switch.
+        // Stale-lock clear on effect switch — same-named ids in
+        // different shaders are unrelated.
         if (nextEffectId !== root.currentShaderEffectId)
             root.lockedShaderParams = ({
         });

--- a/src/settings/qml/AnimationEventCard.qml
+++ b/src/settings/qml/AnimationEventCard.qml
@@ -65,6 +65,15 @@ Item {
     // shaderProfileChanged via the Connections block at the bottom.
     property var currentShaderParams: ({
     })
+    /// Per-card lock state for the parameter editor's lock-all /
+    /// randomize toolbar. Keyed by param id; values are `true` for
+    /// locked. Local to the card — not persisted (locking is a UI
+    /// affordance for shaping the next randomize roll, not a property
+    /// of the saved override). Cleared whenever the assigned shader
+    /// effect changes so a stale lock from the previous shader's
+    /// schema can't shadow the new shader's same-id param.
+    property var lockedShaderParams: ({
+    })
     readonly property string currentCurveString: {
         if (currentTimingMode === CurvePresets.timingModeSpring)
             return "spring:" + currentSpringOmega.toFixed(2) + "," + currentSpringZeta.toFixed(2);
@@ -191,9 +200,34 @@ Item {
         settingsController.animationsPage.setShaderOverride(root.eventPath, effectId, next);
     }
 
+    /// Replace every parameter in one write. Used by the randomize
+    /// affordance so N rolled values land as a single override push
+    /// (and a single daemon round-trip) rather than N sequential
+    /// `setShaderOverride` calls each reading the previous map back.
+    /// Same stale-effect guard as `_writeShaderParam`.
+    function _writeAllShaderParams(effectId, allParams) {
+        if (!effectId)
+            return ;
+
+        if (effectId !== root.currentShaderEffectId)
+            return ;
+
+        root.currentShaderParams = allParams;
+        settingsController.animationsPage.setShaderOverride(root.eventPath, effectId, allParams);
+    }
+
     function refreshShaderFromTree() {
         var resolved = settingsController.animationsPage.resolvedShaderProfile(root.eventPath);
-        root.currentShaderEffectId = (resolved && resolved.effectId) ? resolved.effectId : "";
+        var nextEffectId = (resolved && resolved.effectId) ? resolved.effectId : "";
+        // Drop stale locks whenever the effect changes — keeping a
+        // lock keyed by `seedX` from one shader's schema could pin a
+        // same-named-but-unrelated param in a different shader's
+        // schema across a switch.
+        if (nextEffectId !== root.currentShaderEffectId)
+            root.lockedShaderParams = ({
+        });
+
+        root.currentShaderEffectId = nextEffectId;
         root.currentShaderParams = (resolved && resolved.parameters) ? resolved.parameters : ({
         });
         // Recompute deeper-override count on every shader-tree update —
@@ -677,13 +711,24 @@ Item {
                 visible: root._shaderLegSupported && root.currentShaderEffectId.length > 0 && _paramSchema.length > 0
                 parameters: _paramSchema
                 currentValues: root.currentShaderParams
-                enableLocking: false
-                enableRandomize: false
+                lockedParams: root.lockedShaderParams
+                enableLocking: true
+                enableRandomize: true
                 enableGroups: true
                 enableImage: false
                 compact: true
                 onValueChanged: function(paramId, value) {
                     root._writeShaderParam(root.currentShaderEffectId, paramId, value);
+                }
+                onLockToggled: function(paramId, locked) {
+                    root.lockedShaderParams = animationParamEditor.lockedAfterToggle(paramId, locked);
+                }
+                onLockAllRequested: function(lock) {
+                    root.lockedShaderParams = animationParamEditor.lockedAfterAllToggle(lock);
+                }
+                onRandomizeRequested: {
+                    var rolled = animationParamEditor.computeRandomized();
+                    root._writeAllShaderParams(root.currentShaderEffectId, rolled);
                 }
                 onRequestColorPicker: function(paramId, paramName, current) {
                     // Snapshot the effect id at dialog-open time so the

--- a/src/shared/ShaderParameterEditor.qml
+++ b/src/shared/ShaderParameterEditor.qml
@@ -10,10 +10,9 @@ import org.kde.kirigami as Kirigami
  * @brief Reusable parameter editor for a shader.
  *
  * Wraps the Lock-all / Randomize toolbar plus the flat-or-grouped row
- * rendering that previously lived inline in the editor's
- * `ShaderSettingsDialog`. The animation settings consumes it without the
- * toolbar (`enableLocking: false`, `enableRandomize: false`) and without
- * accordion groups (`enableGroups: false`).
+ * rendering. Both the editor's `ShaderSettingsDialog` and the settings
+ * app's `AnimationEventCard` consume it; each toggles the affordances
+ * it wants via the `enable*` flags below.
  *
  * The component is fully props-and-signals — it does not own state.
  * The host:
@@ -24,6 +23,12 @@ import org.kde.kirigami as Kirigami
  *   - listens for `requestColorPicker` / `requestImagePicker` and opens
  *     the platform dialog at the parent level (image dialogs in
  *     particular need to outlive their delegate row)
+ *
+ * Three pure helpers (`lockedAfterToggle`, `lockedAfterAllToggle`,
+ * `computeRandomized`) compute new maps from the component's current
+ * props for hosts that wire the lock + randomize toolbar — both
+ * consumers route their handler bodies through them so the transforms
+ * live in one place.
  *
  * Accordion behavior: when `enableGroups: true` and the parameter list
  * declares any `group` field, rows are split into ShaderParameterSection
@@ -189,7 +194,15 @@ ColumnLayout {
                 continue;
 
             if ((root.lockedParams && root.lockedParams[param.id] === true) || param.type === "image") {
-                next[param.id] = (root.currentValues && root.currentValues[param.id] !== undefined) ? root.currentValues[param.id] : param.default;
+                // Mirror the switch-path's undefined guard below — a
+                // schema with a missing `default` and a currentValues
+                // map missing this id would otherwise write
+                // `undefined` into the result, and a downstream
+                // `setShaderOverride` would persist a malformed entry.
+                var preserved = (root.currentValues && root.currentValues[param.id] !== undefined) ? root.currentValues[param.id] : param.default;
+                if (preserved !== undefined)
+                    next[param.id] = preserved;
+
                 continue;
             }
             var value;

--- a/src/shared/ShaderParameterEditor.qml
+++ b/src/shared/ShaderParameterEditor.qml
@@ -139,6 +139,94 @@ ColumnLayout {
     signal requestColorPicker(string paramId, string paramName, color current)
     signal requestImagePicker(string paramId)
 
+    // ── Pure helpers for the host's lock / randomize plumbing ───────
+    /// Toggle the lock for one parameter. Returns a new lockedParams
+    /// map; the host assigns it back into its own state property.
+    /// Lives here so the editor and settings card don't carry their
+    /// own copy of the same lookup-and-rewrite boilerplate.
+    function lockedAfterToggle(paramId, locked) {
+        var next = Object.assign({
+        }, root.lockedParams || {
+        });
+        if (locked)
+            next[paramId] = true;
+        else
+            delete next[paramId];
+        return next;
+    }
+
+    /// Lock-or-unlock-every-parameter map. Reads `parameters` from
+    /// the component instance.
+    function lockedAfterAllToggle(locked) {
+        var next = {
+        };
+        if (locked && root.parameters) {
+            for (var i = 0; i < root.parameters.length; i++) {
+                var p = root.parameters[i];
+                if (p && p.id !== undefined)
+                    next[p.id] = true;
+
+            }
+        }
+        return next;
+    }
+
+    /// Roll a fresh value for every unlocked parameter within its
+    /// metadata range. Locked entries and `image`-typed entries are
+    /// preserved verbatim from `currentValues` (or the param default
+    /// when missing). Returns a new full values map. Hosts can
+    /// either feed it back via `currentValues` (editor pattern) or
+    /// push it through their write-back API (settings pattern).
+    function computeRandomized() {
+        var next = {
+        };
+        if (!root.parameters)
+            return next;
+
+        for (var i = 0; i < root.parameters.length; i++) {
+            var param = root.parameters[i];
+            if (!param || param.id === undefined)
+                continue;
+
+            if ((root.lockedParams && root.lockedParams[param.id] === true) || param.type === "image") {
+                next[param.id] = (root.currentValues && root.currentValues[param.id] !== undefined) ? root.currentValues[param.id] : param.default;
+                continue;
+            }
+            var value;
+            switch (param.type) {
+            case "float":
+                var minF = param.min !== undefined ? param.min : 0;
+                var maxF = param.max !== undefined ? param.max : 1;
+                value = minF + Math.random() * (maxF - minF);
+                if (param.step !== undefined && param.step > 0)
+                    value = Math.round(value / param.step) * param.step;
+
+                break;
+            case "int":
+                var minI = param.min !== undefined ? param.min : 0;
+                var maxI = param.max !== undefined ? param.max : 100;
+                value = Math.floor(minI + Math.random() * (maxI - minI + 1));
+                break;
+            case "bool":
+                value = Math.random() < 0.5;
+                break;
+            case "color":
+                var r = Math.floor(Math.random() * 256);
+                var g = Math.floor(Math.random() * 256);
+                var b = Math.floor(Math.random() * 256);
+                value = "#" + r.toString(16).padStart(2, "0") + g.toString(16).padStart(2, "0") + b.toString(16).padStart(2, "0");
+                break;
+            default:
+                value = param.default;
+                break;
+            }
+            if (value !== undefined)
+                next[param.id] = value;
+
+        }
+        return next;
+    }
+
     spacing: Kirigami.Units.smallSpacing
 
     // ── Toolbar (Lock-all / Randomize) ───────────────────────────────


### PR DESCRIPTION
## Summary

- Pull the parameter Lock-all and Randomize transforms into the shared `ShaderParameterEditor` as instance methods (`lockedAfterToggle`, `lockedAfterAllToggle`, `computeRandomized`). The editor dialog's ~80-line inline implementation collapses to three one-line wrappers, and the settings app's animation event card gains the same toolbar end-to-end without duplicating logic.
- Settings card now flips `enableLocking` / `enableRandomize` on, holds a per-card `lockedShaderParams` map (cleared whenever the assigned shader effect changes — a stale lock keyed by `seedX` from one shader's schema would otherwise pin a same-named-but-unrelated param in the next shader's schema across a switch), and routes randomize through a new `_writeAllShaderParams` so a roll lands as one `setShaderOverride` call instead of N.

## Test plan

- [ ] Editor: open Shader Settings on an effect with parameters; lock-toggle one param + Randomize repeatedly — locked param holds, others change, image-typed params hold their path.
- [ ] Editor: Lock-all toggles all parameters; Randomize then leaves them all untouched.
- [ ] Settings → Animations: pick an event with a shader effect (e.g. `osd.show`); the card now shows the Lock + Randomize toolbar.
- [ ] Settings: change params via Randomize → daemon picks up the new override (single round-trip via `_writeAllShaderParams`).
- [ ] Settings: switch the assigned effect → locked map clears, no stale-lock carry-over.
- [ ] Build clean; existing animation/shader test suites pass (verified locally — `test_layersurface` flake is pre-existing on `v3`).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)