### PR TITLE
fix(overlay): first-show OSD animation + snap-assist VS zones

### DIFF
--- a/libs/phosphor-animation/src/surfaceanimator.cpp
+++ b/libs/phosphor-animation/src/surfaceanimator.cpp
@@ -746,24 +746,7 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
     structuralParams.setX(static_cast<float>(pad));
     shaderItem->setCustomParamAt(7, structuralParams);
 
-    // setSourceItem is what wires up FBO sampling and triggers the
-    // shader effect's first sync into the scene graph. Setting it
-    // LAST — after all initial uniforms, custom params, and geometry
-    // are in place — guarantees that the shader's first painted frame
-    // sees a fully-initialised state. Mirrors the setITime ordering
-    // rationale above: any property set after setSourceItem could
-    // race the first paint and produce a visible flash with default-
-    // valued uniforms (boundsPadding=0 collapses the morph remap
-    // regardless of the metadata; un-translated shaderParameters
-    // leaves user uniforms at -1 sentinel; pre-padding geometry would
-    // clip rippled silhouettes).
-    if (shaderSource) {
-        shaderItem->setSourceItem(shaderSource);
-    }
-
-    // Sync geometry if anchor resizes mid-transition. iResolution stays
-    // in logical units (animation shaders derive UV from `vTexCoord`).
-    // Padding around the shader effect tracks the anchor's live size.
+    // Build the geometry-sync lambda + its dependencies.
     //
     // The lambda re-runs the same parent-margin clamp the initial-attach
     // block above does. Anchor x/y/w/h can change mid-leg (parent-layout
@@ -796,6 +779,40 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
         syncShaderGeometryNow(anchorPtr.data(), shaderItemPtr.data(), shaderSourcePtr.data(), *requestedPadPtr,
                               *boundsExtentPtr);
     };
+
+    // Seed the boundsExtent-dependent shader item geometry AND the
+    // animation-extension uniforms (iSurfaceScreenPos, iAnchorSize)
+    // BEFORE `setSourceItem` wires up the first paint. The render
+    // thread's first prepare() copies the extension's m_data verbatim
+    // into the UBO; without this seed the first frame samples zeros at
+    // offsets 672/688 and a fly-in / slide vert reads
+    // `screenW = max(0, 1) = 1`, collapsing `clearancePx` to a single
+    // pixel — the card snaps to its rest position with no slide-in.
+    // Hide legs hide this because they reuse iSurfaceScreenPos values
+    // populated by the show leg's later geometry signals.
+    //
+    // For the persistent-anchor case (zone selector / snap-assist /
+    // layout picker pre-warmed PopupFrames), this also seeds the
+    // shader item's size — width/height stays default-zero otherwise
+    // and the rendered surface collapses to a point for the leg.
+    syncGeometry();
+
+    // setSourceItem wires up FBO sampling and triggers the shader
+    // effect's first sync into the scene graph. Setting it LAST —
+    // after all initial uniforms, custom params, geometry, AND the
+    // post-syncGeometry extension push — guarantees that the shader's
+    // first painted frame sees a fully-initialised state. Mirrors the
+    // setITime ordering rationale above: any state mutation after
+    // setSourceItem could race the first paint and produce a visible
+    // flash with default-valued uniforms (boundsPadding=0 collapses
+    // the morph remap regardless of the metadata; un-translated
+    // shaderParameters leaves user uniforms at -1 sentinel; pre-
+    // padding geometry would clip rippled silhouettes; un-seeded
+    // iSurfaceScreenPos collapses fly-in's slide to a snap).
+    if (shaderSource) {
+        shaderItem->setSourceItem(shaderSource);
+    }
+
     // Connect to all four geometry signals — anchor x/y can shift mid-leg
     // when sibling visibility flips trigger parent layout reflow (we hide
     // visible siblings below; QML Row/ColumnLayout re-pack on visible
@@ -815,16 +832,6 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
     QObject::connect(shaderAnchor, &QQuickItem::heightChanged, shaderItem, syncGeometry);
     QObject::connect(shaderAnchor, &QQuickItem::xChanged, shaderItem, syncGeometry);
     QObject::connect(shaderAnchor, &QQuickItem::yChanged, shaderItem, syncGeometry);
