### PR TITLE
fix(screens): use KWin clientArea as the authoritative panel-strut source

### DIFF
--- a/dbus/org.plasmazones.Screen.xml
+++ b/dbus/org.plasmazones.Screen.xml
@@ -40,6 +40,24 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Connector name from Workspace::outputOrder().first() (e.g. DP-1). Resolved to EDID-based identifier internally."/>
             </arg>
         </method>
+        <method name="setAvailableGeometryFromKWin">
+            <annotation name="org.gtk.GDBus.DocString" value="Record the authoritative per-screen available geometry (panel-excluded work area) as reported by the KWin effect's clientArea(MaximizeArea) query. Overrides the layer-shell sensor + plasmashell D-Bus panel-strut heuristic, which mis-attributes per-edge struts for top-panel layouts. A zero-size rect clears the override. Called by the KWin effect."/>
+            <arg name="screenName" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Connector name (e.g. DP-1)."/>
+            </arg>
+            <arg name="x" type="i" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Work-area X origin."/>
+            </arg>
+            <arg name="y" type="i" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Work-area Y origin."/>
+            </arg>
+            <arg name="width" type="i" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Work-area width."/>
+            </arg>
+            <arg name="height" type="i" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Work-area height."/>
+            </arg>
+        </method>
         <method name="getAvailableGeometry">
             <annotation name="org.gtk.GDBus.DocString" value="Return the available geometry (excluding panels/taskbars) for a screen. Handles virtual screen IDs (e.g. physId/vs:0). Uses layer-shell sensor data when available, falls back to Qt's availableGeometry."/>
             <arg name="screenId" type="s" direction="in">

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -153,6 +153,15 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
         }
     }
 
+    // Push KWin's authoritative per-screen work area (clientArea/MaximizeArea)
+    // so the daemon's available-geometry computation uses the compositor's
+    // exact panel struts instead of the plasmashell D-Bus + layer-shell sensor
+    // heuristic — which mis-attributes struts (everything onto the bottom
+    // edge) for top-panel layouts when the D-Bus panel query returns nothing.
+    if (m_screenChangeHandler) {
+        m_screenChangeHandler->scheduleClientAreaReport();
+    }
+
     // Re-push cursor screen — use the cached effective screen ID (which includes
     // virtual screen IDs like "A/vs:0") so the daemon's shortcut handler resolves
     // to the correct virtual screen, not the physical monitor.

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -403,6 +403,20 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     connect(KWin::effects, &KWin::EffectsHandler::windowAdded, this, &PlasmaZonesEffect::slotWindowAdded);
     connect(KWin::effects, &KWin::EffectsHandler::windowClosed, this, &PlasmaZonesEffect::slotWindowClosed);
 
+    // Panel (dock) lifecycle drives KWin's work area: a panel added, removed,
+    // or resized changes the strut-excluded clientArea. Route dock windows to
+    // the screen-change handler so it re-pushes the authoritative work area
+    // to the daemon. trackDockWindow / onWindowClosed no-op for non-docks.
+    connect(KWin::effects, &KWin::EffectsHandler::windowAdded, m_screenChangeHandler.get(),
+            &ScreenChangeHandler::trackDockWindow);
+    connect(KWin::effects, &KWin::EffectsHandler::windowClosed, m_screenChangeHandler.get(),
+            &ScreenChangeHandler::onWindowClosed);
+    // Panels mapped before the effect loaded never fire windowAdded — hook the
+    // already-present docks now so a later resize of one still re-reports.
+    for (KWin::EffectWindow* existing : KWin::effects->stackingOrder()) {
+        m_screenChangeHandler->trackDockWindow(existing);
+    }
+
     // Belt-and-suspenders: windowClosed removes animations, but if a deferred
     // timer re-adds one between windowClosed and windowDeleted, the Item tree
     // will be torn down while an animation entry still references the window.

--- a/kwin-effect/screenchangehandler.cpp
+++ b/kwin-effect/screenchangehandler.cpp
@@ -11,6 +11,7 @@
 #include <PhosphorIdentity/WindowId.h>
 
 #include <effect/effecthandler.h>
