### PR TITLE
Scroll mode Phase 3 — navigation & niri command vocabulary

### DIFF
--- a/dbus/org.plasmazones.Scroll.xml
+++ b/dbus/org.plasmazones.Scroll.xml
@@ -55,5 +55,15 @@
             <arg name="windowId" type="s" direction="in"/>
             <arg name="minimized" type="b" direction="in"/>
         </method>
+
+        <!-- A scroll-mode window was drag-released (drag-to-reorder). Its
+             column is moved next to the anchor window's column — before it,
+             or after when placeAfter is true. The effect picks the anchor as
+             the on-strip window nearest the drop point. -->
+        <method name="windowDropped">
+            <arg name="draggedWindowId" type="s" direction="in"/>
+            <arg name="anchorWindowId" type="s" direction="in"/>
+            <arg name="placeAfter" type="b" direction="in"/>
+        </method>
     </interface>
 </node>

--- a/docs/scroll-mode-plan.md
+++ b/docs/scroll-mode-plan.md
@@ -3,11 +3,13 @@
 
 # Scroll mode — niri-style scrollable tiling
 
-Planning document. Status: **Phases 0 ✅, 1 ✅ and 2 ✅ complete** — the scroll engine,
-geometry resolver, `Mode::Scroll` routing, daemon geometry pipeline, and the full window
-lifecycle (open/close/focus, minimize, screen hotplug & geometry change, fixed-size
-windows) are implemented, built, and tested — the full `ctest` suite is green. Phase 0
-detail in [`scroll-mode-phase0-findings.md`](scroll-mode-phase0-findings.md). Next: Phase 3.
+Planning document. Status: **Phases 0 ✅, 1 ✅, 2 ✅ and 3 ✅ complete** — the scroll
+engine, geometry resolver, `Mode::Scroll` routing, daemon geometry pipeline, the full
+window lifecycle (open/close/focus, minimize, screen hotplug & geometry change,
+fixed-size windows) and navigation (viewport fit/centered scrolling, consume/expel
+shortcuts, drag-to-reorder, sticky-window exclusion) are implemented, built, and
+tested — the full `ctest` suite is green. Phase 0 detail in
+[`scroll-mode-phase0-findings.md`](scroll-mode-phase0-findings.md). Next: Phase 4.
 
 ## 1. Goal
 
@@ -296,14 +298,28 @@ decision for a window *pinned to all desktops / multiple activities* (force-coll
 the current context vs. exclude) is deferred — sticky-window handling is carried forward
 with the Phase 3 navigation work.
 
-### Phase 3 — Navigation & niri command vocabulary
+### Phase 3 — Navigation & niri command vocabulary — ✅ COMPLETE
 
-- Focus left/right (columns), up/down (tiles).
-- `consume` / `expel` window into/out of column; `move-column`; `move-window-up/down`.
-- **Interactive drag of a tiled window** — untile-on-drag or live column reorder; reuse
-  `kwin-effect/dragtracker.cpp`.
-- View-offset computation: `fit` (minimum scroll) and `centered`.
-- Wire to `ShortcutManager`; pick defaults that do not collide with stock KDE.
+- ✅ **Viewport scrolling** (M1) — the strip scrolls to keep the focused column
+  on-screen. `computeViewportScroll` resolves an absolute scroll position per
+  `ScrollViewportMode`: `Fit` (minimum scroll — leaves an already-visible column
+  untouched) or `Centered`. Fit is the default; the mode becomes a user setting in
+  Phase 5.
+- ✅ **Focus / move / swap navigation** — already routed: the daemon dispatches every
+  navigation shortcut through `ScreenModeRouter::engineFor()` and `ScrollEngine`
+  implements the `IPlacementEngine` contract, so focus left/right/up/down and
+  move-column / move-window work in scroll mode with the existing shortcuts.
+- ✅ **`consume` / `expel`** (M2) — new `Meta+Alt+I` / `Meta+Alt+O` shortcuts pull the
+  next column's window into the focused column / push the focused window out into its
+  own column. The snap/autotile engines inherit the no-op `IPlacementEngine` default,
+  so the shortcuts are harmlessly absorbed on their screens. Settings-UI exposure is
+  Phase 5.
+- ✅ **Interactive drag of a tiled window** (M3) — drag-to-reorder: a dragged window
+  keeps its tile slot during the move and, on release, its column is reordered to the
+  strip slot nearest the drop point, then the strip re-resolves and snaps it in.
+- ✅ **Sticky windows** (M4) — a window pinned to all desktops is never tiled into a
+  strip (it floats); pinning / un-pinning at runtime drops it from / re-adds it to the
+  strip.
 
 ### Phase 4 — Widths/heights & viewport polish
 

--- a/docs/scroll-mode-plan.md
+++ b/docs/scroll-mode-plan.md
@@ -42,9 +42,11 @@ Key rules, all carried over verbatim:
 - **Intent vs. resolved geometry are separate.** Store column *width* and tile *height*
   as intent enums (`Proportion(f)` / `Fixed(px)` / `Preset(idx)`); recompute pixel rects
   on relayout. Never store pixels as the source of truth.
-- **The view offset is relative to the focused column**, not an absolute strip
-  coordinate. This is what stops the focused window drifting when columns to its left
-  are added/removed/resized.
+- **The viewport scroll position (`scrollX`) is an absolute strip coordinate** — the
+  strip-x that maps to the working area's inner-left edge. The daemon recomputes it on
+  every relayout (`computeViewportScroll`, `fit` or `centered`) so the focused column
+  stays on-screen; `fit` leaves an already-visible column untouched, which is what stops
+  the focused window jumping when columns to its left are added/removed/resized.
 - **Fullscreen / maximize / tabbed are column states**, not separate modes — they stay
   first-class participants in the strip.
 
@@ -205,7 +207,7 @@ Persistent per-context (screen / desktop / activity) state:
 ScrollScreenState
   columns: QVector<Column>
   activeColumnIdx
-  viewOffset            // relative to active column — NOT absolute
+  scrollX               // absolute strip-x at the viewport's inner-left edge
 Column
   tiles: QVector<Tile>  // each tile = one windowId
   activeTileIdx

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -462,6 +462,11 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     connect(w, &KWin::EffectWindow::windowFrameGeometryChanged, m_scrollHandler.get(),
             &ScrollHandler::onWindowFrameGeometryChanged);
 
+    // Scroll: drag-to-reorder — when an interactive move of a tiled scroll
+    // window finishes, reorder its column to the drop position.
+    connect(w, &KWin::EffectWindow::windowFinishUserMovedResized, m_scrollHandler.get(),
+            &ScrollHandler::onWindowDragFinished);
+
     // Frame-geometry shadow: push the latest geometry to the daemon so
     // daemon-local shortcut handlers (float toggle, etc.) can read fresh
     // geometry without round-tripping. Debounced at ~50ms per window via

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -212,6 +212,10 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     connect(w, &KWin::EffectWindow::windowDesktopsChanged, this, [this](KWin::EffectWindow* window) {
         updateWindowStickyState(window);
 
+        // Scroll mode excludes all-desktops (sticky) windows — re-evaluate
+        // this window's strip membership when its desktop pinning changes.
+        m_scrollHandler->handleWindowStickyChanged(window);
+
         // When a window is moved to a different desktop (e.g., "Move to Desktop 2"),
         // treat it as removed from the current desktop's tiling. The normal desktop-
         // switch flow will pick it up when the user switches to the target desktop.

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -466,8 +466,11 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
     connect(w, &KWin::EffectWindow::windowFrameGeometryChanged, m_scrollHandler.get(),
             &ScrollHandler::onWindowFrameGeometryChanged);
 
-    // Scroll: drag-to-reorder — when an interactive move of a tiled scroll
-    // window finishes, reorder its column to the drop position.
+    // Scroll: drag-to-reorder — record move-vs-resize at interaction start
+    // (isUserResize() is reliable here), and on finish reorder the dragged
+    // window's column to the drop position (a resize is ignored).
+    connect(w, &KWin::EffectWindow::windowStartUserMovedResized, m_scrollHandler.get(),
+            &ScrollHandler::onWindowMoveResizeStarted);
     connect(w, &KWin::EffectWindow::windowFinishUserMovedResized, m_scrollHandler.get(),
             &ScrollHandler::onWindowDragFinished);
 

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -311,6 +311,59 @@ void ScrollHandler::flushReasserts()
     }
 }
 
