### PR TITLE
Scroll mode Phase 5 — scrolling-mode settings, UI, per-screen overrides & persistence

### DIFF
--- a/docs/scroll-mode-plan.md
+++ b/docs/scroll-mode-plan.md
@@ -3,15 +3,18 @@
 
 # Scroll mode — niri-style scrollable tiling
 
-Planning document. Status: **Phases 0 ✅, 1 ✅, 2 ✅, 3 ✅ and 4 ✅ complete** — the
-scroll engine, geometry resolver, `Mode::Scroll` routing, daemon geometry pipeline, the
-full window lifecycle (open/close/focus, minimize, screen hotplug & geometry change,
-fixed-size windows), navigation (viewport fit/centered scrolling, consume/expel
-shortcuts, drag-to-reorder, sticky-window exclusion) and the width/height controls and
-animation polish (preset cycling, full-width toggle, grow/shrink, runtime centering,
-dedicated `window.scroll` motion profile) are implemented, built, and covered by the
-unit-test suite. Phase 0 detail in
-[`scroll-mode-phase0-findings.md`](scroll-mode-phase0-findings.md). Next: Phase 5.
+Planning document. Status: **Phases 0–5 ✅ complete** — the scroll engine, geometry
+resolver, `Mode::Scroll` routing, daemon geometry pipeline, the full window lifecycle
+(open/close/focus, minimize, screen hotplug & geometry change, fixed-size windows),
+navigation (viewport fit/centered scrolling, consume/expel shortcuts, drag-to-reorder,
+sticky-window exclusion), the width/height controls and animation polish (preset
+cycling, full-width toggle, grow/shrink, runtime centering, dedicated `window.scroll`
+motion profile), and the settings/UI/persistence layer (config-backed tuning with
+per-screen overrides, the "Scrolling" settings page, the "Scrolling" layout-picker
+entry, strip-order persistence across a daemon restart) are implemented, built, and
+covered by the unit-test suite.
+Phase 0 detail in [`scroll-mode-phase0-findings.md`](scroll-mode-phase0-findings.md).
+Scroll mode is feature-complete for v1 — remaining items are the §7 MVP scope cuts.
 
 ## 1. Goal
 
@@ -344,12 +347,46 @@ with the Phase 3 navigation work.
   Open Question 3 below: KWin paints fully-off-screen windows, so the cull-driven
   constraint never arises.
 
-### Phase 5 — Settings, UI, persistence
+### Phase 5 — Settings, UI, persistence — ✅ COMPLETE
 
-- `ConfigDefaults` keys: default/preset column widths, preset heights, gaps, centering
-  mode, animation. Per-screen overrides reuse the existing mechanism.
-- Settings UI + layout-picker entry ("Scrollable").
-- Persist strip order across daemon restart (reuse the `m_lastAutotileOrders` pattern).
+- ✅ **`ConfigDefaults` keys** — `Scrolling.Gaps` (inner/outer) and `Scrolling.Layout`
+  (default new-column width, the `CenterFocusedColumn` viewport toggle, and the two
+  cycle-preset lists for column widths and window heights) are full `PhosphorConfig::
+  Store`-backed settings: `ConfigKeys`/`ConfigDefaults` accessors, `ISettings` virtuals
+  + signals, `Settings` `Q_PROPERTY`s, a `settingsschema.cpp` group with clamp
+  validators (`clampFractionList` for the preset arrays), and `SettingsAdaptor` D-Bus
+  registration. The mode group/UI verbiage is **"Scrolling"** (mirroring "Snapping" /
+  "Tiling"); the C++ accessor/property prefix stays `scroll*` (mirroring `autotile*` —
+  the bare mode noun). "Centering mode" landed as the boolean `scrollCenterFocusedColumn`
+  setting (the `Meta+Alt+C` shortcut flips it, so the choice persists). No separate
+  "animation" key was added — the Phase 4 `window.scroll` motion profile already is the
+  animation config, user-tunable through the Animations settings.
+- ✅ **Per-screen overrides** — scrolling mode has the identical per-screen-override
+  stack as autotile and snapping: `ScrollingScreen:<id>` config groups, a
+  `PerScreenPathResolver` category, `ISettings::getPerScreenScrollSettings` /
+  `setPerScreenScrollSetting` / `clearPerScreenScrollSettings` / `hasPerScreenScrollSettings`
+  virtuals (+ `perScreenScrollSettingsChanged`), `Settings` storage in
+  `perscreen.cpp`, and `SettingsAdaptor`'s `"scrolling"` category. `ScrollEngine` holds
+  per-screen overrides (`applyPerScreenConfig` / `clearPerScreenConfig` /
+  `perScreenOverrides`, mirroring `AutotileEngine`) and resolves every config value as
+  override → global via its `effective*()` accessors; the daemon's
+  `applyPerScreenScrollOverrides()` pushes the per-screen maps. The mode *disable* lists
+  (`ScrollDisabledMonitors` etc.) remain the per-context gate, as before.
+- ✅ **Settings UI + layout-picker entry** — a dedicated "Scrolling" page
+  (`ScrollingModePage.qml`, with the reusable `ScrollingPresetListCard.qml` preset-list
+  editor and a `MonitorSelectorSection` for per-monitor overrides) sits beside Snapping
+  and Tiling in the standalone settings app. The layout picker gains one synthetic
+  **"Scrolling"** entry (`scroll:` id) injected by `buildUnifiedLayoutList`; selecting it
+  routes through `UnifiedLayoutController::applyEntry` to assign `Mode::Scroll` to the
+  current screen/desktop/activity.
+- ✅ **Persistence** — `ScrollEngine::serializeEngineState()` /
+  `deserializeEngineState()` are orchestrated by the daemon: `saveScrollState()` writes
+  `scroll-session.json` on shutdown, `loadScrollState()` restores it at startup before
+  the effect re-reports windows (a still-existing window's `windowOpened` then no-ops,
+  keeping its restored column). This survives a daemon restart (window IDs are stable
+  while KWin keeps running); it is intentionally stale after a full compositor restart
+  — exact-ID restore, no appId-keyed reconciliation (that complexity is out of scope
+  for v1, mirroring the autotile pending-restore boundary).
 
 ## 7. MVP scope cuts
 

--- a/docs/scroll-mode-plan.md
+++ b/docs/scroll-mode-plan.md
@@ -383,10 +383,13 @@ with the Phase 3 navigation work.
   `deserializeEngineState()` are orchestrated by the daemon: `saveScrollState()` writes
   `scroll-session.json` on shutdown, `loadScrollState()` restores it at startup before
   the effect re-reports windows (a still-existing window's `windowOpened` then no-ops,
-  keeping its restored column). This survives a daemon restart (window IDs are stable
-  while KWin keeps running); it is intentionally stale after a full compositor restart
-  — exact-ID restore, no appId-keyed reconciliation (that complexity is out of scope
-  for v1, mirroring the autotile pending-restore boundary).
+  keeping its restored column). The restored strip is structural, so
+  `ScrollEngine::reconcileRestoredWindows()` prunes it against the live window set from
+  the effect's first `windowsOpenedBatch`: a window closed while the daemon was down
+  leaves no phantom column, and after a full compositor restart (every window ID is
+  new) the strip reconciles away cleanly. Restore stays exact-ID — no appId-keyed
+  reconciliation across sessions (out of scope for v1) — so the persisted strip is a
+  hint over the live set, mirroring how autotile reconciles its restored window order.
 
 ## 7. MVP scope cuts
 

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -131,9 +131,12 @@ void ScrollHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& wi
         batchWindowIds.append(windowId);
     }
 
-    if (batchEntries.isEmpty()) {
-        return;
-    }
+    // An empty batch is still sent: org.plasmazones.Scroll.windowsOpenedBatch
+    // doubles as the daemon's post-restore reconcile signal. The daemon must
+    // receive one batch even when no scroll window currently exists — otherwise
+    // a restored strip whose windows all closed while the daemon was down would
+    // never be pruned. The daemon treats a zero-entry batch as "no live
+    // windows" and reconciles the restored strip away.
 
     auto* watcher =
         new QDBusPendingCallWatcher(PhosphorProtocol::ClientHelpers::asyncCall(

--- a/kwin-effect/scrollhandler.cpp
+++ b/kwin-effect/scrollhandler.cpp
@@ -99,6 +99,10 @@ void ScrollHandler::notifyWindowAdded(KWin::EffectWindow* w)
 
 void ScrollHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& windows)
 {
+    // Callers MUST pass the full window list (KWin::effects->stackingOrder()):
+    // the daemon treats the first windowsOpenedBatch after a (re)connect as the
+    // complete live scroll-window set and reconciles a restored strip against
+    // it. A partial list would make the daemon prune live windows.
     PhosphorProtocol::WindowOpenedList batchEntries;
     QStringList batchWindowIds; // for error rollback
 
@@ -543,16 +547,20 @@ void ScrollHandler::loadSettings()
                     m_scrollScreens = QSet<QString>(screens.cbegin(), screens.cend());
                     qCInfo(lcEffect) << "Loaded scroll screens:" << m_scrollScreens;
 
-                    if (!m_scrollScreens.isEmpty()) {
-                        // Batch-notify all existing windows on scroll screens in one
-                        // D-Bus call instead of per-window windowOpened round-trips.
-                        // loadSettings() runs only at construction or right after
-                        // onDaemonReady() — both leave m_notifiedWindows empty — so no
-                        // explicit reset is needed: every window is reported afresh,
-                        // and a window already added individually in the async gap is
-                        // correctly skipped (no duplicate windowOpened).
-                        notifyWindowsAddedBatch(KWin::effects->stackingOrder());
-                    }
+                    // Batch-notify all existing windows on scroll screens in one
+                    // D-Bus call instead of per-window windowOpened round-trips.
+                    // loadSettings() runs only at construction or right after
+                    // onDaemonReady() — both leave m_notifiedWindows empty — so no
+                    // explicit reset is needed: every window is reported afresh,
+                    // and a window already added individually in the async gap is
+                    // correctly skipped (no duplicate windowOpened).
+                    //
+                    // Sent unconditionally — even when m_scrollScreens is empty,
+                    // which yields an empty batch. The batch doubles as the
+                    // daemon's post-restore reconcile signal, so a strip restored
+                    // from scroll-session.json is reconciled (and pruned) even
+                    // when no screen is currently in scroll mode.
+                    notifyWindowsAddedBatch(KWin::effects->stackingOrder());
                 } else {
                     qCDebug(lcEffect) << "Scroll screens: query failed, daemon may not be running";
                 }

--- a/libs/phosphor-engine/include/PhosphorEngine/IScrollNavigation.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IScrollNavigation.h
@@ -43,8 +43,6 @@ public:
     /// Adjust the focused column's width by @p deltaFraction of the working
     /// area (positive grows the column, negative shrinks it).
     virtual void adjustColumnWidth(qreal deltaFraction, const NavigationContext& ctx) = 0;
-    /// Toggle whether the viewport keeps the focused column centred.
-    virtual void toggleCenterFocusedColumn(const NavigationContext& ctx) = 0;
 };
 
 } // namespace PhosphorEngine

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -16,6 +16,8 @@
 #include <QSet>
 #include <QString>
 #include <QStringList>
+#include <QVariant>
+#include <QVariantMap>
 #include <QVector>
 
 #include <cstddef>
@@ -132,6 +134,16 @@ public:
         return m_presetWindowHeights;
     }
 
+    // ── Default column width ────────────────────────────────────────────
+    /// Width a freshly-opened column is created with — a fraction [0..1] of
+    /// the working area. Pushed from settings by the daemon; defaults to
+    /// niri's middle preset (one half) until then.
+    void setDefaultColumnWidth(qreal fraction);
+    qreal defaultColumnWidth() const
+    {
+        return m_defaultColumnWidth;
+    }
+
     // ── Viewport mode ───────────────────────────────────────────────────
     /// How the viewport scrolls to keep the focused column on-screen. The
     /// daemon reads this when resolving the strip. Engine-global runtime
@@ -144,6 +156,42 @@ public:
     {
         m_viewportMode = mode;
     }
+
+    // ── Global gap config ───────────────────────────────────────────────
+    /// Strip gaps in logical pixels — the daemon pushes these from settings.
+    /// The engine is geometry-agnostic and never uses them itself; it holds
+    /// them only so effectiveInnerGap()/effectiveOuterGap() can resolve a
+    /// per-screen override over the global value for the daemon's resolver.
+    void setInnerGap(int gap)
+    {
+        m_innerGap = gap;
+    }
+    void setOuterGap(int gap)
+    {
+        m_outerGap = gap;
+    }
+
+    // ── Per-screen config overrides ─────────────────────────────────────
+    /// Apply a per-screen override map (screen-only key, mirroring autotile's
+    /// applyPerScreenConfig). Recognised keys — unrecognised ones are ignored:
+    ///   "InnerGap" / "OuterGap"            int, logical px
+    ///   "DefaultColumnWidth"               qreal, fraction [0..1]
+    ///   "CenterFocusedColumn"              bool (true → Centered viewport)
+    ///   "PresetColumnWidths" / "PresetWindowHeights"
+    ///                                      QVariantList of qreal fractions
+    /// An empty @p overrides clears the screen's overrides. The effective*()
+    /// accessors resolve a screen's value as override → global default.
+    void applyPerScreenConfig(const QString& screenId, const QVariantMap& overrides);
+    void clearPerScreenConfig(const QString& screenId);
+    QVariantMap perScreenOverrides(const QString& screenId) const;
+
+    // ── Effective config (per-screen override → global default) ─────────
+    QVector<qreal> effectivePresetColumnWidths(const QString& screenId) const;
+    QVector<qreal> effectivePresetWindowHeights(const QString& screenId) const;
+    qreal effectiveDefaultColumnWidth(const QString& screenId) const;
+    ScrollViewportMode effectiveViewportMode(const QString& screenId) const;
+    int effectiveInnerGap(const QString& screenId) const;
+    int effectiveOuterGap(const QString& screenId) const;
 
     // ── State access ────────────────────────────────────────────────────
     PhosphorEngine::IPlacementState* stateForScreen(const QString& screenId) override;
@@ -170,6 +218,9 @@ private:
     ScrollScreenState* resolveNavTarget(const PhosphorEngine::NavigationContext& ctx, QString* outScreenId);
     void emitChanged(const QString& screenId);
     void reportNav(bool success, const QString& action, const QString& screenId);
+    /// Per-screen override for @p key, or an invalid QVariant when the screen
+    /// has no override map or the map lacks @p key.
+    QVariant perScreenValue(const QString& screenId, QLatin1String key) const;
 
     std::unordered_map<PhosphorEngine::TilingStateKey, ScrollScreenState, TilingStateKeyHash> m_states;
     QHash<QString, PhosphorEngine::TilingStateKey> m_windowToKey;
@@ -179,7 +230,13 @@ private:
     QString m_activeScreen;
     QVector<qreal> m_presetColumnWidths;
     QVector<qreal> m_presetWindowHeights;
+    qreal m_defaultColumnWidth = 0.5;
+    int m_innerGap = 8;
+    int m_outerGap = 8;
     ScrollViewportMode m_viewportMode = ScrollViewportMode::Fit;
+    /// Per-screen config overrides, keyed by screenId (screen-only, like
+    /// autotile). Resolved over the globals above by the effective*() helpers.
+    QHash<QString, QVariantMap> m_perScreenConfig;
 };
 
 } // namespace PhosphorScrollEngine

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -176,7 +176,8 @@ public:
 
     // ── Per-screen config overrides ─────────────────────────────────────
     /// Apply a per-screen override map (screen-only key, mirroring autotile's
-    /// applyPerScreenConfig). Recognised keys — unrecognised ones are ignored:
+    /// applyPerScreenConfig). Recognised keys (any other key is stored verbatim
+    /// but never consulted by the effective*() resolvers):
     ///   "InnerGap" / "OuterGap"            int, logical px
     ///   "DefaultColumnWidth"               qreal, fraction [0..1]
     ///   "CenterFocusedColumn"              bool (true → Centered viewport)
@@ -205,6 +206,11 @@ public:
     void loadState() override;
     QJsonObject serializeEngineState() const override;
     void deserializeEngineState(const QJsonObject& state) override;
+
+    /// True when the engine holds strip state worth persisting. Lets the
+    /// daemon decide whether to write or drop scroll-session.json without
+    /// re-parsing serializeEngineState()'s own JSON output.
+    bool hasPersistableState() const;
 
     /// Reconcile a freshly restored strip against the live window set.
     ///

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -113,7 +113,6 @@ public:
     void cyclePresetWindowHeight(const PhosphorEngine::NavigationContext& ctx) override;
     void toggleColumnFullWidth(const PhosphorEngine::NavigationContext& ctx) override;
     void adjustColumnWidth(qreal deltaFraction, const PhosphorEngine::NavigationContext& ctx) override;
-    void toggleCenterFocusedColumn(const PhosphorEngine::NavigationContext& ctx) override;
 
     // ── Tracking queries ────────────────────────────────────────────────
     bool isWindowTracked(const QString& windowId) const override;
@@ -125,6 +124,10 @@ public:
     // ── Preset lists (defaults match niri; settings override later) ─────
     void setPresetColumnWidths(const QVector<qreal>& fractions);
     void setPresetWindowHeights(const QVector<qreal>& fractions);
+    /// Coerce a QVariantList of numbers (e.g. a persisted preset list) into the
+    /// engine's typed fraction vector. Shared with the daemon, which pushes the
+    /// settings-backed preset lists through setPreset*().
+    static QVector<qreal> toFractionVector(const QVariantList& list);
     QVector<qreal> presetColumnWidths() const
     {
         return m_presetColumnWidths;
@@ -181,9 +184,9 @@ public:
     ///                                      QVariantList of qreal fractions
     /// An empty @p overrides clears the screen's overrides. The effective*()
     /// accessors resolve a screen's value as override → global default.
-    void applyPerScreenConfig(const QString& screenId, const QVariantMap& overrides);
-    void clearPerScreenConfig(const QString& screenId);
-    QVariantMap perScreenOverrides(const QString& screenId) const;
+    void applyPerScreenConfig(const QString& screenId, const QVariantMap& overrides) override;
+    void clearPerScreenConfig(const QString& screenId) override;
+    QVariantMap perScreenOverrides(const QString& screenId) const override;
 
     // ── Effective config (per-screen override → global default) ─────────
     QVector<qreal> effectivePresetColumnWidths(const QString& screenId) const;
@@ -202,6 +205,20 @@ public:
     void loadState() override;
     QJsonObject serializeEngineState() const override;
     void deserializeEngineState(const QJsonObject& state) override;
+
+    /// Reconcile a freshly restored strip against the live window set.
+    ///
+    /// deserializeEngineState() rebuilds the strip structurally from disk, so a
+    /// window closed while the daemon was down would survive as a phantom
+    /// column. The daemon calls this once, with the complete window set from
+    /// the effect's initial windowsOpenedBatch after a restore: any restored
+    /// window absent from @p liveWindowIds never came back and is pruned (its
+    /// column dropped when it empties). This makes the persisted strip a hint
+    /// over the live set rather than authoritative — mirroring autotile, whose
+    /// restored window order is likewise only ever reconciled against the
+    /// windows the effect actually reports. A no-op unless a restore is
+    /// pending, so the routine windowsOpenedBatch path stays unaffected.
+    void reconcileRestoredWindows(const QSet<QString>& liveWindowIds);
 
 protected:
     void onWindowClaimed(const QString& windowId) override;
@@ -237,6 +254,10 @@ private:
     /// Per-screen config overrides, keyed by screenId (screen-only, like
     /// autotile). Resolved over the globals above by the effective*() helpers.
     QHash<QString, QVariantMap> m_perScreenConfig;
+    /// True from a non-empty deserializeEngineState() until the first
+    /// reconcileRestoredWindows() prunes the restored strip against the live
+    /// window set. One-shot — see reconcileRestoredWindows().
+    bool m_pendingRestoreReconcile = false;
 };
 
 } // namespace PhosphorScrollEngine

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -238,6 +238,10 @@ private:
     /// Per-screen override for @p key, or an invalid QVariant when the screen
     /// has no override map or the map lacks @p key.
     QVariant perScreenValue(const QString& screenId, QLatin1String key) const;
+    /// toFractionVector() with each entry clamped into [kMinSizeFraction,
+    /// kMaxSizeFraction]; used by the effectivePreset*() resolvers to
+    /// range-check a per-screen override list.
+    static QVector<qreal> clampedFractionVector(const QVariantList& list);
 
     std::unordered_map<PhosphorEngine::TilingStateKey, ScrollScreenState, TilingStateKeyHash> m_states;
     QHash<QString, PhosphorEngine::TilingStateKey> m_windowToKey;

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollEngine.h
@@ -247,7 +247,7 @@ private:
     QString m_activeScreen;
     QVector<qreal> m_presetColumnWidths;
     QVector<qreal> m_presetWindowHeights;
-    qreal m_defaultColumnWidth = 0.5;
+    qreal m_defaultColumnWidth = kDefaultColumnWidthFraction;
     int m_innerGap = 8;
     int m_outerGap = 8;
     ScrollViewportMode m_viewportMode = ScrollViewportMode::Fit;

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
@@ -28,13 +28,14 @@ inline constexpr qreal kDefaultColumnWidthFraction = 0.5;
 /// a strip gap (logical px). ScrollEngine's effective*() resolvers clamp every
 /// per-screen override to these ranges — defence-in-depth mirroring
 /// AutotileEngine's PerScreenConfigResolver, which likewise range-checks every
-/// per-screen override on read. The strip-gap ceiling is generous (the precise
-/// per-mode range is enforced at the Settings boundary); the engine is
-/// geometry-agnostic and only needs to reject corrupt values.
+/// per-screen override on read. The strip-gap range mirrors the Settings
+/// schema's scroll-gap clamp (ConfigDefaults::scrollInnerGapMin/Max, i.e.
+/// the shared autotile MinGap/MaxGap); kept in sync so the engine guard never
+/// disagrees with the boundary the schema and the settings UI enforce.
 inline constexpr qreal kMinSizeFraction = 0.1;
 inline constexpr qreal kMaxSizeFraction = 1.0;
 inline constexpr int kMinStripGap = 0;
-inline constexpr int kMaxStripGap = 200;
+inline constexpr int kMaxStripGap = 50;
 
 /// Per-screen (per desktop/activity) scrollable-tiling state: the niri-style
 /// horizontal strip of columns, the focused column/tile, and the viewport

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
@@ -72,9 +72,11 @@ public:
 
     // ── Window placement ────────────────────────────────────────────────
     /// Open @p windowId as a new column immediately right of the focused
