### PR TITLE
Fixes: daemon state cleanup, screen IDs cache and lookup, shader path…

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -101,6 +101,8 @@ public:
     PlasmaZonesEffect();
     ~PlasmaZonesEffect() override;
 
+    void clearDaemonCompositorState();
+
     // Effect metadata
     static bool supported();
     static bool enabledByDefault();

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -597,6 +597,26 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     qCInfo(lcEffect) << "initialized: C++ effect with D-Bus support and mouseChanged connection";
 }
 
+void PlasmaZonesEffect::clearDaemonCompositorState()
+{
+    qCInfo(lcEffect) << "Clearing daemon compositor drag/overlay state before effect shutdown";
+
+    auto sendNoReply = [](const QString& interfaceName, const QString& methodName) {
+        QDBusMessage msg = QDBusMessage::createMethodCall(
+            PhosphorProtocol::Service::Name,
+            PhosphorProtocol::Service::ObjectPath,
+            interfaceName,
+            methodName);
+        QDBusConnection::sessionBus().send(msg);
+    };
+
+    sendNoReply(PhosphorProtocol::Service::Interface::WindowDrag,
+                QStringLiteral("clearForCompositorReconnect"));
+
+    sendNoReply(PhosphorProtocol::Service::Interface::Overlay,
+                QStringLiteral("hideOverlay"));
+}
+
 PlasmaZonesEffect::~PlasmaZonesEffect()
 {
     // Sever the registry's `effectsChanged` connection BEFORE anything
@@ -627,6 +647,10 @@ PlasmaZonesEffect::~PlasmaZonesEffect()
     // not raced against member destruction.
     m_shaderManager.m_textureLoaderPool.waitForDone();
     m_shaderManager.m_textureLoadsInFlight.clear();
+
+    // Clear daemon-side drag/overlay state while the effect is still alive,
+    // but only after the destructor's local UAF-prevention guards have run.
+    clearDaemonCompositorState();
 
     // Restore borderless and monocle-maximized windows so they recover properly.
     // Guard against compositor teardown — effects may outlive the stacking order.

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -603,18 +603,13 @@ void PlasmaZonesEffect::clearDaemonCompositorState()
 
     auto sendNoReply = [](const QString& interfaceName, const QString& methodName) {
         QDBusMessage msg = QDBusMessage::createMethodCall(
-            PhosphorProtocol::Service::Name,
-            PhosphorProtocol::Service::ObjectPath,
-            interfaceName,
-            methodName);
+            PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath, interfaceName, methodName);
         QDBusConnection::sessionBus().send(msg);
     };
 
-    sendNoReply(PhosphorProtocol::Service::Interface::WindowDrag,
-                QStringLiteral("clearForCompositorReconnect"));
+    sendNoReply(PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("clearForCompositorReconnect"));
 
-    sendNoReply(PhosphorProtocol::Service::Interface::Overlay,
-                QStringLiteral("hideOverlay"));
+    sendNoReply(PhosphorProtocol::Service::Interface::Overlay, QStringLiteral("hideOverlay"));
 }
 
 PlasmaZonesEffect::~PlasmaZonesEffect()

--- a/libs/phosphor-screens/src/manager.cpp
+++ b/libs/phosphor-screens/src/manager.cpp
@@ -74,6 +74,11 @@ void ScreenManager::start()
         }
     }
 
