### PR TITLE
Suppress welcome OSDs during logout / phantom-session restart

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -9,7 +9,12 @@
 #include <QStandardPaths>
 #include <QtConcurrent>
 #include <QScreen>
+#include <QCoreApplication>
 #include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusMessage>
+#include <QDBusObjectPath>
+#include <QDBusReply>
 #include <QDBusError>
 #include <QDir>
 #include <QFile>
@@ -1233,6 +1238,32 @@ void Daemon::start()
         return;
     }
 
+    // Permanently suppress OSDs once the application starts shutting down.
+    // SIGTERM (systemd logout) emits aboutToQuit before stop() runs; any
+    // OSD that fires between aboutToQuit and the daemon's actual exit
+    // captures a torn-down FBO and renders white. The lambda is
+    // self-contained — no captures beyond `this`, and `m_shuttingDown`
+    // is only read from the GUI thread, so no synchronisation needed.
+    if (qGuiApp) {
+        connect(qGuiApp, &QGuiApplication::aboutToQuit, this, [this]() {
+            m_shuttingDown = true;
+        });
+    }
+
+    // Query systemd's user bus for `plasma-workspace.target.ActiveState`.
+    // This is the only signal that uniquely distinguishes a real KDE
+    // Plasma session (orchestrated by `startplasma-wayland`, which is
+    // what flips the target to `active`) from a phantom plasma-restore
+    // session that systemd may spin up between user logout and SDDM.
+    // The phantom has a wl_display socket and a live user@.service —
+    // so neither main.cpp's wayland-socket pre-check nor
+    // `User.State` (which stays `active` while user@.service is up)
+    // can detect it. But the phantom has no `startplasma-wayland`
+    // leader, so `plasma-workspace.target` stays inactive. The query
+    // is also wired through `PropertiesChanged` so a running daemon
+    // flips `m_shuttingDown` when the target leaves active mid-flight.
+    queryPlasmaWorkspaceState();
+
     connectScreenSignals();
     connectDesktopActivity();
 
@@ -1273,6 +1304,12 @@ void Daemon::start()
 
 void Daemon::stop()
 {
+    // Mark shutdown ASAP so any signal handler that fires during the
+    // teardown window bails out of OSD shows. `aboutToQuit` already sets
+    // this on the SIGTERM path; programmatic `stop()` callers (tests,
+    // explicit shutdown) hit this branch instead.
+    m_shuttingDown = true;
+
     // Drop the layout-manager provider lambdas FIRST, before the m_running
     // gate. They capture `this` and dereference m_settings; m_settings is
     // declared after m_layoutManager, so reverse-order member destruction
@@ -1472,6 +1509,110 @@ void Daemon::stop()
     // m_running gate) so this point requires no further teardown.
 
     m_running = false;
+}
+
+void Daemon::queryPlasmaWorkspaceState()
+{
+    // Query the user-bus systemd for `plasma-workspace.target`'s
+    // ActiveState. This is the only signal that uniquely distinguishes
+    // a real KDE Plasma session (orchestrated by `startplasma-wayland`,
+    // which is what flips the target to `active`) from a phantom
+    // plasma-restore session that systemd may briefly spin up between
+    // user logout and SDDM. The phantom has a wl_display socket and a
+    // live user@.service — so neither main.cpp's wayland-socket
+    // pre-check nor logind's `User.State` (stays `active` while
+    // user@.service is up) detect it. But the phantom has no
+    // `startplasma-wayland` leader, so `plasma-workspace.target` stays
+    // inactive there.
+    //
+    // Three failure modes:
+    //   • systemd user bus unavailable (non-systemd, headless tests)
+    //     → leave `m_plasmaWorkspaceActive=true` (fail-open).
+    //   • systemd reachable but `GetUnit("plasma-workspace.target")`
+    //     fails (target not loaded; system without KDE Plasma) →
+    //     fail-open: same rationale, this code path wouldn't have
+    //     welcome OSDs to suppress.
+    //   • systemd reachable, GetUnit succeeds, ActiveState != "active"
+    //     → fail-closed: this is the phantom-session case.
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    if (!sessionBus.isConnected()) {
+        qCDebug(lcDaemon) << "queryPlasmaWorkspaceState: session bus unavailable, leaving m_plasmaWorkspaceActive=true";
+        return;
+    }
+
+    QDBusInterface manager(QStringLiteral("org.freedesktop.systemd1"), QStringLiteral("/org/freedesktop/systemd1"),
+                           QStringLiteral("org.freedesktop.systemd1.Manager"), sessionBus);
+    if (!manager.isValid()) {
+        qCDebug(lcDaemon) << "queryPlasmaWorkspaceState: systemd1.Manager not available, leaving fail-open";
+        return;
+    }
+
+    // Subscribe to systemd events so PropertiesChanged signals start
+    // flowing. Without this call, systemd only emits PropertiesChanged
+    // to clients that explicitly Subscribe()d. Idempotent and cheap.
+    manager.call(QStringLiteral("Subscribe"));
+
+    QDBusReply<QDBusObjectPath> pathReply =
+        manager.call(QStringLiteral("GetUnit"), QStringLiteral("plasma-workspace.target"));
+    if (!pathReply.isValid()) {
+        qCInfo(lcDaemon) << "queryPlasmaWorkspaceState: GetUnit('plasma-workspace.target') failed:"
+                         << pathReply.error().message() << "— leaving fail-open (target not loaded)";
+        return;
+    }
+    m_plasmaWorkspaceTargetPath = pathReply.value().path();
+    if (m_plasmaWorkspaceTargetPath.isEmpty()) {
+        return;
+    }
+
+    QDBusInterface props(QStringLiteral("org.freedesktop.systemd1"), m_plasmaWorkspaceTargetPath,
+                         QStringLiteral("org.freedesktop.DBus.Properties"), sessionBus);
+    QDBusReply<QVariant> stateReply = props.call(QStringLiteral("Get"), QStringLiteral("org.freedesktop.systemd1.Unit"),
+                                                 QStringLiteral("ActiveState"));
+    if (!stateReply.isValid()) {
+        qCDebug(lcDaemon) << "queryPlasmaWorkspaceState: ActiveState Get failed:" << stateReply.error().message();
+        return;
+    }
+    const QString state = stateReply.value().toString();
+    m_plasmaWorkspaceActive = (state == QLatin1String("active"));
+    qCInfo(lcDaemon) << "plasma-workspace.target ActiveState at startup:" << state
+                     << "plasmaWorkspaceActive=" << m_plasmaWorkspaceActive << "path=" << m_plasmaWorkspaceTargetPath;
+
+    // Subscribe to PropertiesChanged on the Unit object so the
+    // running daemon notices when plasma-workspace.target leaves
+    // active (typical logout signal). Filtered to the systemd1.Unit
+    // interface in the slot.
+    const bool ok =
+        sessionBus.connect(QStringLiteral("org.freedesktop.systemd1"), m_plasmaWorkspaceTargetPath,
+                           QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("PropertiesChanged"), this,
+                           SLOT(onPlasmaWorkspaceTargetPropertiesChanged(QString, QVariantMap, QStringList)));
+    if (!ok) {
+        qCWarning(lcDaemon) << "queryPlasmaWorkspaceState: failed to subscribe to Unit PropertiesChanged on"
+                            << m_plasmaWorkspaceTargetPath;
+    }
+}
+
+void Daemon::onPlasmaWorkspaceTargetPropertiesChanged(const QString& interfaceName,
+                                                      const QVariantMap& changedProperties,
+                                                      const QStringList& /*invalidatedProperties*/)
+{
+    if (interfaceName != QLatin1String("org.freedesktop.systemd1.Unit")) {
+        return;
+    }
+    const auto it = changedProperties.constFind(QStringLiteral("ActiveState"));
+    if (it == changedProperties.constEnd()) {
+        return;
+    }
+    const QString state = it->toString();
+    const bool nowActive = (state == QLatin1String("active"));
+    if (m_plasmaWorkspaceActive && !nowActive) {
+        // plasma-workspace.target left active — Plasma is being torn
+        // down. Treat exactly like aboutToQuit so any in-flight or
+        // deferred OSD bails.
+        m_shuttingDown = true;
+        qCInfo(lcDaemon) << "plasma-workspace.target left active state (now" << state
+                         << "); marking daemon as shutting down for OSD-suppression purposes";
+    }
+    m_plasmaWorkspaceActive = nowActive;
 }
 
 } // namespace PlasmaZones

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1239,13 +1239,12 @@ void Daemon::start()
     }
 
     // Suppress OSDs once Qt begins shutdown (SIGTERM, programmatic quit).
