### PR TITLE
fix(editor,preview): compute zone bounding box for fixed-geometry layouts

### DIFF
--- a/libs/phosphor-zones/include/PhosphorZones/LayoutUtils.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutUtils.h
@@ -92,6 +92,16 @@ PHOSPHORZONES_EXPORT QVariantMap layoutToVariantMap(Layout* layout, ZoneFields z
 PHOSPHORZONES_EXPORT void sortZonesByNumber(QVector<Zone*>& zones);
 PHOSPHORZONES_EXPORT QHash<QString, int> buildZonePositionMap(Layout* layout);
 
+/**
+ * @brief Compute the bounding box of all fixed-geometry zones in a layout.
+ *
+ * Returns an empty QRectF when the layout is null, has no fixed zones, or
+ * the computed bounding box has zero area.  Callers use this to derive the
+ * actual screen dimensions that fixed zones occupy (as opposed to
+ * lastRecalcGeometry which may belong to a different screen).
+ */
+PHOSPHORZONES_EXPORT QRectF fixedZoneBoundingBox(Layout* layout);
+
 } // namespace LayoutUtils
 
 } // namespace PhosphorZones

--- a/libs/phosphor-zones/src/layoututils.cpp
+++ b/libs/phosphor-zones/src/layoututils.cpp
@@ -209,6 +209,27 @@ QHash<QString, int> buildZonePositionMap(Layout* layout)
     return map;
 }
 
+QRectF fixedZoneBoundingBox(Layout* layout)
+{
+    if (!layout) {
+        return {};
+    }
+    qreal maxX = 0, maxY = 0;
+    for (Zone* z : layout->zones()) {
+        if (!z || z->geometryMode() != ZoneGeometryMode::Fixed) {
+            continue;
+        }
+        const QRectF& fg = z->fixedGeometry();
+        if (fg.x() + fg.width() > maxX) {
+            maxX = fg.x() + fg.width();
+        }
+        if (fg.y() + fg.height() > maxY) {
+            maxY = fg.y() + fg.height();
+        }
+    }
+    return (maxX > 0 && maxY > 0) ? QRectF(0, 0, maxX, maxY) : QRectF();
+}
+
 } // namespace LayoutUtils
 
 } // namespace PhosphorZones

--- a/libs/phosphor-zones/src/zoneslayoutsource.cpp
+++ b/libs/phosphor-zones/src/zoneslayoutsource.cpp
@@ -4,8 +4,10 @@
 #include <PhosphorLayoutApi/LayoutId.h>
 #include <PhosphorZones/IZoneLayoutRegistry.h>
 #include <PhosphorZones/Layout.h>
+#include <PhosphorZones/LayoutUtils.h>
 #include <PhosphorZones/Zone.h>
 #include <PhosphorZones/ZonesLayoutSource.h>
+#include "zoneslogging.h"
 
 #include <QUuid>
 
