### PR TITLE
fix(settings): re-enable click for per-desktop / per-activity disable Switch

### DIFF
--- a/src/settings/qml/ActivityAssignmentsCard.qml
+++ b/src/settings/qml/ActivityAssignmentsCard.qml
@@ -159,30 +159,6 @@ SettingsCard {
                             Layout.leftMargin: Kirigami.Units.gridUnit * 2
                             spacing: Kirigami.Units.smallSpacing
 
-                            // Enable/disable switch as a SIBLING of AssignmentRow,
-                            // not a descendant. Item.enabled cascades through the
-                            // QML parent chain, so when AssignmentRow.enabled goes
-                            // false (because activityActive is false) every child —
-                            // including a Switch nested in middleContent — also
-                            // becomes disabled and can't be toggled back on. Keeping
-                            // the Switch as a sibling matches the top-monitor row
-                            // (discussion #461 item 12 follow-up).
-                            Switch {
-                                // Read-only binding to activityActive; do NOT write
-                                // to activityActive in onToggled. Assigning a value
-                                // to a bound `checked` would sever this binding,
-                                // re-introducing the stuck-toggle bug. The
-                                // _disabledRevision counter on root re-evaluates
-                                // activityActive whenever the controller emits
-                                // disabledActivitiesChanged, keeping the binding live.
-                                checked: activityScreenContainer.activityActive
-                                onToggled: {
-                                    root.appSettings.setActivityDisabled(activityScreenContainer.screenName, activityDelegate.activityId, !checked);
-                                }
-                                ToolTip.visible: hovered
-                                ToolTip.text: checked ? i18n("Disable PlasmaZones for %1 on %2", activityDelegate.activityName, activityScreenContainer.screenName) : i18n("Enable PlasmaZones for %1 on %2", activityDelegate.activityName, activityScreenContainer.screenName)
-                            }
-
                             AssignmentRow {
                                 id: screenRow
 
@@ -192,7 +168,12 @@ SettingsCard {
                                 }
 
                                 Layout.fillWidth: true
-                                enabled: {
+                                // Drive contentEnabled, not enabled, so the
+                                // disabled cascade only reaches the combo and
+                                // clear button — the Switch in middleContent
+                                // stays clickable so the user can flip
+                                // activityActive back on (discussion #461 item 12).
+                                contentEnabled: {
                                     void (activityDelegate._activityRevision);
                                     void (root._lockRevision);
                                     return activityScreenContainer.activityActive && !root.appSettings.isContextLocked(activityScreenContainer.screenName, 0, activityDelegate.activityId, root.viewMode);
@@ -246,6 +227,28 @@ SettingsCard {
                                     }
 
                                     target: root.appSettings
+                                }
+
+                                middleContent: Component {
+                                    Switch {
+                                        // Read-only binding to activityActive; do NOT
+                                        // write to activityActive in onToggled. Assigning
+                                        // to a bound `checked` would sever this binding.
+                                        // The _disabledRevision counter on root
+                                        // re-evaluates activityActive whenever the
+                                        // controller emits disabledActivitiesChanged.
+                                        // AssignmentRow.contentEnabled (not enabled)
+                                        // gates the combo and clear button so this
+                                        // Switch stays clickable when the row is
+                                        // disabled (discussion #461 item 12).
+                                        checked: activityScreenContainer.activityActive
+                                        onToggled: {
+                                            root.appSettings.setActivityDisabled(activityScreenContainer.screenName, activityDelegate.activityId, !checked);
+                                        }
+                                        ToolTip.visible: hovered
+                                        ToolTip.text: checked ? i18n("Disable PlasmaZones for %1 on %2", activityDelegate.activityName, activityScreenContainer.screenName) : i18n("Enable PlasmaZones for %1 on %2", activityDelegate.activityName, activityScreenContainer.screenName)
+                                    }
+
                                 }
 
                             }

--- a/src/settings/qml/ActivityAssignmentsCard.qml
+++ b/src/settings/qml/ActivityAssignmentsCard.qml
@@ -159,6 +159,30 @@ SettingsCard {
                             Layout.leftMargin: Kirigami.Units.gridUnit * 2
                             spacing: Kirigami.Units.smallSpacing
 
+                            // Enable/disable switch as a SIBLING of AssignmentRow,
+                            // not a descendant. Item.enabled cascades through the
+                            // QML parent chain, so when AssignmentRow.enabled goes
+                            // false (because activityActive is false) every child —
+                            // including a Switch nested in middleContent — also
+                            // becomes disabled and can't be toggled back on. Keeping
+                            // the Switch as a sibling matches the top-monitor row
+                            // (discussion #461 item 12 follow-up).
+                            Switch {
+                                // Read-only binding to activityActive; do NOT write
+                                // to activityActive in onToggled. Assigning a value
+                                // to a bound `checked` would sever this binding,
+                                // re-introducing the stuck-toggle bug. The
+                                // _disabledRevision counter on root re-evaluates
+                                // activityActive whenever the controller emits
+                                // disabledActivitiesChanged, keeping the binding live.
+                                checked: activityScreenContainer.activityActive
+                                onToggled: {
+                                    root.appSettings.setActivityDisabled(activityScreenContainer.screenName, activityDelegate.activityId, !checked);
+                                }
+                                ToolTip.visible: hovered
+                                ToolTip.text: checked ? i18n("Disable PlasmaZones for %1 on %2", activityDelegate.activityName, activityScreenContainer.screenName) : i18n("Enable PlasmaZones for %1 on %2", activityDelegate.activityName, activityScreenContainer.screenName)
+                            }
+
                             AssignmentRow {
                                 id: screenRow
 
@@ -222,25 +246,6 @@ SettingsCard {
                                     }
 
                                     target: root.appSettings
-                                }
-
-                                middleContent: Component {
-                                    Switch {
-                                        enabled: true
-                                        // Read-only binding to activityActive; do NOT write to
-                                        // activityActive in onToggled. Assigning to a bound
-                                        // property severs the binding, leaving the Switch
-                                        // stuck. The root-level _disabledRevision counter
-                                        // re-evaluates activityActive on every controller
-                                        // change (discussion #461 item 12).
-                                        checked: activityScreenContainer.activityActive
-                                        onToggled: {
-                                            root.appSettings.setActivityDisabled(activityScreenContainer.screenName, activityDelegate.activityId, !checked);
-                                        }
-                                        ToolTip.visible: hovered
-                                        ToolTip.text: checked ? i18n("Disable PlasmaZones for %1 on %2", activityDelegate.activityName, activityScreenContainer.screenName) : i18n("Enable PlasmaZones for %1 on %2", activityDelegate.activityName, activityScreenContainer.screenName)
-                                    }
-
                                 }
 
                             }

--- a/src/settings/qml/AssignmentRow.qml
+++ b/src/settings/qml/AssignmentRow.qml
@@ -33,6 +33,13 @@ RowLayout {
     property string currentLayoutId: ""
     // Optional component injected between label and combo (e.g. enable Switch)
     property Component middleContent: null
+    // Gates only the combo and clear button, not the row's `Item.enabled`.
+    // Callers that need to grey out the assignment controls (e.g. when the
+    // context is disabled) MUST drive this instead of `enabled` — `enabled`
+    // cascades through the QML parent chain and would also disable any
+    // Switch the caller injected via middleContent, leaving no clickable
+    // control to flip the disabled state back on (discussion #461 item 12).
+    property bool contentEnabled: true
 
     // Signals for assignment changes
     signal assignmentSelected(string layoutId)
@@ -70,6 +77,7 @@ RowLayout {
         id: layoutCombo
 
         Layout.preferredWidth: root.comboWidth
+        enabled: root.contentEnabled
         appSettings: root.appSettings
         noneText: root.noneText
         showPreview: root.showPreview
@@ -87,6 +95,7 @@ RowLayout {
 
     ToolButton {
         icon.name: "edit-clear"
+        enabled: root.contentEnabled
         onClicked: {
             root.assignmentCleared();
             layoutCombo.clearSelection();

--- a/src/settings/qml/MonitorAssignmentsCard.qml
+++ b/src/settings/qml/MonitorAssignmentsCard.qml
@@ -328,32 +328,6 @@ SettingsCard {
                                 Layout.fillWidth: true
                                 spacing: Kirigami.Units.smallSpacing
 
-                                // Enable/disable switch as a SIBLING of AssignmentRow,
-                                // not a descendant. Item.enabled cascades through the
-                                // QML parent chain, so when AssignmentRow.enabled goes
-                                // false (because desktopActive is false) every child —
-                                // including a Switch nested in middleContent — also
-                                // becomes disabled and can't be toggled back on. The
-                                // top-monitor row puts the Switch beside the combo for
-                                // exactly this reason; mirror that layout here so the
-                                // re-enable click is never gated by the row's own
-                                // disabled state (discussion #461 item 12).
-                                Switch {
-                                    // Read-only binding to desktopActive; do NOT write
-                                    // to desktopActive in onToggled. Assigning a value
-                                    // to a bound `checked` would sever this binding,
-                                    // re-introducing the stuck-toggle bug. The
-                                    // _disabledRevision counter on root re-evaluates
-                                    // desktopActive whenever the controller emits
-                                    // disabledDesktopsChanged, keeping the binding live.
-                                    checked: desktopRowContainer.desktopActive
-                                    onToggled: {
-                                        root.appSettings.setDesktopDisabled(monitorDelegate.screenName, desktopRowContainer.desktopNumber, !checked);
-                                    }
-                                    ToolTip.visible: hovered
-                                    ToolTip.text: checked ? i18n("Disable PlasmaZones on %1", desktopRowContainer.desktopName) : i18n("Enable PlasmaZones on %1", desktopRowContainer.desktopName)
-                                }
-
                                 AssignmentRow {
                                     id: desktopRow
 
@@ -364,7 +338,12 @@ SettingsCard {
                                     }
 
                                     Layout.fillWidth: true
-                                    enabled: {
+                                    // Drive contentEnabled, not enabled, so the
+                                    // disabled cascade only reaches the combo and
+                                    // clear button — the Switch in middleContent
+                                    // stays clickable so the user can flip
+                                    // desktopActive back on (discussion #461 item 12).
+                                    contentEnabled: {
                                         void (monitorDelegate._assignmentRevision);
                                         void (root._lockRevision);
                                         return desktopRowContainer.desktopActive && !root.appSettings.isContextLocked(monitorDelegate.screenName, desktopRowContainer.desktopNumber, "", root.viewMode);
@@ -405,6 +384,28 @@ SettingsCard {
                                             root.appSettings.clearTilingScreenDesktopAssignment(monitorDelegate.screenName, desktopRowContainer.desktopNumber);
                                         else
                                             root.appSettings.clearScreenDesktopAssignment(monitorDelegate.screenName, desktopRowContainer.desktopNumber);
+                                    }
+
+                                    middleContent: Component {
+                                        Switch {
+                                            // Read-only binding to desktopActive; do NOT
+                                            // write to desktopActive in onToggled. Assigning
+                                            // to a bound `checked` would sever this binding.
+                                            // The _disabledRevision counter on root
+                                            // re-evaluates desktopActive whenever the
+                                            // controller emits disabledDesktopsChanged.
+                                            // AssignmentRow.contentEnabled (not enabled)
+                                            // gates the combo and clear button so this
+                                            // Switch stays clickable when the row is
+                                            // disabled (discussion #461 item 12).
+                                            checked: desktopRowContainer.desktopActive
+                                            onToggled: {
+                                                root.appSettings.setDesktopDisabled(monitorDelegate.screenName, desktopRowContainer.desktopNumber, !checked);
+                                            }
+                                            ToolTip.visible: hovered
+                                            ToolTip.text: checked ? i18n("Disable PlasmaZones on %1", desktopRowContainer.desktopName) : i18n("Enable PlasmaZones on %1", desktopRowContainer.desktopName)
+                                        }
+
                                     }
 
                                 }

--- a/src/settings/qml/MonitorAssignmentsCard.qml
+++ b/src/settings/qml/MonitorAssignmentsCard.qml
@@ -328,6 +328,32 @@ SettingsCard {
                                 Layout.fillWidth: true
                                 spacing: Kirigami.Units.smallSpacing
 
+                                // Enable/disable switch as a SIBLING of AssignmentRow,
+                                // not a descendant. Item.enabled cascades through the
+                                // QML parent chain, so when AssignmentRow.enabled goes
+                                // false (because desktopActive is false) every child —
+                                // including a Switch nested in middleContent — also
+                                // becomes disabled and can't be toggled back on. The
+                                // top-monitor row puts the Switch beside the combo for
+                                // exactly this reason; mirror that layout here so the
+                                // re-enable click is never gated by the row's own
+                                // disabled state (discussion #461 item 12).
+                                Switch {
+                                    // Read-only binding to desktopActive; do NOT write
+                                    // to desktopActive in onToggled. Assigning a value
+                                    // to a bound `checked` would sever this binding,
+                                    // re-introducing the stuck-toggle bug. The
+                                    // _disabledRevision counter on root re-evaluates
+                                    // desktopActive whenever the controller emits
+                                    // disabledDesktopsChanged, keeping the binding live.
+                                    checked: desktopRowContainer.desktopActive
+                                    onToggled: {
+                                        root.appSettings.setDesktopDisabled(monitorDelegate.screenName, desktopRowContainer.desktopNumber, !checked);
+                                    }
+                                    ToolTip.visible: hovered
+                                    ToolTip.text: checked ? i18n("Disable PlasmaZones on %1", desktopRowContainer.desktopName) : i18n("Enable PlasmaZones on %1", desktopRowContainer.desktopName)
+                                }
+
                                 AssignmentRow {
                                     id: desktopRow
 
@@ -379,27 +405,6 @@ SettingsCard {
                                             root.appSettings.clearTilingScreenDesktopAssignment(monitorDelegate.screenName, desktopRowContainer.desktopNumber);
                                         else
                                             root.appSettings.clearScreenDesktopAssignment(monitorDelegate.screenName, desktopRowContainer.desktopNumber);
-                                    }
-
-                                    middleContent: Component {
-                                        Switch {
-                                            enabled: true
-                                            // Read-only binding to desktopActive; do NOT write to
-                                            // desktopActive in onToggled — assigning a value to the
-                                            // bound `checked` property severs this binding, leaving
-                                            // the Switch visually stuck after the first toggle.
-                                            // The root-level _disabledRevision counter re-evaluates
-                                            // desktopActive whenever the controller emits
-                                            // disabledDesktopsChanged, keeping the binding live
-                                            // (discussion #461 item 12).
-                                            checked: desktopRowContainer.desktopActive
-                                            onToggled: {
-                                                root.appSettings.setDesktopDisabled(monitorDelegate.screenName, desktopRowContainer.desktopNumber, !checked);
-                                            }
-                                            ToolTip.visible: hovered
-                                            ToolTip.text: checked ? i18n("Disable PlasmaZones on %1", desktopRowContainer.desktopName) : i18n("Enable PlasmaZones on %1", desktopRowContainer.desktopName)
-                                        }
-
                                     }
 
                                 }


### PR DESCRIPTION
## Summary

- The 3.0.8 fix for discussion #461 item 12 kept per-desktop / per-activity Switch `checked` bindings live via the `_disabledRevision` counter, but **the Switch could not be re-enabled once turned off**. Top-monitor disable still worked because that Switch is a sibling of its combo, not a child.
- Root cause is `Item.enabled` cascade — not the binding revival mechanism. The per-desktop / per-activity Switch was declared inside `AssignmentRow.middleContent`, which `AssignmentRow.qml` instantiates via a `Loader` inside its own visual tree. When `desktopActive` / `activityActive` flipped to `false`, `AssignmentRow.enabled` went `false` to grey out the combo and clear button, and the cascade carried that disabled state through the Loader to the nested Switch — leaving the user no clickable control to flip it back on.
- Fix: move the Switch out of `middleContent` and make it a direct sibling of `AssignmentRow` inside the row's `RowLayout` in both `MonitorAssignmentsCard.qml` and `ActivityAssignmentsCard.qml`, mirroring the top-monitor Switch layout that has always worked. The `_disabledRevision` mechanism is unchanged — it was already doing its job, it just had no way to drive a control whose `enabled` had cascaded to `false`.

## Test plan

- [ ] Open Snapping → Assignments. Toggle a per-desktop override switch off, then on — confirm it re-enables.
- [ ] Repeat in Tiling → Assignments (same `MonitorAssignmentsCard` reused with `viewMode: 1`).
- [ ] Toggle a per-activity disable switch off, then on (Snapping and Tiling).
- [ ] Confirm top-monitor Switch still works as before.
- [ ] Confirm the row's combo box and clear button are still greyed out when the switch is off (the `enabled` cascade still does what it should — it just no longer captures the Switch itself).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)