### PR TITLE
fix(editor): shaders not listed in the layout editor

### DIFF
--- a/dbus/org.plasmazones.Settings.xml
+++ b/dbus/org.plasmazones.Settings.xml
@@ -145,7 +145,8 @@
         <!-- Shader methods. These are also published on the dedicated
              org.plasmazones.Shader interface (see org.plasmazones.Shader.xml);
              SettingsAdaptor keeps them here for backward compatibility with
-             callers that bind the Settings interface. Keep both XMLs in sync. -->
+             callers that bind the Settings interface. Keep the method set and
+             signatures consistent across both interfaces. -->
         <method name="availableShaders">
             <annotation name="org.gtk.GDBus.DocString" value="Get list of available shader effects with metadata."/>
             <arg name="shaders" type="av" direction="out">
@@ -178,7 +179,7 @@
             <arg name="params" type="a{sv}" direction="in">
                 <annotation name="org.gtk.GDBus.DocString" value="Map of param IDs to values (e.g. intensity: 0.5)."/>
             </arg>
-            <arg name="result" type="a{sv}" direction="out">
+            <arg name="uniforms" type="a{sv}" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="Map of uniform names to values (e.g. customParams1_x: 0.5)."/>
             </arg>
         </method>

--- a/dbus/org.plasmazones.Settings.xml
+++ b/dbus/org.plasmazones.Settings.xml
@@ -49,6 +49,15 @@
                 <annotation name="org.gtk.GDBus.DocString" value="True if setting was updated."/>
             </arg>
         </method>
+        <method name="setSettings">
+            <annotation name="org.gtk.GDBus.DocString" value="Batch-set multiple settings in one call. Applies every key via the setter registry and saves once. Unknown keys are logged but do not abort the batch."/>
+            <arg name="settings" type="a{sv}" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Map of setting key to value."/>
+            </arg>
+            <arg name="success" type="b" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="True if every key was found and its setter succeeded."/>
+            </arg>
+        </method>
         <method name="getSettingKeys">
             <annotation name="org.gtk.GDBus.DocString" value="Return the list of all setting key names."/>
             <arg name="keys" type="as" direction="out">
@@ -57,6 +66,9 @@
         </method>
         <signal name="settingsChanged">
             <annotation name="org.gtk.GDBus.DocString" value="Emitted when any setting is modified."/>
+        </signal>
+        <signal name="motionProfileTreeChanged">
+            <annotation name="org.gtk.GDBus.DocString" value="Daemon to KWin effect: the per-event motion-profile tree changed (a profiles/&lt;path&gt;.json override was edited and rescanned). Kept separate from settingsChanged so the Settings app's value-change detection is not reset by its own profile-file writes; the KWin effect re-fetches motionProfileTree on this signal."/>
         </signal>
 
         <method name="isZoneSelectorEnabled">
@@ -130,6 +142,34 @@
             </arg>
         </method>
 
+        <!-- Shader methods. These are also published on the dedicated
+             org.plasmazones.Shader interface (see org.plasmazones.Shader.xml);
+             SettingsAdaptor keeps them here for backward compatibility with
+             callers that bind the Settings interface. Keep both XMLs in sync. -->
+        <method name="availableShaders">
+            <annotation name="org.gtk.GDBus.DocString" value="Get list of available shader effects with metadata."/>
+            <arg name="shaders" type="av" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="List of shader metadata maps."/>
+            </arg>
+        </method>
+        <method name="shaderInfo">
+            <annotation name="org.gtk.GDBus.DocString" value="Get detailed information about a specific shader."/>
+            <arg name="shaderId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Shader UUID."/>
+            </arg>
+            <arg name="info" type="a{sv}" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="Shader metadata map (empty if not found)."/>
+            </arg>
+        </method>
+        <method name="defaultShaderParams">
+            <annotation name="org.gtk.GDBus.DocString" value="Get default parameter values for a shader."/>
+            <arg name="shaderId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Shader UUID."/>
+            </arg>
+            <arg name="params" type="a{sv}" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="Map of parameter IDs to default values."/>
+            </arg>
+        </method>
         <method name="translateShaderParams">
             <annotation name="org.gtk.GDBus.DocString" value="Translate shader params from param IDs to uniform names for ZoneShaderItem."/>
             <arg name="shaderId" type="s" direction="in">