@@ -43,45 +45,30 @@ PhosphorLayout::LayoutPreview previewFromLayout(PhosphorZones::Layout* layout, c
     QRectF refGeo;
     if (!canvas.isEmpty()) {
         refGeo = QRectF(0, 0, canvas.width(), canvas.height());
-        qInfo() << "previewFromLayout: using canvas refGeo:" << refGeo << "for layout:" << layout->name();
+        qCDebug(lcZonesLib) << "previewFromLayout: using canvas refGeo:" << refGeo
+                            << "for layout:" << layout->name();
     } else if (layout->hasFixedGeometryZones()) {
         refGeo = layout->lastRecalcGeometry();
+        const QRectF zoneBB = LayoutUtils::fixedZoneBoundingBox(layout);
         if (refGeo.isEmpty() || refGeo.height() <= 0) {
             // No recalc geometry — compute from zones.
-            qreal maxX = 0, maxY = 0;
-            for (auto* z : layout->zones()) {
-                if (!z || z->geometryMode() != PhosphorZones::ZoneGeometryMode::Fixed)
-                    continue;
-                const auto& fg = z->fixedGeometry();
-                if (fg.x() + fg.width() > maxX) maxX = fg.x() + fg.width();
-                if (fg.y() + fg.height() > maxY) maxY = fg.y() + fg.height();
+            if (!zoneBB.isEmpty()) {
+                refGeo = zoneBB;
             }
-            if (maxX > 0 && maxY > 0)
-                refGeo = QRectF(0, 0, maxX, maxY);
+        } else if (!zoneBB.isEmpty()
+                   && (zoneBB.width() > refGeo.width() || zoneBB.height() > refGeo.height())) {
+            // The fixed zones exceed the recalc geometry — use the zone
+            // bounding box directly rather than mixing dimensions from
+            // potentially different screen orientations (e.g. a portrait
+            // screen's 3840px height mixed with a landscape layout's
+            // 2160px maxY would produce a 3840x3840 square instead of
+            // the correct 3840x2160 rectangle).
+            refGeo = zoneBB;
+            qCDebug(lcZonesLib) << "previewFromLayout: replaced recalcGeo" << layout->lastRecalcGeometry()
+                                << "with zone bounding box:" << refGeo << "for layout:" << layout->name();
         } else {
-            // Check if recalc geometry is smaller than the zone bounding box.
-            qreal maxX = 0, maxY = 0;
-            for (auto* z : layout->zones()) {
-                if (!z || z->geometryMode() != PhosphorZones::ZoneGeometryMode::Fixed)
-                    continue;
-                const auto& fg = z->fixedGeometry();
-                if (fg.x() + fg.width() > maxX) maxX = fg.x() + fg.width();
-                if (fg.y() + fg.height() > maxY) maxY = fg.y() + fg.height();
-            }
-            if (maxX > refGeo.width() || maxY > refGeo.height()) {
-                // The fixed zones exceed the recalc geometry — use the zone
-                // bounding box directly rather than mixing dimensions from
-                // potentially different screen orientations (e.g. a portrait
-                // screen's 3840px height mixed with a landscape layout's
-                // 2160px maxY would produce a 3840x3840 square instead of
-                // the correct 3840x2160 rectangle).
-                refGeo = QRectF(0, 0, maxX, maxY);
-                qInfo() << "previewFromLayout: replaced recalcGeo" << layout->lastRecalcGeometry()
-                                      << "with zone bounding box:" << refGeo << "for layout:" << layout->name();
-            } else {
-                qInfo() << "previewFromLayout: using recalcGeo:" << refGeo
-                                     << "for layout:" << layout->name() << "hasFixed:" << layout->hasFixedGeometryZones();
-            }
+            qCDebug(lcZonesLib) << "previewFromLayout: using recalcGeo:" << refGeo
+                                << "for layout:" << layout->name() << "hasFixed:" << layout->hasFixedGeometryZones();
         }
     }
 

--- a/libs/phosphor-zones/src/zoneslayoutsource.cpp
+++ b/libs/phosphor-zones/src/zoneslayoutsource.cpp
@@ -34,9 +34,56 @@ PhosphorLayout::LayoutPreview previewFromLayout(PhosphorZones::Layout* layout, c
     // pass one (the historical single-screen path). The canvas parameter
     // lets two callers on different screens share a Layout* without one
     // poisoning the other's projection via the shared last-recalc cache.
-    const QRectF refGeo = !canvas.isEmpty()
-        ? QRectF(0, 0, canvas.width(), canvas.height())
-        : (layout->hasFixedGeometryZones() ? layout->lastRecalcGeometry() : QRectF());
+    //
+    // For fixed-geometry layouts, if lastRecalcGeometry is smaller than the
+    // actual bounding box of the fixed zones (e.g. when the layout was
+    // authored for a 4K monitor with 2160px height but the screen's
+    // availableGeometry is 2126px due to a panel), compute the bounding box
+    // directly from the zone fixed geometries to avoid normalized coords > 1.
+    QRectF refGeo;
+    if (!canvas.isEmpty()) {
+        refGeo = QRectF(0, 0, canvas.width(), canvas.height());
+        qInfo() << "previewFromLayout: using canvas refGeo:" << refGeo << "for layout:" << layout->name();
+    } else if (layout->hasFixedGeometryZones()) {
+        refGeo = layout->lastRecalcGeometry();
+        if (refGeo.isEmpty() || refGeo.height() <= 0) {
+            // No recalc geometry — compute from zones.
+            qreal maxX = 0, maxY = 0;
+            for (auto* z : layout->zones()) {
+                if (!z || z->geometryMode() != PhosphorZones::ZoneGeometryMode::Fixed)
+                    continue;
+                const auto& fg = z->fixedGeometry();
+                if (fg.x() + fg.width() > maxX) maxX = fg.x() + fg.width();
+                if (fg.y() + fg.height() > maxY) maxY = fg.y() + fg.height();
+            }
+            if (maxX > 0 && maxY > 0)
+                refGeo = QRectF(0, 0, maxX, maxY);
+        } else {
+            // Check if recalc geometry is smaller than the zone bounding box.
+            qreal maxX = 0, maxY = 0;
+            for (auto* z : layout->zones()) {
+                if (!z || z->geometryMode() != PhosphorZones::ZoneGeometryMode::Fixed)
+                    continue;
+                const auto& fg = z->fixedGeometry();
+                if (fg.x() + fg.width() > maxX) maxX = fg.x() + fg.width();
+                if (fg.y() + fg.height() > maxY) maxY = fg.y() + fg.height();
+            }
+            if (maxX > refGeo.width() || maxY > refGeo.height()) {
+                // The fixed zones exceed the recalc geometry — use the zone
+                // bounding box directly rather than mixing dimensions from
+                // potentially different screen orientations (e.g. a portrait
+                // screen's 3840px height mixed with a landscape layout's
+                // 2160px maxY would produce a 3840x3840 square instead of
+                // the correct 3840x2160 rectangle).
+                refGeo = QRectF(0, 0, maxX, maxY);
+                qInfo() << "previewFromLayout: replaced recalcGeo" << layout->lastRecalcGeometry()
+                                      << "with zone bounding box:" << refGeo << "for layout:" << layout->name();
+            } else {
+                qInfo() << "previewFromLayout: using recalcGeo:" << refGeo
+                                     << "for layout:" << layout->name() << "hasFixed:" << layout->hasFixedGeometryZones();
+            }
+        }
+    }
 
     if (layout->hasFixedGeometryZones() && refGeo.height() > 0) {
         preview.referenceAspectRatio = refGeo.width() / refGeo.height();

--- a/src/daemon/overlayservice/osd.cpp
+++ b/src/daemon/overlayservice/osd.cpp
@@ -168,12 +168,16 @@ void OverlayService::showLayoutOsdImpl(PhosphorZones::Layout* layout, const QStr
         return;
     }
 
+    // Pass the actual screen geometry as reference so fixed-mode zones
+    // normalize against the correct screen dimensions rather than
+    // lastRecalcGeometry (which may belong to a different screen).
     LayoutOsdContentParams p;
     p.id = layout->id().toString();
     p.name = layout->name();
     p.zones = layout->zones().isEmpty()
         ? QVariantList()
-        : PhosphorZones::LayoutUtils::zonesToVariantList(layout, PhosphorZones::ZoneField::Full);
+        : PhosphorZones::LayoutUtils::zonesToVariantList(layout, PhosphorZones::ZoneField::Full,
+                                                          QRectF(screenGeom));
     p.category = static_cast<int>(PhosphorZones::LayoutCategory::Manual);
     p.autoAssign = layout->autoAssign();
     p.globalAutoAssign = m_settings && m_settings->autoAssignAllLayouts();
@@ -878,10 +882,13 @@ void OverlayService::showNavigationOsd(bool success, const QString& action, cons
     }
     writeQmlProperty(osdSlot, QStringLiteral("highlightedZoneIds"), highlightedZoneIds);
 
-    // Use shared PhosphorZones::LayoutUtils with minimal fields for zone number lookup
-    // (only need zoneId and zoneNumber, not name/appearance)
+    // Use shared PhosphorZones::LayoutUtils with minimal fields for zone number lookup.
+    // Pass navScreenGeom as reference so fixed-mode zones normalize against the
+    // correct screen dimensions rather than lastRecalcGeometry (which may belong
+    // to a different screen).
     QVariantList zonesList =
-        PhosphorZones::LayoutUtils::zonesToVariantList(screenLayout, PhosphorZones::ZoneField::Minimal);
+        PhosphorZones::LayoutUtils::zonesToVariantList(screenLayout, PhosphorZones::ZoneField::Minimal,
+                                                        QRectF(navScreenGeom));
     writeQmlProperty(osdSlot, QStringLiteral("zones"), zonesList);
 
     // shaderBoundsPadding before mode — the Loader instantiates

--- a/src/editor/controller/layout.cpp
+++ b/src/editor/controller/layout.cpp
@@ -141,11 +141,13 @@ void EditorController::setTargetScreen(const QString& screenName)
         cacheVirtualScreenGeometry(screenName);
 
         Q_EMIT targetScreenChanged();
-        Q_EMIT targetScreenSizeChanged();
         refreshUsableAreaInsets();
-        m_zoneManager->setReferenceScreenSize(targetScreenSize());
 
-        // Load the layout assigned to this screen
+        // Load the layout assigned to this screen. Do not emit targetScreenSizeChanged
+        // here — loadLayout/createNewLayout will emit it after computing the correct
+        // virtual screen size from fixed-zone bounding box (or default). Emitting it
+        // before the layout is loaded causes QML to recompute zone positions using a
+        // stale/wrong screen size, which makes zones jump to wrong positions.
         if (!screenName.isEmpty() && m_layoutService) {
             QString layoutId = m_layoutService->getLayoutIdForScreen(screenName);
             qCDebug(lcEditor) << "setTargetScreen:" << screenName << "daemon returned layoutId:" << layoutId
@@ -158,6 +160,10 @@ void EditorController::setTargetScreen(const QString& screenName)
                 qCInfo(lcEditor) << "No layout assigned to screen" << screenName << "- creating new layout";
                 createNewLayout();
             }
+        } else {
+            // No layout to load — emit size changed now so QML updates with fallback size.
+            Q_EMIT targetScreenSizeChanged();
+            m_zoneManager->setReferenceScreenSize(targetScreenSize());
         }
     }
 }
@@ -347,6 +353,8 @@ void EditorController::createNewLayout()
     Q_EMIT overlayDisplayModeChanged();
     Q_EMIT useFullScreenGeometryChanged();
     Q_EMIT aspectRatioClassChanged();
+    // New layouts have no fixed zones, so use the fallback screen size.
+    Q_EMIT targetScreenSizeChanged();
 }
 
 void EditorController::loadLayout(const QString& layoutId)
