### PR TITLE
feat(animation): per-event durations for KWin window animations

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -546,6 +546,7 @@ private:
     void endShaderTransition(KWin::EffectWindow* window);
     void loadShaderProfileFromDbus();
     void loadAnimationAppRulesFromDbus();
+    void loadMotionProfileTreeFromDbus();
     void loadShaderRegistryFromDbus();
     void tryBeginShaderForEvent(KWin::EffectWindow* window, const QString& profilePath, int durationMs,
                                 bool reverse = false, bool holdCloseGrab = false);
@@ -808,6 +809,13 @@ private:
 private Q_SLOTS:
     /// Handle daemon signal when virtual screen definitions change
     void onVirtualScreensChanged(const QString& physicalScreenId);
+
+    /// Handle daemon signal when the per-event motion-profile tree
+    /// changes (a per-event animation duration was edited). Re-fetches
+    /// `motionProfileTree` so per-event durations apply without a
+    /// logout/login. Dedicated signal (not settingsChanged) so the
+    /// Settings app's change detection is unaffected.
+    void slotMotionProfileTreeChanged();
 };
 
 } // namespace PlasmaZones

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -542,6 +542,7 @@ void PlasmaZonesEffect::loadCachedSettings()
 
     loadShaderProfileFromDbus();
     loadAnimationAppRulesFromDbus();
+    loadMotionProfileTreeFromDbus();
     loadShaderRegistryFromDbus();
     loadSettingAsync(QStringLiteral("toggleActivation"), [this](const QVariant& v) {
         m_cachedToggleActivation = v.toBool();

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -482,6 +482,20 @@ PlasmaZonesEffect::PlasmaZonesEffect()
         qCWarning(lcEffect) << "Failed to connect to daemon virtualScreensChanged D-Bus signal";
     }
 
+    // Connect to per-event motion-profile-tree changes. The daemon emits
+    // this (separate from settingsChanged) when a per-event animation
+    // duration is edited, so per-event durations apply live instead of
+    // only after a logout/login.
+    const bool motionTreeConnected = QDBusConnection::sessionBus().connect(
+        PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+        PhosphorProtocol::Service::Interface::Settings, QStringLiteral("motionProfileTreeChanged"), this,
+        SLOT(slotMotionProfileTreeChanged()));
+    if (motionTreeConnected) {
+        qCInfo(lcEffect) << "Connected to daemon motionProfileTreeChanged D-Bus signal";
+    } else {
+        qCWarning(lcEffect) << "Failed to connect to daemon motionProfileTreeChanged D-Bus signal";
+    }
+
     // Connect to keyboard navigation D-Bus signals
     connectNavigationSignals();
 

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -10,6 +10,10 @@
 #include <PhosphorAnimation/AnimationAppRuleResolver.h>
 #include <PhosphorAnimation/AnimationShaderContract.h>
 #include <PhosphorAnimation/AnimationShaderRegistry.h>
+#include <PhosphorAnimation/CurveRegistry.h>
+#include <PhosphorAnimation/Profile.h>
+#include <PhosphorAnimation/ProfilePaths.h>
+#include <PhosphorAnimation/ProfileTree.h>
 #include <PhosphorAnimation/ShaderProfile.h>
 #include <PhosphorAnimation/ShaderProfileTree.h>
 #include <PhosphorProtocol/ClientHelpers.h>
@@ -1182,11 +1186,42 @@ void PlasmaZonesEffect::tryBeginShaderForEvent(KWin::EffectWindow* window, const
     const auto& profileTree = m_shaderManager.profileTree();
     const auto profile =
         PhosphorAnimationShaders::resolveAnimationShaderProfile(appRules, profileTree, windowClass, profilePath);
+    // Per-event base duration. The daemon mirrors its motion
+    // PhosphorProfileRegistry into `motionProfileTree` over D-Bus —
+    // ProfileTree::resolve walks `window.open → window → global` and
+    // overlays each level, so a user-set `window.open` = 900 ms wins
+    // over the global default exactly as the daemon's SurfaceAnimator
+    // resolves per-event OSD/popup durations from the registry.
+    //
+    // Fall back to the caller-supplied global `animationDurationMs()`
+    // when NO node in the path's parent chain carries an override:
+    // an empty tree (D-Bus race / fresh user) must not silently
+    // collapse every event to the library default (150 ms). The
+    // resolved value is then handed to `resolveAnimationDuration` as
+    // its `defaultDurationMs`, so the per-window-class App Rule timing
+    // cascade still layers on top (rule wins → per-event base →
+    // global), matching the resolver's documented contract.
+    int baseDurationMs = durationMs;
+    {
+        const auto& motionTree = m_shaderManager.motionProfileTree();
+        bool hasChainOverride = false;
+        for (QString cursor = profilePath; !cursor.isEmpty();
+             cursor = PhosphorAnimation::ProfilePaths::parentPath(cursor)) {
+            if (motionTree.hasOverride(cursor)) {
+                hasChainOverride = true;
+                break;
+            }
+        }
+        if (hasChainOverride) {
+            baseDurationMs = qRound(motionTree.resolve(profilePath).effectiveDuration());
+        }
+    }
     // Resolve duration through the rule cascade too — a Timing rule for
-    // the same (class, event) bumps a per-event default. A rule with
-    // durationMs == 0 is the inherit sentinel and falls through.
+    // the same (class, event) bumps the per-event base. A rule with
+    // durationMs == 0 is the inherit sentinel and falls through to the
+    // per-event base resolved above.
     const int effectiveDurationMs =
-        PhosphorAnimationShaders::resolveAnimationDuration(appRules, windowClass, profilePath, durationMs);
+        PhosphorAnimationShaders::resolveAnimationDuration(appRules, windowClass, profilePath, baseDurationMs);
     if (profile.effectiveEffectId().isEmpty()) {
         // Default-state path: a fresh user with no shader overrides
         // anywhere in the tree resolves every event to empty effectId,
@@ -1263,6 +1298,40 @@ void PlasmaZonesEffect::loadAnimationAppRulesFromDbus()
                 qCWarning(lcEffect) << "Failed to parse animationAppRules from D-Bus — not a JSON array";
             }
         });
