### PR TITLE
Scroll mode Phase 2 — window lifecycle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,6 +461,7 @@ install(FILES
     dbus/org.plasmazones.LayoutRegistry.xml
     dbus/org.plasmazones.Overlay.xml
     dbus/org.plasmazones.Screen.xml
+    dbus/org.plasmazones.Scroll.xml
     dbus/org.plasmazones.Settings.xml
     dbus/org.plasmazones.SettingsApp.xml
     dbus/org.plasmazones.Shader.xml

--- a/dbus/org.plasmazones.Scroll.xml
+++ b/dbus/org.plasmazones.Scroll.xml
@@ -1,0 +1,48 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+    "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- SPDX-FileCopyrightText: 2026 fuddlesworth -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+<node>
+    <!--
+        org.plasmazones.Scroll — niri-style scrollable-tiling control.
+
+        The KWin effect reports window lifecycle for screens in scroll mode to
+        this interface; the daemon forwards each event to the ScrollEngine.
+        Window geometry flows back to the effect over org.plasmazones.WindowTracking
+        (applyGeometriesBatch), shared with the other placement modes.
+    -->
+    <interface name="org.plasmazones.Scroll">
+        <!-- Screens currently in scroll mode. The effect subscribes to the
+             change signal so it knows whose windows to report here. -->
+        <property name="scrollScreens" type="as" access="read"/>
+
+        <signal name="scrollScreensChanged">
+            <arg name="screenIds" type="as"/>
+        </signal>
+
+        <!-- A new window appeared on a scroll-mode screen. -->
+        <method name="windowOpened">
+            <arg name="windowId" type="s" direction="in"/>
+            <arg name="screenId" type="s" direction="in"/>
+            <arg name="minWidth" type="i" direction="in"/>
+            <arg name="minHeight" type="i" direction="in"/>
+        </method>
+
+        <!-- Batch form used on daemon startup / mode toggle-on to avoid
+             per-window D-Bus round-trips. -->
+        <method name="windowsOpenedBatch">
+            <arg name="entries" type="a(ssii)" direction="in"/>
+            <annotation name="org.qtproject.QtDBus.QtTypeName.In0"
+                        value="PhosphorProtocol::WindowOpenedList"/>
+        </method>
+
+        <method name="windowClosed">
+            <arg name="windowId" type="s" direction="in"/>
+        </method>
+
+        <method name="notifyWindowFocused">
+            <arg name="windowId" type="s" direction="in"/>
+            <arg name="screenId" type="s" direction="in"/>
+        </method>
+    </interface>
+</node>

--- a/dbus/org.plasmazones.Scroll.xml
+++ b/dbus/org.plasmazones.Scroll.xml
@@ -44,5 +44,13 @@
             <arg name="windowId" type="s" direction="in"/>
             <arg name="screenId" type="s" direction="in"/>
         </method>
+
+        <!-- A scroll-mode window was minimized (true) or restored (false).
+             A minimized window keeps its slot in the strip but drops out of
+             the visible layout. -->
+        <method name="windowMinimizedChanged">
+            <arg name="windowId" type="s" direction="in"/>
+            <arg name="minimized" type="b" direction="in"/>
+        </method>
     </interface>
 </node>

--- a/dbus/org.plasmazones.Scroll.xml
+++ b/dbus/org.plasmazones.Scroll.xml
@@ -31,9 +31,10 @@
         <!-- Batch form used on daemon startup / mode toggle-on to avoid
              per-window D-Bus round-trips. -->
         <method name="windowsOpenedBatch">
-            <arg name="entries" type="a(ssii)" direction="in"/>
-            <annotation name="org.qtproject.QtDBus.QtTypeName.In0"
-                        value="PhosphorProtocol::WindowOpenedList"/>
+            <arg name="entries" type="a(ssii)" direction="in">
+                <annotation name="org.qtproject.QtDBus.QtTypeName.In0"
+                            value="PhosphorProtocol::WindowOpenedList"/>
+            </arg>
         </method>
 
         <method name="windowClosed">

--- a/dbus/org.plasmazones.Scroll.xml
+++ b/dbus/org.plasmazones.Scroll.xml
@@ -24,12 +24,14 @@
         <method name="windowOpened">
             <arg name="windowId" type="s" direction="in"/>
             <arg name="screenId" type="s" direction="in"/>
-            <arg name="minWidth" type="i" direction="in"/>
-            <arg name="minHeight" type="i" direction="in"/>
         </method>
 
         <!-- Batch form used on daemon startup / mode toggle-on to avoid
-             per-window D-Bus round-trips. -->
+             per-window D-Bus round-trips. The (ssii) entry struct is shared
+             with org.plasmazones.Autotile; scroll's strip model is
+             size-agnostic, so the trailing minWidth/minHeight ints are
+             ignored (non-resizable windows are fitted to the tile slot
+             effect-side). -->
         <method name="windowsOpenedBatch">
             <arg name="entries" type="a(ssii)" direction="in">
                 <annotation name="org.qtproject.QtDBus.QtTypeName.In0"

--- a/docs/scroll-mode-plan.md
+++ b/docs/scroll-mode-plan.md
@@ -6,8 +6,8 @@
 Planning document. Status: **Phases 0 ✅, 1 ✅ and 2 ✅ complete** — the scroll engine,
 geometry resolver, `Mode::Scroll` routing, daemon geometry pipeline, and the full window
 lifecycle (open/close/focus, minimize, screen hotplug & geometry change, fixed-size
-windows) are implemented, built, and tested (186 suite tests green). Phase 0 detail in
-[`scroll-mode-phase0-findings.md`](scroll-mode-phase0-findings.md). Next: Phase 3.
+windows) are implemented, built, and tested — the full `ctest` suite is green. Phase 0
+detail in [`scroll-mode-phase0-findings.md`](scroll-mode-phase0-findings.md). Next: Phase 3.
 
 ## 1. Goal
 
@@ -272,7 +272,9 @@ Phase 5 ("Settings, UI").
   mirroring `AutotileHandler` — neither handler knows the other's mode.
 - ✅ **Minimize / unminimize** (M2) — Karousel's `TiledMinimized`: a minimized window
   keeps its slot in the strip but drops out of the resolved layout; a fully-minimized
-  column collapses with no gap and reappears in place on restore.
+  column collapses with no gap and reappears in place on restore. Minimizing the focused
+  window hands focus to the first still-visible window in strip order, so the viewport
+  never anchors on a hidden window.
 - ✅ **Screen hotplug / geometry change** (M3) — the daemon re-resolves every scroll
   strip on a debounced geometry change; `ScrollHandler` re-homes windows that move
   between monitors or virtual screens; the scroll-screen-set diff adopts or releases

--- a/docs/scroll-mode-plan.md
+++ b/docs/scroll-mode-plan.md
@@ -242,7 +242,8 @@ Static code review **complete** — results in
 ### Phase 1 — Strip data model + engine skeleton — ✅ COMPLETE
 
 - ✅ `libs/phosphor-scroll-engine`: `ScrollScreenState` / `Column` / `Tile` model +
-  `resolveScrollLayout()` geometry resolver. Pure logic, no KWin — 32 unit tests.
+  `resolveScrollLayout()` geometry resolver. Pure logic, no KWin, with a dedicated
+  unit-test suite.
 - ✅ `ScrollEngine : IPlacementEngine` (extends `PlacementEngineBase`); the four niri
   operations added as optional `IPlacementEngine` virtuals.
 - ✅ `Mode::Scroll` in `AssignmentEntry`; `LayoutId` `scroll:` helpers; `ScreenModeRouter`

--- a/docs/scroll-mode-plan.md
+++ b/docs/scroll-mode-plan.md
@@ -3,10 +3,11 @@
 
 # Scroll mode — niri-style scrollable tiling
 
-Planning document. Status: **Phase 0 ✅ and Phase 1 ✅ complete** — the scroll engine,
-geometry resolver, `Mode::Scroll` routing, and daemon geometry pipeline are implemented,
-built, and tested (186 suite tests green). Phase 0 detail in
-[`scroll-mode-phase0-findings.md`](scroll-mode-phase0-findings.md). Next: Phase 2.
+Planning document. Status: **Phases 0 ✅, 1 ✅ and 2 ✅ complete** — the scroll engine,
+geometry resolver, `Mode::Scroll` routing, daemon geometry pipeline, and the full window
+lifecycle (open/close/focus, minimize, screen hotplug & geometry change, fixed-size
+windows) are implemented, built, and tested (186 suite tests green). Phase 0 detail in
+[`scroll-mode-phase0-findings.md`](scroll-mode-phase0-findings.md). Next: Phase 3.
 
 ## 1. Goal
 
@@ -262,25 +263,35 @@ plan's phase boundaries): the niri-op **keyboard shortcuts** → Phase 3 ("wire 
 `ShortcutManager`"); the **`ScrollAdaptor`** D-Bus interface for KCM selection →
 Phase 5 ("Settings, UI").
 
-### Phase 2 — Window lifecycle
+### Phase 2 — Window lifecycle — ✅ COMPLETE
 
-- **Open** → new column on the window's output's strip; **close** → remove column/tile,
-  explicitly handling "last visible window closed" focus selection.
-- **Focus** → update active indices + recompute view offset.
-- **App-initiated resize** → relayout the affected column; debounce noisy resize streams.
-- **Minimize / unminimize** → decide and document the rule: a minimized tiled window is
-  removed from the visible strip but its slot/order is remembered, and restored on
-  unminimize (Karousel's `TiledMinimized` state).
-- **Fixed-size / non-resizable windows** → MVP fallback: keep the window at its native
-  size, centered within its column slot (no full floating layer yet — see §7).
-- **Virtual desktop / activity switch** → activate that context's strip; a window pinned
-  to all desktops or multiple activities is force-collapsed to the current context (as
-  Karousel does) or excluded — decide and document.
-- **Screen hotplug / geometry change** → re-resolve outputs, reassign orphaned strips,
-  re-assert geometry on `outputChanged` / rearrange signals (§4.1). This area is already
-  fragile in the codebase — treat as a first-class task, not an afterthought.
-- Aggressive early filtering of transient / clipboard / dock / popup windows.
-- Apply resolved geometry through the effect via `move()`. No animation yet — snap.
+- ✅ **Open / close / focus** (M1) — windows on a scroll-mode screen are reported to
+  the `ScrollEngine` over `org.plasmazones.Scroll`; the engine adds/removes columns and
+  tracks the focused column. The effect-side `ScrollHandler` owns this surface,
+  mirroring `AutotileHandler` — neither handler knows the other's mode.
+- ✅ **Minimize / unminimize** (M2) — Karousel's `TiledMinimized`: a minimized window
+  keeps its slot in the strip but drops out of the resolved layout; a fully-minimized
+  column collapses with no gap and reappears in place on restore.
+- ✅ **Screen hotplug / geometry change** (M3) — the daemon re-resolves every scroll
+  strip on a debounced geometry change; `ScrollHandler` re-homes windows that move
+  between monitors or virtual screens; the scroll-screen-set diff adopts or releases
+  windows when a screen enters or leaves scroll mode at runtime.
+- ✅ **App-initiated resize** (M4) — a window that drifts from its resolved tile
+  geometry is snapped back, debounced to coalesce noisy resize streams.
+- ✅ **Fixed-size / non-resizable windows** (M4) — MVP fallback: the window keeps its
+  constrained size, centered within its tile slot (no floating layer yet — see §7).
+- ✅ **Filtering** — transient / clipboard / dock / popup / menu / tooltip / modal /
+  keep-above / minimized / off-desktop / undersized windows are all rejected by
+  `PlasmaZonesEffect::isEligibleForTilingNotify`, shared with autotile.
+- ✅ **Geometry application** — resolved rects ride the effect's existing
+  `applyGeometriesBatch` path. No animation yet — snap.
+
+**Virtual desktop / activity switch**: handled structurally — `ScrollEngine` keys one
+strip per (screen, desktop, activity) and `updateScrollScreens()` sets the engine's
+context on every switch, so each desktop/activity shows its own strip. The narrower
+decision for a window *pinned to all desktops / multiple activities* (force-collapse to
+the current context vs. exclude) is deferred — sticky-window handling is carried forward
+with the Phase 3 navigation work.
 
 ### Phase 3 — Navigation & niri command vocabulary
 

--- a/kwin-effect/CMakeLists.txt
+++ b/kwin-effect/CMakeLists.txt
@@ -59,10 +59,10 @@ set(plasmazones_effect_SRCS
     autotilehandler/tiling.cpp
     navigationhandler.cpp
     navigationhandler.h
-    scrollhandler.cpp
-    scrollhandler.h
     screenchangehandler.cpp
     screenchangehandler.h
+    scrollhandler.cpp
+    scrollhandler.h
     snapassisthandler.cpp
     snapassisthandler.h
     snapassistthumbnailcapture.cpp

--- a/kwin-effect/CMakeLists.txt
+++ b/kwin-effect/CMakeLists.txt
@@ -59,6 +59,8 @@ set(plasmazones_effect_SRCS
     autotilehandler/tiling.cpp
     navigationhandler.cpp
     navigationhandler.h
+    scrollhandler.cpp
+    scrollhandler.h
     screenchangehandler.cpp
     screenchangehandler.h
     snapassisthandler.cpp

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -98,7 +98,7 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
 
 void AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
 {
-    if (!isEligibleForAutotileNotify(w)) {
+    if (!m_effect->isEligibleForTilingNotify(w)) {
         return;
     }
 
@@ -117,15 +117,9 @@ void AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
     QString screenId = m_effect->getWindowScreenId(w);
     m_notifiedWindowScreens[windowId] = screenId;
 
-    // Notify the placement daemon for windows on a tiling screen — autotile
-    // or scroll. The two screen sets are disjoint (a screen has one mode).
-    const bool isAutotile = m_autotileScreens.contains(screenId);
-    const bool isScroll = m_scrollScreens.contains(screenId);
-    if (!isAutotile && !isScroll) {
-        return;
-    }
-
-    if (isAutotile) {
+    // Only notify autotile daemon for windows on autotile screens. Scroll-mode
+    // screens are handled independently by ScrollHandler.
+    if (m_autotileScreens.contains(screenId)) {
         // Save pre-autotile geometry BEFORE the daemon tiles the window.
         // Without this, a window launched directly into autotile has no saved
         // geometry — floating it would leave it at its tiled position instead
@@ -137,35 +131,34 @@ void AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
         // this flag the isWindowFloating() guard would drop the one-shot save.
         saveAndRecordPreAutotileGeometry(windowId, screenId, w->frameGeometry(),
                                          /*knownFreeFloating=*/true);
-    }
 
-    int minWidth = 0;
-    int minHeight = 0;
-    KWin::Window* kw = w->window();
-    if (kw) {
-        const QSizeF minSize = kw->minSize();
-        if (minSize.isValid()) {
-            minWidth = qCeil(minSize.width());
-            minHeight = qCeil(minSize.height());
+        int minWidth = 0;
+        int minHeight = 0;
+        KWin::Window* kw = w->window();
+        if (kw) {
+            const QSizeF minSize = kw->minSize();
+            if (minSize.isValid()) {
+                minWidth = qCeil(minSize.width());
+                minHeight = qCeil(minSize.height());
+            }
         }
-    }
 
-    const QString iface =
-        isAutotile ? PhosphorProtocol::Service::Interface::Autotile : PhosphorProtocol::Service::Interface::Scroll;
-    auto* watcher = new QDBusPendingCallWatcher(
-        PhosphorProtocol::ClientHelpers::asyncCall(iface, QStringLiteral("windowOpened"),
-                                                   {windowId, screenId, minWidth, minHeight}),
-        this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, windowId](QDBusPendingCallWatcher* w) {
-        w->deleteLater();
-        if (w->isError()) {
-            qCWarning(lcEffect) << "windowOpened D-Bus call failed for" << windowId << ":" << w->error().message();
-            m_notifiedWindows.remove(windowId);
-            m_notifiedWindowScreens.remove(windowId);
-        }
-    });
-    qCDebug(lcEffect) << "Notified" << (isAutotile ? "autotile" : "scroll") << ": windowOpened" << windowId
-                      << "on screen" << screenId << "minSize:" << minWidth << "x" << minHeight;
+        auto* watcher =
+            new QDBusPendingCallWatcher(PhosphorProtocol::ClientHelpers::asyncCall(
+                                            PhosphorProtocol::Service::Interface::Autotile,
+                                            QStringLiteral("windowOpened"), {windowId, screenId, minWidth, minHeight}),
+                                        this);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, windowId](QDBusPendingCallWatcher* w) {
+            w->deleteLater();
+            if (w->isError()) {
+                qCWarning(lcEffect) << "windowOpened D-Bus call failed for" << windowId << ":" << w->error().message();
+                m_notifiedWindows.remove(windowId);
+                m_notifiedWindowScreens.remove(windowId);
+            }
+        });
+        qCDebug(lcEffect) << "Notified autotile: windowOpened" << windowId << "on screen" << screenId
+                          << "minSize:" << minWidth << "x" << minHeight;
+    }
 }
 
 void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows,
@@ -177,7 +170,7 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
     QStringList batchWindowIds; // for error rollback
 
     for (KWin::EffectWindow* w : windows) {
-        if (!isEligibleForAutotileNotify(w)) {
+        if (!m_effect->isEligibleForTilingNotify(w)) {
             continue;
         }
 
@@ -477,16 +470,12 @@ void AutotileHandler::onWindowClosed(const QString& windowId, const QString& scr
         m_savedAutotileStackingOrder[screenId].removeAll(windowId);
     }
 
-    // Notify the placement daemon — autotile or scroll, whichever owns the screen.
-    const bool closedAutotile = m_autotileScreens.contains(screenId);
-    const bool closedScroll = m_scrollScreens.contains(screenId);
-    if (closedAutotile || closedScroll) {
-        const QString iface = closedAutotile ? PhosphorProtocol::Service::Interface::Autotile
-                                             : PhosphorProtocol::Service::Interface::Scroll;
-        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, iface, QStringLiteral("windowClosed"), {windowId},
+    // Notify autotile daemon. Scroll-mode screens are handled by ScrollHandler.
+    if (m_autotileScreens.contains(screenId)) {
+        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Autotile,
+                                                       QStringLiteral("windowClosed"), {windowId},
                                                        QStringLiteral("windowClosed"));
-        qCDebug(lcEffect) << "Notified" << (closedAutotile ? "autotile" : "scroll") << ": windowClosed" << windowId
-                          << "on screen" << screenId;
+        qCDebug(lcEffect) << "Notified autotile: windowClosed" << windowId << "on screen" << screenId;
     }
 }
 
@@ -623,22 +612,7 @@ void AutotileHandler::connectSignals()
                 PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("windowFloatingChanged"), this,
                 SLOT(slotWindowFloatingChanged(QString, bool, QString)));
 
-    // Scroll mode: learn which screens are scroll-mode so notifyWindowAdded /
-    // onWindowClosed report their windows to org.plasmazones.Scroll.
-    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
-                   PhosphorProtocol::Service::Interface::Scroll, QStringLiteral("scrollScreensChanged"), this,
-                   SLOT(slotScrollScreensChanged(QStringList)));
-    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
-                PhosphorProtocol::Service::Interface::Scroll, QStringLiteral("scrollScreensChanged"), this,
-                SLOT(slotScrollScreensChanged(QStringList)));
-
-    qCInfo(lcEffect) << "Connected to autotile + scroll D-Bus signals";
-}
-
-void AutotileHandler::slotScrollScreensChanged(const QStringList& screenIds)
-{
-    m_scrollScreens = QSet<QString>(screenIds.cbegin(), screenIds.cend());
-    qCDebug(lcEffect) << "Scroll screens updated:" << m_scrollScreens;
+    qCInfo(lcEffect) << "Connected to autotile D-Bus signals";
 }
 
 void AutotileHandler::loadSettings()

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -117,8 +117,15 @@ void AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
     QString screenId = m_effect->getWindowScreenId(w);
     m_notifiedWindowScreens[windowId] = screenId;
 
