### PR TITLE
fix: settings not applying / toggle re-enables (#497)

### DIFF
--- a/src/common/daemoncontroller.cpp
+++ b/src/common/daemoncontroller.cpp
@@ -164,40 +164,52 @@ void DaemonController::startDaemon()
     if (isRunning()) {
         return;
     }
-    // Clear any stuck failed-state before issuing start. This is needed when
-    // the user has run plasmazonesd manually (e.g. from a terminal for
-    // logging), which causes systemd's own managed instance to lose the
-    // D-Bus name race and exit; Restart=on-failure then retries until the
-    // unit's StartLimitBurst is exhausted, leaving it wedged in "failed"
-    // until a session restart or manual `systemctl reset-failed`. Without
-    // this, toggling PlasmaZones back on from the settings app silently
-    // does nothing, which was reported in discussion #271.
-    //
-    // reset-failed is a no-op on units not in failed state, so it's safe
-    // to issue unconditionally. Chain the start via callback so it only
-    // runs after reset completes — otherwise the two systemctl processes
-    // race and the start can still arrive at a failed unit.
-    runSystemctl(
-        {QStringLiteral("--user"), QStringLiteral("reset-failed"), QLatin1String(KCMConstants::SystemdServiceName)},
-        [this](bool /*success*/, const QString& /*output*/) {
-            // Ignore reset-failed's exit code: the unit may not
-            // exist yet (service file freshly installed, user's
-            // systemd hasn't scanned) which is fine — start will
-            // handle that error path via its own warning.
-            //
-            // Re-check isRunning() here: the D-Bus service watcher
-            // may have brought the daemon up between the entry
-            // check and this callback (e.g. a parallel toggle from
-            // another settings window, or systemd's own restart
-            // path firing concurrently). Issuing `start` against
-            // an already-active unit is harmless but emits a
-            // "Unit is already active" warning; skipping is cleaner.
-            if (isRunning()) {
-                return;
-            }
-            runSystemctl(
-                {QStringLiteral("--user"), QStringLiteral("start"), QLatin1String(KCMConstants::SystemdServiceName)});
-        });
+    const QLatin1String unit(KCMConstants::SystemdServiceName);
+    // Unmask first. setEnabled(true) runs setAutostart(true) and
+    // startDaemon() in parallel; setAutostart's own unmask is not
+    // guaranteed to win the race against this function's start step,
+    // because reset-failed completes in well under unmask's QProcess
+    // round-trip and frees this chain to issue `start` against a still-
+    // masked unit (which systemd rejects with "Unit is masked"). The
+    // user then sees the toggle flip back to off because the daemon
+    // never actually started. unmask is idempotent — on an already-
+    // unmasked unit it's a no-op — so chaining it here is safe whether
+    // or not setAutostart's parallel unmask has landed first.
+    runSystemctl({QStringLiteral("--user"), QStringLiteral("unmask"), unit},
+                 [this, unit](bool /*success*/, const QString& /*output*/) {
+                     // Clear any stuck failed-state before issuing start. This is needed when
+                     // the user has run plasmazonesd manually (e.g. from a terminal for
+                     // logging), which causes systemd's own managed instance to lose the
+                     // D-Bus name race and exit; Restart=on-failure then retries until the
+                     // unit's StartLimitBurst is exhausted, leaving it wedged in "failed"
+                     // until a session restart or manual `systemctl reset-failed`. Without
+                     // this, toggling PlasmaZones back on from the settings app silently
+                     // does nothing, which was reported in discussion #271.
+                     //
+                     // reset-failed is a no-op on units not in failed state, so it's safe
+                     // to issue unconditionally. Chain the start via callback so it only
+                     // runs after reset completes — otherwise the two systemctl processes
+                     // race and the start can still arrive at a failed unit.
+                     runSystemctl({QStringLiteral("--user"), QStringLiteral("reset-failed"), unit},
+                                  [this, unit](bool /*success*/, const QString& /*output*/) {
+                                      // Ignore reset-failed's exit code: the unit may not
+                                      // exist yet (service file freshly installed, user's
+                                      // systemd hasn't scanned) which is fine — start will
+                                      // handle that error path via its own warning.
+                                      //
+                                      // Re-check isRunning() here: the D-Bus service watcher
+                                      // may have brought the daemon up between the entry
+                                      // check and this callback (e.g. a parallel toggle from
+                                      // another settings window, or systemd's own restart
+                                      // path firing concurrently). Issuing `start` against
+                                      // an already-active unit is harmless but emits a
+                                      // "Unit is already active" warning; skipping is cleaner.
+                                      if (isRunning()) {
+                                          return;
+                                      }
+                                      runSystemctl({QStringLiteral("--user"), QStringLiteral("start"), unit});
+                                  });
+                 });
 }
 
 void DaemonController::stopDaemon()

