### PR TITLE
fix(daemon): diagnose KWin effect version mismatch on bridge timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,16 @@ yay -S plasmazones-bin                                                # Arch (AU
 sudo dnf copr enable fuddlesworth/PlasmaZones && sudo dnf install plasmazones   # Fedora (COPR)
 ```
 
-**NixOS:** install via the flake's `nixosModules.default` (or `homeManagerModules.default`), which builds PlasmaZones against your system's nixpkgs. Avoid `nix profile install` — it compiles the KWin effect against the flake's pinned KWin, and KWin silently refuses to load an effect whose version does not match the running compositor.
+**NixOS:** add the flake to your system config and use `nixosModules.default` — it builds PlasmaZones against *your* nixpkgs, so the KWin effect always matches your running KWin:
+
+```nix
+# flake.nix
+inputs.plasmazones.url = "github:fuddlesworth/PlasmaZones";
+# …then in your nixosSystem modules list:
+modules = [ plasmazones.nixosModules.default { programs.plasmazones.enable = true; } ];
+```
+
+Do **not** install via `nix profile install` / `packages.default`: that compiles the KWin effect against the flake's *pinned* KWin, and KWin silently refuses to load an effect whose version does not match the running compositor (the effect just goes missing from Desktop Effects). `homeManagerModules.default` and `overlays.default` build correctly the same way the module does.
 
 openSUSE Tumbleweed, a portable tarball for Fedora Atomic / no-root setups, and source-build instructions (including the `-DUSE_KDE_FRAMEWORKS=OFF` portable build): **[Install page →](https://phosphor-works.github.io/plasmazones/#install)**.
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -104,6 +104,35 @@ constexpr int GEOMETRY_UPDATE_DEBOUNCE_MS = 400;
 // even when the daemon starts before KWin during login — so a timeout means
 // a genuine failure, not a race.
 constexpr int BRIDGE_WATCHDOG_TIMEOUT_MS = 20000;
+
+// Locate the installed PlasmaZones KWin effect plugin and read the KWin
+// version embedded in its plugin interface ID. The KWin effect is a compiled
+// C++ plugin; KWin bakes its exact version into the IID it accepts
+// (EffectPluginFactory_iid = "org.kde.kwin.EffectPluginFactory" + the KWin
+// version string), and silently rejects any plugin built against a different
+// KWin. metaData() reads only the static metadata section — no dlopen — so it
+// works even on the version-mismatched plugin KWin itself refuses to load.
+// `installed` is set to whether the plugin file was found at all. Returns the
+// KWin version the effect was built against, or empty when the plugin is
+// missing or its IID is not a recognizable KWin effect IID.
+QString probeEffectKWinVersion(bool& installed)
+{
+    static const QLatin1String iidPrefix("org.kde.kwin.EffectPluginFactory");
+    const QString effectRelPath = QStringLiteral("kwin/effects/plugins/kwin_effect_plasmazones.so");
+
+    installed = false;
+    const QStringList libraryPaths = QCoreApplication::libraryPaths();
+    for (const QString& base : libraryPaths) {
+        const QString candidate = base + QLatin1Char('/') + effectRelPath;
+        if (!QFile::exists(candidate)) {
+            continue;
+        }
+        installed = true;
+        const QString iid = QPluginLoader(candidate).metaData().value(QLatin1String("IID")).toString();
+        return iid.startsWith(iidPrefix) ? iid.mid(iidPrefix.size()) : QString();
+    }
+    return QString();
+}
 } // anonymous namespace
 
 Daemon::Daemon(QObject* parent)
@@ -1319,67 +1348,6 @@ void Daemon::start()
     }
 }
 
-QString Daemon::diagnoseEffectLoadFailure() const
-{
-    // The KWin effect is a compiled C++ plugin. KWin embeds its exact version
-    // into the plugin interface ID it will accept — EffectPluginFactory_iid is
-    // "org.kde.kwin.EffectPluginFactory" concatenated with KWin's version
-    // string. An effect built against a different KWin (even one patch release
-    // apart) carries a non-matching IID, and KWin's effect loader silently
-    // refuses to instantiate it: no error, the effect simply never registers.
-    // This diagnoses that case so the watchdog notification can name the real
-    // cause (a stale effect build) instead of a generic "not running".
-    static const QLatin1String iidPrefix("org.kde.kwin.EffectPluginFactory");
-    static const QLatin1String effectRelPath("kwin/effects/plugins/kwin_effect_plasmazones.so");
-
-    // Locate the installed effect plugin under Qt's plugin search paths.
-    QString effectPath;
-    const QStringList libraryPaths = QCoreApplication::libraryPaths();
-    for (const QString& base : libraryPaths) {
-        const QString candidate = base + QLatin1Char('/') + effectRelPath;
-        if (QFile::exists(candidate)) {
-            effectPath = candidate;
-            break;
-        }
-    }
-    if (effectPath.isEmpty()) {
-        return PzI18n::tr(
-            "The PlasmaZones KWin effect plugin is not installed where KWin can find it. "
-            "Reinstall PlasmaZones.");
-    }
-
-    // Read the plugin's embedded interface ID without loading it: metaData()
-    // parses only the static metadata section, so it works even for the
-    // version-mismatched plugin KWin itself refuses to load.
-    const QString effectIid = QPluginLoader(effectPath).metaData().value(QLatin1String("IID")).toString();
-    if (!effectIid.startsWith(iidPrefix)) {
-        return QString();
-    }
-    const QString effectKWinVersion = effectIid.mid(iidPrefix.size());
-
-    // Ask the running KWin for its version. supportInformation() is the only
-    // reliable D-Bus source; a short timeout keeps this already-degraded
-    // startup path from stalling if KWin is unresponsive.
-    QDBusMessage req =
-        QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"), QStringLiteral("/KWin"),
-                                       QStringLiteral("org.kde.KWin"), QStringLiteral("supportInformation"));
-    const QDBusMessage reply = QDBusConnection::sessionBus().call(req, QDBus::Block, 3000);
-    if (reply.type() != QDBusMessage::ReplyMessage || reply.arguments().isEmpty()) {
-        return QString();
-    }
-    const QRegularExpressionMatch match =
-        QRegularExpression(QStringLiteral("KWin version:\\s*(\\S+)")).match(reply.arguments().constFirst().toString());
-    if (!match.hasMatch() || match.captured(1) == effectKWinVersion) {
-        return QString();
-    }
-
-    return PzI18n::tr(
-               "The PlasmaZones KWin effect was built for KWin %1 but KWin %2 is running, so KWin "
-               "will not load it. Rebuild and reinstall PlasmaZones against the running KWin. On "
-               "NixOS, install via the flake's nixosModules or overlay (not packages.default).")
-        .arg(effectKWinVersion, match.captured(1));
-}
-
 void Daemon::warnCompositorBridgeMissing()
 {
     // Stay silent during shutdown. The watchdog may still be armed when the
@@ -1396,12 +1364,70 @@ void Daemon::warnCompositorBridgeMissing()
         return;
     }
 
-    // Try to pin down why the effect never registered (most often a stale
-    // effect build whose IID no longer matches the running KWin). A specific
-    // diagnosis replaces the generic remediation guidance in both the log and
-    // the notification; otherwise fall back to the enable-the-effect advice.
-    const QString diagnosis = diagnoseEffectLoadFailure();
+    // Inspect the installed effect plugin (synchronous, cheap). The most common
+    // silent failure is a stale effect build whose IID no longer matches the
+    // running KWin, so KWin's effect loader rejects it without surfacing an
+    // error and the effect never registers.
+    bool effectInstalled = false;
+    const QString effectKWinVersion = probeEffectKWinVersion(effectInstalled);
 
+    if (!effectInstalled) {
+        emitBridgeMissingWarning(
+            PzI18n::tr("The PlasmaZones KWin effect plugin is not installed where KWin can find it. "
+                       "Reinstall PlasmaZones."));
+        return;
+    }
+    if (effectKWinVersion.isEmpty()) {
+        // Plugin present but its IID is not a recognizable KWin effect IID —
+        // nothing specific to report, fall back to the generic guidance.
+        emitBridgeMissingWarning(QString());
+        return;
+    }
+
+    // Compare the effect's build-time KWin version against the running KWin.
+    // supportInformation() is the only reliable D-Bus source for KWin's
+    // version; query it asynchronously so this degraded startup path never
+    // blocks the daemon's event loop (mirrors the fire-and-forget notification
+    // call in emitBridgeMissingWarning).
+    QDBusMessage req =
+        QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"), QStringLiteral("/KWin"),
+                                       QStringLiteral("org.kde.KWin"), QStringLiteral("supportInformation"));
+    auto* watcher = new QDBusPendingCallWatcher(QDBusConnection::sessionBus().asyncCall(req, 3000), this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, effectKWinVersion](QDBusPendingCallWatcher* call) {
+                call->deleteLater();
+
+                // The 3s round-trip widens the window in which a late effect
+                // registration can land; stay silent if shutdown began or the
+                // bridge registered after all.
+                if (m_shuttingDown || (m_compositorBridge && m_compositorBridge->isBridgeRegistered())) {
+                    return;
+                }
+
+                QString diagnosis;
+                const QDBusPendingReply<QString> reply = *call;
+                if (!reply.isError()) {
+                    const QRegularExpressionMatch match =
+                        QRegularExpression(QStringLiteral("KWin version:\\s*(\\S+)")).match(reply.value());
+                    if (match.hasMatch()) {
+                        const QString runningKWinVersion = match.captured(1);
+                        if (runningKWinVersion != effectKWinVersion) {
+                            diagnosis = PzI18n::tr(
+                                            "The PlasmaZones KWin effect was built for KWin %1 but "
+                                            "KWin %2 is running, so KWin will not load it. Rebuild and "
+                                            "reinstall PlasmaZones against the running KWin. On NixOS, "
+                                            "install via the flake's nixosModules or overlay (not "
+                                            "packages.default).")
+                                            .arg(effectKWinVersion, runningKWinVersion);
+                        }
+                    }
+                }
+                emitBridgeMissingWarning(diagnosis);
+            });
+}
+
+void Daemon::emitBridgeMissingWarning(const QString& diagnosis)
+{
     if (diagnosis.isEmpty()) {
         qCWarning(lcDaemon) << "Compositor bridge did not register within" << (BRIDGE_WATCHDOG_TIMEOUT_MS / 1000)
                             << "s of startup — the PlasmaZones KWin effect is not running or"

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -18,6 +18,8 @@
 #include <QDBusError>
 #include <QDir>
 #include <QFile>
+#include <QPluginLoader>
+#include <QRegularExpression>
 #include <QSet>
 #include <QThread>
 
@@ -1317,6 +1319,67 @@ void Daemon::start()
     }
 }
 
+QString Daemon::diagnoseEffectLoadFailure() const
+{
+    // The KWin effect is a compiled C++ plugin. KWin embeds its exact version
+    // into the plugin interface ID it will accept — EffectPluginFactory_iid is
+    // "org.kde.kwin.EffectPluginFactory" concatenated with KWin's version
+    // string. An effect built against a different KWin (even one patch release
+    // apart) carries a non-matching IID, and KWin's effect loader silently
+    // refuses to instantiate it: no error, the effect simply never registers.
+    // This diagnoses that case so the watchdog notification can name the real
+    // cause (a stale effect build) instead of a generic "not running".
+    static const QLatin1String iidPrefix("org.kde.kwin.EffectPluginFactory");
+    static const QLatin1String effectRelPath("kwin/effects/plugins/kwin_effect_plasmazones.so");
+
+    // Locate the installed effect plugin under Qt's plugin search paths.
+    QString effectPath;
+    const QStringList libraryPaths = QCoreApplication::libraryPaths();
+    for (const QString& base : libraryPaths) {
+        const QString candidate = base + QLatin1Char('/') + effectRelPath;
+        if (QFile::exists(candidate)) {
+            effectPath = candidate;
+            break;
+        }
+    }
+    if (effectPath.isEmpty()) {
+        return PzI18n::tr(
+            "The PlasmaZones KWin effect plugin is not installed where KWin can find it. "
+            "Reinstall PlasmaZones.");
+    }
+
+    // Read the plugin's embedded interface ID without loading it: metaData()
+    // parses only the static metadata section, so it works even for the
+    // version-mismatched plugin KWin itself refuses to load.
+    const QString effectIid = QPluginLoader(effectPath).metaData().value(QLatin1String("IID")).toString();
+    if (!effectIid.startsWith(iidPrefix)) {
+        return QString();
+    }
+    const QString effectKWinVersion = effectIid.mid(iidPrefix.size());
+
+    // Ask the running KWin for its version. supportInformation() is the only
+    // reliable D-Bus source; a short timeout keeps this already-degraded
+    // startup path from stalling if KWin is unresponsive.
+    QDBusMessage req =
+        QDBusMessage::createMethodCall(QStringLiteral("org.kde.KWin"), QStringLiteral("/KWin"),
+                                       QStringLiteral("org.kde.KWin"), QStringLiteral("supportInformation"));
+    const QDBusMessage reply = QDBusConnection::sessionBus().call(req, QDBus::Block, 3000);
+    if (reply.type() != QDBusMessage::ReplyMessage || reply.arguments().isEmpty()) {
+        return QString();
+    }
+    const QRegularExpressionMatch match =
+        QRegularExpression(QStringLiteral("KWin version:\\s*(\\S+)")).match(reply.arguments().constFirst().toString());
+    if (!match.hasMatch() || match.captured(1) == effectKWinVersion) {
+        return QString();
+    }
+
+    return PzI18n::tr(
+               "The PlasmaZones KWin effect was built for KWin %1 but KWin %2 is running, so KWin "
+               "will not load it. Rebuild and reinstall PlasmaZones against the running KWin. On "
+               "NixOS, install via the flake's nixosModules or overlay (not packages.default).")
+        .arg(effectKWinVersion, match.captured(1));
+}
+
 void Daemon::warnCompositorBridgeMissing()
 {
     // Stay silent during shutdown. The watchdog may still be armed when the
@@ -1333,12 +1396,30 @@ void Daemon::warnCompositorBridgeMissing()
         return;
     }
 
-    qCWarning(lcDaemon) << "Compositor bridge did not register within" << (BRIDGE_WATCHDOG_TIMEOUT_MS / 1000)
-                        << "s of startup — the PlasmaZones KWin effect is not running or"
-                        << "failed to register. Window dragging, keyboard shortcuts, and"
-                        << "snapping will not work. Enable the PlasmaZones effect in System"
-                        << "Settings > Desktop Effects, then restart the Plasma session so"
-                        << "KWin loads it.";
+    // Try to pin down why the effect never registered (most often a stale
+    // effect build whose IID no longer matches the running KWin). A specific
+    // diagnosis replaces the generic remediation guidance in both the log and
+    // the notification; otherwise fall back to the enable-the-effect advice.
+    const QString diagnosis = diagnoseEffectLoadFailure();
+
+    if (diagnosis.isEmpty()) {
+        qCWarning(lcDaemon) << "Compositor bridge did not register within" << (BRIDGE_WATCHDOG_TIMEOUT_MS / 1000)
+                            << "s of startup — the PlasmaZones KWin effect is not running or"
+                            << "failed to register. Window dragging, keyboard shortcuts, and"
+                            << "snapping will not work. Enable the PlasmaZones effect in System"
+                            << "Settings > Desktop Effects, then restart the Plasma session so"
+                            << "KWin loads it.";
+    } else {
+        qCWarning(lcDaemon) << "Compositor bridge did not register within" << (BRIDGE_WATCHDOG_TIMEOUT_MS / 1000)
+                            << "s of startup — window control is dead." << diagnosis;
+    }
+
+    const QString body = diagnosis.isEmpty()
+        ? PzI18n::tr(
+              "The PlasmaZones KWin effect has not registered with the daemon, so window "
+              "dragging and shortcuts will not work. Make sure it is enabled in System "
+              "Settings > Desktop Effects, then restart the Plasma session.")
+        : diagnosis;
 
     // Raise a desktop notification via the freedesktop spec so the user sees
     // the problem without having to read the journal. A direct method call
@@ -1354,10 +1435,7 @@ void Daemon::warnCompositorBridgeMissing()
            << 0u // replaces_id
            << QStringLiteral("plasmazones") // app_icon
            << PzI18n::tr("PlasmaZones: window manager integration inactive") // summary
-           << PzI18n::tr(
-                  "The PlasmaZones KWin effect has not registered with the daemon, so window "
-                  "dragging and shortcuts will not work. Make sure it is enabled in System "
-                  "Settings > Desktop Effects, then restart the Plasma session.") // body
+           << body // body
            << QStringList() // actions
            << QVariantMap() // hints
            << -1; // timeout (server default)

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -753,6 +753,14 @@ private:
     // registers. Single-shot.
     QTimer m_bridgeWatchdogTimer;
     void warnCompositorBridgeMissing();
+
+    // Best-effort root-cause check for a KWin effect that never registered.
+    // Detects the common silent failure: the installed effect plugin's IID
+    // embeds a different KWin version than the running KWin, so KWin's effect
+    // loader rejects the plugin without surfacing an error. Returns a
+    // user-facing remediation message, or an empty string when no specific
+    // cause is found (the caller falls back to the generic warning).
+    QString diagnoseEffectLoadFailure() const;
 };
 
 } // namespace PlasmaZones

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -754,13 +754,11 @@ private:
     QTimer m_bridgeWatchdogTimer;
     void warnCompositorBridgeMissing();
 
-    // Best-effort root-cause check for a KWin effect that never registered.
-    // Detects the common silent failure: the installed effect plugin's IID
-    // embeds a different KWin version than the running KWin, so KWin's effect
-    // loader rejects the plugin without surfacing an error. Returns a
-    // user-facing remediation message, or an empty string when no specific
-    // cause is found (the caller falls back to the generic warning).
-    QString diagnoseEffectLoadFailure() const;
+    // Log a "compositor bridge missing" warning and raise a desktop
+    // notification. `diagnosis` carries a specific root cause (e.g. an effect
+    // plugin built against a different KWin version) when one was identified;
+    // an empty string falls back to the generic enable-the-effect guidance.
+    void emitBridgeMissingWarning(const QString& diagnosis);
 };
 
 } // namespace PlasmaZones


### PR DESCRIPTION
## Summary

The KWin effect is a compiled C++ plugin whose interface ID embeds KWin's **exact** version string:

```c
#define EffectPluginFactory_iid "org.kde.kwin.EffectPluginFactory" KWIN_PLUGIN_VERSION_STRING
```

KWin's effect loader silently rejects any plugin whose IID doesn't match the running KWin — even one patch release apart. The effect just never registers, and the bridge watchdog reported only a generic "effect not running" message, leaving the user with no actionable cause.

This is the silent failure behind **discussion #481** (effect missing on NixOS — `packages.default` builds the effect against the flake's *pinned* KWin, not the running one). It is not NixOS-specific: any distro that updates KWin without rebuilding PlasmaZones hits the same dead effect.

## Changes

- **`Daemon::diagnoseEffectLoadFailure()`** — on bridge-watchdog timeout, reads the installed `kwin_effect_plasmazones.so`'s embedded IID via `QPluginLoader::metaData()` (static metadata only — no plugin load, so it works on the very plugin KWin rejected), queries the running KWin version via `org.kde.KWin` `supportInformation()`, and compares.
- On mismatch, the log + desktop notification now name the exact **built-for vs. running** KWin versions and the remediation (on NixOS: install via `nixosModules`/`overlays`, not `packages.default`).
- Degrades safely to the existing generic message when versions match, the `.so` isn't found, or KWin doesn't answer (3 s timeout).
- **README** — NixOS install section now has a copy-pasteable `nixosModules.default` snippet and an explicit warning against `nix profile install` / `packages.default`.

## Testing

- `cmake --build build` — clean.
- `ctest` — 180/180 passing.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)