### PR TITLE
feat(diagnostics): surface KWin effect bridge status in reports and daemon

### DIFF
--- a/scripts/plasmazones-report.sh
+++ b/scripts/plasmazones-report.sh
@@ -191,14 +191,17 @@ if command -v journalctl &>/dev/null; then
         _jctl() { journalctl "$@"; }
     fi
 
+    # collect_journal <scope> <journalctl-args...>
+    #   <scope> is "--user" or "--system".
     collect_journal() {
+        local scope="$1"; shift
         local out err exit_code=0
         # Capture stdout and stderr separately so journalctl warnings
         # (e.g., "No entries") don't pollute the log output.
         err=$(mktemp "${TMPDIR:-/tmp}/pz-journal-err.XXXXXX")
         # Ensure temp file is cleaned up even if the script is killed mid-function.
         trap 'rm -f "$err"; trap - RETURN' RETURN
-        out=$(_jctl --user "$@" \
+        out=$(_jctl "$scope" "$@" \
             --since "$JOURNAL_SINCE min ago" \
             --no-pager -o short-iso 2>"$err") || exit_code=$?
         if [[ $exit_code -ne 0 ]] && [[ $exit_code -ne 1 ]]; then
@@ -210,17 +213,19 @@ if command -v journalctl &>/dev/null; then
         printf '%s' "$out"
     }
 
-    JOURNAL=$(collect_journal -t plasmazonesd)
+    JOURNAL=$(collect_journal --user -t plasmazonesd)
 
     # Fallback: try --identifier if -t returned nothing
     if [[ -z "${JOURNAL:-}" ]]; then
-        JOURNAL=$(collect_journal --identifier=plasmazonesd)
+        JOURNAL=$(collect_journal --user --identifier=plasmazonesd)
     fi
 
-    # Truncate to MaxLogLines, then redact via temp file to avoid SIGPIPE
+    # Truncate to the most recent MaxLogLines (the entries around a failure),
+    # then redact via temp file to avoid SIGPIPE. tail keeps the newest lines,
+    # matching SupportReport::capLogLines() in src/core/supportreport.cpp.
     if [[ -n "${JOURNAL:-}" ]]; then
         printf '%s\n' "$JOURNAL" > "$STAGING/journal.raw"
-        head -n "$MAX_LOG_LINES" "$STAGING/journal.raw" | redact_home > "$STAGING/journal.log"
+        tail -n "$MAX_LOG_LINES" "$STAGING/journal.raw" | redact_home > "$STAGING/journal.log"
         rm -f "$STAGING/journal.raw"
     fi
 
@@ -229,14 +234,19 @@ if command -v journalctl &>/dev/null; then
     # lines (every effect log category contains "plasmazones"). Without this a
     # non-loading effect — the most common "drags/shortcuts do nothing" cause —
     # leaves no trace in the archive.
-    KWIN_JOURNAL=$(collect_journal -t kwin_wayland)
+    KWIN_JOURNAL=$(collect_journal --user -t kwin_wayland)
     if [[ -z "${KWIN_JOURNAL:-}" ]]; then
-        KWIN_JOURNAL=$(collect_journal --identifier=kwin_wayland)
+        KWIN_JOURNAL=$(collect_journal --user --identifier=kwin_wayland)
+    fi
+    # Fall back to the system journal: a compositor that is not a systemd user
+    # service logs there instead of the user journal.
+    if [[ -z "${KWIN_JOURNAL:-}" ]]; then
+        KWIN_JOURNAL=$(collect_journal --system -t kwin_wayland)
     fi
     if [[ -n "${KWIN_JOURNAL:-}" ]]; then
         printf '%s\n' "$KWIN_JOURNAL" > "$STAGING/kwin-effect.raw"
         grep -i plasmazones "$STAGING/kwin-effect.raw" 2>/dev/null \
-            | head -n "$MAX_LOG_LINES" | redact_home > "$STAGING/kwin-effect.log" || true
+            | tail -n "$MAX_LOG_LINES" | redact_home > "$STAGING/kwin-effect.log" || true
         rm -f "$STAGING/kwin-effect.raw"
         # grep matched nothing → drop the empty file rather than ship a blank.
         [[ -s "$STAGING/kwin-effect.log" ]] || rm -f "$STAGING/kwin-effect.log"

--- a/scripts/plasmazones-report.sh
+++ b/scripts/plasmazones-report.sh
@@ -53,6 +53,7 @@ while [[ $# -gt 0 ]]; do
             echo "  session.json     Window session state (home paths redacted)"
             echo "  data/            User data (layouts, algorithms, shaders, etc.)"
             echo "  journal.log      Recent plasmazonesd journal entries"
+            echo "  kwin-effect.log  Recent PlasmaZones KWin effect journal entries"
             exit 0
             ;;
         *)
@@ -221,6 +222,24 @@ if command -v journalctl &>/dev/null; then
         printf '%s\n' "$JOURNAL" > "$STAGING/journal.raw"
         head -n "$MAX_LOG_LINES" "$STAGING/journal.raw" | redact_home > "$STAGING/journal.log"
         rm -f "$STAGING/journal.raw"
+    fi
+
+    # KWin effect logs: the effect runs inside the kwin_wayland process, so its
+    # journal is tagged "kwin_wayland", not "plasmazonesd". Filter to PlasmaZones
+    # lines (every effect log category contains "plasmazones"). Without this a
+    # non-loading effect — the most common "drags/shortcuts do nothing" cause —
+    # leaves no trace in the archive.
+    KWIN_JOURNAL=$(collect_journal -t kwin_wayland)
+    if [[ -z "${KWIN_JOURNAL:-}" ]]; then
+        KWIN_JOURNAL=$(collect_journal --identifier=kwin_wayland)
+    fi
+    if [[ -n "${KWIN_JOURNAL:-}" ]]; then
+        printf '%s\n' "$KWIN_JOURNAL" > "$STAGING/kwin-effect.raw"
+        grep -i plasmazones "$STAGING/kwin-effect.raw" 2>/dev/null \
+            | head -n "$MAX_LOG_LINES" | redact_home > "$STAGING/kwin-effect.log" || true
+        rm -f "$STAGING/kwin-effect.raw"
+        # grep matched nothing → drop the empty file rather than ship a blank.
+        [[ -s "$STAGING/kwin-effect.log" ]] || rm -f "$STAGING/kwin-effect.log"
     fi
 fi
 

--- a/src/core/supportreport.cpp
+++ b/src/core/supportreport.cpp
@@ -247,9 +247,12 @@ QString SupportReport::sectionSession()
     return readAndRedactFile(ConfigDefaults::sessionFilePath(), QStringLiteral("session file"));
 }
 
-static QStringList journalctlArgs(const QString& identifier, int sinceMinutes, bool longForm = false)
+static QStringList journalctlArgs(const QString& identifier, int sinceMinutes, bool longForm = false,
+                                  bool userScope = true)
 {
-    QStringList args{QStringLiteral("--user")};
+    QStringList args;
+    if (userScope)
+        args << QStringLiteral("--user");
     if (longForm) {
         args << QStringLiteral("--identifier=%1").arg(identifier);
     } else {
@@ -274,34 +277,49 @@ static QByteArray runJournalctl(const QStringList& args)
     return proc.readAllStandardOutput();
 }
 
+// Collects the journal for `identifier` over the last `sinceMinutes`. Tries the
+// user journal with -t, then --identifier (some systemd versions report the
+// syslog tag differently), then the system journal (a compositor that is not a
+// systemd user service logs there instead of the user journal). Returns the raw
+// output, or an empty QByteArray if journalctl is unavailable / produced nothing.
+static QByteArray collectJournal(const QString& identifier, int sinceMinutes)
+{
+    QByteArray raw = runJournalctl(journalctlArgs(identifier, sinceMinutes));
+    if (QString::fromUtf8(raw).trimmed().isEmpty())
+        raw = runJournalctl(journalctlArgs(identifier, sinceMinutes, true));
+    if (QString::fromUtf8(raw).trimmed().isEmpty())
+        raw = runJournalctl(journalctlArgs(identifier, sinceMinutes, false, /*userScope=*/false));
+    return raw;
+}
+
+// Caps `lines` to the most recent MaxLogLines, prepending a truncation notice
+// when lines were dropped. Keeping the *newest* lines mirrors what a support
+// archive needs (the entries around a failure) and stays consistent with
+// scripts/plasmazones-report.sh.
+static QString capLogLines(const QStringList& lines)
+{
+    if (lines.size() <= MaxLogLines)
+        return lines.join(QLatin1Char('\n'));
+
+    QString output = QStringLiteral("... (%1 lines total, showing last %2) ...\n").arg(lines.size()).arg(MaxLogLines);
+    output += lines.mid(lines.size() - MaxLogLines).join(QLatin1Char('\n'));
+    return output;
+}
+
 QString SupportReport::sectionLogs(int sinceMinutes)
 {
-    // thread_local for consistency with redactHomePath — sectionLogs runs off the
-    // main thread via QtConcurrent::run in ControlAdaptor::generateSupportReport.
-    thread_local const QString tag = QStringLiteral("plasmazonesd");
-    QByteArray rawOutput = runJournalctl(journalctlArgs(tag, sinceMinutes));
-
-    // Fall back to --identifier if -t returned nothing useful.
-    // Some systemd versions report the syslog tag differently.
-    if (QString::fromUtf8(rawOutput).trimmed().isEmpty()) {
-        rawOutput = runJournalctl(journalctlArgs(tag, sinceMinutes, true));
-    }
-
+    // collectSnapshot()/generateFromSnapshot() run off the main thread via
+    // QtConcurrent::run in ControlAdaptor::generateSupportReport.
+    const QByteArray rawOutput = collectJournal(QStringLiteral("plasmazonesd"), sinceMinutes);
     if (rawOutput.isEmpty())
-        return QStringLiteral("*(journalctl timed out or not available)*\n");
+        return QStringLiteral("*(no log entries in the last %1 minutes, or journalctl unavailable)*\n")
+            .arg(sinceMinutes);
 
-    QString output = QString::fromUtf8(rawOutput);
+    const QString output = QString::fromUtf8(rawOutput);
     if (output.trimmed().isEmpty())
         return QStringLiteral("*(no log entries in the last %1 minutes)*\n").arg(sinceMinutes);
 
-    // Cap line count
-    const QStringList lines = output.split(QLatin1Char('\n'));
-    if (lines.size() > MaxLogLines) {
-        output = QStringLiteral("... (%1 lines total, showing last %2) ...\n").arg(lines.size()).arg(MaxLogLines);
-        output += lines.mid(lines.size() - MaxLogLines).join(QLatin1Char('\n'));
-    }
-
-    return QStringLiteral("```\n%1\n```\n").arg(redactHomePath(output));
+    return QStringLiteral("```\n%1\n```\n").arg(redactHomePath(capLogLines(output.split(QLatin1Char('\n')))));
 }
 
 QString SupportReport::sectionEffectLogs(int sinceMinutes)
@@ -310,20 +328,17 @@ QString SupportReport::sectionEffectLogs(int sinceMinutes)
     // entries are tagged "kwin_wayland", not "plasmazonesd" — sectionLogs()
     // never captures them. Without this section a non-registering effect is
     // invisible in the report.
-    thread_local const QString tag = QStringLiteral("kwin_wayland");
-    QByteArray rawOutput = runJournalctl(journalctlArgs(tag, sinceMinutes));
-
-    // Fall back to --identifier if -t returned nothing, mirroring sectionLogs().
-    if (QString::fromUtf8(rawOutput).trimmed().isEmpty())
-        rawOutput = runJournalctl(journalctlArgs(tag, sinceMinutes, true));
-
+    const QByteArray rawOutput = collectJournal(QStringLiteral("kwin_wayland"), sinceMinutes);
     if (rawOutput.isEmpty())
-        return QStringLiteral("*(journalctl timed out or not available)*\n");
+        return QStringLiteral(
+                   "*(no kwin_wayland journal in the last %1 minutes, or journalctl unavailable — "
+                   "the KWin effect is likely not loaded)*\n")
+            .arg(sinceMinutes);
 
     // Keep only PlasmaZones effect lines — the rest of the kwin_wayland journal
-    // is unrelated compositor noise. Every effect logging category
-    // ("plasmazones.effect", "kwin.effect.plasmazones.*") contains the
-    // substring "plasmazones", and KWin's message pattern prints the category.
+    // is unrelated compositor noise. Every effect logging category begins with
+    // "plasmazones" (e.g. "plasmazones.effect"), and Qt's default message
+    // pattern prints the category, so a substring match catches every line.
     QStringList kept;
     const QStringList lines = QString::fromUtf8(rawOutput).split(QLatin1Char('\n'));
     for (const QString& line : lines) {
@@ -338,13 +353,7 @@ QString SupportReport::sectionEffectLogs(int sinceMinutes)
             .arg(sinceMinutes);
     }
 
-    QString output = kept.join(QLatin1Char('\n'));
-    if (kept.size() > MaxLogLines) {
-        output = QStringLiteral("... (%1 lines total, showing last %2) ...\n").arg(kept.size()).arg(MaxLogLines);
-        output += kept.mid(kept.size() - MaxLogLines).join(QLatin1Char('\n'));
-    }
-
-    return QStringLiteral("```\n%1\n```\n").arg(redactHomePath(output));
+    return QStringLiteral("```\n%1\n```\n").arg(redactHomePath(capLogLines(kept)));
 }
 
 QString SupportReport::generateFromSnapshot(const Snapshot& snapshot, int sinceMinutes)

--- a/src/core/supportreport.cpp
+++ b/src/core/supportreport.cpp
@@ -215,6 +215,33 @@ QString SupportReport::sectionAutotile(const Snapshot& snapshot)
     return out;
 }
 
