### PR TITLE
refactor(animations): DRY duplicated helpers into shared/ headers

### DIFF
--- a/data/animations/broken-glass/effect.frag
+++ b/data/animations/broken-glass/effect.frag
@@ -74,19 +74,6 @@ layout(location = 0) out vec4 fragColor;
 
 const float SHARD_LAYERS = 5.0;
 
-// Local off-window-clipping variant of `bmw_compat.glsl`'s
-// `getInputColor`. The shim's default samples uTexture0 directly,
-// which on a clamp-to-edge sampler smears edge pixels for shards
-// flying past the original window bounds. Returning vec4(0.0) outside
-// [0, 1] crops cleanly to transparent so the cascade reads as a
-// shatter, not a streaked smear. Same pattern as matrix/effect.frag.
-vec4 getClippedInputColor(vec2 coords) {
-    if (coords.x < 0.0 || coords.x > 1.0 || coords.y < 0.0 || coords.y > 1.0) {
-        return vec4(0.0);
-    }
-    return getInputColor(coords);
-}
-
 void main() {
   // Hoist the per-instance hash so we don't recompute it 5×SHARD_LAYERS
   // times per fragment in the loop below.

--- a/data/animations/dissolve/effect.frag
+++ b/data/animations/dissolve/effect.frag
@@ -15,6 +15,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define grain    customParams[0].x  // noise cell size in normalised UV units
@@ -23,11 +24,6 @@
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
 
-float hash(vec2 p)
-{
-    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
-}
-
 void main()
 {
     // UV from the vertex stage; gl_FragCoord/iResolution overshoots [0,1]
@@ -35,7 +31,7 @@ void main()
     vec2 uv = vTexCoord;
     float cellSize = max(grain, 0.01);
     vec2 cell = floor(uv / cellSize);
-    float noise = hash(cell);
+    float noise = niriHash(cell);
 
     // iTime is the per-leg [0,1] progress driven by SurfaceAnimator's
     // shaderTime AnimatedValue. Compare per-cell noise against it with

--- a/data/animations/fade/effect.frag
+++ b/data/animations/fade/effect.frag
@@ -30,6 +30,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define scaleAmount  customParams[0].x
@@ -53,18 +54,8 @@ void main() {
         float scale = mix(1.0, 1.0 - scaleAmount, p);
         vec2 scaled_uv = (uv - center) / scale + center;
 
-        // Soft inside-mask. With scale < 1 the inverse-scaled UVs reach
-        // beyond [0, 1] at boundary fragments (default scaleAmount=0.05
-        // → scaled_uv ∈ ~[-0.026, 1.026] at corners), and `uTexture0` is
-        // clamp-to-edge — the typical edge alpha is 0 (window shadow /
-        // rounded corners) so samples beyond the surface produce a
-        // grey-transparent border. Fade to zero across a tight 0.005-wide
-        // band at each edge so the scaled silhouette crops cleanly. Same
-        // pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), scaled_uv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), scaled_uv);
-        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-        vec4 color = texture(uTexture0, scaled_uv) * mask;
+        // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+        vec4 color = texture(uTexture0, scaled_uv) * boundaryMask(scaled_uv);
 
         float alpha = smoothstep(1.0 - revealStart, 1.0 - revealEnd, p);
 
@@ -79,18 +70,8 @@ void main() {
         float scale = mix(1.0 - scaleAmount, 1.0, p);
         vec2 scaled_uv = (uv - center) / scale + center;
 
-        // Soft inside-mask. With scale < 1 the inverse-scaled UVs reach
-        // beyond [0, 1] at boundary fragments (default scaleAmount=0.05
-        // → scaled_uv ∈ ~[-0.026, 1.026] at corners), and `uTexture0` is
-        // clamp-to-edge — the typical edge alpha is 0 (window shadow /
-        // rounded corners) so samples beyond the surface produce a
-        // grey-transparent border. Fade to zero across a tight 0.005-wide
-        // band at each edge so the scaled silhouette crops cleanly. Same
-        // pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), scaled_uv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), scaled_uv);
-        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-        vec4 color = texture(uTexture0, scaled_uv) * mask;
+        // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+        vec4 color = texture(uTexture0, scaled_uv) * boundaryMask(scaled_uv);
 
         float alpha = smoothstep(revealStart, revealEnd, p);
 

--- a/data/animations/glide/effect.frag
+++ b/data/animations/glide/effect.frag
@@ -25,6 +25,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
@@ -60,19 +61,8 @@ void main() {
   // Move texture coordinate center to corner again.
   coords = coords * 0.5 + 0.5;
 
-  // Boundary mask: with default uScale=0.95 (and uSquish/uTilt non-zero),
-  // the inverse-warped sample UV at corner fragments lands ~5% past the
-  // [0,1] bounds. A clamp-to-edge sample would smear the edge column/row
-  // outward — visible as a dim border + perceived 5% shrink of the
-  // surface. Crop cleanly to transparent across the [0,1] edge with a
-  // narrow smoothstep band (same pattern as morph/effect.frag), so the
-  // warped silhouette stays the size BMW intended without altering the
-  // scale/squish/tilt motion math.
-  vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), coords);
-  vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), coords);
-  float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-
-  vec4 oColor = getInputColor(coords) * mask;
+  // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+  vec4 oColor = getInputColor(coords) * boundaryMask(coords);
 
   // Dissolve window.
   oColor.a = oColor.a * (uForOpening ? uProgress : pow(1.0 - uProgress, 2.0));

--- a/data/animations/glitch/effect.frag
+++ b/data/animations/glitch/effect.frag
@@ -15,6 +15,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define intensity customParams[0].x
@@ -23,11 +24,6 @@
 
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
-
-float hash(vec2 p)
-{
-    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
-}
 
 void main()
 {
@@ -65,11 +61,11 @@ void main()
     // tick BACKWARDS through the same bucket sequence on hide and
     // produce a visible reverse-replay rather than a fresh jitter
     // pattern.
-    float blockNoise = hash(block + floor(float(iFrame) * 0.1));
+    float blockNoise = niriHash(block + floor(float(iFrame) * 0.1));
 
     float displacement = 0.0;
     if (blockNoise > (1.0 - strength * 0.5)) {
-        displacement = (hash(block * 2.0) - 0.5) * strength * 0.2;
+        displacement = (niriHash(block * 2.0) - 0.5) * strength * 0.2;
     }
 
     vec2 uvR = uv + vec2(displacement + rgbSplit * strength, 0.0);

--- a/data/animations/incinerate/effect.frag
+++ b/data/animations/incinerate/effect.frag
@@ -39,15 +39,6 @@ layout(location = 0) out vec4 fragColor;
 // the body samples .rgb. The .a channel is unused.
 #define uColor          customColors[0].rgb
 
-// tritone — BMW common.glsl:201 verbatim. Not hosted in shared/ because
-// no other PlasmaZones animation needs it yet.
-vec3 tritone(float val, vec3 shadows, vec3 midtones, vec3 highlights) {
-  if (val < 0.5) {
-    return mix(shadows, midtones, smoothstep(0.0, 1.0, val * 2.0));
-  }
-  return mix(midtones, highlights, smoothstep(0.0, 1.0, val * 2.0 - 1.0));
-}
-
 // This maps a given value in [0..1] to a color from the rgba color ramp
 // [transparent black ... semi-transparent uColor ... opaque white].
 vec4 getFireColor(float val) {

--- a/data/animations/ink-splash/effect.frag
+++ b/data/animations/ink-splash/effect.frag
@@ -20,6 +20,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define blobScale    customParams[0].x
@@ -30,23 +31,11 @@
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
 
-float is_hash(vec2 p) {
-    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
-}
-
-float is_noise(vec2 p) {
-    vec2 i = floor(p);
-    vec2 f = fract(p);
-    f = f * f * (3.0 - 2.0 * f);
-    return mix(mix(is_hash(i), is_hash(i + vec2(1.0, 0.0)), f.x),
-               mix(is_hash(i + vec2(0.0, 1.0)), is_hash(i + vec2(1.0, 1.0)), f.x), f.y);
-}
-
 float is_fbm(vec2 p) {
     float v = 0.0;
     float amp = 0.5;
     for (int i = 0; i < 5; i++) {
-        v += amp * is_noise(p);
+        v += amp * niriNoise(p);
         p *= 2.1;
         amp *= 0.5;
     }

--- a/data/animations/inkwell-drop/effect.frag
+++ b/data/animations/inkwell-drop/effect.frag
@@ -20,6 +20,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define impactX        customParams[0].x
@@ -47,18 +48,8 @@ void main() {
     vec2 dir = (d > 0.001) ? normalize(c) : vec2(0.0);
     vec2 distorted = uv + dir * ripple;
 
-    // Soft inside-mask. The ripple above pushes UVs past [0, 1] at boundary
-    // fragments, and `uTexture0` is clamp-to-edge — the typical edge alpha
-    // is 0 (window shadow / rounded corners) so samples beyond the surface
-    // produce a grey-transparent border. The previous hard clamp pulled the
-    // same edge texel for every off-surface fragment, which still smeared
-    // the transparent edge. Fade to zero across a tight 0.005-wide band at
-    // each edge so the rippled silhouette crops cleanly. Same pattern as
-    // morph/plasma-flow.
-    vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), distorted);
-    vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), distorted);
-    float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-    vec4 win = texture(uTexture0, distorted) * mask;
+    // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+    vec4 win = texture(uTexture0, distorted) * boundaryMask(distorted);
 
     float reveal = smoothstep(0.05, -0.02, d - front);
     vec4 mixed = win * reveal;

--- a/data/animations/morph/effect.frag
+++ b/data/animations/morph/effect.frag
@@ -14,6 +14,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define warpStrength  customParams[0].x
@@ -68,13 +69,6 @@ void main()
     // the rippled silhouette room to extend OUTSIDE the original
     // anchor rectangle without clipping.
     vec2 sampleUv = anchorUv - warp;
-    // Soft inside-mask. A hard `if (outside) return vec4(0)` produces a
-    // 1-texel discontinuity at the warp silhouette boundary, visibly
-    // aliased on smooth warps. A 0.005-wide smoothstep band fades to
-    // transparent across the [0,1] edge — narrow enough to be invisible
-    // on small windows (~1 texel at 200 px), still smooth at 4K.
-    vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), sampleUv);
-    vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), sampleUv);
-    float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-    fragColor = texture(uTexture0, sampleUv) * mask;
+    // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+    fragColor = texture(uTexture0, sampleUv) * boundaryMask(sampleUv);
 }