-    if (qGuiApp) {
-        connect(
-            qGuiApp, &QGuiApplication::aboutToQuit, this,
-            [this]() {
-                m_shuttingDown = true;
-            },
-            Qt::UniqueConnection);
+    // Connected once — m_aboutToQuitConnected prevents stacking on stop()→start().
+    if (qGuiApp && !m_aboutToQuitConnected) {
+        connect(qGuiApp, &QGuiApplication::aboutToQuit, this, [this]() {
+            m_shuttingDown = true;
+        });
+        m_aboutToQuitConnected = true;
     }
 
     // Detect phantom plasma-restore sessions via systemd's user bus.

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -9,12 +9,12 @@
 #include <QStandardPaths>
 #include <QtConcurrent>
 #include <QScreen>
-#include <QCoreApplication>
 #include <QDBusConnection>
-#include <QDBusInterface>
 #include <QDBusMessage>
 #include <QDBusObjectPath>
-#include <QDBusReply>
+#include <QDBusPendingCall>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
 #include <QDBusError>
 #include <QDir>
 #include <QFile>
@@ -1238,30 +1238,18 @@ void Daemon::start()
         return;
     }
 
-    // Permanently suppress OSDs once the application starts shutting down.
-    // SIGTERM (systemd logout) emits aboutToQuit before stop() runs; any
-    // OSD that fires between aboutToQuit and the daemon's actual exit
-    // captures a torn-down FBO and renders white. The lambda is
-    // self-contained — no captures beyond `this`, and `m_shuttingDown`
-    // is only read from the GUI thread, so no synchronisation needed.
+    // Suppress OSDs once Qt begins shutdown (SIGTERM, programmatic quit).
     if (qGuiApp) {
-        connect(qGuiApp, &QGuiApplication::aboutToQuit, this, [this]() {
-            m_shuttingDown = true;
-        });
+        connect(
+            qGuiApp, &QGuiApplication::aboutToQuit, this,
+            [this]() {
+                m_shuttingDown = true;
+            },
+            Qt::UniqueConnection);
     }
 
-    // Query systemd's user bus for `plasma-workspace.target.ActiveState`.
-    // This is the only signal that uniquely distinguishes a real KDE
-    // Plasma session (orchestrated by `startplasma-wayland`, which is
-    // what flips the target to `active`) from a phantom plasma-restore
-    // session that systemd may spin up between user logout and SDDM.
-    // The phantom has a wl_display socket and a live user@.service —
-    // so neither main.cpp's wayland-socket pre-check nor
-    // `User.State` (which stays `active` while user@.service is up)
-    // can detect it. But the phantom has no `startplasma-wayland`
-    // leader, so `plasma-workspace.target` stays inactive. The query
-    // is also wired through `PropertiesChanged` so a running daemon
-    // flips `m_shuttingDown` when the target leaves active mid-flight.
+    // Detect phantom plasma-restore sessions via systemd's user bus.
+    // See queryPlasmaWorkspaceState() for the full rationale.
     queryPlasmaWorkspaceState();
 
     connectScreenSignals();
