### PR TITLE
fix(overlay): unmap passive shell when effects-off (discussion #515)

### DIFF
--- a/libs/phosphor-overlay/include/PhosphorOverlay/ShellHost.h
+++ b/libs/phosphor-overlay/include/PhosphorOverlay/ShellHost.h
@@ -140,12 +140,17 @@ public:
     /// the consumer's view of what's live on this screen.
     ///
     /// @p anyVisible - true when at least one slot wants the surface
-    /// mapped (driven by the consumer's slot-visibility check). Brings
-    /// the surface up on the first transition from never-shown → live;
-    /// subsequent visibility transitions toggle the input flag directly
-    /// without re-entering Surface::show()/hide() (the keep-mapped hide
-    /// path cancels per-surface animator tracking, which would wipe
-    /// in-flight beginShow's on OTHER slots on the same shell).
+    /// mapped (driven by the consumer's slot-visibility check). Drives
+    /// the Surface state machine in both directions: show() on
+    /// false→true, hide() on true→false. The behavior of hide() is
+    /// governed by the SurfaceConfig the consumer registered:
+    /// keepMappedOnHide=true keeps the wl_surface mapped (animator
+    /// drives root opacity to 0); keepMappedOnHide=false unmaps the
+    /// wl_surface synchronously so the shell stops being composited
+    /// when idle. The shell surface's role typically has no animator
+    /// Config registered, so per-surface cancel/beginHide collapse
+    /// to no-ops and do not interfere with per-slot animator state
+    /// (which lives on different keys).
     ///
     /// @p anyInputGrabbing - true when at least one modal slot
     /// (consumer-defined; PZ today: snap-assist + layout picker) wants

--- a/libs/phosphor-overlay/src/shellhost.cpp
+++ b/libs/phosphor-overlay/src/shellhost.cpp
@@ -165,17 +165,37 @@ void ShellHost::syncSurfaceState(const QString& screenId, bool anyVisible, bool 
     }
     auto& s = *it.value();
 
-    // Bring the surface up on the first transition from never-shown →
-    // any-slot-visible. The first show() call goes through the Surface
-    // state machine (maps the wl_surface, warms the RHI, fires animator
-    // attach callbacks); subsequent input-region toggles flip
-    // Qt::WindowTransparentForInput directly without re-entering the
-    // Surface::show()/hide() path - that path's `animator().cancel(...)`
-    // would wipe per-slot tracking and `beginHide(animatorTarget())`
-    // would animate the shell root opacity, both of which we want to
-    // avoid for a pure click-through toggle.
+    // Show/hide are driven through the Surface state machine on every
+    // anyVisible transition. The behavior in each direction depends on
+    // the SurfaceConfig the consumer registered:
+    //
+    //   show()  - maps the wl_surface, warms the RHI, fires the
+    //             animator's attach callbacks. Always runs on
+    //             false→true.
+    //
+    //   hide()  - under keepMappedOnHide=true the wl_surface stays
+    //             mapped (the animator drives root opacity to 0 and
+    //             the window goes click-through); under
+    //             keepMappedOnHide=false the wl_surface is unmapped
+    //             synchronously. Consumers that need the shell to
+    //             stop being composited every frame when idle opt
+    //             into the latter at creation time.
+    //
+    // The shell surface's role typically has no registered animator
+    // Config, so the animator's cancel / beginHide calls inside
+    // Surface::hide() collapse to no-ops on this surface. Per-slot
+    // tracking lives on slot animator targets (different keys), so
+    // hiding the shell surface does not interfere with slot state.
+    //
+    // The Qt::WindowTransparentForInput toggle below is independent
+    // of show/hide and flips directly on every input-grab transition
+    // (modal slot in / out) - this keeps non-modal slot dismissals
+    // from re-entering the surface state machine for a pure
+    // click-through change.
     if (anyVisible && !s.m_shellSurface->isLogicallyShown()) {
         s.m_shellSurface->show();
+    } else if (!anyVisible && s.m_shellSurface->isLogicallyShown()) {
+        s.m_shellSurface->hide();
     }
 
     // Drive the Qt input flag based purely on whether a modal slot is

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -439,13 +439,30 @@ PhosphorLayer::Surface* OverlayService::createWarmedOsdSurface(const PhosphorLay
         }
     }
 