-    /// column, and focus it — niri's default new-window behaviour. No-op if
-    /// the window is already managed.
-    void addColumnForWindow(const QString& windowId);
+    /// column, and focus it — niri's default new-window behaviour. The new
+    /// column is created with width intent @p width (the daemon passes the
+    /// configured default-column-width setting). No-op if the window is
+    /// already managed.
+    void addColumnForWindow(const QString& windowId, const ColumnWidth& width = ColumnWidth::proportion(0.5));
     /// Add @p windowId as a new tile in the focused column, and focus it.
     /// Falls back to addColumnForWindow when the strip is empty.
     void addWindowToActiveColumn(const QString& windowId);

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
@@ -24,6 +24,18 @@ namespace PhosphorScrollEngine {
 /// addColumn*/addWindow* default arguments all reference it.
 inline constexpr qreal kDefaultColumnWidthFraction = 0.5;
 
+/// Inclusive clamp bounds for a column-width / window-height fraction and for
+/// a strip gap (logical px). ScrollEngine's effective*() resolvers clamp every
+/// per-screen override to these ranges — defence-in-depth mirroring
+/// AutotileEngine's PerScreenConfigResolver, which likewise range-checks every
+/// per-screen override on read. The strip-gap ceiling is generous (the precise
+/// per-mode range is enforced at the Settings boundary); the engine is
+/// geometry-agnostic and only needs to reject corrupt values.
+inline constexpr qreal kMinSizeFraction = 0.1;
+inline constexpr qreal kMaxSizeFraction = 1.0;
+inline constexpr int kMinStripGap = 0;
+inline constexpr int kMaxStripGap = 200;
+
 /// Per-screen (per desktop/activity) scrollable-tiling state: the niri-style
 /// horizontal strip of columns, the focused column/tile, and the viewport
 /// offset.

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
@@ -78,8 +78,10 @@ public:
     /// already managed.
     void addColumnForWindow(const QString& windowId, const ColumnWidth& width = ColumnWidth::proportion(0.5));
     /// Add @p windowId as a new tile in the focused column, and focus it.
-    /// Falls back to addColumnForWindow when the strip is empty.
-    void addWindowToActiveColumn(const QString& windowId);
+    /// Falls back to addColumnForWindow when the strip is empty — that new
+    /// column then takes width intent @p width (the daemon passes the
+    /// configured default-column-width setting).
+    void addWindowToActiveColumn(const QString& windowId, const ColumnWidth& width = ColumnWidth::proportion(0.5));
     /// Remove @p windowId from the strip or the floating set. Drops the
     /// column if it becomes empty. Returns true if the window was found.
     bool removeWindow(const QString& windowId);

--- a/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
+++ b/libs/phosphor-scroll-engine/include/PhosphorScrollEngine/ScrollScreenState.h
@@ -18,6 +18,12 @@
 
 namespace PhosphorScrollEngine {
 
+/// Width a freshly-opened column is created with when no configured default
+/// has been pushed yet — niri's middle preset (one half). The single source
+/// for this fallback: ScrollEngine::m_defaultColumnWidth and the
+/// addColumn*/addWindow* default arguments all reference it.
+inline constexpr qreal kDefaultColumnWidthFraction = 0.5;
+
 /// Per-screen (per desktop/activity) scrollable-tiling state: the niri-style
 /// horizontal strip of columns, the focused column/tile, and the viewport
 /// offset.
@@ -76,12 +82,14 @@ public:
     /// column is created with width intent @p width (the daemon passes the
     /// configured default-column-width setting). No-op if the window is
     /// already managed.
-    void addColumnForWindow(const QString& windowId, const ColumnWidth& width = ColumnWidth::proportion(0.5));
+    void addColumnForWindow(const QString& windowId,
+                            const ColumnWidth& width = ColumnWidth::proportion(kDefaultColumnWidthFraction));
     /// Add @p windowId as a new tile in the focused column, and focus it.
     /// Falls back to addColumnForWindow when the strip is empty — that new
     /// column then takes width intent @p width (the daemon passes the
     /// configured default-column-width setting).
-    void addWindowToActiveColumn(const QString& windowId, const ColumnWidth& width = ColumnWidth::proportion(0.5));
+    void addWindowToActiveColumn(const QString& windowId,
+                                 const ColumnWidth& width = ColumnWidth::proportion(kDefaultColumnWidthFraction));
     /// Remove @p windowId from the strip or the floating set. Drops the
     /// column if it becomes empty. Returns true if the window was found.
     bool removeWindow(const QString& windowId);

--- a/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
@@ -478,8 +478,13 @@ void ScrollEngine::cyclePresetColumnWidth(const NavigationContext& ctx)
         reportNav(false, QStringLiteral("width"), screenId);
         return;
     }
-    const int current = state->activeColumn()->presetWidthIndex();
-    const int next = (current + 1) % static_cast<int>(presets.size());
+    const int presetCount = static_cast<int>(presets.size());
+    // A stale index (the preset list shrank since it was set) or the detached
+    // -1 both normalise to -1, so the next press restarts the cycle at the
+    // first preset rather than wrapping from an out-of-range value.
+    const int rawIndex = state->activeColumn()->presetWidthIndex();
+    const int current = (rawIndex >= 0 && rawIndex < presetCount) ? rawIndex : -1;
+    const int next = (current + 1) % presetCount;
     if (next == current) {
         // Single-element preset list, already on it — nothing changes.
         reportNav(false, QStringLiteral("width"), screenId);
@@ -501,8 +506,13 @@ void ScrollEngine::cyclePresetWindowHeight(const NavigationContext& ctx)
         reportNav(false, QStringLiteral("height"), screenId);
         return;
     }
-    const int current = (tile->height.kind == WindowHeight::Kind::Preset) ? tile->height.presetIndex : -1;
-    const int next = (current + 1) % static_cast<int>(presets.size());
+    const int presetCount = static_cast<int>(presets.size());
+    // A stale preset index (the preset list shrank since it was set) or a
+    // non-preset height both normalise to -1, so the next press restarts the
+    // cycle at the first preset rather than wrapping from an out-of-range value.
+    const int rawIndex = (tile->height.kind == WindowHeight::Kind::Preset) ? tile->height.presetIndex : -1;
+    const int current = (rawIndex >= 0 && rawIndex < presetCount) ? rawIndex : -1;
+    const int next = (current + 1) % presetCount;
     if (next == current) {
         // Single-element preset list, already on it — nothing changes.
         reportNav(false, QStringLiteral("height"), screenId);
@@ -721,6 +731,11 @@ void ScrollEngine::loadState()
 {
     // Counterpart to saveState() — restoration runs through
     // deserializeEngineState() under daemon control.
+}
+
+bool ScrollEngine::hasPersistableState() const
+{
+    return !m_states.empty();
 }
 
 QJsonObject ScrollEngine::serializeEngineState() const

--- a/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
@@ -14,9 +14,7 @@ using PhosphorEngine::IPlacementState;
 using PhosphorEngine::NavigationContext;
 using PhosphorEngine::TilingStateKey;
 
-namespace {
-/// Coerce a QVariantList of numbers into the engine's typed fraction vector.
-QVector<qreal> toFractionVector(const QVariantList& list)
+QVector<qreal> ScrollEngine::toFractionVector(const QVariantList& list)
 {
     QVector<qreal> out;
     out.reserve(list.size());
@@ -25,7 +23,6 @@ QVector<qreal> toFractionVector(const QVariantList& list)
     }
     return out;
 }
-} // namespace
 
 ScrollEngine::ScrollEngine(QObject* parent)
     : PhosphorEngine::PlacementEngineBase(parent)
@@ -560,28 +557,6 @@ void ScrollEngine::adjustColumnWidth(qreal deltaFraction, const NavigationContex
     reportNav(true, QStringLiteral("width"), screenId);
 }
 
-void ScrollEngine::toggleCenterFocusedColumn(const NavigationContext& ctx)
-{
-    QString screenId;
-    resolveNavTarget(ctx, &screenId); // resolves screenId for the nav feedback
-
-    // The viewport mode is engine-global, so flip it through the setter
-    // unconditionally — even when the focused screen has no strip yet. Gating
-    // on the focused screen's state would let an empty scroll screen swallow
-    // the shortcut while every other scroll screen silently keeps the old mode.
-    setViewportMode(m_viewportMode == ScrollViewportMode::Fit ? ScrollViewportMode::Centered : ScrollViewportMode::Fit);
-    // Re-resolve every scroll screen — all of them resolve against this mode.
-    QSet<QString> notified;
-    for (const auto& entry : m_states) {
-        const QString& sid = entry.first.screenId;
-        if (!sid.isEmpty() && !notified.contains(sid)) {
-            notified.insert(sid);
-            emitChanged(sid);
-        }
-    }
-    reportNav(true, QStringLiteral("viewport"), screenId);
-}
-
 // ─────────────────────────────────────────────────────────────────────────
 // Tracking queries
 // ─────────────────────────────────────────────────────────────────────────
@@ -773,6 +748,30 @@ void ScrollEngine::deserializeEngineState(const QJsonObject& state)
         for (const QString& windowId : windows) {
             m_windowToKey.insert(windowId, key);
         }
+    }
+    // A restored strip is structural — it must be reconciled against the live
+    // window set once the effect reports it; see reconcileRestoredWindows().
+    m_pendingRestoreReconcile = !m_states.empty();
+}
+
+void ScrollEngine::reconcileRestoredWindows(const QSet<QString>& liveWindowIds)
+{
+    if (!m_pendingRestoreReconcile) {
+        return;
+    }
+    m_pendingRestoreReconcile = false; // one-shot — only the first batch reconciles
+
+    // Any restored window the live set did not confirm was closed while the
+    // daemon was down: drop it so its column does not linger as a phantom.
+    // Collected first, then removed, so m_windowToKey is not mutated mid-scan.
+    QStringList stale;
+    for (auto it = m_windowToKey.constBegin(); it != m_windowToKey.constEnd(); ++it) {
+        if (!liveWindowIds.contains(it.key())) {
+            stale.append(it.key());
+        }
+    }
+    for (const QString& windowId : stale) {
+        windowClosed(windowId);
     }
 }
 

