### PR TITLE
fix(animations): boundary-mask off-window UV samples (10 shaders) + boundsPadding for broken-glass

### DIFF
--- a/data/animations/broken-glass/effect.frag
+++ b/data/animations/broken-glass/effect.frag
@@ -14,17 +14,23 @@
 // to BMW's). See bmw_compat.glsl header for the BMW-to-PlasmaZones
 // uniform-name remap.
 //
-// Note on actor scale: BMW grows the actor by 2x so shards can fly past
-// the original window bounds. PlasmaZones' runtime does not double the
-// quad, so the shard math produces `coords` outside [0, 1] for shards
-// in the outer half of the cascade. `bmw_compat.glsl`'s default
-// `getInputColor` only divides by alpha — it does NOT clip — so an
-// off-window sample on a clamp-to-edge `uTexture0` would smear edge
-// pixels (visible artefact for opaque-edged windows like terminals or
-// most app chrome). We therefore override `getInputColor` locally to
-// return `vec4(0.0)` outside [0, 1], matching the matrix.frag pattern
-// (matrix/effect.frag:196-205). The cascade still reads as a shatter;
-// shards beyond the window crop cleanly to transparent.
+// Note on actor scale: BMW grows the actor by 2x (ACTOR_SCALE=2.0,
+// PADDING=0.5) so shards can fly past the original window bounds. We
+// match that on PlasmaZones via the `boundsPadding` mechanism: metadata
+// declares `"boundsPadding": 0.5`, SurfaceAnimator expands the
+// shaderItem QUAD accordingly and writes the fraction into
+// customParams[7].x. The morph-style UV remap below converts the padded
+// vTexCoord back into anchor-space coords ∈ [-0.5, 1.5], which is
+// exactly what BMW's `iTexCoord*2 - 0.5` produced upstream.
+//
+// `bmw_compat.glsl`'s default `getInputColor` only divides by alpha —
+// it does NOT clip — so an off-window sample on a clamp-to-edge
+// `uTexture0` would smear edge pixels (visible artefact for opaque-
+// edged windows like terminals or most app chrome). We therefore
+// override `getInputColor` locally to return `vec4(0.0)` outside
+// [0, 1], matching the matrix.frag pattern (matrix/effect.frag:196-205).
+// The cascade still reads as a shatter; shards beyond the window crop
+// cleanly to transparent.
 
 #version 450
 
@@ -40,6 +46,15 @@ layout(location = 0) out vec4 fragColor;
 #define uShardScale customParams[0].x
 #define uBlowForce  customParams[0].y
 #define uGravity    customParams[0].z
+
+// Bounds-padding fraction supplied by SurfaceAnimator from
+// AnimationShaderEffect::boundsPadding (metadata.json `"boundsPadding": 0.5`).
+// See morph/effect.frag for the same contract — customParams[7].x is the
+// reserved structural slot. With boundsPadding=0.5 the UV remap below
+// produces anchorUv ∈ [-0.5, 1.5], reproducing BMW's `coords =
+// iTexCoord*ACTOR_SCALE - PADDING` (ACTOR_SCALE=2, PADDING=0.5) without
+// hardcoding the constants on the GLSL side.
+#define boundsPadding customParams[7].x
 
 // uSeed (BMW: per-leg `Math.random()`) is computed once at the top of
 // `main()` from `hash22(iSurfaceScreenPos.xy)` and bound to a local
@@ -58,8 +73,6 @@ layout(location = 0) out vec4 fragColor;
 #define uShardTexture uTexture1
 
 const float SHARD_LAYERS = 5.0;
-const float ACTOR_SCALE  = 2.0;
-const float PADDING      = ACTOR_SCALE / 2.0 - 0.5;
 
 // Local off-window-clipping variant of `bmw_compat.glsl`'s
 // `getInputColor`. The shim's default samples uTexture0 directly,
