### PR TITLE
fix(daemon): symmetric VS removal — collapse virtual ids back to physical

### DIFF
--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -552,6 +552,31 @@ public:
      */
     void migrateScreenAssignmentsFromVirtual(const QString& physicalScreenId);
 
+    /**
+     * @brief Find physical screens whose state still references virtual ids,
+     *        excluding screens the caller knows are still subdivided.
+     *
+     * Sweeps every state store that holds a screen id (active screen
+     * assignments, pre-float assignments, pending restore queues, pre-tile
+     * geometry on the snap engine) and returns the set of physical screen ids
+     * for which any stored value is still a "physId/vs:N" form whose physId
+     * is NOT in @p subdividedPhysicalIds.
+     *
+     * Pair with @ref migrateScreenAssignmentsFromVirtual on each returned id
+     * to clean up state left over from a config change applied while the
+     * daemon was offline.
+     *
+     * Owning the scan here (rather than the daemon enumerating each store)
+     * keeps state-shape knowledge inside WTS — adding a new screen-id-bearing
+     * store updates this method, not every caller.
+     *
+     * @param subdividedPhysicalIds Physical ids that legitimately have
+     *        virtual subdivisions in the current config (these are kept).
+     * @return Physical ids that should have @ref migrateScreenAssignmentsFromVirtual
+     *         applied. Empty when state is consistent with the policy.
+     */
+    QSet<QString> physicalScreensWithStaleVirtualAssignments(const QSet<QString>& subdividedPhysicalIds) const;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Resolution Change Handling
     // ═══════════════════════════════════════════════════════════════════════════

--- a/libs/phosphor-placement/src/lifecycle.cpp
+++ b/libs/phosphor-placement/src/lifecycle.cpp
@@ -454,6 +454,49 @@ void WindowTrackingService::migrateScreenAssignmentsFromVirtual(const QString& p
     }
 }
 
+QSet<QString>
+WindowTrackingService::physicalScreensWithStaleVirtualAssignments(const QSet<QString>& subdividedPhysicalIds) const
+{
+    // Mirrors the state stores swept by migrateScreenAssignmentsFromVirtual —
+    // missing one here would leave a window stranded on a stale VS id even
+    // after migration runs. Co-locating the scan with the migrator keeps that
+    // pairing maintainable: any future store added to the migrator must also
+    // be added here, both edits land in the same file under the same review.
+    QSet<QString> result;
+    auto check = [&](const QString& screenId) {
+        if (!PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
+            return;
+        }
+        const QString physId = PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId);
+        if (!subdividedPhysicalIds.contains(physId)) {
+            result.insert(physId);
+        }
+    };
+
+    if (m_snapState) {
+        const QHash<QString, QString>& assigns = m_snapState->screenAssignments();
+        for (auto it = assigns.constBegin(); it != assigns.constEnd(); ++it) {
+            check(it.value());
+        }
+        const QHash<QString, QString>& preFloat = m_snapState->preFloatScreenAssignments();
+        for (auto it = preFloat.constBegin(); it != preFloat.constEnd(); ++it) {
+            check(it.value());
+        }
+    }
+    for (auto qit = m_pendingRestoreQueues.constBegin(); qit != m_pendingRestoreQueues.constEnd(); ++qit) {
+        for (const auto& entry : qit.value()) {
+            check(entry.screenId);
+        }
+    }
+    if (m_snapEngine) {
+        const auto& geos = m_snapEngine->unmanagedGeometries();
+        for (auto it = geos.constBegin(); it != geos.constEnd(); ++it) {
+            check(it.value().screenId);
+        }
+    }
+    return result;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Window Lifecycle
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -702,18 +702,15 @@ void Daemon::migrateStartupScreenAssignments()
     // removal handler (onVirtualScreensReconfigured) never ran. Without this
     // pass those windows would survive into a fresh session under orphan
     // virtual ids and resnap/autotile/restore would mis-resolve them.
-    QSet<QString> orphanPhysIds;
-    const QHash<QString, QString>& assigns = m_windowTrackingAdaptor->service()->screenAssignments();
-    for (auto it = assigns.constBegin(); it != assigns.constEnd(); ++it) {
-        if (!PhosphorIdentity::VirtualScreenId::isVirtual(it.value())) {
-            continue;
-        }
-        const QString physId = PhosphorIdentity::VirtualScreenId::extractPhysicalId(it.value());
-        if (!physWithSubdivisions.contains(physId)) {
-            orphanPhysIds.insert(physId);
-        }
-    }
-    for (const QString& physId : std::as_const(orphanPhysIds)) {
+    //
+    // The daemon supplies the policy (which physIds Settings still subdivides);
+    // WTS owns the state-shape question (which physIds carry stale VS ids
+    // anywhere in its bookkeeping). Coupling that to the daemon would force
+    // every future addition of a screen-id-bearing state store to mirror an
+    // orphan-scan update here — exactly the bug class this fix is closing.
+    const QSet<QString> orphanPhysIds =
+        m_windowTrackingAdaptor->service()->physicalScreensWithStaleVirtualAssignments(physWithSubdivisions);
+    for (const QString& physId : orphanPhysIds) {
         m_windowTrackingAdaptor->service()->migrateScreenAssignmentsFromVirtual(physId);
     }
 }

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -39,6 +39,7 @@
 #include <QGuiApplication>
 #include <QScreen>
 #include <PhosphorScreens/ScreenIdentity.h>