-    // Only notify autotile daemon for windows on autotile screens
-    if (m_autotileScreens.contains(screenId)) {
+    // Notify the placement daemon for windows on a tiling screen — autotile
+    // or scroll. The two screen sets are disjoint (a screen has one mode).
+    const bool isAutotile = m_autotileScreens.contains(screenId);
+    const bool isScroll = m_scrollScreens.contains(screenId);
+    if (!isAutotile && !isScroll) {
+        return;
+    }
+
+    if (isAutotile) {
         // Save pre-autotile geometry BEFORE the daemon tiles the window.
         // Without this, a window launched directly into autotile has no saved
         // geometry — floating it would leave it at its tiled position instead
@@ -130,34 +137,35 @@ void AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
         // this flag the isWindowFloating() guard would drop the one-shot save.
         saveAndRecordPreAutotileGeometry(windowId, screenId, w->frameGeometry(),
                                          /*knownFreeFloating=*/true);
-
-        int minWidth = 0;
-        int minHeight = 0;
-        KWin::Window* kw = w->window();
-        if (kw) {
-            const QSizeF minSize = kw->minSize();
-            if (minSize.isValid()) {
-                minWidth = qCeil(minSize.width());
-                minHeight = qCeil(minSize.height());
-            }
-        }
-
-        auto* watcher =
-            new QDBusPendingCallWatcher(PhosphorProtocol::ClientHelpers::asyncCall(
-                                            PhosphorProtocol::Service::Interface::Autotile,
-                                            QStringLiteral("windowOpened"), {windowId, screenId, minWidth, minHeight}),
-                                        this);
-        connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, windowId](QDBusPendingCallWatcher* w) {
-            w->deleteLater();
-            if (w->isError()) {
-                qCWarning(lcEffect) << "windowOpened D-Bus call failed for" << windowId << ":" << w->error().message();
-                m_notifiedWindows.remove(windowId);
-                m_notifiedWindowScreens.remove(windowId);
-            }
-        });
-        qCDebug(lcEffect) << "Notified autotile: windowOpened" << windowId << "on screen" << screenId
-                          << "minSize:" << minWidth << "x" << minHeight;
     }
+
+    int minWidth = 0;
+    int minHeight = 0;
+    KWin::Window* kw = w->window();
+    if (kw) {
+        const QSizeF minSize = kw->minSize();
+        if (minSize.isValid()) {
+            minWidth = qCeil(minSize.width());
+            minHeight = qCeil(minSize.height());
+        }
+    }
+
+    const QString iface =
+        isAutotile ? PhosphorProtocol::Service::Interface::Autotile : PhosphorProtocol::Service::Interface::Scroll;
+    auto* watcher = new QDBusPendingCallWatcher(
+        PhosphorProtocol::ClientHelpers::asyncCall(iface, QStringLiteral("windowOpened"),
+                                                   {windowId, screenId, minWidth, minHeight}),
+        this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, windowId](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+        if (w->isError()) {
+            qCWarning(lcEffect) << "windowOpened D-Bus call failed for" << windowId << ":" << w->error().message();
+            m_notifiedWindows.remove(windowId);
+            m_notifiedWindowScreens.remove(windowId);
+        }
+    });
+    qCDebug(lcEffect) << "Notified" << (isAutotile ? "autotile" : "scroll") << ": windowOpened" << windowId
+                      << "on screen" << screenId << "minSize:" << minWidth << "x" << minHeight;
 }
 
 void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows,
@@ -469,12 +477,16 @@ void AutotileHandler::onWindowClosed(const QString& windowId, const QString& scr
         m_savedAutotileStackingOrder[screenId].removeAll(windowId);
     }
 
-    // Notify autotile daemon
-    if (m_autotileScreens.contains(screenId)) {
-        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Autotile,
-                                                       QStringLiteral("windowClosed"), {windowId},
+    // Notify the placement daemon — autotile or scroll, whichever owns the screen.
+    const bool closedAutotile = m_autotileScreens.contains(screenId);
+    const bool closedScroll = m_scrollScreens.contains(screenId);
+    if (closedAutotile || closedScroll) {
+        const QString iface = closedAutotile ? PhosphorProtocol::Service::Interface::Autotile
+                                             : PhosphorProtocol::Service::Interface::Scroll;
+        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, iface, QStringLiteral("windowClosed"), {windowId},
                                                        QStringLiteral("windowClosed"));
-        qCDebug(lcEffect) << "Notified autotile: windowClosed" << windowId << "on screen" << screenId;
+        qCDebug(lcEffect) << "Notified" << (closedAutotile ? "autotile" : "scroll") << ": windowClosed" << windowId
+                          << "on screen" << screenId;
     }
 }
 
@@ -611,7 +623,22 @@ void AutotileHandler::connectSignals()
                 PhosphorProtocol::Service::Interface::Autotile, QStringLiteral("windowFloatingChanged"), this,
                 SLOT(slotWindowFloatingChanged(QString, bool, QString)));
 
-    qCInfo(lcEffect) << "Connected to autotile D-Bus signals";
+    // Scroll mode: learn which screens are scroll-mode so notifyWindowAdded /
+    // onWindowClosed report their windows to org.plasmazones.Scroll.
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::Scroll, QStringLiteral("scrollScreensChanged"), this,
+                   SLOT(slotScrollScreensChanged(QStringList)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::Scroll, QStringLiteral("scrollScreensChanged"), this,
+                SLOT(slotScrollScreensChanged(QStringList)));
+
+    qCInfo(lcEffect) << "Connected to autotile + scroll D-Bus signals";
+}
+
+void AutotileHandler::slotScrollScreensChanged(const QStringList& screenIds)
+{
+    m_scrollScreens = QSet<QString>(screenIds.cbegin(), screenIds.cend());
+    qCDebug(lcEffect) << "Scroll screens updated:" << m_scrollScreens;
 }
 
 void AutotileHandler::loadSettings()

--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -115,11 +115,6 @@ public:
     {
         return m_autotileScreens;
     }
-    /// Whether @p screenId is currently in scroll mode.
-    bool isScrollScreen(const QString& screenId) const
-    {
-        return m_scrollScreens.contains(screenId);
-    }
 
     /// Check if a window is tracked by the autotile handler (in m_notifiedWindows).
     bool isTrackedWindow(const QString& windowId) const
@@ -248,7 +243,6 @@ public Q_SLOTS:
     void slotFocusWindowRequested(const QString& windowId);
     void slotEnabledChanged(bool enabled);
     void slotScreensChanged(const QStringList& screenIds, bool isDesktopSwitch);
-    void slotScrollScreensChanged(const QStringList& screenIds);
     void slotWindowFloatingChanged(const QString& windowId, bool isFloating, const QString& screenId);
 
     // Window state change handlers (connected per-window in setupWindowConnections)
@@ -279,16 +273,6 @@ private:
      * (per-window D-Bus signal path) and slotWindowsTileRequested (batch float path).
      */
     void applyFloatCleanup(const QString& windowId);