+QString SupportReport::sectionCompositorBridge(const Snapshot& snapshot)
+{
+    if (!snapshot.hasBridgeInfo)
+        return QStringLiteral("*(daemon not running — compositor bridge state unavailable)*\n");
+
+    if (snapshot.bridgeRegistered) {
+        QString out;
+        out += QStringLiteral("**Status:** connected\n");
+        out += QStringLiteral("**Compositor:** %1\n").arg(snapshot.bridgeName);
+        out += QStringLiteral("**Effect protocol version:** %1\n").arg(snapshot.bridgeVersion);
+        if (!snapshot.bridgeCapabilities.isEmpty()) {
+            out += QStringLiteral("**Capabilities:** %1\n").arg(snapshot.bridgeCapabilities.join(QStringLiteral(", ")));
+        }
+        return out;
+    }
+
+    // Not registered: this is the failure mode behind "dragging and shortcuts
+    // do nothing" — the daemon runs fine but has no window control without the
+    // effect. Spell out the fix so the report is self-diagnosing.
+    return QStringLiteral(
+        "**Status:** NOT CONNECTED — the KWin effect has not registered with the daemon.\n\n"
+        "Window dragging, keyboard shortcuts, and snapping cannot work without it. "
+        "Verify that the **PlasmaZones** effect is enabled in System Settings → Desktop Effects, "
+        "then restart the Plasma session so KWin loads it. See the KWin Effect Logs section below "
+        "for why the effect failed to load or register.\n");
+}
+
 QString SupportReport::sectionSession()
 {
     return readAndRedactFile(ConfigDefaults::sessionFilePath(), QStringLiteral("session file"));
@@ -277,6 +304,49 @@ QString SupportReport::sectionLogs(int sinceMinutes)
     return QStringLiteral("```\n%1\n```\n").arg(redactHomePath(output));
 }
 
