### PR TITLE
chore(release): v3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.4] - 2026-05-18
+
 ### Fixed
 
+- **Blank-class windows restored into each other's saved zones** ([#461](https://github.com/fuddlesworth/PlasmaZones/discussions/461)): a window with a blank or whitespace-only KWin class produced a `" "` app identifier that became a live key in the snap restore queue, so unrelated blank-class windows consumed each other's saved zones. App identifiers are now normalized and validated — corrupt keys are rejected at the persist site and dropped by the session loader, which also discards pre-3.0 `"resourceName resourceClass"` keys left over from an upgrade.
+- **Maximized windows ballooning when autotiled** ([#461](https://github.com/fuddlesworth/PlasmaZones/discussions/461)): a user-maximized window kept its `MaximizeFull` state through the autotile `moveResize`, so KWin re-asserted the maximized geometry and the reactive centering loop compounded it into runaway growth. The tile path now clears maximize state before placing the window, and the desktop-switch restore path clears it too.
+- **Per-context disable ignored by auto-snap and keyboard snap** ([#461](https://github.com/fuddlesworth/PlasmaZones/discussions/461)): the interactive drag and autotile paths honored the per-monitor, per-desktop, and per-activity disable lists, but snap-on-open and the keyboard snap-to-zone shortcut did not, so windows still snapped on contexts the user had disabled. Both paths — and the float toggle — now gate on the disable lists.
+- **Windows stayed tiled after switching to an autotile-disabled desktop**: the desktop-switch handler never restored windows on the desktop being switched *to*, so arriving on an autotile-disabled desktop left its windows tiled and borderless. The handler now runs a per-window restore pass for the arrived-at desktop.
+- **Confusing new-window placement toggle labels** ([#461](https://github.com/fuddlesworth/PlasmaZones/discussions/461)): disabling "New windows to last zone" did not stop windows returning to zones — that behavior is governed by "Restore zones on login", whose title implied it applied only at login. Both toggles were retitled to describe what they actually do.
+- **Zone geometry not clamped to the screen** ([#461](https://github.com/fuddlesworth/PlasmaZones/discussions/461)): gap math could produce a zone rectangle extending past the screen edge when fed malformed layout data. `applyGapsToZoneGeometry` now clamps the gapped rectangle to the screen, and resolved snap placements are logged at INFO so geometry reports are diagnosable.
 - **KWin effect missing on NixOS** ([#481](https://github.com/fuddlesworth/PlasmaZones/discussions/481)): the KWin effect plugin's IID embeds KWin's exact upstream version, and KWin refuses to load an effect whose IID does not match the running compositor — even across patch releases. The flake's `nixosModules`, `homeManagerModules`, and `overlay` built PlasmaZones against the flake's own pinned `nixpkgs`, so on a rolling NixOS system whose KWin had moved past `flake.lock` the effect's IID no longer matched and KWin silently dropped it, leaving PlasmaZones absent from System Settings → Desktop Effects. The module and overlay now build against the consumer's nixpkgs, so the effect is always compiled against the KWin the user actually runs — matching the exact-version pinning the RPM, Debian, and Arch packages already do.
 - **Support report crashed on Qt 6.11+** ([#481](https://github.com/fuddlesworth/PlasmaZones/discussions/481)): qttools' `qdbus`/`qdbus6` segfaults at process exit on Qt 6.11+ (a static-destruction-order crash in `registerComplexDBusType`'s `QMetaType` cleanup) when introspecting an object that exposes complex D-Bus types, which `/PlasmaZones` does. The crash could discard the buffered support report before it was printed. `plasmazones-report` now prefers `busctl` — unaffected, and present on every systemd distro — over `qdbus`, and the bug-report template recommends the `busctl` invocation instead of `qdbus6`.
 
@@ -1310,7 +1318,8 @@ Initial packaged release. Wayland-only (X11 support removed). Requires KDE Plasm
 - Session restoration and rotation after login ([#66])
 - Window tracking: snap/restore behavior, zone clearing, startup timing, rotation zone ID matching, floating window exclusion ([#67])
 
-[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.3...HEAD
+[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.4...HEAD
+[3.0.4]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.3...v3.0.4
 [3.0.3]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.0...v3.0.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(PlasmaZones VERSION 3.0.3 LANGUAGES C CXX)
+project(PlasmaZones VERSION 3.0.4 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/data/whatsnew.json
+++ b/data/whatsnew.json
@@ -1,6 +1,18 @@
 {
     "releases": [
         {
+            "version": "3.0.4",
+            "date": "2026-05-18",
+            "highlights": [
+                "Fixed maximized windows ballooning in size when autotiled (#461)",
+                "Fixed snapping and keyboard snap-to-zone ignoring the per-monitor, per-desktop, and per-activity disable settings (#461)",
+                "Fixed windows with a blank window class restoring into each other's saved zones (#461)",
+                "Fixed windows staying tiled after switching onto a desktop where autotiling is disabled (#461)",
+                "Fixed the KWin desktop effect not appearing on NixOS — the flake now builds PlasmaZones against your system's KWin so the effect always matches the running compositor (#481)",
+                "Fixed support report generation crashing on Qt 6.11+ — plasmazones-report and the bug-report instructions now use busctl, which is unaffected (#481)"
+            ]
+        },
+        {
             "version": "3.0.3",
             "date": "2026-05-17",
             "highlights": [


### PR DESCRIPTION
Release prep for **v3.0.4** — a patch release.

## Changes
- `CMakeLists.txt` — `VERSION 3.0.3` → `3.0.4` (single source of truth; packaging derives from it).
- `CHANGELOG.md` — new `[3.0.4]` section + compare-link refs.
- `data/whatsnew.json` — new `3.0.4` entry for the in-app What's New.

## What 3.0.4 contains

Eight user-facing fixes merged to `main` since v3.0.3:

**Discussion #461 (PR #478):**
- Blank-class windows restoring into each other's saved zones
- Maximized windows ballooning when autotiled
- Per-context disable ignored by auto-snap, keyboard snap, and float toggle
- Windows staying tiled after switching to an autotile-disabled desktop
- Confusing new-window placement toggle labels
- Zone geometry not clamped to the screen

**Discussion #481 (PR #483):**
- KWin effect missing on NixOS (flake IID mismatch)
- Support report crashing on Qt 6.11+ (`qdbus` exit segfault)

PR #479 was comment-only (no behavior change) — intentionally no changelog entry. The audit-pass commits are intra-PR review fixes folded into the entries above.

## After merge
Tag `v3.0.4` on the merge commit to trigger the release pipeline.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)