+#include <effect/effectwindow.h>
 
 #include <QDBusArgument>
 #include <QDBusPendingCall>
@@ -62,6 +63,11 @@ void ScreenChangeHandler::slotScreenGeometryChanged()
 
     m_pendingScreenChange = true;
     m_screenChangeDebounce.start(); // Restart timer (debounce)
+
+    // A resolution / arrangement change moves panels and resizes the work
+    // area — re-push KWin's clientArea so the daemon's available geometry
+    // tracks the new layout instead of a stale compositor override.
+    scheduleClientAreaReport();
 }
 
 void ScreenChangeHandler::applyScreenGeometryChange()
@@ -219,6 +225,84 @@ void ScreenChangeHandler::applyWindowGeometries(const PhosphorProtocol::WindowGe
             m_effect->applySnapGeometry(e.window, e.geometry);
         }
     });
+}
+
+void ScreenChangeHandler::trackDockWindow(KWin::EffectWindow* w)
+{
+    if (!w || !w->isDock()) {
+        return;
+    }
+    // A panel mapped (or was already mapped at effect startup). KWin reserves
+    // and adjusts its strut asynchronously, and the panel itself may resize
+    // during its own lifetime (config changes, content-driven thickness).
+    // Hook frame-geometry changes so every strut adjustment re-pushes the
+    // work area. `this` as the connection context auto-disconnects the lambda
+    // when either the dock's EffectWindow or this handler is destroyed.
+    connect(w, &KWin::EffectWindow::windowFrameGeometryChanged, this, [this]() {
+        scheduleClientAreaReport();
+    });
+    scheduleClientAreaReport();
+}
+
+void ScreenChangeHandler::onWindowClosed(KWin::EffectWindow* w)
+{
+    if (!w || !w->isDock()) {
+        return;
+    }
+    // A panel closed — its strut is freed and KWin grows the work area.
+    scheduleClientAreaReport();
+}
+
+void ScreenChangeHandler::scheduleClientAreaReport()
+{
+    if (m_clientAreaReportQueued) {
+        return; // A report is already queued for this event-loop turn.
+    }
+    m_clientAreaReportQueued = true;
+    // Queued, not timed: every scheduleClientAreaReport() in the current
+    // event-loop turn collapses onto this one continuation, which Qt
+    // dispatches after the turn's synchronous work — including KWin's own
+    // strut recompute for the dock signal that triggered us — has run. No
+    // arbitrary delay, and `this` as the context object means the call is
+    // dropped if the handler is destroyed before it fires.
+    QMetaObject::invokeMethod(
+        this,
+        [this]() {
+            m_clientAreaReportQueued = false;
+            reportClientArea();
+        },
+        Qt::QueuedConnection);
+}
+
+void ScreenChangeHandler::reportClientArea()
+{
+    if (!m_effect->m_daemonServiceRegistered) {
+        // Bridge not registered yet — continueDaemonReadySetup() re-schedules
+        // a report once it is, so dropping this one loses nothing.
+        return;
+    }
+
+    // clientArea(MaximizeArea) is the exact panel-excluded work area KWin
+    // reserves for maximized windows: correct per-edge strut attribution,
+    // and auto-hide panels (no strut) correctly excluded. The desktop
+    // argument is required by the API; panels span virtual desktops, so the
+    // current desktop is representative.
+    KWin::VirtualDesktop* desktop = KWin::effects->currentDesktop();
+    const auto outputs = KWin::effects->screens();
+    for (KWin::LogicalOutput* output : outputs) {
+        if (!output) {
+            continue;
+        }
+        const QRect work = KWin::effects->clientArea(KWin::MaximizeArea, output, desktop).toRect();
+        if (!work.isValid() || work.isEmpty()) {
+            continue;
+        }
+        qCDebug(lcScreenChange) << "Reporting KWin work area for" << output->name() << "=" << work;
+        PhosphorProtocol::ClientHelpers::fireAndForget(
+            this, PhosphorProtocol::Service::Interface::Screen, QStringLiteral("setAvailableGeometryFromKWin"),
+            {output->name(), work.x(), work.y(), work.width(), work.height()},
+            QStringLiteral("setAvailableGeometryFromKWin"));
+    }
 }
 
 } // namespace PlasmaZones