--- a/data/animations/plasma-flow/effect.frag
+++ b/data/animations/plasma-flow/effect.frag
@@ -20,6 +20,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define plasmaIntensity customParams[0].x
@@ -28,41 +29,20 @@
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
 
-float pf_hash(vec2 p) {
-    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
-}
-
-float pf_noise(vec2 p) {
-    vec2 i = floor(p);
-    vec2 f = fract(p);
-    f = f * f * (3.0 - 2.0 * f);
-    return mix(mix(pf_hash(i), pf_hash(i + vec2(1.0, 0.0)), f.x),
-               mix(pf_hash(i + vec2(0.0, 1.0)), pf_hash(i + vec2(1.0, 1.0)), f.x), f.y);
-}
-
 void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
 
     vec2 flow = vec2(
-        pf_noise(uv * plasmaScale + vec2(p * 2.0, 0.0)),
-        pf_noise(uv * plasmaScale + vec2(0.0, p * 2.0))
+        niriNoise(uv * plasmaScale + vec2(p * 2.0, 0.0)),
+        niriNoise(uv * plasmaScale + vec2(0.0, p * 2.0))
     ) - 0.5;
     float intensity = sin(p * 3.14159) * plasmaIntensity;
     vec2 distorted = uv + flow * intensity;
 