+#include <PhosphorIdentity/VirtualScreenId.h>
 #include <PhosphorIdentity/WindowId.h>
 #include <algorithm>
 
@@ -682,12 +683,38 @@ void Daemon::migrateStartupScreenAssignments()
         return;
     }
     const auto vsConfigs = m_settings->virtualScreenConfigs();
+
+    // "To virtual": for every physical screen Settings still subdivides, push
+    // any bare-physId or stale VS assignments onto the current VS id set.
+    QSet<QString> physWithSubdivisions;
     for (auto it = vsConfigs.constBegin(); it != vsConfigs.constEnd(); ++it) {
         if (it.value().hasSubdivisions()) {
+            physWithSubdivisions.insert(it.key());
             QStringList vsIds = m_screenManager->virtualScreenIdsFor(it.key());
             m_windowTrackingAdaptor->service()->migrateScreenAssignmentsToVirtual(it.key(), vsIds,
                                                                                   m_screenManager.get());
         }
+    }
+
+    // "From virtual": symmetric pass for the daemon-was-down case. If the user
+    // removed a screen's subdivisions while the daemon was offline, WTS state
+    // on disk still holds "physId/vs:N" for windows on that screen; the live-
+    // removal handler (onVirtualScreensReconfigured) never ran. Without this
+    // pass those windows would survive into a fresh session under orphan
+    // virtual ids and resnap/autotile/restore would mis-resolve them.
+    QSet<QString> orphanPhysIds;
+    const QHash<QString, QString>& assigns = m_windowTrackingAdaptor->service()->screenAssignments();
+    for (auto it = assigns.constBegin(); it != assigns.constEnd(); ++it) {
+        if (!PhosphorIdentity::VirtualScreenId::isVirtual(it.value())) {
+            continue;
+        }
+        const QString physId = PhosphorIdentity::VirtualScreenId::extractPhysicalId(it.value());
+        if (!physWithSubdivisions.contains(physId)) {
+            orphanPhysIds.insert(physId);
+        }
+    }
+    for (const QString& physId : std::as_const(orphanPhysIds)) {
+        m_windowTrackingAdaptor->service()->migrateScreenAssignmentsFromVirtual(physId);
     }
 }
 
@@ -769,13 +796,23 @@ void Daemon::onVirtualScreensReconfigured(const QString& physicalScreenId)
         m_windowTrackingAdaptor->service()->clearResnapBuffer();
     }
 
-    // Migrate window screen assignments to the new VS IDs (when subdivisions
-    // exist). Migration is a no-op for windows already on a valid VS ID in
-    // the new config — those keep their stored screen.
-    if (config.hasSubdivisions() && m_windowTrackingAdaptor) {
-        const QStringList vsIds = m_screenManager->virtualScreenIdsFor(physicalScreenId);
-        m_windowTrackingAdaptor->service()->migrateScreenAssignmentsToVirtual(physicalScreenId, vsIds,
-                                                                              m_screenManager.get());
+    // Migrate window screen assignments symmetrically across the
+    // subdivision/no-subdivision boundary:
+    //   • subdivisions present → move physId (or stale VS ids from a prior
+    //     config) onto the new VS id set;
+    //   • subdivisions removed → collapse any lingering "physId/vs:N"
+    //     assignments back to the bare physId so resnap, autotile, and
+    //     pending-restore lookups don't dangle on orphan screen ids.
+    // Migration is a no-op for windows already on a valid screen id in the
+    // new config — those keep their stored screen.
+    if (m_windowTrackingAdaptor) {
+        if (config.hasSubdivisions()) {
+            const QStringList vsIds = m_screenManager->virtualScreenIdsFor(physicalScreenId);
+            m_windowTrackingAdaptor->service()->migrateScreenAssignmentsToVirtual(physicalScreenId, vsIds,
+                                                                                  m_screenManager.get());
+        } else {
+            m_windowTrackingAdaptor->service()->migrateScreenAssignmentsFromVirtual(physicalScreenId);
+        }
     }
 
     // Prune stale autotile order entries for old virtual screen IDs.

--- a/tests/unit/core/test_wts_virtual_migration.cpp
+++ b/tests/unit/core/test_wts_virtual_migration.cpp
@@ -392,6 +392,51 @@ private Q_SLOTS:
         QCOMPARE(m_service->screenAssignments().value(windowId), physId);
     }
 
