### PR TITLE
fix: KWin SIGSEGV on snap + cross-screen stale snap geometry (discussion #511)

### DIFF
--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -139,7 +139,8 @@ bool AutotileHandler::notifyWindowAdded(KWin::EffectWindow* w)
         int minWidth = 0;
         int minHeight = 0;
         KWin::Window* kw = w->window();
-        if (kw) {
+        // Internal windows (our own overlays) crash on minSize(); see discussion #511.
+        if (kw && !kw->isInternal()) {
             const QSizeF minSize = kw->minSize();
             if (minSize.isValid()) {
                 minWidth = qCeil(minSize.width());
@@ -221,7 +222,8 @@ void AutotileHandler::notifyWindowsAddedBatch(const QList<KWin::EffectWindow*>& 
         int minWidth = 0;
         int minHeight = 0;
         KWin::Window* kw = w->window();
-        if (kw) {
+        // Internal windows (our own overlays) crash on minSize(); see discussion #511.
+        if (kw && !kw->isInternal()) {
             const QSizeF minSize = kw->minSize();
             if (minSize.isValid()) {
                 minWidth = qCeil(minSize.width());

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -322,6 +322,7 @@ bool AutotileHandler::isEligibleForAutotileNotify(KWin::EffectWindow* w) const
     // are never eligible for autotile notification. KWin's InternalWindow::minSize()
     // segfaults when the backing QWindow is null. See discussion #511.
     if (w && w->window() && w->window()->isInternal()) {
+        qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (internal window)" << m_effect->getWindowId(w);
         return false;
     }
     if (!w || !m_effect->shouldHandleWindow(w)) {

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -318,6 +318,12 @@ void AutotileHandler::savePreAutotileForDesktopMove(const QString& windowId, con
 
 bool AutotileHandler::isEligibleForAutotileNotify(KWin::EffectWindow* w) const
 {
+    // Early-out: KWin internal surfaces (overlay QQuickViews, zone overlays, etc.)
+    // are never eligible for autotile notification. KWin's InternalWindow::minSize()
+    // segfaults when the backing QWindow is null. See discussion #511.
+    if (w && w->window() && w->window()->isInternal()) {
+        return false;
+    }
     if (!w || !m_effect->shouldHandleWindow(w)) {
         qCDebug(lcEffect) << "isEligibleForAutotileNotify: rejected (not handleable)"
                           << (w ? m_effect->getWindowId(w) : QStringLiteral("null"));

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -620,7 +620,11 @@ void AutotileHandler::slotWindowFrameGeometryChanged(KWin::EffectWindow* w, cons
     // get min-size enforcement from this path. They still get the initial
     // min-size from the windowOpened D-Bus call (kw->minSize() at open time),
     // and the centering code handles the visual placement correctly.
-    if (dw < -MinCenteringDelta || dh < -MinCenteringDelta) {
+    // !isInternal() guards KWin's InternalWindow::minSize() against a null
+    // backing QWindow (see discussion #511). Internal windows never reach the
+    // autotile-centering pipeline, but the guard keeps the call site safe
+    // independently of the upstream eligibility filter.
+    if ((dw < -MinCenteringDelta || dh < -MinCenteringDelta) && !kw->isInternal()) {
         const QSizeF declaredMin = kw->minSize();
         int discoveredMinW = 0;
         int discoveredMinH = 0;

--- a/kwin-effect/kwin_compositor_bridge.cpp
+++ b/kwin-effect/kwin_compositor_bridge.cpp
@@ -91,7 +91,11 @@ QSizeF KWinCompositorBridge::minSize(WindowHandle w) const
     if (!ew)
         return QSizeF();
     auto* kw = ew->window();
-    return kw ? kw->minSize() : QSizeF();
+    // KWin internal windows (our own zone overlays / snap-assist surfaces) can
+    // carry a non-null KWin::Window* whose backing QWindow is null; KWin's
+    // InternalWindow::minSize() dereferences it unconditionally and segfaults.
+    // See discussion #511.
+    return (kw && !kw->isInternal()) ? kw->minSize() : QSizeF();
 }
 
 bool KWinCompositorBridge::isMinimized(WindowHandle w) const
@@ -144,7 +148,8 @@ WindowInfo KWinCompositorBridge::windowInfo(WindowHandle w) const
     info.hasDecoration = ew->hasDecoration();
 
     auto* kw = ew->window();
-    if (kw) {
+    // Skip InternalWindows; see minSize() above (discussion #511).
+    if (kw && !kw->isInternal()) {
         info.minSize = kw->minSize();
     }
 

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -389,7 +389,7 @@ void PlasmaZonesEffect::logWindowDiagnostics(KWin::EffectWindow* w, const char* 
                           << "onCurrentActivity:" << w->isOnCurrentActivity()
                           << "onAllDesktops:" << w->isOnAllDesktops();
     qCDebug(lcEffectDiag) << "[window-diag]   geometry — frame:" << w->frameGeometry()
-                          << "minSize:" << (kw ? kw->minSize() : QSizeF());
+                          << "minSize:" << (kw && !kw->isInternal() ? kw->minSize() : QSizeF());
 
     if (KWin::EffectWindow* parent = w->transientFor()) {
         qCDebug(lcEffectDiag) << "[window-diag]   transientFor — YES — parent class:" << parent->windowClass()

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -85,6 +85,32 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
     const QRect capturedOriginalGeometry = m_originalGeometry;
     const bool capturedSnapCancelled = m_snapCancelled;
     const bool capturedZoneSelectorShown = m_zoneSelectorShown;
+
+    // Cross-screen stale-geometry guard. capturedZoneGeometry / capturedMultiZoneGeometry
+    // come from the last dragMoved tick, which may have resolved a zone on a different
+    // output than this release. Applying that rect would place the window on the wrong
+    // screen while commitSnap below records it on releaseScreenId. Resolve the captured
+    // rect's own physical screen and require it to match the release screen; on a
+    // mismatch the snap is declined and the window float-drops at its release position.
+    // See discussion #511.
+    bool capturedGeometryMatchesReleaseScreen = true;
+    {
+        const QRect activeCapturedGeometry = (capturedIsMultiZoneMode && capturedMultiZoneGeometry.isValid())
+            ? capturedMultiZoneGeometry
+            : capturedZoneGeometry;
+        if (activeCapturedGeometry.isValid()) {
+            const QString geometryPhysicalId = resolveScreenAt(QPointF(activeCapturedGeometry.center())).physicalId;
+            if (!geometryPhysicalId.isEmpty() && !releaseResolved.physicalId.isEmpty()
+                && geometryPhysicalId != releaseResolved.physicalId) {
+                capturedGeometryMatchesReleaseScreen = false;
+                qCWarning(lcDbusWindow) << "dragStopped: captured zone geometry" << activeCapturedGeometry
+                                        << "is on screen" << geometryPhysicalId << "but window released on"
+                                        << releaseResolved.physicalId << "- declining cross-screen stale snap for"
+                                        << windowId;
+            }
+        }
+    }
+
     // Release on a disabled context: do not snap to overlay zone
     bool useOverlayZone = true;
     int curDesktopDrop = m_layoutManager ? m_layoutManager->currentVirtualDesktop() : 0;
@@ -274,7 +300,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
     // Use captured values to avoid race condition with concurrent drags
     // Do not snap to overlay zone when releasing on a disabled monitor
     if (!usedZoneSelector && !capturedSnapCancelled && !capturedZoneId.isEmpty() && useOverlayZone) {
-        if (capturedIsMultiZoneMode && capturedMultiZoneGeometry.isValid()) {
+        if (capturedIsMultiZoneMode && capturedMultiZoneGeometry.isValid() && capturedGeometryMatchesReleaseScreen) {
             snapX = capturedMultiZoneGeometry.x();
             snapY = capturedMultiZoneGeometry.y();
             snapWidth = capturedMultiZoneGeometry.width();
@@ -300,7 +326,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
                 // Record user-initiated snap (not auto-snap)
                 m_windowTracking->service()->recordSnapIntent(windowId, true);
             }
-        } else if (capturedZoneGeometry.isValid()) {
+        } else if (capturedZoneGeometry.isValid() && capturedGeometryMatchesReleaseScreen) {
             snapX = capturedZoneGeometry.x();
             snapY = capturedZoneGeometry.y();
             snapWidth = capturedZoneGeometry.width();


### PR DESCRIPTION
Fixes the KWin crash reported in discussion #511, and a related cross-screen snap-geometry bug surfaced while investigating it.

## 1. KWin SIGSEGV on snap — `InternalWindow::minSize()` null deref

Snapping a window to a zone could crash KWin entirely (SIGSEGV, fault at `0x8`). `KWin::InternalWindow::minSize()` forwards to its backing `QWindow`; when that `QWindow*` is null the call dereferences `QObject::d_ptr` (offset 8) on a null pointer inside libQt6Gui. PlasmaZones' own overlays (zone overlays, snap-assist surfaces) are KWin internal windows, so the effect could hit this on its own surfaces.

Every `kw->minSize()` call site in the effect is now guarded with `!kw->isInternal()`:

- `KWinCompositorBridge::minSize()` and `::windowInfo()`
- `AutotileHandler::notifyWindowAdded()` and `::notifyWindowsAddedBatch()`
- `AutotileHandler::slotWindowFrameGeometryChanged()` centering path
- `PlasmaZonesEffect::logWindowDiagnostics()` (diagnostic logging path)

`isEligibleForAutotileNotify()` also rejects internal windows up front so they never enter the autotile pipeline.

This relates to #512, which took the same approach but missed two call sites (`tiling.cpp`, `window_filtering.cpp` — the latter a live crash whenever effect diagnostics are enabled). This branch guards all six.

## 2. Cross-screen stale snap geometry on drop

A snap drop paired two independently-captured values with no consistency check: the zone rectangle (`m_currentZoneGeometry`, from the last `dragMoved` tick) and `releaseScreenId` (from the release-cursor position). A drag whose final `dragMoved` resolved a zone on one monitor, then released on another, applied that monitor's zone rect to the window while `commitSnap` recorded it on `releaseScreenId` — placing the window on the wrong screen. The #511 crash log shows exactly this: `commitSnap screen="Samsung S24E650"` applying a full-width Dell zone rect `QRect(1208,1079 2544x693)`.

The drop path now resolves the captured rect's own physical screen and requires it to match the release screen. On a mismatch the snap is declined and the window float-drops at its release position instead of jumping to a wrong-screen rectangle.

## Testing

- Build clean; `kwin_effect_plasmazones` and `plasmazonesd` both compile.
- Full suite: 189/189 tests pass.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)