@@ -90,10 +103,13 @@ void main() {
   // Draw the individual shard layers.
   for (float i = 0.0; i < SHARD_LAYERS; ++i) {
 
-    // To enable drawing shards outside of the window bounds, the actor was scaled
-    // by ACTOR_SCALE. Here we scale and move the texture coordinates so that the
-    // window gets drawn at the correct position again.
-    vec2 coords = iTexCoord.st * ACTOR_SCALE - PADDING;
+    // To enable drawing shards outside of the window bounds, SurfaceAnimator
+    // expands the shaderItem QUAD by `boundsPadding` (metadata.json: 0.5).
+    // Here we remap the padded vTexCoord back into anchor-space so the
+    // window gets drawn at the correct position; coords ∈ [-pad, 1+pad]
+    // reproduces BMW's `iTexCoord * ACTOR_SCALE - PADDING` for pad=0.5.
+    float k = 1.0 + 2.0 * boundsPadding;
+    vec2 coords = iTexCoord.st * k - boundsPadding;
 
     // Scale and rotate around our epicenter.
     coords -= uEpicenter;

--- a/data/animations/broken-glass/metadata.json
+++ b/data/animations/broken-glass/metadata.json
@@ -6,6 +6,7 @@
     "version": "1.0",
     "category": "Particle",
     "fragmentShader": "effect.frag",
+    "boundsPadding": 0.5,
     "parameters": [
         {
             "id": "uShardScale",

--- a/data/animations/fade/effect.frag
+++ b/data/animations/fade/effect.frag
@@ -53,7 +53,18 @@ void main() {
         float scale = mix(1.0, 1.0 - scaleAmount, p);
         vec2 scaled_uv = (uv - center) / scale + center;
 
-        vec4 color = texture(uTexture0, scaled_uv);
+        // Soft inside-mask. With scale < 1 the inverse-scaled UVs reach
+        // beyond [0, 1] at boundary fragments (default scaleAmount=0.05
+        // → scaled_uv ∈ ~[-0.026, 1.026] at corners), and `uTexture0` is
+        // clamp-to-edge — the typical edge alpha is 0 (window shadow /
+        // rounded corners) so samples beyond the surface produce a
+        // grey-transparent border. Fade to zero across a tight 0.005-wide
+        // band at each edge so the scaled silhouette crops cleanly. Same
+        // pattern as morph/plasma-flow.
+        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), scaled_uv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), scaled_uv);
+        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+        vec4 color = texture(uTexture0, scaled_uv) * mask;
 
         float alpha = smoothstep(1.0 - revealStart, 1.0 - revealEnd, p);
 
@@ -68,7 +79,18 @@ void main() {
         float scale = mix(1.0 - scaleAmount, 1.0, p);
         vec2 scaled_uv = (uv - center) / scale + center;
 
-        vec4 color = texture(uTexture0, scaled_uv);
+        // Soft inside-mask. With scale < 1 the inverse-scaled UVs reach
+        // beyond [0, 1] at boundary fragments (default scaleAmount=0.05
+        // → scaled_uv ∈ ~[-0.026, 1.026] at corners), and `uTexture0` is
+        // clamp-to-edge — the typical edge alpha is 0 (window shadow /
+        // rounded corners) so samples beyond the surface produce a
+        // grey-transparent border. Fade to zero across a tight 0.005-wide
+        // band at each edge so the scaled silhouette crops cleanly. Same
+        // pattern as morph/plasma-flow.
+        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), scaled_uv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), scaled_uv);
+        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+        vec4 color = texture(uTexture0, scaled_uv) * mask;
 
         float alpha = smoothstep(revealStart, revealEnd, p);
 

--- a/data/animations/focus/effect.frag
+++ b/data/animations/focus/effect.frag
@@ -51,14 +51,27 @@ float easeInOutSine(float t) {
   return -0.5 * (cos(3.141592653589793 * t) - 1.0);
 }
 