-
-    // Seed the boundsExtent-dependent shader item geometry once
-    // unconditionally. The signal-driven lambda above only fires on
-    // subsequent anchor geometry changes; for surfaces where the anchor
-    // is persistent across show/hide cycles (zone selector / snap-assist /
-    // layout picker — pre-warmed PopupFrames with constant width/height),
-    // the lambda would never fire post-attach and the shader item's
-    // size would stay at its default-constructed zero, collapsing the
-    // rendered surface to a point for the leg's duration.
-    syncGeometry();
 
     // Hide visible decorator siblings — see `hideAnchorSiblings` for the
     // rationale (Qt 6 MultiEffect can't sample our shader item as source).

--- a/libs/phosphor-animation/src/surfaceanimator.cpp
+++ b/libs/phosphor-animation/src/surfaceanimator.cpp
@@ -787,20 +787,20 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
     // into the UBO; without this seed the first frame samples zeros at
     // offsets 672/688 and a fly-in / slide vert reads
     // `screenW = max(0, 1) = 1`, collapsing `clearancePx` to a single
-    // pixel — the card snaps to its rest position with no slide-in.
+    // pixel, so the card snaps to its rest position with no slide-in.
     // Hide legs hide this because they reuse iSurfaceScreenPos values
     // populated by the show leg's later geometry signals.
     //
-    // For the persistent-anchor case (zone selector / snap-assist /
+    // For the persistent-anchor case (zone selector, snap-assist,
     // layout picker pre-warmed PopupFrames), this also seeds the
-    // shader item's size — width/height stays default-zero otherwise
+    // shader item's size: width/height stays default-zero otherwise
     // and the rendered surface collapses to a point for the leg.
     syncGeometry();
 
     // setSourceItem wires up FBO sampling and triggers the shader
-    // effect's first sync into the scene graph. Setting it LAST —
+    // effect's first sync into the scene graph. Setting it LAST,
     // after all initial uniforms, custom params, geometry, AND the
-    // post-syncGeometry extension push — guarantees that the shader's
+    // post-syncGeometry extension push, guarantees that the shader's
     // first painted frame sees a fully-initialised state. Mirrors the
     // setITime ordering rationale above: any state mutation after
     // setSourceItem could race the first paint and produce a visible

--- a/libs/phosphor-animation/src/surfaceanimator.cpp
+++ b/libs/phosphor-animation/src/surfaceanimator.cpp
@@ -788,8 +788,9 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
     // offsets 672/688 and a fly-in / slide vert reads
     // `screenW = max(0, 1) = 1`, collapsing `clearancePx` to a single
     // pixel, so the card snaps to its rest position with no slide-in.
-    // Hide legs hide this because they reuse iSurfaceScreenPos values
-    // populated by the show leg's later geometry signals.
+    // Pre-fix this only manifested on show legs (hide legs ran against
+    // iSurfaceScreenPos values populated by the show leg's later
+    // anchor-geometry signals, so the slide-out played correctly).
     //
     // For the persistent-anchor case (zone selector, snap-assist,
     // layout picker pre-warmed PopupFrames), this also seeds the

--- a/libs/phosphor-placement/src/navigation.cpp
+++ b/libs/phosphor-placement/src/navigation.cpp
@@ -114,6 +114,37 @@ EmptyZoneList WindowTrackingService::getEmptyZones(const QString& screenId) cons
         return {};
     }
 
