### PR TITLE
refactor(protocol): fully-qualify wire types, remove namespace using-shims

### DIFF
--- a/dbus/org.plasmazones.Autotile.xml
+++ b/dbus/org.plasmazones.Autotile.xml
@@ -145,7 +145,7 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Algorithm ID to query."/>
             </arg>
             <arg name="info" type="(sssbbbbdibsbb)" direction="out">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::AlgorithmInfoEntry"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::AlgorithmInfoEntry"/>
                 <annotation name="org.gtk.GDBus.DocString" value="Struct: (id, name, description, supportsMasterCount, supportsSplitRatio, centerLayout, producesOverlappingZones, defaultSplitRatio, defaultMaxWindows, isScripted, zoneNumberDisplay, isUserScript, supportsMemory)."/>
             </arg>
         </method>
@@ -188,7 +188,7 @@
         <signal name="windowsTileRequested">
             <annotation name="org.gtk.GDBus.DocString" value="Emitted when windows should be moved to new geometries (batch)."/>
             <arg name="tileRequests" type="a(siiiissbb)">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::TileRequestList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::TileRequestList"/>
                 <annotation name="org.gtk.GDBus.DocString" value="Array of (windowId, x, y, width, height, zoneId, screenId, monocle, floating)."/>
             </arg>
         </signal>
@@ -247,7 +247,7 @@
         <method name="windowsOpenedBatch">
             <annotation name="org.gtk.GDBus.DocString" value="Batch window-opened notifications: process multiple windowOpened in one D-Bus call. Used on daemon startup/restart and autotile toggle-on. Array of (windowId, screenId, minWidth, minHeight)."/>
             <arg name="entries" type="a(ssii)" direction="in">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="PlasmaZones::WindowOpenedList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="PhosphorProtocol::WindowOpenedList"/>
                 <annotation name="org.gtk.GDBus.DocString" value="Array of window-opened entry structs."/>
             </arg>
         </method>

--- a/dbus/org.plasmazones.CompositorBridge.xml
+++ b/dbus/org.plasmazones.CompositorBridge.xml
@@ -17,7 +17,7 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Supported capabilities: borderless, maximize, animation, borders, modifiers."/>
             </arg>
             <arg name="result" type="(sss)" direction="out">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::BridgeRegistrationResult"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::BridgeRegistrationResult"/>
                 <annotation name="org.gtk.GDBus.DocString" value="Struct: (apiVersion, bridgeName, sessionId)."/>
             </arg>
         </method>
@@ -45,7 +45,7 @@
         <signal name="applyWindowGeometriesBatch">
             <annotation name="org.gtk.GDBus.DocString" value="Apply geometry to a batch of windows."/>
             <arg name="geometries" type="a(siiii)">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::WindowGeometryList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::WindowGeometryList"/>
                 <annotation name="org.gtk.GDBus.DocString" value="Array of (windowId, x, y, width, height)."/>
             </arg>
             <arg name="action" type="s">

--- a/dbus/org.plasmazones.Overlay.xml
+++ b/dbus/org.plasmazones.Overlay.xml
@@ -114,11 +114,11 @@
             </arg>
             <arg name="emptyZones" type="a(siiiiiibsssdd)" direction="in">
                 <annotation name="org.gtk.GDBus.DocString" value="Array of EmptyZoneEntry structs: (zoneId, x, y, width, height, borderWidth, borderRadius, useCustomColors, highlightColor, inactiveColor, borderColor, activeOpacity, inactiveOpacity)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="PlasmaZones::EmptyZoneList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="PhosphorProtocol::EmptyZoneList"/>
             </arg>
             <arg name="candidates" type="a(ssss)" direction="in">
                 <annotation name="org.gtk.GDBus.DocString" value="Array of SnapAssistCandidate structs: (windowId, compositorHandle, icon, caption)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="PlasmaZones::SnapAssistCandidateList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="PhosphorProtocol::SnapAssistCandidateList"/>
             </arg>
             <arg name="success" type="b" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="True if overlay was shown."/>
@@ -171,11 +171,11 @@
             </arg>
             <arg name="emptyZones" type="a(siiiiiibsssdd)">
                 <annotation name="org.gtk.GDBus.DocString" value="Array of EmptyZoneEntry structs: (zoneId, x, y, width, height, borderWidth, borderRadius, useCustomColors, highlightColor, inactiveColor, borderColor, activeOpacity, inactiveOpacity)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="PlasmaZones::EmptyZoneList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="PhosphorProtocol::EmptyZoneList"/>
             </arg>
             <arg name="candidates" type="a(ssss)">
                 <annotation name="org.gtk.GDBus.DocString" value="Array of SnapAssistCandidate structs: (windowId, compositorHandle, icon, caption)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out2" value="PlasmaZones::SnapAssistCandidateList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out2" value="PhosphorProtocol::SnapAssistCandidateList"/>
             </arg>
         </signal>
         <signal name="snapAssistDismissed">

--- a/dbus/org.plasmazones.WindowDrag.xml
+++ b/dbus/org.plasmazones.WindowDrag.xml
@@ -20,7 +20,7 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Qt::MouseButtons flags."/>
             </arg>
             <arg name="policy" type="(bbbbbss)" direction="out">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::DragPolicy"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::DragPolicy"/>
                 <annotation name="org.gtk.GDBus.DocString" value="DragPolicy struct: {streamDragMoved, showOverlay, grabKeyboard, captureGeometry, immediateFloatOnStart, screenId, bypassReason}."/>
             </arg>
         </method>
@@ -51,7 +51,7 @@
                 <annotation name="org.gtk.GDBus.DocString" value="True if the drag was cancelled (Escape, external cancel). False for normal button release."/>
             </arg>
             <arg name="outcome" type="(issiiiisbba(siiiiiibsssdd))" direction="out">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::DragOutcome"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::DragOutcome"/>
                 <annotation name="org.gtk.GDBus.DocString" value="DragOutcome struct: {action, windowId, targetScreenId, x, y, width, height, zoneId, skipAnimation, requestSnapAssist, emptyZones}."/>
             </arg>
         </method>
@@ -114,7 +114,7 @@
             <annotation name="org.gtk.GDBus.DocString" value="Phase 3 drag protocol: daemon detected a policy flip mid-drag (typically because the cursor crossed a virtual-screen boundary that changes autotile↔snap routing). Plugin reacts by applying the transition: entering/exiting autotile bypass, canceling snap overlay, calling handleDragToFloat, etc. Replaces the effect-side cross-VS flip loop that used a stale local cache."/>
             <arg name="windowId" type="s"/>
             <arg name="newPolicy" type="(bbbbbss)">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="PlasmaZones::DragPolicy"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.In1" value="PhosphorProtocol::DragPolicy"/>
             </arg>
         </signal>
         <signal name="snapAssistReady">
@@ -122,7 +122,7 @@
             <arg name="windowId" type="s"/>
             <arg name="releaseScreenId" type="s"/>
             <arg name="emptyZones" type="a(siiiiiibsssdd)">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="PlasmaZones::EmptyZoneList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.In2" value="PhosphorProtocol::EmptyZoneList"/>
             </arg>
         </signal>
     </interface>

--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -43,7 +43,7 @@
         <method name="windowsSnappedBatch">
             <annotation name="org.gtk.GDBus.DocString" value="Batch snap confirmations: process multiple windowSnapped/windowUnsnapped in one D-Bus call. Used by the KWin effect after resnap stagger completes. Array of (windowId, zoneId, screenId, isRestore)."/>
             <arg name="entries" type="a(sssb)" direction="in">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="PlasmaZones::SnapConfirmationList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="PhosphorProtocol::SnapConfirmationList"/>
                 <annotation name="org.gtk.GDBus.DocString" value="Array of snap confirmation structs."/>
             </arg>
         </method>
@@ -93,7 +93,7 @@
             </arg>
             <arg name="emptyZones" type="a(siiiiiibsssdd)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="Array of EmptyZoneEntry structs: (zoneId, x, y, width, height, borderWidth, borderRadius, useCustomColors, highlightColor, inactiveColor, borderColor, activeOpacity, inactiveOpacity)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::EmptyZoneList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::EmptyZoneList"/>
             </arg>
         </method>
         <method name="getLastUsedZoneId">
@@ -220,7 +220,7 @@
             </arg>
             <arg name="result" type="(bassiiii)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="UnfloatRestoreResult: (found, zoneIds, screenName, x, y, width, height)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::UnfloatRestoreResult"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::UnfloatRestoreResult"/>
             </arg>
         </method>
         <method name="getZoneGeometry">
@@ -230,7 +230,7 @@
             </arg>
             <arg name="geometry" type="(iiii)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="ZoneGeometryRect: (x, y, width, height)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::ZoneGeometryRect"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::ZoneGeometryRect"/>
             </arg>
         </method>
         <method name="getZoneGeometryForScreen">
@@ -243,7 +243,7 @@
             </arg>
             <arg name="geometry" type="(iiii)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="ZoneGeometryRect: (x, y, width, height)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::ZoneGeometryRect"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::ZoneGeometryRect"/>
             </arg>
         </method>
         <method name="snapToAppRule">
@@ -384,7 +384,7 @@
         <method name="getUpdatedWindowGeometries">
             <annotation name="org.gtk.GDBus.DocString" value="Return updated window geometries after resolution change."/>
             <arg name="geometries" type="a(siiii)" direction="out">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::WindowGeometryList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::WindowGeometryList"/>
                 <annotation name="org.gtk.GDBus.DocString" value="Array of (windowId, x, y, width, height)."/>
             </arg>
         </method>
@@ -505,7 +505,7 @@
         <signal name="applyGeometriesBatch">
             <annotation name="org.gtk.GDBus.DocString" value="Daemon requests compositor to apply geometries for a batch of windows."/>
             <arg name="geometries" type="a(siiiis)">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::WindowGeometryList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::WindowGeometryList"/>
                 <annotation name="org.gtk.GDBus.DocString" value="Array of (windowId, x, y, width, height, screenId). screenId is the daemon-authoritative target screen — compositor uses it to seed its tracked-screen cache without re-deriving from geometry. Empty screenId means no authoritative answer (fall back to geometry-based resolution)."/>
             </arg>
             <arg name="action" type="s">
@@ -585,7 +585,7 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Screen for layout/geometry resolution."/>
             </arg>
             <arg name="snapResults" type="a(sssiiii)" direction="out">
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::SnapAllResultList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::SnapAllResultList"/>
                 <annotation name="org.gtk.GDBus.DocString" value="Array of (windowId, targetZoneId, sourceZoneId, x, y, width, height)."/>
             </arg>
         </method>
@@ -596,7 +596,7 @@
             <arg name="screenId" type="s" direction="in"/>
             <arg name="result" type="(bssiiiiss)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="MoveTargetResult: (success, reason, zoneId, x, y, width, height, sourceZoneId, screenName)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::MoveTargetResult"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::MoveTargetResult"/>
             </arg>
         </method>
         <method name="getFocusTargetForWindow">
@@ -606,7 +606,7 @@
             <arg name="screenId" type="s" direction="in"/>
             <arg name="result" type="(bsssss)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="FocusTargetResult: (success, reason, windowIdToActivate, sourceZoneId, targetZoneId, screenName)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::FocusTargetResult"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::FocusTargetResult"/>
             </arg>
         </method>
         <method name="getRestoreForWindow">
@@ -615,7 +615,7 @@
             <arg name="screenId" type="s" direction="in"/>
             <arg name="result" type="(bbiiii)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="RestoreTargetResult: (success, found, x, y, width, height)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::RestoreTargetResult"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::RestoreTargetResult"/>
             </arg>
         </method>
         <method name="getCycleTargetForWindow">
@@ -625,7 +625,7 @@
             <arg name="screenId" type="s" direction="in"/>
             <arg name="result" type="(bssss)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="CycleTargetResult: (success, reason, windowIdToActivate, zoneId, screenName)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::CycleTargetResult"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::CycleTargetResult"/>
             </arg>
         </method>
         <method name="getSwapTargetForWindow">
@@ -635,7 +635,7 @@
             <arg name="screenId" type="s" direction="in"/>
             <arg name="result" type="(bssiiiissiiiissss)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="SwapTargetResult: (success, reason, windowId1, x1, y1, w1, h1, zoneId1, windowId2, x2, y2, w2, h2, zoneId2, screenName, sourceZoneId, targetZoneId)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::SwapTargetResult"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::SwapTargetResult"/>
             </arg>
         </method>
         <method name="getPushTargetForWindow">
@@ -644,7 +644,7 @@
             <arg name="screenId" type="s" direction="in"/>
             <arg name="result" type="(bssiiiiss)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="MoveTargetResult: (success, reason, zoneId, x, y, width, height, sourceZoneId, screenName)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::MoveTargetResult"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::MoveTargetResult"/>
             </arg>
         </method>
         <method name="getSnapToZoneByNumberTarget">
@@ -654,7 +654,7 @@
             <arg name="screenId" type="s" direction="in"/>
             <arg name="result" type="(bssiiiiss)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="MoveTargetResult: (success, reason, zoneId, x, y, width, height, sourceZoneId, screenName)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::MoveTargetResult"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::MoveTargetResult"/>
             </arg>
         </method>
         <signal name="snapAllWindowsRequested">
@@ -698,14 +698,14 @@
             </arg>
             <arg name="state" type="(sssbsasb)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="WindowStateEntry: (windowId, zoneId, screenId, isFloating, changeType, zoneIds, isSticky)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::WindowStateEntry"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::WindowStateEntry"/>
             </arg>
         </method>
         <method name="getAllWindowStates">
             <annotation name="org.gtk.GDBus.DocString" value="Get state for all tracked windows (TUI dashboard)."/>
             <arg name="states" type="a(sssbsasb)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="Array of WindowStateEntry structs."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::WindowStateList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::WindowStateList"/>
             </arg>
         </method>
         <signal name="windowStateChanged">
@@ -715,7 +715,7 @@
             </arg>
             <arg name="state" type="(sssbsasb)">
                 <annotation name="org.gtk.GDBus.DocString" value="WindowStateEntry: (windowId, zoneId, screenId, isFloating, changeType, zoneIds, isSticky). changeType: snapped, unsnapped, floated, unfloated, screen_changed."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="PlasmaZones::WindowStateEntry"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out1" value="PhosphorProtocol::WindowStateEntry"/>
             </arg>
         </signal>
     </interface>

--- a/dbus/org.plasmazones.ZoneDetection.xml
+++ b/dbus/org.plasmazones.ZoneDetection.xml
@@ -38,7 +38,7 @@
             </arg>
             <arg name="geometry" type="(iiii)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="Zone geometry struct: (x, y, width, height)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::ZoneGeometryRect"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::ZoneGeometryRect"/>
             </arg>
         </method>
 
@@ -52,7 +52,7 @@
             </arg>
             <arg name="geometry" type="(iiii)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="Zone geometry struct: (x, y, width, height)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::ZoneGeometryRect"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::ZoneGeometryRect"/>
             </arg>
         </method>
 
@@ -115,7 +115,7 @@
             </arg>
             <arg name="geometries" type="a(siiii)" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="List of named zone geometry structs: (zoneId, x, y, width, height)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::NamedZoneGeometryList"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::NamedZoneGeometryList"/>
             </arg>
         </method>
 
@@ -146,7 +146,7 @@
             </arg>
             <arg name="geometry" type="(iiii)">
                 <annotation name="org.gtk.GDBus.DocString" value="Zone geometry struct: (x, y, width, height)."/>
-                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PlasmaZones::ZoneGeometryRect"/>
+                <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="PhosphorProtocol::ZoneGeometryRect"/>
             </arg>
         </signal>
     </interface>

--- a/libs/phosphor-compositor/include/PhosphorCompositor/SnapAssistFilter.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/SnapAssistFilter.h
@@ -14,9 +14,6 @@
 
 namespace PhosphorCompositor {
 
-using PhosphorProtocol::SnapAssistCandidate;
-using PhosphorProtocol::SnapAssistCandidateList;
-
 /**
  * @brief Compositor-agnostic snap assist candidate builder
  *
@@ -41,10 +38,9 @@ namespace SnapAssistFilter {
  * @param snappedWindowIds  Set of window IDs that are already snapped
  * @return Typed list of candidates (windowId, icon, caption; compositorHandle left empty — compositor fills it)
  */
-PHOSPHORCOMPOSITOR_EXPORT SnapAssistCandidateList buildCandidates(ICompositorBridge* bridge,
-                                                                  const QString& excludeWindowId,
-                                                                  const QString& screenId,
-                                                                  const QSet<QString>& snappedWindowIds);
+PHOSPHORCOMPOSITOR_EXPORT PhosphorProtocol::SnapAssistCandidateList
+buildCandidates(ICompositorBridge* bridge, const QString& excludeWindowId, const QString& screenId,
+                const QSet<QString>& snappedWindowIds);
 
 } // namespace SnapAssistFilter
 } // namespace PhosphorCompositor

--- a/libs/phosphor-compositor/src/DaemonClient.cpp
+++ b/libs/phosphor-compositor/src/DaemonClient.cpp
@@ -16,19 +16,18 @@
 
 namespace PhosphorCompositor {
 
-using namespace PhosphorProtocol;
-
 DaemonClient::DaemonClient(QObject* parent)
     : QObject(parent)
 {
     m_serviceWatcher = new QDBusServiceWatcher(
-        Service::Name, QDBusConnection::sessionBus(),
+        PhosphorProtocol::Service::Name, QDBusConnection::sessionBus(),
         QDBusServiceWatcher::WatchForRegistration | QDBusServiceWatcher::WatchForUnregistration, this);
 
     connect(m_serviceWatcher, &QDBusServiceWatcher::serviceRegistered, this, &DaemonClient::onServiceRegistered);
     connect(m_serviceWatcher, &QDBusServiceWatcher::serviceUnregistered, this, &DaemonClient::onServiceUnregistered);
 
-    QDBusConnection::sessionBus().connect(Service::Name, Service::ObjectPath, Service::Interface::LayoutRegistry,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::LayoutRegistry,
                                           QStringLiteral("daemonReady"), this, SLOT(onDaemonReadySignal()));
 }
 
@@ -49,7 +48,8 @@ void DaemonClient::registerBridge(const QString& compositorId, int apiVersion, c
     m_registrationInFlight = true;
 
     QDBusMessage msg = QDBusMessage::createMethodCall(
-        Service::Name, Service::ObjectPath, Service::Interface::CompositorBridge, QStringLiteral("registerBridge"));
+        PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+        PhosphorProtocol::Service::Interface::CompositorBridge, QStringLiteral("registerBridge"));
     msg << compositorId << apiVersion << capabilities;
 
     auto* watcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(msg), this);
