### PR TITLE
refactor(animation): split zone.* paths into window/widget/editor families

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -405,13 +405,13 @@ private:
     // When false and the window is being dragged, defers via windowFinishUserMovedResized signal.
     //
     // profilePath drives the shader-transition resolve (see ShaderProfileTree). This used to be
-    // hardcoded to "zone.snapIn" inside applySnapGeometry, which fired the same shader for every
+    // hardcoded to "window.snapIn" inside applySnapGeometry, which fired the same shader for every
     // motion that flowed through this chokepoint — snap-in, snap-out, resnap, resize, restore, etc.
     // Callers now pass the logical event path so the shader tree can route each one independently.
-    // Default is ZoneSnapIn for source compatibility with the legacy hardcoded path.
+    // Default is WindowSnapIn (the kwin-effect's default snap-into-zone window animation).
     void applySnapGeometry(KWin::EffectWindow* window, const QRect& geometry, bool allowDuringDrag = false,
                            bool skipAnimation = false,
-                           const QString& profilePath = PhosphorAnimation::ProfilePaths::ZoneSnapIn);
+                           const QString& profilePath = PhosphorAnimation::ProfilePaths::WindowSnapIn);
     void repaintSnapRegions(KWin::EffectWindow* window, const QRectF& oldFrame, const QRect& newGeo);
 
     // Async D-Bus helper for 5-arg snap replies (x, y, w, h, shouldSnap).

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -151,7 +151,7 @@ void PlasmaZonesEffect::slotApplyGeometryRequested(const QString& windowId, int 
             // dimensions. Logically a snap-out (the window is leaving zone-managed sizing),
             // not an in-zone resize.
             applySnapGeometry(w, sizeOnlyGeo, /*allowDuringDrag=*/false, /*skipAnimation=*/false,
-                              PhosphorAnimation::ProfilePaths::ZoneSnapOut);
+                              PhosphorAnimation::ProfilePaths::WindowSnapOut);
         }
         return;
     }
@@ -195,8 +195,8 @@ void PlasmaZonesEffect::slotApplyGeometryRequested(const QString& windowId, int 
     // autotile drag-to-float, drag-out unsnap). Non-empty zoneId = snap into a target zone. The
     // shader-tree path differs accordingly so users can give snap-in and snap-out distinct effects.
     applySnapGeometry(w, geometry, /*allowDuringDrag=*/false, /*skipAnimation=*/false,
-                      zoneId.isEmpty() ? PhosphorAnimation::ProfilePaths::ZoneSnapOut
-                                       : PhosphorAnimation::ProfilePaths::ZoneSnapIn);
+                      zoneId.isEmpty() ? PhosphorAnimation::ProfilePaths::WindowSnapOut
+                                       : PhosphorAnimation::ProfilePaths::WindowSnapIn);
     // Note: windowSnapped/recordSnapIntent are NOT called here. For daemon-driven
     // navigation, the daemon handles zone bookkeeping internally before emitting
     // applyGeometryRequested. For legacy callers (autotile float restore via
@@ -276,11 +276,11 @@ void PlasmaZonesEffect::slotApplyGeometriesBatch(const PhosphorProtocol::WindowG
 
     // Map the daemon's action string to a shader-tree ProfilePath. "resnap" / "retile" are layout
     // changes (different layout or autotile recompute) — semantically a layout switch. "rotate"
-    // moves windows between existing zones in the same layout — a snap-in. Default to ZoneSnapIn
+    // moves windows between existing zones in the same layout — a snap-in. Default to WindowSnapIn
     // for unknown actions (forward-compat with future daemon-emitted strings).
     const QString batchProfilePath = (action == QLatin1String("resnap") || action == QLatin1String("retile"))
-        ? PhosphorAnimation::ProfilePaths::ZoneLayoutSwitchIn
-        : PhosphorAnimation::ProfilePaths::ZoneSnapIn;
+        ? PhosphorAnimation::ProfilePaths::WindowLayoutSwitch
+        : PhosphorAnimation::ProfilePaths::WindowSnapIn;
 
     applyStaggeredOrImmediate(
         pending.size(),

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -239,7 +239,7 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
                     }
                     // Drag-to-unsnap: window leaves zone-managed sizing, restore pre-snap dimensions.
                     applySnapGeometry(safeWindow, geo, /*allowDuringDrag=*/false, /*skipAnimation=*/false,
-                                      PhosphorAnimation::ProfilePaths::ZoneSnapOut);
+                                      PhosphorAnimation::ProfilePaths::WindowSnapOut);
                     break;
                 }
                 }
