### PR TITLE
Release v3.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.7] - 2026-05-21
+
+### Changed
+
+- **`bounce` drops the window in from above its frame** ([#475](https://github.com/fuddlesworth/PlasmaZones/pull/475)): `bounce` previously revealed the window from its own top edge downward, clipped to the window box. Animation shaders can now opt into a full-surface render mode that gives them room to draw past the window, and `bounce` uses it to play niri's original drop-from-above motion — the window travels in from above its frame.
+- **Overlay cards unified on one shared frame** ([#475](https://github.com/fuddlesworth/PlasmaZones/pull/475)): the layout OSD, navigation OSD, layout picker, and zone selector each hand-rolled their card background, border, and glow. They now share a single `PopupFrame` component, so all four read as the same surface and the soft glow is captured into the transition and animates with the card rather than being clipped away for the duration. The layout picker and zone selector pick up the same glow the OSDs use.
+- **`wave-warp` gained a `frontSpeed` parameter** ([#475](https://github.com/fuddlesworth/PlasmaZones/pull/475)): `wave-warp` and the former `crosswarp` ran the identical moving-edge warp, differing only in a front-speed dial. That dial is now `wave-warp`'s `frontSpeed` parameter (default `1.0`).
+
+### Removed
+
+- **`crosswarp` transition** ([#475](https://github.com/fuddlesworth/PlasmaZones/pull/475)): it was `wave-warp` with a fixed front speed. Use `wave-warp` with its new `frontSpeed` parameter instead.
+- **`plasma-flow` transition** ([#475](https://github.com/fuddlesworth/PlasmaZones/pull/475)): it was a re-skin of `soft-warp-fade` — the same noise-driven UV warp and fade, differing only in trivial constants.
+
+### Fixed
+
+- **Window open / close animations rendered as ghosted, multi-copy trails on KWin** ([#475](https://github.com/fuddlesworth/PlasmaZones/pull/475)): translation transitions (`bounce`, `fly-in`) drew several overlapping copies of the window during an open or close. `paintWindow` called `OffscreenEffect::drawWindow` directly, leaving KWin's shared draw-window iterator parked at the start, so the offscreen capture re-entered the effect and drew the window's own texture into itself. The transition now routes through `effects->drawWindow` so the capture reaches the real draw stage, and KWin's stock fade / scale / slide builtins are held off the window so they no longer render a second concurrent copy.
+- **New windows flashed at their spawn position before animating into place** ([#475](https://github.com/fuddlesworth/PlasmaZones/pull/475)): KWin places a new window (centered or smart) before the effect sees it, and the reposition into a zone or tile is asynchronous on Wayland, so a snap-restored or autotiled window visibly flickered at the centered spawn position for one to three frames. New-window pixels are now withheld until the reposition lands (with a 250 ms safety deadline), so the window first becomes visible already animating into its zone.
+- **Snap-restored windows played their open animation from the screen center** ([#475](https://github.com/fuddlesworth/PlasmaZones/pull/475)): a snap-restored window ran its `bounce` / `fly-in` open animation from the centered spawn position and then jumped to the zone once KWin's asynchronous move landed. The in-flight open transition is now pinned to the resolved zone, so the effect plays into the zone from the first frame.
+- **OSD glow popped in at the end of a transition** ([#475](https://github.com/fuddlesworth/PlasmaZones/pull/475)): the soft glow behind the layout and navigation OSDs was clipped away for the duration of a show / hide animation and snapped back into place when the animation ended. The glow is now captured together with the card so it scales and moves with it throughout the transition.
+- **Faint grey halo around daemon OSDs during `bounce` / `fly-in`** ([#475](https://github.com/fuddlesworth/PlasmaZones/pull/475)): both effects painted a faint grey border around the OSD while animating — the effect's edge feather fell just outside the captured texture and tinted its clamped edge pixels. The edge crop is now a sub-pixel, edge-aligned antialias band, so the border is gone and the edge stays crisp.
+
 ## [3.0.6] - 2026-05-20
 
 ### Fixed
@@ -1352,7 +1373,8 @@ Initial packaged release. Wayland-only (X11 support removed). Requires KDE Plasm
 - Session restoration and rotation after login ([#66])
 - Window tracking: snap/restore behavior, zone clearing, startup timing, rotation zone ID matching, floating window exclusion ([#67])
 
-[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.6...HEAD
+[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.7...HEAD
+[3.0.7]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.6...v3.0.7
 [3.0.6]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.5...v3.0.6
 [3.0.5]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.4...v3.0.5
 [3.0.4]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.3...v3.0.4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(PlasmaZones VERSION 3.0.6 LANGUAGES C CXX)
+project(PlasmaZones VERSION 3.0.7 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/data/whatsnew.json
+++ b/data/whatsnew.json
@@ -1,6 +1,21 @@
 {
     "releases": [
         {
+            "version": "3.0.7",
+            "date": "2026-05-21",
+            "highlights": [
+                "Window open and close animations (bounce, fly-in) no longer render as ghosted, multi-copy trails on KWin (#475)",
+                "New windows no longer flash at their spawn position before animating into their zone or tile (#475)",
+                "Snap-restored windows now play their open animation into the resolved zone instead of from the screen center (#475)",
+                "The soft glow behind the OSDs now animates with the card instead of popping in when the transition ends (#475)",
+                "Fixed a faint grey halo painted around OSDs during the bounce and fly-in transitions (#475)",
+                "bounce now drops the window in from above its frame, matching niri's original motion (#475)",
+                "The layout OSD, navigation OSD, layout picker, and zone selector now share one card style with a consistent soft glow (#475)",
+                "Removed the crosswarp transition — its front-speed control is now a frontSpeed parameter on wave-warp (#475)",
+                "Removed the plasma-flow transition, which duplicated soft-warp-fade (#475)"
+            ]
+        },
+        {
             "version": "3.0.6",
             "date": "2026-05-20",
             "highlights": [


### PR DESCRIPTION
Patch release bundling PR #475 — a focused pass on the window-transition animation system.

## Version
`3.0.6` → `3.0.7` (`CMakeLists.txt`, `CHANGELOG.md`, `data/whatsnew.json`).

## Changed
- `bounce` drops the window in from above its frame, via a new full-surface render mode for animation shaders.
- The layout OSD, navigation OSD, layout picker, and zone selector unified on one shared `PopupFrame` — consistent soft glow that animates with the card.
- `wave-warp` gained a `frontSpeed` parameter.

## Removed
- `crosswarp` transition (now `wave-warp` with `frontSpeed`).
- `plasma-flow` transition (was a re-skin of `soft-warp-fade`).

## Fixed
- Open / close animations (`bounce`, `fly-in`) rendered as ghosted, multi-copy trails on KWin.
- New windows flashed at their spawn position before animating into their zone or tile.
- Snap-restored windows played their open animation from the screen center.
- The OSD glow popped in at the end of a transition instead of animating with the card.
- A faint grey halo around daemon OSDs during `bounce` / `fly-in`.

See `CHANGELOG.md` for the full per-entry detail.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)