### PR TITLE
Animation: surface-extent broken-glass port + boundary-mask sweep across 14 packs

### DIFF
--- a/data/animations/aura-glow/effect.frag
+++ b/data/animations/aura-glow/effect.frag
@@ -124,7 +124,12 @@ vec4 blurredInputColor(vec2 uv, float radius, float samples)
     // texture read saves 44 redundant samples per fragment on every
     // visible-state frame.
     if (radius < 0.5) {
-        return texture(uTexture0, uv);
+        // boundaryMask (see noise.glsl) crops the sample to transparent
+        // outside [0, 1] — at the "gone" state windowUV is scaled by 1.1
+        // around the centre so the corners drift ~5% past the anchor,
+        // and uTexture0's clamp-to-edge sampler would otherwise smear
+        // the edge texel into a halo around the shrinking-orb silhouette.
+        return texture(uTexture0, uv) * boundaryMask(uv);
     }
     vec4 acc = vec4(0.0);
     const float tau = 6.28318530718;
@@ -145,7 +150,16 @@ vec4 blurredInputColor(vec2 uv, float radius, float samples)
         for (int i = 0; i < sampleCount; ++i) {
             float s = float(i) / sampleCountF;
             vec2 off = vec2(cos(d), sin(d)) * radius * (1.0 - s) / flooredResolution;
-            acc += texture(uTexture0, uv + off);
+            // Per-tap boundaryMask — the radial blur kernel reaches
+            // outside [0, 1] for taps near the anchor edge even when
+            // the centre `uv` is in-bounds; without this each off-
+            // window tap would inherit a smeared edge texel via the
+            // clamp-to-edge sampler and the average would carry the
+            // smear inward. Taps that fall outside contribute zero
+            // (transparent), so the average naturally fades the blur
+            // toward the surface boundary.
+            vec2 tap = uv + off;
+            acc += texture(uTexture0, tap) * boundaryMask(tap);
         }
     }
     return acc / sampleCountF / dirs;
@@ -202,9 +216,13 @@ void main()
     // at gone state the window has scaled up 10%. easeOutCubic
     // makes the scale-up gentle.
     vec2 windowUV  = (vTexCoord - 0.5) * mix(1.1, 1.0, easeOutCubic(progress)) + 0.5;
+    // Non-blur path mirrors the blurredInputColor mask above so off-
+    // anchor windowUV samples (the 1.1× scale at the gone state pushes
+    // corners ~5% past the anchor) clip cleanly to transparent instead
+    // of smearing the edge texel via clamp-to-edge.
     vec4 windowCol = (blurAmount > 0.0)
         ? blurredInputColor(windowUV, (1.0 - progress) * blurAmount, 3.0)
-        : texture(uTexture0, windowUV);
+        : texture(uTexture0, windowUV) * boundaryMask(windowUV);
 
     // Don't draw glow where the window itself is transparent
     // (window-content shaped, not square mask).

--- a/data/animations/aura-glow/effect.frag
+++ b/data/animations/aura-glow/effect.frag
@@ -132,6 +132,7 @@ vec4 blurredInputColor(vec2 uv, float radius, float samples)
         return texture(uTexture0, uv) * boundaryMask(uv);
     }
     vec4 acc = vec4(0.0);
+    float totalWeight = 0.0;
     const float tau = 6.28318530718;
     const float dirs = 15.0;
     // int loop bound so iteration count exactly matches the divisor —
@@ -150,19 +151,13 @@ vec4 blurredInputColor(vec2 uv, float radius, float samples)
         for (int i = 0; i < sampleCount; ++i) {
             float s = float(i) / sampleCountF;
             vec2 off = vec2(cos(d), sin(d)) * radius * (1.0 - s) / flooredResolution;
-            // Per-tap boundaryMask — the radial blur kernel reaches
-            // outside [0, 1] for taps near the anchor edge even when
-            // the centre `uv` is in-bounds; without this each off-
-            // window tap would inherit a smeared edge texel via the
-            // clamp-to-edge sampler and the average would carry the
-            // smear inward. Taps that fall outside contribute zero
-            // (transparent), so the average naturally fades the blur
-            // toward the surface boundary.
             vec2 tap = uv + off;
-            acc += texture(uTexture0, tap) * boundaryMask(tap);
+            float w = boundaryMask(tap);
+            acc += texture(uTexture0, tap) * w;
+            totalWeight += w;
         }
     }
-    return acc / sampleCountF / dirs;
+    return acc / max(totalWeight, 1.0);
 }
 
 void main()