-
-    /**
-     * @brief Check if a window is eligible for autotile notification
-     *
-     * Shared predicate used by both notifyWindowAdded and notifyWindowsAddedBatch
-     * to keep filtering logic in sync.
-     *
-     * @return true if the window should be notified to the autotile daemon
-     */
-    bool isEligibleForAutotileNotify(KWin::EffectWindow* w) const;
 
     /**
      * @brief Cancel a pending debounced minimize→float commit.
@@ -334,7 +318,6 @@ private:
     PlasmaZonesEffect* m_effect;
 
     QSet<QString> m_autotileScreens;
-    QSet<QString> m_scrollScreens; ///< Screens in scroll mode (from org.plasmazones.Scroll).
     /// Pre-autotile frame geometry, keyed [screenId][windowId].
     ///
     /// Ownership: this is a local cache. The daemon's

--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -115,6 +115,11 @@ public:
     {
         return m_autotileScreens;
     }
+    /// Whether @p screenId is currently in scroll mode.
+    bool isScrollScreen(const QString& screenId) const
+    {
+        return m_scrollScreens.contains(screenId);
+    }
 
     /// Check if a window is tracked by the autotile handler (in m_notifiedWindows).
     bool isTrackedWindow(const QString& windowId) const
@@ -243,6 +248,7 @@ public Q_SLOTS:
     void slotFocusWindowRequested(const QString& windowId);
     void slotEnabledChanged(bool enabled);
     void slotScreensChanged(const QStringList& screenIds, bool isDesktopSwitch);
+    void slotScrollScreensChanged(const QStringList& screenIds);
     void slotWindowFloatingChanged(const QString& windowId, bool isFloating, const QString& screenId);
 
     // Window state change handlers (connected per-window in setupWindowConnections)
@@ -328,6 +334,7 @@ private:
     PlasmaZonesEffect* m_effect;
 
     QSet<QString> m_autotileScreens;
+    QSet<QString> m_scrollScreens; ///< Screens in scroll mode (from org.plasmazones.Scroll).
     /// Pre-autotile frame geometry, keyed [screenId][windowId].
     ///
     /// Ownership: this is a local cache. The daemon's

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -262,43 +262,6 @@ void AutotileHandler::savePreAutotileForDesktopMove(const QString& windowId, con
     }
 }
 
-bool AutotileHandler::isEligibleForAutotileNotify(KWin::EffectWindow* w) const
-{
-    if (!w || !m_effect->shouldHandleWindow(w)) {
-        qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (not handleable)"
-                          << (w ? m_effect->getWindowId(w) : QStringLiteral("null"));
-        return false;
-    }
-    if (!m_effect->isTileableWindow(w)) {
-        qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (not tileable)" << m_effect->getWindowId(w);
-        return false;
-    }
-    if (w->isMinimized()) {
-        qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (minimized)" << m_effect->getWindowId(w);
-        return false;
-    }
-    if (!w->isOnCurrentDesktop() || !w->isOnCurrentActivity()) {
-        qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (wrong desktop/activity)"
-                          << m_effect->getWindowId(w);
-        return false;
-    }
-    // Reject windows smaller than the user-configured minimum size.
-    // Prevents small utility windows (emoji picker, color picker, etc.)
-    // from entering the tiling tree and disrupting the layout.
-    const QRectF frame = w->frameGeometry();
-    if ((m_effect->m_cachedMinWindowWidth > 0 && frame.width() < m_effect->m_cachedMinWindowWidth)
-        || (m_effect->m_cachedMinWindowHeight > 0 && frame.height() < m_effect->m_cachedMinWindowHeight)) {
-        qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (too small)" << m_effect->getWindowId(w)
-                          << "size=" << frame.size() << "threshold=" << m_effect->m_cachedMinWindowWidth << "x"
-                          << m_effect->m_cachedMinWindowHeight;
-        return false;
-    }
-    qCDebug(lcEffect) << "isEligibleForAutotileNotify: accepted" << m_effect->getWindowId(w) << "size=" << frame.size()
-                      << "class=" << w->windowClass() << "skipSwitcher=" << w->isSkipSwitcher()
-                      << "keepAbove=" << w->keepAbove() << "transient=" << (w->transientFor() != nullptr);
-    return true;
-}
-
 void AutotileHandler::applyFloatCleanup(const QString& windowId)
 {
     m_effect->m_navigationHandler->setWindowFloating(windowId, true);

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -76,6 +76,7 @@ static_assert(
 
 // Forward declarations for helper classes
 class AutotileHandler;
+class ScrollHandler;
 class KWinCompositorBridge;
 class NavigationHandler;
 class ScreenChangeHandler;
@@ -231,6 +232,16 @@ private:
     bool isTileableWindow(KWin::EffectWindow* w) const;
 
     /**
+     * @brief Whether @p w should be reported to a tiling engine on open.
+     *
+     * Mode-agnostic eligibility predicate shared by AutotileHandler and
+     * ScrollHandler: rejects non-handleable / non-tileable / minimized /
+     * off-desktop windows and those below the user's minimum-size floor.
+     * The per-mode handler still gates on its own screen set afterwards.
+     */
+    bool isEligibleForTilingNotify(KWin::EffectWindow* w) const;
+
+    /**
      * @brief Animation-side window filter.
      *
      * Returns true when @p w should animate, false when the user's
@@ -378,6 +389,10 @@ private:
     {
         return m_autotileHandler.get();
     }
+    ScrollHandler* scrollHandler() const
+    {
+        return m_scrollHandler.get();
+    }
 
     /**
      * @brief Emit navigationFeedback D-Bus signal
@@ -473,6 +488,7 @@ public:
 private:
     // Friend classes for helpers
     friend class AutotileHandler;
+    friend class ScrollHandler;
     friend class NavigationHandler;
     friend class ScreenChangeHandler;
     friend class SnapAssistHandler;
@@ -484,6 +500,7 @@ private:
     // Helper class instances
     // ═══════════════════════════════════════════════════════════════════════════════
     std::unique_ptr<AutotileHandler> m_autotileHandler;
+    std::unique_ptr<ScrollHandler> m_scrollHandler;
 
     QHash<QString, WindowBorder> m_windowBorders; // windowId → border
 

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -635,7 +635,7 @@ private:
     QStringList m_excludedWindowClasses;
 
     // Minimum window size for autotile eligibility. Windows smaller than this
-    // are rejected by isEligibleForAutotileNotify() to prevent small utility
+    // are rejected by isEligibleForTilingNotify() to prevent small utility
     // windows (emoji picker, color picker, etc.) from entering the tiling tree.
     // Defaults match ConfigDefaults::minimumWindowWidth/Height() (200/150).
     // The async loadSettingAsync() call in loadCachedSettings() overrides

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -30,11 +30,53 @@
 
 #include "../autotilehandler.h"
 #include "../navigationhandler.h"
+#include "../scrollhandler.h"
 #include "../snapassisthandler.h"
+
+#include <QtMath>
 
 namespace PlasmaZones {
 
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
+
+namespace {
+/// Fit a scroll-mode window into its tile slot. A window that cannot fill the
+/// slot — fixed-size or max-constrained — keeps its constrained size, centred
+/// in the slot: the Phase 2 MVP fallback for non-resizable windows. A normal
+/// resizable window is returned the slot unchanged.
+QRect constrainToScrollSlot(KWin::EffectWindow* window, const QRect& slot)
+{
+    KWin::Window* kw = window ? window->window() : nullptr;
+    if (!kw) {
+        return slot;
+    }
+    const QSizeF minS = kw->minSize();
+    const QSizeF maxS = kw->maxSize();
+
+    int w = slot.width();
+    int h = slot.height();
+    // maxSize() reports a large sentinel for unconstrained windows, so a
+    // genuine maximum clamps here and an unconstrained one is left alone.
+    if (maxS.width() > 0.0 && w > maxS.width()) {
+        w = qFloor(maxS.width());
+    }
+    if (maxS.height() > 0.0 && h > maxS.height()) {
+        h = qFloor(maxS.height());
+    }
+    // A minimum larger than the slot means the window will overflow — accepted
+    // for the MVP; pin it to the minimum so the daemon's rect is honoured.
+    if (minS.width() > 0.0 && w < minS.width()) {
+        w = qCeil(minS.width());
+    }
+    if (minS.height() > 0.0 && h < minS.height()) {
+        h = qCeil(minS.height());
+    }
+    if (w == slot.width() && h == slot.height()) {
+        return slot; // fills the slot exactly — nothing to centre
+    }
+    return QRect(slot.x() + (slot.width() - w) / 2, slot.y() + (slot.height() - h) / 2, w, h);
+}
+} // namespace
 
 void PlasmaZonesEffect::emitNavigationFeedback(bool success, const QString& action, const QString& reason,
                                                const QString& sourceZoneId, const QString& targetZoneId,
@@ -253,6 +295,13 @@ void PlasmaZonesEffect::slotApplyGeometriesBatch(const PhosphorProtocol::WindowG
         PendingApply p;
         p.window = QPointer<KWin::EffectWindow>(window);
         p.geometry = entry.toRect();
+        // Scroll-mode windows that cannot fill their tile slot (fixed-size or
+        // max-constrained) are centred within it; record the resolved rect so
+        // ScrollHandler can detect and correct an app-initiated resize.
+        if (action == QLatin1String("scroll")) {
+            p.geometry = constrainToScrollSlot(window, p.geometry);
+            m_scrollHandler->recordAppliedGeometry(getWindowId(window), p.geometry);
+        }
         p.screenId = entry.screenId;
         pending.append(p);
     }

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -64,7 +64,9 @@ QRect constrainToScrollSlot(KWin::EffectWindow* window, const QRect& slot)
         h = qFloor(maxS.height());
     }
     // A minimum larger than the slot means the window will overflow — accepted
-    // for the MVP; pin it to the minimum so the daemon's rect is honoured.
+    // for the MVP; pin it to the minimum so the daemon's rect is honoured. The
+    // min clamp runs after the max clamp, so a window with contradictory hints
+    // (minSize > maxSize) resolves to its minimum.
     if (minS.width() > 0.0 && w < minS.width()) {
         w = qCeil(minS.width());
     }

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -74,7 +74,9 @@ QRect constrainToScrollSlot(KWin::EffectWindow* window, const QRect& slot)
     if (w == slot.width() && h == slot.height()) {
         return slot; // fills the slot exactly — nothing to centre
     }
-    return QRect(slot.x() + (slot.width() - w) / 2, slot.y() + (slot.height() - h) / 2, w, h);
+    // Centre the constrained size; qMax keeps an over-min window pinned to the
+    // slot's top-left (overflowing only right/bottom) rather than off both edges.
+    return QRect(slot.x() + qMax(0, (slot.width() - w) / 2), slot.y() + qMax(0, (slot.height() - h) / 2), w, h);
 }
 } // namespace
 

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -6,6 +6,7 @@
 #include "../autotilehandler.h"
 #include "../navigationhandler.h"
 #include "../screenchangehandler.h"
+#include "../scrollhandler.h"
 #include "../snapassisthandler.h"
 #include "../windowanimator.h"
 
@@ -254,6 +255,7 @@ void PlasmaZonesEffect::processDaemonReadyWindowState()
         m_autotileHandler->setPendingReactivateWindow(activeWin);
     }
     m_autotileHandler->onDaemonReady();
+    m_scrollHandler->onDaemonReady();
 
     // Re-announce all existing windows on autotile screens in one batch D-Bus
     // call instead of per-window windowOpened round-trips.

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -25,6 +25,7 @@
 #include <QVarLengthArray>
 
 #include "../autotilehandler.h"
+#include "../scrollhandler.h"
 #include "../compositorclock.h"
 #include "../dragtracker.h"
 #include "../kwin_compositor_bridge.h"
@@ -42,6 +43,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcEffect)
 PlasmaZonesEffect::PlasmaZonesEffect()
     : OffscreenEffect()
     , m_autotileHandler(std::make_unique<AutotileHandler>(this))
+    , m_scrollHandler(std::make_unique<ScrollHandler>(this))
     , m_navigationHandler(std::make_unique<NavigationHandler>(this))
     , m_screenChangeHandler(std::make_unique<ScreenChangeHandler>(this))
     , m_snapAssistHandler(std::make_unique<SnapAssistHandler>(this))
@@ -502,6 +504,10 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     // Connect to autotile D-Bus signals
     m_autotileHandler->connectSignals();
     m_autotileHandler->loadSettings();
+
+    // Connect to scroll D-Bus signals
+    m_scrollHandler->connectSignals();
+    m_scrollHandler->loadSettings();
 
     // Verify daemon availability asynchronously to avoid blocking the compositor.
     // CRITICAL: Do NOT use synchronous isServiceRegistered() here. The daemon

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -265,6 +265,42 @@ bool PlasmaZonesEffect::isTileableWindow(KWin::EffectWindow* w) const
     return true;
 }
 
+bool PlasmaZonesEffect::isEligibleForTilingNotify(KWin::EffectWindow* w) const
+{
+    if (!w || !shouldHandleWindow(w)) {
+        qCDebug(lcEffect) << "isEligibleForTilingNotify: rejected (not handleable)"
+                          << (w ? getWindowId(w) : QStringLiteral("null"));
+        return false;
+    }
+    if (!isTileableWindow(w)) {
+        qCDebug(lcEffect) << "isEligibleForTilingNotify: rejected (not tileable)" << getWindowId(w);
+        return false;
+    }
+    if (w->isMinimized()) {
+        qCDebug(lcEffect) << "isEligibleForTilingNotify: rejected (minimized)" << getWindowId(w);
+        return false;
+    }
+    if (!w->isOnCurrentDesktop() || !w->isOnCurrentActivity()) {
+        qCDebug(lcEffect) << "isEligibleForTilingNotify: rejected (wrong desktop/activity)" << getWindowId(w);
+        return false;
+    }
+    // Reject windows smaller than the user-configured minimum size.
+    // Prevents small utility windows (emoji picker, color picker, etc.)
+    // from entering the tiling tree and disrupting the layout.
+    const QRectF frame = w->frameGeometry();
+    if ((m_cachedMinWindowWidth > 0 && frame.width() < m_cachedMinWindowWidth)
+        || (m_cachedMinWindowHeight > 0 && frame.height() < m_cachedMinWindowHeight)) {
+        qCDebug(lcEffect) << "isEligibleForTilingNotify: rejected (too small)" << getWindowId(w)
+                          << "size=" << frame.size() << "threshold=" << m_cachedMinWindowWidth << "x"
+                          << m_cachedMinWindowHeight;
+        return false;
+    }
+    qCDebug(lcEffect) << "isEligibleForTilingNotify: accepted" << getWindowId(w) << "size=" << frame.size()
+                      << "class=" << w->windowClass() << "skipSwitcher=" << w->isSkipSwitcher()
+                      << "keepAbove=" << w->keepAbove() << "transient=" << (w->transientFor() != nullptr);
+    return true;
+}
+
 bool PlasmaZonesEffect::hasOtherWindowOfClassWithDifferentPid(KWin::EffectWindow* w) const
 {
     if (!w) {

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -19,6 +19,7 @@
 #include "../dragtracker.h"
 #include "../navigationhandler.h"
 #include "../screenchangehandler.h"
+#include "../scrollhandler.h"
 #include "../windowanimator.h"
 
 namespace PlasmaZones {
@@ -119,6 +120,9 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
 
     // Standard path: notify autotile first, then try snap restore
     m_autotileHandler->notifyWindowAdded(w);
+    // Scroll mode reports independently — it acts only on scroll-mode
+    // screens, which are disjoint from autotile screens.
+    m_scrollHandler->notifyWindowAdded(w);
 
     if (!onAutotileScreen && canSnapRestore) {
         callResolveWindowRestore(w);
@@ -170,6 +174,8 @@ void PlasmaZonesEffect::slotWindowClosed(KWin::EffectWindow* w)
 
     // Notify autotile handler for cleanup (tracking sets + autotile D-Bus)
     m_autotileHandler->onWindowClosed(closedWindowId, closedScreenId);
+    // Scroll handler does the same for scroll-mode screens.
+    m_scrollHandler->onWindowClosed(closedWindowId, closedScreenId);
 
     // Remove the window's border item (parent WindowItem is being destroyed anyway,
     // but clean up our tracking hash to avoid stale entries).
@@ -551,15 +557,15 @@ void PlasmaZonesEffect::notifyWindowActivated(KWin::EffectWindow* w)
     PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
                                                    QStringLiteral("windowActivated"), {windowId, screenId});
 
-    // Notify autotile engine of focus change so m_windowToScreen is updated
+    // Notify the placement engine of the focus change. Autotile needs it to
+    // update m_windowToScreen; scroll needs it to track the focused column.
+    // The screen sets are disjoint, so at most one branch fires.
     if (m_autotileHandler->isAutotileScreen(screenId)) {
         PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::Autotile,
                                                        QStringLiteral("notifyWindowFocused"), {windowId, screenId},
                                                        QStringLiteral("notifyWindowFocused"));
-    } else if (m_autotileHandler->isScrollScreen(screenId)) {
-        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::Scroll,
-                                                       QStringLiteral("notifyWindowFocused"), {windowId, screenId},
-                                                       QStringLiteral("notifyWindowFocused"));
+    } else {
+        m_scrollHandler->notifyWindowFocused(windowId, screenId);
     }
 }
 

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -477,6 +477,10 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     connect(w, &KWin::EffectWindow::minimizedChanged, m_autotileHandler.get(),
             &AutotileHandler::slotWindowMinimizedChanged);
 
+    // Scroll: track minimize/unminimize — a minimized scroll window keeps its
+    // slot in the strip but drops out of the visible layout.
+    connect(w, &KWin::EffectWindow::minimizedChanged, m_scrollHandler.get(), &ScrollHandler::onWindowMinimizedChanged);
+
     // Snap mode: track minimize/unminimize to float/unfloat snapped windows
     connect(w, &KWin::EffectWindow::minimizedChanged, this, &PlasmaZonesEffect::slotWindowMinimizedChanged);
 }

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -556,6 +556,10 @@ void PlasmaZonesEffect::notifyWindowActivated(KWin::EffectWindow* w)
         PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::Autotile,
                                                        QStringLiteral("notifyWindowFocused"), {windowId, screenId},
                                                        QStringLiteral("notifyWindowFocused"));
+    } else if (m_autotileHandler->isScrollScreen(screenId)) {
+        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::Scroll,
+                                                       QStringLiteral("notifyWindowFocused"), {windowId, screenId},
+                                                       QStringLiteral("notifyWindowFocused"));
     }
 }
 

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -457,6 +457,11 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     connect(w, &KWin::EffectWindow::windowFrameGeometryChanged, m_autotileHandler.get(),
             &AutotileHandler::slotWindowFrameGeometryChanged);
 
+    // Scroll: re-assert the strip geometry if an app resizes its window out
+    // of its tile slot (debounced inside the handler).
+    connect(w, &KWin::EffectWindow::windowFrameGeometryChanged, m_scrollHandler.get(),
+            &ScrollHandler::onWindowFrameGeometryChanged);
+
     // Frame-geometry shadow: push the latest geometry to the daemon so
     // daemon-local shortcut handlers (float toggle, etc.) can read fresh
     // geometry without round-tripping. Debounced at ~50ms per window via

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -263,6 +263,10 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
             // window from the old screen's tiling state immediately.
             m_autotileHandler->handleWindowOutputChanged(safeW);
 
+            // Scroll mode: re-home the window between scroll strips (or out of
+            // scroll entirely) to match the monitor it moved to.
+            m_scrollHandler->handleWindowOutputChanged(safeW);
+
             // For snapping→snapping cross-screen moves: notify the daemon which
             // decides whether to unsnap based on its own state. If the daemon just
             // assigned this window to the new screen (restore/resnap/snap assist),
@@ -343,6 +347,10 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
             // (snapping→autotile). The autotile handler's own detection only
             // covers windows it already tracks.
             m_autotileHandler->handleWindowOutputChanged(safeW);
+
+            // Scroll mode: a scroll-tracked window crossing a virtual-screen
+            // boundary likewise re-homes to the destination strip.
+            m_scrollHandler->handleWindowOutputChanged(safeW);
 
             // For snapping→snapping cross-VS moves: notify the daemon
             if (!m_autotileHandler->isAutotileScreen(oldScreenId) && !m_autotileHandler->isAutotileScreen(newScreenId)

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -19,6 +19,7 @@
 #include <QDBusPendingReply>
 #include <QDBusVariant>
 #include <QLoggingCategory>
+#include <QTimer>
 #include <QVariant>
 #include <QtMath>
 
@@ -26,10 +27,20 @@ namespace PlasmaZones {
 
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
 
+namespace {
+/// Debounce window for re-asserting geometry after an app-initiated resize —
+/// long enough to coalesce a noisy resize stream into one corrective move.
+constexpr int kReassertDebounceMs = 150;
+} // namespace
+
 ScrollHandler::ScrollHandler(PlasmaZonesEffect* effect, QObject* parent)
     : QObject(parent)
     , m_effect(effect)
+    , m_reassertTimer(new QTimer(this))
 {
+    m_reassertTimer->setSingleShot(true);
+    m_reassertTimer->setInterval(kReassertDebounceMs);
+    connect(m_reassertTimer, &QTimer::timeout, this, &ScrollHandler::flushReasserts);
 }
 
 namespace {
@@ -164,6 +175,8 @@ void ScrollHandler::onWindowClosed(const QString& windowId, const QString& scree
     }
     m_notifiedWindows.remove(windowId);
     m_notifiedWindowScreens.remove(windowId);
+    m_appliedGeometry.remove(windowId);
+    m_reassertPending.remove(windowId);
 
     if (m_scrollScreens.contains(screenId)) {
         PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
@@ -222,6 +235,64 @@ void ScrollHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
     // Arrived somewhere new — notifyWindowAdded re-adds it iff the new screen
     // is a scroll-mode screen and the window is eligible.
     notifyWindowAdded(w);
+}
+
+void ScrollHandler::recordAppliedGeometry(const QString& windowId, const QRect& geometry)
+{
+    m_appliedGeometry[windowId] = geometry;
+    // The window is being moved to match this geometry — drop any stale
+    // re-assert queued from an earlier drift.
+    m_reassertPending.remove(windowId);
+}
+
+void ScrollHandler::onWindowFrameGeometryChanged(KWin::EffectWindow* w)
+{
+    if (!w) {
+        return;
+    }
+    const QString windowId = m_effect->getWindowId(w);
+    if (!m_notifiedWindows.contains(windowId)) {
+        return; // not a scroll-tracked window
+    }
+    const auto it = m_appliedGeometry.constFind(windowId);
+    if (it == m_appliedGeometry.constEnd()) {
+        return; // the daemon has not resolved a geometry to compare against yet
+    }
+    // Ignore sub-pixel rounding and small compositor size-hint adjustments; a
+    // genuine app-initiated resize drifts further than the tolerance.
+    constexpr int kTolerance = 4;
+    const QRect frame = w->frameGeometry().toRect();
+    const QRect& expected = it.value();
+    const bool drifted = qAbs(frame.x() - expected.x()) > kTolerance || qAbs(frame.y() - expected.y()) > kTolerance
+        || qAbs(frame.width() - expected.width()) > kTolerance || qAbs(frame.height() - expected.height()) > kTolerance;
+    if (!drifted) {
+        m_reassertPending.remove(windowId);
+        return;
+    }
+    // Debounce: coalesce a noisy resize stream (and any in-progress user drag)
+    // into one corrective move once it settles.
+    m_reassertPending.insert(windowId);
+    m_reassertTimer->start();
+}
+
+void ScrollHandler::flushReasserts()
+{
+    const QStringList pending(m_reassertPending.cbegin(), m_reassertPending.cend());
+    m_reassertPending.clear();
+    for (const QString& windowId : pending) {
+        const auto it = m_appliedGeometry.constFind(windowId);
+        if (it == m_appliedGeometry.constEnd() || !m_notifiedWindows.contains(windowId)) {
+            continue;
+        }
+        KWin::EffectWindow* w = m_effect->findWindowById(windowId);
+        if (!w || w->isDeleted()) {
+            continue;
+        }
+        // Re-assert the daemon's resolved geometry — an app cannot resize its
+        // way out of the scroll strip. Interactive resize arrives in Phase 3.
+        m_effect->applySnapGeometry(w, it.value(), /*allowDuringDrag=*/false, /*skipAnimation=*/true);
+        qCDebug(lcEffect) << "Re-asserted scroll geometry for" << windowId << "->" << it.value();
+    }
 }
 
 void ScrollHandler::notifyWindowFocused(const QString& windowId, const QString& screenId)

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -10,7 +10,6 @@
 
 #include <effect/effecthandler.h>
 #include <effect/effectwindow.h>
-#include <window.h>
 
 #include <QDBusConnection>
 #include <QDBusMessage>
@@ -21,7 +20,6 @@
 #include <QLoggingCategory>
 #include <QTimer>
 #include <QVariant>
-#include <QtMath>
 
 namespace PlasmaZones {
 
@@ -42,25 +40,6 @@ ScrollHandler::ScrollHandler(PlasmaZonesEffect* effect, QObject* parent)
     m_reassertTimer->setInterval(kReassertDebounceMs);
     connect(m_reassertTimer, &QTimer::timeout, this, &ScrollHandler::flushReasserts);
 }
-
-namespace {
-/// Discover a window's minimum size, ceil-rounded; 0×0 when unconstrained.
-void discoverMinSize(KWin::EffectWindow* w, int& minWidth, int& minHeight)
-{
-    minWidth = 0;
-    minHeight = 0;
-    if (!w) {
-        return;
-    }
-    if (KWin::Window* kw = w->window()) {
-        const QSizeF minSize = kw->minSize();
-        if (minSize.isValid()) {
-            minWidth = qCeil(minSize.width());
-            minHeight = qCeil(minSize.height());
-        }
-    }
-}
-} // namespace
 
 void ScrollHandler::notifyWindowAdded(KWin::EffectWindow* w)
 {
@@ -86,15 +65,10 @@ void ScrollHandler::notifyWindowAdded(KWin::EffectWindow* w)
     m_notifiedWindows.insert(windowId);
     m_notifiedWindowScreens[windowId] = screenId;
 
-    int minWidth = 0;
-    int minHeight = 0;
-    discoverMinSize(w, minWidth, minHeight);
-
-    auto* watcher =
-        new QDBusPendingCallWatcher(PhosphorProtocol::ClientHelpers::asyncCall(
-                                        PhosphorProtocol::Service::Interface::Scroll, QStringLiteral("windowOpened"),
-                                        {windowId, screenId, minWidth, minHeight}),
-                                    this);
+    auto* watcher = new QDBusPendingCallWatcher(
+        PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::Scroll,
+                                                   QStringLiteral("windowOpened"), {windowId, screenId}),
+        this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this,
             [this, windowId, epoch = m_daemonEpoch](QDBusPendingCallWatcher* watcher) {
                 watcher->deleteLater();
@@ -111,11 +85,10 @@ void ScrollHandler::notifyWindowAdded(KWin::EffectWindow* w)
                     m_notifiedWindowScreens.remove(windowId);
                 }
             });
-    qCDebug(lcEffect) << "Notified scroll: windowOpened" << windowId << "on screen" << screenId
-                      << "minSize:" << minWidth << "x" << minHeight;
+    qCDebug(lcEffect) << "Notified scroll: windowOpened" << windowId << "on screen" << screenId;
 }
 
-void ScrollHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows, bool resetNotified)
+void ScrollHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows)
 {
     PhosphorProtocol::WindowOpenedList batchEntries;
     QStringList batchWindowIds; // for error rollback
@@ -132,24 +105,19 @@ void ScrollHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& wi
         if (m_pendingCloses.remove(windowId)) {
             continue;
         }
-        if (resetNotified) {
-            m_notifiedWindows.remove(windowId);
-        }
         if (m_notifiedWindows.contains(windowId)) {
-            continue;
+            continue; // already reported — callers clear the set for a full re-announce
         }
         m_notifiedWindows.insert(windowId);
         m_notifiedWindowScreens[windowId] = screenId;
 
-        int minWidth = 0;
-        int minHeight = 0;
-        discoverMinSize(w, minWidth, minHeight);
-
+        // The shared WindowOpenedList carries minWidth/minHeight (autotile uses
+        // them for column sizing); scroll's strip model is size-agnostic, so
+        // they are left at their 0 default — a non-resizable window is fitted
+        // to its tile slot effect-side via constrainToScrollSlot.
         PhosphorProtocol::WindowOpenedEntry entry;
         entry.windowId = windowId;
         entry.screenId = screenId;
-        entry.minWidth = minWidth;
-        entry.minHeight = minHeight;
         batchEntries.append(entry);
         batchWindowIds.append(windowId);
     }