@@ -140,6 +180,68 @@
             </arg>
             <arg name="result" type="a{sv}" direction="out">
                 <annotation name="org.gtk.GDBus.DocString" value="Map of uniform names to values (e.g. customParams1_x: 0.5)."/>
+            </arg>
+        </method>
+        <method name="shadersEnabled">
+            <annotation name="org.gtk.GDBus.DocString" value="Check if shader effects are enabled (compiled with shader support)."/>
+            <arg name="enabled" type="b" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="True if shaders are available."/>
+            </arg>
+        </method>
+        <method name="userShadersEnabled">
+            <annotation name="org.gtk.GDBus.DocString" value="Check if user-installed shaders are supported."/>
+            <arg name="enabled" type="b" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="True if user shaders can be loaded."/>
+            </arg>
+        </method>
+        <method name="userShaderDirectory">
+            <annotation name="org.gtk.GDBus.DocString" value="Get path to the user shader installation directory."/>
+            <arg name="path" type="s" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="Path to ~/.local/share/plasmazones/shaders."/>
+            </arg>
+        </method>
+        <method name="openUserShaderDirectory">
+            <annotation name="org.gtk.GDBus.DocString" value="Open the user shader directory in the file manager."/>
+        </method>
+        <method name="refreshShaders">
+            <annotation name="org.gtk.GDBus.DocString" value="Reload all shaders from disk."/>
+        </method>
+
+        <!-- Per-screen settings. Categories: 'autotile' | 'snapping' | 'zoneSelector'. -->
+        <method name="getPerScreenSettings">
+            <annotation name="org.gtk.GDBus.DocString" value="Get all per-screen settings for a screen and category."/>
+            <arg name="screenId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Virtual or physical screen identifier."/>
+            </arg>
+            <arg name="category" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="'autotile' | 'snapping' | 'zoneSelector'."/>
+            </arg>
+            <arg name="values" type="a{sv}" direction="out">
+                <annotation name="org.gtk.GDBus.DocString" value="Map of per-screen setting key to value."/>
+            </arg>
+        </method>
+        <method name="setPerScreenSetting">
+            <annotation name="org.gtk.GDBus.DocString" value="Set a single per-screen setting and schedule a debounced save."/>
+            <arg name="screenId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Virtual or physical screen identifier."/>
+            </arg>
+            <arg name="category" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="'autotile' | 'snapping' | 'zoneSelector'."/>
+            </arg>
+            <arg name="key" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Per-screen setting key name."/>
+            </arg>
+            <arg name="value" type="v" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="New value (variant)."/>
+            </arg>
+        </method>
+        <method name="clearPerScreenSettings">
+            <annotation name="org.gtk.GDBus.DocString" value="Clear all per-screen overrides for a screen and category, reverting to global defaults."/>
+            <arg name="screenId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Virtual or physical screen identifier."/>
+            </arg>
+            <arg name="category" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="'autotile' | 'snapping' | 'zoneSelector'."/>
             </arg>
         </method>
 
@@ -171,6 +273,15 @@
         <method name="requestRunningWindows">
             <annotation name="org.gtk.GDBus.DocString" value="Asynchronously request the running-windows list. The daemon emits runningWindowsRequested to the KWin effect; the reply is delivered via the runningWindowsAvailable signal."/>
         </method>
+        <method name="provideRunningWindows">
+            <annotation name="org.gtk.GDBus.DocString" value="KWin effect to daemon callback: deliver the enumerated running-windows list in response to requestRunningWindows. The daemon re-broadcasts it via runningWindowsAvailable."/>
+            <arg name="json" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="JSON array: [{windowClass, appName, caption}, ...]."/>
+            </arg>
+        </method>
+        <signal name="runningWindowsRequested">
+            <annotation name="org.gtk.GDBus.DocString" value="Daemon to KWin effect: please enumerate running windows. Emitted by requestRunningWindows; the effect answers via provideRunningWindows."/>
+        </signal>
         <signal name="runningWindowsAvailable">
             <annotation name="org.gtk.GDBus.DocString" value="Emitted when a fresh running-windows list has arrived from the KWin effect."/>
             <arg name="json" type="s">