-// BMW common.glsl verbatim — radial Poisson-style blur. Samples in
+// BMW common.glsl — radial Poisson-style blur. Samples in
 // `directions` evenly-spaced angles around a circle, each with
 // `samples` taps along the radius (intensity-weighted toward the
 // centre). `uSize` is supplied by `<bmw_compat.glsl>` and converts
 // the pixel-space `radius` into texCoord space.
+//
+// PlasmaZones tweak vs upstream: BMW divides the accumulator by the
+// fixed total tap count (`samples * directions`). On the daemon /
+// kwin-effect path `uTexture0` is a finite, non-tiling surface; taps
+// whose `uv + offset` falls outside [0, 1] return either clamp-to-edge
+// or transparent. Either way, including those taps in the average
+// dims the visible blur near the surface boundary (the reported
+// "edges fade out" artefact at default uBlurAmount=50). We instead
+// accumulate a `weight` that counts only the in-bounds taps and
+// normalise by that — equivalent to BMW upstream when the entire
+// blur kernel lies inside the window, and a clean reconstruction
+// when it doesn't.
 vec4 getBlurredInputColor(vec2 uv, float radius, float samples) {
   // Initialize the color accumulator to zero.
   vec4 color = vec4(0.0);
+  float weight = 0.0;
 
   // Define a constant for 2 * PI (tau), which represents a full circle in radians.
   const float tau = 6.28318530718;
@@ -74,14 +87,23 @@ vec4 getBlurredInputColor(vec2 uv, float radius, float samples) {
       // The (1.0 - s) term ensures more sampling occurs closer to the center.
       vec2 offset = vec2(cos(d), sin(d)) * radius * (1.0 - s) / uSize;
 
-      // Add the sampled color at the offset position to the accumulator.
-      color += getInputColor(uv + offset);
+      // Add the sampled color at the offset position to the accumulator,
+      // but only count the tap toward the average if it lies inside the
+      // surface's [0, 1] uv range — see header note above.
+      vec2 sampleUv = uv + offset;
+      if (sampleUv.x >= 0.0 && sampleUv.x <= 1.0 &&
+          sampleUv.y >= 0.0 && sampleUv.y <= 1.0) {
+        color += getInputColor(sampleUv);
+        weight += 1.0;
+      }
     }
   }
 
-  // Normalize the accumulated color by dividing by the total number of samples
-  // and directions to ensure the result is averaged.
-  return color / samples / directions;
+  // Normalize the accumulated color by the in-bounds tap count so an
+  // off-window kernel doesn't dim the result toward zero. `max(weight, 1.0)`
+  // guards against the (geometrically impossible at radius >= 0) zero-tap
+  // case so the divide can't produce a NaN.
+  return color / max(weight, 1.0);
 }
 
 void main() {

--- a/data/animations/glide/effect.frag
+++ b/data/animations/glide/effect.frag
@@ -60,7 +60,19 @@ void main() {
   // Move texture coordinate center to corner again.
   coords = coords * 0.5 + 0.5;
 
-  vec4 oColor = getInputColor(coords);
+  // Boundary mask: with default uScale=0.95 (and uSquish/uTilt non-zero),
+  // the inverse-warped sample UV at corner fragments lands ~5% past the
+  // [0,1] bounds. A clamp-to-edge sample would smear the edge column/row
+  // outward — visible as a dim border + perceived 5% shrink of the
+  // surface. Crop cleanly to transparent across the [0,1] edge with a
+  // narrow smoothstep band (same pattern as morph/effect.frag), so the
+  // warped silhouette stays the size BMW intended without altering the
+  // scale/squish/tilt motion math.
+  vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), coords);
+  vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), coords);
+  float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+
+  vec4 oColor = getInputColor(coords) * mask;
 
   // Dissolve window.
   oColor.a = oColor.a * (uForOpening ? uProgress : pow(1.0 - uProgress, 2.0));