+}
+
+void PlasmaZonesEffect::loadMotionProfileTreeFromDbus()
+{
+    PhosphorProtocol::ClientHelpers::loadSettingAsync(
+        this, QStringLiteral("motionProfileTree"), [this](const QVariant& v) {
+            const QJsonDocument doc = QJsonDocument::fromJson(v.toString().toUtf8());
+            if (doc.isObject()) {
+                // ProfileTree::fromJson resolves the optional `curve`
+                // field through a CurveRegistry. The effect resolves
+                // ONLY per-event durations from this tree (it never
+                // animates with the motion curve — shader effects carry
+                // their own timing), so a throwaway empty registry is
+                // sufficient: an unresolved curve simply stays null,
+                // and effectiveDuration() reads `duration` directly.
+                PhosphorAnimation::CurveRegistry curves;
+                auto& tree = m_shaderManager.motionProfileTree();
+                tree = PhosphorAnimation::ProfileTree::fromJson(doc.object(), curves);
+                qCDebug(lcEffect) << "loadMotionProfileTreeFromDbus: tree loaded with" << tree.overriddenPaths().size()
+                                  << "per-event overrides — paths=" << tree.overriddenPaths();
+            } else {
+                qCWarning(lcEffect) << "Failed to parse motionProfileTree from D-Bus — not a JSON object";
+            }
+        });
+}
+
+void PlasmaZonesEffect::slotMotionProfileTreeChanged()
+{
+    // A per-event animation duration was edited (daemon rescanned a
+    // `profiles/*.json` override). Re-fetch so per-event durations apply
+    // live, without a logout/login. loadCachedSettings() also re-fetches
+    // it on settingsChanged; this dedicated path covers the profile-file
+    // edits that deliberately do NOT ride settingsChanged.
+    loadMotionProfileTreeFromDbus();
 }
 
 void PlasmaZonesEffect::loadShaderRegistryFromDbus()

--- a/kwin-effect/shadertransitionmanager.h
+++ b/kwin-effect/shadertransitionmanager.h
@@ -6,6 +6,7 @@
 #include <PhosphorAnimation/AnimationAppRule.h>
 #include <PhosphorAnimation/AnimationShaderContract.h>
 #include <PhosphorAnimation/AnimationShaderRegistry.h>
+#include <PhosphorAnimation/ProfileTree.h>
 #include <PhosphorAnimation/ShaderProfile.h>
 #include <PhosphorAnimation/ShaderProfileTree.h>
 
@@ -88,6 +89,20 @@ public:
     const PhosphorAnimationShaders::AnimationAppRuleList& appRules() const
     {
         return m_animationAppRules;
+    }
+
+    /// Per-event motion-profile tree mirrored from the daemon's
+    /// PhosphorProfileRegistry over D-Bus (`motionProfileTree`). Holds
+    /// the per-event base durations (window.open, window.close, …) that
+    /// `tryBeginShaderForEvent` resolves before applying the App Rule
+    /// timing cascade. Refreshed on every settingsChanged signal.
+    PhosphorAnimation::ProfileTree& motionProfileTree()
+    {
+        return m_motionProfileTree;
+    }
+    const PhosphorAnimation::ProfileTree& motionProfileTree() const
+    {
+        return m_motionProfileTree;
     }
 
     // NOTE: Shader transition methods (beginShaderTransition, endShaderTransition,