@@ -415,7 +383,12 @@ void ScrollHandler::loadSettings()
             if (!m_scrollScreens.isEmpty()) {
                 // Batch-notify all existing windows on scroll screens in one
                 // D-Bus call instead of per-window windowOpened round-trips.
-                notifyWindowsAddedBatch(KWin::effects->stackingOrder(), /*resetNotified=*/true);
+                // loadSettings() runs only at construction or right after
+                // onDaemonReady() — both leave m_notifiedWindows empty — so no
+                // explicit reset is needed: every window is reported afresh,
+                // and a window already added individually in the async gap is
+                // correctly skipped (no duplicate windowOpened).
+                notifyWindowsAddedBatch(KWin::effects->stackingOrder());
             }
         } else {
             qCDebug(lcEffect) << "Scroll screens: query failed, daemon may not be running";
@@ -457,7 +430,7 @@ void ScrollHandler::slotScrollScreensChanged(const QStringList& screenIds)
     // so a runtime layout switch or a hotplugged scroll-mode monitor adopts
     // existing windows, not only ones opened afterwards.
     if (!added.isEmpty()) {
-        notifyWindowsAddedBatch(KWin::effects->stackingOrder(), /*resetNotified=*/false);
+        notifyWindowsAddedBatch(KWin::effects->stackingOrder());
     }
     qCDebug(lcEffect) << "Scroll screens updated:" << m_scrollScreens;
 }

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -193,6 +193,7 @@ void ScrollHandler::onWindowClosed(const QString& windowId, const QString& scree
     m_notifiedWindowScreens.remove(windowId);
     m_appliedGeometry.remove(windowId);
     m_reassertPending.remove(windowId);
+    m_reasserted.remove(windowId);
 
     if (m_scrollScreens.contains(screenId)) {
         PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
@@ -264,8 +265,10 @@ void ScrollHandler::recordAppliedGeometry(const QString& windowId, const QRect& 
 {
     m_appliedGeometry[windowId] = geometry;
     // The window is being moved to match this geometry — drop any stale
-    // re-assert queued from an earlier drift.
+    // re-assert queued from an earlier drift, and reset the re-assert budget:
+    // a fresh daemon resolve is a new episode.
     m_reassertPending.remove(windowId);
+    m_reasserted.remove(windowId);
 }
 
 void ScrollHandler::onWindowFrameGeometryChanged(KWin::EffectWindow* w)
@@ -299,6 +302,14 @@ void ScrollHandler::onWindowFrameGeometryChanged(KWin::EffectWindow* w)
         m_reassertPending.remove(windowId);
         return;
     }
+    if (m_reasserted.contains(windowId)) {
+        // Already re-asserted once since the daemon last resolved this window.
+        // The residual drift is the window's own size constraints (e.g. an X11
+        // terminal's cell-size increments) that it cannot resolve to the exact
+        // tile rect — re-asserting again would just loop. Accept it; the next
+        // daemon push (recordAppliedGeometry) resets the budget.
+        return;
+    }
     // Debounce: coalesce a noisy resize stream (and any in-progress user drag)
     // into one corrective move once it settles.
     m_reassertPending.insert(windowId);
@@ -321,6 +332,10 @@ void ScrollHandler::flushReasserts()
         // Re-assert the daemon's resolved geometry — an app cannot resize its
         // way out of the scroll strip. Interactive resize arrives in Phase 3.
         m_effect->applySnapGeometry(w, it.value(), /*allowDuringDrag=*/false, /*skipAnimation=*/true);
+        // One re-assert per daemon-resolve episode: if the window still drifts
+        // after this, it physically cannot hit the tile rect (size hints), so
+        // onWindowFrameGeometryChanged must not re-queue it into a loop.
+        m_reasserted.insert(windowId);
         qCDebug(lcEffect) << "Re-asserted scroll geometry for" << windowId << "->" << it.value();
     }
 }
@@ -350,6 +365,7 @@ void ScrollHandler::onDaemonReady()
     m_pendingCloses.clear();
     m_appliedGeometry.clear();
     m_reassertPending.clear();
+    m_reasserted.clear();
     m_reassertTimer->stop();
     connectSignals();
     loadSettings();

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -49,6 +49,9 @@ void discoverMinSize(KWin::EffectWindow* w, int& minWidth, int& minHeight)
 {
     minWidth = 0;
     minHeight = 0;
+    if (!w) {
+        return;
+    }
     if (KWin::Window* kw = w->window()) {
         const QSizeF minSize = kw->minSize();
         if (minSize.isValid()) {
@@ -337,11 +340,19 @@ void ScrollHandler::onDaemonReady()
     // Bump the epoch so any D-Bus reply still in flight from before this
     // (re)connect skips its rollback instead of corrupting the rebuilt sets.
     ++m_daemonEpoch;
-    loadSettings();
-    connectSignals();
+    // Reset every tracking structure before re-querying — a daemon (re)connect
+    // rebuilds scroll state from scratch, so no stale entry may survive into
+    // the new session. In particular a pending re-assert must be dropped: it
+    // targets geometry the old daemon resolved, which the new one has not.
+    // Cleared first so loadSettings()'s async batch reply repopulates cleanly.
     m_notifiedWindows.clear();
     m_notifiedWindowScreens.clear();
     m_pendingCloses.clear();
+    m_appliedGeometry.clear();
+    m_reassertPending.clear();
+    m_reassertTimer->stop();
+    connectSignals();
+    loadSettings();
 }
 
 void ScrollHandler::connectSignals()

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -173,6 +173,35 @@ void ScrollHandler::onWindowClosed(const QString& windowId, const QString& scree
     }
 }
 
+void ScrollHandler::onWindowMinimizedChanged(KWin::EffectWindow* w)
+{
+    if (!w) {
+        return;
+    }
+    const QString windowId = m_effect->getWindowId(w);
+    const bool minimized = w->isMinimized();
+
+    if (!m_notifiedWindows.contains(windowId)) {
+        // The window was never reported open — e.g. it opened already
+        // minimized (isEligibleForTilingNotify rejects minimized windows).
+        // On restore, treat it as a fresh open; a minimize for a window the
+        // engine never knew about needs no report.
+        if (!minimized) {
+            notifyWindowAdded(w);
+        }
+        return;
+    }
+
+    const QString screenId = m_notifiedWindowScreens.value(windowId);
+    if (!m_scrollScreens.contains(screenId)) {
+        return;
+    }
+    PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
+                                                   QStringLiteral("windowMinimizedChanged"), {windowId, minimized},
+                                                   QStringLiteral("windowMinimizedChanged"));
+    qCDebug(lcEffect) << "Notified scroll: windowMinimizedChanged" << windowId << minimized;
+}
+
 void ScrollHandler::notifyWindowFocused(const QString& windowId, const QString& screenId)
 {
     if (!m_scrollScreens.contains(screenId)) {

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -1,0 +1,250 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "scrollhandler.h"
+#include "plasmazoneseffect.h"
+
+#include <PhosphorProtocol/ClientHelpers.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/WindowMarshalling.h>
+
+#include <effect/effecthandler.h>
+#include <effect/effectwindow.h>
+#include <window.h>
+
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusPendingCall>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+#include <QDBusVariant>
+#include <QLoggingCategory>
+#include <QVariant>
+#include <QtMath>
+
+namespace PlasmaZones {
+
+Q_DECLARE_LOGGING_CATEGORY(lcEffect)
+
+ScrollHandler::ScrollHandler(PlasmaZonesEffect* effect, QObject* parent)
+    : QObject(parent)
+    , m_effect(effect)
+{
+}
+
+namespace {
+/// Discover a window's minimum size, ceil-rounded; 0×0 when unconstrained.
+void discoverMinSize(KWin::EffectWindow* w, int& minWidth, int& minHeight)
+{
+    minWidth = 0;
+    minHeight = 0;
+    if (KWin::Window* kw = w->window()) {
+        const QSizeF minSize = kw->minSize();
+        if (minSize.isValid()) {
+            minWidth = qCeil(minSize.width());
+            minHeight = qCeil(minSize.height());
+        }
+    }
+}
+} // namespace
+
+void ScrollHandler::notifyWindowAdded(KWin::EffectWindow* w)
+{
+    if (!m_effect->isEligibleForTilingNotify(w)) {
+        return;
+    }
+
+    const QString screenId = m_effect->getWindowScreenId(w);
+    if (!m_scrollScreens.contains(screenId)) {
+        return; // not a scroll screen — autotile or snap owns this window
+    }
+
+    const QString windowId = m_effect->getWindowId(w);
+
+    // Window was already closed before we could report the open — skip
+    // (D-Bus ordering race; see m_pendingCloses).
+    if (m_pendingCloses.remove(windowId)) {
+        return;
+    }
+    if (m_notifiedWindows.contains(windowId)) {
+        return;
+    }
+    m_notifiedWindows.insert(windowId);
+    m_notifiedWindowScreens[windowId] = screenId;
+
+    int minWidth = 0;
+    int minHeight = 0;
+    discoverMinSize(w, minWidth, minHeight);
+
+    auto* watcher =
+        new QDBusPendingCallWatcher(PhosphorProtocol::ClientHelpers::asyncCall(
+                                        PhosphorProtocol::Service::Interface::Scroll, QStringLiteral("windowOpened"),
+                                        {windowId, screenId, minWidth, minHeight}),
+                                    this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, windowId](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+        if (w->isError()) {
+            qCWarning(lcEffect) << "scroll windowOpened D-Bus call failed for" << windowId << ":"
+                                << w->error().message();
+            m_notifiedWindows.remove(windowId);
+            m_notifiedWindowScreens.remove(windowId);
+        }
+    });
+    qCDebug(lcEffect) << "Notified scroll: windowOpened" << windowId << "on screen" << screenId
+                      << "minSize:" << minWidth << "x" << minHeight;
+}
+
+void ScrollHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows, bool resetNotified)
+{
+    PhosphorProtocol::WindowOpenedList batchEntries;
+    QStringList batchWindowIds; // for error rollback
+
+    for (KWin::EffectWindow* w : windows) {
+        if (!m_effect->isEligibleForTilingNotify(w)) {
+            continue;
+        }
+        const QString screenId = m_effect->getWindowScreenId(w);
+        if (!m_scrollScreens.contains(screenId)) {
+            continue;
+        }
+        const QString windowId = m_effect->getWindowId(w);
+        if (m_pendingCloses.remove(windowId)) {
+            continue;
+        }
+        if (resetNotified) {
+            m_notifiedWindows.remove(windowId);
+        }
+        if (m_notifiedWindows.contains(windowId)) {
+            continue;
+        }
+        m_notifiedWindows.insert(windowId);
+        m_notifiedWindowScreens[windowId] = screenId;
+
+        int minWidth = 0;
+        int minHeight = 0;
+        discoverMinSize(w, minWidth, minHeight);
+
+        PhosphorProtocol::WindowOpenedEntry entry;
+        entry.windowId = windowId;
+        entry.screenId = screenId;
+        entry.minWidth = minWidth;
+        entry.minHeight = minHeight;
+        batchEntries.append(entry);
+        batchWindowIds.append(windowId);
+    }
+
+    if (batchEntries.isEmpty()) {
+        return;
+    }
+
+    auto* watcher =
+        new QDBusPendingCallWatcher(PhosphorProtocol::ClientHelpers::asyncCall(
+                                        PhosphorProtocol::Service::Interface::Scroll,
+                                        QStringLiteral("windowsOpenedBatch"), {QVariant::fromValue(batchEntries)}),
+                                    this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, batchWindowIds](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+        if (w->isError()) {
+            qCWarning(lcEffect) << "scroll windowsOpenedBatch D-Bus call failed:" << w->error().message();
+            for (const QString& wid : batchWindowIds) {
+                m_notifiedWindows.remove(wid);
+                m_notifiedWindowScreens.remove(wid);
+            }
+        }
+    });
+    qCInfo(lcEffect) << "Notified scroll: windowsOpenedBatch with" << batchEntries.size() << "windows";
+}
+
+void ScrollHandler::onWindowClosed(const QString& windowId, const QString& screenId)
+{
+    // If we haven't reported this window open yet, record the close so a
+    // late windowOpened (D-Bus ordering race) is suppressed.
+    if (!m_notifiedWindows.contains(windowId) && m_scrollScreens.contains(screenId)) {
+        m_pendingCloses.insert(windowId);
+    }
+    m_notifiedWindows.remove(windowId);
+    m_notifiedWindowScreens.remove(windowId);
+
+    if (m_scrollScreens.contains(screenId)) {
+        PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
+                                                       QStringLiteral("windowClosed"), {windowId},
+                                                       QStringLiteral("windowClosed"));
+        qCDebug(lcEffect) << "Notified scroll: windowClosed" << windowId << "on screen" << screenId;
+    }
+}
+
+void ScrollHandler::notifyWindowFocused(const QString& windowId, const QString& screenId)
+{
+    if (!m_scrollScreens.contains(screenId)) {
+        return;
+    }
+    PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
+                                                   QStringLiteral("notifyWindowFocused"), {windowId, screenId},
+                                                   QStringLiteral("notifyWindowFocused"));
+}
+
+void ScrollHandler::onDaemonReady()
+{
+    loadSettings();
+    connectSignals();
+    m_notifiedWindows.clear();
+    m_notifiedWindowScreens.clear();
+    m_pendingCloses.clear();
+}
+
+void ScrollHandler::connectSignals()
+{
+    QDBusConnection bus = QDBusConnection::sessionBus();
+
+    // Disconnect first so daemon restarts don't accumulate duplicate match
+    // rules — Qt registers the same handler twice if connect() is called
+    // twice with identical args.
+    bus.disconnect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                   PhosphorProtocol::Service::Interface::Scroll, QStringLiteral("scrollScreensChanged"), this,
+                   SLOT(slotScrollScreensChanged(QStringList)));
+    bus.connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                PhosphorProtocol::Service::Interface::Scroll, QStringLiteral("scrollScreensChanged"), this,
+                SLOT(slotScrollScreensChanged(QStringList)));
+
+    qCInfo(lcEffect) << "Connected to scroll D-Bus signals";
+}
+
+void ScrollHandler::loadSettings()
+{
+    // Query the initial scroll-mode screen set from the daemon. Mirrors
+    // AutotileHandler::loadSettings — the foreign Properties interface is
+    // correct for D-Bus property reads; bound by SyncCallTimeoutMs so a
+    // wedged daemon doesn't leak a watcher for Qt's default 25 s.
+    QDBusMessage msg =
+        QDBusMessage::createMethodCall(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                       QStringLiteral("org.freedesktop.DBus.Properties"), QStringLiteral("Get"));
+    msg << PhosphorProtocol::Service::Interface::Scroll << QStringLiteral("scrollScreens");
+
+    QDBusPendingCall call = QDBusConnection::sessionBus().asyncCall(msg, PhosphorProtocol::Service::SyncCallTimeoutMs);
+    auto* watcher = new QDBusPendingCallWatcher(call, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+        QDBusPendingReply<QDBusVariant> reply = *w;
+        if (reply.isValid()) {
+            const QStringList screens = reply.value().variant().toStringList();
+            m_scrollScreens = QSet<QString>(screens.cbegin(), screens.cend());
+            qCInfo(lcEffect) << "Loaded scroll screens:" << m_scrollScreens;
+
+            if (!m_scrollScreens.isEmpty()) {
+                // Batch-notify all existing windows on scroll screens in one
+                // D-Bus call instead of per-window windowOpened round-trips.
+                notifyWindowsAddedBatch(KWin::effects->stackingOrder(), /*resetNotified=*/true);
+            }
+        } else {
+            qCDebug(lcEffect) << "Scroll screens: query failed, daemon may not be running";
+        }
+    });
+}
+
+void ScrollHandler::slotScrollScreensChanged(const QStringList& screenIds)
+{
+    m_scrollScreens = QSet<QString>(screenIds.cbegin(), screenIds.cend());
+    qCDebug(lcEffect) << "Scroll screens updated:" << m_scrollScreens;
+}
+
+} // namespace PlasmaZones

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -202,6 +202,28 @@ void ScrollHandler::onWindowMinimizedChanged(KWin::EffectWindow* w)
     qCDebug(lcEffect) << "Notified scroll: windowMinimizedChanged" << windowId << minimized;
 }
 
+void ScrollHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
+{
+    if (!w) {
+        return;
+    }
+    const QString windowId = m_effect->getWindowId(w);
+    const QString newScreenId = m_effect->getWindowScreenId(w);
+    const bool wasTracked = m_notifiedWindows.contains(windowId);
+    if (wasTracked && m_notifiedWindowScreens.value(windowId) == newScreenId) {
+        return; // a tracked window whose screen did not actually change
+    }
+
+    // Left its old strip — drop it there. onWindowClosed reports windowClosed
+    // only when the old screen is (still) scroll mode.
+    if (wasTracked) {
+        onWindowClosed(windowId, m_notifiedWindowScreens.value(windowId));
+    }
+    // Arrived somewhere new — notifyWindowAdded re-adds it iff the new screen
+    // is a scroll-mode screen and the window is eligible.
+    notifyWindowAdded(w);
+}
+
 void ScrollHandler::notifyWindowFocused(const QString& windowId, const QString& screenId)
 {
     if (!m_scrollScreens.contains(screenId)) {
@@ -270,9 +292,42 @@ void ScrollHandler::loadSettings()
     });
 }
 
+QStringList ScrollHandler::trackedWindowsOnScreen(const QString& screenId) const
+{
+    QStringList ids;
+    for (auto it = m_notifiedWindowScreens.cbegin(); it != m_notifiedWindowScreens.cend(); ++it) {
+        if (it.value() == screenId) {
+            ids.append(it.key());
+        }
+    }
+    return ids;
+}
+
 void ScrollHandler::slotScrollScreensChanged(const QStringList& screenIds)
 {
-    m_scrollScreens = QSet<QString>(screenIds.cbegin(), screenIds.cend());
+    const QSet<QString> updated(screenIds.cbegin(), screenIds.cend());
+    const QSet<QString> added = updated - m_scrollScreens;
+    const QSet<QString> removed = m_scrollScreens - updated;
+
+    // Screens leaving scroll mode: drop their tracked windows from the engine
+    // first — while m_scrollScreens still marks them scroll, since
+    // onWindowClosed gates its report on that. The windows stay put; another
+    // placement mode now owns them.
+    for (const QString& screenId : removed) {
+        const QStringList stale = trackedWindowsOnScreen(screenId);
+        for (const QString& windowId : stale) {
+            onWindowClosed(windowId, screenId);
+        }
+    }
+
+    m_scrollScreens = updated;
+
+    // Screens entering scroll mode: batch-report the windows already on them
+    // so a runtime layout switch or a hotplugged scroll-mode monitor adopts
+    // existing windows, not only ones opened afterwards.
+    if (!added.isEmpty()) {
+        notifyWindowsAddedBatch(KWin::effects->stackingOrder(), /*resetNotified=*/false);
+    }
     qCDebug(lcEffect) << "Scroll screens updated:" << m_scrollScreens;
 }
 

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -92,15 +92,22 @@ void ScrollHandler::notifyWindowAdded(KWin::EffectWindow* w)
                                         PhosphorProtocol::Service::Interface::Scroll, QStringLiteral("windowOpened"),
                                         {windowId, screenId, minWidth, minHeight}),
                                     this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, windowId](QDBusPendingCallWatcher* w) {
-        w->deleteLater();
-        if (w->isError()) {
-            qCWarning(lcEffect) << "scroll windowOpened D-Bus call failed for" << windowId << ":"
-                                << w->error().message();
-            m_notifiedWindows.remove(windowId);
-            m_notifiedWindowScreens.remove(windowId);
-        }
-    });
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, windowId, epoch = m_daemonEpoch](QDBusPendingCallWatcher* watcher) {
+                watcher->deleteLater();
+                if (!watcher->isError()) {
+                    return;
+                }
+                qCWarning(lcEffect) << "scroll windowOpened D-Bus call failed for" << windowId << ":"
+                                    << watcher->error().message();
+                // Skip the rollback if the daemon reconnected meanwhile —
+                // onDaemonReady has already rebuilt the tracking sets, and
+                // removing windowId here would corrupt that fresh state.
+                if (epoch == m_daemonEpoch) {
+                    m_notifiedWindows.remove(windowId);
+                    m_notifiedWindowScreens.remove(windowId);
+                }
+            });
     qCDebug(lcEffect) << "Notified scroll: windowOpened" << windowId << "on screen" << screenId
                       << "minSize:" << minWidth << "x" << minHeight;
 }