--- a/data/animations/inkwell-drop/effect.frag
+++ b/data/animations/inkwell-drop/effect.frag
@@ -45,9 +45,20 @@ void main() {
     float ring3 = sin((d - front + 0.16) * 80.0) * exp(-abs(d - front + 0.16) * 10.0) * 0.4;
     float ripple = (ring1 + ring2 + ring3) * rippleStrength * (1.0 - p * 0.5);
     vec2 dir = (d > 0.001) ? normalize(c) : vec2(0.0);
-    vec2 distorted = clamp(uv + dir * ripple, vec2(0.0), vec2(1.0));
+    vec2 distorted = uv + dir * ripple;
 
-    vec4 win = texture(uTexture0, distorted);
+    // Soft inside-mask. The ripple above pushes UVs past [0, 1] at boundary
+    // fragments, and `uTexture0` is clamp-to-edge — the typical edge alpha
+    // is 0 (window shadow / rounded corners) so samples beyond the surface
+    // produce a grey-transparent border. The previous hard clamp pulled the
+    // same edge texel for every off-surface fragment, which still smeared
+    // the transparent edge. Fade to zero across a tight 0.005-wide band at
+    // each edge so the rippled silhouette crops cleanly. Same pattern as
+    // morph/plasma-flow.
+    vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), distorted);
+    vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), distorted);
+    float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+    vec4 win = texture(uTexture0, distorted) * mask;
 
     float reveal = smoothstep(0.05, -0.02, d - front);
     vec4 mixed = win * reveal;

--- a/data/animations/plasma-flow/effect.frag
+++ b/data/animations/plasma-flow/effect.frag
@@ -52,7 +52,17 @@ void main() {
     float intensity = sin(p * 3.14159) * plasmaIntensity;
     vec2 distorted = uv + flow * intensity;
 
-    vec4 win = texture(uTexture0, distorted);
+    // Soft inside-mask. The distortion above pushes UVs slightly past
+    // [0, 1] at boundary fragments (default intensity ±0.09 at peak),
+    // and `uTexture0` is clamp-to-edge — the typical edge alpha is 0
+    // (window shadow / rounded corners) so samples beyond the surface
+    // produce a grey-transparent border. Fade to zero across a tight
+    // 0.005-wide band at each edge so the warped silhouette crops
+    // cleanly without smearing edge pixels. Same pattern as morph.
+    vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), distorted);
+    vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), distorted);
+    float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+    vec4 win = texture(uTexture0, distorted) * mask;
 
     float reveal = smoothstep(0.2, 0.8, p);
     fragColor = win * reveal;

--- a/data/animations/ripple/effect.frag
+++ b/data/animations/ripple/effect.frag
@@ -51,7 +51,16 @@ void main() {
         vec2 offset = dir * (sin(p * dist * rippleAmplitude - p * rippleSpeed + seed) + 0.5) / 30.0;
 
         vec2 wuv = uv + offset * intensity;
-        vec4 color = texture(uTexture0, wuv);
+        // Soft inside-mask. The displacement above pushes UVs slightly past
+        // [0, 1] at boundary fragments, and `uTexture0` is clamp-to-edge —
+        // the typical edge alpha is 0 (window shadow / rounded corners) so
+        // samples beyond the surface produce a grey-transparent border.
+        // Fade to zero across a tight 0.005-wide band at each edge so the
+        // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
+        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), wuv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), wuv);
+        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+        vec4 color = texture(uTexture0, wuv) * mask;
 
         float alpha = smoothstep(1.0, 0.5, p);
         result = color * alpha;
@@ -71,7 +80,16 @@ void main() {
         vec2 offset = dir * (sin(p * dist * rippleAmplitude - p * rippleSpeed + seed) + 0.5) / 30.0;
 
         vec2 wuv = uv + offset * intensity;
-        vec4 color = texture(uTexture0, wuv);
+        // Soft inside-mask. The displacement above pushes UVs slightly past
+        // [0, 1] at boundary fragments, and `uTexture0` is clamp-to-edge —
+        // the typical edge alpha is 0 (window shadow / rounded corners) so
+        // samples beyond the surface produce a grey-transparent border.
+        // Fade to zero across a tight 0.005-wide band at each edge so the
+        // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
+        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), wuv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), wuv);
+        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+        vec4 color = texture(uTexture0, wuv) * mask;
 
         float alpha = smoothstep(0.0, 0.3, p);
         result = color * alpha;