@@ -478,9 +486,85 @@ void EditorController::loadLayout(const QString& layoutId)
         zones.append(zone);
     }
 
+    // Compute the bounding box of all fixed-geometry zones *before* setting
+    // zones so that m_virtualScreenSize is ready when the QML Repeater creates
+    // EditorZone delegates and calls syncFromZoneData().
+    if (!zones.isEmpty()) {
+        qreal maxX = 0, maxY = 0;
+        bool hasFixed = false;
+        for (const auto& v : zones) {
+            const auto& zm = v.toMap();
+            int gm = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::GeometryMode)).toInt();
+            if (gm == 1) {
+                hasFixed = true;
+                qreal fx = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedX)).toReal();
+                qreal fy = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedY)).toReal();
+                qreal fw = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedWidth)).toReal();
+                qreal fh = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedHeight)).toReal();
+                if (fx + fw > maxX) maxX = fx + fw;
+                if (fy + fh > maxY) maxY = fy + fh;
+            }
+        }
+        if (hasFixed && maxX > 0 && maxY > 0) {
+            QSize newVS(maxX, maxY);
+            // Write debug info to a file for easy inspection
+            QFile debugFile(QStringLiteral("/tmp/plasmazones-editor-debug.txt"));
+            if (debugFile.open(QIODevice::WriteOnly | QIODevice::Append)) {
+                QTime now = QTime::currentTime();
+                QString line;
+                line = QString::fromUtf8("=== loadLayout [%1] === layout:%2 name:%3 targetScreen:%4 fixedBB:%5x%6 virtualScreenSize:%7x%8 zones:%9")
+                           .arg(now.toString(Qt::ISODateWithMs),
+                                m_layoutId, m_layoutName, m_targetScreen,
+                                QString::number(newVS.width()), QString::number(newVS.height()),
+                                QString::number(m_virtualScreenSize.width()), QString::number(m_virtualScreenSize.height()),
+                                QString::number(zones.size()));
+                debugFile.write(line.toUtf8());
+                debugFile.write("\n");
+                // Log ALL fixed zone coordinates
+                for (int i = 0; i < zones.size(); ++i) {
+                    const auto& zm = zones[i].toMap();
+                    int gm = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::GeometryMode)).toInt();
+                    if (gm == 1) {
+                        line = QString::fromUtf8("  FIXED zone[%1]: id=%2")
+                                   .arg(i)
+                                   .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::Id)].toString());
+                        line += QString::fromUtf8(" fixedX=%1 fixedY=%2")
+                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedX)].toDouble())
+                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedY)].toDouble());
+                        line += QString::fromUtf8(" fixedW=%1 fixedH=%2")
+                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedWidth)].toDouble())
+                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedHeight)].toDouble());
+                        line += QString::fromUtf8(" relX=%1 relY=%2")
+                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::X)].toDouble())
+                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::Y)].toDouble());
+                        debugFile.write(line.toUtf8());
+                        debugFile.write("\n");
+                    }
+                }
+                // Also log targetScreenSize() that QML will see
+                QSize tsz = targetScreenSize();
+                line = QString::fromUtf8("  targetScreenSize() will return:%1x%2 m_virtualScreenSize=%3x%4")
+                           .arg(QString::number(tsz.width()), QString::number(tsz.height()),
+                                QString::number(m_virtualScreenSize.width()), QString::number(m_virtualScreenSize.height()));
+                debugFile.write(line.toUtf8());
+                debugFile.write("\n\n");
+            }
+            if (m_virtualScreenSize != newVS) {
+                m_virtualScreenSize = newVS;
+                if (m_zoneManager) {
+                    m_zoneManager->setReferenceScreenSize(m_virtualScreenSize);
+                }
+                qCDebug(lcEditor) << "Updated virtual screen size from fixed zones:" << newVS;
+            }
+        }
+    }
+
     if (m_zoneManager) {
         m_zoneManager->setZones(zones);
     }