@@ -1304,10 +1292,6 @@ void Daemon::start()
 
 void Daemon::stop()
 {
-    // Mark shutdown ASAP so any signal handler that fires during the
-    // teardown window bails out of OSD shows. `aboutToQuit` already sets
-    // this on the SIGTERM path; programmatic `stop()` callers (tests,
-    // explicit shutdown) hit this branch instead.
     m_shuttingDown = true;
 
     // Drop the layout-manager provider lambdas FIRST, before the m_running
@@ -1513,82 +1497,96 @@ void Daemon::stop()
 
 void Daemon::queryPlasmaWorkspaceState()
 {
-    // Query the user-bus systemd for `plasma-workspace.target`'s
-    // ActiveState. This is the only signal that uniquely distinguishes
-    // a real KDE Plasma session (orchestrated by `startplasma-wayland`,
-    // which is what flips the target to `active`) from a phantom
-    // plasma-restore session that systemd may briefly spin up between
-    // user logout and SDDM. The phantom has a wl_display socket and a
-    // live user@.service — so neither main.cpp's wayland-socket
-    // pre-check nor logind's `User.State` (stays `active` while
-    // user@.service is up) detect it. But the phantom has no
-    // `startplasma-wayland` leader, so `plasma-workspace.target` stays
-    // inactive there.
+    // Query the user-bus systemd for `plasma-workspace.target`'s ActiveState
+    // to distinguish a real Plasma session from a phantom plasma-restore session.
     //
-    // Three failure modes:
-    //   • systemd user bus unavailable (non-systemd, headless tests)
-    //     → leave `m_plasmaWorkspaceActive=true` (fail-open).
-    //   • systemd reachable but `GetUnit("plasma-workspace.target")`
-    //     fails (target not loaded; system without KDE Plasma) →
-    //     fail-open: same rationale, this code path wouldn't have
-    //     welcome OSDs to suppress.
-    //   • systemd reachable, GetUnit succeeds, ActiveState != "active"
-    //     → fail-closed: this is the phantom-session case.
+    // During user-logout → SDDM handoff, systemd may respawn the daemon into a
+    // transient "phantom" state: a stray `kwin_wayland` from a fallback session-
+    // restore mechanism briefly publishes a fresh `wayland-N` socket inside the
+    // still-dying `user@.service`, and `Restart=on-failure` schedules a daemon
+    // retry after Qt's wayland QPA aborts on the vanished `wl_display`. The
+    // phantom daemon fires welcome OSDs against an output about to be unbound.
+    //
+    // Why this signal works: `plasma-workspace.target` is only flipped to `active`
+    // by `startplasma-wayland`'s orchestration after SDDM hands off. The phantom
+    // has no `startplasma-wayland` leader, so the target stays inactive — a signal
+    // the phantom cannot fake. logind's `User.State` stays `active` whenever
+    // `user@.service` is up (can't distinguish phantom from real), and the
+    // wayland-socket existence probe passes during the phantom.
+    //
+    // Fail-open on all D-Bus errors: `m_plasmaWorkspaceActive` defaults to `true`,
+    // so non-systemd setups and headless tests aren't accidentally silenced.
     QDBusConnection sessionBus = QDBusConnection::sessionBus();
     if (!sessionBus.isConnected()) {
         qCDebug(lcDaemon) << "queryPlasmaWorkspaceState: session bus unavailable, leaving m_plasmaWorkspaceActive=true";
         return;
     }
 
-    QDBusInterface manager(QStringLiteral("org.freedesktop.systemd1"), QStringLiteral("/org/freedesktop/systemd1"),
-                           QStringLiteral("org.freedesktop.systemd1.Manager"), sessionBus);
-    if (!manager.isValid()) {
-        qCDebug(lcDaemon) << "queryPlasmaWorkspaceState: systemd1.Manager not available, leaving fail-open";
-        return;
-    }
+    QDBusMessage subscribeMsg = QDBusMessage::createMethodCall(
+        QStringLiteral("org.freedesktop.systemd1"), QStringLiteral("/org/freedesktop/systemd1"),
+        QStringLiteral("org.freedesktop.systemd1.Manager"), QStringLiteral("Subscribe"));
+    auto* subscribeWatcher = new QDBusPendingCallWatcher(sessionBus.asyncCall(subscribeMsg), this);
+    connect(subscribeWatcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+        QDBusPendingReply<> reply = *w;
+        if (reply.isError()) {
+            qCDebug(lcDaemon) << "queryPlasmaWorkspaceState: Subscribe failed:" << reply.error().message()
+                              << "— PropertiesChanged signals may not arrive";
+        }
+    });
 
-    // Subscribe to systemd events so PropertiesChanged signals start
-    // flowing. Without this call, systemd only emits PropertiesChanged
-    // to clients that explicitly Subscribe()d. Idempotent and cheap.
-    manager.call(QStringLiteral("Subscribe"));
+    QDBusMessage getUnitMsg = QDBusMessage::createMethodCall(
+        QStringLiteral("org.freedesktop.systemd1"), QStringLiteral("/org/freedesktop/systemd1"),
+        QStringLiteral("org.freedesktop.systemd1.Manager"), QStringLiteral("GetUnit"));
+    getUnitMsg << QStringLiteral("plasma-workspace.target");
+    auto* getUnitWatcher = new QDBusPendingCallWatcher(sessionBus.asyncCall(getUnitMsg), this);
+    connect(getUnitWatcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+        QDBusPendingReply<QDBusObjectPath> reply = *w;
+        if (reply.isError()) {
+            qCInfo(lcDaemon) << "queryPlasmaWorkspaceState: GetUnit('plasma-workspace.target') failed:"
+                             << reply.error().message() << "— leaving fail-open (target not loaded)";
+            return;
+        }
+        m_plasmaWorkspaceTargetPath = reply.value().path();
+        if (m_plasmaWorkspaceTargetPath.isEmpty()) {
+            return;
+        }
+        fetchPlasmaWorkspaceActiveState();
+    });
+}
 