@@ -153,16 +160,22 @@ void ScrollHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& wi
                                         PhosphorProtocol::Service::Interface::Scroll,
                                         QStringLiteral("windowsOpenedBatch"), {QVariant::fromValue(batchEntries)}),
                                     this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, batchWindowIds](QDBusPendingCallWatcher* w) {
-        w->deleteLater();
-        if (w->isError()) {
-            qCWarning(lcEffect) << "scroll windowsOpenedBatch D-Bus call failed:" << w->error().message();
-            for (const QString& wid : batchWindowIds) {
-                m_notifiedWindows.remove(wid);
-                m_notifiedWindowScreens.remove(wid);
-            }
-        }
-    });
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, batchWindowIds, epoch = m_daemonEpoch](QDBusPendingCallWatcher* watcher) {
+                watcher->deleteLater();
+                if (!watcher->isError()) {
+                    return;
+                }
+                qCWarning(lcEffect) << "scroll windowsOpenedBatch D-Bus call failed:" << watcher->error().message();
+                // Skip the rollback if the daemon reconnected meanwhile.
+                if (epoch != m_daemonEpoch) {
+                    return;
+                }
+                for (const QString& wid : batchWindowIds) {
+                    m_notifiedWindows.remove(wid);
+                    m_notifiedWindowScreens.remove(wid);
+                }
+            });
     qCInfo(lcEffect) << "Notified scroll: windowsOpenedBatch with" << batchEntries.size() << "windows";
 }
 
@@ -209,6 +222,13 @@ void ScrollHandler::onWindowMinimizedChanged(KWin::EffectWindow* w)
     if (!m_scrollScreens.contains(screenId)) {
         return;
     }
+    if (minimized) {
+        // A minimized window leaves the visible layout — its resolved-geometry
+        // reference is stale until the strip re-resolves on restore. Drop it so
+        // onWindowFrameGeometryChanged cannot re-assert against a stale slot.
+        m_appliedGeometry.remove(windowId);
+        m_reassertPending.remove(windowId);
+    }
     PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
                                                    QStringLiteral("windowMinimizedChanged"), {windowId, minimized},
                                                    QStringLiteral("windowMinimizedChanged"));
@@ -248,6 +268,13 @@ void ScrollHandler::recordAppliedGeometry(const QString& windowId, const QRect& 
 void ScrollHandler::onWindowFrameGeometryChanged(KWin::EffectWindow* w)
 {
     if (!w) {
+        return;
+    }
+    // Never correct geometry mid interactive move/resize — that would fight
+    // the user's drag. A minimized window is not in the visible layout, so its
+    // frame changes are KWin bookkeeping, not an app resize. After an
+    // interactive op ends, a final frame change re-runs this and re-asserts.
+    if (w->isUserMove() || w->isUserResize() || w->isMinimized()) {
         return;
     }
     const QString windowId = m_effect->getWindowId(w);
@@ -307,6 +334,9 @@ void ScrollHandler::notifyWindowFocused(const QString& windowId, const QString& 
 
 void ScrollHandler::onDaemonReady()
 {
+    // Bump the epoch so any D-Bus reply still in flight from before this
+    // (re)connect skips its rollback instead of corrupting the rebuilt sets.
+    ++m_daemonEpoch;
     loadSettings();
     connectSignals();
     m_notifiedWindows.clear();

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -331,11 +331,14 @@ void ScrollHandler::flushReasserts()
         }
         // Re-assert the daemon's resolved geometry — an app cannot resize its
         // way out of the scroll strip. Interactive resize arrives in Phase 3.
-        m_effect->applySnapGeometry(w, it.value(), /*allowDuringDrag=*/false, /*skipAnimation=*/true);
-        // One re-assert per daemon-resolve episode: if the window still drifts
-        // after this, it physically cannot hit the tile rect (size hints), so
-        // onWindowFrameGeometryChanged must not re-queue it into a loop.
+        // Mark re-asserted BEFORE applySnapGeometry: moveResize emits
+        // windowFrameGeometryChanged synchronously, re-entering
+        // onWindowFrameGeometryChanged — which must already see this window as
+        // re-asserted so it does not re-queue a second cycle. One re-assert per
+        // daemon-resolve episode; a window that still drifts after it cannot
+        // hit the exact tile rect (size hints) and is left as-is.
         m_reasserted.insert(windowId);
+        m_effect->applySnapGeometry(w, it.value(), /*allowDuringDrag=*/false, /*skipAnimation=*/true);
         qCDebug(lcEffect) << "Re-asserted scroll geometry for" << windowId << "->" << it.value();
     }
 }

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -372,28 +372,36 @@ void ScrollHandler::loadSettings()
 
     QDBusPendingCall call = QDBusConnection::sessionBus().asyncCall(msg, PhosphorProtocol::Service::SyncCallTimeoutMs);
     auto* watcher = new QDBusPendingCallWatcher(call, this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
-        w->deleteLater();
-        QDBusPendingReply<QDBusVariant> reply = *w;
-        if (reply.isValid()) {
-            const QStringList screens = reply.value().variant().toStringList();
-            m_scrollScreens = QSet<QString>(screens.cbegin(), screens.cend());
-            qCInfo(lcEffect) << "Loaded scroll screens:" << m_scrollScreens;
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, epoch = m_daemonEpoch](QDBusPendingCallWatcher* w) {
+                w->deleteLater();
+                // A reply in flight from before a daemon (re)connect is stale:
+                // onDaemonReady has since bumped the epoch, cleared the tracking sets
+                // and re-issued loadSettings. Applying this older scrollScreens
+                // snapshot (and its batch re-announce) would clobber the fresh state.
+                if (epoch != m_daemonEpoch) {
+                    return;
+                }
+                QDBusPendingReply<QDBusVariant> reply = *w;
+                if (reply.isValid()) {
+                    const QStringList screens = reply.value().variant().toStringList();
+                    m_scrollScreens = QSet<QString>(screens.cbegin(), screens.cend());
+                    qCInfo(lcEffect) << "Loaded scroll screens:" << m_scrollScreens;
 
-            if (!m_scrollScreens.isEmpty()) {
-                // Batch-notify all existing windows on scroll screens in one
-                // D-Bus call instead of per-window windowOpened round-trips.
-                // loadSettings() runs only at construction or right after
-                // onDaemonReady() — both leave m_notifiedWindows empty — so no
-                // explicit reset is needed: every window is reported afresh,
-                // and a window already added individually in the async gap is
-                // correctly skipped (no duplicate windowOpened).
-                notifyWindowsAddedBatch(KWin::effects->stackingOrder());
-            }
-        } else {
-            qCDebug(lcEffect) << "Scroll screens: query failed, daemon may not be running";
-        }
-    });
+                    if (!m_scrollScreens.isEmpty()) {
+                        // Batch-notify all existing windows on scroll screens in one
+                        // D-Bus call instead of per-window windowOpened round-trips.
+                        // loadSettings() runs only at construction or right after
+                        // onDaemonReady() — both leave m_notifiedWindows empty — so no
+                        // explicit reset is needed: every window is reported afresh,
+                        // and a window already added individually in the async gap is
+                        // correctly skipped (no duplicate windowOpened).
+                        notifyWindowsAddedBatch(KWin::effects->stackingOrder());
+                    }
+                } else {
+                    qCDebug(lcEffect) << "Scroll screens: query failed, daemon may not be running";
+                }
+            });
 }
 
 QStringList ScrollHandler::trackedWindowsOnScreen(const QString& screenId) const

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -95,18 +95,6 @@ public:
     void connectSignals();
     void loadSettings();
 
-    /// Whether @p screenId is currently in scroll mode.
-    bool isScrollScreen(const QString& screenId) const
-    {
-        return m_scrollScreens.contains(screenId);
-    }
-
-    /// Whether @p windowId has been reported open to the scroll engine.
-    bool isTrackedWindow(const QString& windowId) const
-    {
-        return m_notifiedWindows.contains(windowId);
-    }
-
 public Q_SLOTS:
     /// Daemon told us the scroll-mode screen set changed.
     void slotScrollScreensChanged(const QStringList& screenIds);
@@ -131,6 +119,10 @@ private:
     QHash<QString, QRect> m_appliedGeometry;
     QSet<QString> m_reassertPending; ///< Windows awaiting a debounced re-assert.
     QTimer* m_reassertTimer = nullptr;
+    /// Incremented on every daemon (re)connect. A D-Bus reply captures the
+    /// epoch at call time and skips its rollback if the daemon reconnected
+    /// meanwhile — onDaemonReady has already rebuilt the tracking sets.
+    int m_daemonEpoch = 0;
 };
 
 } // namespace PlasmaZones

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -63,6 +63,11 @@ public:
     /// Report a window close to the scroll engine if it was on a scroll screen.
     void onWindowClosed(const QString& windowId, const QString& screenId);
 
+    /// Report a minimize/restore for a scroll-mode window. A window restored
+    /// from minimize without ever having been reported open (it opened
+    /// minimized) is treated as a fresh open.
+    void onWindowMinimizedChanged(KWin::EffectWindow* w);
+
     /// Report a focus change to the scroll engine. No-op off scroll screens.
     void notifyWindowFocused(const QString& windowId, const QString& screenId);
 

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -68,6 +68,11 @@ public:
     /// minimized) is treated as a fresh open.
     void onWindowMinimizedChanged(KWin::EffectWindow* w);
 
+    /// React to a window moving between screens (monitor hotplug, "move to
+    /// screen", or a virtual-screen crossing). Drops it from the old strip
+    /// and adds it to the new one when either is scroll mode.
+    void handleWindowOutputChanged(KWin::EffectWindow* w);
+
     /// Report a focus change to the scroll engine. No-op off scroll screens.
     void notifyWindowFocused(const QString& windowId, const QString& screenId);
 
@@ -95,6 +100,9 @@ public Q_SLOTS:
     void slotScrollScreensChanged(const QStringList& screenIds);
 
 private:
+    /// Tracked windows currently reported as being on @p screenId.
+    QStringList trackedWindowsOnScreen(const QString& screenId) const;
+
     PlasmaZonesEffect* m_effect;
 
     QSet<QString> m_scrollScreens; ///< Screens currently in scroll mode.

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -51,18 +51,6 @@ public:
     /// scroll-mode screen. No-op for windows on autotile/snap screens.
     void notifyWindowAdded(KWin::EffectWindow* w);
 
-    /**
-     * @brief Batch-report windows on scroll screens in one D-Bus call.
-     *
-     * Used on effect startup and daemon (re)connect instead of per-window
-     * windowOpened round-trips.
-     *
-     * @param windows Candidate windows to process.
-     * @param resetNotified Drop each window from the notified set before
-     *        processing, so a daemon restart re-announces existing windows.
-     */
-    void notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows, bool resetNotified = false);
-
     /// Report a window close to the scroll engine if it was on a scroll screen.
     void onWindowClosed(const QString& windowId, const QString& screenId);
 
@@ -100,6 +88,19 @@ public Q_SLOTS:
     void slotScrollScreensChanged(const QStringList& screenIds);
 
 private:
+    /**
+     * @brief Batch-report windows on scroll screens in one D-Bus call.
+     *
+     * Used on effect startup and daemon (re)connect instead of per-window
+     * windowOpened round-trips. Internal — driven by loadSettings() and
+     * slotScrollScreensChanged().
+     *
+     * @param windows Candidate windows to process.
+     * @param resetNotified Drop each window from the notified set before
+     *        processing, so a daemon restart re-announces existing windows.
+     */
+    void notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows, bool resetNotified = false);
+
     /// Tracked windows currently reported as being on @p screenId.
     QStringList trackedWindowsOnScreen(const QString& screenId) const;
     /// Debounced re-assert: snap every drifted window back to the geometry the

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -6,9 +6,12 @@
 #include <QHash>
 #include <QList>
 #include <QObject>
+#include <QRect>
 #include <QSet>
 #include <QString>
 #include <QStringList>
+
+class QTimer;
 
 namespace KWin {
 class EffectWindow;
@@ -73,6 +76,15 @@ public:
     /// and adds it to the new one when either is scroll mode.
     void handleWindowOutputChanged(KWin::EffectWindow* w);
 
+    /// Record the geometry the daemon last resolved for a scroll window, so
+    /// an app-initiated resize away from it can be detected and corrected.
+    void recordAppliedGeometry(const QString& windowId, const QRect& geometry);
+
+    /// React to a scroll window's frame geometry changing. An app resizing
+    /// itself out of its tile slot is re-asserted (debounced); the strip owns
+    /// scroll-window geometry.
+    void onWindowFrameGeometryChanged(KWin::EffectWindow* w);
+
     /// Report a focus change to the scroll engine. No-op off scroll screens.
     void notifyWindowFocused(const QString& windowId, const QString& screenId);
 
@@ -102,6 +114,9 @@ public Q_SLOTS:
 private:
     /// Tracked windows currently reported as being on @p screenId.
     QStringList trackedWindowsOnScreen(const QString& screenId) const;
+    /// Debounced re-assert: snap every drifted window back to the geometry the
+    /// daemon resolved for it.
+    void flushReasserts();
 
     PlasmaZonesEffect* m_effect;
 
@@ -111,6 +126,11 @@ private:
     /// Windows closed before their windowOpened D-Bus call resolved; the
     /// matching open is suppressed when it arrives (D-Bus ordering race).
     QSet<QString> m_pendingCloses;
+    /// windowId → geometry the daemon last resolved for it; the reference
+    /// point for detecting app-initiated resizes.
+    QHash<QString, QRect> m_appliedGeometry;
+    QSet<QString> m_reassertPending; ///< Windows awaiting a debounced re-assert.
+    QTimer* m_reassertTimer = nullptr;
 };
 
 } // namespace PlasmaZones

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -93,13 +93,13 @@ private:
      *
      * Used on effect startup and daemon (re)connect instead of per-window
      * windowOpened round-trips. Internal — driven by loadSettings() and
-     * slotScrollScreensChanged().
+     * slotScrollScreensChanged(). Windows already in m_notifiedWindows are
+     * skipped; a caller needing a full re-announce (daemon reconnect) clears
+     * the notified set first — see onDaemonReady().
      *
      * @param windows Candidate windows to process.
-     * @param resetNotified Drop each window from the notified set before
-     *        processing, so a daemon restart re-announces existing windows.
      */
-    void notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows, bool resetNotified = false);
+    void notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows);
 
     /// Tracked windows currently reported as being on @p screenId.
     QStringList trackedWindowsOnScreen(const QString& screenId) const;

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -119,6 +119,10 @@ private:
     /// point for detecting app-initiated resizes.
     QHash<QString, QRect> m_appliedGeometry;
     QSet<QString> m_reassertPending; ///< Windows awaiting a debounced re-assert.
+    /// Windows already re-asserted since the daemon last resolved them — caps
+    /// re-assertion at one attempt per resolve episode so a window that cannot
+    /// hit the exact tile rect (X11 size increments) does not loop.
+    QSet<QString> m_reasserted;
     QTimer* m_reassertTimer = nullptr;
     /// Incremented on every daemon (re)connect. A D-Bus reply captures the
     /// epoch at call time and skips its rollback if the daemon reconnected

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QHash>
+#include <QList>
+#include <QObject>
+#include <QSet>
+#include <QString>
+#include <QStringList>
+
+namespace KWin {
+class EffectWindow;
+}
+
+namespace PlasmaZones {
+
+class PlasmaZonesEffect;
+
+/**
+ * @brief Routes window lifecycle to the niri-style scroll engine.
+ *
+ * The scroll-mode counterpart to AutotileHandler's lifecycle-reporting
+ * surface: tracks which screens are in scroll mode (from the daemon's
+ * @c org.plasmazones.Scroll @c scrollScreensChanged signal) and reports
+ * open / close / focus for windows on those screens to that interface.
+ *
+ * Scroll mode is geometry-agnostic on the effect side — resolved window
+ * geometry arrives over the shared WindowTracking applyGeometriesBatch
+ * path — so this class deliberately has none of AutotileHandler's
+ * borders / monocle / pre-tile-geometry machinery. AutotileHandler knows
+ * nothing of scroll and this class knows nothing of autotile; the daemon's
+ * screen sets are disjoint, so each handler acts only on its own screens.
+ */
+class ScrollHandler : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ScrollHandler(PlasmaZonesEffect* effect, QObject* parent = nullptr);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Integration points (called by PlasmaZonesEffect)
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// Report a newly-mapped window to the scroll engine if it sits on a
+    /// scroll-mode screen. No-op for windows on autotile/snap screens.
+    void notifyWindowAdded(KWin::EffectWindow* w);
+
+    /**
+     * @brief Batch-report windows on scroll screens in one D-Bus call.
+     *
+     * Used on effect startup and daemon (re)connect instead of per-window
+     * windowOpened round-trips.
+     *
+     * @param windows Candidate windows to process.
+     * @param resetNotified Drop each window from the notified set before
+     *        processing, so a daemon restart re-announces existing windows.
+     */
+    void notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows, bool resetNotified = false);
+
+    /// Report a window close to the scroll engine if it was on a scroll screen.
+    void onWindowClosed(const QString& windowId, const QString& screenId);
+
+    /// Report a focus change to the scroll engine. No-op off scroll screens.
+    void notifyWindowFocused(const QString& windowId, const QString& screenId);
+
+    /// Daemon (re)connected: clear stale tracking, re-subscribe, re-query.
+    void onDaemonReady();
+
+    // D-Bus signal connections and initial state query
+    void connectSignals();
+    void loadSettings();
+
+    /// Whether @p screenId is currently in scroll mode.
+    bool isScrollScreen(const QString& screenId) const
+    {
+        return m_scrollScreens.contains(screenId);
+    }
+
+    /// Whether @p windowId has been reported open to the scroll engine.
+    bool isTrackedWindow(const QString& windowId) const
+    {
+        return m_notifiedWindows.contains(windowId);
+    }
+
+public Q_SLOTS:
+    /// Daemon told us the scroll-mode screen set changed.
+    void slotScrollScreensChanged(const QStringList& screenIds);
+
+private:
+    PlasmaZonesEffect* m_effect;
+
+    QSet<QString> m_scrollScreens; ///< Screens currently in scroll mode.
+    QSet<QString> m_notifiedWindows; ///< Windows reported open to the scroll engine.
+    QHash<QString, QString> m_notifiedWindowScreens; ///< windowId → screen ID at report time.
+    /// Windows closed before their windowOpened D-Bus call resolved; the
+    /// matching open is suppressed when it arrives (D-Bus ordering race).
+    QSet<QString> m_pendingCloses;
+};
+
+} // namespace PlasmaZones