-    // Soft inside-mask. The distortion above pushes UVs slightly past
-    // [0, 1] at boundary fragments (default intensity ±0.09 at peak),
-    // and `uTexture0` is clamp-to-edge — the typical edge alpha is 0
-    // (window shadow / rounded corners) so samples beyond the surface
-    // produce a grey-transparent border. Fade to zero across a tight
-    // 0.005-wide band at each edge so the warped silhouette crops
-    // cleanly without smearing edge pixels. Same pattern as morph.
-    vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), distorted);
-    vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), distorted);
-    float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-    vec4 win = texture(uTexture0, distorted) * mask;
+    // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+    vec4 win = texture(uTexture0, distorted) * boundaryMask(distorted);
 
     float reveal = smoothstep(0.2, 0.8, p);
     fragColor = win * reveal;

--- a/data/animations/popin/effect.frag
+++ b/data/animations/popin/effect.frag
@@ -9,6 +9,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define scaleFrom customParams[0].x
@@ -49,14 +50,6 @@ void main()
     // zoomed-out, but with overshoot bouncing past 1 and back).
     vec2 sampleUv = (uv - center) / max(scale, 0.001) + center;
 
-    // Outside the texture's [0,1] range = beyond the surface; fade to
-    // transparent so the pop-in reads as a focused zoom rather than a
-    // stretched edge bleed. A soft 0.005-wide smoothstep band replaces
-    // the prior hard `if (outside) return vec4(0)` — the hard cutoff
-    // produced a visible 1-texel discontinuity during the overshoot
-    // phase when inverse-scaled UV briefly leaves [0,1].
-    vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), sampleUv);
-    vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), sampleUv);
-    float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-    fragColor = texture(uTexture0, sampleUv) * mask;
+    // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+    fragColor = texture(uTexture0, sampleUv) * boundaryMask(sampleUv);
 }