--- a/data/animations/smoke/effect.frag
+++ b/data/animations/smoke/effect.frag
@@ -104,7 +104,16 @@ void main() {
                        sm_fbm(uv * 2.0 + 4.0 * wq + vec2(8.3, 2.8)));
         vec2 warped_uv = uv + (wr - 0.5) * distort_strength;
 
-        vec4 color = texture(uTexture0, warped_uv);
+        // Soft inside-mask. The distortion above pushes UVs slightly past
+        // [0, 1] at boundary fragments, and `uTexture0` is clamp-to-edge —
+        // the typical edge alpha is 0 (window shadow / rounded corners) so
+        // samples beyond the surface produce a grey-transparent border.
+        // Fade to zero across a tight 0.005-wide band at each edge so the
+        // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
+        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), warped_uv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), warped_uv);
+        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+        vec4 color = texture(uTexture0, warped_uv) * mask;
 
         float tail = smoothstep(1.0, 0.8, p);
         result = color * remain * tail;
@@ -131,7 +140,16 @@ void main() {
                        sm_fbm(uv * 2.0 + 4.0 * wq + vec2(8.3, 2.8)));
         vec2 warped_uv = uv + (wr - 0.5) * distort_strength;
 
-        vec4 color = texture(uTexture0, warped_uv);
+        // Soft inside-mask. The distortion above pushes UVs slightly past
+        // [0, 1] at boundary fragments, and `uTexture0` is clamp-to-edge —
+        // the typical edge alpha is 0 (window shadow / rounded corners) so
+        // samples beyond the surface produce a grey-transparent border.
+        // Fade to zero across a tight 0.005-wide band at each edge so the
+        // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
+        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), warped_uv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), warped_uv);
+        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+        vec4 color = texture(uTexture0, warped_uv) * mask;
 
         result = color * reveal;
     }

--- a/data/animations/snap/effect.frag
+++ b/data/animations/snap/effect.frag
@@ -75,7 +75,18 @@ void main() {
             float converge = t * 0.92;
             vec2 sample_uv = (uv - layer_target * converge) / (1.0 - converge);
 
-            vec4 color = texture(uTexture0, sample_uv);
+            // Boundary mask — at peak `converge=0.92` the divide stretches
+            // sample_uv up to 12.5×, easily reaching off-window pixels
+            // (rounded corners, shadows) which sample as alpha=0. That makes
+            // the layer's contribution vanish exactly where it should be
+            // visible. Same soft-mask pattern morph/effect.frag uses to fade
+            // out-of-bounds samples to transparent without a hard 1-texel
+            // discontinuity.
+            vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), sample_uv);
+            vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), sample_uv);
+            float boundsMask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+
+            vec4 color = texture(uTexture0, sample_uv) * boundsMask;
 
             float belongs = step(abs(pixel_layer - layer), 0.5);
             inner += color * belongs * layer_alpha;
@@ -115,7 +126,13 @@ void main() {
             float converge = t * 0.92;
             vec2 sample_uv = (uv - layer_target * converge) / (1.0 - converge);
 
-            vec4 color = texture(uTexture0, sample_uv);
+            // Boundary mask — see close-leg branch above for rationale.
+            // Same divide produces the same UV stretch on the open leg.
+            vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), sample_uv);
+            vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), sample_uv);
+            float boundsMask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+
+            vec4 color = texture(uTexture0, sample_uv) * boundsMask;
 
             float belongs = step(abs(pixel_layer - layer), 0.5);
             inner += color * belongs * layer_alpha;

