### PR TITLE
fix(screens): recompute available geometry when a screen moves

### DIFF
--- a/libs/phosphor-screens/src/manager.cpp
+++ b/libs/phosphor-screens/src/manager.cpp
@@ -624,6 +624,16 @@ void ScreenManager::onScreenGeometryChanged(const QRect& geometry)
         invalidateVirtualGeometryCache();
     }
     m_effectiveScreenIdsDirty = true;
+    // Recompute available geometry against the new screen rect. The
+    // available-geometry cache is screen-origin-relative (availGeom is
+    // built from screenGeom.x()/y() in calculateAvailableGeometry), so a
+    // moved or resized output must refresh it. Without this, an output
+    // re-added at a transient (0,0) origin — DPMS wake, hotplug — keeps
+    // its stale (0,0)-based available rect even after QScreen settles to
+    // the real position, and every layout anchored to that screen renders
+    // shifted to the desktop origin. Mirrors the recompute that
+    // onSensorGeometryChanged and onPanelOffsetsChanged already perform.
+    calculateAvailableGeometry(screen);
     Q_EMIT screenGeometryChanged(screen, geometry);
 }
 


### PR DESCRIPTION
## Problem

Reported in [discussion #465](https://github.com/fuddlesworth/PlasmaZones/discussions/465): on a multi-monitor setup with a **non-origin output** — an ultrawide at desktop offset `+1080+210`, with a portrait monitor to its left — zone layouts **shift to the desktop origin after the screen power-saves and wakes**, and stay wrong until the daemon restarts.

The reporter's journal shows it directly:
```
DP-3 screenGeom= QRect(1080,166 3440x1440)   available= QRect(1080,210 3440x1332)   ✓
DP-3 screenGeom= QRect(0,0    3440x1440)     available= QRect(0,44    3440x1332)     ✗
```
…one second apart, right after "passive shell attached screen was removed". The `(0,0)` value then never recomputes for the rest of that daemon session.

## Root cause

`calculateAvailableGeometry` builds the available rect **origin-relative** (`screenGeom.x()/y()` + panel offsets) and caches it per screen. When an output is removed and re-added — DPMS wake, hotplug — `QScreen` reports a transient `(0,0)` origin before settling; the sensor path computes and caches a `(0,0)`-based available rect in that window.

`QScreen` then settles to its real origin and emits `geometryChanged` — but `onScreenGeometryChanged` only invalidated the *virtual*-geometry cache and re-emitted. It **never recomputed available geometry**, unlike its sibling slots `onSensorGeometryChanged` and `onPanelOffsetsChanged`. The stale `(0,0)`-origin rect persisted, so every layout anchored to that screen rendered shifted to the desktop origin.

## Fix

`onScreenGeometryChanged` now calls `calculateAvailableGeometry(screen)`. That function reads `QScreen::geometry()` fresh, so the available-geometry cache self-corrects the instant the output settles to its real position — and stays correct across every subsequent DPMS cycle.

## Testing

- Build clean; full suite **184/184** (incl. `test_virtual_screen_manager`, `test_per_screen_config`, and the `phosphor-screens` manager-lifecycle tests).

This is the third multi-monitor screen-geometry issue in this area (alongside #461 / PR #466) — all rooted in screen add/remove lifecycle handling.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)