+    // Initial population changes the effective screen set. Ensure the first
+    // effectiveScreenIds() call after start() rebuilds instead of returning a
+    // stale empty cache.
+    m_effectiveScreenIdsDirty = true;
+
     if (m_cfg.panelSource) {
         connect(m_cfg.panelSource, &IPanelSource::panelOffsetsChanged, this, &ScreenManager::onPanelOffsetsChanged);
         connect(m_cfg.panelSource, &IPanelSource::requeryCompleted, this, &ScreenManager::onPanelRequeryCompleted);

--- a/libs/phosphor-screens/src/manager_virtualscreens.cpp
+++ b/libs/phosphor-screens/src/manager_virtualscreens.cpp
@@ -172,6 +172,7 @@ void ScreenManager::refreshVirtualConfigs(const QHash<QString, VirtualScreenConf
 QStringList ScreenManager::effectiveScreenIds() const
 {
     PS_SCREEN_MANAGER_ASSERT_GUI_THREAD();
+
     if (!m_effectiveScreenIdsDirty) {
         return m_cachedEffectiveScreenIds;
     }

--- a/libs/phosphor-screens/src/screenidentity.cpp
+++ b/libs/phosphor-screens/src/screenidentity.cpp
@@ -209,13 +209,16 @@ QScreen* findByIdOrName(const QString& identifier)
         cache.remove(physId);
     }
 
-    // Exact screen ID match (only if it looks like an EDID-style ID).
-    if (physId.contains(QLatin1Char(':'))) {
-        for (QScreen* screen : QGuiApplication::screens()) {
-            if (identifierFor(screen) == physId) {
-                cache.insert(physId, screen);
-                return screen;
-            }
+    // Exact canonical screen ID match.
+    // Use physId, not the raw identifier, because virtual-screen IDs have
+    // already been reduced to their physical parent above.
+    for (QScreen* screen : QGuiApplication::screens()) {
+        if (!screen)
+            continue;
+
+        if (identifierFor(screen) == physId) {
+            cache.insert(physId, screen);
+            return screen;
         }
     }
 
@@ -256,9 +259,13 @@ QScreen* findByIdOrName(const QString& identifier)
     // Reverse fallback: stored config has bare base ID without suffix,
     // but currently-connected monitors are duplicates (so identifierFor
     // adds suffix). Match by base part of current screens.
-    if (identifier.contains(QLatin1Char(':')) && !identifier.contains(QLatin1Char('/'))) {
+    if (physId.contains(QLatin1Char(':')) && !physId.contains(QLatin1Char('/'))) {
         for (QScreen* screen : QGuiApplication::screens()) {
-            if (baseIdentifierFor(screen) == identifier) {
+            if (!screen)
+                continue;
+
+            if (baseIdentifierFor(screen) == physId) {
+                cache.insert(physId, screen);
                 return screen;
             }
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -312,6 +312,8 @@ set(plasmazones_rendering_SRCS
 
 add_library(plasmazones_rendering SHARED ${plasmazones_rendering_SRCS})
 
+set_target_properties(plasmazones_rendering PROPERTIES UNITY_BUILD OFF)
+
 generate_export_header(plasmazones_rendering
     EXPORT_FILE_NAME plasmazones_rendering_export.h
     EXPORT_MACRO_NAME PLASMAZONES_RENDERING_EXPORT

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -312,8 +312,6 @@ set(plasmazones_rendering_SRCS
 
 add_library(plasmazones_rendering SHARED ${plasmazones_rendering_SRCS})
 
-set_target_properties(plasmazones_rendering PROPERTIES UNITY_BUILD OFF)
-
 generate_export_header(plasmazones_rendering
     EXPORT_FILE_NAME plasmazones_rendering_export.h
     EXPORT_MACRO_NAME PLASMAZONES_RENDERING_EXPORT

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -837,9 +837,21 @@ void OverlayService::assertWindowOnScreen(QWindow* window, QScreen* screen, cons
 
 void OverlayService::handleScreenAdded(QScreen* screen)
 {
-    if (!m_visible || !screen) {
+    if (!screen) {
         return;
     }
+
+    // Always attempt to recreate overlay windows for reconnected screens,
+    // even when m_visible is false. This handles monitor power-cycle recovery:
+    // screenRemoved clears m_notificationCreationFailed sentinels, so when the
+    // screen comes back we must retry shell creation. If m_visible is true the
+    // existing path also shows the overlay; if false we just ensure the
+    // windows exist so the next showAtPosition call finds them ready.
+    const bool wasVisible = m_visible;
+    if (!wasVisible) {
+        m_visible = true; // transient — initializeOverlay may set it false again
+    }
+
     const QString physScreenId = Phosphor::Screens::ScreenIdentity::identifierFor(screen);
 
     auto* mgr = m_screenManager;
@@ -877,6 +889,13 @@ void OverlayService::handleScreenAdded(QScreen* screen)
                 }
             }
         }
+    }
+
+    // Restore m_visible if the caller wasn't already in a visible state and
+    // no overlay windows were actually created (transport unavailable, etc.).
+    if (!wasVisible && !m_visible) {
+        qCDebug(lcOverlay) << "handleScreenAdded: no overlay windows created for" << physScreenId
+                           << "— transport may be unavailable";
     }
 }
 

--- a/src/daemon/overlayservice/osd.cpp
+++ b/src/daemon/overlayservice/osd.cpp
@@ -545,15 +545,20 @@ OverlayService::PerScreenOverlayState* OverlayService::ensurePassiveShellFor(con
 void OverlayService::warmUpNotifications()
 {
     const QStringList effectiveIds = (m_screenManager ? m_screenManager->effectiveScreenIds() : QStringList());
+    int createdCount = 0;
     for (const QString& sid : effectiveIds) {
         QScreen* physScreen =
             m_screenManager ? m_screenManager->physicalQScreenFor(sid) : Utils::findScreenAtPosition(QPoint(0, 0));
         if (physScreen) {
-            ensureNotificationWindowFor(sid, physScreen);
+            auto* state = ensureNotificationWindowFor(sid, physScreen);
+            if (state && state->passiveShellSurface) {
+                ++createdCount;
+            }
         }
     }
     m_notificationsWarmed = true;
-    qCInfo(lcOverlay) << "Pre-warmed NotificationOverlay windows for" << effectiveIds.size() << "effective screens";
+    qCInfo(lcOverlay) << "Pre-warmed NotificationOverlay windows for" << createdCount << "of"
+                      << effectiveIds.size() << "effective screens";
     ensureOsdScreenAddedConnected();
 }
 

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -51,8 +51,6 @@ void OverlayService::initializeOverlay(QScreen* cursorScreen, const QPoint& curs
     // Determine if we should show on all monitors (cursorScreen == nullptr means all)
     const bool showOnAllMonitors = (cursorScreen == nullptr);
 
-    m_visible = true;
-
     // Initialize shader timing (shared across all monitors for synchronized effects)
     // Only start timer if invalid - preserves iTime across show/hide for less predictable animations
     ensureShaderTimerStarted(m_shaderTimer, m_shaderTimerMutex, m_lastFrameTime, m_frameCount);
@@ -233,6 +231,28 @@ void OverlayService::initializeOverlay(QScreen* cursorScreen, const QPoint& curs
     }
 
     validateScreenStateInvariant(targetIds);
+
+    // Count how many overlay windows actually have a live shell surface.
+    // If zero, the transport (phosphorwayland) is unavailable and we must
+    // not mark ourselves visible — the caller (e.g. prepareHandlerContext)
+    // will retry on the next drag tick, and handleScreenAdded will also
+    // attempt recreation on screen reconnection.
+    int liveOverlayCount = 0;
+    for (const auto& state : m_screenStates) {
+        if (state.overlayPhysScreen && state.passiveShellWindow) {
+            ++liveOverlayCount;
+        }
+    }
+
+    if (liveOverlayCount == 0) {
+        qCWarning(lcOverlay) << "initializeOverlay: no overlay windows created — "
+                                "phosphorwayland transport unavailable "
+                                "(overlays disabled on this screen)";
+        m_visible = false;
+        return;
+    }
+
+    m_visible = true;
 
     if (anyScreenUsesShader()) {
         updateZonesForAllWindows(); // Push initial zone data
@@ -499,10 +519,22 @@ void OverlayService::dismissOverlayWindow(const QString& screenId)
 {
     auto it = m_screenStates.find(screenId);
     if (it == m_screenStates.end()) {
+        qCDebug(lcOverlay) << "dismissOverlayWindow: no state for" << screenId;
         return;
     }
     auto* slot = it->passiveShellMainOverlaySlot;
     if (!slot) {
+        qCDebug(lcOverlay) << "dismissOverlayWindow: no slot for" << screenId
+                           << "(shell creation may have failed)";
+        // Clean up partial state even when slot is null — the shell
+        // surface may never have been created (transport unavailable),
+        // but we still need to clear the sentinels so a later recreate
+        // doesn't think a stale entry is live.
+        QObject::disconnect(it->overlayGeomConnection);
+        it->overlayGeomConnection = {};
+        it->overlayPhysScreen = nullptr;
+        it->overlayGeometry = QRect();
+        it->labelsTextureHash = 0;
         return;
     }
     // Post-shell-migration: there's no separate wl_surface to destroy.
@@ -715,11 +747,13 @@ QMetaObject::Connection OverlayService::installOverlayGeometryWatcher(QScreen* p
 void OverlayService::destroyOverlayWindow(QScreen* screen)
 {
     const QString screenId = Phosphor::Screens::ScreenIdentity::identifierFor(screen);
+    qCDebug(lcOverlay) << "destroyOverlayWindow:" << screenId;
     destroyOverlayWindow(screenId);
 }
 
 void OverlayService::destroyOverlayWindow(const QString& screenId)
 {
+    qCDebug(lcOverlay) << "destroyOverlayWindow:" << screenId;
     auto it = m_screenStates.find(screenId);
     if (it == m_screenStates.end()) {
         return;

--- a/src/daemon/plasmazones.service.in
+++ b/src/daemon/plasmazones.service.in
@@ -10,6 +10,8 @@ ExecStart=@KDE_INSTALL_FULL_BINDIR@/plasmazonesd
 Restart=on-failure
 RestartSec=5
 Slice=session.slice
+Environment=QT_PLUGIN_PATH=@KDE_INSTALL_FULL_LIBDIR@/qt6/plugins
+Environment=LD_LIBRARY_PATH=@KDE_INSTALL_FULL_LIBDIR@
 
 [Install]
 WantedBy=plasma-workspace.target

--- a/src/daemon/rendering/zoneshadernoderhi.cpp
+++ b/src/daemon/rendering/zoneshadernoderhi.cpp
@@ -9,22 +9,20 @@
 #include <QFileInfo>
 #include <QStandardPaths>
 
-namespace {
-
-void appendUniquePath(QStringList& paths, const QString& path)
+inline void appendUniquePath(QStringList& paths, const QString& path)
 {
     if (!path.isEmpty() && QDir(path).exists() && !paths.contains(path)) {
         paths.append(path);
     }
 }
 
-QStringList trustedShaderRoots()
+inline QStringList trustedShaderRoots()
 {
     return QStandardPaths::locateAll(QStandardPaths::GenericDataLocation, QStringLiteral("plasmazones/shaders"),
                                      QStandardPaths::LocateDirectory);
 }
 
-QStringList expandShaderIncludePaths(const QStringList& inputPaths)
+inline QStringList expandShaderIncludePaths(const QStringList& inputPaths)
 {
     QStringList expanded;
 
@@ -47,8 +45,6 @@ QStringList expandShaderIncludePaths(const QStringList& inputPaths)
 
     return expanded;
 }
-
-} // namespace
 
 namespace PlasmaZones {
 

--- a/src/daemon/rendering/zoneshadernoderhi.cpp
+++ b/src/daemon/rendering/zoneshadernoderhi.cpp
@@ -5,7 +5,50 @@
 
 #include <PhosphorRendering/ShaderCompiler.h>
 
+#include <QDir>
+#include <QFileInfo>
 #include <QStandardPaths>
+
+namespace {
+
+void appendUniquePath(QStringList& paths, const QString& path)
+{
+    if (!path.isEmpty() && QDir(path).exists() && !paths.contains(path)) {
+        paths.append(path);
+    }
+}
+
+QStringList trustedShaderRoots()
+{
+    return QStandardPaths::locateAll(QStandardPaths::GenericDataLocation, QStringLiteral("plasmazones/shaders"),
+                                     QStandardPaths::LocateDirectory);
+}
+
+QStringList expandShaderIncludePaths(const QStringList& inputPaths)
+{
+    QStringList expanded;
+
+    // Trusted PlasmaZones shader roots first. This ensures shared/common.glsl
+    // resolves consistently for bundled, dev-prefix, system, and user shader roots.
+    for (const QString& root : trustedShaderRoots()) {
+        appendUniquePath(expanded, root + QStringLiteral("/shared"));
+        appendUniquePath(expanded, root);
+    }
+
+    // Preserve caller-provided include paths, but do not infer arbitrary parent
+    // directories from them.
+    for (const QString& path : inputPaths) {
+        const QFileInfo info(path);
+        const QString dir = info.isFile() ? info.absolutePath() : info.absoluteFilePath();
+
+        appendUniquePath(expanded, dir + QStringLiteral("/shared"));
+        appendUniquePath(expanded, dir);
+    }
+
+    return expanded;
+}
+
+} // namespace
 
 namespace PlasmaZones {
 
@@ -18,24 +61,9 @@ warmShaderBakeCacheForPaths(const QString& vertexPath, const QString& fragmentPa
         return result;
     }
 
-    // Caller-provided include paths are authoritative when supplied (the daemon
-    // hands us ShaderRegistry::searchPaths(), which exactly matches what the
-    // render path uses). When omitted, fall back to the well-known system data
-    // dirs — this avoids the previous heuristic of "parent of the shader's
-    // parent dir", which silently broke for shaders not nested two levels
-    // deep under a recognised root.
-    QStringList paths = includePaths;
-    if (paths.isEmpty()) {
-        const QStringList systemShaderDirs =
-            QStandardPaths::locateAll(QStandardPaths::GenericDataLocation, QStringLiteral("plasmazones/shaders"),
-                                      QStandardPaths::LocateDirectory);
-        for (const QString& dir : systemShaderDirs) {
-            if (!paths.contains(dir))
-                paths.append(dir);
-        }
-    }
+    const QStringList expandedPaths = expandShaderIncludePaths(includePaths);
 
-    return PhosphorRendering::warmShaderBakeCacheForPaths(vertexPath, fragmentPath, paths);
+    return PhosphorRendering::warmShaderBakeCacheForPaths(vertexPath, fragmentPath, expandedPaths);
 }
 
 } // namespace PlasmaZones


### PR DESCRIPTION
fix(kwin-effect): add daemon state cleanup on effect shutdown
- Clear window-drag and overlay state in daemon before effect teardown to prevent stale references after compositor reconnect.

fix(screens): fix effective screen IDs cache and lookup
- Force rebuild effectiveScreenIds() after start() by marking dirty flag.
- Use physId instead of raw identifier for exact and reverse fallback lookups; add null guards for QScreen pointers.

fix(rendering): refactor shader include path resolution
- Extract trusted roots and expand paths via shared helper. Remove parent-directory inference heuristic that broke for non-standard shader nesting.
- Disable Unity build for plasmazones_rendering to avoid ODR issues with the new static helpers.