### PR TITLE
fix(release): unbreak Nix release script after the flake rewrite

### DIFF
--- a/packaging/nix/generate-release-nix.sh
+++ b/packaging/nix/generate-release-nix.sh
@@ -69,10 +69,37 @@ awk -v version="$VERSION" -v hash="$SRI_HASH" '
     !started && /^#/ { next }
     !started && /^$/ { next }
     /^\{/ { started = 1 }
-    started && /^  src,$/ { print "  fetchFromGitHub,"; next }
+    # Track whether fetchFromGitHub is already declared in the args set.
+    # The pre-flake-rewrite package.nix only took `src,` and we injected
+    # `fetchFromGitHub,` in its place. The current layout already declares
+    # `fetchFromGitHub,` alongside `src,` (for nixpkgs use), so we just drop
+    # `src,` instead of duplicating the argument (which is a Nix parse error).
+    started && /^  fetchFromGitHub,/ { has_fetch = 1; print; next }
+    started && /^  src,$/ {
+        if (!has_fetch) print "  fetchFromGitHub,"
+        next
+    }
     /^let$/ { in_let = 1; next }
     in_let && /^in$/ { in_let = 0; next }
     in_let { next }
+    # Current package.nix derives the version dynamically from a multi-line
+    # `version = let ... readFile ${src}/CMakeLists.txt ... in match` block.
+    # Replace the whole block with a hardcoded version line for release.
+    /^[[:space:]]*version = let$/ {
+        print "  version = \"" version "\";"
+        consuming_version = 1
+        next
+    }
+    consuming_version {
+        # The block ends with the `else throw "..."` line whose terminating `;`
+        # closes the `version = let ... in ...` assignment.
+        if (/else throw "Could not parse version from CMakeLists\.txt";/) {
+            consuming_version = 0
+        }
+        next
+    }
+    # Legacy single-line form. Kept so the script still works if someone
+    # reverts the inline readFile approach to a helper function.
     /version = extractVersion src;/ {
         print "  version = \"" version "\";"
         next


### PR DESCRIPTION
## Summary

The v3.0.5 release workflow's **Verify Nix Build → Generate release package.nix** step failed: <https://github.com/fuddlesworth/PlasmaZones/actions/runs/26128392551>.

PR #489 (Fixing the Nix Flake) restructured `packaging/nix/package.nix` but did not update the release transform `packaging/nix/generate-release-nix.sh` that runs on tag push. The script's awk patterns no longer match the new file shape:

- `package.nix` now declares `fetchFromGitHub,` in its function arguments. The awk's `s/^  src,$/  fetchFromGitHub,/` rewrite produced a **duplicate argument** — a Nix parse error.
- `package.nix` replaced the single-line `version = extractVersion src;` with a multi-line `version = let ... builtins.match ... in ...` block. The awk's old pattern never matched, no hardcoded version line was emitted, and the script's `grep -qE '^[[:space:]]*version = "'` smoke check correctly exited 1.

The smoke check did exactly what it was there for: caught the drift between `package.nix` and the release transform.

## Fix

- Track `fetchFromGitHub,` while scanning the args block. On `src,`, drop the line if it's already declared; inject `fetchFromGitHub,` if not. Keeps the pre-rewrite shape working as a fallback.
- Detect `^  version = let$`, replace the whole multi-line block (up to and including the `else throw "Could not parse version from CMakeLists.txt";` terminator) with `version = "<VERSION>";`. Keep the single-line `version = extractVersion src;` rewrite as a legacy fallback.

Locally smoke-tested with stubbed `nix-prefetch-url`/`nix hash to-sri`. The generated file now has exactly one `fetchFromGitHub,` argument, a hardcoded `version = "3.0.5";`, a `src = fetchFromGitHub { ... v3.0.5 ... };` block, and no surviving `${src}/CMakeLists.txt` interpolation.

## Test plan

- [ ] Merge to `main`
- [ ] Re-dispatch the Release workflow with `tag=v3.0.5` (or push the v3.0.5 tag again after force-deleting it locally — same effect on the workflow that drives the build assets)
- [ ] Confirm Verify Nix Build → Generate release package.nix passes
- [ ] Confirm the build-nix artifact `plasmazones.nix` parses with `nix-instantiate --parse` and contains the correct `v3.0.5` rev + SRI hash
- [ ] Confirm the Create GitHub Release job runs once all distro builds are green

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)