+QString SupportReport::sectionEffectLogs(int sinceMinutes)
+{
+    // The KWin effect runs inside the kwin_wayland process, so its journal
+    // entries are tagged "kwin_wayland", not "plasmazonesd" — sectionLogs()
+    // never captures them. Without this section a non-registering effect is
+    // invisible in the report.
+    thread_local const QString tag = QStringLiteral("kwin_wayland");
+    QByteArray rawOutput = runJournalctl(journalctlArgs(tag, sinceMinutes));
+
+    // Fall back to --identifier if -t returned nothing, mirroring sectionLogs().
+    if (QString::fromUtf8(rawOutput).trimmed().isEmpty())
+        rawOutput = runJournalctl(journalctlArgs(tag, sinceMinutes, true));
+
+    if (rawOutput.isEmpty())
+        return QStringLiteral("*(journalctl timed out or not available)*\n");
+
+    // Keep only PlasmaZones effect lines — the rest of the kwin_wayland journal
+    // is unrelated compositor noise. Every effect logging category
+    // ("plasmazones.effect", "kwin.effect.plasmazones.*") contains the
+    // substring "plasmazones", and KWin's message pattern prints the category.
+    QStringList kept;
+    const QStringList lines = QString::fromUtf8(rawOutput).split(QLatin1Char('\n'));
+    for (const QString& line : lines) {
+        if (line.contains(QLatin1String("plasmazones"), Qt::CaseInsensitive))
+            kept.append(line);
+    }
+
+    if (kept.isEmpty()) {
+        return QStringLiteral(
+                   "*(no PlasmaZones effect log entries in the last %1 minutes — "
+                   "the KWin effect is likely not loaded)*\n")
+            .arg(sinceMinutes);
+    }
+
+    QString output = kept.join(QLatin1Char('\n'));
+    if (kept.size() > MaxLogLines) {
+        output = QStringLiteral("... (%1 lines total, showing last %2) ...\n").arg(kept.size()).arg(MaxLogLines);
+        output += kept.mid(kept.size() - MaxLogLines).join(QLatin1Char('\n'));
+    }
+
+    return QStringLiteral("```\n%1\n```\n").arg(redactHomePath(output));
+}
+
 QString SupportReport::generateFromSnapshot(const Snapshot& snapshot, int sinceMinutes)
 {
     sinceMinutes = (sinceMinutes <= 0) ? DefaultSinceMinutes : qMin(sinceMinutes, MaxSinceMinutes);
@@ -308,12 +378,20 @@ QString SupportReport::generateFromSnapshot(const Snapshot& snapshot, int sinceM
     report += sectionAutotile(snapshot);
     report += QLatin1Char('\n');
 
+    report += QStringLiteral("## Compositor Bridge\n");
+    report += sectionCompositorBridge(snapshot);
+    report += QLatin1Char('\n');
+
     report += QStringLiteral("## Session State\n");
     report += sectionSession();
     report += QLatin1Char('\n');
 
     report += QStringLiteral("## Recent Logs (last %1 minutes)\n").arg(sinceMinutes);
     report += sectionLogs(sinceMinutes);
+    report += QLatin1Char('\n');
+
+    report += QStringLiteral("## KWin Effect Logs (last %1 minutes)\n").arg(sinceMinutes);
+    report += sectionEffectLogs(sinceMinutes);
     report += QLatin1Char('\n');
 
     // Sanitize any literal </details> in section content that would prematurely

--- a/src/core/supportreport.h
+++ b/src/core/supportreport.h
@@ -70,6 +70,16 @@ public:
         bool autotileEnabled = false;
         QStringList autotileScreens;
         bool hasAutotileEngine = false;
+
+        // Compositor bridge (KWin effect) state. The bridge adaptor lives in
+        // the dbus layer, which core/ must not depend on, so these fields are
+        // populated by ControlAdaptor after collectSnapshot() returns rather
+        // than inside collectSnapshot() itself.
+        bool hasBridgeInfo = false;
+        bool bridgeRegistered = false;
+        QString bridgeName;
+        QString bridgeVersion;
+        QStringList bridgeCapabilities;
     };
 
     /**
@@ -132,8 +142,10 @@ private:
     static QString sectionConfig();
     static QString sectionLayouts(const Snapshot& snapshot);
     static QString sectionAutotile(const Snapshot& snapshot);
+    static QString sectionCompositorBridge(const Snapshot& snapshot);
     static QString sectionSession();
     static QString sectionLogs(int sinceMinutes);
+    static QString sectionEffectLogs(int sinceMinutes);
 };
 
 } // namespace PlasmaZones

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -16,6 +16,7 @@
 #include <QDBusPendingCallWatcher>
 #include <QDBusPendingReply>
 #include <QDBusError>
+#include <QDBusInterface>
 #include <QDir>
 #include <QFile>
 #include <QSet>
@@ -55,6 +56,7 @@
 #include "../core/geometryutils.h"
 #include <PhosphorProtocol/ServiceConstants.h>
 #include "../core/logging.h"
+#include "../pz_i18n.h"
 #include "../core/animationbootstrap.h"
 #include "../core/screenmoderouter.h"
 #include "../core/utils.h"
@@ -859,10 +861,9 @@ bool Daemon::init()
     m_shaderAdaptor = new ShaderAdaptor(m_shaderRegistry.get(), this);
 
     // Compositor bridge adaptor - compositor-agnostic window control protocol.
-    // Captured as a local so we can wire its bridgeRegistered signal to
-    // WindowDragAdaptor::resetDragState below. Ownership stays with `this`
-    // via QObject parent (passed to constructor).
-    auto* compositorBridge = new CompositorBridgeAdaptor(this);
+    // Held as a member so the support report and the registration watchdog
+    // can query its state. Ownership stays with `this` via QObject parent.
+    m_compositorBridge = new CompositorBridgeAdaptor(this);
 
     // Overlay adaptor - overlay visibility and highlighting
     m_overlayAdaptor = new OverlayAdaptor(m_overlayService.get(), m_zoneDetector.get(), m_layoutManager.get(),
@@ -921,11 +922,24 @@ bool Daemon::init()
     // no knowledge of the prior drag. Clear it eagerly so the next dragStarted
     // from the fresh effect lands on a clean slate instead of silently
     // colliding with a mismatched windowId in the next handler.
-    connect(compositorBridge, &CompositorBridgeAdaptor::bridgeRegistered, m_windowDragAdaptor,
+    connect(m_compositorBridge, &CompositorBridgeAdaptor::bridgeRegistered, m_windowDragAdaptor,
             [this](const QString& compositorName, const QString&, const QStringList&) {
                 qCInfo(lcDaemon) << "Compositor bridge registered (" << compositorName
                                  << ") — clearing any stale drag state held by daemon";
                 m_windowDragAdaptor->clearForCompositorReconnect();
+            });
+
+    // Registration watchdog: the KWin effect should register as a compositor
+    // bridge within a few seconds of startup. If it never does, the daemon is
+    // alive but has no window control — drags and shortcuts silently do
+    // nothing. Stop the watchdog as soon as the bridge registers; otherwise
+    // warnCompositorBridgeMissing() fires once on timeout. Connecting to the
+    // adaptor (not m_windowDragAdaptor) so a re-registration also cancels it.
+    m_bridgeWatchdogTimer.setSingleShot(true);
+    connect(&m_bridgeWatchdogTimer, &QTimer::timeout, this, &Daemon::warnCompositorBridgeMissing);
+    connect(m_compositorBridge, &CompositorBridgeAdaptor::bridgeRegistered, &m_bridgeWatchdogTimer,
+            [this](const QString&, const QString&, const QStringList&) {
+                m_bridgeWatchdogTimer.stop();
             });
 
     // Initialize scripted algorithm loader BEFORE engine construction so that
@@ -1083,8 +1097,9 @@ bool Daemon::init()
     // Control adaptor - high-level convenience API for third-party integrations.
     // Held as a member so stop() can detach() it before the unique_ptr members
     // it borrows are destroyed.
-    m_controlAdaptor = new ControlAdaptor(m_windowTrackingAdaptor, m_snapAdaptor, m_layoutAdaptor,
-                                          m_layoutManager.get(), autotileEngine, m_screenManager.get(), this);
+    m_controlAdaptor =
+        new ControlAdaptor(m_windowTrackingAdaptor, m_snapAdaptor, m_layoutAdaptor, m_layoutManager.get(),
+                           autotileEngine, m_screenManager.get(), m_compositorBridge, this);
 
     // Handle KCM assignment change resnap/OSD. This runs AFTER the KCM's batch
     // save completes (all setAssignmentEntry + notifyReload finished), so all
@@ -1287,6 +1302,48 @@ void Daemon::start()
     // (or leak past) the startup OSD that finalizeStartup() is responsible for.
     m_running = true;
     // NOTE: daemonReady() is emitted by finalizeStartup() — do NOT emit again here.
+
+    // Arm the compositor-bridge registration watchdog. 20s is comfortably
+    // longer than a healthy effect takes to register (sub-second once KWin
+    // and the daemon's D-Bus name are both up), even when the daemon starts
+    // before KWin during login — so a timeout means a genuine failure, not a
+    // race. Skip if the effect already registered during init().
+    if (m_compositorBridge && !m_compositorBridge->isBridgeRegistered()) {
+        m_bridgeWatchdogTimer.start(20000);
+    }
+}
+
+void Daemon::warnCompositorBridgeMissing()
+{
+    // Re-check: the watchdog is stopped on bridgeRegistered, but a registration
+    // landing in the same event-loop turn as the timeout could still reach
+    // here. Treat a registered bridge as success and stay silent.
+    if (!m_compositorBridge || m_compositorBridge->isBridgeRegistered()) {
+        return;
+    }
+
+    qCWarning(lcDaemon) << "Compositor bridge did not register within 20s of startup —"
+                        << "the PlasmaZones KWin effect is not running. Window dragging,"
+                        << "keyboard shortcuts, and snapping will not work. Enable the"
+                        << "PlasmaZones effect in System Settings > Desktop Effects, then"
+                        << "restart the Plasma session so KWin loads it.";
+
+    // Raise a desktop notification via the freedesktop spec so the user sees
+    // the problem without having to read the journal. QDBusInterface avoids a
+    // hard dependency on KNotification; every Plasma session runs a
+    // notification server. Fire-and-forget — a missing server is non-fatal.
+    QDBusInterface notify(QStringLiteral("org.freedesktop.Notifications"),
+                          QStringLiteral("/org/freedesktop/Notifications"),
+                          QStringLiteral("org.freedesktop.Notifications"), QDBusConnection::sessionBus());
+    if (!notify.isValid()) {
+        return;
+    }
+    notify.asyncCall(QStringLiteral("Notify"), QStringLiteral("PlasmaZones"), 0u, QStringLiteral("plasmazones"),
+                     PzI18n::tr("PlasmaZones: window manager integration inactive"),
+                     PzI18n::tr("The PlasmaZones KWin effect is not running, so window dragging and "
+                                "shortcuts will not work. Enable it in System Settings > Desktop Effects, "
+                                "then restart the Plasma session."),
+                     QStringList(), QVariantMap(), -1);
 }
 
 void Daemon::stop()

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -55,10 +55,10 @@
 #include "../core/geometryutils.h"
 #include <PhosphorProtocol/ServiceConstants.h>
 #include "../core/logging.h"
-#include "../pz_i18n.h"
 #include "../core/animationbootstrap.h"
 #include "../core/screenmoderouter.h"
 #include "../core/utils.h"
+#include "../pz_i18n.h"
 #include "../config/configdefaults.h"
 #include "../config/settingsconfigstore.h"
 #include <PhosphorScreens/DBusScreenAdaptor.h>
@@ -95,6 +95,13 @@ namespace {
 // Conceptually distinct from DELAYED_PANEL_REQUERY_MS in autotile.cpp (which schedules a
 // follow-up panel geometry requery after the debounced update completes).
 constexpr int GEOMETRY_UPDATE_DEBOUNCE_MS = 400;
+
+// Grace period (ms) for the KWin effect to register as a compositor bridge
+// after daemon startup. Comfortably longer than a healthy effect takes to
+// register (sub-second once KWin and the daemon's D-Bus name are both up),
+// even when the daemon starts before KWin during login — so a timeout means
+// a genuine failure, not a race.
+constexpr int BRIDGE_WATCHDOG_TIMEOUT_MS = 20000;
 } // anonymous namespace
 
 Daemon::Daemon(QObject* parent)
@@ -1302,13 +1309,11 @@ void Daemon::start()
     m_running = true;
     // NOTE: daemonReady() is emitted by finalizeStartup() — do NOT emit again here.
 
-    // Arm the compositor-bridge registration watchdog. 20s is comfortably
-    // longer than a healthy effect takes to register (sub-second once KWin
-    // and the daemon's D-Bus name are both up), even when the daemon starts
-    // before KWin during login — so a timeout means a genuine failure, not a
-    // race. Skip if the effect already registered during init().
+    // Arm the compositor-bridge registration watchdog. See
+    // BRIDGE_WATCHDOG_TIMEOUT_MS for the grace-period rationale. Skip if the
+    // effect already registered during init().
     if (m_compositorBridge && !m_compositorBridge->isBridgeRegistered()) {
-        m_bridgeWatchdogTimer.start(20000);
+        m_bridgeWatchdogTimer.start(BRIDGE_WATCHDOG_TIMEOUT_MS);
     }
 }
 
@@ -1328,11 +1333,12 @@ void Daemon::warnCompositorBridgeMissing()
         return;
     }
 
-    qCWarning(lcDaemon) << "Compositor bridge did not register within 20s of startup —"
-                        << "the PlasmaZones KWin effect is not running. Window dragging,"
-                        << "keyboard shortcuts, and snapping will not work. Enable the"
-                        << "PlasmaZones effect in System Settings > Desktop Effects, then"
-                        << "restart the Plasma session so KWin loads it.";
+    qCWarning(lcDaemon) << "Compositor bridge did not register within" << (BRIDGE_WATCHDOG_TIMEOUT_MS / 1000)
+                        << "s of startup — the PlasmaZones KWin effect is not running or"
+                        << "failed to register. Window dragging, keyboard shortcuts, and"
+                        << "snapping will not work. Enable the PlasmaZones effect in System"
+                        << "Settings > Desktop Effects, then restart the Plasma session so"
+                        << "KWin loads it.";
 
     // Raise a desktop notification via the freedesktop spec so the user sees
     // the problem without having to read the journal. A direct method call
@@ -1349,9 +1355,9 @@ void Daemon::warnCompositorBridgeMissing()
            << QStringLiteral("plasmazones") // app_icon
            << PzI18n::tr("PlasmaZones: window manager integration inactive") // summary
            << PzI18n::tr(
-                  "The PlasmaZones KWin effect is not running, so window dragging and "
-                  "shortcuts will not work. Enable it in System Settings > Desktop Effects, "
-                  "then restart the Plasma session.") // body
+                  "The PlasmaZones KWin effect has not registered with the daemon, so window "
+                  "dragging and shortcuts will not work. Make sure it is enabled in System "
+                  "Settings > Desktop Effects, then restart the Plasma session.") // body
            << QStringList() // actions
            << QVariantMap() // hints
            << -1; // timeout (server default)

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -16,7 +16,6 @@
 #include <QDBusPendingCallWatcher>
 #include <QDBusPendingReply>
 #include <QDBusError>
-#include <QDBusInterface>
 #include <QDir>
 #include <QFile>
 #include <QSet>
@@ -1315,6 +1314,13 @@ void Daemon::start()
 
 void Daemon::warnCompositorBridgeMissing()
 {
+    // Stay silent during shutdown. The watchdog may still be armed when the
+    // session ends, and a warning/notification raised on the way out is just
+    // noise — mirrors the OSD suppression gated on m_running/m_shuttingDown.
+    if (m_shuttingDown) {
+        return;
+    }
+
     // Re-check: the watchdog is stopped on bridgeRegistered, but a registration
     // landing in the same event-loop turn as the timeout could still reach
     // here. Treat a registered bridge as success and stay silent.
@@ -1329,21 +1335,27 @@ void Daemon::warnCompositorBridgeMissing()
                         << "restart the Plasma session so KWin loads it.";
 
     // Raise a desktop notification via the freedesktop spec so the user sees
-    // the problem without having to read the journal. QDBusInterface avoids a
-    // hard dependency on KNotification; every Plasma session runs a
-    // notification server. Fire-and-forget — a missing server is non-fatal.
-    QDBusInterface notify(QStringLiteral("org.freedesktop.Notifications"),
-                          QStringLiteral("/org/freedesktop/Notifications"),
-                          QStringLiteral("org.freedesktop.Notifications"), QDBusConnection::sessionBus());
-    if (!notify.isValid()) {
-        return;
-    }
-    notify.asyncCall(QStringLiteral("Notify"), QStringLiteral("PlasmaZones"), 0u, QStringLiteral("plasmazones"),
-                     PzI18n::tr("PlasmaZones: window manager integration inactive"),
-                     PzI18n::tr("The PlasmaZones KWin effect is not running, so window dragging and "
-                                "shortcuts will not work. Enable it in System Settings > Desktop Effects, "
-                                "then restart the Plasma session."),
-                     QStringList(), QVariantMap(), -1);
+    // the problem without having to read the journal. A direct method call
+    // (rather than QDBusInterface) keeps this off the main thread's critical
+    // path: QDBusInterface's constructor does a blocking Introspect round-trip,
+    // whereas createMethodCall + asyncCall is genuinely fire-and-forget. A
+    // missing notification server just makes the async call error out, which
+    // is fine. Mirrors the createMethodCall pattern used elsewhere in daemon.
+    QDBusMessage notify = QDBusMessage::createMethodCall(
+        QStringLiteral("org.freedesktop.Notifications"), QStringLiteral("/org/freedesktop/Notifications"),
+        QStringLiteral("org.freedesktop.Notifications"), QStringLiteral("Notify"));
+    notify << QStringLiteral("PlasmaZones") // app_name
+           << 0u // replaces_id
+           << QStringLiteral("plasmazones") // app_icon
+           << PzI18n::tr("PlasmaZones: window manager integration inactive") // summary
+           << PzI18n::tr(
+                  "The PlasmaZones KWin effect is not running, so window dragging and "
+                  "shortcuts will not work. Enable it in System Settings > Desktop Effects, "
+                  "then restart the Plasma session.") // body
+           << QStringList() // actions
+           << QVariantMap() // hints
+           << -1; // timeout (server default)
+    QDBusConnection::sessionBus().asyncCall(notify);
 }
 
 void Daemon::stop()

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -67,6 +67,7 @@ class LayoutAdaptor;
 class SettingsAdaptor;
 class ShaderAdaptor;
 class ControlAdaptor;
+class CompositorBridgeAdaptor;
 class OverlayAdaptor;
 class ZoneDetectionAdaptor;
 class WindowTrackingAdaptor;
@@ -553,6 +554,9 @@ private:
     // window (and any queued D-Bus call landing in that window would UAF).
     ShaderAdaptor* m_shaderAdaptor = nullptr;
     ControlAdaptor* m_controlAdaptor = nullptr;
+    // Compositor bridge adaptor (KWin effect ↔ daemon protocol endpoint).
+    // Parented to `this`; holds only plain state, so it needs no detach().
+    CompositorBridgeAdaptor* m_compositorBridge = nullptr;
 
     // Mode tracking
     std::unique_ptr<ModeTracker> m_modeTracker;
@@ -741,6 +745,14 @@ private:
 
     // After geometry updates settle, request KWin effect to re-apply window positions (panel editor fix)
     QTimer m_reapplyGeometriesTimer;
+
+    // Watchdog: if the KWin effect has not registered as a compositor bridge
+    // within a grace period after startup, window control is dead (drags and
+    // shortcuts do nothing). On timeout the daemon logs a diagnostic warning
+    // and raises a desktop notification. Stopped early once the bridge
+    // registers. Single-shot.
+    QTimer m_bridgeWatchdogTimer;
+    void warnCompositorBridgeMissing();
 };
 
 } // namespace PlasmaZones

--- a/src/dbus/controladaptor.cpp
+++ b/src/dbus/controladaptor.cpp
@@ -5,6 +5,7 @@
 #include "snapadaptor.h"
 #include "windowtrackingadaptor.h"
 #include "layoutadaptor.h"
+#include "compositorbridgeadaptor.h"
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/Zone.h>
@@ -27,7 +28,8 @@ namespace PlasmaZones {
 ControlAdaptor::ControlAdaptor(WindowTrackingAdaptor* wta, SnapAdaptor* snapAdaptor, LayoutAdaptor* layoutAdaptor,
                                PhosphorZones::LayoutRegistry* layoutManager,
                                PhosphorEngine::IPlacementEngine* autotileEngine,
-                               Phosphor::Screens::ScreenManager* screenManager, QObject* parent)
+                               Phosphor::Screens::ScreenManager* screenManager,
+                               CompositorBridgeAdaptor* compositorBridge, QObject* parent)
     : QDBusAbstractAdaptor(parent)
     , m_wta(wta)
     , m_snapAdaptor(snapAdaptor)
@@ -35,6 +37,7 @@ ControlAdaptor::ControlAdaptor(WindowTrackingAdaptor* wta, SnapAdaptor* snapAdap
     , m_layoutManager(layoutManager)
     , m_autotileEngine(autotileEngine)
     , m_screenManager(screenManager)
+    , m_compositorBridge(compositorBridge)
 {
 }
 
@@ -153,6 +156,7 @@ void ControlAdaptor::detach()
     m_layoutManager = nullptr;
     m_autotileEngine = nullptr;
     m_screenManager = nullptr;
+    m_compositorBridge = nullptr;
 }
 
 QString ControlAdaptor::generateSupportReport(int sinceMinutes, const QDBusMessage& message)
@@ -184,6 +188,18 @@ QString ControlAdaptor::generateSupportReport(int sinceMinutes, const QDBusMessa
 
     // Snapshot QObject state on the main thread (these pointers are not thread-safe).
     auto snapshot = SupportReport::collectSnapshot(m_screenManager, m_layoutManager, m_autotileEngine);
+
+    // Compositor bridge state lives in the dbus layer, so SupportReport (core/)
+    // cannot read it directly — fold it into the snapshot here. Whether the
+    // KWin effect has registered is the single most useful diagnostic for the
+    // "dragging and shortcuts do nothing" class of bug.
+    if (m_compositorBridge) {
+        snapshot.hasBridgeInfo = true;
+        snapshot.bridgeRegistered = m_compositorBridge->isBridgeRegistered();
+        snapshot.bridgeName = m_compositorBridge->bridgeName();
+        snapshot.bridgeVersion = m_compositorBridge->bridgeVersion();
+        snapshot.bridgeCapabilities = m_compositorBridge->bridgeCapabilities();
+    }
 
     // Run blocking work (file I/O, journalctl) off the main thread.
     // No parent — lifetime managed explicitly by the two signal handlers below.

--- a/src/dbus/controladaptor.h
+++ b/src/dbus/controladaptor.h
@@ -22,6 +22,7 @@ namespace PlasmaZones {
 class WindowTrackingAdaptor;
 class SnapAdaptor;
 class LayoutAdaptor;
+class CompositorBridgeAdaptor;
 
 // Phosphor::Screens::ScreenManager moved to libs/phosphor-screens (Phosphor::Screens::ScreenManager).
 } // namespace PlasmaZones
@@ -51,7 +52,8 @@ public:
     explicit ControlAdaptor(WindowTrackingAdaptor* wta, SnapAdaptor* snapAdaptor, LayoutAdaptor* layoutAdaptor,
                             PhosphorZones::LayoutRegistry* layoutManager,
                             PhosphorEngine::IPlacementEngine* autotileEngine,
-                            Phosphor::Screens::ScreenManager* screenManager, QObject* parent = nullptr);
+                            Phosphor::Screens::ScreenManager* screenManager, CompositorBridgeAdaptor* compositorBridge,
+                            QObject* parent = nullptr);
     ~ControlAdaptor() override = default;
 
     /// Null every borrowed pointer. Called from Daemon::stop() before the
@@ -107,6 +109,7 @@ private:
     PhosphorZones::LayoutRegistry* m_layoutManager;
     PhosphorEngine::IPlacementEngine* m_autotileEngine;
     Phosphor::Screens::ScreenManager* m_screenManager;
+    CompositorBridgeAdaptor* m_compositorBridge;
     QPointer<QFutureWatcher<QString>> m_reportWatcher;
 };
 

--- a/tests/unit/core/test_support_report.cpp
+++ b/tests/unit/core/test_support_report.cpp
@@ -81,8 +81,44 @@ private Q_SLOTS:
         QVERIFY(report.contains(QStringLiteral("## Config")));
         QVERIFY(report.contains(QStringLiteral("## Layouts")));
         QVERIFY(report.contains(QStringLiteral("## Autotile")));
+        QVERIFY(report.contains(QStringLiteral("## Compositor Bridge")));
         QVERIFY(report.contains(QStringLiteral("## Session State")));
         QVERIFY(report.contains(QStringLiteral("## Recent Logs")));
+        QVERIFY(report.contains(QStringLiteral("## KWin Effect Logs")));
+    }
+
+    void testGenerate_bridgeUnavailable_whenNoBridgeInfo()
+    {
+        // Default Snapshot has hasBridgeInfo=false (daemon not running, or the
+        // blocking generate() convenience overload which can't reach the bridge).
+        const QString report = SupportReport::generate(nullptr, nullptr, nullptr, 30);
+        QVERIFY(report.contains(QStringLiteral("compositor bridge state unavailable")));
+    }
+
+    void testGenerate_bridgeNotRegistered_warnsNotConnected()
+    {
+        SupportReport::Snapshot snap;
+        snap.hasBridgeInfo = true;
+        snap.bridgeRegistered = false;
+        const QString report = SupportReport::generateFromSnapshot(snap, 30);
+        QVERIFY(report.contains(QStringLiteral("NOT CONNECTED")));
+        // The fix the user must apply is spelled out in the section.
+        QVERIFY(report.contains(QStringLiteral("Desktop Effects")));
+    }
+
+    void testGenerate_bridgeRegistered_showsCompositorDetails()
+    {
+        SupportReport::Snapshot snap;
+        snap.hasBridgeInfo = true;
+        snap.bridgeRegistered = true;
+        snap.bridgeName = QStringLiteral("kwin");
+        snap.bridgeVersion = QStringLiteral("3");
+        snap.bridgeCapabilities = {QStringLiteral("borderless"), QStringLiteral("modifiers")};
+        const QString report = SupportReport::generateFromSnapshot(snap, 30);
+        QVERIFY(report.contains(QStringLiteral("**Status:** connected")));
+        QVERIFY(report.contains(QStringLiteral("kwin")));
+        QVERIFY(report.contains(QStringLiteral("borderless, modifiers")));
+        QVERIFY(!report.contains(QStringLiteral("NOT CONNECTED")));
     }
 
     void testGenerate_sinceMinutesCapped()

--- a/tests/unit/core/test_support_report.cpp
+++ b/tests/unit/core/test_support_report.cpp
@@ -116,7 +116,12 @@ private Q_SLOTS:
         snap.bridgeCapabilities = {QStringLiteral("borderless"), QStringLiteral("modifiers")};
         const QString report = SupportReport::generateFromSnapshot(snap, 30);
         QVERIFY(report.contains(QStringLiteral("**Status:** connected")));
-        QVERIFY(report.contains(QStringLiteral("kwin")));
+        // Match the rendered lines specifically — a bare "kwin" substring is
+        // also produced by the unrelated "no kwin_wayland journal" message in
+        // the KWin Effect Logs section, so it would pass even if the
+        // compositor name were never rendered.
+        QVERIFY(report.contains(QStringLiteral("**Compositor:** kwin")));
+        QVERIFY(report.contains(QStringLiteral("**Effect protocol version:** 3")));
         QVERIFY(report.contains(QStringLiteral("borderless, modifiers")));
         QVERIFY(!report.contains(QStringLiteral("NOT CONNECTED")));
     }

--- a/tests/unit/dbus/test_compositor_bridge.cpp
+++ b/tests/unit/dbus/test_compositor_bridge.cpp
@@ -133,8 +133,8 @@ private Q_SLOTS:
         m_layoutManager->setActiveLayout(layout);
 
         m_controlParent = new QObject(nullptr);
-        m_controlAdaptor =
-            new ControlAdaptor(m_wta, nullptr, nullptr, m_layoutManager, nullptr, nullptr, m_controlParent);
+        m_controlAdaptor = new ControlAdaptor(m_wta, nullptr, nullptr, m_layoutManager, nullptr, nullptr,
+                                              m_bridgeAdaptor, m_controlParent);
     }
 
     void cleanup()


### PR DESCRIPTION
## Problem

Discussion #464: a user on Plasma 6.6.5 reports that PlasmaZones "stopped working" — zone overlays still render, but Alt-dragging and shortcuts do nothing.

Analysis of the attached support archive showed the daemon is healthy (loads layouts, registers shortcuts, draws overlays) but the KWin effect never registered as a compositor bridge — across all four daemon restarts the journal never logs `Compositor bridge registered`. Without the effect the daemon has no window control, so drags and shortcuts silently no-op.

This failure mode was undiagnosable from a support report:
- The report only collected the `plasmazonesd` journal. The effect runs inside `kwin_wayland`, so every effect log line was invisible.
- The daemon emitted no warning when the bridge never registered.

## Changes

**Support report (`src/core/supportreport.*`, `src/dbus/controladaptor.*`)**
- New `## Compositor Bridge` section: reports registration state. When the bridge has not registered it prints `NOT CONNECTED` plus the fix (enable the effect in System Settings, restart the session).
- New `## KWin Effect Logs` section: pulls the `kwin_wayland` journal filtered to PlasmaZones lines.
- `ControlAdaptor` folds bridge state into the `Snapshot` so `core/` keeps no dependency on the dbus layer.

**Report script (`scripts/plasmazones-report.sh`)**
- Collects a matching raw `kwin-effect.log` in the archive.

**Daemon (`src/daemon/daemon.*`)**
- Arms a 20s watchdog after startup. If no compositor bridge registers, the daemon logs a diagnostic warning and raises a desktop notification ("window manager integration inactive"). Cancelled the moment the bridge registers.

## Tests

- Updated `test_compositor_bridge.cpp` for the new `ControlAdaptor` constructor argument.
- Added 3 cases to `test_support_report.cpp` covering the bridge section (unavailable / not-connected / connected).
- Full suite: 179/179 pass.

Refs #464

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)