--- a/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
@@ -712,11 +712,11 @@ void ScrollEngine::loadState()
 
 QJsonObject ScrollEngine::serializeEngineState() const
 {
-    // m_viewportMode is deliberately not serialized: it is runtime-only state
-    // that resets to Fit on restart. Per-column full-width state *is* persisted
-    // (in ScrollScreenState). Both become persisted ConfigDefaults settings in
-    // Phase 5; until then the viewport mode intentionally does not survive a
-    // daemon restart.
+    // m_viewportMode is deliberately not serialized: the daemon re-pushes it
+    // from the scrollCenterFocusedColumn setting (global or per-screen) on
+    // every startup, so persisting it would only risk a stale value shadowing
+    // the configured one. Per-column full-width state *is* persisted (in
+    // ScrollScreenState).
     QJsonArray states;
     for (const auto& entry : m_states) {
         QJsonObject obj = entry.second.toJson();

--- a/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
@@ -14,6 +14,19 @@ using PhosphorEngine::IPlacementState;
 using PhosphorEngine::NavigationContext;
 using PhosphorEngine::TilingStateKey;
 
+namespace {
+/// Coerce a QVariantList of numbers into the engine's typed fraction vector.
+QVector<qreal> toFractionVector(const QVariantList& list)
+{
+    QVector<qreal> out;
+    out.reserve(list.size());
+    for (const QVariant& v : list) {
+        out.append(v.toReal());
+    }
+    return out;
+}
+} // namespace
+
 ScrollEngine::ScrollEngine(QObject* parent)
     : PhosphorEngine::PlacementEngineBase(parent)
 {
@@ -192,7 +205,8 @@ void ScrollEngine::windowOpened(const QString& windowId, const QString& screenId
         return;
     }
     const TilingStateKey key = keyForScreen(screenId);
-    stateForKey(key, /*create=*/true)->addColumnForWindow(windowId);
+    stateForKey(key, /*create=*/true)
+        ->addColumnForWindow(windowId, ColumnWidth::proportion(effectiveDefaultColumnWidth(screenId)));
     m_windowToKey.insert(windowId, key);
     m_activeScreen = screenId;
     emitChanged(screenId);
@@ -272,7 +286,8 @@ void ScrollEngine::setWindowFloat(const QString& windowId, bool shouldFloat)
         state->markFloating(windowId);
     } else {
         state->clearFloating(windowId);
-        state->addColumnForWindow(windowId); // re-enter the strip
+        // Re-enter the strip as a new column at the configured default width.
+        state->addColumnForWindow(windowId, ColumnWidth::proportion(effectiveDefaultColumnWidth(it.value().screenId)));
     }
     Q_EMIT windowFloatingChanged(windowId, shouldFloat, it.value().screenId);
     emitChanged(it.value().screenId);
@@ -461,18 +476,19 @@ void ScrollEngine::cyclePresetColumnWidth(const NavigationContext& ctx)
 {
     QString screenId;
     ScrollScreenState* state = resolveNavTarget(ctx, &screenId);
-    if (!state || !state->activeColumn() || m_presetColumnWidths.isEmpty()) {
+    const QVector<qreal> presets = effectivePresetColumnWidths(screenId);
+    if (!state || !state->activeColumn() || presets.isEmpty()) {
         reportNav(false, QStringLiteral("width"), screenId);
         return;
     }
     const int current = state->activeColumn()->presetWidthIndex();
-    const int next = (current + 1) % static_cast<int>(m_presetColumnWidths.size());
+    const int next = (current + 1) % static_cast<int>(presets.size());
     if (next == current) {
         // Single-element preset list, already on it — nothing changes.
         reportNav(false, QStringLiteral("width"), screenId);
         return;
     }
-    state->setActiveColumnWidth(ColumnWidth::proportion(m_presetColumnWidths.at(next)), next);
+    state->setActiveColumnWidth(ColumnWidth::proportion(presets.at(next)), next);
     emitChanged(screenId);
     reportNav(true, QStringLiteral("width"), screenId);
 }
@@ -483,12 +499,13 @@ void ScrollEngine::cyclePresetWindowHeight(const NavigationContext& ctx)
     ScrollScreenState* state = resolveNavTarget(ctx, &screenId);
     const Column* column = state ? state->activeColumn() : nullptr;
     const Tile* tile = column ? column->activeTile() : nullptr;
-    if (!tile || m_presetWindowHeights.isEmpty()) {
+    const QVector<qreal> presets = effectivePresetWindowHeights(screenId);
+    if (!tile || presets.isEmpty()) {
         reportNav(false, QStringLiteral("height"), screenId);
         return;
     }
     const int current = (tile->height.kind == WindowHeight::Kind::Preset) ? tile->height.presetIndex : -1;
-    const int next = (current + 1) % static_cast<int>(m_presetWindowHeights.size());
+    const int next = (current + 1) % static_cast<int>(presets.size());
     if (next == current) {
         // Single-element preset list, already on it — nothing changes.
         reportNav(false, QStringLiteral("height"), screenId);
@@ -609,6 +626,82 @@ void ScrollEngine::setPresetColumnWidths(const QVector<qreal>& fractions)
 void ScrollEngine::setPresetWindowHeights(const QVector<qreal>& fractions)
 {
     m_presetWindowHeights = fractions;
+}
+
+void ScrollEngine::setDefaultColumnWidth(qreal fraction)
+{
+    m_defaultColumnWidth = fraction;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Per-screen config (override → global default)
+// ─────────────────────────────────────────────────────────────────────────
+
+void ScrollEngine::applyPerScreenConfig(const QString& screenId, const QVariantMap& overrides)
+{
+    if (screenId.isEmpty()) {
+        return;
+    }
+    if (overrides.isEmpty()) {
+        m_perScreenConfig.remove(screenId);
+    } else {
+        m_perScreenConfig.insert(screenId, overrides);
+    }
+}
+
+void ScrollEngine::clearPerScreenConfig(const QString& screenId)
+{
+    m_perScreenConfig.remove(screenId);
+}
+
+QVariantMap ScrollEngine::perScreenOverrides(const QString& screenId) const
+{
+    return m_perScreenConfig.value(screenId);
+}
+
+QVariant ScrollEngine::perScreenValue(const QString& screenId, QLatin1String key) const
+{
+    const auto it = m_perScreenConfig.constFind(screenId);
+    return it == m_perScreenConfig.constEnd() ? QVariant() : it->value(key);
+}
+
+QVector<qreal> ScrollEngine::effectivePresetColumnWidths(const QString& screenId) const
+{
+    const QVariant v = perScreenValue(screenId, QLatin1String("PresetColumnWidths"));
+    return v.isValid() ? toFractionVector(v.toList()) : m_presetColumnWidths;
+}
+
+QVector<qreal> ScrollEngine::effectivePresetWindowHeights(const QString& screenId) const
+{
+    const QVariant v = perScreenValue(screenId, QLatin1String("PresetWindowHeights"));
+    return v.isValid() ? toFractionVector(v.toList()) : m_presetWindowHeights;
+}
+
+qreal ScrollEngine::effectiveDefaultColumnWidth(const QString& screenId) const
+{
+    const QVariant v = perScreenValue(screenId, QLatin1String("DefaultColumnWidth"));
+    return v.isValid() ? v.toReal() : m_defaultColumnWidth;
+}
+
+ScrollViewportMode ScrollEngine::effectiveViewportMode(const QString& screenId) const
+{
+    const QVariant v = perScreenValue(screenId, QLatin1String("CenterFocusedColumn"));
+    if (v.isValid()) {
+        return v.toBool() ? ScrollViewportMode::Centered : ScrollViewportMode::Fit;
+    }
+    return m_viewportMode;
+}
+
+int ScrollEngine::effectiveInnerGap(const QString& screenId) const
+{
+    const QVariant v = perScreenValue(screenId, QLatin1String("InnerGap"));
+    return v.isValid() ? v.toInt() : m_innerGap;
+}
+
+int ScrollEngine::effectiveOuterGap(const QString& screenId) const
+{
+    const QVariant v = perScreenValue(screenId, QLatin1String("OuterGap"));
+    return v.isValid() ? v.toInt() : m_outerGap;
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollEngine.cpp
@@ -528,10 +528,6 @@ void ScrollEngine::toggleColumnFullWidth(const NavigationContext& ctx)
 
 void ScrollEngine::adjustColumnWidth(qreal deltaFraction, const NavigationContext& ctx)
 {
-    // Smallest proportional column width grow/shrink can settle on, so a
-    // column can never shrink away to nothing.
-    constexpr qreal kMinColumnWidthFraction = 0.1;
-
     QString screenId;
     ScrollScreenState* state = resolveNavTarget(ctx, &screenId);
     const Column* column = state ? state->activeColumn() : nullptr;
@@ -542,11 +538,13 @@ void ScrollEngine::adjustColumnWidth(qreal deltaFraction, const NavigationContex
         return;
     }
     // Clamp the starting width into range before applying the delta: a
-    // Proportion width is normally already within [kMinColumnWidthFraction,
-    // 1.0], but clamping here keeps grow/shrink monotonic — without it a
-    // shrink keypress on an out-of-range narrow column would grow it.
-    const qreal current = qBound(kMinColumnWidthFraction, column->width().value, qreal(1.0));
-    const qreal target = qBound(kMinColumnWidthFraction, current + deltaFraction, qreal(1.0));
+    // Proportion width is normally already within [kMinSizeFraction,
+    // kMaxSizeFraction], but clamping here keeps grow/shrink monotonic —
+    // without it a shrink keypress on an out-of-range narrow column would
+    // grow it. kMinSizeFraction is also the smallest width a column can
+    // settle on, so it can never shrink away to nothing.
+    const qreal current = qBound(kMinSizeFraction, column->width().value, kMaxSizeFraction);
+    const qreal target = qBound(kMinSizeFraction, current + deltaFraction, kMaxSizeFraction);
     if (qFuzzyCompare(target, current)) {
         reportNav(false, QStringLiteral("width"), screenId); // already at the limit
         return;
@@ -640,22 +638,37 @@ QVariant ScrollEngine::perScreenValue(const QString& screenId, QLatin1String key
     return it == m_perScreenConfig.constEnd() ? QVariant() : it->value(key);
 }
 
+QVector<qreal> ScrollEngine::clampedFractionVector(const QVariantList& list)
+{
+    QVector<qreal> out = toFractionVector(list);
+    for (qreal& fraction : out) {
+        fraction = qBound(kMinSizeFraction, fraction, kMaxSizeFraction);
+    }
+    return out;
+}
+
+// The effective*() resolvers clamp every per-screen override on read — the
+// daemon already passes Settings-validated values, but clamping here too is
+// the defence-in-depth pattern AutotileEngine's PerScreenConfigResolver uses,
+// and it keeps a malformed override (e.g. a non-numeric DefaultColumnWidth
+// coerced to 0.0) from yielding a degenerate column instead of a sane bound.
+
 QVector<qreal> ScrollEngine::effectivePresetColumnWidths(const QString& screenId) const
 {
     const QVariant v = perScreenValue(screenId, QLatin1String("PresetColumnWidths"));
-    return v.isValid() ? toFractionVector(v.toList()) : m_presetColumnWidths;
+    return v.isValid() ? clampedFractionVector(v.toList()) : m_presetColumnWidths;
 }
 
 QVector<qreal> ScrollEngine::effectivePresetWindowHeights(const QString& screenId) const
 {
     const QVariant v = perScreenValue(screenId, QLatin1String("PresetWindowHeights"));
-    return v.isValid() ? toFractionVector(v.toList()) : m_presetWindowHeights;
+    return v.isValid() ? clampedFractionVector(v.toList()) : m_presetWindowHeights;
 }
 
 qreal ScrollEngine::effectiveDefaultColumnWidth(const QString& screenId) const
 {
     const QVariant v = perScreenValue(screenId, QLatin1String("DefaultColumnWidth"));
-    return v.isValid() ? v.toReal() : m_defaultColumnWidth;
+    return v.isValid() ? qBound(kMinSizeFraction, v.toReal(), kMaxSizeFraction) : m_defaultColumnWidth;
 }
 
 ScrollViewportMode ScrollEngine::effectiveViewportMode(const QString& screenId) const
@@ -670,13 +683,13 @@ ScrollViewportMode ScrollEngine::effectiveViewportMode(const QString& screenId) 
 int ScrollEngine::effectiveInnerGap(const QString& screenId) const
 {
     const QVariant v = perScreenValue(screenId, QLatin1String("InnerGap"));
-    return v.isValid() ? v.toInt() : m_innerGap;
+    return v.isValid() ? qBound(kMinStripGap, v.toInt(), kMaxStripGap) : m_innerGap;
 }
 
 int ScrollEngine::effectiveOuterGap(const QString& screenId) const
 {
     const QVariant v = perScreenValue(screenId, QLatin1String("OuterGap"));
-    return v.isValid() ? v.toInt() : m_outerGap;
+    return v.isValid() ? qBound(kMinStripGap, v.toInt(), kMaxStripGap) : m_outerGap;
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
@@ -45,13 +45,13 @@ void ScrollScreenState::addColumnForWindow(const QString& windowId, const Column
     m_activeColumnIndex = insertAt;
 }
 
-void ScrollScreenState::addWindowToActiveColumn(const QString& windowId)
+void ScrollScreenState::addWindowToActiveColumn(const QString& windowId, const ColumnWidth& width)
 {
     if (windowId.isEmpty() || containsWindow(windowId)) {
         return;
     }
     if (m_activeColumnIndex < 0) {
-        addColumnForWindow(windowId);
+        addColumnForWindow(windowId, width);
         return;
     }
     Column& column = m_columns[m_activeColumnIndex];

--- a/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
+++ b/libs/phosphor-scroll-engine/src/ScrollScreenState.cpp
@@ -32,12 +32,13 @@ QString ScrollScreenState::focusedWindowId() const
     return tile ? tile->windowId : QString();
 }
 
-void ScrollScreenState::addColumnForWindow(const QString& windowId)
+void ScrollScreenState::addColumnForWindow(const QString& windowId, const ColumnWidth& width)
 {
     if (windowId.isEmpty() || containsWindow(windowId)) {
         return;
     }
     Column column;
+    column.setWidth(width);
     column.appendTile(Tile{windowId, WindowHeight::automatic()});
     const int insertAt = (m_activeColumnIndex < 0) ? 0 : m_activeColumnIndex + 1;
     m_columns.insert(insertAt, std::move(column));

--- a/src/common/layoutpreviewserialize.cpp
+++ b/src/common/layoutpreviewserialize.cpp
@@ -26,11 +26,12 @@ constexpr QLatin1String Description{"description"};
 constexpr QLatin1String ZoneCount{"zoneCount"};
 constexpr QLatin1String Zones{"zones"};
 constexpr QLatin1String IsAutotile{"isAutotile"};
-// PhosphorZones::LayoutCategory mirror — `isAutotile` is the canonical
-// boolean, but QML consumers (LayoutCard, CategoryBadge) read a numeric
-// `category` field (0 = Manual, 1 = Autotile, 2 = Scroll) to match the
-// LayoutCategory enum used elsewhere. Emit both so QML doesn't need to
-// translate, and the C++ `isAutotile` consumer keeps its name.
+// `isAutotile` is the canonical boolean, but QML consumers (LayoutCard,
+// CategoryBadge) read a numeric `category` field: 0 = Manual, 1 = Autotile
+// (both mirroring PhosphorZones::LayoutCategory), plus 2 = Scroll — a
+// QML-only value with no LayoutCategory enumerator (scroll mode has no
+// C++ category counterpart). Emit both so QML doesn't need to translate,
+// and the C++ `isAutotile` consumer keeps its name.
 constexpr QLatin1String Category{"category"};
 constexpr QLatin1String IsSystem{"isSystem"};
 // Back-compat alias for isSystem. Older consumers historically read
@@ -110,8 +111,9 @@ QString aspectRatioClassTag(PhosphorLayout::AspectRatioClass cls)
     return PhosphorLayout::ScreenClassification::toString(cls);
 }
 
-/// Numeric `category` field for QML consumers, mirroring the
-/// PhosphorZones::LayoutCategory enum: 0 = Manual, 1 = Autotile, 2 = Scroll.
+/// Numeric `category` field for QML consumers: 0 = Manual, 1 = Autotile
+/// (mirroring PhosphorZones::LayoutCategory), 2 = Scroll (QML-only — scroll
+/// mode has no LayoutCategory enumerator).
 int categoryFor(const PhosphorLayout::LayoutPreview& preview)
 {
     if (PhosphorLayout::LayoutId::isScroll(preview.id)) {

--- a/src/common/layoutpreviewserialize.cpp
+++ b/src/common/layoutpreviewserialize.cpp
@@ -5,6 +5,7 @@
 
 #include <PhosphorLayoutApi/AlgorithmMetadata.h>
 #include <PhosphorLayoutApi/AspectRatioClass.h>
+#include <PhosphorLayoutApi/LayoutId.h>
 #include <PhosphorLayoutApi/LayoutPreview.h>
 
 #include <QJsonArray>
@@ -27,7 +28,7 @@ constexpr QLatin1String Zones{"zones"};
 constexpr QLatin1String IsAutotile{"isAutotile"};
 // PhosphorZones::LayoutCategory mirror — `isAutotile` is the canonical
 // boolean, but QML consumers (LayoutCard, CategoryBadge) read a numeric
-// `category` field (0 = Manual, 1 = Autotile) to match the
+// `category` field (0 = Manual, 1 = Autotile, 2 = Scroll) to match the
 // LayoutCategory enum used elsewhere. Emit both so QML doesn't need to
 // translate, and the C++ `isAutotile` consumer keeps its name.
 constexpr QLatin1String Category{"category"};
@@ -109,6 +110,16 @@ QString aspectRatioClassTag(PhosphorLayout::AspectRatioClass cls)
     return PhosphorLayout::ScreenClassification::toString(cls);
 }
 
+/// Numeric `category` field for QML consumers, mirroring the
+/// PhosphorZones::LayoutCategory enum: 0 = Manual, 1 = Autotile, 2 = Scroll.
+int categoryFor(const PhosphorLayout::LayoutPreview& preview)
+{
+    if (PhosphorLayout::LayoutId::isScroll(preview.id)) {
+        return 2;
+    }
+    return preview.isAutotile() ? 1 : 0;
+}
+
 } // namespace
 
 QJsonObject toJson(const PhosphorLayout::LayoutPreview& preview)
@@ -121,7 +132,7 @@ QJsonObject toJson(const PhosphorLayout::LayoutPreview& preview)
     }
     json[K::ZoneCount] = preview.zoneCount;
     json[K::IsAutotile] = preview.isAutotile();
-    json[K::Category] = preview.isAutotile() ? 1 : 0;
+    json[K::Category] = categoryFor(preview);
     json[K::IsSystem] = preview.isSystem;
     // Back-compat alias: emit alongside `isSystem` for one release cycle.
     json[K::IsSystemEntry] = preview.isSystem;
@@ -176,7 +187,7 @@ QVariantMap toVariantMap(const PhosphorLayout::LayoutPreview& preview)
     }
     map[K::ZoneCount] = preview.zoneCount;
     map[K::IsAutotile] = preview.isAutotile();
-    map[K::Category] = preview.isAutotile() ? 1 : 0;
+    map[K::Category] = categoryFor(preview);
     map[K::IsSystem] = preview.isSystem;
     // Back-compat alias: emit alongside `isSystem` for one release cycle.
     map[K::IsSystemEntry] = preview.isSystem;

--- a/src/config/configdefaults.cpp
+++ b/src/config/configdefaults.cpp
@@ -39,6 +39,11 @@ QString ConfigDefaults::assignmentsFilePath()
     return configDir() + QStringLiteral("/plasmazones/assignments.json");
 }
 
+QString ConfigDefaults::scrollStateFilePath()
+{
+    return configDir() + QStringLiteral("/plasmazones/scroll-session.json");
+}
+
 QString ConfigDefaults::legacyConfigFilePath()
 {
     return configDir() + QStringLiteral("/plasmazonesrc");

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -640,6 +640,14 @@ public:
     // and PhosphorZones::LayoutRegistry have independent ownership of their files.
     PLASMAZONES_EXPORT static QString assignmentsFilePath();
 
+    // Returns the absolute path to scroll-session.json — the persisted
+    // scroll-mode strip state (columns, widths, heights, focus, scroll offset).
+    // Ephemeral per-session state owned by the daemon; kept in its own file so
+    // a scroll relayout never contends with user-preference or window-tracking
+    // saves. Restored on a daemon restart (window IDs are stable while KWin
+    // keeps running); stale after a full compositor restart.
+    PLASMAZONES_EXPORT static QString scrollStateFilePath();
+
     // Returns the absolute path to the legacy plasmazonesrc file (INI format).
     // Used only by the one-time migration module.
     PLASMAZONES_EXPORT static QString legacyConfigFilePath();
@@ -1055,6 +1063,74 @@ public:
     static QStringList lockedScreens()
     {
         return {};
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Scrolling Mode Settings
+    //
+    // Global defaults for the niri-style scrollable-tiling engine; per-screen
+    // overrides layer on top (see PerScreenScrollKey / ScrollingScreen: groups).
+    // The daemon pushes these to ScrollEngine / the geometry resolver on startup
+    // and whenever they change; ScrollEngine's own constructor defaults are a
+    // standalone fallback that intentionally mirror the values below.
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    static constexpr int scrollInnerGap()
+    {
+        return 8;
+    }
+    static constexpr int scrollInnerGapMin()
+    {
+        return PhosphorTiles::AutotileDefaults::MinGap;
+    }
+    static constexpr int scrollInnerGapMax()
+    {
+        return PhosphorTiles::AutotileDefaults::MaxGap;
+    }
+    static constexpr int scrollOuterGap()
+    {
+        return 8;
+    }
+    static constexpr int scrollOuterGapMin()
+    {
+        return PhosphorTiles::AutotileDefaults::MinGap;
+    }
+    static constexpr int scrollOuterGapMax()
+    {
+        return PhosphorTiles::AutotileDefaults::MaxGap;
+    }
+    /// Width of a freshly-opened column as a fraction [0..1] of the working
+    /// area. niri's middle preset (one half).
+    static constexpr double scrollDefaultColumnWidth()
+    {
+        return 0.5;
+    }
+    static constexpr double scrollColumnWidthMin()
+    {
+        return 0.1;
+    }
+    static constexpr double scrollColumnWidthMax()
+    {
+        return 1.0;
+    }
+    /// When true the viewport keeps the focused column centered; when false it
+    /// scrolls the minimum amount to keep the column on-screen (niri "fit").
+    static constexpr bool scrollCenterFocusedColumn()
+    {
+        return false;
+    }
+    /// Column-width presets the cycle-width shortcut steps through — fractions
+    /// [0..1] of the working area. niri defaults: one third, one half, two
+    /// thirds. Persisted as a QVariantList of doubles.
+    static QVariantList scrollPresetColumnWidths()
+    {
+        return {1.0 / 3.0, 0.5, 2.0 / 3.0};
+    }
+    /// Window-height presets the cycle-height shortcut steps through —
+    /// fractions [0..1] of the column content height.
+    static QVariantList scrollPresetWindowHeights()
+    {
+        return {1.0 / 3.0, 0.5, 2.0 / 3.0};
     }
 
     // ── Virtual Screen Limits ──────────────────────────────────────────

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -1113,6 +1113,18 @@ public:
     {
         return 1.0;
     }
+    /// Window-height presets are fractions of the column content height. The
+    /// numeric bounds currently match column width, but they are kept as
+    /// distinct accessors so the two ranges can diverge without silently
+    /// sharing a constant.
+    static constexpr double scrollWindowHeightMin()
+    {
+        return 0.1;
+    }
+    static constexpr double scrollWindowHeightMax()
+    {
+        return 1.0;
+    }
     /// When true the viewport keeps the focused column centered; when false it
     /// scrolls the minimum amount to keep the column on-screen (niri "fit").
     static constexpr bool scrollCenterFocusedColumn()

--- a/src/config/configkeys.h
+++ b/src/config/configkeys.h
@@ -46,6 +46,7 @@ public:
     PZ_CONFIG_GROUP(generalGroup, "General")
     PZ_CONFIG_GROUP(snappingGroup, "Snapping")
     PZ_CONFIG_GROUP(tilingGroup, "Tiling")
+    PZ_CONFIG_GROUP(scrollingGroup, "Scrolling")
     PZ_CONFIG_GROUP(exclusionsGroup, "Exclusions")
     PZ_CONFIG_GROUP(performanceGroup, "Performance")
     PZ_CONFIG_GROUP(renderingGroup, "Rendering")
@@ -88,6 +89,10 @@ public:
     PZ_CONFIG_GROUP(tilingAppearanceDecorationsGroup, "Tiling.Appearance.Decorations")
     PZ_CONFIG_GROUP(tilingAppearanceBordersGroup, "Tiling.Appearance.Borders")
     PZ_CONFIG_GROUP(tilingGapsGroup, "Tiling.Gaps")
+
+    // Scrolling sub-groups
+    PZ_CONFIG_GROUP(scrollingLayoutGroup, "Scrolling.Layout")
+    PZ_CONFIG_GROUP(scrollingGapsGroup, "Scrolling.Gaps")
 
     // Parent groups (for purge enumeration — covers all sub-groups)
     PZ_CONFIG_GROUP(shortcutsGroup, "Shortcuts")
@@ -356,6 +361,17 @@ public:
     PZ_CONFIG_KEY(smartGapsKey, "SmartGaps")
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // Config Keys — Scrolling.Layout
+    //
+    // Scrolling.Gaps reuses innerKey / outerKey — the group context disambiguates.
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    PZ_CONFIG_KEY(defaultColumnWidthKey, "DefaultColumnWidth")
+    PZ_CONFIG_KEY(centerFocusedColumnKey, "CenterFocusedColumn")
+    PZ_CONFIG_KEY(presetColumnWidthsKey, "PresetColumnWidths")
+    PZ_CONFIG_KEY(presetWindowHeightsKey, "PresetWindowHeights")
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // Config Keys — Exclusions
     // ═══════════════════════════════════════════════════════════════════════════
 
@@ -548,6 +564,7 @@ public:
     PZ_CONFIG_GROUP(zoneSelectorGroupPrefix, "ZoneSelector:")
     PZ_CONFIG_GROUP(autotileScreenGroupPrefix, "AutotileScreen:")
     PZ_CONFIG_GROUP(snappingScreenGroupPrefix, "SnappingScreen:")
+    PZ_CONFIG_GROUP(scrollingScreenGroupPrefix, "ScrollingScreen:")
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Legacy v1 key accessors — used ONLY by migration code.

--- a/src/config/perscreenresolver.cpp
+++ b/src/config/perscreenresolver.cpp
@@ -19,6 +19,7 @@ constexpr PerScreenMapping kPerScreenMappings[] = {
     {"ZoneSelector", "ZoneSelector"},
     {"AutotileScreen", "Autotile"},
     {"SnappingScreen", "Snapping"},
+    {"ScrollingScreen", "Scrolling"},
 };
 } // namespace
 

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -548,6 +548,10 @@ void Settings::setAudioSpectrumBarCount(int count)
         Q_EMIT settingsChanged();                                                                                      \
     }
 
+// Unlike PZ_STORE_GET (typed read<T>), the list getter goes through
+// readVariant, which is default-eager: a corrupt on-disk list falls back to
+// the schema default rather than an empty list — the right call for a preset
+// list, since an empty list would silently disable the cycle shortcuts.
 #define PZ_STORE_GET_LIST(fn, group, key)                                                                              \
     QVariantList Settings::fn() const                                                                                  \
     {                                                                                                                  \

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -2845,9 +2845,11 @@ void Settings::applyAutotileBorderSystemColor()
 }
 
 #undef PZ_STORE_GET
+#undef PZ_STORE_GET_LIST
 #undef PZ_STORE_SET_BOOL
 #undef PZ_STORE_SET_INT
 #undef PZ_STORE_SET_DOUBLE
+#undef PZ_STORE_SET_LIST
 #undef PZ_STORE_SET_COLOR
 #undef PZ_STORE_SET_STRING
 

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -231,6 +231,7 @@ QStringList Settings::managedGroupNames()
         ConfigDefaults::generalGroup(), // "General"
         ConfigDefaults::snappingGroup(), // "Snapping"
         ConfigDefaults::tilingGroup(), // "Tiling"
+        ConfigDefaults::scrollingGroup(), // "Scrolling" — covers Scrolling.Layout + Scrolling.Gaps
         ConfigDefaults::displayGroup(), // "Display" — mode-neutral, holds per-mode disable lists (v3+)
         ConfigDefaults::exclusionsGroup(), // "Exclusions"
         ConfigDefaults::performanceGroup(), // "Performance"
@@ -2397,6 +2398,61 @@ PZ_STORE_GET(bool, autotileDragInsertToggle, tilingBehaviorGroup, toggleActivati
 PZ_STORE_SET_BOOL(setAutotileDragInsertToggle, tilingBehaviorGroup, toggleActivationKey,
                   autotileDragInsertToggleChanged)
 
+// ── Scroll Mode Settings (PhosphorConfig::Store-backed) ─────────────────────
+// Scroll.Gaps — reuses innerKey / outerKey; the group context disambiguates.
+PZ_STORE_GET(int, scrollInnerGap, scrollingGapsGroup, innerKey, int)
+PZ_STORE_SET_INT(setScrollInnerGap, scrollingGapsGroup, innerKey, scrollInnerGapChanged)
+PZ_STORE_GET(int, scrollOuterGap, scrollingGapsGroup, outerKey, int)
+PZ_STORE_SET_INT(setScrollOuterGap, scrollingGapsGroup, outerKey, scrollOuterGapChanged)
+// Scroll.Layout
+PZ_STORE_GET(qreal, scrollDefaultColumnWidth, scrollingLayoutGroup, defaultColumnWidthKey, double)
+PZ_STORE_SET_DOUBLE(setScrollDefaultColumnWidth, scrollingLayoutGroup, defaultColumnWidthKey,
+                    scrollDefaultColumnWidthChanged)
+PZ_STORE_GET(bool, scrollCenterFocusedColumn, scrollingLayoutGroup, centerFocusedColumnKey, bool)
+PZ_STORE_SET_BOOL(setScrollCenterFocusedColumn, scrollingLayoutGroup, centerFocusedColumnKey,
+                  scrollCenterFocusedColumnChanged)
+
+QVariantList Settings::scrollPresetColumnWidths() const
+{
+    return m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetColumnWidthsKey())
+        .toList();
+}
+void Settings::setScrollPresetColumnWidths(const QVariantList& fractions)
+{
+    // Pre/post round-trip compare — the schema validator may clamp / drop
+    // out-of-range fractions, so two in-memory-distinct lists can persist
+    // identically; emitting then would dirty the page on a no-op.
+    const QVariantList before =
+        m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetColumnWidthsKey()).toList();
+    m_store->write(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetColumnWidthsKey(), fractions);
+    const QVariantList after =
+        m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetColumnWidthsKey()).toList();
+    if (before == after) {
+        return;
+    }
+    Q_EMIT scrollPresetColumnWidthsChanged();
+    Q_EMIT settingsChanged();
+}
+
+QVariantList Settings::scrollPresetWindowHeights() const
+{
+    return m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetWindowHeightsKey())
+        .toList();
+}
+void Settings::setScrollPresetWindowHeights(const QVariantList& fractions)
+{
+    const QVariantList before =
+        m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetWindowHeightsKey()).toList();
+    m_store->write(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetWindowHeightsKey(), fractions);
+    const QVariantList after =
+        m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetWindowHeightsKey()).toList();
+    if (before == after) {
+        return;
+    }
+    Q_EMIT scrollPresetWindowHeightsChanged();
+    Q_EMIT settingsChanged();
+}
+
 // Tiling.Appearance
 PZ_STORE_GET(QColor, autotileBorderColor, tilingAppearanceColorsGroup, activeKey, QColor)
 PZ_STORE_SET_COLOR(setAutotileBorderColor, tilingAppearanceColorsGroup, activeKey, autotileBorderColorChanged)
@@ -2440,6 +2496,9 @@ void Settings::reset()
     m_configBackend->deleteGroup(ConfigDefaults::tilingQuickLayoutSlotsGroup());
     if (!QFile::remove(ConfigDefaults::sessionFilePath()) && QFile::exists(ConfigDefaults::sessionFilePath())) {
         qCWarning(lcConfig) << "Failed to remove session file:" << ConfigDefaults::sessionFilePath();
+    }
+    if (!QFile::remove(ConfigDefaults::scrollStateFilePath()) && QFile::exists(ConfigDefaults::scrollStateFilePath())) {
+        qCWarning(lcConfig) << "Failed to remove scroll state file:" << ConfigDefaults::scrollStateFilePath();
     }
     deletePerScreenGroups(m_configBackend);
     m_configBackend->sync();

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -548,6 +548,28 @@ void Settings::setAudioSpectrumBarCount(int count)
         Q_EMIT settingsChanged();                                                                                      \
     }
 
+#define PZ_STORE_GET_LIST(fn, group, key)                                                                              \
+    QVariantList Settings::fn() const                                                                                  \
+    {                                                                                                                  \
+        return m_store->readVariant(ConfigDefaults::group(), ConfigDefaults::key()).toList();                          \
+    }
+
+// Pre/post round-trip compare — the schema validator may clamp / drop
+// out-of-range entries, so two in-memory-distinct lists can persist
+// identically; emitting then would dirty the settings page on a no-op.
+#define PZ_STORE_SET_LIST(fn, group, key, signal)                                                                      \
+    void Settings::fn(const QVariantList& value)                                                                       \
+    {                                                                                                                  \
+        const QVariantList before = m_store->readVariant(ConfigDefaults::group(), ConfigDefaults::key()).toList();     \
+        m_store->write(ConfigDefaults::group(), ConfigDefaults::key(), value);                                         \
+        const QVariantList after = m_store->readVariant(ConfigDefaults::group(), ConfigDefaults::key()).toList();      \
+        if (before == after) {                                                                                         \
+            return;                                                                                                    \
+        }                                                                                                              \
+        Q_EMIT signal();                                                                                               \
+        Q_EMIT settingsChanged();                                                                                      \
+    }
+
 #define PZ_STORE_SET_COLOR(fn, group, key, signal)                                                                     \
     void Settings::fn(const QColor& value)                                                                             \
     {                                                                                                                  \
@@ -2399,59 +2421,25 @@ PZ_STORE_SET_BOOL(setAutotileDragInsertToggle, tilingBehaviorGroup, toggleActiva
                   autotileDragInsertToggleChanged)
 
 // ── Scroll Mode Settings (PhosphorConfig::Store-backed) ─────────────────────
-// Scroll.Gaps — reuses innerKey / outerKey; the group context disambiguates.
+// Scrolling.Gaps — reuses innerKey / outerKey; the group context disambiguates.
 PZ_STORE_GET(int, scrollInnerGap, scrollingGapsGroup, innerKey, int)
 PZ_STORE_SET_INT(setScrollInnerGap, scrollingGapsGroup, innerKey, scrollInnerGapChanged)
 PZ_STORE_GET(int, scrollOuterGap, scrollingGapsGroup, outerKey, int)
 PZ_STORE_SET_INT(setScrollOuterGap, scrollingGapsGroup, outerKey, scrollOuterGapChanged)
-// Scroll.Layout
+// Scrolling.Layout
 PZ_STORE_GET(qreal, scrollDefaultColumnWidth, scrollingLayoutGroup, defaultColumnWidthKey, double)
 PZ_STORE_SET_DOUBLE(setScrollDefaultColumnWidth, scrollingLayoutGroup, defaultColumnWidthKey,
                     scrollDefaultColumnWidthChanged)
 PZ_STORE_GET(bool, scrollCenterFocusedColumn, scrollingLayoutGroup, centerFocusedColumnKey, bool)
 PZ_STORE_SET_BOOL(setScrollCenterFocusedColumn, scrollingLayoutGroup, centerFocusedColumnKey,
                   scrollCenterFocusedColumnChanged)
-
-QVariantList Settings::scrollPresetColumnWidths() const
-{
-    return m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetColumnWidthsKey())
-        .toList();
-}
-void Settings::setScrollPresetColumnWidths(const QVariantList& fractions)
-{
-    // Pre/post round-trip compare — the schema validator may clamp / drop
-    // out-of-range fractions, so two in-memory-distinct lists can persist
-    // identically; emitting then would dirty the page on a no-op.
-    const QVariantList before =
-        m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetColumnWidthsKey()).toList();
-    m_store->write(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetColumnWidthsKey(), fractions);
-    const QVariantList after =
-        m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetColumnWidthsKey()).toList();
-    if (before == after) {
-        return;
-    }
-    Q_EMIT scrollPresetColumnWidthsChanged();
-    Q_EMIT settingsChanged();
-}
-
-QVariantList Settings::scrollPresetWindowHeights() const
-{
-    return m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetWindowHeightsKey())
-        .toList();
-}
-void Settings::setScrollPresetWindowHeights(const QVariantList& fractions)
-{
-    const QVariantList before =
-        m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetWindowHeightsKey()).toList();
-    m_store->write(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetWindowHeightsKey(), fractions);
-    const QVariantList after =
-        m_store->readVariant(ConfigDefaults::scrollingLayoutGroup(), ConfigDefaults::presetWindowHeightsKey()).toList();
-    if (before == after) {
-        return;
-    }
-    Q_EMIT scrollPresetWindowHeightsChanged();
-    Q_EMIT settingsChanged();
-}
+// Scrolling.Layout preset lists — QVariantLists of fractions of the working area.
+PZ_STORE_GET_LIST(scrollPresetColumnWidths, scrollingLayoutGroup, presetColumnWidthsKey)
+PZ_STORE_SET_LIST(setScrollPresetColumnWidths, scrollingLayoutGroup, presetColumnWidthsKey,
+                  scrollPresetColumnWidthsChanged)
+PZ_STORE_GET_LIST(scrollPresetWindowHeights, scrollingLayoutGroup, presetWindowHeightsKey)
+PZ_STORE_SET_LIST(setScrollPresetWindowHeights, scrollingLayoutGroup, presetWindowHeightsKey,
+                  scrollPresetWindowHeightsChanged)
 
 // Tiling.Appearance
 PZ_STORE_GET(QColor, autotileBorderColor, tilingAppearanceColorsGroup, activeKey, QColor)

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -259,6 +259,18 @@ public:
     Q_PROPERTY(bool autotileDragInsertToggle READ autotileDragInsertToggle WRITE setAutotileDragInsertToggle NOTIFY
                    autotileDragInsertToggleChanged)
 
