### PR TITLE
feat(animation): stop window animations on panels, desktop, and shell surfaces

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -639,6 +639,11 @@ private:
     // targeted rule). Defaults are permissive (no filter) until D-Bus
     // populates them; matches the per-key defaults in ConfigDefaults.
     bool m_animationExcludeTransientWindows = false;
+    // Notification / OSD surfaces — excluded by default (see
+    // ConfigDefaults::animationExcludeNotificationsAndOsd). Initialised
+    // to the exclude default rather than the permissive value above so
+    // a pre-D-Bus window event doesn't flash a shader on a notification.
+    bool m_animationExcludeNotificationsAndOsd = true;
     int m_animationMinWindowWidth = 0;
     int m_animationMinWindowHeight = 0;
     QStringList m_animationExcludedApplications;

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -521,6 +521,15 @@ void PlasmaZonesEffect::loadCachedSettings()
     loadSettingAsync(QStringLiteral("animationExcludeTransientWindows"), [this](const QVariant& v) {
         m_animationExcludeTransientWindows = v.toBool();
     });
+    // Default true (exclude). Guard on isValid() so a failed reply
+    // leaves the member at its `true` init rather than `toBool()`'s
+    // false-on-invalid — otherwise a missed fetch would animate
+    // notifications/OSDs until the next successful settings load.
+    loadSettingAsync(QStringLiteral("animationExcludeNotificationsAndOsd"), [this](const QVariant& v) {
+        if (v.isValid()) {
+            m_animationExcludeNotificationsAndOsd = v.toBool();
+        }
+    });
     // Clamp on the effect side as a defence-in-depth — the daemon's
     // schema validator already bounds these to [0, 2000], but a
     // malformed reply (`toInt()` returning 0 on a non-int variant or

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -156,6 +156,17 @@ bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
 
     const QString windowClass = w->windowClass();
 
+    // Structural non-window surfaces — panels (docks), the desktop,
+    // plasmoid / Plasma-shell surfaces, and other special or
+    // skip-switcher windows are never application windows; a
+    // window-event shader on them is always wrong. Hard-excluded with
+    // no toggle and ahead of the rule-override path, mirroring the
+    // structural rejections `shouldHandleWindow()` already applies.
+    if (w->isSpecialWindow() || w->isDesktop() || w->isDock() || w->isSkipSwitcher()
+        || isPlasmaShellSurface(windowClass)) {
+        return false;
+    }
+
     // Rule-override path. ANY AnimationAppRule whose classPattern
     // substring-matches the window's class signals deliberate user
     // intent to animate this app — kind (Shader vs Timing) and
@@ -176,6 +187,15 @@ bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
                 }
             }
         }
+    }
+
+    // Notification and OSD surfaces — excluded from window-event
+    // animations by default; the user can opt in via the Window
+    // Filtering toggle (animationExcludeNotificationsAndOsd). Placed
+    // after the rule-override so a class-targeted rule can still
+    // re-enable them, mirroring the transient filter below.
+    if (m_animationExcludeNotificationsAndOsd && (w->isNotification() || w->isOnScreenDisplay())) {
+        return false;
     }
 
     // Transient-window filter — covers dialogs / popups / tooltips /

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -189,11 +189,13 @@ bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
         }
     }
 
-    // Notification and OSD surfaces — excluded from window-event
-    // animations by default; the user can opt in via the Window
-    // Filtering toggle (animationExcludeNotificationsAndOsd). Placed
-    // after the rule-override so a class-targeted rule can still
-    // re-enable them, mirroring the transient filter below.
+    // Notification and OSD surfaces — excluded by default via the
+    // Window Filtering toggle (animationExcludeNotificationsAndOsd).
+    // Most shell notifications/OSDs are layer-shell surfaces already
+    // rejected by the structural block above; this catches the
+    // remainder — notification windows some apps spawn as ordinary
+    // toplevels. Placed after the rule-override so a class-targeted
+    // rule can still re-enable them, mirroring the transient filter.
     if (m_animationExcludeNotificationsAndOsd && (w->isNotification() || w->isOnScreenDisplay())) {
         return false;
     }

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -503,6 +503,14 @@ public:
     {
         return false;
     }
