### PR TITLE
fix: honor global snapping toggle and exclude transient windows (#461)

### DIFF
--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -124,8 +124,16 @@ bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w) const
     // Skip transient/dialog windows unconditionally. Dialogs, utilities, tooltips,
     // notifications, etc. should never be zone-managed. User-configured exclusion
     // lists and minimum size checks are handled by the daemon.
+    //
+    // transientFor() catches child surfaces that Electron/CEF apps (Steam, Discord,
+    // VS Code) spawn for image previews, context menus and popups: these frequently
+    // fail to report an accurate KWin window type (isDialog/isPopupWindow stay
+    // false) but always set the transient-parent relationship. Without this the
+    // popup passes the filter and gets snapped to a zone (discussion #461 item 11).
+    // Mirrors the transient bucket already enforced by shouldAnimateWindow() and
+    // isTileableWindow().
     if (w->isDialog() || w->isUtility() || w->isSplash() || w->isNotification() || w->isOnScreenDisplay()
-        || w->isModal() || w->isPopupWindow()) {
+        || w->isModal() || w->isPopupWindow() || w->transientFor()) {
         return false;
     }
 

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
@@ -14,6 +14,13 @@ class ISnapSettings
 public:
     virtual ~ISnapSettings() = default;
 
+    // Global snapping master toggle. When false the user has turned snapping
+    // off entirely: no window may be auto-snapped on open via any path (app
+    // rule, session restore, empty-zone auto-assign, last-used-zone). The
+    // engine's auto-snap resolver gates on this so the daemon-side D-Bus gate
+    // and this engine-internal one (SnapEngine::windowOpened) stay in lockstep.
+    virtual bool snappingEnabled() const = 0;
+
     virtual QStringList excludedApplications() const = 0;
     virtual QStringList excludedWindowClasses() const = 0;
     virtual StickyWindowHandling stickyWindowHandling() const = 0;

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
@@ -16,9 +16,10 @@ public:
 
     // Global snapping master toggle. When false the user has turned snapping
     // off entirely: no window may be auto-snapped on open via any path (app
-    // rule, session restore, empty-zone auto-assign, last-used-zone). The
-    // engine's auto-snap resolver gates on this so the daemon-side D-Bus gate
-    // and this engine-internal one (SnapEngine::windowOpened) stay in lockstep.
+    // rule, session restore, empty-zone auto-assign, last-used-zone).
+    // SnapEngine::resolveWindowRestore gates on this so the engine-internal
+    // auto-snap path and the daemon-side D-Bus gate (SnapAdaptor::applySnapResult)
+    // stay in lockstep.
     virtual bool snappingEnabled() const = 0;
 
     virtual QStringList excludedApplications() const = 0;

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -70,6 +70,12 @@ public:
     // ═══════════════════════════════════════════════════════════════════════════
 
     bool isActiveOnScreen(const QString& screenId) const override;
+    /// True when snapping is globally enabled. Mirrors AutotileEngine::isEnabled()
+    /// so callers (daemon shortcut dispatch, mode routing) can gate snap-mode
+    /// operations through the IPlacementEngine interface uniformly. Without this
+    /// override SnapEngine inherits IPlacementEngine's `return false` default,
+    /// which made every snap engine a no-op to any isEnabled() caller.
+    bool isEnabled() const noexcept override;
     using IPlacementEngine::windowOpened;
     void windowOpened(const QString& windowId, const QString& screenId, int minWidth, int minHeight) override;
     void windowClosed(const QString& windowId) override;

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -106,13 +106,10 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     // below only covers autotile-mode screens; a screen still carrying a
     // Snapping-mode layout assignment would otherwise keep auto-snapping new
     // windows even with snapping globally disabled (discussion #461 item 2).
-    {
-        auto* s = snapSettings();
-        if (!s || !s->snappingEnabled()) {
-            qCDebug(PhosphorSnapEngine::lcSnapEngine)
-                << "resolveWindowRestore:" << windowId << "snapping globally disabled, skipping";
-            return SnapResult::noSnap();
-        }
+    if (!isEnabled()) {
+        qCDebug(PhosphorSnapEngine::lcSnapEngine)
+            << "resolveWindowRestore:" << windowId << "snapping globally disabled, skipping";
+        return SnapResult::noSnap();
     }
 
     // Pre-check: if this window already has an exact zone assignment (loaded from

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -235,4 +235,14 @@ QString SnapEngine::currentActivity() const
     return m_layoutManager ? m_layoutManager->currentActivity() : QString();
 }
 
+bool SnapEngine::isEnabled() const noexcept
+{
+    // Snapping's global master toggle is the engine's enabled state — there is
+    // no per-screen "is snapping active here" notion (that is the layout-mode
+    // router's job). When false, the whole snap subsystem is off, mirroring
+    // AutotileEngine::isEnabled() reporting autotile's effective state.
+    auto* s = snapSettings();
+    return s && s->snappingEnabled();
+}
+
 } // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -100,6 +100,21 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
         return SnapResult::noSnap();
     }
 