+    // keepMappedOnHide gate (Discussion #515): the Phase-5 keep-mapped
+    // lifecycle exists so shader / animation transitions don't pay the
+    // wl_surface unmap + RHI swapchain teardown cost on every dismiss.
+    // For users with both shaders and animations disabled there are no
+    // transitions that need that headroom, and keeping the shell mapped
+    // means a fullscreen wlr OVERLAY layer surface is composited above
+    // every normal toplevel for the daemon's lifetime - which masks
+    // KWin's Translucency-while-moving effect and exposes hybrid-GPU
+    // composition bugs in the reporter's NVIDIA 595 + Intel setup.
+    // Effects-on path keeps the warm cache (callers paying for shaders
+    // get the perf they signed up for); effects-off path lets the next
+    // ShellHost::syncSurfaceState !anyVisible transition unmap the
+    // wl_surface cleanly.
+    const bool shadersOn = m_shaderRegistry && m_shaderRegistry->shadersEnabled();
+    const bool animationsOn = m_settings && m_settings->animationsEnabled();
+    const bool keepMapped = shadersOn || animationsOn;
+
     auto* surface = createLayerSurface({.qmlUrl = qmlUrl,
                                         .screen = physScreen,
                                         .role = role,
                                         .windowType = windowType,
                                         .anchorsOverride = anchorsOverride,
                                         .marginsOverride = marginsOverride,
-                                        .keepMappedOnHide = true,
+                                        .keepMappedOnHide = keepMapped,
                                         .initialSize = initialSize});
     if (!surface) {
         return nullptr;

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -439,19 +439,17 @@ PhosphorLayer::Surface* OverlayService::createWarmedOsdSurface(const PhosphorLay
         }
     }
 
-    // keepMappedOnHide gate (Discussion #515): the Phase-5 keep-mapped
-    // lifecycle exists so shader / animation transitions don't pay the
-    // wl_surface unmap + RHI swapchain teardown cost on every dismiss.
-    // For users with both shaders and animations disabled there are no
-    // transitions that need that headroom, and keeping the shell mapped
-    // means a fullscreen wlr OVERLAY layer surface is composited above
-    // every normal toplevel for the daemon's lifetime - which masks
-    // KWin's Translucency-while-moving effect and exposes hybrid-GPU
-    // composition bugs in the reporter's NVIDIA 595 + Intel setup.
-    // Effects-on path keeps the warm cache (callers paying for shaders
-    // get the perf they signed up for); effects-off path lets the next
-    // ShellHost::syncSurfaceState !anyVisible transition unmap the
-    // wl_surface cleanly.
+    // keepMappedOnHide is gated on whether any visual effect is enabled.
+    // The keep-mapped lifecycle exists so shader / animation transitions
+    // do not pay the wl_surface unmap + RHI swapchain teardown cost on
+    // every dismiss; with both shaders and animations disabled there is
+    // no transition to amortize, and keeping the shell mapped means a
+    // fullscreen wlr OVERLAY layer surface is composited above every
+    // normal toplevel for the daemon's lifetime - which masks the
+    // compositor's own translucency-while-moving effect and exposes
+    // composition-pipeline bugs on hybrid-GPU setups. Effects-on path
+    // keeps the warm cache; effects-off path lets the next
+    // syncSurfaceState !anyVisible transition unmap the wl_surface.
     const bool shadersOn = m_shaderRegistry && m_shaderRegistry->shadersEnabled();
     const bool animationsOn = m_settings && m_settings->animationsEnabled();
     const bool keepMapped = shadersOn || animationsOn;