--- a/kwin-effect/screenchangehandler.cpp
+++ b/kwin-effect/screenchangehandler.cpp
@@ -294,7 +294,9 @@ void ScreenChangeHandler::reportClientArea()
             continue;
         }
         const QRect work = KWin::effects->clientArea(KWin::MaximizeArea, output, desktop).toRect();
-        if (!work.isValid() || work.isEmpty()) {
+        // isValid() is the exact negation of isEmpty() for QRect — a degenerate
+        // (zero/negative-size) work area is skipped by this single check.
+        if (!work.isValid()) {
             continue;
         }
         qCDebug(lcScreenChange) << "Reporting KWin work area for" << output->name() << "=" << work;

--- a/kwin-effect/screenchangehandler.h
+++ b/kwin-effect/screenchangehandler.h
@@ -34,8 +34,25 @@ class ScreenChangeHandler : public QObject
 public:
     explicit ScreenChangeHandler(PlasmaZonesEffect* effect, QObject* parent = nullptr);
 
-    /// Stop the debounce timer (called from effect destructor)
+    /// Stop the debounce timers (called from effect destructor)
     void stop();
+
+    /// Schedule a push of KWin's authoritative per-screen work area
+    /// (`clientArea(MaximizeArea)`) to the daemon. Coalesces every call made
+    /// within one event-loop turn into a single queued report — so a burst
+    /// of dock add/close/resize signals (session startup, a panel-editor
+    /// drag) produces one push, and that push runs after KWin's synchronous
+    /// strut recompute for the turn. Safe to call before the daemon bridge
+    /// is registered — the report no-ops until it is, and the daemon-ready
+    /// path schedules another.
+    void scheduleClientAreaReport();
+
+    /// Hook @p w for work-area reporting when it is a panel (dock): connects
+    /// its geometry-changed signal and schedules a report. A no-op for
+    /// non-dock windows. Called for every `windowAdded` and once per
+    /// already-mapped window at effect startup so pre-existing panels are
+    /// covered too.
+    void trackDockWindow(KWin::EffectWindow* w);
 
     /// True while a screen geometry change is pending (debounce timer running
     /// or reapply in progress). Used to suppress false windowScreenChanged
@@ -49,10 +66,19 @@ public Q_SLOTS:
     void slotScreenGeometryChanged();
     void slotReapplyWindowGeometriesRequested();
 
+    /// Connected to `EffectsHandler::windowClosed` — schedules a work-area
+    /// report when @p w is a panel (dock) so the strut it freed reaches the
+    /// daemon. A no-op for non-dock windows.
+    void onWindowClosed(KWin::EffectWindow* w);
+
 private:
     void applyScreenGeometryChange();
     void fetchAndApplyWindowGeometries();
     void applyWindowGeometries(const PhosphorProtocol::WindowGeometryList& geometries);
+
+    /// Push KWin's `clientArea(MaximizeArea)` for every output to the daemon.
+    /// Runs as the queued continuation scheduled by @ref scheduleClientAreaReport.
+    void reportClientArea();
 
     PlasmaZonesEffect* m_effect;
     QTimer m_screenChangeDebounce;
@@ -60,6 +86,11 @@ private:
     QRect m_lastVirtualScreenGeometry;
     bool m_reapplyInProgress = false;
     bool m_reapplyPending = false;
+
+    // Set while a queued reportClientArea() is pending. Collapses a burst of
+    // dock signals within one event-loop turn into a single report — see
+    // scheduleClientAreaReport().
+    bool m_clientAreaReportQueued = false;
 };
 
 } // namespace PlasmaZones