+    // =====================================================================
+    // physicalScreensWithStaleVirtualAssignments — orphan-physId discovery
+    // =====================================================================
+
+    void testStaleScan_findsOrphanInActiveAssignments()
+    {
+        const QString physA = QStringLiteral("Dell:U2722D:115107");
+        const QString physB = QStringLiteral("LG:27GP850:ABC123");
+        const QString vsA0 = PhosphorIdentity::VirtualScreenId::make(physA, 0);
+        const QString vsB0 = PhosphorIdentity::VirtualScreenId::make(physB, 0);
+
+        m_service->assignWindowToZone(QStringLiteral("kate|a"), m_zoneIds[0], vsA0, 1);
+        m_service->assignWindowToZone(QStringLiteral("dolphin|b"), m_zoneIds[0], vsB0, 1);
+
+        // Caller declares physA still subdivided; physB is not.
+        const QSet<QString> stillSubdivided{physA};
+        const QSet<QString> orphans = m_service->physicalScreensWithStaleVirtualAssignments(stillSubdivided);
+
+        QCOMPARE(orphans.size(), 1);
+        QVERIFY(orphans.contains(physB));
+        QVERIFY(!orphans.contains(physA));
+    }
+
+    void testStaleScan_emptyWhenAllPolicyHonored()
+    {
+        const QString physId = QStringLiteral("Dell:U2722D:115107");
+        const QString vs0 = PhosphorIdentity::VirtualScreenId::make(physId, 0);
+        m_service->assignWindowToZone(QStringLiteral("kate|a"), m_zoneIds[0], vs0, 1);
+
+        const QSet<QString> orphans = m_service->physicalScreensWithStaleVirtualAssignments({physId});
+
+        QVERIFY(orphans.isEmpty());
+    }
+
+    void testStaleScan_ignoresBarePhysicalIds()
+    {
+        const QString physId = QStringLiteral("Dell:U2722D:115107");
+        m_service->assignWindowToZone(QStringLiteral("kate|a"), m_zoneIds[0], physId, 1);
+
+        // Even with no subdivisions in the policy, a bare physId is not stale.
+        const QSet<QString> orphans = m_service->physicalScreensWithStaleVirtualAssignments({});
+
+        QVERIFY(orphans.isEmpty());
+    }
+
 private:
     std::unique_ptr<IsolatedConfigGuard> m_guard;
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;


### PR DESCRIPTION
## Summary

`migrateScreenAssignmentsToVirtual` was wired into the live VS reconfig handler and the startup migration, but its inverse `migrateScreenAssignmentsFromVirtual` was never called from production code despite being implemented and unit-tested. Removing virtual screens left every window's stored screenId stuck on an orphan \`physId/vs:N\`, so resnap, autotile, and pending-restore lookups mis-resolved against the bare physical id that the rest of the system had already switched to.

## What changed

Two call sites in \`src/daemon/daemon/start.cpp\`:

- **\`onVirtualScreensReconfigured\`** — when the new config has no subdivisions, call \`migrateScreenAssignmentsFromVirtual\` instead of skipping migration entirely. Covers both \"shrink to fewer than 2 VSs\" and \"remove all VSs live via the settings app\". Live-removal goes through this same handler (Settings → \`virtualScreenConfigsChanged\` → \`IConfigStore::changed\` → \`ScreenManager::refreshVirtualConfigs\` → \`virtualScreensChanged\` → daemon).
- **\`migrateStartupScreenAssignments\`** — covers the daemon-was-down case. If the user removed VSs offline, WTS state on disk still holds \`physId/vs:N\` but Settings no longer has a config to iterate. Now we sweep the WTS \`screenAssignments()\` map for any virtual screen ids whose physical parent is no longer subdivided, and call the inverse migration on each.

The two helpers were always designed as opposites — matching naming, matching coverage in \`tests/unit/core/test_wts_virtual_migration.cpp\` (round-trip, no-op, multi-screen). The \`from\` direction was just never connected.

## Test plan

- [x] Build passes in Docker (\`docker run --rm -v \$PWD:/src plasmazones-build\`)
- [x] Existing \`test_wts_virtual_migration\` unit tests still pass (it already covered the \`From\` direction; we just call it from production now)
- [ ] Manual: add 2 VSs to a screen → place windows → remove VSs via settings → confirm windows resolve under the bare physId for resnap/autotile (not on a \`/vs:N\` orphan)
- [ ] Manual: same as above but kill the daemon between \"add VSs\" and \"remove VSs\", confirm startup migration cleans up
- [ ] Manual: shrink 3 VSs → 2 VSs (subdivisions still present) — verify the To-virtual path still works (regression check on the unchanged branch)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)