+void ScrollHandler::onWindowDragFinished(KWin::EffectWindow* w)
+{
+    if (!w) {
+        return;
+    }
+    const QString windowId = m_effect->getWindowId(w);
+    if (!m_notifiedWindows.contains(windowId)) {
+        return; // not a scroll-tracked window
+    }
+    const QString screenId = m_notifiedWindowScreens.value(windowId);
+    if (!m_scrollScreens.contains(screenId)) {
+        return;
+    }
+    // The dragged window kept its tile slot during the move (the geometry
+    // re-assert is suppressed mid-drag). On release, reorder its column to the
+    // strip slot nearest the drop point: find the scroll window on the same
+    // screen whose resolved tile the drop-x is over or closest to — the
+    // anchor — and the engine moves the dragged column next to it.
+    const QRect frame = w->frameGeometry().toRect();
+    const int dropX = frame.center().x();
+    QString anchorId;
+    int bestDistance = -1;
+    bool placeAfter = false;
+    for (auto it = m_appliedGeometry.cbegin(); it != m_appliedGeometry.cend(); ++it) {
+        const QString& otherId = it.key();
+        if (otherId == windowId || m_notifiedWindowScreens.value(otherId) != screenId) {
+            continue;
+        }
+        const QRect& rect = it.value();
+        int distance = 0;
+        if (dropX < rect.left()) {
+            distance = rect.left() - dropX;
+        } else if (dropX > rect.right()) {
+            distance = dropX - rect.right();
+        }
+        if (bestDistance < 0 || distance < bestDistance) {
+            bestDistance = distance;
+            anchorId = otherId;
+            placeAfter = dropX > rect.center().x();
+        }
+    }
+    if (anchorId.isEmpty()) {
+        return; // nothing else on the strip to reorder against
+    }
+    // The reorder supersedes any drift re-assert queued for this window by
+    // onWindowFrameGeometryChanged when the interactive move ended.
+    m_reassertPending.remove(windowId);
+    PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
+                                                   QStringLiteral("windowDropped"), {windowId, anchorId, placeAfter},
+                                                   QStringLiteral("windowDropped"));
+    qCDebug(lcEffect) << "Notified scroll: windowDropped" << windowId << "anchor" << anchorId << "after" << placeAfter;
+}
+
 void ScrollHandler::notifyWindowFocused(const QString& windowId, const QString& screenId)
 {
     if (!m_scrollScreens.contains(screenId)) {

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -171,6 +171,8 @@ void ScrollHandler::onWindowClosed(const QString& windowId, const QString& scree
     m_appliedGeometry.remove(windowId);
     m_reassertPending.remove(windowId);
     m_reasserted.remove(windowId);
+    m_reorderPending.remove(windowId);
+    m_interactiveResize.remove(windowId);
 
     if (m_scrollScreens.contains(screenId)) {
         PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
@@ -259,12 +261,20 @@ void ScrollHandler::handleWindowStickyChanged(KWin::EffectWindow* w)
 
 void ScrollHandler::recordAppliedGeometry(const QString& windowId, const QRect& geometry)
 {
+    if (!m_notifiedWindows.contains(windowId)) {
+        // Only scroll-tracked windows — keeps m_appliedGeometry a subset of
+        // m_notifiedWindows so the two cannot drift apart (a scroll batch may
+        // momentarily name a window dropped from tracking mid-flight).
+        return;
+    }
     m_appliedGeometry[windowId] = geometry;
     // The window is being moved to match this geometry — drop any stale
     // re-assert queued from an earlier drift, and reset the re-assert budget:
-    // a fresh daemon resolve is a new episode.
+    // a fresh daemon resolve is a new episode. A drag-reorder for this window
+    // is likewise now resolved, so the re-assert suppression can lift.
     m_reassertPending.remove(windowId);
     m_reasserted.remove(windowId);
+    m_reorderPending.remove(windowId);
 }
 
 void ScrollHandler::onWindowFrameGeometryChanged(KWin::EffectWindow* w)
@@ -282,6 +292,13 @@ void ScrollHandler::onWindowFrameGeometryChanged(KWin::EffectWindow* w)
     const QString windowId = m_effect->getWindowId(w);
     if (!m_notifiedWindows.contains(windowId)) {
         return; // not a scroll-tracked window
+    }
+    if (m_reorderPending.contains(windowId)) {
+        // A drag-reorder (windowDropped) is in flight for this window; the
+        // daemon's re-resolve will land via recordAppliedGeometry. Suppressing
+        // the drift re-assert until then avoids snapping the window back to its
+        // pre-drag slot in the gap before the reorder applies.
+        return;
     }
     const auto it = m_appliedGeometry.constFind(windowId);
     if (it == m_appliedGeometry.constEnd()) {
@@ -339,12 +356,33 @@ void ScrollHandler::flushReasserts()
     }
 }
 
+void ScrollHandler::onWindowMoveResizeStarted(KWin::EffectWindow* w)
+{
+    if (!w) {
+        return;
+    }
+    // isUserResize() is reliable here (the start signal) — an interactive
+    // resize sets it, a plain move leaves it false — but not necessarily at
+    // the finish signal, so the verdict is recorded now for onWindowDragFinished.
+    const QString windowId = m_effect->getWindowId(w);
+    if (w->isUserResize()) {
+        m_interactiveResize.insert(windowId);
+    } else {
+        m_interactiveResize.remove(windowId);
+    }
+}
+
 void ScrollHandler::onWindowDragFinished(KWin::EffectWindow* w)
 {
     if (!w) {
         return;
     }
     const QString windowId = m_effect->getWindowId(w);
+    // A resize is not a drag-to-reorder. The verdict was recorded at the start
+    // signal (isUserResize() is unreliable at finish); consume it either way.
+    if (m_interactiveResize.remove(windowId)) {
+        return;
+    }
     if (!m_notifiedWindows.contains(windowId)) {
         return; // not a scroll-tracked window
     }
@@ -354,13 +392,25 @@ void ScrollHandler::onWindowDragFinished(KWin::EffectWindow* w)
     }
     // The dragged window kept its tile slot during the move (the geometry
     // re-assert is suppressed mid-drag). On release, reorder its column to the
-    // strip slot nearest the drop point: find the scroll window on the same
-    // screen whose resolved tile the drop-x is over or closest to — the
-    // anchor — and the engine moves the dragged column next to it.
-    const QRect frame = w->frameGeometry().toRect();
-    const int dropX = frame.center().x();
+    // strip slot nearest the drop point.
+    const auto draggedIt = m_appliedGeometry.constFind(windowId);
+    if (draggedIt == m_appliedGeometry.constEnd()) {
+        return; // the daemon has not resolved a slot for this window yet
+    }
+    const QRect draggedRect = draggedIt.value();
+    const int dropX = w->frameGeometry().toRect().center().x();
+    // A drop still within the dragged window's own column is a no-op — the
+    // window was nudged but not carried out of its slot.
+    if (dropX >= draggedRect.left() && dropX <= draggedRect.right()) {
+        return;
+    }
+    // Pick the anchor: among scroll windows on the same screen in a *different*
+    // column (a different resolved x-range than the dragged window's own), the
+    // one whose tile the drop-x is over or nearest. Ties resolve to the
+    // leftmost candidate so the result does not depend on QHash iteration order.
     QString anchorId;
     int bestDistance = -1;
+    int bestLeft = 0;
     bool placeAfter = false;
     for (auto it = m_appliedGeometry.cbegin(); it != m_appliedGeometry.cend(); ++it) {
         const QString& otherId = it.key();
@@ -368,24 +418,35 @@ void ScrollHandler::onWindowDragFinished(KWin::EffectWindow* w)
             continue;
         }
         const QRect& rect = it.value();
+        if (rect.left() == draggedRect.left()) {
+            continue; // a tile of the dragged window's own column
+        }
         int distance = 0;
         if (dropX < rect.left()) {
             distance = rect.left() - dropX;
         } else if (dropX > rect.right()) {
             distance = dropX - rect.right();
         }
-        if (bestDistance < 0 || distance < bestDistance) {
+        if (bestDistance < 0 || distance < bestDistance || (distance == bestDistance && rect.left() < bestLeft)) {
             bestDistance = distance;
+            bestLeft = rect.left();
             anchorId = otherId;
+            // Distance ranks columns by their edges; the side to land on is
+            // taken from the column centre — for a gap drop these compose
+            // (a drop in the gap left of a column is left of its centre).
             placeAfter = dropX > rect.center().x();
         }
     }
     if (anchorId.isEmpty()) {
-        return; // nothing else on the strip to reorder against
+        return; // no other column on the strip to reorder against
     }
-    // The reorder supersedes any drift re-assert queued for this window by
-    // onWindowFrameGeometryChanged when the interactive move ended.
+    // The reorder supersedes the drift re-assert: drop any pending one and
+    // suppress new ones until the daemon's re-resolve lands. The reorder is a
+    // genuine cross-column move (own-column drops and same-column anchors are
+    // excluded above), so the engine always re-resolves and recordAppliedGeometry
+    // clears m_reorderPending.
     m_reassertPending.remove(windowId);
+    m_reorderPending.insert(windowId);
     PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
                                                    QStringLiteral("windowDropped"), {windowId, anchorId, placeAfter},
                                                    QStringLiteral("windowDropped"));
@@ -418,6 +479,8 @@ void ScrollHandler::onDaemonReady()
     m_appliedGeometry.clear();
     m_reassertPending.clear();
     m_reasserted.clear();
+    m_reorderPending.clear();
+    m_interactiveResize.clear();
     m_reassertTimer->stop();
     connectSignals();
     loadSettings();

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -41,9 +41,18 @@ ScrollHandler::ScrollHandler(PlasmaZonesEffect* effect, QObject* parent)
     connect(m_reassertTimer, &QTimer::timeout, this, &ScrollHandler::flushReasserts);
 }
 
+bool ScrollHandler::isEligibleForScroll(KWin::EffectWindow* w) const
+{
+    // Scroll mode adds one exclusion to the shared tiling predicate: a window
+    // pinned to all desktops (sticky) is never tiled — the strip is
+    // per-desktop, so a sticky window would have to occupy every strip at
+    // once. It is left floating instead.
+    return m_effect->isEligibleForTilingNotify(w) && !m_effect->isWindowSticky(w);
+}
+
 void ScrollHandler::notifyWindowAdded(KWin::EffectWindow* w)
 {
-    if (!m_effect->isEligibleForTilingNotify(w)) {
+    if (!isEligibleForScroll(w)) {
         return;
     }
 
@@ -94,7 +103,7 @@ void ScrollHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& wi
     QStringList batchWindowIds; // for error rollback
 
     for (KWin::EffectWindow* w : windows) {
-        if (!m_effect->isEligibleForTilingNotify(w)) {
+        if (!isEligibleForScroll(w)) {
             continue;
         }
         const QString screenId = m_effect->getWindowScreenId(w);
@@ -227,6 +236,25 @@ void ScrollHandler::handleWindowOutputChanged(KWin::EffectWindow* w)
     // Arrived somewhere new — notifyWindowAdded re-adds it iff the new screen
     // is a scroll-mode screen and the window is eligible.
     notifyWindowAdded(w);
+}
+
+void ScrollHandler::handleWindowStickyChanged(KWin::EffectWindow* w)
+{
+    if (!w) {
+        return;
+    }
+    const QString windowId = m_effect->getWindowId(w);
+    if (m_effect->isWindowSticky(w)) {
+        // Pinned to all desktops: drop it from its strip if tracked — scroll
+        // mode does not tile sticky windows. The window stays put and floats.
+        if (m_notifiedWindows.contains(windowId)) {
+            onWindowClosed(windowId, m_notifiedWindowScreens.value(windowId));
+        }
+    } else if (!m_notifiedWindows.contains(windowId)) {
+        // No longer sticky — re-tile it. notifyWindowAdded self-gates on
+        // eligibility, the scroll-screen set and the current desktop.
+        notifyWindowAdded(w);
+    }
 }
 
 void ScrollHandler::recordAppliedGeometry(const QString& windowId, const QRect& geometry)

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -212,10 +212,13 @@ void ScrollHandler::onWindowMinimizedChanged(KWin::EffectWindow* w)
         // and drop any in-flight drag-reorder bookkeeping: a minimize while a
         // windowDropped is in flight supersedes it (the daemon re-resolve that
         // would have cleared m_reorderPending now excludes the minimized
-        // window, so it must be cleared here).
+        // window, so it must be cleared here). Any interactive move/resize is
+        // likewise over once the window is minimized — clear all of this
+        // window's transient effect-side state in one place.
         m_appliedGeometry.remove(windowId);
         m_reassertPending.remove(windowId);
         m_reorderPending.remove(windowId);
+        m_interactiveResize.remove(windowId);
     }
     PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
                                                    QStringLiteral("windowMinimizedChanged"), {windowId, minimized},

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -208,9 +208,14 @@ void ScrollHandler::onWindowMinimizedChanged(KWin::EffectWindow* w)
     if (minimized) {
         // A minimized window leaves the visible layout — its resolved-geometry
         // reference is stale until the strip re-resolves on restore. Drop it so
-        // onWindowFrameGeometryChanged cannot re-assert against a stale slot.
+        // onWindowFrameGeometryChanged cannot re-assert against a stale slot,
+        // and drop any in-flight drag-reorder bookkeeping: a minimize while a
+        // windowDropped is in flight supersedes it (the daemon re-resolve that
+        // would have cleared m_reorderPending now excludes the minimized
+        // window, so it must be cleared here).
         m_appliedGeometry.remove(windowId);
         m_reassertPending.remove(windowId);
+        m_reorderPending.remove(windowId);
     }
     PhosphorProtocol::ClientHelpers::fireAndForget(m_effect, PhosphorProtocol::Service::Interface::Scroll,
                                                    QStringLiteral("windowMinimizedChanged"), {windowId, minimized},

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -64,6 +64,13 @@ public:
     /// and adds it to the new one when either is scroll mode.
     void handleWindowOutputChanged(KWin::EffectWindow* w);
 
+    /// React to a window's all-desktops (sticky) state changing. Scroll mode
+    /// never tiles a sticky window — it cannot occupy every per-desktop strip
+    /// at once — so a window pinned to all desktops is dropped from its strip,
+    /// and one that is un-pinned is re-tiled if it now belongs on a scroll
+    /// screen.
+    void handleWindowStickyChanged(KWin::EffectWindow* w);
+
     /// Record the geometry the daemon last resolved for a scroll window, so
     /// an app-initiated resize away from it can be detected and corrected.
     void recordAppliedGeometry(const QString& windowId, const QRect& geometry);
@@ -106,6 +113,10 @@ private:
      * @param windows Candidate windows to process.
      */
     void notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows);
+
+    /// Whether @p w should be tiled by scroll mode: the mode-generic tiling
+    /// predicate, plus scroll's exclusion of all-desktops (sticky) windows.
+    bool isEligibleForScroll(KWin::EffectWindow* w) const;
 
     /// Tracked windows currently reported as being on @p screenId.
     QStringList trackedWindowsOnScreen(const QString& screenId) const;

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -80,10 +80,16 @@ public:
     /// scroll-window geometry.
     void onWindowFrameGeometryChanged(KWin::EffectWindow* w);
 
+    /// React to a window's interactive move/resize starting. Records whether
+    /// the interaction is a resize — `isUserResize()` is reliable at the start
+    /// signal but not necessarily at finish — so onWindowDragFinished can tell
+    /// a drag-to-reorder from a resize.
+    void onWindowMoveResizeStarted(KWin::EffectWindow* w);
+
     /// React to a scroll window's interactive move/resize finishing. A drag
     /// that released over another column's span reorders the dragged window's
     /// column to the drop position (drag-to-reorder); the strip then re-resolves
-    /// and snaps the window into its new slot.
+    /// and snaps the window into its new slot. A resize is ignored.
     void onWindowDragFinished(KWin::EffectWindow* w);
 
     /// Report a focus change to the scroll engine. No-op off scroll screens.
@@ -136,6 +142,15 @@ private:
     /// point for detecting app-initiated resizes.
     QHash<QString, QRect> m_appliedGeometry;
     QSet<QString> m_reassertPending; ///< Windows awaiting a debounced re-assert.
+    /// Windows currently in an interactive *resize* (recorded at the start
+    /// signal). onWindowDragFinished consults this to skip resizes — only a
+    /// move is a drag-to-reorder.
+    QSet<QString> m_interactiveResize;
+    /// Windows with a drag-reorder (windowDropped) in flight to the daemon.
+    /// Drift re-asserts are suppressed for them until the daemon's re-resolve
+    /// lands (recordAppliedGeometry clears the flag), so a stale re-assert
+    /// cannot snap the window back to its pre-drag slot mid-reorder.
+    QSet<QString> m_reorderPending;
     /// Windows already re-asserted since the daemon last resolved them — caps
     /// re-assertion at one attempt per resolve episode so a window that cannot
     /// hit the exact tile rect (X11 size increments) does not loop.

--- a/kwin-effect/scrollhandler.h
+++ b/kwin-effect/scrollhandler.h
@@ -73,6 +73,12 @@ public:
     /// scroll-window geometry.
     void onWindowFrameGeometryChanged(KWin::EffectWindow* w);
 
+    /// React to a scroll window's interactive move/resize finishing. A drag
+    /// that released over another column's span reorders the dragged window's
+    /// column to the drop position (drag-to-reorder); the strip then re-resolves
+    /// and snaps the window into its new slot.
+    void onWindowDragFinished(KWin::EffectWindow* w);
+
     /// Report a focus change to the scroll engine. No-op off scroll screens.
     void notifyWindowFocused(const QString& windowId, const QString& screenId);
 

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -78,6 +78,11 @@ public:
     /// layout (Karousel's TiledMinimized). Scroll-specific — minimize has no
     /// IPlacementEngine equivalent (autotile routes minimize through float).
     void windowMinimizedChanged(const QString& windowId, bool minimized);
+    /// Reorder the column holding @p draggedWindowId next to the column
+    /// holding @p anchorWindowId (before it, or after when @p placeAfter) and
+    /// focus the dragged window. Drives drag-to-reorder ("reorder on drop");
+    /// scroll-specific — has no IPlacementEngine equivalent.
+    void windowDropped(const QString& draggedWindowId, const QString& anchorWindowId, bool placeAfter);
 
     // ── Float ───────────────────────────────────────────────────────────
     void toggleWindowFloat(const QString& windowId, const QString& screenId) override;

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollLayout.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollLayout.h
@@ -38,6 +38,27 @@ struct ScrollLayoutConfig
     ScrollViewportMode viewportMode = ScrollViewportMode::Fit;
 };
 
+/// Per-column resolved geometry: column widths and strip-space X positions.
+///
+/// Both depend only on the column structure and the working-area width —
+/// never on the scroll position — so a single relayout can resolve them once
+/// and feed the same value to both computeViewportScroll() and
+/// resolveScrollLayout(). @ref widths and @ref stripX are indexed by column;
+/// a collapsed column (every tile minimized) has width 0 and shares the next
+/// column's stripX.
+struct ScrollColumnMetrics
+{
+    QVector<qreal> widths;
+    QVector<qreal> stripX;
+};
+
+/// Resolve column widths and strip-space X positions for @p state against
+/// @p workArea. Pure. Pass the result to computeViewportScroll() and
+/// resolveScrollLayout() to resolve the metrics once per relayout.
+PHOSPHORSCROLLENGINE_EXPORT ScrollColumnMetrics resolveColumnMetrics(const ScrollScreenState& state,
+                                                                     const QRectF& workArea,
+                                                                     const ScrollLayoutConfig& config);
+
 /// Resolve the scrollable-tiling strip into absolute per-window geometry.
 ///
 /// The strip is an unbounded horizontal canvas; the returned rectangles are
@@ -47,10 +68,16 @@ struct ScrollLayoutConfig
 /// inner-left edge of the working area. Callers that want the focused column
 /// on-screen run computeViewportScroll() and store the result first.
 ///
+/// @p metrics, when non-null, supplies pre-resolved column metrics (see
+/// resolveColumnMetrics) so a caller doing both this and computeViewportScroll
+/// resolves them only once; when null they are resolved internally.
+///
 /// Returns windowId → frame rectangle for every tiled window. Floating
 /// windows are not part of the strip and are not placed.
-PHOSPHORSCROLLENGINE_EXPORT QHash<QString, QRectF>
-resolveScrollLayout(const ScrollScreenState& state, const QRectF& workArea, const ScrollLayoutConfig& config);
+PHOSPHORSCROLLENGINE_EXPORT QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state,
+                                                                       const QRectF& workArea,
+                                                                       const ScrollLayoutConfig& config,
+                                                                       const ScrollColumnMetrics* metrics = nullptr);
 
 /// Compute the viewport scroll position (absolute strip-x mapping to the
 /// working area's inner-left edge) that brings the focused column on-screen,
@@ -60,8 +87,11 @@ resolveScrollLayout(const ScrollScreenState& state, const QRectF& workArea, cons
 /// anchors the result; a strip with no visible column keeps the current
 /// scrollX(). Pure — the caller stores the result via ScrollScreenState::
 /// setScrollX().
+///
+/// @p metrics behaves as in resolveScrollLayout().
 PHOSPHORSCROLLENGINE_EXPORT qreal computeViewportScroll(const ScrollScreenState& state, const QRectF& workArea,
-                                                        const ScrollLayoutConfig& config);
+                                                        const ScrollLayoutConfig& config,
+                                                        const ScrollColumnMetrics* metrics = nullptr);
 
 /// Window IDs from @p geometries whose rectangle intersects @p workArea —
 /// i.e. the windows currently (partly) visible. Useful for limiting real

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollLayout.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollLayout.h
@@ -14,6 +14,15 @@
 
 namespace PhosphorScrollEngine {
 
+/// How the viewport scrolls to keep the focused column on-screen.
+enum class ScrollViewportMode {
+    /// Minimum scroll: move only enough to bring the focused column fully
+    /// on-screen; leave the viewport untouched when it is already visible.
+    Fit,
+    /// Always scroll so the focused column is centered in the working area.
+    Centered,
+};
+
 /// Tuning for resolving a ScrollScreenState into pixel geometry.
 struct ScrollLayoutConfig
 {
@@ -25,6 +34,8 @@ struct ScrollLayoutConfig
     /// indexed by WindowHeight::presetIndex. An out-of-range index falls
     /// back to Auto sizing.
     QVector<qreal> presetWindowHeights;
+    /// How computeViewportScroll() repositions the viewport on focus change.
+    ScrollViewportMode viewportMode = ScrollViewportMode::Fit;
 };
 
 /// Resolve the scrollable-tiling strip into absolute per-window geometry.
@@ -32,13 +43,25 @@ struct ScrollLayoutConfig
 /// The strip is an unbounded horizontal canvas; the returned rectangles are
 /// in @p workArea's coordinate space and MAY fall partly or wholly outside
 /// it (off-screen columns) — that is expected and intentional. The viewport
-/// is anchored to the focused column: at viewOffset 0 the focused column's
-/// left edge sits at the inner-left edge of the working area.
+/// is positioned by @p state's scrollX(): that strip-x coordinate maps to the
+/// inner-left edge of the working area. Callers that want the focused column
+/// on-screen run computeViewportScroll() and store the result first.
 ///
 /// Returns windowId → frame rectangle for every tiled window. Floating
 /// windows are not part of the strip and are not placed.
 PHOSPHORSCROLLENGINE_EXPORT QHash<QString, QRectF>
 resolveScrollLayout(const ScrollScreenState& state, const QRectF& workArea, const ScrollLayoutConfig& config);
+
+/// Compute the viewport scroll position (absolute strip-x mapping to the
+/// working area's inner-left edge) that brings the focused column on-screen,
+/// per @p config.viewportMode. Fit mode reads @p state's current scrollX() so
+/// an already-visible column is left untouched; Centered ignores it. When the
+/// focused column is fully minimized (collapsed) the nearest visible column
+/// anchors the result; a strip with no visible column keeps the current
+/// scrollX(). Pure — the caller stores the result via ScrollScreenState::
+/// setScrollX().
+PHOSPHORSCROLLENGINE_EXPORT qreal computeViewportScroll(const ScrollScreenState& state, const QRectF& workArea,
+                                                        const ScrollLayoutConfig& config);
 
 /// Window IDs from @p geometries whose rectangle intersects @p workArea —
 /// i.e. the windows currently (partly) visible. Useful for limiting real

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
@@ -57,15 +57,17 @@ public:
     const Column* activeColumn() const;
     QString focusedWindowId() const;
 
-    /// Viewport offset relative to the active column (logical pixels).
-    /// Stored intent only; geometry resolution interprets it.
-    qreal viewOffset() const
+    /// Absolute viewport scroll position: the strip-x coordinate that maps to
+    /// the inner-left edge of the working area. Stored intent only — the
+    /// daemon computes it (computeViewportScroll) and geometry resolution
+    /// (resolveScrollLayout) interprets it.
+    qreal scrollX() const
     {
-        return m_viewOffset;
+        return m_scrollX;
     }
-    void setViewOffset(qreal offset)
+    void setScrollX(qreal scrollX)
     {
-        m_viewOffset = offset;
+        m_scrollX = scrollX;
     }
 
     // ── Window placement ────────────────────────────────────────────────
@@ -151,7 +153,7 @@ private:
     QString m_screenId;
     QVector<Column> m_columns;
     int m_activeColumnIndex = -1;
-    qreal m_viewOffset = 0.0;
+    qreal m_scrollX = 0.0;
     QSet<QString> m_floatingWindows;
 };
 

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
@@ -114,7 +114,9 @@ public:
     /// immediately before (or after, when @p placeAfter) the column holding
     /// @p anchorWindowId, and focus @p draggedWindowId. Drives drag-to-reorder.
     /// Returns false when either window is not tiled here or both share a
-    /// column (a drop onto the dragged window's own column is a no-op).
+    /// column (a drop onto the dragged window's own column). A drop that
+    /// resolves to the dragged column's existing slot still returns true (it
+    /// is a valid drop — the column order is simply left unchanged).
     bool moveColumnNextTo(const QString& draggedWindowId, const QString& anchorWindowId, bool placeAfter);
 
     // ── Width / height intent ───────────────────────────────────────────

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
@@ -110,6 +110,12 @@ public:
     bool moveColumn(int delta);
     /// Reorder the focused tile within its column by @p delta; focus follows.
     bool moveTile(int delta);
+    /// Reorder the whole column holding @p draggedWindowId so it sits
+    /// immediately before (or after, when @p placeAfter) the column holding
+    /// @p anchorWindowId, and focus @p draggedWindowId. Drives drag-to-reorder.
+    /// Returns false when either window is not tiled here or both share a
+    /// column (a drop onto the dragged window's own column is a no-op).
+    bool moveColumnNextTo(const QString& draggedWindowId, const QString& anchorWindowId, bool placeAfter);
 
     // ── Width / height intent ───────────────────────────────────────────
     /// Set the focused column's width intent (no-op when the strip is empty).

--- a/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
@@ -237,6 +237,21 @@ void ScrollEngine::windowMinimizedChanged(const QString& windowId, bool minimize
     }
 }
 
