### PR TITLE
fix: NixOS effect-missing and support-report crash (#481)

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/bug-reports.yml
+++ b/.github/DISCUSSION_TEMPLATE/bug-reports.yml
@@ -79,8 +79,10 @@ body:
     attributes:
       label: Support Report
       description: |
-        Run `plasmazones-report` and attach the generated archive, or paste the D-Bus output:
-        `qdbus6 org.plasmazones /PlasmaZones org.plasmazones.Control.generateSupportReport 0`
+        Run `plasmazones-report` and attach the generated archive.
+        If that command is unavailable, paste the D-Bus output instead:
+        `busctl --user call org.plasmazones /PlasmaZones org.plasmazones.Control generateSupportReport i 0`
+        (Avoid `qdbus`/`qdbus6` — it segfaults at exit on Qt 6.11+ and can drop the report.)
       render: markdown
 
   - type: checkboxes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **KWin effect missing on NixOS** ([#481](https://github.com/fuddlesworth/PlasmaZones/discussions/481)): the KWin effect plugin's IID embeds KWin's exact upstream version, and KWin refuses to load an effect whose IID does not match the running compositor — even across patch releases. The flake's `nixosModules`, `homeManagerModules`, and `overlay` built PlasmaZones against the flake's own pinned `nixpkgs`, so on a rolling NixOS system whose KWin had moved past `flake.lock` the effect's IID no longer matched and KWin silently dropped it, leaving PlasmaZones absent from System Settings → Desktop Effects. The module and overlay now build against the consumer's nixpkgs, so the effect is always compiled against the KWin the user actually runs — matching the exact-version pinning the RPM, Debian, and Arch packages already do.
+- **Support report crashed on Qt 6.11+** ([#481](https://github.com/fuddlesworth/PlasmaZones/discussions/481)): qttools' `qdbus`/`qdbus6` segfaults at process exit on Qt 6.11+ (a static-destruction-order crash in `registerComplexDBusType`'s `QMetaType` cleanup) when introspecting an object that exposes complex D-Bus types, which `/PlasmaZones` does. The crash could discard the buffered support report before it was printed. `plasmazones-report` now prefers `busctl` — unaffected, and present on every systemd distro — over `qdbus`, and the bug-report template recommends the `busctl` invocation instead of `qdbus6`.
+
 ## [3.0.3] - 2026-05-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Hold **Alt** (or your configured modifier) while dragging a window. Zones light 
 ```bash
 yay -S plasmazones-bin                                                # Arch (AUR, prebuilt)
 sudo dnf copr enable fuddlesworth/PlasmaZones && sudo dnf install plasmazones   # Fedora (COPR)
-nix profile install github:fuddlesworth/PlasmaZones                   # Nix
 ```
+
+**NixOS:** install via the flake's `nixosModules.default` (or `homeManagerModules.default`), which builds PlasmaZones against your system's nixpkgs. Avoid `nix profile install` — it compiles the KWin effect against the flake's pinned KWin, and KWin silently refuses to load an effect whose version does not match the running compositor.
 
 openSUSE Tumbleweed, a portable tarball for Fedora Atomic / no-root setups, and source-build instructions (including the `-DUSE_KDE_FRAMEWORKS=OFF` portable build): **[Install page →](https://phosphor-works.github.io/plasmazones/#install)**.
 

--- a/flake.nix
+++ b/flake.nix
@@ -10,16 +10,29 @@
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Build PlasmaZones against a *caller-supplied* nixpkgs instance.
+      #
+      # The KWin effect plugin's IID embeds KWin's exact upstream version
+      # string; KWin refuses to load any effect whose IID does not match the
+      # running KWin — even across patch releases (6.6.4 -> 6.6.5). So the
+      # package MUST be compiled against the very same `kwin` the user runs.
+      #
+      # For module/overlay consumers that means the *consumer's* `pkgs`, never
+      # this flake's pinned `nixpkgs` input — otherwise a rolling system whose
+      # KWin has moved past flake.lock gets a silently non-loading effect
+      # (see discussion #481).
+      mkPlasmaZones = pkgs: pkgs.callPackage ./packaging/nix/package.nix {
+        src = self;
+      };
     in
     {
       packages = forAllSystems (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-        in
         {
-          default = pkgs.callPackage ./packaging/nix/package.nix {
-            src = self;
-          };
+          # Built against this flake's pinned nixpkgs — fine for `nix build`
+          # and CI checks, but NOT a reliable install path for the KWin effect
+          # on a rolling system. Prefer the nixosModule / overlay below.
+          default = mkPlasmaZones nixpkgs.legacyPackages.${system};
           plasmazones = self.packages.${system}.default;
         }
       );
@@ -39,10 +52,14 @@
             enable = lib.mkEnableOption "PlasmaZones window tiling for KDE Plasma 6.6+";
             package = lib.mkOption {
               type = lib.types.package;
-              default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+              default = mkPlasmaZones pkgs;
               defaultText = lib.literalExpression
-                "inputs.plasmazones.packages.\${pkgs.stdenv.hostPlatform.system}.default";
-              description = "The PlasmaZones package to use.";
+                "pkgs.callPackage \"\${plasmazones}/packaging/nix/package.nix\" { src = plasmazones; }";
+              description = ''
+                The PlasmaZones package to use. Built against the host's
+                nixpkgs so the KWin effect plugin's IID matches the running
+                KWin (see discussion #481).
+              '';
             };
           };
 
@@ -64,10 +81,14 @@
             enable = lib.mkEnableOption "PlasmaZones window tiling for KDE Plasma 6.6+";
             package = lib.mkOption {
               type = lib.types.package;
-              default = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+              default = mkPlasmaZones pkgs;
               defaultText = lib.literalExpression
-                "inputs.plasmazones.packages.\${pkgs.stdenv.hostPlatform.system}.default";
-              description = "The PlasmaZones package to use.";
+                "pkgs.callPackage \"\${plasmazones}/packaging/nix/package.nix\" { src = plasmazones; }";
+              description = ''
+                The PlasmaZones package to use. Built against the host's
+                nixpkgs so the KWin effect plugin's IID matches the running
+                KWin (see discussion #481).
+              '';
             };
           };
 
@@ -90,7 +111,9 @@
         };
 
       overlays.default = final: prev: {
-        plasmazones = self.packages.${prev.system}.default;
+        # Build against the consumer's pkgs (`final`) so the KWin effect is
+        # compiled against their KWin — see mkPlasmaZones above.
+        plasmazones = mkPlasmaZones final;
       };
 
       devShells = forAllSystems (system:

--- a/scripts/plasmazones-report.sh
+++ b/scripts/plasmazones-report.sh
@@ -12,7 +12,7 @@
 # but we also include the raw files (config.json, session.json, data/) so that
 # triagers can inspect exact JSON without re-serialization artefacts.
 #
-# Requires: plasmazonesd running, qdbus6 or busctl, perl (with JSON::PP for busctl)
+# Requires: plasmazonesd running, busctl (or qdbus6/qdbus), perl (with JSON::PP for busctl)
 
 set -euo pipefail
 
@@ -74,11 +74,13 @@ OUTPUT_DIR=$(cd "$OUTPUT_DIR" && pwd)
 # ─── D-Bus call ───────────────────────────────────────────────────────────────
 
 call_dbus() {
-    if command -v qdbus6 &>/dev/null; then
-        qdbus6 org.plasmazones /PlasmaZones org.plasmazones.Control.generateSupportReport "$SINCE_MINUTES"
-    elif command -v qdbus &>/dev/null; then
-        qdbus org.plasmazones /PlasmaZones org.plasmazones.Control.generateSupportReport "$SINCE_MINUTES"
-    elif command -v busctl &>/dev/null; then
+    # Prefer busctl: qttools' `qdbus`/`qdbus6` segfaults at process exit on
+    # Qt 6.11+ (static-destruction-order crash in registerComplexDBusType ->
+    # QMetaType::unregisterMetaType) whenever it introspects an object that
+    # exposes complex D-Bus types — which /PlasmaZones does. That crash can
+    # discard buffered stdout, losing the report entirely. busctl (systemd)
+    # is unaffected and present on every systemd distro, so it is the default.
+    if command -v busctl &>/dev/null; then
         local raw
         if raw=$(busctl --user --json=short call org.plasmazones /PlasmaZones org.plasmazones.Control generateSupportReport i "$SINCE_MINUTES" 2>/dev/null); then
             # Parse busctl JSON output: {"type":"s","data":["..."]}
@@ -93,8 +95,13 @@ call_dbus() {
             # embedded strings (e.g., literal backslash-n) may not round-trip perfectly.
             perl -e '$_=do{local $/;<STDIN>}; s/^s "//; s/"\s*$//; s/\\n/\n/g; s/\\t/\t/g; s/\\"/"/g; s/\\\\/\\/g; print' <<< "$raw"
         fi
+    elif command -v qdbus6 &>/dev/null; then
+        # Fallback only — see the busctl rationale above re: the Qt 6.11+ crash.
+        qdbus6 org.plasmazones /PlasmaZones org.plasmazones.Control.generateSupportReport "$SINCE_MINUTES"
+    elif command -v qdbus &>/dev/null; then
+        qdbus org.plasmazones /PlasmaZones org.plasmazones.Control.generateSupportReport "$SINCE_MINUTES"
     else
-        echo "Error: No D-Bus CLI tool found (qdbus6, qdbus, or busctl required)" >&2
+        echo "Error: No D-Bus CLI tool found (busctl, qdbus6, or qdbus required)" >&2
         exit 1
     fi
 }


### PR DESCRIPTION
Resolves the two problems surfaced in discussion #481.

## 1. KWin effect missing on NixOS

The KWin effect plugin's IID embeds KWin's **exact** upstream version, and KWin refuses to load an effect whose IID does not match the running compositor — even across patch releases. CHANGELOG 2.8.8 fixed this for RPM/Arch/Debian via exact `Requires: kwin = <version>` pins; Nix was never covered.

`flake.nix` pinned its own `nixpkgs` input, and `nixosModules`, `homeManagerModules`, and `overlays.default` all resolved to `self.packages.*` — built against the **flake's** pinned nixpkgs, not the consumer's. On a rolling NixOS system whose KWin had moved past `flake.lock`, the effect's IID no longer matched and KWin silently dropped it.

Fix: a `mkPlasmaZones pkgs` helper; the overlay now builds against `final`, and the module `package` defaults build against the module's `pkgs` arg — so the effect is always compiled against the KWin the user actually runs. `packages.default`/`checks` still use the pinned nixpkgs (fine for `nix build`/CI). `README.md` drops the `nix profile install` one-liner and points NixOS users at the flake module.

## 2. Support report crashed on Qt 6.11+

qttools' `qdbus`/`qdbus6` segfaults at process exit on Qt 6.11+ (a static-destruction-order crash in `registerComplexDBusType`'s `QMetaType` cleanup) when introspecting an object exposing complex D-Bus types, which `/PlasmaZones` does — discarding the buffered support report. `plasmazones-report` now prefers `busctl` (unaffected, present on every systemd distro), and the bug-report template recommends the `busctl` invocation instead of `qdbus6`.

## Testing

- `bash -n scripts/plasmazones-report.sh` passes.
- `flake.nix` not validated locally (no `nix` on the dev machine); the `checks` output is the CI gate.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)