+
+    // Emit after setZones so QML sees the updated size when syncing zones.
+    Q_EMIT targetScreenSizeChanged();
 
     // Load shader settings
     m_currentShaderId = layoutObj[QLatin1String(::PhosphorZones::ZoneJsonKeys::ShaderId)].toString();

--- a/src/editor/controller/layout.cpp
+++ b/src/editor/controller/layout.cpp
@@ -162,8 +162,8 @@ void EditorController::setTargetScreen(const QString& screenName)
             }
         } else {
             // No layout to load — emit size changed now so QML updates with fallback size.
-            Q_EMIT targetScreenSizeChanged();
             m_zoneManager->setReferenceScreenSize(targetScreenSize());
+            Q_EMIT targetScreenSizeChanged();
         }
     }
 }
@@ -489,14 +489,17 @@ void EditorController::loadLayout(const QString& layoutId)
     // Compute the bounding box of all fixed-geometry zones *before* setting
     // zones so that m_virtualScreenSize is ready when the QML Repeater creates
     // EditorZone delegates and calls syncFromZoneData().
-    if (!zones.isEmpty()) {
+    //
+    // We reconstruct a temporary Layout* from the parsed zone data so we can
+    // reuse `fixedZoneBoundingBox` — but since we don't have a real Layout
+    // object here yet, we compute it inline using the proper enum.
+    bool vsSizeChanged = false;
+    {
         qreal maxX = 0, maxY = 0;
-        bool hasFixed = false;
         for (const auto& v : zones) {
             const auto& zm = v.toMap();
-            int gm = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::GeometryMode)).toInt();
-            if (gm == 1) {
-                hasFixed = true;
+            const int gm = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::GeometryMode)).toInt();
+            if (gm == static_cast<int>(PhosphorZones::ZoneGeometryMode::Fixed)) {
                 qreal fx = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedX)).toReal();
                 qreal fy = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedY)).toReal();
                 qreal fw = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedWidth)).toReal();
