### PR TITLE
feat(animations): drill-down sub-pages for Animations sidebar

### DIFF
--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -155,16 +155,27 @@ ApplicationWindow {
         "animations": [{
             "name": "animations-general",
             "label": i18n("General"),
-            "iconName": "configure",
-            "hasDividerAfter": true
-        }, {
-            "name": "animations-windows",
-            "label": i18n("Windows"),
-            "iconName": "window-new"
+            "iconName": "configure"
         }, {
             "name": "animations-app-rules",
             "label": i18n("App Rules"),
-            "iconName": "application-x-executable"
+            "iconName": "application-x-executable",
+            "hasDividerAfter": true
+        }, {
+            "name": "animations-surfaces",
+            "label": i18n("Surfaces"),
+            "iconName": "preferences-desktop-multimedia",
+            "hasChildren": true
+        }, {
+            "name": "animations-library",
+            "label": i18n("Library"),
+            "iconName": "folder-open",
+            "hasChildren": true
+        }],
+        "animations-surfaces": [{
+            "name": "animations-windows",
+            "label": i18n("Windows"),
+            "iconName": "window-new"
         }, {
             "name": "animations-zones",
             "label": i18n("Zones"),
@@ -188,9 +199,9 @@ ApplicationWindow {
         }, {
             "name": "animations-widgets",
             "label": i18n("Widgets"),
-            "iconName": "preferences-desktop-theme",
-            "hasDividerAfter": true
-        }, {
+            "iconName": "preferences-desktop-theme"
+        }],
+        "animations-library": [{
             "name": "animations-presets",
             "label": i18n("Presets"),
             "iconName": "bookmarks"
@@ -203,6 +214,14 @@ ApplicationWindow {
             "label": i18n("Shaders"),
             "iconName": "preferences-desktop-display"
         }]
+    })
+    // Map from sub-mode → its parent mode. Modes not listed here drill
+    // back to "main". Lets `_drillOut` pop one level instead of always
+    // returning to the top, so `animations-surfaces` → `animations` →
+    // `main` works as three discrete steps.
+    readonly property var _parentMode: ({
+        "animations-surfaces": "animations",
+        "animations-library": "animations"
     })
     // Page component map -- loaded on demand by Loader
     readonly property var _pageComponents: ({
@@ -250,6 +269,34 @@ ApplicationWindow {
         "portrait": i18n("Portrait (9:16)")
     })
 
+    // Collect every leaf descendant of @p parentName whose label matches
+    // @p searchText, prefixing nested labels with their immediate parent
+    // ("Surfaces / Windows") so the search hit is unambiguous when the
+    // grandparent has multiple intermediate categories. Walks one extra
+    // level deep to support the three-tier Animations layout (top-level
+    // → Surfaces|Library → leaf page).
+    function _collectMatchingDescendants(parentName, searchText) {
+        let out = [];
+        let children = _childItems[parentName] || [];
+        for (let j = 0; j < children.length; j++) {
+            let child = children[j];
+            if (child.hasChildren) {
+                let nested = _collectMatchingDescendants(child.name, searchText);
+                for (let k = 0; k < nested.length; k++) {
+                    out.push({
+                        "name": nested[k].name,
+                        "label": child.label + " / " + nested[k].label,
+                        "iconName": nested[k].iconName,
+                        "hasDividerAfter": false
+                    });
+                }
+            } else if (child.label.toLowerCase().indexOf(searchText) >= 0) {
+                out.push(child);
+            }
+        }
+        return out;
+    }
+
     function _rebuildSidebar() {
         sidebarModel.clear();
         let searchText = sidebarSearch.text.toLowerCase();
@@ -257,17 +304,12 @@ ApplicationWindow {
             for (let i = 0; i < _mainItems.length; i++) {
                 let item = _mainItems[i];
                 if (searchText) {
-                    // Search both item label and children labels
+                    // Search the item label and walk every descendant
+                    // (children + grand-children) so a Surfaces leaf
+                    // like "Windows" still surfaces under the
+                    // top-level Animations entry.
                     let itemMatches = item.label.toLowerCase().indexOf(searchText) >= 0;
-                    let matchingChildren = [];
-                    if (item.hasChildren) {
-                        let children = _childItems[item.name] || [];
-                        for (let j = 0; j < children.length; j++) {
-                            if (children[j].label.toLowerCase().indexOf(searchText) >= 0)
-                                matchingChildren.push(children[j]);
-
-                        }
-                    }
+                    let matchingChildren = item.hasChildren ? _collectMatchingDescendants(item.name, searchText) : [];
                     if (!itemMatches && matchingChildren.length === 0)
                         continue;
 
@@ -329,14 +371,12 @@ ApplicationWindow {
 
             }
         } else {
-            // Find parent label
-            let parentLabel = _sidebarMode;
-            for (let i = 0; i < _mainItems.length; i++) {
-                if (_mainItems[i].name === _sidebarMode) {
-                    parentLabel = _mainItems[i].label;
-                    break;
-                }
-            }
+            // Back-row label is the CURRENT mode's display label
+            // (so a sub-sidebar "Surfaces" reads "← Surfaces"). The
+            // mode may live in `_mainItems` (top-level parents like
+            // "animations") or inside another `_childItems` entry
+            // (intermediate parents like "animations-surfaces").
+            let parentLabel = _modeLabel(_sidebarMode);
             // Back button row (always visible)
             sidebarModel.append({
                 "name": "__back__",
@@ -358,7 +398,7 @@ ApplicationWindow {
                     "name": children[i].name,
                     "label": children[i].label,
                     "iconName": children[i].iconName,
-                    "hasChildren": false,
+                    "hasChildren": children[i].hasChildren || false,
                     "isBackButton": false,
                     "hasDividerAfter": false,
                     "isDivider": false
@@ -378,28 +418,55 @@ ApplicationWindow {
         }
     }
 
-    // Helper: find the parent label for the current sidebar mode
-    function _parentLabel() {
+    // Look up the display label for any node by name across the whole
+    // navigation tree (top-level parents in `_mainItems` and every
+    // `_childItems` bucket). Returns the raw name as fallback so a
+    // missing entry shows up visibly in the UI rather than silently
+    // collapsing to an empty string.
+    function _modeLabel(name) {
         for (let i = 0; i < _mainItems.length; i++) {
-            if (_mainItems[i].name === _sidebarMode)
+            if (_mainItems[i].name === name)
                 return _mainItems[i].label;
 
         }
-        return _sidebarMode;
+        let buckets = Object.keys(_childItems);
+        for (let b = 0; b < buckets.length; b++) {
+            let entries = _childItems[buckets[b]];
+            for (let e = 0; e < entries.length; e++) {
+                if (entries[e].name === name)
+                    return entries[e].label;
+
+            }
+        }
+        return name;
     }
 
-    // Helper: find a subpage label by name
+    // Helper: find the parent label for the current sidebar mode.
+    // Walks up the lineage to the top-level entry so the breadcrumb
+    // reads "Animations › Windows" even when the user is three deep
+    // (animations → animations-surfaces → animations-windows).
+    function _parentLabel() {
+        let mode = _sidebarMode;
+        while (_parentMode[mode])
+            mode = _parentMode[mode];
+
+        return _modeLabel(mode);
+    }
+
+    // Helper: find a subpage label by name. Searches the current
+    // mode's child list first (fast path) then falls back to the
+    // whole tree so a stale `activePage` from a different mode still
+    // resolves to a readable label in the breadcrumb.
     function _subPageLabel(pageName) {
         let children = _childItems[_sidebarMode];
-        if (!children)
-            return pageName;
+        if (children) {
+            for (let i = 0; i < children.length; i++) {
+                if (children[i].name === pageName)
+                    return children[i].label;
 
-        for (let i = 0; i < children.length; i++) {
-            if (children[i].name === pageName)
-                return children[i].label;
-
+            }
         }
-        return pageName;
+        return _modeLabel(pageName);
     }
 
     // Helper: find a main-item label by name
@@ -412,12 +479,23 @@ ApplicationWindow {
         return pageName;
     }
 
-    // Drill into a parent category and select the first child
+    // Drill into a parent category. Selects the first leaf child
+    // (skipping nested intermediate categories so e.g. drilling into
+    // "animations" lands on the "General" page, not on the "Surfaces"
+    // virtual parent). When every child is itself a parent, the
+    // current page is left untouched and the user picks via the
+    // sub-sidebar.
     function _drillIn(parentName) {
-        let children = _childItems[parentName];
-        let firstChild = (children && children.length > 0) ? children[0].name : "";
+        let children = _childItems[parentName] || [];
+        let firstLeaf = "";
+        for (let i = 0; i < children.length; i++) {
+            if (!children[i].hasChildren) {
+                firstLeaf = children[i].name;
+                break;
+            }
+        }
         sidebarTransition.pendingMode = parentName;
-        sidebarTransition.pendingPage = firstChild;
+        sidebarTransition.pendingPage = firstLeaf;
         sidebarTransition.restart();
     }
 
@@ -435,10 +513,24 @@ ApplicationWindow {
         layoutContextMenu.showForLayout(layout);
     }
 
-    // Return to the main sidebar list, selecting the parent category
+    // Pop one level. Sub-modes registered in `_parentMode` (e.g.
+    // `animations-surfaces` → `animations`) drill back to the
+    // intermediate parent; everything else returns to "main" with the
+    // current parent highlighted as `activePage`. When popping back
+    // into a still-virtual parent (one whose entries are all sub-
+    // categories themselves), `activePage` is left untouched so the
+    // user's last-visited leaf stays visible until they pick another.
     function _drillOut() {
-        sidebarTransition.pendingMode = "main";
-        sidebarTransition.pendingPage = _sidebarMode !== "main" ? _sidebarMode : "overview";
+        let target = _parentMode[_sidebarMode] || "main";
+        sidebarTransition.pendingMode = target;
+        if (target === "main")
+            sidebarTransition.pendingPage = _sidebarMode !== "main" ? _sidebarMode : "overview";
+        else
+            // Stay on the current activePage when popping to an
+            // intermediate parent — the leaf the user came from is
+            // more useful context than re-anchoring on the virtual
+            // category they just stepped out of.
+            sidebarTransition.pendingPage = "";
         sidebarTransition.restart();
     }
 

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -8,6 +8,13 @@ import org.kde.kirigami as Kirigami
 import org.phosphor.animation
 
 ApplicationWindow {
+    // Collect every leaf descendant of @p parentName whose label matches
+    // @p searchText, prefixing nested labels with their immediate parent
+    // ("Surfaces / Windows") so the search hit is unambiguous when the
+    // grandparent has multiple intermediate categories. Walks one extra
+    // level deep to support the three-tier Animations layout (top-level
+    // → Surfaces|Library → leaf page).
+
     id: window
 
     // Expose the layout context menu so Loader-loaded pages can connect to its signals
@@ -20,7 +27,12 @@ ApplicationWindow {
     // Close-without-save guard
     property bool _closeConfirmed: false
     // ── Drill-down sidebar state ─────────────────────────────────────
-    // "main" = top-level list; otherwise the parent name (e.g. "snapping")
+    // "main" = top-level list; any other value names the currently-
+    // displayed parent. Top-level parents (e.g. "snapping", "tiling",
+    // "animations") and mid-level virtual parents registered in
+    // `_parentMode` (e.g. "animations-surfaces", "animations-library")
+    // are both valid values; `_drillOut` walks the lineage one level
+    // at a time using `_parentMode`.
     property string _sidebarMode: "main"
     // Main sidebar items
     readonly property var _mainItems: [{
@@ -269,19 +281,20 @@ ApplicationWindow {
         "portrait": i18n("Portrait (9:16)")
     })
 
-    // Collect every leaf descendant of @p parentName whose label matches
-    // @p searchText, prefixing nested labels with their immediate parent
-    // ("Surfaces / Windows") so the search hit is unambiguous when the
-    // grandparent has multiple intermediate categories. Walks one extra
-    // level deep to support the three-tier Animations layout (top-level
-    // → Surfaces|Library → leaf page).
+    // When an intermediate parent's OWN label matches the query (e.g.
+    // searching "surfaces"), every leaf under it is included unfiltered
+    // so the user sees the full set of pages they were navigating
+    // toward — otherwise typing the category name would yield empty
+    // results because the parent itself is a virtual non-leaf.
     function _collectMatchingDescendants(parentName, searchText) {
         let out = [];
         let children = _childItems[parentName] || [];
         for (let j = 0; j < children.length; j++) {
             let child = children[j];
             if (child.hasChildren) {
-                let nested = _collectMatchingDescendants(child.name, searchText);
+                let intermediateMatches = child.label.toLowerCase().indexOf(searchText) >= 0;
+                let nestedQuery = intermediateMatches ? "" : searchText;
+                let nested = _collectMatchingDescendants(child.name, nestedQuery);
                 for (let k = 0; k < nested.length; k++) {
                     out.push({
                         "name": nested[k].name,
@@ -290,7 +303,7 @@ ApplicationWindow {
                         "hasDividerAfter": false
                     });
                 }
-            } else if (child.label.toLowerCase().indexOf(searchText) >= 0) {
+            } else if (searchText === "" || child.label.toLowerCase().indexOf(searchText) >= 0) {
                 out.push(child);
             }
         }
@@ -390,15 +403,52 @@ ApplicationWindow {
             // Child items
             let children = _childItems[_sidebarMode] || [];
             for (let i = 0; i < children.length; i++) {
-                if (searchText && children[i].label.toLowerCase().indexOf(searchText) < 0)
-                    continue;
+                let child = children[i];
+                let childDivider = child.hasDividerAfter || false;
+                if (searchText) {
+                    // Disable drill-in when we're inlining nested
+                    // matches below (the user can click those
+                    // directly), mirroring the main-mode pattern.
 
-                let childDivider = children[i].hasDividerAfter || false;
+                    // Search inside a sub-sidebar matches the entry's
+                    // own label OR (when it's an intermediate parent)
+                    // any grand-child label. Without the recursion,
+                    // searching "windows" from inside the Animations
+                    // sub-sidebar would silently miss it because
+                    // Windows lives one level deeper under Surfaces —
+                    // a regression compared with the prior flat layout.
+                    let ownMatch = child.label.toLowerCase().indexOf(searchText) >= 0;
+                    let nestedMatches = child.hasChildren ? _collectMatchingDescendants(child.name, searchText) : [];
+                    if (!ownMatch && nestedMatches.length === 0)
+                        continue;
+
+                    sidebarModel.append({
+                        "name": child.name,
+                        "label": child.label,
+                        "iconName": child.iconName,
+                        "hasChildren": nestedMatches.length === 0 && (child.hasChildren || false),
+                        "isBackButton": false,
+                        "hasDividerAfter": false,
+                        "isDivider": false
+                    });
+                    for (let j = 0; j < nestedMatches.length; j++) {
+                        sidebarModel.append({
+                            "name": nestedMatches[j].name,
+                            "label": "  " + nestedMatches[j].label,
+                            "iconName": nestedMatches[j].iconName,
+                            "hasChildren": false,
+                            "isBackButton": false,
+                            "hasDividerAfter": false,
+                            "isDivider": false
+                        });
+                    }
+                    continue;
+                }
                 sidebarModel.append({
-                    "name": children[i].name,
-                    "label": children[i].label,
-                    "iconName": children[i].iconName,
-                    "hasChildren": children[i].hasChildren || false,
+                    "name": child.name,
+                    "label": child.label,
+                    "iconName": child.iconName,
+                    "hasChildren": child.hasChildren || false,
                     "isBackButton": false,
                     "hasDividerAfter": false,
                     "isDivider": false
@@ -447,9 +497,7 @@ ApplicationWindow {
     // (animations → animations-surfaces → animations-windows).
     function _parentLabel() {
         let mode = _sidebarMode;
-        while (_parentMode[mode])
-            mode = _parentMode[mode];
-
+        while (_parentMode[mode])mode = _parentMode[mode]
         return _modeLabel(mode);
     }
 
@@ -467,16 +515,6 @@ ApplicationWindow {
             }
         }
         return _modeLabel(pageName);
-    }
-
-    // Helper: find a main-item label by name
-    function _mainItemLabel(pageName) {
-        for (let i = 0; i < _mainItems.length; i++) {
-            if (_mainItems[i].name === pageName)
-                return _mainItems[i].label;
-
-        }
-        return pageName;
     }
 
     // Drill into a parent category. Selects the first leaf child
@@ -521,15 +559,16 @@ ApplicationWindow {
     // categories themselves), `activePage` is left untouched so the
     // user's last-visited leaf stays visible until they pick another.
     function _drillOut() {
+        // Stay on the current activePage when popping to an
+        // intermediate parent — the leaf the user came from is
+        // more useful context than re-anchoring on the virtual
+        // category they just stepped out of.
+
         let target = _parentMode[_sidebarMode] || "main";
         sidebarTransition.pendingMode = target;
         if (target === "main")
             sidebarTransition.pendingPage = _sidebarMode !== "main" ? _sidebarMode : "overview";
         else
-            // Stay on the current activePage when popping to an
-            // intermediate parent — the leaf the user came from is
-            // more useful context than re-anchoring on the virtual
-            // category they just stepped out of.
             sidebarTransition.pendingPage = "";
         sidebarTransition.restart();
     }
@@ -779,8 +818,14 @@ ApplicationWindow {
                                 window._drillIn(name);
                                 return ;
                             }
-                            // If selecting an inline search result child, clear search and drill into parent
-                            if (sidebarSearch.text.length > 0 && _sidebarMode === "main") {
+                            // If selecting an inline search result, clear
+                            // the search, drill into the leaf's actual
+                            // parent (could be a different sub-sidebar
+                            // bucket), and activate the leaf. The lookup
+                            // walks every `_childItems` bucket so it
+                            // handles top-level search hits AND nested
+                            // matches inlined inside a sub-sidebar.
+                            if (sidebarSearch.text.length > 0) {
                                 let parents = Object.keys(_childItems);
                                 for (let p = 0; p < parents.length; p++) {
                                     let children = _childItems[parents[p]];
@@ -1199,7 +1244,7 @@ ApplicationWindow {
                                 if (window._sidebarMode !== "main")
                                     return window._subPageLabel(settingsController.activePage);
 
-                                return window._mainItemLabel(settingsController.activePage);
+                                return window._modeLabel(settingsController.activePage);
                             }
                             opacity: 0.5
                         }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -8,12 +8,10 @@ import org.kde.kirigami as Kirigami
 import org.phosphor.animation
 
 ApplicationWindow {
-    // Collect every leaf descendant of @p parentName whose label matches
-    // @p searchText, prefixing nested labels with their immediate parent
-    // ("Surfaces / Windows") so the search hit is unambiguous when the
-    // grandparent has multiple intermediate categories. Walks one extra
-    // level deep to support the three-tier Animations layout (top-level
-    // → Surfaces|Library → leaf page).
+    // Stay on the current activePage when popping to an
+    // intermediate parent — the leaf the user came from is
+    // more useful context than re-anchoring on the virtual
+    // category they just stepped out of.
 
     id: window
 
@@ -281,11 +279,14 @@ ApplicationWindow {
         "portrait": i18n("Portrait (9:16)")
     })
 
-    // When an intermediate parent's OWN label matches the query (e.g.
-    // searching "surfaces"), every leaf under it is included unfiltered
-    // so the user sees the full set of pages they were navigating
-    // toward — otherwise typing the category name would yield empty
-    // results because the parent itself is a virtual non-leaf.
+    // Walk @p parentName's descendants and return every leaf whose label
+    // matches @p searchText. Nested labels are prefixed with their
+    // immediate parent ("Surfaces / Windows") so a search hit is
+    // unambiguous when multiple intermediate categories live under the
+    // same grandparent. When an intermediate parent's OWN label matches
+    // the query (e.g. searching "surfaces"), every leaf under it is
+    // included unfiltered — otherwise typing a category name would yield
+    // empty results because the parent itself is a virtual non-leaf.
     function _collectMatchingDescendants(parentName, searchText) {
         let out = [];
         let children = _childItems[parentName] || [];
@@ -384,6 +385,10 @@ ApplicationWindow {
 
             }
         } else {
+            // Disable drill-in when we're inlining nested
+            // matches below (the user can click those
+            // directly), mirroring the main-mode pattern.
+
             // Back-row label is the CURRENT mode's display label
             // (so a sub-sidebar "Surfaces" reads "← Surfaces"). The
             // mode may live in `_mainItems` (top-level parents like
@@ -406,10 +411,6 @@ ApplicationWindow {
                 let child = children[i];
                 let childDivider = child.hasDividerAfter || false;
                 if (searchText) {
-                    // Disable drill-in when we're inlining nested
-                    // matches below (the user can click those
-                    // directly), mirroring the main-mode pattern.
-
                     // Search inside a sub-sidebar matches the entry's
                     // own label OR (when it's an intermediate parent)
                     // any grand-child label. Without the recursion,
@@ -497,9 +498,7 @@ ApplicationWindow {
     // (animations → animations-surfaces → animations-windows).
     function _parentLabel() {
         let mode = _sidebarMode;
-        while (_parentMode[mode])
-            mode = _parentMode[mode];
-
+        while (_parentMode[mode])mode = _parentMode[mode]
         return _modeLabel(mode);
     }
 
@@ -566,10 +565,6 @@ ApplicationWindow {
         if (target === "main")
             sidebarTransition.pendingPage = _sidebarMode !== "main" ? _sidebarMode : "overview";
         else
-            // Stay on the current activePage when popping to an
-            // intermediate parent — the leaf the user came from is
-            // more useful context than re-anchoring on the virtual
-            // category they just stepped out of.
             sidebarTransition.pendingPage = "";
         sidebarTransition.restart();
     }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -8,6 +8,15 @@ import org.kde.kirigami as Kirigami
 import org.phosphor.animation
 
 ApplicationWindow {
+    // Cached breadcrumb segment list for the current navigation
+    // state. Rendered as `[top-parent] › [intermediate] › … ›
+    // [current page]` with every non-leaf segment navigable; current-
+    // mode segment is not clickable since it's where the user already
+    // is. For 2-level navigation the chain has two entries (parent +
+    // page); for the 3-level Animations layout it has three (top-parent
+    // + intermediate-parent + page). In main mode the chain collapses
+    // to just the current page name.
+
     id: window
 
     // Expose the layout context menu so Loader-loaded pages can connect to its signals
@@ -295,6 +304,50 @@ ApplicationWindow {
         }
         return out;
     }
+    // Hard depth ceiling for any walk through `_parentMode` /
+    // `_childItems` — guards against a malformed map (cyclic lineage,
+    // self-referencing parent) producing an infinite loop. Today's
+    // tree never exceeds 2 hops; 16 is an order of magnitude headroom
+    // for any plausible future structure.
+    readonly property int _maxNavDepth: 16
+    // Cached as a `readonly property var` so the Repeater's `model`
+    // and per-delegate separator-visibility binding share a single
+    // computation. Reading `_sidebarMode` and `activePage` inside
+    // the IIFE registers the binding's reactivity dependencies.
+    readonly property var _breadcrumbModel: {
+        if (_sidebarMode === "main") {
+            const activeName = settingsController.activePage;
+            return [{
+                "name": activeName,
+                "label": _modeLabel(activeName),
+                "clickable": false
+            }];
+        }
+        // Walk the parent chain top-down with an explicit depth
+        // bound; `_parentMode[mode]` returning undefined terminates
+        // the walk normally, the bound is belt-and-braces against a
+        // future cyclic map.
+        let chain = [];
+        let mode = _sidebarMode;
+        for (let depth = 0; depth < _maxNavDepth && mode !== undefined; depth++) {
+            chain.unshift(mode);
+            mode = _parentMode[mode];
+        }
+        let segments = [];
+        for (let i = 0; i < chain.length; i++) {
+            segments.push({
+                "name": chain[i],
+                "label": _modeLabel(chain[i]),
+                "clickable": chain[i] !== _sidebarMode
+            });
+        }
+        segments.push({
+            "name": settingsController.activePage,
+            "label": _subPageLabel(settingsController.activePage),
+            "clickable": false
+        });
+        return segments;
+    }
 
     // Walk @p parentName's descendants and return every leaf whose label
     // matches @p searchText. Nested labels are prefixed with their
@@ -496,49 +549,6 @@ ApplicationWindow {
         return label !== undefined ? label : name;
     }
 
-    // Build the breadcrumb segment list for the current navigation
-    // state. Each entry carries `name`, `label`, and `clickable`.
-    // Rendered as `[top-parent] › [intermediate] › … › [current page]`
-    // with every non-leaf segment navigable; current-mode segment is
-    // not clickable since it's where the user already is. For 2-level
-    // navigation the chain has two entries (parent + page); for the
-    // 3-level Animations layout it has three (top-parent +
-    // intermediate-parent + page). In main mode the chain collapses
-    // to just the current page name.
-    function _breadcrumbSegments() {
-        if (_sidebarMode === "main") {
-            const activeName = settingsController.activePage;
-            return [{
-                "name": activeName,
-                "label": _modeLabel(activeName),
-                "clickable": false
-            }];
-        }
-        // Walk the parent chain top-down, then push the active page.
-        // `_parentMode` returns undefined at the top, terminating the
-        // walk. Bounded by tree depth, so a small constant.
-        let chain = [];
-        let mode = _sidebarMode;
-        while (mode !== undefined) {
-            chain.unshift(mode);
-            mode = _parentMode[mode];
-        }
-        let segments = [];
-        for (let i = 0; i < chain.length; i++) {
-            segments.push({
-                "name": chain[i],
-                "label": _modeLabel(chain[i]),
-                "clickable": chain[i] !== _sidebarMode
-            });
-        }
-        segments.push({
-            "name": settingsController.activePage,
-            "label": _subPageLabel(settingsController.activePage),
-            "clickable": false
-        });
-        return segments;
-    }
-
     // Navigate to the breadcrumb segment named @p name. Top-level
     // modes pop to main with that parent name as `activePage` (so the
     // sidebar highlights it); sub-modes pop directly into that
@@ -579,14 +589,21 @@ ApplicationWindow {
     // drilling into "animations" lands on "General", and a future
     // bucket whose immediate children are ALL `hasChildren` still
     // resolves a real leaf instead of showing the LayoutsPage
-    // fallback). Returns true when a transition was kicked off.
-    function _firstLeafOf(parentName) {
+    // fallback). The optional @p depth parameter is incremented on
+    // each recursive call and short-circuits at `_maxNavDepth` to
+    // guard against a cyclic `_childItems` map producing a stack
+    // overflow.
+    function _firstLeafOf(parentName, depth) {
+        const next = depth === undefined ? 0 : depth;
+        if (next >= _maxNavDepth)
+            return "";
+
         let children = _childItems[parentName] || [];
         for (let i = 0; i < children.length; i++) {
             if (!children[i].hasChildren)
                 return children[i].name;
 
-            const nested = _firstLeafOf(children[i].name);
+            const nested = _firstLeafOf(children[i].name, next + 1);
             if (nested.length > 0)
                 return nested;
 
@@ -1314,13 +1331,14 @@ ApplicationWindow {
                         spacing: Kirigami.Units.smallSpacing
 
                         // Render every lineage segment + a separator
-                        // between them. Reading `_sidebarMode` and
-                        // `activePage` inside `_breadcrumbSegments` is
-                        // what makes this binding reactive \u2014 those
-                        // property reads register dependencies for the
-                        // function-call binding.
+                        // between them. The `_breadcrumbModel` cached
+                        // property holds the precomputed segment list
+                        // and re-evaluates only when its inputs
+                        // (`_sidebarMode`, `activePage`) change — far
+                        // cheaper than calling `_breadcrumbSegments()`
+                        // once per delegate per binding fire.
                         Repeater {
-                            model: window._breadcrumbSegments()
+                            model: window._breadcrumbModel
 
                             delegate: Row {
                                 required property int index
@@ -1348,7 +1366,7 @@ ApplicationWindow {
                                 }
 
                                 Label {
-                                    visible: index < window._breadcrumbSegments().length - 1
+                                    visible: index < window._breadcrumbModel.length - 1
                                     text: "\u203A"
                                     opacity: 0.5
                                 }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -492,12 +492,13 @@ ApplicationWindow {
     // reads "Animations › Windows" even when the user is three deep
     // (animations → animations-surfaces → animations-windows).
     function _parentLabel() {
+        // Walk up the lineage chain to the top-level mode. Bounded by
+        // the depth of `_parentMode` (currently at most 1 hop, but
+        // the loop is future-proof if a deeper hierarchy is added).
+        // `!== undefined` rather than truthy-coercion so a parent
+        // registered as the empty string would still terminate
+        // correctly (defensive — current data has no such entries).
         let mode = _sidebarMode;
-        // Walk up the lineage chain; bounded by the depth of
-        // `_parentMode` (currently at most 1 hop, but the loop is
-        // future-proof if a deeper hierarchy is added). Use an
-        // explicit body so qmlformat doesn't strip the loop into a
-        // single hard-to-read line.
         while (_parentMode[mode] !== undefined)mode = _parentMode[mode]
         return _modeLabel(mode);
     }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -273,6 +273,28 @@ ApplicationWindow {
         "super-ultrawide": i18n("Super-Ultrawide (32:9)"),
         "portrait": i18n("Portrait (9:16)")
     })
+    // Flat name → label map computed once from `_mainItems` and
+    // every `_childItems` bucket. Drives `_modeLabel` and the
+    // breadcrumb so resolving a label is a single hash lookup
+    // instead of nested-loop scans on every binding re-evaluation.
+    // Property is `readonly` so QML caches the value at startup;
+    // both source maps are also `readonly`, so the index never goes
+    // stale.
+    readonly property var _labelByName: {
+        let out = ({
+        });
+        for (let i = 0; i < _mainItems.length; i++) {
+            out[_mainItems[i].name] = _mainItems[i].label;
+        }
+        const buckets = Object.keys(_childItems);
+        for (let b = 0; b < buckets.length; b++) {
+            const entries = _childItems[buckets[b]];
+            for (let e = 0; e < entries.length; e++) {
+                out[entries[e].name] = entries[e].label;
+            }
+        }
+        return out;
+    }
 
     // Walk @p parentName's descendants and return every leaf whose label
     // matches @p searchText. Nested labels are prefixed with their
@@ -337,12 +359,13 @@ ApplicationWindow {
                         let childDivider = matchingChildren[j].hasDividerAfter || false;
                         sidebarModel.append({
                             "name": matchingChildren[j].name,
-                            "label": "  " + matchingChildren[j].label,
+                            "label": matchingChildren[j].label,
                             "iconName": matchingChildren[j].iconName,
                             "hasChildren": false,
                             "isBackButton": false,
                             "hasDividerAfter": false,
-                            "isDivider": false
+                            "isDivider": false,
+                            "isSearchChild": true
                         });
                         if (childDivider)
                             sidebarModel.append({
@@ -430,12 +453,13 @@ ApplicationWindow {
                     for (let j = 0; j < nestedMatches.length; j++) {
                         sidebarModel.append({
                             "name": nestedMatches[j].name,
-                            "label": "  " + nestedMatches[j].label,
+                            "label": nestedMatches[j].label,
                             "iconName": nestedMatches[j].iconName,
                             "hasChildren": false,
                             "isBackButton": false,
                             "hasDividerAfter": false,
-                            "isDivider": false
+                            "isDivider": false,
+                            "isSearchChild": true
                         });
                     }
                     continue;
@@ -464,43 +488,74 @@ ApplicationWindow {
         }
     }
 
-    // Look up the display label for any node by name across the whole
-    // navigation tree (top-level parents in `_mainItems` and every
-    // `_childItems` bucket). Returns the raw name as fallback so a
-    // missing entry shows up visibly in the UI rather than silently
-    // collapsing to an empty string.
+    // Returns the display label for any node by name. Falls back to
+    // the raw name so a missing entry shows up visibly in the UI
+    // rather than silently collapsing to an empty string.
     function _modeLabel(name) {
-        for (let i = 0; i < _mainItems.length; i++) {
-            if (_mainItems[i].name === name)
-                return _mainItems[i].label;
-
-        }
-        let buckets = Object.keys(_childItems);
-        for (let b = 0; b < buckets.length; b++) {
-            let entries = _childItems[buckets[b]];
-            for (let e = 0; e < entries.length; e++) {
-                if (entries[e].name === name)
-                    return entries[e].label;
-
-            }
-        }
-        return name;
+        const label = _labelByName[name];
+        return label !== undefined ? label : name;
     }
 
-    // Helper: find the parent label for the current sidebar mode.
-    // Walks up the lineage to the top-level entry so the breadcrumb
-    // reads "Animations › Windows" even when the user is three deep
-    // (animations → animations-surfaces → animations-windows).
-    function _parentLabel() {
-        // Walk up the lineage chain to the top-level mode. Bounded by
-        // the depth of `_parentMode` (currently at most 1 hop, but
-        // the loop is future-proof if a deeper hierarchy is added).
-        // `!== undefined` rather than truthy-coercion so a parent
-        // registered as the empty string would still terminate
-        // correctly (defensive — current data has no such entries).
+    // Build the breadcrumb segment list for the current navigation
+    // state. Each entry carries `name`, `label`, and `clickable`.
+    // Rendered as `[top-parent] › [intermediate] › … › [current page]`
+    // with every non-leaf segment navigable; current-mode segment is
+    // not clickable since it's where the user already is. For 2-level
+    // navigation the chain has two entries (parent + page); for the
+    // 3-level Animations layout it has three (top-parent +
+    // intermediate-parent + page). In main mode the chain collapses
+    // to just the current page name.
+    function _breadcrumbSegments() {
+        if (_sidebarMode === "main") {
+            const activeName = settingsController.activePage;
+            return [{
+                "name": activeName,
+                "label": _modeLabel(activeName),
+                "clickable": false
+            }];
+        }
+        // Walk the parent chain top-down, then push the active page.
+        // `_parentMode` returns undefined at the top, terminating the
+        // walk. Bounded by tree depth, so a small constant.
+        let chain = [];
         let mode = _sidebarMode;
-        while (_parentMode[mode] !== undefined)mode = _parentMode[mode]
-        return _modeLabel(mode);
+        while (mode !== undefined) {
+            chain.unshift(mode);
+            mode = _parentMode[mode];
+        }
+        let segments = [];
+        for (let i = 0; i < chain.length; i++) {
+            segments.push({
+                "name": chain[i],
+                "label": _modeLabel(chain[i]),
+                "clickable": chain[i] !== _sidebarMode
+            });
+        }
+        segments.push({
+            "name": settingsController.activePage,
+            "label": _subPageLabel(settingsController.activePage),
+            "clickable": false
+        });
+        return segments;
+    }
+
+    // Navigate to the breadcrumb segment named @p name. Top-level
+    // modes pop to main with that parent name as `activePage` (so the
+    // sidebar highlights it); sub-modes pop directly into that
+    // intermediate sub-sidebar. Both go through the same fade
+    // transition as a back-button click for visual continuity.
+    function _navigateToBreadcrumbSegment(name) {
+        for (let i = 0; i < _mainItems.length; i++) {
+            if (_mainItems[i].name === name) {
+                sidebarTransition.pendingMode = "main";
+                sidebarTransition.pendingPage = name;
+                sidebarTransition.restart();
+                return ;
+            }
+        }
+        sidebarTransition.pendingMode = name;
+        sidebarTransition.pendingPage = "";
+        sidebarTransition.restart();
     }
 
     // Helper: find a subpage label by name. Searches the current
@@ -519,21 +574,28 @@ ApplicationWindow {
         return _modeLabel(pageName);
     }
 
-    // Drill into a parent category. Selects the first leaf child
-    // (skipping nested intermediate categories so e.g. drilling into
-    // "animations" lands on the "General" page, not on the "Surfaces"
-    // virtual parent). When every child is itself a parent, the
-    // current page is left untouched and the user picks via the
-    // sub-sidebar.
-    function _drillIn(parentName) {
+    // Drill into a parent category and select the first reachable
+    // leaf (recursing through intermediate categories so e.g.
+    // drilling into "animations" lands on "General", and a future
+    // bucket whose immediate children are ALL `hasChildren` still
+    // resolves a real leaf instead of showing the LayoutsPage
+    // fallback). Returns true when a transition was kicked off.
+    function _firstLeafOf(parentName) {
         let children = _childItems[parentName] || [];
-        let firstLeaf = "";
         for (let i = 0; i < children.length; i++) {
-            if (!children[i].hasChildren) {
-                firstLeaf = children[i].name;
-                break;
-            }
+            if (!children[i].hasChildren)
+                return children[i].name;
+
+            const nested = _firstLeafOf(children[i].name);
+            if (nested.length > 0)
+                return nested;
+
         }
+        return "";
+    }
+
+    function _drillIn(parentName) {
+        const firstLeaf = _firstLeafOf(parentName);
         sidebarTransition.pendingMode = parentName;
         sidebarTransition.pendingPage = firstLeaf;
         sidebarTransition.restart();
@@ -595,19 +657,33 @@ ApplicationWindow {
         }
         // Build initial sidebar
         _rebuildSidebar();
-        // If the active page is a child of a category, drill in
+        // If the active page is a child of a category, drill in. Skip
+        // intermediate (`hasChildren: true`) entries so a stale
+        // `activePage = "animations-surfaces"` doesn't masquerade as a
+        // valid restored leaf — the virtual parent name only ever
+        // means "show this sub-sidebar", and there's no QML component
+        // for it in `_pageComponents`. The drill-in transition picks a
+        // real leaf for the user when one of those names round-trips
+        // through stored state.
         let page = settingsController.activePage;
         let parents = Object.keys(_childItems);
         for (let p = 0; p < parents.length; p++) {
             let children = _childItems[parents[p]];
             for (let c = 0; c < children.length; c++) {
-                if (children[c].name === page) {
+                if (children[c].name === page && !children[c].hasChildren) {
                     _sidebarMode = parents[p];
                     _rebuildSidebar();
                     return ;
                 }
             }
         }
+        // Stale activePage is a virtual parent (e.g. saved as
+        // "animations-surfaces") — treat it as a drill-in request so
+        // the user lands on a real leaf instead of seeing the silent
+        // LayoutsPage fallback.
+        if (_childItems[page])
+            _drillIn(page);
+
     }
 
     // Auto-drill-out if feature disabled while viewing its subpages
@@ -786,6 +862,13 @@ ApplicationWindow {
                         required property bool isBackButton
                         required property bool hasDividerAfter
                         required property bool isDivider
+                        // Inline search-result rows under their parent
+                        // carry an `isSearchChild` role; rows without
+                        // it (most of the model) get `false` here via
+                        // the truthy coercion. Reading through `model.`
+                        // rather than as a required property avoids
+                        // forcing every append site to set the role.
+                        readonly property bool isSearchChild: model.isSearchChild === true
                         readonly property bool isActive: {
                             if (isBackButton)
                                 return false;
@@ -840,8 +923,27 @@ ApplicationWindow {
                             }
                             settingsController.activePage = name;
                         }
-                        leftPadding: window.sidebarCompact ? 0 : Kirigami.Units.smallSpacing
+                        leftPadding: {
+                            const base = window.sidebarCompact ? 0 : Kirigami.Units.smallSpacing;
+                            // Inline search-result rows nest under
+                            // their parent — bump leftPadding by an
+                            // iconSize-equivalent so the indent reads
+                            // as hierarchy. Theme-aware via
+                            // `Kirigami.Units` and RTL-correct because
+                            // `leftPadding` flips with layoutDirection.
+                            return base + (navDelegate.isSearchChild ? Kirigami.Units.iconSizes.small : 0);
+                        }
                         rightPadding: window.sidebarCompact ? 0 : Kirigami.Units.smallSpacing
+                        // Strip the "Surfaces / Windows" prefix from
+                        // the Accessible.name so screen readers
+                        // announce the leaf cleanly without the
+                        // visual-hierarchy decoration. The full
+                        // composed label still drives the visible
+                        // Label and ToolTip below.
+                        Accessible.name: {
+                            const slashIdx = navDelegate.label.lastIndexOf(" / ");
+                            return slashIdx >= 0 ? navDelegate.label.substring(slashIdx + 3) : navDelegate.label;
+                        }
                         ToolTip.visible: window.sidebarCompact && navDelegate.hovered
                         ToolTip.text: label
                         ToolTip.delay: 300
@@ -1211,40 +1313,48 @@ ApplicationWindow {
                     Row {
                         spacing: Kirigami.Units.smallSpacing
 
-                        // Parent name (clickable when drilled in)
-                        Label {
-                            visible: window._sidebarMode !== "main"
-                            text: window._parentLabel()
-                            opacity: parentMouse.containsMouse ? 0.8 : 0.5
-                            font.underline: parentMouse.containsMouse
+                        // Render every lineage segment + a separator
+                        // between them. Reading `_sidebarMode` and
+                        // `activePage` inside `_breadcrumbSegments` is
+                        // what makes this binding reactive \u2014 those
+                        // property reads register dependencies for the
+                        // function-call binding.
+                        Repeater {
+                            model: window._breadcrumbSegments()
 
-                            MouseArea {
-                                id: parentMouse
+                            delegate: Row {
+                                required property int index
+                                required property var modelData
 
-                                anchors.fill: parent
-                                hoverEnabled: true
-                                cursorShape: Qt.PointingHandCursor
-                                onClicked: window._drillOut()
+                                spacing: Kirigami.Units.smallSpacing
+
+                                Label {
+                                    text: modelData.label
+                                    opacity: modelData.clickable && segmentMouse.containsMouse ? 0.8 : 0.5
+                                    font.underline: modelData.clickable && segmentMouse.containsMouse
+                                    Accessible.name: modelData.label
+                                    Accessible.role: modelData.clickable ? Accessible.Link : Accessible.StaticText
+
+                                    MouseArea {
+                                        id: segmentMouse
+
+                                        anchors.fill: parent
+                                        hoverEnabled: modelData.clickable
+                                        enabled: modelData.clickable
+                                        cursorShape: modelData.clickable ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                        onClicked: window._navigateToBreadcrumbSegment(modelData.name)
+                                    }
+
+                                }
+
+                                Label {
+                                    visible: index < window._breadcrumbSegments().length - 1
+                                    text: "\u203A"
+                                    opacity: 0.5
+                                }
+
                             }
 
-                        }
-
-                        // Separator
-                        Label {
-                            visible: window._sidebarMode !== "main"
-                            text: "\u203A"
-                            opacity: 0.5
-                        }
-
-                        // Current page name
-                        Label {
-                            text: {
-                                if (window._sidebarMode !== "main")
-                                    return window._subPageLabel(settingsController.activePage);
-
-                                return window._modeLabel(settingsController.activePage);
-                            }
-                            opacity: 0.5
                         }
 
                     }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -497,7 +497,9 @@ ApplicationWindow {
     // (animations → animations-surfaces → animations-windows).
     function _parentLabel() {
         let mode = _sidebarMode;
-        while (_parentMode[mode])mode = _parentMode[mode]
+        while (_parentMode[mode])
+            mode = _parentMode[mode];
+
         return _modeLabel(mode);
     }
 
@@ -559,16 +561,15 @@ ApplicationWindow {
     // categories themselves), `activePage` is left untouched so the
     // user's last-visited leaf stays visible until they pick another.
     function _drillOut() {
-        // Stay on the current activePage when popping to an
-        // intermediate parent — the leaf the user came from is
-        // more useful context than re-anchoring on the virtual
-        // category they just stepped out of.
-
         let target = _parentMode[_sidebarMode] || "main";
         sidebarTransition.pendingMode = target;
         if (target === "main")
             sidebarTransition.pendingPage = _sidebarMode !== "main" ? _sidebarMode : "overview";
         else
+            // Stay on the current activePage when popping to an
+            // intermediate parent — the leaf the user came from is
+            // more useful context than re-anchoring on the virtual
+            // category they just stepped out of.
             sidebarTransition.pendingPage = "";
         sidebarTransition.restart();
     }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -8,11 +8,6 @@ import org.kde.kirigami as Kirigami
 import org.phosphor.animation
 
 ApplicationWindow {
-    // Stay on the current activePage when popping to an
-    // intermediate parent — the leaf the user came from is
-    // more useful context than re-anchoring on the virtual
-    // category they just stepped out of.
-
     id: window
 
     // Expose the layout context menu so Loader-loaded pages can connect to its signals
@@ -385,15 +380,15 @@ ApplicationWindow {
 
             }
         } else {
-            // Disable drill-in when we're inlining nested
-            // matches below (the user can click those
-            // directly), mirroring the main-mode pattern.
-
             // Back-row label is the CURRENT mode's display label
             // (so a sub-sidebar "Surfaces" reads "← Surfaces"). The
             // mode may live in `_mainItems` (top-level parents like
             // "animations") or inside another `_childItems` entry
             // (intermediate parents like "animations-surfaces").
+            // Search-mode entries that have nested matches inlined
+            // below have their drill-in disabled at append time so
+            // the user clicks the leaves directly, mirroring the
+            // main-mode search pattern.
             let parentLabel = _modeLabel(_sidebarMode);
             // Back button row (always visible)
             sidebarModel.append({
@@ -498,7 +493,12 @@ ApplicationWindow {
     // (animations → animations-surfaces → animations-windows).
     function _parentLabel() {
         let mode = _sidebarMode;
-        while (_parentMode[mode])mode = _parentMode[mode]
+        // Walk up the lineage chain; bounded by the depth of
+        // `_parentMode` (currently at most 1 hop, but the loop is
+        // future-proof if a deeper hierarchy is added). Use an
+        // explicit body so qmlformat doesn't strip the loop into a
+        // single hard-to-read line.
+        while (_parentMode[mode] !== undefined)mode = _parentMode[mode]
         return _modeLabel(mode);
     }
 
@@ -556,16 +556,17 @@ ApplicationWindow {
     // `animations-surfaces` → `animations`) drill back to the
     // intermediate parent; everything else returns to "main" with the
     // current parent highlighted as `activePage`. When popping back
-    // into a still-virtual parent (one whose entries are all sub-
-    // categories themselves), `activePage` is left untouched so the
-    // user's last-visited leaf stays visible until they pick another.
+    // into an intermediate (still-virtual) parent, `activePage` is
+    // left untouched (empty pendingPage) so the leaf the user came
+    // from stays visible until they pick another — re-anchoring on
+    // the virtual category they just stepped out of would be less
+    // useful context.
     function _drillOut() {
-        let target = _parentMode[_sidebarMode] || "main";
+        const target = _parentMode[_sidebarMode] || "main";
+        const popToMain = target === "main";
+        const pendingPage = popToMain ? (_sidebarMode !== "main" ? _sidebarMode : "overview") : "";
         sidebarTransition.pendingMode = target;
-        if (target === "main")
-            sidebarTransition.pendingPage = _sidebarMode !== "main" ? _sidebarMode : "overview";
-        else
-            sidebarTransition.pendingPage = "";
+        sidebarTransition.pendingPage = pendingPage;
         sidebarTransition.restart();
     }
 

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -571,6 +571,33 @@ const QHash<QString, QString>& SettingsController::parentPageRedirects()
     return redirects;
 }
 
+const QHash<QString, QSet<QString>>& SettingsController::virtualParentChildren()
+{
+    // Mid-level virtual parents whose children DON'T share their name
+    // prefix. The QML sidebar nests animations leaves under "Surfaces"
+    // and "Library" virtual rows for visual grouping, but the leaf
+    // page names stayed flat (`animations-windows` etc.) so existing
+    // page IDs / persisted-config / D-Bus traffic don't churn. The
+    // dirty-state propagation needs the explicit child set because the
+    // prefix walk used for top-level parents (`animations-windows`
+    // starts with `animations-`) misses the virtual layer
+    // (`animations-windows` does NOT start with `animations-surfaces-`).
+    //
+    // Keep this mapping in sync with the matching `_childItems` keys
+    // in src/settings/qml/Main.qml.
+    static const QHash<QString, QSet<QString>> children{
+        {QStringLiteral("animations-surfaces"),
+         {QStringLiteral("animations-windows"), QStringLiteral("animations-zones"),
+          QStringLiteral("animations-notifications"), QStringLiteral("animations-popups"),
+          QStringLiteral("animations-panels"), QStringLiteral("animations-workspaces"),
+          QStringLiteral("animations-widgets")}},
+        {QStringLiteral("animations-library"),
+         {QStringLiteral("animations-presets"), QStringLiteral("animations-motionsets"),
+          QStringLiteral("animations-shaders")}},
+    };
+    return children;
+}
+
 const QSet<QString>& SettingsController::validPageNames()
 {
     // Keep in sync with _pageComponents in Main.qml — every entry here must
@@ -803,13 +830,33 @@ bool SettingsController::isPageDirty(const QString& page) const
 {
     if (m_dirtyPages.contains(page))
         return true;
-    // Parent category: dirty if any child page is dirty. The redirect map
-    // lists parents → first child, so every key here is a parent category.
+    // Parent category: dirty if any child page is dirty. Two paths:
+    //
+    //   1. Top-level parents (snapping / tiling / animations) where every
+    //      child page name is `<parent>-<leaf>` — the prefix walk is
+    //      cheap and avoids enumerating every child explicitly.
+    //
+    //   2. Mid-level virtual parents (animations-surfaces /
+    //      animations-library) whose children inherit the GRANDPARENT's
+    //      name prefix (e.g. `animations-surfaces` wraps
+    //      `animations-windows`, NOT `animations-surfaces-windows`). The
+    //      prefix walk would miss those, so look up the explicit child
+    //      set instead. Keep the mapping in sync with QML's
+    //      `_childItems` virtual-parent buckets in Main.qml.
     if (parentPageRedirects().contains(page)) {
         const QString prefix = page + QStringLiteral("-");
         for (const QString& dirty : m_dirtyPages) {
             if (dirty.startsWith(prefix))
                 return true;
+        }
+    } else {
+        const auto& groups = virtualParentChildren();
+        const auto it = groups.constFind(page);
+        if (it != groups.constEnd()) {
+            for (const QString& child : *it) {
+                if (m_dirtyPages.contains(child))
+                    return true;
+            }
         }
     }
     return false;

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -571,21 +571,34 @@ const QHash<QString, QString>& SettingsController::parentPageRedirects()
     return redirects;
 }
 
-const QHash<QString, QSet<QString>>& SettingsController::virtualParentChildren()
+const QHash<QString, QSet<QString>>& SettingsController::pageGroupChildren()
 {
-    // Mid-level virtual parents whose children DON'T share their name
-    // prefix. The QML sidebar nests animations leaves under "Surfaces"
-    // and "Library" virtual rows for visual grouping, but the leaf
-    // page names stayed flat (`animations-windows` etc.) so existing
-    // page IDs / persisted-config / D-Bus traffic don't churn. The
-    // dirty-state propagation needs the explicit child set because the
-    // prefix walk used for top-level parents (`animations-windows`
-    // starts with `animations-`) misses the virtual layer
-    // (`animations-windows` does NOT start with `animations-surfaces-`).
+    // Single source of truth: parent name → set of leaf child page
+    // names. Used by `isPageDirty` to propagate dirty state from a
+    // leaf to any group it belongs to. Covers both top-level parents
+    // (snapping / tiling / animations) AND mid-level virtual parents
+    // (animations-surfaces / animations-library) whose children don't
+    // share their name prefix — the explicit set sidesteps the
+    // asymmetry between prefix-walk and direct membership lookup.
     //
-    // Keep this mapping in sync with the matching `_childItems` keys
-    // in src/settings/qml/Main.qml.
-    static const QHash<QString, QSet<QString>> children{
+    // Keep this mapping in sync with the matching `_childItems`
+    // entries in src/settings/qml/Main.qml.
+    static const QHash<QString, QSet<QString>> groups{
+        {QStringLiteral("snapping"),
+         {QStringLiteral("snapping-appearance"), QStringLiteral("snapping-effects"), QStringLiteral("snapping-shaders"),
+          QStringLiteral("snapping-behavior"), QStringLiteral("snapping-zoneselector"),
+          QStringLiteral("snapping-assignments"), QStringLiteral("snapping-apprules"),
+          QStringLiteral("snapping-ordering"), QStringLiteral("snapping-shortcuts")}},
+        {QStringLiteral("tiling"),
+         {QStringLiteral("tiling-appearance"), QStringLiteral("tiling-behavior"), QStringLiteral("tiling-algorithm"),
+          QStringLiteral("tiling-assignments"), QStringLiteral("tiling-ordering"), QStringLiteral("tiling-shortcuts")}},
+        {QStringLiteral("animations"),
+         {QStringLiteral("animations-general"), QStringLiteral("animations-app-rules"),
+          QStringLiteral("animations-windows"), QStringLiteral("animations-zones"),
+          QStringLiteral("animations-notifications"), QStringLiteral("animations-popups"),
+          QStringLiteral("animations-panels"), QStringLiteral("animations-workspaces"),
+          QStringLiteral("animations-widgets"), QStringLiteral("animations-presets"),
+          QStringLiteral("animations-motionsets"), QStringLiteral("animations-shaders")}},
         {QStringLiteral("animations-surfaces"),
          {QStringLiteral("animations-windows"), QStringLiteral("animations-zones"),
           QStringLiteral("animations-notifications"), QStringLiteral("animations-popups"),
@@ -595,7 +608,7 @@ const QHash<QString, QSet<QString>>& SettingsController::virtualParentChildren()
          {QStringLiteral("animations-presets"), QStringLiteral("animations-motionsets"),
           QStringLiteral("animations-shaders")}},
     };
-    return children;
+    return groups;
 }
 
 const QSet<QString>& SettingsController::validPageNames()
@@ -830,33 +843,17 @@ bool SettingsController::isPageDirty(const QString& page) const
 {
     if (m_dirtyPages.contains(page))
         return true;
-    // Parent category: dirty if any child page is dirty. Two paths:
-    //
-    //   1. Top-level parents (snapping / tiling / animations) where every
-    //      child page name is `<parent>-<leaf>` — the prefix walk is
-    //      cheap and avoids enumerating every child explicitly.
-    //
-    //   2. Mid-level virtual parents (animations-surfaces /
-    //      animations-library) whose children inherit the GRANDPARENT's
-    //      name prefix (e.g. `animations-surfaces` wraps
-    //      `animations-windows`, NOT `animations-surfaces-windows`). The
-    //      prefix walk would miss those, so look up the explicit child
-    //      set instead. Keep the mapping in sync with QML's
-    //      `_childItems` virtual-parent buckets in Main.qml.
-    if (parentPageRedirects().contains(page)) {
-        const QString prefix = page + QStringLiteral("-");
-        for (const QString& dirty : m_dirtyPages) {
-            if (dirty.startsWith(prefix))
+    // Parent / virtual-parent category: dirty if any child leaf in
+    // the group is dirty. Single direct-membership lookup against
+    // `pageGroupChildren()` rather than the old prefix-walk-or-hash-
+    // lookup branch — top-level parents (snapping / tiling /
+    // animations) and virtual mid-level parents (animations-surfaces /
+    // animations-library) share the same code path now.
+    const auto it = pageGroupChildren().constFind(page);
+    if (it != pageGroupChildren().constEnd()) {
+        for (const QString& child : *it) {
+            if (m_dirtyPages.contains(child))
                 return true;
-        }
-    } else {
-        const auto& groups = virtualParentChildren();
-        const auto it = groups.constFind(page);
-        if (it != groups.constEnd()) {
-            for (const QString& child : *it) {
-                if (m_dirtyPages.contains(child))
-                    return true;
-            }
         }
     }
     return false;

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -562,11 +562,17 @@ void SettingsController::markWhatsNewSeen()
 const QHash<QString, QString>& SettingsController::parentPageRedirects()
 {
     // Parent sidebar categories have no QML component — resolve them to their
-    // first child so D-Bus / CLI callers get a sensible result.
+    // first child so D-Bus / CLI / Q_INVOKABLE callers get a sensible result.
+    // Includes both top-level parents AND mid-level virtual parents
+    // (`animations-surfaces`, `animations-library`) so any of those names
+    // passed via `--page` or D-Bus lands on a real leaf instead of triggering
+    // the generic "Unknown settings page" warning.
     static const QHash<QString, QString> redirects{
         {QStringLiteral("snapping"), QStringLiteral("snapping-appearance")},
         {QStringLiteral("tiling"), QStringLiteral("tiling-appearance")},
         {QStringLiteral("animations"), QStringLiteral("animations-general")},
+        {QStringLiteral("animations-surfaces"), QStringLiteral("animations-windows")},
+        {QStringLiteral("animations-library"), QStringLiteral("animations-presets")},
     };
     return redirects;
 }
@@ -581,8 +587,26 @@ const QHash<QString, QSet<QString>>& SettingsController::pageGroupChildren()
     // share their name prefix — the explicit set sidesteps the
     // asymmetry between prefix-walk and direct membership lookup.
     //
-    // Keep this mapping in sync with the matching `_childItems`
-    // entries in src/settings/qml/Main.qml.
+    // The "animations" entry is built at static-init by unioning the
+    // virtual sub-buckets (`animations-surfaces`, `animations-library`)
+    // with the leaves that hang directly off `animations` (general,
+    // app-rules). Without this, a future leaf added to a virtual
+    // parent only would silently miss the top-level dirty propagation.
+    //
+    // Keep the per-group leaf lists in sync with the matching
+    // `_childItems` entries in src/settings/qml/Main.qml.
+    static const QSet<QString> kAnimationsSurfacesChildren{
+        QStringLiteral("animations-windows"),       QStringLiteral("animations-zones"),
+        QStringLiteral("animations-notifications"), QStringLiteral("animations-popups"),
+        QStringLiteral("animations-panels"),        QStringLiteral("animations-workspaces"),
+        QStringLiteral("animations-widgets")};
+    static const QSet<QString> kAnimationsLibraryChildren{QStringLiteral("animations-presets"),
+                                                          QStringLiteral("animations-motionsets"),
+                                                          QStringLiteral("animations-shaders")};
+    static const QSet<QString> kAnimationsDirectChildren{QStringLiteral("animations-general"),
+                                                         QStringLiteral("animations-app-rules")};
+    static const QSet<QString> kAnimationsAllLeaves =
+        kAnimationsDirectChildren + kAnimationsSurfacesChildren + kAnimationsLibraryChildren;
     static const QHash<QString, QSet<QString>> groups{
         {QStringLiteral("snapping"),
          {QStringLiteral("snapping-appearance"), QStringLiteral("snapping-effects"), QStringLiteral("snapping-shaders"),
@@ -592,21 +616,9 @@ const QHash<QString, QSet<QString>>& SettingsController::pageGroupChildren()
         {QStringLiteral("tiling"),
          {QStringLiteral("tiling-appearance"), QStringLiteral("tiling-behavior"), QStringLiteral("tiling-algorithm"),
           QStringLiteral("tiling-assignments"), QStringLiteral("tiling-ordering"), QStringLiteral("tiling-shortcuts")}},
-        {QStringLiteral("animations"),
-         {QStringLiteral("animations-general"), QStringLiteral("animations-app-rules"),
-          QStringLiteral("animations-windows"), QStringLiteral("animations-zones"),
-          QStringLiteral("animations-notifications"), QStringLiteral("animations-popups"),
-          QStringLiteral("animations-panels"), QStringLiteral("animations-workspaces"),
-          QStringLiteral("animations-widgets"), QStringLiteral("animations-presets"),
-          QStringLiteral("animations-motionsets"), QStringLiteral("animations-shaders")}},
-        {QStringLiteral("animations-surfaces"),
-         {QStringLiteral("animations-windows"), QStringLiteral("animations-zones"),
-          QStringLiteral("animations-notifications"), QStringLiteral("animations-popups"),
-          QStringLiteral("animations-panels"), QStringLiteral("animations-workspaces"),
-          QStringLiteral("animations-widgets")}},
-        {QStringLiteral("animations-library"),
-         {QStringLiteral("animations-presets"), QStringLiteral("animations-motionsets"),
-          QStringLiteral("animations-shaders")}},
+        {QStringLiteral("animations"), kAnimationsAllLeaves},
+        {QStringLiteral("animations-surfaces"), kAnimationsSurfacesChildren},
+        {QStringLiteral("animations-library"), kAnimationsLibraryChildren},
     };
     return groups;
 }
@@ -786,9 +798,16 @@ void SettingsController::defaults()
     DaemonDBus::notifyReload();
 
     // Defaults is a global action — mark every valid page dirty so the
-    // unsaved indicator appears next to each of them.
-    m_dirtyPages = validPageNames();
-    Q_EMIT dirtyPagesChanged();
+    // unsaved indicator appears next to each of them. Guard the emit
+    // on actual change so a back-to-back `defaults()` (or one called
+    // when state already matches the post-defaults set) doesn't fire
+    // a spurious `dirtyPagesChanged`, matching the emit-on-change
+    // discipline used by `setNeedsSave` everywhere else in this file.
+    const QSet<QString>& fullSet = validPageNames();
+    if (m_dirtyPages != fullSet) {
+        m_dirtyPages = fullSet;
+        Q_EMIT dirtyPagesChanged();
+    }
 }
 
 void SettingsController::launchEditor()

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -849,8 +849,9 @@ bool SettingsController::isPageDirty(const QString& page) const
     // lookup branch — top-level parents (snapping / tiling /
     // animations) and virtual mid-level parents (animations-surfaces /
     // animations-library) share the same code path now.
-    const auto it = pageGroupChildren().constFind(page);
-    if (it != pageGroupChildren().constEnd()) {
+    const auto& groups = pageGroupChildren();
+    const auto it = groups.constFind(page);
+    if (it != groups.constEnd()) {
         for (const QString& child : *it) {
             if (m_dirtyPages.contains(child))
                 return true;

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -121,6 +121,12 @@ public:
 
     static const QSet<QString>& validPageNames();
     static const QHash<QString, QString>& parentPageRedirects();
+    /// Mid-level virtual parents (e.g. `animations-surfaces`) whose
+    /// children don't share the parent's name prefix. Drives the
+    /// dirty-state propagation in `isPageDirty` since the prefix walk
+    /// used for top-level parents would miss these. Keep in sync with
+    /// the QML `_childItems` virtual-parent buckets in Main.qml.
+    static const QHash<QString, QSet<QString>>& virtualParentChildren();
 
     bool needsSave() const
     {

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -121,12 +121,14 @@ public:
 
     static const QSet<QString>& validPageNames();
     static const QHash<QString, QString>& parentPageRedirects();
-    /// Mid-level virtual parents (e.g. `animations-surfaces`) whose
-    /// children don't share the parent's name prefix. Drives the
-    /// dirty-state propagation in `isPageDirty` since the prefix walk
-    /// used for top-level parents would miss these. Keep in sync with
-    /// the QML `_childItems` virtual-parent buckets in Main.qml.
-    static const QHash<QString, QSet<QString>>& virtualParentChildren();
+    /// Parent name → set of leaf child page names. Covers top-level
+    /// sidebar parents (snapping / tiling / animations) AND mid-level
+    /// virtual parents (animations-surfaces / animations-library)
+    /// whose children don't share their name prefix. Drives the
+    /// dirty-state propagation in `isPageDirty` via direct-membership
+    /// lookup. Keep in sync with the QML `_childItems` buckets in
+    /// Main.qml.
+    static const QHash<QString, QSet<QString>>& pageGroupChildren();
 
     bool needsSave() const
     {


### PR DESCRIPTION
## Summary

The Animations sidebar had 12 flat entries — too many for one level. Collapse into 4 top-level rows with two drill-down groups:

```
Animations
├ General
├ App Rules
├ Surfaces  ›   → Windows, Zones, Notifications, Popups, Panels, Workspaces, Widgets
└ Library    ›  → Presets, Motion Sets, Shaders
```

## Implementation

- Generalises the existing 2-level sidebar drill-down to support arbitrary depth via a `_parentMode` map (`animations-surfaces → animations`, `animations-library → animations`). `_drillOut` pops one level at a time instead of always returning to "main".
- `_modeLabel(name)` walks the whole nav tree (`_mainItems` + every `_childItems` bucket) to resolve a label by name. The back-button and breadcrumb both use it so a sub-sub-sidebar reads "← Surfaces" with the breadcrumb showing "Animations › Windows".
- `_drillIn` skips intermediate categories when auto-selecting the first leaf, so drilling into Animations lands on General — not on the Surfaces virtual parent.
- `_collectMatchingDescendants` walks one extra level for search results so a top-level "windows" search still surfaces as "Surfaces / Windows" under Animations.
- Three-level startup auto-drill-in works because `Object.keys(_childItems)` now includes the new sub-mode buckets, so opening on `animations-windows` correctly drills two levels deep.

## Test plan
- [ ] Animations sidebar shows 4 top-level rows (General, App Rules, Surfaces ›, Library ›)
- [ ] Clicking Surfaces drills to a sub-sidebar with the 7 surface pages and a "← Surfaces" back row
- [ ] Clicking Library drills to a sub-sidebar with Presets / Motion Sets / Shaders and a "← Library" back row
- [ ] Back from a sub-sub-sidebar (e.g. "← Surfaces") returns to the Animations sub-sidebar (not all the way to main)
- [ ] Search "windows" from main surfaces an inline "Surfaces / Windows" result that drills correctly when clicked
- [ ] Launching directly into a leaf page (e.g. `animations-windows`) opens the correct sub-sub-sidebar with the page selected
- [ ] Existing 2-level drill-down (Snapping, Tiling) still works

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)