@@ -212,6 +227,7 @@ private:
     PhosphorAnimationShaders::AnimationShaderRegistry m_animationShaderRegistry;
     PhosphorAnimationShaders::ShaderProfileTree m_shaderProfileTree;
     PhosphorAnimationShaders::AnimationAppRuleList m_animationAppRules;
+    PhosphorAnimation::ProfileTree m_motionProfileTree;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Texture Cache

--- a/kwin-effect/shadertransitionmanager.h
+++ b/kwin-effect/shadertransitionmanager.h
@@ -95,7 +95,9 @@ public:
     /// PhosphorProfileRegistry over D-Bus (`motionProfileTree`). Holds
     /// the per-event base durations (window.open, window.close, …) that
     /// `tryBeginShaderForEvent` resolves before applying the App Rule
-    /// timing cascade. Refreshed on every settingsChanged signal.
+    /// timing cascade. Refreshed on the dedicated `motionProfileTreeChanged`
+    /// D-Bus signal (live per-event edits) and on `settingsChanged` via
+    /// `loadCachedSettings()`.
     PhosphorAnimation::ProfileTree& motionProfileTree()
     {
         return m_motionProfileTree;

--- a/libs/phosphor-animation/include/PhosphorAnimation/PhosphorProfileRegistry.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/PhosphorProfileRegistry.h
@@ -105,6 +105,15 @@ public:
     /// Current owner tag for @p path, or empty string.
     QString ownerOf(const QString& path) const;
 
+    /// Thread-safe copy of every registered (path → Profile) pair,
+    /// owner tags discarded. Intended for publishers that need to
+    /// serialize the merged per-event profile set out of process
+    /// (e.g. the daemon broadcasting a `ProfileTree` to the
+    /// kwin-effect over D-Bus). For in-process resolution prefer
+    /// `resolveWithInheritance` — it applies the parent-chain overlay
+    /// the registry cannot encode in a flat snapshot.
+    QHash<QString, Profile> snapshot() const;
+
     /// Current path count. Thread-safe.
     int profileCount() const;
 

--- a/libs/phosphor-animation/src/phosphorprofileregistry.cpp
+++ b/libs/phosphor-animation/src/phosphorprofileregistry.cpp
@@ -388,6 +388,12 @@ QString PhosphorProfileRegistry::ownerOf(const QString& path) const
     return m_owners.value(path);
 }
 