--- a/kwin-effect/screenchangehandler.h
+++ b/kwin-effect/screenchangehandler.h
@@ -19,13 +19,17 @@ namespace PlasmaZones {
 class PlasmaZonesEffect;
 
 /**
- * @brief Handles debounced screen geometry changes and window repositioning.
+ * @brief Liaises screen and work-area changes between KWin and the daemon.
  *
  * Monitors virtualScreenGeometryChanged (resolution / monitor setup changes),
  * debounces rapid-fire signals, and requests updated window geometries from
- * the daemon when the screen size actually changes.
+ * the daemon when the screen size actually changes. Also handles the daemon's
+ * reapplyWindowGeometriesRequested signal.
  *
- * Also handles the daemon's reapplyWindowGeometriesRequested signal.
+ * Additionally reports KWin's authoritative per-screen work area
+ * (`clientArea(MaximizeArea)`) to the daemon: it tracks panel (dock) windows
+ * and pushes a fresh snapshot whenever a panel is added, removed, or resized,
+ * or the screen layout changes — see @ref scheduleClientAreaReport.
  */
 class ScreenChangeHandler : public QObject
 {
@@ -34,7 +38,7 @@ class ScreenChangeHandler : public QObject
 public:
     explicit ScreenChangeHandler(PlasmaZonesEffect* effect, QObject* parent = nullptr);
 
-    /// Stop the debounce timers (called from effect destructor)
+    /// Stop the debounce timer (called from effect destructor)
     void stop();
 
     /// Schedule a push of KWin's authoritative per-screen work area

--- a/libs/phosphor-screens/include/PhosphorScreens/DBusScreenAdaptor.h
+++ b/libs/phosphor-screens/include/PhosphorScreens/DBusScreenAdaptor.h
@@ -59,6 +59,12 @@ public Q_SLOTS:
     QString getPrimaryScreen();
     QString getScreenId(const QString& connectorName);
     void setPrimaryScreenFromKWin(const QString& connectorName);
+    /// Record the authoritative per-screen available geometry as reported by
+    /// the compositor (the KWin effect's `clientArea(MaximizeArea)` query).
+    /// Overrides the panel-strut heuristic in ScreenManager. @p screenName is
+    /// a connector name (e.g. `DP-1`); @p x / @p y / @p width / @p height are
+    /// the work-area rect. A zero-size rect clears the override.
+    void setAvailableGeometryFromKWin(const QString& screenName, int x, int y, int width, int height);
     QRect getAvailableGeometry(const QString& screenId);
     QRect getScreenGeometry(const QString& screenId);
 

--- a/libs/phosphor-screens/include/PhosphorScreens/Manager.h
+++ b/libs/phosphor-screens/include/PhosphorScreens/Manager.h
@@ -197,6 +197,30 @@ public:
     /// underlying timer fires, the timer restarts.
     void scheduleDelayedPanelRequery(int delayMs);
 
+    // ─── Compositor-reported available geometry ──────────────────────────
+
+    /**
+     * @brief Record the authoritative per-screen available geometry as
+     *        reported by the compositor.
+     *
+     * The KWin effect queries @c KWin::clientArea(MaximizeArea) — the exact
+     * panel-excluded work area the compositor itself reserves for maximized
+     * windows, with correct per-edge strut attribution and correct
+     * auto-hide handling — and pushes it here over D-Bus.
+     *
+     * This is the highest-priority source in @ref calculateAvailableGeometry:
+     * when an entry exists for a screen it fully determines that screen's
+     * available rect, bypassing the layer-shell sensor + plasmashell D-Bus
+     * heuristic. That heuristic can only *guess* which edge a strut belongs
+     * to, and guesses wrong (attributes everything to the bottom edge) for
+     * top-panel layouts when the plasmashell D-Bus query returns no panels.
+     *
+     * Pass an invalid or empty rect to clear the override for @p screenName
+     * and fall back to the heuristic. Keyed by connector name. A redundant
+     * call (same rect already recorded) is a no-op.
+     */
+    void setCompositorAvailableGeometry(const QString& screenName, const QRect& available);
+
 Q_SIGNALS:
     void screenAdded(const PhysicalScreen& screen);
     void screenRemoved(const PhysicalScreen& screen);
@@ -294,6 +318,14 @@ private:
     // here without also re-auditing every const accessor to make sure
     // the mutation isn't leaked via returned QString&/QRect& references.
     mutable QHash<QString, QRect> m_availableGeometryCache;
+
+    // Authoritative per-screen available geometry pushed by the compositor
+    // bridge (the KWin effect's clientArea/MaximizeArea query). Keyed by
+    // connector name. When an entry exists for a screen it overrides the
+    // sensor/D-Bus heuristic entirely in calculateAvailableGeometry — see
+    // setCompositorAvailableGeometry. Cleared per-screen on screen removal
+    // (destroyGeometrySensor) and wholesale on stop().
+    QHash<QString, QRect> m_compositorAvailableGeometry;
 
     // Virtual screen configurations, keyed by physical screen ID.
     QHash<QString, VirtualScreenConfig> m_virtualConfigs;

--- a/libs/phosphor-screens/src/dbusscreenadaptor.cpp
+++ b/libs/phosphor-screens/src/dbusscreenadaptor.cpp
@@ -471,6 +471,17 @@ void DBusScreenAdaptor::setPrimaryScreenFromKWin(const QString& connectorName)
     qCInfo(lcPhosphorScreens) << "Primary screen override set from compositor:" << connectorName;
 }
 
+void DBusScreenAdaptor::setAvailableGeometryFromKWin(const QString& screenName, int x, int y, int width, int height)
+{
+    if (!m_screenManager) {
+        return;
+    }
+    // QRect forwards verbatim — ScreenManager::setCompositorAvailableGeometry
+    // treats a zero-size rect as "clear the override", which is exactly what
+    // a (0,0,0,0) payload from the effect means.
+    m_screenManager->setCompositorAvailableGeometry(screenName, QRect(x, y, width, height));
+}
+
 QString DBusScreenAdaptor::getScreenId(const QString& connectorName)
 {
     if (connectorName.isEmpty()) {

--- a/libs/phosphor-screens/src/manager.cpp
+++ b/libs/phosphor-screens/src/manager.cpp
@@ -161,6 +161,12 @@ void ScreenManager::stop()
     m_cachedEffectiveScreenIds.clear();
     m_effectiveScreenIdsDirty = true;
     m_virtualGeometryCache.clear();
+
+    // Drop compositor-reported overrides — the KWin effect re-pushes a fresh
+    // clientArea snapshot for every screen when it re-registers the bridge,
+    // so keeping stale rects across a stop/start cycle would only risk a
+    // transient mismatch before that push lands.
+    m_compositorAvailableGeometry.clear();
 }
 
 QVector<PhysicalScreen> ScreenManager::screens() const
@@ -290,6 +296,10 @@ void ScreenManager::destroyGeometrySensor(const QString& screenName)
         sensor->deleteLater();
     }
     m_availableGeometryCache.remove(screenName);
+    // A disconnected screen's compositor override is meaningless — drop it so
+    // a same-connector reconnect starts from the heuristic until the effect
+    // re-pushes a fresh clientArea for the new output.
+    m_compositorAvailableGeometry.remove(screenName);
 }
 
 void ScreenManager::calculateAvailableGeometry(const PhysicalScreen& screen)
