### PR TITLE
fix(kwin-effect): focus-follows-mouse blocked by own overlay (discussion #461 #3)

### DIFF
--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -58,6 +58,20 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
         if (!w->frameGeometry().contains(pos)) {
             continue;
         }
+        // Our own daemon overlay / editor layer-shell surfaces are full-screen
+        // and always topmost on the autotile monitor — without this exemption,
+        // FFM would see them as the topmost-under-cursor window on every move
+        // and bail forever (discussion #461 #3). Look through them to the real
+        // window beneath. The shouldHandleWindow rejection reason for these is
+        // "own overlay/editor window class"; we match that here directly to
+        // avoid a string round-trip via the rejectReason out-param.
+        {
+            const QString cls = w->windowClass();
+            if (cls.contains(QLatin1String("plasmazonesd"), Qt::CaseInsensitive)
+                || cls.contains(QLatin1String("plasmazones-editor"), Qt::CaseInsensitive)) {
+                continue;
+            }
+        }
         // A non-autotile window (excluded app, keep-above overlay, popup, dialog,
         // Spectacle, etc.) occludes the cursor — don't look through it to focus a
         // tiled window beneath. This prevents focus-stealing from emoji pickers,

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -58,19 +58,11 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
         if (!w->frameGeometry().contains(pos)) {
             continue;
         }
-        // Our own daemon overlay / editor layer-shell surfaces are full-screen
-        // and always topmost on the autotile monitor — without this exemption,
-        // FFM would see them as the topmost-under-cursor window on every move
-        // and bail forever (discussion #461 #3). Look through them to the real
-        // window beneath. The shouldHandleWindow rejection reason for these is
-        // "own overlay/editor window class"; we match that here directly to
-        // avoid a string round-trip via the rejectReason out-param.
-        {
-            const QString cls = w->windowClass();
-            if (cls.contains(QLatin1String("plasmazonesd"), Qt::CaseInsensitive)
-                || cls.contains(QLatin1String("plasmazones-editor"), Qt::CaseInsensitive)) {
-                continue;
-            }
+        // Look through our own overlay/editor layer-shell surfaces — they are
+        // full-screen and always topmost on the autotile monitor, so the bail
+        // below would otherwise kill FFM forever (discussion #461 #3).
+        if (PlasmaZonesEffect::isOwnOverlayClass(w->windowClass())) {
+            continue;
         }
         // A non-autotile window (excluded app, keep-above overlay, popup, dialog,
         // Spectacle, etc.) occludes the cursor — don't look through it to focus a

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -337,6 +337,20 @@ private:
      * (discussion #271).
      */
     static bool isPlasmaShellSurface(const QString& windowClass);
+
+    /**
+     * @brief Recognise the daemon's own overlay / editor layer-shell surfaces
+     *        by window class.
+     *
+     * The shouldHandleWindow filter rejects these as "own overlay/editor
+     * window class" so the snap/tile pipeline never targets them. Other paths
+     * (focus-follows-mouse stacking-order walks) need to *look through* them
+     * to the real user window beneath, rather than treating them as legitimate
+     * occluders the way they'd treat an emoji picker or xdg-desktop-portal
+     * surface. Sharing one substring match keeps both call sites in lockstep.
+     */
+    static bool isOwnOverlayClass(const QString& windowClass);
+
     bool hasOtherWindowOfClassWithDifferentPid(KWin::EffectWindow* w) const;
     bool isWindowSticky(KWin::EffectWindow* w) const;
     void updateWindowStickyState(KWin::EffectWindow* w);

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -163,10 +163,10 @@ bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w, QString* rejec
         return rejectedBecause(rejectReason, "null window");
     }
 
-    // Never snap our own overlay/editor windows (but allow the settings app)
+    // Never snap our own overlay/editor windows (but allow the settings app).
+    // Shared with the FFM stacking-order walk — see isOwnOverlayClass().
     const QString windowClass = w->windowClass();
-    if (windowClass.contains(QLatin1String("plasmazonesd"), Qt::CaseInsensitive)
-        || windowClass.contains(QLatin1String("plasmazones-editor"), Qt::CaseInsensitive)) {
+    if (isOwnOverlayClass(windowClass)) {
         return rejectedBecause(rejectReason, "own overlay/editor window class");
     }
 

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -126,4 +126,14 @@ bool PlasmaZonesEffect::isPlasmaShellSurface(const QString& windowClass)
         || windowClass.contains(QLatin1String("org.kde.krunner"), Qt::CaseInsensitive);
 }
 
+bool PlasmaZonesEffect::isOwnOverlayClass(const QString& windowClass)
+{
+    // Match the same substrings the shouldHandleWindow filter uses for its
+    // "own overlay/editor window class" rejection. The settings app is
+    // deliberately NOT here — it is a real user window the snap/tile pipeline
+    // should treat normally.
+    return windowClass.contains(QLatin1String("plasmazonesd"), Qt::CaseInsensitive)
+        || windowClass.contains(QLatin1String("plasmazones-editor"), Qt::CaseInsensitive);
+}
+
 } // namespace PlasmaZones


### PR DESCRIPTION
## Summary

- `AutotileHandler::handleCursorMoved` was bailing forever once the daemon's full-screen `plasmazonesd` overlay layer-shell surface became the topmost window under the cursor. `shouldHandleWindow` rejects that class as "own overlay/editor window class", and the FFM loop treated the rejection identically to a real occluder (emoji picker, Spectacle), so focus-follows-mouse stopped working as soon as any overlay had been mapped on the autotile monitor.
- Fix: in the stacking-order walk, when the topmost-under-cursor window's class contains `plasmazonesd` or `plasmazones-editor`, `continue` to the next window instead of returning. All other rejection paths (xdg-desktop-portal, plasmashell, user-excluded apps, popups, dialogs, undersized windows) keep their existing bail-out so we still do not focus-steal from legitimate overlays.
- Diff is 14 added lines in `kwin-effect/autotilehandler.cpp`, no header change.

## Test plan

- [x] `cmake --build build --target kwin_effect_plasmazones` clean
- [x] `ctest -R autotile` 17/17 passing
- [x] Reproduced locally: before the patch FFM stayed dead on the autotile monitor as soon as any OSD or snap preview had been shown; after the patch FFM activates the window under the cursor and stays healthy across overlay show/hide cycles.

Refs: discussion #461 item 3 (krakerz follow-up).