--- a/src/daemon/overlayservice/lifecycle.cpp
+++ b/src/daemon/overlayservice/lifecycle.cpp
@@ -129,10 +129,10 @@ void OverlayService::showAtPosition(int cursorX, int cursorY)
         // animates the slot back up.
         //
         // Note: this is a DIFFERENT question from
-        // syncPassiveShellSurfaceState's isMainOverlayLive predicate
-        // (which asks "is the slot rendering content the user sees"
-        // for the surface input-region decision). Both checks are
-        // intentional; do not merge them.
+        // syncPassiveShellSurfaceState's anyVisible predicate (which
+        // asks "should the shell wl_surface be mapped at all" using
+        // raw slot Item visibility). Both checks are intentional; do
+        // not merge them.
         QQuickItem* cursorMainOverlay = cursorVsHasWindow ? cursorIt->mainOverlaySlot() : nullptr;
         const bool cursorSlotVisible =
             cursorMainOverlay != nullptr && !qFuzzyCompare(cursorMainOverlay->opacity(), 0.0);
@@ -234,16 +234,12 @@ void OverlayService::setIdleForDragPause()
         writeQmlProperty(slot, QString(OverlayQmlPropertyNames::HighlightedCount), 0);
         writeQmlProperty(slot, QString(OverlayQmlPropertyNames::HighlightedZoneId), QString());
         writeQmlProperty(slot, QString(OverlayQmlPropertyNames::HighlightedZoneIds), QVariantList());
-        // Re-evaluate the shell surface's input region now that this
-        // screen's main overlay slot is idled. The slot Item stays
-        // setVisible(true) (warm RHI pipeline) but
-        // `syncPassiveShellSurfaceState`'s isMainOverlayLive predicate
-        // treats `_idled` slots as not-blocking-input, so the shell
-        // releases its input region for click-through if no other slot
-        // (OSD, snap-assist, picker, zone-selector) is up. Without this
-        // call the previous show()'s input grab persists for the
-        // surface's lifetime even though the user has released the
-        // activation trigger.
+        // Defensive resync of the shell's input region + mapped state
+        // after the _idled flip. The slot Item stays setVisible(true)
+        // across drag-pause idles (warm RHI pipeline), so anyVisible
+        // does not change; the call is a no-op in the steady state
+        // but guards against any path that left input-region state out
+        // of sync with what anyInputGrabbing reports.
         syncPassiveShellSurfaceState(it.key());
         // NOTE: labelsTextureHash is intentionally NOT cleared here. The QML
         // side's labelsTexture property still holds the previously-built image
@@ -315,14 +311,12 @@ void OverlayService::applyIdleStateForCursor(const QString& activeEffectiveId, b
         const bool shouldBeActive =
             showOnAllMonitors || (it.key() == activeEffectiveId && !activeEffectiveId.isEmpty());
         writeQmlProperty(slot, QString(OverlayQmlPropertyNames::Idled), !shouldBeActive);
-        // Re-evaluate the shell surface's input region after every
-        // _idled flip. In single-monitor mode, the cursor's VS gets
-        // _idled=false (live, grabs input) and every other VS gets
-        // _idled=true (idled, releases input via the
-        // isMainOverlayLive predicate in syncPassiveShellSurfaceState).
-        // Cross-VS cursor moves during a drag flow through this path,
-        // so without the per-flip resync the inactive VS's shell would
-        // keep grabbing clicks even though it should be transparent.
+        // Defensive resync of every per-VS shell after the _idled
+        // flip. Slot Items stay setVisible(true) across _idled toggles
+        // so anyVisible does not change; the call guards against any
+        // path that left input-region state out of sync with what
+        // anyInputGrabbing reports for cross-VS modal slots during a
+        // drag.
         syncPassiveShellSurfaceState(it.key());
     }
 }