@@ -402,17 +412,45 @@ void ScreenManager::calculateAvailableGeometry(const PhysicalScreen& screen)
         source = QStringLiteral("fallback");
     }
 
-    const QRect availGeom(screenGeom.x() + effLeft, screenGeom.y() + effTop, screenGeom.width() - effLeft - effRight,
-                          screenGeom.height() - effTop - effBottom);
+    QRect availGeom(screenGeom.x() + effLeft, screenGeom.y() + effTop, screenGeom.width() - effLeft - effRight,
+                    screenGeom.height() - effTop - effBottom);
+
+    // Source 0 (highest priority): compositor-reported client area. The KWin
+    // effect queries KWin::clientArea(MaximizeArea) — the exact panel-excluded
+    // work area the compositor itself reserves for maximized windows, with
+    // correct per-edge strut attribution and correct auto-hide handling — and
+    // pushes it via setCompositorAvailableGeometry. When present it overrides
+    // the sensor + D-Bus heuristic above, which can only guess per-edge strut
+    // attribution and gets it wrong (dumps everything onto the bottom edge)
+    // for top-panel layouts when the plasmashell D-Bus query returns no
+    // panels. The heuristic stays computed above as the fallback for sessions
+    // where the effect is not loaded.
+    if (const auto compIt = m_compositorAvailableGeometry.constFind(screenKey);
+        compIt != m_compositorAvailableGeometry.constEnd()) {
+        // Clamp to the current screen rect — the compositor snapshot can lag a
+        // screen resize by a frame, and an available rect spilling past the
+        // output would corrupt every downstream relative-geometry calculation.
+        const QRect clamped = compIt.value().intersected(screenGeom);
+        if (clamped.isValid() && !clamped.isEmpty()) {
+            availGeom = clamped;
+            source = QStringLiteral("compositor");
+        }
+    }
 
     const QRect oldGeom = m_availableGeometryCache.value(screenKey);
     if (availGeom == oldGeom) {
         return;
     }
 