+    // Scroll Mode Settings (niri-style scrollable tiling)
+    Q_PROPERTY(int scrollInnerGap READ scrollInnerGap WRITE setScrollInnerGap NOTIFY scrollInnerGapChanged)
+    Q_PROPERTY(int scrollOuterGap READ scrollOuterGap WRITE setScrollOuterGap NOTIFY scrollOuterGapChanged)
+    Q_PROPERTY(double scrollDefaultColumnWidth READ scrollDefaultColumnWidth WRITE setScrollDefaultColumnWidth NOTIFY
+                   scrollDefaultColumnWidthChanged)
+    Q_PROPERTY(bool scrollCenterFocusedColumn READ scrollCenterFocusedColumn WRITE setScrollCenterFocusedColumn NOTIFY
+                   scrollCenterFocusedColumnChanged)
+    Q_PROPERTY(QVariantList scrollPresetColumnWidths READ scrollPresetColumnWidths WRITE setScrollPresetColumnWidths
+                   NOTIFY scrollPresetColumnWidthsChanged)
+    Q_PROPERTY(QVariantList scrollPresetWindowHeights READ scrollPresetWindowHeights WRITE setScrollPresetWindowHeights
+                   NOTIFY scrollPresetWindowHeightsChanged)
+
     // Animation Settings (applies to both snapping and autotiling geometry changes)
     Q_PROPERTY(bool animationsEnabled READ animationsEnabled WRITE setAnimationsEnabled NOTIFY animationsEnabledChanged)
     Q_PROPERTY(int animationDuration READ animationDuration WRITE setAnimationDuration NOTIFY animationDurationChanged)
@@ -722,6 +734,13 @@ public:
     Q_INVOKABLE void clearPerScreenSnappingSettings(const QString& screenIdOrName) override;
     Q_INVOKABLE bool hasPerScreenSnappingSettings(const QString& screenIdOrName) const override;
 
+    // Per-screen scrolling config (override > global fallback)
+    Q_INVOKABLE QVariantMap getPerScreenScrollSettings(const QString& screenIdOrName) const override;
+    Q_INVOKABLE void setPerScreenScrollSetting(const QString& screenIdOrName, const QString& key,
+                                               const QVariant& value) override;
+    Q_INVOKABLE void clearPerScreenScrollSettings(const QString& screenIdOrName) override;
+    Q_INVOKABLE bool hasPerScreenScrollSettings(const QString& screenIdOrName) const override;
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Autotiling Settings (ISettings interface)
     // ═══════════════════════════════════════════════════════════════════════════
@@ -770,6 +789,20 @@ public:
     void setAutotileDragInsertTriggers(const QVariantList& triggers) override;
     bool autotileDragInsertToggle() const override;
     void setAutotileDragInsertToggle(bool enable) override;
+
+    // Scroll Mode Settings — PhosphorConfig::Store-backed.
+    int scrollInnerGap() const override;
+    void setScrollInnerGap(int gap) override;
+    int scrollOuterGap() const override;
+    void setScrollOuterGap(int gap) override;
+    double scrollDefaultColumnWidth() const override;
+    void setScrollDefaultColumnWidth(double fraction) override;
+    bool scrollCenterFocusedColumn() const override;
+    void setScrollCenterFocusedColumn(bool center) override;
+    QVariantList scrollPresetColumnWidths() const override;
+    void setScrollPresetColumnWidths(const QVariantList& fractions) override;
+    QVariantList scrollPresetWindowHeights() const override;
+    void setScrollPresetWindowHeights(const QVariantList& fractions) override;
 
     // Autotile Shortcuts — PhosphorConfig::Store-backed.
     QString autotileToggleShortcut() const;
@@ -1281,6 +1314,9 @@ private:
 
     // Per-screen snapping overrides (screenIdOrName -> settings map)
     QHash<QString, QVariantMap> m_perScreenSnappingSettings;
+
+    // Per-screen scrolling overrides (screenIdOrName -> settings map)
+    QHash<QString, QVariantMap> m_perScreenScrollSettings;
 
     // Autotiling Settings
     // Autotiling stored in m_store.

--- a/src/config/settings/perscreen.cpp
+++ b/src/config/settings/perscreen.cpp
@@ -4,6 +4,7 @@
 #include "../settings.h"
 #include "../configbackends.h"
 #include "../configdefaults.h"
+#include "../settingsschema.h"
 #include "../../core/constants.h"
 #include "../../core/logging.h"
 #include "../../core/utils.h"
@@ -247,23 +248,6 @@ const QLatin1String kPerScreenScrollKeys[] = {
     QLatin1String(PerScreenScrollKey::PresetColumnWidths), QLatin1String(PerScreenScrollKey::PresetWindowHeights),
 };
 
-/// Clamp every entry of a fraction list into the scroll column-width range,
-/// dropping non-numeric junk. Mirrors settingsschema.cpp's clampFractionList so
-/// a per-screen preset override is range-checked exactly like the global list.
-QVariantList clampScrollFractionList(const QVariant& value)
-{
-    QVariantList out;
-    const QVariantList raw = value.toList();
-    for (const QVariant& entry : raw) {
-        bool ok = false;
-        const double d = entry.toDouble(&ok);
-        if (ok) {
-            out.append(qBound(ConfigDefaults::scrollColumnWidthMin(), d, ConfigDefaults::scrollColumnWidthMax()));
-        }
-    }
-    return out;
-}
-
 QVariant validatePerScreenScrollValue(const QString& key, const QVariant& value)
 {
     namespace K = PerScreenScrollKey;
@@ -278,8 +262,15 @@ QVariant validatePerScreenScrollValue(const QString& key, const QVariant& value)
             qBound(ConfigDefaults::scrollColumnWidthMin(), value.toDouble(), ConfigDefaults::scrollColumnWidthMax()));
     if (key == QLatin1String(K::CenterFocusedColumn))
         return QVariant(value.toBool());
-    if (key == QLatin1String(K::PresetColumnWidths) || key == QLatin1String(K::PresetWindowHeights))
-        return QVariant(clampScrollFractionList(value));
+    // Preset lists are range-checked with the shared clampFractionListValue —
+    // the same helper the global Scrolling.Layout schema uses — so a global
+    // and a per-screen preset list are validated identically.
+    if (key == QLatin1String(K::PresetColumnWidths))
+        return QVariant(clampFractionListValue(value, ConfigDefaults::scrollColumnWidthMin(),
+                                               ConfigDefaults::scrollColumnWidthMax()));
+    if (key == QLatin1String(K::PresetWindowHeights))
+        return QVariant(clampFractionListValue(value, ConfigDefaults::scrollWindowHeightMin(),
+                                               ConfigDefaults::scrollWindowHeightMax()));
     return QVariant();
 }
 

--- a/src/config/settings/perscreen.cpp
+++ b/src/config/settings/perscreen.cpp
@@ -9,6 +9,8 @@
 #include "../../core/utils.h"
 #include <PhosphorScreens/ScreenIdentity.h>
 
+#include <QJsonArray>
+
 namespace PlasmaZones {
 
 namespace {
@@ -239,6 +241,60 @@ QVariant readPerScreenZoneSelectorEntry(PhosphorConfig::IGroup& group, const QSt
     return QVariant(group.readInt(key, 0));
 }
 
+const QLatin1String kPerScreenScrollKeys[] = {
+    QLatin1String(PerScreenScrollKey::InnerGap),           QLatin1String(PerScreenScrollKey::OuterGap),
+    QLatin1String(PerScreenScrollKey::DefaultColumnWidth), QLatin1String(PerScreenScrollKey::CenterFocusedColumn),
+    QLatin1String(PerScreenScrollKey::PresetColumnWidths), QLatin1String(PerScreenScrollKey::PresetWindowHeights),
+};
+
+/// Clamp every entry of a fraction list into the scroll column-width range,
+/// dropping non-numeric junk. Mirrors settingsschema.cpp's clampFractionList so
+/// a per-screen preset override is range-checked exactly like the global list.
+QVariantList clampScrollFractionList(const QVariant& value)
+{
+    QVariantList out;
+    const QVariantList raw = value.toList();
+    for (const QVariant& entry : raw) {
+        bool ok = false;
+        const double d = entry.toDouble(&ok);
+        if (ok) {
+            out.append(qBound(ConfigDefaults::scrollColumnWidthMin(), d, ConfigDefaults::scrollColumnWidthMax()));
+        }
+    }
+    return out;
+}
+
+QVariant validatePerScreenScrollValue(const QString& key, const QVariant& value)
+{
+    namespace K = PerScreenScrollKey;
+    if (key == QLatin1String(K::InnerGap))
+        return QVariant(
+            qBound(ConfigDefaults::scrollInnerGapMin(), value.toInt(), ConfigDefaults::scrollInnerGapMax()));
+    if (key == QLatin1String(K::OuterGap))
+        return QVariant(
+            qBound(ConfigDefaults::scrollOuterGapMin(), value.toInt(), ConfigDefaults::scrollOuterGapMax()));
+    if (key == QLatin1String(K::DefaultColumnWidth))
+        return QVariant(
+            qBound(ConfigDefaults::scrollColumnWidthMin(), value.toDouble(), ConfigDefaults::scrollColumnWidthMax()));
+    if (key == QLatin1String(K::CenterFocusedColumn))
+        return QVariant(value.toBool());
+    if (key == QLatin1String(K::PresetColumnWidths) || key == QLatin1String(K::PresetWindowHeights))
+        return QVariant(clampScrollFractionList(value));
+    return QVariant();
+}
+
+QVariant readPerScreenScrollEntry(PhosphorConfig::IGroup& group, const QString& key)
+{
+    namespace K = PerScreenScrollKey;
+    if (key == QLatin1String(K::DefaultColumnWidth))
+        return QVariant(group.readDouble(key, ConfigDefaults::scrollDefaultColumnWidth()));
+    if (key == QLatin1String(K::CenterFocusedColumn))
+        return QVariant(group.readBool(key, ConfigDefaults::scrollCenterFocusedColumn()));
+    if (key == QLatin1String(K::PresetColumnWidths) || key == QLatin1String(K::PresetWindowHeights))
+        return QVariant(group.readJson(key).toArray().toVariantList());
+    return QVariant(group.readInt(key, 0));
+}
+
 void savePerScreenOverrides(PhosphorConfig::IBackend* backend, const QString& prefix,
                             const QHash<QString, QVariantMap>& source)
 {
@@ -265,6 +321,11 @@ void savePerScreenOverrides(PhosphorConfig::IBackend* backend, const QString& pr
             case QMetaType::Double:
             case QMetaType::Float:
                 screenGroup->writeDouble(oit.key(), val.toDouble());
+                break;
+            case QMetaType::QVariantList:
+                // List-valued override (scroll preset lists) — stored as a
+                // native JSON array by JsonBackend, compact-JSON string elsewhere.
+                screenGroup->writeJson(oit.key(), QJsonArray::fromVariantList(val.toList()));
                 break;
             default:
                 screenGroup->writeString(oit.key(), val.toString());
@@ -374,6 +435,9 @@ void Settings::loadPerScreenOverrides(PhosphorConfig::IBackend* backend)
     loadPerScreenGroup(backend, allGroups, ConfigDefaults::snappingScreenGroupPrefix(), kPerScreenSnappingKeys,
                        std::size(kPerScreenSnappingKeys), readPerScreenSnappingEntry, validatePerScreenSnappingValue,
                        m_perScreenSnappingSettings);
+    loadPerScreenGroup(backend, allGroups, ConfigDefaults::scrollingScreenGroupPrefix(), kPerScreenScrollKeys,
+                       std::size(kPerScreenScrollKeys), readPerScreenScrollEntry, validatePerScreenScrollValue,
+                       m_perScreenScrollSettings);
 }
 
 /**
@@ -414,6 +478,7 @@ void Settings::saveAllPerScreenOverrides(PhosphorConfig::IBackend* backend)
     savePerScreenOverrides(backend, ConfigDefaults::autotileScreenGroupPrefix(),
                            expandAutotileKeys(m_perScreenAutotileSettings));
     savePerScreenOverrides(backend, ConfigDefaults::snappingScreenGroupPrefix(), m_perScreenSnappingSettings);
+    savePerScreenOverrides(backend, ConfigDefaults::scrollingScreenGroupPrefix(), m_perScreenScrollSettings);
 }
 
 template<typename T>
@@ -626,6 +691,52 @@ void Settings::clearPerScreenSnappingSettings(const QString& screenIdOrName)
 bool Settings::hasPerScreenSnappingSettings(const QString& screenIdOrName) const
 {
     return findPerScreenEntry(m_perScreenSnappingSettings, screenIdOrName) != m_perScreenSnappingSettings.constEnd();
+}
+
+// ── Per-Screen Scrolling Config ──────────────────────────────────────────────
+
+QVariantMap Settings::getPerScreenScrollSettings(const QString& screenIdOrName) const
+{
+    auto it = findPerScreenEntry(m_perScreenScrollSettings, screenIdOrName);
+    return (it != m_perScreenScrollSettings.constEnd()) ? it.value() : QVariantMap();
+}
+
+void Settings::setPerScreenScrollSetting(const QString& screenIdOrName, const QString& key, const QVariant& value)
+{
+    if (screenIdOrName.isEmpty() || key.isEmpty()) {
+        return;
+    }
+
+    QVariant validated = validatePerScreenScrollValue(key, value);
+    if (!validated.isValid()) {
+        qCWarning(lcConfig) << "Rejected per-screen scrolling setting:" << key + QLatin1String("=") << value;
+        return;
+    }
+
+    // Resolve to EDID-based screen ID so the key matches daemon lookups.
+    const QString resolved = Phosphor::Screens::ScreenIdentity::isConnectorName(screenIdOrName)
+        ? Phosphor::Screens::ScreenIdentity::idForName(screenIdOrName)
+        : screenIdOrName;
+    QVariantMap& screenSettings = m_perScreenScrollSettings[resolved];
+    if (screenSettings.value(key) == validated) {
+        return;
+    }
+    screenSettings[key] = validated;
+    Q_EMIT perScreenScrollSettingsChanged();
+    Q_EMIT settingsChanged();
+}
+
+void Settings::clearPerScreenScrollSettings(const QString& screenIdOrName)
+{
+    if (removePerScreenEntry(m_perScreenScrollSettings, screenIdOrName)) {
+        Q_EMIT perScreenScrollSettingsChanged();
+        Q_EMIT settingsChanged();
+    }
+}
+
+bool Settings::hasPerScreenScrollSettings(const QString& screenIdOrName) const
+{
+    return findPerScreenEntry(m_perScreenScrollSettings, screenIdOrName) != m_perScreenScrollSettings.constEnd();
 }
 
 } // namespace PlasmaZones

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -59,22 +59,13 @@ auto clampDouble(double minVal, double maxVal)
     };
 }
 
-/// Canonicalize a fraction list: coerce each entry to a double clamped into
-/// [minVal, maxVal], dropping non-numeric entries. Used by the scroll-mode
-/// preset width / height lists — each entry is a fraction of the working area.
+/// Schema-validator factory wrapping the shared clampFractionListValue helper,
+/// for the scroll-mode preset width / height lists — each entry is a fraction
+/// of the working area.
 auto clampFractionList(double minVal, double maxVal)
 {
     return [minVal, maxVal](const QVariant& v) -> QVariant {
-        QVariantList out;
-        const QVariantList raw = v.toList();
-        for (const QVariant& entry : raw) {
-            bool ok = false;
-            const double d = entry.toDouble(&ok);
-            if (ok) {
-                out.append(qBound(minVal, d, maxVal));
-            }
-        }
-        return QVariant(out);
+        return QVariant(clampFractionListValue(v, minVal, maxVal));
     };
 }
 
@@ -902,8 +893,22 @@ void appendScrollingSchema(PhosphorConfig::Schema& schema)
          CD::scrollPresetWindowHeights(),
          QMetaType::QVariantList,
          {},
-         clampFractionList(CD::scrollColumnWidthMin(), CD::scrollColumnWidthMax())},
+         clampFractionList(CD::scrollWindowHeightMin(), CD::scrollWindowHeightMax())},
     };
+}
+
+QVariantList clampFractionListValue(const QVariant& value, double minVal, double maxVal)
+{
+    QVariantList out;
+    const QVariantList raw = value.toList();
+    for (const QVariant& entry : raw) {
+        bool ok = false;
+        const double d = entry.toDouble(&ok);
+        if (ok) {
+            out.append(qBound(minVal, d, maxVal));
+        }
+    }
+    return out;
 }
 
 } // namespace PlasmaZones

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -35,6 +35,7 @@ PhosphorConfig::Schema buildSettingsSchema()
     appendActivationSchema(s);
     appendBehaviorSchema(s);
     appendAutotilingSchema(s);
+    appendScrollingSchema(s);
 
     return s;
 }
@@ -55,6 +56,25 @@ auto clampDouble(double minVal, double maxVal)
 {
     return [minVal, maxVal](const QVariant& v) -> QVariant {
         return qBound(minVal, v.toDouble(), maxVal);
+    };
+}
+
+/// Canonicalize a fraction list: coerce each entry to a double clamped into
+/// [minVal, maxVal], dropping non-numeric entries. Used by the scroll-mode
+/// preset width / height lists — each entry is a fraction of the working area.
+auto clampFractionList(double minVal, double maxVal)
+{
+    return [minVal, maxVal](const QVariant& v) -> QVariant {
+        QVariantList out;
+        const QVariantList raw = v.toList();
+        for (const QVariant& entry : raw) {
+            bool ok = false;
+            const double d = entry.toDouble(&ok);
+            if (ok) {
+                out.append(qBound(minVal, d, maxVal));
+            }
+        }
+        return QVariant(out);
     };
 }
 
@@ -842,6 +862,47 @@ void appendAutotilingSchema(PhosphorConfig::Schema& schema)
          {},
          clampInt(CD::autotileOuterGapRightMin(), CD::autotileOuterGapRightMax())},
         {CD::smartGapsKey(), CD::autotileSmartGaps(), QMetaType::Bool},
+    };
+}
+
+// ─── Scrolling mode (niri-style scrollable tiling) ──────────────────────────
+// Scrolling.Gaps reuses innerKey / outerKey (the group disambiguates).
+// Scrolling.Layout holds the default new-column width, the viewport centering
+// toggle, and the two cycle-preset lists — QVariantLists of fractions of the
+// working area.
+
+void appendScrollingSchema(PhosphorConfig::Schema& schema)
+{
+    using CD = ConfigDefaults;
+    schema.groups[CD::scrollingGapsGroup()] = {
+        {CD::innerKey(),
+         CD::scrollInnerGap(),
+         QMetaType::Int,
+         {},
+         clampInt(CD::scrollInnerGapMin(), CD::scrollInnerGapMax())},
+        {CD::outerKey(),
+         CD::scrollOuterGap(),
+         QMetaType::Int,
+         {},
+         clampInt(CD::scrollOuterGapMin(), CD::scrollOuterGapMax())},
+    };
+    schema.groups[CD::scrollingLayoutGroup()] = {
+        {CD::defaultColumnWidthKey(),
+         CD::scrollDefaultColumnWidth(),
+         QMetaType::Double,
+         {},
+         clampDouble(CD::scrollColumnWidthMin(), CD::scrollColumnWidthMax())},
+        {CD::centerFocusedColumnKey(), CD::scrollCenterFocusedColumn(), QMetaType::Bool},
+        {CD::presetColumnWidthsKey(),
+         CD::scrollPresetColumnWidths(),
+         QMetaType::QVariantList,
+         {},
+         clampFractionList(CD::scrollColumnWidthMin(), CD::scrollColumnWidthMax())},
+        {CD::presetWindowHeightsKey(),
+         CD::scrollPresetWindowHeights(),
+         QMetaType::QVariantList,
+         {},
+         clampFractionList(CD::scrollColumnWidthMin(), CD::scrollColumnWidthMax())},
     };
 }
 

--- a/src/config/settingsschema.h
+++ b/src/config/settingsschema.h
@@ -16,12 +16,21 @@
 
 #include <PhosphorConfig/Schema.h>
 
+#include <QVariant>
+#include <QVariantList>
+
 namespace PlasmaZones {
 
 /// Returns the full PZ settings schema, populated with every group migrated
 /// to PhosphorConfig::Store so far. Called once during Settings construction
 /// and handed to Store; add new groups here as they're migrated.
 PLASMAZONES_EXPORT PhosphorConfig::Schema buildSettingsSchema();
+
+/// Canonicalize a fraction list: coerce each entry to a double clamped into
+/// [minVal, maxVal], dropping non-numeric entries. Shared by the scroll-mode
+/// schema validators and the per-screen scroll override validator so a global
+/// and a per-screen preset list are range-checked identically.
+QVariantList clampFractionListValue(const QVariant& value, double minVal, double maxVal);
 
 // ─── Group helpers ──────────────────────────────────────────────────────────
 // Each helper appends one group's KeyDefs to the schema. Kept as free

--- a/src/config/settingsschema.h
+++ b/src/config/settingsschema.h
@@ -43,5 +43,6 @@ void appendZoneSelectorSchema(PhosphorConfig::Schema& schema);
 void appendActivationSchema(PhosphorConfig::Schema& schema);
 void appendBehaviorSchema(PhosphorConfig::Schema& schema);
 void appendAutotilingSchema(PhosphorConfig::Schema& schema);
+void appendScrollingSchema(PhosphorConfig::Schema& schema);
 
 } // namespace PlasmaZones

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -163,6 +163,22 @@ public:
     virtual bool autotileDragInsertToggle() const = 0;
     virtual void setAutotileDragInsertToggle(bool enable) = 0;
 
+    // Scroll-mode (niri-style scrollable tiling) settings. The daemon pushes
+    // these to ScrollEngine / the geometry resolver; the standalone settings
+    // app and KCM edit them. Preset lists are QVariantList of doubles.
+    virtual int scrollInnerGap() const = 0;
+    virtual void setScrollInnerGap(int gap) = 0;
+    virtual int scrollOuterGap() const = 0;
+    virtual void setScrollOuterGap(int gap) = 0;
+    virtual double scrollDefaultColumnWidth() const = 0;
+    virtual void setScrollDefaultColumnWidth(double fraction) = 0;
+    virtual bool scrollCenterFocusedColumn() const = 0;
+    virtual void setScrollCenterFocusedColumn(bool center) = 0;
+    virtual QVariantList scrollPresetColumnWidths() const = 0;
+    virtual void setScrollPresetColumnWidths(const QVariantList& fractions) = 0;
+    virtual QVariantList scrollPresetWindowHeights() const = 0;
+    virtual void setScrollPresetWindowHeights(const QVariantList& fractions) = 0;
+
     // Rendering backend (pipeline-level, not specific to any sub-interface)
     virtual QString renderingBackend() const = 0;
     virtual void setRenderingBackend(const QString& backend) = 0;
@@ -222,6 +238,22 @@ public:
     {
     }
     virtual bool hasPerScreenSnappingSettings(const QString& /*screenIdOrName*/) const
+    {
+        return false;
+    }
+
+    virtual QVariantMap getPerScreenScrollSettings(const QString& /*screenIdOrName*/) const
+    {
+        return {};
+    }
+    virtual void setPerScreenScrollSetting(const QString& /*screenIdOrName*/, const QString& /*key*/,
+                                           const QVariant& /*value*/)
+    {
+    }
+    virtual void clearPerScreenScrollSettings(const QString& /*screenIdOrName*/)
+    {
+    }
+    virtual bool hasPerScreenScrollSettings(const QString& /*screenIdOrName*/) const
     {
         return false;
     }
@@ -322,6 +354,7 @@ Q_SIGNALS:
     void perScreenZoneSelectorSettingsChanged();
     void perScreenAutotileSettingsChanged();
     void perScreenSnappingSettingsChanged();
+    void perScreenScrollSettingsChanged();
     // Rendering
     void renderingBackendChanged();
     // Shader effects
@@ -468,6 +501,14 @@ Q_SIGNALS:
     void autotileDecMasterCountShortcutChanged();
     void autotileIncMasterRatioShortcutChanged();
     void autotileDecMasterRatioShortcutChanged();
+
+    // Scroll-mode settings
+    void scrollInnerGapChanged();
+    void scrollOuterGapChanged();
+    void scrollDefaultColumnWidthChanged();
+    void scrollCenterFocusedColumnChanged();
+    void scrollPresetColumnWidthsChanged();
+    void scrollPresetWindowHeightsChanged();
 };
 
 } // namespace PlasmaZones

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -105,6 +105,24 @@ inline constexpr QLatin1String ZoneSelectorPreviewWidth{"ZoneSelectorPreviewWidt
 inline constexpr QLatin1String ZoneSelectorPreviewHeight{"ZoneSelectorPreviewHeight"};
 } // namespace PerScreenSnappingKey
 
