### PR TITLE
fix(animations): shift boundary-mask smoothstep bands OUTSIDE [0, 1]

### DIFF
--- a/data/animations/fade/effect.frag
+++ b/data/animations/fade/effect.frag
@@ -61,8 +61,8 @@ void main() {
         // grey-transparent border. Fade to zero across a tight 0.005-wide
         // band at each edge so the scaled silhouette crops cleanly. Same
         // pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), scaled_uv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), scaled_uv);
+        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), scaled_uv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), scaled_uv);
         float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
         vec4 color = texture(uTexture0, scaled_uv) * mask;
 
@@ -87,8 +87,8 @@ void main() {
         // grey-transparent border. Fade to zero across a tight 0.005-wide
         // band at each edge so the scaled silhouette crops cleanly. Same
         // pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), scaled_uv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), scaled_uv);
+        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), scaled_uv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), scaled_uv);
         float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
         vec4 color = texture(uTexture0, scaled_uv) * mask;
 

--- a/data/animations/glide/effect.frag
+++ b/data/animations/glide/effect.frag
@@ -68,8 +68,8 @@ void main() {
   // narrow smoothstep band (same pattern as morph/effect.frag), so the
   // warped silhouette stays the size BMW intended without altering the
   // scale/squish/tilt motion math.
-  vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), coords);
-  vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), coords);
+  vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), coords);
+  vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), coords);
   float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
 
   vec4 oColor = getInputColor(coords) * mask;

--- a/data/animations/inkwell-drop/effect.frag
+++ b/data/animations/inkwell-drop/effect.frag
@@ -55,8 +55,8 @@ void main() {
     // the transparent edge. Fade to zero across a tight 0.005-wide band at
     // each edge so the rippled silhouette crops cleanly. Same pattern as
     // morph/plasma-flow.
-    vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), distorted);
-    vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), distorted);
+    vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), distorted);
+    vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), distorted);
     float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
     vec4 win = texture(uTexture0, distorted) * mask;
 

--- a/data/animations/morph/effect.frag
+++ b/data/animations/morph/effect.frag
@@ -73,8 +73,8 @@ void main()
     // aliased on smooth warps. A 0.005-wide smoothstep band fades to
     // transparent across the [0,1] edge — narrow enough to be invisible
     // on small windows (~1 texel at 200 px), still smooth at 4K.
-    vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), sampleUv);
-    vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), sampleUv);
+    vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), sampleUv);
+    vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), sampleUv);
     float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
     fragColor = texture(uTexture0, sampleUv) * mask;
 }

--- a/data/animations/plasma-flow/effect.frag
+++ b/data/animations/plasma-flow/effect.frag
@@ -59,8 +59,8 @@ void main() {
     // produce a grey-transparent border. Fade to zero across a tight
     // 0.005-wide band at each edge so the warped silhouette crops
     // cleanly without smearing edge pixels. Same pattern as morph.
-    vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), distorted);
-    vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), distorted);
+    vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), distorted);
+    vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), distorted);
     float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
     vec4 win = texture(uTexture0, distorted) * mask;
 

--- a/data/animations/popin/effect.frag
+++ b/data/animations/popin/effect.frag
@@ -55,8 +55,8 @@ void main()
     // the prior hard `if (outside) return vec4(0)` — the hard cutoff
     // produced a visible 1-texel discontinuity during the overshoot
     // phase when inverse-scaled UV briefly leaves [0,1].
-    vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), sampleUv);
-    vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), sampleUv);
+    vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), sampleUv);
+    vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), sampleUv);
     float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
     fragColor = texture(uTexture0, sampleUv) * mask;
 }

--- a/data/animations/ripple/effect.frag
+++ b/data/animations/ripple/effect.frag
@@ -57,8 +57,8 @@ void main() {
         // samples beyond the surface produce a grey-transparent border.
         // Fade to zero across a tight 0.005-wide band at each edge so the
         // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), wuv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), wuv);
+        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), wuv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), wuv);
         float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
         vec4 color = texture(uTexture0, wuv) * mask;
 
@@ -86,8 +86,8 @@ void main() {
         // samples beyond the surface produce a grey-transparent border.
         // Fade to zero across a tight 0.005-wide band at each edge so the
         // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), wuv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), wuv);
+        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), wuv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), wuv);
         float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
         vec4 color = texture(uTexture0, wuv) * mask;
 

--- a/data/animations/smoke/effect.frag
+++ b/data/animations/smoke/effect.frag
@@ -110,8 +110,8 @@ void main() {
         // samples beyond the surface produce a grey-transparent border.
         // Fade to zero across a tight 0.005-wide band at each edge so the
         // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), warped_uv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), warped_uv);
+        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), warped_uv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), warped_uv);
         float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
         vec4 color = texture(uTexture0, warped_uv) * mask;
 