+    // Resolve the SCOPE the layout was authored for. For a virtual
+    // screen the scope is the VS sub-rect within the physical monitor;
+    // for a non-VS screenId it's the physical screen's geometry. The
+    // overlay surface that renders snap-assist is anchored to the VS
+    // top-left, so emitting zone coordinates relative to anything
+    // other than the VS rect produces zone rectangles wider than the
+    // surface — manifesting as "zone right edge clipped flat without
+    // a rounded corner" because the visible content can't extend past
+    // the surface's bounds.
+    //
+    // Pre-fix path: `getZoneGeometryWithGaps(mgr, zone, screen, …)` +
+    // `availableAreaToOverlayCoordinates(geom, screen->geometry())`
+    // computed against the PHYSICAL screen, so a layout assigned to
+    // a smaller VS produced zones sized for the full monitor.
+    const QRect physGeom = screen->geometry();
+    QRect scopeGeom = m_screenManager ? m_screenManager->screenGeometry(screenId) : QRect();
+    if (!scopeGeom.isValid()) {
+        scopeGeom = physGeom;
+    }
+    const QRect scopeAvailGeom = m_screenManager ? m_screenManager->actualAvailableGeometry(screen) : scopeGeom;
+    const QRect availForLayout =
+        scopeAvailGeom.intersected(scopeGeom).isEmpty() ? scopeGeom : scopeAvailGeom.intersected(scopeGeom);
+
+    // No `LayoutComputeService::recalculateSync` here — that mutates the
+    // shared layout's cached zone geometries to whatever rect we pass,
+    // which clobbers OSD / main-overlay consumers reading
+    // `zone->geometry()` against the last compute pass. The VS-aware
+    // `getZoneGeometryWithGaps(mgr, zone, scopeGeom, availForLayout, …)`
+    // overload below computes from `zone->relativeGeometry()` against
+    // the explicit `scopeGeom` rect, so it doesn't need the cache primed.
+
     // Screen-filtered + desktop-filtered occupancy — without the screen filter,
     // zones occupied on screen A appear occupied on screen B when both use the
     // same layout (same zone IDs). Without the desktop filter, windows parked on
@@ -133,10 +164,16 @@ EmptyZoneList WindowTrackingService::getEmptyZones(const QString& screenId) cons
         if (occupied.contains(zone->id())) {
             continue;
         }
-        QRectF geom = PhosphorZones::GeometryUtils::getZoneGeometryWithGaps(m_screenManager, zone, screen, zp, og,
-                                                                            !layout->useFullScreenGeometry(), screenId);
+        // VS-aware overload — uses the explicit scopeGeom rect for
+        // layout maths instead of pulling QScreen::geometry() (which
+        // is always physical).
+        QRectF geom = PhosphorZones::GeometryUtils::getZoneGeometryWithGaps(
+            m_screenManager, zone, scopeGeom, availForLayout, zp, og, !layout->useFullScreenGeometry(), screenId);
+        // Translate to overlay-local coords against the SCOPE (VS or
+        // physical) origin so zone.x = 0 lines up with the snap-assist
+        // surface's top-left anchor.
         QRect overlayGeom =
-            PhosphorGeometry::snapToRect(PhosphorGeometry::availableAreaToOverlayCoordinates(geom, screen->geometry()));
+            PhosphorGeometry::snapToRect(PhosphorGeometry::availableAreaToOverlayCoordinates(geom, scopeGeom));
 
         PhosphorProtocol::EmptyZoneEntry entry;
         entry.zoneId = zone->id().toString();

--- a/libs/phosphor-placement/src/navigation.cpp
+++ b/libs/phosphor-placement/src/navigation.cpp
@@ -120,7 +120,7 @@ EmptyZoneList WindowTrackingService::getEmptyZones(const QString& screenId) cons
     // overlay surface that renders snap-assist is anchored to the VS
     // top-left, so emitting zone coordinates relative to anything
     // other than the VS rect produces zone rectangles wider than the
-    // surface — manifesting as "zone right edge clipped flat without
+    // surface, manifesting as "zone right edge clipped flat without
     // a rounded corner" because the visible content can't extend past
     // the surface's bounds.
     //
@@ -128,18 +128,17 @@ EmptyZoneList WindowTrackingService::getEmptyZones(const QString& screenId) cons
     // `availableAreaToOverlayCoordinates(geom, screen->geometry())`
     // computed against the PHYSICAL screen, so a layout assigned to
     // a smaller VS produced zones sized for the full monitor.