+QHash<QString, Profile> PhosphorProfileRegistry::snapshot() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_profiles;
+}
+
 int PhosphorProfileRegistry::profileCount() const
 {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -851,7 +851,7 @@ bool Daemon::init()
     m_layoutAdaptor->setAutotileLayoutSource(m_autotileLayoutSource);
     // Invalidate D-Bus getActiveLayout() cache when the default layout changes in settings
     connect(m_settings.get(), &Settings::defaultLayoutIdChanged, m_layoutAdaptor, &LayoutAdaptor::invalidateCache);
-    m_settingsAdaptor = new SettingsAdaptor(m_settings.get(), m_shaderRegistry.get(), this);
+    m_settingsAdaptor = new SettingsAdaptor(m_settings.get(), m_shaderRegistry.get(), &m_profileRegistry, this);
 
     // Shader adaptor - shader discovery, compilation lifecycle, file monitoring.
     // Held as a member so stop() can detach() it before the unique_ptr member

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -35,6 +35,7 @@ SettingsAdaptor::SettingsAdaptor(ISettings* settings, ShaderRegistry* shaderRegi
     , m_shaderRegistry(shaderRegistry)
     , m_profileRegistry(profileRegistry)
     , m_saveTimer(new QTimer(this))
+    , m_motionTreeNotifyTimer(new QTimer(this))
 {
     Q_ASSERT(settings);
     initializeRegistry();
@@ -47,6 +48,11 @@ SettingsAdaptor::SettingsAdaptor(ISettings* settings, ShaderRegistry* shaderRegi
         qCInfo(lcDbusSettings) << "Settings save completed";
     });
 
+    // Configure the debounced motion-profile-tree notifier (see member doc).
+    m_motionTreeNotifyTimer->setSingleShot(true);
+    m_motionTreeNotifyTimer->setInterval(MotionTreeNotifyDebounceMs);
+    connect(m_motionTreeNotifyTimer, &QTimer::timeout, this, &SettingsAdaptor::motionProfileTreeChanged);
+
     // Connect to interface signals (DIP)
     connect(m_settings, &ISettings::settingsChanged, this, &SettingsAdaptor::settingsChanged);
 
@@ -54,22 +60,29 @@ SettingsAdaptor::SettingsAdaptor(ISettings* settings, ShaderRegistry* shaderRegi
     // settings-shaped state: editing a `window.open` duration rewrites
     // a `profiles/*.json` file, the daemon's ProfileLoader file-watch
     // rescans it into the registry, and the registry fires
-    // profileChanged / profilesReloaded. The kwin-effect (a separate
-    // process) must re-fetch `motionProfileTree` when that happens, so
-    // bridge the registry mutations to a DEDICATED `motionProfileTreeChanged`
-    // D-Bus signal — NOT the generic `settingsChanged`. The Settings app
-    // listens only to `settingsChanged`; routing registry mutations
-    // there made the daemon echo the app's own immediate profile-file
-    // writes back through onExternalSettingsChanged(), which reset its
-    // value-change / save-discard detection. The effect subscribes to
+    // profileChanged / profilesReloaded / ownerReloaded. The kwin-effect
+    // (a separate process) must re-fetch `motionProfileTree` when that
+    // happens, so bridge the registry mutations to a DEDICATED
+    // `motionProfileTreeChanged` D-Bus signal — NOT the generic
+    // `settingsChanged`. The Settings app listens only to
+    // `settingsChanged`; routing registry mutations there made the
+    // daemon echo the app's own immediate profile-file writes back
+    // through onExternalSettingsChanged(), which reset its value-change
+    // / save-discard detection. The effect subscribes to
     // `motionProfileTreeChanged` specifically; the app never sees it.
+    //
+    // The three registry signals feed the debounce timer rather than
+    // motionProfileTreeChanged directly: a reloadFromOwner() batch emits
+    // one profileChanged per path plus a closing ownerReloaded, so a
+    // direct bridge would fan one logical change out into N+1 D-Bus
+    // emissions. start() on a single-shot timer collapses the burst.
     if (m_profileRegistry) {
-        connect(m_profileRegistry, &PhosphorAnimation::PhosphorProfileRegistry::profileChanged, this,
-                &SettingsAdaptor::motionProfileTreeChanged);
-        connect(m_profileRegistry, &PhosphorAnimation::PhosphorProfileRegistry::profilesReloaded, this,
-                &SettingsAdaptor::motionProfileTreeChanged);
-        connect(m_profileRegistry, &PhosphorAnimation::PhosphorProfileRegistry::ownerReloaded, this,
-                &SettingsAdaptor::motionProfileTreeChanged);
+        connect(m_profileRegistry, &PhosphorAnimation::PhosphorProfileRegistry::profileChanged, m_motionTreeNotifyTimer,
+                qOverload<>(&QTimer::start));
+        connect(m_profileRegistry, &PhosphorAnimation::PhosphorProfileRegistry::profilesReloaded,
+                m_motionTreeNotifyTimer, qOverload<>(&QTimer::start));
+        connect(m_profileRegistry, &PhosphorAnimation::PhosphorProfileRegistry::ownerReloaded, m_motionTreeNotifyTimer,
+                qOverload<>(&QTimer::start));
     }
 
     // Drop shader caches whenever the registry reloads from disk. The
@@ -118,6 +131,11 @@ void SettingsAdaptor::detach()
     if (m_profileRegistry) {
         disconnect(m_profileRegistry, nullptr, this, nullptr);
     }
+    // Cancel any pending coalesced motion-tree notification — its inputs
+    // are severed above and the daemon is tearing down. Constructed in
+    // the initializer list and never nulled, so no null-check (same as
+    // m_saveTimer).
+    m_motionTreeNotifyTimer->stop();
     // Clear the registries before nulling m_settings so a queued D-Bus
     // call that slipped past unregisterObject() lands on an empty-getter
     // hash (returning an empty QVariant) instead of the registered

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -6,6 +6,9 @@
 #include "../config/settings.h" // For concrete Settings type
 #include "../core/dbusvariantutils.h"
 #include <PhosphorAnimation/AnimationAppRule.h>
+#include <PhosphorAnimation/PhosphorProfileRegistry.h>
+#include <PhosphorAnimation/ProfilePaths.h>
+#include <PhosphorAnimation/ProfileTree.h>
 #include <PhosphorAnimation/ShaderProfileTree.h>
 #include "../core/logging.h"
 #include "../core/shaderregistry.h"
@@ -25,10 +28,12 @@ constexpr qsizetype kMaxShaderProfileTreeBytes = 64 * 1024;
 constexpr qsizetype kMaxAnimationAppRulesBytes = 64 * 1024;
 }
 
-SettingsAdaptor::SettingsAdaptor(ISettings* settings, ShaderRegistry* shaderRegistry, QObject* parent)
+SettingsAdaptor::SettingsAdaptor(ISettings* settings, ShaderRegistry* shaderRegistry,
+                                 PhosphorAnimation::PhosphorProfileRegistry* profileRegistry, QObject* parent)
     : QDBusAbstractAdaptor(parent)
     , m_settings(settings)
     , m_shaderRegistry(shaderRegistry)
+    , m_profileRegistry(profileRegistry)
     , m_saveTimer(new QTimer(this))
 {
     Q_ASSERT(settings);
@@ -44,6 +49,28 @@ SettingsAdaptor::SettingsAdaptor(ISettings* settings, ShaderRegistry* shaderRegi
 
     // Connect to interface signals (DIP)
     connect(m_settings, &ISettings::settingsChanged, this, &SettingsAdaptor::settingsChanged);
+
+    // The per-event motion-profile registry is a second source of
+    // settings-shaped state: editing a `window.open` duration rewrites
+    // a `profiles/*.json` file, the daemon's ProfileLoader file-watch
+    // rescans it into the registry, and the registry fires
+    // profileChanged / profilesReloaded. The kwin-effect (a separate
+    // process) must re-fetch `motionProfileTree` when that happens, so
+    // bridge the registry mutations to a DEDICATED `motionProfileTreeChanged`
+    // D-Bus signal — NOT the generic `settingsChanged`. The Settings app
+    // listens only to `settingsChanged`; routing registry mutations
+    // there made the daemon echo the app's own immediate profile-file
+    // writes back through onExternalSettingsChanged(), which reset its
+    // value-change / save-discard detection. The effect subscribes to
+    // `motionProfileTreeChanged` specifically; the app never sees it.
+    if (m_profileRegistry) {
+        connect(m_profileRegistry, &PhosphorAnimation::PhosphorProfileRegistry::profileChanged, this,
+                &SettingsAdaptor::motionProfileTreeChanged);
+        connect(m_profileRegistry, &PhosphorAnimation::PhosphorProfileRegistry::profilesReloaded, this,
+                &SettingsAdaptor::motionProfileTreeChanged);
+        connect(m_profileRegistry, &PhosphorAnimation::PhosphorProfileRegistry::ownerReloaded, this,
+                &SettingsAdaptor::motionProfileTreeChanged);
+    }
 
     // Drop shader caches whenever the registry reloads from disk. The
     // registry is per-process and injected via constructor; unit tests
@@ -88,6 +115,9 @@ void SettingsAdaptor::detach()
     if (m_shaderRegistry) {
         disconnect(m_shaderRegistry, nullptr, this, nullptr);
     }
+    if (m_profileRegistry) {
+        disconnect(m_profileRegistry, nullptr, this, nullptr);
+    }
     // Clear the registries before nulling m_settings so a queued D-Bus
     // call that slipped past unregisterObject() lands on an empty-getter
     // hash (returning an empty QVariant) instead of the registered
@@ -100,6 +130,7 @@ void SettingsAdaptor::detach()
     m_cachedShaderDefaults.clear();
     m_settings = nullptr;
     m_shaderRegistry = nullptr;
+    m_profileRegistry = nullptr;
 }
 
 void SettingsAdaptor::scheduleSave()
@@ -544,6 +575,40 @@ void SettingsAdaptor::initializeRegistry()
             return true;
         };
         m_schemas[QStringLiteral("animationAppRules")] = QStringLiteral("string");
+    }
+
+    // Per-event motion-profile tree (read-only, JSON blob round-trip).
+    //
+    // The merged per-event `PhosphorAnimation::Profile` set — every
+    // entry the daemon's `m_profileRegistry` holds, which is the SAME
+    // registry the OverlayService SurfaceAnimator resolves OSD / popup
+    // durations from. Settings persists per-event overrides as one
+    // `profiles/<path>.json` file each; the daemon's ProfileLoader
+    // scans them into the registry, and `publishActiveAnimationProfile`
+    // registers the settings-driven `Global` profile on top.
+    //
+    // The kwin-effect lives in a separate process and cannot share the
+    // registry object, so the merged set is flattened into a
+    // `ProfileTree` and shipped over the bus: `Global` becomes the
+    // tree baseline, every other path an override. The effect resolves
+    // per-event durations from the tree exactly as the SurfaceAnimator
+    // resolves them from the registry. Read-only — Settings owns the
+    // authoritative per-event files, never the effect.
+    if (m_profileRegistry) {
+        auto* registry = m_profileRegistry;
+        m_getters[QStringLiteral("motionProfileTree")] = [registry]() {
+            const QHash<QString, PhosphorAnimation::Profile> profiles = registry->snapshot();
+            PhosphorAnimation::ProfileTree tree;
+            for (auto it = profiles.constBegin(); it != profiles.constEnd(); ++it) {
+                if (it.key() == PhosphorAnimation::ProfilePaths::Global) {
+                    tree.setBaseline(it.value());
+                } else {
+                    tree.setOverride(it.key(), it.value());
+                }
+            }
+            return QString::fromUtf8(QJsonDocument(tree.toJson()).toJson(QJsonDocument::Compact));
+        };
+        m_schemas[QStringLiteral("motionProfileTree")] = QStringLiteral("string");
     }
 
     // Phase 6: shader search paths (read-only, for KWin effect registry population).

--- a/src/dbus/settingsadaptor.h
+++ b/src/dbus/settingsadaptor.h
@@ -13,6 +13,10 @@
 #include <functional>
 #include <QHash>
 
+namespace PhosphorAnimation {
+class PhosphorProfileRegistry;
+}
+
 namespace PlasmaZones {
 
 class ISettings;
@@ -38,9 +42,17 @@ public:
     ///        outlive the adaptor. Optional in tests / unit fixtures —
     ///        when null, every shader-related method returns an empty
     ///        result and the on-disk hot-reload connection is skipped.
+    /// @param profileRegistry Per-process motion-profile registry holding
+    ///        the merged per-event `PhosphorAnimation::Profile` set (the
+    ///        same registry the daemon's SurfaceAnimator path resolves
+    ///        durations from). Borrowed; must outlive the adaptor.
+    ///        Optional — when null, the `motionProfileTree` getter is not
+    ///        registered and consumers fall back to the global duration.
     /// @param parent Qt parent (D-Bus adaptors are owned by their adapted
     ///        QObject via Qt parent-child).
-    explicit SettingsAdaptor(ISettings* settings, ShaderRegistry* shaderRegistry = nullptr, QObject* parent = nullptr);
+    explicit SettingsAdaptor(ISettings* settings, ShaderRegistry* shaderRegistry = nullptr,
+                             PhosphorAnimation::PhosphorProfileRegistry* profileRegistry = nullptr,
+                             QObject* parent = nullptr);
     ~SettingsAdaptor() override;
 
     /// Null the borrowed ISettings / ShaderRegistry pointers, sever their
@@ -220,6 +232,19 @@ Q_SIGNALS:
     void settingsChanged();
 
     /**
+     * @brief Daemon → KWin effect: the per-event motion-profile tree changed.
+     *
+     * Emitted when the motion-profile registry mutates (a per-event
+     * `profiles/*.json` override was edited and the daemon rescanned it).
+     * Deliberately separate from @ref settingsChanged: the Settings app
+     * listens only to settingsChanged, so routing registry mutations
+     * here keeps the app's value-change / save-discard detection from
+     * being reset by its own immediate profile-file writes. The kwin
+     * effect subscribes to this signal and re-fetches `motionProfileTree`.
+     */
+    void motionProfileTreeChanged();
+
+    /**
      * @brief Daemon → KWin effect: please enumerate running windows.
      *
      * Emitted by requestRunningWindows(). The effect answers by calling
@@ -261,6 +286,7 @@ private:
 
     ISettings* m_settings; // Interface type (DIP)
     ShaderRegistry* m_shaderRegistry = nullptr; ///< Borrowed; outlives adaptor
+    PhosphorAnimation::PhosphorProfileRegistry* m_profileRegistry = nullptr; ///< Borrowed; outlives adaptor
 
     // Registry pattern
     using Getter = std::function<QVariant()>;

--- a/src/dbus/settingsadaptor.h
+++ b/src/dbus/settingsadaptor.h
@@ -235,7 +235,8 @@ Q_SIGNALS:
      * @brief Daemon → KWin effect: the per-event motion-profile tree changed.
      *
      * Emitted when the motion-profile registry mutates (a per-event
-     * `profiles/*.json` override was edited and the daemon rescanned it).
+     * `profiles/<path>.json` override was edited and the daemon
+     * rescanned it).
      * Deliberately separate from @ref settingsChanged: the Settings app
      * listens only to settingsChanged, so routing registry mutations
      * here keeps the app's value-change / save-discard detection from
@@ -299,6 +300,16 @@ private:
     // Debounced save timer (performance optimization)
     QTimer* m_saveTimer = nullptr;
     static constexpr int SaveDebounceMs = 500; // 500ms debounce
+
+    // Debounced motion-profile-tree change notifier. A single
+    // ProfileLoader rescan calls reloadFromOwner(), which emits one
+    // profileChanged per touched path plus a closing ownerReloaded —
+    // N+1 registry signals for one logical change. Without coalescing,
+    // each would emit motionProfileTreeChanged() and the kwin-effect
+    // would re-fetch + re-parse the whole tree N+1 times. This timer
+    // collapses the burst into a single emission.
+    QTimer* m_motionTreeNotifyTimer = nullptr;
+    static constexpr int MotionTreeNotifyDebounceMs = 50;
 
     // ═══════════════════════════════════════════════════════════════════════
     // ShaderRegistry caches

--- a/tests/unit/dbus/bench_dbus_adaptors.cpp
+++ b/tests/unit/dbus/bench_dbus_adaptors.cpp
@@ -58,7 +58,8 @@ private Q_SLOTS:
         // teardown. See test_settings_adaptor_batch.cpp for the same pattern.
         m_settings = new StubSettings(nullptr);
         m_parent = new QObject(nullptr);
-        m_settingsAdaptor = new SettingsAdaptor(m_settings, /*shaderRegistry=*/nullptr, m_parent);
+        m_settingsAdaptor =
+            new SettingsAdaptor(m_settings, /*shaderRegistry=*/nullptr, /*profileRegistry=*/nullptr, m_parent);
 
         m_layoutManager = new PhosphorZones::LayoutRegistry(PlasmaZones::createAssignmentsBackend(),
                                                             QStringLiteral("plasmazones/layouts"), m_parent);

--- a/tests/unit/dbus/test_settings_adaptor_batch.cpp
+++ b/tests/unit/dbus/test_settings_adaptor_batch.cpp
@@ -54,7 +54,7 @@ private Q_SLOTS:
         m_guard = std::make_unique<IsolatedConfigGuard>();
         m_settings = new CountingStubSettings(nullptr);
         m_parent = new QObject(nullptr);
-        m_adaptor = new SettingsAdaptor(m_settings, /*shaderRegistry=*/nullptr, m_parent);
+        m_adaptor = new SettingsAdaptor(m_settings, /*shaderRegistry=*/nullptr, /*profileRegistry=*/nullptr, m_parent);
     }
 
     void cleanup()