--- a/libs/phosphor-protocol/include/PhosphorProtocol/ServiceConstants.h
+++ b/libs/phosphor-protocol/include/PhosphorProtocol/ServiceConstants.h
@@ -27,6 +27,7 @@ inline constexpr QLatin1String Screen("org.plasmazones.Screen");
 inline constexpr QLatin1String ZoneDetection("org.plasmazones.ZoneDetection");
 inline constexpr QLatin1String CompositorBridge("org.plasmazones.CompositorBridge");
 inline constexpr QLatin1String Snap("org.plasmazones.Snap");
+inline constexpr QLatin1String Scroll("org.plasmazones.Scroll");
 }
 
 /// D-Bus error names returned via `QDBusMessage::createErrorReply`. Centralised

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/Column.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/Column.h
@@ -18,6 +18,10 @@ struct Tile
 {
     QString windowId;
     WindowHeight height;
+    /// A minimized tile keeps its slot in the column/strip order but is
+    /// excluded from the visible layout — Karousel's `TiledMinimized` state.
+    /// Cleared on unminimize, restoring the window in place.
+    bool minimized = false;
 };
 
 /// A vertical stack of one or more tiles — one cell of the horizontal strip
@@ -54,6 +58,17 @@ public:
     /// Reorder a tile. Returns true if @p from and @p to are valid and differ;
     /// tile focus follows the moved tile.
     bool moveTile(int from, int to);
+
+    // ── Minimize state ──────────────────────────────────────────────────
+    /// Whether the column has at least one non-minimized tile. A column with
+    /// none collapses out of the visible strip while keeping its slot order.
+    bool hasVisibleTiles() const;
+    /// Whether @p windowId's tile is minimized. False if the window is not
+    /// in this column.
+    bool isWindowMinimized(const QString& windowId) const;
+    /// Set the minimized flag of @p windowId's tile. Returns true only if the
+    /// flag actually changed.
+    bool setWindowMinimized(const QString& windowId, bool minimized);
 
     // ── Active tile ─────────────────────────────────────────────────────
     /// Index of the focused tile, or -1 when the column is empty.

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -73,6 +73,11 @@ public:
     void windowOpened(const QString& windowId, const QString& screenId, int minWidth, int minHeight) override;
     void windowClosed(const QString& windowId) override;
     void windowFocused(const QString& windowId, const QString& screenId) override;
+    /// React to a tracked window being minimized or restored. A minimized
+    /// window keeps its slot in the strip but drops out of the resolved
+    /// layout (Karousel's TiledMinimized). Scroll-specific — minimize has no
+    /// IPlacementEngine equivalent (autotile routes minimize through float).
+    void windowMinimizedChanged(const QString& windowId, bool minimized);
 
     // ── Float ───────────────────────────────────────────────────────────
     void toggleWindowFloat(const QString& windowId, const QString& screenId) override;

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
@@ -80,6 +80,16 @@ public:
     /// column if it becomes empty. Returns true if the window was found.
     bool removeWindow(const QString& windowId);
 
+    /// Mark @p windowId minimized or restored. A minimized tiled window keeps
+    /// its slot in the strip but is excluded from the resolved layout —
+    /// Karousel's TiledMinimized state — so its column collapses out of view
+    /// (and reappears in place) without losing column/tile order. Returns
+    /// true if the state changed. Minimizing the focused window hands focus
+    /// to the nearest still-visible window.
+    bool setWindowMinimized(const QString& windowId, bool minimized);
+    /// Whether @p windowId is a minimized tiled window.
+    bool isWindowMinimized(const QString& windowId) const;
+
     // ── niri column / tile operations ───────────────────────────────────
     /// Pull the focused tile of the next column into the focused column.
     bool consumeIntoColumn();
@@ -133,6 +143,9 @@ private:
     /// Re-point the focus at @p preferredWindowId if it is still tiled,
     /// otherwise clamp the active index into range.
     void refocus(const QString& preferredWindowId);
+    /// First non-minimized window in strip order, or empty when every tiled
+    /// window is minimized. Used to move focus off a window being minimized.
+    QString firstVisibleWindowId() const;
 
     QString m_screenId;
     QVector<Column> m_columns;

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
@@ -85,7 +85,8 @@ public:
     /// Karousel's TiledMinimized state — so its column collapses out of view
     /// (and reappears in place) without losing column/tile order. Returns
     /// true if the state changed. Minimizing the focused window hands focus
-    /// to the nearest still-visible window.
+    /// to the first still-visible window in strip order; if every tiled
+    /// window is minimized, focus is left unchanged.
     bool setWindowMinimized(const QString& windowId, bool minimized);
     /// Whether @p windowId is a minimized tiled window.
     bool isWindowMinimized(const QString& windowId) const;

--- a/libs/phosphor-scroll-engine/src/Column.cpp
+++ b/libs/phosphor-scroll-engine/src/Column.cpp
@@ -135,6 +135,32 @@ bool Column::moveTile(int from, int to)
     return true;
 }
 
+bool Column::hasVisibleTiles() const
+{
+    for (const Tile& tile : m_tiles) {
+        if (!tile.minimized) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Column::isWindowMinimized(const QString& windowId) const
+{
+    const int index = indexOfWindow(windowId);
+    return index >= 0 && m_tiles.at(index).minimized;
+}
+
+bool Column::setWindowMinimized(const QString& windowId, bool minimized)
+{
+    const int index = indexOfWindow(windowId);
+    if (index < 0 || m_tiles.at(index).minimized == minimized) {
+        return false;
+    }
+    m_tiles[index].minimized = minimized;
+    return true;
+}
+
 void Column::setActiveTileIndex(int index)
 {
     m_activeTileIndex = index;
@@ -172,6 +198,7 @@ QJsonObject Column::toJson() const
         QJsonObject tileObj;
         tileObj.insert(QLatin1String("windowId"), tile.windowId);
         tileObj.insert(QLatin1String("height"), windowHeightToJson(tile.height));
+        tileObj.insert(QLatin1String("minimized"), tile.minimized);
         tiles.append(tileObj);
     }
 
@@ -192,6 +219,7 @@ Column Column::fromJson(const QJsonObject& obj)
         Tile tile;
         tile.windowId = tileObj.value(QLatin1String("windowId")).toString();
         tile.height = windowHeightFromJson(tileObj.value(QLatin1String("height")).toObject());
+        tile.minimized = tileObj.value(QLatin1String("minimized")).toBool(false);
         if (!tile.windowId.isEmpty()) {
             column.m_tiles.append(tile);
         }

--- a/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
@@ -223,6 +223,18 @@ void ScrollEngine::windowFocused(const QString& windowId, const QString& screenI
     }
 }
 
+void ScrollEngine::windowMinimizedChanged(const QString& windowId, bool minimized)
+{
+    const auto it = m_windowToKey.constFind(windowId);
+    if (it == m_windowToKey.constEnd()) {
+        return;
+    }
+    if (ScrollScreenState* state = stateForKey(it.value(), /*create=*/false);
+        state && state->setWindowMinimized(windowId, minimized)) {
+        emitChanged(it.value().screenId);
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // Float
 // ─────────────────────────────────────────────────────────────────────────

--- a/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
@@ -181,8 +181,10 @@ void ScrollEngine::pruneStatesForActivities(const QStringList& validActivities)
 
 void ScrollEngine::windowOpened(const QString& windowId, const QString& screenId, int minWidth, int minHeight)
 {
-    // Minimum-size constraints are honoured at geometry-resolution time
-    // (daemon side); the strip model itself is size-agnostic.
+    // minWidth/minHeight are part of the IPlacementEngine::windowOpened
+    // signature (autotile uses them for column sizing). Scroll's strip model
+    // is size-agnostic: a non-resizable window is fitted to its tile slot
+    // effect-side (constrainToScrollSlot), so the constraints are unused here.
     Q_UNUSED(minWidth)
     Q_UNUSED(minHeight)
     if (windowId.isEmpty() || screenId.isEmpty() || m_windowToKey.contains(windowId)) {

--- a/libs/phosphor-scroll-engine/src/ScrollLayout.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollLayout.cpp
@@ -73,13 +73,22 @@ QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const
     const int activeIndex = state.activeColumnIndex();
     qreal viewPos = 0.0;
     if (activeIndex >= 0 && activeIndex < stripX.size()) {
-        viewPos = stripX.at(activeIndex) + state.viewOffset();
+        viewPos = stripX.at(activeIndex);
+        // viewOffset is an offset *within* the focused column's width — add it
+        // only when that column is actually visible. A fully-minimized
+        // (collapsed) focused column has zero width and its stripX already
+        // coincides with the next visible column, so anchor there with no
+        // offset rather than scrolling the strip to a zero-width slot.
+        if (widths.at(activeIndex) > 0.0) {
+            viewPos += state.viewOffset();
+        }
     }
 
     for (int ci = 0; ci < columns.size(); ++ci) {
         // Lay out only the visible (non-minimized) tiles. A minimized tile
         // keeps its place in the column order but contributes no geometry.
         QVector<const Tile*> visible;
+        visible.reserve(columns.at(ci).tileCount());
         for (const Tile& tile : columns.at(ci).tiles()) {
             if (!tile.minimized) {
                 visible.append(&tile);

--- a/libs/phosphor-scroll-engine/src/ScrollLayout.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollLayout.cpp
@@ -50,17 +50,21 @@ QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const
     const qreal usableW = qMax(workArea.width() - 2.0 * outer, qreal(0.0));
     const qreal usableH = qMax(workArea.height() - 2.0 * outer, qreal(0.0));
 
-    // Column widths and strip-space X positions (columns packed left to
-    // right from strip-x 0, separated by the inner gap).
-    QVector<qreal> widths;
-    QVector<qreal> stripX;
-    widths.reserve(columns.size());
-    stripX.reserve(columns.size());
+    // Column widths and strip-space X positions. Columns pack left to right
+    // from strip-x 0, separated by the inner gap. A column whose every tile
+    // is minimized collapses out of the strip — zero width, no gap, the
+    // cursor does not advance — so it keeps its slot in the column order
+    // (restored when one of its tiles is unminimized) without leaving a gap.
+    QVector<qreal> widths(columns.size(), 0.0);
+    QVector<qreal> stripX(columns.size(), 0.0);
     qreal cursor = 0.0;
-    for (const Column& column : columns) {
-        stripX.append(cursor);
-        const qreal width = resolveColumnWidth(column.width(), usableW);
-        widths.append(width);
+    for (int ci = 0; ci < columns.size(); ++ci) {
+        stripX[ci] = cursor;
+        if (!columns.at(ci).hasVisibleTiles()) {
+            continue; // collapsed column — keeps its slot, takes no strip space
+        }
+        const qreal width = resolveColumnWidth(columns.at(ci).width(), usableW);
+        widths[ci] = width;
         cursor += width + inner;
     }
 
@@ -73,10 +77,17 @@ QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const
     }
 
     for (int ci = 0; ci < columns.size(); ++ci) {
-        const QVector<Tile>& tiles = columns.at(ci).tiles();
-        const int tileCount = static_cast<int>(tiles.size());
+        // Lay out only the visible (non-minimized) tiles. A minimized tile
+        // keeps its place in the column order but contributes no geometry.
+        QVector<const Tile*> visible;
+        for (const Tile& tile : columns.at(ci).tiles()) {
+            if (!tile.minimized) {
+                visible.append(&tile);
+            }
+        }
+        const int tileCount = static_cast<int>(visible.size());
         if (tileCount == 0) {
-            continue; // ScrollScreenState never exposes an empty column; defensive.
+            continue; // empty or fully-minimized column — nothing to place
         }
 
         const qreal columnX = usableX + stripX.at(ci) - viewPos;
@@ -90,24 +101,25 @@ QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const
         qreal weightSum = 0.0;
         int autoCount = 0;
         for (int ti = 0; ti < tileCount; ++ti) {
-            const qreal concrete = resolveConcreteTileHeight(tiles.at(ti).height, usableH, config.presetWindowHeights);
+            const qreal concrete =
+                resolveConcreteTileHeight(visible.at(ti)->height, usableH, config.presetWindowHeights);
             if (concrete >= 0.0) {
                 heights[ti] = concrete;
                 concreteTotal += concrete;
             } else {
                 ++autoCount;
-                weightSum += qMax(tiles.at(ti).height.weight, qreal(0.0));
+                weightSum += qMax(visible.at(ti)->height.weight, qreal(0.0));
             }
         }
         const qreal autoSpace = qMax(availableH - concreteTotal, qreal(0.0));
 
         // Second pass: size the Auto tiles from the leftover space and lay
-        // every tile out top to bottom.
+        // every visible tile out top to bottom.
         qreal y = usableY;
         for (int ti = 0; ti < tileCount; ++ti) {
             qreal height = heights.at(ti);
             if (height < 0.0) {
-                const qreal weight = qMax(tiles.at(ti).height.weight, qreal(0.0));
+                const qreal weight = qMax(visible.at(ti)->height.weight, qreal(0.0));
                 height = (weightSum > 0.0) ? autoSpace * weight / weightSum : autoSpace / autoCount;
             }
             // Floor to a positive height, mirroring resolveColumnWidth — a
@@ -115,7 +127,7 @@ QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const
             // whose concrete heights exhaust the space) is not usable
             // downstream.
             height = qMax(height, qreal(1.0));
-            geometries.insert(tiles.at(ti).windowId, QRectF(columnX, y, columnW, height));
+            geometries.insert(visible.at(ti)->windowId, QRectF(columnX, y, columnW, height));
             y += height + inner;
         }
     }

--- a/libs/phosphor-scroll-engine/src/ScrollLayout.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollLayout.cpp
@@ -72,15 +72,36 @@ QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const
     // coordinate that maps to the inner-left edge of the working area.
     const int activeIndex = state.activeColumnIndex();
     qreal viewPos = 0.0;
-    if (activeIndex >= 0 && activeIndex < stripX.size()) {
-        viewPos = stripX.at(activeIndex);
-        // viewOffset is an offset *within* the focused column's width — add it
-        // only when that column is actually visible. A fully-minimized
-        // (collapsed) focused column has zero width and its stripX already
-        // coincides with the next visible column, so anchor there with no
-        // offset rather than scrolling the strip to a zero-width slot.
+    if (activeIndex >= 0 && activeIndex < columns.size()) {
         if (widths.at(activeIndex) > 0.0) {
-            viewPos += state.viewOffset();
+            // Focused column is visible: anchor on it, plus the in-column
+            // viewOffset (an offset *within* the focused column's width).
+            viewPos = stripX.at(activeIndex) + state.viewOffset();
+        } else {
+            // Focused column is fully minimized (collapsed, zero width).
+            // viewOffset is meaningless against a zero-width column, and the
+            // collapsed column's own stripX is only on-screen when a visible
+            // column follows it — a trailing run of collapsed columns has a
+            // stripX past the strip's end, which would scroll every visible
+            // column off the left edge. Anchor on the nearest visible column
+            // (forward first, since a mid-strip collapsed column shares the
+            // next column's stripX; otherwise the last visible column).
+            int anchor = -1;
+            for (int ci = activeIndex; ci < columns.size(); ++ci) {
+                if (widths.at(ci) > 0.0) {
+                    anchor = ci;
+                    break;
+                }
+            }
+            if (anchor < 0) {
+                for (int ci = activeIndex - 1; ci >= 0; --ci) {
+                    if (widths.at(ci) > 0.0) {
+                        anchor = ci;
+                        break;
+                    }
+                }
+            }
+            viewPos = (anchor >= 0) ? stripX.at(anchor) : 0.0;
         }
     }
 

--- a/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
@@ -76,6 +76,34 @@ bool ScrollScreenState::removeWindow(const QString& windowId)
     return true;
 }
 
+bool ScrollScreenState::setWindowMinimized(const QString& windowId, bool minimized)
+{
+    const int columnIndex = locateWindow(windowId).first;
+    if (columnIndex < 0) {
+        return false;
+    }
+    if (!m_columns[columnIndex].setWindowMinimized(windowId, minimized)) {
+        return false; // flag already in the requested state
+    }
+    // The focused window must stay visible: the viewport offset and keyboard
+    // navigation anchor on the focused column/tile. Hand focus to the nearest
+    // still-visible window when the one being minimized was focused. (A
+    // subsequent windowFocused event from the compositor may refine this.)
+    if (minimized && focusedWindowId() == windowId) {
+        const QString visible = firstVisibleWindowId();
+        if (!visible.isEmpty()) {
+            focusWindow(visible);
+        }
+    }
+    return true;
+}
+
+bool ScrollScreenState::isWindowMinimized(const QString& windowId) const
+{
+    const int columnIndex = locateWindow(windowId).first;
+    return columnIndex >= 0 && m_columns.at(columnIndex).isWindowMinimized(windowId);
+}
+
 bool ScrollScreenState::consumeIntoColumn()
 {
     if (m_activeColumnIndex < 0) {
@@ -371,6 +399,18 @@ void ScrollScreenState::refocus(const QString& preferredWindowId)
         }
     }
     clampActiveColumnIndex();
+}
+
+QString ScrollScreenState::firstVisibleWindowId() const
+{
+    for (const Column& column : m_columns) {
+        for (const Tile& tile : column.tiles()) {
+            if (!tile.minimized) {
+                return tile.windowId;
+            }
+        }
+    }
+    return QString();
 }
 
 } // namespace PhosphorScrollEngine

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,6 +135,7 @@ set(plasmazones_core_SRCS
     dbus/windowdragadaptor.h
     dbus/autotileadaptor.cpp
     dbus/scrolladaptor.cpp
+    dbus/scrolladaptor.h
     dbus/autotileadaptor/config.cpp
     dbus/autotileadaptor.h
     dbus/snapadaptor.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,7 @@ set(plasmazones_core_SRCS
     dbus/windowdragadaptor/dragactivation.h
     dbus/windowdragadaptor.h
     dbus/autotileadaptor.cpp
+    dbus/scrolladaptor.cpp
     dbus/autotileadaptor/config.cpp
     dbus/autotileadaptor.h
     dbus/snapadaptor.cpp

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1553,9 +1553,10 @@ void Daemon::stop()
     // explicit teardown for the same "queued D-Bus call lands during
     // destruction window" defense-in-depth.
     //
-    // The other eight raw-Qt-parented adaptors (LayoutAdaptor,
+    // The other nine raw-Qt-parented adaptors (LayoutAdaptor,
     // OverlayAdaptor, ZoneDetectionAdaptor, WindowTrackingAdaptor,
-    // DBusScreenAdaptor, WindowDragAdaptor, SnapAdaptor, AutotileAdaptor) all
+    // DBusScreenAdaptor, WindowDragAdaptor, SnapAdaptor, AutotileAdaptor,
+    // ScrollAdaptor) all
     // ship `= default` destructors (verified — see their class headers),
     // so they have no dtor body to UAF. QDBusConnection::unregisterObject
     // (invoked above) blocks new method dispatch to them before we begin

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -75,6 +75,7 @@
 #include "../dbus/windowtrackingadaptor.h"
 #include "../dbus/windowdragadaptor.h"
 #include "../dbus/autotileadaptor.h"
+#include "../dbus/scrolladaptor.h"
 #include "../dbus/snapadaptor.h"
 #include "../dbus/shaderadaptor.h"
 #include "../dbus/compositorbridgeadaptor.h"
@@ -970,6 +971,7 @@ bool Daemon::init()
                                  m_virtualDesktopManager.get(), m_windowRegistry.get(), this);
     auto* autotileEngine = engines.autotile.get();
     auto* snapEngine = engines.snap.get();
+    auto* scrollEngine = engines.scroll.get();
     m_autotileEngine = std::move(engines.autotile);
     m_snapEngine = std::move(engines.snap);
     m_scrollEngine = std::move(engines.scroll);
@@ -1106,6 +1108,7 @@ bool Daemon::init()
     m_snapAdaptor = new SnapAdaptor(snapEngine, m_windowTrackingAdaptor, m_settings.get(), this);
     m_snapAdaptor->setScreenModeRouter(m_screenModeRouter.get());
     m_autotileAdaptor = new AutotileAdaptor(autotileEngine, m_screenManager.get(), m_algorithmRegistry.get(), this);
+    m_scrollAdaptor = new ScrollAdaptor(scrollEngine, this);
 
     // Control adaptor - high-level convenience API for third-party integrations.
     // Held as a member so stop() can detach() it before the unique_ptr members
@@ -1499,6 +1502,9 @@ void Daemon::stop()
     // access freed memory. After clearing, ensureEngine() returns false.
     if (m_autotileAdaptor) {
         m_autotileAdaptor->clearEngine();
+    }
+    if (m_scrollAdaptor) {
+        m_scrollAdaptor->clearEngine();
     }
     if (m_snapAdaptor) {
         m_snapAdaptor->clearEngine();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1563,7 +1563,7 @@ void Daemon::stop()
     // tearing down, and Qt's sender-destruction auto-disconnect cleans
     // up signal wiring when the borrowed sender (m_layoutManager, etc.)
     // is destroyed during member destruction. Adding detach() to those
-    // eight would require null-guarding every slot body (they currently
+    // nine would require null-guarding every slot body (they currently
     // rely on the "borrowed pointer is always valid" invariant), which
     // is a larger refactor than the defense-in-depth buys. If a future
     // adaptor grows a dtor body that derefs a borrowed member, add

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1556,9 +1556,8 @@ void Daemon::stop()
     // The other nine raw-Qt-parented adaptors (LayoutAdaptor,
     // OverlayAdaptor, ZoneDetectionAdaptor, WindowTrackingAdaptor,
     // DBusScreenAdaptor, WindowDragAdaptor, SnapAdaptor, AutotileAdaptor,
-    // ScrollAdaptor) all
-    // ship `= default` destructors (verified — see their class headers),
-    // so they have no dtor body to UAF. QDBusConnection::unregisterObject
+    // ScrollAdaptor) all ship `= default` destructors (verified — see their
+    // class headers), so they have no dtor body to UAF. QDBusConnection::unregisterObject
     // (invoked above) blocks new method dispatch to them before we begin
     // tearing down, and Qt's sender-destruction auto-disconnect cleans
     // up signal wiring when the borrowed sender (m_layoutManager, etc.)

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -76,6 +76,7 @@ class ModeTracker;
 class ZoneSelectorController;
 class UnifiedLayoutController;
 class AutotileAdaptor;
+class ScrollAdaptor;
 class ScreenModeRouter;
 class SettingsConfigStore;
 class SnapAdaptor;
@@ -605,6 +606,7 @@ private:
     std::unique_ptr<Phosphor::Screens::VirtualScreenSwapper> m_virtualScreenSwapper;
     SnapAdaptor* m_snapAdaptor = nullptr;
     AutotileAdaptor* m_autotileAdaptor = nullptr;
+    ScrollAdaptor* m_scrollAdaptor = nullptr;
 
     /// Phase 6: animation shader effect discovery. Scans
     /// `plasmazones/animations` from XDG data dirs and monitors for

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -572,6 +572,17 @@ void Daemon::processPendingGeometryUpdates()
     if (m_autotileEngine && m_autotileEngine->isEnabled()) {
         m_autotileEngine->retile();
     }
+
+    // Re-resolve scroll-mode strips against the new screen geometry. The
+    // ScrollEngine is geometry-agnostic — a working-area change (resolution,
+    // scale, panel add/remove) only takes effect when the daemon re-runs
+    // resolveScrollLayout, which onScrollPlacementChanged does per screen.
+    if (m_scrollEngine && m_scrollEngine->isEnabled()) {
+        const QSet<QString> scrollScreens = m_scrollEngine->activeScreens();
+        for (const QString& screenId : scrollScreens) {
+            onScrollPlacementChanged(screenId);
+        }
+    }
 }
 
 } // namespace PlasmaZones

--- a/src/daemon/daemon/scroll.cpp
+++ b/src/daemon/daemon/scroll.cpp
@@ -66,12 +66,12 @@ void Daemon::updateScrollScreens()
     m_scrollEngine->setActiveScreens(scrollScreens);
     if (screensChanged && m_scrollAdaptor) {
         // Tell the KWin effect which screens are scroll-mode so it reports
-        // their windows to the org.plasmazones.Scroll interface.
-        // Sorted so the signal payload is deterministic — QSet iteration
-        // order is unspecified, which would otherwise emit spurious churn.
-        QStringList scrollScreenIds(scrollScreens.cbegin(), scrollScreens.cend());
-        scrollScreenIds.sort();
-        Q_EMIT m_scrollAdaptor->scrollScreensChanged(scrollScreenIds);
+        // their windows to the org.plasmazones.Scroll interface. The payload
+        // is sourced from ScrollAdaptor::scrollScreens() — the same accessor
+        // that backs the scrollScreens property — so the signal and a
+        // subsequent property read cannot disagree. It is sorted there, since
+        // QSet iteration order is unspecified.
+        Q_EMIT m_scrollAdaptor->scrollScreensChanged(m_scrollAdaptor->scrollScreens());
     }
     qCDebug(lcDaemon) << "Updated scroll screens=" << scrollScreens;
 }

--- a/src/daemon/daemon/scroll.cpp
+++ b/src/daemon/daemon/scroll.cpp
@@ -67,7 +67,11 @@ void Daemon::updateScrollScreens()
     if (screensChanged && m_scrollAdaptor) {
         // Tell the KWin effect which screens are scroll-mode so it reports
         // their windows to the org.plasmazones.Scroll interface.
-        Q_EMIT m_scrollAdaptor->scrollScreensChanged(QStringList(scrollScreens.cbegin(), scrollScreens.cend()));
+        // Sorted so the signal payload is deterministic — QSet iteration
+        // order is unspecified, which would otherwise emit spurious churn.
+        QStringList scrollScreenIds(scrollScreens.cbegin(), scrollScreens.cend());
+        scrollScreenIds.sort();
+        Q_EMIT m_scrollAdaptor->scrollScreensChanged(scrollScreenIds);
     }
     qCDebug(lcDaemon) << "Updated scroll screens=" << scrollScreens;
 }

--- a/src/daemon/daemon/scroll.cpp
+++ b/src/daemon/daemon/scroll.cpp
@@ -4,6 +4,7 @@
 #include "../daemon.h"
 
 #include "../../core/logging.h"
+#include "../../dbus/scrolladaptor.h"
 #include "../../dbus/windowtrackingadaptor.h"
 #include "../config/settings.h"
 #include <PhosphorEngine/IPlacementEngine.h>
@@ -61,7 +62,13 @@ void Daemon::updateScrollScreens()
         }
     }
 
+    const bool screensChanged = (m_scrollEngine->activeScreens() != scrollScreens);
     m_scrollEngine->setActiveScreens(scrollScreens);
+    if (screensChanged && m_scrollAdaptor) {
+        // Tell the KWin effect which screens are scroll-mode so it reports
+        // their windows to the org.plasmazones.Scroll interface.
+        Q_EMIT m_scrollAdaptor->scrollScreensChanged(QStringList(scrollScreens.cbegin(), scrollScreens.cend()));
+    }
     qCDebug(lcDaemon) << "Updated scroll screens=" << scrollScreens;
 }
 

--- a/src/dbus/scrolladaptor.cpp
+++ b/src/dbus/scrolladaptor.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "scrolladaptor.h"
+
+#include "core/logging.h"
+
+#include <PhosphorScrollEngine/ScrollEngine.h>
+
+#include <QSet>
+
+namespace PlasmaZones {
+
+ScrollAdaptor::ScrollAdaptor(PhosphorScrollEngine::ScrollEngine* engine, QObject* parent)
+    : QDBusAbstractAdaptor(parent)
+    , m_engine(engine)
+{
+    if (!m_engine) {
+        qCWarning(lcDaemon) << "ScrollAdaptor created with null engine";
+    }
+}
+
+QStringList ScrollAdaptor::scrollScreens() const
+{
+    if (!m_engine) {
+        return {};
+    }
+    const QSet<QString> screens = m_engine->activeScreens();
+    return QStringList(screens.cbegin(), screens.cend());
+}
+
+void ScrollAdaptor::clearEngine()
+{
+    m_engine = nullptr;
+}
+
+bool ScrollAdaptor::ensureEngine(const char* methodName) const
+{
+    if (!m_engine) {
+        qCWarning(lcDaemon) << "ScrollAdaptor::" << methodName << "called with no engine";
+        return false;
+    }
+    return true;
+}
+
+void ScrollAdaptor::windowOpened(const QString& windowId, const QString& screenId, int minWidth, int minHeight)
+{
+    if (!ensureEngine("windowOpened")) {
+        return;
+    }
+    m_engine->windowOpened(windowId, screenId, qMax(0, minWidth), qMax(0, minHeight));
+}
+
+void ScrollAdaptor::windowsOpenedBatch(const PhosphorProtocol::WindowOpenedList& entries)
+{
+    if (!ensureEngine("windowsOpenedBatch")) {
+        return;
+    }
+    for (const PhosphorProtocol::WindowOpenedEntry& entry : entries) {
+        m_engine->windowOpened(entry.windowId, entry.screenId, qMax(0, entry.minWidth), qMax(0, entry.minHeight));
+    }
+}
+
+void ScrollAdaptor::windowClosed(const QString& windowId)
+{
+    if (!ensureEngine("windowClosed")) {
+        return;
+    }
+    m_engine->windowClosed(windowId);
+}
+
+void ScrollAdaptor::notifyWindowFocused(const QString& windowId, const QString& screenId)
+{
+    if (!ensureEngine("notifyWindowFocused")) {
+        return;
+    }
+    m_engine->windowFocused(windowId, screenId);
+}
+
+} // namespace PlasmaZones

--- a/src/dbus/scrolladaptor.cpp
+++ b/src/dbus/scrolladaptor.cpp
@@ -26,7 +26,11 @@ QStringList ScrollAdaptor::scrollScreens() const
         return {};
     }
     const QSet<QString> screens = m_engine->activeScreens();