+    // Log effective insets derived from the final rect so the line is correct
+    // regardless of which source won (the eff* locals reflect only the
+    // heuristic path and would be stale under a compositor override).
     qCInfo(lcPhosphorScreens) << "calculateAvailableGeometry: screen=" << screenKey << "screenGeom=" << screenGeom
-                              << "available=" << availGeom << "source=" << source << "effOffsets L=" << effLeft
-                              << "T=" << effTop << "R=" << effRight << "B=" << effBottom;
+                              << "available=" << availGeom << "source=" << source
+                              << "effOffsets L=" << (availGeom.x() - screenGeom.x())
+                              << "T=" << (availGeom.y() - screenGeom.y())
+                              << "R=" << (screenGeom.right() - availGeom.right())
+                              << "B=" << (screenGeom.bottom() - availGeom.bottom());
 
     m_availableGeometryCache.insert(screenKey, availGeom);
     Q_EMIT availableGeometryChanged(screen, availGeom);
@@ -549,6 +587,40 @@ void ScreenManager::scheduleDelayedPanelRequery(int delayMs)
     // semantic instead of silently dropping the call. Callers that truly
     // want a delay pass a positive value.
     m_cfg.panelSource->requestRequery(delayMs);
+}
+
+void ScreenManager::setCompositorAvailableGeometry(const QString& screenName, const QRect& available)
+{
+    if (screenName.isEmpty()) {
+        return;
+    }
+
+    // An invalid/empty rect clears the override and reverts the screen to the
+    // sensor + D-Bus heuristic. A valid rect records it as the authoritative
+    // source. Both paths early-return when nothing actually changed so a
+    // redundant push (the effect re-reports every screen on each trigger)
+    // collapses to a no-op instead of churning availableGeometryChanged.
+    const bool valid = available.isValid() && !available.isEmpty();
+    if (valid) {
+        if (m_compositorAvailableGeometry.value(screenName) == available) {
+            return;
+        }
+        m_compositorAvailableGeometry.insert(screenName, available);
+        qCInfo(lcPhosphorScreens) << "Compositor available geometry for" << screenName << "=" << available;
+    } else {
+        if (m_compositorAvailableGeometry.remove(screenName) == 0) {
+            return;
+        }
+        qCInfo(lcPhosphorScreens) << "Compositor available geometry cleared for" << screenName;
+    }
+
+    // Recompute against the new authoritative source. calculateAvailableGeometry
+    // diffs against m_availableGeometryCache and only emits availableGeometryChanged
+    // on a real change, so the daemon's reapply path stays edge-triggered.
+    const PhysicalScreen tracked = trackedScreenByName(screenName);
+    if (tracked.isValid()) {
+        calculateAvailableGeometry(tracked);
+    }
 }
 
 void ScreenManager::propagateIdentifierDrift(const QHash<QString, QString>& oldIds)