--- a/data/animations/ripple/effect.frag
+++ b/data/animations/ripple/effect.frag
@@ -51,16 +51,8 @@ void main() {
         vec2 offset = dir * (sin(p * dist * rippleAmplitude - p * rippleSpeed + seed) + 0.5) / 30.0;
 
         vec2 wuv = uv + offset * intensity;
-        // Soft inside-mask. The displacement above pushes UVs slightly past
-        // [0, 1] at boundary fragments, and `uTexture0` is clamp-to-edge —
-        // the typical edge alpha is 0 (window shadow / rounded corners) so
-        // samples beyond the surface produce a grey-transparent border.
-        // Fade to zero across a tight 0.005-wide band at each edge so the
-        // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), wuv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), wuv);
-        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-        vec4 color = texture(uTexture0, wuv) * mask;
+        // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+        vec4 color = texture(uTexture0, wuv) * boundaryMask(wuv);
 
         float alpha = smoothstep(1.0, 0.5, p);
         result = color * alpha;
@@ -80,16 +72,8 @@ void main() {
         vec2 offset = dir * (sin(p * dist * rippleAmplitude - p * rippleSpeed + seed) + 0.5) / 30.0;
 
         vec2 wuv = uv + offset * intensity;
-        // Soft inside-mask. The displacement above pushes UVs slightly past
-        // [0, 1] at boundary fragments, and `uTexture0` is clamp-to-edge —
-        // the typical edge alpha is 0 (window shadow / rounded corners) so
-        // samples beyond the surface produce a grey-transparent border.
-        // Fade to zero across a tight 0.005-wide band at each edge so the
-        // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), wuv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), wuv);
-        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-        vec4 color = texture(uTexture0, wuv) * mask;
+        // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+        vec4 color = texture(uTexture0, wuv) * boundaryMask(wuv);
 
         float alpha = smoothstep(0.0, 0.3, p);
         result = color * alpha;

--- a/data/animations/shared/bmw_compat.glsl
+++ b/data/animations/shared/bmw_compat.glsl
@@ -221,6 +221,47 @@ float simplex3DFractal(vec3 m) {
            0.0666667 * simplex3D(8.0 * m);
 }
 
+// ── hash12: BMW common.glsl:489 verbatim ────────────────────────────
+// 1D hash from vec2 input using BMW's IQ-style `fract(p3 * 0.1031)`
+// chain (distinct from `noise.glsl::niriHash`'s `sin(dot(...))`
+// pattern). Used by aura-glow, tv-glitch, and wisps; lifted to
+// remove the per-shader duplicates.
+float hash12(vec2 p) {
+    vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+// ── tritone: BMW common.glsl:201 verbatim ───────────────────────────
+// Maps val ∈ [0, 1] to a 3-color gradient (shadows → midtones →
+// highlights). Used by incinerate and wisps for fire/wisp colour
+// ramps; lifted to remove the per-shader duplicates.
+vec3 tritone(float val, vec3 shadows, vec3 midtones, vec3 highlights) {
+    if (val < 0.5) {
+        return mix(shadows, midtones, smoothstep(0.0, 1.0, val * 2.0));
+    }
+    return mix(midtones, highlights, smoothstep(0.0, 1.0, val * 2.0 - 1.0));
+}
+
+// ── Off-window-clipping variant of getInputColor ────────────────────
+// Returns vec4(0) when coords falls outside [0, 1] before delegating
+// to getInputColor. Used by broken-glass (where the BMW actor-scale
+// math pushes shard sample UVs past the anchor's bounds) and
+// tv-glitch (where the vertical scale offsets sampled rows past the
+// bottom). Both ports previously defined this helper inline; lifted
+// here for DRY. The hard clip is intentional — bmw_compat's
+// getInputColor reads premultiplied uTexture0 and a clamp-to-edge
+// sampler would smear transparent edge pixels onto displaced
+// fragments. Soft-mask alternatives (see noise.glsl::boundaryMask)
+// do the same job with an antialiased edge for shaders that prefer
+// a smooth crop.
+vec4 getClippedInputColor(vec2 coords) {
+    if (coords.x < 0.0 || coords.x > 1.0 || coords.y < 0.0 || coords.y > 1.0) {
+        return vec4(0.0);
+    }
+    return getInputColor(coords);
+}
+
 // ── Edge masks: BMW common.glsl:403, 423, 432 verbatim ──────────────
 float getEdgeMask(vec2 uv, vec2 maxUV, float fadeWidth) {
     float mask = 1.0;

--- a/data/animations/shared/noise.glsl
+++ b/data/animations/shared/noise.glsl
@@ -76,4 +76,54 @@ float surfaceSeed() {
     return fract(sin(dot(iSurfaceScreenPos.xy, vec2(12.9898, 78.233))) * 43758.5453);
 }
 
+// niri-style 1D hash from vec2: the classic `fract(sin(dot(p,
+// (127.1, 311.7))) * 43758.5453)` pattern. Used by the niri-derived
+// ports for per-cell / per-instance pseudo-random in [0, 1). Lifted
+// from the file-scope copies that previously lived in dissolve,
+// glitch, ink-splash, plasma-flow, smoke, snap, and soft-warp-fade
+// — all bit-equivalent except for sub-ULP variance in the
+// constant's last decimals (43758.5453 vs 43758.5453123, identical
+// in float32). Other niri ports keep their own hashes when the
+// constants are deliberately different (crosshatch, randomsquares
+// use (12.9898, 78.233); static-fade uses unique magic constants;
+// perlin pre-mods the dot product). Voronoi-shatter's vs_hash2
+// returns vec2 and stays local.
+float niriHash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+}
+
+// niri-style bilinear value noise on niriHash (smooth-step interp
+// at integer lattice corners). Used by the 4 niri ports that need
+// procedural noise — plasma-flow, soft-warp-fade, ink-splash,
+// smoke. Identical body across all four; lifting deduplicates ~10
+// lines per shader. Perlin's perlin_noise stays local because it
+// uses an alternative bilinear formulation tied to perlin_random's
+// non-shareable hash.
+float niriNoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(mix(niriHash(i),                    niriHash(i + vec2(1.0, 0.0)), f.x),
+               mix(niriHash(i + vec2(0.0, 1.0)),   niriHash(i + vec2(1.0, 1.0)), f.x), f.y);
+}
+
+// Boundary mask for shaders that displace sample UVs. Returns 1.0
+// when uv is fully within [0, 1] and fades to 0 over a 0.005-wide
+// band placed JUST OUTSIDE the [0, 1] boundary. uTexture0's
+// clamp-to-edge sampler would otherwise smear transparent
+// window-edge pixels (alpha = 0 from rounded corners / drop
+// shadows) into the rendered output, producing a grey-transparent
+// border around the warped silhouette.
+//
+// Bands sit OUTSIDE [0, 1] so identity sampling (sample_uv ∈
+// [0, 1]) gets mask = 1 everywhere — no inner-edge alpha clipping.
+// Used by morph, popin, fade, inkwell-drop, plasma-flow, ripple,
+// smoke, snap, soft-warp-fade, and glide. See PR #425 for the
+// inside-vs-outside-band fix history.
+float boundaryMask(vec2 uv) {
+    vec2 lo = smoothstep(vec2(-0.005), vec2(0.0),   uv);
+    vec2 hi = vec2(1.0) - smoothstep(vec2(1.0),     vec2(1.005), uv);
+    return lo.x * lo.y * hi.x * hi.y;
+}
+
 #endif

--- a/data/animations/smoke/effect.frag
+++ b/data/animations/smoke/effect.frag
@@ -40,26 +40,11 @@
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
 
-float sm_hash(vec2 p) {
-    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
-}
-
-float sm_noise(vec2 p) {
-    vec2 i = floor(p);
-    vec2 f = fract(p);
-    f = f * f * (3.0 - 2.0 * f);
-    float a = sm_hash(i);
-    float b = sm_hash(i + vec2(1.0, 0.0));
-    float c = sm_hash(i + vec2(0.0, 1.0));
-    float d = sm_hash(i + vec2(1.0, 1.0));
-    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
-}
-
 float sm_fbm(vec2 p) {
     float v = 0.0;
     float amp = 0.5;
     for (int i = 0; i < 6; i++) {
-        v += amp * sm_noise(p);
+        v += amp * niriNoise(p);
         p *= 2.0;
         amp *= 0.5;
     }
@@ -104,16 +89,8 @@ void main() {
                        sm_fbm(uv * 2.0 + 4.0 * wq + vec2(8.3, 2.8)));
         vec2 warped_uv = uv + (wr - 0.5) * distort_strength;
 
-        // Soft inside-mask. The distortion above pushes UVs slightly past
-        // [0, 1] at boundary fragments, and `uTexture0` is clamp-to-edge —
-        // the typical edge alpha is 0 (window shadow / rounded corners) so
-        // samples beyond the surface produce a grey-transparent border.
-        // Fade to zero across a tight 0.005-wide band at each edge so the
-        // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), warped_uv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), warped_uv);
-        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-        vec4 color = texture(uTexture0, warped_uv) * mask;
+        // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+        vec4 color = texture(uTexture0, warped_uv) * boundaryMask(warped_uv);
 
         float tail = smoothstep(1.0, 0.8, p);
         result = color * remain * tail;
@@ -140,16 +117,8 @@ void main() {
                        sm_fbm(uv * 2.0 + 4.0 * wq + vec2(8.3, 2.8)));
         vec2 warped_uv = uv + (wr - 0.5) * distort_strength;
 
-        // Soft inside-mask. The distortion above pushes UVs slightly past
-        // [0, 1] at boundary fragments, and `uTexture0` is clamp-to-edge —
-        // the typical edge alpha is 0 (window shadow / rounded corners) so
-        // samples beyond the surface produce a grey-transparent border.
-        // Fade to zero across a tight 0.005-wide band at each edge so the
-        // warped silhouette crops cleanly. Same pattern as morph/plasma-flow.
-        vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), warped_uv);
-        vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), warped_uv);
-        float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-        vec4 color = texture(uTexture0, warped_uv) * mask;
+        // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+        vec4 color = texture(uTexture0, warped_uv) * boundaryMask(warped_uv);
 
         result = color * reveal;
     }

