### PR TITLE
fix: discussion #461 follow-ups (Esc hijack, stuck disable toggles)

### DIFF
--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -21,6 +21,13 @@ namespace PlasmaZones {
 // emitting its own definition.
 Q_LOGGING_CATEGORY(lcEffect, "plasmazones.effect", QtInfoMsg)
 
+// Opt-in window-classification diagnostics. Defaults to QtWarningMsg so the
+// per-window property dump (logWindowDiagnostics) is silent unless explicitly
+// enabled with QT_LOGGING_RULES="plasmazones.effect.diag.debug=true" — keeps
+// the journal clean by default while still letting users reproduce Steam/CEF
+// mis-classification on request.
+Q_LOGGING_CATEGORY(lcEffectDiag, "plasmazones.effect.diag", QtWarningMsg)
+
 bool PlasmaZonesEffect::supported()
 {
     // This effect is a compositor plugin that works in KWin on Wayland

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -236,8 +236,39 @@ private:
      */
     void pushWindowMetadata(KWin::EffectWindow* w);
 
-    bool shouldHandleWindow(KWin::EffectWindow* w) const;
-    bool isTileableWindow(KWin::EffectWindow* w) const;
+    /**
+     * @brief Snapping/zone-management window filter.
+     *
+     * @param w            window to classify.
+     * @param rejectReason when non-null, set to a human-readable description
+     *                     of the first failing clause on a false return, and
+     *                     cleared on a true return. Default nullptr — hot-loop
+     *                     callers pay nothing. Used by logWindowDiagnostics()
+     *                     so the rejection reason has a single source of truth
+     *                     (this function) and cannot drift from the filter.
+     */
+    bool shouldHandleWindow(KWin::EffectWindow* w, QString* rejectReason = nullptr) const;
+
+    /**
+     * @brief Autotile-tree eligibility filter. @see shouldHandleWindow for the
+     *        @p rejectReason out-parameter contract.
+     */
+    bool isTileableWindow(KWin::EffectWindow* w, QString* rejectReason = nullptr) const;
+
+    /**
+     * @brief Emit a full info-level dump of a window's KWin properties plus the
+     *        snap and autotile filter verdicts.
+     *
+     * One call per window-open (slotWindowAdded) and per class/metadata change,
+     * so the volume is bounded by how often windows actually appear or mutate —
+     * safe at info level. Exists to diagnose apps whose windows KWin
+     * mis-classifies: Steam and other CEF/Electron clients report inconsistent
+     * window-type flags and reparent surfaces mid-session, so the only reliable
+     * way to fix their tiling behaviour is to see every flag the filters
+     * consult. The dump lists each flag and the exact clause that rejected the
+     * window.
+     */
+    void logWindowDiagnostics(KWin::EffectWindow* w, const char* context) const;
 
     /**
      * @brief Animation-side window filter.

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -256,17 +256,34 @@ private:
     bool isTileableWindow(KWin::EffectWindow* w, QString* rejectReason = nullptr) const;
 
     /**
-     * @brief Emit a full info-level dump of a window's KWin properties plus the
-     *        snap and autotile filter verdicts.
+     * @brief Shared window-TYPE rejection predicate.
      *
-     * One call per window-open (slotWindowAdded) and per class/metadata change,
-     * so the volume is bounded by how often windows actually appear or mutate —
-     * safe at info level. Exists to diagnose apps whose windows KWin
-     * mis-classifies: Steam and other CEF/Electron clients report inconsistent
-     * window-type flags and reparent surfaces mid-session, so the only reliable
-     * way to fix their tiling behaviour is to see every flag the filters
-     * consult. The dump lists each flag and the exact clause that rejected the
-     * window.
+     * Returns true when @p w is a structurally unmanageable window kind
+     * (special/desktop/dock/fullscreen/skipSwitcher, or the transient/dialog/
+     * menu/popup/tooltip family). Single source of truth behind both
+     * shouldHandleWindow()'s structural clause and notifyWindowActivated()'s
+     * focus-tracking filter, so the two can never drift (discussion #461
+     * item 11).
+     *
+     * @param w            window to classify; must be non-null.
+     * @param rejectReason when non-null, set to a human-readable reason on a
+     *                     true return. @see shouldHandleWindow.
+     */
+    bool isStructurallyUnmanageableWindowType(KWin::EffectWindow* w, QString* rejectReason = nullptr) const;
+
+    /**
+     * @brief Emit a full dump of a window's KWin properties plus the snap and
+     *        autotile filter verdicts.
+     *
+     * One call per window-open (slotWindowAdded) and per class/metadata change.
+     * Logged under the opt-in `plasmazones.effect.diag` category at debug
+     * level, so it is silent by default and never floods the journal; enable
+     * it on demand with QT_LOGGING_RULES="plasmazones.effect.diag.debug=true".
+     * Exists to diagnose apps whose windows KWin mis-classifies: Steam and
+     * other CEF/Electron clients report inconsistent window-type flags and
+     * reparent surfaces mid-session, so the only reliable way to fix their
+     * tiling behaviour is to see every flag the filters consult. The dump
+     * lists each flag and the exact clause that rejected the window.
      */
     void logWindowDiagnostics(KWin::EffectWindow* w, const char* context) const;
 

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -332,12 +332,22 @@ void PlasmaZonesEffect::slotApplyGeometriesBatch(const PhosphorProtocol::WindowG
             // non-mode-toggle batches (rotate, vs_reconfigure, snap_all)
             // the pending set is empty and the call is a no-op.
             m_autotileHandler->drainPendingBorderlessRestore();
-            // Show snap assist after resnap if applicable
+            // Show snap assist after resnap if applicable.
+            //
+            // A resnap is a bulk operation (autotile→snap toggle, rotate,
+            // vs-reconfigure) — not a per-window snap — so the continuation is
+            // anchored to the active window: snap assist shows ONLY if the
+            // resnap actually placed the active window in a zone. Passing its
+            // windowId as the anchor makes showContinuationIfNeeded gate on
+            // "this window is snapped", which also guarantees at least one
+            // zone is occupied. Without the anchor, a resnap that snapped
+            // nothing (e.g. toggling to snap mode with no prior assignments)
+            // left every zone empty and popped snap assist for all of them.
             if (action == QLatin1String("resnap") && m_snapAssistHandler->isEnabled()) {
                 KWin::EffectWindow* activeWin = getActiveWindow();
                 QString activeScreenId = activeWin ? getWindowScreenId(activeWin) : QString();
-                if (!activeScreenId.isEmpty() && !m_autotileHandler->isAutotileScreen(activeScreenId)) {
-                    m_snapAssistHandler->showContinuationIfNeeded(activeScreenId);
+                if (activeWin && !activeScreenId.isEmpty() && !m_autotileHandler->isAutotileScreen(activeScreenId)) {
+                    m_snapAssistHandler->showContinuationIfNeeded(activeScreenId, getWindowId(activeWin));
                 }
             }
         });

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -16,6 +16,7 @@
 namespace PlasmaZones {
 
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
+Q_DECLARE_LOGGING_CATEGORY(lcEffectDiag)
 
 namespace {
 // Record a filter rejection: when @p out is non-null, store @p reason into it.
@@ -98,6 +99,52 @@ bool PlasmaZonesEffect::isWindowFloating(const QString& windowId) const
     return m_navigationHandler->isWindowFloating(windowId);
 }
 
+bool PlasmaZonesEffect::isStructurallyUnmanageableWindowType(KWin::EffectWindow* w, QString* rejectReason) const
+{
+    // Single source of truth for the window-TYPE rejection set shared by
+    // shouldHandleWindow() (snap/zone filter) and notifyWindowActivated()
+    // (focus-tracking filter). Both must reject the exact same structural
+    // types: a window kind that can never legitimately be a snap/autotile
+    // target must also never be reported as the active window, or the daemon's
+    // focus tracking gets pinned to a popup. Discussion #461 item 11 (Steam
+    // image popups) was a missed sync between two hand-maintained copies of
+    // this list — keeping it in one function makes that class of drift
+    // unrepresentable.
+    //
+    // isTileableWindow() deliberately keeps its own, narrower list (it gates
+    // on !isNormalWindow()) and is NOT folded in here.
+    //
+    // @p w must be non-null — both callers null-check before reaching here.
+
+    // Special / non-manageable window types (inherently effect-side — KWin metadata).
+    if (w->isSpecialWindow() || w->isDesktop() || w->isDock() || w->isFullScreen() || w->isSkipSwitcher()) {
+        if (rejectReason) {
+            *rejectReason = QStringLiteral("special/desktop/dock/fullscreen/skipSwitcher window type");
+        }
+        return true;
+    }
+
+    // Transient / dialog / menu family. transientFor() catches child surfaces
+    // that Electron/CEF apps (Steam, Discord, VS Code) spawn for image
+    // previews, context menus and popups: these frequently fail to report an
+    // accurate KWin window type (isDialog/isPopupWindow stay false) but always
+    // set the transient-parent relationship. Without this the popup passes the
+    // filter and gets snapped to a zone (discussion #461 item 11).
+    if (w->isDialog() || w->isUtility() || w->isSplash() || w->isNotification() || w->isCriticalNotification()
+        || w->isOnScreenDisplay() || w->isModal() || w->isPopupWindow() || w->isPopupMenu() || w->isDropdownMenu()
+        || w->isMenu() || w->isTooltip() || w->transientFor()) {
+        if (rejectReason) {
+            // Coarse reason — logWindowDiagnostics() dumps every flag in this
+            // clause individually, so the caller can pinpoint which one fired.
+            *rejectReason =
+                QStringLiteral("transient/dialog/utility/splash/notification/osd/modal/popup/menu/tooltip window type");
+        }
+        return true;
+    }
+
+    return false;
+}
+
 bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w, QString* rejectReason) const
 {
     if (rejectReason) {
@@ -135,42 +182,11 @@ bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w, QString* rejec
         }
     }
 
-    // Skip special / non-manageable window types (inherently effect-side — KWin metadata)
-    if (w->isSpecialWindow() || w->isDesktop() || w->isDock() || w->isFullScreen() || w->isSkipSwitcher()) {
-        return rejectedBecause(rejectReason, "special/desktop/dock/fullscreen/skipSwitcher window type");
-    }
-
-    // Skip transient/dialog/menu windows unconditionally. Dialogs, utilities,
-    // tooltips, menus, notifications, etc. should never be zone-managed.
-    // User-configured exclusion lists and minimum size checks are handled by
-    // the daemon.
-    //
-    // transientFor() catches child surfaces that Electron/CEF apps (Steam, Discord,
-    // VS Code) spawn for image previews, context menus and popups: these frequently
-    // fail to report an accurate KWin window type (isDialog/isPopupWindow stay
-    // false) but always set the transient-parent relationship. Without this the
-    // popup passes the filter and gets snapped to a zone (discussion #461 item 11).
-    //
-    // Relationship with isTileableWindow(): the autotile filter starts with
-    // `!isNormalWindow()`, which structurally catches every flag enumerated here
-    // (KWin marks Dialog/Utility/Splash/Notification/etc. as non-Normal types).
-    // We enumerate them explicitly on the snap side because the snap path runs
-    // before isNormalWindow() classification in some KWin versions, and the
-    // explicit list documents which window kinds the snap filter rejects.
-    // Anything in this block that ALSO appears verbatim in isTileableWindow
-    // (isModal, isPopupWindow, isPopupMenu, isDropdownMenu, isMenu, isTooltip,
-    // transientFor) must stay in lockstep with that filter — the Steam image-
-    // popup regression (#461 item 11) came from a missed sync of exactly that
-    // intersection. The flags isTileableWindow does NOT enumerate (isDialog,
-    // isUtility, isSplash, isNotification, isCriticalNotification,
-    // isOnScreenDisplay) are caught there by !isNormalWindow().
-    if (w->isDialog() || w->isUtility() || w->isSplash() || w->isNotification() || w->isCriticalNotification()
-        || w->isOnScreenDisplay() || w->isModal() || w->isPopupWindow() || w->isPopupMenu() || w->isDropdownMenu()
-        || w->isMenu() || w->isTooltip() || w->transientFor()) {
-        // Coarse reason — logWindowDiagnostics() dumps every flag in this
-        // clause individually, so the caller can pinpoint which one fired.
-        return rejectedBecause(rejectReason,
-                               "transient/dialog/utility/splash/notification/osd/modal/popup/menu/tooltip window type");
+    // Skip structural / transient / dialog / menu window types. The predicate
+    // is shared verbatim with notifyWindowActivated() so the two filters can
+    // never drift — see isStructurallyUnmanageableWindowType().
+    if (isStructurallyUnmanageableWindowType(w, rejectReason)) {
+        return false;
     }
 
     // Keep-above overlays (Spectacle, color pickers, screen rulers, screenshot
@@ -329,7 +345,7 @@ bool PlasmaZonesEffect::isTileableWindow(KWin::EffectWindow* w, QString* rejectR
 void PlasmaZonesEffect::logWindowDiagnostics(KWin::EffectWindow* w, const char* context) const
 {
     if (!w) {
-        qCInfo(lcEffect) << "[window-diag]" << context << "— null window";
+        qCDebug(lcEffectDiag) << "[window-diag]" << context << "— null window";
         return;
     }
 
@@ -340,37 +356,40 @@ void PlasmaZonesEffect::logWindowDiagnostics(KWin::EffectWindow* w, const char* 
 
     KWin::Window* kw = w->window();
 
-    qCInfo(lcEffect) << "[window-diag]" << context << "— class:" << w->windowClass() << "role:" << w->windowRole()
-                     << "caption:" << w->caption() << "desktopFile:" << (kw ? kw->desktopFileName() : QString())
-                     << "pid:" << w->pid();
-    qCInfo(lcEffect) << "[window-diag]   verdict — shouldHandleWindow:" << handle
-                     << (handle ? QString() : QStringLiteral("[rejected: %1]").arg(handleReason))
-                     << "| isTileableWindow:" << tileable
-                     << (tileable ? QString() : QStringLiteral("[rejected: %1]").arg(tileReason));
-    qCInfo(lcEffect) << "[window-diag]   type — normal:" << w->isNormalWindow() << "special:" << w->isSpecialWindow()
-                     << "dialog:" << w->isDialog() << "utility:" << w->isUtility() << "splash:" << w->isSplash()
-                     << "modal:" << w->isModal() << "toolbar:" << w->isToolbar() << "menu:" << w->isMenu()
-                     << "popupWindow:" << w->isPopupWindow() << "popupMenu:" << w->isPopupMenu()
-                     << "dropdownMenu:" << w->isDropdownMenu() << "tooltip:" << w->isTooltip()
-                     << "notification:" << w->isNotification() << "criticalNotification:" << w->isCriticalNotification()
-                     << "onScreenDisplay:" << w->isOnScreenDisplay() << "appletPopup:" << w->isAppletPopup()
-                     << "desktop:" << w->isDesktop() << "dock:" << w->isDock();
-    qCInfo(lcEffect) << "[window-diag]   state — managed:" << w->isManaged() << "x11:" << w->isX11Client()
-                     << "wayland:" << w->isWaylandClient() << "fullScreen:" << w->isFullScreen()
-                     << "minimized:" << w->isMinimized() << "skipSwitcher:" << w->isSkipSwitcher()
-                     << "keepAbove:" << w->keepAbove() << "hasDecoration:" << w->hasDecoration()
-                     << "onCurrentDesktop:" << w->isOnCurrentDesktop()
-                     << "onCurrentActivity:" << w->isOnCurrentActivity() << "onAllDesktops:" << w->isOnAllDesktops();
-    qCInfo(lcEffect) << "[window-diag]   geometry — frame:" << w->frameGeometry()
-                     << "minSize:" << (kw ? kw->minSize() : QSizeF());
+    qCDebug(lcEffectDiag) << "[window-diag]" << context << "— class:" << w->windowClass() << "role:" << w->windowRole()
+                          << "caption:" << w->caption() << "desktopFile:" << (kw ? kw->desktopFileName() : QString())
+                          << "pid:" << w->pid();
+    qCDebug(lcEffectDiag) << "[window-diag]   verdict — shouldHandleWindow:" << handle
+                          << (handle ? QString() : QStringLiteral("[rejected: %1]").arg(handleReason))
+                          << "| isTileableWindow:" << tileable
+                          << (tileable ? QString() : QStringLiteral("[rejected: %1]").arg(tileReason));
+    qCDebug(lcEffectDiag) << "[window-diag]   type — normal:" << w->isNormalWindow()
+                          << "special:" << w->isSpecialWindow() << "dialog:" << w->isDialog()
+                          << "utility:" << w->isUtility() << "splash:" << w->isSplash() << "modal:" << w->isModal()
+                          << "toolbar:" << w->isToolbar() << "menu:" << w->isMenu()
+                          << "popupWindow:" << w->isPopupWindow() << "popupMenu:" << w->isPopupMenu()
+                          << "dropdownMenu:" << w->isDropdownMenu() << "tooltip:" << w->isTooltip()
+                          << "notification:" << w->isNotification()
+                          << "criticalNotification:" << w->isCriticalNotification()
+                          << "onScreenDisplay:" << w->isOnScreenDisplay() << "appletPopup:" << w->isAppletPopup()
+                          << "desktop:" << w->isDesktop() << "dock:" << w->isDock();
+    qCDebug(lcEffectDiag) << "[window-diag]   state — managed:" << w->isManaged() << "x11:" << w->isX11Client()
+                          << "wayland:" << w->isWaylandClient() << "fullScreen:" << w->isFullScreen()
+                          << "minimized:" << w->isMinimized() << "skipSwitcher:" << w->isSkipSwitcher()
+                          << "keepAbove:" << w->keepAbove() << "hasDecoration:" << w->hasDecoration()
+                          << "onCurrentDesktop:" << w->isOnCurrentDesktop()
+                          << "onCurrentActivity:" << w->isOnCurrentActivity()
+                          << "onAllDesktops:" << w->isOnAllDesktops();
+    qCDebug(lcEffectDiag) << "[window-diag]   geometry — frame:" << w->frameGeometry()
+                          << "minSize:" << (kw ? kw->minSize() : QSizeF());
 
     if (KWin::EffectWindow* parent = w->transientFor()) {
-        qCInfo(lcEffect) << "[window-diag]   transientFor — YES — parent class:" << parent->windowClass()
-                         << "caption:" << parent->caption() << "normal:" << parent->isNormalWindow()
-                         << "special:" << parent->isSpecialWindow() << "pid:" << parent->pid()
-                         << "frame:" << parent->frameGeometry();
+        qCDebug(lcEffectDiag) << "[window-diag]   transientFor — YES — parent class:" << parent->windowClass()
+                              << "caption:" << parent->caption() << "normal:" << parent->isNormalWindow()
+                              << "special:" << parent->isSpecialWindow() << "pid:" << parent->pid()
+                              << "frame:" << parent->frameGeometry();
     } else {
-        qCInfo(lcEffect) << "[window-diag]   transientFor — none";
+        qCDebug(lcEffectDiag) << "[window-diag]   transientFor — none";
     }
 }
 

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -17,6 +17,21 @@ namespace PlasmaZones {
 
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
 
+namespace {
+// Record a filter rejection: when @p out is non-null, store @p reason into it.
+// Lets each filter early-exit read as a single `return rejectedBecause(out,
+// "...");`, keeping the reason text co-located with the clause that produced
+// it — so logWindowDiagnostics never has to re-derive (and risk drifting from)
+// the filter logic.
+bool rejectedBecause(QString* out, const char* reason)
+{
+    if (out) {
+        *out = QString::fromLatin1(reason);
+    }
+    return false;
+}
+} // namespace
+
 void PlasmaZonesEffect::ensurePreSnapGeometryStored(KWin::EffectWindow* w, const QString& windowId,
                                                     const QRectF& preCapturedGeometry)
 {
@@ -83,27 +98,31 @@ bool PlasmaZonesEffect::isWindowFloating(const QString& windowId) const
     return m_navigationHandler->isWindowFloating(windowId);
 }
 
-bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w) const
+bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w, QString* rejectReason) const
 {
+    if (rejectReason) {
+        rejectReason->clear();
+    }
+
     if (!w) {
-        return false;
+        return rejectedBecause(rejectReason, "null window");
     }
 
     // Never snap our own overlay/editor windows (but allow the settings app)
     const QString windowClass = w->windowClass();
     if (windowClass.contains(QLatin1String("plasmazonesd"), Qt::CaseInsensitive)
         || windowClass.contains(QLatin1String("plasmazones-editor"), Qt::CaseInsensitive)) {
-        return false;
+        return rejectedBecause(rejectReason, "own overlay/editor window class");
     }
 
     // Exclude XDG desktop portal windows (file dialogs, color pickers, etc.)
     if (windowClass.contains(QLatin1String("xdg-desktop-portal"), Qt::CaseInsensitive)) {
-        return false;
+        return rejectedBecause(rejectReason, "xdg-desktop-portal window class");
     }
 
     // Plasma shell layer-shell surfaces — see isPlasmaShellSurface() for rationale.
     if (isPlasmaShellSurface(windowClass)) {
-        return false;
+        return rejectedBecause(rejectReason, "Plasma shell layer-shell surface");
     }
 
     // Check user-configured exclusion lists (needed for drag gating — daemon also enforces
@@ -112,13 +131,13 @@ bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w) const
         KWin::Window* kw = w->window();
         const QString appName = kw ? kw->desktopFileName() : QString();
         if (matchesExclusionLists(appName, windowClass, m_excludedApplications, m_excludedWindowClasses)) {
-            return false;
+            return rejectedBecause(rejectReason, "user exclusion list match (app/class)");
         }
     }
 
     // Skip special / non-manageable window types (inherently effect-side — KWin metadata)
     if (w->isSpecialWindow() || w->isDesktop() || w->isDock() || w->isFullScreen() || w->isSkipSwitcher()) {
-        return false;
+        return rejectedBecause(rejectReason, "special/desktop/dock/fullscreen/skipSwitcher window type");
     }
 
     // Skip transient/dialog/menu windows unconditionally. Dialogs, utilities,
@@ -148,14 +167,17 @@ bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w) const
     if (w->isDialog() || w->isUtility() || w->isSplash() || w->isNotification() || w->isCriticalNotification()
         || w->isOnScreenDisplay() || w->isModal() || w->isPopupWindow() || w->isPopupMenu() || w->isDropdownMenu()
         || w->isMenu() || w->isTooltip() || w->transientFor()) {
-        return false;
+        // Coarse reason — logWindowDiagnostics() dumps every flag in this
+        // clause individually, so the caller can pinpoint which one fired.
+        return rejectedBecause(rejectReason,
+                               "transient/dialog/utility/splash/notification/osd/modal/popup/menu/tooltip window type");
     }
 
     // Keep-above overlays (Spectacle, color pickers, screen rulers, screenshot
     // tools that linger after capture) shouldn't be snapped to a zone — same
     // rationale as isTileableWindow's keep-above gate.
     if (w->keepAbove()) {
-        return false;
+        return rejectedBecause(rejectReason, "keep-above window");
     }
 
     return true;
@@ -275,24 +297,81 @@ bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
     return true;
 }
 
-bool PlasmaZonesEffect::isTileableWindow(KWin::EffectWindow* w) const
+bool PlasmaZonesEffect::isTileableWindow(KWin::EffectWindow* w, QString* rejectReason) const
 {
+    if (rejectReason) {
+        rejectReason->clear();
+    }
+
+    if (!w) {
+        return rejectedBecause(rejectReason, "null window");
+    }
+
     // Reject menus, popups, tooltips, modals, and transient children.
     // Electron apps (Vesktop, VS Code, Discord) create separate windows
     // for context menus and dropdowns that pass shouldHandleWindow() but
     // must never enter the autotile tree.
     if (!w->isNormalWindow() || w->isModal() || w->isPopupWindow() || w->isDropdownMenu() || w->isPopupMenu()
         || w->isTooltip() || w->isMenu() || w->transientFor()) {
-        return false;
+        // Coarse reason — logWindowDiagnostics() dumps every flag individually.
+        return rejectedBecause(rejectReason, "non-normal/modal/popup/dropdown/menu/tooltip/transient window type");
     }
     // Reject keep-above windows — overlay/utility tools (Spectacle, color
     // pickers, screen rulers, etc.) set keep-above and should not enter the
     // autotile tree or receive auto-focus. Without this guard, opening
     // Spectacle while focusNewWindows is enabled disrupts the tiled layout.
     if (w->keepAbove()) {
-        return false;
+        return rejectedBecause(rejectReason, "keep-above window");
     }
     return true;
+}
+
+void PlasmaZonesEffect::logWindowDiagnostics(KWin::EffectWindow* w, const char* context) const
+{
+    if (!w) {
+        qCInfo(lcEffect) << "[window-diag]" << context << "— null window";
+        return;
+    }
+
+    QString handleReason;
+    QString tileReason;
+    const bool handle = shouldHandleWindow(w, &handleReason);
+    const bool tileable = isTileableWindow(w, &tileReason);
+
+    KWin::Window* kw = w->window();
+
+    qCInfo(lcEffect) << "[window-diag]" << context << "— class:" << w->windowClass() << "role:" << w->windowRole()
+                     << "caption:" << w->caption() << "desktopFile:" << (kw ? kw->desktopFileName() : QString())
+                     << "pid:" << w->pid();
+    qCInfo(lcEffect) << "[window-diag]   verdict — shouldHandleWindow:" << handle
+                     << (handle ? QString() : QStringLiteral("[rejected: %1]").arg(handleReason))
+                     << "| isTileableWindow:" << tileable
+                     << (tileable ? QString() : QStringLiteral("[rejected: %1]").arg(tileReason));
+    qCInfo(lcEffect) << "[window-diag]   type — normal:" << w->isNormalWindow() << "special:" << w->isSpecialWindow()
+                     << "dialog:" << w->isDialog() << "utility:" << w->isUtility() << "splash:" << w->isSplash()
+                     << "modal:" << w->isModal() << "toolbar:" << w->isToolbar() << "menu:" << w->isMenu()
+                     << "popupWindow:" << w->isPopupWindow() << "popupMenu:" << w->isPopupMenu()
+                     << "dropdownMenu:" << w->isDropdownMenu() << "tooltip:" << w->isTooltip()
+                     << "notification:" << w->isNotification() << "criticalNotification:" << w->isCriticalNotification()
+                     << "onScreenDisplay:" << w->isOnScreenDisplay() << "appletPopup:" << w->isAppletPopup()
+                     << "desktop:" << w->isDesktop() << "dock:" << w->isDock();
+    qCInfo(lcEffect) << "[window-diag]   state — managed:" << w->isManaged() << "x11:" << w->isX11Client()
+                     << "wayland:" << w->isWaylandClient() << "fullScreen:" << w->isFullScreen()
+                     << "minimized:" << w->isMinimized() << "skipSwitcher:" << w->isSkipSwitcher()
+                     << "keepAbove:" << w->keepAbove() << "hasDecoration:" << w->hasDecoration()
+                     << "onCurrentDesktop:" << w->isOnCurrentDesktop()
+                     << "onCurrentActivity:" << w->isOnCurrentActivity() << "onAllDesktops:" << w->isOnAllDesktops();
+    qCInfo(lcEffect) << "[window-diag]   geometry — frame:" << w->frameGeometry()
+                     << "minSize:" << (kw ? kw->minSize() : QSizeF());
+
+    if (KWin::EffectWindow* parent = w->transientFor()) {
+        qCInfo(lcEffect) << "[window-diag]   transientFor — YES — parent class:" << parent->windowClass()
+                         << "caption:" << parent->caption() << "normal:" << parent->isNormalWindow()
+                         << "special:" << parent->isSpecialWindow() << "pid:" << parent->pid()
+                         << "frame:" << parent->frameGeometry();
+    } else {
+        qCInfo(lcEffect) << "[window-diag]   transientFor — none";
+    }
 }
 
 bool PlasmaZonesEffect::hasOtherWindowOfClassWithDifferentPid(KWin::EffectWindow* w) const

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -113,8 +113,16 @@ bool PlasmaZonesEffect::isStructurallyUnmanageableWindowType(KWin::EffectWindow*
     //
     // isTileableWindow() deliberately keeps its own, narrower list (it gates
     // on !isNormalWindow()) and is NOT folded in here.
-    //
-    // @p w must be non-null — both callers null-check before reaching here.
+
+    // Null is structurally unmanageable. Both current callers null-check before
+    // reaching here, so this is a defensive guard that keeps the precondition
+    // enforced rather than merely documented for any future caller.
+    if (!w) {
+        if (rejectReason) {
+            *rejectReason = QStringLiteral("null window");
+        }
+        return true;
+    }
 
     // Special / non-manageable window types (inherently effect-side — KWin metadata).
     if (w->isSpecialWindow() || w->isDesktop() || w->isDock() || w->isFullScreen() || w->isSkipSwitcher()) {

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -67,9 +67,10 @@ void PlasmaZonesEffect::endRestoreSuppression(KWin::EffectWindow* window)
 
 void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
 {
-    // Full property + filter-verdict dump for every window as it opens. Bounded
-    // by window-open frequency, so it is safe at info level; gives the data
-    // needed to fix apps KWin mis-classifies (Steam / CEF child surfaces).
+    // Full property + filter-verdict dump for every window as it opens. Silent
+    // unless the opt-in plasmazones.effect.diag category is enabled (see
+    // logWindowDiagnostics) — gives the data needed to fix apps KWin
+    // mis-classifies (Steam / CEF child surfaces) without journal noise.
     logWindowDiagnostics(w, "windowAdded");
 
     setupWindowConnections(w);
@@ -769,20 +770,18 @@ void PlasmaZonesEffect::notifyWindowActivated(KWin::EffectWindow* w)
     if (isPlasmaShellSurface(windowClass)) {
         return;
     }
-    // Rejection set must stay in lockstep with shouldHandleWindow's structural
-    // filter (window_filtering.cpp). If a window type can never legitimately be
-    // a snap/autotile target, reporting it as the active window pollutes the
-    // daemon's focus tracking — m_lastActiveWindowId / m_lastActiveScreenId get
-    // pinned to a popup, and downstream paths (moveNewWindowsToLastZone,
-    // shortcut screen resolution, snap fallbacks) then route real windows to
-    // the popup's zone. Discussion #461 item 11: Steam image popups (Electron
-    // child surfaces with transient_for set but isPopupWindow false) leaked
-    // through the older shorter list and ended up driving snap geometry on
-    // their parents.
-    if (w->isSpecialWindow() || w->isDesktop() || w->isDock() || w->isFullScreen() || w->isSkipSwitcher()
-        || w->isDialog() || w->isUtility() || w->isSplash() || w->isNotification() || w->isCriticalNotification()
-        || w->isOnScreenDisplay() || w->isModal() || w->isPopupWindow() || w->isPopupMenu() || w->isDropdownMenu()
-        || w->isMenu() || w->isTooltip() || w->transientFor()) {
+    // Reject structurally unmanageable window types via the predicate shared
+    // verbatim with shouldHandleWindow() — see isStructurallyUnmanageableWindowType().
+    // If a window type can never legitimately be a snap/autotile target,
+    // reporting it as the active window pollutes the daemon's focus tracking:
+    // m_lastActiveWindowId / m_lastActiveScreenId get pinned to a popup, and
+    // downstream paths (moveNewWindowsToLastZone, shortcut screen resolution,
+    // snap fallbacks) then route real windows to the popup's zone. Discussion
+    // #461 item 11: Steam image popups (Electron child surfaces with
+    // transient_for set but isPopupWindow false) leaked through an older
+    // hand-maintained copy of this list — the shared predicate makes that
+    // drift impossible.
+    if (isStructurallyUnmanageableWindowType(w)) {
         return;
     }
 

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -67,6 +67,11 @@ void PlasmaZonesEffect::endRestoreSuppression(KWin::EffectWindow* window)
 
 void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
 {
+    // Full property + filter-verdict dump for every window as it opens. Bounded
+    // by window-open frequency, so it is safe at info level; gives the data
+    // needed to fix apps KWin mis-classifies (Steam / CEF child surfaces).
+    logWindowDiagnostics(w, "windowAdded");
+
     setupWindowConnections(w);
     updateWindowStickyState(w);
 
@@ -149,7 +154,6 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
     // Rare race: the saved screen may have flipped from snap→autotile between
     // when the cache was populated and when the window opens. Re-check the
     // entry's screen mode via the autotile handler before applying.
-    bool instantRestoreApplied = false;
     if (canSnapRestore && !m_snapRestoreCache.isEmpty()) {
         QString appId = ::PhosphorIdentity::WindowId::extractAppId(windowId);
         auto cacheIt = m_snapRestoreCache.find(appId);
@@ -160,7 +164,6 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
             if (cached.geometry.isValid() && !savedScreenNowAutotile) {
                 qCInfo(lcEffect) << "Instant snap restore for" << appId << "to:" << cached.geometry
                                  << "screen:" << cached.screenId;
-                instantRestoreApplied = true;
                 // skipAnimation=true: teleport straight into the zone.
                 // First-frame open suppression (beginRestoreSuppression
                 // above in slotWindowAdded) withholds the window from
@@ -194,7 +197,7 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
         }
     }
 
-    if (onAutotileScreen && canSnapRestore && !instantRestoreApplied) {
+    if (onAutotileScreen && canSnapRestore) {
         // Window landed on an autotile screen, but may have a pending snap restore
         // to a non-autotile screen. KWin's session restore places windows at their
         // saved geometry, which may be a pre-snap floating position in the autotile
@@ -202,12 +205,6 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
         // before logout. Try snap restore FIRST: if it moves the window off the
         // autotile screen, we avoid the autotile add→float→remove→resnap dance
         // that causes visible flickering and repeated resizing.
-        //
-        // Skip when `instantRestoreApplied` is true: the window was already
-        // teleported by the instant-restore branch above, the cache entry
-        // is consumed, and a second daemon round-trip would just confirm
-        // "no zone" (cache cleared) or — worse — re-stamp `targetGeometry`
-        // on the still-active suppression entry on a redundant moveResize.
         QPointer<KWin::EffectWindow> safeW = w;
         // releaseSuppressionOnMiss=false: if snap-restore finds no zone, the
         // onComplete autotile path may still reposition the window — keep it
@@ -242,16 +239,30 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
         endRestoreSuppression(w);
     }
 
-    if (!onAutotileScreen && canSnapRestore && !instantRestoreApplied) {
-        // Skip when `instantRestoreApplied` is true: the cache entry was
-        // consumed and the daemon would just answer "no zone".
+    if (!onAutotileScreen && canSnapRestore) {
+        // Always run the daemon round-trip — INCLUDING after an instant
+        // restore. Instant restore only teleports the window to the cached
+        // zone geometry; it does NOT register the window in the daemon's
+        // SnapState. Zone registration happens exclusively via the daemon's
+        // resolveWindowRestore → commitSnap path, so skipping this call left
+        // every instant-restored window a "ghost": visually in its zone but
+        // absent from SnapState::zoneAssignments. buildOccupiedZoneSet() then
+        // reported the occupied zone as free, so getEmptyZones / snap-assist
+        // / empty-zone auto-placement all treated it as empty. On login the
+        // instant-restore cache serves nearly every window at once, so almost
+        // nothing got registered (zones=1 of 7 in the field logs).
+        //
+        // The earlier skip of this call after an instant restore assumed the
+        // daemon "would just answer no zone" once the effect's m_snapRestoreCache
+        // entry was consumed. That is false: m_snapRestoreCache is an effect-side
+        // latency cache, separate from the daemon's pending-restore queue.
+        // pendingRestoreGeometries() (which populates the cache) is a const
+        // read and does NOT consume the daemon queue, so resolveWindowRestore
+        // still matches the pending entry, consumes it, and commits. When
+        // instant restore already placed the window the daemon returns the
+        // same zone rect, so the re-apply is a no-op moveResize to the
+        // current geometry — the price of correct registration.
         callResolveWindowRestore(w);
-    } else if (instantRestoreApplied) {
-        // Instant-restore already moved the window into its zone, but
-        // first-frame suppression is still active waiting for a settle
-        // signal. The settle hook (windowFrameGeometryChanged) already
-        // fires once moveResize commits, so suppression releases on its
-        // own — no extra work here.
     }
 }
 
@@ -565,6 +576,22 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
         connect(kw, &KWin::Window::windowClassChanged, this, pushLatest);
         connect(kw, &KWin::Window::desktopFileNameChanged, this, pushLatest);
         connect(kw, &KWin::Window::captionChanged, this, pushLatest);
+
+        // Diagnostic dump on identity change — but ONLY for class / desktop-file,
+        // never caption. CEF/Electron apps (Steam included) map with a
+        // placeholder class and swap in the real one here, so re-dumping on
+        // those catches the final classification the filters act on. Caption
+        // is deliberately excluded: it feeds no filter, and terminals /
+        // browsers (and this very tool's progress spinner) rewrite their title
+        // every frame — dumping on captionChanged floods the journal with
+        // identical blocks. See logWindowDiagnostics().
+        auto logIdentityChange = [this, safeW]() {
+            if (safeW && !safeW->isDeleted()) {
+                logWindowDiagnostics(safeW, "identityChanged");
+            }
+        };
+        connect(kw, &KWin::Window::windowClassChanged, this, logIdentityChange);
+        connect(kw, &KWin::Window::desktopFileNameChanged, this, logIdentityChange);
     }
 
     // Detect drag start/end via KWin's per-window signals instead of polling.
@@ -742,9 +769,20 @@ void PlasmaZonesEffect::notifyWindowActivated(KWin::EffectWindow* w)
     if (isPlasmaShellSurface(windowClass)) {
         return;
     }
+    // Rejection set must stay in lockstep with shouldHandleWindow's structural
+    // filter (window_filtering.cpp). If a window type can never legitimately be
+    // a snap/autotile target, reporting it as the active window pollutes the
+    // daemon's focus tracking — m_lastActiveWindowId / m_lastActiveScreenId get
+    // pinned to a popup, and downstream paths (moveNewWindowsToLastZone,
+    // shortcut screen resolution, snap fallbacks) then route real windows to
+    // the popup's zone. Discussion #461 item 11: Steam image popups (Electron
+    // child surfaces with transient_for set but isPopupWindow false) leaked
+    // through the older shorter list and ended up driving snap geometry on
+    // their parents.
     if (w->isSpecialWindow() || w->isDesktop() || w->isDock() || w->isFullScreen() || w->isSkipSwitcher()
         || w->isDialog() || w->isUtility() || w->isSplash() || w->isNotification() || w->isCriticalNotification()
-        || w->isOnScreenDisplay() || w->isModal() || w->isPopupWindow()) {
+        || w->isOnScreenDisplay() || w->isModal() || w->isPopupWindow() || w->isPopupMenu() || w->isDropdownMenu()
+        || w->isMenu() || w->isTooltip() || w->transientFor()) {
         return;
     }
 

--- a/kwin-effect/snapassisthandler.cpp
+++ b/kwin-effect/snapassisthandler.cpp
@@ -34,7 +34,7 @@ SnapAssistHandler::SnapAssistHandler(PlasmaZonesEffect* effect, QObject* parent)
 {
 }
 
-void SnapAssistHandler::showContinuationIfNeeded(const QString& screenId)
+void SnapAssistHandler::showContinuationIfNeeded(const QString& screenId, const QString& requireSnappedWindowId)
 {
     if (screenId.isEmpty()) {
         qCInfo(lcSnapAssist) << "Snap assist continuation skipped: empty screen name";
@@ -51,21 +51,25 @@ void SnapAssistHandler::showContinuationIfNeeded(const QString& screenId)
     QDBusPendingCall emptyCall = PhosphorProtocol::ClientHelpers::asyncCall(
         PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getEmptyZones"), {screenId});
     auto* watcher = new QDBusPendingCallWatcher(emptyCall, this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, screenId](QDBusPendingCallWatcher* w) {
-        w->deleteLater();
-        QDBusPendingReply<PhosphorProtocol::EmptyZoneList> reply = *w;
-        if (!reply.isValid() || reply.value().isEmpty()) {
-            qCInfo(lcSnapAssist) << "Snap assist continuation: no empty zones"
-                                 << (reply.isValid() ? QStringLiteral("(empty list)")
-                                                     : QStringLiteral("(invalid reply)"));
-            return;
-        }
-        asyncShow(QString(), screenId, reply.value());
-    });
+    connect(watcher, &QDBusPendingCallWatcher::finished, this,
+            [this, screenId, requireSnappedWindowId](QDBusPendingCallWatcher* w) {
+                w->deleteLater();
+                QDBusPendingReply<PhosphorProtocol::EmptyZoneList> reply = *w;
+                if (!reply.isValid() || reply.value().isEmpty()) {
+                    qCInfo(lcSnapAssist) << "Snap assist continuation: no empty zones"
+                                         << (reply.isValid() ? QStringLiteral("(empty list)")
+                                                             : QStringLiteral("(invalid reply)"));
+                    return;
+                }
+                // When an anchor window is required, it is also the window to
+                // exclude from candidates — it is already placed in a zone.
+                asyncShow(requireSnappedWindowId, screenId, reply.value(), requireSnappedWindowId);
+            });
 }
 
 void SnapAssistHandler::asyncShow(const QString& excludeWindowId, const QString& screenId,
-                                  const PhosphorProtocol::EmptyZoneList& emptyZones)
+                                  const PhosphorProtocol::EmptyZoneList& emptyZones,
+                                  const QString& requireSnappedWindowId)
 {
     if (!m_effect->isDaemonReady("snap assist snapped windows")) {
         return;
@@ -74,7 +78,7 @@ void SnapAssistHandler::asyncShow(const QString& excludeWindowId, const QString&
         PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
     auto* snapWatcher = new QDBusPendingCallWatcher(snapCall, this);
     connect(snapWatcher, &QDBusPendingCallWatcher::finished, this,
-            [this, excludeWindowId, screenId, emptyZones](QDBusPendingCallWatcher* w) {
+            [this, excludeWindowId, screenId, emptyZones, requireSnappedWindowId](QDBusPendingCallWatcher* w) {
                 w->deleteLater();
                 QDBusPendingReply<QStringList> reply = *w;
                 QSet<QString> snappedWindowIds;
@@ -82,6 +86,19 @@ void SnapAssistHandler::asyncShow(const QString& excludeWindowId, const QString&
                     for (const QString& id : reply.value()) {
                         snappedWindowIds.insert(id);
                     }
+                }
+                // Resnap anchor gate: the resnap-completion path keys the
+                // continuation to the active window. If that window is not
+                // among the daemon's snapped windows, the resnap placed
+                // nothing meaningful in a zone (e.g. an autotile→snap toggle
+                // with no prior snap assignments) — every zone is empty and a
+                // "continuation" would just be snap assist for the whole
+                // layout. Bail. Empty requireSnappedWindowId (drag-snap and
+                // overlay-driven continuations) skips the gate entirely.
+                if (!requireSnappedWindowId.isEmpty() && !snappedWindowIds.contains(requireSnappedWindowId)) {
+                    qCInfo(lcSnapAssist) << "Snap assist skipped: anchor window" << requireSnappedWindowId
+                                         << "is not snapped — resnap placed nothing in a zone on" << screenId;
+                    return;
                 }
                 PhosphorProtocol::SnapAssistCandidateList candidates =
                     buildCandidates(excludeWindowId, screenId, snappedWindowIds);

--- a/kwin-effect/snapassisthandler.h
+++ b/kwin-effect/snapassisthandler.h
@@ -31,12 +31,26 @@ class SnapAssistHandler : public QObject
 public:
     explicit SnapAssistHandler(PlasmaZonesEffect* effect, QObject* parent = nullptr);
 
-    /// Show snap assist continuation for a screen (checks enabled, queries empty zones)
-    void showContinuationIfNeeded(const QString& screenId);
+    /// Show snap assist continuation for a screen (checks enabled, queries empty zones).
+    ///
+    /// @param requireSnappedWindowId when non-empty, the continuation is gated:
+    ///   snap assist is shown only if this window is actually snapped into a
+    ///   zone on the daemon side, and the window is also excluded from the
+    ///   candidate list (it is already placed). Used by the resnap-completion
+    ///   path — a bulk resnap (autotile→snap toggle, rotate, vs-reconfigure)
+    ///   is not a per-window snap, so it must not pop snap assist for every
+    ///   empty zone when it happened to place nothing. The anchor window
+    ///   stands in for "the window the user just snapped"; if it did not land
+    ///   in a zone, there is no continuation to offer.
+    void showContinuationIfNeeded(const QString& screenId, const QString& requireSnappedWindowId = QString());
 
-    /// Full async snap assist: get snapped windows, build candidates, show overlay
+    /// Full async snap assist: get snapped windows, build candidates, show overlay.
+    ///
+    /// @param requireSnappedWindowId when non-empty, abort if this window is
+    ///   not among the daemon's snapped windows. @see showContinuationIfNeeded.
     void asyncShow(const QString& excludeWindowId, const QString& screenId,
-                   const PhosphorProtocol::EmptyZoneList& emptyZones);
+                   const PhosphorProtocol::EmptyZoneList& emptyZones,
+                   const QString& requireSnappedWindowId = QString());
 
     /// Update the enabled flag (from loadCachedSettings)
     void setEnabled(bool enabled)

--- a/libs/phosphor-shortcuts/include/PhosphorShortcuts/IBackend.h
+++ b/libs/phosphor-shortcuts/include/PhosphorShortcuts/IBackend.h
@@ -56,11 +56,22 @@ public:
      *                    defaultSeq on a fresh install. May be empty (no grab).
      * @param description Human-readable label surfaced in portal settings
      *                    UIs and kglobalaccel listings.
+     * @param persistent  When false, the binding is transient — the backend
+     *                    must avoid leaving an entry in any user-visible
+     *                    persistent registry (e.g. KGlobalAccel's
+     *                    kglobalshortcutsrc) that would survive an
+     *                    unexpected daemon exit. The backend is responsible
+     *                    for purging the entry on destruction so a crash
+     *                    cannot leak a global key grab into the user's
+     *                    System Settings (discussion #461 item 14).
+     *                    Persistent (true) is the historical default and
+     *                    the only correct value for user-customizable
+     *                    shortcuts.
      *
      * Registration is queued until flush() is called.
      */
     virtual void registerShortcut(const QString& id, const QKeySequence& defaultSeq, const QKeySequence& currentSeq,
-                                  const QString& description) = 0;
+                                  const QString& description, bool persistent = true) = 0;
 
     /**
      * Change the active binding for an already-registered id. Takes both

--- a/libs/phosphor-shortcuts/include/PhosphorShortcuts/Registry.h
+++ b/libs/phosphor-shortcuts/include/PhosphorShortcuts/Registry.h
@@ -140,6 +140,12 @@ private:
         QKeySequence lastSentDefault;
         QKeySequence lastSentCurrent;
         bool registered = false; // has registerShortcut been sent yet?
+        // Persistent flag last forwarded to the backend. flush() re-registers
+        // when this drifts from `persistent` so a re-bind() that flips the flag
+        // without changing the key still reaches the backend — the backend's
+        // crash-purge decision (KGlobalAccelBackend) depends on the latest
+        // value. Only meaningful once `registered` is true.
+        bool lastSentPersistent = true;
         bool persistent = true; // surfaces in bindings(persistentOnly=true)
     };
 

--- a/libs/phosphor-shortcuts/src/backends.h
+++ b/libs/phosphor-shortcuts/src/backends.h
@@ -29,7 +29,7 @@ public:
     explicit DBusTriggerBackend(QObject* parent = nullptr);
 
     void registerShortcut(const QString& id, const QKeySequence& defaultSeq, const QKeySequence& currentSeq,
-                          const QString& description) override;
+                          const QString& description, bool persistent) override;
     void updateShortcut(const QString& id, const QKeySequence& defaultSeq, const QKeySequence& newTrigger) override;
     void unregisterShortcut(const QString& id) override;
     void flush() override;
@@ -51,7 +51,7 @@ public:
     ~PortalBackend() override;
 
     void registerShortcut(const QString& id, const QKeySequence& defaultSeq, const QKeySequence& currentSeq,
-                          const QString& description) override;
+                          const QString& description, bool persistent) override;
     void updateShortcut(const QString& id, const QKeySequence& defaultSeq, const QKeySequence& newTrigger) override;
     void unregisterShortcut(const QString& id) override;
     void flush() override;
@@ -145,7 +145,7 @@ public:
     ~KGlobalAccelBackend() override;
 
     void registerShortcut(const QString& id, const QKeySequence& defaultSeq, const QKeySequence& currentSeq,
-                          const QString& description) override;
+                          const QString& description, bool persistent) override;
     void updateShortcut(const QString& id, const QKeySequence& defaultSeq, const QKeySequence& newTrigger) override;
     void unregisterShortcut(const QString& id) override;
     void flush() override;

--- a/libs/phosphor-shortcuts/src/dbustriggerbackend.cpp
+++ b/libs/phosphor-shortcuts/src/dbustriggerbackend.cpp
@@ -25,11 +25,15 @@ DBusTriggerBackend::DBusTriggerBackend(QObject* parent)
                                 << "org.Phosphor.Shortcuts.TriggerAction string:\"<id>\"";
 }
 
-void DBusTriggerBackend::registerShortcut(const QString& id, const QKeySequence& /*defaultSeq*/,
-                                          const QKeySequence& /*currentSeq*/, const QString& description)
+void DBusTriggerBackend::registerShortcut(const QString& id, const QKeySequence& defaultSeq,
+                                          const QKeySequence& currentSeq, const QString& description, bool persistent)
 {
     // DBusTrigger doesn't grab keys — the compositor binds them to dbus-send
-    // calls externally — so both sequences are ignored.
+    // calls externally — so both sequences are ignored. The persistent flag
+    // is irrelevant: this backend has no on-disk registry to leak into.
+    Q_UNUSED(defaultSeq);
+    Q_UNUSED(currentSeq);
+    Q_UNUSED(persistent);
     m_descriptions.insert(id, description);
 }
 

--- a/libs/phosphor-shortcuts/src/kglobalaccelbackend.cpp
+++ b/libs/phosphor-shortcuts/src/kglobalaccelbackend.cpp
@@ -145,6 +145,15 @@ void KGlobalAccelBackend::registerShortcut(const QString& id, const QKeySequence
         // including over fullscreen games (discussion #461 item 14).
         // Persistent ids deliberately keep their on-disk record; that's
         // where user customisations live.
+        //
+        // Note this is the FIRST-registration scrub, so after an abnormal
+        // exit a leaked transient entry is only cleared the next time that
+        // transient shortcut is registered again (i.e. the next drag/overlay
+        // that needs it). That is the self-heal path; the destructor below is
+        // the clean-shutdown path. The only uncovered window is "crashed and
+        // the transient shortcut is never registered again" — acceptable, as
+        // the grab is harmless until the key is actually pressed and the next
+        // use scrubs it.
         if (!persistent) {
             KGlobalAccel::self()->removeAllShortcuts(entry.action);
         }

--- a/libs/phosphor-shortcuts/src/kglobalaccelbackend.cpp
+++ b/libs/phosphor-shortcuts/src/kglobalaccelbackend.cpp
@@ -36,6 +36,17 @@ public:
         // means "nothing sent yet".
         QKeySequence lastDefault;
         QKeySequence lastCurrent;
+        // True for transient/ad-hoc shortcuts (e.g. the cancel-overlay
+        // Escape grab bound only while a drag or overlay is up). The
+        // backend has to purge these from kglobalshortcutsrc on
+        // destruction — otherwise an unexpected daemon exit (crash, kill,
+        // segfault) leaves the entry visible in System Settings AND with
+        // KGlobalAccel still grabbing the key system-wide on next login,
+        // including over fullscreen games (discussion #461 item 14).
+        // Persistent (false) entries always go through removeAllShortcuts
+        // on unregisterShortcut, so the only leak window is unexpected
+        // process exit.
+        bool persistent = true;
     };
     QHash<QString, Entry> entries;
 };
@@ -63,14 +74,31 @@ KGlobalAccelBackend::KGlobalAccelBackend(QObject* parent)
 
 KGlobalAccelBackend::~KGlobalAccelBackend()
 {
-    // IMPORTANT: do NOT call KGlobalAccel::removeAllShortcuts here.
+    // IMPORTANT: do NOT call KGlobalAccel::removeAllShortcuts on PERSISTENT
+    // shortcuts here.
     //
     // removeAllShortcuts purges the binding from the persistent on-disk
     // registry (kglobalshortcutsrc). On a normal daemon shutdown that would
     // wipe every user-customised shortcut — users would reset to defaults
     // on each restart. KGlobalAccel cleans up its in-memory action table
     // automatically when the QAction is destroyed, so a plain delete is the
-    // correct teardown path.
+    // correct teardown path for persistent ids.
+    //
+    // For NON-PERSISTENT (transient) shortcuts the situation is the
+    // opposite: they're only ever supposed to be active while a specific
+    // UI state is up (drag in progress, overlay visible, layout picker
+    // open). On a normal shutdown the consumer has already called
+    // unregisterShortcut. On an UNEXPECTED exit (crash, SIGKILL, segfault
+    // mid-drag) the entry would otherwise survive — KGlobalAccel keeps
+    // the persistent record AND keeps grabbing the key on next login,
+    // routing it to a daemon action that no longer exists. End-user
+    // surface: a stale "Esc" grab in System Settings that disables the
+    // Escape key in fullscreen games even when no drag is happening
+    // (discussion #461 item 14).
+    //
+    // Purge the on-disk entry for transient ids here so even an abnormal
+    // exit can't outlive the daemon. Persistent ids skip the purge so
+    // user customisations survive the shutdown.
     //
     // The QActions are parented to `this`, so Qt's ~QObject cleanup would
     // destroy them anyway. We delete explicitly to clear the hash table's
@@ -86,6 +114,9 @@ KGlobalAccelBackend::~KGlobalAccelBackend()
     for (auto& entry : m_impl->entries) {
         if (entry.action) {
             entry.action->disconnect();
+            if (!entry.persistent) {
+                KGlobalAccel::self()->removeAllShortcuts(entry.action);
+            }
             delete entry.action;
             entry.action = nullptr;
         }
@@ -93,10 +124,11 @@ KGlobalAccelBackend::~KGlobalAccelBackend()
 }
 
 void KGlobalAccelBackend::registerShortcut(const QString& id, const QKeySequence& defaultSeq,
-                                           const QKeySequence& currentSeq, const QString& description)
+                                           const QKeySequence& currentSeq, const QString& description, bool persistent)
 {
     auto& entry = m_impl->entries[id];
-    if (!entry.action) {
+    const bool firstRegistration = !entry.action;
+    if (firstRegistration) {
         entry.action = new QAction(description, this);
         entry.action->setObjectName(id);
         entry.action->setProperty("componentName", QCoreApplication::applicationName());
@@ -104,9 +136,26 @@ void KGlobalAccelBackend::registerShortcut(const QString& id, const QKeySequence
         connect(entry.action, &QAction::triggered, this, [this, idCopy] {
             Q_EMIT activated(idCopy);
         });
+        // For TRANSIENT shortcuts, scrub any stale on-disk record left by a
+        // prior daemon process that exited abnormally before its destructor
+        // ran. Without this, KGlobalAccel autoloads the orphan entry on the
+        // next setShortcut call below, the user-visible "Cancel Zone Overlay
+        // = Esc" registration in System Settings persists, and Esc keeps
+        // being grabbed compositor-side outside any drag/overlay context —
+        // including over fullscreen games (discussion #461 item 14).
+        // Persistent ids deliberately keep their on-disk record; that's
+        // where user customisations live.
+        if (!persistent) {
+            KGlobalAccel::self()->removeAllShortcuts(entry.action);
+        }
     } else if (!description.isEmpty() && entry.action->text() != description) {
         entry.action->setText(description);
     }
+    // Latest persistent flag wins. A re-bind that escalates a transient
+    // grab to persistent (or vice versa) updates the destructor-time
+    // purge decision accordingly. Same-id rebinds with a different flag
+    // are uncommon but not forbidden by the IBackend contract.
+    entry.persistent = persistent;
 
     // setDefaultShortcut establishes the "reset to default" binding shown in
     // System Settings. Must be called with the compiled-in default (NOT the

--- a/libs/phosphor-shortcuts/src/portalbackend.cpp
+++ b/libs/phosphor-shortcuts/src/portalbackend.cpp
@@ -124,13 +124,20 @@ PortalBackend::~PortalBackend()
     QDBusConnection::sessionBus().asyncCall(msg);
 }
 
-void PortalBackend::registerShortcut(const QString& id, const QKeySequence& defaultSeq,
-                                     const QKeySequence& /*currentSeq*/, const QString& description)
+void PortalBackend::registerShortcut(const QString& id, const QKeySequence& defaultSeq, const QKeySequence& currentSeq,
+                                     const QString& description, bool persistent)
 {
     // Portal: preferred_trigger is advisory and the compositor assigns the
     // actual binding via its own settings UI. Send the compiled-in default
     // as the app's preferred key rather than the consumer's current value —
     // if the user re-binds, they do so compositor-side, not in our config.
+    //
+    // The persistent flag is irrelevant for this backend: portal-bound
+    // shortcuts only live for the duration of the GlobalShortcuts session
+    // (see ~PortalBackend), so there is no on-disk leak hazard like the one
+    // KGlobalAccelBackend has to defend against.
+    Q_UNUSED(currentSeq);
+    Q_UNUSED(persistent);
     m_pending.insert(id, {defaultSeq, description});
     m_descriptions.insert(id, description);
 }

--- a/libs/phosphor-shortcuts/src/registry.cpp
+++ b/libs/phosphor-shortcuts/src/registry.cpp
@@ -123,7 +123,7 @@ void Registry::flush()
             // "reset to default" target — KGlobalAccelBackend and
             // PortalBackend both handle this idempotently.
             m_backend->registerShortcut(entry.binding.id, entry.binding.defaultSeq, entry.binding.currentSeq,
-                                        entry.binding.description);
+                                        entry.binding.description, entry.persistent);
             entry.registered = true;
             entry.lastSentDefault = entry.binding.defaultSeq;
             entry.lastSentCurrent = entry.binding.currentSeq;

--- a/libs/phosphor-shortcuts/src/registry.cpp
+++ b/libs/phosphor-shortcuts/src/registry.cpp
@@ -111,22 +111,25 @@ void Registry::flush()
             continue;
         }
 
-        const bool needsRegister = !entry.registered || entry.lastSentDefault != entry.binding.defaultSeq;
+        const bool needsRegister = !entry.registered || entry.lastSentDefault != entry.binding.defaultSeq
+            || entry.lastSentPersistent != entry.persistent;
         if (needsRegister) {
-            // First flush for this id, OR the compiled-in default has changed
-            // since the last send. Call registerShortcut in both cases: on the
-            // first flush it's the only way to hand both the compiled-in
-            // default (for KGlobalAccel's setDefaultShortcut / portal's
-            // preferred_trigger) and the current user value (what actually
-            // gets grabbed) to the backend in one shot. On a default change,
-            // re-calling registerShortcut lets the backend refresh its
-            // "reset to default" target — KGlobalAccelBackend and
-            // PortalBackend both handle this idempotently.
+            // First flush for this id, the compiled-in default changed, OR the
+            // persistent flag flipped since the last send. Call registerShortcut
+            // in all cases: on the first flush it's the only way to hand both
+            // the compiled-in default (for KGlobalAccel's setDefaultShortcut /
+            // portal's preferred_trigger) and the current user value (what
+            // actually gets grabbed) to the backend in one shot. On a default
+            // or persistent-flag change, re-calling registerShortcut lets the
+            // backend refresh its "reset to default" target and its crash-purge
+            // decision — KGlobalAccelBackend and PortalBackend both handle this
+            // idempotently.
             m_backend->registerShortcut(entry.binding.id, entry.binding.defaultSeq, entry.binding.currentSeq,
                                         entry.binding.description, entry.persistent);
             entry.registered = true;
             entry.lastSentDefault = entry.binding.defaultSeq;
             entry.lastSentCurrent = entry.binding.currentSeq;
+            entry.lastSentPersistent = entry.persistent;
         } else if (entry.lastSentCurrent != entry.binding.currentSeq) {
             m_backend->updateShortcut(entry.binding.id, entry.binding.defaultSeq, entry.binding.currentSeq);
             entry.lastSentCurrent = entry.binding.currentSeq;

--- a/libs/phosphor-shortcuts/tests/test_registry.cpp
+++ b/libs/phosphor-shortcuts/tests/test_registry.cpp
@@ -29,6 +29,7 @@ public:
         QKeySequence defaultSeq;
         QKeySequence currentSeq;
         QString description;
+        bool persistent = true;
     };
     struct UpdateCall
     {
@@ -40,9 +41,9 @@ public:
     using IBackend::IBackend;
 
     void registerShortcut(const QString& id, const QKeySequence& defaultSeq, const QKeySequence& currentSeq,
-                          const QString& description) override
+                          const QString& description, bool persistent) override
     {
-        registers.push_back({id, defaultSeq, currentSeq, description});
+        registers.push_back({id, defaultSeq, currentSeq, description, persistent});
     }
 
     void updateShortcut(const QString& id, const QKeySequence& defaultSeq, const QKeySequence& newTrigger) override
@@ -513,6 +514,40 @@ private Q_SLOTS:
         QCOMPARE(backend.registers.size(), 0);
         QCOMPARE(backend.updates.size(), 1);
         QCOMPARE(backend.updates[0].newTrigger, QKeySequence(QStringLiteral("Meta+2")));
+    }
+
+    void registerForwardsPersistentFlag_toBackend()
+    {
+        // Regression: the persistent flag must reach the backend, not just
+        // gate the bindings() filter. KGlobalAccelBackend uses it to decide
+        // whether to purge kglobalshortcutsrc on destruction; sending only
+        // `true` would have left the cancel-overlay Escape grab persisting
+        // across daemon crashes (discussion #461 item 14).
+        FakeBackend backend;
+        Registry registry(&backend);
+
+        registry.bind(QStringLiteral("pz.user"), QKeySequence(QStringLiteral("Meta+U")), QStringLiteral("User"), {},
+                      /*persistent=*/true);
+        registry.bind(QStringLiteral("pz.adhoc"), QKeySequence(QStringLiteral("Esc")), QStringLiteral("Adhoc"), {},
+                      /*persistent=*/false);
+        registry.flush();
+
+        QCOMPARE(backend.registers.size(), 2);
+        // QHash iteration order is unspecified — locate by id rather than
+        // index.
+        bool sawUserPersistent = false;
+        bool sawAdhocTransient = false;
+        for (const auto& call : backend.registers) {
+            if (call.id == QStringLiteral("pz.user")) {
+                QVERIFY(call.persistent);
+                sawUserPersistent = true;
+            } else if (call.id == QStringLiteral("pz.adhoc")) {
+                QVERIFY(!call.persistent);
+                sawAdhocTransient = true;
+            }
+        }
+        QVERIFY(sawUserPersistent);
+        QVERIFY(sawAdhocTransient);
     }
 
     void bindings_persistentOnly_filtersTransient()

--- a/libs/phosphor-shortcuts/tests/test_registry.cpp
+++ b/libs/phosphor-shortcuts/tests/test_registry.cpp
@@ -550,6 +550,35 @@ private Q_SLOTS:
         QVERIFY(sawAdhocTransient);
     }
 
+    void rebindWithFlippedPersistentFlag_reReachesBackend()
+    {
+        // Regression: a re-bind() that flips `persistent` without changing the
+        // key must still reach the backend. flush()'s change-detection keys off
+        // the sequences AND the persistent flag — without the persistent term a
+        // same-key/same-default re-bind would be treated as a no-op, the
+        // backend would never learn the new flag, and KGlobalAccelBackend's
+        // crash-purge decision would be stale (discussion #461 item 14).
+        FakeBackend backend;
+        Registry registry(&backend);
+
+        registry.bind(QStringLiteral("pz.flip"), QKeySequence(QStringLiteral("Meta+F")), QStringLiteral("Flip"), {},
+                      /*persistent=*/true);
+        registry.flush();
+        QCOMPARE(backend.registers.size(), 1);
+        QVERIFY(backend.registers[0].persistent);
+
+        // Same id, same key, persistent flipped to false.
+        registry.bind(QStringLiteral("pz.flip"), QKeySequence(QStringLiteral("Meta+F")), QStringLiteral("Flip"), {},
+                      /*persistent=*/false);
+        registry.flush();
+        QCOMPARE(backend.registers.size(), 2);
+        QVERIFY(!backend.registers[1].persistent);
+
+        // A further flush with nothing changed must NOT re-register.
+        registry.flush();
+        QCOMPARE(backend.registers.size(), 2);
+    }
+
     void bindings_persistentOnly_filtersTransient()
     {
         // Adhoc / transient bindings (persistent=false) must not surface in

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -78,6 +78,46 @@ public:
     bool isEnabled() const noexcept override;
     using IPlacementEngine::windowOpened;
     void windowOpened(const QString& windowId, const QString& screenId, int minWidth, int minHeight) override;
+
+    /**
+     * @brief Predicate consulted on the auto-snap entry path to suppress
+     *        zone restores onto a context the user disabled.
+     *
+     * Returns true if the screenId is currently active for snap mode, false
+     * if disabled. The engine library is intentionally settings-agnostic
+     * (LGPL boundary) so the daemon adaptor injects the predicate; SnapEngine
+     * itself has no notion of disabled contexts. The daemon-side closure is
+     * responsible for resolving the current virtual desktop / activity at
+     * call time — SnapState does not track those.
+     *
+     * Applied inside `resolveWindowRestore` so BOTH the engine's own
+     * `windowOpened` path AND the D-Bus `SnapAdaptor::resolveWindowRestore`
+     * path (used by the KWin effect for per-window restores) hit the same
+     * gate. A PendingRestore authored before the user disabled the context
+     * can no longer drag a freshly opened window into a zone the user told
+     * us to stay out of (discussion #461 item 7). Without this gate,
+     * restarting the daemon was the only way to evict stale in-memory
+     * entries — the `isPersistedContextDisabled` filter on disk load only
+     * fires on startup, so any restore queued during the running session
+     * leaked through.
+     *
+     * When unset (default), the engine behaves as if every context is
+     * active — the historical default that unit tests rely on.
+     */
+    using ShouldRestorePredicate = std::function<bool(const QString& screenId)>;
+
+    /**
+     * @brief Inject the auto-snap-restore gate. See ShouldRestorePredicate.
+     *
+     * Ownership: the caller keeps any captured state valid for the engine's
+     * lifetime. To detach safely, clear via `setShouldRestorePredicate({})`
+     * before destroying the captured object.
+     */
+    void setShouldRestorePredicate(ShouldRestorePredicate predicate)
+    {
+        m_shouldRestorePredicate = std::move(predicate);
+    }
+
     void windowClosed(const QString& windowId) override;
     void windowFocused(const QString& windowId, const QString& screenId) override;
     void toggleWindowFloat(const QString& windowId, const QString& screenId) override;
@@ -537,6 +577,12 @@ private:
 
     // Last-focused screen (updated by windowFocused)
     QString m_lastActiveScreenId;
+
+    // Auto-snap entry gate. Empty until the daemon wires it; while empty
+    // the engine treats every (screen, desktop) as active — preserving the
+    // historical default that unit tests rely on. See ShouldRestorePredicate
+    // doc above and discussion #461 item 7.
+    ShouldRestorePredicate m_shouldRestorePredicate{};
 };
 
 } // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -45,6 +45,10 @@ void SnapEngine::windowOpened(const QString& windowId, const QString& screenId, 
         return;
     }
 
+    // The disabled-context gate lives inside resolveWindowRestore so the
+    // direct D-Bus path (SnapAdaptor::resolveWindowRestore, used by the
+    // KWin effect's per-window restore call) is covered by the same check
+    // — see the predicate gate near the top of resolveWindowRestore below.
     SnapResult result = resolveWindowRestore(windowId, screenId, false);
     if (!result.shouldSnap) {
         return;
@@ -123,6 +127,30 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
         return SnapResult::noSnap();
     }
 
+    // Disabled-context gate: refuse auto-snap onto a (screen, virtualDesktop,
+    // activity) the user has disabled snap for. Catches BOTH windowOpened
+    // and the direct D-Bus resolveWindowRestore path the KWin effect uses,
+    // so a PendingRestore authored before the toggle can no longer drag a
+    // freshly opened window into a zone the user told us to stay out of.
+    // Without this gate the only fix was a daemon restart — the
+    // `isPersistedContextDisabled` filter on disk load fired only once per
+    // session, leaving any in-memory entry recorded earlier free to leak
+    // through. Discussion #461 item 7.
+    //
+    // Placed AFTER the isWindowSnapped/consume guard so windows that are
+    // already snapped still consume their appId pending entry; placed
+    // BEFORE the exclusion lookup and the calculate* chain so app rules,
+    // session restore, empty-zone, and last-zone fallbacks are all gated
+    // by the same predicate.
+    //
+    // Predicate is daemon-injected; absence means "no gating" — the
+    // historical default that unit tests rely on.
+    if (m_shouldRestorePredicate && !m_shouldRestorePredicate(screenId)) {
+        qCDebug(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore: skipping" << windowId << "on" << screenId
+                                                  << "— disabled-context gate rejected restore";
+        return SnapResult::noSnap();
+    }
+
     // Exclusion check: skip auto-snap for excluded applications/window classes.
     // This must run before any calculate method so excluded apps are never snapped
     // by app rules, session restore, empty zone, or last zone features.
@@ -164,6 +192,16 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     {
         SnapResult result = calculateSnapToAppRule(windowId, screenId, sticky);
         if (result.shouldSnap) {
+            // An app rule may target a screen other than the caller's. The
+            // disabled-context gate above validated only the caller's screenId,
+            // so re-check the predicate against the result's destination
+            // screen. An app rule must not route a window onto a context the
+            // user disabled.
+            if (m_shouldRestorePredicate && !m_shouldRestorePredicate(result.screenId)) {
+                qCDebug(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore:" << windowId << "appRule target"
+                                                          << result.screenId << "rejected by disabled-context gate";
+                return SnapResult::noSnap();
+            }
             qCInfo(PhosphorSnapEngine::lcSnapEngine)
                 << "resolveWindowRestore: appRule matched for" << windowId << "zone=" << result.zoneId;
             return result;
@@ -177,6 +215,17 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     if (s && s->restoreWindowsToZonesOnLogin()) {
         SnapResult result = calculateRestoreFromSession(windowId, screenId, sticky);
         if (result.shouldSnap) {
+            // Session restore may cross-screen migrate: the PendingRestore
+            // records its own saved screen. Re-check the predicate against the
+            // destination before consuming the pending entry. A restore onto a
+            // disabled screen is refused, and the pending entry is left intact
+            // so the window can restore once the user re-enables the context.
+            if (m_shouldRestorePredicate && !m_shouldRestorePredicate(result.screenId)) {
+                qCDebug(PhosphorSnapEngine::lcSnapEngine)
+                    << "resolveWindowRestore:" << windowId << "persisted restore target" << result.screenId
+                    << "rejected by disabled-context gate";
+                return SnapResult::noSnap();
+            }
             m_windowTracker->consumePendingAssignment(windowId);
             qCInfo(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore: persisted matched for" << windowId
                                                      << "zone=" << result.zoneId << "screen=" << result.screenId;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,7 @@ set(plasmazones_core_SRCS
     dbus/zonedetectionadaptor.h
     # snapnavigationtargets moved to libs/phosphor-snap-engine/
     dbus/windowtrackingadaptor.cpp
+    dbus/windowtrackingadaptor/enginewiring.cpp
     dbus/windowtrackingadaptor/navigation.cpp
     dbus/windowtrackingadaptor/float.cpp
     dbus/windowtrackingadaptor/persistence.cpp

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -219,6 +219,26 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
             snap->setAutotileEngine(autotile);
         }
 
+        // Disabled-context gate for snap auto-restore (discussion #461 item 7).
+        // The persist-on-close gate (setShouldTrackPredicate above) blocks NEW
+        // PendingRestore entries on disabled contexts, but pre-existing
+        // in-memory entries (recorded before the user toggled the disable, or
+        // before the disable propagated through settingsChanged) would still
+        // restore the window when it reopens. This gate fires on the open
+        // path, so the same isPersistedContextDisabled rule that filters reads
+        // and writes also covers the window-arrives-during-running-session
+        // case. Resolves the user-visible "windows tracked even on disabled
+        // monitor — restarting the service fixes it" symptom: a restart
+        // re-loaded from disk, where the read-time filter dropped the same
+        // entries; this gate makes the running session match.
+        //
+        // Activity is left unset — SnapState carries no per-window activity
+        // tag, mirroring isPersistedContextDisabled's snap-side default.
+        snap->setShouldRestorePredicate([this](const QString& screenId) -> bool {
+            const int desktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+            return !isPersistedContextDisabled(screenId, desktop);
+        });
+
         // Snap-specific signal: carries PhosphorProtocol::WindowStateEntry which is snap-mode-only.
         // Connected via qobject_cast since the member type is PlacementEngineBase.
         connect(snap, &PhosphorSnapEngine::SnapEngine::windowSnapStateChanged, this,

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -188,113 +188,13 @@ PhosphorSnapEngine::SnapEngine* WindowTrackingAdaptor::snapEngine() const
     return m_cachedSnapEngine;
 }
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// Engine wiring — cross-references and shared navigation feedback
-//
-// Signal relay is handled by dedicated adaptors (SnapAdaptor, AutotileAdaptor).
-// This method only wires cross-engine references and the shared OSD path.
-// ═══════════════════════════════════════════════════════════════════════════════
-
-void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snapEngine,
-                                       PhosphorEngine::PlacementEngineBase* autotileEngine)
+// Current virtual desktop, with a safe fallback of 0 when no
+// VirtualDesktopManager is wired (guiless tests, minimal sessions).
+// Centralises the null-guarded read shared by the disabled-context gates and
+// last-used-zone tracking. setEngines() lives in enginewiring.cpp.
+int WindowTrackingAdaptor::currentDesktop() const
 {
-    // Disconnect previous autotile engine nav feedback (the only signal connected here)
-    if (m_autotileEngine) {
-        disconnect(m_autotileEngine, &PhosphorEngine::PlacementEngineBase::navigationFeedback, this, nullptr);
-    }
-
-    m_snapEngine = snapEngine;
-    m_autotileEngine = autotileEngine;
-    m_cachedSnapEngine = qobject_cast<PhosphorSnapEngine::SnapEngine*>(snapEngine);
-
-    // ═══════════════════════════════════════════════════════════════════════════
-    // Cross-engine references — SnapEngine needs AutotileEngine for
-    // isActiveOnScreen() routing and ZoneDetectionAdaptor for adjacency queries.
-    // When clearing (nullptr, nullptr), we also clear stale cross-references
-    // to prevent dangling pointer access.
-    // ═══════════════════════════════════════════════════════════════════════════
-    if (auto* snap = qobject_cast<PhosphorSnapEngine::SnapEngine*>(snapEngine)) {
-        snap->setZoneAdjacencyResolver(m_zoneDetectionAdaptor);
-        if (auto* autotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(autotileEngine)) {
-            snap->setAutotileEngine(autotile);
-        }
-
-        // Disabled-context gate for snap auto-restore (discussion #461 item 7).
-        // The persist-on-close gate (setShouldTrackPredicate above) blocks NEW
-        // PendingRestore entries on disabled contexts, but pre-existing
-        // in-memory entries (recorded before the user toggled the disable, or
-        // before the disable propagated through settingsChanged) would still
-        // restore the window when it reopens. This gate fires on the open
-        // path, so the same isPersistedContextDisabled rule that filters reads
-        // and writes also covers the window-arrives-during-running-session
-        // case. Resolves the user-visible "windows tracked even on disabled
-        // monitor — restarting the service fixes it" symptom: a restart
-        // re-loaded from disk, where the read-time filter dropped the same
-        // entries; this gate makes the running session match.
-        //
-        // Activity is left unset — SnapState carries no per-window activity
-        // tag, mirroring isPersistedContextDisabled's snap-side default.
-        //
-        // Desktop: resolveWindowRestore carries no per-restore virtual desktop,
-        // so the CURRENT desktop is used. This is exact for the common case (a
-        // window opens on the current desktop) and is the only desktop the
-        // predicate signature can observe; a cross-virtual-desktop session
-        // restore onto a desktop other than the current one is therefore gated
-        // by the current desktop's disable state rather than the target's.
-        snap->setShouldRestorePredicate([this](const QString& screenId) -> bool {
-            const int desktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
-            return !isPersistedContextDisabled(screenId, desktop);
-        });
-
-        // Snap-specific signal: carries PhosphorProtocol::WindowStateEntry which is snap-mode-only.
-        // Connected via qobject_cast since the member type is PlacementEngineBase.
-        connect(snap, &PhosphorSnapEngine::SnapEngine::windowSnapStateChanged, this,
-                &WindowTrackingAdaptor::windowStateChanged);
-        connect(snap, &PhosphorSnapEngine::SnapEngine::windowFloatingClearedForSnap, this,
-                [this](const QString& windowId, const QString& screenId) {
-                    Q_EMIT windowFloatingChanged(windowId, false, screenId);
-                });
-    } else if (snapEngine) {
-        // Snap-mode window state signals are critical for WTS correctness.
-        // A non-SnapEngine in the snap slot means state notifications are lost.
-        Q_ASSERT_X(false, "WindowTrackingAdaptor::setEngines",
-                   "snapEngine must be a SnapEngine — snap-specific signals not connected");
-    }
-
-    // ═══════════════════════════════════════════════════════════════════════════
-    // AutotileEngine navigation feedback — shared OSD path
-    //
-    // Both engines' navigation feedback routes through this adaptor's
-    // navigationFeedback signal because the KWin effect listens for OSD
-    // data on org.plasmazones.WindowTracking regardless of engine mode.
-    //
-    // SnapEngine's navigation feedback is connected by SnapAdaptor (mirrors
-    // AutotileAdaptor's constructor pattern). This single connection is the
-    // only autotile signal that routes through WTA — all other autotile
-    // signals go through AutotileAdaptor on org.plasmazones.Autotile.
-    //
-    // NOTE: AutotileEngine::windowFloatingChanged is NOT relayed here.
-    // The daemon intercepts it with a lambda (signals.cpp) for cross-mode
-    // state management (autotile-float markers, snap-float preservation,
-    // geometry application). See ADR docs/adr-snapengine-migration.md.
-    // ═══════════════════════════════════════════════════════════════════════════
-    if (m_autotileEngine) {
-        connect(m_autotileEngine, &PhosphorEngine::PlacementEngineBase::navigationFeedback, this,
-                &WindowTrackingAdaptor::navigationFeedback);
-
-        // Disabled-context gate for autotile pending restores (discussion
-        // #461 item 2). Mirror of the snap-side ShouldTrackPredicate wired
-        // in the constructor — both routes share isPersistedContextDisabled
-        // so the live, save-time, and load-time gates can never drift.
-        // Activity is threaded through because autotile entries carry it
-        // (snap entries do not). See AutotileEngine::ShouldPersistRestorePredicate.
-        if (auto* autotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(autotileEngine)) {
-            autotile->setShouldPersistRestorePredicate(
-                [this](const QString& screenId, int desktop, const QString& activity) -> bool {
-                    return !isPersistedContextDisabled(screenId, desktop, activity);
-                });
-        }
-    }
+    return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
 }
 
 void WindowTrackingAdaptor::setScreenModeRouter(ScreenModeRouter* router)
@@ -686,8 +586,7 @@ void WindowTrackingAdaptor::windowActivated(const QString& windowId, const QStri
     if (!zoneId.isEmpty() && m_settings && m_settings->moveNewWindowsToLastZone()
         && !m_service->isAutoSnapped(windowId)) {
         QString windowClass = m_service->currentAppIdFor(windowId);
-        int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
-        m_service->updateLastUsedZone(zoneId, resolvedScreen, windowClass, currentDesktop);
+        m_service->updateLastUsedZone(zoneId, resolvedScreen, windowClass, currentDesktop());
     }
 }
 

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -234,6 +234,13 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
         //
         // Activity is left unset — SnapState carries no per-window activity
         // tag, mirroring isPersistedContextDisabled's snap-side default.
+        //
+        // Desktop: resolveWindowRestore carries no per-restore virtual desktop,
+        // so the CURRENT desktop is used. This is exact for the common case (a
+        // window opens on the current desktop) and is the only desktop the
+        // predicate signature can observe; a cross-virtual-desktop session
+        // restore onto a desktop other than the current one is therefore gated
+        // by the current desktop's disable state rather than the target's.
         snap->setShouldRestorePredicate([this](const QString& screenId) -> bool {
             const int desktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
             return !isPersistedContextDisabled(screenId, desktop);

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -808,6 +808,13 @@ private:
     bool isPersistedContextDisabled(const QString& screenId, int virtualDesktop,
                                     const QString& activity = QString()) const;
 
+    /**
+     * @brief Current virtual desktop index, or 0 when no VirtualDesktopManager
+     *        is wired. Centralises the null-guarded read shared by the
+     *        disabled-context gates and last-used-zone tracking.
+     */
+    int currentDesktop() const;
+
     // clearFloatingStateForSnap was removed — PhosphorPlacement::WindowTrackingService::commitSnap
     // now handles floating-state clearing internally (and emits
     // windowFloatingClearedForSnap which the adaptor relays to its own

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// WindowTrackingAdaptor — engine cross-wiring
+//
+// Split out of windowtrackingadaptor.cpp to keep that translation unit under the
+// 800-line limit. Holds setEngines(), which wires cross-engine references, the
+// disabled-context restore predicates, and the shared OSD navigation path.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#include "../windowtrackingadaptor.h"
+
+#include "../zonedetectionadaptor.h"
+#include <PhosphorEngine/IPlacementEngine.h>
+#include <PhosphorSnapEngine/SnapEngine.h>
+#include <PhosphorTileEngine/AutotileEngine.h>
+
+namespace PlasmaZones {
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Engine wiring — cross-references and shared navigation feedback
+//
+// Signal relay is handled by dedicated adaptors (SnapAdaptor, AutotileAdaptor).
+// This method only wires cross-engine references and the shared OSD path.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snapEngine,
+                                       PhosphorEngine::PlacementEngineBase* autotileEngine)
+{
+    // Disconnect previous autotile engine nav feedback (the only signal connected here)
+    if (m_autotileEngine) {
+        disconnect(m_autotileEngine, &PhosphorEngine::PlacementEngineBase::navigationFeedback, this, nullptr);
+    }
+
+    // Detach the restore predicates from the outgoing engines before dropping
+    // the references. Both predicates capture `this`; clearing them honours the
+    // engine headers' detach contract ("clear via setShould*Predicate({})
+    // before destroying the captured object") instead of relying on daemon
+    // destruction order. Symmetric with the autotile nav-feedback disconnect.
+    if (m_cachedSnapEngine) {
+        m_cachedSnapEngine->setShouldRestorePredicate({});
+    }
+    if (auto* oldAutotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(m_autotileEngine)) {
+        oldAutotile->setShouldPersistRestorePredicate({});
+    }
+
+    m_snapEngine = snapEngine;
+    m_autotileEngine = autotileEngine;
+    m_cachedSnapEngine = qobject_cast<PhosphorSnapEngine::SnapEngine*>(snapEngine);
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Cross-engine references — SnapEngine needs AutotileEngine for
+    // isActiveOnScreen() routing and ZoneDetectionAdaptor for adjacency queries.
+    // When clearing (nullptr, nullptr), we also clear stale cross-references
+    // to prevent dangling pointer access.
+    // ═══════════════════════════════════════════════════════════════════════════
+    if (auto* snap = qobject_cast<PhosphorSnapEngine::SnapEngine*>(snapEngine)) {
+        snap->setZoneAdjacencyResolver(m_zoneDetectionAdaptor);
+        if (auto* autotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(autotileEngine)) {
+            snap->setAutotileEngine(autotile);
+        }
+
+        // Disabled-context gate for snap auto-restore (discussion #461 item 7).
+        // The persist-on-close gate (setShouldTrackPredicate above) blocks NEW
+        // PendingRestore entries on disabled contexts, but pre-existing
+        // in-memory entries (recorded before the user toggled the disable, or
+        // before the disable propagated through settingsChanged) would still
+        // restore the window when it reopens. This gate fires on the open
+        // path, so the same isPersistedContextDisabled rule that filters reads
+        // and writes also covers the window-arrives-during-running-session
+        // case. Resolves the user-visible "windows tracked even on disabled
+        // monitor — restarting the service fixes it" symptom: a restart
+        // re-loaded from disk, where the read-time filter dropped the same
+        // entries; this gate makes the running session match.
+        //
+        // Activity is left unset — SnapState carries no per-window activity
+        // tag, mirroring isPersistedContextDisabled's snap-side default.
+        //
+        // Desktop: resolveWindowRestore carries no per-restore virtual desktop,
+        // so the CURRENT desktop is used. This is exact for the common case (a
+        // window opens on the current desktop) and is the only desktop the
+        // predicate signature can observe; a cross-virtual-desktop session
+        // restore onto a desktop other than the current one is therefore gated
+        // by the current desktop's disable state rather than the target's.
+        snap->setShouldRestorePredicate([this](const QString& screenId) -> bool {
+            return !isPersistedContextDisabled(screenId, currentDesktop());
+        });
+
+        // Snap-specific signal: carries PhosphorProtocol::WindowStateEntry which is snap-mode-only.
+        // Connected via qobject_cast since the member type is PlacementEngineBase.
+        connect(snap, &PhosphorSnapEngine::SnapEngine::windowSnapStateChanged, this,
+                &WindowTrackingAdaptor::windowStateChanged);
+        connect(snap, &PhosphorSnapEngine::SnapEngine::windowFloatingClearedForSnap, this,
+                [this](const QString& windowId, const QString& screenId) {
+                    Q_EMIT windowFloatingChanged(windowId, false, screenId);
+                });
+    } else if (snapEngine) {
+        // Snap-mode window state signals are critical for WTS correctness.
+        // A non-SnapEngine in the snap slot means state notifications are lost.
+        Q_ASSERT_X(false, "WindowTrackingAdaptor::setEngines",
+                   "snapEngine must be a SnapEngine — snap-specific signals not connected");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // AutotileEngine navigation feedback — shared OSD path
+    //
+    // Both engines' navigation feedback routes through this adaptor's
+    // navigationFeedback signal because the KWin effect listens for OSD
+    // data on org.plasmazones.WindowTracking regardless of engine mode.
+    //
+    // SnapEngine's navigation feedback is connected by SnapAdaptor (mirrors
+    // AutotileAdaptor's constructor pattern). This single connection is the
+    // only autotile signal that routes through WTA — all other autotile
+    // signals go through AutotileAdaptor on org.plasmazones.Autotile.
+    //
+    // NOTE: AutotileEngine::windowFloatingChanged is NOT relayed here.
+    // The daemon intercepts it with a lambda (signals.cpp) for cross-mode
+    // state management (autotile-float markers, snap-float preservation,
+    // geometry application). See ADR docs/adr-snapengine-migration.md.
+    // ═══════════════════════════════════════════════════════════════════════════
+    if (m_autotileEngine) {
+        connect(m_autotileEngine, &PhosphorEngine::PlacementEngineBase::navigationFeedback, this,
+                &WindowTrackingAdaptor::navigationFeedback);
+
+        // Disabled-context gate for autotile pending restores (discussion
+        // #461 item 2). Mirror of the snap-side ShouldTrackPredicate wired
+        // in the constructor — both routes share isPersistedContextDisabled
+        // so the live, save-time, and load-time gates can never drift.
+        // Activity is threaded through because autotile entries carry it
+        // (snap entries do not). See AutotileEngine::ShouldPersistRestorePredicate.
+        if (auto* autotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(autotileEngine)) {
+            autotile->setShouldPersistRestorePredicate(
+                [this](const QString& screenId, int desktop, const QString& activity) -> bool {
+                    return !isPersistedContextDisabled(screenId, desktop, activity);
+                });
+        }
+    }
+}
+
+} // namespace PlasmaZones

--- a/src/dbus/windowtrackingadaptor/persistence.cpp
+++ b/src/dbus/windowtrackingadaptor/persistence.cpp
@@ -209,9 +209,31 @@ QString WindowTrackingAdaptor::getPendingRestoreGeometries()
         return QStringLiteral("{}");
     }
 
+    // Disabled-context gate (discussion #461 item 7). The KWin effect's
+    // instant-restore fast path teleports a window straight into target.geometry
+    // from this cache, BEFORE the daemon's resolveWindowRestore predicate gate
+    // runs — so an entry left here for a disabled monitor would be snapped onto
+    // it regardless of the engine-side ShouldRestorePredicate, leaving a window
+    // visually placed on a disabled context but absent from SnapState (the
+    // "ghost" the instant-restore registration fix otherwise eliminates).
+    // Funnel this read through the same isPersistedContextDisabled check that
+    // guards saveState, loadState and the engine restore path so all four
+    // paths can never drift.
+    //
+    // resolveWindowRestore carries no per-restore desktop, so the current
+    // virtual desktop is used — consistent with the snap-side
+    // setShouldRestorePredicate gate. Activity is left unset: snap-mode storage
+    // carries no per-window activity tag (see isPersistedContextDisabled).
+    const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+
     QJsonObject result;
     for (auto it = targets.constBegin(); it != targets.constEnd(); ++it) {
         const auto& target = it.value();
+        if (isPersistedContextDisabled(target.screenId, currentDesktop)) {
+            qCDebug(lcDbusWindow) << "getPendingRestoreGeometries: skipping" << it.key()
+                                  << "— disabled context on screen" << target.screenId;
+            continue;
+        }
         QJsonObject geoObj;
         geoObj[QLatin1String("x")] = target.geometry.x();
         geoObj[QLatin1String("y")] = target.geometry.y();

--- a/src/dbus/windowtrackingadaptor/persistence.cpp
+++ b/src/dbus/windowtrackingadaptor/persistence.cpp
@@ -224,12 +224,12 @@ QString WindowTrackingAdaptor::getPendingRestoreGeometries()
     // virtual desktop is used — consistent with the snap-side
     // setShouldRestorePredicate gate. Activity is left unset: snap-mode storage
     // carries no per-window activity tag (see isPersistedContextDisabled).
-    const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    const int desktop = currentDesktop();
 
     QJsonObject result;
     for (auto it = targets.constBegin(); it != targets.constEnd(); ++it) {
         const auto& target = it.value();
-        if (isPersistedContextDisabled(target.screenId, currentDesktop)) {
+        if (isPersistedContextDisabled(target.screenId, desktop)) {
             qCDebug(lcDbusWindow) << "getPendingRestoreGeometries: skipping" << it.key()
                                   << "— disabled context on screen" << target.screenId;
             continue;
@@ -309,7 +309,7 @@ QString WindowTrackingAdaptor::detectScreenForZone(const QString& zoneId) const
         return QString();
     }
 
-    int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    const int desktop = currentDesktop();
 
     // Search per-screen layouts to find which screen's layout contains this zone.
     // This correctly handles multi-monitor setups where each screen has a different layout.
@@ -318,7 +318,7 @@ QString WindowTrackingAdaptor::detectScreenForZone(const QString& zoneId) const
         (m_service->screenManager() ? m_service->screenManager()->effectiveScreenIds() : QStringList());
     for (const QString& sid : effectiveIds) {
         PhosphorZones::Layout* layout =
-            m_layoutManager->layoutForScreen(sid, currentDesktop, m_layoutManager->currentActivity());
+            m_layoutManager->layoutForScreen(sid, desktop, m_layoutManager->currentActivity());
         if (layout && layout->zoneById(*zoneUuid)) {
             return sid;
         }

--- a/src/settings/qml/ActivityAssignmentsCard.qml
+++ b/src/settings/qml/ActivityAssignmentsCard.qml
@@ -18,6 +18,11 @@ SettingsCard {
     // 0 = snapping (zone layouts), 1 = tiling (autotile algorithms)
     property int viewMode: 0
     property int _lockRevision: 0
+    // Same pattern: re-evaluate activityActive bindings on
+    // disabledActivitiesChanged without imperatively writing to bound
+    // properties (which severs Switch.checked → activityActive).
+    // Discussion #461 item 12.
+    property int _disabledRevision: 0
 
     function getScreenLayout(screenName) {
         return viewMode === 1 ? (appSettings.getTilingLayoutForScreen(screenName) || "") : (appSettings.getLayoutForScreen(screenName) || "");
@@ -51,6 +56,9 @@ SettingsCard {
     Connections {
         function onLockedScreensChanged() {
             root._lockRevision++;
+        }
+        function onDisabledActivitiesChanged() {
+            root._disabledRevision++;
         }
 
         target: root.appSettings
@@ -139,7 +147,13 @@ SettingsCard {
                             required property var modelData
                             required property int index
                             property string screenName: modelData.name || ""
-                            property bool activityActive: !root.appSettings.isActivityDisabled(screenName, activityDelegate.activityId)
+                            // Touch _disabledRevision so this binding re-evaluates whenever
+                            // the controller emits disabledActivitiesChanged. Imperative
+                            // writes severed the binding, leaving the Switch stuck.
+                            property bool activityActive: {
+                                void (root._disabledRevision);
+                                return !root.appSettings.isActivityDisabled(screenName, activityDelegate.activityId);
+                            }
 
                             Layout.fillWidth: true
                             Layout.leftMargin: Kirigami.Units.gridUnit * 2
@@ -213,22 +227,18 @@ SettingsCard {
                                 middleContent: Component {
                                     Switch {
                                         enabled: true
+                                        // Read-only binding to activityActive; do NOT write to
+                                        // activityActive in onToggled. Assigning to a bound
+                                        // property severs the binding, leaving the Switch
+                                        // stuck. The root-level _disabledRevision counter
+                                        // re-evaluates activityActive on every controller
+                                        // change (discussion #461 item 12).
                                         checked: activityScreenContainer.activityActive
                                         onToggled: {
                                             root.appSettings.setActivityDisabled(activityScreenContainer.screenName, activityDelegate.activityId, !checked);
-                                            activityScreenContainer.activityActive = checked;
                                         }
                                         ToolTip.visible: hovered
                                         ToolTip.text: checked ? i18n("Disable PlasmaZones for %1 on %2", activityDelegate.activityName, activityScreenContainer.screenName) : i18n("Enable PlasmaZones for %1 on %2", activityDelegate.activityName, activityScreenContainer.screenName)
-
-                                        Connections {
-                                            function onDisabledActivitiesChanged() {
-                                                activityScreenContainer.activityActive = !root.appSettings.isActivityDisabled(activityScreenContainer.screenName, activityDelegate.activityId);
-                                            }
-
-                                            target: root.appSettings
-                                        }
-
                                     }
 
                                 }

--- a/src/settings/qml/MonitorAssignmentsCard.qml
+++ b/src/settings/qml/MonitorAssignmentsCard.qml
@@ -20,6 +20,12 @@ SettingsCard {
     // Revision counter — incremented when lock state changes externally,
     // forcing lock-dependent bindings to re-evaluate.
     property int _lockRevision: 0
+    // Same pattern for disabled-context changes (per-desktop and per-monitor).
+    // Drives the desktopActive and monitorActive bindings so each Switch's
+    // `checked` binding stays live (imperative writes to bound properties
+    // sever the binding, which previously left toggles stuck in the off
+    // state — discussion #461 item 12).
+    property int _disabledRevision: 0
 
     headerText: root.viewMode === 1 ? i18n("Monitor Tiling Assignments") : i18n("Monitor Assignments")
     collapsible: true
@@ -27,6 +33,14 @@ SettingsCard {
     Connections {
         function onLockedScreensChanged() {
             root._lockRevision++;
+        }
+
+        function onDisabledDesktopsChanged() {
+            root._disabledRevision++;
+        }
+
+        function onDisabledMonitorsChanged() {
+            root._disabledRevision++;
         }
 
         target: root.appSettings
@@ -136,24 +150,23 @@ SettingsCard {
                         Switch {
                             id: monitorEnableSwitch
 
-                            property bool monitorActive: !root.appSettings.isMonitorDisabled(monitorDelegate.screenName)
+                            // Touch _disabledRevision so this binding re-evaluates
+                            // whenever the controller emits disabledMonitorsChanged,
+                            // keeping the `checked` binding live. Assigning
+                            // monitorActive in onToggled would sever the binding,
+                            // leaving the Switch visually stuck after the first
+                            // toggle — discussion #461 item 12.
+                            property bool monitorActive: {
+                                void (root._disabledRevision);
+                                return !root.appSettings.isMonitorDisabled(monitorDelegate.screenName);
+                            }
 
                             checked: monitorActive
                             onToggled: {
                                 root.appSettings.setMonitorDisabled(monitorDelegate.screenName, !checked);
-                                monitorActive = checked;
                             }
                             ToolTip.visible: hovered
                             ToolTip.text: checked ? i18n("Disable PlasmaZones on this monitor") : i18n("Enable PlasmaZones on this monitor")
-
-                            Connections {
-                                function onDisabledMonitorsChanged() {
-                                    monitorEnableSwitch.monitorActive = !root.appSettings.isMonitorDisabled(monitorDelegate.screenName);
-                                }
-
-                                target: root.appSettings
-                            }
-
                         }
 
                         Label {
@@ -304,7 +317,13 @@ SettingsCard {
                                 required property int index
                                 property int desktopNumber: index + 1
                                 property string desktopName: root.appSettings.virtualDesktopNames[index] || i18n("Desktop %1", desktopNumber)
-                                property bool desktopActive: !root.appSettings.isDesktopDisabled(monitorDelegate.screenName, desktopNumber)
+                                // Touch _disabledRevision so this binding re-evaluates whenever
+                                // the controller emits disabledDesktopsChanged. Imperative
+                                // writes (the prior approach) severed the binding chain.
+                                property bool desktopActive: {
+                                    void (root._disabledRevision);
+                                    return !root.appSettings.isDesktopDisabled(monitorDelegate.screenName, desktopNumber);
+                                }
 
                                 Layout.fillWidth: true
                                 spacing: Kirigami.Units.smallSpacing
@@ -365,22 +384,20 @@ SettingsCard {
                                     middleContent: Component {
                                         Switch {
                                             enabled: true
+                                            // Read-only binding to desktopActive; do NOT write to
+                                            // desktopActive in onToggled — assigning a value to the
+                                            // bound `checked` property severs this binding, leaving
+                                            // the Switch visually stuck after the first toggle.
+                                            // The root-level _disabledRevision counter re-evaluates
+                                            // desktopActive whenever the controller emits
+                                            // disabledDesktopsChanged, keeping the binding live
+                                            // (discussion #461 item 12).
                                             checked: desktopRowContainer.desktopActive
                                             onToggled: {
                                                 root.appSettings.setDesktopDisabled(monitorDelegate.screenName, desktopRowContainer.desktopNumber, !checked);
-                                                desktopRowContainer.desktopActive = checked;
                                             }
                                             ToolTip.visible: hovered
                                             ToolTip.text: checked ? i18n("Disable PlasmaZones on %1", desktopRowContainer.desktopName) : i18n("Enable PlasmaZones on %1", desktopRowContainer.desktopName)
-
-                                            Connections {
-                                                function onDisabledDesktopsChanged() {
-                                                    desktopRowContainer.desktopActive = !root.appSettings.isDesktopDisabled(monitorDelegate.screenName, desktopRowContainer.desktopNumber);
-                                                }
-
-                                                target: root.appSettings
-                                            }
-
                                         }
 
                                     }
@@ -428,18 +445,17 @@ SettingsCard {
                             }
 
                             Layout.fillWidth: true
-                            visible: allDesktopsDisabledOnScreen()
+                            // Touch _disabledRevision so this binding re-evaluates whenever
+                            // the controller emits disabledDesktopsChanged. The previous
+                            // imperative `parent.visible = ...` write would have severed
+                            // the binding the same way the desktopActive write did
+                            // (discussion #461 item 12).
+                            visible: {
+                                void (root._disabledRevision);
+                                return allDesktopsDisabledOnScreen();
+                            }
                             type: Kirigami.MessageType.Warning
                             text: i18n("All desktops are disabled on this monitor.")
-
-                            Connections {
-                                function onDisabledDesktopsChanged() {
-                                    parent.visible = parent.allDesktopsDisabledOnScreen();
-                                }
-
-                                target: root.appSettings
-                            }
-
                         }
 
                     }

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -936,7 +936,13 @@ private Q_SLOTS:
         const QStringList lines =
             captureResolveLogs(engine, QStringLiteral("app|uuid-gate-on"), QStringLiteral("DP-1"), &result);
 
-        QVERIFY2(!lines.join(QLatin1Char('\n')).contains(QStringLiteral("disabled-context gate")),
+        QVERIFY2(!result.shouldSnap,
+                 "guiless fixture has no layout/app-rule/session entry — restore resolves to noSnap");
+        // Match the exact top-level gate line, not the broader "disabled-context
+        // gate" substring (the appRule/session re-checks log a different
+        // phrasing) — so the assertion fails only if the caller-screen gate
+        // actually rejected an enabled context.
+        QVERIFY2(!lines.join(QLatin1Char('\n')).contains(QStringLiteral("disabled-context gate rejected restore")),
                  "an enabled context must pass the disabled-context gate");
         m_wts->setSnapState(nullptr);
     }
@@ -953,7 +959,9 @@ private Q_SLOTS:
         const QStringList lines =
             captureResolveLogs(engine, QStringLiteral("app|uuid-no-pred"), QStringLiteral("DP-1"), &result);
 
-        QVERIFY2(!lines.join(QLatin1Char('\n')).contains(QStringLiteral("disabled-context gate")),
+        QVERIFY2(!result.shouldSnap,
+                 "guiless fixture has no layout/app-rule/session entry — restore resolves to noSnap");
+        QVERIFY2(!lines.join(QLatin1Char('\n')).contains(QStringLiteral("disabled-context gate rejected restore")),
                  "with no predicate the disabled-context gate must never fire");
         m_wts->setSnapState(nullptr);
     }

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -786,6 +786,26 @@ private:
         return gateLogSink();
     }
 
+    /// Run resolveWindowRestore while capturing snap-engine debug logs, so a
+    /// test can assert WHICH branch produced the result — the disabled-context
+    /// gate logs a distinctive line. Mirrors runGate()'s capture pattern.
+    QStringList captureResolveLogs(SnapEngine& engine, const QString& windowId, const QString& screenId,
+                                   PhosphorEngine::SnapResult* outResult)
+    {
+        QLoggingCategory::setFilterRules(QStringLiteral("org.phosphor.snap-engine.debug=true"));
+        gateLogSink().clear();
+        QtMessageHandler prev = qInstallMessageHandler(&TestSnapEngine::gateLogHandler);
+
+        const PhosphorEngine::SnapResult result = engine.resolveWindowRestore(windowId, screenId, /*sticky*/ false);
+        if (outResult) {
+            *outResult = result;
+        }
+
+        qInstallMessageHandler(prev);
+        QLoggingCategory::setFilterRules(QString());
+        return gateLogSink();
+    }
+
 private Q_SLOTS:
 
     void testCalculateSnapToEmptyZone_gate_globalOff_perLayoutOff_blocks()
@@ -862,6 +882,79 @@ private Q_SLOTS:
         const QString joined = lines.join(QLatin1Char('\n'));
         QVERIFY2(!joined.contains(QStringLiteral("autoAssign=false")),
                  "both inputs true must pass the gate (no autoAssign=false log)");
+        m_wts->setSnapState(nullptr);
+    }
+
+    // =========================================================================
+    // resolveWindowRestore — disabled-context gate (ShouldRestorePredicate,
+    // discussion #461 item 7)
+    //
+    // The daemon injects a predicate that returns false for a screen the user
+    // disabled snapping on. resolveWindowRestore must then refuse the restore —
+    // and it must be that GATE that refuses, which the log capture asserts via
+    // the distinctive debug line. With no predicate the engine behaves as if
+    // every context is active (the historical default the rest of this suite
+    // relies on).
+    // =========================================================================
+
+    void testResolveWindowRestore_disabledContextGate_rejectsDisabledScreen()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        // Predicate marks DP-OFF as a disabled context, every other screen active.
+        engine.setShouldRestorePredicate([](const QString& screenId) {
+            return screenId != QStringLiteral("DP-OFF");
+        });
+
+        PhosphorEngine::SnapResult result;
+        const QStringList lines =
+            captureResolveLogs(engine, QStringLiteral("app|uuid-gate-off"), QStringLiteral("DP-OFF"), &result);
+
+        QVERIFY2(!result.shouldSnap, "a restore onto a disabled context must be refused");
+        QVERIFY2(lines.join(QLatin1Char('\n')).contains(QStringLiteral("disabled-context gate rejected restore")),
+                 "the disabled-context gate must be the branch that refused the restore");
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testResolveWindowRestore_disabledContextGate_allowsEnabledScreen()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        engine.setShouldRestorePredicate([](const QString& screenId) {
+            return screenId != QStringLiteral("DP-OFF");
+        });
+
+        // DP-1 is active — the gate must not be the branch that fires. The
+        // restore still resolves to noSnap in this guiless fixture (no app
+        // rules / pending session entries / ScreenManager); this asserts only
+        // that the GATE did not reject it.
+        PhosphorEngine::SnapResult result;
+        const QStringList lines =
+            captureResolveLogs(engine, QStringLiteral("app|uuid-gate-on"), QStringLiteral("DP-1"), &result);
+
+        QVERIFY2(!lines.join(QLatin1Char('\n')).contains(QStringLiteral("disabled-context gate")),
+                 "an enabled context must pass the disabled-context gate");
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testResolveWindowRestore_noPredicate_gateInactive()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        // No predicate injected — the engine must behave as if every context
+        // is active (the historical default the rest of the suite relies on).
+        PhosphorEngine::SnapResult result;
+        const QStringList lines =
+            captureResolveLogs(engine, QStringLiteral("app|uuid-no-pred"), QStringLiteral("DP-1"), &result);
+
+        QVERIFY2(!lines.join(QLatin1Char('\n')).contains(QStringLiteral("disabled-context gate")),
+                 "with no predicate the disabled-context gate must never fire");
         m_wts->setSnapState(nullptr);
     }
 };


### PR DESCRIPTION
Re-applies the discussion #461 follow-up work. PR #508 carried this change set, was merged, then reverted by PR #509. This branch restores it cleanly on top of the revert so it can be reviewed and merged fresh.

## What this includes

- **Escape-key hijack fix** in the shortcut backends. Transient Esc grabs are scrubbed from `kglobalshortcutsrc` on first registration and purged on destruction, so a daemon crash cannot leak a stale Esc binding into System Settings. A `persistent` flag was threaded through `IBackend::registerShortcut`.
- **Stuck disable toggles** (item 12). The per-monitor, per-desktop, and per-activity disable `Switch` controls were severed by imperative writes to bound properties, leaving them visually stuck after the first toggle. Converted to a reactive `_disabledRevision` revision-counter pattern.
- **Disabled-context auto-snap gate** (item 7). A daemon-injected `ShouldRestorePredicate` refuses auto-snap onto a screen or virtual desktop the user disabled, including a re-check against the cross-screen-migrated destination of app-rule and session-restore results. (Snap-mode storage carries no per-window activity tag, so the per-activity disable list is enforced on the autotile side only.)
- **Steam popup focus pollution** (item 11). The `windowActivated` filter now rejects the same transient, menu, and popup window types as `shouldHandleWindow`, so Electron/CEF child surfaces no longer pin the daemon's focus tracking.
- **Instant-restore zone registration.** Instant-restored windows now run the daemon round-trip so they register in `SnapState`, instead of becoming "ghosts" that `getEmptyZones` and snap-assist treat as empty.
- **Window-classification diagnostics.** A per-window property dump (`logWindowDiagnostics`) for diagnosing apps KWin mis-classifies (Steam and other CEF surfaces).

## Verification

The 18 changed files are byte-identical to the audited tip of the original branch. A multi-pass code audit was run on this change set: 4 findings (1 HIGH, 2 MEDIUM, 1 LOW) were found and fixed, and a second pass confirmed the fixes regression-free.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)