-    return QStringList(screens.cbegin(), screens.cend());
+    // Sorted for a deterministic property value — QSet iteration order is
+    // unspecified.
+    QStringList ids(screens.cbegin(), screens.cend());
+    ids.sort();
+    return ids;
 }
 
 void ScrollAdaptor::clearEngine()

--- a/src/dbus/scrolladaptor.cpp
+++ b/src/dbus/scrolladaptor.cpp
@@ -77,4 +77,12 @@ void ScrollAdaptor::notifyWindowFocused(const QString& windowId, const QString& 
     m_engine->windowFocused(windowId, screenId);
 }
 
+void ScrollAdaptor::windowMinimizedChanged(const QString& windowId, bool minimized)
+{
+    if (!ensureEngine("windowMinimizedChanged")) {
+        return;
+    }
+    m_engine->windowMinimizedChanged(windowId, minimized);
+}
+
 } // namespace PlasmaZones

--- a/src/dbus/scrolladaptor.cpp
+++ b/src/dbus/scrolladaptor.cpp
@@ -47,12 +47,12 @@ bool ScrollAdaptor::ensureEngine(const char* methodName) const
     return true;
 }
 
-void ScrollAdaptor::windowOpened(const QString& windowId, const QString& screenId, int minWidth, int minHeight)
+void ScrollAdaptor::windowOpened(const QString& windowId, const QString& screenId)
 {
     if (!ensureEngine("windowOpened")) {
         return;
     }
-    m_engine->windowOpened(windowId, screenId, qMax(0, minWidth), qMax(0, minHeight));
+    m_engine->windowOpened(windowId, screenId);
 }
 
 void ScrollAdaptor::windowsOpenedBatch(const PhosphorProtocol::WindowOpenedList& entries)
@@ -60,8 +60,12 @@ void ScrollAdaptor::windowsOpenedBatch(const PhosphorProtocol::WindowOpenedList&
     if (!ensureEngine("windowsOpenedBatch")) {
         return;
     }
+    // WindowOpenedList is shared with org.plasmazones.Autotile and carries
+    // per-entry minWidth/minHeight; scroll's strip model is size-agnostic and
+    // ignores them (non-resizable windows are fitted to the tile slot
+    // effect-side), so only windowId/screenId are forwarded.
     for (const PhosphorProtocol::WindowOpenedEntry& entry : entries) {
-        m_engine->windowOpened(entry.windowId, entry.screenId, qMax(0, entry.minWidth), qMax(0, entry.minHeight));
+        m_engine->windowOpened(entry.windowId, entry.screenId);
     }
 }
 

--- a/src/dbus/scrolladaptor.h
+++ b/src/dbus/scrolladaptor.h
@@ -59,7 +59,7 @@ public:
     void clearEngine();
 
 public Q_SLOTS:
-    void windowOpened(const QString& windowId, const QString& screenId, int minWidth, int minHeight);
+    void windowOpened(const QString& windowId, const QString& screenId);
     void windowsOpenedBatch(const PhosphorProtocol::WindowOpenedList& entries);
     void windowClosed(const QString& windowId);
     void notifyWindowFocused(const QString& windowId, const QString& screenId);

--- a/src/dbus/scrolladaptor.h
+++ b/src/dbus/scrolladaptor.h
@@ -63,6 +63,7 @@ public Q_SLOTS:
     void windowsOpenedBatch(const PhosphorProtocol::WindowOpenedList& entries);
     void windowClosed(const QString& windowId);
     void notifyWindowFocused(const QString& windowId, const QString& screenId);
+    void windowMinimizedChanged(const QString& windowId, bool minimized);
 
 Q_SIGNALS:
     /// Emitted when the set of scroll-mode screens changes; the KWin effect

--- a/src/dbus/scrolladaptor.h
+++ b/src/dbus/scrolladaptor.h
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "plasmazones_export.h"
+
+#include <PhosphorProtocol/WindowMarshalling.h>
+#include <QDBusAbstractAdaptor>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+namespace PhosphorScrollEngine {
+class ScrollEngine;
+}
+
+namespace PlasmaZones {
+
+/**
+ * @brief D-Bus adaptor for niri-style scrollable tiling.
+ *
+ * Provides the @c org.plasmazones.Scroll interface. The KWin effect reports
+ * window lifecycle (open / close / focus) for scroll-mode screens here, and
+ * the adaptor forwards each event to the ScrollEngine. The effect learns
+ * which screens are scroll-mode from the @c scrollScreensChanged signal.
+ *
+ * Window geometry flows back to the effect over the shared
+ * WindowTrackingAdaptor::applyGeometriesBatch path, not through this adaptor.
+ *
+ * Mirrors AutotileAdaptor's lifecycle-input surface; algorithm / master /
+ * gap controls have no scroll equivalent and are intentionally absent.
+ */
+class PLASMAZONES_EXPORT ScrollAdaptor : public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.plasmazones.Scroll")
+
+    Q_PROPERTY(QStringList scrollScreens READ scrollScreens NOTIFY scrollScreensChanged)
+
+public:
+    /**
+     * @brief Construct a ScrollAdaptor.
+     * @param engine The ScrollEngine to feed; borrowed, must outlive the adaptor.
+     * @param parent Parent QObject (the daemon — its registerObject() exposes this).
+     */
+    explicit ScrollAdaptor(PhosphorScrollEngine::ScrollEngine* engine, QObject* parent = nullptr);
+    ~ScrollAdaptor() override = default;
+
+    /// Screens currently using scroll mode.
+    QStringList scrollScreens() const;
+
+    /**
+     * @brief Clear the engine pointer during shutdown.
+     *
+     * Called by Daemon::stop() before the ScrollEngine is destroyed, so a
+     * late D-Bus call hits the null guard instead of a dangling pointer.
+     */
+    void clearEngine();
+
+public Q_SLOTS:
+    void windowOpened(const QString& windowId, const QString& screenId, int minWidth, int minHeight);
+    void windowsOpenedBatch(const PhosphorProtocol::WindowOpenedList& entries);
+    void windowClosed(const QString& windowId);
+    void notifyWindowFocused(const QString& windowId, const QString& screenId);
+
+Q_SIGNALS:
+    /// Emitted when the set of scroll-mode screens changes; the KWin effect
+    /// subscribes so it reports the right screens' windows to this interface.
+    void scrollScreensChanged(const QStringList& screenIds);
+
+private:
+    bool ensureEngine(const char* methodName) const;
+
+    PhosphorScrollEngine::ScrollEngine* m_engine = nullptr;
+};
+
+} // namespace PlasmaZones

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -122,6 +122,10 @@ void TestScrollEngine::minimizeWindow()
     QVERIFY(state->isWindowMinimized(QStringLiteral("b")));
     QCOMPARE(state->columnCount(), 2); // the slot is kept
     QVERIFY(engine.isWindowTracked(QStringLiteral("b"))); // still tracked while minimized