--- a/src/editor/helpers/ShaderDbusQueries.cpp
+++ b/src/editor/helpers/ShaderDbusQueries.cpp
@@ -49,13 +49,18 @@ QVariantList queryAvailableShaders()
 
     QVariantList result;
 
-    // D-Bus returns nested structures (QVariantMap, QVariantList) as QDBusArgument
-    // Use DBusVariantUtils::convertDbusArgument to recursively convert them to proper Qt types
-    const QVariantList payload = reply.arguments().constFirst().toList();
+    // The reply carries a single D-Bus `av` argument (array of variant). Unlike
+    // `a{sv}`, QtDBus does NOT auto-demarshal a bare `av` into a QVariantList —
+    // it hands it back wrapped in a QDBusArgument, so calling `.toList()` on it
+    // directly yields an empty list and every shader is silently dropped. Run
+    // the top-level argument through convertDbusArgument first (which also
+    // recursively converts the nested `a{sv}` entries), exactly as
+    // queryShaderInfo() / queryTranslateShaderParams() already do.
+    const QVariant converted = DBusVariantUtils::convertDbusArgument(reply.arguments().constFirst());
+    const QVariantList payload = converted.toList();
     for (const QVariant& item : payload) {
-        QVariant converted = DBusVariantUtils::convertDbusArgument(item);
-        if (converted.typeId() == QMetaType::QVariantMap) {
-            QVariantMap map = converted.toMap();
+        if (item.typeId() == QMetaType::QVariantMap) {
+            QVariantMap map = item.toMap();
             // Validate that required fields exist
             if (map.contains(QLatin1String("id")) && map.contains(QLatin1String("name"))) {
                 result.append(map);
@@ -63,7 +68,7 @@ QVariantList queryAvailableShaders()
                 qCWarning(lcDbus) << "Shader entry missing required fields (id/name):" << map;
             }
         } else {
-            qCWarning(lcDbus) << "Unexpected shader list item type after conversion:" << converted.typeName();
+            qCWarning(lcDbus) << "Unexpected shader list item type after conversion:" << item.typeName();
         }
     }
 


### PR DESCRIPTION
## Problem

In the layout editor's shader settings dialog, checking **"Enable shader effect"** left the shader dropdown disabled — no shaders could be selected. The daemon was serving all 26 shaders correctly over D-Bus; the editor just received an empty list.

## Root cause

`ShaderDbusQueries::queryAvailableShaders()` called `.toList()` directly on the top-level D-Bus reply argument:

```cpp
const QVariantList payload = reply.arguments().constFirst().toList();  // always empty
```

The daemon returns the shader list as a D-Bus `av` (array of variant). Unlike `a{sv}`, QtDBus does **not** auto-demarshal a bare `av` into a `QVariantList` — it arrives wrapped in a `QDBusArgument`, so `.toList()` silently yields an empty list and every shader is dropped. `firstEffectId()` then finds nothing, `hasShaderEffect` stays false, and the picker stays disabled.

This regressed when `QDBusInterface` (which knew return types from introspection) was replaced with raw `QDBusMessage` calls. The sibling functions `queryShaderInfo()` / `queryTranslateShaderParams()` already route the top-level argument through `convertDbusArgument()`; `queryAvailableShaders()` was missed.

## Fix

Route the top-level reply argument through `DBusVariantUtils::convertDbusArgument()` first, consistent with the sibling functions. The per-item conversion in the loop became redundant (the recursive convert already handles nested entries) and was removed.

## Secondary: D-Bus XML contract sync

While investigating, `dbus/org.plasmazones.Settings.xml` was found stale — it omitted many members `SettingsAdaptor` actually exposes (third-party clients and `qdbus-qt6` introspection resolve against this install-only file). Added: the shader method family, `setSettings`, the per-screen single-key methods, `provideRunningWindows`, and the `motionProfileTreeChanged` / `runningWindowsRequested` signals. A slot-vs-XML diff now reports zero missing methods and zero missing signals.

## Verification

- Build: `plasmazones-editor` compiles clean.
- Runtime: patched editor logs **`Loaded 26 shaders`** (was `0`).
- Tests: **185/185 passing.**
- `xmllint`: `Settings.xml` well-formed.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)