--- a/data/animations/snap/effect.frag
+++ b/data/animations/snap/effect.frag
@@ -42,10 +42,6 @@
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
 
-float sn_hash(vec2 p) {
-    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
-}
-
 void main() {
     vec4 result;
     if (iIsReversed != 0) {
@@ -55,7 +51,7 @@ void main() {
         float seed = surfaceSeed() * 100.0;
 
         float num_layers = 10.0;
-        float pixel_layer = floor(sn_hash(floor(uv * max(iAnchorSize, vec2(1.0))) + seed) * num_layers);
+        float pixel_layer = floor(niriHash(floor(uv * max(iAnchorSize, vec2(1.0))) + seed) * num_layers);
 
         vec4 inner = vec4(0.0);
         vec2 target = vec2(targetX, targetY);
@@ -69,24 +65,14 @@ void main() {
 
             float layer_alpha = 1.0 - smoothstep(0.3, 0.85, layer_p);
 
-            float lh = sn_hash(vec2(layer + 0.5, seed));
+            float lh = niriHash(vec2(layer + 0.5, seed));
             vec2 layer_target = target + vec2((-0.5 + lh) * layerSpread, (-0.5 + lh) * layerSpread * 0.5);
 
             float converge = t * 0.92;
             vec2 sample_uv = (uv - layer_target * converge) / (1.0 - converge);
 
-            // Boundary mask — at peak `converge=0.92` the divide stretches
-            // sample_uv up to 12.5×, easily reaching off-window pixels
-            // (rounded corners, shadows) which sample as alpha=0. That makes
-            // the layer's contribution vanish exactly where it should be
-            // visible. Same soft-mask pattern morph/effect.frag uses to fade
-            // out-of-bounds samples to transparent without a hard 1-texel
-            // discontinuity.
-            vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), sample_uv);
-            vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), sample_uv);
-            float boundsMask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-
-            vec4 color = texture(uTexture0, sample_uv) * boundsMask;
+            // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+            vec4 color = texture(uTexture0, sample_uv) * boundaryMask(sample_uv);
 
             float belongs = step(abs(pixel_layer - layer), 0.5);
             inner += color * belongs * layer_alpha;
