### PR TITLE
Feature/fix kwin crash on snapping

### DIFF
--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -139,7 +139,7 @@ bool AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
         int minWidth = 0;
         int minHeight = 0;
         KWin::Window* kw = w->window();
-        if (kw) {
+        if (kw && !w->isInternal()) {
             const QSizeF minSize = kw->minSize();
             if (minSize.isValid()) {
                 minWidth = qCeil(minSize.width());
@@ -221,7 +221,7 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
         int minWidth = 0;
         int minHeight = 0;
         KWin::Window* kw = w->window();
-        if (kw) {
+        if (kw && !w->isInternal()) {
             const QSizeF minSize = kw->minSize();
             if (minSize.isValid()) {
                 minWidth = qCeil(minSize.width());

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -139,7 +139,7 @@ bool AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
         int minWidth = 0;
         int minHeight = 0;
         KWin::Window* kw = w->window();
-        if (kw && !w->isInternal()) {
+        if (kw && !kw->isInternal()) {
             const QSizeF minSize = kw->minSize();
             if (minSize.isValid()) {
                 minWidth = qCeil(minSize.width());
@@ -221,7 +221,7 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
         int minWidth = 0;
         int minHeight = 0;
         KWin::Window* kw = w->window();
-        if (kw && !w->isInternal()) {
+        if (kw && !kw->isInternal()) {
             const QSizeF minSize = kw->minSize();
             if (minSize.isValid()) {
                 minWidth = qCeil(minSize.width());

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-FileCopyrightText: 2026 KHalkjaer
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "autotilehandler.h"

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-FileCopyrightText: 2026 KHalkjaer
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "../autotilehandler.h"

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -318,6 +318,12 @@ void AutotileHandler::savePreAutotileForDesktopMove(const QString& windowId, con
 
 bool AutotileHandler::isEligibleForAutotileNotify(KWin::EffectWindow* w) const
 {
+    // Early-out: KWin internal surfaces (overlay QQuickViews, zone overlays, etc.)
+    // are never eligible for autotile notification. Their InternalWindow::minSize()
+    // crashes if the backing QWindow is not yet ready.
+    if (w && w->isInternal()) {
+        return false;
+    }
     if (!w || !m_effect->shouldHandleWindow(w)) {
         qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (not handleable)"
                           << (w ? m_effect->getWindowId(w) : QStringLiteral("null"));

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -321,7 +321,7 @@ bool AutotileHandler::isEligibleForAutotileNotify(KWin::EffectWindow* w) const
     // Early-out: KWin internal surfaces (overlay QQuickViews, zone overlays, etc.)
     // are never eligible for autotile notification. Their InternalWindow::minSize()
     // crashes if the backing QWindow is not yet ready.
-    if (w && w->isInternal()) {
+    if (w && w->window() && w->window()->isInternal()) {
         return false;
     }
     if (!w || !m_effect->shouldHandleWindow(w)) {

--- a/kwin-effect/kwin_compositor_bridge.cpp
+++ b/kwin-effect/kwin_compositor_bridge.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-FileCopyrightText: 2026 KHalkjaer
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "kwin_compositor_bridge.h"

--- a/kwin-effect/kwin_compositor_bridge.cpp
+++ b/kwin-effect/kwin_compositor_bridge.cpp
@@ -94,7 +94,7 @@ QSizeF KWinCompositorBridge::minSize(WindowHandle w) const
     // InternalWindows (zone overlays) may have a non-null KWin::Window* whose
     // backing QWindow is not yet initialised; calling minSize() on them segfaults
     // inside QWindowPrivate on KWin 6.6.5 (introduced in 3.0.x rewrite).
-    return (kw && !ew->isInternal()) ? kw->minSize() : QSizeF();
+    return (kw && !kw->isInternal()) ? kw->minSize() : QSizeF();
 }
 
 bool KWinCompositorBridge::isMinimized(WindowHandle w) const
@@ -147,7 +147,7 @@ WindowInfo KWinCompositorBridge::windowInfo(WindowHandle w) const
     info.hasDecoration = ew->hasDecoration();
 
     auto* kw = ew->window();
-    if (kw && !ew->isInternal()) {
+    if (kw && !kw->isInternal()) {
         info.minSize = kw->minSize();
     }
 

--- a/kwin-effect/kwin_compositor_bridge.cpp
+++ b/kwin-effect/kwin_compositor_bridge.cpp
@@ -91,7 +91,10 @@ QSizeF KWinCompositorBridge::minSize(WindowHandle w) const
     if (!ew)
         return QSizeF();
     auto* kw = ew->window();
-    return kw ? kw->minSize() : QSizeF();
+    // InternalWindows (zone overlays) may have a non-null KWin::Window* whose
+    // backing QWindow is not yet initialised; calling minSize() on them segfaults
+    // inside QWindowPrivate on KWin 6.6.5 (introduced in 3.0.x rewrite).
+    return (kw && !ew->isInternal()) ? kw->minSize() : QSizeF();
 }
 
 bool KWinCompositorBridge::isMinimized(WindowHandle w) const
@@ -144,7 +147,7 @@ WindowInfo KWinCompositorBridge::windowInfo(WindowHandle w) const
     info.hasDecoration = ew->hasDecoration();
 
     auto* kw = ew->window();
-    if (kw) {
+    if (kw && !ew->isInternal()) {
         info.minSize = kw->minSize();
     }
 


### PR DESCRIPTION
Fix for https://github.com/fuddlesworth/PlasmaZones/discussions/511 

This pull request addresses a stability issue related to handling KWin internal windows (such as overlays) by ensuring that code paths avoid calling `minSize()` on internal windows, which could otherwise lead to crashes if the underlying `QWindow` is not yet initialized. It also adds SPDX copyright attributions.

**Bug fixes and stability improvements:**

* Updated all relevant checks in `autotilehandler.cpp`, `state.cpp`, and `kwin_compositor_bridge.cpp` to skip internal KWin windows when accessing `minSize()`, preventing potential crashes when the backing `QWindow` is not ready. [[1]](diffhunk://#diff-002e394fc053f998b0bb9dc328acdd4d6eae95e5240d09ba14a3ff4e0e4efb8eL142-R143) [[2]](diffhunk://#diff-002e394fc053f998b0bb9dc328acdd4d6eae95e5240d09ba14a3ff4e0e4efb8eL224-R225) [[3]](diffhunk://#diff-95d4be4a1b7b2a07175dd841010c551428742a2712955f666d4c0a9ef4ac2a22R322-R327) [[4]](diffhunk://#diff-67f7995741df75e93c581197c13092fd0b8636d884544fa2804d9e28b98c425cL94-R98) [[5]](diffhunk://#diff-67f7995741df75e93c581197c13092fd0b8636d884544fa2804d9e28b98c425cL147-R151)

**Legal and attribution updates:**

* Added `KHalkjaer` to SPDX copyright headers in all affected files. [[1]](diffhunk://#diff-002e394fc053f998b0bb9dc328acdd4d6eae95e5240d09ba14a3ff4e0e4efb8eR2) [[2]](diffhunk://#diff-95d4be4a1b7b2a07175dd841010c551428742a2712955f666d4c0a9ef4ac2a22R2) [[3]](diffhunk://#diff-67f7995741df75e93c581197c13092fd0b8636d884544fa2804d9e28b98c425cR2)

**Test**

* Tested, builds and the fix works on my machine. 