--- a/data/animations/soft-warp-fade/effect.frag
+++ b/data/animations/soft-warp-fade/effect.frag
@@ -55,7 +55,16 @@ void main() {
     ) - 0.5;
     vec2 warped = uv + warp * strength;
 
-    vec4 win = texture(uTexture0, warped);
+    // Soft inside-mask. The warp above pushes UVs slightly past [0, 1] at
+    // boundary fragments, and `uTexture0` is clamp-to-edge — the typical
+    // edge alpha is 0 (window shadow / rounded corners) so samples beyond
+    // the surface produce a grey-transparent border. Fade to zero across
+    // a tight 0.005-wide band at each edge so the warped silhouette crops
+    // cleanly. Same pattern as morph/plasma-flow.
+    vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), warped);
+    vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), warped);
+    float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
+    vec4 win = texture(uTexture0, warped) * mask;
 
     float t = smoothstep(0.05, 0.95, p);
     t = t * t * (3.0 - 2.0 * t);

--- a/data/animations/tv-glitch/effect.frag
+++ b/data/animations/tv-glitch/effect.frag
@@ -58,6 +58,19 @@ float hash12(vec2 p) {
     return fract((p3.x + p3.y) * p3.z);
 }
 
+// Local off-window-clipping variant of `bmw_compat.glsl`'s `getInputColor`.
+// The y-rescale and x-displacement below push sample coords outside [0, 1]
+// at boundary fragments, and `uTexture0` is clamp-to-edge — the typical
+// edge alpha is 0 (window shadow / rounded corners) so samples beyond the
+// surface produce a grey-transparent border. Returning vec4(0.0) outside
+// [0, 1] crops cleanly to transparent. Same pattern as broken-glass.
+vec4 getClippedInputColor(vec2 coords) {
+    if (coords.x < 0.0 || coords.x > 1.0 || coords.y < 0.0 || coords.y > 1.0) {
+        return vec4(0.0);
+    }
+    return getInputColor(coords);
+}
+
 const float BLUR_WIDTH = 0.01;  // Width of the gradients.
 const float TB_TIME    = 0.7;   // Relative time for the top/bottom animation.
 const float LR_TIME    = 0.4;   // Relative time for the left/right animation.