+void ScrollEngine::windowDropped(const QString& draggedWindowId, const QString& anchorWindowId, bool placeAfter)
+{
+    const auto it = m_windowToKey.constFind(draggedWindowId);
+    if (it == m_windowToKey.constEnd()) {
+        return;
+    }
+    if (ScrollScreenState* state = stateForKey(it.value(), /*create=*/false);
+        state && state->moveColumnNextTo(draggedWindowId, anchorWindowId, placeAfter)) {
+        // The drag focused the window — make its screen active so the viewport
+        // fit-scrolls to it on the next resolve.
+        m_activeScreen = it.value().screenId;
+        emitChanged(it.value().screenId);
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // Float
 // ─────────────────────────────────────────────────────────────────────────

--- a/libs/phosphor-scroll-engine/src/ScrollLayout.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollLayout.cpp
@@ -13,28 +13,6 @@ qreal resolveColumnWidth(const ColumnWidth& width, qreal usableWidth)
     return qMax(resolved, qreal(1.0));
 }
 
-/// Resolve per-column widths and strip-space X positions. Columns pack left
-/// to right from strip-x 0, separated by the inner gap; a column whose every
-/// tile is minimized collapses — zero width, no gap, the cursor does not
-/// advance — so it keeps its slot in the column order without leaving a gap.
-/// A collapsed column's stripX therefore coincides with the next column's.
-void resolveColumnMetrics(const QVector<Column>& columns, qreal usableW, qreal inner, QVector<qreal>& widths,
-                          QVector<qreal>& stripX)
-{
-    widths = QVector<qreal>(columns.size(), 0.0);
-    stripX = QVector<qreal>(columns.size(), 0.0);
-    qreal cursor = 0.0;
-    for (int ci = 0; ci < columns.size(); ++ci) {
-        stripX[ci] = cursor;
-        if (!columns.at(ci).hasVisibleTiles()) {
-            continue; // collapsed column — keeps its slot, takes no strip space
-        }
-        const qreal width = resolveColumnWidth(columns.at(ci).width(), usableW);
-        widths[ci] = width;
-        cursor += width + inner;
-    }
-}
-
 /// Index of the column that anchors the viewport: the focused column when it
 /// is visible, otherwise the nearest visible column (searching right first,
 /// since a mid-strip collapsed column shares the next column's stripX, then
@@ -79,8 +57,37 @@ qreal resolveConcreteTileHeight(const WindowHeight& height, qreal columnHeight, 
 
 } // namespace
 
+ScrollColumnMetrics resolveColumnMetrics(const ScrollScreenState& state, const QRectF& workArea,
+                                         const ScrollLayoutConfig& config)
+{
+    // Columns pack left to right from strip-x 0, separated by the inner gap;
+    // a column whose every tile is minimized collapses — zero width, no gap,
+    // the cursor does not advance — so it keeps its slot in the column order
+    // without leaving a gap. A collapsed column's stripX therefore coincides
+    // with the next column's.
+    const QVector<Column>& columns = state.columns();
+    const qreal outer = qMax(config.outerGap, qreal(0.0));
+    const qreal inner = qMax(config.innerGap, qreal(0.0));
+    const qreal usableW = qMax(workArea.width() - 2.0 * outer, qreal(0.0));
+
+    ScrollColumnMetrics metrics;
+    metrics.widths = QVector<qreal>(columns.size(), 0.0);
+    metrics.stripX = QVector<qreal>(columns.size(), 0.0);
+    qreal cursor = 0.0;
+    for (int ci = 0; ci < columns.size(); ++ci) {
+        metrics.stripX[ci] = cursor;
+        if (!columns.at(ci).hasVisibleTiles()) {
+            continue; // collapsed column — keeps its slot, takes no strip space
+        }
+        const qreal width = resolveColumnWidth(columns.at(ci).width(), usableW);
+        metrics.widths[ci] = width;
+        cursor += width + inner;
+    }
+    return metrics;
+}
+
 QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const QRectF& workArea,
-                                           const ScrollLayoutConfig& config)
+                                           const ScrollLayoutConfig& config, const ScrollColumnMetrics* metrics)
 {
     QHash<QString, QRectF> geometries;
     const QVector<Column>& columns = state.columns();
@@ -92,12 +99,18 @@ QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const
     const qreal inner = qMax(config.innerGap, qreal(0.0));
     const qreal usableX = workArea.x() + outer;
     const qreal usableY = workArea.y() + outer;
-    const qreal usableW = qMax(workArea.width() - 2.0 * outer, qreal(0.0));
     const qreal usableH = qMax(workArea.height() - 2.0 * outer, qreal(0.0));
 
-    QVector<qreal> widths;
-    QVector<qreal> stripX;
-    resolveColumnMetrics(columns, usableW, inner, widths, stripX);
+    // Column metrics are scroll-independent; reuse the caller's when supplied
+    // (one relayout resolves them once for both viewport + geometry), else
+    // resolve them here.
+    ScrollColumnMetrics ownMetrics;
+    if (!metrics) {
+        ownMetrics = resolveColumnMetrics(state, workArea, config);
+        metrics = &ownMetrics;
+    }
+    const QVector<qreal>& widths = metrics->widths;
+    const QVector<qreal>& stripX = metrics->stripX;
 
     // The viewport's inner-left edge maps to this strip-x coordinate. It is
     // computed by computeViewportScroll() and stored on the state by the
@@ -163,7 +176,8 @@ QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const
     return geometries;
 }
 