-    const QRect physGeom = screen->geometry();
     QRect scopeGeom = m_screenManager ? m_screenManager->screenGeometry(screenId) : QRect();
     if (!scopeGeom.isValid()) {
-        scopeGeom = physGeom;
+        scopeGeom = screen->geometry();
     }
     const QRect scopeAvailGeom = m_screenManager ? m_screenManager->actualAvailableGeometry(screen) : scopeGeom;
     const QRect availForLayout =
         scopeAvailGeom.intersected(scopeGeom).isEmpty() ? scopeGeom : scopeAvailGeom.intersected(scopeGeom);
 
-    // No `LayoutComputeService::recalculateSync` here — that mutates the
-    // shared layout's cached zone geometries to whatever rect we pass,
-    // which clobbers OSD / main-overlay consumers reading
+    // No `LayoutComputeService::recalculateSync` here. That call mutates
+    // the shared layout's cached zone geometries to whatever rect we
+    // pass, which clobbers OSD / main-overlay consumers reading
     // `zone->geometry()` against the last compute pass. The VS-aware
     // `getZoneGeometryWithGaps(mgr, zone, scopeGeom, availForLayout, …)`
     // overload below computes from `zone->relativeGeometry()` against
@@ -164,7 +163,7 @@ EmptyZoneList WindowTrackingService::getEmptyZones(const QString& screenId) cons
         if (occupied.contains(zone->id())) {
             continue;
         }