--- a/tests/unit/dbus/test_settings_adaptor_batch.cpp
+++ b/tests/unit/dbus/test_settings_adaptor_batch.cpp
@@ -14,10 +14,21 @@
  */
 
 #include <QTest>
+#include <QDBusVariant>
+#include <QHash>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QSignalSpy>
 #include <QString>
 #include <QStringList>
 #include <QVariant>
 #include <QVariantMap>
+
+#include <PhosphorAnimation/CurveRegistry.h>
+#include <PhosphorAnimation/PhosphorProfileRegistry.h>
+#include <PhosphorAnimation/Profile.h>
+#include <PhosphorAnimation/ProfilePaths.h>
+#include <PhosphorAnimation/ProfileTree.h>
 
 #include "dbus/settingsadaptor.h"
 #include "../helpers/StubSettings.h"
@@ -25,6 +36,18 @@
 
 using namespace PlasmaZones;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
+
+namespace {
+// Build a Profile carrying only an explicit duration — enough to assert
+// the motionProfileTree getter's baseline/override placement and the
+// debounced motionProfileTreeChanged emission.
+PhosphorAnimation::Profile profileWithDuration(qreal ms)
+{
+    PhosphorAnimation::Profile p;
+    p.duration = ms;
+    return p;
+}
+} // namespace
 
 // Counting-stub: overrides one setter so the guard-fires test can
 // distinguish "setter not invoked" (guard hit) from "setter invoked,
