### PR TITLE
fix(ci): correct update-flake-lock action pin to a real commit SHA

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -31,9 +31,9 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update flake.lock
-        # DeterminateSystems/update-flake-lock v24 — pinned by SHA, same
+        # DeterminateSystems/update-flake-lock v28 — pinned by SHA, same
         # rationale. Bump when verifying a newer commit on the action.
-        uses: DeterminateSystems/update-flake-lock@a2e3e8e30c66d57e6f64ef9aa6f3a35bb20ddf91
+        uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6
         with:
           pr-title: "chore(nix): update flake.lock"
           pr-labels: dependencies,nix


### PR DESCRIPTION
## Problem

[Workflow run #26065589727](https://github.com/fuddlesworth/PlasmaZones/actions/runs/26065589727) fails at **Set up job** with:

> Unable to resolve action `DeterminateSystems/update-flake-lock@a2e3e8e30c66d57e6f64ef9aa6f3a35bb20ddf91`, unable to find version `a2e3e8e30c66d57e6f64ef9aa6f3a35bb20ddf91`

The `update-flake-lock.yml` workflow pinned `DeterminateSystems/update-flake-lock` to a SHA that **does not exist** in the action's repository (the comment claimed "v24", but real v24 is `a2bbe02…`). GitHub resolves all `uses:` refs during job setup, so the workflow dies before any step runs.

## Fix

Repin to `834c491b2ece4de0bbd00d85214bb5e83b4da5c6` — the real **v28** release commit (latest stable) — and update the version comment. The `pr-title` / `pr-labels` / `pr-assignees` / `pr-reviewers` inputs used here are unchanged across v24..v28.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)