### PR TITLE
fix(snap): correct applySnapResult disabled-context gate comment

### DIFF
--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -242,11 +242,14 @@ bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
         // whose mode differs from the caller's, so the disable list to consult
         // is the one for result.screenId's mode — not a hard-coded Snapping.
         //
-        // The desktop and activity are the session's CURRENT ones, not the
-        // restore target's — SnapResult carries no destination desktop. The
-        // screen/mode axis is therefore the precise gate; desktop/activity are
-        // best-effort against the active context, so a window restoring onto a
-        // disabled NON-current desktop is not caught here.
+        // currentVirtualDesktop()/currentActivity() are the precise destination
+        // context here, not an approximation: a restore only ever targets the
+        // current desktop. Every calculator feeding this path either snaps a
+        // window opening now on the current desktop (calculateSnapToAppRule /
+        // calculateSnapToEmptyZone) or refuses outright when the saved desktop
+        // is not the current one — calculateRestoreFromSession and
+        // calculateSnapToLastZone both return noSnap on a desktop mismatch. A
+        // restored window therefore lands on the current desktop/activity.
         const PhosphorZones::AssignmentEntry::Mode mode = m_screenModeRouter
             ? m_screenModeRouter->modeFor(result.screenId)
             : PhosphorZones::AssignmentEntry::Snapping;


### PR DESCRIPTION
## Summary

Corrects a misleading comment in `SnapAdaptor::applySnapResult`'s disabled-context gate. No behavior change.

The comment, added during the PR #478 code audit, claimed the gate's desktop/activity arguments were a best-effort approximation and that "a window restoring onto a disabled NON-current desktop is not caught here." That is **not true** — it was a false-positive audit finding that did not account for the upstream calculators.

## Why the gate is already precise

Every `SnapResult` that reaches `applySnapResult` is destined for the **current** desktop:

- `calculateRestoreFromSession` (`calculate.cpp:415-426`) returns `noSnap()` when the saved desktop ≠ current desktop (unless sticky / desktop 0).
- `calculateSnapToLastZone` (`calculate.cpp:215-222`) has the same desktop-match gate.
- `calculateSnapToAppRule` / `calculateSnapToEmptyZone` only ever snap a window opening now on the current screen/desktop.

So `currentVirtualDesktop()` / `currentActivity()` in the gate are the precise destination context, not an approximation. Threading a destination-desktop field through `SnapResult` (the "fix" the stale comment implied was needed) would be dead complexity for a non-existent bug.

## Change

- `src/dbus/snapadaptor/snaprestore.cpp` — replaced the inaccurate caveat with an accurate explanation of why the current-context gate is precise (the upstream desktop-match gates).

## Testing

- Build: PASS
- `ctest`: 185/185 PASS

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)