@@ -106,7 +92,7 @@ void main() {
         float rp = 1.0 - p;
 
         float num_layers = 10.0;
-        float pixel_layer = floor(sn_hash(floor(uv * max(iAnchorSize, vec2(1.0))) + seed) * num_layers);
+        float pixel_layer = floor(niriHash(floor(uv * max(iAnchorSize, vec2(1.0))) + seed) * num_layers);
 
         vec4 inner = vec4(0.0);
         vec2 target = vec2(targetX, targetY);
@@ -120,19 +106,14 @@ void main() {
 
             float layer_alpha = 1.0 - smoothstep(0.3, 0.85, layer_p);
 
-            float lh = sn_hash(vec2(layer + 0.5, seed));
+            float lh = niriHash(vec2(layer + 0.5, seed));
             vec2 layer_target = target + vec2((-0.5 + lh) * layerSpread, (-0.5 + lh) * layerSpread * 0.5);
 
             float converge = t * 0.92;
             vec2 sample_uv = (uv - layer_target * converge) / (1.0 - converge);
 
-            // Boundary mask — see close-leg branch above for rationale.
-            // Same divide produces the same UV stretch on the open leg.
-            vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), sample_uv);
-            vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), sample_uv);
-            float boundsMask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-
-            vec4 color = texture(uTexture0, sample_uv) * boundsMask;
+            // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+            vec4 color = texture(uTexture0, sample_uv) * boundaryMask(sample_uv);
 
             float belongs = step(abs(pixel_layer - layer), 0.5);
             inner += color * belongs * layer_alpha;