@@ -146,8 +146,8 @@ void main() {
         // samples beyond the surface produce a grey-transparent border.
         // Fade to zero across a tight 0.005-wide band at each edge so the
         // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), warped_uv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), warped_uv);
+        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), warped_uv);
+        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), warped_uv);
         float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
         vec4 color = texture(uTexture0, warped_uv) * mask;
 

--- a/data/animations/snap/effect.frag
+++ b/data/animations/snap/effect.frag
@@ -82,8 +82,8 @@ void main() {
             // visible. Same soft-mask pattern morph/effect.frag uses to fade
             // out-of-bounds samples to transparent without a hard 1-texel
             // discontinuity.
-            vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), sample_uv);
-            vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), sample_uv);
+            vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), sample_uv);
+            vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), sample_uv);
             float boundsMask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
 
             vec4 color = texture(uTexture0, sample_uv) * boundsMask;
@@ -128,8 +128,8 @@ void main() {
 
             // Boundary mask — see close-leg branch above for rationale.
             // Same divide produces the same UV stretch on the open leg.
-            vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), sample_uv);
-            vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), sample_uv);
+            vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), sample_uv);
+            vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), sample_uv);
             float boundsMask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
 
             vec4 color = texture(uTexture0, sample_uv) * boundsMask;

--- a/data/animations/soft-warp-fade/effect.frag
+++ b/data/animations/soft-warp-fade/effect.frag
@@ -61,8 +61,8 @@ void main() {
     // the surface produce a grey-transparent border. Fade to zero across
     // a tight 0.005-wide band at each edge so the warped silhouette crops
     // cleanly. Same pattern as morph/plasma-flow.
-    vec2 insideLo = smoothstep(vec2(0.0), vec2(0.005), warped);
-    vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0), warped);
+    vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), warped);
+    vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), warped);
     float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
     vec4 win = texture(uTexture0, warped) * mask;
 


### PR DESCRIPTION
## Summary
Fixes a 1-2 px edge "popup at end" the user reported on the layout picker + zone selector — prominent on `glide` and visible on every shader that uses the boundary mask.

## Root cause
The soft boundary masks I added in PR #420 (morph) and PR #423 (8 more shaders + popin from earlier) placed the smoothstep fade bands **INSIDE** the `[0, 1]` sampling range:

```glsl
vec2 insideLo = smoothstep(vec2(0.0),   vec2(0.005), uv);  // fades in [0,    0.005]
vec2 insideHi = vec2(1.0) - smoothstep(vec2(0.995), vec2(1.0),   uv);  // fades in [0.995, 1.0]
```

This zeroed alpha across the **outer 0.5%** of the sampled texture even when the shader was at perfect identity (no UV displacement) — about 1-2 px on a typical 400-pixel popup. During the animation the mask did its intended job (off-window samples cropped to transparent), but at leg-end (iTime hits exactly 0 or 1 → identity), the outer 1-2 px ring stayed masked while the rest rendered fine. When the shader detached and `setHideSource(false)` revealed the original anchor, those 1-2 px reappeared — the visible "popup at end".

`glide` is the most prominent because at its leg endpoints (`uProgress = 0` or `1`) it's at exact mathematical identity — the *only* difference between shader output and original anchor is the masked ring.

## Fix
Shift the smoothstep bands so they lie **OUTSIDE** `[0, 1]`:

```glsl
vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0),   uv);  // fades in [-0.005, 0]
vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0),    vec2(1.005), uv);  // fades in [1.0,    1.005]
```

Identity sampling (`sample_uv ∈ [0, 1]`) now gets `mask = 1` everywhere — no inner-edge clipping. Only samples that *actually exceed* `[0, 1]` fade to transparent over the new bands.

The off-window soft-cropping behaviour the original PRs intended is preserved verbatim — samples that drift past the anchor still fade cleanly to transparent.

## Files changed (10)
morph, popin, fade, inkwell-drop, plasma-flow, ripple, smoke, snap, soft-warp-fade, glide. Mechanical sed sweep — `+28 / −28`.

## Test plan
- [x] `cmake --build build --parallel` clean build
- [x] `test_animation_shader_bake` — all 54 shaders bake clean
- [x] `test_animation_shader_param_wiring` — green
- [x] Full ctest suite — 175/175 passing
- [ ] Visual confirmation on the layout picker + zone selector that the 1-2 px edge popup is gone, especially on glide

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)