--- a/libs/phosphor-screens/src/manager.cpp
+++ b/libs/phosphor-screens/src/manager.cpp
@@ -431,7 +431,9 @@ void ScreenManager::calculateAvailableGeometry(const PhysicalScreen& screen)
         // screen resize by a frame, and an available rect spilling past the
         // output would corrupt every downstream relative-geometry calculation.
         const QRect clamped = compIt.value().intersected(screenGeom);
-        if (clamped.isValid() && !clamped.isEmpty()) {
+        // QRect::isValid() is the exact negation of isEmpty() — a valid rect
+        // is non-empty by definition, so isValid() alone is the usable check.
+        if (clamped.isValid()) {
             availGeom = clamped;
             source = QStringLiteral("compositor");
         }
@@ -600,7 +602,9 @@ void ScreenManager::setCompositorAvailableGeometry(const QString& screenName, co
     // source. Both paths early-return when nothing actually changed so a
     // redundant push (the effect re-reports every screen on each trigger)
     // collapses to a no-op instead of churning availableGeometryChanged.
-    const bool valid = available.isValid() && !available.isEmpty();
+    // QRect::isValid() already implies a non-empty rect (isEmpty() == !isValid()),
+    // so it covers every zero- or negative-size payload the effect can send.
+    const bool valid = available.isValid();
     if (valid) {
         if (m_compositorAvailableGeometry.value(screenName) == available) {
             return;

--- a/libs/phosphor-screens/tests/test_screenmanager_geometry.cpp
+++ b/libs/phosphor-screens/tests/test_screenmanager_geometry.cpp
@@ -155,6 +155,81 @@ private Q_SLOTS:
         QVERIFY(mgr.physicalScreenFor(QStringLiteral("DP-1")).isValid());
         QCOMPARE(mgr.actualAvailableGeometry(mgr.physicalScreenFor(QStringLiteral("DP-1"))), settled);
     }
+
+    // Compositor-reported client area (the KWin effect's clientArea push)
+    // overrides the panel-strut heuristic. Direct regression for discussion
+    // #461: a top panel left the heuristic attributing the whole reservation
+    // to the bottom edge — the compositor source pins the correct top inset.
+    void testCompositorGeometryOverridesHeuristic()
+    {
+        FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 1920, 1080));
+
+        ScreenManager mgr(ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        mgr.start();
+
+        const PhysicalScreen screen = mgr.physicalScreenFor(QStringLiteral("DP-1"));
+        QVERIFY(screen.isValid());
+        // No panel source / sensors: the heuristic yields the full screen rect.
+        QCOMPARE(mgr.actualAvailableGeometry(screen), QRect(0, 0, 1920, 1080));
+
+        QSignalSpy availSpy(&mgr, &ScreenManager::availableGeometryChanged);
+
+        // KWin reports a 32px top panel.
+        const QRect topPanelWorkArea(0, 32, 1920, 1048);
+        mgr.setCompositorAvailableGeometry(QStringLiteral("DP-1"), topPanelWorkArea);
+
+        QCOMPARE(availSpy.count(), 1);
+        QCOMPARE(availSpy.at(0).at(1).toRect(), topPanelWorkArea);
+        QCOMPARE(mgr.actualAvailableGeometry(screen), topPanelWorkArea);
+
+        // A redundant push of the identical rect is a no-op — no extra signal.
+        mgr.setCompositorAvailableGeometry(QStringLiteral("DP-1"), topPanelWorkArea);
+        QCOMPARE(availSpy.count(), 1);
+
+        // Clearing the override (empty rect) reverts to the heuristic.
+        mgr.setCompositorAvailableGeometry(QStringLiteral("DP-1"), QRect());
+        QCOMPARE(availSpy.count(), 2);
+        QCOMPARE(mgr.actualAvailableGeometry(screen), QRect(0, 0, 1920, 1080));
+    }
+
+    // A compositor rect spilling past the output is clamped to the screen —
+    // guards against a snapshot that lags a resize corrupting downstream
+    // relative-geometry math.
+    void testCompositorGeometryClampedToScreen()
+    {
+        FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 1920, 1080));
+
+        ScreenManager mgr(ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        mgr.start();
+
+        // 32px top inset but height still the full 1080 — bottom edge spills
+        // 32px past the output. The intersect clamps it back.
+        mgr.setCompositorAvailableGeometry(QStringLiteral("DP-1"), QRect(0, 32, 1920, 1080));
+        QCOMPARE(mgr.actualAvailableGeometry(mgr.physicalScreenFor(QStringLiteral("DP-1"))), QRect(0, 32, 1920, 1048));
+    }
+
+    // A compositor override is dropped when its screen disconnects, so a
+    // same-connector reconnect starts from the heuristic rather than a stale
+    // rect for the old output.
+    void testCompositorGeometryDroppedOnScreenRemoval()
+    {
+        FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 1920, 1080));
+
+        ScreenManager mgr(ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        mgr.start();
+
+        mgr.setCompositorAvailableGeometry(QStringLiteral("DP-1"), QRect(0, 32, 1920, 1048));
+        QCOMPARE(mgr.actualAvailableGeometry(mgr.physicalScreenFor(QStringLiteral("DP-1"))), QRect(0, 32, 1920, 1048));
+
+        fake.removeScreen(QStringLiteral("DP-1"));
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 1920, 1080));
+
+        // Override gone — back to the heuristic's full-screen rect.
+        QCOMPARE(mgr.actualAvailableGeometry(mgr.physicalScreenFor(QStringLiteral("DP-1"))), QRect(0, 0, 1920, 1080));
+    }
 };
 
 QTEST_MAIN(TestScreenManagerGeometry)