@@ -246,6 +269,82 @@ private Q_SLOTS:
         values[QStringLiteral("masterCount")] = 2;
         const bool ok = m_adaptor->setPerScreenSettings(QStringLiteral("DP-1"), QStringLiteral("autotile"), values);
         QVERIFY(ok);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Per-event motion-profile tree surface (PR #457).
+    //
+    // The motionProfileTree getter and the motionProfileTreeChanged signal
+    // only exist when SettingsAdaptor is constructed with a real
+    // PhosphorProfileRegistry. The init() fixture passes nullptr, so the
+    // getter must not be registered there at all — consumers fall back to
+    // the global animation duration.
+    // ─────────────────────────────────────────────────────────────────────
+    void testMotionProfileTree_absentWhenNoRegistry()
+    {
+        QVERIFY(!m_adaptor->getSettingKeys().contains(QStringLiteral("motionProfileTree")));
+    }
+
+    // With a registry injected, the getter flattens the merged profile set
+    // into a ProfileTree JSON blob: the Global profile becomes the tree
+    // baseline, every other path an override. Round-tripped back through
+    // ProfileTree so the assertion pins resolved durations, not wire shape.
+    void testMotionProfileTree_getterSerializesBaselineAndOverrides()
+    {
+        PhosphorAnimation::PhosphorProfileRegistry registry;
+        registry.registerProfile(PhosphorAnimation::ProfilePaths::Global, profileWithDuration(400.0));
+        registry.registerProfile(QStringLiteral("window.open"), profileWithDuration(900.0));
+
+        QObject parent;
+        auto* adaptor = new SettingsAdaptor(m_settings, /*shaderRegistry=*/nullptr, &registry, &parent);
+
+        QVERIFY(adaptor->getSettingKeys().contains(QStringLiteral("motionProfileTree")));
+
+        const QString json = adaptor->getSetting(QStringLiteral("motionProfileTree")).variant().toString();
+        QVERIFY(!json.isEmpty());
+
+        const QJsonDocument doc = QJsonDocument::fromJson(json.toUtf8());
+        QVERIFY(doc.isObject());
+
+        PhosphorAnimation::CurveRegistry curves;
+        const PhosphorAnimation::ProfileTree tree = PhosphorAnimation::ProfileTree::fromJson(doc.object(), curves);
+
+        // Global landed as the baseline: a path with no override resolves
+        // to the baseline duration.
+        QCOMPARE(qRound(tree.resolve(QStringLiteral("window.close")).effectiveDuration()), 400);
+        // window.open landed as an override and wins over the baseline.
+        QVERIFY(tree.hasOverride(QStringLiteral("window.open")));
+        QCOMPARE(qRound(tree.resolve(QStringLiteral("window.open")).effectiveDuration()), 900);
+    }
+
+    // A single reloadFromOwner() batch emits one profileChanged per touched
+    // path plus a closing ownerReloaded — N+1 registry signals for one
+    // logical change. The adaptor's debounce timer must collapse that burst
+    // into exactly one motionProfileTreeChanged D-Bus emission.
+    void testMotionProfileTreeChanged_coalescesRegistryBurst()
+    {
+        PhosphorAnimation::PhosphorProfileRegistry registry;
+        registry.registerProfile(PhosphorAnimation::ProfilePaths::Global, profileWithDuration(400.0));
+
+        QObject parent;
+        auto* adaptor = new SettingsAdaptor(m_settings, /*shaderRegistry=*/nullptr, &registry, &parent);
+
+        QSignalSpy spy(adaptor, &SettingsAdaptor::motionProfileTreeChanged);
+        QVERIFY(spy.isValid());
+
+        QHash<QString, PhosphorAnimation::Profile> batch;
+        batch.insert(QStringLiteral("window.open"), profileWithDuration(100.0));
+        batch.insert(QStringLiteral("window.close"), profileWithDuration(200.0));
+        batch.insert(QStringLiteral("window.focus"), profileWithDuration(300.0));
+        registry.reloadFromOwner(QStringLiteral("test-owner"), batch);
+
+        // The registry signals fire synchronously; the single-shot debounce
+        // timer has only been (re)started, not yet fired.
+        QCOMPARE(spy.count(), 0);
+
+        // Spin the event loop until the coalesced emission lands.
+        QVERIFY(spy.wait(1000));
+        QCOMPARE(spy.count(), 1);
     }
 
 private:

--- a/tests/unit/dbus/test_settings_schema.cpp
+++ b/tests/unit/dbus/test_settings_schema.cpp
@@ -40,7 +40,7 @@ private Q_SLOTS:
         m_settings = new StubSettings(nullptr);
         // SettingsAdaptor is a QDBusAbstractAdaptor and needs a parent
         m_parent = new QObject(nullptr);
-        m_adaptor = new SettingsAdaptor(m_settings, /*shaderRegistry=*/nullptr, m_parent);
+        m_adaptor = new SettingsAdaptor(m_settings, /*shaderRegistry=*/nullptr, /*profileRegistry=*/nullptr, m_parent);
     }
 
     void cleanup()