--- a/src/daemon/overlayservice/shellhost_bridge.cpp
+++ b/src/daemon/overlayservice/shellhost_bridge.cpp
@@ -39,7 +39,9 @@ namespace PlasmaZones {
 // the OSD path is ready by the time the user fires their first
 // hot-plug-induced shortcut. The m_notificationsWarmed flag gates
 // whether new screens get a per-screen passive overlay shell after
-// the initial warm-up.
+// the initial warm-up. The effects-disabled gate (Discussion #515)
+// also applies here - if shaders + animations are both off, hot-plug
+// follows the same lazy-create rule as initial warm-up.
 void OverlayService::ensureOsdScreenAddedConnected()
 {
     if (m_screenAddedConnected) {
@@ -47,6 +49,11 @@ void OverlayService::ensureOsdScreenAddedConnected()
     }
     connect(qGuiApp, &QGuiApplication::screenAdded, this, [this](QScreen* screen) {
         if (!m_notificationsWarmed) {
+            return;
+        }
+        const bool shadersOn = m_shaderRegistry && m_shaderRegistry->shadersEnabled();
+        const bool animationsOn = m_settings && m_settings->animationsEnabled();
+        if (!shadersOn && !animationsOn) {
             return;
         }
         auto* mgr2 = m_screenManager;
@@ -188,23 +195,46 @@ void OverlayService::wirePassiveShellSlots(const QString& screenId, PhosphorOver
 // Pre-create the per-screen passive overlay shell for every effective
 // screen the manager knows about, then mark notifications warmed and ensure
 // the screenAdded hot-plug hook is installed.
+//
+// Effects-disabled gate (Discussion #515): the sole purpose of the
+// prewarm is to prime the wl_surface map + RHI swapchain so the first
+// user-triggered slot show doesn't race the FBO capture used by
+// shader-exclusive transitions. When both shaders and animations are
+// disabled there is no transition to race - so we skip the prewarm
+// (and the screenAdded hot-plug hook follows the same skip rule).
+// Each slot consumer (snapassist / selector / osd / overlay) already
+// calls ensurePassiveShellFor on its show path, so the shell is still
+// created lazily on first use - it just isn't sitting on the wlr
+// OVERLAY layer composited over every frame for users who never wanted
+// the effects in the first place.
 void OverlayService::warmUpNotifications()
 {
+    const bool shadersOn = m_shaderRegistry && m_shaderRegistry->shadersEnabled();
+    const bool animationsOn = m_settings && m_settings->animationsEnabled();
+    const bool effectsEnabled = shadersOn || animationsOn;
+
     const QStringList effectiveIds = (m_screenManager ? m_screenManager->effectiveScreenIds() : QStringList());
     int createdCount = 0;
-    for (const QString& sid : effectiveIds) {
-        QScreen* physScreen = m_screenManager ? m_screenManager->physicalScreenFor(sid).qscreen
-                                              : Utils::findScreenAtPosition(QPoint(0, 0));
-        if (physScreen) {
-            auto* state = ensurePassiveShellFor(sid, physScreen);
-            if (state && state->shell && state->shell->shellSurface()) {
-                ++createdCount;
+    if (effectsEnabled) {
+        for (const QString& sid : effectiveIds) {
+            QScreen* physScreen = m_screenManager ? m_screenManager->physicalScreenFor(sid).qscreen
+                                                  : Utils::findScreenAtPosition(QPoint(0, 0));
+            if (physScreen) {
+                auto* state = ensurePassiveShellFor(sid, physScreen);
+                if (state && state->shell && state->shell->shellSurface()) {
+                    ++createdCount;
+                }
             }
         }
     }
     m_notificationsWarmed = true;
-    qCInfo(lcOverlay) << "Pre-warmed passive overlay shell windows for" << createdCount << "of" << effectiveIds.size()
-                      << "effective screens";
+    if (effectsEnabled) {
+        qCInfo(lcOverlay) << "Pre-warmed passive overlay shell windows for" << createdCount << "of"
+                          << effectiveIds.size() << "effective screens";
+    } else {
+        qCInfo(lcOverlay) << "Skipping passive overlay shell prewarm: shaders and animations both disabled"
+                          << "(" << effectiveIds.size() << "effective screens; lazy-create on first slot show)";
+    }
     ensureOsdScreenAddedConnected();
 }
 

--- a/src/daemon/overlayservice/shellhost_bridge.cpp
+++ b/src/daemon/overlayservice/shellhost_bridge.cpp
@@ -39,9 +39,10 @@ namespace PlasmaZones {
 // the OSD path is ready by the time the user fires their first
 // hot-plug-induced shortcut. The m_notificationsWarmed flag gates
 // whether new screens get a per-screen passive overlay shell after
-// the initial warm-up. The effects-disabled gate (Discussion #515)
-// also applies here - if shaders + animations are both off, hot-plug
-// follows the same lazy-create rule as initial warm-up.
+// the initial warm-up; the effects-enabled predicate (shaders ||
+// animations) applies the same lazy-create rule as the warm-up
+// sweep, so hot-plug never proactively creates an always-on overlay
+// surface when no transition needs the warm cache.
 void OverlayService::ensureOsdScreenAddedConnected()
 {
     if (m_screenAddedConnected) {
@@ -193,20 +194,19 @@ void OverlayService::wirePassiveShellSlots(const QString& screenId, PhosphorOver
 }
 
 // Pre-create the per-screen passive overlay shell for every effective
-// screen the manager knows about, then mark notifications warmed and ensure
-// the screenAdded hot-plug hook is installed.
+// screen the manager knows about, then mark notifications warmed and
+// ensure the screenAdded hot-plug hook is installed.
 //
-// Effects-disabled gate (Discussion #515): the sole purpose of the
-// prewarm is to prime the wl_surface map + RHI swapchain so the first
-// user-triggered slot show doesn't race the FBO capture used by
-// shader-exclusive transitions. When both shaders and animations are
-// disabled there is no transition to race - so we skip the prewarm
-// (and the screenAdded hot-plug hook follows the same skip rule).
-// Each slot consumer (snapassist / selector / osd / overlay) already
-// calls ensurePassiveShellFor on its show path, so the shell is still
+// Effects-enabled gate: the sole purpose of the prewarm is to prime
+// the wl_surface map + RHI swapchain so the first user-triggered slot
+// show does not race the FBO capture used by shader-exclusive
+// transitions. When both shaders and animations are disabled there is
+// no transition to race, so the prewarm sweep is skipped (the
+// screenAdded hot-plug hook follows the same rule). Each slot
+// consumer (snapassist / selector / osd / overlay) calls
+// ensurePassiveShellFor on its show path, so the shell is still
 // created lazily on first use - it just isn't sitting on the wlr
-// OVERLAY layer composited over every frame for users who never wanted
-// the effects in the first place.
+// OVERLAY layer composited over every frame when no slot is up.
 void OverlayService::warmUpNotifications()
 {
     const bool shadersOn = m_shaderRegistry && m_shaderRegistry->shadersEnabled();
@@ -304,21 +304,16 @@ void OverlayService::syncPassiveShellSurfaceState(const QString& effectiveId)
     auto isVisible = [](QQuickItem* item) {
         return item != nullptr && item->isVisible();
     };
-    // Main overlay slot stays setVisible(true) across drag-pause idles
-    // (setIdleForDragPause / applyIdleStateForCursor) so the warm RHI
-    // pipeline survives mid-drag trigger thrashing. During those idles
-    // the slot's `_idled` property is true and the inner content's
-    // `visible: !root._idled` binding makes the rendered subtree invisible
-    // - but the slot Item itself stays Qt-visible. Treat `_idled` slots
-    // as not visible for the surface-show predicate.
-    auto isMainOverlayLive = [](QQuickItem* slot) {
-        if (!slot || !slot->isVisible()) {
-            return false;
-        }
-        return !slot->property("_idled").toBool();
-    };
+    // anyVisible drives the wl_surface map/unmap edge. The main overlay
+    // slot stays setVisible(true) for the entire drag (even across
+    // modifier-trigger drag pauses set by setIdleForDragPause, which
+    // only flip the slot's `_idled` property to blank the rendered
+    // content) so a mid-drag trigger thrash does not churn the shell's
+    // wl_surface map state. The slot transitions to !isVisible only on
+    // real drag-end via dismissOverlayWindow - that is the right edge
+    // for the shell to actually unmap when no other slot is up.
     const bool anyVisible = isVisible(s.osdSlot()) || isVisible(s.snapAssistSlot()) || isVisible(s.layoutPickerSlot())
-        || isVisible(s.zoneSelectorSlot()) || isMainOverlayLive(s.mainOverlaySlot());
+        || isVisible(s.zoneSelectorSlot()) || isVisible(s.mainOverlaySlot());
     const bool anyInputGrabbing = isVisible(s.snapAssistSlot()) || isVisible(s.layoutPickerSlot());
 
     m_shellHost->syncSurfaceState(effectiveId, anyVisible, anyInputGrabbing);


### PR DESCRIPTION
## Summary

Discussion [#515](https://github.com/fuddlesworth/PlasmaZones/discussions/515): reporter has shaders + animations both disabled and sees visual artifacts / flicker when moving any window, with KDE's "Translucency while moving" desktop effect not being respected. Reporter confirmed disabling KDE's Translucency stops the flicker, proving the moving toplevel is being composited *under* PZ's overlay surface instead of through it.

Root cause: `OverlayService::warmUpNotifications` creates a fullscreen wlr `OVERLAY` layer-shell surface per screen at startup and keeps it mapped for the daemon's lifetime (Phase-5 `keepMappedOnHide=true`), even when all slots are idle. For users with no visual effects enabled, this surface has no reason to exist and ends up masking KWin's translucency effect + exposing hybrid-GPU composition bugs (reporter is on NVIDIA 595 + Intel).

Two-phase fix on this branch:

- **Phase 1 (`6d027c9f`)**: gate the prewarm sweep in `warmUpNotifications` (and the `screenAdded` hot-plug hook) on `shaders || animations`. Slot consumers (snapassist / selector / osd / overlay) already call `ensurePassiveShellFor` on their show path, so the shell is created lazily on first use.
- **Phase 2 (`eb16eb02`)**: gate `keepMappedOnHide` on the same predicate in `createWarmedOsdSurface`, and add the symmetric `!anyVisible && isLogicallyShown() → hide()` branch in `ShellHost::syncSurfaceState`. For effects-off consumers `hide()` now actually unmaps the wl_surface each time all slots go idle, instead of just flipping click-through. Effects-on consumers keep the existing Phase-5 keep-mapped lifecycle exactly as before — they paid for shaders and get the warm cache.

The shell surface's role (`PzRoles::PassiveShell`) has no registered animator `Config`, so `Surface::hide()`'s internal `cancel` / `beginHide` calls collapse to no-ops on this surface — per-slot animator state lives on different keys and is untouched. Header doc + inline comment block on `syncSurfaceState` (which previously documented why `hide()` was deliberately avoided) are updated.

Same shared architectural root as the #461 cluster (PRs #517 / #518) — those patched FFM / kind-match consequences of the always-on overlay; this patches the rendering consequence.

## Test plan

- [x] `cmake --build build --parallel` — clean
- [x] `ctest --output-on-failure` — 189/189 passed
- [ ] Reporter (or maintainer) confirms flicker is gone with Translucency desktop effect still enabled, shaders + animations both off
- [ ] Smoke test with shaders **on** to confirm the keep-mapped path is unchanged (warm cache preserved, no regression in first-show latency for shader transitions)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)