-qreal computeViewportScroll(const ScrollScreenState& state, const QRectF& workArea, const ScrollLayoutConfig& config)
+qreal computeViewportScroll(const ScrollScreenState& state, const QRectF& workArea, const ScrollLayoutConfig& config,
+                            const ScrollColumnMetrics* metrics)
 {
     const QVector<Column>& columns = state.columns();
     const int activeIndex = state.activeColumnIndex();
@@ -172,20 +186,23 @@ qreal computeViewportScroll(const ScrollScreenState& state, const QRectF& workAr
     }
 
     const qreal outer = qMax(config.outerGap, qreal(0.0));
-    const qreal inner = qMax(config.innerGap, qreal(0.0));
     const qreal usableW = qMax(workArea.width() - 2.0 * outer, qreal(0.0));
 
-    QVector<qreal> widths;
-    QVector<qreal> stripX;
-    resolveColumnMetrics(columns, usableW, inner, widths, stripX);
+    // Column metrics are scroll-independent; reuse the caller's when supplied,
+    // else resolve them here (see resolveScrollLayout).
+    ScrollColumnMetrics ownMetrics;
+    if (!metrics) {
+        ownMetrics = resolveColumnMetrics(state, workArea, config);
+        metrics = &ownMetrics;
+    }
 
-    const int anchor = viewportAnchorColumn(widths, activeIndex);
+    const int anchor = viewportAnchorColumn(metrics->widths, activeIndex);
     if (anchor < 0) {
         return state.scrollX(); // every column collapsed — leave the viewport put
     }
 
-    const qreal colLeft = stripX.at(anchor);
-    const qreal colWidth = widths.at(anchor);
+    const qreal colLeft = metrics->stripX.at(anchor);
+    const qreal colWidth = metrics->widths.at(anchor);
 
     if (config.viewportMode == ScrollViewportMode::Centered) {
         // Center the anchor column in the working area.
@@ -196,7 +213,11 @@ qreal computeViewportScroll(const ScrollScreenState& state, const QRectF& workAr
     // on-screen, and not at all when it already is.
     const qreal current = state.scrollX();
     if (colWidth >= usableW) {
-        return colLeft; // wider than the viewport — pin its left edge
+        // Wider than the viewport — it cannot fit. Keep the current scroll
+        // when the column already fills the viewport edge to edge, otherwise
+        // scroll the minimum to close the dead space: clamp to the range that
+        // keeps the viewport entirely within the column.
+        return qBound(colLeft, current, colLeft + colWidth - usableW);
     }
     if (colLeft < current) {
         return colLeft; // off the left edge — scroll left just enough

--- a/libs/phosphor-scroll-engine/src/ScrollLayout.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollLayout.cpp
@@ -13,6 +13,51 @@ qreal resolveColumnWidth(const ColumnWidth& width, qreal usableWidth)
     return qMax(resolved, qreal(1.0));
 }
 
+/// Resolve per-column widths and strip-space X positions. Columns pack left
+/// to right from strip-x 0, separated by the inner gap; a column whose every
+/// tile is minimized collapses — zero width, no gap, the cursor does not
+/// advance — so it keeps its slot in the column order without leaving a gap.
+/// A collapsed column's stripX therefore coincides with the next column's.
+void resolveColumnMetrics(const QVector<Column>& columns, qreal usableW, qreal inner, QVector<qreal>& widths,
+                          QVector<qreal>& stripX)
+{
+    widths = QVector<qreal>(columns.size(), 0.0);
+    stripX = QVector<qreal>(columns.size(), 0.0);
+    qreal cursor = 0.0;
+    for (int ci = 0; ci < columns.size(); ++ci) {
+        stripX[ci] = cursor;
+        if (!columns.at(ci).hasVisibleTiles()) {
+            continue; // collapsed column — keeps its slot, takes no strip space
+        }
+        const qreal width = resolveColumnWidth(columns.at(ci).width(), usableW);
+        widths[ci] = width;
+        cursor += width + inner;
+    }
+}
+
+/// Index of the column that anchors the viewport: the focused column when it
+/// is visible, otherwise the nearest visible column (searching right first,
+/// since a mid-strip collapsed column shares the next column's stripX, then
+/// left). Returns -1 when no column is visible. @p widths is from
+/// resolveColumnMetrics; @p activeIndex must be a valid column index.
+int viewportAnchorColumn(const QVector<qreal>& widths, int activeIndex)
+{
+    if (widths.at(activeIndex) > 0.0) {
+        return activeIndex;
+    }
+    for (int ci = activeIndex + 1; ci < widths.size(); ++ci) {
+        if (widths.at(ci) > 0.0) {
+            return ci;
+        }
+    }
+    for (int ci = activeIndex - 1; ci >= 0; --ci) {
+        if (widths.at(ci) > 0.0) {
+            return ci;
+        }
+    }
+    return -1;
+}
+
 /// Resolve a tile's concrete (non-Auto) height. Returns a value >= 0 for
 /// Fixed/Preset tiles, or -1.0 for Auto tiles (and for out-of-range Preset
 /// indices, which fall back to Auto).
@@ -50,60 +95,14 @@ QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const
     const qreal usableW = qMax(workArea.width() - 2.0 * outer, qreal(0.0));
     const qreal usableH = qMax(workArea.height() - 2.0 * outer, qreal(0.0));
 
-    // Column widths and strip-space X positions. Columns pack left to right
-    // from strip-x 0, separated by the inner gap. A column whose every tile
-    // is minimized collapses out of the strip — zero width, no gap, the
-    // cursor does not advance — so it keeps its slot in the column order
-    // (restored when one of its tiles is unminimized) without leaving a gap.
-    QVector<qreal> widths(columns.size(), 0.0);
-    QVector<qreal> stripX(columns.size(), 0.0);
-    qreal cursor = 0.0;
-    for (int ci = 0; ci < columns.size(); ++ci) {
-        stripX[ci] = cursor;
-        if (!columns.at(ci).hasVisibleTiles()) {
-            continue; // collapsed column — keeps its slot, takes no strip space
-        }
-        const qreal width = resolveColumnWidth(columns.at(ci).width(), usableW);
-        widths[ci] = width;
-        cursor += width + inner;
-    }
+    QVector<qreal> widths;
+    QVector<qreal> stripX;
+    resolveColumnMetrics(columns, usableW, inner, widths, stripX);
 
-    // The viewport is anchored to the focused column: viewPos is the strip-x
-    // coordinate that maps to the inner-left edge of the working area.
-    const int activeIndex = state.activeColumnIndex();
-    qreal viewPos = 0.0;
-    if (activeIndex >= 0 && activeIndex < columns.size()) {
-        if (widths.at(activeIndex) > 0.0) {
-            // Focused column is visible: anchor on it, plus the in-column
-            // viewOffset (an offset *within* the focused column's width).
-            viewPos = stripX.at(activeIndex) + state.viewOffset();
-        } else {
-            // Focused column is fully minimized (collapsed, zero width).
-            // viewOffset is meaningless against a zero-width column, and the
-            // collapsed column's own stripX is only on-screen when a visible
-            // column follows it — a trailing run of collapsed columns has a
-            // stripX past the strip's end, which would scroll every visible
-            // column off the left edge. Anchor on the nearest visible column
-            // (forward first, since a mid-strip collapsed column shares the
-            // next column's stripX; otherwise the last visible column).
-            int anchor = -1;
-            for (int ci = activeIndex; ci < columns.size(); ++ci) {
-                if (widths.at(ci) > 0.0) {
-                    anchor = ci;
-                    break;
-                }
-            }
-            if (anchor < 0) {
-                for (int ci = activeIndex - 1; ci >= 0; --ci) {
-                    if (widths.at(ci) > 0.0) {
-                        anchor = ci;
-                        break;
-                    }
-                }
-            }
-            viewPos = (anchor >= 0) ? stripX.at(anchor) : 0.0;
-        }
-    }
+    // The viewport's inner-left edge maps to this strip-x coordinate. It is
+    // computed by computeViewportScroll() and stored on the state by the
+    // daemon before resolving; resolveScrollLayout only consumes it.
+    const qreal viewPos = state.scrollX();
 
     for (int ci = 0; ci < columns.size(); ++ci) {
         // Lay out only the visible (non-minimized) tiles. A minimized tile
@@ -162,6 +161,50 @@ QHash<QString, QRectF> resolveScrollLayout(const ScrollScreenState& state, const
         }
     }
     return geometries;
+}
+
+qreal computeViewportScroll(const ScrollScreenState& state, const QRectF& workArea, const ScrollLayoutConfig& config)
+{
+    const QVector<Column>& columns = state.columns();
+    const int activeIndex = state.activeColumnIndex();
+    if (columns.isEmpty() || activeIndex < 0 || activeIndex >= columns.size()) {
+        return 0.0; // empty strip — viewport at the origin
+    }
+
+    const qreal outer = qMax(config.outerGap, qreal(0.0));
+    const qreal inner = qMax(config.innerGap, qreal(0.0));
+    const qreal usableW = qMax(workArea.width() - 2.0 * outer, qreal(0.0));
+
+    QVector<qreal> widths;
+    QVector<qreal> stripX;
+    resolveColumnMetrics(columns, usableW, inner, widths, stripX);
+
+    const int anchor = viewportAnchorColumn(widths, activeIndex);
+    if (anchor < 0) {
+        return state.scrollX(); // every column collapsed — leave the viewport put
+    }
+
+    const qreal colLeft = stripX.at(anchor);
+    const qreal colWidth = widths.at(anchor);
+
+    if (config.viewportMode == ScrollViewportMode::Centered) {
+        // Center the anchor column in the working area.
+        return colLeft + (colWidth - usableW) / 2.0;
+    }
+
+    // Fit: scroll the minimum needed to bring the anchor column fully
+    // on-screen, and not at all when it already is.
+    const qreal current = state.scrollX();
+    if (colWidth >= usableW) {
+        return colLeft; // wider than the viewport — pin its left edge
+    }
+    if (colLeft < current) {
+        return colLeft; // off the left edge — scroll left just enough
+    }
+    if (colLeft + colWidth > current + usableW) {
+        return colLeft + colWidth - usableW; // off the right edge — scroll right
+    }
+    return current; // already fully visible — do not move
 }
 
 QStringList scrollVisibleWindows(const QHash<QString, QRectF>& geometries, const QRectF& workArea)

--- a/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
@@ -219,6 +219,25 @@ bool ScrollScreenState::moveTile(int delta)
     return column.moveTile(column.activeTileIndex(), target);
 }
 
+bool ScrollScreenState::moveColumnNextTo(const QString& draggedWindowId, const QString& anchorWindowId, bool placeAfter)
+{
+    const int from = locateWindow(draggedWindowId).first;
+    const int anchorColumn = locateWindow(anchorWindowId).first;
+    if (from < 0 || anchorColumn < 0 || from == anchorColumn) {
+        return false;
+    }
+    const Column column = m_columns.takeAt(from);
+    // Removing the dragged column shifts every later index left by one, so the
+    // anchor's index moves too when it sat to the right of the removed column.
+    const int anchorAfterRemoval = (anchorColumn > from) ? anchorColumn - 1 : anchorColumn;
+    const int target =
+        qBound(0, placeAfter ? anchorAfterRemoval + 1 : anchorAfterRemoval, static_cast<int>(m_columns.size()));
+    m_columns.insert(target, column);
+    // The user just dragged this window — focus it (and its column).
+    focusWindow(draggedWindowId);
+    return true;
+}
+
 void ScrollScreenState::setActiveColumnWidth(const ColumnWidth& width, int presetIndex)
 {
     if (m_activeColumnIndex >= 0) {

--- a/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
@@ -325,7 +325,7 @@ QJsonObject ScrollScreenState::toJson() const
     obj.insert(QLatin1String("screenId"), m_screenId);
     obj.insert(QLatin1String("columns"), columns);
     obj.insert(QLatin1String("activeColumnIndex"), m_activeColumnIndex);
-    obj.insert(QLatin1String("viewOffset"), m_viewOffset);
+    obj.insert(QLatin1String("scrollX"), m_scrollX);
     obj.insert(QLatin1String("floating"), floating);
     return obj;
 }
@@ -353,7 +353,7 @@ ScrollScreenState ScrollScreenState::fromJson(const QJsonObject& obj)
             state.m_columns.append(std::move(column));
         }
     }