### PR DESCRIPTION
## Summary

Window-event animations (`window.open`/`close`/`focus`/`minimize`/`maximize`) used the single global `animationDuration`. Per-event durations set in the Settings app — stored as `profiles/*.json` overrides and already resolved by the daemon's `SurfaceAnimator` for OSD/surface animations — never reached the kwin-effect, so every window event ran at one duration regardless of its per-event setting.

This wires the per-event motion-profile tree through to the effect.

## Changes

- **`SettingsAdaptor`** exposes the daemon's merged `PhosphorProfileRegistry` as a read-only `motionProfileTree` D-Bus getter (`Global` → tree baseline, every other path → override), flattened via a new thread-safe `PhosphorProfileRegistry::snapshot()`.
- Registry mutations are bridged to a **dedicated `motionProfileTreeChanged` D-Bus signal**, not the generic `settingsChanged`. The Settings app listens only to `settingsChanged`; routing registry mutations there echoed the app's own immediate profile-file writes back through `onExternalSettingsChanged()` and reset its value-change / save-discard detection. The effect subscribes to the dedicated signal so per-event edits apply live without a logout/login.
- The effect loads `motionProfileTree` into a `ShaderTransitionManager` `ProfileTree` (initial load via `loadCachedSettings`, live refresh via `slotMotionProfileTreeChanged`).
- `tryBeginShaderForEvent` resolves the per-event base duration from the tree (`ProfileTree::resolve` walks `window.open` → `window` → `global`), falling back to the global `animationDuration` when no node in the chain carries an override. The App Rule timing cascade still layers on top.

## Testing

- `cmake --build` of `plasmazonesd` + `kwin_effect_plasmazones` clean.
- D-Bus/settings/profile tests pass (13/13).
- Manually verified: per-event durations apply live on a settings change (no logout/login), and the Settings app's save/discard detection is unaffected.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)