--- a/data/animations/soft-warp-fade/effect.frag
+++ b/data/animations/soft-warp-fade/effect.frag
@@ -17,12 +17,13 @@
 // niri's `niri_geo_to_tex` is the identity mat3 in PlasmaZones (geometry
 // == texture coords here), so the matrix multiply is dropped and
 // `texture(uTexture0, uv)` samples directly. `texture2D` (GLSL ES) is
-// rewritten to `texture` (GLSL 4.50 core) inline. Niri's `swf_hash` and
-// `swf_noise` helpers lift to file scope unchanged.
+// rewritten to `texture` (GLSL 4.50 core) inline. Niri's `swf_hash` /
+// `swf_noise` helpers come from `<noise.glsl>` as `niriHash` / `niriNoise`.
 
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define warpStrength customParams[0].x
@@ -31,18 +32,6 @@
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
 
-float swf_hash(vec2 p) {
-    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
-}
-
-float swf_noise(vec2 p) {
-    vec2 i = floor(p);
-    vec2 f = fract(p);
-    f = f * f * (3.0 - 2.0 * f);
-    return mix(mix(swf_hash(i), swf_hash(i + vec2(1.0, 0.0)), f.x),
-               mix(swf_hash(i + vec2(0.0, 1.0)), swf_hash(i + vec2(1.0, 1.0)), f.x), f.y);
-}
-
 void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
@@ -50,21 +39,13 @@ void main() {
 
     float strength = sin(p * 3.14159) * warpStrength;
     vec2 warp = vec2(
-        swf_noise(uv * noiseScale + vec2(0.0, p * 0.5)),
-        swf_noise(uv * noiseScale + vec2(p * 0.5, 0.0))
+        niriNoise(uv * noiseScale + vec2(0.0, p * 0.5)),
+        niriNoise(uv * noiseScale + vec2(p * 0.5, 0.0))
     ) - 0.5;
     vec2 warped = uv + warp * strength;
 
-    // Soft inside-mask. The warp above pushes UVs slightly past [0, 1] at
-    // boundary fragments, and `uTexture0` is clamp-to-edge — the typical
-    // edge alpha is 0 (window shadow / rounded corners) so samples beyond
-    // the surface produce a grey-transparent border. Fade to zero across
-    // a tight 0.005-wide band at each edge so the warped silhouette crops
-    // cleanly. Same pattern as morph/plasma-flow.
-    vec2 insideLo = smoothstep(vec2(-0.005), vec2(0.0), warped);
-    vec2 insideHi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.005), warped);
-    float mask = insideLo.x * insideLo.y * insideHi.x * insideHi.y;
-    vec4 win = texture(uTexture0, warped) * mask;
+    // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
+    vec4 win = texture(uTexture0, warped) * boundaryMask(warped);
 
     float t = smoothstep(0.05, 0.95, p);
     t = t * t * (3.0 - 2.0 * t);

--- a/data/animations/tv-glitch/effect.frag
+++ b/data/animations/tv-glitch/effect.frag
@@ -49,28 +49,6 @@ layout(location = 0) out vec4 fragColor;
 // a per-leg duration uniform to derive the BMW-equivalent value.
 #define uDuration 0.75
 
-// hash12: BMW common.glsl:489 verbatim. Used for per-line interference.
-// Kept as a local function rather than promoted to noise.glsl to
-// keep the LGPL-2.1 noise header BMW-helper-free.
-float hash12(vec2 p) {
-    vec3 p3 = fract(vec3(p.xyx) * .1031);
-    p3 += dot(p3, p3.yzx + 33.33);
-    return fract((p3.x + p3.y) * p3.z);
-}
-
-// Local off-window-clipping variant of `bmw_compat.glsl`'s `getInputColor`.
-// The y-rescale and x-displacement below push sample coords outside [0, 1]
-// at boundary fragments, and `uTexture0` is clamp-to-edge — the typical
-// edge alpha is 0 (window shadow / rounded corners) so samples beyond the
-// surface produce a grey-transparent border. Returning vec4(0.0) outside
-// [0, 1] crops cleanly to transparent. Same pattern as broken-glass.
-vec4 getClippedInputColor(vec2 coords) {
-    if (coords.x < 0.0 || coords.x > 1.0 || coords.y < 0.0 || coords.y > 1.0) {
-        return vec4(0.0);
-    }
-    return getInputColor(coords);
-}
-
 const float BLUR_WIDTH = 0.01;  // Width of the gradients.
 const float TB_TIME    = 0.7;   // Relative time for the top/bottom animation.
 const float LR_TIME    = 0.4;   // Relative time for the left/right animation.