+/**
+ * Per-screen scrolling-mode override key constants.
+ *
+ * Used in config group keys ([ScrollingScreen:ScreenId]), QVariantMap override
+ * storage, and QML writeSetting() calls. Short keys with no mode prefix — the
+ * ScrollingScreen: group already scopes them (mirrors ZoneSelectorConfigKey,
+ * unlike the prefixed PerScreenAutotileKey). The preset keys carry QVariantList
+ * values; the rest are scalars.
+ */
+namespace PerScreenScrollKey {
+inline constexpr const char InnerGap[] = "InnerGap";
+inline constexpr const char OuterGap[] = "OuterGap";
+inline constexpr const char DefaultColumnWidth[] = "DefaultColumnWidth";
+inline constexpr const char CenterFocusedColumn[] = "CenterFocusedColumn";
+inline constexpr const char PresetColumnWidths[] = "PresetColumnWidths";
+inline constexpr const char PresetWindowHeights[] = "PresetWindowHeights";
+} // namespace PerScreenScrollKey
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Settings Interfaces
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/core/unifiedlayoutlist.cpp
+++ b/src/core/unifiedlayoutlist.cpp
@@ -10,6 +10,7 @@
 
 #include <PhosphorLayoutApi/AspectRatioClass.h>
 #include <PhosphorLayoutApi/ILayoutSource.h>
+#include <PhosphorLayoutApi/LayoutId.h>
 #include <PhosphorScreens/ScreenIdentity.h>
 #include <PhosphorTiles/AutotileLayoutSource.h>
 #include <PhosphorTiles/AutotilePreviewRender.h>
@@ -146,6 +147,31 @@ void appendAutotilePreviews(QVector<LayoutPreview>& list, PhosphorTiles::ITileAl
     }
 }
 