--- a/src/common/daemoncontroller.cpp
+++ b/src/common/daemoncontroller.cpp
@@ -123,13 +123,40 @@ void DaemonController::refreshEnabledState()
 
 void DaemonController::setAutostart(bool enabled)
 {
-    QString action = enabled ? QStringLiteral("enable") : QStringLiteral("disable");
-    runSystemctl({QStringLiteral("--user"), action, QLatin1String(KCMConstants::SystemdServiceName)},
-                 [this](bool success, const QString& /*output*/) {
-                     if (success) {
-                         refreshEnabledState();
-                     }
-                 });
+    const QLatin1String unit(KCMConstants::SystemdServiceName);
+    if (enabled) {
+        // Two steps: unmask (in case the previous disable masked the unit —
+        // see the else branch) then enable. `systemctl enable` against a
+        // masked unit fails with "Unit is masked", so the unmask must run
+        // first. Both are no-ops in their inert state, so the chain is
+        // safe whether or not the unit was actually masked.
+        runSystemctl({QStringLiteral("--user"), QStringLiteral("unmask"), unit},
+                     [this, unit](bool /*success*/, const QString& /*output*/) {
+                         runSystemctl({QStringLiteral("--user"), QStringLiteral("enable"), unit},
+                                      [this](bool success, const QString& /*output*/) {
+                                          if (success) {
+                                              refreshEnabledState();
+                                          }
+                                      });
+                     });
+    } else {
+        // Mask, not just disable. A plain `disable` only blocks boot-time
+        // autostart — D-Bus activation via the org.plasmazones.service
+        // file (SystemdService=plasmazones.service) still routes through
+        // systemd and brings the daemon back the next time any client
+        // (KWin effect, settings app, editor) sends a method call. That
+        // is why the toggle re-enables itself within seconds in
+        // discussion #497: the KWin effect's window-lifecycle callbacks
+        // keep triggering activation as the user moves / closes windows.
+        // Masking blocks both autostart and activation. Re-enabling
+        // unmasks first (see the if branch).
+        runSystemctl({QStringLiteral("--user"), QStringLiteral("mask"), unit},
+                     [this](bool success, const QString& /*output*/) {
+                         if (success) {
+                             refreshEnabledState();
+                         }
+                     });
+    }
 }
 
 void DaemonController::startDaemon()

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -881,6 +881,7 @@ bool Daemon::init()
         new LayoutAdaptor(m_layoutManager.get(), m_virtualDesktopManager.get(), m_screenManager.get(), this);
     m_layoutAdaptor->setActivityManager(m_activityManager.get());
     m_layoutAdaptor->setSettings(m_settings.get());
+    m_layoutAdaptor->setAlgorithmRegistry(m_algorithmRegistry.get());
     m_layoutAdaptor->setLayoutSource(m_layoutSources.composite());
     // Thread the bundle-owned autotile source through the adaptor's
     // buildUnifiedLayoutList path so its preview cache survives across


### PR DESCRIPTION
## Summary

Fixes [discussion #497](https://github.com/fuddlesworth/PlasmaZones/discussions/497). Two structural bugs were eating every tiling assignment the user saved and preventing them from keeping the daemon disabled — together they made it look like "settings aren't being applied anywhere."

- **Tiling assignments silently dropped.** `LayoutAdaptor::m_algorithmRegistry` was never wired up after the [b425af04](https://github.com/fuddlesworth/PlasmaZones/commit/b425af04) DI refactor — the daemon's composition root sets it on `OverlayService`, `ZoneSelectorController`, etc., but the line for `LayoutAdaptor` was missed. Result: `setAssignmentEntry`'s validation branch sees `!m_algorithmRegistry` and returns before storing, so every per-monitor / per-activity tiling-mode assignment via the settings app logs `unknown tiling algorithm: "<id>"` and is dropped. The user's snapping saves persisted; their tiling saves vanished and the cascade fell back to the global default, which the user (correctly) read as "my changes reverted to the default I set in Layouts."
- **Disable toggle won't stay off.** `setEnabled(false)` ran `systemctl --user disable`, which only blocks boot-time autostart. The installed `/usr/share/dbus-1/services/org.plasmazones.service` file pins `SystemdService=plasmazones.service`, so any subsequent D-Bus call from the KWin effect (window-lifecycle callbacks like `setWindowMetadata`, `windowClosed`) routes through systemd, starts the unit, and the toggle binds back to running within a couple of seconds. Switching to `systemctl --user mask` blocks both autostart and D-Bus-routed activation. Re-enable chains `unmask` → `enable`.

The user-attached `journal.log` confirms #1 (`unknown tiling algorithm: "centered-master"`, `unknown tiling algorithm: "rows"` on every save attempt) and `kwin-effect.log` confirms #2 (`Could not activate remote peer 'org.plasmazones': activation request ... unit is invalid` repeated as the user moves windows).

## Test plan

- [ ] Build daemon + settings, restart daemon (`systemctl --user restart plasmazones`).
- [ ] On the Overview page, switch a monitor to Tiling, pick `rows` (or any autotile algorithm), Save → navigate to another tab → return. The selection should persist instead of reverting to the default layout.
- [ ] `journalctl --user -u plasmazones | grep "unknown tiling algorithm"` should show no new entries after the rebuild.
- [ ] On the same Overview page, set a tiling assignment, then visit Tiling > Assignments. Per-activity and per-monitor tiling assignments configured there should persist across tab navigation too.
- [ ] Toggle the daemon off via the settings sidebar. `systemctl --user is-enabled plasmazones.service` should print `masked`. The toggle should stay off while moving / closing windows.
- [ ] Toggle the daemon back on. `is-enabled` should print `enabled` and the daemon should be running.
- [ ] Snapping assignments (already working) still persist after the fix — sanity check.

## Caveats

- Masking persists as `~/.config/systemd/user/plasmazones.service → /dev/null`. A user who later runs `systemctl --user start plasmazones` after disabling via the toggle will hit `Unit is masked` and need to toggle back on (or `unmask` manually). Matches the user's intent ("I disabled it, keep it off") and the established pattern for power users on other units.
- Rapid off→on toggling races two async `systemctl` invocations (`mask` from off, `unmask`+`enable` from on). Not addressed here; would need to serialize `setAutostart` into a state machine. Not in the report.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)