--- a/data/animations/wisps/effect.frag
+++ b/data/animations/wisps/effect.frag
@@ -38,21 +38,6 @@ layout(location = 0) out vec4 fragColor;
 #define uColor2         customColors[1].rgb
 #define uColor3         customColors[2].rgb
 
-// hash12 / tritone — BMW common.glsl:489 / :201 verbatim. Not hosted in
-// shared/ because no other PlasmaZones animation needs them yet.
-float hash12(vec2 p) {
-  vec3 p3 = fract(vec3(p.xyx) * .1031);
-  p3 += dot(p3, p3.yzx + 33.33);
-  return fract((p3.x + p3.y) * p3.z);
-}
-
-vec3 tritone(float val, vec3 shadows, vec3 midtones, vec3 highlights) {
-  if (val < 0.5) {
-    return mix(shadows, midtones, smoothstep(0.0, 1.0, val * 2.0));
-  }
-  return mix(midtones, highlights, smoothstep(0.0, 1.0, val * 2.0 - 1.0));
-}
-
 const float WISPS_RADIUS    = 20.0;
 const float WISPS_SPEED     = 10.0;
 const float WISPS_SPACING   = 40.0 + WISPS_RADIUS;


### PR DESCRIPTION
## Summary
Inspired by the overlay-shader pattern in `data/shaders/shared/`. Lifts helper functions duplicated across 17 animation `effect.frag` files into the existing shared headers, removing **~150 net lines** of redundant code.

**Net diff: 19 files, +144 / −287 (–143 lines).**

## Lifted into `noise.glsl` (LGPL-2.1-or-later)

| Helper | Replaces local copies in |
|---|---|
| `niriHash(vec2)` — niri-style `fract(sin(dot(p, (127.1, 311.7))) * 43758.5453)` 1D hash | dissolve, glitch, ink-splash, plasma-flow, smoke, snap, soft-warp-fade |
| `niriNoise(vec2)` — bilinear value noise on niriHash | ink-splash, plasma-flow, smoke, soft-warp-fade |
| `boundaryMask(vec2)` — outside-bands smoothstep, returns 1 in `[0, 1]` and fades to 0 over `[-0.005, 0]` / `[1, 1.005]` | morph, popin, fade, inkwell-drop, plasma-flow, ripple, smoke, snap, soft-warp-fade, glide |

## Lifted into `bmw_compat.glsl` (GPL-3.0-or-later, BMW-derived)

| Helper | Replaces local copies in |
|---|---|
| `hash12(vec2)` — BMW common.glsl:489, IQ-style fract chain | tv-glitch, wisps |
| `tritone(...)` — BMW common.glsl:201, 3-color gradient | incinerate, wisps |
| `getClippedInputColor(vec2)` — `vec4(0)` outside `[0, 1]`, else delegates to `getInputColor` | broken-glass, tv-glitch |

`aura-glow` keeps its local `hash12` / `easeOutCubic` / `offsetHue` / `alphaOver`: it's LGPL-2.1, and pulling `<bmw_compat.glsl>` would force GPL-3 contamination on a shader that was independently authored.

## Intentionally NOT consolidated

- **`perlin_random`** (perlin) — uses `mod(dt, 3.14)` before the sin; unique math.
- **`sf_rnd`** (static-fade) — different magic constants; unique visual pattern.
- **`vs_hash2`** (voronoi-shatter) — vec2 output, different signature.
- **Per-shader `*_fbm`** — ink-splash uses 5 octaves with `p *= 2.1`, smoke uses 6 octaves with `p *= 2.0`; different lacunarity/octave count, not bit-equivalent.
- **Single-consumer helpers** — apparition's `whirl`, fire's `effectMask` + `getFireColor`, hexagon's `getHexagons`, honeycomb's axial-coord helpers, matrix's `getRain` + `getText`, paint-brush's `getMask`, focus's `easeInOutSine` + `getBlurredInputColor`, rgb-warp's `fadeInOut`, wisps's `getWisps`. Lifting them would just spread cognitive load across files without DRY benefit.

## Test plan
- [x] `cmake --build build --parallel` clean build
- [x] `test_animation_shader_bake` — all 54 shaders bake clean
- [x] `test_animation_shader_param_wiring` — green
- [x] Full ctest suite — 175/175 passing
- [ ] Manual visual check that no shader's output changed (the lifts are bit-equivalent or sub-ULP-equivalent to the originals)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)