### PR TITLE
refactor(examples): shared shader includes + popup drop shadows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,6 +613,7 @@ if(BUILD_PHOSPHOR_SHELL)
         FILES_MATCHING
             PATTERN "*.qml"
             PATTERN "*.frag"
+            PATTERN "*.glsl"
     )
 endif()
 

--- a/examples/phosphor-shell/CMakeLists.txt
+++ b/examples/phosphor-shell/CMakeLists.txt
@@ -33,6 +33,13 @@ qt_add_qml_module(phosphor_shell_example
     VERSION 1.0
     STATIC
     RESOURCE_PREFIX /qt/qml
+    # The module's build-tree output directory must END in the URI path
+    # (Phosphor/Shell/Example) or qmllint and other QML tooling can't
+    # resolve the module. The default is CMAKE_CURRENT_BINARY_DIR, which
+    # doesn't — so place it under a URI-shaped subdirectory. This is a
+    # build-tree path only; the linked-in resource still lives at
+    # qrc:/qt/qml/Phosphor/Shell/Example via RESOURCE_PREFIX above.
+    OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Phosphor/Shell/Example
     QML_FILES
         shell.qml
         TopPanel.qml

--- a/examples/phosphor-shell/CMakeLists.txt
+++ b/examples/phosphor-shell/CMakeLists.txt
@@ -49,4 +49,6 @@ qt_add_qml_module(phosphor_shell_example
     RESOURCES
         shaders/frosted_glass.frag
         shaders/gradient.frag
+        shaders/corners.glsl
+        shaders/shadow.glsl
 )

--- a/examples/phosphor-shell/PanelPopup.qml
+++ b/examples/phosphor-shell/PanelPopup.qml
@@ -17,6 +17,9 @@ PopupWindow {
     property int contentHeight: 320
     // Inset of the content body inside the border.
     property real contentMargins: 14
+    // Corner rounding of the visible popup — shared by the border
+    // Rectangle and the shader's rounded-box SDF so they stay aligned.
+    property int cornerRadius: 14
     // Transparent ring around the visible popup that the drop shadow is
     // drawn into. The xdg_popup surface is oversized by this on every
     // side and the shader fills the ring with the shadow falloff.
@@ -52,7 +55,7 @@ PopupWindow {
             "customParams1_y": 0,
             "customParams1_z": 0.9,
             "customParams1_w": 0,
-            "customParams2_x": 14,
+            "customParams2_x": popup.cornerRadius,
             "customParams2_y": 24,
             "customParams3_x": popup.shadowMargin,
             "customParams4_y": 0.45
@@ -66,7 +69,7 @@ PopupWindow {
         anchors.fill: parent
         anchors.margins: popup.shadowMargin
         color: "transparent"
-        radius: 14
+        radius: popup.cornerRadius
         border.color: "#80a6adc8"
         border.width: 1
     }

--- a/examples/phosphor-shell/PanelPopup.qml
+++ b/examples/phosphor-shell/PanelPopup.qml
@@ -5,26 +5,43 @@ import Phosphor.Shell 1.0
 import QtQuick
 
 // Shared panel-popup chrome — one xdg_popup with a translucent animated
-// gradient backdrop and a hairline border. Callers supply geometry via
-// the PopupWindow properties and the body via `content`; this collapses
-// the per-popup boilerplate that used to be copied three times in
-// PanelPopupHost.qml.
+// gradient backdrop, a hairline border, and a soft all-around drop
+// shadow. Callers supply the visible size via contentWidth/contentHeight
+// and the body via `content`; this collapses the per-popup boilerplate
+// that used to be copied three times in PanelPopupHost.qml.
 PopupWindow {
     id: popup
 
-    // Inset applied to the content body inside the border.
+    // Visible popup size — the rounded panel the user actually sees.
+    property int contentWidth: 280
+    property int contentHeight: 320
+    // Inset of the content body inside the border.
     property real contentMargins: 14
+    // Transparent ring around the visible popup that the drop shadow is
+    // drawn into. The xdg_popup surface is oversized by this on every
+    // side and the shader fills the ring with the shadow falloff.
+    property int shadowMargin: 20
     // Body of the popup. Assigned by callers; lands inside the margin
     // holder so a child `anchors.fill: parent` resolves to the inset
     // client area rather than the full popup surface.
     property alias content: contentHolder.data
 
     popupEdge: PopupWindow.Below
-    gap: 8
+    // The xdg_popup surface carries the shadow ring, so it is larger
+    // than the visible popup on every side...
+    popupWidth: contentWidth + 2 * shadowMargin
+    popupHeight: contentHeight + 2 * shadowMargin
+    // ...and its top edge starts shadowMargin px above the visible
+    // popup. The intended 8 px visual gap below the anchor therefore
+    // becomes (8 - shadowMargin) once expressed as the surface gap fed
+    // to the xdg-positioner.
+    gap: 8 - shadowMargin
     popupVisible: false
 
-    // Translucent animated gradient — no wallpaper sampling; the
-    // compositor blends it over whatever sits behind the popup surface.
+    // Translucent animated gradient + all-around drop shadow. The shader
+    // runs in popup mode because shadowMargin > 0: it draws the gradient
+    // panel inset by shadowMargin and the shadow into the surrounding
+    // ring (see shaders/gradient.frag).
     ShaderBackground {
         anchors.fill: parent
         playing: popup.popupVisible
@@ -36,14 +53,18 @@ PopupWindow {
             "customParams1_z": 0.9,
             "customParams1_w": 0,
             "customParams2_x": 14,
-            "customParams2_y": 24
+            "customParams2_y": 24,
+            "customParams3_x": popup.shadowMargin,
+            "customParams4_y": 0.45
         }
         customColor1: "#cba6f7"
         customColor2: "#89dceb"
     }
 
+    // Hairline border around the VISIBLE popup, inset past the shadow ring.
     Rectangle {
         anchors.fill: parent
+        anchors.margins: popup.shadowMargin
         color: "transparent"
         radius: 14
         border.color: "#80a6adc8"
@@ -54,7 +75,7 @@ PopupWindow {
         id: contentHolder
 
         anchors.fill: parent
-        anchors.margins: popup.contentMargins
+        anchors.margins: popup.shadowMargin + popup.contentMargins
     }
 
 }

--- a/examples/phosphor-shell/PanelPopupHost.qml
+++ b/examples/phosphor-shell/PanelPopupHost.qml
@@ -113,8 +113,8 @@ Item {
         id: calendarPopup
 
         anchor: host.topPanel.calendarAnchor
-        popupWidth: 280
-        popupHeight: 320
+        contentWidth: 280
+        contentHeight: 320
         contentMargins: 14
 
         content: CalendarContent {
@@ -129,8 +129,8 @@ Item {
         id: mediaPopup
 
         anchor: host.topPanel.mediaAnchor
-        popupWidth: 300
-        popupHeight: 360
+        contentWidth: 300
+        contentHeight: 360
         contentMargins: 16
 
         content: MprisContent {
@@ -146,8 +146,8 @@ Item {
         id: menuPopup
 
         anchor: host.topPanel.menuAnchor
-        popupWidth: 220
-        popupHeight: 240
+        contentWidth: 220
+        contentHeight: 240
         contentMargins: 8
 
         content: MenuContent {

--- a/examples/phosphor-shell/shaders/corners.glsl
+++ b/examples/phosphor-shell/shaders/corners.glsl
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Reusable rounded-corner / concave-carve helpers for PhosphorShell
+// panel and popup shaders. `#include "corners.glsl"` to get rounded-box
+// surface masking and the carved panel-outline distance field without
+// copying the SDF math into every shader.
+//
+// No `#version` / no UBO references — include this AFTER the `#version`
+// line and the `layout` blocks of the consuming shader.
+
+#ifndef PHOSPHOR_CORNERS_GLSL
+#define PHOSPHOR_CORNERS_GLSL
+
+// Signed distance from `p` (relative to the box centre) to a rounded
+// box of half-extent `halfSize` and corner `radius`. Negative inside,
+// positive outside.
+float roundedBoxSDF(vec2 p, vec2 halfSize, float radius) {
+    vec2 d = abs(p) - halfSize + radius;
+    return length(max(d, 0.0)) - radius;
+}
+
+// Antialiased 0..1 coverage for a rounded-box surface of size
+// `resolution`, evaluated at framebuffer coord `fragCoord`. `radius`
+// must be >= 1.0 — the rounded-box SDF degenerates at r == 0 (interior
+// fragments return 0 rather than a negative distance, which would zero
+// the whole surface out).
+float roundedSurfaceMask(vec2 fragCoord, vec2 resolution, float radius) {
+    vec2 halfSize = resolution * 0.5;
+    float dist = roundedBoxSDF(fragCoord - halfSize, halfSize, radius);
+    return 1.0 - smoothstep(-1.0, 0.0, dist);
+}
+
+// Signed distance (pixels) from the panel's bottom outline at the
+// top-down surface coord `vPx`, for a panel whose flat bottom edge sits
+// at `panelBottomYPx`. When `carveRpx > 0.5` each bottom corner is
+// replaced by a concave quarter-arc of that radius; the outline stays a
+// single continuous field, so a drop-shadow measured from it follows
+// the carve instead of leaving a rectangular strip behind a curved
+// edge. Negative = inside the panel, positive = below the outline.
+float carvedOutlineDistance(vec2 vPx, vec2 resolution, float panelBottomYPx, float carveRpx) {
+    if (carveRpx > 0.5 && vPx.y > panelBottomYPx - carveRpx) {
+        // Bottom-left arc
+        if (vPx.x < carveRpx) {
+            vec2 arcCenter = vec2(carveRpx, panelBottomYPx - carveRpx);
+            return length(vPx - arcCenter) - carveRpx;
+        }
+        // Bottom-right arc
+        if (vPx.x > resolution.x - carveRpx) {
+            vec2 arcCenter = vec2(resolution.x - carveRpx, panelBottomYPx - carveRpx);
+            return length(vPx - arcCenter) - carveRpx;
+        }
+    }
+    // Middle column, above the carve band, or carve disabled — the
+    // outline is the flat horizontal bottom edge.
+    return vPx.y - panelBottomYPx;
+}
+
+#endif // PHOSPHOR_CORNERS_GLSL

--- a/examples/phosphor-shell/shaders/gradient.frag
+++ b/examples/phosphor-shell/shaders/gradient.frag
@@ -142,15 +142,14 @@ void main() {
         float sdf = roundedBoxSDF(fragCoord - iResolution.xy * 0.5, innerHalf, radius);
         // Panel coverage: AA'd across the 1-px band just inside the edge.
         float panelMask = 1.0 - smoothstep(-1.0, 0.0, sdf);
-        // Shadow rings the box and stays full-strength under that 1-px
-        // AA band, so the panel fades onto the shadow with no
-        // transparent seam — but it does NOT extend under the solid
-        // panel interior (which would tint the whole popup darker).
-        float shadowA = 0.0;
-        if (sdf > -1.0) {
-            shadowA = (sdf <= 0.0) ? shadowOpacity
-                                   : dropShadowAlpha(sdf, shadowMargin, shadowOpacity);
-        }
+        // Shadow rings the box at full strength right at the edge, then
+        // attenuated by the panel's own coverage: it vanishes smoothly
+        // under the solid interior (no darkening of the popup) yet still
+        // backs the edge AA band so the panel fades onto the shadow with
+        // neither a transparent seam nor a 1-px alpha step.
+        float baseShadowA = (sdf <= 0.0) ? shadowOpacity
+                                         : dropShadowAlpha(sdf, shadowMargin, shadowOpacity);
+        float shadowA = baseShadowA * (1.0 - panelMask);
 
         vec3 rgb = vec3(0.0);
         float panelAlpha = 0.0;

--- a/examples/phosphor-shell/shaders/gradient.frag
+++ b/examples/phosphor-shell/shaders/gradient.frag
@@ -6,24 +6,30 @@
 // grain, emitted at `tintOpacity` alpha so the compositor blends it
 // over whatever sits behind the surface — no wallpaper sampling.
 //
-// The rounded-corner / concave-carve masking and the drop-shadow strip
-// are factored into shared includes (corners.glsl, shadow.glsl) so
-// other shaders can reuse them without copying the SDF math.
-// Pre-multiplied alpha output.
+// Two surface modes, selected by whether shadowMargin is set:
+//   - Panel mode (shadowMargin == 0): a panel flush with a screen edge.
+//     Optional bottom drop-shadow strip (shadowFraction) and concave
+//     corner carve (cornerCarveFraction).
+//   - Popup mode (shadowMargin > 0): a floating surface oversized by
+//     shadowMargin on every side; the visible popup is the inset
+//     rounded box and the margin ring is a soft all-around drop shadow.
+//
+// The rounded-corner / carve SDF and the shadow falloff are factored
+// into shared includes (corners.glsl, shadow.glsl) so other shaders can
+// reuse them without copying the math. Pre-multiplied alpha output.
 //
 // customParams[0]: x=speed             y=baseAngle      z=tintOpacity    w=frostAmount
 // customParams[1]: x=cornerRadius      y=frostScale
+// customParams[2]: x=shadowMargin (px; >0 selects popup mode)
 // customParams[3]: x=shadowFraction    y=shadowOpacity
 // customParams[4]: x=cornerCarveFraction
-//   - shadowFraction: shadowSize / (thickness + shadowSize). DPR-
-//     independent ratio of "how much of the surface is shadow". 0
-//     disables the shadow.
-//   - shadowOpacity: alpha of the shadow at its strongest (right below
-//     the panel edge); fades quadratically to 0 at the far end.
+//   - shadowFraction: shadowSize / (thickness + shadowSize). Panel-mode
+//     ratio of "how much of the surface is the bottom shadow strip".
+//   - shadowOpacity: alpha of the shadow at its strongest; fades
+//     quadratically to 0. Used by both modes.
 //   - cornerCarveFraction: radius of the concave quarter-arc carved
-//     into each bottom corner, as a fraction of total surface height.
-//     0 disables the carve. The drop-shadow follows the same carved
-//     outline (see corners.glsl / shadow.glsl).
+//     into each bottom corner, as a fraction of total surface height
+//     (panel mode). The strip shadow follows the carved outline.
 // customColors[0]: gradient start color (customColor1 in QML)
 // customColors[1]: gradient end color   (customColor2 in QML)
 
@@ -78,6 +84,31 @@ float voronoi(vec2 p) {
     return sqrt(secondMin) - sqrt(minDist);
 }
 
+// Animated two-colour gradient with crystalline grain, evaluated at
+// panel-local UV [0..1]. Reads its inputs straight from the UBO so both
+// surface modes can call it with just the local coordinate.
+vec3 computeGradient(vec2 panelUv) {
+    float speed       = customParams[0].x >= 0.0 ? customParams[0].x : 0.5;
+    float angle       = customParams[0].y;
+    float frostAmount = customParams[0].w >= 0.0 ? customParams[0].w : 0.1;
+    float frostScale  = customParams[1].y > 0.0 ? customParams[1].y : 24.0;
+    vec4 colorA = customColors[0].a > 0.0 ? customColors[0] : vec4(0.118, 0.118, 0.180, 0.9);
+    vec4 colorB = customColors[1].a > 0.0 ? customColors[1] : vec4(0.180, 0.118, 0.235, 0.9);
+
+    float rotatedAngle = angle + iTime * speed;
+    vec2 dir = vec2(cos(rotatedAngle), sin(rotatedAngle));
+    float t = dot(panelUv - 0.5, dir) + 0.5;
+    t += sin(iTime * speed * 2.7) * 0.55 + sin(iTime * speed * 1.7 + 1.57) * 0.35;
+    t = smoothstep(0.0, 1.0, t);
+    vec3 gradient = mix(colorA, colorB, t).rgb;
+
+    // Crystalline grain — slow drift, centred on zero so it darkens and
+    // lightens symmetrically.
+    vec2 frostUv = panelUv * frostScale + vec2(iTime * speed * 0.08, iTime * speed * 0.05);
+    float frost = voronoi(frostUv);
+    return clamp(gradient + vec3(frost - 0.5) * frostAmount, 0.0, 1.0);
+}
+
 void main() {
     if (iResolution.x <= 0.0 || iResolution.y <= 0.0) {
         fragColor = vec4(0.0);
@@ -85,39 +116,62 @@ void main() {
     }
     vec2 fragCoord = gl_FragCoord.xy;
     vec2 uv = fragCoord / iResolution.xy;
-
-    // Per-param "use default when QML didn't set it" convention:
-    //   `>= 0.0`  — 0 is a meaningful value (no tint, no frost, …),
-    //              so the fallback fires only for negative sentinels.
-    //   `> 0.0`   — 0 is invalid (divide-by-zero / degenerate math),
-    //              fallback fires to keep the shader producing valid output.
-    float speed        = customParams[0].x >= 0.0 ? customParams[0].x : 0.5;
-    float angle        = customParams[0].y;
-    float tintOpacity  = customParams[0].z >= 0.0 ? customParams[0].z : 0.7;
-    float frostAmount  = customParams[0].w >= 0.0 ? customParams[0].w : 0.1;
-    // Lower-clamp at 1.0 — the rounded-box SDF degenerates at r == 0;
-    // r=1 is visually indistinguishable from "no rounding".
-    float radius       = max(1.0, customParams[1].x);
-    float frostScale   = customParams[1].y > 0.0 ? customParams[1].y : 24.0;
-    float shadowFraction = clamp(customParams[3].x, 0.0, 1.0);
-    float shadowOpacity  = customParams[3].y >= 0.0 ? customParams[3].y : 0.5;
-    // Hard-clamp the carve to 0..0.5 so it can never eat the whole panel.
-    float cornerCarveFraction = clamp(customParams[4].x, 0.0, 0.5);
-
-    // Convert from Qt RHI's Y-up viewport coords (uv.y=0 at visual
-    // BOTTOM) to top-down "panel surface" coords (visualUv.y=0 at visual
-    // TOP) matching QML's QQuickItem coord system. The Y-asymmetric
-    // logic below (shadow split, corner carve, panel-local gradient
-    // remap) uses visualUv.
+    // Qt RHI's viewport is Y-up (uv.y=0 at visual BOTTOM); flip to a
+    // top-down "surface" coordinate matching QML's QQuickItem space.
     vec2 visualUv = vec2(uv.x, 1.0 - uv.y);
 
-    // Split the surface into the visible panel region (top) and the
-    // drop-shadow strip (bottom). shadowFraction==0 collapses this to
-    // "everything is panel".
+    // Per-param "use default when QML didn't set it" convention:
+    //   `>= 0.0` — 0 is meaningful (no tint, no shadow); fallback only
+    //              fires for the negative "unset" sentinel.
+    //   `> 0.0`  — 0 is invalid (degenerate math); fallback always fires.
+    float tintOpacity  = customParams[0].z >= 0.0 ? customParams[0].z : 0.7;
+    // Lower-clamp the corner radius at 1.0 — the rounded-box SDF
+    // degenerates at r == 0; r=1 looks like "no rounding".
+    float radius       = max(1.0, customParams[1].x);
+    float shadowMargin = max(customParams[2].x, 0.0);
+    float shadowFraction = clamp(customParams[3].x, 0.0, 1.0);
+    float shadowOpacity  = customParams[3].y >= 0.0 ? customParams[3].y : 0.5;
+    float cornerCarveFraction = clamp(customParams[4].x, 0.0, 0.5);
+
+    // ─── Popup mode: floating surface with an all-around drop shadow ──
+    // The surface is oversized by shadowMargin px on every side. The
+    // visible popup is the inset rounded box; the margin ring is a soft
+    // drop shadow that follows the rounded corners.
+    if (shadowMargin > 0.0) {
+        vec2 innerHalf = max(iResolution.xy * 0.5 - vec2(shadowMargin), vec2(1.0));
+        float sdf = roundedBoxSDF(fragCoord - iResolution.xy * 0.5, innerHalf, radius);
+        // Panel coverage: AA'd across the 1-px band just inside the edge.
+        float panelMask = 1.0 - smoothstep(-1.0, 0.0, sdf);
+        // Shadow rings the box and stays full-strength under that 1-px
+        // AA band, so the panel fades onto the shadow with no
+        // transparent seam — but it does NOT extend under the solid
+        // panel interior (which would tint the whole popup darker).
+        float shadowA = 0.0;
+        if (sdf > -1.0) {
+            shadowA = (sdf <= 0.0) ? shadowOpacity
+                                   : dropShadowAlpha(sdf, shadowMargin, shadowOpacity);
+        }
+
+        vec3 rgb = vec3(0.0);
+        float panelAlpha = 0.0;
+        if (panelMask > 0.0) {
+            vec2 panelUv = (visualUv * iResolution - vec2(shadowMargin))
+                           / max(iResolution - 2.0 * shadowMargin, vec2(1.0));
+            panelAlpha = tintOpacity * panelMask;
+            rgb = computeGradient(panelUv) * panelAlpha; // pre-multiplied
+        }
+        // Shadow is pure black — it adds alpha but no colour.
+        float a = panelAlpha + shadowA * (1.0 - panelAlpha);
+        fragColor = vec4(rgb, a) * qt_Opacity;
+        return;
+    }
+
+    // ─── Panel mode: edge-flush panel with a bottom shadow strip ──────
+    // Split the surface into the visible panel (top) and the drop-shadow
+    // strip (bottom). shadowFraction==0 collapses this to "all panel".
     float shadowStartV = 1.0 - shadowFraction;
     float panelBottomYPx = iResolution.y * shadowStartV;
 
-    // Antialiased rounded-box mask for the whole surface.
     float surfaceMask = roundedSurfaceMask(fragCoord, iResolution, radius);
     if (surfaceMask <= 0.0) {
         fragColor = vec4(0.0);
@@ -148,29 +202,8 @@ void main() {
     // centre of the VISIBLE panel, not the shadow-extended surface.
     vec2 panelUv = vec2(visualUv.x, visualUv.y / max(shadowStartV, 0.001));
 
-    // ─── Animated gradient ────────────────────────────────────────────
-    vec4 colorA = customColors[0].a > 0.0 ? customColors[0] : vec4(0.118, 0.118, 0.180, 0.9);
-    vec4 colorB = customColors[1].a > 0.0 ? customColors[1] : vec4(0.180, 0.118, 0.235, 0.9);
-
-    float rotatedAngle = angle + iTime * speed * 1.0;
-    vec2 dir = vec2(cos(rotatedAngle), sin(rotatedAngle));
-    float t = dot(panelUv - 0.5, dir) + 0.5;
-    float wave1 = sin(iTime * speed * 2.7) * 0.55;
-    float wave2 = sin(iTime * speed * 1.7 + 1.57) * 0.35;
-    t += wave1 + wave2;
-    t = smoothstep(0.0, 1.0, t);
-    vec3 gradient = mix(colorA, colorB, t).rgb;
-
-    // Crystalline grain — slow drift on sample coords, centred around
-    // zero so it darkens and lightens symmetrically.
-    vec2 frostUv = panelUv * frostScale + vec2(iTime * speed * 0.08, iTime * speed * 0.05);
-    float frost = voronoi(frostUv);
-    gradient = clamp(gradient + vec3(frost - 0.5) * frostAmount, 0.0, 1.0);
-
-    // ─── Composite ────────────────────────────────────────────────────
     // The gradient is drawn translucently at tintOpacity so the
     // compositor blends it over whatever is behind the surface.
-    // Pre-multiplied alpha output.
     float finalAlpha = tintOpacity * mask;
-    fragColor = vec4(gradient * finalAlpha, finalAlpha) * qt_Opacity;
+    fragColor = vec4(computeGradient(panelUv) * finalAlpha, finalAlpha) * qt_Opacity;
 }

--- a/examples/phosphor-shell/shaders/gradient.frag
+++ b/examples/phosphor-shell/shaders/gradient.frag
@@ -4,35 +4,26 @@
 // Translucent animated gradient panel/popup shader for PhosphorShell.
 // Renders an animated two-colour gradient with crystalline (voronoi)
 // grain, emitted at `tintOpacity` alpha so the compositor blends it
-// over whatever sits behind the surface — no wallpaper sampling. SDF
-// rounded-box mask with a hard cutoff to avoid fringing; an optional
-// drop-shadow strip and concave corner carve for top-edge panels.
+// over whatever sits behind the surface — no wallpaper sampling.
+//
+// The rounded-corner / concave-carve masking and the drop-shadow strip
+// are factored into shared includes (corners.glsl, shadow.glsl) so
+// other shaders can reuse them without copying the SDF math.
 // Pre-multiplied alpha output.
 //
 // customParams[0]: x=speed             y=baseAngle      z=tintOpacity    w=frostAmount
 // customParams[1]: x=cornerRadius      y=frostScale
 // customParams[3]: x=shadowFraction    y=shadowOpacity
 // customParams[4]: x=cornerCarveFraction
-//   - cornerCarveFraction: radius of the concave quarter-arc carved
-//     into each bottom corner of the visible panel, expressed as a
-//     fraction of total surface height (DPR-independent). 0 disables
-//     the carve. Each carve replaces the panel's straight bottom-
-//     corner with a quarter-circle whose center is INWARD by
-//     `carveRadius` pixels in both axes. The drop-shadow follows the
-//     SAME curve — the shader computes a single signed-distance field
-//     from the carved outline and uses it for both panel rendering and
-//     shadow falloff, so the corner curve doesn't leave a rectangular
-//     shadow strip behind. Produces the Quickshell/Noctalia "desktop
-//     wraps around the panel" look.
 //   - shadowFraction: shadowSize / (thickness + shadowSize). DPR-
 //     independent ratio of "how much of the surface is shadow". 0
-//     disables the shadow. The C++ side (PhosphorShell::PanelWindow::
-//     shadowSize + ShellEngine::materializePanels) is responsible for
-//     allocating the extra surface space; this param just tells the
-//     shader where the panel-to-shadow split lives.
-//   - shadowOpacity: alpha of the shadow at its strongest (right
-//     below the panel edge); fades quadratically to 0 at the far end
-//     of the strip.
+//     disables the shadow.
+//   - shadowOpacity: alpha of the shadow at its strongest (right below
+//     the panel edge); fades quadratically to 0 at the far end.
+//   - cornerCarveFraction: radius of the concave quarter-arc carved
+//     into each bottom corner, as a fraction of total surface height.
+//     0 disables the carve. The drop-shadow follows the same carved
+//     outline (see corners.glsl / shadow.glsl).
 // customColors[0]: gradient start color (customColor1 in QML)
 // customColors[1]: gradient end color   (customColor2 in QML)
 
@@ -55,10 +46,8 @@ layout(std140, binding = 0) uniform buf {
 
 layout(location = 0) out vec4 fragColor;
 
-float roundedBoxSDF(vec2 p, vec2 b, float r) {
-    vec2 d = abs(p) - b + r;
-    return length(max(d, 0.0)) - r;
-}
+#include "corners.glsl"
+#include "shadow.glsl"
 
 float hash(vec2 p) {
     vec3 p3 = fract(vec3(p.xyx) * vec3(0.1031, 0.1030, 0.0973));
@@ -106,119 +95,57 @@ void main() {
     float angle        = customParams[0].y;
     float tintOpacity  = customParams[0].z >= 0.0 ? customParams[0].z : 0.7;
     float frostAmount  = customParams[0].w >= 0.0 ? customParams[0].w : 0.1;
-    // Lower-clamp at 1.0: the standard rounded-box SDF
-    //   length(max(abs(p) - b + r, 0)) - r
-    // degenerates at r == 0 — interior fragments return SDF=0 (not
-    // negative), so the `1 - smoothstep(-1, 0, dist)` mask zeroes the
-    // whole panel out. r=1 gives a sharp-looking corner at one pixel
-    // (visually indistinguishable from "no rounding" at typical panel
-    // thickness) and keeps the SDF properly negative on the interior.
+    // Lower-clamp at 1.0 — the rounded-box SDF degenerates at r == 0;
+    // r=1 is visually indistinguishable from "no rounding".
     float radius       = max(1.0, customParams[1].x);
     float frostScale   = customParams[1].y > 0.0 ? customParams[1].y : 24.0;
-    // shadowFraction: ratio of the surface that's the shadow strip
-    // (0..1). 0 disables the shadow branch entirely.
     float shadowFraction = clamp(customParams[3].x, 0.0, 1.0);
     float shadowOpacity  = customParams[3].y >= 0.0 ? customParams[3].y : 0.5;
-    // cornerCarveFraction: radius of the concave corner carve as a
-    // fraction of surface height. Hard-clamp to 0..0.5 so the carve
-    // can never eat the whole panel.
+    // Hard-clamp the carve to 0..0.5 so it can never eat the whole panel.
     float cornerCarveFraction = clamp(customParams[4].x, 0.0, 0.5);
 
     // Convert from Qt RHI's Y-up viewport coords (uv.y=0 at visual
-    // BOTTOM, uv.y=1 at visual TOP) to top-down "panel surface" coords
-    // (visualUv.y=0 at visual TOP, visualUv.y=1 at visual BOTTOM)
-    // matching QML's QQuickItem coord system. The Y-asymmetric logic
-    // below (shadow split, corner carve, panel-local gradient remap)
-    // uses visualUv — without the flip the shadow strip would render
-    // at the visual TOP of the surface instead of the bottom.
-    //
-    // Symmetric logic (SDF rounded-box mask, gradient direction
-    // rotation centred on 0.5, voronoi grain) can use either uv or
-    // visualUv — they're identical under the y-flip.
+    // BOTTOM) to top-down "panel surface" coords (visualUv.y=0 at visual
+    // TOP) matching QML's QQuickItem coord system. The Y-asymmetric
+    // logic below (shadow split, corner carve, panel-local gradient
+    // remap) uses visualUv.
     vec2 visualUv = vec2(uv.x, 1.0 - uv.y);
 
     // Split the surface into the visible panel region (top) and the
     // drop-shadow strip (bottom). shadowFraction==0 collapses this to
-    // "everything is panel" — shadowStartV becomes 1.0 and the shadow
-    // branch never fires.
+    // "everything is panel".
     float shadowStartV = 1.0 - shadowFraction;
     float panelBottomYPx = iResolution.y * shadowStartV;
 
-    // SDF rounded rectangle mask for the SURFACE — gives AA at all
-    // four outer edges of the wl_surface. Cheap to always evaluate.
-    vec2 center = iResolution.xy * 0.5;
-    vec2 halfSize = iResolution.xy * 0.5;
-    float dist = roundedBoxSDF(fragCoord - center, halfSize, radius);
-    float surfaceMask = 1.0 - smoothstep(-1.0, 0.0, dist);
+    // Antialiased rounded-box mask for the whole surface.
+    float surfaceMask = roundedSurfaceMask(fragCoord, iResolution, radius);
     if (surfaceMask <= 0.0) {
         fragColor = vec4(0.0);
         return;
     }
 
-    // ─── Distance from the carved panel outline ───────────────────────
-    // Single signed-distance field for the panel's bottom edge,
-    // measured in pixels. Negative => inside panel. Positive => below
-    // the outline (shadow region). Crucially this is a CONTINUOUS
-    // field across the bottom corners: in the middle the outline is
-    // the horizontal line y=panelBottomYPx, and in each corner column
-    // the outline becomes the quarter-arc of radius `carveRpx`
-    // centred inward. The shadow rendering reads this same value so
-    // the shadow follows the curve at the corners instead of leaving
-    // a rectangular strip behind a curved panel edge.
+    // Signed distance from the panel's (optionally carved) bottom
+    // outline. Shared with the shadow so both follow the same curve.
     vec2 vPx = visualUv * iResolution;
     float carveRpx = cornerCarveFraction * iResolution.y;
-    float distFromOutline;
-    if (carveRpx > 0.5 && vPx.y > panelBottomYPx - carveRpx) {
-        // Bottom-left arc
-        if (vPx.x < carveRpx) {
-            vec2 arcCenter = vec2(carveRpx, panelBottomYPx - carveRpx);
-            distFromOutline = length(vPx - arcCenter) - carveRpx;
-        }
-        // Bottom-right arc
-        else if (vPx.x > iResolution.x - carveRpx) {
-            vec2 arcCenter = vec2(iResolution.x - carveRpx, panelBottomYPx - carveRpx);
-            distFromOutline = length(vPx - arcCenter) - carveRpx;
-        }
-        // Middle column — flat bottom edge
-        else {
-            distFromOutline = vPx.y - panelBottomYPx;
-        }
-    } else {
-        // Above the carve band (or carve disabled): always the flat
-        // horizontal bottom edge.
-        distFromOutline = vPx.y - panelBottomYPx;
-    }
+    float distFromOutline = carvedOutlineDistance(vPx, iResolution, panelBottomYPx, carveRpx);
 
-    // ─── Shadow region (below the carved outline) ─────────────────────
-    // distFromOutline > 0.5 — fully outside the panel, can skip the
-    // expensive panel-material work. The 0.5-px slack lets the panel
-    // branch handle outline AA on the inside.
-    float shadowSizePx = iResolution.y - panelBottomYPx;
+    // Below the outline: drop-shadow strip (transparent black falloff).
     if (distFromOutline > 0.5) {
-        if (shadowFraction <= 0.001 || shadowSizePx <= 0.0 || distFromOutline >= shadowSizePx) {
-            fragColor = vec4(0.0);
-            return;
-        }
-        float t = distFromOutline / shadowSizePx;
-        float falloff = 1.0 - t;
-        falloff *= falloff;
-        float a = shadowOpacity * falloff * surfaceMask;
+        float shadowSizePx = iResolution.y - panelBottomYPx;
+        float a = shadowStripAlpha(distFromOutline, shadowSizePx, shadowOpacity) * surfaceMask;
         fragColor = vec4(0.0, 0.0, 0.0, a) * qt_Opacity;
         return;
     }
 
-    // Save mask for the panel branch below — both surface AA and a
-    // 0.5-px smoothstep across the outline so the curved edge is AA'd
-    // against the shadow underneath.
+    // Panel material. `mask` folds surface AA together with a 0.5-px
+    // smoothstep across the outline so the carved edge is AA'd against
+    // the shadow underneath.
     float outlineFade = 1.0 - smoothstep(-0.5, 0.5, distFromOutline);
     float mask = surfaceMask * outlineFade;
 
-    // Remap visualUv.y to "panel-local" coordinates [0..1] so the
-    // gradient direction rotates around the centre of the VISIBLE
-    // panel rather than the centre of the (shadow-extended) surface.
-    // visualUv.y is already in top-down convention, so the panel zone
-    // is [0, shadowStartV] and dividing by shadowStartV gives a clean
-    // 0..1 panel-local range.
+    // Panel-local coords [0..1] so the gradient rotates around the
+    // centre of the VISIBLE panel, not the shadow-extended surface.
     vec2 panelUv = vec2(visualUv.x, visualUv.y / max(shadowStartV, 0.001));
 
     // ─── Animated gradient ────────────────────────────────────────────
@@ -242,10 +169,8 @@ void main() {
 
     // ─── Composite ────────────────────────────────────────────────────
     // The gradient is drawn translucently at tintOpacity so the
-    // compositor blends it over whatever is behind the surface. `mask`
-    // folds in surface AA and the carved-outline AA, so the material
-    // fades cleanly to 0 across the curved edge and the shadow region
-    // below picks up from there. Pre-multiplied alpha output.
+    // compositor blends it over whatever is behind the surface.
+    // Pre-multiplied alpha output.
     float finalAlpha = tintOpacity * mask;
     fragColor = vec4(gradient * finalAlpha, finalAlpha) * qt_Opacity;
 }

--- a/examples/phosphor-shell/shaders/shadow.glsl
+++ b/examples/phosphor-shell/shaders/shadow.glsl
@@ -1,11 +1,14 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
-// Reusable drop-shadow helper for PhosphorShell panel shaders.
-// `#include "shadow.glsl"` to render the panel's drop-shadow strip
-// without copying the falloff math. Pair with corners.glsl: feed the
-// `carvedOutlineDistance()` result in so the shadow follows a carved
-// corner.
+// Reusable drop-shadow helpers for PhosphorShell panel/popup shaders.
+// `#include "shadow.glsl"` to render a shadow without copying the
+// falloff math:
+//   - shadowStripAlpha() — a one-edge strip shadow below a panel that
+//     is flush with a screen edge. Pair with corners.glsl's
+//     carvedOutlineDistance() so the strip follows a carved corner.
+//   - dropShadowAlpha() — an all-around soft shadow ringing a floating
+//     surface (popup). Pair with corners.glsl's roundedBoxSDF().
 //
 // No `#version` / no UBO references — include this AFTER the `#version`
 // line and the `layout` blocks of the consuming shader.
@@ -25,6 +28,22 @@ float shadowStripAlpha(float distFromOutline, float shadowSizePx, float shadowOp
         return 0.0;
     }
     float t = distFromOutline / shadowSizePx;
+    float falloff = 1.0 - t;
+    return shadowOpacity * falloff * falloff;
+}
+
+// Soft drop-shadow alpha for a fragment `sdfDist` pixels OUTSIDE a
+// rounded box (positive = outside; pass roundedBoxSDF() from
+// corners.glsl). Alpha is `shadowOpacity` right at the box edge and
+// falls off quadratically to 0 over `margin` pixels. Returns 0 inside
+// the box. For a floating surface (popup), oversize the surface by
+// `margin` on every side, make the visible element the inset rounded
+// box, and ring it with this.
+float dropShadowAlpha(float sdfDist, float margin, float shadowOpacity) {
+    if (sdfDist <= 0.0 || margin <= 0.0) {
+        return 0.0;
+    }
+    float t = clamp(sdfDist / margin, 0.0, 1.0);
     float falloff = 1.0 - t;
     return shadowOpacity * falloff * falloff;
 }

--- a/examples/phosphor-shell/shaders/shadow.glsl
+++ b/examples/phosphor-shell/shaders/shadow.glsl
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Reusable drop-shadow helper for PhosphorShell panel shaders.
+// `#include "shadow.glsl"` to render the panel's drop-shadow strip
+// without copying the falloff math. Pair with corners.glsl: feed the
+// `carvedOutlineDistance()` result in so the shadow follows a carved
+// corner.
+//
+// No `#version` / no UBO references — include this AFTER the `#version`
+// line and the `layout` blocks of the consuming shader.
+
+#ifndef PHOSPHOR_SHADOW_GLSL
+#define PHOSPHOR_SHADOW_GLSL
+
+// Drop-shadow alpha for a fragment `distFromOutline` pixels below the
+// panel outline. The shadow strip is `shadowSizePx` tall; alpha is
+// `shadowOpacity` right at the panel edge and falls off quadratically
+// to 0 at the far end of the strip. Returns 0 for fragments inside the
+// panel, beyond the strip, or when there is no strip (shadowSizePx 0).
+float shadowStripAlpha(float distFromOutline, float shadowSizePx, float shadowOpacity) {
+    // 0.5-px slack: the panel branch of the consumer handles outline AA
+    // on the inside, so the shadow only owns fragments clearly outside.
+    if (distFromOutline <= 0.5 || shadowSizePx <= 0.0 || distFromOutline >= shadowSizePx) {
+        return 0.0;
+    }
+    float t = distFromOutline / shadowSizePx;
+    float falloff = 1.0 - t;
+    return shadowOpacity * falloff * falloff;
+}
+
+#endif // PHOSPHOR_SHADOW_GLSL


### PR DESCRIPTION
## Summary

Splits the panel/popup shader's reusable math into shared GLSL
`#include` headers, fixes a QML-module tooling warning, and gives the
panel popups a drop shadow. All scoped to `examples/phosphor-shell`.

## Changes

**1. Factor corner/shadow math into GLSL includes** (`764baa6d`)
- `shaders/corners.glsl` — `roundedBoxSDF`, `roundedSurfaceMask`,
  `carvedOutlineDistance`.
- `shaders/shadow.glsl` — `shadowStripAlpha`, `dropShadowAlpha`.
- `gradient.frag` `#include`s both; its `customParams` interface is
  unchanged. The pipeline already resolves `#include` via
  `ShaderCompiler::loadAndExpand` + `ShaderIncludeResolver`. The `.glsl`
  headers ship as qml-module resources and are installed, so includes
  resolve from the config / installed / qrc copies alike.

**2. URI-shaped QML module output directory** (`66861837`)
- `qt_add_qml_module` warned that `phosphor_shell_example`'s
  `OUTPUT_DIRECTORY` didn't end in the module's URI path, so qmllint
  couldn't resolve the module. Set `OUTPUT_DIRECTORY` accordingly
  (build-tree only — `RESOURCE_PREFIX` is untouched).

**3. Panel popup drop shadows** (`e4e46133`)
- `gradient.frag` gains a popup mode (selected by `shadowMargin > 0`):
  the xdg_popup surface is oversized by `shadowMargin` and the shader
  draws the gradient panel inset, ringed by an SDF drop shadow that
  follows the rounded corners. The gradient is factored into a shared
  `computeGradient()`; the panel strip-shadow mode is unchanged.
- `PanelPopup.qml` sizes the surface to `content + 2·shadowMargin`,
  offsets the anchor gap to keep the visible popup in place, and insets
  the border + content past the shadow ring.

## Test

- `cmake --build build` green; `ctest` 184/184 pass.
- Shaders compile at runtime (not baked), so the GLSL was verified by
  running the example shell — panel and popups render correctly, popups
  show the drop shadow with no edge seam.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)