### PR TITLE
fix(animation): correct shader Y orientation on the kwin path

### DIFF
--- a/data/animations/apparition/effect.frag
+++ b/data/animations/apparition/effect.frag
@@ -128,7 +128,7 @@ void main()
     vec2 sampleUV  = coords + center;
     vec2 inside    = step(vec2(0.0), sampleUV) * step(sampleUV, vec2(1.0));
     float onScreen = inside.x * inside.y;
-    vec4 sampled   = texture(uTexture0, sampleUV) * onScreen;
+    vec4 sampled   = surfaceColor(sampleUV) * onScreen;
 
     // Alpha envelope: linear in iTime. Keeping this linear (rather
     // than smootherstepping) means the suction/whirl amplitudes and

--- a/data/animations/aura-glow/effect.frag
+++ b/data/animations/aura-glow/effect.frag
@@ -129,7 +129,7 @@ vec4 blurredInputColor(vec2 uv, float radius, float samples)
         // around the centre so the corners drift ~5% past the anchor,
         // and uTexture0's clamp-to-edge sampler would otherwise smear
         // the edge texel into a halo around the shrinking-orb silhouette.
-        return texture(uTexture0, uv) * boundaryMask(uv);
+        return surfaceColor(uv) * boundaryMask(uv);
     }
     vec4 acc = vec4(0.0);
     float totalWeight = 0.0;
@@ -153,7 +153,7 @@ vec4 blurredInputColor(vec2 uv, float radius, float samples)
             vec2 off = vec2(cos(d), sin(d)) * radius * (1.0 - s) / flooredResolution;
             vec2 tap = uv + off;
             float w = boundaryMask(tap);
-            acc += texture(uTexture0, tap) * w;
+            acc += surfaceColor(tap) * w;
             totalWeight += w;
         }
     }
@@ -217,7 +217,7 @@ void main()
     // of smearing the edge texel via clamp-to-edge.
     vec4 windowCol = (blurAmount > 0.0)
         ? blurredInputColor(windowUV, (1.0 - progress) * blurAmount, 3.0)
-        : texture(uTexture0, windowUV) * boundaryMask(windowUV);
+        : surfaceColor(windowUV) * boundaryMask(windowUV);
 
     // Don't draw glow where the window itself is transparent
     // (window-content shaped, not square mask).