-    state.m_viewOffset = obj.value(QLatin1String("viewOffset")).toDouble(0.0);
+    state.m_scrollX = obj.value(QLatin1String("scrollX")).toDouble(0.0);
     state.m_activeColumnIndex = obj.value(QLatin1String("activeColumnIndex")).toInt(-1);
     state.clampActiveColumnIndex();
 

--- a/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
@@ -226,13 +226,18 @@ bool ScrollScreenState::moveColumnNextTo(const QString& draggedWindowId, const Q
     if (from < 0 || anchorColumn < 0 || from == anchorColumn) {
         return false;
     }
-    const Column column = m_columns.takeAt(from);
-    // Removing the dragged column shifts every later index left by one, so the
-    // anchor's index moves too when it sat to the right of the removed column.
+    // Lifting the dragged column out shifts every later index left by one, so
+    // the anchor's index drops by one when it sat to the right of it.
     const int anchorAfterRemoval = (anchorColumn > from) ? anchorColumn - 1 : anchorColumn;
     const int target =
-        qBound(0, placeAfter ? anchorAfterRemoval + 1 : anchorAfterRemoval, static_cast<int>(m_columns.size()));
-    m_columns.insert(target, column);
+        qBound(0, placeAfter ? anchorAfterRemoval + 1 : anchorAfterRemoval, static_cast<int>(m_columns.size()) - 1);
+    // A drop that lands the column back in its own slot (it was dragged only
+    // just past an adjacent column's centre) is a positional no-op: skip the
+    // reorder. The caller still re-resolves and focuses the window — that
+    // round-trip snaps the dragged window back into its (unchanged) slot.
+    if (target != from) {
+        m_columns.move(from, target);
+    }
     // The user just dragged this window — focus it (and its column).
     focusWindow(draggedWindowId);
     return true;

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -1342,6 +1342,18 @@ public:
     {
         return QStringLiteral("Meta+Alt+,");
     }
+    /// Scroll mode: pull the next column's focused window into the current
+    /// column (niri "consume"). "I" for "in".
+    static QString consumeWindowShortcut()
+    {
+        return QStringLiteral("Meta+Alt+I");
+    }
+    /// Scroll mode: push the focused window out into its own new column (niri
+    /// "expel"). "O" for "out".
+    static QString expelWindowShortcut()
+    {
+        return QStringLiteral("Meta+Alt+O");
+    }
     static QString resnapToNewLayoutShortcut()
     {
         return QStringLiteral("Meta+Ctrl+Z");

--- a/src/config/configkeys.h
+++ b/src/config/configkeys.h
@@ -459,6 +459,8 @@ public:
     PZ_CONFIG_KEY(rotateWindowsCounterclockwiseKey, "RotateWindowsCounterclockwise")
     PZ_CONFIG_KEY(cycleWindowForwardKey, "CycleWindowForward")
     PZ_CONFIG_KEY(cycleWindowBackwardKey, "CycleWindowBackward")
+    PZ_CONFIG_KEY(consumeWindowKey, "ConsumeWindow")
+    PZ_CONFIG_KEY(expelWindowKey, "ExpelWindow")
     PZ_CONFIG_KEY(resnapToNewLayoutKey, "ResnapToNewLayout")
     PZ_CONFIG_KEY(snapAllWindowsKey, "SnapAllWindows")
     PZ_CONFIG_KEY(layoutPickerKey, "LayoutPicker")

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -2617,6 +2617,10 @@ PZ_STORE_SET_STRING(setCycleWindowForwardShortcut, shortcutsGlobalGroup, cycleWi
 PZ_STORE_GET(QString, cycleWindowBackwardShortcut, shortcutsGlobalGroup, cycleWindowBackwardKey, QString)
 PZ_STORE_SET_STRING(setCycleWindowBackwardShortcut, shortcutsGlobalGroup, cycleWindowBackwardKey,
                     cycleWindowBackwardShortcutChanged)
+PZ_STORE_GET(QString, consumeWindowShortcut, shortcutsGlobalGroup, consumeWindowKey, QString)
+PZ_STORE_SET_STRING(setConsumeWindowShortcut, shortcutsGlobalGroup, consumeWindowKey, consumeWindowShortcutChanged)
+PZ_STORE_GET(QString, expelWindowShortcut, shortcutsGlobalGroup, expelWindowKey, QString)
+PZ_STORE_SET_STRING(setExpelWindowShortcut, shortcutsGlobalGroup, expelWindowKey, expelWindowShortcutChanged)
 PZ_STORE_GET(QString, resnapToNewLayoutShortcut, shortcutsGlobalGroup, resnapToNewLayoutKey, QString)
 PZ_STORE_SET_STRING(setResnapToNewLayoutShortcut, shortcutsGlobalGroup, resnapToNewLayoutKey,
                     resnapToNewLayoutShortcutChanged)

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -433,6 +433,12 @@ public:
     Q_PROPERTY(QString cycleWindowBackwardShortcut READ cycleWindowBackwardShortcut WRITE setCycleWindowBackwardShortcut
                    NOTIFY cycleWindowBackwardShortcutChanged)
 
+    // Scroll-mode consume / expel column (Meta+Alt+I / Meta+Alt+O)
+    Q_PROPERTY(QString consumeWindowShortcut READ consumeWindowShortcut WRITE setConsumeWindowShortcut NOTIFY
+                   consumeWindowShortcutChanged)
+    Q_PROPERTY(QString expelWindowShortcut READ expelWindowShortcut WRITE setExpelWindowShortcut NOTIFY
+                   expelWindowShortcutChanged)
+
     // Resnap to New PhosphorZones::Layout (Meta+Ctrl+Z, easy pinky key)
     Q_PROPERTY(QString resnapToNewLayoutShortcut READ resnapToNewLayoutShortcut WRITE setResnapToNewLayoutShortcut
                    NOTIFY resnapToNewLayoutShortcutChanged)
@@ -986,6 +992,10 @@ public:
     void setCycleWindowForwardShortcut(const QString& shortcut);
     QString cycleWindowBackwardShortcut() const;
     void setCycleWindowBackwardShortcut(const QString& shortcut);
+    QString consumeWindowShortcut() const;
+    void setConsumeWindowShortcut(const QString& shortcut);
+    QString expelWindowShortcut() const;
+    void setExpelWindowShortcut(const QString& shortcut);
     QString resnapToNewLayoutShortcut() const;
     void setResnapToNewLayoutShortcut(const QString& shortcut);
     QString snapAllWindowsShortcut() const;

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -419,6 +419,8 @@ void appendShortcutsSchema(PhosphorConfig::Schema& schema)
     addShortcut(globals, CD::rotateWindowsCounterclockwiseKey(), CD::rotateWindowsCounterclockwiseShortcut());
     addShortcut(globals, CD::cycleWindowForwardKey(), CD::cycleWindowForwardShortcut());
     addShortcut(globals, CD::cycleWindowBackwardKey(), CD::cycleWindowBackwardShortcut());
+    addShortcut(globals, CD::consumeWindowKey(), CD::consumeWindowShortcut());
+    addShortcut(globals, CD::expelWindowKey(), CD::expelWindowShortcut());
     addShortcut(globals, CD::resnapToNewLayoutKey(), CD::resnapToNewLayoutShortcut());
     addShortcut(globals, CD::snapAllWindowsKey(), CD::snapAllWindowsShortcut());
     addShortcut(globals, CD::layoutPickerKey(), CD::layoutPickerShortcut());

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -382,6 +382,10 @@ Q_SIGNALS:
     void cycleWindowForwardShortcutChanged();
     void cycleWindowBackwardShortcutChanged();
 
+    // Scroll-mode consume / expel column Shortcuts
+    void consumeWindowShortcutChanged();
+    void expelWindowShortcutChanged();
+
     // Resnap to New PhosphorZones::Layout Shortcut
     void resnapToNewLayoutShortcutChanged();
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -258,6 +258,8 @@ private:
     void handleSwap(NavigationDirection direction);
     void handleSnap(int zoneNumber);
     void handleCycle(bool forward);
+    void handleConsume();
+    void handleExpel();
     void handleResnap();
     void handleSnapAll();
     void handleFocusMaster();

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -156,6 +156,28 @@ void Daemon::handlePush()
     }
 }
 
+void Daemon::handleConsume()
+{
+    // niri "consume": pull the next column's focused window into the focused
+    // column. Meaningful only in scroll mode — the snap/autotile engines'
+    // IPlacementEngine default is a no-op, so this is harmlessly absorbed on
+    // their screens, mirroring handlePush().
+    NavigationContext ctx;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "ConsumeWindow")) {
+        nav->consumeWindowIntoColumn(ctx);
+    }
+}
+
+void Daemon::handleExpel()
+{
+    // niri "expel": push the focused window out into its own new column.
+    // Scroll-mode only; a no-op on snap/autotile screens (see handleConsume).
+    NavigationContext ctx;
+    if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "ExpelWindow")) {
+        nav->expelWindowFromColumn(ctx);
+    }
+}
+
 void Daemon::handleRestore()
 {
     NavigationContext ctx;

--- a/src/daemon/daemon/scroll.cpp
+++ b/src/daemon/daemon/scroll.cpp
@@ -87,7 +87,7 @@ void Daemon::onScrollPlacementChanged(const QString& screenId)
     if (!scroll) {
         return;
     }
-    const auto* state = dynamic_cast<const PhosphorScrollEngine::ScrollScreenState*>(scroll->stateForScreen(screenId));
+    auto* state = dynamic_cast<PhosphorScrollEngine::ScrollScreenState*>(scroll->stateForScreen(screenId));
     if (!state) {
         return;
     }
@@ -108,6 +108,13 @@ void Daemon::onScrollPlacementChanged(const QString& screenId)
     config.outerGap = SCROLL_OUTER_GAP;
     config.innerGap = SCROLL_INNER_GAP;
     config.presetWindowHeights = scroll->presetWindowHeights();
+    // config.viewportMode stays at its Fit default — the Phase 3 default;
+    // it becomes a user setting in Phase 5.
+
+    // Scroll the strip so the focused column is on-screen, then resolve. The
+    // viewport is geometry-dependent (it needs the working area), so the
+    // daemon owns its computation; the engine only stores the result.
+    state->setScrollX(PhosphorScrollEngine::computeViewportScroll(*state, QRectF(workArea), config));
 
     const QHash<QString, QRectF> geometries =
         PhosphorScrollEngine::resolveScrollLayout(*state, QRectF(workArea), config);

--- a/src/daemon/daemon/scroll.cpp
+++ b/src/daemon/daemon/scroll.cpp
@@ -111,13 +111,18 @@ void Daemon::onScrollPlacementChanged(const QString& screenId)
     // config.viewportMode stays at its Fit default — the Phase 3 default;
     // it becomes a user setting in Phase 5.
 
+    // Column metrics are scroll-independent — resolve them once and feed the
+    // same value to both the viewport computation and the geometry resolve.
+    const PhosphorScrollEngine::ScrollColumnMetrics metrics =
+        PhosphorScrollEngine::resolveColumnMetrics(*state, QRectF(workArea), config);
+
     // Scroll the strip so the focused column is on-screen, then resolve. The
     // viewport is geometry-dependent (it needs the working area), so the
     // daemon owns its computation; the engine only stores the result.
-    state->setScrollX(PhosphorScrollEngine::computeViewportScroll(*state, QRectF(workArea), config));
+    state->setScrollX(PhosphorScrollEngine::computeViewportScroll(*state, QRectF(workArea), config, &metrics));
 
     const QHash<QString, QRectF> geometries =
-        PhosphorScrollEngine::resolveScrollLayout(*state, QRectF(workArea), config);
+        PhosphorScrollEngine::resolveScrollLayout(*state, QRectF(workArea), config, &metrics);
     if (geometries.isEmpty()) {
         return;
     }

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -499,6 +499,12 @@ void Daemon::connectShortcutSignals()
     connect(m_shortcutManager.get(), &ShortcutManager::cycleWindowsInZoneRequested, this, [this](bool fwd) {
         handleCycle(fwd);
     });
+    connect(m_shortcutManager.get(), &ShortcutManager::consumeWindowRequested, this, [this]() {
+        handleConsume();
+    });
+    connect(m_shortcutManager.get(), &ShortcutManager::expelWindowRequested, this, [this]() {
+        handleExpel();
+    });
     connect(m_shortcutManager.get(), &ShortcutManager::resnapToNewLayoutRequested, this, [this]() {
         handleResnap();
     });

--- a/src/daemon/shortcutmanager.cpp
+++ b/src/daemon/shortcutmanager.cpp
@@ -51,6 +51,8 @@ constexpr auto kIdRotateWindowsCW = "rotate_windows_clockwise";
 constexpr auto kIdRotateWindowsCCW = "rotate_windows_counterclockwise";
 constexpr auto kIdCycleWindowForward = "cycle_window_forward";
 constexpr auto kIdCycleWindowBackward = "cycle_window_backward";
+constexpr auto kIdConsumeWindow = "consume_window";
+constexpr auto kIdExpelWindow = "expel_window";
 constexpr auto kIdResnapToNewLayout = "resnap_to_new_layout";
 constexpr auto kIdSnapAllWindows = "snap_all_windows";
 constexpr auto kIdLayoutPicker = "layout_picker";
@@ -240,6 +242,17 @@ const StaticEntry kStaticEntries[] = {
      "Cycle Window Backward in Zone",
      [](ShortcutManager* sm) {
          Q_EMIT sm->cycleWindowsInZoneRequested(false);
+     }},
+
+    // ─── Scroll mode: consume / expel column ───────────────────────────────
+    {kIdConsumeWindow, &ConfigDefaults::consumeWindowShortcut, &Settings::consumeWindowShortcut,
+     "Consume Window Into Column",
+     [](ShortcutManager* sm) {
+         Q_EMIT sm->consumeWindowRequested();
+     }},
+    {kIdExpelWindow, &ConfigDefaults::expelWindowShortcut, &Settings::expelWindowShortcut, "Expel Window From Column",
+     [](ShortcutManager* sm) {
+         Q_EMIT sm->expelWindowRequested();
      }},
 
     // ─── Misc layout ops ───────────────────────────────────────────────────

--- a/src/daemon/shortcutmanager.h
+++ b/src/daemon/shortcutmanager.h
@@ -90,6 +90,8 @@ Q_SIGNALS:
     void snapToZoneRequested(int zoneNumber);
     void rotateWindowsRequested(bool clockwise);
     void cycleWindowsInZoneRequested(bool forward);
+    void consumeWindowRequested();
+    void expelWindowRequested();
     void resnapToNewLayoutRequested();
     void snapAllWindowsRequested();
     void layoutPickerRequested();

--- a/src/dbus/scrolladaptor.cpp
+++ b/src/dbus/scrolladaptor.cpp
@@ -93,4 +93,12 @@ void ScrollAdaptor::windowMinimizedChanged(const QString& windowId, bool minimiz
     m_engine->windowMinimizedChanged(windowId, minimized);
 }
 
+void ScrollAdaptor::windowDropped(const QString& draggedWindowId, const QString& anchorWindowId, bool placeAfter)
+{
+    if (!ensureEngine("windowDropped")) {
+        return;
+    }
+    m_engine->windowDropped(draggedWindowId, anchorWindowId, placeAfter);
+}
+
 } // namespace PlasmaZones

