### PR TITLE
fix(autotile): focus-follows-mouse stale-cache prevented re-focus after focus steal

### DIFF
--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -76,15 +76,20 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
                 return;
             }
         }
-        const QString windowId = m_effect->getWindowId(w);
-        if (windowId == m_lastFocusFollowsMouseWindowId) {
+        // Skip the activateWindow call when the window under the cursor
+        // already holds compositor focus. The live activeWindow() read is
+        // load-bearing: a local "last auto-focused window" cache would go
+        // stale every time focus moved through another path (keyboard
+        // shortcut, click, daemon-driven activate, focus-stealing window),
+        // and the next cursor pass over the originally-cached window would
+        // short-circuit without re-focusing it. See discussion #461 item 13.
+        if (w == KWin::effects->activeWindow()) {
             return; // Already focused — no-op
         }
         // Only focus windows on autotile screens
         if (!m_autotileScreens.contains(m_effect->getWindowScreenId(w))) {
             return;
         }
-        m_lastFocusFollowsMouseWindowId = windowId;
         KWin::effects->activateWindow(w);
         return;
     }
@@ -453,9 +458,6 @@ void AutotileHandler::onWindowClosed(const QString& windowId, const QString& scr
     // KWin-specific cleanup not covered by the shared helper
     m_savedNotifiedForDesktopReturn.remove(windowId);
     m_savedPreAutotileForDesktopMove.remove(windowId);
-    if (m_lastFocusFollowsMouseWindowId == windowId) {
-        m_lastFocusFollowsMouseWindowId.clear();
-    }
     auto pendingConn = m_pendingCrossScreenRestore.find(windowId);
     if (pendingConn != m_pendingCrossScreenRestore.end()) {
         QObject::disconnect(pendingConn.value());

--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -385,7 +385,6 @@ private:
     int m_suppressMaximizeChanged = 0;
     // ── Focus follows mouse ──
     bool m_focusFollowsMouse = false;
-    QString m_lastFocusFollowsMouseWindowId;
     // ── Border state — uses shared BorderState from compositor-common ──
     BorderState m_border;
 };

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -312,7 +312,6 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
     }
 
     m_autotileScreens = newScreens;
-    m_lastFocusFollowsMouseWindowId.clear();
 
     if (!added.isEmpty()) {
         if (isDesktopSwitch) {

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -131,9 +131,6 @@ void AutotileHandler::updateShowBorderSetting(bool enabled)
 void AutotileHandler::setFocusFollowsMouse(bool enabled)
 {
     m_focusFollowsMouse = enabled;
-    if (!enabled) {
-        m_lastFocusFollowsMouseWindowId.clear();
-    }
 }
 
 bool AutotileHandler::saveAndRecordPreAutotileGeometry(const QString& windowId, const QString& screenId,


### PR DESCRIPTION
## Summary

Fixes discussion [#461 item 13](https://github.com/fuddlesworth/PlasmaZones/discussions/461#discussioncomment-16983427) — "auto follow mouse in tiling mode is not working" (krakerz).

The handler short-circuited against a local cache of the last auto-focused windowId, but the cache was never invalidated when focus moved through any other path. The fix swaps the cache for a live read against \`KWin::effects->activeWindow()\`.

## Root cause

\`AutotileHandler::handleCursorMoved\` (\`kwin-effect/autotilehandler.cpp:80\` pre-fix) compared the windowId under the cursor against \`m_lastFocusFollowsMouseWindowId\` and returned early on match:

\`\`\`cpp
if (windowId == m_lastFocusFollowsMouseWindowId) {
    return; // Already focused — no-op
}
\`\`\`

The cache was only cleared in three places:
1. \`setFocusFollowsMouse(false)\` — user disables the setting
2. \`onWindowClosed\` for the cached id
3. \`slotScreensChanged\` — desktop / activity switch

It was **not** cleared when focus moved through any other route — keyboard shortcut (Alt-Tab, Meta+arrow), click on a different window, daemon-driven \`slotActivateWindowRequested\`, or a new window stealing focus. After any of those fired, the cache pointed at a window the compositor was no longer focusing on. The next cursor pass over (or onto) the cached window matched the stale cache and skipped \`activateWindow\` — focus stayed wherever it had drifted to.

## Fix

Read live focus state instead:

\`\`\`cpp
if (w == KWin::effects->activeWindow()) {
    return; // Already focused — no-op
}
\`\`\`

\`KWin::effects->activeWindow()\` is always in sync with whichever path last changed focus, so the no-op gate fires only when the window the cursor is over actually still holds focus. The \`m_lastFocusFollowsMouseWindowId\` member and its three remaining write sites are now dead and deleted.

Net diff: -3 lines.

## On krakerz's specific report

Their attached \`plasmazones-report-20260520-*.tar.gz\` configs show \`Tiling.Behavior.FocusFollowsMouse: false\` on disk in both the \"before\" and the \"after reset to defaults\" snapshots — meaning the setting was never actually persisted as enabled. The fix here addresses the underlying broken-feel they reported (cursor returning to a window doesn't re-focus it after something else steals focus), but they should also verify the toggle is saved: toggle the switch, then click **Save**, then re-check \`grep -i FocusFollowsMouse ~/.config/plasmazones/config.json\`.

## Test plan

- [x] Build clean: \`cmake --build build --parallel\`
- [x] Full suite: 187/187 pass (no behavior tests for focus-follows-mouse exist; the handler runs inside KWin and is awkward to unit-test in isolation)
- [ ] Manual smoke (needs KWin session):
  - Enable \"Focus follows mouse\" in TilingBehaviorPage, click Save
  - Hover window A → A focused
  - Alt-Tab to B → B focused
  - Move cursor back onto A (still on autotile screen) → **A should now re-focus** (was: stayed on B before this fix)
  - Click B explicitly, then move cursor onto A → A re-focuses
  - Toggle setting off → cursor moves no longer steal focus

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)