@@ -88,25 +88,27 @@ void DaemonClient::registerBridge(const QString& compositorId, int apiVersion, c
 
 void DaemonClient::notifyWindowOpened(const QString& windowId, const QString& screenId, int minWidth, int minHeight)
 {
-    ClientHelpers::sendOneWay(Service::Interface::Autotile, QStringLiteral("windowOpened"),
-                              {windowId, screenId, minWidth, minHeight});
+    PhosphorProtocol::ClientHelpers::sendOneWay(PhosphorProtocol::Service::Interface::Autotile,
+                                                QStringLiteral("windowOpened"),
+                                                {windowId, screenId, minWidth, minHeight});
 }
 
 void DaemonClient::notifyWindowOpenedBatch(const PhosphorProtocol::WindowOpenedList& windows)
 {
-    ClientHelpers::sendOneWay(Service::Interface::Autotile, QStringLiteral("windowsOpenedBatch"),
-                              {QVariant::fromValue(windows)});
+    PhosphorProtocol::ClientHelpers::sendOneWay(PhosphorProtocol::Service::Interface::Autotile,
+                                                QStringLiteral("windowsOpenedBatch"), {QVariant::fromValue(windows)});
 }
 
 void DaemonClient::notifyWindowClosed(const QString& windowId)
 {
-    ClientHelpers::sendOneWay(Service::Interface::Autotile, QStringLiteral("windowClosed"), {windowId});
+    PhosphorProtocol::ClientHelpers::sendOneWay(PhosphorProtocol::Service::Interface::Autotile,
+                                                QStringLiteral("windowClosed"), {windowId});
 }
 
 void DaemonClient::notifyWindowActivated(const QString& windowId, const QString& screenId)
 {
-    ClientHelpers::sendOneWay(Service::Interface::WindowTracking, QStringLiteral("windowActivated"),
-                              {windowId, screenId});
+    PhosphorProtocol::ClientHelpers::sendOneWay(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                QStringLiteral("windowActivated"), {windowId, screenId});
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -115,20 +117,21 @@ void DaemonClient::notifyWindowActivated(const QString& windowId, const QString&
 
 void DaemonClient::dragStarted(const QString& windowId, const QString& screenId, const QRect& geometry)
 {
-    ClientHelpers::sendOneWay(Service::Interface::WindowDrag, QStringLiteral("dragStarted"),
-                              {windowId, screenId, geometry.x(), geometry.y(), geometry.width(), geometry.height()});
+    PhosphorProtocol::ClientHelpers::sendOneWay(
+        PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("dragStarted"),
+        {windowId, screenId, geometry.x(), geometry.y(), geometry.width(), geometry.height()});
 }
 
 void DaemonClient::dragMoved(const QString& windowId, int cursorX, int cursorY)
 {
-    ClientHelpers::sendOneWay(Service::Interface::WindowDrag, QStringLiteral("dragMoved"),
-                              {windowId, cursorX, cursorY});
+    PhosphorProtocol::ClientHelpers::sendOneWay(PhosphorProtocol::Service::Interface::WindowDrag,
+                                                QStringLiteral("dragMoved"), {windowId, cursorX, cursorY});
 }
 
 void DaemonClient::dragStopped(const QString& windowId, const QString& screenId, const QString& zoneId)
 {
-    ClientHelpers::sendOneWay(Service::Interface::WindowDrag, QStringLiteral("dragStopped"),
-                              {windowId, screenId, zoneId});
+    PhosphorProtocol::ClientHelpers::sendOneWay(PhosphorProtocol::Service::Interface::WindowDrag,
+                                                QStringLiteral("dragStopped"), {windowId, screenId, zoneId});
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -137,12 +140,14 @@ void DaemonClient::dragStopped(const QString& windowId, const QString& screenId,
 
 void DaemonClient::notifyCursorScreenChanged(const QString& screenId)
 {
-    ClientHelpers::sendOneWay(Service::Interface::WindowTracking, QStringLiteral("cursorScreenChanged"), {screenId});
+    PhosphorProtocol::ClientHelpers::sendOneWay(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                QStringLiteral("cursorScreenChanged"), {screenId});
 }
 
 void DaemonClient::notifyPrimaryScreen(const QString& screenName)
 {
-    ClientHelpers::sendOneWay(Service::Interface::Screen, QStringLiteral("setPrimaryScreenFromKWin"), {screenName});
+    PhosphorProtocol::ClientHelpers::sendOneWay(PhosphorProtocol::Service::Interface::Screen,
+                                                QStringLiteral("setPrimaryScreenFromKWin"), {screenName});
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -152,7 +157,9 @@ void DaemonClient::notifyPrimaryScreen(const QString& screenName)
 void DaemonClient::queryFloatingWindows()
 {
     auto* watcher = new QDBusPendingCallWatcher(
-        ClientHelpers::asyncCall(Service::Interface::WindowTracking, QStringLiteral("getFloatingWindows")), this);
+        PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                   QStringLiteral("getFloatingWindows")),
+        this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
         w->deleteLater();
         if (w->isError())
@@ -167,7 +174,9 @@ void DaemonClient::queryFloatingWindows()
 void DaemonClient::querySnappedWindows()
 {
     auto* watcher = new QDBusPendingCallWatcher(
-        ClientHelpers::asyncCall(Service::Interface::WindowTracking, QStringLiteral("getSnappedWindows")), this);
+        PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                   QStringLiteral("getSnappedWindows")),
+        this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
         w->deleteLater();
         if (w->isError())
@@ -182,7 +191,8 @@ void DaemonClient::querySnappedWindows()
 void DaemonClient::queryPendingRestoreGeometries()
 {
     auto* watcher = new QDBusPendingCallWatcher(
-        ClientHelpers::asyncCall(Service::Interface::WindowTracking, QStringLiteral("getPendingRestoreGeometries")),
+        PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                   QStringLiteral("getPendingRestoreGeometries")),
         this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
         w->deleteLater();
@@ -198,7 +208,9 @@ void DaemonClient::queryPendingRestoreGeometries()
 void DaemonClient::queryVirtualScreens(const QString& screenId)
 {
     auto* watcher = new QDBusPendingCallWatcher(
-        ClientHelpers::asyncCall(Service::Interface::Screen, QStringLiteral("getVirtualScreens"), {screenId}), this);
+        PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::Screen,
+                                                   QStringLiteral("getVirtualScreens"), {screenId}),
+        this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, screenId](QDBusPendingCallWatcher* w) {
         w->deleteLater();
         if (w->isError())
@@ -212,7 +224,8 @@ void DaemonClient::queryVirtualScreens(const QString& screenId)
 
 void DaemonClient::pruneStaleWindows(const QStringList& liveWindowIds)
 {
-    ClientHelpers::sendOneWay(Service::Interface::WindowTracking, QStringLiteral("pruneStaleWindows"), {liveWindowIds});
+    PhosphorProtocol::ClientHelpers::sendOneWay(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                QStringLiteral("pruneStaleWindows"), {liveWindowIds});
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -227,9 +240,11 @@ void DaemonClient::onDaemonReadySignal()
 void DaemonClient::onServiceRegistered()
 {
     // Daemon process appeared — wait for daemonReady signal before registering
-    QDBusConnection::sessionBus().disconnect(Service::Name, Service::ObjectPath, Service::Interface::LayoutRegistry,
+    QDBusConnection::sessionBus().disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                             PhosphorProtocol::Service::Interface::LayoutRegistry,
                                              QStringLiteral("daemonReady"), this, SLOT(onDaemonReadySignal()));
-    QDBusConnection::sessionBus().connect(Service::Name, Service::ObjectPath, Service::Interface::LayoutRegistry,
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::LayoutRegistry,
                                           QStringLiteral("daemonReady"), this, SLOT(onDaemonReadySignal()));
 }
 
@@ -250,96 +265,117 @@ void DaemonClient::connectDaemonSignals()
 {
     auto bus = QDBusConnection::sessionBus();
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                QStringLiteral("applyGeometryRequested"), this,
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("applyGeometryRequested"), this,
                 SLOT(handleApplyGeometry(QString, int, int, int, int, QString, QString, bool)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                QStringLiteral("applyGeometriesBatch"), this,
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("applyGeometriesBatch"), this,
                 SLOT(handleApplyGeometriesBatch(PhosphorProtocol::WindowGeometryList, QString)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                QStringLiteral("raiseWindowsRequested"), this, SLOT(handleRaiseWindows(QStringList)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("raiseWindowsRequested"), this,
+                SLOT(handleRaiseWindows(QStringList)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                QStringLiteral("activateWindowRequested"), this, SLOT(handleActivateWindow(QString)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("activateWindowRequested"), this,
+                SLOT(handleActivateWindow(QString)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                QStringLiteral("windowFloatingChanged"), this,
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("windowFloatingChanged"), this,
                 SLOT(handleWindowFloatingChanged(QString, bool, QString)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                QStringLiteral("pendingRestoresAvailable"), this, SIGNAL(pendingRestoresAvailable()));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("pendingRestoresAvailable"), this,
+                SIGNAL(pendingRestoresAvailable()));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowTracking,
                 QStringLiteral("reapplyWindowGeometriesRequested"), this, SIGNAL(reapplyGeometriesRequested()));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowDrag, QStringLiteral("dragPolicyChanged"),
-                this, SLOT(handleDragPolicyChanged(QString, int)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("dragPolicyChanged"), this,
+                SLOT(handleDragPolicyChanged(QString, int)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowDrag, QStringLiteral("snapAssistReady"),
-                this, SLOT(handleSnapAssistReady(QString, QString, PhosphorProtocol::EmptyZoneList)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("snapAssistReady"), this,
+                SLOT(handleSnapAssistReady(QString, QString, PhosphorProtocol::EmptyZoneList)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowDrag,
-                QStringLiteral("restoreSizeDuringDragChanged"), this,
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("restoreSizeDuringDragChanged"), this,
                 SLOT(handleRestoreSizeDuringDrag(QString, int, int)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowTracking,
                 QStringLiteral("moveSpecificWindowToZoneRequested"), this,
                 SLOT(handleMoveWindowToZone(QString, QString, int, int, int, int)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                QStringLiteral("snapAllWindowsRequested"), this, SLOT(handleSnapAllWindows(QString)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("snapAllWindowsRequested"), this,
+                SLOT(handleSnapAllWindows(QString)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::Settings, QStringLiteral("settingsChanged"),
-                this, SIGNAL(settingsChanged()));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::Settings, QStringLiteral("settingsChanged"), this,
+                SIGNAL(settingsChanged()));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::Screen, QStringLiteral("virtualScreensChanged"),
-                this, SIGNAL(virtualScreensChanged(QString)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::Screen, QStringLiteral("virtualScreensChanged"), this,
+                SIGNAL(virtualScreensChanged(QString)));
 
-    bus.connect(Service::Name, Service::ObjectPath, Service::Interface::Settings,
-                QStringLiteral("runningWindowsRequested"), this, SIGNAL(runningWindowsRequested()));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::Settings, QStringLiteral("runningWindowsRequested"), this,
+                SIGNAL(runningWindowsRequested()));
 }
 
 void DaemonClient::disconnectDaemonSignals()
 {
     auto bus = QDBusConnection::sessionBus();
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                   QStringLiteral("applyGeometryRequested"), this,
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("applyGeometryRequested"), this,
                    SLOT(handleApplyGeometry(QString, int, int, int, int, QString, QString, bool)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                   QStringLiteral("applyGeometriesBatch"), this,
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("applyGeometriesBatch"), this,
                    SLOT(handleApplyGeometriesBatch(PhosphorProtocol::WindowGeometryList, QString)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                   QStringLiteral("raiseWindowsRequested"), this, SLOT(handleRaiseWindows(QStringList)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                   QStringLiteral("activateWindowRequested"), this, SLOT(handleActivateWindow(QString)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                   QStringLiteral("windowFloatingChanged"), this,
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("raiseWindowsRequested"), this,
+                   SLOT(handleRaiseWindows(QStringList)));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("activateWindowRequested"),
+                   this, SLOT(handleActivateWindow(QString)));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("windowFloatingChanged"), this,
                    SLOT(handleWindowFloatingChanged(QString, bool, QString)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                   QStringLiteral("pendingRestoresAvailable"), this, SIGNAL(pendingRestoresAvailable()));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("pendingRestoresAvailable"),
+                   this, SIGNAL(pendingRestoresAvailable()));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowTracking,
                    QStringLiteral("reapplyWindowGeometriesRequested"), this, SIGNAL(reapplyGeometriesRequested()));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowDrag,
-                   QStringLiteral("dragPolicyChanged"), this, SLOT(handleDragPolicyChanged(QString, int)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowDrag,
-                   QStringLiteral("snapAssistReady"), this,
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("dragPolicyChanged"), this,
+                   SLOT(handleDragPolicyChanged(QString, int)));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("snapAssistReady"), this,
                    SLOT(handleSnapAssistReady(QString, QString, PhosphorProtocol::EmptyZoneList)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowDrag,
-                   QStringLiteral("restoreSizeDuringDragChanged"), this,
-                   SLOT(handleRestoreSizeDuringDrag(QString, int, int)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowDrag, QStringLiteral("restoreSizeDuringDragChanged"),
+                   this, SLOT(handleRestoreSizeDuringDrag(QString, int, int)));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowTracking,
                    QStringLiteral("moveSpecificWindowToZoneRequested"), this,
                    SLOT(handleMoveWindowToZone(QString, QString, int, int, int, int)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::WindowTracking,
-                   QStringLiteral("snapAllWindowsRequested"), this, SLOT(handleSnapAllWindows(QString)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::Settings, QStringLiteral("settingsChanged"),
-                   this, SIGNAL(settingsChanged()));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::Screen,
-                   QStringLiteral("virtualScreensChanged"), this, SIGNAL(virtualScreensChanged(QString)));
-    bus.disconnect(Service::Name, Service::ObjectPath, Service::Interface::Settings,
-                   QStringLiteral("runningWindowsRequested"), this, SIGNAL(runningWindowsRequested()));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("snapAllWindowsRequested"),
+                   this, SLOT(handleSnapAllWindows(QString)));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::Settings, QStringLiteral("settingsChanged"), this,
+                   SIGNAL(settingsChanged()));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::Screen, QStringLiteral("virtualScreensChanged"), this,
+                   SIGNAL(virtualScreensChanged(QString)));
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::Settings, QStringLiteral("runningWindowsRequested"), this,
+                   SIGNAL(runningWindowsRequested()));
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -434,7 +470,9 @@ void DaemonClient::handleSnapAssistReady(const QString& windowId, const QString&
 void DaemonClient::querySetting(const QString& key)
 {
     auto* watcher = new QDBusPendingCallWatcher(
-        ClientHelpers::asyncCall(Service::Interface::Settings, QStringLiteral("getSetting"), {key}), this);
+        PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::Settings,
+                                                   QStringLiteral("getSetting"), {key}),
+        this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, key](QDBusPendingCallWatcher* w) {
         w->deleteLater();
         if (w->isError())
@@ -448,9 +486,9 @@ void DaemonClient::querySetting(const QString& key)
 
 void DaemonClient::probeDaemonAvailable(int timeoutMs)
 {
-    QDBusMessage msg = QDBusMessage::createMethodCall(Service::Name, Service::ObjectPath,
-                                                      QStringLiteral("org.freedesktop.DBus.Introspectable"),
-                                                      QStringLiteral("Introspect"));
+    QDBusMessage msg = QDBusMessage::createMethodCall(
+        PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+        QStringLiteral("org.freedesktop.DBus.Introspectable"), QStringLiteral("Introspect"));
     auto* watcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(msg, timeoutMs), this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
         w->deleteLater();

--- a/libs/phosphor-compositor/src/SnapAssistFilter.cpp
+++ b/libs/phosphor-compositor/src/SnapAssistFilter.cpp
@@ -10,10 +10,11 @@
 namespace PhosphorCompositor {
 namespace SnapAssistFilter {
 
-SnapAssistCandidateList buildCandidates(ICompositorBridge* bridge, const QString& excludeWindowId,
-                                        const QString& screenId, const QSet<QString>& snappedWindowIds)
+PhosphorProtocol::SnapAssistCandidateList buildCandidates(ICompositorBridge* bridge, const QString& excludeWindowId,
+                                                          const QString& screenId,
+                                                          const QSet<QString>& snappedWindowIds)
 {
-    SnapAssistCandidateList candidates;
+    PhosphorProtocol::SnapAssistCandidateList candidates;
     if (!bridge) {
         return candidates;
     }
@@ -80,7 +81,7 @@ SnapAssistCandidateList buildCandidates(ICompositorBridge* bridge, const QString
             iconName = QStringLiteral("application-x-executable");
         }
 
-        SnapAssistCandidate c;
+        PhosphorProtocol::SnapAssistCandidate c;
         c.windowId = info.windowId;
         // compositorHandle left empty — compositor-specific code fills it (e.g. KWin's internalId)
         c.icon = iconName;

--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -52,11 +52,6 @@ class ScreenManager;
 
 namespace PhosphorPlacement {
 
-using PhosphorProtocol::EmptyZoneList;
-using PhosphorProtocol::WindowGeometryEntry;
-using PhosphorProtocol::WindowGeometryList;
-using PhosphorProtocol::WindowStateEntry;
-
 /**
  * @brief Window-zone tracking service (business logic layer)
  *
@@ -455,9 +450,9 @@ public:
     /**
      * @brief Get typed list of all empty zones for Snap Assist continuation
      * @param screenId Screen to find layout for (e.g. DP-1)
-     * @return EmptyZoneList of empty zone entries with overlay-local geometry
+     * @return PhosphorProtocol::EmptyZoneList of empty zone entries with overlay-local geometry
      */
-    EmptyZoneList getEmptyZones(const QString& screenId) const;
+    PhosphorProtocol::EmptyZoneList getEmptyZones(const QString& screenId) const;
 
     /**
      * @brief Get geometry for a zone on a specific screen

--- a/libs/phosphor-placement/src/navigation.cpp
+++ b/libs/phosphor-placement/src/navigation.cpp
@@ -100,7 +100,7 @@ QString WindowTrackingService::findEmptyZone(const QString& screenId) const
     return findEmptyZoneInLayout(layout, screenId, desktopFilter);
 }
 
-EmptyZoneList WindowTrackingService::getEmptyZones(const QString& screenId) const
+PhosphorProtocol::EmptyZoneList WindowTrackingService::getEmptyZones(const QString& screenId) const
 {
     PhosphorZones::Layout* layout = m_layoutManager->resolveLayoutForScreen(screenId);
     if (!layout) {
@@ -158,7 +158,7 @@ EmptyZoneList WindowTrackingService::getEmptyZones(const QString& screenId) cons
     int defaultBw = m_geometryResolver ? m_geometryResolver->defaultBorderWidth() : 2;
     int defaultBr = m_geometryResolver ? m_geometryResolver->defaultBorderRadius() : 0;
 
-    EmptyZoneList result;
+    PhosphorProtocol::EmptyZoneList result;
     for (PhosphorZones::Zone* zone : layout->zones()) {
         if (occupied.contains(zone->id())) {
             continue;

--- a/libs/phosphor-protocol/src/marshalling.cpp
+++ b/libs/phosphor-protocol/src/marshalling.cpp
@@ -366,21 +366,17 @@ const QDBusArgument& operator>>(const QDBusArgument& arg, DragOutcome& o)
 
 void registerWireTypes()
 {
-    // IMPORTANT: register each type under BOTH its qualified and unqualified
-    // names. Q_DECLARE_METATYPE must be at global scope, so it registers under
-    // the fully-qualified name "PhosphorProtocol::Foo". The authoritative fix is
-    // to fully-qualify the type in every adaptor slot parameter declaration (see
-    // e.g. autotileadaptor.h) so moc records "PhosphorProtocol::Foo" and matches
-    // the qualified registration. This unqualified-alias registration is a
-    // defensive belt-and-suspenders so that a future adaptor written with
-    // unqualified slot parameters still works rather than crashing D-Bus
-    // dispatch at runtime (see dbus_adaptor_routing integration test for the
-    // failure mode — "Could not find slot ..." / "demarshalling function for
-    // type 'QString' failed" observed in production on 2026-04-10).
+    // Each type is registered under its fully-qualified name
+    // "PhosphorProtocol::Foo" — the name Q_DECLARE_METATYPE records at global
+    // scope, and the name moc records for every adaptor slot/signal parameter
+    // (all such declarations are fully qualified). The two agree, so D-Bus
+    // dispatch resolves the slot and its demarshaller without an unqualified
+    // alias. Keep adaptor type spellings fully qualified — an unqualified slot
+    // parameter would make moc record "Foo", which is not registered, and
+    // crash dispatch at runtime (see the dbus_adaptor_routing integration
+    // test for that failure mode).
 
-#define PZ_REGISTER_DBUS_TYPE(Type)                                                                                    \
-    qRegisterMetaType<Type>(#Type);                                                                                    \
-    qDBusRegisterMetaType<Type>()
+#define PZ_REGISTER_DBUS_TYPE(Type) qDBusRegisterMetaType<Type>()
 
     PZ_REGISTER_DBUS_TYPE(WindowGeometryEntry);
     PZ_REGISTER_DBUS_TYPE(WindowGeometryList);

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/snapnavigationtargets.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/snapnavigationtargets.h
@@ -17,12 +17,6 @@ class LayoutRegistry;
 
 namespace PhosphorSnapEngine {
 
-using PhosphorProtocol::CycleTargetResult;
-using PhosphorProtocol::FocusTargetResult;
-using PhosphorProtocol::MoveTargetResult;
-using PhosphorProtocol::RestoreTargetResult;
-using PhosphorProtocol::SwapTargetResult;
-
 class ISettings;
 class IZoneAdjacencyResolver;
 
@@ -50,7 +44,7 @@ class IZoneAdjacencyResolver;
  * This class is deliberately not a QObject — it needs no signals of
  * its own, and the absence of QObject machinery makes it trivially
  * constructable for unit tests. The single dependency on Qt is the
- * shared result-struct types (MoveTargetResult etc. from PhosphorProtocol/NavigationTypes.h).
+ * shared result-struct types (PhosphorProtocol::MoveTargetResult etc. from PhosphorProtocol/NavigationTypes.h).
  *
  * All methods are intended to be called only for screens that the
  * router (ScreenModeRouter) has confirmed are in Snapping mode. The
@@ -84,20 +78,24 @@ public:
     /// it becomes available.
     void setZoneAdjacencyResolver(IZoneAdjacencyResolver* resolver);
 
-    MoveTargetResult getMoveTargetForWindow(const QString& windowId, const QString& direction, const QString& screenId);
+    PhosphorProtocol::MoveTargetResult getMoveTargetForWindow(const QString& windowId, const QString& direction,
+                                                              const QString& screenId);
 
-    FocusTargetResult getFocusTargetForWindow(const QString& windowId, const QString& direction,
-                                              const QString& screenId);
+    PhosphorProtocol::FocusTargetResult getFocusTargetForWindow(const QString& windowId, const QString& direction,
+                                                                const QString& screenId);
 
-    RestoreTargetResult getRestoreForWindow(const QString& windowId, const QString& screenId);
+    PhosphorProtocol::RestoreTargetResult getRestoreForWindow(const QString& windowId, const QString& screenId);
 
-    CycleTargetResult getCycleTargetForWindow(const QString& windowId, bool forward, const QString& screenId);
+    PhosphorProtocol::CycleTargetResult getCycleTargetForWindow(const QString& windowId, bool forward,
+                                                                const QString& screenId);
 
-    SwapTargetResult getSwapTargetForWindow(const QString& windowId, const QString& direction, const QString& screenId);
+    PhosphorProtocol::SwapTargetResult getSwapTargetForWindow(const QString& windowId, const QString& direction,
+                                                              const QString& screenId);
 
-    MoveTargetResult getPushTargetForWindow(const QString& windowId, const QString& screenId);
+    PhosphorProtocol::MoveTargetResult getPushTargetForWindow(const QString& windowId, const QString& screenId);
 
-    MoveTargetResult getSnapToZoneByNumberTarget(const QString& windowId, int zoneNumber, const QString& screenId);
+    PhosphorProtocol::MoveTargetResult getSnapToZoneByNumberTarget(const QString& windowId, int zoneNumber,
+                                                                   const QString& screenId);
 
 private:
     /// Single emission point so call sites don't have to null-check the

--- a/libs/phosphor-snap-engine/src/commit.cpp
+++ b/libs/phosphor-snap-engine/src/commit.cpp
@@ -13,9 +13,6 @@ namespace PhosphorSnapEngine {
 
 using PhosphorEngine::SnapIntent;
 using PhosphorEngine::ZoneAssignmentEntry;
-using PhosphorProtocol::WindowGeometryEntry;
-using PhosphorProtocol::WindowGeometryList;
-using PhosphorProtocol::WindowStateEntry;
 
 void SnapEngine::commitSnapImpl(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
                                 SnapIntent intent)
@@ -57,9 +54,9 @@ void SnapEngine::commitSnapImpl(const QString& windowId, const QStringList& zone
         << "commitSnap:" << windowId << "zones=" << zoneIds << "screen=" << screenId
         << "intent=" << (intent == SnapIntent::UserInitiated ? "user" : "auto");
 
-    Q_EMIT windowSnapStateChanged(
-        windowId,
-        WindowStateEntry{windowId, primaryZoneId, screenId, false, QStringLiteral("snapped"), zoneIds, false});
+    Q_EMIT windowSnapStateChanged(windowId,
+                                  PhosphorProtocol::WindowStateEntry{windowId, primaryZoneId, screenId, false,
+                                                                     QStringLiteral("snapped"), zoneIds, false});
 }
 
 void SnapEngine::commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId, SnapIntent intent)
@@ -99,15 +96,17 @@ void SnapEngine::uncommitSnap(const QString& windowId)
 
     qCInfo(PhosphorSnapEngine::lcSnapEngine) << "uncommitSnap:" << windowId << "from zone" << previousZoneId;
 
-    Q_EMIT windowSnapStateChanged(
-        windowId,
-        WindowStateEntry{windowId, QString(), QString(), false, QStringLiteral("unsnapped"), QStringList{}, false});
+    Q_EMIT windowSnapStateChanged(windowId,
+                                  PhosphorProtocol::WindowStateEntry{windowId, QString(), QString(), false,
+                                                                     QStringLiteral("unsnapped"), QStringList{},
+                                                                     false});
 }
 
-WindowGeometryList SnapEngine::applyBatchAssignments(const QVector<ZoneAssignmentEntry>& entries, SnapIntent intent,
-                                                     std::function<QString()> fallbackScreenResolver)
+PhosphorProtocol::WindowGeometryList SnapEngine::applyBatchAssignments(const QVector<ZoneAssignmentEntry>& entries,
+                                                                       SnapIntent intent,
+                                                                       std::function<QString()> fallbackScreenResolver)
 {
-    WindowGeometryList geometries;
+    PhosphorProtocol::WindowGeometryList geometries;
     if (entries.isEmpty()) {
         return geometries;
     }
@@ -163,8 +162,8 @@ WindowGeometryList SnapEngine::applyBatchAssignments(const QVector<ZoneAssignmen
         // any other entry — but with empty screenId, since the window is being
         // returned to free-floating state and no tracked-screen seeding should
         // override the compositor's geometry-based resolution for it.
-        geometries.append(
-            WindowGeometryEntry::fromRect(entry.windowId, entry.targetGeometry, resolvedScreens.value(i)));
+        geometries.append(PhosphorProtocol::WindowGeometryEntry::fromRect(entry.windowId, entry.targetGeometry,
+                                                                          resolvedScreens.value(i)));
     }
     return geometries;
 }

--- a/libs/phosphor-snap-engine/src/navigation.cpp
+++ b/libs/phosphor-snap-engine/src/navigation.cpp
@@ -13,8 +13,6 @@
 namespace PhosphorSnapEngine {
 
 using PhosphorEngine::ZoneAssignmentEntry;
-using PhosphorProtocol::SnapAllResultEntry;
-using PhosphorProtocol::SnapAllResultList;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Snap-mode resnap coordination
@@ -114,14 +112,15 @@ void SnapEngine::emitBatchedResnap(const QVector<ZoneAssignmentEntry>& entries)
     Q_EMIT resnapToNewLayoutRequested(resnapData);
 }
 
-SnapAllResultList SnapEngine::calculateSnapAllWindows(const QStringList& windowIds, const QString& screenId)
+PhosphorProtocol::SnapAllResultList SnapEngine::calculateSnapAllWindows(const QStringList& windowIds,
+                                                                        const QString& screenId)
 {
     QVector<ZoneAssignmentEntry> entries = calculateSnapAllWindowEntries(windowIds, screenId);
 
-    SnapAllResultList result;
+    PhosphorProtocol::SnapAllResultList result;
     result.reserve(entries.size());
     for (const auto& entry : entries) {
-        SnapAllResultEntry r;
+        PhosphorProtocol::SnapAllResultEntry r;
         r.windowId = entry.windowId;
         r.targetZoneId = entry.targetZoneId;
         r.sourceZoneId = entry.sourceZoneId;

--- a/libs/phosphor-snap-engine/src/navigation_actions.cpp
+++ b/libs/phosphor-snap-engine/src/navigation_actions.cpp
@@ -42,12 +42,6 @@ namespace PhosphorSnapEngine {
 using PhosphorEngine::NavigationContext;
 using PhosphorEngine::SnapIntent;
 using PhosphorEngine::ZoneAssignmentEntry;
-using PhosphorProtocol::CycleTargetResult;
-using PhosphorProtocol::FocusTargetResult;
-using PhosphorProtocol::MoveTargetResult;
-using PhosphorProtocol::RestoreTargetResult;
-using PhosphorProtocol::SwapTargetResult;
-using PhosphorProtocol::WindowGeometryList;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Private helpers
@@ -176,7 +170,7 @@ void SnapEngine::focusInDirection(const QString& direction, const NavigationCont
         return;
     }
     const QString screenId = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
-    FocusTargetResult result = resolver->getFocusTargetForWindow(windowId, direction, screenId);
+    PhosphorProtocol::FocusTargetResult result = resolver->getFocusTargetForWindow(windowId, direction, screenId);
     if (!result.success) {
         return; // resolver already emitted feedback via its callback
     }
@@ -212,7 +206,7 @@ void SnapEngine::moveFocusedInDirection(const QString& direction, const Navigati
         return;
     }
     const QString screenId = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
-    MoveTargetResult result = resolver->getMoveTargetForWindow(windowId, direction, screenId);
+    PhosphorProtocol::MoveTargetResult result = resolver->getMoveTargetForWindow(windowId, direction, screenId);
     if (!result.success) {
         return;
     }
@@ -255,7 +249,7 @@ void SnapEngine::swapFocusedInDirection(const QString& direction, const Navigati
         return;
     }
     const QString screenId = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
-    SwapTargetResult result = resolver->getSwapTargetForWindow(windowId, direction, screenId);
+    PhosphorProtocol::SwapTargetResult result = resolver->getSwapTargetForWindow(windowId, direction, screenId);
     if (!result.success) {
         return;
     }
@@ -306,7 +300,8 @@ void SnapEngine::moveFocusedToPosition(int zoneNumber, const NavigationContext& 
         return;
     }
     const QString effectiveScreen = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
-    MoveTargetResult result = resolver->getSnapToZoneByNumberTarget(windowId, zoneNumber, effectiveScreen);
+    PhosphorProtocol::MoveTargetResult result =
+        resolver->getSnapToZoneByNumberTarget(windowId, zoneNumber, effectiveScreen);
     if (!result.success) {
         return;
     }
@@ -344,7 +339,7 @@ void SnapEngine::pushFocusedToEmptyZone(const NavigationContext& ctx)
         return;
     }
     const QString effectiveScreen = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
-    MoveTargetResult result = resolver->getPushTargetForWindow(windowId, effectiveScreen);
+    PhosphorProtocol::MoveTargetResult result = resolver->getPushTargetForWindow(windowId, effectiveScreen);
     if (!result.success) {
         return;
     }
@@ -379,7 +374,7 @@ void SnapEngine::restoreFocusedWindow(const NavigationContext& ctx)
         return;
     }
     const QString screenId = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
-    RestoreTargetResult result = resolver->getRestoreForWindow(windowId, screenId);
+    PhosphorProtocol::RestoreTargetResult result = resolver->getRestoreForWindow(windowId, screenId);
     if (!result.success) {
         return;
     }
@@ -445,7 +440,7 @@ void SnapEngine::cycleFocus(bool forward, const NavigationContext& ctx)
         return;
     }
     const QString screenId = resolveNavScreen(m_navState, windowId, m_windowTracker, ctx.screenId);
-    CycleTargetResult result = resolver->getCycleTargetForWindow(windowId, forward, screenId);
+    PhosphorProtocol::CycleTargetResult result = resolver->getCycleTargetForWindow(windowId, forward, screenId);
     if (!result.success) {
         return;
     }
@@ -485,16 +480,17 @@ void SnapEngine::rotateWindowsInLayout(bool clockwise, const QString& screenId)
     // cursor/active-screen shadows via INavigationStateProvider — only
     // used when none of the built-in strategies (targetScreenId /
     // geometry.center() / QGuiApplication::screens()) yield a screen.
-    WindowGeometryList geometries = applyBatchAssignments(entries, SnapIntent::UserInitiated, [this]() -> QString {
-        if (!m_navState) {
-            return QString();
-        }
-        QString cursor = m_navState->lastCursorScreenName();
-        if (cursor.isEmpty()) {
-            cursor = m_navState->lastActiveScreenName();
-        }
-        return cursor;
-    });
+    PhosphorProtocol::WindowGeometryList geometries =
+        applyBatchAssignments(entries, SnapIntent::UserInitiated, [this]() -> QString {
+            if (!m_navState) {
+                return QString();
+            }
+            QString cursor = m_navState->lastCursorScreenName();
+            if (cursor.isEmpty()) {
+                cursor = m_navState->lastActiveScreenName();
+            }
+            return cursor;
+        });
     if (!geometries.isEmpty()) {
         Q_EMIT applyGeometriesBatch(geometries, QStringLiteral("rotate"));
     }

--- a/libs/phosphor-snap-engine/src/snapnavigationtargets.cpp
+++ b/libs/phosphor-snap-engine/src/snapnavigationtargets.cpp
@@ -23,29 +23,32 @@ namespace {
 // Result builders
 // ═══════════════════════════════════════════════════════════════════════════
 
-MoveTargetResult moveResult(bool success, const QString& reason, const QString& zoneId, const QRect& geometry,
-                            const QString& sourceZoneId, const QString& screenId)
+PhosphorProtocol::MoveTargetResult moveResult(bool success, const QString& reason, const QString& zoneId,
+                                              const QRect& geometry, const QString& sourceZoneId,
+                                              const QString& screenId)
 {
     return {success,           reason,       zoneId,  geometry.x(), geometry.y(), geometry.width(),
             geometry.height(), sourceZoneId, screenId};
 }
 
-FocusTargetResult focusResult(bool success, const QString& reason, const QString& windowIdToActivate,
-                              const QString& sourceZoneId, const QString& targetZoneId, const QString& screenId)
+PhosphorProtocol::FocusTargetResult focusResult(bool success, const QString& reason, const QString& windowIdToActivate,
+                                                const QString& sourceZoneId, const QString& targetZoneId,
+                                                const QString& screenId)
 {
     return {success, reason, windowIdToActivate, sourceZoneId, targetZoneId, screenId};
 }
 
-CycleTargetResult cycleResult(bool success, const QString& reason, const QString& windowIdToActivate,
-                              const QString& zoneId, const QString& screenId)
+PhosphorProtocol::CycleTargetResult cycleResult(bool success, const QString& reason, const QString& windowIdToActivate,
+                                                const QString& zoneId, const QString& screenId)
 {
     return {success, reason, windowIdToActivate, zoneId, screenId};
 }
 
-SwapTargetResult swapResult(bool success, const QString& reason, const QString& windowId1, int x1, int y1, int w1,
-                            int h1, const QString& zoneId1, const QString& windowId2, int x2, int y2, int w2, int h2,
-                            const QString& zoneId2, const QString& screenId, const QString& sourceZoneId,
-                            const QString& targetZoneId)
+PhosphorProtocol::SwapTargetResult swapResult(bool success, const QString& reason, const QString& windowId1, int x1,
+                                              int y1, int w1, int h1, const QString& zoneId1, const QString& windowId2,
+                                              int x2, int y2, int w2, int h2, const QString& zoneId2,
+                                              const QString& screenId, const QString& sourceZoneId,
+                                              const QString& targetZoneId)
 {
     return {success, reason, windowId1, x1, y1,      w1,       h1,           zoneId1,     windowId2,
             x2,      y2,     w2,        h2, zoneId2, screenId, sourceZoneId, targetZoneId};
@@ -120,8 +123,9 @@ void SnapNavigationTargetResolver::setZoneAdjacencyResolver(IZoneAdjacencyResolv
 // Navigation Target Computation
 // ═══════════════════════════════════════════════════════════════════════════
 
-MoveTargetResult SnapNavigationTargetResolver::getMoveTargetForWindow(const QString& windowId, const QString& direction,
-                                                                      const QString& screenId)
+PhosphorProtocol::MoveTargetResult SnapNavigationTargetResolver::getMoveTargetForWindow(const QString& windowId,
+                                                                                        const QString& direction,
+                                                                                        const QString& screenId)
 {
     if (!checkWindowId(windowId)) {
         qCWarning(PhosphorSnapEngine::lcSnapEngine) << "Cannot getMoveTargetForWindow - empty window ID";
@@ -193,9 +197,9 @@ MoveTargetResult SnapNavigationTargetResolver::getMoveTargetForWindow(const QStr
     return moveResult(true, QString(), targetZoneId, geo, currentZoneId, effectiveScreenId);
 }
 
-FocusTargetResult SnapNavigationTargetResolver::getFocusTargetForWindow(const QString& windowId,
-                                                                        const QString& direction,
-                                                                        const QString& screenId)
+PhosphorProtocol::FocusTargetResult SnapNavigationTargetResolver::getFocusTargetForWindow(const QString& windowId,
+                                                                                          const QString& direction,
+                                                                                          const QString& screenId)
 {
     if (!checkWindowId(windowId)) {
         qCWarning(PhosphorSnapEngine::lcSnapEngine) << "Cannot getFocusTargetForWindow - empty window ID";
@@ -247,7 +251,8 @@ FocusTargetResult SnapNavigationTargetResolver::getFocusTargetForWindow(const QS
     return focusResult(true, QString(), windowsInZone.first(), currentZoneId, targetZoneId, effectiveScreenId);
 }
 
-RestoreTargetResult SnapNavigationTargetResolver::getRestoreForWindow(const QString& windowId, const QString& screenId)
+PhosphorProtocol::RestoreTargetResult SnapNavigationTargetResolver::getRestoreForWindow(const QString& windowId,
+                                                                                        const QString& screenId)
 {
     if (!checkWindowId(windowId)) {
         qCWarning(PhosphorSnapEngine::lcSnapEngine) << "Cannot getRestoreForWindow - empty window ID";
@@ -272,8 +277,8 @@ RestoreTargetResult SnapNavigationTargetResolver::getRestoreForWindow(const QStr
     return {success, success, x, y, w, h};
 }
 
-CycleTargetResult SnapNavigationTargetResolver::getCycleTargetForWindow(const QString& windowId, bool forward,
-                                                                        const QString& screenId)
+PhosphorProtocol::CycleTargetResult
+SnapNavigationTargetResolver::getCycleTargetForWindow(const QString& windowId, bool forward, const QString& screenId)
 {
     if (!checkWindowId(windowId)) {
         qCWarning(PhosphorSnapEngine::lcSnapEngine) << "Cannot getCycleTargetForWindow - empty window ID";
@@ -316,8 +321,9 @@ CycleTargetResult SnapNavigationTargetResolver::getCycleTargetForWindow(const QS
     return cycleResult(true, QString(), targetWindowId, currentZoneId, screenId);
 }
 
-SwapTargetResult SnapNavigationTargetResolver::getSwapTargetForWindow(const QString& windowId, const QString& direction,
-                                                                      const QString& screenId)
+PhosphorProtocol::SwapTargetResult SnapNavigationTargetResolver::getSwapTargetForWindow(const QString& windowId,
+                                                                                        const QString& direction,
+                                                                                        const QString& screenId)
 {
     // On failure, windowId1 is returned empty so that a caller which forgets
     // to check `success` cannot accidentally act on the calling window.
@@ -388,7 +394,8 @@ SwapTargetResult SnapNavigationTargetResolver::getSwapTargetForWindow(const QStr
                       targetZoneId);
 }
 
-MoveTargetResult SnapNavigationTargetResolver::getPushTargetForWindow(const QString& windowId, const QString& screenId)
+PhosphorProtocol::MoveTargetResult SnapNavigationTargetResolver::getPushTargetForWindow(const QString& windowId,
+                                                                                        const QString& screenId)
 {
     if (!checkWindowId(windowId)) {
         qCWarning(PhosphorSnapEngine::lcSnapEngine) << "Cannot getPushTargetForWindow - empty window ID";
@@ -411,8 +418,9 @@ MoveTargetResult SnapNavigationTargetResolver::getPushTargetForWindow(const QStr
     return moveResult(true, QString(), emptyZoneId, geo, QString(), screenId);
 }
 
-MoveTargetResult SnapNavigationTargetResolver::getSnapToZoneByNumberTarget(const QString& windowId, int zoneNumber,
-                                                                           const QString& screenId)
+PhosphorProtocol::MoveTargetResult SnapNavigationTargetResolver::getSnapToZoneByNumberTarget(const QString& windowId,
+                                                                                             int zoneNumber,
+                                                                                             const QString& screenId)
 {
     if (!checkWindowId(windowId)) {
         qCWarning(PhosphorSnapEngine::lcSnapEngine) << "Cannot getSnapToZoneByNumberTarget - empty window ID";

--- a/src/core/geometryutils.cpp
+++ b/src/core/geometryutils.cpp
@@ -151,12 +151,12 @@ QRect getZoneGeometryForScreen(Phosphor::Screens::ScreenManager* mgr, PhosphorZo
     return ::PhosphorZones::GeometryUtils::getZoneGeometryForScreen(mgr, zone, screen, screenId, layout, zp, og);
 }
 
-static EmptyZoneList buildEmptyZoneListImpl(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
-                                            const std::optional<QRect>& screenGeometry, const QRect& availableGeometry,
-                                            const QString& screenId, int zonePadding,
-                                            const ::PhosphorLayout::EdgeGaps& outerGaps, bool useAvail,
-                                            ISettings* settings, const QRect& overlayOriginRect, QScreen* physScreen,
-                                            const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty)
+static PhosphorProtocol::EmptyZoneList
+buildEmptyZoneListImpl(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
+                       const std::optional<QRect>& screenGeometry, const QRect& availableGeometry,
+                       const QString& screenId, int zonePadding, const ::PhosphorLayout::EdgeGaps& outerGaps,
+                       bool useAvail, ISettings* settings, const QRect& overlayOriginRect, QScreen* physScreen,
+                       const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty)
 {
     QRect resolvedScreenGeom;
     QRect resolvedAvailGeom;
@@ -173,7 +173,7 @@ static EmptyZoneList buildEmptyZoneListImpl(Phosphor::Screens::ScreenManager* mg
         return {};
     }
 
-    EmptyZoneList result;
+    PhosphorProtocol::EmptyZoneList result;
     for (PhosphorZones::Zone* zone : layout->zones()) {
         if (!isZoneEmpty(zone)) {
             continue;
@@ -189,7 +189,7 @@ static EmptyZoneList buildEmptyZoneListImpl(Phosphor::Screens::ScreenManager* mg
             ? zone->borderRadius()
             : (settings ? settings->borderRadius() : ::PhosphorZones::ZoneDefaults::BorderRadius);
 
-        EmptyZoneEntry entry;
+        PhosphorProtocol::EmptyZoneEntry entry;
         entry.zoneId = zone->id().toString();
         entry.x = overlayGeom.x();
         entry.y = overlayGeom.y();
@@ -210,9 +210,9 @@ static EmptyZoneList buildEmptyZoneListImpl(Phosphor::Screens::ScreenManager* mg
     return result;
 }
 
-EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout, QScreen* screen,
-                                 ISettings* settings,
-                                 const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty)
+PhosphorProtocol::EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
+                                                   QScreen* screen, ISettings* settings,
+                                                   const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty)
 {
     if (!layout || !screen) {
         return {};
@@ -229,9 +229,9 @@ EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr, Phosphor
                                   settings, QRect(), screen, isZoneEmpty);
 }
 
-EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
-                                 const QString& screenId, QScreen* physScreen, ISettings* settings,
-                                 const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty)
+PhosphorProtocol::EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout,
+                                                   const QString& screenId, QScreen* physScreen, ISettings* settings,
+                                                   const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty)
 {
     if (!layout) {
         return {};
@@ -251,7 +251,8 @@ EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr, Phosphor
                                       outerGaps, useAvail, settings, vsGeom, nullptr, isZoneEmpty);
     }
 
-    return physScreen ? buildEmptyZoneList(mgr, layout, physScreen, settings, isZoneEmpty) : EmptyZoneList{};
+    return physScreen ? buildEmptyZoneList(mgr, layout, physScreen, settings, isZoneEmpty)
+                      : PhosphorProtocol::EmptyZoneList{};
 }
 
 } // namespace GeometryUtils

--- a/src/core/geometryutils.h
+++ b/src/core/geometryutils.h
@@ -29,9 +29,6 @@ class ScreenManager;
 
 namespace PlasmaZones {
 
-using PhosphorProtocol::EmptyZoneEntry;
-using PhosphorProtocol::EmptyZoneList;
-
 class ISettings;
 
 /**
@@ -123,14 +120,14 @@ using ::PhosphorZones::GeometryUtils::setZoneGeometry;
  * @param screen Screen to calculate geometry for
  * @param settings Settings for zone padding/outer gap
  * @param isZoneEmpty Predicate: returns true if zone has no windows
- * @return EmptyZoneList of empty zone entries with overlay-local geometry
+ * @return PhosphorProtocol::EmptyZoneList of empty zone entries with overlay-local geometry
  *
  * Used by PhosphorPlacement::WindowTrackingService::getEmptyZones and WindowDragAdaptor::dragStopped
  * to avoid duplicating the empty-zones building logic.
  */
-PLASMAZONES_EXPORT EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr,
-                                                    PhosphorZones::Layout* layout, QScreen* screen, ISettings* settings,
-                                                    const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty);
+PLASMAZONES_EXPORT PhosphorProtocol::EmptyZoneList
+buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout, QScreen* screen,
+                   ISettings* settings, const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty);
 
 /**
  * @brief Build typed list of empty zones using explicit screen ID (virtual-screen-aware)
@@ -138,10 +135,10 @@ PLASMAZONES_EXPORT EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenMan
  * Uses Phosphor::Screens::ScreenManager to resolve virtual screen geometry when available, falling back
  * to the physical QScreen* geometry.
  */
-PLASMAZONES_EXPORT EmptyZoneList buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr,
-                                                    PhosphorZones::Layout* layout, const QString& screenId,
-                                                    QScreen* physScreen, ISettings* settings,
-                                                    const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty);
+PLASMAZONES_EXPORT PhosphorProtocol::EmptyZoneList
+buildEmptyZoneList(Phosphor::Screens::ScreenManager* mgr, PhosphorZones::Layout* layout, const QString& screenId,
+                   QScreen* physScreen, ISettings* settings,
+                   const std::function<bool(const PhosphorZones::Zone*)>& isZoneEmpty);
 
 using ::PhosphorGeometry::enforceMinSizes;
 using ::PhosphorGeometry::removeRectOverlaps;

--- a/src/core/ioverlayservice.h
+++ b/src/core/ioverlayservice.h
@@ -29,9 +29,6 @@ class Zone;
 
 namespace PlasmaZones {
 
-using PhosphorProtocol::EmptyZoneList;
-using PhosphorProtocol::SnapAssistCandidateList;
-
 class ISettings;
 
 /**
@@ -110,8 +107,8 @@ public:
     virtual void hideShaderPreview() = 0;
 
     // Snap Assist overlay (window picker after snapping)
-    virtual void showSnapAssist(const QString& screenId, const EmptyZoneList& emptyZones,
-                                const SnapAssistCandidateList& candidates) = 0;
+    virtual void showSnapAssist(const QString& screenId, const PhosphorProtocol::EmptyZoneList& emptyZones,
+                                const PhosphorProtocol::SnapAssistCandidateList& candidates) = 0;
     virtual void hideSnapAssist() = 0;
     virtual bool isSnapAssistVisible() const = 0;
     /// Deliver a thumbnail as raw ARGB32 pixels. @p pixels MUST be exactly
@@ -164,8 +161,8 @@ Q_SIGNALS:
      * `showSnapAssist` call sequence (not in response to this signal); the
      * signal is exposed for external observers (KCMs, debugging tools).
      */
-    void snapAssistShown(const QString& screenId, const EmptyZoneList& emptyZones,
-                         const SnapAssistCandidateList& candidates);
+    void snapAssistShown(const QString& screenId, const PhosphorProtocol::EmptyZoneList& emptyZones,
+                         const PhosphorProtocol::SnapAssistCandidateList& candidates);
 
     /**
      * @brief Emitted when Snap Assist overlay is dismissed (by selection, Escape, or any other means).

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1002,7 +1002,7 @@ bool Daemon::init()
     // incorrectly processes the already-snapped window as autotile-managed.
     // Wired here (daemon) because engines must not know about each other.
     connect(snapEngine, &PhosphorSnapEngine::SnapEngine::windowSnapStateChanged, this,
-            [this](const QString& windowId, const WindowStateEntry&) {
+            [this](const QString& windowId, const PhosphorProtocol::WindowStateEntry&) {
                 if (m_autotileEngine) {
                     m_autotileEngine->clearModeSpecificFloatMarker(windowId);
                 }
@@ -1222,7 +1222,7 @@ bool Daemon::init()
 
     // Connect zone detection to overlay updates
     connect(m_zoneDetectionAdaptor, &ZoneDetectionAdaptor::zoneDetected, this,
-            [this](const QString& zoneId, const ZoneGeometryRect& geometry) {
+            [this](const QString& zoneId, const PhosphorProtocol::ZoneGeometryRect& geometry) {
                 Q_UNUSED(zoneId)
                 Q_UNUSED(geometry)
                 // Update overlay when zone is detected

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -546,7 +546,8 @@ void Daemon::connectShortcutSignals()
     // matching unregister fires on snapAssistDismissed via
     // WindowDragAdaptor::onSnapAssistDismissed.
     connect(m_overlayService.get(), &IOverlayService::snapAssistShown, this,
-            [this](const QString&, const EmptyZoneList&, const SnapAssistCandidateList&) {
+            [this](const QString&, const PhosphorProtocol::EmptyZoneList&,
+                   const PhosphorProtocol::SnapAssistCandidateList&) {
                 if (m_windowDragAdaptor) {
                     m_windowDragAdaptor->ensureCancelOverlayShortcutRegistered();
                 }

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -370,8 +370,8 @@ public:
     void hideShaderPreview() override;
 
     // Snap Assist overlay (window picker after snapping)
-    void showSnapAssist(const QString& screenId, const EmptyZoneList& emptyZones,
-                        const SnapAssistCandidateList& candidates) override;
+    void showSnapAssist(const QString& screenId, const PhosphorProtocol::EmptyZoneList& emptyZones,
+                        const PhosphorProtocol::SnapAssistCandidateList& candidates) override;
     void hideSnapAssist() override;
     bool isSnapAssistVisible() const override;
     bool setSnapAssistThumbnail(const QString& compositorHandle, int width, int height,

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -31,8 +31,8 @@ namespace PlasmaZones {
 
 namespace {
 
-/// Convert EmptyZoneList to QVariantList for QML property push
-QVariantList emptyZonesToVariantList(const EmptyZoneList& zones)
+/// Convert PhosphorProtocol::EmptyZoneList to QVariantList for QML property push
+QVariantList emptyZonesToVariantList(const PhosphorProtocol::EmptyZoneList& zones)
 {
     QVariantList result;
     result.reserve(zones.size());
@@ -58,8 +58,8 @@ QVariantList emptyZonesToVariantList(const EmptyZoneList& zones)
     return result;
 }
 
-/// Convert SnapAssistCandidateList to QVariantList for QML property push
-QVariantList candidatesToVariantList(const SnapAssistCandidateList& candidates)
+/// Convert PhosphorProtocol::SnapAssistCandidateList to QVariantList for QML property push
+QVariantList candidatesToVariantList(const PhosphorProtocol::SnapAssistCandidateList& candidates)
 {
     QVariantList result;
     result.reserve(candidates.size());
@@ -76,8 +76,8 @@ QVariantList candidatesToVariantList(const SnapAssistCandidateList& candidates)
 
 } // namespace
 
-void OverlayService::showSnapAssist(const QString& screenId, const EmptyZoneList& emptyZones,
-                                    const SnapAssistCandidateList& candidates)
+void OverlayService::showSnapAssist(const QString& screenId, const PhosphorProtocol::EmptyZoneList& emptyZones,
+                                    const PhosphorProtocol::SnapAssistCandidateList& candidates)
 {
     if (emptyZones.isEmpty() || candidates.isEmpty()) {
         qCDebug(lcOverlay) << "showSnapAssist: no empty zones or candidates";

--- a/src/dbus/autotileadaptor.cpp
+++ b/src/dbus/autotileadaptor.cpp
@@ -203,7 +203,7 @@ int AutotileAdaptor::pendingWindowOpensCount() const
     return m_pendingOpens.size();
 }
 
-void AutotileAdaptor::dispatchWindowOpened(const WindowOpenedEntry& entry)
+void AutotileAdaptor::dispatchWindowOpened(const PhosphorProtocol::WindowOpenedEntry& entry)
 {
     if (entry.windowId.isEmpty() || entry.screenId.isEmpty()) {
         return;
@@ -245,7 +245,7 @@ void AutotileAdaptor::flushPendingWindowOpens()
     // Move-then-clear so any re-entrant dispatchWindowOpened → slot callback → new
     // deferral (unlikely post-ready, but defensive) queues into a fresh list rather
     // than mutating the one we're iterating.
-    const WindowOpenedList toFlush = std::move(m_pendingOpens);
+    const PhosphorProtocol::WindowOpenedList toFlush = std::move(m_pendingOpens);
     m_pendingOpens.clear();
     qCInfo(lcDbusAutotile) << "flushPendingWindowOpens: processing" << toFlush.size()
                            << "deferred windows after panel geometry became ready";
@@ -273,7 +273,7 @@ void AutotileAdaptor::windowOpened(const QString& windowId, const QString& scree
     // is empty until the sensor windows and Plasma D-Bus panel query finish), and
     // the daemon would emit a visible correction a frame later. Flushing happens in
     // flushPendingWindowOpens() when panelGeometryReady fires.
-    WindowOpenedEntry entry{windowId, screenId, minWidth, minHeight};
+    PhosphorProtocol::WindowOpenedEntry entry{windowId, screenId, minWidth, minHeight};
     if (deferUntilPanelReady()) {
         qCInfo(lcDbusAutotile) << "windowOpened: deferring" << windowId
                                << "until panel geometry ready (queue size=" << (m_pendingOpens.size() + 1) << ")";
@@ -285,7 +285,7 @@ void AutotileAdaptor::windowOpened(const QString& windowId, const QString& scree
     dispatchWindowOpened(entry);
 }
 
-void AutotileAdaptor::windowsOpenedBatch(const WindowOpenedList& entries)
+void AutotileAdaptor::windowsOpenedBatch(const PhosphorProtocol::WindowOpenedList& entries)
 {
     if (!ensureEngine("windowsOpenedBatch")) {
         return;
@@ -368,7 +368,7 @@ QStringList AutotileAdaptor::availableAlgorithms()
     return m_algorithmRegistry->availableAlgorithms();
 }
 
-AlgorithmInfoEntry AutotileAdaptor::algorithmInfo(const QString& algorithmId)
+PhosphorProtocol::AlgorithmInfoEntry AutotileAdaptor::algorithmInfo(const QString& algorithmId)
 {
     PhosphorTiles::TilingAlgorithm* algo = m_algorithmRegistry->algorithm(algorithmId);
     if (!algo) {
@@ -376,7 +376,7 @@ AlgorithmInfoEntry AutotileAdaptor::algorithmInfo(const QString& algorithmId)
         return {};
     }
 
-    AlgorithmInfoEntry entry;
+    PhosphorProtocol::AlgorithmInfoEntry entry;
     entry.id = algorithmId; // Validated by successful lookup above
     entry.name = algo->name();
     entry.description = algo->description();
@@ -411,10 +411,10 @@ void AutotileAdaptor::onWindowsTiled(const QString& tileRequestsJson)
         return;
     }
 
-    TileRequestList requests;
+    PhosphorProtocol::TileRequestList requests;
     for (const QJsonValue& val : doc.array()) {
         QJsonObject obj = val.toObject();
-        TileRequestEntry entry;
+        PhosphorProtocol::TileRequestEntry entry;
         entry.windowId = obj.value(QLatin1String("windowId")).toString();
         entry.floating = obj.value(QLatin1String("floating")).toBool(false);
         if (!entry.floating) {

--- a/src/dbus/autotileadaptor.h
+++ b/src/dbus/autotileadaptor.h
@@ -28,12 +28,6 @@ class AutotileEngine;
 
 namespace PlasmaZones {
 
-using PhosphorProtocol::AlgorithmInfoEntry;
-using PhosphorProtocol::TileRequestEntry;
-using PhosphorProtocol::TileRequestList;
-using PhosphorProtocol::WindowOpenedEntry;
-using PhosphorProtocol::WindowOpenedList;
-
 /**
  * @brief D-Bus adaptor for autotiling control
  *
@@ -206,7 +200,7 @@ public Q_SLOTS:
      *
      * @param entries Array of (windowId, screenId, minWidth, minHeight) structs
      */
-    void windowsOpenedBatch(const PlasmaZones::WindowOpenedList& entries);
+    void windowsOpenedBatch(const PhosphorProtocol::WindowOpenedList& entries);
 
     /**
      * @brief Update a window's minimum size at runtime
@@ -285,9 +279,9 @@ public Q_SLOTS:
     /**
      * @brief Get information about a specific algorithm
      * @param algorithmId Algorithm ID to query
-     * @return AlgorithmInfoEntry struct with algorithm metadata
+     * @return PhosphorProtocol::AlgorithmInfoEntry struct with algorithm metadata
      */
-    AlgorithmInfoEntry algorithmInfo(const QString& algorithmId);
+    PhosphorProtocol::AlgorithmInfoEntry algorithmInfo(const QString& algorithmId);
 
 Q_SIGNALS:
     // ═══════════════════════════════════════════════════════════════════════════
@@ -328,7 +322,7 @@ Q_SIGNALS:
      *
      * @param tileRequestsJson JSON array of {windowId,x,y,width,height}
      */
-    void windowsTileRequested(const PlasmaZones::TileRequestList& tileRequests);
+    void windowsTileRequested(const PhosphorProtocol::TileRequestList& tileRequests);
 
     /**
      * @brief Emitted when a window should be focused
@@ -406,7 +400,7 @@ private:
      * flushPendingWindowOpens() so all three paths validate arguments and
      * invoke the engine identically.
      */
-    void dispatchWindowOpened(const WindowOpenedEntry& entry);
+    void dispatchWindowOpened(const PhosphorProtocol::WindowOpenedEntry& entry);
 
     /**
      * @brief Decide whether an incoming windowOpened must be deferred
@@ -425,7 +419,7 @@ private:
     // Processing them immediately would compute zones against the unreserved screen rect
     // (the s_availableGeometryCache in Phosphor::Screens::ScreenManager is still empty), so we queue them
     // until panelGeometryReady fires. Non-blocking — no nested event loops, no reentrancy.
-    WindowOpenedList m_pendingOpens;
+    PhosphorProtocol::WindowOpenedList m_pendingOpens;
     bool m_pendingOpensListenerInstalled = false;
 
 public:

--- a/src/dbus/compositorbridgeadaptor.cpp
+++ b/src/dbus/compositorbridgeadaptor.cpp
@@ -25,8 +25,9 @@ CompositorBridgeAdaptor::CompositorBridgeAdaptor(QObject* parent)
 {
 }
 
-BridgeRegistrationResult CompositorBridgeAdaptor::registerBridge(const QString& compositorName, const QString& version,
-                                                                 const QStringList& capabilities)
+PhosphorProtocol::BridgeRegistrationResult CompositorBridgeAdaptor::registerBridge(const QString& compositorName,
+                                                                                   const QString& version,
+                                                                                   const QStringList& capabilities)
 {
     if (!m_bridgeName.isEmpty()) {
         qCWarning(lcDbusWindow) << "Compositor bridge re-registration: replacing" << m_bridgeName << m_bridgeVersion
@@ -40,7 +41,7 @@ BridgeRegistrationResult CompositorBridgeAdaptor::registerBridge(const QString& 
         qCWarning(lcDbusWindow) << "Compositor bridge REJECTED: peer apiVersion" << peerApiVersion << "is below minimum"
                                 << DaemonMinPeerApiVersion << "(compositor:" << compositorName << ")."
                                 << "Update the effect to match the daemon.";
-        BridgeRegistrationResult result;
+        PhosphorProtocol::BridgeRegistrationResult result;
         result.apiVersion = QString::number(DaemonApiVersion);
         result.bridgeName = compositorName;
         result.sessionId = QStringLiteral("REJECTED");
@@ -56,7 +57,7 @@ BridgeRegistrationResult CompositorBridgeAdaptor::registerBridge(const QString& 
 
     Q_EMIT bridgeRegistered(compositorName, version, capabilities);
 
-    BridgeRegistrationResult result;
+    PhosphorProtocol::BridgeRegistrationResult result;
     result.apiVersion = QString::number(DaemonApiVersion);
     result.bridgeName = compositorName;
     result.sessionId = QUuid::createUuid().toString(QUuid::WithoutBraces);

--- a/src/dbus/compositorbridgeadaptor.h
+++ b/src/dbus/compositorbridgeadaptor.h
@@ -14,9 +14,6 @@
 
 namespace PlasmaZones {
 
-using PhosphorProtocol::BridgeRegistrationResult;
-using PhosphorProtocol::WindowGeometryList;
-
 /**
  * @brief D-Bus adaptor for the compositor bridge protocol
  *
@@ -75,7 +72,7 @@ public Q_SLOTS:
      * @param compositorName Name of the compositor (e.g. "kwin", "hyprland", "sway")
      * @param version Compositor version string
      * @param capabilities List of supported capabilities
-     * @return BridgeRegistrationResult struct: {apiVersion, bridgeName, sessionId}
+     * @return PhosphorProtocol::BridgeRegistrationResult struct: {apiVersion, bridgeName, sessionId}
      *
      * Capabilities:
      *   "borderless"  — bridge supports setWindowBorderless
@@ -84,8 +81,8 @@ public Q_SLOTS:
      *   "borders"     — bridge supports native window border rendering
      *   "modifiers"   — bridge reports keyboard modifier state
      */
-    PlasmaZones::BridgeRegistrationResult registerBridge(const QString& compositorName, const QString& version,
-                                                         const QStringList& capabilities);
+    PhosphorProtocol::BridgeRegistrationResult registerBridge(const QString& compositorName, const QString& version,
+                                                              const QStringList& capabilities);
 
     /**
      * @brief Report keyboard modifier and mouse button state
@@ -111,7 +108,7 @@ Q_SIGNALS:
      * @param batchJson JSON array of [{windowId, x, y, width, height, targetZoneId, ...}]
      * @param action Operation type ("rotate", "resnap", "snap_all")
      */
-    void applyWindowGeometriesBatch(const PlasmaZones::WindowGeometryList& geometries, const QString& action);
+    void applyWindowGeometriesBatch(const PhosphorProtocol::WindowGeometryList& geometries, const QString& action);
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Window focus and stacking commands (daemon → compositor)

--- a/src/dbus/overlayadaptor.cpp
+++ b/src/dbus/overlayadaptor.cpp
@@ -55,11 +55,11 @@ OverlayAdaptor::OverlayAdaptor(IOverlayService* overlay, PhosphorZones::IZoneDet
         Q_EMIT zoneHighlightChanged(QString());
     });
 
-    connect(
-        m_overlayService, &IOverlayService::snapAssistShown, this,
-        [this](const QString& screenId, const EmptyZoneList& emptyZones, const SnapAssistCandidateList& candidates) {
-            Q_EMIT snapAssistShown(screenId, emptyZones, candidates);
-        });
+    connect(m_overlayService, &IOverlayService::snapAssistShown, this,
+            [this](const QString& screenId, const PhosphorProtocol::EmptyZoneList& emptyZones,
+                   const PhosphorProtocol::SnapAssistCandidateList& candidates) {
+                Q_EMIT snapAssistShown(screenId, emptyZones, candidates);
+            });
 
     // Mirror snapAssistShown's path on the way out so external observers
     // (KCMs, debugging tools, the kwin-effect's thumbnail-injection
@@ -216,8 +216,8 @@ void OverlayAdaptor::hideShaderPreview()
     m_overlayService->hideShaderPreview();
 }
 
-bool OverlayAdaptor::showSnapAssist(const QString& screenId, const EmptyZoneList& emptyZones,
-                                    const SnapAssistCandidateList& candidates)
+bool OverlayAdaptor::showSnapAssist(const QString& screenId, const PhosphorProtocol::EmptyZoneList& emptyZones,
+                                    const PhosphorProtocol::SnapAssistCandidateList& candidates)
 {
     if (!m_overlayService) {
         qCWarning(lcDbus) << "showSnapAssist: overlay service not wired";
@@ -239,7 +239,7 @@ bool OverlayAdaptor::showSnapAssist(const QString& screenId, const EmptyZoneList
     if (!PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
         auto* mgr = m_screenManager;
         if (mgr && mgr->hasVirtualScreens(screenId) && !emptyZones.isEmpty()) {
-            const EmptyZoneEntry& first = emptyZones.first();
+            const PhosphorProtocol::EmptyZoneEntry& first = emptyZones.first();
             QPoint center(first.x + first.width / 2, first.y + first.height / 2);
             QString vsId = mgr->effectiveScreenAt(center);
             if (!vsId.isEmpty()) {

--- a/src/dbus/overlayadaptor.h
+++ b/src/dbus/overlayadaptor.h
@@ -24,10 +24,6 @@ class IZoneDetector;
 
 namespace PlasmaZones {
 
-using PhosphorProtocol::EmptyZoneEntry;
-using PhosphorProtocol::EmptyZoneList;
-using PhosphorProtocol::SnapAssistCandidateList;
-
 class IOverlayService;
 class ISettings;
 
@@ -86,8 +82,8 @@ public Q_SLOTS:
     void hideShaderPreview();
 
     // Snap Assist overlay (window picker after snapping)
-    bool showSnapAssist(const QString& screenId, const PlasmaZones::EmptyZoneList& emptyZones,
-                        const PlasmaZones::SnapAssistCandidateList& candidates);
+    bool showSnapAssist(const QString& screenId, const PhosphorProtocol::EmptyZoneList& emptyZones,
+                        const PhosphorProtocol::SnapAssistCandidateList& candidates);
     void hideSnapAssist();
     bool isSnapAssistVisible();
     bool setSnapAssistThumbnail(const QString& compositorHandle, int width, int height, const QByteArray& pixels);
@@ -95,8 +91,8 @@ public Q_SLOTS:
 Q_SIGNALS:
     void overlayVisibilityChanged(bool visible);
     void zoneHighlightChanged(const QString& zoneId);
-    void snapAssistShown(const QString& screenId, const PlasmaZones::EmptyZoneList& emptyZones,
-                         const PlasmaZones::SnapAssistCandidateList& candidates);
+    void snapAssistShown(const QString& screenId, const PhosphorProtocol::EmptyZoneList& emptyZones,
+                         const PhosphorProtocol::SnapAssistCandidateList& candidates);
     /**
      * @brief Emitted when the Snap Assist overlay closes.
      *

--- a/src/dbus/snapadaptor.cpp
+++ b/src/dbus/snapadaptor.cpp
@@ -57,7 +57,7 @@ SnapAdaptor::SnapAdaptor(PhosphorSnapEngine::SnapEngine* engine, WindowTrackingA
                                  &SnapAdaptor::handleBatchedResnap));
 
     // Batched geometry application: rotate / resnap / snap-all paths build
-    // a WindowGeometryList and emit it here. WTA's applyGeometriesBatch
+    // a PhosphorProtocol::WindowGeometryList and emit it here. WTA's applyGeometriesBatch
     // signal is the D-Bus surface.
     m_connections.append(connect(m_engine, &PhosphorSnapEngine::SnapEngine::applyGeometriesBatch, adaptor,
                                  &WindowTrackingAdaptor::applyGeometriesBatch));

--- a/src/dbus/snapadaptor.h
+++ b/src/dbus/snapadaptor.h
@@ -19,11 +19,6 @@ class SnapEngine;
 
 namespace PlasmaZones {
 
-using PhosphorProtocol::SnapAllResultList;
-using PhosphorProtocol::SnapConfirmationList;
-using PhosphorProtocol::UnfloatRestoreResult;
-using PhosphorProtocol::WindowGeometryList;
-
 class ScreenModeRouter;
 class WindowTrackingAdaptor;
 class ISettings;
@@ -114,7 +109,7 @@ public Q_SLOTS:
     /**
      * @brief Batch snap confirmations from the KWin effect
      */
-    void windowsSnappedBatch(const PlasmaZones::SnapConfirmationList& entries);
+    void windowsSnappedBatch(const PhosphorProtocol::SnapConfirmationList& entries);
 
     /**
      * @brief Record that a window class was USER-snapped (not auto-snapped)
@@ -178,7 +173,7 @@ public Q_SLOTS:
     /**
      * @brief Calculate snap assignments for all provided windows
      */
-    PlasmaZones::SnapAllResultList calculateSnapAllWindows(const QStringList& windowIds, const QString& screenId);
+    PhosphorProtocol::SnapAllResultList calculateSnapAllWindows(const QStringList& windowIds, const QString& screenId);
 
     /**
      * @brief Trigger snap-all-windows from daemon shortcut
@@ -283,9 +278,9 @@ public Q_SLOTS:
      * @brief Calculate unfloat restore geometry and zone IDs in a single call
      * @param windowId Window identifier
      * @param screenId Screen for geometry calculation
-     * @return UnfloatRestoreResult with found, zoneIds, screenName, x, y, width, height
+     * @return PhosphorProtocol::UnfloatRestoreResult with found, zoneIds, screenName, x, y, width, height
      */
-    PlasmaZones::UnfloatRestoreResult calculateUnfloatRestore(const QString& windowId, const QString& screenId);
+    PhosphorProtocol::UnfloatRestoreResult calculateUnfloatRestore(const QString& windowId, const QString& screenId);
 
     /**
      * @brief Unsnap a window for floating: save its zone to restore on unfloat

--- a/src/dbus/snapadaptor/commit.cpp
+++ b/src/dbus/snapadaptor/commit.cpp
@@ -65,7 +65,7 @@ void SnapAdaptor::windowUnsnapped(const QString& windowId)
     m_engine->uncommitSnap(windowId);
 }
 
-void SnapAdaptor::windowsSnappedBatch(const SnapConfirmationList& entries)
+void SnapAdaptor::windowsSnappedBatch(const PhosphorProtocol::SnapConfirmationList& entries)
 {
     qCInfo(lcDbusWindow) << "windowsSnappedBatch: processing" << entries.size() << "entries";
 
@@ -233,25 +233,26 @@ void SnapAdaptor::setWindowFloat(const QString& windowId, bool floating)
     }
 }
 
-PlasmaZones::UnfloatRestoreResult SnapAdaptor::calculateUnfloatRestore(const QString& windowId, const QString& screenId)
+PhosphorProtocol::UnfloatRestoreResult SnapAdaptor::calculateUnfloatRestore(const QString& windowId,
+                                                                            const QString& screenId)
 {
     if (windowId.isEmpty()) {
-        return UnfloatRestoreResult{};
+        return PhosphorProtocol::UnfloatRestoreResult{};
     }
 
     if (!m_engine) {
-        return UnfloatRestoreResult{};
+        return PhosphorProtocol::UnfloatRestoreResult{};
     }
 
     UnfloatResult unfloat = m_engine->resolveUnfloatGeometry(windowId, screenId);
     if (!unfloat.found) {
         qCDebug(lcDbusWindow) << "calculateUnfloatRestore: no restore target for" << windowId;
-        return UnfloatRestoreResult{};
+        return PhosphorProtocol::UnfloatRestoreResult{};
     }
 
     qCDebug(lcDbusWindow) << "calculateUnfloatRestore for" << windowId << "-> zones:" << unfloat.zoneIds
                           << "geo:" << unfloat.geometry;
-    return UnfloatRestoreResult{
+    return PhosphorProtocol::UnfloatRestoreResult{
         true,
         unfloat.zoneIds,
         unfloat.screenId,

--- a/src/dbus/snapadaptor/navigation.cpp
+++ b/src/dbus/snapadaptor/navigation.cpp
@@ -90,7 +90,7 @@ static bool processBatchEntries(WindowTrackingAdaptor* wta, PhosphorSnapEngine::
         return false;
     }
 
-    WindowGeometryList geometries =
+    PhosphorProtocol::WindowGeometryList geometries =
         engine->applyBatchAssignments(entries, SnapIntent::UserInitiated, [wta]() -> QString {
             const QString cursor = wta->lastCursorScreenName();
             return cursor.isEmpty() ? wta->lastActiveScreenName() : cursor;
@@ -162,7 +162,8 @@ void SnapAdaptor::resnapForVirtualScreenReconfigure(const QString& physicalScree
     processBatchEntries(m_adaptor, m_engine, entries, QStringLiteral("vs_reconfigure"));
 }
 
-SnapAllResultList SnapAdaptor::calculateSnapAllWindows(const QStringList& windowIds, const QString& screenId)
+PhosphorProtocol::SnapAllResultList SnapAdaptor::calculateSnapAllWindows(const QStringList& windowIds,
+                                                                         const QString& screenId)
 {
     qCDebug(lcDbusWindow) << "calculateSnapAllWindows: count=" << windowIds.size() << "screen=" << screenId;
     if (m_engine) {

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -38,11 +38,6 @@ class IPlacementEngine;
 
 namespace PlasmaZones {
 
-using PhosphorProtocol::DragBypassReason;
-using PhosphorProtocol::DragOutcome;
-using PhosphorProtocol::DragPolicy;
-using PhosphorProtocol::EmptyZoneList;
-
 class IOverlayService;
 
 class ISettings;
@@ -156,7 +151,7 @@ public Q_SLOTS:
      *
      * Replaces dragStarted as the canonical drag-begin entry point. Compositor
      * plugin calls this synchronously at drag start and uses the returned
-     * DragPolicy to decide whether to stream cursor updates, grab keyboard,
+     * PhosphorProtocol::DragPolicy to decide whether to stream cursor updates, grab keyboard,
      * apply an immediate float transition (autotile), etc. Single source of
      * truth replaces the effect-side m_dragBypassedForAutotile cache that
      * went stale after every settings reload.
@@ -168,14 +163,14 @@ public Q_SLOTS:
      * updateDragCursor / endDrag calls match.
      *
      */
-    PlasmaZones::DragPolicy beginDrag(const QString& windowId, int frameX, int frameY, int frameWidth, int frameHeight,
-                                      const QString& startScreenId, int mouseButtons);
+    PhosphorProtocol::DragPolicy beginDrag(const QString& windowId, int frameX, int frameY, int frameWidth,
+                                           int frameHeight, const QString& startScreenId, int mouseButtons);
 
     /**
      * End a drag session — daemon-authoritative action.
      *
      * Replaces dragStopped as the canonical drag-end entry point. Returns a
-     * DragOutcome that the compositor plugin applies verbatim — no further
+     * PhosphorProtocol::DragOutcome that the compositor plugin applies verbatim — no further
      * decisions on the plugin side. Covers the full dispatch matrix:
      *
      *   - autotile_screen bypass → ApplyFloat at the release cursor
@@ -187,8 +182,8 @@ public Q_SLOTS:
      * Must be called after beginDrag for the same windowId. If beginDrag
      * was never called (or the ids mismatch), returns NoOp.
      */
-    PlasmaZones::DragOutcome endDrag(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons,
-                                     bool cancelled);
+    PhosphorProtocol::DragOutcome endDrag(const QString& windowId, int cursorX, int cursorY, int modifiers,
+                                          int mouseButtons, bool cancelled);
 
     /**
      * Update drag cursor position — fire-and-forget counterpart to
@@ -255,7 +250,7 @@ Q_SIGNALS:
      * Replaces the effect-side cross-VS flip logic that used a local cache
      * and could go stale after settings reloads.
      */
-    void dragPolicyChanged(const QString& windowId, const PlasmaZones::DragPolicy& newPolicy);
+    void dragPolicyChanged(const QString& windowId, const PhosphorProtocol::DragPolicy& newPolicy);
 
     /**
      * Emitted asynchronously after endDrag returns, when the drop requested
@@ -264,7 +259,7 @@ Q_SIGNALS:
      * reply path. The effect discards this if a new drag has already started.
      */
     void snapAssistReady(const QString& windowId, const QString& releaseScreenId,
-                         const PlasmaZones::EmptyZoneList& emptyZones);
+                         const PhosphorProtocol::EmptyZoneList& emptyZones);
 
 private:
     // Tolerance constants for geometry matching (fallback detection)
@@ -308,7 +303,7 @@ private:
     void dragStopped(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons, int& snapX,
                      int& snapY, int& snapWidth, int& snapHeight, bool& shouldApplyGeometry,
                      QString& releaseScreenIdOut, bool& restoreSizeOnly, bool& snapAssistRequested,
-                     PlasmaZones::EmptyZoneList& emptyZonesOut, QString& resolvedZoneIdOut);
+                     PhosphorProtocol::EmptyZoneList& emptyZonesOut, QString& resolvedZoneIdOut);
 
     // Promote the pending snap-path drag (stashed by beginDrag) to an
     // active drag by running the legacy dragStarted setup. Called from
@@ -344,10 +339,10 @@ public:
      * @param curDesktop Current virtual desktop (for context-disabled check)
      * @param curActivity Current activity (for context-disabled check)
      */
-    static PlasmaZones::DragPolicy computeDragPolicy(const ISettings* settings,
-                                                     const PhosphorEngine::IPlacementEngine* autotileEngine,
-                                                     const QString& windowId, const QString& screenId, int curDesktop,
-                                                     const QString& curActivity);
+    static PhosphorProtocol::DragPolicy computeDragPolicy(const ISettings* settings,
+                                                          const PhosphorEngine::IPlacementEngine* autotileEngine,
+                                                          const QString& windowId, const QString& screenId,
+                                                          int curDesktop, const QString& curActivity);
 
 private:
     // Helper: Find screen containing a point (returns primary screen if not found)
@@ -413,9 +408,9 @@ private:
     // comparator in updateDragCursor re-emit dragPolicyChanged on any
     // policy-relevant field change, including same-bypass-reason
     // variations like autotile→autotile cross-VS or (future) per-screen
-    // snap-behavior differences. operator== on DragPolicy is a defaulted
+    // snap-behavior differences. operator== on PhosphorProtocol::DragPolicy is a defaulted
     // structural compare, so new fields are picked up automatically.
-    DragPolicy m_currentDragPolicy;
+    PhosphorProtocol::DragPolicy m_currentDragPolicy;
     QRect m_originalGeometry;
 
     // Pending snap-path drag awaiting first activation. Populated by

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -22,12 +22,12 @@
 
 namespace PlasmaZones {
 
-DragPolicy WindowDragAdaptor::computeDragPolicy(const ISettings* settings,
-                                                const PhosphorEngine::IPlacementEngine* autotileEngine,
-                                                const QString& windowId, const QString& screenId, int curDesktop,
-                                                const QString& curActivity)
+PhosphorProtocol::DragPolicy
+WindowDragAdaptor::computeDragPolicy(const ISettings* settings, const PhosphorEngine::IPlacementEngine* autotileEngine,
+                                     const QString& windowId, const QString& screenId, int curDesktop,
+                                     const QString& curActivity)
 {
-    DragPolicy policy;
+    PhosphorProtocol::DragPolicy policy;
     policy.screenId = screenId;
 
     // Order matters — strongest disables checked first so the reason string
@@ -37,7 +37,7 @@ DragPolicy WindowDragAdaptor::computeDragPolicy(const ISettings* settings,
     //    Dead drag: no overlay, no cursor stream, no float transition.
     if (settings && !screenId.isEmpty()
         && isContextDisabled(settings, PhosphorZones::AssignmentEntry::Snapping, screenId, curDesktop, curActivity)) {
-        policy.bypassReason = DragBypassReason::ContextDisabled;
+        policy.bypassReason = PhosphorProtocol::DragBypassReason::ContextDisabled;
         return policy;
     }
 
@@ -53,7 +53,7 @@ DragPolicy WindowDragAdaptor::computeDragPolicy(const ISettings* settings,
     //    so both the effect fast path and its async reply handler skip the
     //    handleDragToFloat call.
     if (autotileEngine && !screenId.isEmpty() && autotileEngine->isActiveOnScreen(screenId)) {
-        policy.bypassReason = DragBypassReason::AutotileScreen;
+        policy.bypassReason = PhosphorProtocol::DragBypassReason::AutotileScreen;
         policy.captureGeometry = true; // preserve pre-autotile size for unfloat restore
         const bool reorderMode = settings && settings->autotileDragBehavior() == AutotileDragBehavior::Reorder;
         if (!windowId.isEmpty() && !reorderMode) {
@@ -66,7 +66,7 @@ DragPolicy WindowDragAdaptor::computeDragPolicy(const ISettings* settings,
     //    the user configured the tool with snap mode off. beginDrag still
     //    returns a policy so endDrag can clean up consistently.
     if (settings && !settings->snappingEnabled()) {
-        policy.bypassReason = DragBypassReason::SnappingDisabled;
+        policy.bypassReason = PhosphorProtocol::DragBypassReason::SnappingDisabled;
         return policy;
     }
 
@@ -78,16 +78,17 @@ DragPolicy WindowDragAdaptor::computeDragPolicy(const ISettings* settings,
     policy.showOverlay = true;
     policy.grabKeyboard = true;
     policy.captureGeometry = true;
-    policy.bypassReason = DragBypassReason::None;
+    policy.bypassReason = PhosphorProtocol::DragBypassReason::None;
     return policy;
 }
 
-DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int frameY, int frameWidth,
-                                        int frameHeight, const QString& startScreenId, int mouseButtons)
+PhosphorProtocol::DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int frameY,
+                                                          int frameWidth, int frameHeight, const QString& startScreenId,
+                                                          int mouseButtons)
 {
     if (windowId.isEmpty()) {
         qCWarning(lcDbusWindow) << "beginDrag: empty windowId";
-        return DragPolicy{};
+        return PhosphorProtocol::DragPolicy{};
     }
 
     // Any stale pending state from a previous drag that didn't complete
@@ -119,18 +120,18 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
 
     const int curDesktop = m_layoutManager ? m_layoutManager->currentVirtualDesktop() : 0;
     const QString curActivity = m_layoutManager ? m_layoutManager->currentActivity() : QString();
-    const DragPolicy policy =
+    const PhosphorProtocol::DragPolicy policy =
         computeDragPolicy(m_settings, m_autotileEngine, windowId, startScreenId, curDesktop, curActivity);
 
     // Reusable mutable copy — the reorder fallback path below may need to
     // restore immediateFloatOnStart that computeDragPolicy proactively cleared.
-    DragPolicy effectivePolicy = policy;
+    PhosphorProtocol::DragPolicy effectivePolicy = policy;
 
     qCInfo(lcDbusWindow) << "beginDrag:" << windowId << "screen=" << startScreenId
                          << "bypass=" << effectivePolicy.bypassReason << "stream=" << effectivePolicy.streamDragMoved
                          << "immediateFloat=" << effectivePolicy.immediateFloatOnStart;
 
-    if (effectivePolicy.bypassReason != DragBypassReason::None) {
+    if (effectivePolicy.bypassReason != PhosphorProtocol::DragBypassReason::None) {
         // Bypass path — record the id so the matching endDrag can find us,
         // but skip the full snap-path setup (overlay, zone state, etc.).
         // Trigger cache and stale-preview cleanup both happen above so bypass
@@ -157,8 +158,8 @@ DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int
         // during the drag and a sudden float on drop. Restore the
         // legacy float-on-start behavior here so the UX matches the Float
         // mode default for the rest of this drag.
-        if (effectivePolicy.bypassReason == DragBypassReason::AutotileScreen && m_autotileEngine && m_settings
-            && m_settings->autotileDragBehavior() == AutotileDragBehavior::Reorder
+        if (effectivePolicy.bypassReason == PhosphorProtocol::DragBypassReason::AutotileScreen && m_autotileEngine
+            && m_settings && m_settings->autotileDragBehavior() == AutotileDragBehavior::Reorder
             && m_autotileEngine->isWindowTiled(windowId)) {
             if (m_autotileEngine->beginDragInsertPreview(windowId, startScreenId)) {
                 m_dragReorderActive = true;
@@ -268,10 +269,10 @@ void WindowDragAdaptor::clearPendingSnapDragState()
     cancelDragInsertIfActive();
 }
 
-DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int cursorY, int modifiers,
-                                       int mouseButtons, bool cancelled)
+PhosphorProtocol::DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int cursorY,
+                                                         int modifiers, int mouseButtons, bool cancelled)
 {
-    DragOutcome outcome;
+    PhosphorProtocol::DragOutcome outcome;
     outcome.windowId = windowId;
 
     if (windowId.isEmpty()) {
@@ -295,7 +296,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
         if (!cancelled && wasSnapped && m_windowTracking) {
             m_windowTracking->notifyDragOutUnsnap(windowId);
         }
-        outcome.action = DragOutcome::NoOp;
+        outcome.action = PhosphorProtocol::DragOutcome::NoOp;
         return outcome;
     }
 
@@ -305,7 +306,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
         return outcome;
     }
 
-    const DragBypassReason bypassReason = m_currentDragPolicy.bypassReason;
+    const PhosphorProtocol::DragBypassReason bypassReason = m_currentDragPolicy.bypassReason;
     m_currentDragPolicy = {}; // next drag starts fresh
     // m_dragReorderActive lives for one drag only. Reset here (before the
     // various early-return branches below) so no branch has to remember.
@@ -319,7 +320,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     // we still delegate to legacy dragStopped so it can reset its own
     // internal state machine, then emit CancelSnap back.
     if (cancelled) {
-        if (bypassReason == DragBypassReason::None) {
+        if (bypassReason == PhosphorProtocol::DragBypassReason::None) {
             // Snap path cancelled — run dragStopped through the legacy
             // adaptor so overlay/zone-state cleanup happens, but discard
             // the geometry outputs.
@@ -328,7 +329,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
             bool restoreSizeOnly = false;
             bool snapAssistRequested = false;
             QString releaseScreen;
-            EmptyZoneList emptyZones;
+            PhosphorProtocol::EmptyZoneList emptyZones;
             QString resolvedZoneId;
             dragStopped(windowId, cursorX, cursorY, modifiers, mouseButtons, sx, sy, sw, sh, shouldApply, releaseScreen,
                         restoreSizeOnly, snapAssistRequested, emptyZones, resolvedZoneId);
@@ -339,7 +340,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
             cancelDragInsertIfActive();
             m_draggedWindowId.clear();
         }
-        outcome.action = DragOutcome::CancelSnap;
+        outcome.action = PhosphorProtocol::DragOutcome::CancelSnap;
         return outcome;
     }
 
@@ -347,20 +348,20 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     // Daemon has no placement decision to make; the outcome just carries
     // the release screen so the plugin can pass it to
     // setWindowFloatingForScreen.
-    if (bypassReason == DragBypassReason::AutotileScreen) {
+    if (bypassReason == PhosphorProtocol::DragBypassReason::AutotileScreen) {
         // Autotile drag-insert: if a preview is live, commit it so the
         // window takes its picked slot in the stack on the next retile.
         // The autotile engine owns final geometry; no float outcome needed.
         if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
             m_autotileEngine->commitDragInsertPreview();
-            outcome.action = DragOutcome::NoOp;
+            outcome.action = PhosphorProtocol::DragOutcome::NoOp;
             m_draggedWindowId.clear();
             return outcome;
         }
         // Release screen is resolved plugin-side from the cursor position,
         // but we pass the cursor through so the daemon can log it. The
         // plugin passes its own view of "current screen" to the float call.
-        outcome.action = DragOutcome::ApplyFloat;
+        outcome.action = PhosphorProtocol::DragOutcome::ApplyFloat;
         outcome.targetScreenId.clear(); // plugin resolves from cursor
         outcome.x = cursorX;
         outcome.y = cursorY;
@@ -369,14 +370,15 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     }
 
     // Snapping disabled / context disabled — dead drag. No action.
-    if (bypassReason == DragBypassReason::SnappingDisabled || bypassReason == DragBypassReason::ContextDisabled) {
-        outcome.action = DragOutcome::NoOp;
+    if (bypassReason == PhosphorProtocol::DragBypassReason::SnappingDisabled
+        || bypassReason == PhosphorProtocol::DragBypassReason::ContextDisabled) {
+        outcome.action = PhosphorProtocol::DragOutcome::NoOp;
         m_draggedWindowId.clear();
         return outcome;
     }
 
     // Snap path — delegate to legacy dragStopped and translate its
-    // out-params into a DragOutcome. dragStopped handles the full
+    // out-params into a PhosphorProtocol::DragOutcome. dragStopped handles the full
     // dispatch matrix (snap-to-zone, drag-out unsnap, cross-screen
     // cleanup, zone selector, snap assist).
     //
@@ -387,14 +389,14 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     // snapshotting m_currentZoneId before the call, which missed the
     // zone-selector path (that branch never wrote m_currentZoneId and
     // left an empty zoneId on the outcome — rejected post-Phase-1B by
-    // DragOutcome::validationError).
+    // PhosphorProtocol::DragOutcome::validationError).
 
     int sx = 0, sy = 0, sw = 0, sh = 0;
     bool shouldApply = false;
     bool restoreSizeOnly = false;
     bool snapAssistRequested = false;
     QString releaseScreen;
-    EmptyZoneList emptyZones;
+    PhosphorProtocol::EmptyZoneList emptyZones;
     QString resolvedZoneId;
     dragStopped(windowId, cursorX, cursorY, modifiers, mouseButtons, sx, sy, sw, sh, shouldApply, releaseScreen,
                 restoreSizeOnly, snapAssistRequested, emptyZones, resolvedZoneId);
@@ -413,14 +415,15 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     outcome.emptyZones.clear();
 
     if (shouldApply) {
-        outcome.action = restoreSizeOnly ? DragOutcome::RestoreSize : DragOutcome::ApplySnap;
+        outcome.action =
+            restoreSizeOnly ? PhosphorProtocol::DragOutcome::RestoreSize : PhosphorProtocol::DragOutcome::ApplySnap;
         // Only ApplySnap carries a target zone. RestoreSize is drag-out
         // unsnap (no target zone by definition).
         if (!restoreSizeOnly) {
             outcome.zoneId = resolvedZoneId;
         }
     } else {
-        outcome.action = DragOutcome::NoOp;
+        outcome.action = PhosphorProtocol::DragOutcome::NoOp;
     }
 
     m_draggedWindowId.clear();
@@ -428,7 +431,7 @@ DragOutcome WindowDragAdaptor::endDrag(const QString& windowId, int cursorX, int
     // Schedule the snap-assist compute to run after this function returns and
     // the D-Bus reply has been dispatched. QTimer::singleShot(0) queues the
     // call for the next event loop iteration, which happens after Qt finishes
-    // handing the DragOutcome off to the D-Bus marshaller.
+    // handing the PhosphorProtocol::DragOutcome off to the D-Bus marshaller.
     if (snapAssistRequested) {
         QTimer::singleShot(0, this, &WindowDragAdaptor::computeAndEmitSnapAssist);
     }
@@ -464,7 +467,7 @@ void WindowDragAdaptor::updateDragCursor(const QString& windowId, int cursorX, i
     // effect-side detection loop in the dragMoved lambda that used the
     // stale m_autotileScreens cache to decide when to flip.
     //
-    // Full-struct comparison via DragPolicy::operator== catches every
+    // Full-struct comparison via PhosphorProtocol::DragPolicy::operator== catches every
     // policy-relevant transition: bypass-reason flips, autotile→autotile
     // cross-VS (distinct screenIds), and any future per-screen field added
     // to the struct (snap behavior, zone-selector corner, etc.) without
@@ -474,7 +477,7 @@ void WindowDragAdaptor::updateDragCursor(const QString& windowId, int cursorX, i
     if (!cursorScreenId.isEmpty()) {
         const int curDesktop = m_layoutManager ? m_layoutManager->currentVirtualDesktop() : 0;
         const QString curActivity = m_layoutManager ? m_layoutManager->currentActivity() : QString();
-        const DragPolicy candidate =
+        const PhosphorProtocol::DragPolicy candidate =
             computeDragPolicy(m_settings, m_autotileEngine, windowId, cursorScreenId, curDesktop, curActivity);
         if (candidate != m_currentDragPolicy) {
             // Log both bypass reason and screenId on each side so same-reason

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -26,7 +26,7 @@ namespace PlasmaZones {
 void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cursorY, int modifiers, int mouseButtons,
                                     int& snapX, int& snapY, int& snapWidth, int& snapHeight, bool& shouldApplyGeometry,
                                     QString& releaseScreenIdOut, bool& restoreSizeOnlyOut, bool& snapAssistRequestedOut,
-                                    EmptyZoneList& emptyZonesOut, QString& resolvedZoneIdOut)
+                                    PhosphorProtocol::EmptyZoneList& emptyZonesOut, QString& resolvedZoneIdOut)
 {
     // Initialize output parameters
     // shouldApplyGeometry: true = KWin should set window to (snapX, snapY, snapWidth, snapHeight)
@@ -34,7 +34,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
     // (drag-to-unsnap)
     // resolvedZoneIdOut: the primary zone ID the window snapped to, across every snap
     //   path (hover-detect, zone selector, modifier multi-zone). Empty when no snap
-    //   happened. The caller uses this for DragOutcome.zoneId, which the post-Phase-1B
+    //   happened. The caller uses this for PhosphorProtocol::DragOutcome.zoneId, which the post-Phase-1B
     //   validator requires on ApplySnap — see drag_protocol.cpp.
     snapX = 0;
     snapY = 0;
@@ -221,7 +221,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
                         zoneUuid = QStringLiteral("zoneselector-%1-%2").arg(selectedLayoutId).arg(selectedZoneIndex);
                     }
                     // Publish the resolved id so drag_protocol.cpp can populate
-                    // DragOutcome.zoneId. Without this, the zone-selector path
+                    // PhosphorProtocol::DragOutcome.zoneId. Without this, the zone-selector path
                     // would still surface m_currentZoneId (which is never written
                     // by this branch) and the post-Phase-1B validator would drop
                     // the ApplySnap outcome for an empty zoneId.
@@ -430,10 +430,10 @@ void WindowDragAdaptor::computeAndEmitSnapAssist()
     // by PhosphorPlacement::WindowTrackingService::getEmptyZones()/calculateSnapAllWindows().
     const int desktopFilter = m_layoutManager ? m_layoutManager->currentVirtualDesktop() : 0;
     QSet<QUuid> occupied = m_windowTracking->service()->buildOccupiedZoneSet(screenId, desktopFilter);
-    EmptyZoneList emptyZones = GeometryUtils::buildEmptyZoneList(m_screenManager, layout, screenId, releaseScreen,
-                                                                 m_settings, [&occupied](const PhosphorZones::Zone* z) {
-                                                                     return !occupied.contains(z->id());
-                                                                 });
+    PhosphorProtocol::EmptyZoneList emptyZones = GeometryUtils::buildEmptyZoneList(
+        m_screenManager, layout, screenId, releaseScreen, m_settings, [&occupied](const PhosphorZones::Zone* z) {
+            return !occupied.contains(z->id());
+        });
 
     if (emptyZones.isEmpty()) {
         return;

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -210,7 +210,7 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
             snap->setAutotileEngine(autotile);
         }
 
-        // Snap-specific signal: carries WindowStateEntry which is snap-mode-only.
+        // Snap-specific signal: carries PhosphorProtocol::WindowStateEntry which is snap-mode-only.
         // Connected via qobject_cast since the member type is PlacementEngineBase.
         connect(snap, &PhosphorSnapEngine::SnapEngine::windowSnapStateChanged, this,
                 &WindowTrackingAdaptor::windowStateChanged);
@@ -413,8 +413,9 @@ void WindowTrackingAdaptor::windowScreenChanged(const QString& windowId, const Q
 
     // Emit unified state change for screen-change-triggered unsnap
     Q_EMIT windowStateChanged(windowId,
-                              WindowStateEntry{windowId, QString(), newScreenId, false,
-                                               QStringLiteral("screen_changed"), QStringList{}, false});
+                              PhosphorProtocol::WindowStateEntry{windowId, QString(), newScreenId, false,
+                                                                 QStringLiteral("screen_changed"), QStringList{},
+                                                                 false});
 }
 
 void WindowTrackingAdaptor::setWindowSticky(const QString& windowId, bool sticky)
@@ -683,7 +684,7 @@ void WindowTrackingAdaptor::pruneStaleWindows(const QStringList& aliveWindowIds)
     }
 }
 
-EmptyZoneList WindowTrackingAdaptor::getEmptyZones(const QString& screenId)
+PhosphorProtocol::EmptyZoneList WindowTrackingAdaptor::getEmptyZones(const QString& screenId)
 {
     return m_service->getEmptyZones(screenId);
 }
@@ -714,18 +715,19 @@ QString WindowTrackingAdaptor::findEmptyZone()
     return m_service->findEmptyZone(m_lastCursorScreenId);
 }
 
-ZoneGeometryRect WindowTrackingAdaptor::getZoneGeometry(const QString& zoneId)
+PhosphorProtocol::ZoneGeometryRect WindowTrackingAdaptor::getZoneGeometry(const QString& zoneId)
 {
     return getZoneGeometryForScreen(zoneId, QString());
 }
 
-ZoneGeometryRect WindowTrackingAdaptor::getZoneGeometryForScreen(const QString& zoneId, const QString& screenId)
+PhosphorProtocol::ZoneGeometryRect WindowTrackingAdaptor::getZoneGeometryForScreen(const QString& zoneId,
+                                                                                   const QString& screenId)
 {
     QRect geo = zoneGeometryRect(zoneId, screenId);
     if (!geo.isValid()) {
-        return ZoneGeometryRect{};
+        return PhosphorProtocol::ZoneGeometryRect{};
     }
-    return ZoneGeometryRect::fromRect(geo);
+    return PhosphorProtocol::ZoneGeometryRect::fromRect(geo);
 }
 
 QRect WindowTrackingAdaptor::zoneGeometryRect(const QString& zoneId, const QString& screenId)

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -48,15 +48,6 @@ class VirtualDesktopManager;
 
 namespace PlasmaZones {
 
-using PhosphorProtocol::EmptyZoneList;
-using PhosphorProtocol::PreTileGeometryEntry;
-using PhosphorProtocol::PreTileGeometryList;
-using PhosphorProtocol::WindowGeometryEntry;
-using PhosphorProtocol::WindowGeometryList;
-using PhosphorProtocol::WindowStateEntry;
-using PhosphorProtocol::WindowStateList;
-using PhosphorProtocol::ZoneGeometryRect;
-
 class ScreenModeRouter;
 
 class PersistenceWorker;
@@ -303,7 +294,7 @@ public Q_SLOTS:
      * Get all pre-tile geometries as a typed list (for effect pre-population on restart).
      * Each entry carries appId, geometry rect, and the screen it was on.
      */
-    PlasmaZones::PreTileGeometryList getPreTileGeometries();
+    PhosphorProtocol::PreTileGeometryList getPreTileGeometries();
 
     /**
      * Clean up all tracking data for a closed window
@@ -398,9 +389,9 @@ public Q_SLOTS:
     /**
      * Get typed list of empty zones for Snap Assist continuation
      * @param screenId Screen ID (e.g. DP-1)
-     * @return EmptyZoneList of empty zone entries with overlay-local geometry
+     * @return PhosphorProtocol::EmptyZoneList of empty zone entries with overlay-local geometry
      */
-    PlasmaZones::EmptyZoneList getEmptyZones(const QString& screenId);
+    PhosphorProtocol::EmptyZoneList getEmptyZones(const QString& screenId);
 
     /**
      * Get the last zone a window was snapped to
@@ -417,7 +408,7 @@ public Q_SLOTS:
      * @return JSON array of objects: [{windowId, x, y, width, height}, ...]
      * @note Returns empty if keepWindowsInZonesOnResolutionChange is disabled
      */
-    PlasmaZones::WindowGeometryList getUpdatedWindowGeometries();
+    PhosphorProtocol::WindowGeometryList getUpdatedWindowGeometries();
 
     /**
      * @brief Pre-computed zone geometries for pending restore entries.
@@ -436,15 +427,15 @@ public Q_SLOTS:
     /**
      * @brief Get comprehensive state for a single window
      * @param windowId Window to query
-     * @return WindowStateEntry with windowId, zoneId, screenId, isFloating, changeType
+     * @return PhosphorProtocol::WindowStateEntry with windowId, zoneId, screenId, isFloating, changeType
      */
-    PlasmaZones::WindowStateEntry getWindowState(const QString& windowId);
+    PhosphorProtocol::WindowStateEntry getWindowState(const QString& windowId);
 
     /**
      * @brief Get state for all tracked windows (TUI dashboard)
-     * @return List of WindowStateEntry structs
+     * @return List of PhosphorProtocol::WindowStateEntry structs
      */
-    PlasmaZones::WindowStateList getAllWindowStates();
+    PhosphorProtocol::WindowStateList getAllWindowStates();
 
     /**
      * @brief Check if a window is temporarily floating (excluded from snapping)
@@ -482,17 +473,17 @@ public Q_SLOTS:
     /**
      * @brief Get geometry for a specific zone ID (uses primary screen)
      * @param zoneId PhosphorZones::Zone UUID string
-     * @return ZoneGeometryRect with x, y, width, height (all zero if not found)
+     * @return PhosphorProtocol::ZoneGeometryRect with x, y, width, height (all zero if not found)
      */
-    PlasmaZones::ZoneGeometryRect getZoneGeometry(const QString& zoneId);
+    PhosphorProtocol::ZoneGeometryRect getZoneGeometry(const QString& zoneId);
 
     /**
      * @brief Get geometry for a specific zone ID on a specific screen
      * @param zoneId PhosphorZones::Zone UUID string
      * @param screenId Screen ID (empty = primary screen)
-     * @return ZoneGeometryRect with x, y, width, height (all zero if not found)
+     * @return PhosphorProtocol::ZoneGeometryRect with x, y, width, height (all zero if not found)
      */
-    PlasmaZones::ZoneGeometryRect getZoneGeometryForScreen(const QString& zoneId, const QString& screenId);
+    PhosphorProtocol::ZoneGeometryRect getZoneGeometryForScreen(const QString& zoneId, const QString& screenId);
 
     /// Internal: returns QRect directly (avoids JSON round-trip for daemon-internal callers)
     QRect zoneGeometryRect(const QString& zoneId, const QString& screenId);
@@ -595,10 +586,10 @@ Q_SIGNALS:
     /**
      * @brief Unified window state change stream
      * @param windowId Window whose state changed
-     * @param state WindowStateEntry with windowId, zoneId, screenId, isFloating, changeType
+     * @param state PhosphorProtocol::WindowStateEntry with windowId, zoneId, screenId, isFloating, changeType
      *        changeType: "snapped", "unsnapped", "floated", "unfloated", "screen_changed"
      */
-    void windowStateChanged(const QString& windowId, const PlasmaZones::WindowStateEntry& state);
+    void windowStateChanged(const QString& windowId, const PhosphorProtocol::WindowStateEntry& state);
 
     /**
      * @brief Emitted when pending window restores become available
@@ -682,7 +673,7 @@ Q_SIGNALS:
      * @note Daemon handles windowSnapped bookkeeping internally before emitting.
      *       Effect just applies geometry with stagger — no windowsSnappedBatch callback.
      */
-    void applyGeometriesBatch(const PlasmaZones::WindowGeometryList& geometries, const QString& action);
+    void applyGeometriesBatch(const PhosphorProtocol::WindowGeometryList& geometries, const QString& action);
 
     /**
      * @brief Daemon requests KWin to raise windows in order (z-order restoration)

--- a/src/dbus/windowtrackingadaptor/convenience.cpp
+++ b/src/dbus/windowtrackingadaptor/convenience.cpp
@@ -13,14 +13,14 @@
 
 namespace PlasmaZones {
 
-WindowStateEntry WindowTrackingAdaptor::getWindowState(const QString& windowId)
+PhosphorProtocol::WindowStateEntry WindowTrackingAdaptor::getWindowState(const QString& windowId)
 {
     if (windowId.isEmpty()) {
         qCWarning(lcDbusWindow) << "getWindowState: empty window ID";
-        return WindowStateEntry{};
+        return PhosphorProtocol::WindowStateEntry{};
     }
 
-    return WindowStateEntry{
+    return PhosphorProtocol::WindowStateEntry{
         windowId,
         m_service->zoneForWindow(windowId),
         m_service->screenAssignments().value(windowId),
@@ -31,9 +31,9 @@ WindowStateEntry WindowTrackingAdaptor::getWindowState(const QString& windowId)
     };
 }
 
-WindowStateList WindowTrackingAdaptor::getAllWindowStates()
+PhosphorProtocol::WindowStateList WindowTrackingAdaptor::getAllWindowStates()
 {
-    WindowStateList result;
+    PhosphorProtocol::WindowStateList result;
 
     // Collect all tracked windows: snapped + floating
     QSet<QString> allWindowIds;
@@ -52,7 +52,7 @@ WindowStateList WindowTrackingAdaptor::getAllWindowStates()
 
     // Build state for each window
     for (const QString& windowId : std::as_const(allWindowIds)) {
-        result.append(WindowStateEntry{
+        result.append(PhosphorProtocol::WindowStateEntry{
             windowId,
             m_service->zoneForWindow(windowId),
             m_service->screenAssignments().value(windowId),

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -110,7 +110,7 @@ void WindowTrackingAdaptor::setWindowFloating(const QString& windowId, bool floa
 
     // Emit unified state change
     Q_EMIT windowStateChanged(windowId,
-                              WindowStateEntry{
+                              PhosphorProtocol::WindowStateEntry{
                                   windowId,
                                   m_service->zoneForWindow(windowId),
                                   screen,

--- a/src/dbus/windowtrackingadaptor/persistence.cpp
+++ b/src/dbus/windowtrackingadaptor/persistence.cpp
@@ -108,15 +108,15 @@ void WindowTrackingAdaptor::clearPreTileGeometry(const QString& windowId)
     }
 }
 
-PreTileGeometryList WindowTrackingAdaptor::getPreTileGeometries()
+PhosphorProtocol::PreTileGeometryList WindowTrackingAdaptor::getPreTileGeometries()
 {
-    PreTileGeometryList result;
+    PhosphorProtocol::PreTileGeometryList result;
     if (!m_snapEngine) {
         return result;
     }
     const auto& map = m_snapEngine->unmanagedGeometries();
     for (auto it = map.constBegin(); it != map.constEnd(); ++it) {
-        PreTileGeometryEntry entry;
+        PhosphorProtocol::PreTileGeometryEntry entry;
         entry.appId = m_service->currentAppIdFor(it.key());
         entry.x = it.value().geometry.x();
         entry.y = it.value().geometry.y();
@@ -190,13 +190,13 @@ bool WindowTrackingAdaptor::isGeometryOnScreen(int x, int y, int width, int heig
     return false;
 }
 
-WindowGeometryList WindowTrackingAdaptor::getUpdatedWindowGeometries()
+PhosphorProtocol::WindowGeometryList WindowTrackingAdaptor::getUpdatedWindowGeometries()
 {
     QHash<QString, QRect> geometries = m_service->updatedWindowGeometries();
-    WindowGeometryList result;
+    PhosphorProtocol::WindowGeometryList result;
     result.reserve(geometries.size());
     for (auto it = geometries.constBegin(); it != geometries.constEnd(); ++it) {
-        result.append(WindowGeometryEntry::fromRect(it.key(), it.value()));
+        result.append(PhosphorProtocol::WindowGeometryEntry::fromRect(it.key(), it.value()));
     }
     qCDebug(lcDbusWindow) << "Returning updated geometries for" << result.size() << "windows";
     return result;

--- a/src/dbus/zonedetectionadaptor.cpp
+++ b/src/dbus/zonedetectionadaptor.cpp
@@ -75,7 +75,7 @@ QString ZoneDetectionAdaptor::detectZoneAtPosition(int x, int y)
     if (foundZone) {
         m_zoneDetector->highlightZone(foundZone);
         // Trigger overlay update via signal (decoupled)
-        ZoneGeometryRect geom = getZoneGeometry(foundZone->id().toString());
+        PhosphorProtocol::ZoneGeometryRect geom = getZoneGeometry(foundZone->id().toString());
         Q_EMIT zoneDetected(foundZone->id().toString(), geom);
         return foundZone->id().toString();
     }
@@ -84,20 +84,21 @@ QString ZoneDetectionAdaptor::detectZoneAtPosition(int x, int y)
     return QString();
 }
 
-ZoneGeometryRect ZoneDetectionAdaptor::getZoneGeometry(const QString& zoneId)
+PhosphorProtocol::ZoneGeometryRect ZoneDetectionAdaptor::getZoneGeometry(const QString& zoneId)
 {
     // Use empty screen name to fall back to primary screen
     return getZoneGeometryForScreen(zoneId, QString());
 }
 
-ZoneGeometryRect ZoneDetectionAdaptor::getZoneGeometryForScreen(const QString& zoneId, const QString& screenId)
+PhosphorProtocol::ZoneGeometryRect ZoneDetectionAdaptor::getZoneGeometryForScreen(const QString& zoneId,
+                                                                                  const QString& screenId)
 {
     // Find the zone - it may be in any layout (not just activeLayout)
     // when per-screen layout assignments are used
     PhosphorZones::Zone* zone =
         DbusHelpers::findZoneInAnyLayout(m_layoutManager, zoneId, QStringLiteral("get zone geometry"));
     if (!zone) {
-        return ZoneGeometryRect{};
+        return PhosphorProtocol::ZoneGeometryRect{};
     }
 
     // Find target screen - use specified screen ID or fall back to primary
@@ -108,7 +109,7 @@ ZoneGeometryRect ZoneDetectionAdaptor::getZoneGeometryForScreen(const QString& z
         qCWarning(lcDbus) << "getZoneGeometryForScreen: screen not found:" << screenId;
     }
     if (!screen) {
-        return ZoneGeometryRect{};
+        return PhosphorProtocol::ZoneGeometryRect{};
     }
 
     // Use geometry with gaps (matches snap behavior), auto-resolving virtual screen geometry
@@ -119,7 +120,7 @@ ZoneGeometryRect ZoneDetectionAdaptor::getZoneGeometryForScreen(const QString& z
     QRect snapped = GeometryUtils::getZoneGeometryForScreen(m_screenManager, zone, screen, resolvedScreenId, zoneLayout,
                                                             m_settings);
 
-    return ZoneGeometryRect::fromRect(snapped);
+    return PhosphorProtocol::ZoneGeometryRect::fromRect(snapped);
 }
 
 QStringList ZoneDetectionAdaptor::getZonesForScreen(const QString& screenId)
@@ -332,9 +333,9 @@ QString ZoneDetectionAdaptor::getZoneByNumber(int zoneNumber, const QString& scr
     return zone->id().toString();
 }
 
-NamedZoneGeometryList ZoneDetectionAdaptor::getAllZoneGeometries(const QString& screenId)
+PhosphorProtocol::NamedZoneGeometryList ZoneDetectionAdaptor::getAllZoneGeometries(const QString& screenId)
 {
-    NamedZoneGeometryList result;
+    PhosphorProtocol::NamedZoneGeometryList result;
 
     QString resolvedScreenId = DbusHelpers::resolveScreenId(m_screenManager, screenId);
     auto* layout = m_layoutManager->resolveLayoutForScreen(resolvedScreenId);
@@ -362,7 +363,7 @@ NamedZoneGeometryList ZoneDetectionAdaptor::getAllZoneGeometries(const QString& 
         // Use geometry with gaps (matches snap behavior), auto-resolving virtual screen geometry
         QRect snapped = GeometryUtils::getZoneGeometryForScreen(m_screenManager, zone, screen, resolvedScreenId, layout,
                                                                 m_settings);
-        NamedZoneGeometry entry;
+        PhosphorProtocol::NamedZoneGeometry entry;
         entry.zoneId = zone->id().toString();
         entry.x = snapped.x();
         entry.y = snapped.y();

--- a/src/dbus/zonedetectionadaptor.h
+++ b/src/dbus/zonedetectionadaptor.h
@@ -21,10 +21,6 @@ class LayoutRegistry;
 
 namespace PlasmaZones {
 
-using PhosphorProtocol::NamedZoneGeometry;
-using PhosphorProtocol::NamedZoneGeometryList;
-using PhosphorProtocol::ZoneGeometryRect;
-
 class ISettings;
 
 /**
@@ -51,8 +47,8 @@ public Q_SLOTS:
     // PhosphorZones::Zone detection for cursor position
     QString detectZoneAtPosition(int x, int y);
     QStringList detectMultiZoneAtPosition(int x, int y);
-    PlasmaZones::ZoneGeometryRect getZoneGeometry(const QString& zoneId);
-    PlasmaZones::ZoneGeometryRect getZoneGeometryForScreen(const QString& zoneId, const QString& screenId);
+    PhosphorProtocol::ZoneGeometryRect getZoneGeometry(const QString& zoneId);
+    PhosphorProtocol::ZoneGeometryRect getZoneGeometryForScreen(const QString& zoneId, const QString& screenId);
     QStringList getZonesForScreen(const QString& screenId);
 
     // PhosphorZones::Zone navigation - get adjacent zone in a direction
@@ -80,7 +76,7 @@ public Q_SLOTS:
     QString getZoneByNumber(int zoneNumber, const QString& screenId = QString());
 
     // Get all zone geometries, optionally for a specific screen
-    PlasmaZones::NamedZoneGeometryList getAllZoneGeometries(const QString& screenId = QString());
+    PhosphorProtocol::NamedZoneGeometryList getAllZoneGeometries(const QString& screenId = QString());
 
     /**
      * @brief Get current keyboard modifier state
@@ -112,7 +108,7 @@ public Q_SLOTS:
     QString detectZoneWithModifiers(int x, int y);
 
 Q_SIGNALS:
-    void zoneDetected(const QString& zoneId, const PlasmaZones::ZoneGeometryRect& geometry);
+    void zoneDetected(const QString& zoneId, const PhosphorProtocol::ZoneGeometryRect& geometry);
 
 private:
     PhosphorZones::IZoneDetector* m_zoneDetector; // Interface type (DIP)

--- a/tests/unit/autotile/test_autotile_tile_request_validation.cpp
+++ b/tests/unit/autotile/test_autotile_tile_request_validation.cpp
@@ -5,7 +5,7 @@
  * @file test_autotile_tile_request_validation.cpp
  * @brief Producer-side guard for AutotileEngine::windowsTiled JSON.
  *
- * Phase 1B added TileRequestEntry::validationError(), and
+ * Phase 1B added PhosphorProtocol::TileRequestEntry::validationError(), and
  * AutotileAdaptor::slotWindowsTileRequested on the effect side drops any
  * batch entry that fails validation. The JSON producer in
  * AutotileEngine::applyTiling must therefore populate every field the
@@ -44,19 +44,19 @@ using namespace PhosphorProtocol;
 
 namespace {
 
-/// Mirrors AutotileAdaptor::onWindowsTiled's JSON → TileRequestList parse.
+/// Mirrors AutotileAdaptor::onWindowsTiled's JSON → PhosphorProtocol::TileRequestList parse.
 /// Kept in sync with src/dbus/autotileadaptor.cpp so the producer test
 /// exercises the exact same deserialization the D-Bus pipe performs.
-TileRequestList parseWindowsTiledJson(const QString& json)
+PhosphorProtocol::TileRequestList parseWindowsTiledJson(const QString& json)
 {
-    TileRequestList requests;
+    PhosphorProtocol::TileRequestList requests;
     QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
     if (!doc.isArray()) {
         return requests;
     }
     for (const QJsonValue& val : doc.array()) {
         QJsonObject obj = val.toObject();
-        TileRequestEntry entry;
+        PhosphorProtocol::TileRequestEntry entry;
         entry.windowId = obj.value(QLatin1String("windowId")).toString();
         entry.floating = obj.value(QLatin1String("floating")).toBool(false);
         if (!entry.floating) {
@@ -116,9 +116,9 @@ private Q_SLOTS:
         QVERIFY(tiledSpy.count() >= 1);
 
         const QString json = tiledSpy.last().first().toString();
-        const TileRequestList entries = parseWindowsTiledJson(json);
+        const PhosphorProtocol::TileRequestList entries = parseWindowsTiledJson(json);
         QVERIFY2(!entries.isEmpty(), "applyTiling emitted no entries");
-        for (const TileRequestEntry& entry : entries) {
+        for (const PhosphorProtocol::TileRequestEntry& entry : entries) {
             const QString err = entry.validationError();
             QVERIFY2(err.isEmpty(), qPrintable(err));
             // Belt-and-braces: the screenId must match what we retiled.
@@ -152,9 +152,9 @@ private Q_SLOTS:
         engine.retile(screenName);
 
         QVERIFY(tiledSpy.count() >= 1);
-        const TileRequestList entries = parseWindowsTiledJson(tiledSpy.last().first().toString());
+        const PhosphorProtocol::TileRequestList entries = parseWindowsTiledJson(tiledSpy.last().first().toString());
         QVERIFY(!entries.isEmpty());
-        for (const TileRequestEntry& entry : entries) {
+        for (const PhosphorProtocol::TileRequestEntry& entry : entries) {
             QVERIFY(entry.monocle);
             QVERIFY2(entry.validationError().isEmpty(), qPrintable(entry.validationError()));
             QCOMPARE(entry.screenId, screenName);
@@ -191,11 +191,11 @@ private Q_SLOTS:
         engine.retile(screenName);
 
         QVERIFY(tiledSpy.count() >= 1);
-        const TileRequestList entries = parseWindowsTiledJson(tiledSpy.last().first().toString());
+        const PhosphorProtocol::TileRequestList entries = parseWindowsTiledJson(tiledSpy.last().first().toString());
         QVERIFY2(!entries.isEmpty(), "applyTiling emitted no entries");
 
         bool sawFloating = false;
-        for (const TileRequestEntry& entry : entries) {
+        for (const PhosphorProtocol::TileRequestEntry& entry : entries) {
             QVERIFY2(entry.validationError().isEmpty(), qPrintable(entry.validationError()));
             QCOMPARE(entry.screenId, screenName);
             if (entry.floating) {

--- a/tests/unit/compositor-common/test_wire_types.cpp
+++ b/tests/unit/compositor-common/test_wire_types.cpp
@@ -46,7 +46,7 @@ class TestWireTypes : public QObject
 private Q_SLOTS:
 
     // =================================================================
-    // D-Bus types: WindowGeometryEntry roundtrip
+    // D-Bus types: PhosphorProtocol::WindowGeometryEntry roundtrip
     // =================================================================
 
     void testWindowGeometryEntryRoundtrip()
@@ -82,7 +82,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: TileRequestEntry roundtrip
+    // D-Bus types: PhosphorProtocol::TileRequestEntry roundtrip
     // =================================================================
 
     void testTileRequestEntryRoundtrip()
@@ -119,7 +119,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: SnapAllResultEntry roundtrip
+    // D-Bus types: PhosphorProtocol::SnapAllResultEntry roundtrip
     // =================================================================
 
     void testSnapAllResultEntryRoundtrip()
@@ -158,7 +158,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // WindowGeometryEntry::toRect() and fromRect()
+    // PhosphorProtocol::WindowGeometryEntry::toRect() and fromRect()
     // =================================================================
 
     void testWindowGeometryToRect()
@@ -177,7 +177,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // TileRequestEntry::toRect()
+    // PhosphorProtocol::TileRequestEntry::toRect()
     // =================================================================
 
     void testTileRequestToRect()
@@ -188,7 +188,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // SnapAllResultEntry::toGeometryEntry()
+    // PhosphorProtocol::SnapAllResultEntry::toGeometryEntry()
     // =================================================================
 
     void testSnapAllResultToGeometryEntry()
@@ -212,7 +212,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: WindowStateEntry roundtrip
+    // D-Bus types: PhosphorProtocol::WindowStateEntry roundtrip
     // =================================================================
 
     void testWindowStateEntryRoundtrip()
@@ -248,7 +248,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: UnfloatRestoreResult roundtrip
+    // D-Bus types: PhosphorProtocol::UnfloatRestoreResult roundtrip
     // =================================================================
 
     void testUnfloatRestoreResultRoundtrip()
@@ -276,7 +276,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: ZoneGeometryRect roundtrip
+    // D-Bus types: PhosphorProtocol::ZoneGeometryRect roundtrip
     // =================================================================
 
     void testZoneGeometryRectRoundtrip()
@@ -302,7 +302,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: EmptyZoneEntry roundtrip
+    // D-Bus types: PhosphorProtocol::EmptyZoneEntry roundtrip
     // =================================================================
 
     void testEmptyZoneEntryRoundtrip()
@@ -347,7 +347,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: SnapAssistCandidate roundtrip
+    // D-Bus types: PhosphorProtocol::SnapAssistCandidate roundtrip
     // =================================================================
 
     void testSnapAssistCandidateRoundtrip()
@@ -370,7 +370,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: NamedZoneGeometry roundtrip
+    // D-Bus types: PhosphorProtocol::NamedZoneGeometry roundtrip
     // =================================================================
 
     void testNamedZoneGeometryRoundtrip()
@@ -389,7 +389,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: AlgorithmInfoEntry roundtrip
+    // D-Bus types: PhosphorProtocol::AlgorithmInfoEntry roundtrip
     // =================================================================
 
     void testAlgorithmInfoEntryRoundtrip()
@@ -431,7 +431,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: BridgeRegistrationResult roundtrip
+    // D-Bus types: PhosphorProtocol::BridgeRegistrationResult roundtrip
     // =================================================================
 
     void testBridgeRegistrationResultRoundtrip()
@@ -452,7 +452,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: MoveTargetResult roundtrip
+    // D-Bus types: PhosphorProtocol::MoveTargetResult roundtrip
     // =================================================================
 
     void testMoveTargetResultRoundtrip()
@@ -483,7 +483,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: FocusTargetResult roundtrip
+    // D-Bus types: PhosphorProtocol::FocusTargetResult roundtrip
     // =================================================================
 
     void testFocusTargetResultRoundtrip()
@@ -510,7 +510,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: CycleTargetResult roundtrip
+    // D-Bus types: PhosphorProtocol::CycleTargetResult roundtrip
     // =================================================================
 
     void testCycleTargetResultRoundtrip()
@@ -532,7 +532,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: SwapTargetResult roundtrip
+    // D-Bus types: PhosphorProtocol::SwapTargetResult roundtrip
     // =================================================================
 
     void testSwapTargetResultRoundtrip()
@@ -581,7 +581,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: RestoreTargetResult roundtrip
+    // D-Bus types: PhosphorProtocol::RestoreTargetResult roundtrip
     // =================================================================
 
     void testRestoreTargetResultRoundtrip()
@@ -606,7 +606,7 @@ private Q_SLOTS:
     }
 
     // =================================================================
-    // D-Bus types: WindowOpenedEntry roundtrip
+    // D-Bus types: PhosphorProtocol::WindowOpenedEntry roundtrip
     // =================================================================
 
     void testWindowOpenedEntryRoundtrip()

--- a/tests/unit/core/test_snap_assist_virtual.cpp
+++ b/tests/unit/core/test_snap_assist_virtual.cpp
@@ -261,7 +261,7 @@ private Q_SLOTS:
         // getEmptyZones with virtual screen ID should return a list
         // (may be empty in headless mode since there's no QScreen, but must not crash)
         QString vsId = QStringLiteral("Dell:U2722D:115107/vs:0");
-        EmptyZoneList result = m_service->getEmptyZones(vsId);
+        PhosphorProtocol::EmptyZoneList result = m_service->getEmptyZones(vsId);
         // Just verify it doesn't crash and returns a valid (possibly empty) list
         Q_UNUSED(result);
     }
@@ -269,7 +269,7 @@ private Q_SLOTS:
     void testGetEmptyZones_emptyScreenId_returnsValidList()
     {
         // Empty screen ID fallback should not crash
-        EmptyZoneList result = m_service->getEmptyZones(QString());
+        PhosphorProtocol::EmptyZoneList result = m_service->getEmptyZones(QString());
         Q_UNUSED(result);
     }
 

--- a/tests/unit/dbus/test_autotile_adaptor_panel_gate.cpp
+++ b/tests/unit/dbus/test_autotile_adaptor_panel_gate.cpp
@@ -78,9 +78,11 @@ private Q_SLOTS:
         // Batch-open path: queues atomically on top of the existing entry,
         // preserving order so flush replays them as if the batch had arrived
         // after panel ready.
-        WindowOpenedList batch;
-        batch.append(WindowOpenedEntry{QStringLiteral("firefox|uuid-b"), QStringLiteral("HDMI-1"), 800, 600});
-        batch.append(WindowOpenedEntry{QStringLiteral("vesktop|uuid-c"), QStringLiteral("HDMI-1"), 940, 500});
+        PhosphorProtocol::WindowOpenedList batch;
+        batch.append(
+            PhosphorProtocol::WindowOpenedEntry{QStringLiteral("firefox|uuid-b"), QStringLiteral("HDMI-1"), 800, 600});
+        batch.append(
+            PhosphorProtocol::WindowOpenedEntry{QStringLiteral("vesktop|uuid-c"), QStringLiteral("HDMI-1"), 940, 500});
         adaptor.windowsOpenedBatch(batch);
         QCOMPARE(adaptor.pendingWindowOpensCount(), 3);
 
@@ -131,9 +133,10 @@ private Q_SLOTS:
         QObject adaptorParent;
         AutotileAdaptor adaptor(&engine, &mgr, PlasmaZones::TestHelpers::testRegistry(), &adaptorParent);
 
-        WindowOpenedList batch;
+        PhosphorProtocol::WindowOpenedList batch;
         for (int i = 0; i < 5; ++i) {
-            batch.append(WindowOpenedEntry{QStringLiteral("app|uuid-%1").arg(i), QStringLiteral("HDMI-1"), 0, 0});
+            batch.append(PhosphorProtocol::WindowOpenedEntry{QStringLiteral("app|uuid-%1").arg(i),
+                                                             QStringLiteral("HDMI-1"), 0, 0});
         }
         adaptor.windowsOpenedBatch(batch);
         QCOMPARE(adaptor.pendingWindowOpensCount(), 5);

--- a/tests/unit/dbus/test_compositor_bridge.cpp
+++ b/tests/unit/dbus/test_compositor_bridge.cpp
@@ -166,7 +166,7 @@ private Q_SLOTS:
 
     void testRegisterBridge_returnsApiVersion()
     {
-        BridgeRegistrationResult result = m_bridgeAdaptor->registerBridge(
+        PhosphorProtocol::BridgeRegistrationResult result = m_bridgeAdaptor->registerBridge(
             QStringLiteral("kwin"), QStringLiteral("3"), {QStringLiteral("borderless"), QStringLiteral("animation")});
 
         QCOMPARE(result.apiVersion, QStringLiteral("3"));
@@ -210,8 +210,8 @@ private Q_SLOTS:
     {
         QSignalSpy spy(m_bridgeAdaptor, &CompositorBridgeAdaptor::bridgeRegistered);
 
-        BridgeRegistrationResult result = m_bridgeAdaptor->registerBridge(QStringLiteral("kwin"), QStringLiteral("2"),
-                                                                          {QStringLiteral("borderless")});
+        PhosphorProtocol::BridgeRegistrationResult result = m_bridgeAdaptor->registerBridge(
+            QStringLiteral("kwin"), QStringLiteral("2"), {QStringLiteral("borderless")});
 
         QCOMPARE(result.sessionId, QStringLiteral("REJECTED"));
         QCOMPARE(result.apiVersion, QStringLiteral("3"));
@@ -223,7 +223,7 @@ private Q_SLOTS:
     // below MinPeerApiVersion and must also be rejected.
     void testRegisterBridge_rejectsNonNumericVersion()
     {
-        BridgeRegistrationResult result =
+        PhosphorProtocol::BridgeRegistrationResult result =
             m_bridgeAdaptor->registerBridge(QStringLiteral("weird-compositor"), QStringLiteral("garbage"), {});
 
         QCOMPARE(result.sessionId, QStringLiteral("REJECTED"));

--- a/tests/unit/dbus/test_dbus_adaptor_routing.cpp
+++ b/tests/unit/dbus/test_dbus_adaptor_routing.cpp
@@ -6,8 +6,8 @@
  * @brief End-to-end D-Bus routing test for typed-struct slot dispatch.
  *
  * Regression guard for the 2026-04-10 resnap crash. Root cause: slots written
- * as `void slot(const WindowOpenedList&)` inside `namespace PlasmaZones` were
- * recorded by moc with the unqualified type name "WindowOpenedList", but the
+ * as `void slot(const PhosphorProtocol::WindowOpenedList&)` inside `namespace PlasmaZones` were
+ * recorded by moc with the unqualified type name "PhosphorProtocol::WindowOpenedList", but the
  * metatype was registered via `Q_DECLARE_METATYPE(PhosphorProtocol::WindowOpenedList)`
  * under the qualified name "PhosphorProtocol::WindowOpenedList". QDBusAbstractAdaptor
  * dispatch couldn't resolve the type → "Could not find slot ..." at runtime →
@@ -231,15 +231,15 @@ private Q_SLOTS:
     void metatypesAreRegisteredUnderBothNames()
     {
         QVERIFY(QMetaType::fromName("PhosphorProtocol::WindowOpenedList").isValid());
-        QVERIFY(QMetaType::fromName("WindowOpenedList").isValid());
+        QVERIFY(QMetaType::fromName("PhosphorProtocol::WindowOpenedList").isValid());
         QCOMPARE(QMetaType::fromName("PhosphorProtocol::WindowOpenedList").id(),
-                 QMetaType::fromName("WindowOpenedList").id());
+                 QMetaType::fromName("PhosphorProtocol::WindowOpenedList").id());
 
         QVERIFY(QMetaType::fromName("PhosphorProtocol::MoveTargetResult").isValid());
-        QVERIFY(QMetaType::fromName("MoveTargetResult").isValid());
+        QVERIFY(QMetaType::fromName("PhosphorProtocol::MoveTargetResult").isValid());
 
         QVERIFY(QMetaType::fromName("PhosphorProtocol::WindowStateEntry").isValid());
-        QVERIFY(QMetaType::fromName("WindowStateEntry").isValid());
+        QVERIFY(QMetaType::fromName("PhosphorProtocol::WindowStateEntry").isValid());
     }
 
 private:

--- a/tests/unit/dbus/test_dbus_adaptor_routing.cpp
+++ b/tests/unit/dbus/test_dbus_adaptor_routing.cpp
@@ -5,22 +5,21 @@
  * @file test_dbus_adaptor_routing.cpp
  * @brief End-to-end D-Bus routing test for typed-struct slot dispatch.
  *
- * Regression guard for the 2026-04-10 resnap crash. Root cause: slots written
- * as `void slot(const PhosphorProtocol::WindowOpenedList&)` inside `namespace PlasmaZones` were
- * recorded by moc with the unqualified type name "PhosphorProtocol::WindowOpenedList", but the
- * metatype was registered via `Q_DECLARE_METATYPE(PhosphorProtocol::WindowOpenedList)`
- * under the qualified name "PhosphorProtocol::WindowOpenedList". QDBusAbstractAdaptor
- * dispatch couldn't resolve the type → "Could not find slot ..." at runtime →
- * kwin_wayland downstream crash with "demarshalling function for type 'QString'
- * failed".
+ * Regression guard for the 2026-04-10 resnap crash. Root cause: adaptor
+ * slots whose typed-struct parameter was spelled unqualified (or with a
+ * since-removed `PlasmaZones::` alias) were recorded by moc under a type
+ * name that did not match the metatype — which is registered, via
+ * `Q_DECLARE_METATYPE(PhosphorProtocol::WindowOpenedList)`, under the
+ * fully-qualified name. QDBusAbstractAdaptor dispatch could not resolve the
+ * type → "Could not find slot ..." at runtime → kwin_wayland downstream
+ * crash with "demarshalling function for type 'QString' failed".
  *
- * The structural fix is that every typed-struct slot parameter in the adaptor
- * headers is now fully-qualified (e.g. `const PhosphorProtocol::WindowOpenedList&`).
- * This test registers an adaptor on a private QDBusConnection and verifies
- * that a method call with a typed-struct payload is actually dispatched to
- * the slot. If a future adaptor regresses by using an unqualified slot
- * parameter, this test will fail (or the alias registration in
- * registerDBusTypes() will save it — both layers are exercised here).
+ * The fix is that every typed-struct slot parameter in the adaptor headers
+ * is fully qualified (e.g. `const PhosphorProtocol::WindowOpenedList&`), so
+ * moc records exactly the name `registerWireTypes()` registers. This test
+ * registers an adaptor on a private QDBusConnection and verifies that a
+ * method call with a typed-struct payload is dispatched to the slot, and
+ * that a typed-struct return value round-trips.
  */
 
 #include <QTest>
@@ -61,8 +60,9 @@ public:
     }
 
     // All slots use FULLY-QUALIFIED types exactly the way the real adaptors
-    // are expected to declare them. If someone later writes these without
-    // the `PlasmaZones::` prefix, the test will start failing.
+    // declare them, so moc records the same name `registerWireTypes()`
+    // registers. An unqualified parameter here would regress the dispatch
+    // the tests below exercise.
 public Q_SLOTS:
     void takeWindowOpenedList(const PhosphorProtocol::WindowOpenedList& entries)
     {
@@ -222,23 +222,15 @@ private Q_SLOTS:
     }
 
     // ─────────────────────────────────────────────────────────────────────
-    // Sanity: metatype is registered under BOTH the qualified and
-    // unqualified names. The authoritative fix is to fully-qualify slot
-    // parameters, but `registerDBusTypes()` also registers an unqualified
-    // alias as belt-and-suspenders. This test asserts the alias exists so
-    // nobody accidentally removes it.
+    // Sanity: every wire type is registered with the Qt metatype system
+    // under its canonical fully-qualified name — the name moc records for
+    // the fully-qualified adaptor slot parameters, so D-Bus dispatch
+    // resolves the type. registerWireTypes() registers under this name only.
     // ─────────────────────────────────────────────────────────────────────
-    void metatypesAreRegisteredUnderBothNames()
+    void metatypesAreRegisteredUnderQualifiedName()
     {
         QVERIFY(QMetaType::fromName("PhosphorProtocol::WindowOpenedList").isValid());
-        QVERIFY(QMetaType::fromName("PhosphorProtocol::WindowOpenedList").isValid());
-        QCOMPARE(QMetaType::fromName("PhosphorProtocol::WindowOpenedList").id(),
-                 QMetaType::fromName("PhosphorProtocol::WindowOpenedList").id());
-
         QVERIFY(QMetaType::fromName("PhosphorProtocol::MoveTargetResult").isValid());
-        QVERIFY(QMetaType::fromName("PhosphorProtocol::MoveTargetResult").isValid());
-
-        QVERIFY(QMetaType::fromName("PhosphorProtocol::WindowStateEntry").isValid());
         QVERIFY(QMetaType::fromName("PhosphorProtocol::WindowStateEntry").isValid());
     }
 

--- a/tests/unit/dbus/test_dbus_validation.cpp
+++ b/tests/unit/dbus/test_dbus_validation.cpp
@@ -33,19 +33,19 @@ class TestDbusValidation : public QObject
 private Q_SLOTS:
 
     // ═════════════════════════════════════════════════════════════════════
-    // DragOutcome
+    // PhosphorProtocol::DragOutcome
     // ═════════════════════════════════════════════════════════════════════
 
     void dragOutcome_noOp_noRequirements()
     {
-        DragOutcome o;
-        o.action = DragOutcome::NoOp;
+        PhosphorProtocol::DragOutcome o;
+        o.action = PhosphorProtocol::DragOutcome::NoOp;
         QVERIFY(o.validationError().isEmpty());
     }
 
     void dragOutcome_actionOutOfRange_rejected()
     {
-        DragOutcome o;
+        PhosphorProtocol::DragOutcome o;
         o.action = 999;
         o.windowId = QStringLiteral("win-1");
         const QString err = o.validationError();
@@ -55,7 +55,7 @@ private Q_SLOTS:
 
     void dragOutcome_negativeAction_rejected()
     {
-        DragOutcome o;
+        PhosphorProtocol::DragOutcome o;
         o.action = -1;
         const QString err = o.validationError();
         QVERIFY(!err.isEmpty());
@@ -64,8 +64,8 @@ private Q_SLOTS:
 
     void dragOutcome_applyFloatRequiresWindowId()
     {
-        DragOutcome o;
-        o.action = DragOutcome::ApplyFloat;
+        PhosphorProtocol::DragOutcome o;
+        o.action = PhosphorProtocol::DragOutcome::ApplyFloat;
         // windowId empty
         const QString err = o.validationError();
         QVERIFY(!err.isEmpty());
@@ -74,8 +74,8 @@ private Q_SLOTS:
 
     void dragOutcome_applyFloat_valid()
     {
-        DragOutcome o;
-        o.action = DragOutcome::ApplyFloat;
+        PhosphorProtocol::DragOutcome o;
+        o.action = PhosphorProtocol::DragOutcome::ApplyFloat;
         o.windowId = QStringLiteral("win-1");
         // x/y can be zero (top-left corner), targetScreenId optional
         QVERIFY(o.validationError().isEmpty());
@@ -83,8 +83,8 @@ private Q_SLOTS:
 
     void dragOutcome_applySnapRequiresZoneId()
     {
-        DragOutcome o;
-        o.action = DragOutcome::ApplySnap;
+        PhosphorProtocol::DragOutcome o;
+        o.action = PhosphorProtocol::DragOutcome::ApplySnap;
         o.windowId = QStringLiteral("win-1");
         o.width = 800;
         o.height = 600;
@@ -96,8 +96,8 @@ private Q_SLOTS:
 
     void dragOutcome_applySnapRequiresNonZeroSize()
     {
-        DragOutcome o;
-        o.action = DragOutcome::ApplySnap;
+        PhosphorProtocol::DragOutcome o;
+        o.action = PhosphorProtocol::DragOutcome::ApplySnap;
         o.windowId = QStringLiteral("win-1");
         o.zoneId = QStringLiteral("zone-1");
         o.width = 0;
@@ -109,8 +109,8 @@ private Q_SLOTS:
 
     void dragOutcome_applySnap_valid()
     {
-        DragOutcome o;
-        o.action = DragOutcome::ApplySnap;
+        PhosphorProtocol::DragOutcome o;
+        o.action = PhosphorProtocol::DragOutcome::ApplySnap;
         o.windowId = QStringLiteral("win-1");
         o.zoneId = QStringLiteral("zone-1");
         o.targetScreenId = QStringLiteral("DP-1");
@@ -123,8 +123,8 @@ private Q_SLOTS:
 
     void dragOutcome_restoreSizeRequiresNonZeroSize()
     {
-        DragOutcome o;
-        o.action = DragOutcome::RestoreSize;
+        PhosphorProtocol::DragOutcome o;
+        o.action = PhosphorProtocol::DragOutcome::RestoreSize;
         o.windowId = QStringLiteral("win-1");
         o.width = 800;
         o.height = 0;
@@ -135,8 +135,8 @@ private Q_SLOTS:
 
     void dragOutcome_cancelSnap_noSizeNeeded()
     {
-        DragOutcome o;
-        o.action = DragOutcome::CancelSnap;
+        PhosphorProtocol::DragOutcome o;
+        o.action = PhosphorProtocol::DragOutcome::CancelSnap;
         o.windowId = QStringLiteral("win-1");
         // CancelSnap has no geometry requirement
         QVERIFY(o.validationError().isEmpty());
@@ -144,8 +144,8 @@ private Q_SLOTS:
 
     void dragOutcome_notifyDragOutUnsnap_requiresWindowId()
     {
-        DragOutcome o;
-        o.action = DragOutcome::NotifyDragOutUnsnap;
+        PhosphorProtocol::DragOutcome o;
+        o.action = PhosphorProtocol::DragOutcome::NotifyDragOutUnsnap;
         // windowId empty
         const QString err = o.validationError();
         QVERIFY(!err.isEmpty());
@@ -153,25 +153,25 @@ private Q_SLOTS:
     }
 
     // ═════════════════════════════════════════════════════════════════════
-    // DragPolicy
+    // PhosphorProtocol::DragPolicy
     // ═════════════════════════════════════════════════════════════════════
 
     void dragPolicy_canonicalSnap_valid()
     {
-        DragPolicy p;
+        PhosphorProtocol::DragPolicy p;
         p.streamDragMoved = true;
         p.showOverlay = true;
         p.grabKeyboard = true;
         p.captureGeometry = true;
         p.screenId = QStringLiteral("DP-1");
-        p.bypassReason = DragBypassReason::None;
+        p.bypassReason = PhosphorProtocol::DragBypassReason::None;
         QVERIFY(p.validationError().isEmpty());
     }
 
     void dragPolicy_autotileBypassRequiresScreenId()
     {
-        DragPolicy p;
-        p.bypassReason = DragBypassReason::AutotileScreen;
+        PhosphorProtocol::DragPolicy p;
+        p.bypassReason = PhosphorProtocol::DragBypassReason::AutotileScreen;
         p.captureGeometry = true;
         // screenId empty
         const QString err = p.validationError();
@@ -181,8 +181,8 @@ private Q_SLOTS:
 
     void dragPolicy_autotileBypass_valid()
     {
-        DragPolicy p;
-        p.bypassReason = DragBypassReason::AutotileScreen;
+        PhosphorProtocol::DragPolicy p;
+        p.bypassReason = PhosphorProtocol::DragBypassReason::AutotileScreen;
         p.screenId = QStringLiteral("HP-1");
         p.captureGeometry = true;
         QVERIFY(p.validationError().isEmpty());
@@ -193,19 +193,19 @@ private Q_SLOTS:
         // beginDrag with empty startScreenId returns SnappingDisabled with
         // empty screenId. That path is deliberately tolerated — the drag
         // still needs to complete via endDrag NoOp.
-        DragPolicy p;
-        p.bypassReason = DragBypassReason::SnappingDisabled;
+        PhosphorProtocol::DragPolicy p;
+        p.bypassReason = PhosphorProtocol::DragBypassReason::SnappingDisabled;
         p.screenId = QString();
         QVERIFY(p.validationError().isEmpty());
     }
 
     // ═════════════════════════════════════════════════════════════════════
-    // TileRequestEntry
+    // PhosphorProtocol::TileRequestEntry
     // ═════════════════════════════════════════════════════════════════════
 
     void tileRequestEntry_emptyWindowId_rejected()
     {
-        TileRequestEntry e;
+        PhosphorProtocol::TileRequestEntry e;
         e.screenId = QStringLiteral("DP-1");
         e.width = 800;
         e.height = 600;
@@ -216,7 +216,7 @@ private Q_SLOTS:
 
     void tileRequestEntry_emptyScreenId_rejected()
     {
-        TileRequestEntry e;
+        PhosphorProtocol::TileRequestEntry e;
         e.windowId = QStringLiteral("win-1");
         e.width = 800;
         e.height = 600;
@@ -227,7 +227,7 @@ private Q_SLOTS:
 
     void tileRequestEntry_negativeSize_rejected()
     {
-        TileRequestEntry e;
+        PhosphorProtocol::TileRequestEntry e;
         e.windowId = QStringLiteral("win-1");
         e.screenId = QStringLiteral("DP-1");
         e.width = -10;
@@ -239,7 +239,7 @@ private Q_SLOTS:
 
     void tileRequestEntry_tiledZeroSize_rejected()
     {
-        TileRequestEntry e;
+        PhosphorProtocol::TileRequestEntry e;
         e.windowId = QStringLiteral("win-1");
         e.screenId = QStringLiteral("DP-1");
         e.floating = false;
@@ -254,7 +254,7 @@ private Q_SLOTS:
     {
         // Floating requests legitimately carry zero size — the plugin
         // resolves geometry from the current frame.
-        TileRequestEntry e;
+        PhosphorProtocol::TileRequestEntry e;
         e.windowId = QStringLiteral("win-1");
         e.screenId = QStringLiteral("DP-1");
         e.floating = true;
@@ -265,7 +265,7 @@ private Q_SLOTS:
 
     void tileRequestEntry_tiledValid()
     {
-        TileRequestEntry e;
+        PhosphorProtocol::TileRequestEntry e;
         e.windowId = QStringLiteral("win-1");
         e.screenId = QStringLiteral("DP-1");
         e.zoneId = QStringLiteral("zone-1");
@@ -277,12 +277,12 @@ private Q_SLOTS:
     }
 
     // ═════════════════════════════════════════════════════════════════════
-    // BridgeRegistrationResult
+    // PhosphorProtocol::BridgeRegistrationResult
     // ═════════════════════════════════════════════════════════════════════
 
     void bridgeRegistration_valid()
     {
-        BridgeRegistrationResult r;
+        PhosphorProtocol::BridgeRegistrationResult r;
         r.apiVersion = QStringLiteral("2");
         r.bridgeName = QStringLiteral("kwin");
         r.sessionId = QStringLiteral("abcd-1234");
@@ -293,7 +293,7 @@ private Q_SLOTS:
     {
         // "REJECTED" is how the daemon signals version mismatch. It's
         // not an invalid result — callers branch on it explicitly.
-        BridgeRegistrationResult r;
+        PhosphorProtocol::BridgeRegistrationResult r;
         r.apiVersion = QStringLiteral("999");
         r.bridgeName = QString(); // sentinel path may leave these empty
         r.sessionId = QStringLiteral("REJECTED");
@@ -302,7 +302,7 @@ private Q_SLOTS:
 
     void bridgeRegistration_emptyApiVersion_rejected()
     {
-        BridgeRegistrationResult r;
+        PhosphorProtocol::BridgeRegistrationResult r;
         r.bridgeName = QStringLiteral("kwin");
         r.sessionId = QStringLiteral("abcd-1234");
         const QString err = r.validationError();
@@ -312,7 +312,7 @@ private Q_SLOTS:
 
     void bridgeRegistration_nonNumericApiVersion_rejected()
     {
-        BridgeRegistrationResult r;
+        PhosphorProtocol::BridgeRegistrationResult r;
         r.apiVersion = QStringLiteral("one");
         r.bridgeName = QStringLiteral("kwin");
         r.sessionId = QStringLiteral("abcd-1234");
@@ -323,7 +323,7 @@ private Q_SLOTS:
 
     void bridgeRegistration_emptyBridgeName_rejected()
     {
-        BridgeRegistrationResult r;
+        PhosphorProtocol::BridgeRegistrationResult r;
         r.apiVersion = QStringLiteral("2");
         r.sessionId = QStringLiteral("abcd-1234");
         const QString err = r.validationError();
@@ -333,7 +333,7 @@ private Q_SLOTS:
 
     void bridgeRegistration_emptySessionId_rejected()
     {
-        BridgeRegistrationResult r;
+        PhosphorProtocol::BridgeRegistrationResult r;
         r.apiVersion = QStringLiteral("2");
         r.bridgeName = QStringLiteral("kwin");
         const QString err = r.validationError();
@@ -342,14 +342,15 @@ private Q_SLOTS:
     }
 
     // ═════════════════════════════════════════════════════════════════════
-    // DragBypassReason wire round-trip
+    // PhosphorProtocol::DragBypassReason wire round-trip
     // ═════════════════════════════════════════════════════════════════════
 
     void dragBypassReason_wireRoundTrip_all()
     {
         // Every enum value must round-trip through the wire format.
-        for (auto r : {DragBypassReason::None, DragBypassReason::AutotileScreen, DragBypassReason::SnappingDisabled,
-                       DragBypassReason::ContextDisabled}) {
+        for (auto r : {PhosphorProtocol::DragBypassReason::None, PhosphorProtocol::DragBypassReason::AutotileScreen,
+                       PhosphorProtocol::DragBypassReason::SnappingDisabled,
+                       PhosphorProtocol::DragBypassReason::ContextDisabled}) {
             QCOMPARE(bypassReasonFromWireString(toWireString(r)), r);
         }
     }
@@ -359,8 +360,8 @@ private Q_SLOTS:
         // Unknown wire strings map to None to preserve the legacy
         // fall-through behavior where unrecognized values didn't match
         // the autotile branch.
-        QCOMPARE(bypassReasonFromWireString(QStringLiteral("future_reason")), DragBypassReason::None);
-        QCOMPARE(bypassReasonFromWireString(QString()), DragBypassReason::None);
+        QCOMPARE(bypassReasonFromWireString(QStringLiteral("future_reason")), PhosphorProtocol::DragBypassReason::None);
+        QCOMPARE(bypassReasonFromWireString(QString()), PhosphorProtocol::DragBypassReason::None);
     }
 };
 

--- a/tests/unit/dbus/test_drag_policy.cpp
+++ b/tests/unit/dbus/test_drag_policy.cpp
@@ -14,7 +14,7 @@
  * three inputs that can change routing:
  *
  *   (snap_enabled, screen_is_autotile, context_disabled)
- *     → DragPolicy.bypassReason + flags
+ *     → PhosphorProtocol::DragPolicy.bypassReason + flags
  *
  * Precedence (first match wins, strongest disable first):
  *   context_disabled → autotile_screen → snapping_disabled → canonical_snap
@@ -111,10 +111,10 @@ private Q_SLOTS:
         settings.m_monitorDisabled = false;
         auto engine = makeEngine(/*screenIsAutotile=*/false, QStringLiteral("DP-1"));
 
-        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
-                                                            QStringLiteral("DP-1"), 1, QString());
+        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("DP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, DragBypassReason::None);
+        QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::None);
         QVERIFY(p.streamDragMoved);
         QVERIFY(p.showOverlay);
         QVERIFY(p.grabKeyboard);
@@ -139,10 +139,10 @@ private Q_SLOTS:
         settings.m_snapEnabled = true;
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
-        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
-                                                            QStringLiteral("HP-1"), 1, QString());
+        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, DragBypassReason::AutotileScreen);
+        QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::AutotileScreen);
         QVERIFY(!p.streamDragMoved);
         QVERIFY(!p.showOverlay);
         QVERIFY(!p.grabKeyboard);
@@ -167,10 +167,10 @@ private Q_SLOTS:
         settings.m_snapEnabled = false;
         auto engine = makeEngine(/*screenIsAutotile=*/false, QStringLiteral("DP-1"));
 
-        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
-                                                            QStringLiteral("DP-1"), 1, QString());
+        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("DP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, DragBypassReason::SnappingDisabled);
+        QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::SnappingDisabled);
         QVERIFY(!p.streamDragMoved);
         QVERIFY(!p.showOverlay);
         QVERIFY(!p.grabKeyboard);
@@ -194,10 +194,10 @@ private Q_SLOTS:
         settings.m_snapEnabled = false;
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
-        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
-                                                            QStringLiteral("HP-1"), 1, QString());
+        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, DragBypassReason::AutotileScreen);
+        QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::AutotileScreen);
         QVERIFY(p.captureGeometry);
         QVERIFY(p.validationError().isEmpty());
     }
@@ -214,10 +214,10 @@ private Q_SLOTS:
         settings.m_monitorDisabled = true;
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
-        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
-                                                            QStringLiteral("HP-1"), 1, QString());
+        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, DragBypassReason::ContextDisabled);
+        QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::ContextDisabled);
         QVERIFY(!p.streamDragMoved);
         QVERIFY(!p.showOverlay);
         QVERIFY(!p.immediateFloatOnStart);
@@ -231,13 +231,13 @@ private Q_SLOTS:
         settings.m_monitorDisabled = true;
         auto engine = makeEngine(/*screenIsAutotile=*/false, QStringLiteral("DP-1"));
 
-        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
-                                                            QStringLiteral("DP-1"), 1, QString());
+        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("DP-1"), 1, QString());
 
         // Context-disabled is checked before snapping_disabled — the reason
         // is stable at ContextDisabled even though either would produce
         // the same flag set.
-        QCOMPARE(p.bypassReason, DragBypassReason::ContextDisabled);
+        QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::ContextDisabled);
         QVERIFY(p.validationError().isEmpty());
     }
 
@@ -249,10 +249,10 @@ private Q_SLOTS:
     // ─────────────────────────────────────────────────────────────────────
     void nullDeps_returnsCanonicalSnap()
     {
-        DragPolicy p = WindowDragAdaptor::computeDragPolicy(nullptr, nullptr, QStringLiteral("win-1"),
-                                                            QStringLiteral("DP-1"), 1, QString());
+        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(nullptr, nullptr, QStringLiteral("win-1"),
+                                                                              QStringLiteral("DP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, DragBypassReason::None);
+        QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::None);
         QVERIFY(p.streamDragMoved);
         QVERIFY(p.validationError().isEmpty());
     }
@@ -268,13 +268,13 @@ private Q_SLOTS:
         settings.m_snapEnabled = false;
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
-        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"), QString(),
-                                                            1, QString());
+        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
+            &settings, engine.get(), QStringLiteral("win-1"), QString(), 1, QString());
 
         // Autotile check is skipped for empty screenId, so snapping_disabled wins.
-        QCOMPARE(p.bypassReason, DragBypassReason::SnappingDisabled);
+        QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::SnappingDisabled);
         // SnappingDisabled with empty screenId is explicitly tolerated by
-        // the validator (see DragPolicy::validationError).
+        // the validator (see PhosphorProtocol::DragPolicy::validationError).
         QVERIFY(p.validationError().isEmpty());
     }
 
@@ -294,10 +294,10 @@ private Q_SLOTS:
         settings.m_dragBehavior = AutotileDragBehavior::Reorder;
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
-        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
-                                                            QStringLiteral("HP-1"), 1, QString());
+        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, DragBypassReason::AutotileScreen);
+        QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::AutotileScreen);
         // Even though the engine would normally flip this on for tracked
         // windows, Reorder mode must leave it cleared.
         QVERIFY(!p.immediateFloatOnStart);
@@ -317,10 +317,10 @@ private Q_SLOTS:
         settings.m_dragBehavior = AutotileDragBehavior::Float;
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
-        DragPolicy p = WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"),
-                                                            QStringLiteral("HP-1"), 1, QString());
+        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), 1, QString());
 
-        QCOMPARE(p.bypassReason, DragBypassReason::AutotileScreen);
+        QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::AutotileScreen);
         // No windowOpened flowed through the engine so isWindowTracked
         // returns false — immediateFloatOnStart stays false either way.
         // The useful assertion here is that the reorder test above isn't
@@ -331,7 +331,7 @@ private Q_SLOTS:
     }
 
     // ─────────────────────────────────────────────────────────────────────
-    // Structural equality contract. DragPolicy::operator== (defaulted) is
+    // Structural equality contract. PhosphorProtocol::DragPolicy::operator== (defaulted) is
     // the cross-VS flip trigger inside WindowDragAdaptor::updateDragCursor
     // — any field that differs between the in-force policy and a freshly
     // computed one must flip the comparator so dragPolicyChanged fires.
@@ -342,51 +342,51 @@ private Q_SLOTS:
     // ─────────────────────────────────────────────────────────────────────
     void operatorEquals_flipsOnAnyFieldChange()
     {
-        DragPolicy base;
+        PhosphorProtocol::DragPolicy base;
         base.streamDragMoved = true;
         base.showOverlay = true;
         base.grabKeyboard = true;
         base.captureGeometry = true;
         base.immediateFloatOnStart = false;
         base.screenId = QStringLiteral("DP-1");
-        base.bypassReason = DragBypassReason::None;
+        base.bypassReason = PhosphorProtocol::DragBypassReason::None;
 
-        DragPolicy same = base;
+        PhosphorProtocol::DragPolicy same = base;
         QVERIFY(same == base);
 
         // Cross-screen transition within the same bypass category — the
         // exact case the old bypassReason-only comparator missed. With
         // full-struct ==, screenId diff trips the flip.
-        DragPolicy diffScreen = base;
+        PhosphorProtocol::DragPolicy diffScreen = base;
         diffScreen.screenId = QStringLiteral("DP-2");
         QVERIFY(!(diffScreen == base));
 
         // Bypass-reason change still flips (regression guard).
-        DragPolicy diffReason = base;
-        diffReason.bypassReason = DragBypassReason::AutotileScreen;
+        PhosphorProtocol::DragPolicy diffReason = base;
+        diffReason.bypassReason = PhosphorProtocol::DragBypassReason::AutotileScreen;
         QVERIFY(!(diffReason == base));
 
         // Every routing flag participates — these cases exist so a future
         // refactor that replaces `= default` with a hand-written operator==
-        // can't silently drop a field. If you add a field to DragPolicy, add
+        // can't silently drop a field. If you add a field to PhosphorProtocol::DragPolicy, add
         // a case here too.
-        DragPolicy diffOverlay = base;
+        PhosphorProtocol::DragPolicy diffOverlay = base;
         diffOverlay.showOverlay = false;
         QVERIFY(!(diffOverlay == base));
 
-        DragPolicy diffStream = base;
+        PhosphorProtocol::DragPolicy diffStream = base;
         diffStream.streamDragMoved = false;
         QVERIFY(!(diffStream == base));
 
-        DragPolicy diffKeyboard = base;
+        PhosphorProtocol::DragPolicy diffKeyboard = base;
         diffKeyboard.grabKeyboard = false;
         QVERIFY(!(diffKeyboard == base));
 
-        DragPolicy diffCapture = base;
+        PhosphorProtocol::DragPolicy diffCapture = base;
         diffCapture.captureGeometry = false;
         QVERIFY(!(diffCapture == base));
 
-        DragPolicy diffImmediateFloat = base;
+        PhosphorProtocol::DragPolicy diffImmediateFloat = base;
         diffImmediateFloat.immediateFloatOnStart = true;
         QVERIFY(!(diffImmediateFloat == base));
     }

--- a/tests/unit/dbus/test_wta_convenience.cpp
+++ b/tests/unit/dbus/test_wta_convenience.cpp
@@ -276,7 +276,7 @@ private Q_SLOTS:
 
         m_snapEngine->commitSnap(windowId, m_zoneIds[0], m_screenId);
 
-        WindowStateEntry state = m_wta->getWindowState(windowId);
+        PhosphorProtocol::WindowStateEntry state = m_wta->getWindowState(windowId);
         QCOMPARE(state.windowId, windowId);
         QCOMPARE(state.zoneId, m_zoneIds[0]);
         QCOMPARE(state.screenId, m_screenId);
@@ -291,7 +291,7 @@ private Q_SLOTS:
         m_snapEngine->commitSnap(windowId, m_zoneIds[0], m_screenId);
         m_wta->setWindowFloating(windowId, true);
 
-        WindowStateEntry state = m_wta->getWindowState(windowId);
+        PhosphorProtocol::WindowStateEntry state = m_wta->getWindowState(windowId);
         QCOMPARE(state.isFloating, true);
     }
 
@@ -299,7 +299,7 @@ private Q_SLOTS:
     {
         QString windowId = QStringLiteral("unknown|99999");
 
-        WindowStateEntry state = m_wta->getWindowState(windowId);
+        PhosphorProtocol::WindowStateEntry state = m_wta->getWindowState(windowId);
         QVERIFY(state.zoneId.isEmpty());
     }
 
@@ -315,7 +315,7 @@ private Q_SLOTS:
         m_snapEngine->commitSnap(window1, m_zoneIds[0], m_screenId);
         m_snapEngine->commitSnap(window2, m_zoneIds[1], m_screenId);
 
-        WindowStateList allStates = m_wta->getAllWindowStates();
+        PhosphorProtocol::WindowStateList allStates = m_wta->getAllWindowStates();
         QCOMPARE(allStates.size(), 2);
 
         // Collect all window IDs from the list
@@ -344,7 +344,7 @@ private Q_SLOTS:
         // Find the "snapped" emission
         bool foundSnapped = false;
         for (int i = 0; i < spy.count(); ++i) {
-            auto state = spy.at(i).at(1).value<WindowStateEntry>();
+            auto state = spy.at(i).at(1).value<PhosphorProtocol::WindowStateEntry>();
             if (state.changeType == QLatin1String("snapped")) {
                 QCOMPARE(spy.at(i).at(0).toString(), windowId);
                 foundSnapped = true;
@@ -368,7 +368,7 @@ private Q_SLOTS:
 
         bool foundUnsnapped = false;
         for (int i = 0; i < spy.count(); ++i) {
-            auto state = spy.at(i).at(1).value<WindowStateEntry>();
+            auto state = spy.at(i).at(1).value<PhosphorProtocol::WindowStateEntry>();
             if (state.changeType == QLatin1String("unsnapped")) {
                 QCOMPARE(spy.at(i).at(0).toString(), windowId);
                 foundUnsnapped = true;
@@ -392,7 +392,7 @@ private Q_SLOTS:
 
         bool foundFloated = false;
         for (int i = 0; i < spy.count(); ++i) {
-            auto state = spy.at(i).at(1).value<WindowStateEntry>();
+            auto state = spy.at(i).at(1).value<PhosphorProtocol::WindowStateEntry>();
             if (state.changeType == QLatin1String("floated")) {
                 QCOMPARE(spy.at(i).at(0).toString(), windowId);
                 foundFloated = true;


### PR DESCRIPTION
## Problem

When the wire types were extracted into the `PhosphorProtocol` namespace, consumer headers were given blocks of `using PhosphorProtocol::X;` declarations inside `namespace PlasmaZones` / `PhosphorSnapEngine` / `PhosphorCompositor` so existing call sites kept compiling without being updated. That is the using-alias migration shim the project rules explicitly prohibit — *refactors update every call site*. Surfaced as a follow-up from the #453 audit.

## What changed

**Removed ~56 `using PhosphorProtocol::X;` declarations** across 15 headers/sources and fully-qualified every reference (bare and `PlasmaZones::`-qualified) to `PhosphorProtocol::X` — matching how `kwin-effect` already spells these types.

**Updated 6 D-Bus interface XML files.** Their `QtTypeName` annotations spelled the types `PlasmaZones::X`; `qdbusxml2cpp`-generated adaptor code depended on the same shim. Updated to `PhosphorProtocol::X` so generated and hand-written code agree.

**Dropped the unqualified metatype registration.** `registerWireTypes()` registered every type twice — once under a bare `"Foo"` alias for adaptors whose slot parameters weren't fully qualified. Every slot/signal is now fully qualified, so `moc` always records `PhosphorProtocol::Foo` — the canonical name `qDBusRegisterMetaType` already registers. The alias is dead; removed.

This is the fix `registerWireTypes()`'s own comment called *"the authoritative fix"*: fully-qualify so `moc` records the canonical name.

## Verification

Full build clean; **all 184 tests pass**, including `test_dbus_adaptor_routing` — the integration test written specifically to catch the "could not find slot" / demarshalling-failure mode the unqualified alias guarded against.

## Scope notes

- `kwin-effect` already fully-qualified these types — untouched.
- The two `using namespace PhosphorProtocol;` directives (one `.cpp`, one test) are left as-is: a `using namespace` in an implementation file is idiomatic C++, not a per-type migration alias.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)