### PR TITLE
fix(overlay): prevent bad overlay states after screen power-cycle and hide/show cycle

### DIFF
--- a/src/daemon/overlayservice/lifecycle.cpp
+++ b/src/daemon/overlayservice/lifecycle.cpp
@@ -119,7 +119,19 @@ void OverlayService::showAtPosition(int cursorX, int cursorY)
         // the next hide()/show() cycle.
         const bool cursorVsHasWindow = m_screenStates.contains(cursorEffectiveId)
             && m_screenStates.value(cursorEffectiveId).overlayPhysScreen != nullptr;
-        if (cursorVsHasWindow || m_excludedScreens.contains(cursorEffectiveId)) {
+        // Also check that the slot is not mid-hide-animation (opacity near 0
+        // means the hide callback hasn't fired yet, or the slot was hidden
+        // via dismissOverlayWindow which sets opacity to 0 via the animator).
+        // If the slot is hidden, fall through to initializeOverlay which
+        // properly recreates the overlay state (loaded toggle, setVisible,
+        // beginShow) rather than taking the fast path that only calls
+        // applyIdleStateForCursor.
+        auto cursorIt = m_screenStates.find(cursorEffectiveId);
+        const bool cursorSlotVisible = (cursorIt != m_screenStates.end()
+            && cursorIt->passiveShellMainOverlaySlot
+            ? !qFuzzyCompare(cursorIt->passiveShellMainOverlaySlot->opacity(), 0.0)
+            : false);
+        if ((cursorVsHasWindow && cursorSlotVisible) || m_excludedScreens.contains(cursorEffectiveId)) {
             m_currentOverlayScreenId = showOnAllMonitors ? QString() : cursorEffectiveId;
             applyIdleStateForCursor(cursorEffectiveId, showOnAllMonitors);
             return;

--- a/src/daemon/overlayservice/osd.cpp
+++ b/src/daemon/overlayservice/osd.cpp
@@ -449,6 +449,13 @@ OverlayService::PerScreenOverlayState* OverlayService::ensurePassiveShellFor(con
 {
     auto it = m_screenStates.find(effectiveId);
     if (it != m_screenStates.end() && it->passiveShellSurface) {
+        // Ensure the shell window defaults to click-through even on
+        // re-entry (e.g., after screen power-cycle where the shell
+        // survived but the flag may have been set to false by a modal
+        // popup or hide function).
+        if (auto* window = it->passiveShellWindow) {
+            window->setFlag(Qt::WindowTransparentForInput, true);
+        }
         return &it.value();
     }
 
@@ -475,6 +482,19 @@ OverlayService::PerScreenOverlayState* OverlayService::ensurePassiveShellFor(con
     state.passiveShellSurface = surface;
     state.passiveShellWindow = surface->window();
     state.notificationPhysScreen = physScreen;
+
+    // Default the shell window to click-through. The shell starts in a
+    // state where no modal popup is active, so it should never steal
+    // clicks unless a modal slot (snap-assist / layout picker) is
+    // explicitly shown. Setting this as the default means that even if
+    // syncPassiveShellSurfaceState is missed (e.g., during screen
+    // power-cycle reconnection where ensurePassiveShellFor returns an
+    // existing entry without re-syncing), the overlay remains
+    // click-through by default rather than inheriting a stale
+    // wantTransparent=false from a prior modal popup.
+    if (auto* window = surface->window()) {
+        window->setFlag(Qt::WindowTransparentForInput, true);
+    }
 
     // Cache the per-content slot Items — exposed as `osdSlotItem` /
     // `snapAssistSlotItem` on the shell window root via QML aliases.


### PR DESCRIPTION
Layer 1: osd.cpp — set Qt::WindowTransparentForInput=true as default on
  passive shell windows (new creation + existing re-entry in
  ensurePassiveShellFor). Without this, a missed syncPassiveShellSurfaceState
  during screen power-cycle left the shell blocking clicks.

Layer 2: lifecycle.cpp — fast path in showAtPosition now checks cursor slot
  opacity. If opacity near 0 (slot hidden/idled), falls through to
  initializeOverlay instead of taking the fast path that only calls
  applyIdleStateForCursor, which can't render through opacity=0.
  

This is the last hard bug fix I needed to get stable. I'll start digging into the new setting now.