@@ -92,7 +105,7 @@ void main() {
 
   // Apply the noise as x displacement for every line.
   float xPos  = clamp(coords.x - displace * noise * noise, 0.0, 1.0);
-  vec4 oColor = getInputColor(vec2(xPos, coords.y));
+  vec4 oColor = getClippedInputColor(vec2(xPos, coords.y));
 
   // Mix in some random interference lines.
   vec3 interference          = uColor.rgb * hash12(vec2(yPos * time));
@@ -111,8 +124,8 @@ void main() {
 
   // Shift green/blue channels.
   float offset = 0.1 * noise * displace;
-  oColor.g     = mix(oColor.g, getInputColor(vec2(xPos + offset, coords.y)).g, 0.25);
-  oColor.b     = mix(oColor.b, getInputColor(vec2(xPos - offset, coords.y)).b, 0.25);
+  oColor.g     = mix(oColor.g, getClippedInputColor(vec2(xPos + offset, coords.y)).g, 0.25);
+  oColor.b     = mix(oColor.b, getClippedInputColor(vec2(xPos - offset, coords.y)).b, 0.25);
 
   // Now hide the window according to the TV effect.
 


### PR DESCRIPTION
## Summary

User reported visible bugs across many animation shaders:
- **"Grey/transparent border around the distortion"** on plasma-flow, ripple, fade, soft-warp-fade, tv-glitch, inkwell-drop, smoke.
- **"Surface gets small"** on broken-glass.
- **"Blur dims at edges"** (described as part of the same complaint) on focus.
- **"Can't tell what snap is supposed to do"** — entire effect rendered mostly invisible.
- **glide** — perceived shrink during animation.
- **fire reverse** + **pixelate** investigated but no concrete bug identified; need visual reproduction.

## Root causes

### Off-window UV samples (8 shaders)
Each shader displaces `sample_uv` past `[0, 1]` at boundary fragments. `uTexture0` is clamp-to-edge, but window edges typically carry `alpha = 0` (rounded corners, drop shadows). Off-window samples smear transparent pixels into the rendered output — visible as a grey border tracking the warped silhouette.

### broken-glass shrink
Uses BMW's `ACTOR_SCALE = 2.0; PADDING = 0.5;` math that assumes the renderer doubles the actor's quad. PlasmaZones' SurfaceAnimator does **not** double the quad — at the start of the leg, `coords = iTexCoord * 2 - 0.5` lands outside `[0, 1]` for most fragments and `getClippedInputColor` correctly returns `vec4(0)`, making the surface visibly shrink.

### focus edge-dim
Multi-tap blur drifts outside `[0, 1]` at default `uBlurAmount=50` on small surfaces. Off-window taps get `alpha=0` from the transparent-edge clamp, dim-averaging into the result and pulling brightness off the visible content near the surface boundary.

## Fixes

**Boundary-mask pattern** (already in `morph.frag` + recently-added to `plasma-flow.frag`):
```glsl
vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), sample_uv);
vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), sample_uv);
float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
vec4 color = texture(uTexture0, sample_uv) * mask;
```

Applied to: **ripple, fade, smoke, snap** (all four in BOTH `iIsReversed` branches); **soft-warp-fade, plasma-flow, glide**; **inkwell-drop** (replaced its prior hard `clamp(uv, 0, 1)` which still smeared transparent edge texels via clamp-to-edge); **tv-glitch** (added a local `getClippedInputColor` helper since bmw_compat owns the unmasked `getInputColor`).

**broken-glass — boundsPadding**: switched from hardcoded `ACTOR_SCALE = 2.0` to PlasmaZones' `boundsPadding` mechanic. metadata.json now declares `"boundsPadding": 0.5`; SurfaceAnimator expands the shaderItem quad, the fragment remaps `coords = iTexCoord * (1 + 2*pad) - pad` (same math BMW intended). The shard cascade flies past the original window bounds without the surface shrinking. `getClippedInputColor` clip preserved.

**focus — weighted-blur accumulation**: refactored `getBlurredInputColor` from fixed-divisor average (`color / samples / directions`) to weighted accumulation. Each tap contributes `1.0` to a `weight` accumulator only if its sampleUv is in `[0, 1]`; final divide is `color / max(weight, 1.0)`. Off-window taps no longer dim visible content near the surface boundary.

## Investigated, no code change

- **fire** — traced close-leg math at concrete iTime values. The `if (uForOpening) windowMask = 1.0 - windowMask` flip is correctly oriented under bmw_compat's `uForOpening = (iIsReversed == 0)` mapping. Both runtimes (kwin-effect + daemon RHI) converge on Y=0-at-top vTexCoord. Math correct in both legs; user report needs visual reproduction to localise a concrete bug.
- **pixelate** — body matches its description, no off-window asymmetry, no direction inversion. Math correct; needs visual reproduction.

## Test plan
- [x] `cmake --build build --parallel` clean build
- [x] `test_animation_shader_bake` — all 54 shaders bake clean
- [x] `test_animation_shader_param_wiring` — green
- [x] Full ctest suite — 175/175 passing
- [ ] Visual confirmation that the grey-border / shrink artifacts are gone on the affected shaders

## Files changed (12)

`broken-glass/effect.frag` + `metadata.json`, `fade/effect.frag`, `focus/effect.frag`, `glide/effect.frag`, `inkwell-drop/effect.frag`, `plasma-flow/effect.frag`, `ripple/effect.frag`, `smoke/effect.frag`, `snap/effect.frag`, `soft-warp-fade/effect.frag`, `tv-glitch/effect.frag`. +208 / −39.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)