### PR TITLE
fix: discussion #461 — snap-restore, maximize, per-context disable, zone clamp

### DIFF
--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -265,6 +265,14 @@ private:
     void setWindowBorderless(KWin::EffectWindow* w, const QString& windowId, bool borderless, const QString& screenId);
     void unmaximizeMonocleWindow(const QString& windowId);
 
+    /// Restore a window's title bar on every screen whose borderless set still
+    /// tracks it, then drop it from all border tracking. @p w may be null (the
+    /// EffectWindow can be gone on a screen-removal path) — when it is, the
+    /// per-screen border state is cleared directly without a setNoBorder call.
+    /// Shared by the desktop-switch Pass 2 and the genuine autotile-disable
+    /// branch of slotScreensChanged.
+    void restoreWindowBorders(KWin::EffectWindow* w, const QString& windowId);
+
     /**
      * @brief Shared float-state cleanup for a window being floated
      *

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -166,15 +166,21 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                 // un-tiles the window, since the daemon does not resnap on a
                 // desktop switch. m_preAutotileGeometries is read non-
                 // destructively (the entry stays for the next genuine toggle).
-                auto screenIt = m_preAutotileGeometries.constFind(screenId);
-                if (screenIt != m_preAutotileGeometries.constEnd()) {
-                    const QString geoKey = AutotileStateHelpers::findSavedGeometryKey(screenIt.value(), windowId);
-                    if (!geoKey.isEmpty()) {
-                        const QRectF savedGeo = screenIt.value().value(geoKey);
-                        if (savedGeo.isValid()) {
-                            m_effect->applySnapGeometry(w, savedGeo.toRect());
-                        }
+                // Scan every screen's bucket for this window's saved rect — a
+                // window that transferred between autotile screens during the
+                // session may have its pre-autotile geometry stored under a
+                // screen key other than its current one.
+                for (auto sgIt = m_preAutotileGeometries.constBegin(); sgIt != m_preAutotileGeometries.constEnd();
+                     ++sgIt) {
+                    const QString geoKey = AutotileStateHelpers::findSavedGeometryKey(sgIt.value(), windowId);
+                    if (geoKey.isEmpty()) {
+                        continue;
                     }
+                    const QRectF savedGeo = sgIt.value().value(geoKey);
+                    if (savedGeo.isValid()) {
+                        m_effect->applySnapGeometry(w, savedGeo.toRect());
+                    }
+                    break;
                 }
             }
             m_effect->updateAllBorders();

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -99,18 +99,14 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
 
     if (!removed.isEmpty()) {
         if (isDesktopSwitch) {
-            qCInfo(lcEffect) << "slotScreensChanged: desktop switch detected, skipping"
-                             << "restore for removed screens:" << removed;
-            // Only update m_notifiedWindows — windows on removed screens are no
-            // longer autotiled on this desktop. Don't touch pre-autotile geometries,
-            // stacking orders, or borderless state — they belong to the other desktop.
-            // Save which windows we're removing from tracking — needed by the
-            // added path to distinguish "daemon already has this window" from
-            // "genuinely new window opened while desktop was not active".
+            qCInfo(lcEffect) << "slotScreensChanged: desktop switch, removed screens:" << removed;
+            // Pass 1: windows on the desktop just LEFT. They are no longer
+            // autotiled on this desktop; demote their tracking and remember
+            // them for the desktop-return `added` branch. Do NOT restore —
+            // their borderless / geometry state belongs to the other
+            // desktop's still-live autotile session.
             for (KWin::EffectWindow* w : windows) {
                 if (w && removed.contains(m_effect->getWindowScreenId(w))) {
-                    // Only remove from notified if the window is on the OLD desktop
-                    // (not current). Desktop 2's windows were never notified.
                     if (!w->isOnCurrentDesktop()) {
                         const QString wid = m_effect->getWindowId(w);
                         if (m_notifiedWindows.remove(wid)) {
@@ -120,6 +116,68 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                     }
                 }
             }
+            // Pass 2 (discussion #461): windows on the desktop just ARRIVED
+            // AT, on a screen no longer autotiled here — the user switched
+            // onto an autotile-disabled desktop. The daemon emits no
+            // windowsReleased / resnap for a desktop switch (it deliberately
+            // suppresses both), so these windows are stuck at their tiled
+            // frame, borderless. Run the per-window restore — borders,
+            // monocle, pre-autotile geometry, tracking — WITHOUT the
+            // per-screen state clearing the genuine-toggle branch does: that
+            // state belongs to the desktop we left. Every step below is a
+            // no-op for a window that was never autotiled, so this is inert
+            // on a healthy desktop switch.
+            for (KWin::EffectWindow* w : windows) {
+                if (!w || !w->isOnCurrentDesktop()) {
+                    continue;
+                }
+                const QString screenId = m_effect->getWindowScreenId(w);
+                if (!removed.contains(screenId)) {
+                    continue;
+                }
+                // setNoBorder() is a global KWin property — skip sticky
+                // windows while other screens still autotile (mirrors the
+                // genuine-toggle guard below).
+                if (w->isOnAllDesktops() && !newScreens.isEmpty()) {
+                    continue;
+                }
+                const QString windowId = m_effect->getWindowId(w);
+                if (m_notifiedWindows.remove(windowId)) {
+                    m_notifiedWindowScreens.remove(windowId);
+                }
+                QStringList screensHoldingBorderless;
+                for (auto it = m_border.borderlessWindowsByScreen.constBegin();
+                     it != m_border.borderlessWindowsByScreen.constEnd(); ++it) {
+                    if (it.value().contains(windowId)) {
+                        screensHoldingBorderless.append(it.key());
+                    }
+                }
+                for (const QString& sid : std::as_const(screensHoldingBorderless)) {
+                    setWindowBorderless(w, windowId, false, sid);
+                }
+                AutotileStateHelpers::removeFromAllScreens(m_border, windowId);
+                unmaximizeMonocleWindow(windowId);
+                // Drop stale zone-centering tracking so a later
+                // frameGeometryChanged does not re-snap the window into an
+                // old autotile zone.
+                m_autotileTargetZones.remove(windowId);
+                m_centeredWaylandZones.remove(windowId);
+                // Apply the pre-autotile geometry — the ONLY thing that
+                // un-tiles the window, since the daemon does not resnap on a
+                // desktop switch. m_preAutotileGeometries is read non-
+                // destructively (the entry stays for the next genuine toggle).
+                auto screenIt = m_preAutotileGeometries.constFind(screenId);
+                if (screenIt != m_preAutotileGeometries.constEnd()) {
+                    const QString geoKey = AutotileStateHelpers::findSavedGeometryKey(screenIt.value(), windowId);
+                    if (!geoKey.isEmpty()) {
+                        const QRectF savedGeo = screenIt.value().value(geoKey);
+                        if (savedGeo.isValid()) {
+                            m_effect->applySnapGeometry(w, savedGeo.toRect());
+                        }
+                    }
+                }
+            }
+            m_effect->updateAllBorders();
         } else {
             QSet<QString> windowsOnRemovedScreens;
             for (KWin::EffectWindow* w : windows) {

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -23,6 +23,7 @@
 #include <QDBusPendingReply>
 #include <QLoggingCategory>
 #include <QPointer>
+#include <QScopeGuard>
 #include <QTimer>
 
 namespace PlasmaZones {
@@ -192,16 +193,29 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                     }
                     const QRectF savedGeo = sgIt.value().value(geoKey);
                     if (savedGeo.isValid()) {
-                        // applySnapGeometry's moveResize emits
-                        // windowFrameGeometryChanged synchronously; suppress the
-                        // VS-crossing detectors (autotile slotWindowFrameGeometryChanged
-                        // and the snapping windowFrameGeometryChanged handler) so
-                        // this same-screen restore is not mistaken for a
-                        // virtual-screen crossing — the genuine retile path
-                        // guards the same way (tiling.cpp).
+                        // applySnapGeometry's moveResize, and the maximize-state
+                        // clear below, emit windowFrameGeometryChanged
+                        // synchronously; suppress the VS-crossing detectors
+                        // (autotile slotWindowFrameGeometryChanged and the
+                        // snapping windowFrameGeometryChanged handler) so this
+                        // same-screen restore is not mistaken for a virtual-
+                        // screen crossing — the genuine retile path guards the
+                        // same way (tiling.cpp).
                         m_effect->m_inDaemonGeometryApply = true;
+                        const auto geomGuard = qScopeGuard([this] {
+                            m_effect->m_inDaemonGeometryApply = false;
+                        });
+                        // Clear any lingering KWin maximize flag before restoring
+                        // the pre-autotile geometry: a still-maximized window
+                        // makes KWin re-assert the maximize-area rect and defeat
+                        // the restore — the tile-request path clears it for the
+                        // same reason (discussion #461).
+                        if (KWin::Window* kw = w->window(); kw && kw->maximizeMode() != KWin::MaximizeRestore) {
+                            ++m_suppressMaximizeChanged;
+                            kw->maximize(KWin::MaximizeRestore);
+                            --m_suppressMaximizeChanged;
+                        }
                         m_effect->applySnapGeometry(w, savedGeo.toRect());
-                        m_effect->m_inDaemonGeometryApply = false;
                         break;
                     }
                     // Found-but-invalid entry: keep scanning. A valid rect may

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -83,6 +83,30 @@ void AutotileHandler::clearAllPendingMinimizeFloats()
     m_pendingMinimizeFloat.clear();
 }
 
+void AutotileHandler::restoreWindowBorders(KWin::EffectWindow* w, const QString& windowId)
+{
+    // Find every screen whose borderless bucket still tracks this window —
+    // stale entries can span multiple screens if the window transferred
+    // between autotile screens during the session — and clear each. When the
+    // EffectWindow is gone (screen-removal path), drop the per-screen border
+    // state directly since setNoBorder needs a live window.
+    QStringList screensHoldingBorderless;
+    for (auto it = m_border.borderlessWindowsByScreen.constBegin(); it != m_border.borderlessWindowsByScreen.constEnd();
+         ++it) {
+        if (it.value().contains(windowId)) {
+            screensHoldingBorderless.append(it.key());
+        }
+    }
+    for (const QString& sid : std::as_const(screensHoldingBorderless)) {
+        if (w) {
+            setWindowBorderless(w, windowId, false, sid);
+        } else {
+            AutotileStateHelpers::removeBorderlessOnScreen(m_border, sid, windowId);
+        }
+    }
+    AutotileStateHelpers::removeFromAllScreens(m_border, windowId);
+}
+
 void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDesktopSwitch)
 {
     // Invalidate in-flight stagger timers from prior autotile/restore operations.
@@ -145,17 +169,7 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                 if (m_notifiedWindows.remove(windowId)) {
                     m_notifiedWindowScreens.remove(windowId);
                 }
-                QStringList screensHoldingBorderless;
-                for (auto it = m_border.borderlessWindowsByScreen.constBegin();
-                     it != m_border.borderlessWindowsByScreen.constEnd(); ++it) {
-                    if (it.value().contains(windowId)) {
-                        screensHoldingBorderless.append(it.key());
-                    }
-                }
-                for (const QString& sid : std::as_const(screensHoldingBorderless)) {
-                    setWindowBorderless(w, windowId, false, sid);
-                }
-                AutotileStateHelpers::removeFromAllScreens(m_border, windowId);
+                restoreWindowBorders(w, windowId);
                 unmaximizeMonocleWindow(windowId);
                 // Drop stale zone-centering tracking so a later
                 // frameGeometryChanged does not re-snap the window into an
@@ -179,8 +193,11 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                     const QRectF savedGeo = sgIt.value().value(geoKey);
                     if (savedGeo.isValid()) {
                         m_effect->applySnapGeometry(w, savedGeo.toRect());
+                        break;
                     }
-                    break;
+                    // Found-but-invalid entry: keep scanning. A valid rect may
+                    // still be stored under another screen's bucket from a
+                    // mid-session autotile-screen transfer.
                 }
             }
             m_effect->updateAllBorders();
@@ -212,27 +229,7 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
 
             // Restore title bars and clear tiled tracking for windows on removed screens
             for (const QString& windowId : std::as_const(windowsOnRemovedScreens)) {
-                // Find every screen that currently tracks this window and
-                // remove it from each. We don't know which specific screen
-                // the window "belongs to" in our buckets at this point —
-                // there may be stale entries across multiple screens if the
-                // window ever transferred. Clean them all.
-                QStringList screensHoldingBorderless;
-                for (auto it = m_border.borderlessWindowsByScreen.constBegin();
-                     it != m_border.borderlessWindowsByScreen.constEnd(); ++it) {
-                    if (it.value().contains(windowId)) {
-                        screensHoldingBorderless.append(it.key());
-                    }
-                }
-                KWin::EffectWindow* w = m_effect->findWindowById(windowId);
-                for (const QString& sid : std::as_const(screensHoldingBorderless)) {
-                    if (w) {
-                        setWindowBorderless(w, windowId, false, sid);
-                    } else {
-                        AutotileStateHelpers::removeBorderlessOnScreen(m_border, sid, windowId);
-                    }
-                }
-                AutotileStateHelpers::removeFromAllScreens(m_border, windowId);
+                restoreWindowBorders(m_effect->findWindowById(windowId), windowId);
             }
             m_effect->updateAllBorders();
 

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -192,7 +192,16 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                     }
                     const QRectF savedGeo = sgIt.value().value(geoKey);
                     if (savedGeo.isValid()) {
+                        // applySnapGeometry's moveResize emits
+                        // windowFrameGeometryChanged synchronously; suppress the
+                        // VS-crossing detectors (autotile slotWindowFrameGeometryChanged
+                        // and the snapping windowFrameGeometryChanged handler) so
+                        // this same-screen restore is not mistaken for a
+                        // virtual-screen crossing — the genuine retile path
+                        // guards the same way (tiling.cpp).
+                        m_effect->m_inDaemonGeometryApply = true;
                         m_effect->applySnapGeometry(w, savedGeo.toRect());
+                        m_effect->m_inDaemonGeometryApply = false;
                         break;
                     }
                     // Found-but-invalid entry: keep scanning. A valid rect may

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -354,6 +354,20 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
                 }
             } else {
                 unmaximizeMonocleWindow(snap.windowId);
+                // Clear any KWin maximize state before tiling. A user-
+                // maximized window keeps its MaximizeFull flag through
+                // moveResize; KWin then re-asserts the maximize-area
+                // geometry and the reactive centering in
+                // slotWindowFrameGeometryChanged re-applies — the two
+                // authorities never converge and compound into the
+                // "ballooning" growth (discussion #461). unmaximizeMonocleWindow
+                // above only restores windows PlasmaZones itself maximized
+                // for monocle; a user-maximized window is never in that set.
+                if (KWin::Window* kw = snap.window->window(); kw && kw->maximizeMode() != KWin::MaximizeRestore) {
+                    ++m_suppressMaximizeChanged;
+                    kw->maximize(KWin::MaximizeRestore);
+                    --m_suppressMaximizeChanged;
+                }
                 QRect geo = snap.geometry;
 
                 // For Wayland windows being retiled to the same zone, skip the

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -387,6 +387,13 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
                 // "ballooning" growth (discussion #461). unmaximizeMonocleWindow
                 // above only restores windows PlasmaZones itself maximized
                 // for monocle; a user-maximized window is never in that set.
+                //
+                // The MaximizeRestore call resizes the window to its pre-
+                // maximize restore geometry before applySnapGeometry below
+                // overwrites it; that intermediate frameGeometryChanged is
+                // intentionally absorbed by the m_inDaemonGeometryApply guard
+                // set at the top of this lambda — a refactor that moves or
+                // narrows that guard reintroduces the ballooning re-entry.
                 if (KWin::Window* kw = snap.window->window(); kw && kw->maximizeMode() != KWin::MaximizeRestore) {
                     ++m_suppressMaximizeChanged;
                     kw->maximize(KWin::MaximizeRestore);

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -24,6 +24,27 @@ namespace PlasmaZones {
 
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
 
+namespace {
+// Human-readable KWin maximize mode for the tile-request log. The autotile
+// "ballooning" feedback loop (discussion #461) hinges on a window still
+// carrying a maximize flag when it is tiled, so the tile-request log records
+// this to keep a future report diagnosable without a reproduction.
+const char* maximizeModeName(KWin::MaximizeMode mode)
+{
+    switch (mode) {
+    case KWin::MaximizeRestore:
+        return "restore";
+    case KWin::MaximizeVertical:
+        return "vertical";
+    case KWin::MaximizeHorizontal:
+        return "horizontal";
+    case KWin::MaximizeFull:
+        return "full";
+    }
+    return "unknown";
+}
+} // namespace
+
 void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileRequestList& tileRequests)
 {
     if (tileRequests.isEmpty()) {
@@ -319,7 +340,10 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
                 m_effect->m_inDaemonGeometryApply = false;
             });
             saveAndRecordPreAutotileGeometry(snap.windowId, snap.screenId, snap.window->frameGeometry());
-            qCInfo(lcEffect) << "Autotile tile request:" << snap.windowId << "QRect=" << snap.geometry;
+            KWin::Window* kwForLog = snap.window->window();
+            qCInfo(lcEffect) << "Autotile tile request:" << snap.windowId << "QRect=" << snap.geometry
+                             << "monocle=" << snap.isMonocle << "maximizeMode="
+                             << (kwForLog ? maximizeModeName(kwForLog->maximizeMode()) : "no-window");
             // A window can only be tile-managed by one screen at a time.
             // If this is a cross-screen transfer, strip the stale tracking
             // from any other screen before recording the new owner. This

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -542,7 +542,11 @@ void PlasmaZonesEffect::applySnapGeometry(KWin::EffectWindow* window, const QRec
 
     KWin::Window* kwinWindow = window->window();
     if (kwinWindow) {
-        qCInfo(lcEffect) << "moveResize: QRect=" << geo << "-> QRectF=" << QRectF(geo);
+        // DEBUG: the resolved rect is already logged at INFO above ("Setting
+        // window geometry from ... to ..."), which covers both the animated
+        // and non-animated paths — keep this one at debug to avoid a
+        // duplicate INFO line for the same apply.
+        qCDebug(lcEffect) << "moveResize: QRect=" << geo << "-> QRectF=" << QRectF(geo);
         kwinWindow->moveResize(QRectF(geo));
 
         repaintSnapRegions(window, oldFrame, geo);

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -398,7 +398,12 @@ void PlasmaZonesEffect::applySnapGeometry(KWin::EffectWindow* window, const QRec
         return;
     }
 
-    qCDebug(lcEffect) << "Setting window geometry from" << window->frameGeometry() << "to" << geo;
+    // INFO level: a standing record of every resolved window placement.
+    // Generally useful operationally, and the resolved pixel rect is the one
+    // number a support report needs to diagnose zone-geometry bugs (the zone
+    // id is logged elsewhere; the resolved rect previously was not). Mirrors
+    // the autotile path, which already logs "Autotile tile request: QRect=".
+    qCInfo(lcEffect) << "Setting window geometry from" << window->frameGeometry() << "to" << geo;
 
     // Capture old frame before moveResize for repaint region
     const QRectF oldFrame = window->frameGeometry();

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -73,7 +73,7 @@ QString PlasmaZonesEffect::getWindowAppId(KWin::EffectWindow* w) const
     // Canonical appId derivation lives in PhosphorIdentity so the daemon and
     // effect spell it identically. A blank / whitespace-only window class
     // yields an empty appId (never " ") — see normalizeAppId.
-    return PhosphorIdentity::WindowId::normalizeAppId(window->desktopFileName(), w->windowClass());
+    return ::PhosphorIdentity::WindowId::normalizeAppId(window->desktopFileName(), w->windowClass());
 }
 
 void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w)

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -70,17 +70,10 @@ QString PlasmaZonesEffect::getWindowAppId(KWin::EffectWindow* w) const
     if (!window) {
         return QString();
     }
-    // Prefer desktopFileName (stable cross-session identifier when available).
-    QString appId = window->desktopFileName();
-    if (appId.isEmpty()) {
-        // Fallback: normalize windowClass
-        //   X11: "resourceName resourceClass" → extract resourceClass
-        //   Wayland: app_id as-is
-        QString wc = w->windowClass();
-        int spaceIdx = wc.indexOf(QLatin1Char(' '));
-        appId = (spaceIdx > 0) ? wc.mid(spaceIdx + 1) : wc;
-    }
-    return appId.toLower();
+    // Canonical appId derivation lives in PhosphorIdentity so the daemon and
+    // effect spell it identically. A blank / whitespace-only window class
+    // yields an empty appId (never " ") — see normalizeAppId.
+    return PhosphorIdentity::WindowId::normalizeAppId(window->desktopFileName(), w->windowClass());
 }
 
 void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w)

--- a/libs/phosphor-identity/include/PhosphorIdentity/WindowId.h
+++ b/libs/phosphor-identity/include/PhosphorIdentity/WindowId.h
@@ -82,6 +82,55 @@ inline QString extractInstanceId(const QString& windowId)
 }
 
 /**
+ * @brief Derive a canonical appId from a window's desktop-file name and class.
+ *
+ * Prefers @p desktopFileName (stable across sessions). Falls back to the
+ * LAST whitespace-delimited token of @p windowClass: an X11 window class is
+ * "resourceName resourceClass" and the resourceName may itself contain
+ * spaces, so the last space is the split point and the resourceClass is the
+ * token kept. A Wayland app_id has no space and is taken whole.
+ *
+ * The result is trimmed and lower-cased. A blank or whitespace-only input
+ * (KWin reports a bare " " class for some unmapped / transient surfaces)
+ * yields an EMPTY string, never " " — a space-only appId would otherwise
+ * become a live key in every appId-map (most damagingly the snap restore
+ * queue, where it lets unrelated blank-class windows consume each other's
+ * saved zones). @c isValidAppId rejects whatever survives.
+ */
+inline QString normalizeAppId(const QString& desktopFileName, const QString& windowClass)
+{
+    QString appId = desktopFileName.trimmed();
+    if (appId.isEmpty()) {
+        const int sep = windowClass.lastIndexOf(QLatin1Char(' '));
+        appId = (sep >= 0 ? windowClass.mid(sep + 1) : windowClass).trimmed();
+    }
+    return appId.toLower();
+}
+
+/**
+ * @brief Whether @p appId is a well-formed canonical app identifier.
+ *
+ * A canonical appId is a non-empty, whitespace-free token — a desktop-file
+ * name ("org.kde.konsole") or a normalized window-class token. A blank,
+ * whitespace-only, or whitespace-bearing string is a corrupt identity (a
+ * KWin bare-" " class, or a stale pre-3.0 "resourceName resourceClass"
+ * key) and must never be used as a map key. Gate every appId-keyed insert
+ * and every persisted-key load on this.
+ */
+inline bool isValidAppId(const QString& appId)
+{
+    if (appId.isEmpty()) {
+        return false;
+    }
+    for (const QChar c : appId) {
+        if (c.isSpace()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
  * @brief Derive short name from app ID for icon/app display
  * Reverse-DNS: "org.kde.dolphin" → last dot-segment (e.g., "dolphin")
  * Simple name: "firefox" → as-is

--- a/libs/phosphor-identity/include/PhosphorIdentity/WindowId.h
+++ b/libs/phosphor-identity/include/PhosphorIdentity/WindowId.h
@@ -101,8 +101,13 @@ inline QString normalizeAppId(const QString& desktopFileName, const QString& win
 {
     QString appId = desktopFileName.trimmed();
     if (appId.isEmpty()) {
-        const int sep = windowClass.lastIndexOf(QLatin1Char(' '));
-        appId = (sep >= 0 ? windowClass.mid(sep + 1) : windowClass).trimmed();
+        // Trim the whole class BEFORE the split: a class with trailing
+        // whitespace ("resourceName resourceClass ") would otherwise split at
+        // the trailing space, yield an empty token, and drop an otherwise
+        // valid identity.
+        const QString trimmedClass = windowClass.trimmed();
+        const int sep = trimmedClass.lastIndexOf(QLatin1Char(' '));
+        appId = (sep >= 0 ? trimmedClass.mid(sep + 1) : trimmedClass);
     }
     return appId.toLower();
 }

--- a/libs/phosphor-placement/src/lifecycle.cpp
+++ b/libs/phosphor-placement/src/lifecycle.cpp
@@ -563,7 +563,12 @@ void WindowTrackingService::windowClosed(const QString& windowId)
     // Check floating with full windowId first, fallback to appId
     bool isFloating = isWindowFloating(windowId);
     if (!zoneId.isEmpty() && !zoneId.startsWith(kZoneSelectorIdPrefix) && !isFloating) {
-        if (!appId.isEmpty()) {
+        // A whitespace-only / whitespace-bearing appId is a corrupt window
+        // identity (KWin reported a blank class). Persisting a PendingRestore
+        // under it pollutes the restore queue with a key no real window
+        // matches cleanly — and a blank " " key is then consumed
+        // indiscriminately by every later blank-class window. Drop it.
+        if (PhosphorIdentity::WindowId::isValidAppId(appId)) {
             PendingRestore entry;
             entry.zoneIds = zoneIds;
 

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -57,6 +57,13 @@ public:
                         QObject* parent = nullptr);
     ~SnapEngine() override;
 
+    /// Current virtual desktop (1-based) and activity, forwarded from the
+    /// injected managers. Exposed so daemon adaptors that gate on disabled
+    /// context (see isContextDisabled) can read the same values the engine's
+    /// own restore logic uses, without each adaptor wiring its own managers.
+    int currentVirtualDesktop() const;
+    QString currentActivity() const;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // IPlacementEngine — lifecycle
     // ═══════════════════════════════════════════════════════════════════════════

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -57,10 +57,11 @@ public:
                         QObject* parent = nullptr);
     ~SnapEngine() override;
 
-    /// Current virtual desktop (1-based) and activity, forwarded from the
-    /// injected managers. Exposed so daemon adaptors that gate on disabled
-    /// context (see isContextDisabled) can read the same values the engine's
-    /// own restore logic uses, without each adaptor wiring its own managers.
+    /// Current virtual desktop (1-based; 0 when no virtual-desktop manager is
+    /// wired) and activity, forwarded from the injected managers. Exposed so
+    /// daemon adaptors that gate on disabled context (see isContextDisabled)
+    /// can read the same values the engine's own restore logic uses, without
+    /// each adaptor wiring its own managers.
     int currentVirtualDesktop() const;
     QString currentActivity() const;
 

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -210,4 +210,14 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     return SnapResult::noSnap();
 }
 
+int SnapEngine::currentVirtualDesktop() const
+{
+    return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+}
+
+QString SnapEngine::currentActivity() const
+{
+    return m_layoutManager ? m_layoutManager->currentActivity() : QString();
+}
+
 } // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -178,8 +178,8 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     // on an autotile screen must not be auto-assigned, autotile owns
     // placement there.
     if (m_layoutManager) {
-        int dt = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
-        if (m_layoutManager->modeForScreen(screenId, dt, m_layoutManager->currentActivity())
+        const int dt = currentVirtualDesktop();
+        if (m_layoutManager->modeForScreen(screenId, dt, currentActivity())
             != PhosphorZones::AssignmentEntry::Mode::Snapping) {
             qCDebug(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore:" << windowId << "caller screen"
                                                       << screenId << "is autotile — skipping empty/last zone fallbacks";

--- a/libs/phosphor-zones/src/geometryutils.cpp
+++ b/libs/phosphor-zones/src/geometryutils.cpp
@@ -94,14 +94,14 @@ QRectF applyGapsToZoneGeometry(const QRectF& zoneGeom, Zone* zone, const QRectF&
     if (geoF.height() < 1.0) {
         geoF.setHeight(1.0);
     }
-    // Clamp the gapped rect to the reference (screen / available) area. A
-    // zone is a subdivision of the screen, so a well-formed zone's gapped
-    // rect is already inside referenceGeom and this is a no-op. It is a
-    // guard against malformed layout data — a hand-edited layout whose
-    // relative x+width or y+height exceeds 1.0 would otherwise place a
-    // window past the screen edge. Boundary validation on untrusted layout
-    // input, not a workaround.
-    if (referenceGeom.isValid()) {
+    // Clamp the gapped rect into the reference (screen / available) area.
+    // A well-formed zone is a subdivision of the screen, so its gapped rect
+    // is already inside referenceGeom and the contains() check makes this a
+    // true no-op. It acts only on malformed layout data — a hand-edited
+    // layout whose relative x+width or y+height exceeds 1.0 — which would
+    // otherwise place a window past the screen edge. Boundary validation on
+    // untrusted layout input, not a workaround.
+    if (referenceGeom.isValid() && !referenceGeom.contains(geoF)) {
         geoF = geoF.intersected(referenceGeom);
     }
     return geoF;

--- a/libs/phosphor-zones/src/geometryutils.cpp
+++ b/libs/phosphor-zones/src/geometryutils.cpp
@@ -94,6 +94,16 @@ QRectF applyGapsToZoneGeometry(const QRectF& zoneGeom, Zone* zone, const QRectF&
     if (geoF.height() < 1.0) {
         geoF.setHeight(1.0);
     }
+    // Clamp the gapped rect to the reference (screen / available) area. A
+    // zone is a subdivision of the screen, so a well-formed zone's gapped
+    // rect is already inside referenceGeom and this is a no-op. It is a
+    // guard against malformed layout data — a hand-edited layout whose
+    // relative x+width or y+height exceeds 1.0 would otherwise place a
+    // window past the screen edge. Boundary validation on untrusted layout
+    // input, not a workaround.
+    if (referenceGeom.isValid()) {
+        geoF = geoF.intersected(referenceGeom);
+    }
     return geoF;
 }
 } // anonymous namespace

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -188,9 +188,11 @@ void Daemon::handleSnap(int zoneNumber)
         // Honor the per-context disable lists. engineFor() routes purely on
         // mode and never consults them, so a keyboard snap-to-zone would
         // otherwise place a window on a monitor / desktop / activity the user
-        // disabled (discussion #461). Gate against the routed engine's mode.
-        const auto mode = nav->engineId() == QLatin1String("autotile") ? PhosphorZones::AssignmentEntry::Autotile
-                                                                       : PhosphorZones::AssignmentEntry::Snapping;
+        // disabled (discussion #461). Take the screen's mode from the router
+        // (the single source of truth) rather than inferring it from the
+        // engine-id string, which a future third engine would misroute.
+        const auto mode =
+            m_screenModeRouter ? m_screenModeRouter->modeFor(ctx.screenId) : PhosphorZones::AssignmentEntry::Snapping;
         if (isContextDisabled(m_settings.get(), mode, ctx.screenId, currentDesktop(), currentActivity())) {
             return;
         }

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -111,6 +111,15 @@ void Daemon::handleFloat()
     // reaching back into WTA state.
     NavigationContext ctx;
     if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "Float")) {
+        // Honor the per-context disable lists, same as handleSnap. Un-floating
+        // a window re-runs commitSnap; without this gate that re-snaps the
+        // window on a monitor / desktop / activity the user disabled
+        // (discussion #461 — observed re-snapping on a disabled desktop).
+        const auto mode =
+            m_screenModeRouter ? m_screenModeRouter->modeFor(ctx.screenId) : PhosphorZones::AssignmentEntry::Snapping;
+        if (isContextDisabled(m_settings.get(), mode, ctx.screenId, currentDesktop(), currentActivity())) {
+            return;
+        }
         nav->toggleFocusedFloat(ctx);
     }
 }

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -185,6 +185,15 @@ void Daemon::handleSnap(int zoneNumber)
 {
     NavigationContext ctx;
     if (auto* nav = navigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx, "SnapToZone")) {
+        // Honor the per-context disable lists. engineFor() routes purely on
+        // mode and never consults them, so a keyboard snap-to-zone would
+        // otherwise place a window on a monitor / desktop / activity the user
+        // disabled (discussion #461). Gate against the routed engine's mode.
+        const auto mode = nav->engineId() == QLatin1String("autotile") ? PhosphorZones::AssignmentEntry::Autotile
+                                                                       : PhosphorZones::AssignmentEntry::Snapping;
+        if (isContextDisabled(m_settings.get(), mode, ctx.screenId, currentDesktop(), currentActivity())) {
+            return;
+        }
         nav->moveFocusedToPosition(zoneNumber, ctx);
     }
 }

--- a/src/dbus/snapadaptor.h
+++ b/src/dbus/snapadaptor.h
@@ -313,8 +313,13 @@ private:
     /**
      * @brief Apply a successful SnapResult: assign outputs, mark auto-snapped,
      *        clear floating state, and track the zone assignment.
+     *
+     * Returns false (and leaves the out-params at 0 / false) when the snap is
+     * refused — missing dependencies, or the target context is disabled. A
+     * false return means no commit happened; callers must skip any post-snap
+     * work (e.g. consumePendingAssignment, success logging).
      */
-    void applySnapResult(const SnapResult& result, const QString& windowId, int& snapX, int& snapY, int& snapWidth,
+    bool applySnapResult(const SnapResult& result, const QString& windowId, int& snapX, int& snapY, int& snapWidth,
                          int& snapHeight, bool& shouldSnap);
 
     PhosphorSnapEngine::SnapEngine* m_engine = nullptr;

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -8,6 +8,7 @@
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorScreens/Manager.h>
 #include "../../core/isettings.h"
+#include "../../core/screenmoderouter.h"
 #include <PhosphorSnapEngine/SnapEngine.h>
 
 namespace PlasmaZones {
@@ -235,12 +236,20 @@ bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
     // slot funnels through here — did not, so windows still snapped on a
     // disabled context (discussion #461). Gating here covers all restore
     // entry points in one place.
-    if (m_settings
-        && isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, result.screenId,
-                             m_engine->currentVirtualDesktop(), m_engine->currentActivity())) {
-        qCInfo(lcDbusWindow) << "applySnapResult: refusing auto-snap of" << windowId
-                             << "— PlasmaZones is disabled for screen" << result.screenId;
-        return false;
+    if (m_settings && !result.screenId.isEmpty()) {
+        // Gate against the DESTINATION screen's actual mode. A restore result
+        // can cross-screen-migrate (app rule / session restore) onto a screen
+        // whose mode differs from the caller's, so the disable list to consult
+        // is the one for result.screenId's mode — not a hard-coded Snapping.
+        const PhosphorZones::AssignmentEntry::Mode mode = m_screenModeRouter
+            ? m_screenModeRouter->modeFor(result.screenId)
+            : PhosphorZones::AssignmentEntry::Snapping;
+        if (isContextDisabled(m_settings, mode, result.screenId, m_engine->currentVirtualDesktop(),
+                              m_engine->currentActivity())) {
+            qCInfo(lcDbusWindow) << "applySnapResult: refusing auto-snap of" << windowId
+                                 << "— PlasmaZones is disabled for screen" << result.screenId;
+            return false;
+        }
     }
 
     snapX = result.geometry.x();

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -241,6 +241,12 @@ bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
         // can cross-screen-migrate (app rule / session restore) onto a screen
         // whose mode differs from the caller's, so the disable list to consult
         // is the one for result.screenId's mode — not a hard-coded Snapping.
+        //
+        // The desktop and activity are the session's CURRENT ones, not the
+        // restore target's — SnapResult carries no destination desktop. The
+        // screen/mode axis is therefore the precise gate; desktop/activity are
+        // best-effort against the active context, so a window restoring onto a
+        // disabled NON-current desktop is not caught here.
         const PhosphorZones::AssignmentEntry::Mode mode = m_screenModeRouter
             ? m_screenModeRouter->modeFor(result.screenId)
             : PhosphorZones::AssignmentEntry::Snapping;

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -70,7 +70,9 @@ void SnapAdaptor::snapToLastZone(const QString& windowId, const QString& windowS
         return;
     }
 
-    applySnapResult(result, windowId, snapX, snapY, snapWidth, snapHeight, shouldSnap);
+    if (!applySnapResult(result, windowId, snapX, snapY, snapWidth, snapHeight, shouldSnap)) {
+        return;
+    }
     qCInfo(lcDbusWindow) << "Snapping new window" << windowId << "to last used zone" << result.zoneId;
 }
 
@@ -101,7 +103,9 @@ void SnapAdaptor::snapToAppRule(const QString& windowId, const QString& windowSc
         return;
     }
 
-    applySnapResult(result, windowId, snapX, snapY, snapWidth, snapHeight, shouldSnap);
+    if (!applySnapResult(result, windowId, snapX, snapY, snapWidth, snapHeight, shouldSnap)) {
+        return;
+    }
     qCInfo(lcDbusWindow) << "App rule snapping window" << windowId << "to zone" << result.zoneId;
 }
 
@@ -134,7 +138,9 @@ void SnapAdaptor::snapToEmptyZone(const QString& windowId, const QString& window
         return;
     }
 
-    applySnapResult(result, windowId, snapX, snapY, snapWidth, snapHeight, shouldSnap);
+    if (!applySnapResult(result, windowId, snapX, snapY, snapWidth, snapHeight, shouldSnap)) {
+        return;
+    }
     qCInfo(lcDbusWindow) << "Auto-assign snapping window" << windowId << "to empty zone" << result.zoneId;
 }
 
@@ -170,7 +176,9 @@ void SnapAdaptor::restoreToPersistedZone(const QString& windowId, const QString&
         return;
     }
 
-    applySnapResult(result, windowId, snapX, snapY, snapWidth, snapHeight, shouldRestore);
+    if (!applySnapResult(result, windowId, snapX, snapY, snapWidth, snapHeight, shouldRestore)) {
+        return;
+    }
     // Consume the pending assignment so other windows of the same class won't restore to this zone
     m_adaptor->service()->consumePendingAssignment(windowId);
     qCInfo(lcDbusWindow) << "Restoring window" << windowId << "to zone(s)" << result.zoneIds;
@@ -205,20 +213,41 @@ void SnapAdaptor::resolveWindowRestore(const QString& windowId, const QString& s
     }
 
     applySnapResult(result, windowId, snapX, snapY, snapWidth, snapHeight, shouldSnap);
+    // Return value intentionally ignored: applySnapResult has already set
+    // shouldSnap (false on a disabled-context refusal) and there is no
+    // post-snap work in this slot to skip.
 }
 
-void SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windowId, int& snapX, int& snapY,
+bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windowId, int& snapX, int& snapY,
                                   int& snapWidth, int& snapHeight, bool& shouldSnap)
 {
+    snapX = snapY = snapWidth = snapHeight = 0;
+    shouldSnap = false;
+
+    if (!m_adaptor || !m_adaptor->service() || !m_engine) {
+        return false;
+    }
+
+    // Disabled-context gate. The interactive drag path (WindowDragAdaptor)
+    // and autotile (Daemon::updateAutotileScreens) already refuse to place
+    // windows on a monitor / desktop / activity the user marked disabled.
+    // The auto-snap-on-open restore path — every snapTo* / resolveWindowRestore
+    // slot funnels through here — did not, so windows still snapped on a
+    // disabled context (discussion #461). Gating here covers all restore
+    // entry points in one place.
+    if (m_settings
+        && isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, result.screenId,
+                             m_engine->currentVirtualDesktop(), m_engine->currentActivity())) {
+        qCInfo(lcDbusWindow) << "applySnapResult: refusing auto-snap of" << windowId
+                             << "— PlasmaZones is disabled for screen" << result.screenId;
+        return false;
+    }
+
     snapX = result.geometry.x();
     snapY = result.geometry.y();
     snapWidth = result.geometry.width();
     snapHeight = result.geometry.height();
     shouldSnap = true;
-
-    if (!m_adaptor || !m_adaptor->service() || !m_engine) {
-        return;
-    }
 
     // Mark auto-snapped first so the flag persists through commitSnap
     // (AutoRestored leaves it alone). commitSnap runs the full
@@ -232,6 +261,7 @@ void SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
     } else {
         m_engine->commitSnap(windowId, zoneIds.first(), result.screenId, SnapIntent::AutoRestored);
     }