+/// Build the single synthetic "Scrolling" entry that lets the picker assign
+/// niri-style scrolling mode to a screen. There is exactly one such entry (the
+/// ScrollEngine needs no per-algorithm setup), so it is appended
+/// unconditionally — analogous to there always being at least one autotile
+/// algorithm. The bare `"scroll:"` id round-trips through
+/// AssignmentEntry::fromLayoutId() to Mode::Scroll.
+LayoutPreview makeScrollPreview()
+{
+    LayoutPreview preview;
+    preview.id = PhosphorLayout::LayoutId::makeScrollId(QString());
+    preview.displayName = PzI18n::tr("Scrolling");
+    preview.description = PzI18n::tr("niri-style scrollable tiling — an unbounded horizontal strip of columns");
+    preview.isSystem = true;
+    preview.zoneCount = LayoutPreview::UnlimitedZoneCount;
+    // Three side-by-side column rects in 0..1 space suggesting a horizontal
+    // strip. zoneNumbers left empty (the strip is unbounded — no fixed count).
+    preview.zones = {
+        QRectF(0.04, 0.08, 0.28, 0.84),
+        QRectF(0.36, 0.08, 0.28, 0.84),
+        QRectF(0.68, 0.08, 0.28, 0.84),
+    };
+    // algorithm left unset so isAutotile() stays false.
+    return preview;
+}
+
 bool defaultPreviewLessThan(const LayoutPreview& a, const LayoutPreview& b)
 {
     if (a.recommended != b.recommended) {
@@ -216,6 +242,9 @@ QVector<LayoutPreview> buildUnifiedLayoutList(PhosphorZones::IZoneLayoutRegistry
     if (includeAutotile) {
         appendAutotilePreviews(list, algorithmRegistry, autotileSource, autotilePreviewCanvas);
     }
+
+    // Synthetic scroll-mode entry — always present, like autotile.
+    list.append(makeScrollPreview());
 
     sortPreviews(list, customOrder);
 
@@ -297,6 +326,9 @@ QVector<LayoutPreview> buildUnifiedLayoutList(PhosphorZones::IZoneLayoutRegistry
     if (includeAutotile) {
         appendAutotilePreviews(list, algorithmRegistry, autotileSource, autotilePreviewCanvas);
     }
+
+    // Synthetic scroll-mode entry — always present, like autotile.
+    list.append(makeScrollPreview());
 
     sortPreviews(list, customOrder);
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -990,6 +990,22 @@ bool Daemon::init()
 
     autotileEngine->refreshConfigFromSettings();
 
+    // Restore the persisted scroll strip before pushing config, so a restored
+    // strip is resolved against the current scroll settings.
+    loadScrollState();
+
+    // Push scroll-mode settings into ScrollEngine, and keep them in sync: each
+    // scroll setting has its own change signal, so connecting them individually
+    // (rather than the catch-all settingsChanged) keeps the strip re-resolve
+    // off the hot path of unrelated settings edits.
+    refreshScrollConfigFromSettings();
+    for (const auto signal : {&ISettings::scrollInnerGapChanged, &ISettings::scrollOuterGapChanged,
+                              &ISettings::scrollDefaultColumnWidthChanged, &ISettings::scrollCenterFocusedColumnChanged,
+                              &ISettings::scrollPresetColumnWidthsChanged, &ISettings::scrollPresetWindowHeightsChanged,
+                              &ISettings::perScreenScrollSettingsChanged}) {
+        connect(m_settings.get(), signal, this, &Daemon::refreshScrollConfigFromSettings);
+    }
+
     // Give the window drag adaptor access to the autotile engine for per-screen
     // autotile checks (overlay suppression and snap rejection on autotile screens).
     // Uses the base-class pointer — WDA only needs isActiveOnScreen().
@@ -1483,6 +1499,8 @@ void Daemon::stop()
     if (m_windowTrackingAdaptor) {
         m_windowTrackingAdaptor->saveStateOnShutdown();
     }
+    // Persist the scroll strip before the engines are destroyed below.
+    saveScrollState();
 
     // ModeTracker delegates to LayoutManager's KConfig — no separate save needed
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -435,7 +435,9 @@ private:
      * to scroll-session.json on shutdown; loadScrollState() feeds it back
      * through deserializeEngineState() at startup, before the effect re-reports
      * windows (a still-existing window's windowOpened then no-ops, keeping its
-     * restored column).
+     * restored column). A restored window that did not survive the restart is
+     * pruned by ScrollEngine::reconcileRestoredWindows() when the effect's first
+     * windowsOpenedBatch arrives, so no phantom column lingers.
      */
     void saveScrollState();
     void loadScrollState();

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -417,6 +417,10 @@ private:
      * viewport-centering mode from Settings into ScrollEngine, then re-resolves
      * each active scroll strip so gap / preset / centering changes take effect
      * immediately. Invoked once at startup and on any scroll settings change.
+     *
+     * At the startup invocation no scroll screen is active yet, so only the
+     * engine-global config is seeded; the per-screen-override push and the
+     * strip re-resolve are picked up by the first updateScrollScreens().
      */
     void refreshScrollConfigFromSettings();
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -44,6 +44,10 @@ namespace PhosphorEngine {
 class WindowRegistry;
 }
 
+namespace PhosphorScrollEngine {
+class ScrollEngine;
+}
+
 namespace PhosphorWorkspaces {
 class ActivityManager;
 class VirtualDesktopManager;
@@ -441,6 +445,16 @@ private:
      */
     void saveScrollState();
     void loadScrollState();
+
+    /**
+     * @brief The scroll placement engine narrowed to its concrete type.
+     *
+     * m_scrollEngine is held as the base PlacementEngineBase pointer, but the
+     * scroll-specific config / persistence / reconciliation API lives on
+     * ScrollEngine. Centralises the down-cast the scroll handlers all need;
+     * returns nullptr when no scroll engine is active.
+     */
+    PhosphorScrollEngine::ScrollEngine* scrollEngine() const;
 
     /**
      * @brief Respond to a Phosphor::Screens::ScreenManager VS cache change for a physical screen

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -406,6 +406,41 @@ private:
     void onScrollPlacementChanged(const QString& screenId);
 
     /**
+     * @brief Push scroll-mode settings to ScrollEngine and re-resolve every
+     *        active scroll screen.
+     *
+     * Pushes the preset width/height lists, the default-column-width and the
+     * viewport-centering mode from Settings into ScrollEngine, then re-resolves
+     * each active scroll strip so gap / preset / centering changes take effect
+     * immediately. Invoked once at startup and on any scroll settings change.
+     */
+    void refreshScrollConfigFromSettings();
+
+    /**
+     * @brief Push each active scroll screen's per-screen override map into
+     *        ScrollEngine.
+     *
+     * Mirrors updateAutotileScreens()' per-screen autotile push: reads
+     * Settings::getPerScreenScrollSettings() for every active scroll screen
+     * and hands it to ScrollEngine::applyPerScreenConfig (or clears it). The
+     * engine's effective*() accessors then resolve override → global default.
+     */
+    void applyPerScreenScrollOverrides();
+
+    /**
+     * @brief Persist / restore the scroll-mode strip state across a restart.
+     *
+     * ScrollEngine is geometry-agnostic and daemon-orchestrated, so the daemon
+     * owns its disk persistence: saveScrollState() writes serializeEngineState()
+     * to scroll-session.json on shutdown; loadScrollState() feeds it back
+     * through deserializeEngineState() at startup, before the effect re-reports
+     * windows (a still-existing window's windowOpened then no-ops, keeping its
+     * restored column).
+     */
+    void saveScrollState();
+    void loadScrollState();
+
+    /**
      * @brief Respond to a Phosphor::Screens::ScreenManager VS cache change for a physical screen
      *
      * Wired to Phosphor::Screens::ScreenManager::virtualScreensChanged. Performs the post-change

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -256,12 +256,15 @@ void Daemon::handleShrinkColumnWidth()
 
 void Daemon::handleToggleCenterFocusedColumn()
 {
-    // Toggle the viewport between fit and centered. Scroll-mode only; skipped
-    // on snap/autotile screens (see handleConsume).
-    NavigationContext ctx;
-    if (auto* nav = scrollNavigatorForShortcut(m_screenModeRouter.get(), m_windowTrackingAdaptor, ctx,
-                                               "ToggleCenterFocusedColumn")) {
-        nav->toggleCenterFocusedColumn(ctx);
+    // Scroll mode: toggle the persisted viewport-centering setting. Phase 5
+    // makes the centering mode a setting, so the shortcut flips the setting —
+    // the change signal re-pushes it to ScrollEngine and re-resolves every
+    // scroll strip via refreshScrollConfigFromSettings(). Flipped
+    // unconditionally, like a settings-UI edit: the viewport mode is
+    // engine-global, so it must not be gated on the focused screen being a
+    // scroll screen.
+    if (m_settings) {
+        m_settings->setScrollCenterFocusedColumn(!m_settings->scrollCenterFocusedColumn());
     }
 }
 

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -11,6 +11,7 @@
 #include <PhosphorEngine/IScrollNavigation.h>
 #include "../../core/logging.h"
 #include "../../core/screenmoderouter.h"
+#include "../../core/settings_interfaces.h"
 #include "../../core/utils.h"
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorScreens/Swapper.h>

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -257,15 +257,29 @@ void Daemon::handleShrinkColumnWidth()
 void Daemon::handleToggleCenterFocusedColumn()
 {
     // Scroll mode: toggle the persisted viewport-centering setting. Phase 5
-    // makes the centering mode a setting, so the shortcut flips the setting —
-    // the change signal re-pushes it to ScrollEngine and re-resolves every
-    // scroll strip via refreshScrollConfigFromSettings(). Flipped
-    // unconditionally, like a settings-UI edit: the viewport mode is
-    // engine-global, so it must not be gated on the focused screen being a
-    // scroll screen.
-    if (m_settings) {
-        m_settings->setScrollCenterFocusedColumn(!m_settings->scrollCenterFocusedColumn());
+    // makes the centering mode a setting, so the shortcut flips it — the
+    // change signal re-pushes it to ScrollEngine and re-resolves every scroll
+    // strip via refreshScrollConfigFromSettings().
+    //
+    // The focused screen may carry a per-screen CenterFocusedColumn override,
+    // which shadows the global value (ScrollEngine::effectiveViewportMode).
+    // Flipping the global on such a screen would be a silent no-op, so the
+    // shortcut targets whichever level is actually in effect for that screen:
+    // the per-screen override when one exists, the global setting otherwise.
+    if (!m_settings) {
+        return;
     }
+    const QString screenId = resolveShortcutScreenId(m_screenManager.get(), m_windowTrackingAdaptor);
+    if (!screenId.isEmpty()) {
+        const QVariantMap overrides = m_settings->getPerScreenScrollSettings(screenId);
+        const auto it = overrides.constFind(QLatin1String(PerScreenScrollKey::CenterFocusedColumn));
+        if (it != overrides.constEnd()) {
+            m_settings->setPerScreenScrollSetting(screenId, QLatin1String(PerScreenScrollKey::CenterFocusedColumn),
+                                                  !it.value().toBool());
+            return;
+        }
+    }
+    m_settings->setScrollCenterFocusedColumn(!m_settings->scrollCenterFocusedColumn());
 }
 
 void Daemon::handleRestore()

--- a/src/daemon/daemon/scroll.cpp
+++ b/src/daemon/daemon/scroll.cpp
@@ -6,8 +6,8 @@
 #include "../../core/logging.h"
 #include "../../dbus/scrolladaptor.h"
 #include "../../dbus/windowtrackingadaptor.h"
-#include "../config/configdefaults.h"
-#include "../config/settings.h"
+#include "../../config/configdefaults.h"
+#include "../../config/settings.h"
 #include <PhosphorEngine/IPlacementEngine.h>
 #include <PhosphorIdentity/VirtualScreenId.h>
 #include <PhosphorProtocol/WindowTypes.h>
@@ -37,6 +37,11 @@
 #include <QVector>
 
 namespace PlasmaZones {
+
+PhosphorScrollEngine::ScrollEngine* Daemon::scrollEngine() const
+{
+    return dynamic_cast<PhosphorScrollEngine::ScrollEngine*>(m_scrollEngine.get());
+}
 
 void Daemon::updateScrollScreens()
 {
@@ -70,14 +75,24 @@ void Daemon::updateScrollScreens()
     // A screen entering scroll mode needs its per-screen overrides in the
     // engine before its windows resolve geometry.
     applyPerScreenScrollOverrides();
-    if (screensChanged && m_scrollAdaptor) {
-        // Tell the KWin effect which screens are scroll-mode so it reports
-        // their windows to the org.plasmazones.Scroll interface. The payload
-        // is sourced from ScrollAdaptor::scrollScreens() — the same accessor
-        // that backs the scrollScreens property — so the signal and a
-        // subsequent property read cannot disagree. It is sorted there, since
-        // QSet iteration order is unspecified.
-        Q_EMIT m_scrollAdaptor->scrollScreensChanged(m_scrollAdaptor->scrollScreens());
+    if (screensChanged) {
+        // Resolve every active scroll strip now. setActiveScreens() emits no
+        // placementChanged, and a restored window's windowOpened no-ops
+        // (already tracked), so a strip restored from scroll-session.json — or
+        // a screen newly entering scroll mode — would otherwise never be
+        // pushed to the effect. onScrollPlacementChanged no-ops for a screen
+        // with no strip yet.
+        for (const QString& screenId : scrollScreens) {
+            onScrollPlacementChanged(screenId);
+        }
+        if (m_scrollAdaptor) {
+            // Tell the KWin effect which screens are scroll-mode so it reports
+            // their windows to the org.plasmazones.Scroll interface. The
+            // payload is sourced from ScrollAdaptor::scrollScreens() — the same
+            // accessor that backs the scrollScreens property — so the signal
+            // and a subsequent property read cannot disagree.
+            Q_EMIT m_scrollAdaptor->scrollScreensChanged(m_scrollAdaptor->scrollScreens());
+        }
     }
     qCDebug(lcDaemon) << "Updated scroll screens=" << scrollScreens;
 }
@@ -89,7 +104,7 @@ void Daemon::onScrollPlacementChanged(const QString& screenId)
     }
     // ScrollEngine is geometry-agnostic — it stores the strip; the daemon
     // resolves it to pixels because only the daemon knows the working area.
-    auto* scroll = dynamic_cast<PhosphorScrollEngine::ScrollEngine*>(m_scrollEngine.get());
+    auto* scroll = scrollEngine();
     if (!scroll) {
         return;
     }
@@ -149,7 +164,7 @@ void Daemon::refreshScrollConfigFromSettings()
     if (!m_scrollEngine || !m_settings) {
         return;
     }
-    auto* scroll = dynamic_cast<PhosphorScrollEngine::ScrollEngine*>(m_scrollEngine.get());
+    auto* scroll = scrollEngine();
     if (!scroll) {
         return;
     }
@@ -184,7 +199,7 @@ void Daemon::applyPerScreenScrollOverrides()
     if (!m_scrollEngine || !m_settings) {
         return;
     }
-    auto* scroll = dynamic_cast<PhosphorScrollEngine::ScrollEngine*>(m_scrollEngine.get());
+    auto* scroll = scrollEngine();
     if (!scroll) {
         return;
     }
@@ -204,7 +219,7 @@ void Daemon::applyPerScreenScrollOverrides()
 
 void Daemon::saveScrollState()
 {
-    auto* scroll = dynamic_cast<PhosphorScrollEngine::ScrollEngine*>(m_scrollEngine.get());
+    auto* scroll = scrollEngine();
     if (!scroll) {
         return;
     }
@@ -233,7 +248,7 @@ void Daemon::saveScrollState()
 
 void Daemon::loadScrollState()
 {
-    auto* scroll = dynamic_cast<PhosphorScrollEngine::ScrollEngine*>(m_scrollEngine.get());
+    auto* scroll = scrollEngine();
     if (!scroll) {
         return;
     }

--- a/src/daemon/daemon/scroll.cpp
+++ b/src/daemon/daemon/scroll.cpp
@@ -6,6 +6,7 @@
 #include "../../core/logging.h"
 #include "../../dbus/scrolladaptor.h"
 #include "../../dbus/windowtrackingadaptor.h"
+#include "../config/configdefaults.h"
 #include "../config/settings.h"
 #include <PhosphorEngine/IPlacementEngine.h>
 #include <PhosphorIdentity/VirtualScreenId.h>
@@ -17,23 +18,24 @@
 #include <PhosphorScrollEngine/ScrollScreenState.h>
 #include <PhosphorZones/LayoutRegistry.h>
 
+#include <QFile>
 #include <QHash>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
 #include <QRect>
 #include <QRectF>
 #include <QScreen>
 #include <QSet>
 #include <QString>
 #include <QStringList>
+#include <QVariant>
+#include <QVariantList>
+#include <QVariantMap>
+#include <QVector>
 
 namespace PlasmaZones {
-
-namespace {
-// Scroll-mode layout gaps in logical pixels. The outer gap insets the strip
-// from the working-area edges; the inner gap separates adjacent columns and
-// the tiles within a column.
-constexpr qreal SCROLL_OUTER_GAP = 8.0;
-constexpr qreal SCROLL_INNER_GAP = 8.0;
-} // anonymous namespace
 
 void Daemon::updateScrollScreens()
 {
@@ -64,6 +66,9 @@ void Daemon::updateScrollScreens()
 
     const bool screensChanged = (m_scrollEngine->activeScreens() != scrollScreens);
     m_scrollEngine->setActiveScreens(scrollScreens);
+    // A screen entering scroll mode needs its per-screen overrides in the
+    // engine before its windows resolve geometry.
+    applyPerScreenScrollOverrides();
     if (screensChanged && m_scrollAdaptor) {
         // Tell the KWin effect which screens are scroll-mode so it reports
         // their windows to the org.plasmazones.Scroll interface. The payload
@@ -105,12 +110,14 @@ void Daemon::onScrollPlacementChanged(const QString& screenId)
     }
 
     PhosphorScrollEngine::ScrollLayoutConfig config;
-    config.outerGap = SCROLL_OUTER_GAP;
-    config.innerGap = SCROLL_INNER_GAP;
-    config.presetWindowHeights = scroll->presetWindowHeights();
-    // Viewport mode is engine-global, toggled at runtime by the center-column
-    // shortcut.
-    config.viewportMode = scroll->viewportMode();
+    // Gaps (logical px): the outer gap insets the strip from the working-area
+    // edges; the inner gap separates adjacent columns and the tiles within a
+    // column. The engine resolves each value as a per-screen override over the
+    // global default — see ScrollEngine::effective*().
+    config.outerGap = scroll->effectiveOuterGap(screenId);
+    config.innerGap = scroll->effectiveInnerGap(screenId);
+    config.presetWindowHeights = scroll->effectivePresetWindowHeights(screenId);
+    config.viewportMode = scroll->effectiveViewportMode(screenId);
 
     // Column metrics are scroll-independent — resolve them once and feed the
     // same value to both the viewport computation and the geometry resolve.
@@ -134,6 +141,114 @@ void Daemon::onScrollPlacementChanged(const QString& screenId)
         batch.append(PhosphorProtocol::WindowGeometryEntry::fromRect(it.key(), it.value().toRect(), screenId));
     }
     Q_EMIT m_windowTrackingAdaptor->applyGeometriesBatch(batch, QStringLiteral("scroll"));
+}
+
+void Daemon::refreshScrollConfigFromSettings()
+{
+    if (!m_scrollEngine || !m_settings) {
+        return;
+    }
+    auto* scroll = dynamic_cast<PhosphorScrollEngine::ScrollEngine*>(m_scrollEngine.get());
+    if (!scroll) {
+        return;
+    }
+
+    // Coerce a persisted QVariantList of fractions into the engine's typed
+    // QVector<qreal>. Non-numeric junk is already dropped by the schema's
+    // clampFractionList validator, so a plain toReal() per entry suffices.
+    const auto toFractions = [](const QVariantList& list) {
+        QVector<qreal> out;
+        out.reserve(list.size());
+        for (const QVariant& v : list) {
+            out.append(v.toReal());
+        }
+        return out;
+    };
+
+    // Global defaults. Per-screen overrides layer on top via the engine's
+    // effective*() accessors — see applyPerScreenScrollOverrides() below.
+    scroll->setPresetColumnWidths(toFractions(m_settings->scrollPresetColumnWidths()));
+    scroll->setPresetWindowHeights(toFractions(m_settings->scrollPresetWindowHeights()));
+    scroll->setDefaultColumnWidth(m_settings->scrollDefaultColumnWidth());
+    scroll->setInnerGap(m_settings->scrollInnerGap());
+    scroll->setOuterGap(m_settings->scrollOuterGap());
+    scroll->setViewportMode(m_settings->scrollCenterFocusedColumn() ? PhosphorScrollEngine::ScrollViewportMode::Centered
+                                                                    : PhosphorScrollEngine::ScrollViewportMode::Fit);
+
+    applyPerScreenScrollOverrides();
+
+    // Re-resolve every active scroll strip so a gap / preset / centering change
+    // surfaces immediately. onScrollPlacementChanged reads the just-updated
+    // engine config (global + per-screen) when it builds the layout config.
+    const QSet<QString> screens = m_scrollEngine->activeScreens();
+    for (const QString& screenId : screens) {
+        onScrollPlacementChanged(screenId);
+    }
+}
+
+void Daemon::applyPerScreenScrollOverrides()
+{
+    if (!m_scrollEngine || !m_settings) {
+        return;
+    }
+    auto* scroll = dynamic_cast<PhosphorScrollEngine::ScrollEngine*>(m_scrollEngine.get());
+    if (!scroll) {
+        return;
+    }
+    // Push each active scroll screen's per-screen override map into the engine
+    // (mirrors updateAutotileScreens' per-screen autotile push). The engine's
+    // effective*() accessors then resolve override → global per screen.
+    const QSet<QString> screens = m_scrollEngine->activeScreens();
+    for (const QString& screenId : screens) {
+        const QVariantMap overrides = m_settings->getPerScreenScrollSettings(screenId);
+        if (overrides.isEmpty()) {
+            scroll->clearPerScreenConfig(screenId);
+        } else {
+            scroll->applyPerScreenConfig(screenId, overrides);
+        }
+    }
+}
+
+void Daemon::saveScrollState()
+{
+    auto* scroll = dynamic_cast<PhosphorScrollEngine::ScrollEngine*>(m_scrollEngine.get());
+    if (!scroll) {
+        return;
+    }
+    const QString path = ConfigDefaults::scrollStateFilePath();
+    const QJsonObject state = scroll->serializeEngineState();
+    if (state.value(QLatin1String("states")).toArray().isEmpty()) {
+        // No strips to persist — drop any stale file so a later restart does
+        // not restore an obsolete layout.
+        QFile::remove(path);
+        return;
+    }
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qCWarning(lcDaemon) << "Failed to write scroll state to" << path;
+        return;
+    }
+    file.write(QJsonDocument(state).toJson(QJsonDocument::Compact));
+}
+
+void Daemon::loadScrollState()
+{
+    auto* scroll = dynamic_cast<PhosphorScrollEngine::ScrollEngine*>(m_scrollEngine.get());
+    if (!scroll) {
+        return;
+    }
+    QFile file(ConfigDefaults::scrollStateFilePath());
+    if (!file.exists() || !file.open(QIODevice::ReadOnly)) {
+        return;
+    }
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        qCWarning(lcDaemon) << "Ignoring malformed scroll state:" << err.errorString();
+        return;
+    }
+    scroll->deserializeEngineState(doc.object());
+    qCDebug(lcDaemon) << "Restored scroll state from" << file.fileName();
 }
 
 } // namespace PlasmaZones

--- a/src/daemon/daemon/scroll.cpp
+++ b/src/daemon/daemon/scroll.cpp
@@ -26,6 +26,7 @@
 #include <QJsonParseError>
 #include <QRect>
 #include <QRectF>
+#include <QSaveFile>
 #include <QScreen>
 #include <QSet>
 #include <QString>
@@ -153,22 +154,14 @@ void Daemon::refreshScrollConfigFromSettings()
         return;
     }
 
-    // Coerce a persisted QVariantList of fractions into the engine's typed
-    // QVector<qreal>. Non-numeric junk is already dropped by the schema's
-    // clampFractionList validator, so a plain toReal() per entry suffices.
-    const auto toFractions = [](const QVariantList& list) {
-        QVector<qreal> out;
-        out.reserve(list.size());
-        for (const QVariant& v : list) {
-            out.append(v.toReal());
-        }
-        return out;
-    };
-
     // Global defaults. Per-screen overrides layer on top via the engine's
     // effective*() accessors — see applyPerScreenScrollOverrides() below.
-    scroll->setPresetColumnWidths(toFractions(m_settings->scrollPresetColumnWidths()));
-    scroll->setPresetWindowHeights(toFractions(m_settings->scrollPresetWindowHeights()));
+    // ScrollEngine::toFractionVector coerces the persisted QVariantList into
+    // the engine's typed QVector<qreal>; non-numeric junk is already dropped by
+    // the schema's clampFractionList validator.
+    using PhosphorScrollEngine::ScrollEngine;
+    scroll->setPresetColumnWidths(ScrollEngine::toFractionVector(m_settings->scrollPresetColumnWidths()));
+    scroll->setPresetWindowHeights(ScrollEngine::toFractionVector(m_settings->scrollPresetWindowHeights()));
     scroll->setDefaultColumnWidth(m_settings->scrollDefaultColumnWidth());
     scroll->setInnerGap(m_settings->scrollInnerGap());
     scroll->setOuterGap(m_settings->scrollOuterGap());
@@ -223,12 +216,19 @@ void Daemon::saveScrollState()
         QFile::remove(path);
         return;
     }
-    QFile file(path);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    // QSaveFile commits atomically (write to a temp file, then rename), so a
+    // crash mid-write cannot leave a truncated scroll-session.json behind.
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly)) {
         qCWarning(lcDaemon) << "Failed to write scroll state to" << path;
         return;
     }
     file.write(QJsonDocument(state).toJson(QJsonDocument::Compact));
+    if (!file.commit()) {
+        qCWarning(lcDaemon) << "Failed to commit scroll state to" << path;
+        return;
+    }
+    qCDebug(lcDaemon) << "Saved scroll state to" << path;
 }
 
 void Daemon::loadScrollState()

--- a/src/daemon/daemon/scroll.cpp
+++ b/src/daemon/daemon/scroll.cpp
@@ -20,7 +20,6 @@
 
 #include <QFile>
 #include <QHash>
-#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
@@ -224,13 +223,13 @@ void Daemon::saveScrollState()
         return;
     }
     const QString path = ConfigDefaults::scrollStateFilePath();
-    const QJsonObject state = scroll->serializeEngineState();
-    if (state.value(QLatin1String("states")).toArray().isEmpty()) {
+    if (!scroll->hasPersistableState()) {
         // No strips to persist — drop any stale file so a later restart does
         // not restore an obsolete layout.
         QFile::remove(path);
         return;
     }
+    const QJsonObject state = scroll->serializeEngineState();
     // QSaveFile commits atomically (write to a temp file, then rename), so a
     // crash mid-write cannot leave a truncated scroll-session.json behind.
     QSaveFile file(path);

--- a/src/daemon/unifiedlayoutcontroller.cpp
+++ b/src/daemon/unifiedlayoutcontroller.cpp
@@ -9,6 +9,7 @@
 #include "../core/logging.h"
 #include "../core/utils.h"
 #include <PhosphorLayoutApi/ILayoutSource.h>
+#include <PhosphorLayoutApi/LayoutId.h>
 #include <PhosphorTiles/AlgorithmRegistry.h>
 #include <PhosphorTiles/ITileAlgorithmRegistry.h>
 
@@ -275,6 +276,26 @@ bool UnifiedLayoutController::applyEntry(const PhosphorLayout::LayoutPreview& pr
             return true;
         }
         qCWarning(lcDaemon) << "applyEntry: autotile engine not available for" << preview.id;
+        return false;
+    }
+
+    // Handle the synthetic scroll entry: assign the "scroll:" id to the
+    // current screen. Unlike autotile there is no engine call — the
+    // ScrollEngine needs no per-algorithm setup; the daemon's layoutAssigned
+    // handler derives per-screen scroll state from the assignment cascade.
+    if (PhosphorLayout::LayoutId::isScroll(preview.id)) {
+        if (m_layoutManager && !m_currentScreenName.isEmpty()) {
+            // Write to the current context (screen, desktop, activity) —
+            // most specific context wins in the assignment cascade.
+            m_layoutManager->assignLayoutById(m_currentScreenName, m_currentVirtualDesktop, m_currentActivity,
+                                              preview.id);
+            setCurrentLayoutId(preview.id);
+            qCInfo(lcDaemon) << "Applied scroll mode=" << preview.displayName << "screen=" << m_currentScreenName;
+            // No scroll-specific applied signal exists (cf. autotileApplied) —
+            // nothing to emit here.
+            return true;
+        }
+        qCWarning(lcDaemon) << "applyEntry: layout manager or screen unavailable for scroll entry" << preview.id;
         return false;
     }
 

--- a/src/dbus/scrolladaptor.cpp
+++ b/src/dbus/scrolladaptor.cpp
@@ -64,9 +64,17 @@ void ScrollAdaptor::windowsOpenedBatch(const PhosphorProtocol::WindowOpenedList&
     // per-entry minWidth/minHeight; scroll's strip model is size-agnostic and
     // ignores them (non-resizable windows are fitted to the tile slot
     // effect-side), so only windowId/screenId are forwarded.
+    QSet<QString> liveWindowIds;
+    liveWindowIds.reserve(entries.size());
     for (const PhosphorProtocol::WindowOpenedEntry& entry : entries) {
         m_engine->windowOpened(entry.windowId, entry.screenId);
+        liveWindowIds.insert(entry.windowId);
     }
+    // The effect's first batch after a daemon (re)connect is the complete live
+    // scroll-window set across every scroll screen — reconcile a just-restored
+    // strip against it so a window closed while the daemon was down leaves no
+    // phantom column. A no-op on every later (routine) batch.
+    m_engine->reconcileRestoredWindows(liveWindowIds);
 }
 
 void ScrollAdaptor::windowClosed(const QString& windowId)

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -325,6 +325,30 @@ void SettingsAdaptor::initializeRegistry()
     m_schemas[QStringLiteral("autotileDragInsertTriggers")] = QStringLiteral("stringlist");
 
     REGISTER_BOOL_SETTING("autotileDragInsertToggle", autotileDragInsertToggle, setAutotileDragInsertToggle)
+
+    // Scroll-mode (niri-style scrollable tiling) settings — interface-backed.
+    REGISTER_INT_SETTING("scrollInnerGap", scrollInnerGap, setScrollInnerGap)
+    REGISTER_INT_SETTING("scrollOuterGap", scrollOuterGap, setScrollOuterGap)
+    REGISTER_DOUBLE_SETTING("scrollDefaultColumnWidth", scrollDefaultColumnWidth, setScrollDefaultColumnWidth)
+    REGISTER_BOOL_SETTING("scrollCenterFocusedColumn", scrollCenterFocusedColumn, setScrollCenterFocusedColumn)
+    // Preset lists (multi-bind) — QVariantLists of width / height fractions.
+    m_getters[QStringLiteral("scrollPresetColumnWidths")] = [this]() {
+        return QVariant::fromValue(m_settings->scrollPresetColumnWidths());
+    };
+    m_setters[QStringLiteral("scrollPresetColumnWidths")] = [this](const QVariant& v) {
+        m_settings->setScrollPresetColumnWidths(v.toList());
+        return true;
+    };
+    m_schemas[QStringLiteral("scrollPresetColumnWidths")] = QStringLiteral("stringlist");
+    m_getters[QStringLiteral("scrollPresetWindowHeights")] = [this]() {
+        return QVariant::fromValue(m_settings->scrollPresetWindowHeights());
+    };
+    m_setters[QStringLiteral("scrollPresetWindowHeights")] = [this](const QVariant& v) {
+        m_settings->setScrollPresetWindowHeights(v.toList());
+        return true;
+    };
+    m_schemas[QStringLiteral("scrollPresetWindowHeights")] = QStringLiteral("stringlist");
+
     REGISTER_BOOL_SETTING("toggleActivation", toggleActivation, setToggleActivation)
     REGISTER_BOOL_SETTING("snappingEnabled", snappingEnabled, setSnappingEnabled)
 
@@ -1140,6 +1164,19 @@ std::optional<PerScreenDispatch> dispatchFor(ISettings* settings, const QString&
             },
             [settings](const QString& id) {
                 settings->clearPerScreenZoneSelectorSettings(id);
+            },
+        };
+    }
+    if (category == QLatin1String("scrolling")) {
+        return PerScreenDispatch{
+            [settings](const QString& id) {
+                return settings->getPerScreenScrollSettings(id);
+            },
+            [settings](const QString& id, const QString& k, const QVariant& v) {
+                settings->setPerScreenScrollSetting(id, k, v);
+            },
+            [settings](const QString& id) {
+                settings->clearPerScreenScrollSettings(id);
             },
         };
     }

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -108,6 +108,8 @@ qt_add_qml_module(plasmazones-settings
         qml/TilingAppearancePage.qml
         qml/TilingBehaviorPage.qml
         qml/TilingAlgorithmPage.qml
+        qml/ScrollingModePage.qml
+        qml/ScrollingPresetListCard.qml
         qml/ExclusionsPage.qml
         qml/EditorPage.qml
         qml/LayoutsPage.qml

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -66,6 +66,12 @@ ApplicationWindow {
         "label": i18n("Tiling"),
         "iconName": "window-duplicate",
         "hasChildren": true,
+        "hasDividerAfter": false
+    }, {
+        "name": "scrolling",
+        "label": i18n("Scrolling"),
+        "iconName": "transform-move-horizontal",
+        "hasChildren": false,
         "hasDividerAfter": true
     }, {
         "name": "animations",
@@ -246,6 +252,7 @@ ApplicationWindow {
         "tiling-appearance": "TilingAppearancePage.qml",
         "tiling-behavior": "TilingBehaviorPage.qml",
         "tiling-algorithm": "TilingAlgorithmPage.qml",
+        "scrolling": "ScrollingModePage.qml",
         "snapping-assignments": "SnappingAssignmentsPage.qml",
         "snapping-apprules": "AssignmentsAppRulesPage.qml",
         "snapping-shortcuts": "SnappingQuickShortcutsPage.qml",

--- a/src/settings/qml/ScrollingModePage.qml
+++ b/src/settings/qml/ScrollingModePage.qml
@@ -89,7 +89,10 @@ SettingsFlickable {
 
                     SettingsSpinBox {
                         from: 0
-                        to: 200
+                        // Matches the Scrolling.Gaps schema clamp
+                        // (ConfigDefaults::scrollInnerGapMax) — a larger value
+                        // would be silently truncated on save.
+                        to: 50
                         value: root.settingValue("InnerGap", appSettings.scrollInnerGap)
                         unitText: i18n("px")
                         onValueModified: function(newValue) {
@@ -110,7 +113,10 @@ SettingsFlickable {
 
                     SettingsSpinBox {
                         from: 0
-                        to: 200
+                        // Matches the Scrolling.Gaps schema clamp
+                        // (ConfigDefaults::scrollOuterGapMax) — a larger value
+                        // would be silently truncated on save.
+                        to: 50
                         value: root.settingValue("OuterGap", appSettings.scrollOuterGap)
                         unitText: i18n("px")
                         onValueModified: function(newValue) {

--- a/src/settings/qml/ScrollingModePage.qml
+++ b/src/settings/qml/ScrollingModePage.qml
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+/**
+ * @brief Settings page for scrolling mode — niri-style scrollable tiling.
+ *
+ * Edits the scrolling-mode tuning — strip gaps, the width of a freshly opened
+ * column, the viewport-centering mode, and the column-width / window-height
+ * preset lists — as global defaults or per-monitor overrides, selected by the
+ * MonitorSelectorSection (identical pattern to TilingAlgorithmPage). Every
+ * value is routed through PerScreenOverrideHelper so a control writes either
+ * the global Settings Q_PROPERTY or the screen's override map.
+ */
+SettingsFlickable {
+    id: root
+
+    // Per-screen override helper surface — mirrors TilingAlgorithmPage.
+    property alias selectedScreenName: psHelper.selectedScreenName
+    readonly property alias isPerScreen: psHelper.isPerScreen
+    readonly property alias hasOverrides: psHelper.hasOverrides
+
+    // Settings persists column / height presets and the default column width
+    // as fractions [0..1]; the UI edits whole percents.
+    function fractionToPercent(fraction) {
+        return Math.round(fraction * 100);
+    }
+
+    // Resolve a value: per-screen override when a monitor is selected and it
+    // carries the key, otherwise the global default.
+    function settingValue(key, globalValue) {
+        return psHelper.settingValue(key, globalValue);
+    }
+
+    // Write a value: to the selected monitor's override map, or — when "All
+    // Monitors" is selected — to the global setter.
+    function writeSetting(key, value, globalSetter) {
+        psHelper.writeSetting(key, value, globalSetter);
+    }
+
+    contentHeight: content.implicitHeight
+    clip: true
+
+    PerScreenOverrideHelper {
+        id: psHelper
+
+        appSettings: settingsController
+        getterMethod: "getPerScreenScrollSettings"
+        setterMethod: "setPerScreenScrollSetting"
+        clearerMethod: "clearPerScreenScrollSettings"
+    }
+
+    ColumnLayout {
+        id: content
+
+        width: parent.width
+        spacing: Kirigami.Units.largeSpacing
+
+        // =================================================================
+        // Monitor Selector (per-screen overrides)
+        // =================================================================
+        MonitorSelectorSection {
+            Layout.fillWidth: true
+            appSettings: settingsController
+            selectedScreenName: root.selectedScreenName
+            hasOverrides: root.hasOverrides
+            onSelectedScreenNameChanged: root.selectedScreenName = selectedScreenName
+            onResetClicked: psHelper.clearOverrides()
+        }
+
+        // =================================================================
+        // Gaps
+        // =================================================================
+        SettingsCard {
+            Layout.fillWidth: true
+            headerText: i18n("Gaps")
+            collapsible: true
+
+            contentItem: ColumnLayout {
+                spacing: Kirigami.Units.smallSpacing
+
+                SettingsRow {
+                    title: i18n("Inner gap")
+                    description: i18n("Spacing between columns, and between windows stacked within a column")
+
+                    SettingsSpinBox {
+                        from: 0
+                        to: 200
+                        value: root.settingValue("InnerGap", appSettings.scrollInnerGap)
+                        unitText: i18n("px")
+                        onValueModified: function(newValue) {
+                            root.writeSetting("InnerGap", newValue, function(v) {
+                                appSettings.scrollInnerGap = v;
+                            });
+                        }
+                    }
+
+                }
+
+                SettingsSeparator {
+                }
+
+                SettingsRow {
+                    title: i18n("Outer gap")
+                    description: i18n("Spacing between the strip and the screen edges")
+
+                    SettingsSpinBox {
+                        from: 0
+                        to: 200
+                        value: root.settingValue("OuterGap", appSettings.scrollOuterGap)
+                        unitText: i18n("px")
+                        onValueModified: function(newValue) {
+                            root.writeSetting("OuterGap", newValue, function(v) {
+                                appSettings.scrollOuterGap = v;
+                            });
+                        }
+                    }
+
+                }
+
+            }
+
+        }
+
+        // =================================================================
+        // Layout
+        // =================================================================
+        SettingsCard {
+            Layout.fillWidth: true
+            headerText: i18n("Layout")
+            collapsible: true
+
+            contentItem: ColumnLayout {
+                spacing: Kirigami.Units.smallSpacing
+
+                SettingsRow {
+                    title: i18n("New column width")
+                    description: i18n("Width a freshly opened column takes, as a fraction of the screen")
+
+                    SettingsSlider {
+                        from: 10
+                        to: 100
+                        stepSize: 1
+                        value: root.fractionToPercent(root.settingValue("DefaultColumnWidth", appSettings.scrollDefaultColumnWidth))
+                        onMoved: function(newValue) {
+                            root.writeSetting("DefaultColumnWidth", newValue / 100, function(v) {
+                                appSettings.scrollDefaultColumnWidth = v;
+                            });
+                        }
+                    }
+
+                }
+
+                SettingsSeparator {
+                }
+
+                SettingsRow {
+                    title: i18n("Center focused column")
+                    description: i18n("Keep the focused column centered in the viewport, instead of scrolling only as far as needed to reveal it")
+
+                    SettingsSwitch {
+                        checked: root.settingValue("CenterFocusedColumn", appSettings.scrollCenterFocusedColumn)
+                        accessibleName: i18n("Center the focused column")
+                        onToggled: function(newValue) {
+                            root.writeSetting("CenterFocusedColumn", newValue, function(v) {
+                                appSettings.scrollCenterFocusedColumn = v;
+                            });
+                        }
+                    }
+
+                }
+
+            }
+
+        }
+
+        // =================================================================
+        // Preset lists
+        // =================================================================
+        ScrollingPresetListCard {
+            Layout.fillWidth: true
+            headerText: i18n("Column width presets")
+            description: i18n("Widths the cycle-column-width shortcut steps through, as a percentage of the screen")
+            values: root.settingValue("PresetColumnWidths", appSettings.scrollPresetColumnWidths)
+            onValuesModified: function(newValues) {
+                root.writeSetting("PresetColumnWidths", newValues, function(v) {
+                    appSettings.scrollPresetColumnWidths = v;
+                });
+            }
+        }
+
+        ScrollingPresetListCard {
+            Layout.fillWidth: true
+            headerText: i18n("Window height presets")
+            description: i18n("Heights the cycle-window-height shortcut steps through, as a percentage of the column")
+            values: root.settingValue("PresetWindowHeights", appSettings.scrollPresetWindowHeights)
+            onValuesModified: function(newValues) {
+                root.writeSetting("PresetWindowHeights", newValues, function(v) {
+                    appSettings.scrollPresetWindowHeights = v;
+                });
+            }
+        }
+
+    }
+
+}

--- a/src/settings/qml/ScrollingPresetListCard.qml
+++ b/src/settings/qml/ScrollingPresetListCard.qml
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+/**
+ * @brief Editor card for a scroll-mode preset list (column widths or window
+ *        heights).
+ *
+ * Each entry is a fraction [0.1..1.0] of the working area, edited as a whole
+ * percent. The card never mutates @c values in place — every edit emits the
+ * complete edited list through @c valuesModified so the page can route it
+ * back through the Settings setter.
+ */
+SettingsCard {
+    id: card
+
+    // Fractions [0.1..1.0]; the page binds this to a Settings QVariantList.
+    property var values: []
+    property string description: ""
+
+    signal valuesModified(var values)
+
+    collapsible: true
+
+    contentItem: ColumnLayout {
+        spacing: Kirigami.Units.smallSpacing
+
+        Label {
+            Layout.fillWidth: true
+            Layout.leftMargin: Kirigami.Units.smallSpacing
+            Layout.rightMargin: Kirigami.Units.smallSpacing
+            visible: card.description.length > 0
+            text: card.description
+            wrapMode: Text.WordWrap
+            opacity: 0.7
+            font: Kirigami.Theme.smallFont
+        }
+
+        Repeater {
+            model: card.values
+
+            delegate: RowLayout {
+                id: presetRow
+
+                required property int index
+                required property var modelData
+
+                Layout.fillWidth: true
+                Layout.leftMargin: Kirigami.Units.smallSpacing
+                Layout.rightMargin: Kirigami.Units.smallSpacing
+                spacing: Kirigami.Units.smallSpacing
+
+                Label {
+                    text: i18n("Preset %1", presetRow.index + 1)
+                    Layout.preferredWidth: Kirigami.Units.gridUnit * 6
+                }
+
+                SpinBox {
+                    from: 10
+                    to: 100
+                    stepSize: 5
+                    value: Math.round(presetRow.modelData * 100)
+                    Accessible.name: i18n("Preset %1 size in percent", presetRow.index + 1)
+                    textFromValue: function(value, locale) {
+                        return Number(value).toLocaleString(locale, 'f', 0) + "%";
+                    }
+                    onValueModified: {
+                        let copy = card.values.slice();
+                        copy[presetRow.index] = value / 100;
+                        card.valuesModified(copy);
+                    }
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                Button {
+                    icon.name: "list-remove"
+                    Accessible.name: i18n("Remove preset %1", presetRow.index + 1)
+                    // Keep at least one preset — an empty list disables the
+                    // cycle shortcut entirely.
+                    enabled: card.values.length > 1
+                    onClicked: {
+                        let copy = card.values.slice();
+                        copy.splice(presetRow.index, 1);
+                        card.valuesModified(copy);
+                    }
+                }
+
+            }
+
+        }
+
+        Button {
+            Layout.leftMargin: Kirigami.Units.smallSpacing
+            text: i18n("Add preset")
+            icon.name: "list-add"
+            onClicked: {
+                let copy = card.values.slice();
+                copy.push(0.5);
+                card.valuesModified(copy);
+            }
+        }
+
+    }
+
+}

--- a/src/settings/qml/ScrollingPresetListCard.qml
+++ b/src/settings/qml/ScrollingPresetListCard.qml
@@ -39,7 +39,10 @@ SettingsCard {
         if (presetModel.count === v.length) {
             let identical = true;
             for (let i = 0; i < v.length; ++i) {
-                if (presetModel.get(i).fraction !== v[i]) {
+                // Epsilon compare — fractions are doubles; an exact !== would
+                // rebuild every delegate (losing spin-box focus) on any
+                // sub-ulp drift a future round-trip might introduce.
+                if (Math.abs(presetModel.get(i).fraction - v[i]) > 1e-09) {
                     identical = false;
                     break;
                 }
@@ -105,7 +108,7 @@ SettingsCard {
                 SpinBox {
                     from: 10
                     to: 100
-                    stepSize: 5
+                    stepSize: 1
                     value: Math.round(presetRow.fraction * 100)
                     Accessible.name: i18n("Preset %1 size in percent", presetRow.index + 1)
                     textFromValue: function(value, locale) {

--- a/src/settings/qml/ScrollingPresetListCard.qml
+++ b/src/settings/qml/ScrollingPresetListCard.qml
@@ -14,6 +14,12 @@ import org.kde.kirigami as Kirigami
  * percent. The card never mutates @c values in place — every edit emits the
  * complete edited list through @c valuesModified so the page can route it
  * back through the Settings setter.
+ *
+ * The Repeater binds to an internal ListModel rather than the @c values array
+ * directly: a value edit updates that model in place and re-syncs only when
+ * the round-tripped @c values genuinely differ. An in-range edit round-trips
+ * to an identical list, so the delegates are not rebuilt and the spin box
+ * being edited keeps focus.
  */
 SettingsCard {
     id: card
@@ -24,7 +30,44 @@ SettingsCard {
 
     signal valuesModified(var values)
 
+    // Repopulate the internal model from `values`, but only when the two
+    // genuinely differ — an in-range edit round-trips back through Settings to
+    // an identical list, and skipping the rebuild then keeps every delegate
+    // (and the spin box's keyboard focus) alive.
+    function syncModel() {
+        const v = card.values || [];
+        if (presetModel.count === v.length) {
+            let identical = true;
+            for (let i = 0; i < v.length; ++i) {
+                if (presetModel.get(i).fraction !== v[i]) {
+                    identical = false;
+                    break;
+                }
+            }
+            if (identical)
+                return ;
+
+        }
+        presetModel.clear();
+        for (let i = 0; i < v.length; ++i) presetModel.append({
+            "fraction": v[i]
+        })
+    }
+
+    // Emit the current model contents as the complete edited list.
+    function emitValues() {
+        let out = [];
+        for (let i = 0; i < presetModel.count; ++i) out.push(presetModel.get(i).fraction)
+        card.valuesModified(out);
+    }
+
     collapsible: true
+    onValuesChanged: syncModel()
+    Component.onCompleted: syncModel()
+
+    ListModel {
+        id: presetModel
+    }
 
     contentItem: ColumnLayout {
         spacing: Kirigami.Units.smallSpacing
@@ -41,13 +84,13 @@ SettingsCard {
         }
 
         Repeater {
-            model: card.values
+            model: presetModel
 
             delegate: RowLayout {
                 id: presetRow
 
                 required property int index
-                required property var modelData
+                required property real fraction
 
                 Layout.fillWidth: true
                 Layout.leftMargin: Kirigami.Units.smallSpacing
@@ -63,15 +106,16 @@ SettingsCard {
                     from: 10
                     to: 100
                     stepSize: 5
-                    value: Math.round(presetRow.modelData * 100)
+                    value: Math.round(presetRow.fraction * 100)
                     Accessible.name: i18n("Preset %1 size in percent", presetRow.index + 1)
                     textFromValue: function(value, locale) {
                         return Number(value).toLocaleString(locale, 'f', 0) + "%";
                     }
                     onValueModified: {
-                        let copy = card.values.slice();
-                        copy[presetRow.index] = value / 100;
-                        card.valuesModified(copy);
+                        // Update the model in place — no structural change, so
+                        // the Repeater keeps this delegate (and its focus).
+                        presetModel.setProperty(presetRow.index, "fraction", value / 100);
+                        card.emitValues();
                     }
                 }
 
@@ -84,11 +128,10 @@ SettingsCard {
                     Accessible.name: i18n("Remove preset %1", presetRow.index + 1)
                     // Keep at least one preset — an empty list disables the
                     // cycle shortcut entirely.
-                    enabled: card.values.length > 1
+                    enabled: presetModel.count > 1
                     onClicked: {
-                        let copy = card.values.slice();
-                        copy.splice(presetRow.index, 1);
-                        card.valuesModified(copy);
+                        presetModel.remove(presetRow.index);
+                        card.emitValues();
                     }
                 }
 
@@ -101,9 +144,10 @@ SettingsCard {
             text: i18n("Add preset")
             icon.name: "list-add"
             onClicked: {
-                let copy = card.values.slice();
-                copy.push(0.5);
-                card.valuesModified(copy);
+                presetModel.append({
+                    "fraction": 0.5
+                });
+                card.emitValues();
             }
         }
 

--- a/tests/unit/config/test_settings_core.cpp
+++ b/tests/unit/config/test_settings_core.cpp
@@ -450,8 +450,14 @@ private Q_SLOTS:
 
         const QVariantList widths = reloaded.scrollPresetColumnWidths();
         QCOMPARE(widths.size(), 3);
+        QVERIFY(qFuzzyCompare(widths.at(0).toDouble(), 0.25));
         QVERIFY(qFuzzyCompare(widths.at(1).toDouble(), 0.5));
-        QCOMPARE(reloaded.scrollPresetWindowHeights().size(), 2);
+        QVERIFY(qFuzzyCompare(widths.at(2).toDouble(), 0.75));
+
+        const QVariantList heights = reloaded.scrollPresetWindowHeights();
+        QCOMPARE(heights.size(), 2);
+        QVERIFY(qFuzzyCompare(heights.at(0).toDouble(), 0.3));
+        QVERIFY(qFuzzyCompare(heights.at(1).toDouble(), 0.6));
     }
 
     /**
@@ -464,13 +470,18 @@ private Q_SLOTS:
         IsolatedConfigGuard guard;
 
         Settings settings;
-        // 0.0 is below the minimum, 5.0 above the maximum.
-        settings.setScrollPresetColumnWidths(QVariantList{0.0, 0.5, 5.0});
+        // 0.0 is below the minimum, 5.0 above the maximum, and the string is
+        // non-numeric junk that must be dropped entirely.
+        settings.setScrollPresetColumnWidths(QVariantList{0.0, 0.5, 5.0, QStringLiteral("junk")});
 
         const QVariantList clamped = settings.scrollPresetColumnWidths();
+        // The non-numeric entry is dropped; the three numeric entries survive.
         QCOMPARE(clamped.size(), 3);
-        QVERIFY(clamped.at(0).toDouble() >= ConfigDefaults::scrollColumnWidthMin());
-        QVERIFY(clamped.at(2).toDouble() <= ConfigDefaults::scrollColumnWidthMax());
+        // Out-of-range fractions are clamped to the exact range bounds; the
+        // in-range value is left untouched.
+        QVERIFY(qFuzzyCompare(clamped.at(0).toDouble(), ConfigDefaults::scrollColumnWidthMin()));
+        QVERIFY(qFuzzyCompare(clamped.at(1).toDouble(), 0.5));
+        QVERIFY(qFuzzyCompare(clamped.at(2).toDouble(), ConfigDefaults::scrollColumnWidthMax()));
     }
 
     // =========================================================================

--- a/tests/unit/config/test_settings_core.cpp
+++ b/tests/unit/config/test_settings_core.cpp
@@ -482,6 +482,15 @@ private Q_SLOTS:
         QVERIFY(qFuzzyCompare(clamped.at(0).toDouble(), ConfigDefaults::scrollColumnWidthMin()));
         QVERIFY(qFuzzyCompare(clamped.at(1).toDouble(), 0.5));
         QVERIFY(qFuzzyCompare(clamped.at(2).toDouble(), ConfigDefaults::scrollColumnWidthMax()));
+
+        // Window-height presets run through an independent schema entry with
+        // their own scrollWindowHeightMin/Max bounds — clamp them too.
+        settings.setScrollPresetWindowHeights(QVariantList{0.0, 0.5, 9.0});
+        const QVariantList heights = settings.scrollPresetWindowHeights();
+        QCOMPARE(heights.size(), 3);
+        QVERIFY(qFuzzyCompare(heights.at(0).toDouble(), ConfigDefaults::scrollWindowHeightMin()));
+        QVERIFY(qFuzzyCompare(heights.at(1).toDouble(), 0.5));
+        QVERIFY(qFuzzyCompare(heights.at(2).toDouble(), ConfigDefaults::scrollWindowHeightMax()));
     }
 
     // =========================================================================

--- a/tests/unit/config/test_settings_core.cpp
+++ b/tests/unit/config/test_settings_core.cpp
@@ -422,6 +422,57 @@ private Q_SLOTS:
         QVariantMap first = triggers.first().toMap();
         QCOMPARE(first.value(QStringLiteral("modifier")).toInt(), 3);
     }
+    /**
+     * Scroll-mode settings (Phase 5) must survive a save/load round-trip:
+     * gaps, the default column width, the viewport-centering toggle, and the
+     * two preset lists. The preset lists are QVariantLists of fractions.
+     */
+    void testScrollSettings_roundtrip()
+    {
+        IsolatedConfigGuard guard;
+
+        {
+            Settings settings;
+            settings.setScrollInnerGap(14);
+            settings.setScrollOuterGap(22);
+            settings.setScrollDefaultColumnWidth(0.42);
+            settings.setScrollCenterFocusedColumn(true);
+            settings.setScrollPresetColumnWidths(QVariantList{0.25, 0.5, 0.75});
+            settings.setScrollPresetWindowHeights(QVariantList{0.3, 0.6});
+            settings.save();
+        }
+
+        Settings reloaded;
+        QCOMPARE(reloaded.scrollInnerGap(), 14);
+        QCOMPARE(reloaded.scrollOuterGap(), 22);
+        QVERIFY(qFuzzyCompare(reloaded.scrollDefaultColumnWidth(), 0.42));
+        QCOMPARE(reloaded.scrollCenterFocusedColumn(), true);
+
+        const QVariantList widths = reloaded.scrollPresetColumnWidths();
+        QCOMPARE(widths.size(), 3);
+        QVERIFY(qFuzzyCompare(widths.at(1).toDouble(), 0.5));
+        QCOMPARE(reloaded.scrollPresetWindowHeights().size(), 2);
+    }
+
+    /**
+     * The preset-list schema validator clamps each fraction into the valid
+     * range and drops non-numeric junk, so a hand-edited config can never
+     * feed the engine an out-of-range column width.
+     */
+    void testScrollPresets_clampOutOfRange()
+    {
+        IsolatedConfigGuard guard;
+
+        Settings settings;
+        // 0.0 is below the minimum, 5.0 above the maximum.
+        settings.setScrollPresetColumnWidths(QVariantList{0.0, 0.5, 5.0});
+
+        const QVariantList clamped = settings.scrollPresetColumnWidths();
+        QCOMPARE(clamped.size(), 3);
+        QVERIFY(clamped.at(0).toDouble() >= ConfigDefaults::scrollColumnWidthMin());
+        QVERIFY(clamped.at(2).toDouble() <= ConfigDefaults::scrollColumnWidthMax());
+    }
+
     // =========================================================================
     // Stale key purging
     // =========================================================================

--- a/tests/unit/config/test_settings_perscreen.cpp
+++ b/tests/unit/config/test_settings_perscreen.cpp
@@ -111,7 +111,8 @@ private Q_SLOTS:
             settings.setPerScreenScrollSetting(screen, QStringLiteral("InnerGap"), 18);
             settings.setPerScreenScrollSetting(screen, QStringLiteral("CenterFocusedColumn"), true);
             settings.setPerScreenScrollSetting(screen, QStringLiteral("PresetColumnWidths"), QVariantList{0.25, 0.75});
-            QVERIFY(spy.count() >= 3);
+            // Three distinct keys, each a genuine change — exactly three emissions.
+            QCOMPARE(spy.count(), 3);
             QVERIFY(settings.hasPerScreenScrollSettings(screen));
 
             const QVariantMap overrides = settings.getPerScreenScrollSettings(screen);

--- a/tests/unit/config/test_settings_perscreen.cpp
+++ b/tests/unit/config/test_settings_perscreen.cpp
@@ -90,6 +90,55 @@ private Q_SLOTS:
     }
 
     // =========================================================================
+    // Per-screen scrolling overrides
+    // =========================================================================
+
+    /**
+     * Per-screen scrolling: set scalar + list-valued overrides, verify they
+     * resolve, survive a save/load round-trip, and clear. The PresetColumnWidths
+     * key exercises the QVariantList per-screen storage path (writeJson).
+     */
+    void testPerScreenScroll_setSaveLoadClear()
+    {
+        IsolatedConfigGuard guard;
+
+        const QString screen = QStringLiteral("test-screen-1");
+        {
+            Settings settings;
+            QVERIFY(!settings.hasPerScreenScrollSettings(screen));
+            QSignalSpy spy(&settings, &Settings::perScreenScrollSettingsChanged);
+
+            settings.setPerScreenScrollSetting(screen, QStringLiteral("InnerGap"), 18);
+            settings.setPerScreenScrollSetting(screen, QStringLiteral("CenterFocusedColumn"), true);
+            settings.setPerScreenScrollSetting(screen, QStringLiteral("PresetColumnWidths"), QVariantList{0.25, 0.75});
+            QVERIFY(spy.count() >= 3);
+            QVERIFY(settings.hasPerScreenScrollSettings(screen));
+
+            const QVariantMap overrides = settings.getPerScreenScrollSettings(screen);
+            QCOMPARE(overrides.value(QStringLiteral("InnerGap")).toInt(), 18);
+            QCOMPARE(overrides.value(QStringLiteral("CenterFocusedColumn")).toBool(), true);
+            QCOMPARE(overrides.value(QStringLiteral("PresetColumnWidths")).toList().size(), 2);
+
+            settings.save();
+        }
+
+        // A fresh Settings reloads the per-screen overrides from disk.
+        {
+            Settings reloaded;
+            QVERIFY(reloaded.hasPerScreenScrollSettings(screen));
+            const QVariantMap overrides = reloaded.getPerScreenScrollSettings(screen);
+            QCOMPARE(overrides.value(QStringLiteral("InnerGap")).toInt(), 18);
+            QCOMPARE(overrides.value(QStringLiteral("CenterFocusedColumn")).toBool(), true);
+            const QVariantList widths = overrides.value(QStringLiteral("PresetColumnWidths")).toList();
+            QCOMPARE(widths.size(), 2);
+            QVERIFY(qFuzzyCompare(widths.at(1).toDouble(), 0.75));
+
+            reloaded.clearPerScreenScrollSettings(screen);
+            QVERIFY(!reloaded.hasPerScreenScrollSettings(screen));
+        }
+    }
+
+    // =========================================================================
     // P2: edge cases -- fresh config defaults
     // =========================================================================
 

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -847,6 +847,48 @@ public:
     void setAutotileDragInsertToggle(bool) override
     {
     }
+    int scrollInnerGap() const override
+    {
+        return ConfigDefaults::scrollInnerGap();
+    }
+    void setScrollInnerGap(int) override
+    {
+    }
+    int scrollOuterGap() const override
+    {
+        return ConfigDefaults::scrollOuterGap();
+    }
+    void setScrollOuterGap(int) override
+    {
+    }
+    double scrollDefaultColumnWidth() const override
+    {
+        return ConfigDefaults::scrollDefaultColumnWidth();
+    }
+    void setScrollDefaultColumnWidth(double) override
+    {
+    }
+    bool scrollCenterFocusedColumn() const override
+    {
+        return ConfigDefaults::scrollCenterFocusedColumn();
+    }
+    void setScrollCenterFocusedColumn(bool) override
+    {
+    }
+    QVariantList scrollPresetColumnWidths() const override
+    {
+        return ConfigDefaults::scrollPresetColumnWidths();
+    }
+    void setScrollPresetColumnWidths(const QVariantList&) override
+    {
+    }
+    QVariantList scrollPresetWindowHeights() const override
+    {
+        return ConfigDefaults::scrollPresetWindowHeights();
+    }
+    void setScrollPresetWindowHeights(const QVariantList&) override
+    {
+    }
     QStringList lockedScreens() const override
     {
         return {};

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -7,6 +7,8 @@
 #include <PhosphorEngine/PlacementEngineBase.h>
 
 #include <QSet>
+#include <QVariantList>
+#include <QVariantMap>
 #include <QtTest>
 
 using namespace PhosphorScrollEngine;
@@ -39,6 +41,8 @@ class TestScrollEngine : public QObject
 
 private Q_SLOTS:
     void windowLifecycle();
+    void defaultColumnWidth();
+    void perScreenConfig();
     void focusAndMoveNavigation();
     void consumeAndExpel();
     void minimizeWindow();
@@ -74,6 +78,77 @@ void TestScrollEngine::windowLifecycle()
     engine.windowClosed(QStringLiteral("b"));
     QVERIFY(!engine.isWindowTracked(QStringLiteral("b")));
     QCOMPARE(state->columnCount(), 2);
+}
+
+void TestScrollEngine::defaultColumnWidth()
+{
+    ScrollEngine engine;
+
+    // Until a default is pushed, a freshly opened column uses niri's middle
+    // preset (one half).
+    engine.windowOpened(QStringLiteral("a"), QStringLiteral("S1"));
+    const ScrollScreenState* state = scrollState(engine, QStringLiteral("S1"));
+    QVERIFY(state);
+    QCOMPARE(state->columns().at(0).width().kind, ColumnWidth::Kind::Proportion);
+    QVERIFY(qFuzzyCompare(state->columns().at(0).width().value, 0.5));
+
+    // A pushed default applies to subsequently opened columns; the existing
+    // column keeps its width.
+    engine.setDefaultColumnWidth(0.4);
+    QVERIFY(qFuzzyCompare(engine.defaultColumnWidth(), 0.4));
+    engine.windowOpened(QStringLiteral("b"), QStringLiteral("S1"));
+    QCOMPARE(state->columnCount(), 2);
+    QVERIFY(qFuzzyCompare(state->columns().at(1).width().value, 0.4));
+    QVERIFY(qFuzzyCompare(state->columns().at(0).width().value, 0.5));
+}
+
+void TestScrollEngine::perScreenConfig()
+{
+    ScrollEngine engine;
+    engine.setDefaultColumnWidth(0.5);
+    engine.setInnerGap(8);
+    engine.setOuterGap(8);
+    engine.setPresetColumnWidths({1.0 / 3.0, 0.5, 2.0 / 3.0});
+
+    // No override → effective resolves to the global default.
+    QVERIFY(qFuzzyCompare(engine.effectiveDefaultColumnWidth(QStringLiteral("S1")), 0.5));
+    QCOMPARE(engine.effectiveInnerGap(QStringLiteral("S1")), 8);
+    QVERIFY(engine.effectiveViewportMode(QStringLiteral("S1")) == ScrollViewportMode::Fit);
+
+    // A per-screen override map shadows the globals for that screen only.
+    QVariantMap overrides;
+    overrides.insert(QStringLiteral("DefaultColumnWidth"), 0.25);
+    overrides.insert(QStringLiteral("InnerGap"), 20);
+    overrides.insert(QStringLiteral("CenterFocusedColumn"), true);
+    overrides.insert(QStringLiteral("PresetColumnWidths"), QVariantList{0.4, 0.8});
+    engine.applyPerScreenConfig(QStringLiteral("S1"), overrides);
+
+    QVERIFY(qFuzzyCompare(engine.effectiveDefaultColumnWidth(QStringLiteral("S1")), 0.25));
+    QCOMPARE(engine.effectiveInnerGap(QStringLiteral("S1")), 20);
+    QVERIFY(engine.effectiveViewportMode(QStringLiteral("S1")) == ScrollViewportMode::Centered);
+    QCOMPARE(engine.effectivePresetColumnWidths(QStringLiteral("S1")).size(), 2);
+    QVERIFY(qFuzzyCompare(engine.effectivePresetColumnWidths(QStringLiteral("S1")).at(1), 0.8));
+
+    // A screen with no override still resolves to the globals.
+    QVERIFY(qFuzzyCompare(engine.effectiveDefaultColumnWidth(QStringLiteral("S2")), 0.5));
+    QCOMPARE(engine.effectiveInnerGap(QStringLiteral("S2")), 8);
+
+    // A window opened on S1 takes that screen's overridden default width.
+    engine.windowOpened(QStringLiteral("a"), QStringLiteral("S1"));
+    const ScrollScreenState* s1 = scrollState(engine, QStringLiteral("S1"));
+    QVERIFY(s1);
+    QVERIFY(qFuzzyCompare(s1->columns().at(0).width().value, 0.25));
+
+    // clearPerScreenConfig reverts the screen to the globals.
+    engine.clearPerScreenConfig(QStringLiteral("S1"));
+    QVERIFY(qFuzzyCompare(engine.effectiveDefaultColumnWidth(QStringLiteral("S1")), 0.5));
+    QVERIFY(engine.effectiveViewportMode(QStringLiteral("S1")) == ScrollViewportMode::Fit);
+
+    // An empty override map clears the screen too (apply-empty == clear).
+    engine.applyPerScreenConfig(QStringLiteral("S1"), overrides);
+    engine.applyPerScreenConfig(QStringLiteral("S1"), QVariantMap{});
+    QVERIFY(engine.perScreenOverrides(QStringLiteral("S1")).isEmpty());
+    QCOMPARE(engine.effectiveInnerGap(QStringLiteral("S1")), 8);
 }
 
 void TestScrollEngine::focusAndMoveNavigation()

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -509,13 +509,15 @@ void TestScrollEngine::restoreReconciliation()
     QCOMPARE(scrollState(restored, QStringLiteral("S1"))->columnCount(), 2);
 
     // Zero live windows after a restart — the effect sends an empty batch and
-    // every restored column is reconciled away.
+    // every restored column is reconciled away. The screen state survives as
+    // an empty strip (windowClosed drops emptied columns, not the state).
     ScrollEngine emptied;
     emptied.deserializeEngineState(saved);
     emptied.reconcileRestoredWindows(QSet<QString>{});
     QVERIFY(!emptied.isWindowTracked(QStringLiteral("a")));
     const ScrollScreenState* emptiedState = scrollState(emptied, QStringLiteral("S1"));
-    QVERIFY(emptiedState == nullptr || emptiedState->columnCount() == 0);
+    QVERIFY(emptiedState);
+    QCOMPARE(emptiedState->columnCount(), 0);
 
     // An engine with no pending restore ignores reconciliation entirely — a
     // live-opened window is never pruned by a stray batch.

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -149,6 +149,20 @@ void TestScrollEngine::perScreenConfig()
     engine.applyPerScreenConfig(QStringLiteral("S1"), QVariantMap{});
     QVERIFY(engine.perScreenOverrides(QStringLiteral("S1")).isEmpty());
     QCOMPARE(engine.effectiveInnerGap(QStringLiteral("S1")), 8);
+
+    // Out-of-range per-screen override values are clamped on read by the
+    // effective*() resolvers — defence-in-depth over the Settings boundary.
+    QVariantMap outOfRange;
+    outOfRange.insert(QStringLiteral("DefaultColumnWidth"), 5.0); // above max
+    outOfRange.insert(QStringLiteral("InnerGap"), -10); // below min
+    outOfRange.insert(QStringLiteral("PresetColumnWidths"), QVariantList{0.0, 99.0});
+    engine.applyPerScreenConfig(QStringLiteral("S3"), outOfRange);
+    QVERIFY(qFuzzyCompare(engine.effectiveDefaultColumnWidth(QStringLiteral("S3")), 1.0));
+    QCOMPARE(engine.effectiveInnerGap(QStringLiteral("S3")), 0);
+    const QVector<qreal> clampedPresets = engine.effectivePresetColumnWidths(QStringLiteral("S3"));
+    QCOMPARE(clampedPresets.size(), 2);
+    QVERIFY(qFuzzyCompare(clampedPresets.at(0), 0.1));
+    QVERIFY(qFuzzyCompare(clampedPresets.at(1), 1.0));
 }
 
 void TestScrollEngine::focusAndMoveNavigation()

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -495,18 +495,22 @@ void TestScrollEngine::restoreReconciliation()
     // be pruned; a and c keep their restored columns.
     ScrollEngine restored;
     restored.deserializeEngineState(saved);
-    QCOMPARE(scrollState(restored, QStringLiteral("S1"))->columnCount(), 3);
+    // The screen state pointer is stable across reconciliation (windowClosed
+    // prunes columns but never erases the state), so bind and guard it once.
+    const ScrollScreenState* restoredState = scrollState(restored, QStringLiteral("S1"));
+    QVERIFY(restoredState);
+    QCOMPARE(restoredState->columnCount(), 3);
     restored.reconcileRestoredWindows(QSet<QString>{QStringLiteral("a"), QStringLiteral("c")});
     QVERIFY(restored.isWindowTracked(QStringLiteral("a")));
     QVERIFY(!restored.isWindowTracked(QStringLiteral("b")));
     QVERIFY(restored.isWindowTracked(QStringLiteral("c")));
-    QCOMPARE(scrollState(restored, QStringLiteral("S1"))->columnCount(), 2);
+    QCOMPARE(restoredState->columnCount(), 2);
 
     // Reconciliation is one-shot: a later batch (e.g. a screen entering scroll
     // mode at runtime) must not prune the now-authoritative live strip.
     restored.reconcileRestoredWindows(QSet<QString>{QStringLiteral("a")});
     QVERIFY(restored.isWindowTracked(QStringLiteral("c")));
-    QCOMPARE(scrollState(restored, QStringLiteral("S1"))->columnCount(), 2);
+    QCOMPARE(restoredState->columnCount(), 2);
 
     // Zero live windows after a restart — the effect sends an empty batch and
     // every restored column is reconciled away. The screen state survives as

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -51,10 +51,10 @@ private Q_SLOTS:
     void cyclePresetHeight();
     void toggleColumnFullWidth();
     void adjustColumnWidth();
-    void toggleCenterFocusedColumn();
     void floatToggle();
     void perDesktopState();
     void serializeRoundTrip();
+    void restoreReconciliation();
 };
 
 void TestScrollEngine::windowLifecycle()
@@ -426,41 +426,6 @@ void TestScrollEngine::adjustColumnWidth()
     QVERIFY(state->activeColumn() == nullptr);
 }
 
-void TestScrollEngine::toggleCenterFocusedColumn()
-{
-    ScrollEngine engine;
-    engine.windowOpened(QStringLiteral("a"), QStringLiteral("S1"));
-    engine.windowOpened(QStringLiteral("b"), QStringLiteral("S2"));
-    const NavigationContext ctx = contextFor(QStringLiteral("S1"));
-    QSignalSpy spy(&engine, &PhosphorEngine::PlacementEngineBase::placementChanged);
-
-    // The viewport mode is engine-global and starts at Fit. A toggle from one
-    // screen flips it and re-resolves *every* scroll screen, not just the
-    // focused one — so both S1 and S2 emit placementChanged on each toggle.
-    QCOMPARE(engine.viewportMode(), ScrollViewportMode::Fit);
-    engine.toggleCenterFocusedColumn(ctx);
-    QCOMPARE(engine.viewportMode(), ScrollViewportMode::Centered);
-    QCOMPARE(spy.count(), 2);
-
-    // Both physical screens are re-resolved — not one screen twice.
-    QSet<QString> notified;
-    for (const auto& emission : spy) {
-        notified.insert(emission.at(0).toString());
-    }
-    QCOMPARE(notified, QSet<QString>({QStringLiteral("S1"), QStringLiteral("S2")}));
-
-    engine.toggleCenterFocusedColumn(ctx);
-    QCOMPARE(engine.viewportMode(), ScrollViewportMode::Fit);
-    QCOMPARE(spy.count(), 4);
-
-    // The mode is engine-global, so a toggle still flips it when the focused
-    // screen has no strip of its own (S99 was never opened) — and it still
-    // re-resolves the scroll screens that do exist.
-    engine.toggleCenterFocusedColumn(contextFor(QStringLiteral("S99")));
-    QCOMPARE(engine.viewportMode(), ScrollViewportMode::Centered);
-    QCOMPARE(spy.count(), 6);
-}
-
 void TestScrollEngine::floatToggle()
 {
     ScrollEngine engine;
@@ -514,6 +479,50 @@ void TestScrollEngine::serializeRoundTrip()
     const ScrollScreenState* state = scrollState(restored, QStringLiteral("S1"));
     QVERIFY(state);
     QCOMPARE(state->columnCount(), 2);
+}
+
+void TestScrollEngine::restoreReconciliation()
+{
+    // Build a three-column strip and persist it.
+    ScrollEngine source;
+    source.windowOpened(QStringLiteral("a"), QStringLiteral("S1"));
+    source.windowOpened(QStringLiteral("b"), QStringLiteral("S1"));
+    source.windowOpened(QStringLiteral("c"), QStringLiteral("S1"));
+    const QJsonObject saved = source.serializeEngineState();
+
+    // Restore it, then reconcile: the effect's first batch reports only a and
+    // c live — b was closed while the daemon was down. b's phantom column must
+    // be pruned; a and c keep their restored columns.
+    ScrollEngine restored;
+    restored.deserializeEngineState(saved);
+    QCOMPARE(scrollState(restored, QStringLiteral("S1"))->columnCount(), 3);
+    restored.reconcileRestoredWindows(QSet<QString>{QStringLiteral("a"), QStringLiteral("c")});
+    QVERIFY(restored.isWindowTracked(QStringLiteral("a")));
+    QVERIFY(!restored.isWindowTracked(QStringLiteral("b")));
+    QVERIFY(restored.isWindowTracked(QStringLiteral("c")));
+    QCOMPARE(scrollState(restored, QStringLiteral("S1"))->columnCount(), 2);
+
+    // Reconciliation is one-shot: a later batch (e.g. a screen entering scroll
+    // mode at runtime) must not prune the now-authoritative live strip.
+    restored.reconcileRestoredWindows(QSet<QString>{QStringLiteral("a")});
+    QVERIFY(restored.isWindowTracked(QStringLiteral("c")));
+    QCOMPARE(scrollState(restored, QStringLiteral("S1"))->columnCount(), 2);
+
+    // Zero live windows after a restart — the effect sends an empty batch and
+    // every restored column is reconciled away.
+    ScrollEngine emptied;
+    emptied.deserializeEngineState(saved);
+    emptied.reconcileRestoredWindows(QSet<QString>{});
+    QVERIFY(!emptied.isWindowTracked(QStringLiteral("a")));
+    const ScrollScreenState* emptiedState = scrollState(emptied, QStringLiteral("S1"));
+    QVERIFY(emptiedState == nullptr || emptiedState->columnCount() == 0);
+
+    // An engine with no pending restore ignores reconciliation entirely — a
+    // live-opened window is never pruned by a stray batch.
+    ScrollEngine fresh;
+    fresh.windowOpened(QStringLiteral("x"), QStringLiteral("S1"));
+    fresh.reconcileRestoredWindows(QSet<QString>{});
+    QVERIFY(fresh.isWindowTracked(QStringLiteral("x")));
 }
 
 QTEST_GUILESS_MAIN(TestScrollEngine)

--- a/tests/unit/scroll/test_scroll_engine.cpp
+++ b/tests/unit/scroll/test_scroll_engine.cpp
@@ -119,15 +119,20 @@ void TestScrollEngine::perScreenConfig()
     QVariantMap overrides;
     overrides.insert(QStringLiteral("DefaultColumnWidth"), 0.25);
     overrides.insert(QStringLiteral("InnerGap"), 20);
+    overrides.insert(QStringLiteral("OuterGap"), 12);
     overrides.insert(QStringLiteral("CenterFocusedColumn"), true);
     overrides.insert(QStringLiteral("PresetColumnWidths"), QVariantList{0.4, 0.8});
+    overrides.insert(QStringLiteral("PresetWindowHeights"), QVariantList{0.3, 0.6, 0.9});
     engine.applyPerScreenConfig(QStringLiteral("S1"), overrides);
 
     QVERIFY(qFuzzyCompare(engine.effectiveDefaultColumnWidth(QStringLiteral("S1")), 0.25));
     QCOMPARE(engine.effectiveInnerGap(QStringLiteral("S1")), 20);
+    QCOMPARE(engine.effectiveOuterGap(QStringLiteral("S1")), 12);
     QVERIFY(engine.effectiveViewportMode(QStringLiteral("S1")) == ScrollViewportMode::Centered);
     QCOMPARE(engine.effectivePresetColumnWidths(QStringLiteral("S1")).size(), 2);
     QVERIFY(qFuzzyCompare(engine.effectivePresetColumnWidths(QStringLiteral("S1")).at(1), 0.8));
+    QCOMPARE(engine.effectivePresetWindowHeights(QStringLiteral("S1")).size(), 3);
+    QVERIFY(qFuzzyCompare(engine.effectivePresetWindowHeights(QStringLiteral("S1")).at(2), 0.9));
 
     // A screen with no override still resolves to the globals.
     QVERIFY(qFuzzyCompare(engine.effectiveDefaultColumnWidth(QStringLiteral("S2")), 0.5));
@@ -155,14 +160,21 @@ void TestScrollEngine::perScreenConfig()
     QVariantMap outOfRange;
     outOfRange.insert(QStringLiteral("DefaultColumnWidth"), 5.0); // above max
     outOfRange.insert(QStringLiteral("InnerGap"), -10); // below min
+    outOfRange.insert(QStringLiteral("OuterGap"), 9999); // above max
     outOfRange.insert(QStringLiteral("PresetColumnWidths"), QVariantList{0.0, 99.0});
+    outOfRange.insert(QStringLiteral("PresetWindowHeights"), QVariantList{-1.0, 0.5});
     engine.applyPerScreenConfig(QStringLiteral("S3"), outOfRange);
     QVERIFY(qFuzzyCompare(engine.effectiveDefaultColumnWidth(QStringLiteral("S3")), 1.0));
     QCOMPARE(engine.effectiveInnerGap(QStringLiteral("S3")), 0);
+    QCOMPARE(engine.effectiveOuterGap(QStringLiteral("S3")), 50); // clamped to kMaxStripGap
     const QVector<qreal> clampedPresets = engine.effectivePresetColumnWidths(QStringLiteral("S3"));
     QCOMPARE(clampedPresets.size(), 2);
     QVERIFY(qFuzzyCompare(clampedPresets.at(0), 0.1));
     QVERIFY(qFuzzyCompare(clampedPresets.at(1), 1.0));
+    const QVector<qreal> clampedHeights = engine.effectivePresetWindowHeights(QStringLiteral("S3"));
+    QCOMPARE(clampedHeights.size(), 2);
+    QVERIFY(qFuzzyCompare(clampedHeights.at(0), 0.1));
+    QVERIFY(qFuzzyCompare(clampedHeights.at(1), 0.5));
 }
 
 void TestScrollEngine::focusAndMoveNavigation()


### PR DESCRIPTION
Completes **Phase 5** of niri-style scroll mode — the settings / UI / persistence layer — bringing scrolling mode to full parity with the snapping and autotile engines.

## Config
- New `Scrolling.Gaps` + `Scrolling.Layout` config groups (inner/outer gaps, default new-column width, viewport-centering toggle, column-width / window-height cycle-preset lists) as full `PhosphorConfig::Store`-backed settings: `ConfigKeys`/`ConfigDefaults` accessors, `ISettings` virtuals + signals, `Settings` `Q_PROPERTY`s, `settingsschema` clamp validators (incl. `clampFractionList` for the preset arrays), and `SettingsAdaptor` D-Bus registration.

## Per-screen overrides (full parity with autotile / snapping)
- `ScrollingScreen:<id>` config groups, a `PerScreenPathResolver` category, `getPerScreenScrollSettings` / `set` / `clear` / `has` `ISettings` virtuals (+ `perScreenScrollSettingsChanged`), `Settings` storage in `perscreen.cpp`, and a `SettingsAdaptor` `"scrolling"` category.
- `ScrollEngine` holds per-screen overrides (`applyPerScreenConfig` / `clearPerScreenConfig` / `perScreenOverrides`, mirroring `AutotileEngine`) and resolves every config value as override → global via `effective*()` accessors; the daemon's `applyPerScreenScrollOverrides()` pushes the per-screen maps.
- `savePerScreenOverrides` gained a `QVariantList` case (native JSON array) for the list-valued preset overrides.

## UI + layout picker
- New `ScrollingModePage.qml` + reusable `ScrollingPresetListCard.qml`, with a `MonitorSelectorSection` for per-monitor overrides, sitting beside Snapping and Tiling in the settings app.
- The layout picker gains one synthetic **"Scrolling"** entry; selecting it assigns `Mode::Scroll` through `UnifiedLayoutController::applyEntry`.

## Persistence
- `ScrollEngine` strip state is saved to `scroll-session.json` on shutdown and restored on startup — survives a daemon restart (stale after a full compositor restart; exact-ID restore, matching autotile's boundary).

## Verbiage
- The mode is **"Scrolling"** throughout the UI and config groups (mirrors "Snapping" / "Tiling"); C++ setting accessors keep the `scroll*` mode-noun prefix (mirrors `autotile*`).

## Testing
- Build clean; full suite **186/186 passing**.
- Added `ScrollEngine::perScreenConfig` (override resolution, window-open width, clear) and `Settings::testPerScreenScroll_setSaveLoadClear` (set/save/load round-trip incl. the list path), plus `testScrollSettings_roundtrip` / `testScrollPresets_clampOutOfRange`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)