--- a/src/dbus/scrolladaptor.h
+++ b/src/dbus/scrolladaptor.h
@@ -64,6 +64,7 @@ public Q_SLOTS:
     void windowClosed(const QString& windowId);
     void notifyWindowFocused(const QString& windowId, const QString& screenId);
     void windowMinimizedChanged(const QString& windowId, bool minimized);
+    void windowDropped(const QString& draggedWindowId, const QString& anchorWindowId, bool placeAfter);
 
 Q_SIGNALS:
     /// Emitted when the set of scroll-mode screens changes; the KWin effect

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -813,6 +813,8 @@ void SettingsAdaptor::initializeRegistry()
                                  setCycleWindowForwardShortcut)
         REGISTER_CONCRETE_STRING("cycleWindowBackwardShortcut", cycleWindowBackwardShortcut,
                                  setCycleWindowBackwardShortcut)
+        REGISTER_CONCRETE_STRING("consumeWindowShortcut", consumeWindowShortcut, setConsumeWindowShortcut)
+        REGISTER_CONCRETE_STRING("expelWindowShortcut", expelWindowShortcut, setExpelWindowShortcut)
         REGISTER_CONCRETE_STRING("resnapToNewLayoutShortcut", resnapToNewLayoutShortcut, setResnapToNewLayoutShortcut)
         REGISTER_CONCRETE_STRING("snapAllWindowsShortcut", snapAllWindowsShortcut, setSnapAllWindowsShortcut)
         REGISTER_CONCRETE_STRING("layoutPickerShortcut", layoutPickerShortcut, setLayoutPickerShortcut)

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -166,13 +166,37 @@ void TestScrollEngine::windowDropped()
     QCOMPARE(state->columns().at(2).windowIds().first(), QStringLiteral("a"));
     QCOMPARE(state->focusedWindowId(), QStringLiteral("a"));
 
-    // A drop onto the dragged window's own column, against an unknown window,
-    // or against an anchor on a different screen, changes nothing and emits no
-    // signal (moveColumnNextTo resolves both windows within one strip).
+    // Each of these drops hits a distinct rejection path and must emit no
+    // signal — asserted per call so a regression on one path cannot hide
+    // behind another: the dragged window's own column, an unknown dragged
+    // window, and an anchor on a different screen's strip.
     engine.windowDropped(QStringLiteral("a"), QStringLiteral("a"), true);
+    QCOMPARE(spy.count(), 1);
     engine.windowDropped(QStringLiteral("missing"), QStringLiteral("b"), true);
+    QCOMPARE(spy.count(), 1);
     engine.windowDropped(QStringLiteral("a"), QStringLiteral("z"), true);
     QCOMPARE(spy.count(), 1);
+    // ...and the column order is genuinely untouched, not merely signal-free.
+    QCOMPARE(state->columns().at(0).windowIds().first(), QStringLiteral("b"));
+    QCOMPARE(state->columns().at(1).windowIds().first(), QStringLiteral("c"));
+    QCOMPARE(state->columns().at(2).windowIds().first(), QStringLiteral("a"));
+
+    // placeAfter=false: drop "a" before "b" -> [a][b][c].
+    engine.windowDropped(QStringLiteral("a"), QStringLiteral("b"), /*placeAfter=*/false);
+    QCOMPARE(spy.count(), 2);
+    QCOMPARE(state->columns().at(0).windowIds().first(), QStringLiteral("a"));
+    QCOMPARE(state->columns().at(1).windowIds().first(), QStringLiteral("b"));
+    QCOMPARE(state->columns().at(2).windowIds().first(), QStringLiteral("c"));
+
+    // A positional no-op — dropping "a" before "b" again, where it already
+    // sits — emits without reordering: moveColumnNextTo skips the column move
+    // but still returns true, so the daemon re-resolves and snaps the dragged
+    // window back into its unchanged slot.
+    engine.windowDropped(QStringLiteral("a"), QStringLiteral("b"), /*placeAfter=*/false);
+    QCOMPARE(spy.count(), 3);
+    QCOMPARE(state->columns().at(0).windowIds().first(), QStringLiteral("a"));
+    QCOMPARE(state->columns().at(1).windowIds().first(), QStringLiteral("b"));
+    QCOMPARE(state->columns().at(2).windowIds().first(), QStringLiteral("c"));
 }
 
 void TestScrollEngine::cyclePresetWidth()

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -155,6 +155,7 @@ void TestScrollEngine::windowDropped()
     engine.windowOpened(QStringLiteral("a"), QStringLiteral("S1"));
     engine.windowOpened(QStringLiteral("b"), QStringLiteral("S1"));
     engine.windowOpened(QStringLiteral("c"), QStringLiteral("S1")); // [a][b][c]
+    engine.windowOpened(QStringLiteral("z"), QStringLiteral("S2")); // a separate strip
     QSignalSpy spy(&engine, &PhosphorEngine::PlacementEngineBase::placementChanged);
 
     // Drag-to-reorder: drop "a" after "c" -> [b][c][a], focus follows "a".
@@ -165,10 +166,12 @@ void TestScrollEngine::windowDropped()
     QCOMPARE(state->columns().at(2).windowIds().first(), QStringLiteral("a"));
     QCOMPARE(state->focusedWindowId(), QStringLiteral("a"));
 
-    // A drop onto the dragged window's own column, or against an unknown
-    // window, changes nothing and emits no signal.
+    // A drop onto the dragged window's own column, against an unknown window,
+    // or against an anchor on a different screen, changes nothing and emits no
+    // signal (moveColumnNextTo resolves both windows within one strip).
     engine.windowDropped(QStringLiteral("a"), QStringLiteral("a"), true);
     engine.windowDropped(QStringLiteral("missing"), QStringLiteral("b"), true);
+    engine.windowDropped(QStringLiteral("a"), QStringLiteral("z"), true);
     QCOMPARE(spy.count(), 1);
 }
 

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -36,6 +36,7 @@ private Q_SLOTS:
     void focusAndMoveNavigation();
     void consumeAndExpel();
     void minimizeWindow();
+    void windowDropped();
     void cyclePresetWidth();
     void cyclePresetHeight();
     void floatToggle();
@@ -146,6 +147,29 @@ void TestScrollEngine::minimizeWindow()
     QVERIFY(state->isWindowMinimized(QStringLiteral("b")));
     QCOMPARE(state->focusedWindowId(), QStringLiteral("b")); // retained, not cleared
     QCOMPARE(state->columnCount(), 2); // both slots kept
+}
+
+void TestScrollEngine::windowDropped()
+{
+    ScrollEngine engine;
+    engine.windowOpened(QStringLiteral("a"), QStringLiteral("S1"));
+    engine.windowOpened(QStringLiteral("b"), QStringLiteral("S1"));
+    engine.windowOpened(QStringLiteral("c"), QStringLiteral("S1")); // [a][b][c]
+    QSignalSpy spy(&engine, &PhosphorEngine::PlacementEngineBase::placementChanged);
+
+    // Drag-to-reorder: drop "a" after "c" -> [b][c][a], focus follows "a".
+    engine.windowDropped(QStringLiteral("a"), QStringLiteral("c"), /*placeAfter=*/true);
+    QCOMPARE(spy.count(), 1);
+    const ScrollScreenState* state = scrollState(engine, QStringLiteral("S1"));
+    QVERIFY(state);
+    QCOMPARE(state->columns().at(2).windowIds().first(), QStringLiteral("a"));
+    QCOMPARE(state->focusedWindowId(), QStringLiteral("a"));
+
+    // A drop onto the dragged window's own column, or against an unknown
+    // window, changes nothing and emits no signal.
+    engine.windowDropped(QStringLiteral("a"), QStringLiteral("a"), true);
+    engine.windowDropped(QStringLiteral("missing"), QStringLiteral("b"), true);
+    QCOMPARE(spy.count(), 1);
 }
 
 void TestScrollEngine::cyclePresetWidth()

--- a/tests/unit/scroll/test_scroll_layout.cpp
+++ b/tests/unit/scroll/test_scroll_layout.cpp
@@ -45,6 +45,8 @@ private Q_SLOTS:
     void viewportFitScrollsLeftToColumn();
     void viewportCenteredCentersColumn();
     void viewportCollapsedFocusedColumnAnchorsVisible();
+    void viewportCollapsedMidColumnAnchorsForward();
+    void viewportAllMinimizedKeepsScroll();
     void viewportWideColumnPinsLeft();
 };
 
@@ -248,11 +250,18 @@ void TestScrollLayout::viewportFitScrollsLeftToColumn()
     ScrollScreenState state;
     state.addColumnForWindow(QStringLiteral("a"));
     state.addColumnForWindow(QStringLiteral("b"));
+    state.addColumnForWindow(QStringLiteral("c"));
     QVERIFY(state.focusWindow(QStringLiteral("a"))); // strip-x 0
 
     // Viewport scrolled right past "a"; fit scrolls left exactly to its edge.
     state.setScrollX(300.0);
     QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 0.0);
+
+    // A mid-strip column off the left edge scrolls left to its non-zero
+    // strip-x: "b" sits at strip-x 500.
+    QVERIFY(state.focusWindow(QStringLiteral("b")));
+    state.setScrollX(900.0);
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 500.0);
 }
 
 void TestScrollLayout::viewportCenteredCentersColumn()
@@ -286,6 +295,37 @@ void TestScrollLayout::viewportCollapsedFocusedColumnAnchorsVisible()
     ScrollLayoutConfig centered = standardConfig();
     centered.viewportMode = ScrollViewportMode::Centered;
     QCOMPARE(computeViewportScroll(state, kWorkArea, centered), -245.0);