--- a/data/animations/bounce/effect.frag
+++ b/data/animations/bounce/effect.frag
@@ -26,6 +26,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define bounces customParams[0].x
@@ -47,7 +48,13 @@ void main() {
 
     vec2 sample_uv = uv;
     sample_uv.y = uv.y + (1.0 - yy);
-    vec4 win = texture(uTexture0, sample_uv);
+    // boundaryMask (see noise.glsl) crops samples outside [0, 1] —
+    // sample_uv.y is shifted by (1 - yy) which puts it past the top
+    // of the surface for most of the bounce, and uTexture0's clamp-to-
+    // edge sampler would otherwise smear the top row of texels along
+    // the leading edge of the drop. The mask bands sit OUTSIDE [0, 1]
+    // so identity sampling (idle end of the bounce) is unaffected.
+    vec4 win = texture(uTexture0, sample_uv) * boundaryMask(sample_uv);
 
     float reveal = step(d, 0.0);
     fragColor = win * reveal;

--- a/data/animations/broken-glass/effect.frag
+++ b/data/animations/broken-glass/effect.frag
@@ -56,28 +56,7 @@ layout(location = 0) out vec4 fragColor;
 #define uBlowForce  customParams[0].y
 #define uGravity    customParams[0].z
 
-// Surface-UV → anchor-relative UV. On the daemon path the shader item
-// covers the entire wl_surface, so `vTexCoord` spans the full surface
-// FBO; this remap converts it to the captured anchor's UV space, where
-// `[0, 1]` is the anchor itself and values outside that range land in
-// the surface area surrounding the anchor. The BMW shard cascade below
-// operates in this anchor-space directly — there's no `iTexCoord*2 -
-// 0.5` because the surface naturally provides more room than BMW's
-// 2x-padded actor.
-//
-// Defence in depth: `iResolution` and `iAnchorSize` are runtime-pushed
-// and normally positive by leg start, but transient pre-attach paints
-// or mid-relayout frames can land at zero. `max(..., 1.0)` keeps the
-// divisor strictly positive so a stale frame samples a degenerate but
-// finite UV rather than propagating Inf / NaN through the shard
-// cascade. Mirrors morph/effect.frag's resSafe pattern.
-vec2 anchorRemap(vec2 uv) {
-    vec2 resSafe = max(iResolution, vec2(1.0));
-    vec2 anchorSizePx = max(iAnchorSize, vec2(1.0));
-    vec2 anchorTopLeftUv = iAnchorPosInFbo / resSafe;
-    vec2 anchorSizeUv = anchorSizePx / resSafe;
-    return (uv - anchorTopLeftUv) / anchorSizeUv;
-}
+#include <anchor_remap.glsl>
 
 // uEpicenter: BMW defaults to (0.5, 0.5) and only overrides via the
 // `broken-glass-use-pointer` setting. PlasmaZones doesn't carry a

--- a/data/animations/broken-glass/effect.frag
+++ b/data/animations/broken-glass/effect.frag
@@ -26,15 +26,13 @@
 // anchor's region those coords land outside `[0, 1]` and the
 // `getClippedInputColor` helper crops the sample to transparent.
 //
-// Kwin-effect path: surface-extent transitions don't perform any quad
-// expansion — `PlasmaZonesEffect::apply` (paint_pipeline.cpp) early-
-// returns when `fboExtentRing <= 0.0`, so the rasterised quad is the
-// natural one-over-frameGeometry mesh. `iAnchorPosInFbo` is `(0, 0)`
-// and `iAnchorSize == iResolution`, so `anchorRemap` collapses to
-// identity (`coords == vTexCoord`, range `[0, 1]`). Shards stay
-// within the captured frame on kwin; the cascade still produces the
-// shatter look since the close-leg's progress sweeps the per-shard
-// alpha threshold past every visible shard.
+// Kwin-effect path: the rasterised quad is the natural one-over-
+// frameGeometry mesh. `iAnchorPosInFbo` is `(0, 0)` and
+// `iAnchorSize == iResolution`, so `anchorRemap` collapses to identity
+// (`coords == vTexCoord`, range `[0, 1]`). Shards stay within the
+// captured frame on kwin; the cascade still produces the shatter look
+// since the close-leg's progress sweeps the per-shard alpha threshold
+// past every visible shard.
 //
 // `bmw_compat.glsl`'s default `getInputColor` only un-premultiplies the
 // sample — it does NOT clip, so an off-anchor lookup on a clamp-to-edge

--- a/data/animations/broken-glass/effect.frag
+++ b/data/animations/broken-glass/effect.frag
@@ -3,36 +3,45 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 // Broken Glass transition — ported from Burn-My-Windows' broken-glass.frag
-// (https://github.com/Schneegans/Burn-My-Windows). Surface shatters into
-// glass shards that fly apart. The shards.png atlas (`uTexture1`) encodes
-// per-shard layer index in the green channel and per-shard distance-to-
-// edge in the red channel; five layers each draw a subset of the shards
-// with independent rotation, scale, and gravity for the cascade.
+// (https://github.com/Schneegans/Burn-My-Windows). The surface shatters
+// into glass shards that fly apart. The shards.png atlas (`uTexture1`)
+// encodes per-shard layer index in the green channel and per-shard
+// distance-to-edge in the red channel; five layers each draw a subset of
+// the shards with independent rotation, scale, and gravity for the
+// cascade.
 //
-// BMW uniform shims come from `<bmw_compat.glsl>`; helpers
-// `hash22` / `simplex2D` come from `<noise.glsl>` (byte-equivalent
-// to BMW's). See bmw_compat.glsl header for the BMW-to-PlasmaZones
-// uniform-name remap.
+// BMW uniform shims come from `<bmw_compat.glsl>`; the `hash22` helper
+// comes from `<noise.glsl>` (byte-equivalent to BMW's). See
+// `bmw_compat.glsl` for the BMW→PlasmaZones uniform-name remap.
 //
 // Note on actor scale: BMW grows the actor by 2x (ACTOR_SCALE=2.0,
-// PADDING=0.5) so shards can fly past the original window bounds. We
-// match that on PlasmaZones via the `fboExtent` metadata grammar:
-// metadata declares `"fboExtent": "anchor+0.5"`, SurfaceAnimator
-// expands the shaderItem QUAD accordingly, and the runtime pushes
-// the anchor's region inside the padded FBO via `iAnchorPosInFbo`
-// (= (padW, padH)) alongside `iAnchorSize` and Qt-auto-derived
-// `iResolution`. The `anchorRemap` helper below converts the padded
-// vTexCoord back into anchor-space coords (-0.5..1.5 for ring=0.5),
-// exactly what BMW's `iTexCoord*2 - 0.5` produced upstream.
+// PADDING=0.5) so shards can fly past the original window bounds.
+// PlasmaZones achieves the same outcome via `fboExtent: "surface"`
+// (metadata.json) — SurfaceAnimator sizes the shader item to the
+// QQuickWindow's contentItem, so the cascade has the entire surface
+// (= host screen / VS rect post-fullscreen-OSD migration) to fly into,
+// not just a 2x bounding box. The `anchorRemap` helper below converts
+// the surface-UV `vTexCoord` (Qt-interpolated [0, 1] over the shader
+// item) into anchor-space coords; for fragments outside the captured
+// anchor's region those coords land outside `[0, 1]` and the
+// `getClippedInputColor` helper crops the sample to transparent.
 //
-// `bmw_compat.glsl`'s default `getInputColor` only divides by alpha,
-// it does NOT clip, so an off-window sample on a clamp-to-edge
+// Kwin-effect path: surface-extent transitions don't perform any quad
+// expansion — `PlasmaZonesEffect::apply` (paint_pipeline.cpp) early-
+// returns when `fboExtentRing <= 0.0`, so the rasterised quad is the
+// natural one-over-frameGeometry mesh. `iAnchorPosInFbo` is `(0, 0)`
+// and `iAnchorSize == iResolution`, so `anchorRemap` collapses to
+// identity (`coords == vTexCoord`, range `[0, 1]`). Shards stay
+// within the captured frame on kwin; the cascade still produces the
+// shatter look since the close-leg's progress sweeps the per-shard
+// alpha threshold past every visible shard.
+//
+// `bmw_compat.glsl`'s default `getInputColor` only un-premultiplies the
+// sample — it does NOT clip, so an off-anchor lookup on a clamp-to-edge
 // `uTexture0` would smear edge pixels (visible artefact for opaque-
-// edged windows like terminals or most app chrome). The cascade
-// below calls the `getClippedInputColor` helper (defined in
-// bmw_compat.glsl) instead, which crops samples outside [0, 1] to
-// `vec4(0.0)` before delegating to `getInputColor`. Shards beyond
-// the window crop cleanly to transparent.
+// edged windows like terminals or most app chrome). The cascade below
+// calls `getClippedInputColor` instead, which crops samples outside
+// `[0, 1]` to `vec4(0.0)` before delegating to `getInputColor`.
 
 #version 450
 
@@ -49,36 +58,22 @@ layout(location = 0) out vec4 fragColor;
 #define uBlowForce  customParams[0].y
 #define uGravity    customParams[0].z
 
-// Anchor's region inside the shader FBO. SurfaceAnimator expands the
-// shaderItem QUAD by metadata's `fboExtent: "anchor+N"` ring fraction.
-// The runtime pushes `iAnchorPosInFbo` = (padW, padH) and `iAnchorSize`
-// = the captured-anchor pixel size; Qt auto-derives `iResolution` from
-// the padded shaderItem bounds. The remap below converts the padded
-// `iTexCoord` (0..1 over the expanded FBO) back into anchor-space coords
-// (-ring..1+ring over the original anchor), reproducing BMW's
-// `iTexCoord*ACTOR_SCALE - PADDING` without hardcoding the constants.
-// With ring=0.5 (ACTOR_SCALE=2 equivalent) the coords land in [-0.5, 1.5]
-// exactly as BMW's broken-glass.frag expects.
+// Surface-UV → anchor-relative UV. On the daemon path the shader item
+// covers the entire wl_surface, so `vTexCoord` spans the full surface
+// FBO; this remap converts it to the captured anchor's UV space, where
+// `[0, 1]` is the anchor itself and values outside that range land in
+// the surface area surrounding the anchor. The BMW shard cascade below
+// operates in this anchor-space directly — there's no `iTexCoord*2 -
+// 0.5` because the surface naturally provides more room than BMW's
+// 2x-padded actor.
 //
-// Kwin-effect path: actor expansion is implemented at quad-construction
-// time. PlasmaZonesEffect::apply() (paint_pipeline.cpp) rebuilds the
-// window's quads at `(1+2·ring) × frame` with texCoord remapped to
-// `[-ring, 1+ring]`, so `iTexCoord` already arrives in anchor-space.
-// `iAnchorPosInFbo` is pushed as (0, 0) and `iAnchorSize == iResolution`,
-// so the unified remap math collapses to coords == iTexCoord, giving
-// the same `[-ring, 1+ring]` range the daemon path produces. The
-// `getClippedInputColor` helper used in the cascade below (defined in
-// bmw_compat.glsl) crops samples outside [0, 1] to transparent so the
-// redirected texture's clamp-to-edge wrap mode doesn't smear edge
-// pixels into the ring. BMW visual parity (shards flying past the
-// natural frame) works on both runtimes.
+// Defence in depth: `iResolution` and `iAnchorSize` are runtime-pushed
+// and normally positive by leg start, but transient pre-attach paints
+// or mid-relayout frames can land at zero. `max(..., 1.0)` keeps the
+// divisor strictly positive so a stale frame samples a degenerate but
+// finite UV rather than propagating Inf / NaN through the shard
+// cascade. Mirrors morph/effect.frag's resSafe pattern.
 vec2 anchorRemap(vec2 uv) {
-    // Defence in depth: see morph/effect.frag's resSafe comment. The
-    // runtime normally pushes positive iResolution / iAnchorSize at
-    // leg start, but transient pre-attach or mid-relayout frames can
-    // land at zero. Clamp the divisors so a stale frame samples a
-    // degenerate but finite UV rather than propagating Inf / NaN
-    // through the shard cascade.
     vec2 resSafe = max(iResolution, vec2(1.0));
     vec2 anchorSizePx = max(iAnchorSize, vec2(1.0));
     vec2 anchorTopLeftUv = iAnchorPosInFbo / resSafe;
@@ -86,15 +81,9 @@ vec2 anchorRemap(vec2 uv) {
     return (uv - anchorTopLeftUv) / anchorSizeUv;
 }
 
-// uSeed (BMW: per-leg `Math.random()`) is computed once at the top of
-// `main()` from `hash22(iSurfaceScreenPos.xy)` and bound to a local
-// `surfaceHash` so the loop below doesn't recompute the hash 5× per
-// fragment. See noise.glsl header for the per-instance vs per-leg
-// trade-off rationale.
-
 // uEpicenter: BMW defaults to (0.5, 0.5) and only overrides via the
 // `broken-glass-use-pointer` setting. PlasmaZones doesn't carry a
-// per-leg pointer position uniform, so always use the centre.
+// per-leg pointer position uniform, so always use the anchor centre.
 #define uEpicenter vec2(0.5)
 
 // Shard atlas: BMW binds shards.png to layer 1 as `uShardTexture`.
@@ -104,10 +93,41 @@ vec2 anchorRemap(vec2 uv) {
 
 const float SHARD_LAYERS = 5.0;
 
+// Shard atlas density per anchor-UV unit. BMW computed this from
+// `uSize / 500.0` (where `uSize` is the 2x-actor pixel size), so for a
+// 1000-pixel window the BMW density was `2000/500 = 4` atlas tiles
+// visible across the 2x actor, i.e. ~2 tiles visible across the window
+// itself.
+//
+// PlasmaZones can't reuse that formula safely: under the surface-extent
+// model `iAnchorSize` is the captured-anchor pixel size and is normally
+// pushed at leg start by `SurfaceAnimator::syncShaderGeometryNow`, but
+// transient pre-attach paints, mid-relayout frames, or kwin paths that
+// arrive before the first `iAnchorSize` uniform write briefly carry
+// `iAnchorSize == (0, 0)`. With `uSize = max(iAnchorSize, vec2(1.0))`
+// from bmw_compat that collapses the divisor to 1, making `shardCoords`
+// vary by `1/500` per anchor-UV unit — so the atlas barely advances
+// across the rendered surface and the discretised `shardGroup` ends up
+// piecewise-constant in horizontal bands. Combined with each layer's
+// per-row Y-gravity displacement that produced the "horizontal lines
+// breaking out" symptom seen on the previous port. Hardcoding the
+// equivalent density removes the dependency on a uniform that can
+// reach zero, mirroring BMW's effective 2-tiles-across-window default.
+const float kShardTilesAcrossAnchor = 2.0;
+
 void main() {
-  // Hoist the per-instance hash so we don't recompute it 5×SHARD_LAYERS
-  // times per fragment in the loop below.
-  vec2 surfaceHash = hash22(iSurfaceScreenPos.xy);
+  // Per-window pseudo-random seed offset for the shard atlas sampling.
+  // BMW pulls a fresh `Math.random()` pair per leg; PlasmaZones has no
+  // per-leg random uniform, so we derive a deterministic offset from
+  // the surface's screen position instead. Add irrational constants to
+  // `iSurfaceScreenPos.xy` before hashing — for integer screen
+  // positions (common: titlebar-aligned windows on integer DPR
+  // displays) the raw `hash22` chain collapses to `(0, 0)` because
+  // `fract(int * const)` is zero, and the atlas sampling then loses
+  // its per-instance offset (all windows at integer positions get
+  // identical shard patterns).
+  vec2 surfaceHash = hash22(iSurfaceScreenPos.xy + vec2(11.31, 17.71));
+
   // Defence-in-depth on the divisor: metadata declares min 0.2, but a
   // host that bypasses validation could push uShardScale to zero and
   // turn the shard-atlas UV math below into NaN.
@@ -120,14 +140,13 @@ void main() {
   // Draw the individual shard layers.
   for (float i = 0.0; i < SHARD_LAYERS; ++i) {
 
-    // To enable drawing shards outside of the window bounds, SurfaceAnimator
-    // expands the shaderItem QUAD by metadata's `fboExtent: "anchor+0.5"`
-    // ring fraction. The helper above turns the padded `iTexCoord` back into
-    // anchor-space coords (-0.5..1.5 for ring=0.5), reproducing BMW's
-    // `iTexCoord*ACTOR_SCALE - PADDING` from `iAnchorPosInFbo` /
-    // `iAnchorSize` / `iResolution` instead of the previous structural
-    // `customParams[7].x` slot.
-    vec2 coords = anchorRemap(iTexCoord.st);
+    // Convert this fragment's surface-UV into anchor-space coords.
+    // Replaces BMW's `iTexCoord*ACTOR_SCALE - PADDING`. For anchors
+    // smaller than the surface (typical case) the range naturally
+    // exceeds BMW's `[-0.5, 1.5]` — shards fly all the way to the
+    // surface boundary instead of being clipped at the 2x bounding
+    // box.
+    vec2 coords = anchorRemap(vTexCoord);
 
     // Scale and rotate around our epicenter.
     coords -= uEpicenter;
@@ -138,7 +157,7 @@ void main() {
     // Rotate each layer a bit differently.
     float rotation = (mod(i, 2.0) - 0.5) * 0.2 * progress;
     coords         = vec2(coords.x * cos(rotation) - coords.y * sin(rotation),
-                  coords.x * sin(rotation) + coords.y * cos(rotation));
+                          coords.x * sin(rotation) + coords.y * cos(rotation));
 
     // Move down each layer a bit.
     float gravity =
@@ -149,7 +168,11 @@ void main() {
     coords += uEpicenter;
 
     // Retrieve information from the shard texture for our layer.
-    vec2 shardCoords = (coords + surfaceHash) * uSize / shardScaleSafe / 500.0;
+    // `fract` enforces atlas tiling at the shader level so a sampler-
+    // wrap-mode misconfiguration (or a runtime path that bypasses the
+    // metadata `"wrap": "repeat"` value) can't collapse the cascade
+    // back to clamp-to-edge behaviour.
+    vec2 shardCoords = fract((coords + surfaceHash) * kShardTilesAcrossAnchor / shardScaleSafe);
     vec2 shardMap    = texture(uShardTexture, shardCoords).rg;
 
     // The green channel contains a random value in [0..1] for each shard. We

--- a/data/animations/broken-glass/effect.vert
+++ b/data/animations/broken-glass/effect.vert
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Broken-glass vertex shader — pass-through. The rasterised quad covers
+// the entire surface FBO (sized to the QQuickWindow's contentItem by
+// the daemon's surface-extent geometry, or the captured window frame
+// on the kwin-effect path). The fragment shader uses
+// `iAnchorPosInFbo / iAnchorSize / iResolution` to convert each
+// fragment's surface-UV into anchor-relative coords; the shard
+// cascade naturally fills the entire shader-item region so shards can
+// fly into the part of the surface that sits outside the original
+// anchor.
+//
+// Y-flip on the kwin path is mandatory — see
+// `data/animations/shared/animation_uniforms.glsl` for the full
+// contract. KWin's `OffscreenData::paint` populates `texCoord` with
+// Y-up FBO sampling coordinates; the canonical daemon Y=0-at-top
+// convention requires this flip. Matches morph/effect.vert.
+
+#version 450
+
+#include <animation_uniforms.glsl>
+
+layout(location = 0) in vec2 position;
+layout(location = 1) in vec2 texCoord;
+
+layout(location = 0) out vec2 vTexCoord;
+
+#ifdef PLASMAZONES_KWIN
+uniform mat4 modelViewProjectionMatrix;
+#endif
+
+void main() {
+#ifdef PLASMAZONES_KWIN
+    vTexCoord = vec2(texCoord.x, 1.0 - texCoord.y);
+    gl_Position = modelViewProjectionMatrix * vec4(position, 0.0, 1.0);
+#else
+    vTexCoord = texCoord;
+    gl_Position = vec4(position, 0.0, 1.0);
+#endif
+}

--- a/data/animations/broken-glass/effect.vert
+++ b/data/animations/broken-glass/effect.vert
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 // Broken-glass vertex shader — pass-through. The rasterised quad covers
 // the entire surface FBO (sized to the QQuickWindow's contentItem by

--- a/data/animations/broken-glass/metadata.json
+++ b/data/animations/broken-glass/metadata.json
@@ -6,7 +6,8 @@
     "version": "1.0",
     "category": "Particle",
     "fragmentShader": "effect.frag",
-    "fboExtent": "anchor+0.5",
+    "vertexShader": "effect.vert",
+    "fboExtent": "surface",
     "parameters": [
         {
             "id": "uShardScale",

--- a/data/animations/crosswarp/effect.frag
+++ b/data/animations/crosswarp/effect.frag
@@ -19,6 +19,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define frontSpeed customParams[0].x
@@ -32,9 +33,15 @@ void main() {
     vec2 uv = vTexCoord;
 
     float x = smoothstep(0.0, 1.0, (p * frontSpeed + uv.x - 1.0));
-    vec2 warped = clamp((uv - 0.5) * x + 0.5, vec2(0.0), vec2(1.0));
+    // niri's `clamp(warped, 0, 1)` was the bug: pinning off-window UVs
+    // to the edge texel via clamp-to-edge produced a smeared border
+    // around the warped silhouette. Drop the clamp and crop sampled
+    // texels via boundaryMask (see noise.glsl) instead — same shape
+    // as crosswarp wants (off-surface = transparent), but without the
+    // edge-pixel bleed.
+    vec2 warped = (uv - 0.5) * x + 0.5;
 
-    vec4 win = texture(uTexture0, warped);
+    vec4 win = texture(uTexture0, warped) * boundaryMask(warped);
 
     float in_bounds = step(0.0, uv.x) * step(uv.x, 1.0) * step(0.0, uv.y) * step(uv.y, 1.0);
     fragColor = win * x * in_bounds;

--- a/data/animations/fly-in/effect.vert
+++ b/data/animations/fly-in/effect.vert
@@ -105,24 +105,29 @@ void main() {
     vec2 shifted = position + vec2(offsetPx, 0.0);
     gl_Position = modelViewProjectionMatrix * vec4(shifted, 0.0, 1.0);
 #else
-    // Daemon (fboExtent=surface): the FBO spans iResolution (= the
-    // shader item's bounds = the QQuickWindow's contentItem = host
-    // screen / VS rect post-fullscreen-OSD migration). Map the
-    // standard (-1..1) clip-space quad onto the card's region within
-    // the FBO so the captured anchor texture renders at native pixel
-    // size at the card's resting screen position, then add the
-    // fly-in offset.
+    // Daemon (fboExtent=surface): the FBO spans the QQuickWindow's
+    // contentItem (host screen / VS rect post-fullscreen-OSD
+    // migration). Map the standard (-1..1) clip-space quad onto the
+    // card's region within the FBO so the captured anchor texture
+    // renders at native pixel size at the card's resting screen
+    // position, then add the fly-in offset.
     //
-    // iResolution naturally tracks the FBO size (Qt auto-syncs it
-    // from the shader item's geometry). On the animation path
-    // `ShaderEffect::syncBasePropertiesToNode` keeps it in LOGICAL
-    // pixels (gated on the AnimationUniformExtension's
-    // `requiresPhysicalResolution() == false`), so it matches the
-    // logical-pixel units of `iAnchorSize` and `iSurfaceScreenPos`
-    // and the clip-space ratio math below cancels cleanly. For card
-    // pixel size we read iAnchorSize; see the comment above for why
-    // iResolution is unsafe for "size of the card."
-    vec2 fboSizePx = vec2(max(iResolution.x, 1.0), max(iResolution.y, 1.0));
+    // CRITICAL: use `iSurfaceScreenPos.zw` (logical pixels) — NOT
+    // `iResolution` — for the FBO-size denominator. iResolution is
+    // auto-synced by Qt from the shader item's geometry events; on
+    // the FIRST frame of a leg attached against a fresh-from-warmup
+    // Window (login / reboot), the geometry-change signal that
+    // would resize iResolution to the screen-sized FBO has not yet
+    // propagated. Reading iResolution there returns the QML
+    // Window-default size (15×4 gridUnits = ~210×60 px), and the
+    // clip-space math below collapses to placing the card at clip
+    // coords far outside [-1, 1], cropping the rendered output to
+    // a sliver at the FBO edge — the visible "OSD displayed at the
+    // very top, almost cut off" symptom reported at login. The
+    // `iSurfaceScreenPos.zw` field is pushed synchronously by
+    // SurfaceAnimator::syncShaderGeometryNow from the scene root's
+    // bounds and is fresh on the very first frame of every leg.
+    vec2 fboSizePx = vec2(max(iSurfaceScreenPos.z, 1.0), max(iSurfaceScreenPos.w, 1.0));
 
     // Card centre in clip space. Qt's QSGRenderNode convention matches
     // the screen: clip-space Y = -1 is the top of the FBO and Y = +1

--- a/data/animations/fly-in/effect.vert
+++ b/data/animations/fly-in/effect.vert
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 // Fly-in vertex shader — translates the surface horizontally on enter so it
 // appears to fly in from the screen edge nearest to its current resting

--- a/data/animations/fly-in/effect.vert
+++ b/data/animations/fly-in/effect.vert
@@ -105,26 +105,24 @@ void main() {
     vec2 shifted = position + vec2(offsetPx, 0.0);
     gl_Position = modelViewProjectionMatrix * vec4(shifted, 0.0, 1.0);
 #else
-    // Daemon (fboExtent=surface): the FBO spans the QQuickWindow's
-    // contentItem = host screen / VS rect (post-fullscreen-OSD
-    // migration). Map the standard (-1..1) clip-space quad onto the
-    // card's region within the FBO so the captured anchor texture
-    // renders at native pixel size at the card's resting screen
-    // position, then add the fly-in offset.
+    // Daemon (fboExtent=surface): the FBO spans iResolution (= the
+    // shader item's bounds = the QQuickWindow's contentItem = host
+    // screen / VS rect post-fullscreen-OSD migration). Map the
+    // standard (-1..1) clip-space quad onto the card's region within
+    // the FBO so the captured anchor texture renders at native pixel
+    // size at the card's resting screen position, then add the
+    // fly-in offset.
     //
-    // CRITICAL: use `iSurfaceScreenPos.zw` (logical pixels) — NOT
-    // `iResolution` — for the FBO-size denominator. The daemon path
-    // uploads `iResolution` to the UBO multiplied by the window's DPR
-    // (so fragment shaders that read `gl_FragCoord` see matching
-    // units), but the animation-extension fields the rest of this
-    // math consumes (`iAnchorSize`, `iSurfaceScreenPos.xy`) are
-    // LOGICAL pixels. Mixing a physical iResolution denominator with
-    // logical numerators shrinks the rendered card by exactly 1/DPR —
-    // the "fly-in lands at smaller-than-resting size" symptom this
-    // comment is the fix for. `iSurfaceScreenPos.zw` mirrors the
-    // contentItem's logical width/height under `fboExtent: surface`,
-    // which is the same FBO this shader item renders into.
-    vec2 fboSizePx = vec2(max(iSurfaceScreenPos.z, 1.0), max(iSurfaceScreenPos.w, 1.0));
+    // iResolution naturally tracks the FBO size (Qt auto-syncs it
+    // from the shader item's geometry). On the animation path
+    // `ShaderEffect::syncBasePropertiesToNode` keeps it in LOGICAL
+    // pixels (gated on the AnimationUniformExtension's
+    // `requiresPhysicalResolution() == false`), so it matches the
+    // logical-pixel units of `iAnchorSize` and `iSurfaceScreenPos`
+    // and the clip-space ratio math below cancels cleanly. For card
+    // pixel size we read iAnchorSize; see the comment above for why
+    // iResolution is unsafe for "size of the card."
+    vec2 fboSizePx = vec2(max(iResolution.x, 1.0), max(iResolution.y, 1.0));
 
     // Card centre in clip space. Qt's QSGRenderNode convention matches
     // the screen: clip-space Y = -1 is the top of the FBO and Y = +1

--- a/data/animations/flyeye/effect.frag
+++ b/data/animations/flyeye/effect.frag
@@ -20,6 +20,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots
 #define displacement    customParams[0].x
@@ -37,7 +38,12 @@ void main() {
     vec2 disp = displacement * vec2(cos(facetFrequency * uv.x), sin(facetFrequency * uv.y));
     vec2 sample_uv = uv + inv * disp;
 
-    vec4 win = texture(uTexture0, sample_uv);
+    // boundaryMask (see noise.glsl) crops samples outside [0, 1] —
+    // the cos/sin facet displacement carries `sample_uv` past the
+    // anchor edge along the lens facets, and uTexture0's clamp-to-
+    // edge sampler would otherwise smear the rim texels into the
+    // facet ripple.
+    vec4 win = texture(uTexture0, sample_uv) * boundaryMask(sample_uv);
 
     fragColor = win * p;
 }

--- a/data/animations/hexagon/effect.frag
+++ b/data/animations/hexagon/effect.frag
@@ -114,8 +114,13 @@ void main()
         // the cell centre as tileProgress grows. The (1-tileProgress)
         // divisor makes the offset diverge as the tile shrinks to
         // nothing, so the lookup eventually goes off the texture.
+        // boundaryMask (see noise.glsl) crops the off-texture lookup
+        // to transparent so the shrinking tile fades cleanly into the
+        // background instead of carrying smeared edge texels outward
+        // through the clamp-to-edge sampler.
         vec2 lookupOffset = tileProgress * hex.xy / texScale / max(1.0 - tileProgress, 0.001);
-        oColor = texture(uTexture0, uv + lookupOffset);
+        vec2 lookupCoords = uv + lookupOffset;
+        oColor = texture(uTexture0, lookupCoords) * boundaryMask(lookupCoords);
 
         vec4 glow = glowColor;
         vec4 line = lineColor;

--- a/data/animations/incinerate/effect.frag
+++ b/data/animations/incinerate/effect.frag
@@ -138,7 +138,13 @@ void main() {
     }
 #endif
 
-    oColor = getInputColor(iTexCoord + distort);
+    // boundaryMask (see noise.glsl) crops the distorted sample to
+    // transparent outside [0, 1] — the dFdx/dFdy distort pushes the
+    // sample UV past the anchor edge along the scorch front, and
+    // uTexture0's clamp-to-edge sampler would otherwise smear the
+    // rim texel into the heat-distorted region.
+    vec2 sampleUv = iTexCoord + distort;
+    oColor = getInputColor(sampleUv) * boundaryMask(sampleUv);
   }
 
   // Add smoke and embers.

--- a/data/animations/morph/effect.frag
+++ b/data/animations/morph/effect.frag
@@ -23,20 +23,7 @@
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
 
-// Surface-UV → anchor-relative UV. With pass-through vTexCoord covering
-// the full surface FBO, this maps the captured anchor's region back to
-// `[0, 1]` for the warp math; fragments outside the anchor land at
-// `anchorUv < 0` or `> 1` and the `mask` block at the bottom clips
-// them to transparent. On the kwin-effect path `iAnchorPosInFbo` is
-// `(0, 0)` and `iAnchorSize == iResolution == frame`, so the remap
-// collapses to identity (`anchorUv == vTexCoord`).
-vec2 anchorRemap(vec2 uv) {
-    vec2 resSafe = max(iResolution, vec2(1.0));
-    vec2 anchorSizePx = max(iAnchorSize, vec2(1.0));
-    vec2 anchorTopLeftUv = iAnchorPosInFbo / resSafe;
-    vec2 anchorSizeUv = anchorSizePx / resSafe;
-    return (uv - anchorTopLeftUv) / anchorSizeUv;
-}
+#include <anchor_remap.glsl>
 
 void main()
 {

--- a/data/animations/morph/effect.frag
+++ b/data/animations/morph/effect.frag
@@ -23,39 +23,24 @@
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
 
-void main()
-{
-    // Remap padded vTexCoord → anchor-space UV. SurfaceAnimator expands
-    // the shaderItem QUAD by metadata's `fboExtent: "anchor+N"` ring
-    // fraction and pushes `iAnchorPosInFbo` = (padW, padH) alongside
-    // `iAnchorSize` = the captured-anchor pixel size; Qt auto-derives
-    // `iResolution` from the padded shaderItem bounds. The unified
-    // remap below produces an anchorUv range of `[-ring, 1+ring]` for
-    // a ring fraction of `ring`. Replaces the previous
-    // `customParams[7].x`-based math.
-    //
-    // Kwin-effect path: actor expansion is implemented at quad-
-    // construction time. PlasmaZonesEffect::apply() (paint_pipeline.cpp)
-    // rebuilds the window's quads at `(1+2·ring) × frame` size and
-    // remaps the texCoord to `[-ring, 1+ring]`, so `vTexCoord` already
-    // arrives in anchor-space coordinates. iAnchorPosInFbo is pushed as
-    // (0, 0) and iAnchorSize == iResolution, so the math collapses to
-    // anchorUv == vTexCoord, giving the same `[-ring, 1+ring]` range
-    // the daemon path produces via uniform-driven remap. Different
-    // runtime mechanism, same shader source.
-    // Defence in depth: iResolution and iAnchorSize are runtime-pushed
-    // and normally positive by leg start, but in a few well-known
-    // transient windows (pre-attach paint, anchor mid-relayout where
-    // width / height drop to zero between bindings) they can land at
-    // zero. `max(..., 1.0)` keeps the divisor strictly positive so a
-    // stale frame samples a degenerate but finite UV rather than
-    // propagating Inf / NaN through the warp math and dropping the
-    // surface to transparent.
+// Surface-UV → anchor-relative UV. With pass-through vTexCoord covering
+// the full surface FBO, this maps the captured anchor's region back to
+// `[0, 1]` for the warp math; fragments outside the anchor land at
+// `anchorUv < 0` or `> 1` and the `mask` block at the bottom clips
+// them to transparent. On the kwin-effect path `iAnchorPosInFbo` is
+// `(0, 0)` and `iAnchorSize == iResolution == frame`, so the remap
+// collapses to identity (`anchorUv == vTexCoord`).
+vec2 anchorRemap(vec2 uv) {
     vec2 resSafe = max(iResolution, vec2(1.0));
     vec2 anchorSizePx = max(iAnchorSize, vec2(1.0));
     vec2 anchorTopLeftUv = iAnchorPosInFbo / resSafe;
     vec2 anchorSizeUv = anchorSizePx / resSafe;
-    vec2 anchorUv = (vTexCoord - anchorTopLeftUv) / anchorSizeUv;
+    return (uv - anchorTopLeftUv) / anchorSizeUv;
+}
+
+void main()
+{
+    vec2 anchorUv = anchorRemap(vTexCoord);
 
     // Envelope peaks at iTime == 0.5 (mid-transition) and returns to
     // 0 at the endpoints. Same shape as glitch; gives both show and

--- a/data/animations/morph/effect.vert
+++ b/data/animations/morph/effect.vert
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Morph vertex shader — pass-through. The rasterised quad covers the
+// entire surface FBO (sized to the QQuickWindow's contentItem by the
+// daemon's surface-extent geometry). The fragment shader uses
+// `iAnchorPosInFbo / iAnchorSize / iResolution` to convert each
+// fragment's surface-UV into anchor-relative coords, clip to the
+// anchor's region, and apply the warp.
+//
+// Pass-through here means: no clip-space remap. Qt's QSG geometry for
+// a surface-sized QQuickShaderEffect is already a (-1..1) quad
+// covering the FBO, and `texCoord` (and the kwin-effect's `texCoord`
+// attribute) interpolates 0..1 over that quad — exactly the contract
+// the fragment shader expects.
+
+#version 450
+
+#include <animation_uniforms.glsl>
+
+layout(location = 0) in vec2 position;
+layout(location = 1) in vec2 texCoord;
+
+layout(location = 0) out vec2 vTexCoord;
+
+#ifdef PLASMAZONES_KWIN
+uniform mat4 modelViewProjectionMatrix;
+#endif
+
+void main() {
+#ifdef PLASMAZONES_KWIN
+    // Y-flip — kwin's FBO is Y-up but the daemon (and BMW math) uses
+    // Y-down. Mirrors `kKwinDefaultVertexSource` in
+    // kwin-effect/plasmazoneseffect.cpp.
+    vTexCoord = vec2(texCoord.x, 1.0 - texCoord.y);
+    gl_Position = modelViewProjectionMatrix * vec4(position, 0.0, 1.0);
+#else
+    // Daemon: Qt-RHI gives `position` in (-1..1) clip space and
+    // `texCoord` in [0, 1] over the FBO; pass both through.
+    vTexCoord = texCoord;
+    gl_Position = vec4(position, 0.0, 1.0);
+#endif
+}

--- a/data/animations/morph/effect.vert
+++ b/data/animations/morph/effect.vert
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 //
 // Morph vertex shader — pass-through. The rasterised quad covers the
 // entire surface FBO (sized to the QQuickWindow's contentItem by the

--- a/data/animations/morph/metadata.json
+++ b/data/animations/morph/metadata.json
@@ -6,7 +6,8 @@
     "version": "1.0",
     "category": "Distortion",
     "fragmentShader": "effect.frag",
-    "fboExtent": "anchor+0.5",
+    "vertexShader": "effect.vert",
+    "fboExtent": "surface",
     "parameters": [
         {
             "id": "warpStrength",

--- a/data/animations/paint-brush/effect.frag
+++ b/data/animations/paint-brush/effect.frag
@@ -31,6 +31,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
@@ -70,7 +71,16 @@ void main() {
     for (float i = 0.0; i < SHADOW_STEPS; ++i) {
       vec2 shadowTexCoord = iTexCoord.st - vec2(0.0, i * SHADOW_WIDTH / SHADOW_STEPS);
       float shadowMask = getMask(shadowTexCoord, uProgress);
-      float shadowAlpha = (1.0 - i / SHADOW_STEPS) * shadowMask * getInputColor(shadowTexCoord).a;
+      // boundaryMask (see noise.glsl) crops the alpha read to zero
+      // outside [0, 1] — shadowTexCoord.y goes negative for fragments
+      // near the top of the window (the shadow loop walks UP from
+      // each fragment), and uTexture0's clamp-to-edge sampler would
+      // otherwise read the top row's alpha (typically opaque content)
+      // as the shadow source, painting a phantom shadow above the
+      // window's top edge.
+      float shadowAlpha = (1.0 - i / SHADOW_STEPS) * shadowMask
+                        * getInputColor(shadowTexCoord).a
+                        * boundaryMask(shadowTexCoord);
 
       if (shadowAlpha > 0.0) {
         oColor = vec4(vec3(0.0), shadowAlpha * 0.2);

--- a/data/animations/pixel-wheel/effect.frag
+++ b/data/animations/pixel-wheel/effect.frag
@@ -30,6 +30,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 #define maxPixelSize customParams[0].x
 #define spokeCount   customParams[0].y
@@ -52,7 +53,12 @@ void main()
     // this with the actual surface size.
     vec2 pixelGrid  = vec2(pixelSize) / max(iResolution, vec2(1.0));
     vec2 cellUV     = uv - mod(uv, pixelGrid) + pixelGrid * 0.5;
-    vec4 sampled    = texture(uTexture0, cellUV);
+    // boundaryMask (see noise.glsl) crops the right/bottom-edge cell
+    // whose centre can exceed 1.0 by up to half a cell. Without it,
+    // uTexture0's clamp-to-edge sampler returns the last-column /
+    // last-row texel for that cell, smearing the window's edge alpha
+    // into a ~½-cell-wide band past the surface boundary.
+    vec4 sampled    = texture(uTexture0, cellUV) * boundaryMask(cellUV);
 
     // Spoke parameterisation. `down = (0, 1)`; `dot(down, fragDir)`
     // is just `fragDir.y`. `acos(y)` ∈ [0, π], divided by 2π gives

--- a/data/animations/pixel-wipe/effect.frag
+++ b/data/animations/pixel-wipe/effect.frag
@@ -70,7 +70,12 @@ void main()
     // divide-by-zero into an infinite pixelGrid.
     vec2 pixelGrid  = vec2(pixelSize) / max(iResolution, vec2(1.0));
     vec2 cellUV     = uv - mod(uv, pixelGrid) + pixelGrid * 0.5;
-    vec4 sampled    = texture(uTexture0, cellUV);
+    // boundaryMask (see noise.glsl) crops the right/bottom-edge cell
+    // whose centre can exceed 1.0 by up to half a cell. Without it,
+    // uTexture0's clamp-to-edge sampler returns the last-column /
+    // last-row texel for that cell, smearing the window's edge alpha
+    // into a ~½-cell-wide band past the surface boundary.
+    vec4 sampled    = texture(uTexture0, cellUV) * boundaryMask(cellUV);
 
     // Per-cell noise threshold gates the dissolve so the wavefront
     // is a chunky speckled pattern rather than a smooth ring. A cell

--- a/data/animations/pixelate/effect.frag
+++ b/data/animations/pixelate/effect.frag
@@ -26,6 +26,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots.
 // `maxBlockSize` is interpreted in NORMALISED UV units (0..1 across
@@ -61,7 +62,13 @@ void main()
     // same texel — this is what produces the pixelation visual.
     vec2 cell = (floor(uv / blockPx) + 0.5) * blockPx;
 
-    vec4 sampled = texture(uTexture0, cell);
+    // boundaryMask (see noise.glsl) crops the right/bottom-edge cell
+    // whose centre can exceed 1.0 by up to half a cell. Without it,
+    // uTexture0's clamp-to-edge sampler returns the last-column /
+    // last-row texel for that cell, smearing the window's edge alpha
+    // (rounded corners, drop shadows) into a ~½-cell-wide band past
+    // the original surface boundary.
+    vec4 sampled = texture(uTexture0, cell) * boundaryMask(cell);
 
     // The captured surface already encodes its own alpha; the parent-
     // chain scene-graph opacity is applied at blend time, so the

--- a/data/animations/pixelfade-wave/effect.frag
+++ b/data/animations/pixelfade-wave/effect.frag
@@ -20,6 +20,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots.
 // `peakBlocks` is the chunkiest endpoint of the wave (fewest blocks
@@ -46,7 +47,12 @@ void main() {
     float blocks = mix(baselineBlocks, peakBlocks, bump);
     vec2 q = floor(uv * blocks) / blocks + 0.5 / blocks;
 
-    vec4 win = texture(uTexture0, q);
+    // boundaryMask (see noise.glsl) crops the right/bottom-edge cell
+    // whose centre can exceed 1.0 by up to half a cell. Without it,
+    // uTexture0's clamp-to-edge sampler returns the last-column /
+    // last-row texel for that cell, smearing the window's edge alpha
+    // into a ~½-cell-wide band past the surface boundary.
+    vec4 win = texture(uTexture0, q) * boundaryMask(q);
 
     float reveal = smoothstep(0.0, 1.0, wave_p);
     fragColor = win * reveal;

--- a/data/animations/rgb-warp/effect.frag
+++ b/data/animations/rgb-warp/effect.frag
@@ -36,6 +36,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 #define brightness customParams[0].x
 #define speedR     customParams[0].y
@@ -109,9 +110,20 @@ void main()
     float mulG = speedGClamped - minSpeed + 1.0;
     float mulB = speedBClamped - minSpeed + 1.0;
 
-    vec4 colorR = texture(uTexture0, uv + vec2(0.0, offset * mulR));
-    vec4 colorG = texture(uTexture0, uv + vec2(0.0, offset * mulG));
-    vec4 colorB = texture(uTexture0, uv + vec2(0.0, offset * mulB));
+    // boundaryMask (see noise.glsl) crops each per-channel sample
+    // outside [0, 1] — the lift-off offset carries each sample UV
+    // past the top of the surface at different speeds, and
+    // uTexture0's clamp-to-edge sampler would otherwise smear the
+    // top row of texels into the lifted region, producing chromatic
+    // streaks pinned to the top edge. The downstream `edgeFade`
+    // smoothstep masks the OUTPUT uv, not the sample UVs, so it
+    // doesn't address this on its own.
+    vec2 sampleR = uv + vec2(0.0, offset * mulR);
+    vec2 sampleG = uv + vec2(0.0, offset * mulG);
+    vec2 sampleB = uv + vec2(0.0, offset * mulB);
+    vec4 colorR = texture(uTexture0, sampleR) * boundaryMask(sampleR);
+    vec4 colorG = texture(uTexture0, sampleG) * boundaryMask(sampleG);
+    vec4 colorB = texture(uTexture0, sampleB) * boundaryMask(sampleB);
 
     // Recombine. The texture is pre-multiplied; un-premultiply each
     // channel against its OWN alpha (those are the only valid divisors

--- a/data/animations/shared/anchor_remap.glsl
+++ b/data/animations/shared/anchor_remap.glsl
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Surface-UV to anchor-relative UV remap. Used by surface-extent
+// shaders (broken-glass, morph) that need to convert vTexCoord (which
+// spans the full surface FBO) into the captured anchor's UV space.
+//
+// On the kwin-effect path `iAnchorPosInFbo` is `(0, 0)` and
+// `iAnchorSize == iResolution`, so the remap collapses to identity.
+//
+// Requires: <animation_uniforms.glsl> (provides iResolution,
+// iAnchorSize, iAnchorPosInFbo).
+
+#ifndef ANCHOR_REMAP_GLSL
+#define ANCHOR_REMAP_GLSL
+
+vec2 anchorRemap(vec2 uv) {
+    vec2 resSafe = max(iResolution, vec2(1.0));
+    vec2 anchorSizePx = max(iAnchorSize, vec2(1.0));
+    vec2 anchorTopLeftUv = iAnchorPosInFbo / resSafe;
+    vec2 anchorSizeUv = anchorSizePx / resSafe;
+    return (uv - anchorTopLeftUv) / anchorSizeUv;
+}
+
+#endif

--- a/data/animations/wave-warp/effect.frag
+++ b/data/animations/wave-warp/effect.frag
@@ -20,6 +20,7 @@
 #version 450
 
 #include <animation_uniforms.glsl>
+#include <noise.glsl>
 
 // metadata.json declaration order → customParams[0] sub-slots.
 // `waveAngle` (radians) replaces niri's hardcoded `vec2 dir = (1, 0)`
@@ -47,8 +48,14 @@ void main() {
     float d = v.x * 0.5 + v.y * 0.5;
     float m = 1.0 - smoothstep(-waveSmoothness, 0.0, v.x * uv.x + v.y * uv.y - (d - 0.5 + p * (1.0 + waveSmoothness)));
 
-    vec2 warped = clamp((uv - 0.5) * m + 0.5, vec2(0.0), vec2(1.0));
-    vec4 win = texture(uTexture0, warped);
+    // niri's `clamp(warped, 0, 1)` was the bug: pinning off-window UVs
+    // to the edge texel via clamp-to-edge produced a smeared border
+    // around the contracted silhouette. Drop the clamp and crop
+    // sampled texels via boundaryMask (see noise.glsl) instead — same
+    // shape wave-warp wants (off-surface = transparent), but without
+    // the edge-pixel bleed.
+    vec2 warped = (uv - 0.5) * m + 0.5;
+    vec4 win = texture(uTexture0, warped) * boundaryMask(warped);
 
     float in_bounds = step(0.0, uv.x) * step(uv.x, 1.0) * step(0.0, uv.y) * step(uv.y, 1.0);
     fragColor = win * m * in_bounds;

--- a/data/animations/wisps/effect.frag
+++ b/data/animations/wisps/effect.frag
@@ -96,7 +96,17 @@ void main() {
   vec2 coords = iTexCoord.st * (scale + 1.0) - scale * 0.5;
 
   // Get the color of the window.
-  vec4 oColor = getInputColor(coords);
+  // boundaryMask (see noise.glsl) crops sample texels that drift outside
+  // [0, 1] — the `(scale + 1.0)` scale-down above pushes `coords` slightly
+  // past the anchor on every edge at progress > 0, and uTexture0's
+  // clamp-to-edge sampler would otherwise smear the edge texel into the
+  // surrounding region, producing a 1-pixel-wide smear instead of
+  // letting the dissolve mask take the surface cleanly to transparent.
+  // The mask's bands sit OUTSIDE [0, 1] so identity sampling at
+  // progress == 0 gets mask = 1 everywhere with no inner-edge clipping.
+  // Same fix glide, fade, morph, popin, inkwell-drop, plasma-flow,
+  // ripple, smoke, snap, and soft-warp-fade already apply.
+  vec4 oColor = getInputColor(coords) * boundaryMask(coords);
 
   // Compute several layers of moving wisps.
   vec2 uv = (iTexCoord.st - 0.5) / mix(1.0, 0.5, progress) + 0.5;

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -120,16 +120,6 @@ public:
     void paintWindow(const KWin::RenderTarget& renderTarget, const KWin::RenderViewport& viewport,
                      KWin::EffectWindow* w, int mask, const KWin::Region& deviceRegion,
                      KWin::WindowPaintData& data) override;
-    /// OffscreenEffect hook for transforming the redirected window before
-    /// the GL pipeline composites it. For active shader transitions with
-    /// `fboExtentRing > 0` (morph, broken-glass, future BMW-style ring
-    /// effects), this rebuilds @p quads as a single expanded quad sized
-    /// `(1 + 2·ring) × frame` with `texCoord` range `[-ring, 1+ring]` so
-    /// the shader has room to draw past the window's natural bounds
-    /// (BMW's actor-expansion model). For ring == 0 (surface-extent
-    /// shaders + the 53 default-shader case) the base class default
-    /// behaviour passes through.
-    void apply(KWin::EffectWindow* window, int mask, KWin::WindowPaintData& data, KWin::WindowQuadList& quads) override;
     void grabbedKeyboardEvent(QKeyEvent* e) override;
 
 private Q_SLOTS:

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -113,21 +113,6 @@ void PlasmaZonesEffect::postPaintScreen()
                     if (repaintRect.isEmpty()) {
                         repaintRect = w->frameGeometry().toAlignedRect();
                     }
-                    // Actor-expansion: when the active transition declares
-                    // a non-zero `fboExtentRing`, the apply() override
-                    // renders the redirected texture over a region
-                    // `(1 + 2·ring) × frame` instead of the natural frame.
-                    // Without growing the repaint rect to match, KWin's
-                    // damage tracking would clip the visible result back
-                    // to the natural expanded rect (shadow extents only)
-                    // and the BMW-style shards-past-window-bounds visual
-                    // would be cropped flat at the shadow edge.
-                    if (transition.fboExtentRing > 0.0) {
-                        const QRect ringRect =
-                            ShaderInternal::inflatedByRingFraction(w->frameGeometry(), transition.fboExtentRing)
-                                .toAlignedRect();
-                        repaintRect = repaintRect.united(ringRect);
-                    }
                     w->addLayerRepaint(repaintRect);
                 }
             }
@@ -399,26 +384,16 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                                        QVector2D(static_cast<float>(geo.width()), static_cast<float>(geo.height())));
                 }
                 if (cached->iAnchorPosInFboLoc >= 0) {
-                    // Always (0, 0) on the kwin path, even when the active
-                    // transition declares `fboExtentRing > 0`. Reason:
-                    // actor expansion on kwin is done at quad-construction
-                    // time (apply() in paint_pipeline.cpp) by remapping
-                    // the expanded quad's `texCoord` to `[-ring, 1+ring]`,
-                    // so the fragment shader already receives `vTexCoord`
-                    // in anchor-space coordinates. iAnchorSize == iResolution
-                    // (both = window frame size) so the shader's unified
-                    // remap math collapses to identity:
+                    // Always (0, 0) on the kwin path. The fragment shader's
+                    // `anchorRemap` math collapses to identity here:
                     //   anchorTopLeftUv = (0, 0) / frame  = (0, 0)
                     //   anchorSizeUv    = frame  / frame  = (1, 1)
                     //   anchorUv        = vTexCoord - 0   = vTexCoord
-                    // and vTexCoord arrives in `[-ring, 1+ring]` from the
-                    // expanded quad, giving the BMW-style anchor-space
-                    // range morph + broken-glass expect. The daemon path
-                    // uses different uniform values (iAnchorPosInFbo =
-                    // (padW, padH), iResolution = expanded size) to
-                    // produce the same anchor-space range from a `[0, 1]`
-                    // vTexCoord; different runtime mechanism, same shader
-                    // source.
+                    // so shaders that use anchorRemap (broken-glass, morph)
+                    // see coords in `[0, 1]` over the captured frame on
+                    // the kwin path. The daemon's surface-extent uses
+                    // non-zero iAnchorPosInFbo / iAnchorSize to produce
+                    // wider anchor-space coords from a surface-sized FBO.
                     shader->setUniform(cached->iAnchorPosInFboLoc, QVector2D(0.0f, 0.0f));
                 }
                 for (int slot = 0; slot < PhosphorAnimationShaders::AnimationShaderContract::kMaxCustomParams; ++slot) {
@@ -573,69 +548,6 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
     }
 
     OffscreenEffect::drawWindow(renderTarget, viewport, w, mask, deviceRegion, data);
-}
-
-void PlasmaZonesEffect::apply(KWin::EffectWindow* window, int mask, KWin::WindowPaintData& data,
-                              KWin::WindowQuadList& quads)
-{
-    // Match BMW's "grow the actor" approach when the active transition's
-    // effect declares `fboExtent: "anchor+N"`. The redirected texture
-    // (allocated by OffscreenEffect::redirect at window-frame size) gets
-    // sampled by an expanded quad with `texCoord` spanning [-ring, 1+ring]
-    // The central [0..1] sub-region maps to the captured window content
-    // and the surrounding ring lets the shader render past the natural
-    // frame. Morph and broken-glass already guard their out-of-anchor
-    // samples (boundaryMask / getInputColor override → vec4(0)), so the
-    // edge texels don't smear when the redirected texture's clamp-to-edge
-    // wrap mode hits.
-    //
-    // For ring == 0 (53-of-56 default-shader case, plus the fly-in
-    // surface-extent case that uses MVP translation instead of actor
-    // expansion), pass through to the base implementation which leaves
-    // `quads` as the natural single-quad-over-frameGeometry mesh.
-    if (!window) {
-        OffscreenEffect::apply(window, mask, data, quads);
-        return;
-    }
-    const auto it = m_shaderManager.m_shaderTransitions.find(window);
-    if (it == m_shaderManager.m_shaderTransitions.end() || it->second.fboExtentRing <= 0.0) {
-        OffscreenEffect::apply(window, mask, data, quads);
-        return;
-    }
-
-    const qreal ring = it->second.fboExtentRing;
-    const QRectF geo = window->frameGeometry();
-    if (geo.width() < 1.0 || geo.height() < 1.0) {
-        OffscreenEffect::apply(window, mask, data, quads);
-        return;
-    }
-
-    // Replace the (potentially multi-quad) input mesh with a single quad
-    // covering the expanded region. Vertex positions are in window-local
-    // coords (KWin's MVP matrix translates to screen position downstream),
-    // so subtracting padW/padH from the natural frame origin shifts the
-    // top-left into negative window-local space. That's the "render
-    // past the frame" semantic. Texture coordinates follow the same
-    // ring convention so the captured-window texture (`uTexture0` on
-    // KWin) lands in the central [0..1] region, matching what the
-    // shader's `anchorUv` remap recovers via the unified
-    // `iAnchorPosInFbo / iResolution / iAnchorSize` math.
-    //
-    // The expanded rect is computed via `inflatedByRingFraction` (single
-    // source of truth shared with `postPaintScreen`'s
-    // `addLayerRepaint` ring-rect union).
-    const QRectF expandedGeo = ShaderInternal::inflatedByRingFraction(geo, ring);
-    const qreal leftLocal = expandedGeo.x() - geo.x();
-    const qreal topLocal = expandedGeo.y() - geo.y();
-    const qreal rightLocal = leftLocal + expandedGeo.width();
-    const qreal bottomLocal = topLocal + expandedGeo.height();
-    KWin::WindowQuad expanded;
-    expanded[0] = KWin::WindowVertex(leftLocal, topLocal, -ring, -ring); // TL
-    expanded[1] = KWin::WindowVertex(rightLocal, topLocal, 1.0 + ring, -ring); // TR
-    expanded[2] = KWin::WindowVertex(rightLocal, bottomLocal, 1.0 + ring, 1.0 + ring); // BR
-    expanded[3] = KWin::WindowVertex(leftLocal, bottomLocal, -ring, 1.0 + ring); // BL
-    quads.clear();
-    quads.append(expanded);
 }
 
 } // namespace PlasmaZones

--- a/kwin-effect/plasmazoneseffect/shader_internal.h
+++ b/kwin-effect/plasmazoneseffect/shader_internal.h
@@ -13,25 +13,6 @@
 
 namespace PlasmaZones::ShaderInternal {
 
-/// Inflate @p geo on every side by `ring * dimension` (BMW-style
-/// actor expansion). For `ring == 0.5` this returns the original
-/// rect inflated by half its width on left+right and half its height
-/// on top+bottom, total dimensions `2x` the original, matching
-/// BMW's `ACTOR_SCALE = 2`.
-///
-/// Single source of truth for the ring-rect math: `apply()` uses it
-/// to rebuild the WindowQuadList at expanded size, and
-/// `postPaintScreen` uses it to union the expanded rect into the
-/// addLayerRepaint region so KWin doesn't damage-clip the result.
-/// A future ring semantic change (asymmetric ring, percent vs
-/// fraction, etc.) only has to touch this helper.
-inline QRectF inflatedByRingFraction(const QRectF& geo, qreal ring)
-{
-    const qreal padW = ring * geo.width();
-    const qreal padH = ring * geo.height();
-    return QRectF(geo.x() - padW, geo.y() - padH, geo.width() + 2.0 * padW, geo.height() + 2.0 * padH);
-}
-
 /// Monotonic milliseconds since steady_clock epoch. Used by time-based shader
 /// transitions for elapsed-progress math. We deliberately avoid
 /// QDateTime::currentMSecsSinceEpoch — wall-clock isn't monotonic, and an NTP

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -760,15 +760,6 @@ void PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
     const auto& cachedEntry = cacheIt->second;
     ShaderTransition transition;
     transition.cached = &cachedEntry;
-    // Carry the effect's FBO-extent ring fraction so the apply() override
-    // can rebuild quads at expanded size and the per-frame uniform push
-    // can adjust iAnchorPosInFbo / iResolution. Only meaningful when
-    // `fboExtentKind == Anchor` and ring > 0; surface-extent effects
-    // (fly-in) use MVP translation instead and leave this at 0.
-    transition.fboExtentRing =
-        (eff.fboExtentKind == PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind::Anchor)
-        ? eff.fboExtentRing
-        : 0.0;
 
     // Translate the friendly parameter map (e.g. {"direction": 1,
     // "parallax": 0.2}) to slot keys, then pack each
@@ -1067,20 +1058,6 @@ void PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
     QRect repaintRect = window->expandedGeometry().toAlignedRect();
     if (repaintRect.isEmpty()) {
         repaintRect = window->frameGeometry().toAlignedRect();
-    }
-    // Actor-expansion ring union: mirrors `postPaintScreen`'s addLayerRepaint
-    // loop in paint_pipeline.cpp. Without this, the very first frame of a
-    // transition with `fboExtentRing > 0` would have damage scheduled only
-    // for the natural expanded rect (shadow extents) and KWin would clip
-    // the visible ring back to that boundary on frame 1. Subsequent frames
-    // pick up the ring via postPaintScreen, but the first-frame "shards
-    // popping in cropped" artefact would be visible at transition install
-    // time without this union here.
-    const qreal installFboExtentRing = emplaceResult.first->second.fboExtentRing;
-    if (installFboExtentRing > 0.0) {
-        const QRect ringRect =
-            ShaderInternal::inflatedByRingFraction(window->frameGeometry(), installFboExtentRing).toAlignedRect();
-        repaintRect = repaintRect.united(ringRect);
     }
     window->addLayerRepaint(repaintRect);
     if (KWin::effects) {

--- a/kwin-effect/plasmazoneseffect/types.h
+++ b/kwin-effect/plasmazoneseffect/types.h
@@ -209,20 +209,6 @@ struct ShaderTransition
     /// no-op, and clearing it on a deleted window lets KWin proceed with
     /// final destruction.
     bool closeGrabHeld = false;
-    /// FBO-extent ring fraction copied from the resolved effect's
-    /// `AnimationShaderEffect::fboExtentRing`. When > 0, the `apply()`
-    /// override rebuilds the window's quads to render the redirected
-    /// texture at `(1 + 2·ring) * windowFrame` size with texCoord range
-    /// `[-ring, 1+ring]`, giving the shader room to draw past the
-    /// window's natural bounds (BMW's actor-expansion model). The
-    /// `prePaintWindow` paint-region expansion and the `paint_pipeline`
-    /// uniform pushes (`iAnchorPosInFbo`, `iResolution`, `iAnchorSize`)
-    /// all read this value to stay consistent with the quad rebuild.
-    /// Zero ring (the 53-of-56 default-shader case + the
-    /// `fboExtent: "surface"` fly-in case which uses MVP translation
-    /// instead of actor expansion) leaves the quads untouched, so the
-    /// expansion is opt-in per effect metadata.
-    qreal fboExtentRing = 0.0;
 };
 
 /// Pre-computed snap restore target for a pending app

--- a/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderEffect.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderEffect.h
@@ -128,64 +128,33 @@ struct PHOSPHORANIMATION_EXPORT AnimationShaderEffect
     /// can sample window depth. Daemon-only.
     bool useDepthBuffer = false;
 
-    /// Ring fraction for `FboExtentKind::Anchor`: enlarge the FBO beyond
-    /// the anchor's bounds by this fraction of the anchor's width/height
-    /// on each side. Set by the `"anchor+N"` form of the `fboExtent`
-    /// metadata grammar (see `parseFboExtent` in animationshadereffect.cpp).
-    /// At `fboExtentRing = 0.5` the FBO is `(1+2·0.5) = 2x` the anchor
-    /// on each axis, reproducing BMW's `ACTOR_SCALE=2, PADDING=0.5`
-    /// convention. Default 0.0; FBO matches the anchor exactly.
-    /// Shaders that opt in must remap `vTexCoord` through
-    /// `iAnchorPosInFbo / iAnchorSize / iResolution` to recover anchor-
-    /// space UV (see `data/animations/morph/effect.frag`).
-    ///
-    /// Ignored when `fboExtentKind == Surface`: the FBO already covers
-    /// the entire surface and adding ring padding would push it past the
-    /// rendering canvas.
-    qreal fboExtentRing = 0.0;
-
     /// How wide the shader effect's render target is — relative to its
     /// anchor (default), or filling the surface scene root.
     ///
-    ///   • `Anchor` (default): FBO covers `anchor + 2 · fboExtentRing ·
-    ///     anchor` on each axis. iResolution equals the FBO size, so
-    ///     `vTexCoord` 0..1 spans the padded FBO. Existing fragment-
-    ///     only effects (dissolve, glitch, …) leave the ring at 0;
-    ///     morph + broken-glass set `fboExtent: "anchor+0.5"` to get
-    ///     BMW-style overshoot room.
+    ///   • `Anchor` (default): FBO covers the captured anchor 1:1. Used
+    ///     by fragment-only effects (dissolve, glitch, …) whose math
+    ///     stays inside `vTexCoord ∈ [0, 1]` over the anchor.
     ///
     ///   • `Surface`: FBO covers the anchor's enclosing surface scene
-    ///     root (the wl_surface size on the daemon path). Vertex-stage
-    ///     effects that translate the rendered card across the surface
-    ///     (fly-in, slide) declare `fboExtent: "surface"` to get full-
-    ///     surface clip-space runway. Authors who pick `Surface` MUST
-    ///     ship a custom vertex shader that remaps `position` to the
-    ///     card's region within the FBO via `iAnchorPosInFbo /
-    ///     iAnchorSize / iResolution`; the default identity vertex
-    ///     stage stretches the card texture across the entire surface.
-    ///     See `data/animations/fly-in/effect.vert`.
+    ///     root (the wl_surface size on the daemon path). Used by
+    ///     effects that need to render past the captured anchor
+    ///     (fly-in translates the card across the surface, broken-glass
+    ///     fires shards into the surrounding screen). Authors who pick
+    ///     `Surface` typically ship a custom vertex shader that uses
+    ///     `iAnchorPosInFbo / iAnchorSize / iResolution` to position
+    ///     the card within the FBO; the fragment shader then either
+    ///     reads `vTexCoord` directly (if the vert remaps the quad to
+    ///     the anchor's region — fly-in) or calls `anchorRemap` to
+    ///     convert surface-UV back to anchor-space (broken-glass,
+    ///     morph).
     ///
-    /// Mirrors the public `fboExtent` JSON grammar: `"anchor"` /
-    /// `"anchor+N"` map to `Anchor`, `"surface"` maps to `Surface`.
+    /// Mirrors the public `fboExtent` JSON grammar: `"anchor"` →
+    /// `Anchor`, `"surface"` → `Surface`. No other forms are accepted.
     enum class FboExtentKind {
         Anchor,
         Surface,
     };
     FboExtentKind fboExtentKind = FboExtentKind::Anchor;
-
-    /// Hard ceiling on `fboExtentRing`. SHARED source-of-truth between
-    /// the metadata clamp in `parseFboExtent` (animationshadereffect.cpp)
-    /// and the runtime clamp in `surfaceanimator.cpp` (via the local
-    /// `kMaxFboExtentRingFraction` mirror). Drift between the two would
-    /// silently allow a programmatic in-memory effect to exceed the
-    /// FBO-size budget that the metadata clamp enforces. At ring=2.0 the
-    /// shader effect is 5x the anchor on each axis (k=1+2·ring=5) → 25x
-    /// area; a 1080p RGBA8 FBO at that scale is already ~200 MB, the
-    /// edge of what Vulkan validation passes on integrated GPUs. No
-    /// shipping shader needs >1.0 (morph + broken-glass use 0.5); 2.0
-    /// accommodates plugin authors with extreme silhouette warps
-    /// without permitting prior 4.0-cap excess (9x axis = 81x area).
-    static constexpr qreal kMaxFboExtentRing = 2.0;
 
     /// Lower / upper bounds on `bufferScale` (multipass FBO downscale
     /// factor). 0.125 means a 1/8 downscale on each axis (1/64 area —

--- a/libs/phosphor-animation/include/PhosphorAnimation/AnimationUniformExtension.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/AnimationUniformExtension.h
@@ -92,6 +92,20 @@ public:
         m_dirty.store(false, std::memory_order_release);
     }
 
+    /// Animation shaders pair `iResolution` with logical-pixel
+    /// extension fields (`iAnchorSize`, `iAnchorPosInFbo`,
+    /// `iSurfaceScreenPos`) for UV / clip-space ratios, and use the
+    /// vertex-stage `vTexCoord` instead of `gl_FragCoord` — so the
+    /// legacy DPR-scaling of `iResolution` would mismatch units across
+    /// the UBO and shrink the rendered card by 1/DPR (fly-in) or
+    /// shift the anchor UV remap by the same factor (broken-glass,
+    /// morph). Override to publish `iResolution` in logical pixels so
+    /// every ratio in animation shaders is dimensionally consistent.
+    bool requiresPhysicalResolution() const override
+    {
+        return false;
+    }
+
     /// Surface origin in **logical** screen pixels (.xy) plus host
     /// screen dimensions (.zw). Pushed by SurfaceAnimator on every leg
     /// attach and on each anchor / window geometry signal. Logical-

--- a/libs/phosphor-animation/src/animationshadereffect.cpp
+++ b/libs/phosphor-animation/src/animationshadereffect.cpp
@@ -14,21 +14,17 @@ namespace PhosphorAnimationShaders {
 namespace {
 Q_LOGGING_CATEGORY(lcAnimationShader, "phosphoranimationshaders.effect")
 
-/// Parse a `fboExtent` string into the internal `FboExtentKind` +
-/// `fboExtentRing` representation. Grammar:
-///   * `"anchor"`            → Anchor, pad = 0
-///   * `"anchor+0.5"`        → Anchor, pad = 0.5 (fraction form)
-///   * `"anchor+50%"`        → Anchor, pad = 0.5 (percent form, identical effect)
-///   * `"surface"`           → Surface, pad = 0
-/// Padding is clamped to `[0, kMaxFboExtentRing]` at the parse boundary
-/// to mirror the legacy `fboExtentRing` read clamp.
+/// Parse a `fboExtent` string into the internal `FboExtentKind`.
+/// Grammar:
+///   * `"anchor"`     → Anchor (default; FBO == captured anchor)
+///   * `"surface"`    → Surface (FBO == QQuickWindow contentItem)
 ///
-/// Returns `true` on success and writes through `outExtent` / `outPad`;
-/// returns `false` for an unknown / malformed string and emits a
-/// `qCWarning` so a typo in metadata.json surfaces on the journal
-/// rather than degrading silently. Caller keeps the struct's default
-/// values (Anchor, pad=0) on failure.
-bool parseFboExtent(const QString& raw, AnimationShaderEffect::FboExtentKind& outExtent, qreal& outPad)
+/// Returns `true` on success and writes through `outExtent`; returns
+/// `false` for an unknown / malformed string and emits a `qCWarning`
+/// so a typo in metadata.json surfaces on the journal rather than
+/// degrading silently. Caller keeps the struct's default value
+/// (Anchor) on failure.
+bool parseFboExtent(const QString& raw, AnimationShaderEffect::FboExtentKind& outExtent)
 {
     const QString s = raw.trimmed();
     if (s.isEmpty()) {
@@ -36,79 +32,27 @@ bool parseFboExtent(const QString& raw, AnimationShaderEffect::FboExtentKind& ou
     }
     if (s.compare(QLatin1String("anchor"), Qt::CaseInsensitive) == 0) {
         outExtent = AnimationShaderEffect::FboExtentKind::Anchor;
-        outPad = 0.0;
         return true;
     }
     if (s.compare(QLatin1String("surface"), Qt::CaseInsensitive) == 0) {
         outExtent = AnimationShaderEffect::FboExtentKind::Surface;
-        outPad = 0.0;
         return true;
     }
-    // `anchor+N` / `anchor+N%` form. Split on '+'; left half must be
-    // `anchor`, right half is a float (with optional trailing `%`).
-    const int plusIdx = s.indexOf(QLatin1Char('+'));
-    if (plusIdx > 0 && s.left(plusIdx).trimmed().compare(QLatin1String("anchor"), Qt::CaseInsensitive) == 0) {
-        QString tail = s.mid(plusIdx + 1).trimmed();
-        bool percent = false;
-        if (tail.endsWith(QLatin1Char('%'))) {
-            percent = true;
-            tail.chop(1);
-            tail = tail.trimmed();
-        }
-        bool ok = false;
-        const double v = tail.toDouble(&ok);
-        // QString::toDouble parses "nan" / "inf" / "+inf" / "-inf" as
-        // floating-point literals (ok == true) but those values aren't
-        // safe to flow downstream: qBound propagates NaN through
-        // qMax/qMin rather than clamping it, and consumers that read
-        // `effect.fboExtentRing` raw (e.g. osd.cpp's
-        // `resolveOsdShaderPadding` feeding QML's `shaderBoundsPadding`)
-        // would collapse window dimensions to NaN. Reject at the parse
-        // boundary so bad metadata surfaces on the warning channel
-        // rather than corrupting OSD geometry silently.
-        if (ok && qIsFinite(v)) {
-            const qreal pad = percent ? (v / 100.0) : v;
-            // Reject negatives at the parse boundary instead of silently
-            // clamping to 0. An authoring typo like "anchor+-0.5" would
-            // otherwise masquerade as a valid `anchor` extent with no ring,
-            // losing the operator's chance to spot the bad value in
-            // metadata. The unrecognised-grammar fallback below emits the
-            // warning and returns false; caller keeps the struct defaults.
-            if (pad >= 0.0) {
-                outExtent = AnimationShaderEffect::FboExtentKind::Anchor;
-                outPad = qMin(pad, AnimationShaderEffect::kMaxFboExtentRing);
-                return true;
-            }
-        }
-    }
-    qCWarning(lcAnimationShader)
-        << "AnimationShaderEffect::fromJson: unrecognised fboExtent" << raw
-        << "Accepted forms are \"anchor\", \"anchor+0.5\", \"anchor+50%\", \"surface\". Falling back to defaults.";
+    qCWarning(lcAnimationShader) << "AnimationShaderEffect::fromJson: unrecognised fboExtent" << raw
+                                 << "Accepted forms are \"anchor\" and \"surface\". Falling back to defaults.";
     return false;
 }
 
-/// Emit the internal `FboExtentKind` + `fboExtentRing` representation
-/// as a `fboExtent` string. Inverse of `parseFboExtent`. Empty result
-/// = "Anchor extent with zero padding" (omitted from JSON to keep
-/// authored metadata terse, same idiom as the rest of `toJson`).
-QString formatFboExtent(AnimationShaderEffect::FboExtentKind extent, qreal pad)
+/// Emit the internal `FboExtentKind` as a `fboExtent` string. Inverse
+/// of `parseFboExtent`. Empty result = "Anchor extent" (default,
+/// omitted from JSON to keep authored metadata terse — same idiom as
+/// the rest of `toJson`).
+QString formatFboExtent(AnimationShaderEffect::FboExtentKind extent)
 {
     if (extent == AnimationShaderEffect::FboExtentKind::Surface) {
         return QStringLiteral("surface");
     }
-    // Anchor extent: omit when there's no ring (the common case in
-    // 53 of 56 shipping shaders).
-    const qreal clamped = qBound(qreal(0.0), pad, AnimationShaderEffect::kMaxFboExtentRing);
-    if (clamped <= 0.0) {
-        return QString();
-    }
-    // Pin `g` format to 17 significant digits so a programmatically
-    // assigned ring (e.g. 1.0/3.0 in C++ code) survives toJson -> fromJson
-    // round-trip. `arg(double)` defaults to 6 sig digits, which collapses
-    // 0.333333... to "0.333333" and breaks strict-equality comparison on
-    // the resulting AnimationShaderEffect. 17 digits is the IEEE-754
-    // double-precision round-trip width.
-    return QStringLiteral("anchor+%1").arg(clamped, 0, 'g', 17);
+    return QString();
 }
 } // namespace
 
@@ -132,14 +76,12 @@ QJsonObject AnimationShaderEffect::toJson() const
         obj.insert(QLatin1String("vertexShader"), vertexShaderPath);
     if (!previewPath.isEmpty())
         obj.insert(QLatin1String("preview"), previewPath);
-    // Single `fboExtent` string field replaces the previous split
-    // `fboExtentKind` + `fboExtentRing` pair. See `parseFboExtent` /
-    // `formatFboExtent` for the grammar. Emit only when the combined
-    // value diverges from the Anchor-no-pad default (53 of 56 shipping
-    // shaders); the empty-string return from `formatFboExtent` signals
-    // that case so authored metadata.json files stay terse.
+    // `fboExtent` string: emit only when the value diverges from the
+    // Anchor default (most shipping shaders); the empty-string return
+    // from `formatFboExtent` signals that case so authored metadata.json
+    // files stay terse.
     {
-        const QString fboExtentStr = formatFboExtent(fboExtentKind, fboExtentRing);
+        const QString fboExtentStr = formatFboExtent(fboExtentKind);
         if (!fboExtentStr.isEmpty())
             obj.insert(QLatin1String("fboExtent"), fboExtentStr);
     }
@@ -277,25 +219,17 @@ AnimationShaderEffect AnimationShaderEffect::fromJson(const QJsonObject& obj)
     }
     e.useDepthBuffer = obj.value(QLatin1String("depthBuffer")).toBool(false);
 
-    // `fboExtent` (string). Single grammar replaces the previous split
-    // `fboExtentKind` + `fboExtentRing` pair. Accepted forms (see
-    // `parseFboExtent` for full details):
-    //   "anchor"        is Anchor extent, no padding (default)
-    //   "anchor+0.5"    is Anchor extent with ring-padding fraction
-    //   "anchor+50%"    is the percent form
-    //   "surface"       fills the anchor's QQuickWindow content
+    // `fboExtent` (string). Accepted forms:
+    //   "anchor"        Anchor extent — FBO == captured anchor (default)
+    //   "surface"       Surface extent — FBO fills QQuickWindow content
     //                     root (= the wl_surface scene root on daemon)
-    // Missing field falls through to the struct's defaults (Anchor,
-    // pad=0); a recognised but malformed value (`parseFboExtent`
-    // returns false) emits a journal warning and ALSO falls through to
-    // the defaults. Same lenient pattern as the legacy split fields,
-    // but typos now surface to the operator instead of being silent.
-    // Per the project's no-legacy-shims rule, the prior `fboExtentRing`
-    // / `fboExtentKind` JSON keys are NOT read here. Authored metadata
-    // must use `fboExtent`.
+    // Missing field falls through to the struct's default (Anchor).
+    // A recognised-but-malformed value emits a journal warning and
+    // also falls through to the default — typos surface to the
+    // operator instead of being silent.
     const QString fboExtentRaw = obj.value(QLatin1String("fboExtent")).toString();
     if (!fboExtentRaw.isEmpty()) {
-        parseFboExtent(fboExtentRaw, e.fboExtentKind, e.fboExtentRing);
+        parseFboExtent(fboExtentRaw, e.fboExtentKind);
     }
 
     const QJsonArray params = obj.value(QLatin1String("parameters")).toArray();
@@ -400,15 +334,6 @@ bool AnimationShaderEffect::operator==(const AnimationShaderEffect& other) const
     if (previewPath != other.previewPath)
         return false;
     if (fboExtentKind != other.fboExtentKind)
-        return false;
-    // `fboExtentRing` is semantically dead when kind == Surface (the FBO
-    // already covers the entire surface, ring padding is ignored); the
-    // docstring on the field declares this. Mirror that contract in
-    // operator==: a programmatic Surface effect with ring != 0 would
-    // otherwise compare unequal to its `fromJson(toJson(x))` round-trip
-    // because formatFboExtent drops the ring for Surface and parseFboExtent
-    // reads it back as 0.
-    if (fboExtentKind == FboExtentKind::Anchor && !qFuzzyCompare(fboExtentRing + 1.0, other.fboExtentRing + 1.0))
         return false;
     if (isMultipass != other.isMultipass || useWallpaper != other.useWallpaper || bufferFeedback != other.bufferFeedback
         || useDepthBuffer != other.useDepthBuffer)

--- a/libs/phosphor-animation/src/surfaceanimator.cpp
+++ b/libs/phosphor-animation/src/surfaceanimator.cpp
@@ -67,129 +67,19 @@ inline PhosphorAnimation::AnimationUniformExtension* animExtensionFor(PhosphorRe
 constexpr int kTickIntervalMs = 16;
 constexpr qreal kRefreshRateHz = 1000.0 / kTickIntervalMs;
 
-/// Hard ceiling on `fboExtentRing` after the parent-margin clamp.
-/// Without this, an anchor centred in a much larger parent permits an
-/// arbitrarily large pad (`min(left, right) / anchorW` could be e.g.
-/// 50 for a tiny anchor in a 4K parent), which inflates the shader
-/// item to (1+2*pad)² × anchor area — gigabytes of FBO at extreme
-/// values. The metadata-side clamp at AnimationShaderEffect::fromJson
-/// caps at the shared constant; this is a runtime backstop against any
-/// path that bypasses that clamp (test fixtures, future scripted-shader
-/// hooks).
-constexpr qreal kMaxFboExtentRingFraction = PhosphorAnimationShaders::AnimationShaderEffect::kMaxFboExtentRing;
-
-/// Compute the effective fboExtentRing fraction for a shader item
-/// parented to @p anchor's parent. Result is clamped to:
-///   1. Non-negative AND non-NaN (`qMax(0, ...)` propagates NaN, so an
-///      explicit `qIsNaN` short-circuit is required — a NaN pad would
-///      cascade into NaN geometry on the shader item and the SG
-///      gracelessly skips painting).
-///   2. The smallest margin between the anchor and its parent's bounds.
-///      Without clamping, the shader item extends past the parent → the
-///      framebuffer surface clips → QRhi viewport shrinks to the visible
-///      subset → vTexCoord interpolates across the rasterized QUAD into
-///      the CLIPPED viewport, shifting UV values relative to the item's
-///      logical bounds. Morph then samples iChannel0 at wrong positions
-///      ("rendered further down and smaller" symptom on tight popups).
-///   3. `kMaxFboExtentRingFraction` ceiling. Stops a centred-in-huge-
-///      parent anchor from asking for a multi-GB FBO.
-///
-/// Centralised here so the initial-attach and the live geometry-sync
-/// path share one clamp implementation; previously the math was
-/// duplicated and the two copies had drifted slightly.
-inline qreal clampPaddingToParent(QQuickItem* anchor, qreal requestedPad)
-{
-    if (qIsNaN(requestedPad)) {
-        return 0.0;
-    }
-    qreal pad = qMax(qreal(0.0), requestedPad);
-    if (anchor) {
-        // Clamp against the QQuickWindow's contentItem (the surface scene
-        // root) rather than the anchor's immediate parentItem. The
-        // framebuffer that actually clips rendering is the wl_surface,
-        // and the contentItem matches that 1:1; the anchor's QML
-        // parentItem can be a much smaller inner container (e.g. a
-        // popup's PopupContent wrapping a PopupFrame anchor), which
-        // would pinch `maxPadH` to a tiny fraction when the anchor sits
-        // near its container's edge (morph on zoneSelector reported
-        // ~3.7% pad because the PopupFrame's `anchor.y == 10` inside
-        // its container), the visible "morph hits edge limits"
-        // symptom. Qt scene graph items render past their QML parent's
-        // bounds without explicit `clip: true`, so the only hard limit
-        // is the surface FBO.
-        QQuickItem* clipFrame = nullptr;
-        QPointF anchorPosInClipFrame(anchor->x(), anchor->y());
-        if (QQuickWindow* win = anchor->window()) {
-            if (QQuickItem* root = win->contentItem()) {
-                clipFrame = root;
-                anchorPosInClipFrame = anchor->mapToItem(root, QPointF(0.0, 0.0));
-            }
-        }
-        if (!clipFrame) {
-            clipFrame = anchor->parentItem();
-        }
-        if (clipFrame) {
-            const qreal frameW = clipFrame->width();
-            const qreal frameH = clipFrame->height();
-            const qreal anchorW = anchor->width();
-            const qreal anchorH = anchor->height();
-            // Reject NaN derived from anchor/frame geometry. The input-
-            // only NaN guard above doesn't catch the case where
-            // `anchorPosInClipFrame.y()` is NaN (anchor mid-recompute,
-            // layout binding partially evaluated), which would propagate
-            // through qMax and yield a NaN clamp result that cascades
-            // into NaN shader-item geometry. `qIsFinite` catches NaN
-            // AND Inf.
-            const bool geomFinite = qIsFinite(frameW) && qIsFinite(frameH) && qIsFinite(anchorW) && qIsFinite(anchorH)
-                && qIsFinite(anchorPosInClipFrame.x()) && qIsFinite(anchorPosInClipFrame.y());
-            if (geomFinite && frameW > 0.0 && frameH > 0.0 && anchorW > 0.0 && anchorH > 0.0) {
-                const qreal availTop = qMax(qreal(0.0), anchorPosInClipFrame.y());
-                const qreal availBottom = qMax(qreal(0.0), frameH - (anchorPosInClipFrame.y() + anchorH));
-                const qreal availLeft = qMax(qreal(0.0), anchorPosInClipFrame.x());
-                const qreal availRight = qMax(qreal(0.0), frameW - (anchorPosInClipFrame.x() + anchorW));
-                const qreal maxPadH = qMin(availTop, availBottom) / anchorH;
-                const qreal maxPadW = qMin(availLeft, availRight) / anchorW;
-                pad = qMin(pad, qMin(maxPadH, maxPadW));
-            }
-        }
-    }
-    return qMin(pad, kMaxFboExtentRingFraction);
-}
-
-/// Sanitise a `fboExtentRing` source value into a NaN-free, finite
-/// qreal suitable for storage in a Track's `fboExtentRingPtr`. The
-/// `clampPaddingToParent` clamp above also rejects NaN, but inputs
-/// to this helper land in a `shared_ptr<qreal>` cell that the
-/// syncGeometry lambda dereferences without a NaN-check of its own
-/// — so a NaN in the cell would propagate through clampPaddingToParent's
-/// own input-side `qIsNaN` guard producing a 0.0 result on every paint.
-/// Sanitising at the assignment boundary keeps both the reuse-path
-/// refresh and the fresh-attach init using the same single-source
-/// rule and centralises a guard that previously duplicated.
-inline qreal sanitiseFboExtentRing(qreal requested)
-{
-    return qIsNaN(requested) ? qreal(0.0) : requested;
-}
-
-/// Apply the shader-item geometry derived from @p anchor + @p requestedPad.
+/// Apply the shader-item geometry derived from @p anchor.
 /// Centralises the math behind the per-leg syncGeometry lambda so the
-/// reuse path can re-fire it explicitly after a metadata hot-reload that
-/// changes `fboExtentRing` between legs. Without it, the persistent
+/// reuse path can re-fire it explicitly after a metadata hot-reload
+/// that flips `fboExtentKind` between legs. Without it, the persistent
 /// lambda only re-runs on the next anchor geometry signal, which for a
-/// static popup (snap-assist, OSD) may never come, leaving the shader
-/// rendered with the previous leg's pad until the anchor next moves or
-/// resizes. Idempotent on identity (every setter no-ops when the value
-/// is unchanged), so the common no-hot-reload reuse path costs nothing.
+/// static popup (snap-assist, OSD) may never come. Idempotent on
+/// identity (every setter no-ops when the value is unchanged), so the
+/// common no-hot-reload reuse path costs nothing.
 ///
 /// `extent` selects where the shader item lives in the QML scene:
-///   - Anchor (default): item covers `anchor + 2 · pad · anchor`,
-///     positioned at anchor's scene rect minus pad. iResolution = FBO
+///   - Anchor (default): item == anchor. iResolution = anchor pixel
 ///     size. vTexCoord 0..1 maps the captured anchor texture 1:1 over
-///     the FBO. Existing fragment-only shaders use this. Vertex-shader
-///     effects that translate the quad (fly-in / slide) opt in to a
-///     `fboExtentRing` value > 0 in their metadata: the resulting
-///     padded FBO gives them clip-space room to translate the rendered
-///     card off the anchor's natural bounds without escaping the FBO.
+///     the FBO. Existing fragment-only shaders use this.
 ///   - Surface: item fills the anchor's enclosing
 ///     QQuickWindow::contentItem (the surface scene root, which equals
 ///     the wl_surface logical size in the screen-sized OSD / popup
@@ -199,12 +89,11 @@ inline qreal sanitiseFboExtentRing(qreal requested)
 ///     iResolution to the shader item's bounds on every geometry
 ///     event, so iResolution naturally tracks the FBO size. Used by
 ///     vertex-shader effects (fly-in, slide) that need full-surface
-///     clip-space travel for their MVP translation; the shader's
-///     vertex stage remaps the standard (-1..1) clip-space quad onto
-///     the captured-anchor's region within the surface-sized FBO via
-///     iSurfaceScreenPos / iAnchorSize / iAnchorPosInFbo.
+///     clip-space travel for their MVP translation, and by fragment
+///     shaders (broken-glass, morph) that use `anchorRemap` to convert
+///     surface-UV back to anchor-space.
 inline void syncShaderGeometryNow(QQuickItem* anchor, PhosphorRendering::ShaderEffect* shaderItem,
-                                  QQuickShaderEffectSource* shaderSource, qreal /*requestedPad*/,
+                                  QQuickShaderEffectSource* shaderSource,
                                   PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind extent)
 {
     if (!anchor || !shaderItem) {
@@ -222,15 +111,15 @@ inline void syncShaderGeometryNow(QQuickItem* anchor, PhosphorRendering::ShaderE
     //     the QQuickWindow's contentItem (= wl_surface scene root).
     //     Used by shaders that need to render past the captured
     //     anchor — fly-in translates the card across the surface,
-    //     etc. `iAnchorPosInFbo` / `iAnchorSize` / `iResolution`
-    //     tell the shader where the anchor sits inside the surface.
+    //     broken-glass fires shards into the surrounding screen.
+    //     `iAnchorPosInFbo` / `iAnchorSize` / `iResolution` tell the
+    //     shader where the anchor sits inside the surface.
     //
-    //   • Anchor (default): shader item == anchor. No ring expansion;
-    //     the legacy `anchor+N` ring grammar is dropped. Animation
-    //     shaders work in `vTexCoord ∈ [0, 1]` over the captured
-    //     window content, sample-stage `coords` for out-of-anchor
-    //     lookups clamp at the captured-window's edge (BMW shaders'
-    //     natural behaviour for shards past the window boundary).
+    //   • Anchor (default): shader item == anchor, no padding.
+    //     Animation shaders work in `vTexCoord ∈ [0, 1]` over the
+    //     captured window content; off-window sampling is the
+    //     shader's responsibility via `boundaryMask` or
+    //     `getClippedInputColor`.
     if (extent == PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind::Surface) {
         // Position the shader item so its (0, 0) corner aligns with
         // the scene root's origin in parentItem-local coords. For
@@ -303,12 +192,9 @@ inline void syncShaderGeometryNow(QQuickItem* anchor, PhosphorRendering::ShaderE
         // shaderItem's top-left, which IS the FBO origin (the FBO
         // covers shaderItem's bounds 1:1 via QQuickShaderEffectSource).
         //
-        // Resolves identically across the three extent modes:
-        //   Anchor (no pad): shaderItem at (anchor.x, anchor.y),
-        //     diff = (0, 0). Anchor fills the FBO.
-        //   Anchor + ring:   shaderItem at (anchor.x - padW,
-        //     anchor.y - padH), diff = (padW, padH). Anchor centred
-        //     in padded FBO.
+        // Resolves identically across both extent modes:
+        //   Anchor: shaderItem at (anchor.x, anchor.y), diff = (0, 0).
+        //     Anchor fills the FBO.
         //   Surface: shaderItem repositioned so its (0,0) corner sits
         //     at the scene root in parentItem-local coords, diff =
         //     (anchor.x, anchor.y) in parentItem's coords. For OSD /
@@ -636,17 +522,10 @@ struct ShaderAttachResult
     /// non-stock QQuickItem subclass. Hide for now; the
     /// shadow-pop-in at teardown is the lesser evil.
     QList<QPointer<QQuickItem>> hiddenSiblings;
-    /// Live fboExtentRing. Written here by attachShaderToAnchor at
-    /// fresh attach, re-written by the reuse path on metadata hot-
-    /// reload. The syncGeometry lambda captures this shared_ptr by
-    /// value so it always re-reads the current value when anchor
-    /// geometry signals fire mid-leg.
-    std::shared_ptr<qreal> fboExtentRingPtr;
-    /// Live fboExtentKind. Same lifecycle / hot-reload semantics as
-    /// `fboExtentRingPtr`. Captured by the syncGeometry lambda so a
-    /// metadata edit that flips an effect from Anchor to Surface (or
-    /// vice versa) takes effect on the next geometry signal without
-    /// reattaching the shader.
+    /// Live fboExtentKind. Captured by the syncGeometry lambda by
+    /// `shared_ptr` so a metadata edit that flips an effect from
+    /// Anchor to Surface (or vice versa) takes effect on the next
+    /// geometry signal without reattaching the shader.
     std::shared_ptr<PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind> fboExtentKindPtr;
 };
 
@@ -863,20 +742,18 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
     // explicit deleteLater outside teardownShaderLeg) doesn't leave the
     // lambda dereferencing freed memory. Auto-disconnect on shaderItem
     // destruction normally protects this — QPointer is belt-and-braces.
-    // requestedPad is captured by `shared_ptr<qreal>` so the reuse
-    // path can rewrite it under metadata hot-reload (a settings edit
-    // that swaps the effect's `fboExtentRing` between legs) and the
-    // already-connected syncGeometry lambda picks up the new value
-    // on the next anchor geometry signal. Capturing by value would
-    // freeze the lambda on the original metadata.
-    auto fboExtentRingPtr = std::make_shared<qreal>(sanitiseFboExtentRing(effect.fboExtentRing));
+    // fboExtentKind is captured by `shared_ptr` so the reuse path can
+    // rewrite it under metadata hot-reload (a settings edit that flips
+    // the effect's `fboExtent` between Anchor and Surface) and the
+    // already-connected syncGeometry lambda picks up the new value on
+    // the next anchor geometry signal. Capturing by value would freeze
+    // the lambda on the original metadata.
     auto fboExtentKindPtr =
         std::make_shared<PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind>(effect.fboExtentKind);
     QPointer<PhosphorRendering::ShaderEffect> shaderItemPtr{shaderItem};
     auto syncGeometry = [shaderItemPtr, shaderSourcePtr = QPointer<QQuickShaderEffectSource>(shaderSource),
-                         fboExtentRingPtr, fboExtentKindPtr, anchorPtr = QPointer<QQuickItem>(shaderAnchor)]() {
-        syncShaderGeometryNow(anchorPtr.data(), shaderItemPtr.data(), shaderSourcePtr.data(), *fboExtentRingPtr,
-                              *fboExtentKindPtr);
+                         fboExtentKindPtr, anchorPtr = QPointer<QQuickItem>(shaderAnchor)]() {
+        syncShaderGeometryNow(anchorPtr.data(), shaderItemPtr.data(), shaderSourcePtr.data(), *fboExtentKindPtr);
     };
 
     // Seed the fboExtentKind-dependent shader item geometry AND the
@@ -904,11 +781,9 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
     // first painted frame sees a fully-initialised state. Mirrors the
     // setITime ordering rationale above: any state mutation after
     // setSourceItem could race the first paint and produce a visible
-    // flash with default-valued uniforms (fboExtentRing=0 collapses
-    // the morph remap regardless of the metadata; un-translated
-    // shaderParameters leaves user uniforms at -1 sentinel; pre-
-    // padding geometry would clip rippled silhouettes; un-seeded
-    // iSurfaceScreenPos collapses fly-in's slide to a snap).
+    // flash with default-valued uniforms (un-translated shaderParameters
+    // leaves user uniforms at -1 sentinel; un-seeded iSurfaceScreenPos
+    // collapses fly-in's slide to a snap).
     if (shaderSource) {
         shaderItem->setSourceItem(shaderSource);
     }
@@ -960,7 +835,6 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
     out.shaderAnchor = shaderAnchor;
     out.foundExplicitAnchor = foundExplicitAnchor;
     out.hiddenSiblings = std::move(hiddenSiblings);
-    out.fboExtentRingPtr = std::move(fboExtentRingPtr);
     out.fboExtentKindPtr = std::move(fboExtentKindPtr);
     return out;
 }
@@ -1028,15 +902,9 @@ public:
         /// otherwise leaks render-thread RHI resources under rapid
         /// show/hide toggling (zone selector during a drag).
         QString shaderEffectId;
-        /// Shared with the syncGeometry lambda so the reuse path can
-        /// rewrite `fboExtentRing` under metadata hot-reload and the
-        /// already-connected lambda picks up the new value on the
-        /// next anchor geometry signal.
-        std::shared_ptr<qreal> fboExtentRingPtr;
-        /// Same lifecycle as `fboExtentRingPtr`; shared with the
-        /// syncGeometry lambda so a metadata hot-reload that flips
-        /// fboExtentKind (Anchor ↔ Surface) takes effect on the next
-        /// geometry signal without reattaching.
+        /// Shared with the syncGeometry lambda so a metadata hot-reload
+        /// that flips fboExtentKind (Anchor ↔ Surface) takes effect on
+        /// the next geometry signal without reattaching.
         std::shared_ptr<PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind> fboExtentKindPtr;
         int pendingLegs = 0;
         bool shaderExclusive = false; ///< Shader replaces motion legs
@@ -1066,8 +934,6 @@ public:
         bool foundExplicitAnchor = false;
         QString shaderEffectId;
         QPointer<QQuickItem> target;
-        /// See Track::fboExtentRingPtr.
-        std::shared_ptr<qreal> fboExtentRingPtr;
         /// See Track::fboExtentKindPtr.
         std::shared_ptr<PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind> fboExtentKindPtr;
     };
@@ -1197,7 +1063,6 @@ public:
             track.shaderAnchor.clear();
             track.foundExplicitAnchor = false;
             track.shaderEffectId.clear();
-            track.fboExtentRingPtr.reset();
             track.fboExtentKindPtr.reset();
             return;
         }
@@ -1217,7 +1082,6 @@ public:
         pending.foundExplicitAnchor = track.foundExplicitAnchor;
         pending.shaderEffectId = std::move(track.shaderEffectId);
         pending.target = track.target;
-        pending.fboExtentRingPtr = std::move(track.fboExtentRingPtr);
         pending.fboExtentKindPtr = std::move(track.fboExtentKindPtr);
 
         // Make parked pieces dormant — see method docstring.
@@ -1238,7 +1102,6 @@ public:
         track.shaderAnchor.clear();
         track.foundExplicitAnchor = false;
         track.shaderEffectId.clear();
-        track.fboExtentRingPtr.reset();
         track.fboExtentKindPtr.reset();
     }
 
@@ -1264,7 +1127,6 @@ public:
         pending.foundExplicitAnchor = false;
         pending.shaderEffectId.clear();
         pending.target.clear();
-        pending.fboExtentRingPtr.reset();
         pending.fboExtentKindPtr.reset();
     }
 
@@ -1518,7 +1380,6 @@ public:
         QPointer<QQuickShaderEffectSource> reusedShaderSource;
         QPointer<QQuickItem> reusedShaderAnchor;
         bool reusedFoundExplicit = false;
-        std::shared_ptr<qreal> reusedFboExtentRingPtr;
         std::shared_ptr<PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind> reusedFboExtentKindPtr;
         if (hasShaderLeg) {
             const auto pendIt = m_pendingReuse.find(TrackKey{surface, target});
@@ -1552,19 +1413,15 @@ public:
                     reusedShaderSource = std::move(pending.shaderSource);
                     reusedShaderAnchor = pending.shaderAnchor;
                     reusedFoundExplicit = pending.foundExplicitAnchor;
-                    reusedFboExtentRingPtr = std::move(pending.fboExtentRingPtr);
                     reusedFboExtentKindPtr = std::move(pending.fboExtentKindPtr);
-                    // Refresh the live fboExtentRing so the persistent
+                    // Refresh the live fboExtentKind so the persistent
                     // syncGeometry lambda (still connected from the
                     // original attach) picks up the new metadata value
                     // on the next anchor geometry signal. Without this
                     // refresh, an in-place metadata.json hot-reload that
-                    // changes `fboExtentRing` between legs leaves the
-                    // lambda using the OLD value when the anchor next
-                    // moves/resizes.
-                    if (reusedFboExtentRingPtr) {
-                        *reusedFboExtentRingPtr = sanitiseFboExtentRing(resolvedShaderEff.fboExtentRing);
-                    }
+                    // flips `fboExtent` between Anchor and Surface
+                    // leaves the lambda using the OLD kind when the
+                    // anchor next moves/resizes.
                     if (reusedFboExtentKindPtr) {
                         *reusedFboExtentKindPtr = resolvedShaderEff.fboExtentKind;
                     }
@@ -1619,7 +1476,6 @@ public:
             slot.hiddenSiblings.clear();
             slot.foundExplicitAnchor = false;
             slot.shaderEffectId.clear();
-            slot.fboExtentRingPtr.reset();
             slot.fboExtentKindPtr.reset();
             slot.target = target;
             slot.onComplete = std::move(onComplete);
@@ -1722,17 +1578,15 @@ public:
                     // unchanged), so the common no-hot-reload case costs
                     // only a wallpaper-cache lookup.
                     applyEffectStaticConfig(reusedShaderItem.data(), resolvedShaderEff, animIncludePaths);
-                    // Re-fire the geometry sync so a fboExtentRing
+                    // Re-fire the geometry sync so a fboExtentKind
                     // hot-reload between legs (refreshed into the
                     // shared cell at the reuse-claim site above) takes
                     // effect immediately on the new leg's first frame.
                     // The persistent syncGeometry lambda only runs on
                     // anchor geometry signals; for static popups
-                    // (snap-assist, OSD) those may never fire while the
-                    // pad is wrong. Manually invoking the same logic
-                    // here closes that gap.
+                    // (snap-assist, OSD) those may never fire. Manually
+                    // invoking the same logic here closes that gap.
                     syncShaderGeometryNow(reusedShaderAnchor.data(), reusedShaderItem.data(), reusedShaderSource.data(),
-                                          reusedFboExtentRingPtr ? *reusedFboExtentRingPtr : qreal(0.0),
                                           reusedFboExtentKindPtr
                                               ? *reusedFboExtentKindPtr
                                               : PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind::Anchor);
@@ -1772,7 +1626,6 @@ public:
                     it->second.foundExplicitAnchor = reusedFoundExplicit;
                     it->second.hiddenSiblings = std::move(hidden);
                     it->second.shaderEffectId = shaderEffectId;
-                    it->second.fboExtentRingPtr = std::move(reusedFboExtentRingPtr);
                     it->second.fboExtentKindPtr = std::move(reusedFboExtentKindPtr);
                     it->second.shaderTime = std::make_unique<PhosphorAnimation::AnimatedValue<qreal>>();
                     seedShaderUniformsAtAttach(it->second);
@@ -1794,7 +1647,6 @@ public:
                     it->second.foundExplicitAnchor = attached.foundExplicitAnchor;
                     it->second.hiddenSiblings = std::move(attached.hiddenSiblings);
                     it->second.shaderEffectId = shaderEffectId;
-                    it->second.fboExtentRingPtr = std::move(attached.fboExtentRingPtr);
                     it->second.fboExtentKindPtr = std::move(attached.fboExtentKindPtr);
                     it->second.shaderTime = std::make_unique<PhosphorAnimation::AnimatedValue<qreal>>();
                     seedShaderUniformsAtAttach(it->second);

--- a/libs/phosphor-animation/src/surfaceanimator.cpp
+++ b/libs/phosphor-animation/src/surfaceanimator.cpp
@@ -204,7 +204,7 @@ inline qreal sanitiseFboExtentRing(qreal requested)
 ///     the captured-anchor's region within the surface-sized FBO via
 ///     iSurfaceScreenPos / iAnchorSize / iAnchorPosInFbo.
 inline void syncShaderGeometryNow(QQuickItem* anchor, PhosphorRendering::ShaderEffect* shaderItem,
-                                  QQuickShaderEffectSource* shaderSource, qreal requestedPad,
+                                  QQuickShaderEffectSource* shaderSource, qreal /*requestedPad*/,
                                   PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind extent)
 {
     if (!anchor || !shaderItem) {
@@ -215,35 +215,29 @@ inline void syncShaderGeometryNow(QQuickItem* anchor, PhosphorRendering::ShaderE
     if (w <= 0.0 || h <= 0.0) {
         return;
     }
-    const qreal pad = clampPaddingToParent(anchor, requestedPad);
-    const qreal padW = w * pad;
-    const qreal padH = h * pad;
+    // Two-mode extent model — the `fboExtent` JSON key (see
+    // AnimationShaderEffect.h) picks the shader item's geometry:
+    //
+    //   • Surface (opt-in, "fboExtent": "surface"): shader item fills
+    //     the QQuickWindow's contentItem (= wl_surface scene root).
+    //     Used by shaders that need to render past the captured
+    //     anchor — fly-in translates the card across the surface,
+    //     etc. `iAnchorPosInFbo` / `iAnchorSize` / `iResolution`
+    //     tell the shader where the anchor sits inside the surface.
+    //
+    //   • Anchor (default): shader item == anchor. No ring expansion;
+    //     the legacy `anchor+N` ring grammar is dropped. Animation
+    //     shaders work in `vTexCoord ∈ [0, 1]` over the captured
+    //     window content, sample-stage `coords` for out-of-anchor
+    //     lookups clamp at the captured-window's edge (BMW shaders'
+    //     natural behaviour for shards past the window boundary).
     if (extent == PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind::Surface) {
-        // Fill the anchor's enclosing QQuickWindow::contentItem (the
-        // surface scene root), NOT the immediate QML parentItem. The
-        // shader item is parented to anchor->parentItem() (see
-        // attachShaderToAnchor), but Qt scene-graph items render past
-        // their QML parent's bounds without explicit `clip: true`,
-        // the only hard clipping limit is the wl_surface FBO, which
-        // matches the contentItem 1:1. Sizing to the immediate parent
-        // would collapse Surface extent to a small inner container
-        // (e.g. a `PopupContent` around a `PopupFrame`), defeating the
-        // semantic intent (fly-in's "translate across the wl_surface"
-        // would only translate across the popup-content box). The
-        // shader item's local coord system stays parentItem-relative,
-        // so the size lookup uses the scene root but the position
-        // lookup converts via `parentItem->mapFromItem(sceneRoot)` to
-        // express the scene-root origin in parentItem-local pixels.
-        //
-        // iResolution naturally tracks the FBO size; Qt's
-        // QQuickItem::geometryChange auto-resets it to the shader
-        // item's bounds on every geometry event, so we DO NOT try to
-        // override it to anchor size here; that override would silently
-        // get clobbered mid-leg.
-        //
-        // Fall back to anchor->parentItem() if no QQuickWindow is
-        // reachable (headless tests, parentless anchors mid-construction);
-        // and to the Anchor branch if neither is available.
+        // Position the shader item so its (0, 0) corner aligns with
+        // the scene root's origin in parentItem-local coords. For
+        // anchors.fill ancestor chains this resolves to (0, 0)
+        // directly; for offset popup containers the conversion picks
+        // up the parent's local offset so the shader item still maps
+        // 1:1 onto the contentItem.
         QQuickItem* sceneRoot = nullptr;
         if (QQuickWindow* win = anchor->window()) {
             sceneRoot = win->contentItem();
@@ -256,25 +250,29 @@ inline void syncShaderGeometryNow(QQuickItem* anchor, PhosphorRendering::ShaderE
             shaderItem->setWidth(sceneRoot->width());
             shaderItem->setHeight(sceneRoot->height());
         } else if (parent) {
-            const qreal pw = parent->width();
-            const qreal ph = parent->height();
+            // Headless / mid-construction fallback: fill the immediate
+            // parent. Qt's geometryChange will auto-resize iResolution.
             shaderItem->setX(0.0);
             shaderItem->setY(0.0);
-            shaderItem->setWidth(pw);
-            shaderItem->setHeight(ph);
+            shaderItem->setWidth(parent->width());
+            shaderItem->setHeight(parent->height());
         } else {
-            shaderItem->setWidth(w + 2.0 * padW);
-            shaderItem->setHeight(h + 2.0 * padH);
-            shaderItem->setX(anchor->x() - padW);
-            shaderItem->setY(anchor->y() - padH);
-            shaderItem->setIResolution(QSizeF(w + 2.0 * padW, h + 2.0 * padH));
+            // Parentless anchor — drop back to anchor-relative sizing as
+            // a last-resort floor (test-fixture fallback).
+            shaderItem->setX(anchor->x());
+            shaderItem->setY(anchor->y());
+            shaderItem->setWidth(w);
+            shaderItem->setHeight(h);
+            shaderItem->setIResolution(QSizeF(w, h));
         }
     } else {
-        shaderItem->setWidth(w + 2.0 * padW);
-        shaderItem->setHeight(h + 2.0 * padH);
-        shaderItem->setX(anchor->x() - padW);
-        shaderItem->setY(anchor->y() - padH);
-        shaderItem->setIResolution(QSizeF(w + 2.0 * padW, h + 2.0 * padH));
+        // Anchor mode (default) — no expansion. Shader item exactly
+        // covers the captured anchor.
+        shaderItem->setX(anchor->x());
+        shaderItem->setY(anchor->y());
+        shaderItem->setWidth(w);
+        shaderItem->setHeight(h);
+        shaderItem->setIResolution(QSizeF(w, h));
     }
     if (shaderSource) {
         shaderSource->setWidth(w);
@@ -807,31 +805,39 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
 
     // Size + position the shader.
     //
-    // fboExtentRing (from metadata.json) enlarges the shader effect's
-    // bounding box by a fraction of the anchor's size on every side so
-    // shaders that distort their silhouette outward (morph's UV warp)
-    // have room to render the rippled outline before the bounding box
-    // clips it. The anchor sits in the centre of the padded box; shaders
-    // that opt in (fboExtentRing > 0) must remap vTexCoord back to anchor
-    // [0,1] for their UV math.
-    //
     // iResolution stays in LOGICAL units to match the project-wide shader
     // convention (libs/phosphor-rendering/src/shadereffect.cpp:763-765,
     // common.glsl pxScale()). Animation shaders derive UV from the vertex-
     // stage `vTexCoord` varying, not from `gl_FragCoord.xy / iResolution`
     // — gl_FragCoord is post-DPR pixel coords and would overshoot [0,1]
     // by a factor of DPR.
-    // Clamp the metadata pad to fit the anchor's parent bounds. See
-    // clampPaddingToParent docstring for why this matters (viewport
-    // clipping breaks the morph shader's UV remap).
-    const qreal pad = clampPaddingToParent(shaderAnchor, effect.fboExtentRing);
-    const qreal padW = shaderAnchor->width() * pad;
-    const qreal padH = shaderAnchor->height() * pad;
-    shaderItem->setWidth(shaderAnchor->width() + 2.0 * padW);
-    shaderItem->setHeight(shaderAnchor->height() + 2.0 * padH);
-    shaderItem->setX(shaderAnchor->x() - padW);
-    shaderItem->setY(shaderAnchor->y() - padH);
-    shaderItem->setIResolution(QSizeF(shaderAnchor->width() + 2.0 * padW, shaderAnchor->height() + 2.0 * padH));
+    //
+    // Initial-attach geometry mirrors syncShaderGeometryNow's two-mode
+    // logic (Anchor default vs Surface opt-in). Pre-seeding here keeps
+    // the first paint between attach and the next syncGeometry() call
+    // correctly sized; syncGeometry() refreshes on subsequent geometry
+    // events.
+    if (effect.fboExtentKind == PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind::Surface) {
+        if (QQuickWindow* win = shaderAnchor->window()) {
+            if (QQuickItem* sceneRoot = win->contentItem()) {
+                QQuickItem* parent = shaderAnchor->parentItem();
+                const QPointF rootOriginInParent =
+                    parent ? parent->mapFromItem(sceneRoot, QPointF(0.0, 0.0)) : QPointF(0.0, 0.0);
+                shaderItem->setX(rootOriginInParent.x());
+                shaderItem->setY(rootOriginInParent.y());
+                shaderItem->setWidth(sceneRoot->width());
+                shaderItem->setHeight(sceneRoot->height());
+                shaderItem->setIResolution(QSizeF(sceneRoot->width(), sceneRoot->height()));
+            }
+        }
+    } else {
+        // Anchor mode (default) — shader item exactly covers the anchor.
+        shaderItem->setX(shaderAnchor->x());
+        shaderItem->setY(shaderAnchor->y());
+        shaderItem->setWidth(shaderAnchor->width());
+        shaderItem->setHeight(shaderAnchor->height());
+        shaderItem->setIResolution(QSizeF(shaderAnchor->width(), shaderAnchor->height()));
+    }
 
     // No more customParams[7].x structural write: morph and broken-glass
     // (the only consumers) were ported to read the pad implicitly via

--- a/libs/phosphor-animation/src/surfaceanimator.cpp
+++ b/libs/phosphor-animation/src/surfaceanimator.cpp
@@ -697,17 +697,30 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
     // correctly sized; syncGeometry() refreshes on subsequent geometry
     // events.
     if (effect.fboExtentKind == PhosphorAnimationShaders::AnimationShaderEffect::FboExtentKind::Surface) {
+        QQuickItem* sceneRoot = nullptr;
         if (QQuickWindow* win = shaderAnchor->window()) {
-            if (QQuickItem* sceneRoot = win->contentItem()) {
-                QQuickItem* parent = shaderAnchor->parentItem();
-                const QPointF rootOriginInParent =
-                    parent ? parent->mapFromItem(sceneRoot, QPointF(0.0, 0.0)) : QPointF(0.0, 0.0);
-                shaderItem->setX(rootOriginInParent.x());
-                shaderItem->setY(rootOriginInParent.y());
-                shaderItem->setWidth(sceneRoot->width());
-                shaderItem->setHeight(sceneRoot->height());
-                shaderItem->setIResolution(QSizeF(sceneRoot->width(), sceneRoot->height()));
-            }
+            sceneRoot = win->contentItem();
+        }
+        QQuickItem* parent = shaderAnchor->parentItem();
+        if (sceneRoot && parent) {
+            const QPointF rootOriginInParent = parent->mapFromItem(sceneRoot, QPointF(0.0, 0.0));
+            shaderItem->setX(rootOriginInParent.x());
+            shaderItem->setY(rootOriginInParent.y());
+            shaderItem->setWidth(sceneRoot->width());
+            shaderItem->setHeight(sceneRoot->height());
+            shaderItem->setIResolution(QSizeF(sceneRoot->width(), sceneRoot->height()));
+        } else if (parent) {
+            shaderItem->setX(0.0);
+            shaderItem->setY(0.0);
+            shaderItem->setWidth(parent->width());
+            shaderItem->setHeight(parent->height());
+            shaderItem->setIResolution(QSizeF(parent->width(), parent->height()));
+        } else {
+            shaderItem->setX(shaderAnchor->x());
+            shaderItem->setY(shaderAnchor->y());
+            shaderItem->setWidth(shaderAnchor->width());
+            shaderItem->setHeight(shaderAnchor->height());
+            shaderItem->setIResolution(QSizeF(shaderAnchor->width(), shaderAnchor->height()));
         }
     } else {
         // Anchor mode (default) — shader item exactly covers the anchor.

--- a/libs/phosphor-animation/tests/test_animationshadereffect.cpp
+++ b/libs/phosphor-animation/tests/test_animationshadereffect.cpp
@@ -130,7 +130,6 @@ private Q_SLOTS:
         original.bufferFilter = QStringLiteral("linear");
         original.bufferFilters = {QStringLiteral("nearest"), QStringLiteral("linear")};
         original.useDepthBuffer = true;
-        original.fboExtentRing = 0.25;
 
         const AnimationShaderEffect restored = AnimationShaderEffect::fromJson(original.toJson());
         QCOMPARE(restored, original);
@@ -156,82 +155,43 @@ private Q_SLOTS:
         QCOMPARE(undershoot.bufferScale, qreal(0.125));
     }
 
-    /// `fboExtent` grammar parser coverage. The Phase 3 refactor
-    /// replaced the split `boundsExtent` enum + `boundsPadding` qreal
-    /// JSON keys with a single string field; the parser at
-    /// `parseFboExtent` in animationshadereffect.cpp accepts four forms
-    /// (`"anchor"`, `"anchor+0.5"` fraction, `"anchor+50%"` percent,
-    /// `"surface"`) and rejects malformed values with a journal warning
-    /// + struct-defaults fallback.
-    ///
-    /// Driven by a `_data()` table so a regression that silently drops
-    /// a form (e.g. percent support) surfaces in CI rather than waiting
-    /// on a metadata round-trip. Each row pins (input, expected kind,
-    /// expected ring) and any new rule (e.g. negative-value rejection)
-    /// gets a single new row instead of a fresh slot.
-    ///
-    /// Coverage of the runtime fallback for parentless / windowless
-    /// anchors lives in `clampPaddingToParent` (anonymous-namespace
-    /// helper in surfaceanimator.cpp) and is exercised end-to-end via
-    /// `tests/test_surface_animator.cpp`. The math contract for that
-    /// path is "fall back to the global `kMaxFboExtentRing` ceiling",
-    /// which IS pinned here directly via `kMaxFboExtentRing` row below.
+    /// `fboExtent` grammar parser coverage. Accepts exactly two forms
+    /// — `"anchor"` and `"surface"` — case-insensitive. Anything else
+    /// (including the legacy `anchor+N` ring-fraction grammar) is
+    /// rejected with a journal warning and falls back to the default
+    /// (Anchor). Driven by a `_data()` table so a regression that
+    /// silently accepts a malformed form surfaces in CI rather than
+    /// waiting on a visual regression.
     void testFromJsonFboExtent_data()
     {
         QTest::addColumn<QString>("input");
         QTest::addColumn<AnimationShaderEffect::FboExtentKind>("expectedKind");
-        QTest::addColumn<qreal>("expectedRing");
 
         const auto kAnchor = AnimationShaderEffect::FboExtentKind::Anchor;
         const auto kSurface = AnimationShaderEffect::FboExtentKind::Surface;
-        const qreal kMax = AnimationShaderEffect::kMaxFboExtentRing;
 
         // Accepted grammar.
-        QTest::newRow("anchor") << QStringLiteral("anchor") << kAnchor << qreal(0.0);
-        QTest::newRow("anchor+0.5") << QStringLiteral("anchor+0.5") << kAnchor << qreal(0.5);
-        QTest::newRow("anchor+50%") << QStringLiteral("anchor+50%") << kAnchor << qreal(0.5);
-        QTest::newRow("anchor+0") << QStringLiteral("anchor+0") << kAnchor << qreal(0.0);
-        QTest::newRow("surface") << QStringLiteral("surface") << kSurface << qreal(0.0);
-        QTest::newRow("anchor-uppercase") << QStringLiteral("ANCHOR") << kAnchor << qreal(0.0);
-        QTest::newRow("surface-mixed") << QStringLiteral("Surface") << kSurface << qreal(0.0);
-        QTest::newRow("anchor+ws") << QStringLiteral("anchor + 0.5") << kAnchor << qreal(0.5);
-        QTest::newRow("leading-ws") << QStringLiteral("  anchor") << kAnchor << qreal(0.0);
+        QTest::newRow("anchor") << QStringLiteral("anchor") << kAnchor;
+        QTest::newRow("surface") << QStringLiteral("surface") << kSurface;
+        QTest::newRow("anchor-uppercase") << QStringLiteral("ANCHOR") << kAnchor;
+        QTest::newRow("surface-mixed") << QStringLiteral("Surface") << kSurface;
+        QTest::newRow("leading-ws") << QStringLiteral("  anchor") << kAnchor;
 
-        // Clamped to the runtime ceiling: a metadata value above
-        // kMaxFboExtentRing is treated as the ceiling instead of
-        // allocating gigabyte FBOs.
-        QTest::newRow("clamp-over") << QStringLiteral("anchor+10.0") << kAnchor << kMax;
-
-        // Malformed values: parser falls back to struct defaults
-        // (Anchor, ring=0) and emits a journal warning.
-        QTest::newRow("empty") << QString() << kAnchor << qreal(0.0);
-        QTest::newRow("whitespace-only") << QStringLiteral("   ") << kAnchor << qreal(0.0);
-        QTest::newRow("garbage") << QStringLiteral("foo") << kAnchor << qreal(0.0);
-        QTest::newRow("anchor-bad-frac") << QStringLiteral("anchor+abc") << kAnchor << qreal(0.0);
-        QTest::newRow("anchor-only-plus") << QStringLiteral("anchor+") << kAnchor << qreal(0.0);
-        QTest::newRow("anchor-only-pct") << QStringLiteral("anchor+%") << kAnchor << qreal(0.0);
-        QTest::newRow("anchor-double-pct") << QStringLiteral("anchor+50%%") << kAnchor << qreal(0.0);
-
-        // NaN / Inf rejection at the parse boundary so downstream
-        // consumers (osd.cpp::resolveOsdShaderPadding feeding QML's
-        // `shaderBoundsPadding`) can't NaN out window dimensions.
-        QTest::newRow("nan") << QStringLiteral("anchor+nan") << kAnchor << qreal(0.0);
-        QTest::newRow("inf") << QStringLiteral("anchor+inf") << kAnchor << qreal(0.0);
-        QTest::newRow("neg-inf") << QStringLiteral("anchor+-inf") << kAnchor << qreal(0.0);
-
-        // Negative ring rejection. A typo like "anchor+-0.5" would
-        // otherwise silently clamp to 0 (parse "succeeds", qBound
-        // floors to 0) and the operator loses the chance to spot the
-        // bad value. Parser now fails-loud on negatives.
-        QTest::newRow("neg-fraction") << QStringLiteral("anchor+-0.5") << kAnchor << qreal(0.0);
-        QTest::newRow("neg-percent") << QStringLiteral("anchor+-50%") << kAnchor << qreal(0.0);
+        // Malformed / unsupported values: parser falls back to the
+        // struct default (Anchor) and emits a journal warning. The
+        // legacy `anchor+N` ring grammar lives in this bucket since
+        // ring expansion is no longer supported on either runtime.
+        QTest::newRow("empty") << QString() << kAnchor;
+        QTest::newRow("whitespace-only") << QStringLiteral("   ") << kAnchor;
+        QTest::newRow("garbage") << QStringLiteral("foo") << kAnchor;
+        QTest::newRow("legacy-anchor+0.5") << QStringLiteral("anchor+0.5") << kAnchor;
+        QTest::newRow("legacy-anchor+50%") << QStringLiteral("anchor+50%") << kAnchor;
     }
 
     void testFromJsonFboExtent()
     {
         QFETCH(QString, input);
         QFETCH(AnimationShaderEffect::FboExtentKind, expectedKind);
-        QFETCH(qreal, expectedRing);
 
         QJsonObject obj;
         obj.insert(QLatin1String("id"), QStringLiteral("test"));
@@ -239,7 +199,6 @@ private Q_SLOTS:
         obj.insert(QLatin1String("fboExtent"), input);
         const AnimationShaderEffect e = AnimationShaderEffect::fromJson(obj);
         QCOMPARE(e.fboExtentKind, expectedKind);
-        QCOMPARE(e.fboExtentRing, expectedRing);
     }
 
     /// Round-trip Surface extent through JSON. toJson emits
@@ -253,25 +212,6 @@ private Q_SLOTS:
 
         const AnimationShaderEffect restored = AnimationShaderEffect::fromJson(original.toJson());
         QCOMPARE(restored.fboExtentKind, AnimationShaderEffect::FboExtentKind::Surface);
-        QCOMPARE(restored.fboExtentRing, qreal(0.0));
-    }
-
-    /// `formatFboExtent` writes the ring with 17 sig digits so a
-    /// programmatically-assigned non-round value (1.0/3.0, sqrt(0.5),
-    /// etc.) survives toJson -> fromJson without losing precision.
-    /// Default `arg(double)` truncates to 6 sig digits, which collapses
-    /// 0.333... -> "0.333333" and breaks strict-equality compare.
-    void testFboExtentRingPrecisionRoundTrip()
-    {
-        AnimationShaderEffect original;
-        original.id = QStringLiteral("test");
-        original.fragmentShaderPath = QStringLiteral("effect.frag");
-        original.fboExtentKind = AnimationShaderEffect::FboExtentKind::Anchor;
-        original.fboExtentRing = 1.0 / 3.0;
-
-        const AnimationShaderEffect restored = AnimationShaderEffect::fromJson(original.toJson());
-        QCOMPARE(restored.fboExtentKind, AnimationShaderEffect::FboExtentKind::Anchor);
-        QCOMPARE(restored.fboExtentRing, original.fboExtentRing);
     }
 };
 

--- a/libs/phosphor-rendering/src/shadereffect.cpp
+++ b/libs/phosphor-rendering/src/shadereffect.cpp
@@ -1280,23 +1280,37 @@ void ShaderEffect::syncBasePropertiesToNode(ShaderNodeRhi* node)
     node->setTimeDelta(static_cast<float>(m_iTimeDelta));
     node->setFrame(m_iFrame);
     node->setIsReversed(m_isReversed);
-    // iResolution must be in PHYSICAL pixels (DPR-scaled), not logical, so it
-    // matches gl_FragCoord — which is the viewport coordinate of the
-    // rasterised fragment. QtQuick's QRhi viewport is set in physical pixels
-    // (item.size * DPR), so gl_FragCoord ranges 0..viewport.size in physical
-    // pixels too. Setting iResolution in logical pixels meant fragCoord and
-    // iResolution disagreed by a factor of DPR — at DPR > 1 the SDF rounded-
-    // rect mask covered only the *logical-sized* region of the *physical-
-    // sized* surface, leaving a transparent stripe on the trailing edge that
-    // looked exactly like content overflow. With DPR == 1 the bug was
-    // invisible (factor 1 — no mismatch) so it lay dormant on all the test
-    // setups that used 1.0 scaling.
+    // iResolution unit semantics — controlled by the installed uniform
+    // extension's `requiresPhysicalResolution()`:
     //
-    // `m_iResolution` itself stays in logical units (Q_PROPERTY semantics —
-    // QML callers expect the same units they bound it from). Only the GPU-
-    // bound value is multiplied.
+    //   * physical (default, overlay path): DPR-scaled so the value
+    //     matches `gl_FragCoord` — which is the viewport coordinate of
+    //     the rasterised fragment. QtQuick's QRhi viewport is set in
+    //     physical pixels (item.size * DPR), so `gl_FragCoord` ranges
+    //     0..viewport.size in physical pixels too. Zone-overlay
+    //     fragment shaders that compute SDF masks via
+    //     `gl_FragCoord / iResolution` need both operands in physical
+    //     pixels; setting iResolution in logical pixels at DPR > 1
+    //     caused the rounded-rect mask to cover only the logical-sized
+    //     region of the physical-sized surface (transparent edge
+    //     stripe).
+    //
+    //   * logical (animation path): the AnimationUniformExtension
+    //     reports `requiresPhysicalResolution() == false`. Animation
+    //     shaders use the vertex-stage `vTexCoord` (auto-interpolated
+    //     0..1 over the rasterised quad regardless of DPR) and pair
+    //     `iResolution` with logical-pixel companions (`iAnchorSize`,
+    //     `iAnchorPosInFbo`, `iSurfaceScreenPos`) for UV / clip-space
+    //     ratios. Scaling iResolution by DPR there would mismatch
+    //     units across the UBO and shrink rendered output by 1/DPR
+    //     (fly-in) or shift the anchor UV remap (broken-glass, morph).
+    //
+    // `m_iResolution` itself stays in logical units (Q_PROPERTY
+    // semantics — QML callers expect the same units they bound it
+    // from). Only the GPU-bound value is conditionally multiplied.
     qreal dpr = 1.0;
-    if (window() && window()->screen()) {
+    const bool needsPhysical = !m_uniformExtension || m_uniformExtension->requiresPhysicalResolution();
+    if (needsPhysical && window() && window()->screen()) {
         dpr = window()->effectiveDevicePixelRatio();
     }
     node->setResolution(static_cast<float>(m_iResolution.width() * dpr),

--- a/libs/phosphor-shaders/include/PhosphorShaders/IUniformExtension.h
+++ b/libs/phosphor-shaders/include/PhosphorShaders/IUniformExtension.h
@@ -38,6 +38,26 @@ public:
 
     /// Mark as clean after a successful write.
     virtual void clearDirty() = 0;
+
+    /// Whether `iResolution` in this extension's UBO should be uploaded
+    /// in PHYSICAL pixels (DPR-scaled, matches `gl_FragCoord`) or
+    /// LOGICAL pixels (matches the QQuickItem's bounds and Qt's
+    /// auto-interpolated `vTexCoord`).
+    ///
+    /// Default `true` (physical) is the legacy overlay-shader contract
+    /// — zone-overlay fragment shaders sample `gl_FragCoord /
+    /// iResolution` for SDF masks and expect both sides in physical
+    /// pixels. Extensions whose shader contract uses `vTexCoord` (the
+    /// rasterised quad's 0..1 interpolated UV, DPR-independent) and
+    /// reads other-extension fields that ride on logical-pixel
+    /// semantics (animation shaders' `iAnchorSize` / `iAnchorPosInFbo`
+    /// / `iSurfaceScreenPos` magic-constant tuning) override to
+    /// `false` so the ratios stay dimensionally consistent across the
+    /// UBO.
+    virtual bool requiresPhysicalResolution() const
+    {
+        return true;
+    }
 };
 
 } // namespace PhosphorShaders

--- a/src/daemon/overlayservice/osd.cpp
+++ b/src/daemon/overlayservice/osd.cpp
@@ -22,10 +22,6 @@
 #include "pz_slot_keys.h"
 #include <PhosphorScreens/ScreenIdentity.h>
 
-#include <PhosphorAnimation/AnimationShaderEffect.h>
-#include <PhosphorAnimation/AnimationShaderRegistry.h>
-#include <PhosphorAnimation/ProfilePaths.h>
-#include <PhosphorAnimation/ShaderProfileTree.h>
 #include <PhosphorAnimation/SurfaceAnimator.h>
 
 #include "../../core/isettings.h"
@@ -33,37 +29,6 @@
 namespace PlasmaZones {
 
 namespace {
-
-// Resolve the per-side padding (fraction of container size) the active
-// SurfaceAnimator shader leg needs reserved around the OSD's inner card.
-// The wl_surface itself is now screen-sized (see `createWarmedOsdSurface`)
-// and no longer needs to grow per-effect, but the QML side still consumes
-// this fraction to set `shaderBoundsPadding` so the inner card's
-// shader-anchor metadata stays consistent across legs.
-//
-// Returns 0.0 when no shader is selected for either leg, when the shader
-// id doesn't resolve in the registry, or when settings/registry are not
-// yet wired (pre-construction races). The QML side defaults shaderBounds-
-// Padding to 0.0 too - written to confirm intent each show, not to rely on
-// stale prior writes.
-qreal resolveOsdShaderPadding(ISettings* settings, PhosphorAnimationShaders::AnimationShaderRegistry* registry,
-                              const QString& showPath, const QString& hidePath)
-{
-    if (!settings || !registry) {
-        return 0.0;
-    }
-    const auto tree = settings->shaderProfileTree();
-    qreal pad = 0.0;
-    const QString showId = tree.resolve(showPath).effectiveEffectId();
-    if (!showId.isEmpty()) {
-        pad = qMax(pad, registry->effect(showId).fboExtentRing);
-    }
-    const QString hideId = tree.resolve(hidePath).effectiveEffectId();
-    if (!hideId.isEmpty()) {
-        pad = qMax(pad, registry->effect(hideId).fboExtentRing);
-    }
-    return pad;
-}
 
 // Size the OSD window to its target screen rect. The wl_surface is now
 // screen-sized (mirrors zone-selector / snap-assist) - anchors and
@@ -186,16 +151,6 @@ void OverlayService::showLayoutOsdImpl(PhosphorZones::Layout* layout, const QStr
     p.screenAspectRatio = aspectRatio;
     p.aspectRatioClass = PhosphorLayout::ScreenClassification::toString(layout->aspectRatioClass());
     pushLayoutOsdContent(osdSlot, p);
-    // shaderBoundsPadding written BEFORE the mode flip so the Loader's
-    // freshly-instantiated content observes the correct padding on first
-    // binding evaluation. The wl_surface itself is screen-sized
-    // regardless (see `createWarmedOsdSurface`); this fraction propagates
-    // into the loaded content for shader-anchor bookkeeping.
-    {
-        namespace PP = PhosphorAnimation::ProfilePaths;
-        writeQmlProperty(osdSlot, QStringLiteral("shaderBoundsPadding"),
-                         resolveOsdShaderPadding(m_settings, m_animShaderRegistry, PP::OsdShow, PP::OsdHide));
-    }
     writeQmlProperty(osdSlot, QStringLiteral("mode"), QStringLiteral("layout-osd"));
 
     sizeOsdToScreen(window, screenGeom);
@@ -290,13 +245,6 @@ void OverlayService::showLayoutOsd(const QString& id, const QString& name, const
     p.zoneNumberDisplay = zoneNumberDisplay;
     p.masterCount = masterCount;
     pushLayoutOsdContent(osdSlot, p);
-    // shaderBoundsPadding before mode - see the matching note in
-    // showLayoutOsdImpl above.
-    {
-        namespace PP = PhosphorAnimation::ProfilePaths;
-        writeQmlProperty(osdSlot, QStringLiteral("shaderBoundsPadding"),
-                         resolveOsdShaderPadding(m_settings, m_animShaderRegistry, PP::OsdShow, PP::OsdHide));
-    }
     writeQmlProperty(osdSlot, QStringLiteral("mode"), QStringLiteral("layout-osd"));
 
     sizeOsdToScreen(window, screenGeom);
@@ -388,12 +336,6 @@ void OverlayService::showDisabledOsd(const QString& reason, const QString& scree
     pushLayoutOsdContent(osdSlot, p);
     writeQmlProperty(osdSlot, QStringLiteral("disabled"), true);
     writeQmlProperty(osdSlot, QStringLiteral("disabledReason"), reason);
-    // shaderBoundsPadding before mode - see showLayoutOsdImpl note.
-    {
-        namespace PP = PhosphorAnimation::ProfilePaths;
-        writeQmlProperty(osdSlot, QStringLiteral("shaderBoundsPadding"),
-                         resolveOsdShaderPadding(m_settings, m_animShaderRegistry, PP::OsdShow, PP::OsdHide));
-    }
     writeQmlProperty(osdSlot, QStringLiteral("mode"), QStringLiteral("layout-osd"));
 
     sizeOsdToScreen(window, screenGeom);
@@ -621,16 +563,6 @@ void OverlayService::showNavigationOsd(bool success, const QString& action, cons
         screenLayout, PhosphorZones::ZoneField::Minimal, QRectF(navScreenGeom));
     writeQmlProperty(osdSlot, QStringLiteral("zones"), zonesList);
 
-    // shaderBoundsPadding before mode - the Loader instantiates
-    // NavigationOsdContent on the mode flip and the inner card's
-    // shader-anchor bookkeeping reads this fraction at instantiation.
-    // Surface dimensions are screen-sized regardless (see
-    // `createWarmedOsdSurface`).
-    {
-        namespace PP = PhosphorAnimation::ProfilePaths;
-        writeQmlProperty(osdSlot, QStringLiteral("shaderBoundsPadding"),
-                         resolveOsdShaderPadding(m_settings, m_animShaderRegistry, PP::OsdShow, PP::OsdHide));
-    }
     // Write mode AFTER data properties so the Loader-instantiated
     // NavigationOsdContent picks up correct values on first binding pass.
     writeQmlProperty(osdSlot, QStringLiteral("mode"), QStringLiteral("navigation-osd"));

--- a/src/ui/LayoutOsdContent.qml
+++ b/src/ui/LayoutOsdContent.qml
@@ -86,19 +86,11 @@ Item {
     property bool locked: false
     property bool disabled: false
     property string disabledReason: ""
-    // Per-side padding (fraction of container width/height) reserved for
-    // shader transition effects whose silhouette extends outside the
-    // container's rectangle. Set by the daemon to the active SurfaceAnimator
-    // shader's metadata `fboExtentRing` (max of show + hide so the surface
-    // accommodates whichever leg is currently running). 0.0 = no padding.
-    property real shaderBoundsPadding: 0
     // Content-driven desired size, exposed for the unified host (which binds
     // its Window width/height to these readonly properties; C++ also reads
     // them after every property write to compute matching layer-shell margins).
-    // Inflated by `2 * shaderBoundsPadding` on each axis so the wayland surface
-    // has room for shader silhouettes that ripple outside the container.
-    readonly property int contentDesiredWidth: Math.round(container.width * (1 + 2 * shaderBoundsPadding)) + Math.round(Kirigami.Units.gridUnit * 2.5)
-    readonly property int contentDesiredHeight: Math.round(container.height * (1 + 2 * shaderBoundsPadding)) + Math.round(Kirigami.Units.gridUnit * 2.5)
+    readonly property int contentDesiredWidth: Math.round(container.width) + Math.round(Kirigami.Units.gridUnit * 2.5)
+    readonly property int contentDesiredHeight: Math.round(container.height) + Math.round(Kirigami.Units.gridUnit * 2.5)
 
     /// Auto-dismiss request emitted by the dismissTimer / click MouseArea.
     /// The unified NotificationOverlay host re-emits this as its own

--- a/src/ui/NavigationOsdContent.qml
+++ b/src/ui/NavigationOsdContent.qml
@@ -170,18 +170,11 @@ Item {
             return i18n("Action completed");
         }
     }
-    // Per-side padding (fraction of container width/height) reserved for
-    // shader transition effects whose silhouette extends outside the
-    // container's rectangle. Set by the daemon based on the active shader's
-    // metadata.
-    property real shaderBoundsPadding: 0
     // Content-driven desired size, exposed for the unified host (which binds
     // its Window width/height to these readonly properties; C++ also reads
     // them after every property write to compute matching layer-shell margins).
-    // Inflated by `2 * shaderBoundsPadding` on each axis so the wayland surface
-    // has room for shader silhouettes that ripple outside the container.
-    readonly property int contentDesiredWidth: Math.round(container.width * (1 + 2 * shaderBoundsPadding)) + Math.round(Kirigami.Units.gridUnit * 2.5)
-    readonly property int contentDesiredHeight: Math.round(container.height * (1 + 2 * shaderBoundsPadding)) + Math.round(Kirigami.Units.gridUnit * 2.5)
+    readonly property int contentDesiredWidth: Math.round(container.width) + Math.round(Kirigami.Units.gridUnit * 2.5)
+    readonly property int contentDesiredHeight: Math.round(container.height) + Math.round(Kirigami.Units.gridUnit * 2.5)
 
     /// Auto-dismiss request emitted by the dismissTimer / click MouseArea.
     /// The unified NotificationOverlay host re-emits this as its own

--- a/src/ui/PassiveOverlayShell.qml
+++ b/src/ui/PassiveOverlayShell.qml
@@ -157,7 +157,6 @@ Window {
         property string sourceZoneId: ""
         property int windowCount: 1
         property color errorColor: Kirigami.Theme.negativeTextColor
-        property real shaderBoundsPadding: 0
 
         /// Restart the loaded OSD content's auto-dismiss timer. C++
         /// invokes this after every OSD show via QMetaObject::invokeMethod.
@@ -220,7 +219,6 @@ Window {
                 backgroundColor: osdSlot.backgroundColor
                 textColor: osdSlot.textColor
                 highlightColor: osdSlot.highlightColor
-                shaderBoundsPadding: osdSlot.shaderBoundsPadding
                 layoutId: osdSlot.layoutId
                 layoutName: osdSlot.layoutName
                 category: osdSlot.category
@@ -253,7 +251,6 @@ Window {
                 backgroundColor: osdSlot.backgroundColor
                 textColor: osdSlot.textColor
                 highlightColor: osdSlot.highlightColor
-                shaderBoundsPadding: osdSlot.shaderBoundsPadding
                 success: osdSlot.success
                 action: osdSlot.action
                 reason: osdSlot.reason

--- a/src/ui/PassiveOverlayShell.qml
+++ b/src/ui/PassiveOverlayShell.qml
@@ -104,11 +104,23 @@ Window {
     // syncPassiveShellSurfaceState, and the order is undefined.
     flags: Qt.FramelessWindowHint | Qt.WindowDoesNotAcceptFocus
     color: "transparent"
-    // Initial size — the C++ side resizes to per-screen geometry on
-    // creation. The shell wl_surface is screen-sized so vertex-shader
-    // transitions have geometry runway equal to the screen.
-    width: Kirigami.Units.gridUnit * 15
-    height: Kirigami.Units.gridUnit * 4
+    // No explicit width/height — `OverlayService::createWarmedOsdSurface`
+    // passes `initialSize = screenGeom.size()` to `createLayerSurface`,
+    // and `surface.cpp::computeWarmupGeometry` calls `setGeometry` with
+    // that screen-sized rect BEFORE `completeCreate` fires QML
+    // evaluation. A QML `width: …` / `height: …` binding here would
+    // re-evaluate during `completeCreate` and OVERWRITE the C++-set
+    // screen-sized geometry — committing the wl_surface at the QML
+    // binding's value (15×4 gridUnits ≈ 270×72 px) and forcing the
+    // compositor to configure the first frame at that small size. The
+    // first OSD show on login then rendered with a wl_surface still
+    // sized to ~270×72 while the QML internal layout was at the
+    // (eventually-re-asserted) screen size — `container.centerIn` math
+    // produced negative scene Y, surfaceAnimator pushed
+    // `iSurfaceScreenPos.xy` with that negative Y, and fly-in's
+    // `cardCenterClip.y` landed above clip-y = -1, rendering the OSD
+    // card above the screen top with the bottom partially cut off.
+    // Leaving the size to C++ entirely closes the race.
     // Start hidden; first per-content show flips visible=true. The
     // surface stays mapped (keepMappedOnHide=true) for the daemon's
     // lifetime so swapchain + RHI pipelines stay warm across show


### PR DESCRIPTION
## Summary

- **Architecture refactor** — replace the legacy `fboExtent: "anchor+N"` ring-expansion model on the daemon path with a two-mode `Anchor` / `Surface` extent, and decouple `iResolution` units from DPR for animation shaders so UV math stays dimensionally consistent with the logical-pixel companion uniforms (`iAnchorSize`, `iAnchorPosInFbo`, `iSurfaceScreenPos`). Morph and fly-in migrate onto the new contract.
- **Broken-glass re-port** — fresh BMW broken-glass.frag port under the surface-extent model: pass-through vert + `anchorRemap` in frag. Hardens against two bugs that would otherwise reproduce as horizontal banding: (1) shard-atlas density was tied to `iAnchorSize`, which is transiently `(0, 0)` on pre-attach paints — now a unitless constant; (2) per-instance seed hash collapsed to `(0, 0)` at integer screen positions — shifted by irrationals.
- **Edge-smear sweep** — 14 packs (aura-glow, bounce, crosswarp, flyeye, hexagon, incinerate, paint-brush, pixel-wheel, pixel-wipe, pixelate, pixelfade-wave, rgb-warp, wave-warp, wisps) were sampling `uTexture0` at displaced coords without an off-surface mask, so the clamp-to-edge sampler smeared the window's edge texel into a 1-pixel halo around the silhouette. Apply the existing `boundaryMask(uv)` helper (or drop the inner `clamp(warped, 0, 1)` in crosswarp/wave-warp, which was the literal mechanism of the smear). `glitch` is intentionally skipped — its chromatic-aberration edge bleed is part of the look.

## Test plan

- [x] `cmake --build build --parallel` succeeds against `v3` baseline + all changes
- [x] `ctest -L phosphoranimation|phosphoranimationshaders` — 31/31 pass (includes the bake test that runs `qsb` over every shader for both daemon SPIR-V and kwin classic-GL)
- [x] Visual: broken-glass shatters into polygonal shards (verified by user) instead of horizontal bands
- [x] Visual: wisps no longer shows the 1-pixel inset at high progress (verified by user)
- [ ] Visual smoke-test on the remaining 13 packs after install — no regressions at progress=0 (boundaryMask bands sit outside [0, 1] so first-frame appearance is unchanged by construction)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)