### PR DESCRIPTION
## Problem

[Discussion #461](https://github.com/fuddlesworth/PlasmaZones/discussions/461#discussioncomment-16951910): on 3.0.2, with a **top panel**, zones slide *under* the panel and the bottom edge is over-reserved.

`ScreenManager::calculateAvailableGeometry` reconciled two sources:

1. **Layer-shell sensor** — authoritative *total* reservation per axis, but **no direction**.
2. **plasmashell D-Bus script** — which *edge* each panel is on.

When the D-Bus panel query returns nothing (common on real systems — confirmed in the #461 support report, where DP-1/DP-2 stay `source="sensor-only"`), the degenerate branch dumps **100% of the vertical reservation onto the bottom edge**. For a top-panel layout that is exactly backwards: top inset `0` → windows slide under the panel; bottom inset doubled → over-reserved.

## Fix

Stop guessing edge attribution. The KWin effect runs *inside* the compositor and can ask KWin directly for the authoritative work area via `clientArea(MaximizeArea)` — the exact panel-excluded rect KWin reserves for maximized windows, with correct per-edge strut attribution and correct auto-hide handling.

- **`ScreenManager::setCompositorAvailableGeometry`** stores the per-screen rect; `calculateAvailableGeometry` consumes it as **Source 0** (clamped to the screen rect), overriding the sensor + D-Bus heuristic. The heuristic remains the fallback for sessions where the effect is not loaded. The override is dropped on screen disconnect and on `stop()`.
- **New D-Bus method** `org.plasmazones.Screen.setAvailableGeometryFromKWin`.
- **KWin effect** reports `clientArea` on daemon-ready, `virtualScreenGeometryChanged`, and dock add/close/resize (each dock's `windowFrameGeometryChanged` is hooked; pre-existing docks are enumerated at effect startup). Reports are coalesced per event-loop turn via a queued continuation — no timed debounce, so the push runs after KWin's synchronous strut recompute.

## Tests

Adds 3 regression tests to `test_screenmanager_geometry.cpp`: override-beats-heuristic (the #461 top-panel case), clamp-to-screen, and drop-on-screen-removal. Full suite: 185/185 passing; daemon and KWin effect both build clean.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)