+}
+
+void TestScrollLayout::viewportCollapsedMidColumnAnchorsForward()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b"));
+    state.addColumnForWindow(QStringLiteral("c")); // [a][b][c]
+
+    // Collapse the middle column and focus it. viewportAnchorColumn searches
+    // forward first, so the viewport anchors on "c" (strip-x 500 — the
+    // collapsed column shares it), not the visible column to the left. "c"
+    // spans [500, 990]; fit scrolls right to 990 - 980 = 10. (A backward
+    // anchor on the already-visible "a" would have left scrollX at 0.)
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true));
+    QVERIFY(state.focusWindow(QStringLiteral("b")));
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 10.0);
+}
+
+void TestScrollLayout::viewportAllMinimizedKeepsScroll()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b"));
+    QVERIFY(state.setWindowMinimized(QStringLiteral("a"), true));
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true));
+
+    // Every column collapsed: nothing anchors the viewport, so
+    // computeViewportScroll leaves the stored scroll position untouched.
+    state.setScrollX(700.0);
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 700.0);
 }
 
 void TestScrollLayout::viewportWideColumnPinsLeft()

--- a/tests/unit/scroll/test_scroll_layout.cpp
+++ b/tests/unit/scroll/test_scroll_layout.cpp
@@ -364,18 +364,22 @@ void TestScrollLayout::sharedMetricsMatchInternalResolve()
     QVERIFY(state.focusWindow(QStringLiteral("c")));
     state.setScrollX(300.0);
 
+    // One config drives the metrics resolve and every consuming call, so the
+    // parity check below cannot be skewed by a config field the metrics path
+    // happens to ignore.
+    const ScrollLayoutConfig config = standardConfig();
+
     // resolveColumnMetrics resolves widths + strip-x: "a" and "c" are 490 wide,
     // the collapsed "b" is zero-width and shares "c"'s strip-x (500).
-    const ScrollColumnMetrics metrics = resolveColumnMetrics(state, kWorkArea, standardConfig());
+    const ScrollColumnMetrics metrics = resolveColumnMetrics(state, kWorkArea, config);
     QCOMPARE(metrics.widths, (QVector<qreal>{490.0, 0.0, 490.0}));
     QCOMPARE(metrics.stripX, (QVector<qreal>{0.0, 500.0, 500.0}));
 
     // Passing pre-resolved metrics must yield byte-identical results to the
     // internal (nullptr) resolve — the shared-metrics fast path is pure reuse.
-    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig(), &metrics),
-             computeViewportScroll(state, kWorkArea, standardConfig()));
-    QCOMPARE(resolveScrollLayout(state, kWorkArea, standardConfig(), &metrics),
-             resolveScrollLayout(state, kWorkArea, standardConfig()));
+    QCOMPARE(computeViewportScroll(state, kWorkArea, config, &metrics),
+             computeViewportScroll(state, kWorkArea, config));
+    QCOMPARE(resolveScrollLayout(state, kWorkArea, config, &metrics), resolveScrollLayout(state, kWorkArea, config));
 }
 
 QTEST_GUILESS_MAIN(TestScrollLayout)

--- a/tests/unit/scroll/test_scroll_layout.cpp
+++ b/tests/unit/scroll/test_scroll_layout.cpp
@@ -31,16 +31,21 @@ private Q_SLOTS:
     void emptyStrip();
     void singleWindowFillsColumn();
     void twoColumnsSideBySide();
-    void viewOffsetShiftsStrip();
+    void scrollXShiftsStrip();
     void autoTilesShareColumnHeight();
     void fixedHeightTileTakesSpaceFirst();
     void presetHeightResolved();
     void fixedWidthColumn();
     void minimizedTileExcluded();
     void fullyMinimizedColumnCollapses();
-    void collapsedFocusedColumnIgnoresViewOffset();
     void soleColumnCollapsesToEmptyLayout();
     void visibilityHelper();
+    void viewportFitBringsColumnIntoView();
+    void viewportFitLeavesVisibleColumnPut();
+    void viewportFitScrollsLeftToColumn();
+    void viewportCenteredCentersColumn();
+    void viewportCollapsedFocusedColumnAnchorsVisible();
+    void viewportWideColumnPinsLeft();
 };
 
 void TestScrollLayout::emptyStrip()
@@ -65,25 +70,22 @@ void TestScrollLayout::twoColumnsSideBySide()
 {
     ScrollScreenState state;
     state.addColumnForWindow(QStringLiteral("a"));
-    state.addColumnForWindow(QStringLiteral("b")); // focus = b (index 1)
+    state.addColumnForWindow(QStringLiteral("b")); // [a][b]
 
-    QHash<QString, QRectF> geometry = resolveScrollLayout(state, kWorkArea, standardConfig());
-    // The focused column sits flush against the inner-left edge; "a" is
-    // off-screen to the left.
-    QCOMPARE(geometry.value(QStringLiteral("b")), QRectF(10.0, 10.0, 490.0, 780.0));
-    QCOMPARE(geometry.value(QStringLiteral("a")), QRectF(-490.0, 10.0, 490.0, 780.0));
-
-    QVERIFY(state.focusColumn(-1)); // focus "a"
-    geometry = resolveScrollLayout(state, kWorkArea, standardConfig());
+    // resolveScrollLayout positions the strip purely from scrollX (0 here):
+    // columns pack left-to-right from the inner edge, separated by the gap.
+    const QHash<QString, QRectF> geometry = resolveScrollLayout(state, kWorkArea, standardConfig());
     QCOMPARE(geometry.value(QStringLiteral("a")), QRectF(10.0, 10.0, 490.0, 780.0));
     QCOMPARE(geometry.value(QStringLiteral("b")), QRectF(510.0, 10.0, 490.0, 780.0));
 }
 
-void TestScrollLayout::viewOffsetShiftsStrip()
+void TestScrollLayout::scrollXShiftsStrip()
 {
     ScrollScreenState state;
     state.addColumnForWindow(QStringLiteral("a"));
-    state.setViewOffset(-100.0); // viewport begins 100px left of the focused column
+    // scrollX is the strip-x coordinate mapped to the inner-left edge; a
+    // negative value pushes the strip to the right.
+    state.setScrollX(-100.0);
 
     const QHash<QString, QRectF> geometry = resolveScrollLayout(state, kWorkArea, standardConfig());
     QCOMPARE(geometry.value(QStringLiteral("a")), QRectF(110.0, 10.0, 490.0, 780.0));
@@ -180,41 +182,6 @@ void TestScrollLayout::fullyMinimizedColumnCollapses()
     QCOMPARE(restored.value(QStringLiteral("c")), QRectF(1010.0, 10.0, 490.0, 780.0));
 }
 
-void TestScrollLayout::collapsedFocusedColumnIgnoresViewOffset()
-{
-    ScrollScreenState state;
-    state.addColumnForWindow(QStringLiteral("a"));
-    state.addColumnForWindow(QStringLiteral("b")); // [a][b]
-
-    // Minimize "b" (the last column): it collapses to zero width. Then focus
-    // that collapsed column directly — viewOffset is an offset *within* the
-    // focused column, meaningless against a zero-width one.
-    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true));
-    QVERIFY(state.focusWindow(QStringLiteral("b")));
-
-    state.setViewOffset(0.0);
-    const QHash<QString, QRectF> noOffset = resolveScrollLayout(state, kWorkArea, standardConfig());
-    state.setViewOffset(500.0);
-    const QHash<QString, QRectF> withOffset = resolveScrollLayout(state, kWorkArea, standardConfig());
-
-    QVERIFY(!withOffset.contains(QStringLiteral("b"))); // collapsed — no geometry
-    // The non-zero viewOffset had no effect: the focused column is collapsed.
-    QCOMPARE(withOffset.value(QStringLiteral("a")), noOffset.value(QStringLiteral("a")));
-    // ...and the strip stays on-screen: a collapsed *trailing* focused column
-    // has no visible column after it, so the viewport anchors on the nearest
-    // visible column to the left — "a" sits at the work-area origin rather
-    // than scrolled off the left edge.
-    QCOMPARE(withOffset.value(QStringLiteral("a")), QRectF(10.0, 10.0, 490.0, 780.0));
-
-    // Positive control: with a *visible* focused column, viewOffset DOES shift
-    // the strip — proving the equality above is the collapsed-column guard at
-    // work, not the resolver ignoring viewOffset unconditionally.
-    QVERIFY(state.focusWindow(QStringLiteral("a")));
-    state.setViewOffset(100.0);
-    const QHash<QString, QRectF> shifted = resolveScrollLayout(state, kWorkArea, standardConfig());
-    QCOMPARE(shifted.value(QStringLiteral("a")).x(), noOffset.value(QStringLiteral("a")).x() - 100.0);
-}
-
 void TestScrollLayout::soleColumnCollapsesToEmptyLayout()
 {
     ScrollScreenState state;
@@ -237,12 +204,100 @@ void TestScrollLayout::visibilityHelper()
 {
     ScrollScreenState state;
     state.addColumnForWindow(QStringLiteral("a"));
-    state.addColumnForWindow(QStringLiteral("b")); // focus = b; "a" off-screen left
+    state.addColumnForWindow(QStringLiteral("b")); // [a][b]
 
+    // Scroll the strip far enough right that "a" is fully off the left edge of
+    // the working area while "b" stays partly visible.
+    state.setScrollX(600.0);
     const QHash<QString, QRectF> geometry = resolveScrollLayout(state, kWorkArea, standardConfig());
     const QStringList visible = scrollVisibleWindows(geometry, kWorkArea);
     QVERIFY(visible.contains(QStringLiteral("b")));
     QVERIFY(!visible.contains(QStringLiteral("a"))); // fully left of the working area
+}
+
+void TestScrollLayout::viewportFitBringsColumnIntoView()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b"));
+    state.addColumnForWindow(QStringLiteral("c"));
+    state.addColumnForWindow(QStringLiteral("d"));
+    state.addColumnForWindow(QStringLiteral("e")); // addColumnForWindow focuses "e"
+
+    // "e" sits at strip-x 4 * (490 + 10) = 2000, width 490. From scrollX 0 it
+    // is off the right edge; fit scrolls right just enough: 2000 + 490 - 980.
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 1510.0);
+}
+
+void TestScrollLayout::viewportFitLeavesVisibleColumnPut()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b"));
+    state.addColumnForWindow(QStringLiteral("c"));
+    QVERIFY(state.focusWindow(QStringLiteral("b"))); // strip-x 500, width 490
+
+    // "b" spans strip-x [500, 990]; a viewport of [100, 1080] fully contains
+    // it, so fit must leave the scroll position untouched.
+    state.setScrollX(100.0);
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 100.0);
+}
+
+void TestScrollLayout::viewportFitScrollsLeftToColumn()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b"));
+    QVERIFY(state.focusWindow(QStringLiteral("a"))); // strip-x 0
+
+    // Viewport scrolled right past "a"; fit scrolls left exactly to its edge.
+    state.setScrollX(300.0);
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 0.0);
+}
+
+void TestScrollLayout::viewportCenteredCentersColumn()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b"));
+    state.addColumnForWindow(QStringLiteral("c")); // focus "c": strip-x 1000, width 490
+
+    ScrollLayoutConfig config = standardConfig();
+    config.viewportMode = ScrollViewportMode::Centered;
+    // Centered: colLeft + (colWidth - usableW) / 2 = 1000 + (490 - 980) / 2.
+    QCOMPARE(computeViewportScroll(state, kWorkArea, config), 755.0);
+}
+
+void TestScrollLayout::viewportCollapsedFocusedColumnAnchorsVisible()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b")); // [a][b]
+
+    // Minimize "b" so its column collapses, then focus that collapsed column.
+    // computeViewportScroll anchors on the nearest visible column ("a"), not
+    // the zero-width collapsed slot.
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true));
+    QVERIFY(state.focusWindow(QStringLiteral("b")));
+    // "a" (strip-x 0, width 490) is already fully visible from scrollX 0.
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 0.0);
+
+    // Centered anchors on "a" too: 0 + (490 - 980) / 2 = -245.
+    ScrollLayoutConfig centered = standardConfig();
+    centered.viewportMode = ScrollViewportMode::Centered;
+    QCOMPARE(computeViewportScroll(state, kWorkArea, centered), -245.0);
+}
+
+void TestScrollLayout::viewportWideColumnPinsLeft()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b")); // focus "b"
+    // Make the focused column wider than the working area; fit cannot fit it,
+    // so it pins the column's left edge (strip-x 490 + 10 = 500).
+    state.setActiveColumnWidth(ColumnWidth::fixed(1200.0));
+    state.setScrollX(50.0);
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 500.0);
 }
 
 QTEST_GUILESS_MAIN(TestScrollLayout)

--- a/tests/unit/scroll/test_scroll_layout.cpp
+++ b/tests/unit/scroll/test_scroll_layout.cpp
@@ -47,7 +47,8 @@ private Q_SLOTS:
     void viewportCollapsedFocusedColumnAnchorsVisible();
     void viewportCollapsedMidColumnAnchorsForward();
     void viewportAllMinimizedKeepsScroll();
-    void viewportWideColumnPinsLeft();
+    void viewportWideColumnClampsToColumn();
+    void sharedMetricsMatchInternalResolve();
 };
 
 void TestScrollLayout::emptyStrip()
@@ -328,16 +329,53 @@ void TestScrollLayout::viewportAllMinimizedKeepsScroll()
     QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 700.0);
 }
 