@@ -577,7 +577,7 @@ void PlasmaZonesEffect::slotRestoreSizeDuringDrag(const QString& windowId, int w
     // Live drag-out unsnap: restoring pre-snap dimensions while the user is still dragging.
     // Logically a snap-out (the window is leaving zone-managed sizing).
     applySnapGeometry(window, geometry, /*allowDuringDrag=*/true, /*skipAnimation=*/false,
-                      PhosphorAnimation::ProfilePaths::ZoneSnapOut);
+                      PhosphorAnimation::ProfilePaths::WindowSnapOut);
 }
 
 void PlasmaZonesEffect::slotSnapAssistReady(const QString& windowId, const QString& releaseScreenId,

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -109,8 +109,8 @@ PlasmaZonesEffect::PlasmaZonesEffect()
         // (durationMs == 0; the leg rides m_windowAnimator's timeline).
         // Time-based transitions (durationMs > 0; window.open / close /
         // focus / etc.) have their own QTimer teardown scheduled by
-        // tryBeginShaderForEvent — without this guard, a zone.snapIn
-        // transition that's been superseded by a window.* event leaves
+        // tryBeginShaderForEvent — without this guard, a window.snapIn
+        // transition that's been superseded by another window.* event leaves
         // the original animator running its geometry tween, and that
         // animator's eventual completion would prematurely kill the
         // successor (whose own QTimer hasn't fired yet).

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -1233,7 +1233,7 @@ void PlasmaZonesEffect::tryBeginShaderForEvent(KWin::EffectWindow* window, const
     // Capture the just-installed transition's generation so the deferred
     // teardown bails if a successor has replaced us by the time the timer
     // fires. Without this, two events overlapping on the same window
-    // (window.move during zone.snapIn, window.focus interrupting
+    // (window.move during window.snapIn, window.focus interrupting
     // window.maximize) leave a stale timer that tears down the SUCCESSOR
     // when its own timer hasn't fired yet.
     auto it = m_shaderManager.m_shaderTransitions.find(window);

--- a/libs/phosphor-animation/README.md
+++ b/libs/phosphor-animation/README.md
@@ -23,7 +23,7 @@ that interpolates toward a target, a curve family that decides *how*
   family, polymorphic `Curve`s, the `IMotionClock` clock contract,
   retarget policy, snap policy, stagger, and the `Profile` /
   `ProfileTree` / `PhosphorProfileRegistry` system that maps event
-  names like `window.open` and `zone.snapIn` to motion configs.
+  names like `window.open` and `editor.snapIn` to motion configs.
 - **Shader transitions** (namespace `PhosphorAnimationShaders`) — the
   `AnimationShaderRegistry` that discovers transition shader packs from
   search paths, parameter metadata for a picker UI, and the parallel
@@ -93,7 +93,7 @@ registry.refresh();
 AnimatedValue<QRectF> geometry(initialRect);
 
 MotionSpec<QRectF> spec{
-    .profile        = registry.profileFor(QStringLiteral("zone.snapIn")),
+    .profile        = registry.profileFor(QStringLiteral("editor.snapIn")),
     .clock          = &clock,
     .retargetPolicy = RetargetPolicy::PreserveVelocity,
 };

--- a/libs/phosphor-animation/README.md
+++ b/libs/phosphor-animation/README.md
@@ -118,7 +118,7 @@ shaders.refresh();
 
 ShaderProfile sp = shaderProfileTree.profileFor(QStringLiteral("window.open"));
 QString effectId    = sp.effectId.value_or(QStringLiteral("dissolve"));
-QVariantMap params  = sp.params.value_or(QVariantMap{});
+QVariantMap params  = sp.parameters.value_or(QVariantMap{});
 ```
 
 ## Design notes

--- a/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
@@ -30,7 +30,7 @@ namespace PhosphorAnimationShaders {
 ///   • **Compositor (window-content) execution** — `kwin-effect` running
 ///     inside the KWin compositor process. Uses classic OpenGL via
 ///     `KWin::GLShader`. Animates window contents during lifecycle
-///     events (`window.open`, `window.move`, `editor.snapIn`, …).
+///     events (`window.open`, `window.move`, `window.snapIn`, …).
 ///
 ///   • **Daemon (overlay-surface) execution** — `SurfaceAnimator::runLeg`
 ///     in the PlasmaZones daemon. Uses Qt RHI via
@@ -157,8 +157,10 @@ namespace AnimationShaderContract {
 ///   • Compositor (kwin-effect): `paintWindow` reads progress from either
 ///     the time-based (`(now - startTimeMs) / durationMs`, linear) or
 ///     `m_windowAnimator->animationFor(w)` (curved by the geometry
-///     animation's profile). Lifecycle events ride the linear branch;
-///     `zone.*` events ride the curved one.
+///     animation's profile). Lifecycle events (`window.open`,
+///     `window.close`, focus etc.) ride the linear branch;
+///     `window.snap*` / `window.layoutSwitch` events ride the curved
+///     one (their geometry tween drives progress).
 ///   • Daemon (SurfaceAnimator): the `shaderTime` AnimatedValue runs
 ///     under the resolved `showShaderProfile` / `hideShaderProfile`
 ///     curve, falling back to the opacity profile's curve when the

--- a/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
@@ -30,7 +30,7 @@ namespace PhosphorAnimationShaders {
 ///   • **Compositor (window-content) execution** — `kwin-effect` running
 ///     inside the KWin compositor process. Uses classic OpenGL via
 ///     `KWin::GLShader`. Animates window contents during lifecycle
-///     events (`window.open`, `window.move`, `zone.snapIn`, …).
+///     events (`window.open`, `window.move`, `editor.snapIn`, …).
 ///
 ///   • **Daemon (overlay-surface) execution** — `SurfaceAnimator::runLeg`
 ///     in the PlasmaZones daemon. Uses Qt RHI via

--- a/libs/phosphor-animation/include/PhosphorAnimation/ProfilePaths.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/ProfilePaths.h
@@ -27,7 +27,11 @@ namespace ProfilePaths {
 // Root
 PHOSPHORANIMATION_EXPORT extern const QString Global;
 
-// window.*
+// window.* — runtime window-lifecycle animations driven by the
+// kwin-effect's OffscreenEffect via tryBeginShaderForEvent. The
+// snap/layout-switch leaves are window events triggered by zone
+// interaction (the WINDOW animates when it snaps into/out of a zone
+// or when a layout switch repositions it).
 PHOSPHORANIMATION_EXPORT extern const QString Window;
 PHOSPHORANIMATION_EXPORT extern const QString WindowOpen;
 PHOSPHORANIMATION_EXPORT extern const QString WindowClose;
@@ -36,20 +40,20 @@ PHOSPHORANIMATION_EXPORT extern const QString WindowMaximize;
 PHOSPHORANIMATION_EXPORT extern const QString WindowMove;
 PHOSPHORANIMATION_EXPORT extern const QString WindowResize;
 PHOSPHORANIMATION_EXPORT extern const QString WindowFocus;
+PHOSPHORANIMATION_EXPORT extern const QString WindowSnapIn;
+PHOSPHORANIMATION_EXPORT extern const QString WindowSnapOut;
+PHOSPHORANIMATION_EXPORT extern const QString WindowSnapResize;
+PHOSPHORANIMATION_EXPORT extern const QString WindowLayoutSwitch;
 
-// zone.*
-PHOSPHORANIMATION_EXPORT extern const QString Zone;
-PHOSPHORANIMATION_EXPORT extern const QString ZoneSnapIn;
-PHOSPHORANIMATION_EXPORT extern const QString ZoneSnapOut;
-PHOSPHORANIMATION_EXPORT extern const QString ZoneSnapResize;
-PHOSPHORANIMATION_EXPORT extern const QString ZoneHighlight;
-PHOSPHORANIMATION_EXPORT extern const QString ZoneHighlightPop;
-PHOSPHORANIMATION_EXPORT extern const QString ZoneHighlightBorder;
-PHOSPHORANIMATION_EXPORT extern const QString ZoneLayoutSwitchIn;
-// `zone.layoutSwitchOut` is intentionally absent — the layout-switch
-// flash (`ZoneOverlay.qml`) is a one-shot fade that has no out-leg
-// surface. If a future consumer needs an out-leg shape, add the
-// constant in lockstep with the consumer.
+// editor.* — Layout-editor-only zone manipulation animations
+// (fill-preview, drag-resize-preview). NOT triggered by runtime
+// window snapping — window-snap animations are KWin's
+// compositor-level domain. These paths only fire inside the
+// PlasmaZones layout editor.
+PHOSPHORANIMATION_EXPORT extern const QString Editor;
+PHOSPHORANIMATION_EXPORT extern const QString EditorSnapIn;
+PHOSPHORANIMATION_EXPORT extern const QString EditorSnapOut;
+PHOSPHORANIMATION_EXPORT extern const QString EditorSnapResize;
 
 // osd.*
 PHOSPHORANIMATION_EXPORT extern const QString Osd;
@@ -110,6 +114,18 @@ PHOSPHORANIMATION_EXPORT extern const QString WidgetProgress; ///< 200 ms OutCub
 PHOSPHORANIMATION_EXPORT extern const QString WidgetPulse; ///< 1000 ms sinusoidal (family root)
 PHOSPHORANIMATION_EXPORT extern const QString WidgetPulseFast; ///< 500 ms
 PHOSPHORANIMATION_EXPORT extern const QString WidgetPulseSlow; ///< 1500 ms
+// Zone-rect widget (used by ZoneItem.qml, LayoutPreview.qml,
+// ZonePreview.qml — i.e. the reusable QML zone-rectangle that gets
+// embedded in the runtime overlay, settings dialogs, layout
+// thumbnails, etc.). The animation lives with the widget; the
+// surface it's hosted on is incidental.
+PHOSPHORANIMATION_EXPORT extern const QString WidgetZoneHighlight;
+PHOSPHORANIMATION_EXPORT extern const QString WidgetZoneHighlightPop;
+PHOSPHORANIMATION_EXPORT extern const QString WidgetZoneHighlightBorder;
+// One-shot flash on the main zone-overlay surface when the active
+// layout changes mid-drag (ZoneOverlayContent.qml). A widget-level
+// content effect on the overlay, not a per-zone animation.
+PHOSPHORANIMATION_EXPORT extern const QString WidgetZoneOverlayFlash;
 
 /// Full list of built-in paths in taxonomy order.
 PHOSPHORANIMATION_EXPORT QStringList allBuiltInPaths();

--- a/libs/phosphor-animation/include/PhosphorAnimation/ShaderProfile.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/ShaderProfile.h
@@ -19,7 +19,7 @@ namespace PhosphorAnimationShaders {
  * Parallel to `PhosphorAnimation::Profile` which configures *motion*
  * (curve, duration, stagger), `ShaderProfile` configures *visual effect*
  * (which shader, with what parameters). Both use the same dot-path event
- * namespace (window.open, zone.snapIn, etc.) but are resolved through
+ * namespace (window.open, editor.snapIn, etc.) but are resolved through
  * separate trees so the two concerns evolve independently.
  *
  * ## "Set" vs "unset" semantics

--- a/libs/phosphor-animation/src/profilepaths.cpp
+++ b/libs/phosphor-animation/src/profilepaths.cpp
@@ -18,17 +18,17 @@ const QString WindowMaximize = QStringLiteral("window.maximize");
 const QString WindowMove = QStringLiteral("window.move");
 const QString WindowResize = QStringLiteral("window.resize");
 const QString WindowFocus = QStringLiteral("window.focus");
+const QString WindowSnapIn = QStringLiteral("window.snapIn");
+const QString WindowSnapOut = QStringLiteral("window.snapOut");
+const QString WindowSnapResize = QStringLiteral("window.snapResize");
+const QString WindowLayoutSwitch = QStringLiteral("window.layoutSwitch");
 
-// zone.*
-const QString Zone = QStringLiteral("zone");
-const QString ZoneSnapIn = QStringLiteral("zone.snapIn");
-const QString ZoneSnapOut = QStringLiteral("zone.snapOut");
-const QString ZoneSnapResize = QStringLiteral("zone.snapResize");
-const QString ZoneHighlight = QStringLiteral("zone.highlight");
-const QString ZoneHighlightPop = QStringLiteral("zone.highlight.pop");
-const QString ZoneHighlightBorder = QStringLiteral("zone.highlight.border");
-const QString ZoneLayoutSwitchIn = QStringLiteral("zone.layoutSwitchIn");
-// `zone.layoutSwitchOut` intentionally undeclared — see ProfilePaths.h.
+// editor.* — Layout-editor-only zone manipulation. NOT runtime
+// window snapping (that's KWin's domain).
+const QString Editor = QStringLiteral("editor");
+const QString EditorSnapIn = QStringLiteral("editor.snapIn");
+const QString EditorSnapOut = QStringLiteral("editor.snapOut");
+const QString EditorSnapResize = QStringLiteral("editor.snapResize");
 
 // osd.*
 const QString Osd = QStringLiteral("osd");
@@ -87,6 +87,10 @@ const QString WidgetProgress = QStringLiteral("widget.progress");
 const QString WidgetPulse = QStringLiteral("widget.pulse");
 const QString WidgetPulseFast = QStringLiteral("widget.pulse.fast");
 const QString WidgetPulseSlow = QStringLiteral("widget.pulse.slow");
+const QString WidgetZoneHighlight = QStringLiteral("widget.zoneHighlight");
+const QString WidgetZoneHighlightPop = QStringLiteral("widget.zoneHighlight.pop");
+const QString WidgetZoneHighlightBorder = QStringLiteral("widget.zoneHighlight.border");
+const QString WidgetZoneOverlayFlash = QStringLiteral("widget.zoneOverlayFlash");
 
 QStringList allBuiltInPaths()
 {
@@ -105,14 +109,14 @@ QStringList allBuiltInPaths()
         WindowMove,
         WindowResize,
         WindowFocus,
-        Zone,
-        ZoneSnapIn,
-        ZoneSnapOut,
-        ZoneSnapResize,
-        ZoneHighlight,
-        ZoneHighlightPop,
-        ZoneHighlightBorder,
-        ZoneLayoutSwitchIn,
+        WindowSnapIn,
+        WindowSnapOut,
+        WindowSnapResize,
+        WindowLayoutSwitch,
+        Editor,
+        EditorSnapIn,
+        EditorSnapOut,
+        EditorSnapResize,
         Osd,
         OsdShow,
         OsdPop,
@@ -159,6 +163,10 @@ QStringList allBuiltInPaths()
         WidgetPulse,
         WidgetPulseFast,
         WidgetPulseSlow,
+        WidgetZoneHighlight,
+        WidgetZoneHighlightPop,
+        WidgetZoneHighlightBorder,
+        WidgetZoneOverlayFlash,
     };
     return kAllPaths;
 }

--- a/libs/phosphor-animation/src/profilepaths.cpp
+++ b/libs/phosphor-animation/src/profilepaths.cpp
@@ -178,7 +178,7 @@ QString parentPath(const QString& path)
     }
     const int dotIdx = path.lastIndexOf(QLatin1Char('.'));
     if (dotIdx < 0) {
-        // Category root ("window", "zone", …) → Global.
+        // Category root ("window", "editor", "widget", …) → Global.
         return Global;
     }
     return path.left(dotIdx);

--- a/libs/phosphor-animation/tests/test_profiletree.cpp
+++ b/libs/phosphor-animation/tests/test_profiletree.cpp
@@ -43,6 +43,34 @@ private Q_SLOTS:
         QVERIFY(paths.contains(PP::EditorSnapIn));
     }
 
+    // Pin the post-rename taxonomy: every new path constant from the
+    // zone.* → window.* / editor.* / widget.* split must appear in
+    // allBuiltInPaths(), and no legacy zone.* string may slip back in.
+    void testPostRenameTaxonomyComplete()
+    {
+        const QStringList paths = PP::allBuiltInPaths();
+        // Editor family (layout-editor zone-rect animations).
+        QVERIFY(paths.contains(PP::Editor));
+        QVERIFY(paths.contains(PP::EditorSnapIn));
+        QVERIFY(paths.contains(PP::EditorSnapOut));
+        QVERIFY(paths.contains(PP::EditorSnapResize));
+        // Window snap family (kwin-effect window-quad animations).
+        QVERIFY(paths.contains(PP::WindowSnapIn));
+        QVERIFY(paths.contains(PP::WindowSnapOut));
+        QVERIFY(paths.contains(PP::WindowSnapResize));
+        QVERIFY(paths.contains(PP::WindowLayoutSwitch));
+        // Widget zone-rect highlight family.
+        QVERIFY(paths.contains(PP::WidgetZoneHighlight));
+        QVERIFY(paths.contains(PP::WidgetZoneHighlightPop));
+        QVERIFY(paths.contains(PP::WidgetZoneHighlightBorder));
+        QVERIFY(paths.contains(PP::WidgetZoneOverlayFlash));
+        // No regression: legacy zone.* strings must not reappear.
+        for (const QString& path : paths) {
+            QVERIFY2(!path.startsWith(QLatin1String("zone.")) && path != QLatin1String("zone"),
+                     qPrintable(QStringLiteral("legacy zone.* path leaked back into allBuiltInPaths(): ") + path));
+        }
+    }
+
     // ─── Resolve walk-up ───
 
     void testResolveEmptyTreeReturnsLibraryDefaults()

--- a/libs/phosphor-animation/tests/test_profiletree.cpp
+++ b/libs/phosphor-animation/tests/test_profiletree.cpp
@@ -40,7 +40,7 @@ private Q_SLOTS:
         QVERIFY(!paths.isEmpty());
         QVERIFY(paths.contains(PP::Global));
         QVERIFY(paths.contains(PP::WindowOpen));
-        QVERIFY(paths.contains(PP::ZoneSnapIn));
+        QVERIFY(paths.contains(PP::EditorSnapIn));
     }
 
     // ─── Resolve walk-up ───
@@ -177,14 +177,14 @@ private Q_SLOTS:
         ProfileTree tree;
         Profile p;
         p.duration = 999.0;
-        tree.setOverride(PP::ZoneSnapIn, p);
-        QVERIFY(tree.hasOverride(PP::ZoneSnapIn));
+        tree.setOverride(PP::EditorSnapIn, p);
+        QVERIFY(tree.hasOverride(PP::EditorSnapIn));
 
-        QVERIFY(tree.clearOverride(PP::ZoneSnapIn));
-        QVERIFY(!tree.hasOverride(PP::ZoneSnapIn));
+        QVERIFY(tree.clearOverride(PP::EditorSnapIn));
+        QVERIFY(!tree.hasOverride(PP::EditorSnapIn));
         QVERIFY(tree.overriddenPaths().isEmpty());
 
-        QVERIFY(!tree.clearOverride(PP::ZoneSnapIn));
+        QVERIFY(!tree.clearOverride(PP::EditorSnapIn));
     }
 
     void testClearAllOverrides()
@@ -192,7 +192,7 @@ private Q_SLOTS:
         ProfileTree tree;
         Profile p;
         tree.setOverride(PP::Window, p);
-        tree.setOverride(PP::Zone, p);
+        tree.setOverride(PP::Editor, p);
         tree.setOverride(PP::Osd, p);
 
         Profile baseline;
@@ -231,7 +231,7 @@ private Q_SLOTS:
         Profile overrideB;
         overrideB.curve = std::make_shared<Easing>();
         overrideB.sequenceMode = SequenceMode::Cascade;
-        original.setOverride(PP::ZoneSnapIn, overrideB);
+        original.setOverride(PP::EditorSnapIn, overrideB);
 
         const QJsonObject encoded = original.toJson();
         const ProfileTree restored = ProfileTree::fromJson(encoded, PhosphorAnimation::CurveRegistry{});
@@ -243,7 +243,7 @@ private Q_SLOTS:
     {
         ProfileTree original;
         original.setOverride(PP::Window, Profile());
-        original.setOverride(PP::Zone, Profile());
+        original.setOverride(PP::Editor, Profile());
         original.setOverride(PP::Osd, Profile());
 
         const QStringList before = original.overriddenPaths();

--- a/libs/phosphor-animation/tests/test_shaderprofiletree.cpp
+++ b/libs/phosphor-animation/tests/test_shaderprofiletree.cpp
@@ -127,12 +127,12 @@ private Q_SLOTS:
         ShaderProfileTree tree;
         ShaderProfile p;
         p.effectId = QStringLiteral("glitch");
-        tree.setOverride(PP::ZoneSnapIn, p);
-        QVERIFY(tree.hasOverride(PP::ZoneSnapIn));
+        tree.setOverride(PP::EditorSnapIn, p);
+        QVERIFY(tree.hasOverride(PP::EditorSnapIn));
 
-        QVERIFY(tree.clearOverride(PP::ZoneSnapIn));
-        QVERIFY(!tree.hasOverride(PP::ZoneSnapIn));
-        QVERIFY(!tree.clearOverride(PP::ZoneSnapIn));
+        QVERIFY(tree.clearOverride(PP::EditorSnapIn));
+        QVERIFY(!tree.hasOverride(PP::EditorSnapIn));
+        QVERIFY(!tree.clearOverride(PP::EditorSnapIn));
     }
 
     void testClearAllOverrides()
@@ -140,7 +140,7 @@ private Q_SLOTS:
         ShaderProfileTree tree;
         ShaderProfile p;
         tree.setOverride(PP::Window, p);
-        tree.setOverride(PP::Zone, p);
+        tree.setOverride(PP::Editor, p);
 
         ShaderProfile baseline;
         baseline.effectId = QStringLiteral("dissolve");
@@ -175,7 +175,7 @@ private Q_SLOTS:
 
         ShaderProfile overrideB;
         overrideB.effectId = QString();
-        original.setOverride(PP::ZoneSnapIn, overrideB);
+        original.setOverride(PP::EditorSnapIn, overrideB);
 
         const QJsonObject encoded = original.toJson();
         const ShaderProfileTree restored = ShaderProfileTree::fromJson(encoded);
@@ -187,7 +187,7 @@ private Q_SLOTS:
     {
         ShaderProfileTree original;
         original.setOverride(PP::Window, ShaderProfile());
-        original.setOverride(PP::Zone, ShaderProfile());
+        original.setOverride(PP::Editor, ShaderProfile());
         original.setOverride(PP::Osd, ShaderProfile());
 
         const QStringList before = original.overriddenPaths();

--- a/src/core/animationbootstrap.cpp
+++ b/src/core/animationbootstrap.cpp
@@ -176,7 +176,7 @@ void seedShellAnimationFamilies(PhosphorAnimation::PhosphorProfileRegistry& regi
         QLatin1StringView curveSpec;
         qreal durationMs;
     };
-    constexpr std::array<FamilySeed, 28> seeds{{
+    constexpr std::array<FamilySeed, 29> seeds{{
         // ── Popups ────────────────────────────────────────────────
         // Family parent — leaves (popup.layoutPicker.*,
         // popup.zoneSelector.*, popup.snapAssist.*) inherit from this.
@@ -238,10 +238,17 @@ void seedShellAnimationFamilies(PhosphorAnimation::PhosphorProfileRegistry& regi
         {QLatin1StringView{"window"}, QLatin1StringView{"widget-out"}, 200.0},
         {QLatin1StringView{"window.close"}, QLatin1StringView{"cubic-in"}, 150.0},
 
-        // ── Zones ─────────────────────────────────────────────────
-        // Snap in/out/resize, layout switch, and highlight all
-        // hover around 200 ms ease-out.
-        {QLatin1StringView{"zone"}, QLatin1StringView{"widget-out"}, 200.0},
+        // ── Editor ────────────────────────────────────────────────
+        // Layout-editor fill-preview / snap-resize animations on the
+        // editor's zone-rect outlines. NOT runtime window snapping —
+        // that's KWin's domain. ~200 ms ease-out family root.
+        {QLatin1StringView{"editor"}, QLatin1StringView{"widget-out"}, 200.0},
+
+        // ── Widget zone-rect ──────────────────────────────────────
+        // Reusable Zone widget (ZoneItem.qml et al.) embedded across
+        // overlay surfaces, settings dialogs, layout thumbnails. The
+        // highlight family root inherits the widget OutCubic feel.
+        {QLatin1StringView{"widget.zoneHighlight"}, QLatin1StringView{"widget-out"}, 200.0},
 
         // No `workspace.*` seeds: virtual-desktop transitions are KWin's
         // compositor-level domain (Slide / Fade Desktop / etc.). PZ does

--- a/src/core/animationshadersupportedpaths.h
+++ b/src/core/animationshadersupportedpaths.h
@@ -49,6 +49,14 @@ inline QStringList shaderConsumedLeafEventPaths()
         PP::WindowMove,
         PP::WindowResize,
         PP::WindowFocus,
+        // Snap-into-zone window animations driven by the kwin-effect's
+        // applySnapGeometry / daemon_apply chokepoints. Each routes
+        // through tryBeginShaderForEvent so the user can pick a
+        // distinct shader per snap event.
+        PP::WindowSnapIn,
+        PP::WindowSnapOut,
+        PP::WindowSnapResize,
+        PP::WindowLayoutSwitch,
     };
 }
 
@@ -62,7 +70,7 @@ inline QStringList shaderConsumedLeafEventPaths()
 /// `popup.layoutPicker.show = pixelate` overrides only that one leg.
 ///
 /// Paths that are NOT ancestors of any consumed leaf (e.g.
-/// `panel.slideIn`, `osd.pop`, `widget.fadeIn`, `zone.snapIn`) are
+/// `panel.slideIn`, `osd.pop`, `widget.fadeIn`, `editor.snapIn`) are
 /// excluded — there is no resolver path that walks through them, so
 /// any assignment would be runtime-dead and silently shadow what the
 /// user thought they set on a sibling. The settings UI hides the

--- a/src/core/animationshadersupportedpaths.h
+++ b/src/core/animationshadersupportedpaths.h
@@ -53,9 +53,16 @@ inline QStringList shaderConsumedLeafEventPaths()
         // applySnapGeometry / daemon_apply chokepoints. Each routes
         // through tryBeginShaderForEvent so the user can pick a
         // distinct shader per snap event.
+        //
+        // `window.snapResize` is intentionally NOT listed: no
+        // kwin-effect callsite passes it today (the resize-only
+        // branch of applySnapGeometry currently inherits the
+        // snap-in shader). Adding a resize-only shader leg is a
+        // feature, not a rename — the path constant exists for
+        // motion tuning but the shader picker stays hidden until
+        // a caller wires it through tryBeginShaderForEvent.
         PP::WindowSnapIn,
         PP::WindowSnapOut,
-        PP::WindowSnapResize,
         PP::WindowLayoutSwitch,
     };
 }

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -196,7 +196,7 @@ private:
      * live-reload watchers. Registers the daemon's active animation
      * Profile under every well-known `ProfilePaths` shell path that
      * maps to PlasmaZones's single-Profile settings surface so QML
-     * consumers can reference specific paths (`zone.highlight`,
+     * consumers can reference specific paths (`widget.zoneHighlight`,
      * `osd.show`, etc.) without the daemon carrying per-event
      * sub-profiles — future sub-commits can diverge paths when
      * per-event customisation is actually exposed to users.

--- a/src/editor/qml/EditorZone.qml
+++ b/src/editor/qml/EditorZone.qml
@@ -645,7 +645,7 @@ Item {
         enabled: root.animateFillPreview
 
         PhosphorMotionAnimation {
-            profile: "zone.snapResize"
+            profile: "editor.snapResize"
             durationOverride: 150
         }
 
@@ -655,7 +655,7 @@ Item {
         enabled: root.animateFillPreview
 
         PhosphorMotionAnimation {
-            profile: "zone.snapResize"
+            profile: "editor.snapResize"
             durationOverride: 150
         }
 
@@ -665,7 +665,7 @@ Item {
         enabled: root.animateFillPreview
 
         PhosphorMotionAnimation {
-            profile: "zone.snapResize"
+            profile: "editor.snapResize"
             durationOverride: 150
         }
 
@@ -675,7 +675,7 @@ Item {
         enabled: root.animateFillPreview
 
         PhosphorMotionAnimation {
-            profile: "zone.snapResize"
+            profile: "editor.snapResize"
             durationOverride: 150
         }
 

--- a/src/editor/qml/ZoneFillAnimation.qml
+++ b/src/editor/qml/ZoneFillAnimation.qml
@@ -93,7 +93,7 @@ Item {
             target: zoneRoot
             properties: "visualX"
             to: fillAnimator.targetX
-            profile: "zone.snapIn"
+            profile: "editor.snapIn"
             durationOverride: 150
         }
 
@@ -101,7 +101,7 @@ Item {
             target: zoneRoot
             properties: "visualY"
             to: fillAnimator.targetY
-            profile: "zone.snapIn"
+            profile: "editor.snapIn"
             durationOverride: 150
         }
 
@@ -109,7 +109,7 @@ Item {
             target: zoneRoot
             properties: "visualWidth"
             to: fillAnimator.targetWidth
-            profile: "zone.snapIn"
+            profile: "editor.snapIn"
             durationOverride: 150
         }
 
@@ -117,7 +117,7 @@ Item {
             target: zoneRoot
             properties: "visualHeight"
             to: fillAnimator.targetHeight
-            profile: "zone.snapIn"
+            profile: "editor.snapIn"
             durationOverride: 150
         }
 

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -167,7 +167,7 @@ qt_add_qml_module(plasmazones-settings
         qml/AnimationProfileEditor.qml
         qml/AnimationsWindowsPage.qml
         qml/AnimationsAppRulesPage.qml
-        qml/AnimationsZonesPage.qml
+        qml/AnimationsEditorPage.qml
         qml/AnimationsOsdsPage.qml
         qml/AnimationsOverlaysPage.qml
         qml/AnimationsSidePanelsPage.qml

--- a/src/settings/animationspagecontroller.cpp
+++ b/src/settings/animationspagecontroller.cpp
@@ -475,7 +475,7 @@ QString AnimationsPageController::userProfilesDir() const
 
 QString AnimationsPageController::profileFilePath(const QString& path) const
 {
-    // Filenames mirror the path (e.g. `zone.snapIn.json`) — same
+    // Filenames mirror the path (e.g. `editor.snapIn.json`) — same
     // convention as the daemon's shipped defaults. Validation on @p
     // path happens at every call site so this helper trusts its input;
     // assert in debug builds so a future caller that forgets the gate

--- a/src/settings/animationspagecontroller.h
+++ b/src/settings/animationspagecontroller.h
@@ -107,7 +107,7 @@ public:
     /// global root. Drives the sidebar grouping.
     Q_INVOKABLE QString sectionForPath(const QString& path) const;
 
-    /// Title-cased label for @p path's last segment (e.g. `"zone.snapIn"`
+    /// Title-cased label for @p path's last segment (e.g. `"editor.snapIn"`
     /// → `"Snap In"`). Falls back to the segment itself if humanisation
     /// fails. Translation hook lives in QML; this is the raw English
     /// form.

--- a/src/settings/qml/AnimationEventCard.qml
+++ b/src/settings/qml/AnimationEventCard.qml
@@ -10,7 +10,7 @@ import org.kde.kirigami as Kirigami
  * @brief Reusable card for per-event animation configuration.
  *
  * Each card edits one event in the `PhosphorAnimation::ProfilePaths`
- * taxonomy (e.g. `zone.snapIn`, `osd.show`). The override toggle
+ * taxonomy (e.g. `editor.snapIn`, `osd.show`). The override toggle
  * creates/clears one Profile JSON file under
  * `~/.local/share/plasmazones/profiles/`; the daemon's existing
  * `ProfileLoader` watches that dir and live-reloads the registry.
@@ -21,7 +21,7 @@ import org.kde.kirigami as Kirigami
  * land in Phase 6 alongside the shader-picker controller.
  *
  * Required properties:
- *   - eventPath:  full path string from `ProfilePaths::` (e.g. "zone.snapIn")
+ *   - eventPath:  full path string from `ProfilePaths::` (e.g. "editor.snapIn")
  *   - eventLabel: human-readable label
  *
  * Optional properties:

--- a/src/settings/qml/AnimationEventCard.qml
+++ b/src/settings/qml/AnimationEventCard.qml
@@ -135,7 +135,7 @@ Item {
 
     function parentChainText() {
         var chain = settingsController.animationsPage.parentChain(root.eventPath);
-        // Drop chain[0] (self) — show only ancestors as "zone ← global"
+        // Drop chain[0] (self) — show only ancestors as "window ← global"
         if (chain.length <= 1)
             return "";
 

--- a/src/settings/qml/AnimationsEditorPage.qml
+++ b/src/settings/qml/AnimationsEditorPage.qml
@@ -4,10 +4,14 @@ import QtQuick
 import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
 
+// Layout-editor zone-manipulation animations. Fires only inside the
+// PlasmaZones layout editor (fill-preview, snap-resize-preview).
+// Runtime window snapping is KWin's compositor-level domain and is
+// NOT controlled here.
 SettingsFlickable {
     contentHeight: col.implicitHeight
     clip: true
-    Accessible.name: i18n("Zone animation events")
+    Accessible.name: i18n("Layout editor animation events")
 
     ColumnLayout {
         id: col
@@ -17,33 +21,27 @@ SettingsFlickable {
 
         AnimationEventCard {
             Layout.fillWidth: true
-            eventPath: "zone"
-            eventLabel: i18n("All Zone Events")
+            eventPath: "editor"
+            eventLabel: i18n("All Editor Events")
             isParentNode: true
         }
 
         AnimationEventCard {
             Layout.fillWidth: true
-            eventPath: "zone.snapIn"
-            eventLabel: i18n("Snap In")
+            eventPath: "editor.snapIn"
+            eventLabel: i18n("Snap In (Fill)")
         }
 
         AnimationEventCard {
             Layout.fillWidth: true
-            eventPath: "zone.snapResize"
-            eventLabel: i18n("Snap Resize")
+            eventPath: "editor.snapOut"
+            eventLabel: i18n("Snap Out")
         }
 
         AnimationEventCard {
             Layout.fillWidth: true
-            eventPath: "zone.highlight"
-            eventLabel: i18n("Highlight")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "zone.layoutSwitchIn"
-            eventLabel: i18n("Layout Switch")
+            eventPath: "editor.snapResize"
+            eventLabel: i18n("Snap Resize (Drag Preview)")
         }
 
     }

--- a/src/settings/qml/AnimationsEditorPage.qml
+++ b/src/settings/qml/AnimationsEditorPage.qml
@@ -29,13 +29,13 @@ SettingsFlickable {
         AnimationEventCard {
             Layout.fillWidth: true
             eventPath: "editor.snapIn"
-            eventLabel: i18n("Snap In (Fill)")
+            eventLabel: i18n("Snap Into Zone (Fill Preview)")
         }
 
         AnimationEventCard {
             Layout.fillWidth: true
             eventPath: "editor.snapOut"
-            eventLabel: i18n("Snap Out")
+            eventLabel: i18n("Snap Out of Zone")
         }
 
         AnimationEventCard {

--- a/src/settings/qml/AnimationsWidgetsPage.qml
+++ b/src/settings/qml/AnimationsWidgetsPage.qml
@@ -112,6 +112,36 @@ SettingsFlickable {
             eventLabel: i18n("Progress")
         }
 
+        // Zone-rect widget. Embedded across the runtime overlay,
+        // settings dialogs, layout thumbnails, the new-layout dialog,
+        // shared previews. The animation lives with the widget; the
+        // surface hosting it is incidental.
+        AnimationEventCard {
+            Layout.fillWidth: true
+            eventPath: "widget.zoneHighlight"
+            eventLabel: i18n("Zone Highlight")
+        }
+
+        AnimationEventCard {
+            Layout.fillWidth: true
+            eventPath: "widget.zoneHighlight.pop"
+            eventLabel: i18n("Zone Highlight: Pop")
+        }
+
+        AnimationEventCard {
+            Layout.fillWidth: true
+            eventPath: "widget.zoneHighlight.border"
+            eventLabel: i18n("Zone Highlight: Border")
+        }
+
+        // One-shot flash on the main zone-overlay surface when the
+        // active layout switches mid-drag.
+        AnimationEventCard {
+            Layout.fillWidth: true
+            eventPath: "widget.zoneOverlayFlash"
+            eventLabel: i18n("Zone Overlay: Layout-Switch Flash")
+        }
+
         AnimationEventCard {
             Layout.fillWidth: true
             eventPath: "cursor.hover"

--- a/src/settings/qml/AnimationsWindowsPage.qml
+++ b/src/settings/qml/AnimationsWindowsPage.qml
@@ -10,6 +10,11 @@ SettingsFlickable {
     Accessible.name: i18n("Window animation events")
 
     ColumnLayout {
+        // `window.snapResize` (resize-only branch of applySnapGeometry)
+        // is intentionally NOT exposed here: no kwin-effect callsite
+        // routes a resize-only event through tryBeginShaderForEvent
+        // today, so a card here would be runtime-dead.
+
         id: col
 
         width: parent.width
@@ -77,12 +82,6 @@ SettingsFlickable {
             Layout.fillWidth: true
             eventPath: "window.snapOut"
             eventLabel: i18n("Snap Out of Zone")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.snapResize"
-            eventLabel: i18n("Snap Resize")
         }
 
         AnimationEventCard {

--- a/src/settings/qml/AnimationsWindowsPage.qml
+++ b/src/settings/qml/AnimationsWindowsPage.qml
@@ -64,6 +64,33 @@ SettingsFlickable {
             eventLabel: i18n("Focus")
         }
 
+        // Snap-into-zone window animations driven by the kwin-effect.
+        // The window quad animates when it snaps into / out of a zone
+        // or when a layout switch repositions it.
+        AnimationEventCard {
+            Layout.fillWidth: true
+            eventPath: "window.snapIn"
+            eventLabel: i18n("Snap Into Zone")
+        }
+
+        AnimationEventCard {
+            Layout.fillWidth: true
+            eventPath: "window.snapOut"
+            eventLabel: i18n("Snap Out of Zone")
+        }
+
+        AnimationEventCard {
+            Layout.fillWidth: true
+            eventPath: "window.snapResize"
+            eventLabel: i18n("Snap Resize")
+        }
+
+        AnimationEventCard {
+            Layout.fillWidth: true
+            eventPath: "window.layoutSwitch"
+            eventLabel: i18n("Layout Switch")
+        }
+
     }
 
 }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -191,10 +191,6 @@ ApplicationWindow {
             "label": i18n("Windows"),
             "iconName": "window-new"
         }, {
-            "name": "animations-zones",
-            "label": i18n("Zones"),
-            "iconName": "view-grid"
-        }, {
             "name": "animations-osds",
             "label": i18n("OSDs"),
             "iconName": "dialog-information"
@@ -210,6 +206,10 @@ ApplicationWindow {
             "name": "animations-widgets",
             "label": i18n("Widgets"),
             "iconName": "preferences-desktop-theme"
+        }, {
+            "name": "animations-editor",
+            "label": i18n("Layout Editor"),
+            "iconName": "document-edit"
         }],
         "animations-library": [{
             "name": "animations-presets",
@@ -260,7 +260,7 @@ ApplicationWindow {
         "animations-general": "AnimationsGeneralPage.qml",
         "animations-windows": "AnimationsWindowsPage.qml",
         "animations-app-rules": "AnimationsAppRulesPage.qml",
-        "animations-zones": "AnimationsZonesPage.qml",
+        "animations-editor": "AnimationsEditorPage.qml",
         "animations-osds": "AnimationsOsdsPage.qml",
         "animations-overlays": "AnimationsOverlaysPage.qml",
         "animations-side-panels": "AnimationsSidePanelsPage.qml",

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -596,9 +596,9 @@ const QHash<QString, QSet<QString>>& SettingsController::pageGroupChildren()
     // Keep the per-group leaf lists in sync with the matching
     // `_childItems` entries in src/settings/qml/Main.qml.
     static const QSet<QString> kAnimationsSurfacesChildren{
-        QStringLiteral("animations-windows"),     QStringLiteral("animations-zones"),
-        QStringLiteral("animations-osds"),        QStringLiteral("animations-overlays"),
-        QStringLiteral("animations-side-panels"), QStringLiteral("animations-widgets")};
+        QStringLiteral("animations-windows"),  QStringLiteral("animations-osds"),
+        QStringLiteral("animations-overlays"), QStringLiteral("animations-side-panels"),
+        QStringLiteral("animations-widgets"),  QStringLiteral("animations-editor")};
     static const QSet<QString> kAnimationsLibraryChildren{QStringLiteral("animations-presets"),
                                                           QStringLiteral("animations-motionsets"),
                                                           QStringLiteral("animations-shaders")};
@@ -652,7 +652,7 @@ const QSet<QString>& SettingsController::validPageNames()
         QStringLiteral("animations-general"),
         QStringLiteral("animations-windows"),
         QStringLiteral("animations-app-rules"),
-        QStringLiteral("animations-zones"),
+        QStringLiteral("animations-editor"),
         QStringLiteral("animations-osds"),
         QStringLiteral("animations-overlays"),
         QStringLiteral("animations-side-panels"),

--- a/src/shared/ZonePreview.qml
+++ b/src/shared/ZonePreview.qml
@@ -249,7 +249,7 @@ Item {
             // AlgorithmPreview) still drive the timing here.
             Behavior on color {
                 PhosphorMotionAnimation {
-                    profile: "zone.highlight"
+                    profile: "widget.zoneHighlight"
                     durationOverride: root.animationDuration
                 }
 
@@ -257,7 +257,7 @@ Item {
 
             Behavior on opacity {
                 PhosphorMotionAnimation {
-                    profile: "zone.highlight"
+                    profile: "widget.zoneHighlight"
                     durationOverride: root.animationDuration
                 }
 
@@ -265,20 +265,20 @@ Item {
 
             Behavior on scale {
                 // OutBack overshoot=1.20 feel — restored faithfully via the
-                // osd-pop curve referenced through zone.highlight.pop.
+                // osd-pop curve referenced through widget.zoneHighlight.pop.
                 PhosphorMotionAnimation {
-                    profile: "zone.highlight.pop"
+                    profile: "widget.zoneHighlight.pop"
                     durationOverride: root.animationDuration
                 }
 
             }
 
-            // Border feedback uses the half-duration zone.highlight.border
+            // Border feedback uses the half-duration widget.zoneHighlight.border
             // profile so the border snaps in twice as fast as the fill —
             // matches the pre-PR-344 `duration: animationDuration / 2` shape.
             Behavior on border.color {
                 PhosphorMotionAnimation {
-                    profile: "zone.highlight.border"
+                    profile: "widget.zoneHighlight.border"
                     durationOverride: Math.round(root.animationDuration / 2)
                 }
 
@@ -286,7 +286,7 @@ Item {
 
             Behavior on border.width {
                 PhosphorMotionAnimation {
-                    profile: "zone.highlight.border"
+                    profile: "widget.zoneHighlight.border"
                     durationOverride: Math.round(root.animationDuration / 2)
                 }
 

--- a/src/ui/LayoutPreview.qml
+++ b/src/ui/LayoutPreview.qml
@@ -190,7 +190,7 @@ Rectangle {
 
         Behavior on opacity {
             PhosphorMotionAnimation {
-                profile: "zone.highlight"
+                profile: "widget.zoneHighlight"
                 durationOverride: constants.animationDuration
             }
 
@@ -257,7 +257,7 @@ Rectangle {
     // Color animation
     Behavior on color {
         PhosphorMotionAnimation {
-            profile: "zone.highlight"
+            profile: "widget.zoneHighlight"
             durationOverride: constants.animationDuration
         }
 
@@ -267,16 +267,16 @@ Rectangle {
     // (matches the original `duration: animationDuration / 2` pattern).
     Behavior on border.width {
         PhosphorMotionAnimation {
-            profile: "zone.highlight.border"
+            profile: "widget.zoneHighlight.border"
             durationOverride: Math.round(constants.animationDuration / 2)
         }
 
     }
 
-    // Scale uses zone.highlight.pop for the OutBack overshoot=1.20 feel.
+    // Scale uses widget.zoneHighlight.pop for the OutBack overshoot=1.20 feel.
     Behavior on scale {
         PhosphorMotionAnimation {
-            profile: "zone.highlight.pop"
+            profile: "widget.zoneHighlight.pop"
             durationOverride: constants.animationDuration
         }
 

--- a/src/ui/ZoneItem.qml
+++ b/src/ui/ZoneItem.qml
@@ -57,19 +57,19 @@ Item {
         }
 
         // Phase 4: zone highlight transitions use the user's active
-        // animation Profile via the "zone.highlight" registry path.
+        // animation Profile via the "widget.zoneHighlight" registry path.
         // Daemon publishes Settings::animationProfile() here; live-updates
         // on settings edit with no daemon restart.
         Behavior on color {
             PhosphorMotionAnimation {
-                profile: "zone.highlight"
+                profile: "widget.zoneHighlight"
             }
 
         }
 
         Behavior on opacity {
             PhosphorMotionAnimation {
-                profile: "zone.highlight"
+                profile: "widget.zoneHighlight"
             }
 
         }
@@ -105,7 +105,7 @@ Item {
 
             Behavior on opacity {
                 PhosphorMotionAnimation {
-                    profile: "zone.highlight"
+                    profile: "widget.zoneHighlight"
                 }
 
             }
@@ -128,7 +128,7 @@ Item {
 
             Behavior on opacity {
                 PhosphorMotionAnimation {
-                    profile: "zone.highlight"
+                    profile: "widget.zoneHighlight"
                 }
 
             }

--- a/src/ui/ZoneOverlayContent.qml
+++ b/src/ui/ZoneOverlayContent.qml
@@ -240,7 +240,7 @@ Item {
                     properties: "opacity"
                     from: 0.3
                     to: 0
-                    profile: "zone.layoutSwitchIn"
+                    profile: "widget.zoneOverlayFlash"
                 }
 
             }

--- a/tests/unit/config/test_settings_shader_tree.cpp
+++ b/tests/unit/config/test_settings_shader_tree.cpp
@@ -256,7 +256,7 @@ private Q_SLOTS:
             PhosphorAnimationShaders::ShaderProfile pixelate;
             pixelate.effectId = QStringLiteral("pixelate");
             // Stale leaf at an unsupported subtree.
-            tree.setOverride(QStringLiteral("zone.snapIn"), pixelate);
+            tree.setOverride(QStringLiteral("editor.snapIn"), pixelate);
             // Supported leaf the user has set since.
             PhosphorAnimationShaders::ShaderProfile slide;
             slide.effectId = QStringLiteral("slide");
@@ -268,7 +268,7 @@ private Q_SLOTS:
         // Settings::shaderProfileTree() must return the pruned view.
         Settings s;
         const auto loaded = s.shaderProfileTree();
-        QVERIFY2(!loaded.hasOverride(QStringLiteral("zone.snapIn")),
+        QVERIFY2(!loaded.hasOverride(QStringLiteral("editor.snapIn")),
                  "read-side prune must drop overrides on unsupported paths even before the next save");
         QVERIFY2(loaded.hasOverride(QStringLiteral("osd.show")), "supported path must survive read-side prune");
     }

--- a/tests/unit/daemon/test_animation_profile_publication.cpp
+++ b/tests/unit/daemon/test_animation_profile_publication.cpp
@@ -119,8 +119,8 @@ private Q_SLOTS:
 
         // Drop a profile JSON. Note: filename basename must match the
         // inner `name` field (ProfileLoader rejects mismatches).
-        writeFile(profileDir + QStringLiteral("/zone.highlight.json"), QStringLiteral(R"({
-            "name": "zone.highlight",
+        writeFile(profileDir + QStringLiteral("/widget.zoneHighlight.json"), QStringLiteral(R"({
+            "name": "widget.zoneHighlight",
             "duration": 175,
             "curve": "0.42,0.00,0.58,1.00"
         })"));
@@ -133,17 +133,17 @@ private Q_SLOTS:
 
         // Registry now contains the user profile.
         auto& registry = m_registry;
-        QVERIFY(registry.hasProfile(QStringLiteral("zone.highlight")));
+        QVERIFY(registry.hasProfile(QStringLiteral("widget.zoneHighlight")));
 
         // The owner tag is the loader's — partitioning means this
         // entry is subject to wholesale replacement by another
         // `reloadFromOwner(loaderTag, ...)` but invisible to direct
         // `registerProfile(path, profile)` calls (those land under the
         // empty/direct tag).
-        QCOMPARE(registry.ownerOf(QStringLiteral("zone.highlight")), kLoaderOwnerTag);
+        QCOMPARE(registry.ownerOf(QStringLiteral("widget.zoneHighlight")), kLoaderOwnerTag);
 
         // The resolved Profile carries the values from the JSON file.
-        const auto resolved = registry.resolve(QStringLiteral("zone.highlight"));
+        const auto resolved = registry.resolve(QStringLiteral("widget.zoneHighlight"));
         QVERIFY(resolved.has_value());
         QCOMPARE(resolved->effectiveDuration(), 175.0);
     }

--- a/tests/unit/settings/test_animations_motion_sets.cpp
+++ b/tests/unit/settings/test_animations_motion_sets.cpp
@@ -70,7 +70,7 @@ private Q_SLOTS:
         QVERIFY(
             c.addUserPreset(QStringLiteral("My Curve"), {{QStringLiteral("curve"), QStringLiteral("0.5,0,0.5,1")}}));
         // Override file at a known path
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 250}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 250}}));
 
         // userPresets sees ONLY the preset, not the override
         const QVariantList presets = c.userPresets();
@@ -128,9 +128,9 @@ private Q_SLOTS:
         c.setUserProfilesDirOverride(tmp.path());
 
         QSignalSpy spy(&c, &AnimationsPageController::userPresetsChanged);
-        // "zone.snapIn" is a known event path — would shadow the
+        // "editor.snapIn" is a known event path — would shadow the
         // override slot.
-        QVERIFY(!c.addUserPreset(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 100}}));
+        QVERIFY(!c.addUserPreset(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 100}}));
         QCOMPARE(spy.count(), 0);
         QVERIFY(c.userPresets().isEmpty());
     }
@@ -188,27 +188,28 @@ private Q_SLOTS:
         AnimationsPageController c;
         c.setUserProfilesDirOverride(tmp.path());
 
-        // Write an override file. Its on-disk `name` field is "zone.snapIn"
+        // Write an override file. Its on-disk `name` field is "editor.snapIn"
         // (per setOverride's stamping rule).
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 250}}));
-        const QString overrideFilePath = tmp.path() + QStringLiteral("/zone.snapIn.json");
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 250}}));
+        const QString overrideFilePath = tmp.path() + QStringLiteral("/editor.snapIn.json");
         QVERIFY(QFileInfo::exists(overrideFilePath));
 
-        // Hand-craft a hostile preset on disk: `name` field = "zone.snapIn"
+        // Hand-craft a hostile preset on disk: `name` field = "editor.snapIn"
         // but the FILE is not at the canonical override slot. The library
         // skips it on userPresets() (collision filter) but a naive
         // remove-by-name walk would still delete it. We're asserting the
         // override file in the canonical slot remains intact regardless.
         QSignalSpy spy(&c, &AnimationsPageController::userPresetsChanged);
-        QVERIFY(!c.removeUserPreset(QStringLiteral("zone.snapIn")));
+        QVERIFY(!c.removeUserPreset(QStringLiteral("editor.snapIn")));
         QCOMPARE(spy.count(), 0);
 
         // The override file MUST still exist — this is the load-bearing
         // assertion: removeUserPreset cannot collateral-damage overrides.
-        QVERIFY2(QFileInfo::exists(overrideFilePath),
-                 "override file was deleted by removeUserPreset(\"zone.snapIn\") — preset CRUD MUST NOT touch override "
-                 "slots");
-        QCOMPARE(c.rawProfile(QStringLiteral("zone.snapIn")).value(QStringLiteral("duration")).toInt(), 250);
+        QVERIFY2(
+            QFileInfo::exists(overrideFilePath),
+            "override file was deleted by removeUserPreset(\"editor.snapIn\") — preset CRUD MUST NOT touch override "
+            "slots");
+        QCOMPARE(c.rawProfile(QStringLiteral("editor.snapIn")).value(QStringLiteral("duration")).toInt(), 250);
     }
 
     // ─── Motion sets ──────────────────────────────────────────────────────
@@ -221,7 +222,7 @@ private Q_SLOTS:
         c.setUserProfilesDirOverride(tmp.path());
 
         // Mix of path overrides and a user preset
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 222}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 222}}));
         QVERIFY(
             c.setOverride(QStringLiteral("osd.show"), {{QStringLiteral("curve"), QStringLiteral("spring:10,0.7")}}));
         QVERIFY(
@@ -247,14 +248,14 @@ private Q_SLOTS:
         c.setUserProfilesDirOverride(tmp.path());
 
         // Build set, then clear overrides, then apply
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 333}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 333}}));
         QVERIFY(c.saveCurrentAsMotionSet(QStringLiteral("snappy-set"), QString()));
-        QVERIFY(c.clearOverride(QStringLiteral("zone.snapIn")));
-        QVERIFY(!c.hasOverride(QStringLiteral("zone.snapIn")));
+        QVERIFY(c.clearOverride(QStringLiteral("editor.snapIn")));
+        QVERIFY(!c.hasOverride(QStringLiteral("editor.snapIn")));
 
         QVERIFY(c.applyMotionSet(QStringLiteral("snappy-set")));
-        QVERIFY(c.hasOverride(QStringLiteral("zone.snapIn")));
-        QCOMPARE(c.rawProfile(QStringLiteral("zone.snapIn")).value(QStringLiteral("duration")).toInt(), 333);
+        QVERIFY(c.hasOverride(QStringLiteral("editor.snapIn")));
+        QCOMPARE(c.rawProfile(QStringLiteral("editor.snapIn")).value(QStringLiteral("duration")).toInt(), 333);
     }
 
     void applyMotionSet_mergesPreservesOtherPaths()
@@ -265,9 +266,9 @@ private Q_SLOTS:
         c.setUserProfilesDirOverride(tmp.path());
 
         // Save a set with one path
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 222}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 222}}));
         QVERIFY(c.saveCurrentAsMotionSet(QStringLiteral("set-a"), QString()));
-        QVERIFY(c.clearOverride(QStringLiteral("zone.snapIn")));
+        QVERIFY(c.clearOverride(QStringLiteral("editor.snapIn")));
 
         // Set an UNRELATED override
         QVERIFY(c.setOverride(QStringLiteral("osd.show"), {{QStringLiteral("duration"), 555}}));
@@ -275,7 +276,7 @@ private Q_SLOTS:
         // Apply set-a; osd.show should still be 555 (merge, not replace)
         QVERIFY(c.applyMotionSet(QStringLiteral("set-a")));
         QCOMPARE(c.rawProfile(QStringLiteral("osd.show")).value(QStringLiteral("duration")).toInt(), 555);
-        QVERIFY(c.hasOverride(QStringLiteral("zone.snapIn")));
+        QVERIFY(c.hasOverride(QStringLiteral("editor.snapIn")));
     }
 
     void removeMotionSet_emitsAndDeletes()
@@ -285,7 +286,7 @@ private Q_SLOTS:
         AnimationsPageController c;
         c.setUserProfilesDirOverride(tmp.path());
 
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 222}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 222}}));
         QVERIFY(c.saveCurrentAsMotionSet(QStringLiteral("To Remove"), QString()));
         QCOMPARE(c.availableMotionSets().size(), 1);
 
@@ -314,7 +315,7 @@ private Q_SLOTS:
         const QString setPath = setsDir + QStringLiteral("/bad-set.json");
 
         QJsonObject validEntry;
-        validEntry.insert(QStringLiteral("path"), QStringLiteral("zone.snapIn"));
+        validEntry.insert(QStringLiteral("path"), QStringLiteral("editor.snapIn"));
         QJsonObject validProfile;
         validProfile.insert(QStringLiteral("duration"), 222);
         validEntry.insert(QStringLiteral("profile"), validProfile);
@@ -337,14 +338,14 @@ private Q_SLOTS:
         f.write(QJsonDocument(root).toJson());
         f.close();
 
-        // No prior override at zone.snapIn.
-        QVERIFY(!c.hasOverride(QStringLiteral("zone.snapIn")));
+        // No prior override at editor.snapIn.
+        QVERIFY(!c.hasOverride(QStringLiteral("editor.snapIn")));
 
         QVERIFY(!c.applyMotionSet(QStringLiteral("bad-set")));
 
         // Critical: the valid entry MUST NOT have been written. Atomic
         // semantics — all-or-nothing. Pre-fix this would be true.
-        QVERIFY2(!c.hasOverride(QStringLiteral("zone.snapIn")),
+        QVERIFY2(!c.hasOverride(QStringLiteral("editor.snapIn")),
                  "applyMotionSet wrote partial state from a malformed set — should have rejected atomically");
     }
 
@@ -367,7 +368,7 @@ private Q_SLOTS:
         c.setUserProfilesDirOverride(tmp.path());
 
         QSignalSpy spy(&c, &AnimationsPageController::pendingChangesChanged);
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 250}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 250}}));
         QCOMPARE(spy.count(), 1);
         QVERIFY(c.hasPendingChanges());
     }
@@ -380,18 +381,18 @@ private Q_SLOTS:
         c.setUserProfilesDirOverride(tmp.path());
 
         // Establish a pre-edit baseline: write 100 ms.
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 100}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 100}}));
         c.commitPending();
         QVERIFY(!c.hasPendingChanges());
 
         // Edit to 250 ms → should snapshot the 100ms file.
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 250}}));
-        QCOMPARE(c.rawProfile(QStringLiteral("zone.snapIn")).value(QStringLiteral("duration")).toInt(), 250);
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 250}}));
+        QCOMPARE(c.rawProfile(QStringLiteral("editor.snapIn")).value(QStringLiteral("duration")).toInt(), 250);
 
         // Revert → file content restored to 100 ms.
         c.revertPending();
         QVERIFY(!c.hasPendingChanges());
-        QCOMPARE(c.rawProfile(QStringLiteral("zone.snapIn")).value(QStringLiteral("duration")).toInt(), 100);
+        QCOMPARE(c.rawProfile(QStringLiteral("editor.snapIn")).value(QStringLiteral("duration")).toInt(), 100);
     }
 
     void revertPending_deletesFilesThatDidntExistBefore()
@@ -416,7 +417,7 @@ private Q_SLOTS:
         AnimationsPageController c;
         c.setUserProfilesDirOverride(tmp.path());
 
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 200}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 200}}));
         QVERIFY(c.setOverride(QStringLiteral("osd.show"), {{QStringLiteral("duration"), 300}}));
 
         QSignalSpy spy(&c, &AnimationsPageController::overrideChanged);
@@ -428,7 +429,7 @@ private Q_SLOTS:
         QStringList emitted;
         for (const auto& args : spy)
             emitted << args.at(0).toString();
-        QVERIFY(emitted.contains(QStringLiteral("zone.snapIn")));
+        QVERIFY(emitted.contains(QStringLiteral("editor.snapIn")));
         QVERIFY(emitted.contains(QStringLiteral("osd.show")));
     }
 
@@ -439,7 +440,7 @@ private Q_SLOTS:
         AnimationsPageController c;
         c.setUserProfilesDirOverride(tmp.path());
 
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 250}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 250}}));
         QVERIFY(c.hasPendingChanges());
 
         // commitPending clears the snapshot and only emits

--- a/tests/unit/settings/test_animations_page_controller.cpp
+++ b/tests/unit/settings/test_animations_page_controller.cpp
@@ -73,8 +73,8 @@ private Q_SLOTS:
     {
         AnimationsPageController c;
         QCOMPARE(c.sectionForPath(QStringLiteral("global")), QStringLiteral("global"));
-        QCOMPARE(c.sectionForPath(QStringLiteral("zone")), QStringLiteral("zone"));
-        QCOMPARE(c.sectionForPath(QStringLiteral("zone.snapIn")), QStringLiteral("zone"));
+        QCOMPARE(c.sectionForPath(QStringLiteral("editor")), QStringLiteral("editor"));
+        QCOMPARE(c.sectionForPath(QStringLiteral("editor.snapIn")), QStringLiteral("editor"));
         QCOMPARE(c.sectionForPath(QStringLiteral("popup.layoutPicker.show")), QStringLiteral("overlays"));
         QCOMPARE(c.sectionForPath(QString()), QString());
     }
@@ -83,7 +83,7 @@ private Q_SLOTS:
     {
         AnimationsPageController c;
         QCOMPARE(c.eventLabel(QStringLiteral("global")), QStringLiteral("Global"));
-        QCOMPARE(c.eventLabel(QStringLiteral("zone.snapIn")), QStringLiteral("Snap In"));
+        QCOMPARE(c.eventLabel(QStringLiteral("editor.snapIn")), QStringLiteral("Snap In"));
         QCOMPARE(c.eventLabel(QStringLiteral("popup.layoutPicker")), QStringLiteral("Layout Picker"));
         QCOMPARE(c.eventLabel(QStringLiteral("popup.layoutPicker.popIn")), QStringLiteral("Pop In"));
     }
@@ -91,8 +91,9 @@ private Q_SLOTS:
     void parentChain_walksToGlobal()
     {
         AnimationsPageController c;
-        const auto chain = c.parentChain(QStringLiteral("zone.snapIn"));
-        QCOMPARE(chain, (QStringList{QStringLiteral("zone.snapIn"), QStringLiteral("zone"), QStringLiteral("global")}));
+        const auto chain = c.parentChain(QStringLiteral("editor.snapIn"));
+        QCOMPARE(chain,
+                 (QStringList{QStringLiteral("editor.snapIn"), QStringLiteral("editor"), QStringLiteral("global")}));
     }
 
     void parentChain_globalIsRoot()
@@ -133,23 +134,23 @@ private Q_SLOTS:
         AnimationsPageController c;
         const QVariantList sections = c.eventSections();
 
-        // Find the "zone" section's "zone" entry — it should be flagged
-        // isCategory=true because zone.snapIn etc. live under it.
+        // Find the "editor" section's "editor" entry — it should be flagged
+        // isCategory=true because editor.snapIn etc. live under it.
         bool foundZoneCategory = false;
         bool zoneCategoryFlag = false;
         bool foundZoneSnapIn = false;
         bool zoneSnapInCategoryFlag = true; // pessimistic default
         for (const QVariant& sectionVar : sections) {
             const QVariantMap section = sectionVar.toMap();
-            if (section.value(QStringLiteral("section")).toString() != QLatin1String("zone"))
+            if (section.value(QStringLiteral("section")).toString() != QLatin1String("editor"))
                 continue;
             for (const QVariant& entry : section.value(QStringLiteral("paths")).toList()) {
                 const QVariantMap m = entry.toMap();
                 const QString path = m.value(QStringLiteral("path")).toString();
-                if (path == QLatin1String("zone")) {
+                if (path == QLatin1String("editor")) {
                     foundZoneCategory = true;
                     zoneCategoryFlag = m.value(QStringLiteral("isCategory")).toBool();
-                } else if (path == QLatin1String("zone.snapIn")) {
+                } else if (path == QLatin1String("editor.snapIn")) {
                     foundZoneSnapIn = true;
                     zoneSnapInCategoryFlag = m.value(QStringLiteral("isCategory")).toBool();
                 }
@@ -158,7 +159,7 @@ private Q_SLOTS:
         QVERIFY(foundZoneCategory);
         QVERIFY(foundZoneSnapIn);
         QVERIFY2(zoneCategoryFlag, "'zone' should be flagged as a category — it has children");
-        QVERIFY2(!zoneSnapInCategoryFlag, "'zone.snapIn' is a leaf — not a category");
+        QVERIFY2(!zoneSnapInCategoryFlag, "'editor.snapIn' is a leaf — not a category");
     }
 
     // ─── Override CRUD ────────────────────────────────────────────────────
@@ -175,19 +176,19 @@ private Q_SLOTS:
         QVariantMap profile;
         profile.insert(QStringLiteral("duration"), 250);
         profile.insert(QStringLiteral("curve"), QStringLiteral("0.33,1,0.68,1"));
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), profile));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), profile));
 
         QCOMPARE(spy.count(), 1);
-        QCOMPARE(spy.first().at(0).toString(), QStringLiteral("zone.snapIn"));
+        QCOMPARE(spy.first().at(0).toString(), QStringLiteral("editor.snapIn"));
 
-        const QString filePath = tmp.path() + QStringLiteral("/zone.snapIn.json");
+        const QString filePath = tmp.path() + QStringLiteral("/editor.snapIn.json");
         QVERIFY(QFileInfo::exists(filePath));
 
         // Verify the on-disk shape: name field present, Profile fields preserved.
         const auto doc = QJsonDocument::fromJson(readFile(filePath).toUtf8());
         QVERIFY(doc.isObject());
         const QJsonObject obj = doc.object();
-        QCOMPARE(obj.value(QStringLiteral("name")).toString(), QStringLiteral("zone.snapIn"));
+        QCOMPARE(obj.value(QStringLiteral("name")).toString(), QStringLiteral("editor.snapIn"));
         QCOMPARE(obj.value(QStringLiteral("duration")).toInt(), 250);
         QCOMPARE(obj.value(QStringLiteral("curve")).toString(), QStringLiteral("0.33,1,0.68,1"));
     }
@@ -199,9 +200,9 @@ private Q_SLOTS:
         AnimationsPageController c;
         c.setUserProfilesDirOverride(tmp.path());
 
-        QVERIFY(!c.hasOverride(QStringLiteral("zone.snapIn")));
-        c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 200}});
-        QVERIFY(c.hasOverride(QStringLiteral("zone.snapIn")));
+        QVERIFY(!c.hasOverride(QStringLiteral("editor.snapIn")));
+        c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 200}});
+        QVERIFY(c.hasOverride(QStringLiteral("editor.snapIn")));
     }
 
     void rawProfile_roundTripsProfileFieldsStripsName()
@@ -251,7 +252,7 @@ private Q_SLOTS:
         c.setUserProfilesDirOverride(tmp.path());
 
         QSignalSpy spy(&c, &AnimationsPageController::overrideChanged);
-        QVERIFY(!c.clearOverride(QStringLiteral("zone.snapIn")));
+        QVERIFY(!c.clearOverride(QStringLiteral("editor.snapIn")));
         QCOMPARE(spy.count(), 0);
     }
 
@@ -277,7 +278,7 @@ private Q_SLOTS:
         c.setUserProfilesDirOverride(tmp.path());
 
         // No registry, no files. Walk falls through to library defaults.
-        const QVariantMap resolved = c.resolvedProfile(QStringLiteral("zone.snapIn"));
+        const QVariantMap resolved = c.resolvedProfile(QStringLiteral("editor.snapIn"));
         using P = PhosphorAnimation::Profile;
         QCOMPARE(resolved.value(QStringLiteral("duration")).toDouble(), P::DefaultDuration);
         QCOMPARE(resolved.value(QStringLiteral("minDistance")).toInt(), P::DefaultMinDistance);
@@ -292,11 +293,11 @@ private Q_SLOTS:
         AnimationsPageController c;
         c.setUserProfilesDirOverride(tmp.path());
 
-        // Override the parent (zone) but not the leaf (zone.snapIn). The
+        // Override the parent (zone) but not the leaf (editor.snapIn). The
         // leaf must inherit the parent's duration via walk-up.
-        QVERIFY(c.setOverride(QStringLiteral("zone"), {{QStringLiteral("duration"), 222}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor"), {{QStringLiteral("duration"), 222}}));
 
-        const QVariantMap resolved = c.resolvedProfile(QStringLiteral("zone.snapIn"));
+        const QVariantMap resolved = c.resolvedProfile(QStringLiteral("editor.snapIn"));
         QCOMPARE(resolved.value(QStringLiteral("duration")).toInt(), 222);
     }
 
@@ -307,10 +308,10 @@ private Q_SLOTS:
         AnimationsPageController c;
         c.setUserProfilesDirOverride(tmp.path());
 
-        QVERIFY(c.setOverride(QStringLiteral("zone"), {{QStringLiteral("duration"), 100}}));
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 333}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor"), {{QStringLiteral("duration"), 100}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 333}}));
 
-        const QVariantMap resolved = c.resolvedProfile(QStringLiteral("zone.snapIn"));
+        const QVariantMap resolved = c.resolvedProfile(QStringLiteral("editor.snapIn"));
         QCOMPARE(resolved.value(QStringLiteral("duration")).toInt(), 333);
     }
 
@@ -324,10 +325,11 @@ private Q_SLOTS:
         // Parent supplies curve only; leaf supplies duration only.
         // Resolved should have BOTH from their respective sources, plus
         // library defaults for everything else.
-        QVERIFY(c.setOverride(QStringLiteral("zone"), {{QStringLiteral("curve"), QStringLiteral("spring:14.0,0.6")}}));
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), {{QStringLiteral("duration"), 444}}));
+        QVERIFY(
+            c.setOverride(QStringLiteral("editor"), {{QStringLiteral("curve"), QStringLiteral("spring:14.0,0.6")}}));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), {{QStringLiteral("duration"), 444}}));
 
-        const QVariantMap resolved = c.resolvedProfile(QStringLiteral("zone.snapIn"));
+        const QVariantMap resolved = c.resolvedProfile(QStringLiteral("editor.snapIn"));
         QCOMPARE(resolved.value(QStringLiteral("duration")).toInt(), 444);
         QCOMPARE(resolved.value(QStringLiteral("curve")).toString(), QStringLiteral("spring:14.0,0.6"));
         // Library default for the unspecified field:
@@ -399,12 +401,12 @@ private Q_SLOTS:
         QSignalSpy overrideSpy(&c, &AnimationsPageController::overrideChanged);
         QSignalSpy pendingSpy(&c, &AnimationsPageController::pendingChangesChanged);
 
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), profile));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), profile));
         QCOMPARE(overrideSpy.count(), 1);
         QCOMPARE(pendingSpy.count(), 1);
 
         // Second identical write — must short-circuit, no extra signals.
-        QVERIFY(c.setOverride(QStringLiteral("zone.snapIn"), profile));
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), profile));
         QCOMPARE(overrideSpy.count(), 1);
         QCOMPARE(pendingSpy.count(), 1);
     }
@@ -471,8 +473,8 @@ private Q_SLOTS:
         // Paths the resolver never walks through — any assignment would
         // be runtime-dead and silently shadow what the user thought
         // they set on a sibling. Must stay unsupported.
-        QVERIFY(!c.supportsShaderLeg(QStringLiteral("zone")));
-        QVERIFY(!c.supportsShaderLeg(QStringLiteral("zone.snapIn")));
+        QVERIFY(!c.supportsShaderLeg(QStringLiteral("editor")));
+        QVERIFY(!c.supportsShaderLeg(QStringLiteral("editor.snapIn")));
         QVERIFY(!c.supportsShaderLeg(QStringLiteral("widget")));
         QVERIFY(!c.supportsShaderLeg(QStringLiteral("widget.fadeIn")));
         QVERIFY(!c.supportsShaderLeg(QStringLiteral("workspace")));

--- a/tests/unit/settings/test_animations_page_controller.cpp
+++ b/tests/unit/settings/test_animations_page_controller.cpp
@@ -136,10 +136,10 @@ private Q_SLOTS:
 
         // Find the "editor" section's "editor" entry — it should be flagged
         // isCategory=true because editor.snapIn etc. live under it.
-        bool foundZoneCategory = false;
-        bool zoneCategoryFlag = false;
-        bool foundZoneSnapIn = false;
-        bool zoneSnapInCategoryFlag = true; // pessimistic default
+        bool foundEditorCategory = false;
+        bool editorCategoryFlag = false;
+        bool foundEditorSnapIn = false;
+        bool editorSnapInCategoryFlag = true; // pessimistic default
         for (const QVariant& sectionVar : sections) {
             const QVariantMap section = sectionVar.toMap();
             if (section.value(QStringLiteral("section")).toString() != QLatin1String("editor"))
@@ -148,18 +148,18 @@ private Q_SLOTS:
                 const QVariantMap m = entry.toMap();
                 const QString path = m.value(QStringLiteral("path")).toString();
                 if (path == QLatin1String("editor")) {
-                    foundZoneCategory = true;
-                    zoneCategoryFlag = m.value(QStringLiteral("isCategory")).toBool();
+                    foundEditorCategory = true;
+                    editorCategoryFlag = m.value(QStringLiteral("isCategory")).toBool();
                 } else if (path == QLatin1String("editor.snapIn")) {
-                    foundZoneSnapIn = true;
-                    zoneSnapInCategoryFlag = m.value(QStringLiteral("isCategory")).toBool();
+                    foundEditorSnapIn = true;
+                    editorSnapInCategoryFlag = m.value(QStringLiteral("isCategory")).toBool();
                 }
             }
         }
-        QVERIFY(foundZoneCategory);
-        QVERIFY(foundZoneSnapIn);
-        QVERIFY2(zoneCategoryFlag, "'zone' should be flagged as a category — it has children");
-        QVERIFY2(!zoneSnapInCategoryFlag, "'editor.snapIn' is a leaf — not a category");
+        QVERIFY(foundEditorCategory);
+        QVERIFY(foundEditorSnapIn);
+        QVERIFY2(editorCategoryFlag, "'editor' should be flagged as a category: it has children");
+        QVERIFY2(!editorSnapInCategoryFlag, "'editor.snapIn' is a leaf: not a category");
     }
 
     // ─── Override CRUD ────────────────────────────────────────────────────
@@ -293,7 +293,7 @@ private Q_SLOTS:
         AnimationsPageController c;
         c.setUserProfilesDirOverride(tmp.path());
 
-        // Override the parent (zone) but not the leaf (editor.snapIn). The
+        // Override the parent (editor) but not the leaf (editor.snapIn). The
         // leaf must inherit the parent's duration via walk-up.
         QVERIFY(c.setOverride(QStringLiteral("editor"), {{QStringLiteral("duration"), 222}}));
 
@@ -353,7 +353,7 @@ private Q_SLOTS:
         QVERIFY(!c.setOverride(QStringLiteral("../etc/passwd"), {{QStringLiteral("duration"), 100}}));
         QVERIFY(!c.setOverride(QStringLiteral("../../bad"), {{QStringLiteral("duration"), 100}}));
         QVERIFY(!c.setOverride(QStringLiteral("..\\windows-path"), {{QStringLiteral("duration"), 100}}));
-        QVERIFY(!c.setOverride(QStringLiteral("zone/../../etc"), {{QStringLiteral("duration"), 100}}));
+        QVERIFY(!c.setOverride(QStringLiteral("editor/../../etc"), {{QStringLiteral("duration"), 100}}));
         // Plausible-looking but unknown paths are also rejected
         // (membership in allBuiltInPaths is the gate, not just lexical
         // shape).


### PR DESCRIPTION
## Summary

The "Animations › Surfaces › Zones" settings page was a misnomer. The four entries it exposed weren't really zone-overlay events — they fired on different surfaces and conceptually belonged in different families:

- `zone.snapIn` / `zone.snapOut` / `zone.snapResize` / `zone.layoutSwitchIn` were CONSUMED BY THE KWIN-EFFECT (`tryBeginShaderForEvent` in `daemon_apply.cpp` / `drag_snap.cpp` / `applySnapGeometry`). They animate the WINDOW QUAD when a window snaps into / out of a zone, gets resized while snapped, or is repositioned by a layout switch. **Window events triggered by zone interaction.**
- `zone.highlight` (+ `.pop` / `.border`) animates the highlight property of the reusable `ZoneItem` QML widget. Embedded in 12+ sites: runtime overlay, layout thumbnails, new-layout dialog, layout combo boxes, shared previews. **Widget event** — animation lives with the widget; the surface hosting it is incidental.
- `zone.snapIn` / `zone.snapResize` (the editor's separate uses in `ZoneFillAnimation.qml` and `EditorZone.qml`) animate the editor's zone-rect outline during fill-preview. **Editor-only event** distinct from the runtime window animation that shares the verb.
- `zone.layoutSwitchIn` (the QML side at `ZoneOverlayContent.qml:243`) is a one-shot flash on the main zone-overlay surface. Separate concern from the kwin-effect's window-side `window.layoutSwitch`.

## Path renames

| Old path                  | New path                      | Where it fires                                  |
|---------------------------|-------------------------------|--------------------------------------------------|
| `zone.snapIn`             | `window.snapIn`               | kwin-effect window quad on snap-in              |
| `zone.snapOut`            | `window.snapOut`              | kwin-effect window quad on snap-out             |
| `zone.snapResize`         | `window.snapResize`           | kwin-effect snapped-window resize               |
| `zone.snapResize` (editor)| `editor.snapResize`           | EditorZone.qml fill-preview Behavior            |
| `zone.snapIn` (editor)    | `editor.snapIn`               | ZoneFillAnimation.qml fill                      |
| `zone.snapOut` (editor)   | `editor.snapOut`              | reserved for editor unfill leg                  |
| `zone.highlight`          | `widget.zoneHighlight`        | ZoneItem widget highlight (12 embed sites)      |
| `zone.highlight.pop`      | `widget.zoneHighlight.pop`    | sub-event                                       |
| `zone.highlight.border`   | `widget.zoneHighlight.border` | sub-event                                       |
| `zone.layoutSwitchIn`     | `window.layoutSwitch`         | kwin-effect window quad on layout switch        |
| `zone.layoutSwitchIn`     | `widget.zoneOverlayFlash`     | ZoneOverlayContent.qml flash overlay            |

## Settings UI reorganisation

- **Removed**: `AnimationsZonesPage.qml` + the `animations-zones` sidebar entry.
- **Added**: `AnimationsEditorPage.qml` (sidebar entry "Layout Editor") for `editor.*` paths.
- `AnimationsWidgetsPage.qml` gains `widget.zoneHighlight` (+ pop / border) and `widget.zoneOverlayFlash` cards.
- `AnimationsWindowsPage.qml` gains `window.snapIn`, `window.snapOut`, `window.snapResize`, `window.layoutSwitch` cards. These are now shader-tunable (added to `shaderSupportedEventPaths()`) since the kwin-effect resolves them through `tryBeginShaderForEvent`.

## ProfilePaths.h

- **Removed**: `Zone`, `ZoneSnapIn`, `ZoneSnapOut`, `ZoneSnapResize`, `ZoneHighlight`, `ZoneHighlightPop`, `ZoneHighlightBorder`, `ZoneLayoutSwitchIn`.
- **Added**: `Editor`, `EditorSnapIn`, `EditorSnapOut`, `EditorSnapResize`, `WidgetZoneHighlight`, `WidgetZoneHighlightPop`, `WidgetZoneHighlightBorder`, `WidgetZoneOverlayFlash`, `WindowSnapIn`, `WindowSnapOut`, `WindowSnapResize`, `WindowLayoutSwitch`.

## Bootstrap seeds

`animationbootstrap.cpp`: replaced `zone → widget-out 200ms` with two new family roots — `editor → widget-out 200ms` and `widget.zoneHighlight → widget-out 200ms`.

## Backwards compatibility

Per `CLAUDE.md` "no ad-hoc backwards-compat shims": old user-JSON overrides at `~/.local/share/plasmazones/profiles/zone.*.json` are silently dropped on first load. Users that customised any zone-family profile get the new family default and must re-set on the new path.

## Test plan

- [x] Build clean
- [x] 178/178 unit tests pass (test files migrated to new paths: `test_profiletree`, `test_shaderprofiletree`, `test_settings_shader_tree`, `test_animations_page_controller`, `test_animations_motion_sets`, `test_animation_profile_publication`)
- [ ] Manual: confirm "Layout Editor" appears in Settings sidebar under Animations › Surfaces
- [ ] Manual: confirm "Zones" no longer appears in the sidebar
- [ ] Manual: confirm Widgets page shows the new Zone Highlight / Pop / Border / Overlay Flash cards
- [ ] Manual: confirm Windows page shows the new Snap Into Zone / Snap Out / Snap Resize / Layout Switch cards
- [ ] Manual: open Layout Editor, drag a zone to fill — animation runs through `editor.snapIn` profile
- [ ] Manual: snap a window into a zone — kwin-effect animates via `window.snapIn` profile (+ shader if assigned)
- [ ] Manual: hover-highlight a zone in the runtime overlay — animation runs through `widget.zoneHighlight`
- [ ] Manual: switch layouts mid-drag — overlay flashes via `widget.zoneOverlayFlash`, windows reposition via `window.layoutSwitch`