+    return true;
 }
 
 } // namespace PlasmaZones

--- a/src/dbus/windowtrackingadaptor/saveload.cpp
+++ b/src/dbus/windowtrackingadaptor/saveload.cpp
@@ -410,6 +410,15 @@ void WindowTrackingAdaptor::loadState()
                 // falls back to string parsing — same behavior as the old code
                 // but consistent with the rest of the codebase.
                 QString appId = m_service->currentAppIdFor(windowId);
+                // Skip a corrupt appId for the same reason the persisted-queue
+                // loop below does: currentAppIdFor falls back to string parsing
+                // here (the registry is empty during load), so a pre-3.0
+                // windowId yields a whitespace-bearing key no live window
+                // matches. Without this gate the merge would reintroduce the
+                // corrupt key the persisted-queue gate set out to drop.
+                if (!PhosphorIdentity::WindowId::isValidAppId(appId)) {
+                    continue;
+                }
                 PendingRestore pending;
                 pending.zoneIds = zoneIds;
                 pending.screenId = screen;

--- a/src/dbus/windowtrackingadaptor/saveload.cpp
+++ b/src/dbus/windowtrackingadaptor/saveload.cpp
@@ -19,6 +19,7 @@
 #include "../../config/configkeys.h"
 #include <QTimer>
 #include <PhosphorScreens/ScreenIdentity.h>