-        // VS-aware overload — uses the explicit scopeGeom rect for
+        // VS-aware overload: uses the explicit scopeGeom rect for
         // layout maths instead of pulling QScreen::geometry() (which
         // is always physical).
         QRectF geom = PhosphorZones::GeometryUtils::getZoneGeometryWithGaps(

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -553,7 +553,7 @@ bool Daemon::init()
     // on the first OSD; every subsequent OSD show animates correctly
     // because the cache is now warm.
     //
-    // Shares m_shaderBakePool with the zone-shader warm-bake — the
+    // Shares m_shaderBakePool with the zone-shader warm-bake. The
     // pool is single-threaded (QShaderBaker / glslang isn't thread-
     // safe), so animation and zone bakes serialise without interfering.
     //
@@ -563,7 +563,7 @@ bool Daemon::init()
     // and the bake worker resolves it identically to the render-
     // thread load path. The vertex-path fallback (default
     // `shared/animation.vert` when an effect doesn't ship its own)
-    // also mirrors the runtime — otherwise the warm-baked entry's
+    // also mirrors the runtime, otherwise the warm-baked entry's
     // cache key would differ from what runtime queries.
     if (m_animationShaderRegistry) {
         auto scheduleWarmForAnimEffect = [this,

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -543,6 +543,89 @@ bool Daemon::init()
         scheduleWarmForShader(info);
     }
 
+    // Warm-bake ANIMATION shaders (fly-in / dissolve / etc.) the same
+    // way zone shaders are warmed above. Without this, the first OSD
+    // show after a fresh daemon start hits a cold cache: QShaderBaker
+    // compiles the animation shader synchronously on the render thread
+    // during the first frame, and the AV's animation duration (e.g.
+    // 500 ms) can elapse before the shader is ready to paint. The
+    // observed symptom: card "pops in" at rest with no slide animation
+    // on the first OSD; every subsequent OSD show animates correctly
+    // because the cache is now warm.
+    //
+    // Shares m_shaderBakePool with the zone-shader warm-bake — the
+    // pool is single-threaded (QShaderBaker / glslang isn't thread-
+    // safe), so animation and zone bakes serialise without interfering.
+    //
+    // Include-path resolution mirrors surfaceanimator.cpp:1358-1361:
+    // every animation search-path's `/shared` subdir is added so an
+    // effect's vert / frag can `#include <animation_uniforms.glsl>`
+    // and the bake worker resolves it identically to the render-
+    // thread load path. The vertex-path fallback (default
+    // `shared/animation.vert` when an effect doesn't ship its own)
+    // also mirrors the runtime — otherwise the warm-baked entry's
+    // cache key would differ from what runtime queries.
+    if (m_animationShaderRegistry) {
+        auto scheduleWarmForAnimEffect = [this,
+                                          registryPtr = QPointer<PhosphorAnimationShaders::AnimationShaderRegistry>(
+                                              m_animationShaderRegistry.get())](
+                                             const PhosphorAnimationShaders::AnimationShaderEffect& info) {
+            if (!info.isValid() || info.fragmentShaderPath.isEmpty() || !QFile::exists(info.fragmentShaderPath)) {
+                return;
+            }
+            PhosphorAnimationShaders::AnimationShaderRegistry* reg = registryPtr.data();
+            if (!reg) {
+                return;
+            }
+            QString vertPath = info.vertexShaderPath;
+            QStringList includePaths;
+            for (const QString& sp : reg->searchPaths()) {
+                const QString sharedDir = sp + QStringLiteral("/shared");
+                if (QDir(sharedDir).exists()) {
+                    includePaths.append(sharedDir);
+                    if (vertPath.isEmpty()) {
+                        const QString sharedVert = sharedDir + QStringLiteral("/animation.vert");
+                        if (QFile::exists(sharedVert)) {
+                            vertPath = sharedVert;
+                        }
+                    }
+                }
+            }
+            if (vertPath.isEmpty() || !QFile::exists(vertPath)) {
+                return;
+            }
+            const QString effectId = info.id;
+            auto* watcher = new QFutureWatcher<PhosphorRendering::WarmShaderBakeResult>(this);
+            connect(watcher, &QFutureWatcher<PhosphorRendering::WarmShaderBakeResult>::finished, this,
+                    [watcher, effectId]() {
+                        const PhosphorRendering::WarmShaderBakeResult r = watcher->result();
+                        if (!r.success) {
+                            qCWarning(lcDaemon) << "Animation shader bake: failed for" << effectId << r.errorMessage;
+                        }
+                        watcher->deleteLater();
+                    });
+            watcher->setFuture(
+                QtConcurrent::run(&m_shaderBakePool, [vertPath, fragPath = info.fragmentShaderPath, includePaths]() {
+                    return warmShaderBakeCacheForPaths(vertPath, fragPath, includePaths);
+                }));
+        };
+        connect(m_animationShaderRegistry.get(), &PhosphorAnimationShaders::AnimationShaderRegistry::effectsChanged,
+                this, [this, scheduleWarmForAnimEffect]() {
+                    if (!m_animationShaderRegistry) {
+                        return;
+                    }
+                    const QList<PhosphorAnimationShaders::AnimationShaderEffect> effects =
+                        m_animationShaderRegistry->availableEffects();
+                    for (const PhosphorAnimationShaders::AnimationShaderEffect& info : effects) {
+                        scheduleWarmForAnimEffect(info);
+                    }
+                });
+        for (const PhosphorAnimationShaders::AnimationShaderEffect& info :
+             m_animationShaderRegistry->availableEffects()) {
+            scheduleWarmForAnimEffect(info);
+        }
+    }
+
     // Wire the level-1 (global) cascade tier as two pass-through
     // providers — snap default layout id and autotile default algorithm
     // id — symmetric in shape and each gated on its own enabled flag.

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -515,6 +515,21 @@ void Daemon::connectLayoutSignals()
                 if (m_overlayService && m_overlayService->isSnapAssistVisible()) {
                     m_overlayService->hideSnapAssist();
                 }
+                // Suppress during startup — mirrors the algorithmChanged gate above.
+                // `loadState()` from finalizeStartup() synchronously emits
+                // `layoutApplied` per screen as layouts get assigned, and
+                // finalizeStartup() is the authoritative startup-OSD path
+                // (it calls `showOsdForAllScreens`). Letting this handler also
+                // fire double-queues a show on every screen: the first OSD
+                // begins its fly-in shader leg, the second show immediately
+                // cancels that AV via `cancelTrackingFor → parkShaderForReuse`
+                // and re-enters via the reuse path. The user sees the slide
+                // animation get nuked mid-flight and visually perceives "show
+                // doesn't animate" — only the hide leg (no duplicate) plays
+                // cleanly.
+                if (!m_running) {
+                    return;
+                }
                 // Defer OSD display (same rationale as autotileApplied — first-time
                 // QML compilation of the passive shell blocks the event loop
                 // ~100-300ms). Capture layout ID (not raw pointer) to avoid

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -546,8 +546,21 @@ void Daemon::connectLayoutSignals()
             [this](const QString& algorithmName, int windowCount) {
                 Q_UNUSED(windowCount)
                 // Dismiss snap assist — autotile mode replaces snapping entirely
-                if (m_overlayService->isSnapAssistVisible()) {
+                if (m_overlayService && m_overlayService->isSnapAssistVisible()) {
                     m_overlayService->hideSnapAssist();
+                }
+                // Suppress during startup. Mirrors the algorithmChanged and
+                // layoutApplied gates above. `loadState()` from finalizeStartup()
+                // synchronously emits `autotileApplied` per screen as layouts get
+                // assigned for autotile-mode entries, and finalizeStartup() is the
+                // authoritative startup-OSD path (it calls `showOsdForAllScreens`).
+                // Without this gate, autotile users would hit the same first-OSD
+                // double-queue that the layoutApplied gate fixes for snap-mode
+                // users: the first OSD begins its fly-in shader leg, the second
+                // show cancels that AV via cancelTrackingFor + parkShaderForReuse,
+                // and the slide-in animation gets nuked mid-flight.
+                if (!m_running) {
+                    return;
                 }
                 // Defer OSD display so QML window creation (first-time ~100-300ms for
                 // NotificationOverlay.qml compilation + scene graph) doesn't block the

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -515,18 +515,18 @@ void Daemon::connectLayoutSignals()
                 if (m_overlayService && m_overlayService->isSnapAssistVisible()) {
                     m_overlayService->hideSnapAssist();
                 }
-                // Suppress during startup — mirrors the algorithmChanged gate above.
+                // Suppress during startup. Mirrors the algorithmChanged gate above.
                 // `loadState()` from finalizeStartup() synchronously emits
                 // `layoutApplied` per screen as layouts get assigned, and
                 // finalizeStartup() is the authoritative startup-OSD path
                 // (it calls `showOsdForAllScreens`). Letting this handler also
                 // fire double-queues a show on every screen: the first OSD
                 // begins its fly-in shader leg, the second show immediately
-                // cancels that AV via `cancelTrackingFor → parkShaderForReuse`
+                // cancels that AV via `cancelTrackingFor` + `parkShaderForReuse`
                 // and re-enters via the reuse path. The user sees the slide
                 // animation get nuked mid-flight and visually perceives "show
-                // doesn't animate" — only the hide leg (no duplicate) plays
-                // cleanly.
+                // doesn't animate", because only the hide leg (no duplicate)
+                // plays cleanly.
                 if (!m_running) {
                     return;
                 }

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -185,7 +185,11 @@ void OverlayService::showSnapAssist(const QString& screenId, const EmptyZoneList
     }
 
     // Resize the shell window to the target screen geometry (matches
-    // OSD path's sizeOsdToScreen).
+    // OSD path's sizeOsdToScreen). The shell is shared with OSD /
+    // selector / picker slots — sizing it to anything other than the
+    // VS rect would shift their positioning to physical-screen
+    // coordinates, so the snap-assist path holds to the same per-VS
+    // sizing the rest of the shell uses.
     if (shellWindow) {
         assertWindowOnScreen(shellWindow, screen, screenGeom);
         shellWindow->setWidth(screenGeom.width());

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -185,8 +185,8 @@ void OverlayService::showSnapAssist(const QString& screenId, const EmptyZoneList
     }
 
     // Resize the shell window to the target screen geometry (matches
-    // OSD path's sizeOsdToScreen). The shell is shared with OSD /
-    // selector / picker slots — sizing it to anything other than the
+    // OSD path's sizeOsdToScreen). The shell is shared with OSD,
+    // selector, and picker slots: sizing it to anything other than the
     // VS rect would shift their positioning to physical-screen
     // coordinates, so the snap-assist path holds to the same per-VS
     // sizing the rest of the shell uses.

--- a/src/ui/SnapAssistContent.qml
+++ b/src/ui/SnapAssistContent.qml
@@ -125,14 +125,11 @@ Item {
                 readonly property real flowSpacing: Math.max(2, Math.min(8, zoneSize * 0.02))
                 readonly property int itemsPerRow: Math.max(1, Math.floor((availableWidth + flowSpacing) / (cardTotalWidth + flowSpacing)))
                 // Width sized to exactly one row's worth of content so
-                // Flow wraps at the right item count and the natural
-                // `anchors.centerIn` lands on the visual centre of the
-                // zone. The previous leftPadding-as-centering hack
-                // worked only when `Flow.leftPadding` actually shifted
-                // children rightward; on Qt 6 the combination of
-                // `anchors.horizontalCenter` + explicit `width` +
-                // `leftPadding` was producing right-aligned cards
-                // instead of centred ones.
+                // Flow wraps at the right item count. Paired with the
+                // explicit `x` / `y` centring math below, this gives
+                // the cards a stable width to centre against without
+                // depending on Flow's `implicitWidth` (which fluctuates
+                // with child layout passes).
                 readonly property real contentWidth: {
                     var n = root.candidates.length;
                     if (n <= 0)
@@ -146,7 +143,7 @@ Item {
                 // the Flow's `implicitHeight` is `0` until its
                 // Repeater-spawned card delegates lay out, and the
                 // anchor resolves once at first paint with that 0
-                // height — leaving the Flow stuck at parent's `(0, 0)`
+                // height, leaving the Flow stuck at parent's `(0, 0)`
                 // even after children populate. Computing `x`/`y`
                 // directly from `contentWidth` / `implicitHeight`
                 // re-evaluates whenever the implicit dimensions

--- a/src/ui/SnapAssistContent.qml
+++ b/src/ui/SnapAssistContent.qml
@@ -26,7 +26,10 @@ import org.phosphor.animation
 Item {
     id: root
 
-    /// shaderAnchor for SurfaceAnimator.
+    /// shaderAnchor for SurfaceAnimator. The shell wl_surface is sized
+    /// to the VS rect (see `OverlayService::showSnapAssist`), so this
+    /// item filling the surface naturally scopes the per-event
+    /// transition shader's FBO + animation runway to the VS bounds.
     property bool shaderAnchor: true
     property var emptyZones: []
     property var candidates: []
@@ -117,28 +120,43 @@ Item {
                     var scaledSize = baseSize * Math.max(root.minFontScale, Math.min(1, scaleFactor));
                     return Math.max(root.minFontPx, Math.round(scaledSize));
                 }
-                readonly property real flowWidth: zoneContainer.width - Kirigami.Units.smallSpacing * 2
+                readonly property real availableWidth: zoneContainer.width - Kirigami.Units.smallSpacing * 2
                 readonly property real cardTotalWidth: cardWidth + Kirigami.Units.smallSpacing * 2
                 readonly property real flowSpacing: Math.max(2, Math.min(8, zoneSize * 0.02))
-                readonly property int itemsPerRow: Math.max(1, Math.floor((flowWidth + flowSpacing) / (cardTotalWidth + flowSpacing)))
+                readonly property int itemsPerRow: Math.max(1, Math.floor((availableWidth + flowSpacing) / (cardTotalWidth + flowSpacing)))
+                // Width sized to exactly one row's worth of content so
+                // Flow wraps at the right item count and the natural
+                // `anchors.centerIn` lands on the visual centre of the
+                // zone. The previous leftPadding-as-centering hack
+                // worked only when `Flow.leftPadding` actually shifted
+                // children rightward; on Qt 6 the combination of
+                // `anchors.horizontalCenter` + explicit `width` +
+                // `leftPadding` was producing right-aligned cards
+                // instead of centred ones.
                 readonly property real contentWidth: {
                     var n = root.candidates.length;
                     if (n <= 0)
                         return 0;
 
-                    var perRow = itemsPerRow;
-                    if (n <= perRow)
-                        return n * cardTotalWidth + (n - 1) * flowSpacing;
-
+                    var perRow = Math.min(n, itemsPerRow);
                     return perRow * cardTotalWidth + (perRow - 1) * flowSpacing;
                 }
-                readonly property real centerPadding: Math.max(0, (flowWidth - contentWidth) / 2)
 
-                width: flowWidth
-                leftPadding: centerPadding
-                anchors.horizontalCenter: parent.horizontalCenter
-                anchors.top: parent.top
-                anchors.topMargin: Math.max(Kirigami.Units.smallSpacing, (zoneContainer.height - candidateFlow.implicitHeight) / 2)
+                // Explicit centring math instead of `anchors.centerIn`:
+                // the Flow's `implicitHeight` is `0` until its
+                // Repeater-spawned card delegates lay out, and the
+                // anchor resolves once at first paint with that 0
+                // height — leaving the Flow stuck at parent's `(0, 0)`
+                // even after children populate. Computing `x`/`y`
+                // directly from `contentWidth` / `implicitHeight`
+                // re-evaluates whenever the implicit dimensions
+                // settle, so the cards always land at the zone's
+                // visual centre. Same approach the rest of the
+                // overlay code uses for size-binding-driven
+                // centring (see ZoneOverlayContent's preview cards).
+                x: (zoneContainer.width - width) / 2
+                y: (zoneContainer.height - implicitHeight) / 2
+                width: contentWidth
                 spacing: flowSpacing
 
                 Repeater {


### PR DESCRIPTION
## Summary

Two independent overlay-animation regressions:

- **Snap-assist on a virtual screen** rendered zone outlines clipped to the physical monitor instead of the VS rect (zones flush against the VS right edge lost their rounded corner). Root cause in `WindowTrackingService::getEmptyZones`: zone maths and the post-compute translation both used `screen->geometry()` instead of the VS rect. Fixed by resolving `scopeGeom` via `ScreenManager::screenGeometry(screenId)` and calling the VS-aware `getZoneGeometryWithGaps` overload that computes from `zone->relativeGeometry()` against the supplied rect (no shared-state mutation). Also fixes a QML centring regression: the candidate Flow's `anchors.centerIn: parent` resolved at first paint with `implicitHeight=0` and left cards right-aligned. Replaced with explicit centring math against `contentWidth` and `implicitHeight`.

- **First OSD after daemon start popped in at rest** with no slide animation. Every subsequent OSD show animated correctly. Three independent issues stacked, each sufficient on its own under the right timing:
  1. Animation shaders had no warm-bake worker. Zone shaders run through `scheduleWarmForShader` in `Daemon::init()`; the parallel `AnimationShaderRegistry` had no equivalent. First OSD's render thread compiled fly-in synchronously and the AV duration elapsed before the shader was ready. Added `scheduleWarmForAnimEffect` sharing the same single-threaded bake pool.
  2. Startup fired the OSD show twice per screen. `loadState()` emits `layoutApplied` per screen, which `signals.cpp:509` dispatched as an OSD; `finalizeStartup → showOsdForAllScreens` dispatched a second OSD on the same screen. The second show cancelled the first AV mid-flight via `parkShaderForReuse` and re-entered through the reuse branch, killing visible frames. Mirrored the existing `algorithmChanged` `!m_running` gate.
  3. `SurfaceAnimator::attachShaderToAnchor` set `setSourceItem(shaderSource)` before `syncGeometry()`. The render thread's first `prepare()` copied zero-initialised `AnimationUniformExtension` data into the UBO at offsets 672 / 688, fly-in's vertex stage read `screenW = max(0, 1) = 1`, and `clearancePx` collapsed to one pixel. Moved the geometry sync ahead of `setSourceItem` so the first painted frame sees fully initialised uniforms.

## Test plan

- [x] `cmake --build build` clean
- [x] `ctest -j$(nproc)` 176/176 passing
- [x] Manual: fly-in OSD on first daemon-start show now slides in from the closest VS edge (previously popped in at rest)
- [x] Manual: fly-in OSD hide unchanged (still slides out)
- [x] Manual: snap-assist on a virtual screen renders zone outlines clipped to the VS rect with rounded corners on every edge
- [x] Manual: snap-assist candidate cards centred horizontally inside each zone

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)