--- a/data/animations/bounce/effect.frag
+++ b/data/animations/bounce/effect.frag
@@ -54,7 +54,7 @@ void main() {
     // edge sampler would otherwise smear the top row of texels along
     // the leading edge of the drop. The mask bands sit OUTSIDE [0, 1]
     // so identity sampling (idle end of the bounce) is unaffected.
-    vec4 win = texture(uTexture0, sample_uv) * boundaryMask(sample_uv);
+    vec4 win = surfaceColor(sample_uv) * boundaryMask(sample_uv);
 
     float reveal = step(d, 0.0);
     fragColor = win * reveal;

--- a/data/animations/broken-glass/effect.vert
+++ b/data/animations/broken-glass/effect.vert
@@ -31,10 +31,13 @@ uniform mat4 modelViewProjectionMatrix;
 #endif
 
 void main() {
-    vTexCoord = texCoord;
 #ifdef PLASMAZONES_KWIN
+    // kwin's offscreen FBO is Y-up; flip so vTexCoord is the Y-down
+    // screen UV the shader contract specifies on both runtimes.
+    vTexCoord = vec2(texCoord.x, 1.0 - texCoord.y);
     gl_Position = modelViewProjectionMatrix * vec4(position, 0.0, 1.0);
 #else
+    vTexCoord = texCoord;
     gl_Position = vec4(position, 0.0, 1.0);
 #endif
 }

--- a/data/animations/broken-glass/effect.vert
+++ b/data/animations/broken-glass/effect.vert
@@ -11,11 +11,11 @@
 // fly into the part of the surface that sits outside the original
 // anchor.
 //
-// texCoord is passed through unchanged on both paths — KWin's
-// `OffscreenData::paint` and the daemon's Qt-RHI quad deliver it in
-// the same Y=0-at-top orientation. Only `gl_Position` differs (KWin
-// needs the MVP matrix). See `animation_uniforms.glsl` for the
-// contract. Matches morph/effect.vert.
+// vTexCoord is a Y-down screen UV on both paths. The daemon's Qt-RHI
+// quad delivers texCoord Y-down already; KWin's `OffscreenData::paint`
+// delivers it from a Y-up offscreen FBO, so the kwin path flips it.
+// `gl_Position` also differs (KWin needs the MVP matrix). See
+// `animation_uniforms.glsl` for the contract. Matches morph/effect.vert.
 
 #version 450
 

--- a/data/animations/circle/effect.frag
+++ b/data/animations/circle/effect.frag
@@ -48,7 +48,7 @@ void main() {
     float m = smoothstep(-smoothness, 0.0, dist - p * (1.0 + smoothness));
     float reveal = 1.0 - m;
 
-    vec4 color = texture(uTexture0, uv);
+    vec4 color = surfaceColor(uv);
 
     fragColor = color * reveal;
 }

--- a/data/animations/colour-distance/effect.frag
+++ b/data/animations/colour-distance/effect.frag
@@ -31,7 +31,7 @@ void main() {
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
 
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     float colorMag = length(win.rgb);
     float m = step(colorMag, p);

--- a/data/animations/crosshatch/effect.frag
+++ b/data/animations/crosshatch/effect.frag
@@ -35,7 +35,7 @@ void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     vec2 center = vec2(0.5);
     float dist = distance(center, uv) / radialFalloff;

--- a/data/animations/crosswarp/effect.frag
+++ b/data/animations/crosswarp/effect.frag
@@ -41,7 +41,7 @@ void main() {
     // edge-pixel bleed.
     vec2 warped = (uv - 0.5) * x + 0.5;
 
-    vec4 win = texture(uTexture0, warped) * boundaryMask(warped);
+    vec4 win = surfaceColor(warped) * boundaryMask(warped);
 
     float in_bounds = step(0.0, uv.x) * step(uv.x, 1.0) * step(0.0, uv.y) * step(uv.y, 1.0);
     fragColor = win * x * in_bounds;

--- a/data/animations/directional-wipe/effect.frag
+++ b/data/animations/directional-wipe/effect.frag
@@ -33,7 +33,7 @@ void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     vec2 dir = vec2(dirX, dirY);
     // Defend against (0,0) which would NaN through normalize().

--- a/data/animations/dissolve/effect.frag
+++ b/data/animations/dissolve/effect.frag
@@ -49,6 +49,6 @@ void main()
     // surface alpha. Multiplying both colour and alpha keeps the
     // pre-multiplied-alpha invariant the daemon's blend pipeline
     // expects.
-    vec4 sampled = texture(uTexture0, uv);
+    vec4 sampled = surfaceColor(uv);
     fragColor = sampled * (1.0 - gate);
 }

--- a/data/animations/doom/effect.frag
+++ b/data/animations/doom/effect.frag
@@ -108,7 +108,7 @@ void main()
     // the bottom rather than smearing edge texels via clamp-to-edge.
     vec2 inside    = step(vec2(0.0), sampleUV) * step(sampleUV, vec2(1.0));
     float onScreen = inside.x * inside.y;
-    vec4 sampled   = texture(uTexture0, sampleUV) * onScreen;
+    vec4 sampled   = surfaceColor(sampleUV) * onScreen;
 
     // Top/bottom soft edge so the column tops fade rather than pop.
     float edgeFade = smoothstep(0.0, 0.1, uv.y) * smoothstep(0.0, 0.1, 1.0 - uv.y);

--- a/data/animations/energize-a/effect.frag
+++ b/data/animations/energize-a/effect.frag
@@ -172,7 +172,7 @@ void main()
     // pre-multiplied space, so we scale the effect colour by the
     // sampled alpha to avoid the "halo of effect colour around
     // transparent regions" artefact that plain mix would produce.
-    vec4 sampled = texture(uTexture0, uv);
+    vec4 sampled = surfaceColor(uv);
     float tint = 0.25 * (1.0 - windowAlpha);
     sampled.rgb = mix(sampled.rgb, effectColor * sampled.a, tint);
     sampled *= windowAlpha;

--- a/data/animations/energize-b/effect.frag
+++ b/data/animations/energize-b/effect.frag
@@ -180,7 +180,7 @@ void main()
     // tint is 0.5 (matter "becomes energy"). Tint is computed on
     // pre-multiplied colour so transparent regions don't acquire a
     // colour halo.
-    vec4 sampled = texture(uTexture0, uv);
+    vec4 sampled = surfaceColor(uv);
     float tint = 0.5 * (1.0 - windowAlpha);
     sampled.rgb = mix(sampled.rgb, effectColor * sampled.a, tint);
     sampled *= windowAlpha;

--- a/data/animations/fade/effect.frag
+++ b/data/animations/fade/effect.frag
@@ -55,7 +55,7 @@ void main() {
         vec2 scaled_uv = (uv - center) / scale + center;
 
         // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-        vec4 color = texture(uTexture0, scaled_uv) * boundaryMask(scaled_uv);
+        vec4 color = surfaceColor(scaled_uv) * boundaryMask(scaled_uv);
 
         float alpha = smoothstep(1.0 - revealStart, 1.0 - revealEnd, p);
 
@@ -71,7 +71,7 @@ void main() {
         vec2 scaled_uv = (uv - center) / scale + center;
 
         // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-        vec4 color = texture(uTexture0, scaled_uv) * boundaryMask(scaled_uv);
+        vec4 color = surfaceColor(scaled_uv) * boundaryMask(scaled_uv);
 
         float alpha = smoothstep(revealStart, revealEnd, p);
 

--- a/data/animations/fadecolor/effect.frag
+++ b/data/animations/fadecolor/effect.frag
@@ -34,7 +34,7 @@ void main() {
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
 
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     float reveal = smoothstep(colorPhase, 1.0, p);
     fragColor = win * reveal;

--- a/data/animations/fly-in/effect.frag
+++ b/data/animations/fly-in/effect.frag
@@ -15,5 +15,5 @@ layout(location = 0) in vec2 vTexCoord;
 layout(location = 0) out vec4 fragColor;
 
 void main() {
-    fragColor = texture(uTexture0, vTexCoord);
+    fragColor = surfaceColor(vTexCoord);
 }

--- a/data/animations/fly-in/effect.vert
+++ b/data/animations/fly-in/effect.vert
@@ -36,7 +36,8 @@
 //    card on this path), and the FBO is the redirected window texture's
 //    full bounds. Adding `offsetPx` to position.x directly translates
 //    the rendered window across the screen — no remap needed. texCoord
-//    is passed through unchanged, same as the daemon path.
+//    is flipped to a Y-down screen UV on the kwin path (KWin's
+//    offscreen FBO is Y-up); the daemon delivers it Y-down already.
 
 #version 450
 

--- a/data/animations/fly-in/effect.vert
+++ b/data/animations/fly-in/effect.vert
@@ -52,10 +52,15 @@ uniform mat4 modelViewProjectionMatrix;
 #endif
 
 void main() {
-    // texCoord pass-through — KWin and the daemon both deliver it
-    // Y=0-at-top. Mirrors `kKwinDefaultVertexSource` /
-    // `kDefaultVertexShaderSource` from the C++ side.
+    // texCoord -> Y-down screen UV. The daemon's Qt-RHI quad delivers
+    // it Y-down already; KWin's offscreen FBO is Y-up, so flip on that
+    // path. Mirrors `kKwinDefaultVertexSource` and the canonical
+    // header's vertex-stage contract.
+#ifdef PLASMAZONES_KWIN
+    vTexCoord = vec2(texCoord.x, 1.0 - texCoord.y);
+#else
     vTexCoord = texCoord;
+#endif
 
     // Horizontal translation amount, monotonically reducing 1 → 0 over
     // iTime. Clamp because bouncy curves overshoot iTime past 1 — we

--- a/data/animations/flyeye/effect.frag
+++ b/data/animations/flyeye/effect.frag
@@ -43,7 +43,7 @@ void main() {
     // anchor edge along the lens facets, and uTexture0's clamp-to-
     // edge sampler would otherwise smear the rim texels into the
     // facet ripple.
-    vec4 win = texture(uTexture0, sample_uv) * boundaryMask(sample_uv);
+    vec4 win = surfaceColor(sample_uv) * boundaryMask(sample_uv);
 
     fragColor = win * p;
 }

--- a/data/animations/glitch/effect.frag
+++ b/data/animations/glitch/effect.frag
@@ -47,7 +47,7 @@ void main()
     // single sample so the endpoint frames don't pay the redundant
     // texture cost on every fragment.
     if (strength < 1e-4) {
-        fragColor = texture(uTexture0, uv);
+        fragColor = surfaceColor(uv);
         return;
     }
 
@@ -78,9 +78,9 @@ void main()
     // Qt Quick uses premultiplied-alpha blending, so un-premultiply
     // each sample before extracting the single channel, then
     // re-premultiply against the chosen alpha.
-    vec4 sR = texture(uTexture0, uvR);
-    vec4 sG = texture(uTexture0, uvG);
-    vec4 sB = texture(uTexture0, uvB);
+    vec4 sR = surfaceColor(uvR);
+    vec4 sG = surfaceColor(uvG);
+    vec4 sB = surfaceColor(uvB);
     // Output alpha is the MAX of the three sample alphas, not just sG.a.
     // When chromatic offset lands R or B on opaque pixels but G on a
     // transparent edge, using sG.a alone would zero the entire pixel and

--- a/data/animations/heat-melt/effect.frag
+++ b/data/animations/heat-melt/effect.frag
@@ -60,7 +60,7 @@ void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     vec2 center = vec2(meltOriginX, meltOriginY);
     float dist = distance(center, uv) - p * exp(hm_snoise(vec2(uv.x * meltNoiseScale, 0.0)) * meltAggressiveness);

--- a/data/animations/hexagon/effect.frag
+++ b/data/animations/hexagon/effect.frag
@@ -120,7 +120,7 @@ void main()
         // through the clamp-to-edge sampler.
         vec2 lookupOffset = tileProgress * hex.xy / texScale / max(1.0 - tileProgress, 0.001);
         vec2 lookupCoords = uv + lookupOffset;
-        oColor = texture(uTexture0, lookupCoords) * boundaryMask(lookupCoords);
+        oColor = surfaceColor(lookupCoords) * boundaryMask(lookupCoords);
 
         vec4 glow = glowColor;
         vec4 line = lineColor;

--- a/data/animations/honeycomb/effect.frag
+++ b/data/animations/honeycomb/effect.frag
@@ -185,6 +185,6 @@ void main()
     // Premult-alpha invariant: multiplying both colour and alpha by
     // the same scalar keeps the daemon's blend pipeline composing
     // correctly with the parent chain's opacity.
-    vec4 sampled = texture(uTexture0, vTexCoord);
+    vec4 sampled = surfaceColor(vTexCoord);
     fragColor = sampled * (1.0 - steppedMask);
 }

--- a/data/animations/ink-splash/effect.frag
+++ b/data/animations/ink-splash/effect.frag
@@ -46,7 +46,7 @@ void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     float blob = is_fbm(uv * blobScale);
     float fingers = is_fbm(uv * fingerScale);

--- a/data/animations/inkwell-drop/effect.frag
+++ b/data/animations/inkwell-drop/effect.frag
@@ -49,7 +49,7 @@ void main() {
     vec2 distorted = uv + dir * ripple;
 
     // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-    vec4 win = texture(uTexture0, distorted) * boundaryMask(distorted);
+    vec4 win = surfaceColor(distorted) * boundaryMask(distorted);
 
     float reveal = smoothstep(0.05, -0.02, d - front);
     vec4 mixed = win * reveal;

--- a/data/animations/matrix/effect.frag
+++ b/data/animations/matrix/effect.frag
@@ -197,7 +197,7 @@ vec4 getInputColor(vec2 coords) {
     if (coords.x < 0.0 || coords.x > 1.0 || coords.y < 0.0 || coords.y > 1.0) {
         return vec4(0.0);
     }
-    vec4 color = texture(uTexture0, coords);
+    vec4 color = surfaceColor(coords);
     if (color.a > 0.001) {
         color.rgb /= color.a;
     }

--- a/data/animations/morph/effect.frag
+++ b/data/animations/morph/effect.frag
@@ -75,7 +75,7 @@ void main()
     // and lose sub-pixel AA on the silhouette.
     vec2 sampleUv = anchorUv - warp;
     vec2 sampleInside = step(vec2(0.0), sampleUv) * step(sampleUv, vec2(1.0));
-    vec4 warpedSample = texture(uTexture0, sampleUv) * sampleInside.x * sampleInside.y;
+    vec4 warpedSample = surfaceColor(sampleUv) * sampleInside.x * sampleInside.y;
 
     float feather = max(strength, 0.005);
     vec2 lo = smoothstep(vec2(-feather), vec2(0.0), anchorUv);

--- a/data/animations/morph/effect.vert
+++ b/data/animations/morph/effect.vert
@@ -28,14 +28,16 @@ uniform mat4 modelViewProjectionMatrix;
 #endif
 
 void main() {
-    // texCoord pass-through — KWin and the daemon both deliver it
-    // Y=0-at-top. Mirrors `kKwinDefaultVertexSource` /
-    // `kDefaultVertexShaderSource` on the C++ side. Only gl_Position
-    // differs: KWin needs the MVP matrix, the daemon emits clip space.
-    vTexCoord = texCoord;
+    // texCoord -> Y-down screen UV. The daemon's Qt-RHI quad delivers
+    // it Y-down already; KWin's offscreen FBO is Y-up, so flip on that
+    // path. Mirrors `kKwinDefaultVertexSource` and the canonical
+    // header's vertex-stage contract. gl_Position also differs: KWin
+    // needs the MVP matrix, the daemon emits clip space.
 #ifdef PLASMAZONES_KWIN
+    vTexCoord = vec2(texCoord.x, 1.0 - texCoord.y);
     gl_Position = modelViewProjectionMatrix * vec4(position, 0.0, 1.0);
 #else
+    vTexCoord = texCoord;
     gl_Position = vec4(position, 0.0, 1.0);
 #endif
 }

--- a/data/animations/overexposure/effect.frag
+++ b/data/animations/overexposure/effect.frag
@@ -44,7 +44,7 @@ void main() {
     vec2 uv = vTexCoord;
     float PI = 3.141592653589793;
 
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     float to_m = p + sin(PI * p) * strength;
     fragColor = vec4(

--- a/data/animations/perlin/effect.frag
+++ b/data/animations/perlin/effect.frag
@@ -66,7 +66,7 @@ void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float pr = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     float n = perlin_noise(uv * noiseScale);
     float p = mix(-edgeSoftness, 1.0 + edgeSoftness, pr);

--- a/data/animations/pixel-wheel/effect.frag
+++ b/data/animations/pixel-wheel/effect.frag
@@ -58,7 +58,7 @@ void main()
     // uTexture0's clamp-to-edge sampler returns the last-column /
     // last-row texel for that cell, smearing the window's edge alpha
     // into a ~½-cell-wide band past the surface boundary.
-    vec4 sampled    = texture(uTexture0, cellUV) * boundaryMask(cellUV);
+    vec4 sampled    = surfaceColor(cellUV) * boundaryMask(cellUV);
 
     // Spoke parameterisation. `down = (0, 1)`; `dot(down, fragDir)`
     // is just `fragDir.y`. `acos(y)` ∈ [0, π], divided by 2π gives

--- a/data/animations/pixel-wipe/effect.frag
+++ b/data/animations/pixel-wipe/effect.frag
@@ -75,7 +75,7 @@ void main()
     // uTexture0's clamp-to-edge sampler returns the last-column /
     // last-row texel for that cell, smearing the window's edge alpha
     // into a ~½-cell-wide band past the surface boundary.
-    vec4 sampled    = texture(uTexture0, cellUV) * boundaryMask(cellUV);
+    vec4 sampled    = surfaceColor(cellUV) * boundaryMask(cellUV);
 
     // Per-cell noise threshold gates the dissolve so the wavefront
     // is a chunky speckled pattern rather than a smooth ring. A cell

--- a/data/animations/pixelate/effect.frag
+++ b/data/animations/pixelate/effect.frag
@@ -68,7 +68,7 @@ void main()
     // last-row texel for that cell, smearing the window's edge alpha
     // (rounded corners, drop shadows) into a ~½-cell-wide band past
     // the original surface boundary.
-    vec4 sampled = texture(uTexture0, cell) * boundaryMask(cell);
+    vec4 sampled = surfaceColor(cell) * boundaryMask(cell);
 
     // The captured surface already encodes its own alpha; the parent-
     // chain scene-graph opacity is applied at blend time, so the

--- a/data/animations/pixelfade-wave/effect.frag
+++ b/data/animations/pixelfade-wave/effect.frag
@@ -52,7 +52,7 @@ void main() {
     // uTexture0's clamp-to-edge sampler returns the last-column /
     // last-row texel for that cell, smearing the window's edge alpha
     // into a ~½-cell-wide band past the surface boundary.
-    vec4 win = texture(uTexture0, q) * boundaryMask(q);
+    vec4 win = surfaceColor(q) * boundaryMask(q);
 
     float reveal = smoothstep(0.0, 1.0, wave_p);
     fragColor = win * reveal;

--- a/data/animations/plasma-flow/effect.frag
+++ b/data/animations/plasma-flow/effect.frag
@@ -42,7 +42,7 @@ void main() {
     vec2 distorted = uv + flow * intensity;
 
     // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-    vec4 win = texture(uTexture0, distorted) * boundaryMask(distorted);
+    vec4 win = surfaceColor(distorted) * boundaryMask(distorted);
 
     float reveal = smoothstep(0.2, 0.8, p);
     fragColor = win * reveal;

--- a/data/animations/polar-function/effect.frag
+++ b/data/animations/polar-function/effect.frag
@@ -33,7 +33,7 @@ void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     int segments = int(segmentsParam);
     float angle = atan(uv.y - 0.5, uv.x - 0.5);

--- a/data/animations/polka-dots-curtain/effect.frag
+++ b/data/animations/polka-dots-curtain/effect.frag
@@ -36,7 +36,7 @@ void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     vec2 center = vec2(centerX, centerY);
     float reveal = step(distance(fract(uv * dotCount), vec2(0.5, 0.5)), p / max(distance(uv, center), 0.0001));

--- a/data/animations/popin/effect.frag
+++ b/data/animations/popin/effect.frag
@@ -51,5 +51,5 @@ void main()
     vec2 sampleUv = (uv - center) / max(scale, 0.001) + center;
 
     // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-    fragColor = texture(uTexture0, sampleUv) * boundaryMask(sampleUv);
+    fragColor = surfaceColor(sampleUv) * boundaryMask(sampleUv);
 }

--- a/data/animations/randomsquares/effect.frag
+++ b/data/animations/randomsquares/effect.frag
@@ -37,7 +37,7 @@ void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     vec2 sz = vec2(gridDensity);
     float r = rs_rand(floor(sz * uv));

--- a/data/animations/rgb-warp/effect.frag
+++ b/data/animations/rgb-warp/effect.frag
@@ -121,9 +121,9 @@ void main()
     vec2 sampleR = uv + vec2(0.0, offset * mulR);
     vec2 sampleG = uv + vec2(0.0, offset * mulG);
     vec2 sampleB = uv + vec2(0.0, offset * mulB);
-    vec4 colorR = texture(uTexture0, sampleR) * boundaryMask(sampleR);
-    vec4 colorG = texture(uTexture0, sampleG) * boundaryMask(sampleG);
-    vec4 colorB = texture(uTexture0, sampleB) * boundaryMask(sampleB);
+    vec4 colorR = surfaceColor(sampleR) * boundaryMask(sampleR);
+    vec4 colorG = surfaceColor(sampleG) * boundaryMask(sampleG);
+    vec4 colorB = surfaceColor(sampleB) * boundaryMask(sampleB);
 
     // Recombine. The texture is pre-multiplied; un-premultiply each
     // channel against its OWN alpha (those are the only valid divisors

--- a/data/animations/ripple/effect.frag
+++ b/data/animations/ripple/effect.frag
@@ -52,7 +52,7 @@ void main() {
 
         vec2 wuv = uv + offset * intensity;
         // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-        vec4 color = texture(uTexture0, wuv) * boundaryMask(wuv);
+        vec4 color = surfaceColor(wuv) * boundaryMask(wuv);
 
         float alpha = smoothstep(1.0, 0.5, p);
         result = color * alpha;
@@ -73,7 +73,7 @@ void main() {
 
         vec2 wuv = uv + offset * intensity;
         // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-        vec4 color = texture(uTexture0, wuv) * boundaryMask(wuv);
+        vec4 color = surfaceColor(wuv) * boundaryMask(wuv);
 
         float alpha = smoothstep(0.0, 0.3, p);
         result = color * alpha;

--- a/data/animations/shared/animation_uniforms.glsl
+++ b/data/animations/shared/animation_uniforms.glsl
@@ -26,20 +26,27 @@
 // The `#define PLASMAZONES_KWIN` switch describes the uniform-binding
 // ABI, not the runtime's feature set.
 //
-// Custom vertex stage: animation shaders are authored against a
-// Y=0-at-top texCoord convention. BOTH runtimes deliver texCoord in
-// that orientation — the daemon's Qt-RHI quad and KWin's
-// `OffscreenData::paint` agree — so a vertex stage simply passes it
-// through: `vTexCoord = texCoord`, identical on both paths. (An
-// earlier revision applied a `1.0 - texCoord.y` flip on the kwin path
-// in the belief that KWin's FBO sampling was Y-up; it is not, and the
-// flip rendered every window animation upside-down.) The ONLY
-// per-runtime difference is `gl_Position`: the kwin path multiplies
-// `position` by `modelViewProjectionMatrix`, the daemon emits
-// clip-space directly. See `kKwinDefaultVertexSource` in
+// Coordinate convention: `vTexCoord` is a Y-down screen UV — y = 0 at
+// the TOP of the surface — on BOTH runtimes, so effect-space math may
+// use it directly. The vertex stage is what guarantees that: the
+// daemon's Qt-RHI quad emits texCoord Y-down already and passes it
+// through (`vTexCoord = texCoord`); the kwin path receives texCoord
+// from KWin's Y-up offscreen FBO and flips it
+// (`vTexCoord = vec2(texCoord.x, 1.0 - texCoord.y)`). `gl_Position`
+// also differs: the kwin path multiplies `position` by
+// `modelViewProjectionMatrix`, the daemon emits clip-space directly.
+// See `kKwinDefaultVertexSource` in
 // `kwin-effect/plasmazoneseffect/shader_transitions.cpp` and
 // `kDefaultVertexShaderSource` in
 // `libs/phosphor-rendering/src/shadereffect.cpp`.
+//
+// Surface texture: the redirected surface is stored in a Y-up texture
+// on the kwin path (KWin's bottom-origin FBO) and a Y-down texture on
+// the daemon, so — unlike `vTexCoord` — it does NOT share one
+// convention. Never sample `uTexture0` directly; call
+// `surfaceColor(uv)` (defined at the end of this header). It flips on
+// the kwin path so one shader source reads the surface upright on
+// both runtimes.
 //
 // Layout-drift guard: the offsets in the UBO branch MUST stay aligned
 // with `PhosphorShaders::BaseUniforms`. The C++ side enforces that via
@@ -241,5 +248,26 @@ layout(binding = 9) uniform sampler2D uTexture2;
 layout(binding = 10) uniform sampler2D uTexture3;
 
 #endif // PLASMAZONES_KWIN
+
+// ─── Surface sampling helper ───────────────────────────────────────────
+// Read the transitioning surface (the redirected window / popup
+// content) through this helper instead of sampling `uTexture0`
+// directly. `uv` is a Y-down screen UV — pass `vTexCoord` (or any
+// coordinate derived from it) straight in.
+//
+// The surface texture's storage orientation is the one thing the two
+// runtimes genuinely disagree on: KWin's offscreen FBO is bottom-origin
+// (Y-up), the daemon's Qt-RHI texture is top-origin (Y-down). This
+// helper flips the sample coordinate on the kwin path so the returned
+// texel is upright on both runtimes — keeping effect-space math, which
+// uses the Y-down `vTexCoord` directly, decoupled from the surface
+// texture's physical layout.
+vec4 surfaceColor(vec2 uv) {
+#ifdef PLASMAZONES_KWIN
+    return texture(uTexture0, vec2(uv.x, 1.0 - uv.y));
+#else
+    return texture(uTexture0, uv);
+#endif
+}
 
 #endif // PLASMAZONES_ANIMATION_UNIFORMS_GLSL

--- a/data/animations/shared/bmw_compat.glsl
+++ b/data/animations/shared/bmw_compat.glsl
@@ -80,8 +80,12 @@
 #define uIsFullscreen (false)
 
 // ── I/O bridges (premul ↔ straight-alpha) ───────────────────────────
+// Reads the surface through `surfaceColor()` (from animation_uniforms.glsl,
+// which the caller contract above requires be included first) so the
+// kwin-path Y-flip is applied — a raw `texture(uTexture0, ...)` here
+// would render the surface upside-down on the compositor path.
 vec4 getInputColor(vec2 coords) {
-    vec4 color = texture(uTexture0, coords);
+    vec4 color = surfaceColor(coords);
     if (color.a > 0.0) {
         color.rgb /= color.a;
     }

--- a/data/animations/slide/effect.frag
+++ b/data/animations/slide/effect.frag
@@ -68,5 +68,5 @@ void main()
         fragColor = vec4(0.0);
         return;
     }
-    fragColor = texture(uTexture0, sampleUv);
+    fragColor = surfaceColor(sampleUv);
 }

--- a/data/animations/slidefade/effect.frag
+++ b/data/animations/slidefade/effect.frag
@@ -46,6 +46,6 @@ void main()
     float alpha = smoothstep(scaledVis - fw, scaledVis, coord);
     alpha = 1.0 - alpha; // 1 inside the revealed region, 0 outside
 
-    vec4 sampled = texture(uTexture0, uv);
+    vec4 sampled = surfaceColor(uv);
     fragColor = sampled * alpha;
 }

--- a/data/animations/smoke/effect.frag
+++ b/data/animations/smoke/effect.frag
@@ -90,7 +90,7 @@ void main() {
         vec2 warped_uv = uv + (wr - 0.5) * distort_strength;
 
         // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-        vec4 color = texture(uTexture0, warped_uv) * boundaryMask(warped_uv);
+        vec4 color = surfaceColor(warped_uv) * boundaryMask(warped_uv);
 
         float tail = smoothstep(1.0, 0.8, p);
         result = color * remain * tail;
@@ -118,7 +118,7 @@ void main() {
         vec2 warped_uv = uv + (wr - 0.5) * distort_strength;
 
         // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-        vec4 color = texture(uTexture0, warped_uv) * boundaryMask(warped_uv);
+        vec4 color = surfaceColor(warped_uv) * boundaryMask(warped_uv);
 
         result = color * reveal;
     }

--- a/data/animations/snap/effect.frag
+++ b/data/animations/snap/effect.frag
@@ -72,7 +72,7 @@ void main() {
             vec2 sample_uv = (uv - layer_target * converge) / (1.0 - converge);
 
             // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-            vec4 color = texture(uTexture0, sample_uv) * boundaryMask(sample_uv);
+            vec4 color = surfaceColor(sample_uv) * boundaryMask(sample_uv);
 
             float belongs = step(abs(pixel_layer - layer), 0.5);
             inner += color * belongs * layer_alpha;
@@ -80,7 +80,7 @@ void main() {
 
         float initial_fade = smoothstep(0.0, 0.05, p);
         inner.a *= mix(1.0, 0.0, initial_fade);
-        vec4 base_color = texture(uTexture0, uv);
+        vec4 base_color = surfaceColor(uv);
         float base_alpha = 1.0 - smoothstep(0.0, 0.1, p);
 
         result = base_color * base_alpha + inner * (1.0 - base_alpha);
@@ -113,7 +113,7 @@ void main() {
             vec2 sample_uv = (uv - layer_target * converge) / (1.0 - converge);
 
             // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-            vec4 color = texture(uTexture0, sample_uv) * boundaryMask(sample_uv);
+            vec4 color = surfaceColor(sample_uv) * boundaryMask(sample_uv);
 
             float belongs = step(abs(pixel_layer - layer), 0.5);
             inner += color * belongs * layer_alpha;
@@ -121,7 +121,7 @@ void main() {
 
         float initial_form = smoothstep(0.0, 0.05, rp);
         inner.a *= mix(1.0, 0.0, initial_form);
-        vec4 base_color = texture(uTexture0, uv);
+        vec4 base_color = surfaceColor(uv);
         float base_alpha = 1.0 - smoothstep(0.0, 0.1, rp);
 
         result = base_color * base_alpha + inner * (1.0 - base_alpha);

--- a/data/animations/soft-warp-fade/effect.frag
+++ b/data/animations/soft-warp-fade/effect.frag
@@ -45,7 +45,7 @@ void main() {
     vec2 warped = uv + warp * strength;
 
     // boundaryMask: see noise.glsl. Crops off-window samples to transparent.
-    vec4 win = texture(uTexture0, warped) * boundaryMask(warped);
+    vec4 win = surfaceColor(warped) * boundaryMask(warped);
 
     float t = smoothstep(0.05, 0.95, p);
     t = t * t * (3.0 - 2.0 * t);

--- a/data/animations/static-fade/effect.frag
+++ b/data/animations/static-fade/effect.frag
@@ -52,7 +52,7 @@ void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     vec2 uvStatic = floor(uv * pixelGrid) / pixelGrid;
     vec4 staticColor = sf_static(uvStatic, p, staticBrightness);

--- a/data/animations/tv/effect.frag
+++ b/data/animations/tv/effect.frag
@@ -92,7 +92,7 @@ void main()
     // transparent so the squash doesn't smear edge texels.
     vec2 inside    = step(vec2(0.0), coords) * step(coords, vec2(1.0));
     float onScreen = inside.x * inside.y;
-    vec4 sampled   = texture(uTexture0, coords) * onScreen;
+    vec4 sampled   = surfaceColor(coords) * onScreen;
 
     // Tint toward the flash colour as the collapse progresses.
     // sampled is pre-multiplied; multiplying the flash colour by

--- a/data/animations/voronoi-shatter/effect.frag
+++ b/data/animations/voronoi-shatter/effect.frag
@@ -39,7 +39,7 @@ void main() {
     // ── niri OPEN body (handles both legs via runtime iTime flip) ──
     float p = clamp(iTime, 0.0, 1.0);
     vec2 uv = vTexCoord;
-    vec4 win = texture(uTexture0, uv);
+    vec4 win = surfaceColor(uv);
 
     float scale = cellDensity;
     vec2 q = uv * scale;

--- a/data/animations/wave-warp/effect.frag
+++ b/data/animations/wave-warp/effect.frag
@@ -55,7 +55,7 @@ void main() {
     // shape wave-warp wants (off-surface = transparent), but without
     // the edge-pixel bleed.
     vec2 warped = (uv - 0.5) * m + 0.5;
-    vec4 win = texture(uTexture0, warped) * boundaryMask(warped);
+    vec4 win = surfaceColor(warped) * boundaryMask(warped);
 
     float in_bounds = step(0.0, uv.x) * step(uv.x, 1.0) * step(0.0, uv.y) * step(uv.y, 1.0);
     fragColor = win * m * in_bounds;

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -543,23 +543,28 @@ void PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
     //     name-only and would mismatch our `texCoord` vs KWin's
     //     `texcoord`).
     //
-    // texCoord is passed straight through, exactly as the daemon's
-    // `kDefaultVertexShaderSource` does. KWin's `OffscreenData::paint`
-    // populates the texCoord attribute in the same Y=0-at-top
-    // orientation the daemon's Qt-RHI quad delivers, so a flip here
-    // would render the whole window upside-down for every animation.
-    // (An earlier version applied `1.0 - texCoord.y` on the belief
-    // that KWin's FBO sampling was Y-up; it is not — the flip was the
-    // bug.) The only kwin-vs-daemon difference is `gl_Position`: KWin
-    // needs the modelViewProjectionMatrix to place the redirected
+    // texCoord is flipped to a Y-down screen UV. KWin's
+    // `OffscreenData::paint` populates the texCoord attribute from its
+    // bottom-origin offscreen FBO (Y-up). The shader contract — and the
+    // daemon's `kDefaultVertexShaderSource` — expect `vTexCoord` Y-down
+    // (y = 0 at the top), so flip here. The redirected window texture
+    // is Y-up to match KWin's FBO, which is why shaders read it through
+    // `surfaceColor()` (which re-flips the sample coordinate) instead
+    // of sampling `uTexture0` directly — see the canonical header
+    // `data/animations/shared/animation_uniforms.glsl`. Without the
+    // flip, `vTexCoord` is Y-up on this path: the window still composes
+    // upright (the Y-up texture cancels it) but every screen-space
+    // effect — matrix rain direction, directional wipes — renders
+    // inverted. The other kwin-vs-daemon difference is `gl_Position`:
+    // KWin needs the modelViewProjectionMatrix to place the redirected
     // quad, the daemon emits clip-space directly.
     //
     // Authors that ship a per-shader vertex stage via metadata's
     // `vertexShader` field own the matrix / attribute contract
-    // themselves: emit `vTexCoord = texCoord` (pass-through, same on
-    // both paths) and multiply `position` by modelViewProjectionMatrix
-    // on the kwin path. See the canonical GLSL header
-    // (`data/animations/shared/animation_uniforms.glsl`).
+    // themselves: emit the same `vTexCoord` flip under
+    // `#ifdef PLASMAZONES_KWIN` and multiply `position` by
+    // modelViewProjectionMatrix on the kwin path. See the canonical
+    // GLSL header (`data/animations/shared/animation_uniforms.glsl`).
     static const QByteArray kKwinDefaultVertexSource = QByteArrayLiteral(
         "#version 450\n"
         "\n"
@@ -571,7 +576,7 @@ void PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
         "uniform mat4 modelViewProjectionMatrix;\n"
         "\n"
         "void main() {\n"
-        "    vTexCoord = texCoord;\n"
+        "    vTexCoord = vec2(texCoord.x, 1.0 - texCoord.y);\n"
         "    gl_Position = modelViewProjectionMatrix * vec4(position, 0.0, 1.0);\n"
         "}\n");
 


### PR DESCRIPTION
## Problem

Window-transition shaders render **upside down on the kwin path** — `matrix` rain falls up, directional wipes invert — while the same shaders are correct on the daemon overlay path.

## Root cause

The two runtimes disagree on Y:

| | `vTexCoord` | surface texture (`uTexture0`) |
|---|---|---|
| Daemon (Qt-RHI) | Y-down | Y-down |
| kwin (OffscreenEffect FBO) | Y-**up** | Y-**up** |

With `vTexCoord = texCoord` (no flip) the window *composes* upright on kwin because the two Y-ups cancel inside `texture(uTexture0, vTexCoord)` — but `vTexCoord.y` as a **screen coordinate** is inverted, so every screen-space effect runs upside down. An earlier fix removed the vertex flip to cure an upside-down *window*, which just traded one symptom for the other: a single coordinate drove both the surface sample and the effect math, so you could only ever fix one.

A C++-only fix isn't possible — KWin's `OffscreenEffect` exposes no accessor for the redirected texture.

## Fix — decouple the two

- **kwin vertex stages** (`kKwinDefaultVertexSource` + the `broken-glass` / `morph` / `fly-in` `effect.vert` files) flip `texCoord` so `vTexCoord` is Y-down, identical to the daemon. Effect-space math is now correct and runtime-agnostic.
- A new **`surfaceColor(uv)`** helper in the shared `animation_uniforms.glsl` header reads the redirected surface, re-flipping the sample coordinate on the kwin path so the surface texture is sampled upright regardless of its storage orientation. All 46 transition shaders' `texture(uTexture0, …)` calls are rewritten to `surfaceColor(…)`.

`vTexCoord` is now genuinely Y-down on both runtimes — the contract the header always claimed — and the one real per-runtime difference (surface-texture storage) is absorbed in exactly one place.

## Testing

- Build clean (effect + daemon).
- Full suite 184/184; `test_animation_shader_bake` compiles every animation shader via `qsb`.
- 51 files: shared header, `kKwinDefaultVertexSource`, 3 custom vertex shaders, 46 fragment shaders.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)