-    QDBusReply<QDBusObjectPath> pathReply =
-        manager.call(QStringLiteral("GetUnit"), QStringLiteral("plasma-workspace.target"));
-    if (!pathReply.isValid()) {
-        qCInfo(lcDaemon) << "queryPlasmaWorkspaceState: GetUnit('plasma-workspace.target') failed:"
-                         << pathReply.error().message() << "— leaving fail-open (target not loaded)";
-        return;
-    }
-    m_plasmaWorkspaceTargetPath = pathReply.value().path();
-    if (m_plasmaWorkspaceTargetPath.isEmpty()) {
-        return;
-    }
+void Daemon::fetchPlasmaWorkspaceActiveState()
+{
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+    QDBusMessage msg =
+        QDBusMessage::createMethodCall(QStringLiteral("org.freedesktop.systemd1"), m_plasmaWorkspaceTargetPath,
+                                       QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("Get"));
+    msg << QStringLiteral("org.freedesktop.systemd1.Unit") << QStringLiteral("ActiveState");
+    auto* watcher = new QDBusPendingCallWatcher(sessionBus.asyncCall(msg), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+        QDBusPendingReply<QVariant> reply = *w;
+        if (reply.isError()) {
+            qCDebug(lcDaemon) << "queryPlasmaWorkspaceState: ActiveState Get failed:" << reply.error().message();
+            return;
+        }
+        const QString state = reply.value().toString();
+        m_plasmaWorkspaceActive = (state == QLatin1String("active"));
+        qCInfo(lcDaemon) << "plasma-workspace.target ActiveState at startup:" << state
+                         << "plasmaWorkspaceActive=" << m_plasmaWorkspaceActive
+                         << "path=" << m_plasmaWorkspaceTargetPath;
 
-    QDBusInterface props(QStringLiteral("org.freedesktop.systemd1"), m_plasmaWorkspaceTargetPath,
-                         QStringLiteral("org.freedesktop.DBus.Properties"), sessionBus);
-    QDBusReply<QVariant> stateReply = props.call(QStringLiteral("Get"), QStringLiteral("org.freedesktop.systemd1.Unit"),
-                                                 QStringLiteral("ActiveState"));
-    if (!stateReply.isValid()) {
-        qCDebug(lcDaemon) << "queryPlasmaWorkspaceState: ActiveState Get failed:" << stateReply.error().message();
-        return;
-    }
-    const QString state = stateReply.value().toString();
-    m_plasmaWorkspaceActive = (state == QLatin1String("active"));
-    qCInfo(lcDaemon) << "plasma-workspace.target ActiveState at startup:" << state
-                     << "plasmaWorkspaceActive=" << m_plasmaWorkspaceActive << "path=" << m_plasmaWorkspaceTargetPath;
-
-    // Subscribe to PropertiesChanged on the Unit object so the
-    // running daemon notices when plasma-workspace.target leaves
-    // active (typical logout signal). Filtered to the systemd1.Unit
-    // interface in the slot.
-    const bool ok =
-        sessionBus.connect(QStringLiteral("org.freedesktop.systemd1"), m_plasmaWorkspaceTargetPath,
-                           QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("PropertiesChanged"), this,
-                           SLOT(onPlasmaWorkspaceTargetPropertiesChanged(QString, QVariantMap, QStringList)));
-    if (!ok) {
-        qCWarning(lcDaemon) << "queryPlasmaWorkspaceState: failed to subscribe to Unit PropertiesChanged on"
-                            << m_plasmaWorkspaceTargetPath;
-    }
+        QDBusConnection bus = QDBusConnection::sessionBus();
+        const bool ok =
+            bus.connect(QStringLiteral("org.freedesktop.systemd1"), m_plasmaWorkspaceTargetPath,
+                        QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("PropertiesChanged"), this,
+                        SLOT(onPlasmaWorkspaceTargetPropertiesChanged(QString, QVariantMap, QStringList)));
+        if (!ok) {
+            qCWarning(lcDaemon) << "queryPlasmaWorkspaceState: failed to subscribe to Unit PropertiesChanged on"
+                                << m_plasmaWorkspaceTargetPath;
+        }
+    });
 }
 
 void Daemon::onPlasmaWorkspaceTargetPropertiesChanged(const QString& interfaceName,
@@ -1604,13 +1602,8 @@ void Daemon::onPlasmaWorkspaceTargetPropertiesChanged(const QString& interfaceNa
     }
     const QString state = it->toString();
     const bool nowActive = (state == QLatin1String("active"));
-    if (m_plasmaWorkspaceActive && !nowActive) {
-        // plasma-workspace.target left active — Plasma is being torn
-        // down. Treat exactly like aboutToQuit so any in-flight or
-        // deferred OSD bails.
-        m_shuttingDown = true;
-        qCInfo(lcDaemon) << "plasma-workspace.target left active state (now" << state
-                         << "); marking daemon as shutting down for OSD-suppression purposes";
+    if (m_plasmaWorkspaceActive != nowActive) {
+        qCInfo(lcDaemon) << "plasma-workspace.target state changed:" << state;
     }
     m_plasmaWorkspaceActive = nowActive;
 }

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -10,6 +10,7 @@
 #include <QHash>
 #include <QSet>
 #include <QThreadPool>
+#include <chrono>
 #include <memory>
 
 #include "shortcutmanager.h"
@@ -662,6 +663,88 @@ private:
     bool m_running = false;
     int m_suppressResnapOsd = 0;
 
+    /// Set true once Qt's `aboutToQuit` fires (SIGTERM, plasma session-
+    /// end, programmatic `quit()`) and at the very top of `stop()`. Once
+    /// set, every OSD entry point in `daemon/osd.cpp` bails — the OSD
+    /// surface's QQuickShaderEffectSource captures a torn-down FBO during
+    /// shutdown and renders a white card briefly before the daemon dies,
+    /// which is visible as a flash on the way to the SDDM login screen.
+    bool m_shuttingDown = false;
+
+    /// Steady-clock deadline written by `screenRemoved` (in start.cpp).
+    /// Until this time, OSD shows are suppressed — KWin tearing down
+    /// outputs during logout fires `screenRemoved` → ScreenManager's
+    /// `virtualScreensChanged` → `onVirtualScreensReconfigured` →
+    /// layoutApplied / autotileApplied signals → `showLayoutOsdDeferred`,
+    /// and the resulting OSD lands on a wl_surface whose compositor
+    /// output is mid-unbind. A short cooldown lets those signals drain
+    /// without firing the deferred OSD. Same suppression covers monitor
+    /// hot-unplug noise. ~1 s window.
+    std::chrono::steady_clock::time_point m_screensSettlingUntil;
+
+    /// Mirrors `org.freedesktop.systemd1.Unit.ActiveState` for the
+    /// user-bus systemd unit `plasma-workspace.target`. Initialised by
+    /// `queryPlasmaWorkspaceState()` at `start()` time, updated by a
+    /// `PropertiesChanged` subscription on the target's object path.
+    /// `true` when ActiveState == "active" (real KDE Plasma session
+    /// orchestrated by `startplasma-wayland`); `false` when "inactive"
+    /// / "activating" / "deactivating" / "failed" (phantom plasma-
+    /// restore session mid-logout, SDDM-only state, headless tests).
+    ///
+    /// Why this signal: the user-logout → SDDM transition can leave
+    /// `user@.service` alive while `plasma-workspace.target` is
+    /// inactive. systemd may briefly re-spawn the daemon into that
+    /// transient window (or a stray `kwin_wayland` from a fallback
+    /// restore service can briefly publish a `wayland-N` socket the
+    /// daemon's main.cpp pre-check accepts). logind's `User.State`
+    /// reports `active` throughout that window because user@.service
+    /// is alive, so a logind-based gate doesn't help. But
+    /// `plasma-workspace.target` is the dependency root the daemon's
+    /// `WantedBy=` chain hooks onto — it is ONLY flipped to `active`
+    /// by `startplasma-wayland` after SDDM hands off. The phantom
+    /// session has no `startplasma-wayland` leader, so the target
+    /// stays inactive there.
+    ///
+    /// Defaults to `true` (fail-open) for environments without
+    /// systemd's user-bus (non-systemd setups, headless tests) so
+    /// the suppression doesn't accidentally silence OSDs there.
+    bool m_plasmaWorkspaceActive = true;
+
+    /// Object path of the systemd Unit for `plasma-workspace.target`
+    /// on the user session bus, resolved via
+    /// `org.freedesktop.systemd1.Manager.GetUnit`. Empty when systemd
+    /// isn't reachable or the target isn't loaded. The
+    /// `PropertiesChanged` slot uses this to filter signals to the
+    /// right unit.
+    QString m_plasmaWorkspaceTargetPath;
+
+    /// Returns true when the daemon is shutting down, when a screen
+    /// was removed within the last ~1 s (see `m_screensSettlingUntil`),
+    /// or when systemd reports `plasma-workspace.target` as non-active
+    /// (phantom plasma-restore session mid-logout, SDDM-only state).
+    /// Every public OSD entry point in daemon/osd.cpp calls this and
+    /// bails on true.
+    bool shouldSuppressOsd() const;
+
+    /// Synchronously queries systemd's user bus for
+    /// `plasma-workspace.target`'s `ActiveState`, sets
+    /// `m_plasmaWorkspaceActive` accordingly, and subscribes to
+    /// `PropertiesChanged` on the target object so subsequent state
+    /// transitions flip `m_plasmaWorkspaceActive` (and, when leaving
+    /// `active`, `m_shuttingDown`). Fail-open: D-Bus / systemd errors
+    /// leave `m_plasmaWorkspaceActive` at its default `true`. Called
+    /// once from `start()`.
+    void queryPlasmaWorkspaceState();
+
+private Q_SLOTS:
+    /// Slot for the systemd Unit PropertiesChanged signal subscribed in
+    /// `queryPlasmaWorkspaceState`. Filters by interface name and
+    /// updates `m_plasmaWorkspaceActive` / `m_shuttingDown` when
+    /// `ActiveState` changes.
+    void onPlasmaWorkspaceTargetPropertiesChanged(const QString& interfaceName, const QVariantMap& changedProperties,
+                                                  const QStringList& invalidatedProperties);
+
+private:
     // Debounce timers for shortcuts that generate expensive work (Vulkan surface
     // creation, geometry batches, OSD churn) when triggered faster than ~100ms
     // by keyboard auto-repeat. Checked at the top of each handler.

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -663,84 +663,33 @@ private:
     bool m_running = false;
     int m_suppressResnapOsd = 0;
 
-    /// Set true once Qt's `aboutToQuit` fires (SIGTERM, plasma session-
-    /// end, programmatic `quit()`) and at the very top of `stop()`. Once
-    /// set, every OSD entry point in `daemon/osd.cpp` bails — the OSD
-    /// surface's QQuickShaderEffectSource captures a torn-down FBO during
-    /// shutdown and renders a white card briefly before the daemon dies,
-    /// which is visible as a flash on the way to the SDDM login screen.
+    /// Shutdown flag — set by `aboutToQuit`, `stop()`. Gates `shouldSuppressOsd()`.
     bool m_shuttingDown = false;
 
-    /// Steady-clock deadline written by `screenRemoved` (in start.cpp).
-    /// Until this time, OSD shows are suppressed — KWin tearing down
-    /// outputs during logout fires `screenRemoved` → ScreenManager's
-    /// `virtualScreensChanged` → `onVirtualScreensReconfigured` →
-    /// layoutApplied / autotileApplied signals → `showLayoutOsdDeferred`,
-    /// and the resulting OSD lands on a wl_surface whose compositor
-    /// output is mid-unbind. A short cooldown lets those signals drain
-    /// without firing the deferred OSD. Same suppression covers monitor
-    /// hot-unplug noise. ~1 s window.
+    /// Deadline bumped by `screenRemoved` (start.cpp). ~1 s cooldown prevents
+    /// OSD shows during output teardown cascades and monitor hot-unplug.
     std::chrono::steady_clock::time_point m_screensSettlingUntil;
 
-    /// Mirrors `org.freedesktop.systemd1.Unit.ActiveState` for the
-    /// user-bus systemd unit `plasma-workspace.target`. Initialised by
-    /// `queryPlasmaWorkspaceState()` at `start()` time, updated by a
-    /// `PropertiesChanged` subscription on the target's object path.
-    /// `true` when ActiveState == "active" (real KDE Plasma session
-    /// orchestrated by `startplasma-wayland`); `false` when "inactive"
-    /// / "activating" / "deactivating" / "failed" (phantom plasma-
-    /// restore session mid-logout, SDDM-only state, headless tests).
-    ///
-    /// Why this signal: the user-logout → SDDM transition can leave
-    /// `user@.service` alive while `plasma-workspace.target` is
-    /// inactive. systemd may briefly re-spawn the daemon into that
-    /// transient window (or a stray `kwin_wayland` from a fallback
-    /// restore service can briefly publish a `wayland-N` socket the
-    /// daemon's main.cpp pre-check accepts). logind's `User.State`
-    /// reports `active` throughout that window because user@.service
-    /// is alive, so a logind-based gate doesn't help. But
-    /// `plasma-workspace.target` is the dependency root the daemon's
-    /// `WantedBy=` chain hooks onto — it is ONLY flipped to `active`
-    /// by `startplasma-wayland` after SDDM hands off. The phantom
-    /// session has no `startplasma-wayland` leader, so the target
-    /// stays inactive there.
-    ///
-    /// Defaults to `true` (fail-open) for environments without
-    /// systemd's user-bus (non-systemd setups, headless tests) so
-    /// the suppression doesn't accidentally silence OSDs there.
+    /// Mirrors `plasma-workspace.target` ActiveState on the user-bus systemd.
+    /// `true` = real session, `false` = phantom/inactive. Defaults to `true`
+    /// (fail-open for non-systemd / headless). See `queryPlasmaWorkspaceState()`
+    /// for the full rationale.
     bool m_plasmaWorkspaceActive = true;
 
-    /// Object path of the systemd Unit for `plasma-workspace.target`
-    /// on the user session bus, resolved via
-    /// `org.freedesktop.systemd1.Manager.GetUnit`. Empty when systemd
-    /// isn't reachable or the target isn't loaded. The
-    /// `PropertiesChanged` slot uses this to filter signals to the
-    /// right unit.
+    /// D-Bus object path for `plasma-workspace.target`, resolved by GetUnit.
     QString m_plasmaWorkspaceTargetPath;
 
-    /// Returns true when the daemon is shutting down, when a screen
-    /// was removed within the last ~1 s (see `m_screensSettlingUntil`),
-    /// or when systemd reports `plasma-workspace.target` as non-active
-    /// (phantom plasma-restore session mid-logout, SDDM-only state).
-    /// Every public OSD entry point in daemon/osd.cpp calls this and
-    /// bails on true.
     bool shouldSuppressOsd() const;
 
-    /// Synchronously queries systemd's user bus for
-    /// `plasma-workspace.target`'s `ActiveState`, sets
-    /// `m_plasmaWorkspaceActive` accordingly, and subscribes to
-    /// `PropertiesChanged` on the target object so subsequent state
-    /// transitions flip `m_plasmaWorkspaceActive` (and, when leaving
-    /// `active`, `m_shuttingDown`). Fail-open: D-Bus / systemd errors
-    /// leave `m_plasmaWorkspaceActive` at its default `true`. Called
-    /// once from `start()`.
+    /// Async query of systemd's user bus for `plasma-workspace.target` state.
+    /// Fail-open on all D-Bus errors. Called once from `start()`.
     void queryPlasmaWorkspaceState();
 
+    /// Continuation of `queryPlasmaWorkspaceState()` — fetches ActiveState
+    /// and subscribes to PropertiesChanged after GetUnit resolves.
+    void fetchPlasmaWorkspaceActiveState();
+
 private Q_SLOTS:
-    /// Slot for the systemd Unit PropertiesChanged signal subscribed in
-    /// `queryPlasmaWorkspaceState`. Filters by interface name and
-    /// updates `m_plasmaWorkspaceActive` / `m_shuttingDown` when
-    /// `ActiveState` changes.
     void onPlasmaWorkspaceTargetPropertiesChanged(const QString& interfaceName, const QVariantMap& changedProperties,
                                                   const QStringList& invalidatedProperties);
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -665,6 +665,7 @@ private:
 
     /// Shutdown flag — set by `aboutToQuit`, `stop()`. Gates `shouldSuppressOsd()`.
     bool m_shuttingDown = false;
+    bool m_aboutToQuitConnected = false;
 
     /// Deadline bumped by `screenRemoved` (start.cpp). ~1 s cooldown prevents
     /// OSD shows during output teardown cascades and monitor hot-unplug.

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -78,9 +78,46 @@ void Daemon::clearHighlight()
     m_zoneDetector->clearHighlights();
 }
 