@@ -505,52 +508,11 @@ void EditorController::loadLayout(const QString& layoutId)
                 if (fy + fh > maxY) maxY = fy + fh;
             }
         }
-        if (hasFixed && maxX > 0 && maxY > 0) {
+        if (maxX > 0 && maxY > 0) {
             QSize newVS(maxX, maxY);
-            // Write debug info to a file for easy inspection
-            QFile debugFile(QStringLiteral("/tmp/plasmazones-editor-debug.txt"));
-            if (debugFile.open(QIODevice::WriteOnly | QIODevice::Append)) {
-                QTime now = QTime::currentTime();
-                QString line;
-                line = QString::fromUtf8("=== loadLayout [%1] === layout:%2 name:%3 targetScreen:%4 fixedBB:%5x%6 virtualScreenSize:%7x%8 zones:%9")
-                           .arg(now.toString(Qt::ISODateWithMs),
-                                m_layoutId, m_layoutName, m_targetScreen,
-                                QString::number(newVS.width()), QString::number(newVS.height()),
-                                QString::number(m_virtualScreenSize.width()), QString::number(m_virtualScreenSize.height()),
-                                QString::number(zones.size()));
-                debugFile.write(line.toUtf8());
-                debugFile.write("\n");
-                // Log ALL fixed zone coordinates
-                for (int i = 0; i < zones.size(); ++i) {
-                    const auto& zm = zones[i].toMap();
-                    int gm = zm.value(QLatin1String(::PhosphorZones::ZoneJsonKeys::GeometryMode)).toInt();
-                    if (gm == 1) {
-                        line = QString::fromUtf8("  FIXED zone[%1]: id=%2")
-                                   .arg(i)
-                                   .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::Id)].toString());
-                        line += QString::fromUtf8(" fixedX=%1 fixedY=%2")
-                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedX)].toDouble())
-                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedY)].toDouble());
-                        line += QString::fromUtf8(" fixedW=%1 fixedH=%2")
-                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedWidth)].toDouble())
-                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::FixedHeight)].toDouble());
-                        line += QString::fromUtf8(" relX=%1 relY=%2")
-                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::X)].toDouble())
-                                    .arg(zm[QLatin1String(::PhosphorZones::ZoneJsonKeys::Y)].toDouble());
-                        debugFile.write(line.toUtf8());
-                        debugFile.write("\n");
-                    }
-                }
-                // Also log targetScreenSize() that QML will see
-                QSize tsz = targetScreenSize();
-                line = QString::fromUtf8("  targetScreenSize() will return:%1x%2 m_virtualScreenSize=%3x%4")
-                           .arg(QString::number(tsz.width()), QString::number(tsz.height()),
-                                QString::number(m_virtualScreenSize.width()), QString::number(m_virtualScreenSize.height()));
-                debugFile.write(line.toUtf8());
-                debugFile.write("\n\n");
-            }
             if (m_virtualScreenSize != newVS) {
                 m_virtualScreenSize = newVS;
+                vsSizeChanged = true;
                 if (m_zoneManager) {
                     m_zoneManager->setReferenceScreenSize(m_virtualScreenSize);
                 }
@@ -564,7 +526,10 @@ void EditorController::loadLayout(const QString& layoutId)
     }
 
     // Emit after setZones so QML sees the updated size when syncing zones.
-    Q_EMIT targetScreenSizeChanged();
+    // Gate on actual change to avoid unnecessary QML re-layouts.
+    if (vsSizeChanged) {
+        Q_EMIT targetScreenSizeChanged();
+    }
 
     // Load shader settings
     m_currentShaderId = layoutObj[QLatin1String(::PhosphorZones::ZoneJsonKeys::ShaderId)].toString();


### PR DESCRIPTION
Fixes layout scaling in Editor canvas and previews (settings overview and startup notification overlay)

lastRecalcGeometry may belong to a different screen (e.g. panel height difference or mixed orientation) causing normalized coordinates > 1 or square instead of rectangular reference frames. Compute bounding box directly from zone fixed geometries in previewFromLayout and loadLayout, and pass actual screen geometry through zonesToVariantList so OSD and editor normalize against correct dimensions.