+    // Global snapping kill-switch. When the user turns snapping off entirely,
+    // no window may be auto-snapped on open — not via app rules, session
+    // restore, empty-zone auto-assign, or last-used-zone. The screen-mode gate
+    // below only covers autotile-mode screens; a screen still carrying a
+    // Snapping-mode layout assignment would otherwise keep auto-snapping new
+    // windows even with snapping globally disabled (discussion #461 item 2).
+    {
+        auto* s = snapSettings();
+        if (!s || !s->snappingEnabled()) {
+            qCDebug(PhosphorSnapEngine::lcSnapEngine)
+                << "resolveWindowRestore:" << windowId << "snapping globally disabled, skipping";
+            return SnapResult::noSnap();
+        }
+    }
+
     // Pre-check: if this window already has an exact zone assignment (loaded from
     // KConfig with full windowId after daemon-only restart), skip the restore chain.
     // Consume the appId-based pending entry to prevent other instances of the same

--- a/src/daemon/daemon/navigation.cpp
+++ b/src/daemon/daemon/navigation.cpp
@@ -87,7 +87,19 @@ static PhosphorEngine::IPlacementEngine* navigatorForShortcut(ScreenModeRouter* 
     if (!router) {
         return nullptr;
     }
-    return router->engineFor(outCtx.screenId);
+    PhosphorEngine::IPlacementEngine* nav = router->engineFor(outCtx.screenId);
+    // Global feature-toggle gate. engineFor() routes purely on the screen's
+    // layout mode; it does not consult whether that mode's master toggle is
+    // on. isEnabled() reports the effective on/off state for both engines
+    // (SnapEngine → snappingEnabled, AutotileEngine → any-screen autotiling),
+    // so one check here suppresses every snap- and autotile-mode shortcut
+    // when its feature is globally disabled — the keyboard-nav counterpart of
+    // the auto-snap-on-open kill-switch in SnapEngine::resolveWindowRestore.
+    if (nav && !nav->isEnabled()) {
+        qCDebug(lcDaemon) << shortcutName << "shortcut: ignored — engine disabled for screen" << outCtx.screenId;
+        return nullptr;
+    }
+    return nav;
 }
 
 void Daemon::handleRotate(bool clockwise)

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -229,6 +229,17 @@ bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
         return false;
     }
 
+    // Global snapping kill-switch — see discussion #461 item 2. Every snapTo*
+    // / restoreToPersistedZone / resolveWindowRestore D-Bus slot funnels
+    // through here, so a single gate suppresses all auto-snap-on-open paths
+    // when the user has turned snapping off entirely. Mirrors the
+    // engine-internal gate in SnapEngine::resolveWindowRestore.
+    if (m_settings && !m_settings->snappingEnabled()) {
+        qCInfo(lcDbusWindow) << "applySnapResult: refusing auto-snap of" << windowId
+                             << "— snapping is globally disabled";
+        return false;
+    }
+
     // Disabled-context gate. The interactive drag path (WindowDragAdaptor)
     // and autotile (Daemon::updateAutotileScreens) already refuse to place
     // windows on a monitor / desktop / activity the user marked disabled.


### PR DESCRIPTION
Addresses bugs from discussion #461 (3.0.x bug report) and makes the
`Snapping.Enabled` master toggle a true kill-switch, at parity with autotiling.

## #461 item 11 — Steam/Electron popups snapped to zones

`shouldHandleWindow()` in the KWin effect filtered dialogs, utilities,
splashes, notifications, OSDs, modals and popup windows but never
checked `w->transientFor()` — despite a comment claiming it skips
transient windows. Its two sibling filters in the same file
(`shouldAnimateWindow()`, `isTileableWindow()`) already exclude
transient children. Electron/CEF apps spawn child surfaces for image
previews/popups that report no accurate KWin window type but always set
the transient-parent relationship, so they passed the filter and got
snapped.

## #461 item 2 — windows stuck in last zone with snapping disabled

The auto-snap-on-open path never consulted the global snapping toggle:
`resolveWindowRestore` gated empty/last-zone fallbacks only on
`modeForScreen() == Snapping` (the assigned layout mode, independent of
the global toggle); the `snapTo*` D-Bus slots and `applySnapResult()`
never checked it either.

`snappingEnabled()` added to `ISnapSettings`; both chokepoints gated —
`SnapEngine::resolveWindowRestore` (covers `windowOpened`) and
`SnapAdaptor::applySnapResult` (covers every snap D-Bus slot).

## Snapping kill-switch parity with autotiling

`IPlacementEngine::isEnabled()` (default `false`) was overridden by
`AutotileEngine` but not `SnapEngine` — so `SnapEngine::isEnabled()` was
a constant `false`, and the daemon's snap-mode keyboard handlers had no
enabled-gate (unlike the autotile handlers). `SnapEngine` now overrides
`isEnabled()` → `snappingEnabled()`, and the shared shortcut dispatcher
`navigatorForShortcut()` gates on it — suppressing all snap- and
autotile-mode shortcuts when the feature is globally off.

With this, `Snapping.Enabled=false` suppresses every snap path:
auto-snap-on-open, interactive drag (already gated in `dragStarted`),
and keyboard navigation.

## Testing

- `cmake --build build` — clean, no warnings
- `ctest` — 185/185 passing

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)