-void TestScrollLayout::viewportWideColumnPinsLeft()
+void TestScrollLayout::viewportWideColumnClampsToColumn()
 {
     ScrollScreenState state;
     state.addColumnForWindow(QStringLiteral("a"));
     state.addColumnForWindow(QStringLiteral("b")); // focus "b"
-    // Make the focused column wider than the working area; fit cannot fit it,
-    // so it pins the column's left edge (strip-x 490 + 10 = 500).
+    // Make the focused column wider than the working area; fit cannot fit it.
+    // "b" spans strip-x [500, 1700]; usableW is 980, so the viewport stays
+    // entirely within the column for scrollX in [500, 720].
     state.setActiveColumnWidth(ColumnWidth::fixed(1200.0));
+
+    // Dead space on the left (scrollX < colLeft): scroll right to the column's
+    // left edge — the minimum move.
     state.setScrollX(50.0);
     QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 500.0);
+
+    // Already edge-to-edge inside the column: fit leaves the scroll untouched.
+    state.setScrollX(600.0);
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 600.0);
+
+    // Dead space on the right (scrollX past the column's far extent): scroll
+    // left just enough to keep the viewport filled — 1700 - 980 = 720.
+    state.setScrollX(900.0);
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig()), 720.0);
+}
+
+void TestScrollLayout::sharedMetricsMatchInternalResolve()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b"));
+    state.addColumnForWindow(QStringLiteral("c"));
+    QVERIFY(state.setWindowMinimized(QStringLiteral("b"), true)); // a collapsed column
+    QVERIFY(state.focusWindow(QStringLiteral("c")));
+    state.setScrollX(300.0);
+
+    // resolveColumnMetrics resolves widths + strip-x: "a" and "c" are 490 wide,
+    // the collapsed "b" is zero-width and shares "c"'s strip-x (500).
+    const ScrollColumnMetrics metrics = resolveColumnMetrics(state, kWorkArea, standardConfig());
+    QCOMPARE(metrics.widths, (QVector<qreal>{490.0, 0.0, 490.0}));
+    QCOMPARE(metrics.stripX, (QVector<qreal>{0.0, 500.0, 500.0}));
+
+    // Passing pre-resolved metrics must yield byte-identical results to the
+    // internal (nullptr) resolve — the shared-metrics fast path is pure reuse.
+    QCOMPARE(computeViewportScroll(state, kWorkArea, standardConfig(), &metrics),
+             computeViewportScroll(state, kWorkArea, standardConfig()));
+    QCOMPARE(resolveScrollLayout(state, kWorkArea, standardConfig(), &metrics),
+             resolveScrollLayout(state, kWorkArea, standardConfig()));
 }
 
 QTEST_GUILESS_MAIN(TestScrollLayout)

--- a/tests/unit/scroll/test_scroll_screen_state.cpp
+++ b/tests/unit/scroll/test_scroll_screen_state.cpp
@@ -213,14 +213,14 @@ void TestScrollScreenState::jsonRoundTrip()
     state.addColumnForWindow(QStringLiteral("a"));
     state.addWindowToActiveColumn(QStringLiteral("b"));
     state.addColumnForWindow(QStringLiteral("c"));
-    state.setViewOffset(-128.0);
+    state.setScrollX(-128.0);
     state.markFloating(QStringLiteral("f1"));
 
     const ScrollScreenState restored = ScrollScreenState::fromJson(state.toJson());
     QCOMPARE(restored.screenId(), QStringLiteral("HDMI-1"));
     QCOMPARE(restored.columnCount(), state.columnCount());
     QCOMPARE(restored.activeColumnIndex(), state.activeColumnIndex());
-    QCOMPARE(restored.viewOffset(), -128.0);
+    QCOMPARE(restored.scrollX(), -128.0);
     QCOMPARE(restored.focusedWindowId(), state.focusedWindowId());
     QVERIFY(restored.isFloating(QStringLiteral("f1")));
     QCOMPARE(restored.placementIdForWindow(QStringLiteral("b")), QStringLiteral("0:1"));

--- a/tests/unit/scroll/test_scroll_screen_state.cpp
+++ b/tests/unit/scroll/test_scroll_screen_state.cpp
@@ -174,12 +174,22 @@ void TestScrollScreenState::dragReordersColumn()
     QCOMPARE(state.columns().at(2).windowIds().first(), QStringLiteral("c"));
 
     // A drop onto the dragged window's own column, or against an unknown
-    // window, is a no-op — and leaves the column order untouched.
+    // window, returns false — and leaves the column order untouched.
     QVERIFY(!state.moveColumnNextTo(QStringLiteral("a"), QStringLiteral("a"), true));
     QVERIFY(!state.moveColumnNextTo(QStringLiteral("a"), QStringLiteral("missing"), true));
     QCOMPARE(state.columns().at(0).windowIds().first(), QStringLiteral("a"));
     QCOMPARE(state.columns().at(1).windowIds().first(), QStringLiteral("b"));
     QCOMPARE(state.columns().at(2).windowIds().first(), QStringLiteral("c"));
+
+    // A drop that resolves to the column's own slot ("a" before "b" — where
+    // "a" already sits) is a positional no-op: it still returns true and
+    // focuses the window, but leaves the order untouched.
+    QVERIFY(state.focusWindow(QStringLiteral("c")));
+    QVERIFY(state.moveColumnNextTo(QStringLiteral("a"), QStringLiteral("b"), /*placeAfter=*/false));
+    QCOMPARE(state.columns().at(0).windowIds().first(), QStringLiteral("a"));
+    QCOMPARE(state.columns().at(1).windowIds().first(), QStringLiteral("b"));
+    QCOMPARE(state.columns().at(2).windowIds().first(), QStringLiteral("c"));
+    QCOMPARE(state.focusedWindowId(), QStringLiteral("a"));
 
     // A multi-tile column moves as a whole, carrying both tiles; focus lands
     // on the dragged window.

--- a/tests/unit/scroll/test_scroll_screen_state.cpp
+++ b/tests/unit/scroll/test_scroll_screen_state.cpp
@@ -20,6 +20,7 @@ private Q_SLOTS:
     void removeDropsEmptyColumn();
     void consumeAndExpel();
     void minimizeKeepsSlot();
+    void dragReordersColumn();
     void focusAndMoveColumns();
     void tileNavigation();
     void placementAndFloating();
@@ -150,6 +151,32 @@ void TestScrollScreenState::minimizeKeepsSlot()
     QCOMPARE(state.columnCount(), 3); // every slot kept
     QCOMPARE(state.focusedWindowId(), QStringLiteral("b")); // retained, not cleared
     QVERIFY(state.isWindowMinimized(state.focusedWindowId())); // ...even though hidden
+}
+
+void TestScrollScreenState::dragReordersColumn()
+{
+    ScrollScreenState state;
+    state.addColumnForWindow(QStringLiteral("a"));
+    state.addColumnForWindow(QStringLiteral("b"));
+    state.addColumnForWindow(QStringLiteral("c")); // [a][b][c]
+
+    // Drop "a" after "c": column order becomes [b][c][a]; focus follows "a".
+    QVERIFY(state.moveColumnNextTo(QStringLiteral("a"), QStringLiteral("c"), /*placeAfter=*/true));
+    QCOMPARE(state.columns().at(0).windowIds().first(), QStringLiteral("b"));
+    QCOMPARE(state.columns().at(1).windowIds().first(), QStringLiteral("c"));
+    QCOMPARE(state.columns().at(2).windowIds().first(), QStringLiteral("a"));
+    QCOMPARE(state.focusedWindowId(), QStringLiteral("a"));
+
+    // Drop "a" before "b": back to [a][b][c].
+    QVERIFY(state.moveColumnNextTo(QStringLiteral("a"), QStringLiteral("b"), /*placeAfter=*/false));
+    QCOMPARE(state.columns().at(0).windowIds().first(), QStringLiteral("a"));
+    QCOMPARE(state.columns().at(1).windowIds().first(), QStringLiteral("b"));
+    QCOMPARE(state.columns().at(2).windowIds().first(), QStringLiteral("c"));
+
+    // A drop onto the dragged window's own column, or against an unknown
+    // window, is a no-op.
+    QVERIFY(!state.moveColumnNextTo(QStringLiteral("a"), QStringLiteral("a"), true));
+    QVERIFY(!state.moveColumnNextTo(QStringLiteral("a"), QStringLiteral("missing"), true));
 }
 
 void TestScrollScreenState::focusAndMoveColumns()

--- a/tests/unit/scroll/test_scroll_screen_state.cpp
+++ b/tests/unit/scroll/test_scroll_screen_state.cpp
@@ -174,9 +174,24 @@ void TestScrollScreenState::dragReordersColumn()
     QCOMPARE(state.columns().at(2).windowIds().first(), QStringLiteral("c"));
 
     // A drop onto the dragged window's own column, or against an unknown
-    // window, is a no-op.
+    // window, is a no-op — and leaves the column order untouched.
     QVERIFY(!state.moveColumnNextTo(QStringLiteral("a"), QStringLiteral("a"), true));
     QVERIFY(!state.moveColumnNextTo(QStringLiteral("a"), QStringLiteral("missing"), true));
+    QCOMPARE(state.columns().at(0).windowIds().first(), QStringLiteral("a"));
+    QCOMPARE(state.columns().at(1).windowIds().first(), QStringLiteral("b"));
+    QCOMPARE(state.columns().at(2).windowIds().first(), QStringLiteral("c"));
+
+    // A multi-tile column moves as a whole, carrying both tiles; focus lands
+    // on the dragged window.
+    ScrollScreenState multi;
+    multi.addColumnForWindow(QStringLiteral("x"));
+    multi.addWindowToActiveColumn(QStringLiteral("x2")); // column [x, x2]
+    multi.addColumnForWindow(QStringLiteral("y")); // [x,x2][y]
+    QVERIFY(multi.moveColumnNextTo(QStringLiteral("x"), QStringLiteral("y"), /*placeAfter=*/true));
+    QCOMPARE(multi.columnCount(), 2);
+    QCOMPARE(multi.columns().at(0).windowIds().first(), QStringLiteral("y"));
+    QCOMPARE(multi.columns().at(1).windowIds(), QStringList({QStringLiteral("x"), QStringLiteral("x2")}));
+    QCOMPARE(multi.focusedWindowId(), QStringLiteral("x"));
 }
 
 void TestScrollScreenState::focusAndMoveColumns()


### PR DESCRIPTION
Implements **Phase 3 (navigation & niri command vocabulary)** of niri-style scroll mode, on top of the Phase 2 window-lifecycle work. Scroll mode now scrolls its viewport to follow focus, exposes the niri command set on the keymap, supports drag-to-reorder, and excludes sticky windows.

## Milestones

**M1 — Viewport scrolling** (`c342a3f4`)
- Until now `resolveScrollLayout` pinned the focused column flush to the work-area's left edge — every focus change jumped the whole strip. The relative `viewOffset` is replaced by an absolute `scrollX` (the strip-x mapped to the working area's inner-left edge), and a pure `computeViewportScroll()` resolves it per `ScrollViewportMode`: `Fit` (minimum scroll — leaves an already-visible column untouched) or `Centered`. Fit is the default; the mode becomes a user setting in Phase 5. The daemon computes + stores it before each resolve.

**M2 — `consume` / `expel` shortcuts** (`22231f7a`)
- Focus / move / swap navigation was already routed to `ScrollEngine` — the daemon's nav dispatch is mode-agnostic via `ScreenModeRouter::engineFor()` and `ScrollEngine` implements the `IPlacementEngine` contract. The two niri ops with no keymap entry were consume and expel: new `Meta+Alt+I` / `Meta+Alt+O` shortcuts, wired end-to-end (configkeys → ConfigDefaults → ISettings → Settings → ShortcutManager → daemon handlers). The snap/autotile engines inherit the no-op `IPlacementEngine` default, so the shortcuts are harmlessly absorbed on their screens.

**M3 — Drag-to-reorder** (`7d8651d3`)
- A tiled scroll window can be reordered by dragging it: it keeps its tile slot during the move and, on release, its whole column is reordered to the strip slot nearest the drop point (`ScrollScreenState::moveColumnNextTo`, new `org.plasmazones.Scroll.windowDropped`). The effect picks the anchor from the resolved tile rects it already tracks; the engine does the pure index reorder.

**M4 — Sticky windows** (`d7507278`)
- Resolves the sticky-window question carried from Phase 2: a window pinned to all desktops is never tiled into a strip (it floats); pinning / un-pinning at runtime drops it from / re-adds it to the strip.

## Audit

Two `/code-audit` passes (5 domain-partitioned reviewers) ran on the branch — `a08b0991` (pass 1) and `0b9cdc7d` (pass 2). Pass 1 fixed a CRITICAL (interactive resize misclassified as a drag-to-reorder), drag-handler HIGH/MEDIUM defects, two stale doc sections, and test-coverage gaps; pass 2 fixed one MEDIUM in the drag state machine. Verdict: CLEAN.

## Notes
- No engine-logic regressions — **186/186 tests pass**, full build green incl. `kwin_effect_plasmazones`.
- Plan doc updated to mark Phase 3 complete (`68d35fbf`). Next: Phase 4 (widths/heights & viewport polish).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)