+#include <PhosphorIdentity/WindowId.h>
 
 namespace PlasmaZones {
 using namespace WindowTrackingInternal;
@@ -433,6 +434,15 @@ void WindowTrackingAdaptor::loadState()
             QJsonObject obj = doc.object();
             for (auto it = obj.constBegin(); it != obj.constEnd(); ++it) {
                 if (!it.value().isArray()) {
+                    continue;
+                }
+                // Drop entries under a corrupt key — blank " " keys and the
+                // pre-3.0 "resourceName resourceClass" composites that survive
+                // an upgrade (session state outlives a ~/.config wipe).
+                // Loading them verbatim lets them be consumed by unrelated
+                // windows on reopen. See WindowId::isValidAppId.
+                if (!PhosphorIdentity::WindowId::isValidAppId(it.key())) {
+                    qCInfo(lcDbusWindow) << "Dropping pending-restore entries under corrupt appId key:" << it.key();
                     continue;
                 }
                 for (const QJsonValue& entryVal : it.value().toArray()) {

--- a/src/settings/qml/SnappingBehaviorPage.qml
+++ b/src/settings/qml/SnappingBehaviorPage.qml
@@ -335,12 +335,12 @@ SettingsFlickable {
                     }
 
                     SettingsRow {
-                        title: i18n("New windows to last zone")
-                        description: i18n("Automatically move newly opened windows to the zone they last occupied")
+                        title: i18n("Open new windows in the last-used zone")
+                        description: i18n("Snap every newly opened window into whichever zone you most recently snapped a window into")
 
                         SettingsSwitch {
                             checked: appSettings.moveNewWindowsToLastZone
-                            accessibleName: i18n("Move new windows to last zone")
+                            accessibleName: i18n("Open new windows in the last-used zone")
                             onToggled: function(newValue) {
                                 appSettings.moveNewWindowsToLastZone = newValue;
                             }
@@ -386,12 +386,12 @@ SettingsFlickable {
                     }
 
                     SettingsRow {
-                        title: i18n("Restore zones on login")
-                        description: i18n("Return windows to their previous zone when reopened or after a session restart")
+                        title: i18n("Restore windows to their previous zone")
+                        description: i18n("When an app reopens, during the session or after a logout, return it to the zone it was last snapped in")
 
                         SettingsSwitch {
                             checked: appSettings.restoreWindowsToZonesOnLogin
-                            accessibleName: i18n("Restore zones on login")
+                            accessibleName: i18n("Restore windows to their previous zone")
                             onToggled: function(newValue) {
                                 appSettings.restoreWindowsToZonesOnLogin = newValue;
                             }

--- a/tests/unit/core/test_window_identity.cpp
+++ b/tests/unit/core/test_window_identity.cpp
@@ -75,6 +75,25 @@ private Q_SLOTS:
         QCOMPARE(normalizeAppId(QString(), QStringLiteral("Alacritty")), QStringLiteral("alacritty"));
     }
 
+    void testNormalizeAppId_trimsWindowClassBeforeSplit()
+    {
+        // A class carrying surrounding whitespace must be trimmed BEFORE the
+        // last-space split — otherwise a trailing space becomes the split
+        // point and collapses an otherwise valid resourceClass to empty.
+        QCOMPARE(normalizeAppId(QString(), QStringLiteral("konsole org.kde.konsole ")),
+                 QStringLiteral("org.kde.konsole"));
+        QCOMPARE(normalizeAppId(QString(), QStringLiteral("  Alacritty  ")), QStringLiteral("alacritty"));
+    }
+
+    void testNormalizeAppId_desktopFileNameTakenWhole()
+    {
+        // desktopFileName is trimmed and lower-cased but never split on
+        // whitespace the way an X11 windowClass is — a space-bearing desktop
+        // name survives intact (and isValidAppId then rejects it).
+        QCOMPARE(normalizeAppId(QStringLiteral("  Some Desktop Name  "), QString()),
+                 QStringLiteral("some desktop name"));
+    }
+
     void testNormalizeAppId_blankClassYieldsEmpty()
     {
         // The krakerz #2 regression: a bare " " class must NOT become a " "
@@ -106,8 +125,11 @@ private Q_SLOTS:
     void testIsValidAppId_rejectsWhitespaceBearingLegacyKeys()
     {
         // Pre-3.0 PendingRestoreQueues keys used the raw "resourceName
-        // resourceClass" class, sometimes doubled. They contain spaces and
-        // must be rejected so a stale key can't be loaded as a live appId.
+        // resourceClass" window class as the key. Every such key contains a
+        // space, and isValidAppId rejects on whitespace alone — so a stale
+        // raw-class key can never be loaded as a live appId. The colons in
+        // these fixtures are incidental; only the whitespace triggers the
+        // rejection.
         QVERIFY(!isValidAppId(QStringLiteral("opera Opera:opera Opera")));
         QVERIFY(!isValidAppId(QStringLiteral("konsole org.kde.konsole")));
         QVERIFY(!isValidAppId(QStringLiteral(" : ")));

--- a/tests/unit/core/test_window_identity.cpp
+++ b/tests/unit/core/test_window_identity.cpp
@@ -37,12 +37,82 @@ using PhosphorIdentity::WindowId::buildCompositeId;
 using PhosphorIdentity::WindowId::deriveShortName;
 using PhosphorIdentity::WindowId::extractAppId;
 using PhosphorIdentity::WindowId::extractInstanceId;
+using PhosphorIdentity::WindowId::isValidAppId;
+using PhosphorIdentity::WindowId::normalizeAppId;
 
 class TestWindowIdentity : public QObject
 {
     Q_OBJECT
 
 private Q_SLOTS:
+    // =====================================================================
+    // normalizeAppId() — canonical appId derivation (krakerz #2 regression)
+    // =====================================================================
+
+    void testNormalizeAppId_prefersDesktopFileName()
+    {
+        QCOMPARE(normalizeAppId(QStringLiteral("org.kde.Konsole"), QStringLiteral("konsole konsole")),
+                 QStringLiteral("org.kde.konsole"));
+    }
+
+    void testNormalizeAppId_fallsBackToWindowClassLastToken()
+    {
+        // X11 class is "resourceName resourceClass" — keep the resourceClass.
+        QCOMPARE(normalizeAppId(QString(), QStringLiteral("konsole org.kde.konsole")),
+                 QStringLiteral("org.kde.konsole"));
+    }
+
+    void testNormalizeAppId_lastSpaceWinsForMultiTokenClass()
+    {
+        // resourceName may itself contain spaces — split on the LAST one so
+        // the resourceClass token is recovered intact.
+        QCOMPARE(normalizeAppId(QString(), QStringLiteral("Google Chrome google-chrome")),
+                 QStringLiteral("google-chrome"));
+    }
+
+    void testNormalizeAppId_waylandSingleTokenClass()
+    {
+        QCOMPARE(normalizeAppId(QString(), QStringLiteral("Alacritty")), QStringLiteral("alacritty"));
+    }
+
+    void testNormalizeAppId_blankClassYieldsEmpty()
+    {
+        // The krakerz #2 regression: a bare " " class must NOT become a " "
+        // appId — it must collapse to empty so isValidAppId rejects it and no
+        // space-keyed snap-restore entry is ever created.
+        QVERIFY(normalizeAppId(QString(), QStringLiteral(" ")).isEmpty());
+        QVERIFY(normalizeAppId(QString(), QString()).isEmpty());
+        QVERIFY(normalizeAppId(QStringLiteral("  "), QStringLiteral("   ")).isEmpty());
+    }
+
+    // =====================================================================
+    // isValidAppId() — appId-key gate (krakerz #2 regression)
+    // =====================================================================
+
+    void testIsValidAppId_acceptsCanonicalTokens()
+    {
+        QVERIFY(isValidAppId(QStringLiteral("org.kde.konsole")));
+        QVERIFY(isValidAppId(QStringLiteral("alacritty")));
+        QVERIFY(isValidAppId(QStringLiteral("com.vysp3r.protonplus")));
+    }
+
+    void testIsValidAppId_rejectsEmptyAndWhitespace()
+    {
+        QVERIFY(!isValidAppId(QString()));
+        QVERIFY(!isValidAppId(QStringLiteral(" ")));
+        QVERIFY(!isValidAppId(QStringLiteral("\t")));
+    }
+
+    void testIsValidAppId_rejectsWhitespaceBearingLegacyKeys()
+    {
+        // Pre-3.0 PendingRestoreQueues keys used the raw "resourceName
+        // resourceClass" class, sometimes doubled. They contain spaces and
+        // must be rejected so a stale key can't be loaded as a live appId.
+        QVERIFY(!isValidAppId(QStringLiteral("opera Opera:opera Opera")));
+        QVERIFY(!isValidAppId(QStringLiteral("konsole org.kde.konsole")));
+        QVERIFY(!isValidAppId(QStringLiteral(" : ")));
+    }
+
     // =====================================================================
     // Basic extractAppId() tests
     // =====================================================================


### PR DESCRIPTION
## Summary

Addresses the issues in discussion #461 (krakerz's 3.0.0 bug report, corroborated by pairomaniac).

## Changes

**fix(snap): reject corrupt appId keys in the snap restore queue** — krakerz #2. A window with a blank/whitespace KWin class produced a `" "` appId that became a live `PendingRestoreQueues` key, so unrelated blank-class windows consumed each other's saved zones. Adds `WindowId::normalizeAppId` / `isValidAppId`; `getWindowAppId` no longer yields `" "`; the persist site and the session loader reject corrupt keys (the loader also drops pre-3.0 `"resourceName resourceClass"` keys that survive an upgrade).

**fix(settings): clarify the three new-window placement toggles** — krakerz disabled "New windows to last zone" expecting windows to stop returning to zones, but that behavior comes from "Restore zones on login", whose title implied login-only. Both retitled to describe actual behavior.

**fix(autotile): clear maximize state before tiling a window** — krakerz's "ballooning". A user-maximized window kept its `MaximizeFull` flag through the tile `moveResize`; KWin re-asserted the maximize geometry and the reactive centering loop compounded it. The non-monocle tile path now restores maximize state first.

**fix(snap): honor per-context disable in auto-snap and keyboard snap** — krakerz's "disable on desktop/monitor not working". The interactive drag and autotile paths gated on the disable lists, but auto-snap-on-open (`snaprestore.cpp`) and keyboard snap-to-zone (`handleSnap`) did not. Log-confirmed from krakerz's `journal.log`. Both now gate via `isContextDisabled`.

**fix(autotile): un-tile windows when switching to a disabled desktop** — the effect's `slotScreensChanged` desktop-switch branch never restored windows on the desktop just arrived at, so switching onto an autotile-disabled desktop left them tiled and borderless. Adds a per-window restore pass without the per-screen state clearing that belongs to the desktop being left.

**fix(zones): clamp zone geometry to the screen; log resolved placements** — krakerz's bottom-right-zone issue (A) could not be reproduced from the support report (availGeom, the active layout, and the gap math all checked out, and no bundled layout has an overflowing zone). Two changes follow: `applyGapsToZoneGeometry` now clamps the gapped rect to the screen (boundary validation against malformed layout data), and `applySnapGeometry` logs the resolved pixel rect at INFO so a future report is diagnosable.

## Not changed

- **Problem 4** (services auto-start/restart): working as designed. D-Bus activation revives the daemon on any client call; `systemctl --user mask plasmazones.service` is the intended way to fully stop it.
- **Problem 5** (default-layout save, visual): krakerz asked to defer.

## Testing

Builds clean (daemon, KWin effect, settings app). Unit tests pass: window-identity (including 8 new `normalizeAppId` / `isValidAppId` cases), snap engine, settings, session persistence, window tracking, and 17 geometry/zone/tiling tests.

The KWin-effect and compositor-path behavior (maximize handling, desktop-switch un-tiling) needs a live KWin session for visual confirmation. Issue A's root cause remains open: the support report contained no reproduction, so the clamp is a guard and the new INFO log makes the next report decisive.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