+    // "b" was the focused window (opened last); minimizing it hands focus to
+    // the nearest still-visible window so the viewport never anchors on a
+    // hidden window.
+    QCOMPARE(state->focusedWindowId(), QStringLiteral("a"));
 
     engine.windowMinimizedChanged(QStringLiteral("b"), true); // no change — no signal
     QCOMPARE(spy.count(), 1);
@@ -132,6 +136,16 @@ void TestScrollEngine::minimizeWindow()
 
     engine.windowMinimizedChanged(QStringLiteral("missing"), true); // untracked — no-op
     QCOMPARE(spy.count(), 2);
+
+    // Every window minimized: focus has nowhere visible to go, so it is left
+    // on its window rather than cleared. Minimizing focused "a" hands focus to
+    // "b"; minimizing "b" then finds nothing visible and leaves focus on "b".
+    engine.windowMinimizedChanged(QStringLiteral("a"), true);
+    engine.windowMinimizedChanged(QStringLiteral("b"), true);
+    QVERIFY(state->isWindowMinimized(QStringLiteral("a")));
+    QVERIFY(state->isWindowMinimized(QStringLiteral("b")));
+    QCOMPARE(state->focusedWindowId(), QStringLiteral("b")); // retained, not cleared
+    QCOMPARE(state->columnCount(), 2); // both slots kept
 }
 
 void TestScrollEngine::cyclePresetWidth()

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -35,6 +35,7 @@ private Q_SLOTS:
     void windowLifecycle();
     void focusAndMoveNavigation();
     void consumeAndExpel();
+    void minimizeWindow();
     void cyclePresetWidth();
     void cyclePresetHeight();
     void floatToggle();
@@ -105,6 +106,32 @@ void TestScrollEngine::consumeAndExpel()
 
     engine.expelWindowFromColumn(ctx);
     QCOMPARE(state->columnCount(), 2);
+}
+
+void TestScrollEngine::minimizeWindow()
+{
+    ScrollEngine engine;
+    engine.windowOpened(QStringLiteral("a"), QStringLiteral("S1"));
+    engine.windowOpened(QStringLiteral("b"), QStringLiteral("S1"));
+    QSignalSpy spy(&engine, &PhosphorEngine::PlacementEngineBase::placementChanged);
+
+    engine.windowMinimizedChanged(QStringLiteral("b"), true);
+    QCOMPARE(spy.count(), 1);
+    const ScrollScreenState* state = scrollState(engine, QStringLiteral("S1"));
+    QVERIFY(state);
+    QVERIFY(state->isWindowMinimized(QStringLiteral("b")));
+    QCOMPARE(state->columnCount(), 2); // the slot is kept
+    QVERIFY(engine.isWindowTracked(QStringLiteral("b"))); // still tracked while minimized
+
+    engine.windowMinimizedChanged(QStringLiteral("b"), true); // no change — no signal
+    QCOMPARE(spy.count(), 1);
+
+    engine.windowMinimizedChanged(QStringLiteral("b"), false); // restore
+    QCOMPARE(spy.count(), 2);
+    QVERIFY(!state->isWindowMinimized(QStringLiteral("b")));
+
+    engine.windowMinimizedChanged(QStringLiteral("missing"), true); // untracked — no-op
+    QCOMPARE(spy.count(), 2);
 }
 
 void TestScrollEngine::cyclePresetWidth()

--- a/tests/unit/scroll/test_scroll_layout.cpp
+++ b/tests/unit/scroll/test_scroll_layout.cpp
@@ -36,6 +36,8 @@ private Q_SLOTS:
     void fixedHeightTileTakesSpaceFirst();
     void presetHeightResolved();
     void fixedWidthColumn();
+    void minimizedTileExcluded();
+    void fullyMinimizedColumnCollapses();
     void visibilityHelper();
 };
 
@@ -136,6 +138,44 @@ void TestScrollLayout::fixedWidthColumn()
 
     const QHash<QString, QRectF> geometry = resolveScrollLayout(state, kWorkArea, standardConfig());
     QCOMPARE(geometry.value(QStringLiteral("a")).width(), 300.0);
+}
+
+void TestScrollLayout::minimizedTileExcluded()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addWindowToActiveColumn(QStringLiteral("b")); // column [a, b]
+
+    // With "b" minimized, "a" alone fills the column's full height — the
+    // minimized tile takes no slot in the vertical layout.
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true));
+    const QHash<QString, QRectF> geometry = resolveScrollLayout(state, kWorkArea, standardConfig());
+    QCOMPARE(static_cast<int>(geometry.size()), 1);
+    QVERIFY(!geometry.contains(QStringLiteral("b")));
+    QCOMPARE(geometry.value(QStringLiteral("a")), QRectF(10.0, 10.0, 490.0, 780.0));
+}
+
+void TestScrollLayout::fullyMinimizedColumnCollapses()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b"));
+    state.addColumnForWindow(QStringLiteral("c")); // [a][b][c]
+    QVERIFY(state.focusWindow(QStringLiteral("a")));
+
+    // Minimizing the whole middle column collapses it out of the strip with
+    // no gap: "c" sits flush after "a", exactly where "b" used to be.
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true));
+    const QHash<QString, QRectF> geometry = resolveScrollLayout(state, kWorkArea, standardConfig());
+    QVERIFY(!geometry.contains(QStringLiteral("b")));
+    QCOMPARE(geometry.value(QStringLiteral("a")), QRectF(10.0, 10.0, 490.0, 780.0));
+    QCOMPARE(geometry.value(QStringLiteral("c")), QRectF(510.0, 10.0, 490.0, 780.0));
+
+    // Restoring "b" brings it back in its original slot, between "a" and "c".
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), false));
+    const QHash<QString, QRectF> restored = resolveScrollLayout(state, kWorkArea, standardConfig());
+    QCOMPARE(restored.value(QStringLiteral("b")), QRectF(510.0, 10.0, 490.0, 780.0));
+    QCOMPARE(restored.value(QStringLiteral("c")), QRectF(1010.0, 10.0, 490.0, 780.0));
 }
 
 void TestScrollLayout::visibilityHelper()

--- a/tests/unit/scroll/test_scroll_layout.cpp
+++ b/tests/unit/scroll/test_scroll_layout.cpp
@@ -38,6 +38,7 @@ private Q_SLOTS:
     void fixedWidthColumn();
     void minimizedTileExcluded();
     void fullyMinimizedColumnCollapses();
+    void collapsedFocusedColumnIgnoresViewOffset();
     void visibilityHelper();
 };
 
@@ -176,6 +177,31 @@ void TestScrollLayout::fullyMinimizedColumnCollapses()
     const QHash<QString, QRectF> restored = resolveScrollLayout(state, kWorkArea, standardConfig());
     QCOMPARE(restored.value(QStringLiteral("b")), QRectF(510.0, 10.0, 490.0, 780.0));
     QCOMPARE(restored.value(QStringLiteral("c")), QRectF(1010.0, 10.0, 490.0, 780.0));
+}
+
+void TestScrollLayout::collapsedFocusedColumnIgnoresViewOffset()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b")); // [a][b]
+
+    // Minimize "b": its column collapses to zero width. Then focus that
+    // collapsed column directly — viewOffset is an offset *within* the
+    // focused column, meaningless against a zero-width one, so resolution
+    // must anchor on the column's strip position and ignore the offset.
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true));
+    QVERIFY(state.focusWindow(QStringLiteral("b")));
+
+    state.setViewOffset(0.0);
+    const QHash<QString, QRectF> noOffset = resolveScrollLayout(state, kWorkArea, standardConfig());
+    state.setViewOffset(500.0);
+    const QHash<QString, QRectF> withOffset = resolveScrollLayout(state, kWorkArea, standardConfig());
+
+    QVERIFY(!withOffset.contains(QStringLiteral("b"))); // collapsed — no geometry
+    QVERIFY(withOffset.contains(QStringLiteral("a")));
+    // The non-zero viewOffset had no effect: the focused column is collapsed,
+    // so "a" lands in exactly the same place as with a zero offset.
+    QCOMPARE(withOffset.value(QStringLiteral("a")), noOffset.value(QStringLiteral("a")));
 }
 
 void TestScrollLayout::visibilityHelper()

--- a/tests/unit/scroll/test_scroll_layout.cpp
+++ b/tests/unit/scroll/test_scroll_layout.cpp
@@ -39,6 +39,7 @@ private Q_SLOTS:
     void minimizedTileExcluded();
     void fullyMinimizedColumnCollapses();
     void collapsedFocusedColumnIgnoresViewOffset();
+    void soleColumnCollapsesToEmptyLayout();
     void visibilityHelper();
 };
 
@@ -185,10 +186,9 @@ void TestScrollLayout::collapsedFocusedColumnIgnoresViewOffset()
     state.addColumnForWindow(QStringLiteral("a"));
     state.addColumnForWindow(QStringLiteral("b")); // [a][b]
 
-    // Minimize "b": its column collapses to zero width. Then focus that
-    // collapsed column directly — viewOffset is an offset *within* the
-    // focused column, meaningless against a zero-width one, so resolution
-    // must anchor on the column's strip position and ignore the offset.
+    // Minimize "b" (the last column): it collapses to zero width. Then focus
+    // that collapsed column directly — viewOffset is an offset *within* the
+    // focused column, meaningless against a zero-width one.
     QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true));
     QVERIFY(state.focusWindow(QStringLiteral("b")));
 
@@ -198,10 +198,39 @@ void TestScrollLayout::collapsedFocusedColumnIgnoresViewOffset()
     const QHash<QString, QRectF> withOffset = resolveScrollLayout(state, kWorkArea, standardConfig());
 
     QVERIFY(!withOffset.contains(QStringLiteral("b"))); // collapsed — no geometry
-    QVERIFY(withOffset.contains(QStringLiteral("a")));
-    // The non-zero viewOffset had no effect: the focused column is collapsed,
-    // so "a" lands in exactly the same place as with a zero offset.
+    // The non-zero viewOffset had no effect: the focused column is collapsed.
     QCOMPARE(withOffset.value(QStringLiteral("a")), noOffset.value(QStringLiteral("a")));
+    // ...and the strip stays on-screen: a collapsed *trailing* focused column
+    // has no visible column after it, so the viewport anchors on the nearest
+    // visible column to the left — "a" sits at the work-area origin rather
+    // than scrolled off the left edge.
+    QCOMPARE(withOffset.value(QStringLiteral("a")), QRectF(10.0, 10.0, 490.0, 780.0));
+
+    // Positive control: with a *visible* focused column, viewOffset DOES shift
+    // the strip — proving the equality above is the collapsed-column guard at
+    // work, not the resolver ignoring viewOffset unconditionally.
+    QVERIFY(state.focusWindow(QStringLiteral("a")));
+    state.setViewOffset(100.0);
+    const QHash<QString, QRectF> shifted = resolveScrollLayout(state, kWorkArea, standardConfig());
+    QCOMPARE(shifted.value(QStringLiteral("a")).x(), noOffset.value(QStringLiteral("a")).x() - 100.0);
+}
+
+void TestScrollLayout::soleColumnCollapsesToEmptyLayout()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+
+    // The strip's only window is minimized: its column collapses, leaving no
+    // visible tile anywhere. resolveScrollLayout must return an empty hash
+    // (not a stale or zero-size rect, not a crash).
+    QVERIFY(state.setWindowMinimized(QStringLiteral("a"), true));
+    const QHash<QString, QRectF> geometry = resolveScrollLayout(state, kWorkArea, standardConfig());
+    QVERIFY(geometry.isEmpty());
+
+    // Restoring it brings the window back — default column width 0.5 * 980.
+    QVERIFY(state.setWindowMinimized(QStringLiteral("a"), false));
+    const QHash<QString, QRectF> restored = resolveScrollLayout(state, kWorkArea, standardConfig());
+    QCOMPARE(restored.value(QStringLiteral("a")), QRectF(10.0, 10.0, 490.0, 780.0));
 }
 
 void TestScrollLayout::visibilityHelper()

--- a/tests/unit/scroll/test_scroll_screen_state.cpp
+++ b/tests/unit/scroll/test_scroll_screen_state.cpp
@@ -19,6 +19,7 @@ private Q_SLOTS:
     void addToActiveColumn();
     void removeDropsEmptyColumn();
     void consumeAndExpel();
+    void minimizeKeepsSlot();
     void focusAndMoveColumns();
     void tileNavigation();
     void placementAndFloating();
@@ -109,6 +110,35 @@ void TestScrollScreenState::consumeAndExpel()
     QCOMPARE(state.columnCount(), 2);
     QCOMPARE(state.activeColumnIndex(), 1);
     QCOMPARE(state.focusedWindowId(), QStringLiteral("b"));
+}
+
+void TestScrollScreenState::minimizeKeepsSlot()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b"));
+    state.addColumnForWindow(QStringLiteral("c")); // [a][b][c]
+
+    QVERIFY(state.focusWindow(QStringLiteral("b")));
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true));
+    QVERIFY(state.isWindowMinimized(QStringLiteral("b")));
+    QCOMPARE(state.columnCount(), 3); // slot kept — the column is not dropped
+    QCOMPARE(state.tiledWindowCount(), 3); // still tiled, only hidden
+    // The focused window must not be a minimized one.
+    QVERIFY(state.focusedWindowId() != QStringLiteral("b"));
+    QVERIFY(!state.isWindowMinimized(state.focusedWindowId()));
+
+    QVERIFY(!state.setWindowMinimized(QStringLiteral("b"), true)); // already minimized — no-op
+    QVERIFY(!state.setWindowMinimized(QStringLiteral("missing"), true));
+
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), false)); // restore
+    QVERIFY(!state.isWindowMinimized(QStringLiteral("b")));
+
+    // The minimized flag survives a JSON round-trip.
+    QVERIFY(state.setWindowMinimized(QStringLiteral("c"), true));
+    const ScrollScreenState restored = ScrollScreenState::fromJson(state.toJson());
+    QVERIFY(restored.isWindowMinimized(QStringLiteral("c")));
+    QVERIFY(!restored.isWindowMinimized(QStringLiteral("a")));
 }
 
 void TestScrollScreenState::focusAndMoveColumns()

--- a/tests/unit/scroll/test_scroll_screen_state.cpp
+++ b/tests/unit/scroll/test_scroll_screen_state.cpp
@@ -124,9 +124,9 @@ void TestScrollScreenState::minimizeKeepsSlot()
     QVERIFY(state.isWindowMinimized(QStringLiteral("b")));
     QCOMPARE(state.columnCount(), 3); // slot kept — the column is not dropped
     QCOMPARE(state.tiledWindowCount(), 3); // still tiled, only hidden
-    // The focused window must not be a minimized one.
-    QVERIFY(state.focusedWindowId() != QStringLiteral("b"));
-    QVERIFY(!state.isWindowMinimized(state.focusedWindowId()));
+    // Minimizing focused "b" hands focus to the first still-visible window in
+    // strip order — deterministically "a".
+    QCOMPARE(state.focusedWindowId(), QStringLiteral("a"));
 
     QVERIFY(!state.setWindowMinimized(QStringLiteral("b"), true)); // already minimized — no-op
     QVERIFY(!state.setWindowMinimized(QStringLiteral("missing"), true));
@@ -139,6 +139,17 @@ void TestScrollScreenState::minimizeKeepsSlot()
     const ScrollScreenState restored = ScrollScreenState::fromJson(state.toJson());
     QVERIFY(restored.isWindowMinimized(QStringLiteral("c")));
     QVERIFY(!restored.isWindowMinimized(QStringLiteral("a")));
+
+    // Every tiled window minimized: setWindowMinimized still reports each
+    // change, every slot is kept, and focus is left on its (now hidden)
+    // window — there is nothing visible to hand off to — rather than cleared.
+    // "c" is already minimized above; minimizing "a" then "b" completes the set.
+    QVERIFY(state.setWindowMinimized(QStringLiteral("a"), true));
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true));
+    QCOMPARE(state.tiledWindowCount(), 3); // all still tiled, just hidden
+    QCOMPARE(state.columnCount(), 3); // every slot kept
+    QCOMPARE(state.focusedWindowId(), QStringLiteral("b")); // retained, not cleared
+    QVERIFY(state.isWindowMinimized(state.focusedWindowId())); // ...even though hidden
 }
 
 void TestScrollScreenState::focusAndMoveColumns()


### PR DESCRIPTION
Implements **Phase 2 (window lifecycle)** of niri-style scroll mode, on top of the Phase 1 engine/geometry pipeline. Scroll mode now manages the full window lifecycle end-to-end: a window opened on a scroll-mode screen tiles into the strip, follows focus, survives minimize, screen hotplug and geometry changes, and is held to its tile by the strip.

## Milestones

**M1 — window lifecycle wired** (`92589f1a`, `3841f6e9`, `412ef27a`)
- New `ScrollAdaptor` + `org.plasmazones.Scroll` D-Bus interface — the per-mode window-lifecycle channel, mirroring `AutotileAdaptor`.
- The KWin effect reports open/close/focus for scroll-mode screens; the daemon forwards to `ScrollEngine`, which resolves geometry back via the shared `applyGeometriesBatch` path.
- **Refactor:** the effect-side lifecycle reporting was extracted from `AutotileHandler` into a dedicated `ScrollHandler` — neither handler knows the other's mode (the mode-generic eligibility filter moved onto the effect as `isEligibleForTilingNotify`).

**M2 — minimize/unminimize** (`e6a1b116`)
- Karousel's `TiledMinimized`: a minimized window keeps its slot but drops out of the resolved layout; a fully-minimized column collapses with no gap and reappears in place on restore. Engine-level, with tests in all three scroll suites.

**M3 — screen geometry & output moves** (`6a6d90f9`)
- Daemon re-resolves every scroll strip on a debounced screen geometry change; `ScrollHandler` re-homes windows that move between monitors or virtual screens; the scroll-screen-set diff adopts/releases windows when a screen enters or leaves scroll mode at runtime.

**M4 — fixed-size windows & app-resize re-assert** (`ad48d837`)
- Fixed-size / max-constrained windows keep their native size centered in the tile slot (the plan's MVP fallback). A window that drifts from its resolved geometry is snapped back, debounced. Filtering (transient/dock/popup/…) verified against `isEligibleForTilingNotify`.

## Notes
- Virtual desktop / activity switch is handled structurally (one strip per screen×desktop×activity); the sticky / all-desktops-window decision is carried forward to Phase 3.
- No engine logic regressions — **186/186 tests pass**, full build green incl. `kwin_effect_plasmazones`.
- Plan doc updated to mark Phase 2 complete (`129f21ab`).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)