+    // Notification and OSD surfaces are excluded from window-event
+    // animations by default — unlike transient windows they are almost
+    // never something a user wants a window-open shader on, and they
+    // are driven by the shell rather than the user. Opt-in available.
+    static bool animationExcludeNotificationsAndOsd()
+    {
+        return true;
+    }
     static int animationMinimumWindowWidth()
     {
         return 0;

--- a/src/config/configkeys.h
+++ b/src/config/configkeys.h
@@ -357,6 +357,7 @@ public:
     // ═══════════════════════════════════════════════════════════════════════════
 
     PZ_CONFIG_KEY(transientWindowsKey, "TransientWindows")
+    PZ_CONFIG_KEY(notificationsAndOsdKey, "NotificationsAndOsd")
     PZ_CONFIG_KEY(minimumWindowWidthKey, "MinimumWindowWidth")
     PZ_CONFIG_KEY(minimumWindowHeightKey, "MinimumWindowHeight")
     PZ_CONFIG_KEY(applicationsKey, "Applications")

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -1570,6 +1570,9 @@ PZ_STORE_SET_INT(setMinimumWindowHeight, exclusionsGroup, minimumWindowHeightKey
 PZ_STORE_GET(bool, animationExcludeTransientWindows, animationsWindowFilteringGroup, transientWindowsKey, bool)
 PZ_STORE_SET_BOOL(setAnimationExcludeTransientWindows, animationsWindowFilteringGroup, transientWindowsKey,
                   animationExcludeTransientWindowsChanged)
+PZ_STORE_GET(bool, animationExcludeNotificationsAndOsd, animationsWindowFilteringGroup, notificationsAndOsdKey, bool)
+PZ_STORE_SET_BOOL(setAnimationExcludeNotificationsAndOsd, animationsWindowFilteringGroup, notificationsAndOsdKey,
+                  animationExcludeNotificationsAndOsdChanged)
 PZ_STORE_GET(int, animationMinimumWindowWidth, animationsWindowFilteringGroup, minimumWindowWidthKey, int)
 PZ_STORE_SET_INT(setAnimationMinimumWindowWidth, animationsWindowFilteringGroup, minimumWindowWidthKey,
                  animationMinimumWindowWidthChanged)

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -190,6 +190,8 @@ public:
     // exclusions so the two filter sets can diverge.
     Q_PROPERTY(bool animationExcludeTransientWindows READ animationExcludeTransientWindows WRITE
                    setAnimationExcludeTransientWindows NOTIFY animationExcludeTransientWindowsChanged)
+    Q_PROPERTY(bool animationExcludeNotificationsAndOsd READ animationExcludeNotificationsAndOsd WRITE
+                   setAnimationExcludeNotificationsAndOsd NOTIFY animationExcludeNotificationsAndOsdChanged)
     Q_PROPERTY(int animationMinimumWindowWidth READ animationMinimumWindowWidth WRITE setAnimationMinimumWindowWidth
                    NOTIFY animationMinimumWindowWidthChanged)
     Q_PROPERTY(int animationMinimumWindowHeight READ animationMinimumWindowHeight WRITE setAnimationMinimumWindowHeight
@@ -634,6 +636,8 @@ public:
     // exclusions but stored under `Animations.WindowFiltering`.
     bool animationExcludeTransientWindows() const override;
     void setAnimationExcludeTransientWindows(bool exclude) override;
+    bool animationExcludeNotificationsAndOsd() const override;
+    void setAnimationExcludeNotificationsAndOsd(bool exclude) override;
     int animationMinimumWindowWidth() const override;
     void setAnimationMinimumWindowWidth(int width) override;
     int animationMinimumWindowHeight() const override;

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -530,6 +530,7 @@ void appendExclusionsSchema(PhosphorConfig::Schema& schema)
         {CD::applicationsKey(), QString(), QMetaType::QString, {}, canonicalCommaList},
         {CD::windowClassesKey(), QString(), QMetaType::QString, {}, canonicalCommaList},
         {CD::transientWindowsKey(), CD::animationExcludeTransientWindows(), QMetaType::Bool},
+        {CD::notificationsAndOsdKey(), CD::animationExcludeNotificationsAndOsd(), QMetaType::Bool},
         {CD::minimumWindowWidthKey(),
          CD::animationMinimumWindowWidth(),
          QMetaType::Int,

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -121,6 +121,8 @@ public:
     // lives in its own namespace so the two filter sets can diverge.
     virtual bool animationExcludeTransientWindows() const = 0;
     virtual void setAnimationExcludeTransientWindows(bool exclude) = 0;
+    virtual bool animationExcludeNotificationsAndOsd() const = 0;
+    virtual void setAnimationExcludeNotificationsAndOsd(bool exclude) = 0;
     virtual int animationMinimumWindowWidth() const = 0;
     virtual void setAnimationMinimumWindowWidth(int width) = 0;
     virtual int animationMinimumWindowHeight() const = 0;
@@ -302,6 +304,7 @@ Q_SIGNALS:
     // (the kwin-effect, the AnimationsPageController) don't have to
     // discriminate when filtering NOTIFY traffic.
     void animationExcludeTransientWindowsChanged();
+    void animationExcludeNotificationsAndOsdChanged();
     void animationMinimumWindowWidthChanged();
     void animationMinimumWindowHeightChanged();
     void animationExcludedApplicationsChanged();

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -487,6 +487,8 @@ void SettingsAdaptor::initializeRegistry()
     // user can disable animations for an app while still snapping it.
     REGISTER_BOOL_SETTING("animationExcludeTransientWindows", animationExcludeTransientWindows,
                           setAnimationExcludeTransientWindows)
+    REGISTER_BOOL_SETTING("animationExcludeNotificationsAndOsd", animationExcludeNotificationsAndOsd,
+                          setAnimationExcludeNotificationsAndOsd)
     REGISTER_INT_SETTING("animationMinimumWindowWidth", animationMinimumWindowWidth, setAnimationMinimumWindowWidth)
     REGISTER_INT_SETTING("animationMinimumWindowHeight", animationMinimumWindowHeight, setAnimationMinimumWindowHeight)
     REGISTER_STRINGLIST_SETTING("animationExcludedApplications", animationExcludedApplications,

--- a/src/settings/qml/AnimationsAppRulesPage.qml
+++ b/src/settings/qml/AnimationsAppRulesPage.qml
@@ -263,6 +263,23 @@ SettingsFlickable {
                 }
 
                 SettingsRow {
+                    title: i18n("Exclude notifications and OSDs")
+                    description: i18n("Skip animations for notification popups and on-screen displays such as volume and brightness")
+
+                    SettingsSwitch {
+                        checked: appSettings.animationExcludeNotificationsAndOsd
+                        accessibleName: i18n("Exclude notifications and on-screen displays from animations")
+                        onToggled: function(newValue) {
+                            appSettings.animationExcludeNotificationsAndOsd = newValue;
+                        }
+                    }
+
+                }
+
+                SettingsSeparator {
+                }
+
+                SettingsRow {
                     title: i18n("Minimum window width")
                     description: appSettings.animationMinimumWindowWidth === 0 ? i18n("Disabled. No width threshold.") : i18n("Windows narrower than this will not animate")
 

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -461,6 +461,19 @@ public:
         Q_EMIT animationExcludeTransientWindowsChanged();
         Q_EMIT settingsChanged();
     }
+    bool animationExcludeNotificationsAndOsd() const override
+    {
+        return m_animationExcludeNotificationsAndOsd;
+    }
+    void setAnimationExcludeNotificationsAndOsd(bool exclude) override
+    {
+        if (m_animationExcludeNotificationsAndOsd == exclude) {
+            return;
+        }
+        m_animationExcludeNotificationsAndOsd = exclude;
+        Q_EMIT animationExcludeNotificationsAndOsdChanged();
+        Q_EMIT settingsChanged();
+    }
     int animationMinimumWindowWidth() const override
     {
         return m_animationMinimumWindowWidth;
@@ -893,6 +906,7 @@ private:
     QVariantList m_dragActivationTriggers;
     PhosphorAnimationShaders::AnimationAppRuleList m_animationAppRules;
     bool m_animationExcludeTransientWindows = false;
+    bool m_animationExcludeNotificationsAndOsd = true;
     int m_animationMinimumWindowWidth = 0;
     int m_animationMinimumWindowHeight = 0;
     QStringList m_animationExcludedApplications;


### PR DESCRIPTION
## Problem

The kwin-effect's `shouldAnimateWindow()` gate — used for every window-event shader transition — only filtered the transient-window family (dialogs / menus / tooltips), and only when the user turned on the existing toggle. It never checked the structural KWin window types.

Result: KDE **panels, the desktop, plasmoid / Plasma-shell surfaces, notifications, and OSDs** all received `window.open` / `window.close` / etc. shader animations. `shouldHandleWindow()` (snapping) already excludes these; `shouldAnimateWindow()` had drifted out of sync.

## Changes

- **Hard-exclude structural non-windows** — `isSpecialWindow` / `isDesktop` / `isDock` / `isSkipSwitcher` / Plasma-shell surfaces — unconditionally and ahead of the rule-override path. These are never application windows; a window-event shader on them is always wrong, so no toggle.

- **`animationExcludeNotificationsAndOsd` setting (default `true`)** — notification popups and on-screen displays (volume, brightness) are excluded by default, with an "Exclude notifications and OSDs" toggle in the Animations → Window Filtering card for users who want them animated. Placed after the rule-override so a class-targeted App Rule can still re-enable them, consistent with the transient filter.

The setting is plumbed end to end mirroring `animationExcludeTransientWindows`: `ConfigDefaults`, config key, `Settings` `Q_PROPERTY`, `ISettings` interface + signal, schema, D-Bus getter/setter, `StubSettings`, the effect's D-Bus-cached member, and the QML toggle.

## Testing

- Full build clean (daemon, effect, settings app) — no warnings.
- Full suite: 184/184 tests pass. `test_settings_schema`'s key-coverage test transitively validates the new D-Bus surface.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)