+bool Daemon::shouldSuppressOsd() const
+{
+    // Shutdown path: aboutToQuit fired (SIGTERM, programmatic quit), or
+    // stop() was entered. Any OSD that lands now captures a torn-down
+    // FBO and renders white.
+    if (m_shuttingDown) {
+        return true;
+    }
+    // systemd reports `plasma-workspace.target` as non-active. The
+    // wayland-socket precheck in main.cpp passes during phantom
+    // plasma-restore sessions (a stray `kwin_wayland` publishes a
+    // fresh socket inside user@.service mid-logout), and logind's
+    // `User.State` stays `active` whenever user@.service is up — so
+    // neither catches the phantom. `plasma-workspace.target` is only
+    // flipped to `active` by `startplasma-wayland`'s orchestration
+    // after SDDM hands off; the phantom has no startplasma leader so
+    // the target stays inactive. See `Daemon::queryPlasmaWorkspaceState`
+    // for the subscription wiring.
+    if (!m_plasmaWorkspaceActive) {
+        return true;
+    }
+    // Screens-settling cooldown: a screenRemoved event fired recently
+    // (typically KWin tearing down outputs during logout). VS reconfig
+    // signals cascading off that removal can synchronously emit
+    // layoutApplied / autotileApplied → showLayoutOsdDeferred, which
+    // races against compositor output unbind and surfaces as a brief
+    // white card on the way to SDDM. Suppress for a short window after
+    // any screen removal — also damps OSD noise on monitor hot-unplug.
+    if (std::chrono::steady_clock::now() < m_screensSettlingUntil) {
+        return true;
+    }
+    return false;
+}
+
 void Daemon::showLayoutOsd(PhosphorZones::Layout* layout, const QString& screenId)
 {
     if (!layout) {
+        return;
+    }
+    if (shouldSuppressOsd()) {
         return;
     }
 
@@ -208,6 +245,9 @@ void Daemon::showContextDisabledOsd(const QString& screenId, int desktop, const 
 
 void Daemon::showLayoutOsdForAlgorithm(const QString& algorithmId, const QString& displayName, const QString& screenId)
 {
+    if (shouldSuppressOsd()) {
+        return;
+    }
     auto* algo = m_algorithmRegistry.get()->algorithm(algorithmId);
     if (!algo) {
         qCWarning(lcDaemon) << "OSD: algorithm not found, algorithmId=" << algorithmId;
@@ -293,8 +333,14 @@ void Daemon::showLayoutOsdForAlgorithm(const QString& algorithmId, const QString
 
 void Daemon::showLayoutOsdDeferred(const QUuid& layoutId, const QString& screenId)
 {
+    if (shouldSuppressOsd()) {
+        return;
+    }
     // Defer OSD display so first-time QML compilation of NotificationOverlay.qml
     // (~100-300ms) doesn't block the daemon event loop during layout switches.
+    // The inner `showLayoutOsd` re-checks `shouldSuppressOsd()` on dispatch —
+    // covers the case where a screenRemoved fires between this queue and
+    // the timer's tick.
     QTimer::singleShot(0, this, [this, layoutId, screenId]() {
         PhosphorZones::Layout* l = m_layoutManager ? m_layoutManager->layoutById(layoutId) : nullptr;
         if (l) {
@@ -305,6 +351,9 @@ void Daemon::showLayoutOsdDeferred(const QUuid& layoutId, const QString& screenI
 
 void Daemon::showAlgorithmOsdDeferred(const QString& algorithmId, const QString& algorithmName, const QString& screenId)
 {
+    if (shouldSuppressOsd()) {
+        return;
+    }
     QTimer::singleShot(0, this, [this, algorithmId, algorithmName, screenId]() {
         showLayoutOsdForAlgorithm(algorithmId, algorithmName, screenId);
     });
@@ -444,11 +493,17 @@ void Daemon::showOsdForAllScreens(int desktop, const QString& activity)
     if (!m_layoutManager || !m_screenManager) {
         return;
     }
+    if (shouldSuppressOsd()) {
+        return;
+    }
     // Batch all per-screen OSD shows into one deferred call so every
     // screen's surface->show() fires in the same event loop pass and the
     // compositor renders them simultaneously.
     QTimer::singleShot(0, this, [this, desktop, activity]() {
         if (!m_layoutManager || !m_screenManager) {
+            return;
+        }
+        if (shouldSuppressOsd()) {
             return;
         }
         const QStringList effectiveIds = m_screenManager->effectiveScreenIds();

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -152,6 +152,9 @@ void Daemon::showLayoutOsd(PhosphorZones::Layout* layout, const QString& screenI
 
 void Daemon::showLockedOsd(const QString& screenId)
 {
+    if (shouldSuppressOsd()) {
+        return;
+    }
     OsdStyle style = m_settings ? m_settings->osdStyle() : OsdStyle::Preview;
     if (style == OsdStyle::None) {
         return;
@@ -163,6 +166,9 @@ void Daemon::showLockedOsd(const QString& screenId)
 
 void Daemon::showLockedPreviewOsd(const QString& screenId)
 {
+    if (shouldSuppressOsd()) {
+        return;
+    }
     OsdStyle style = m_settings ? m_settings->osdStyle() : OsdStyle::Preview;
     if (style == OsdStyle::None) {
         return;
@@ -186,6 +192,9 @@ void Daemon::showLockedPreviewOsd(const QString& screenId)
 void Daemon::showContextDisabledOsd(const QString& screenId, int desktop, const QString& activity,
                                     DisabledReason reason)
 {
+    if (shouldSuppressOsd()) {
+        return;
+    }
     OsdStyle style = m_settings ? m_settings->osdStyle() : OsdStyle::Preview;
     if (style == OsdStyle::None) {
         return;
@@ -479,6 +488,9 @@ void Daemon::showDesktopSwitchOsd(int desktop, const QString& activity)
     // Skip during startup — the initial activity/desktop detection fires
     // before start() completes and should not produce an OSD flash.
     if (!m_running) {
+        return;
+    }
+    if (shouldSuppressOsd()) {
         return;
     }
     if (!m_settings || !m_settings->showOsdOnDesktopSwitch() || !m_overlayService || !m_layoutManager

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -80,32 +80,14 @@ void Daemon::clearHighlight()
 
 bool Daemon::shouldSuppressOsd() const
 {
-    // Shutdown path: aboutToQuit fired (SIGTERM, programmatic quit), or
-    // stop() was entered. Any OSD that lands now captures a torn-down
-    // FBO and renders white.
     if (m_shuttingDown) {
         return true;
     }
-    // systemd reports `plasma-workspace.target` as non-active. The
-    // wayland-socket precheck in main.cpp passes during phantom
-    // plasma-restore sessions (a stray `kwin_wayland` publishes a
-    // fresh socket inside user@.service mid-logout), and logind's
-    // `User.State` stays `active` whenever user@.service is up — so
-    // neither catches the phantom. `plasma-workspace.target` is only
-    // flipped to `active` by `startplasma-wayland`'s orchestration
-    // after SDDM hands off; the phantom has no startplasma leader so
-    // the target stays inactive. See `Daemon::queryPlasmaWorkspaceState`
-    // for the subscription wiring.
+    // See queryPlasmaWorkspaceState() for why this catches phantom sessions.
     if (!m_plasmaWorkspaceActive) {
         return true;
     }
-    // Screens-settling cooldown: a screenRemoved event fired recently
-    // (typically KWin tearing down outputs during logout). VS reconfig
-    // signals cascading off that removal can synchronously emit
-    // layoutApplied / autotileApplied → showLayoutOsdDeferred, which
-    // races against compositor output unbind and surfaces as a brief
-    // white card on the way to SDDM. Suppress for a short window after
-    // any screen removal — also damps OSD noise on monitor hot-unplug.
+    // Screen-removal cooldown — see m_screensSettlingUntil in daemon.h.
     if (std::chrono::steady_clock::now() < m_screensSettlingUntil) {
         return true;
     }
@@ -345,11 +327,8 @@ void Daemon::showLayoutOsdDeferred(const QUuid& layoutId, const QString& screenI
     if (shouldSuppressOsd()) {
         return;
     }
-    // Defer OSD display so first-time QML compilation of NotificationOverlay.qml
-    // (~100-300ms) doesn't block the daemon event loop during layout switches.
-    // The inner `showLayoutOsd` re-checks `shouldSuppressOsd()` on dispatch —
-    // covers the case where a screenRemoved fires between this queue and
-    // the timer's tick.
+    // Defer so first-time QML compilation doesn't block the event loop.
+    // Inner showLayoutOsd re-checks shouldSuppressOsd() on dispatch.
     QTimer::singleShot(0, this, [this, layoutId, screenId]() {
         PhosphorZones::Layout* l = m_layoutManager ? m_layoutManager->layoutById(layoutId) : nullptr;
         if (l) {

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -133,14 +133,7 @@ void Daemon::connectScreenSignals()
     });
 
     connect(m_screenManager.get(), &Phosphor::Screens::ScreenManager::screenRemoved, this, [this](QScreen* screen) {
-        // Bump the OSD-suppression deadline whenever a screen disappears.
-        // KWin tearing down outputs at logout fires `screenRemoved` for
-        // each output; the cascading `virtualScreensChanged` → recalc →
-        // layoutApplied / autotileApplied → showLayoutOsdDeferred chain
-        // would otherwise fire an OSD onto a wl_surface whose compositor
-        // output is mid-unbind, producing a brief white card on the way
-        // to SDDM. Also damps OSD churn on monitor hot-unplug. See
-        // `Daemon::shouldSuppressOsd` for the gating helper.
+        // Suppress OSD shows for ~1 s after any screen removal — see m_screensSettlingUntil.
         m_screensSettlingUntil = std::chrono::steady_clock::now() + std::chrono::seconds(1);
 
         m_overlayService->handleScreenRemoved(screen);

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -133,6 +133,16 @@ void Daemon::connectScreenSignals()
     });
 
     connect(m_screenManager.get(), &Phosphor::Screens::ScreenManager::screenRemoved, this, [this](QScreen* screen) {
+        // Bump the OSD-suppression deadline whenever a screen disappears.
+        // KWin tearing down outputs at logout fires `screenRemoved` for
+        // each output; the cascading `virtualScreensChanged` → recalc →
+        // layoutApplied / autotileApplied → showLayoutOsdDeferred chain
+        // would otherwise fire an OSD onto a wl_surface whose compositor
+        // output is mid-unbind, producing a brief white card on the way
+        // to SDDM. Also damps OSD churn on monitor hot-unplug. See
+        // `Daemon::shouldSuppressOsd` for the gating helper.
+        m_screensSettlingUntil = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+
         m_overlayService->handleScreenRemoved(screen);
 
         // Capture screen ID BEFORE invalidating cache (screenIdentifier reads cached EDID)

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -18,6 +18,7 @@
 #include <QCommandLineParser>
 #include <QDBusConnection>
 #include <QDBusInterface>
+#include <QFile>
 #include <QIcon>
 #include <QLibrary>
 #include <QMutex>
@@ -29,6 +30,7 @@
 #include <QtQml/qqml.h>
 #include "pz_i18n.h"
 #include <cerrno>
+#include <cstdio>
 #include <cstring>
 #include <signal.h>
 
@@ -49,6 +51,48 @@ void signalHandler(int /*signal*/)
 
 int main(int argc, char* argv[])
 {
+    // Wayland-availability pre-check — runs BEFORE QGuiApplication
+    // construction. During logout the user's wl_display socket
+    // disappears while `plasmazones.service`'s `Restart=on-failure`
+    // is still active. If we let QGuiApplication run in that state,
+    // its wayland QPA plugin calls `qFatal("Failed to create
+    // wl_display")` → SIGABRT → systemd treats it as failure → schedules
+    // another restart → repeat. During the restart loop the brief
+    // moments when the SDDM transition leaves a Wayland socket reachable
+    // give just enough time for the daemon to start, fire its welcome
+    // OSDs against an output that's in mid-unbind (visible as a white
+    // OSD card on the way to the login screen), then die again.
+    //
+    // The clean fix is to exit with code 0 BEFORE QGuiApplication runs
+    // when WAYLAND_DISPLAY is set but the socket isn't accessible. A
+    // clean exit doesn't satisfy `Restart=on-failure`, so systemd stops
+    // restarting and the logout completes without further OSD flashes.
+    {
+        const QByteArray waylandDisplay = qgetenv("WAYLAND_DISPLAY");
+        if (!waylandDisplay.isEmpty()) {
+            QByteArray socketPath;
+            if (waylandDisplay.startsWith('/')) {
+                socketPath = waylandDisplay;
+            } else {
+                const QByteArray runtimeDir = qgetenv("XDG_RUNTIME_DIR");
+                if (!runtimeDir.isEmpty()) {
+                    socketPath = runtimeDir + '/' + waylandDisplay;
+                }
+            }
+            if (!socketPath.isEmpty() && !QFile::exists(QString::fromLocal8Bit(socketPath))) {
+                // Log via stderr (Qt logging machinery isn't initialised
+                // yet) so the journal entry surfaces the deferred-exit
+                // rationale and the systemd unit's restart cycle is
+                // explainable.
+                std::fprintf(stderr,
+                             "plasmazones: WAYLAND_DISPLAY=%s but socket %s missing — "
+                             "wayland session not available, exiting cleanly to avoid restart loop\n",
+                             waylandDisplay.constData(), socketPath.constData());
+                return 0;
+            }
+        }
+    }
+
     // Opt out of MangoHud's implicit Vulkan layer injection. MangoHud's
     // implicit_layer manifest attaches whenever MANGOHUD=1 is in the
     // environment (e.g. set globally for games), and its NVIDIA stat-polling

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -51,22 +51,9 @@ void signalHandler(int /*signal*/)
 
 int main(int argc, char* argv[])
 {
-    // Wayland-availability pre-check — runs BEFORE QGuiApplication
-    // construction. During logout the user's wl_display socket
-    // disappears while `plasmazones.service`'s `Restart=on-failure`
-    // is still active. If we let QGuiApplication run in that state,
-    // its wayland QPA plugin calls `qFatal("Failed to create
-    // wl_display")` → SIGABRT → systemd treats it as failure → schedules
-    // another restart → repeat. During the restart loop the brief
-    // moments when the SDDM transition leaves a Wayland socket reachable
-    // give just enough time for the daemon to start, fire its welcome
-    // OSDs against an output that's in mid-unbind (visible as a white
-    // OSD card on the way to the login screen), then die again.
-    //
-    // The clean fix is to exit with code 0 BEFORE QGuiApplication runs
-    // when WAYLAND_DISPLAY is set but the socket isn't accessible. A
-    // clean exit doesn't satisfy `Restart=on-failure`, so systemd stops
-    // restarting and the logout completes without further OSD flashes.
+    // Exit cleanly (code 0) if the Wayland socket is already gone — avoids
+    // a SIGABRT → Restart=on-failure loop. See queryPlasmaWorkspaceState()
+    // in daemon.cpp for the full phantom-session analysis.
     {
         const QByteArray waylandDisplay = qgetenv("WAYLAND_DISPLAY");
         if (!waylandDisplay.isEmpty()) {
@@ -80,10 +67,6 @@ int main(int argc, char* argv[])
                 }
             }
             if (!socketPath.isEmpty() && !QFile::exists(QString::fromLocal8Bit(socketPath))) {
-                // Log via stderr (Qt logging machinery isn't initialised
-                // yet) so the journal entry surfaces the deferred-exit
-                // rationale and the systemd unit's restart cycle is
-                // explainable.
                 std::fprintf(stderr,
                              "plasmazones: WAYLAND_DISPLAY=%s but socket %s missing — "
                              "wayland session not available, exiting cleanly to avoid restart loop\n",

--- a/src/daemon/plasmazones.service.in
+++ b/src/daemon/plasmazones.service.in
@@ -9,6 +9,19 @@ Type=simple
 ExecStart=@KDE_INSTALL_FULL_BINDIR@/plasmazonesd
 Restart=on-failure
 RestartSec=5
+# Don't retry after qFatal-driven SIGABRT. Qt's wayland QPA aborts
+# when wl_display disappears during user logout (Qt's design: qFatal
+# is "unrecoverable, do not retry me"). systemd's `Restart=on-failure`
+# blindly treated it as a transient failure and rescheduled the
+# daemon — sometimes into a phantom plasma-restore session that
+# briefly publishes a wl_display socket inside the still-dying
+# user@.service, which let the daemon fire welcome OSDs the user
+# saw flashing on the way to SDDM. The daemon's logind session-
+# state check (in daemon.cpp::queryLogindSessionState) is the
+# correct gate for "should I be running?"; systemd's blind retry
+# fights against it. SIGABRT here covers both Qt's qFatal path
+# and any explicit `abort()` in our code.
+RestartPreventExitStatus=SIGABRT
 Slice=session.slice
 Environment=QT_PLUGIN_PATH=@KDE_INSTALL_FULL_LIBDIR@/qt6/plugins
 Environment=LD_LIBRARY_PATH=@KDE_INSTALL_FULL_LIBDIR@

--- a/src/daemon/plasmazones.service.in
+++ b/src/daemon/plasmazones.service.in
@@ -9,18 +9,9 @@ Type=simple
 ExecStart=@KDE_INSTALL_FULL_BINDIR@/plasmazonesd
 Restart=on-failure
 RestartSec=5
-# Don't retry after qFatal-driven SIGABRT. Qt's wayland QPA aborts
-# when wl_display disappears during user logout (Qt's design: qFatal
-# is "unrecoverable, do not retry me"). systemd's `Restart=on-failure`
-# blindly treated it as a transient failure and rescheduled the
-# daemon — sometimes into a phantom plasma-restore session that
-# briefly publishes a wl_display socket inside the still-dying
-# user@.service, which let the daemon fire welcome OSDs the user
-# saw flashing on the way to SDDM. The daemon's logind session-
-# state check (in daemon.cpp::queryPlasmaWorkspaceState) is the
-# correct gate for "should I be running?"; systemd's blind retry
-# fights against it. SIGABRT here covers both Qt's qFatal path
-# and any explicit `abort()` in our code.
+# Qt's qFatal (e.g. wayland QPA losing wl_display at logout) is
+# "unrecoverable, do not retry". See queryPlasmaWorkspaceState()
+# in daemon.cpp for the phantom-session analysis.
 RestartPreventExitStatus=SIGABRT
 Slice=session.slice
 Environment=QT_PLUGIN_PATH=@KDE_INSTALL_FULL_LIBDIR@/qt6/plugins

--- a/src/daemon/plasmazones.service.in
+++ b/src/daemon/plasmazones.service.in
@@ -17,7 +17,7 @@ RestartSec=5
 # briefly publishes a wl_display socket inside the still-dying
 # user@.service, which let the daemon fire welcome OSDs the user
 # saw flashing on the way to SDDM. The daemon's logind session-
-# state check (in daemon.cpp::queryLogindSessionState) is the
+# state check (in daemon.cpp::queryPlasmaWorkspaceState) is the
 # correct gate for "should I be running?"; systemd's blind retry
 # fights against it. SIGABRT here covers both Qt's qFatal path
 # and any explicit `abort()` in our code.


### PR DESCRIPTION
## Summary

Fixes a brief white BSP OSD card flashing on the SDDM greeter after logout.

**Root cause** (after several iterations through wrong layers): between user logout and SDDM handoff, systemd was respawning the daemon into a transient "phantom Plasma" state — a stray `kwin_wayland` from a fallback session-restore mechanism briefly publishes a fresh `wayland-N` socket inside the still-dying `user@.service`, and `Restart=on-failure` schedules a daemon retry after Qt's wayland QPA aborts on the original session's vanished `wl_display`. The phantom daemon runs long enough to fire startup welcome OSDs against an output about to be unbound by the SDDM compositor switch.

**The signal that uniquely catches this**: `plasma-workspace.target.ActiveState` on the user-bus systemd. The target is only flipped to `active` by `startplasma-wayland`'s orchestration *after* SDDM hands off; the phantom has no startplasma leader, so the target stays `inactive`. logind's `User.State` stays `active` whenever `user@.service` is up (so it can't distinguish phantom from real), `GetSessionByPID` returns "no session" for any `systemd --user`-spawned process (so it suppresses legitimate restarts too), and the wayland-socket existence probe passes during the phantom (stray kwin publishes one).

## Defense in depth (six layers)

1. **`src/daemon/main.cpp`** — pre-`QGuiApplication` Wayland-socket probe. If `$WAYLAND_DISPLAY` is set but the socket at `$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY` is missing, `return 0` cleanly. Stops the trivial "wayland already gone" respawn loop.
2. **`Daemon::queryPlasmaWorkspaceState()`** — at `start()` time, query systemd's user bus for `plasma-workspace.target.ActiveState`. Cache in `m_plasmaWorkspaceActive`. Subscribe to `PropertiesChanged` so a running daemon also catches mid-flight transitions out of active. Fail-open if systemd's user bus is unreachable (non-systemd / headless).
3. **`Daemon::start()` `QGuiApplication::aboutToQuit` hook** — flips `m_shuttingDown` on SIGTERM so any in-flight or deferred OSD bails.
4. **`Daemon::stop()`** — sets `m_shuttingDown = true` at the top, before the `m_running` gate, so programmatic stops also suppress.
5. **`screenRemoved` handler** (`src/daemon/daemon/start.cpp`) — bumps a 1-second `m_screensSettlingUntil` deadline. KWin tearing down outputs at logout fires cascading `screenRemoved` → `virtualScreensChanged` → `layoutApplied` → `showLayoutOsdDeferred`; the cooldown lets that drain. Also damps monitor hot-unplug churn.
6. **`Daemon::shouldSuppressOsd()`** (`src/daemon/daemon/osd.cpp`) — single helper gating every OSD entry point. Returns true on any of `m_shuttingDown`, `!m_plasmaWorkspaceActive`, or `now < m_screensSettlingUntil`.

Plus **`plasmazones.service.in`**: `RestartPreventExitStatus=SIGABRT`. Qt's `qFatal` is "unrecoverable, do not retry" — systemd's blind `Restart=on-failure` was fighting that contract.

## Test plan

- [x] Real session start: welcome OSDs fire normally (verified by user; journal shows `plasma-workspace.target ActiveState at startup: "active"`).
- [x] `systemctl --user restart plasmazones`: welcome OSDs fire normally (regression check for an earlier flawed `GetSessionByPID` approach that broke this).
- [x] Logout → SDDM: no white BSP OSD on the login screen (verified by user — primary symptom is gone).
- [ ] Monitor hot-unplug while OSD visible: existing OSD finishes gracefully, no new OSDs fire for ~1 s after (`m_screensSettlingUntil` cooldown).
- [ ] Non-Plasma host (sway, GNOME): fail-open path leaves welcome OSDs enabled. Daemon doesn't crash on missing `plasma-workspace.target`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)