### PR TITLE
fix: FFM pause while excluded window active + prune exclusion-listed pending restores (discussion #461)

### DIFF
--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -60,10 +60,10 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
     if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
         if (!PlasmaZonesEffect::isOwnOverlayClass(active->windowClass())
             && m_effect->getWindowScreenId(active) == screenId) {
-            // Filter first, size check second — mirrors the under-cursor
-            // guard below so the two predicates stay structurally aligned
-            // and the cheap-to-skip min-size check is only paid when the
-            // active window is otherwise tileable.
+            // Filter first, then size-check. This mirrors the under-cursor
+            // guard below so the two predicates stay structurally aligned.
+            // The cheap-to-skip min-size check is only paid when the active
+            // window is otherwise tileable.
             if (!m_effect->isTileableWindow(active) || !m_effect->shouldHandleWindow(active)) {
                 return;
             }

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -46,6 +46,30 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
         return;
     }
 
+    // Pause focus-follows-mouse while the currently active window is one we
+    // would refuse to focus via FFM anyway: excluded app, dialog, popup,
+    // keep-above overlay, or a window below the min-size threshold. Without
+    // this, the user opens an emoji picker or notification inside a zone,
+    // moves the cursor across the underlying tiled window's visible area, and
+    // FFM activates that tiled window first, sending the just-opened popup
+    // straight to the background (discussion #461 item 3 follow-up).
+    // Resumes naturally on the next cursor move once a tileable window is
+    // active (e.g. the user clicks one). Scoped to the same screen as the
+    // cursor so an unrelated focused window on another monitor never freezes
+    // FFM here.
+    if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
+        if (!PlasmaZonesEffect::isOwnOverlayClass(active->windowClass())
+            && m_effect->getWindowScreenId(active) == screenId) {
+            const QRectF aframe = active->frameGeometry();
+            const bool belowMinSize =
+                (m_effect->m_cachedMinWindowWidth > 0 && aframe.width() < m_effect->m_cachedMinWindowWidth)
+                || (m_effect->m_cachedMinWindowHeight > 0 && aframe.height() < m_effect->m_cachedMinWindowHeight);
+            if (!m_effect->isTileableWindow(active) || !m_effect->shouldHandleWindow(active) || belowMinSize) {
+                return;
+            }
+        }
+    }
+
     // Find the topmost autotile-managed window under the cursor.
     // Iterate stacking order in reverse (top → bottom).
     const auto windows = KWin::effects->stackingOrder();

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -60,11 +60,16 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
     if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
         if (!PlasmaZonesEffect::isOwnOverlayClass(active->windowClass())
             && m_effect->getWindowScreenId(active) == screenId) {
+            // Filter first, size check second — mirrors the under-cursor
+            // guard below so the two predicates stay structurally aligned
+            // and the cheap-to-skip min-size check is only paid when the
+            // active window is otherwise tileable.
+            if (!m_effect->isTileableWindow(active) || !m_effect->shouldHandleWindow(active)) {
+                return;
+            }
             const QRectF aframe = active->frameGeometry();
-            const bool belowMinSize =
-                (m_effect->m_cachedMinWindowWidth > 0 && aframe.width() < m_effect->m_cachedMinWindowWidth)
-                || (m_effect->m_cachedMinWindowHeight > 0 && aframe.height() < m_effect->m_cachedMinWindowHeight);
-            if (!m_effect->isTileableWindow(active) || !m_effect->shouldHandleWindow(active) || belowMinSize) {
+            if ((m_effect->m_cachedMinWindowWidth > 0 && aframe.width() < m_effect->m_cachedMinWindowWidth)
+                || (m_effect->m_cachedMinWindowHeight > 0 && aframe.height() < m_effect->m_cachedMinWindowHeight)) {
                 return;
             }
         }

--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -54,9 +54,8 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
     // FFM activates that tiled window first, sending the just-opened popup
     // straight to the background (discussion #461 item 3 follow-up).
     // Resumes naturally on the next cursor move once a tileable window is
-    // active (e.g. the user clicks one). Scoped to the same screen as the
-    // cursor so an unrelated focused window on another monitor never freezes
-    // FFM here.
+    // active. Scoped to the same screen as the cursor so an unrelated focused
+    // window on another monitor never freezes FFM here.
     if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
         if (!PlasmaZonesEffect::isOwnOverlayClass(active->windowClass())
             && m_effect->getWindowScreenId(active) == screenId) {

--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -484,26 +484,30 @@ public:
      *        pattern.
      *
      * The snap engine already refuses to honor a pending restore for an
-     * excluded app at runtime (see resolveWindowRestore in
-     * phosphor-snap-engine/lifecycle.cpp), so the entries are functionally
-     * dead. They still live on disk in PendingRestoreQueues until the next
-     * save cycle, generating one "pending snap:" log line per entry at every
-     * daemon startup and bloating session state with values that can never
-     * be replayed. This method walks the queues, removes appIds that match
-     * any pattern via PhosphorIdentity::WindowId::appIdMatches (the same
-     * predicate the engine uses), and marks DirtyPendingRestores when any
-     * removal happened so the next debounced save persists the pruned set.
+     * excluded app at runtime. See resolveWindowRestore in
+     * phosphor-snap-engine/lifecycle.cpp. So the entries are functionally
+     * dead, yet they still live on disk in PendingRestoreQueues until the
+     * next save cycle. Their persistence generates one "pending snap:" log
+     * line per entry at every daemon startup, and bloats session state
+     * with values that can never be replayed. This method walks the queues
+     * and removes appIds that match any pattern via
+     * PhosphorIdentity::WindowId::appIdMatches. That is the same predicate
+     * the snap engine itself uses. When any removal happens it marks
+     * DirtyPendingRestores so the next debounced save persists the pruned
+     * set.
      *
-     * Called from the daemon adaptor at startup (after loadState) and on
-     * every excludedApplicationsChanged / excludedWindowClassesChanged
-     * signal, so freshly excluded apps don't strand their old queues.
+     * Called from the daemon adaptor at startup right after loadState.
+     * Also called on every excludedApplicationsChanged or
+     * excludedWindowClassesChanged signal so freshly excluded apps don't
+     * strand their old queues.
      *
      * @param exclusionPatterns combined list of excludedApplications and
-     *                          excludedWindowClasses entries; empty
+     *                          excludedWindowClasses entries. Empty
      *                          patterns and an empty list are no-ops.
-     * @return number of appId entries fully removed (the queue may have
-     *         contained multiple PendingRestores for one appId; one removal
-     *         counts once, mirroring m_pendingRestoreQueues' QHash shape).
+     * @return number of appId entries fully removed. The queue may have
+     *         contained multiple PendingRestores for one appId. One
+     *         removal counts once. This mirrors the shape of
+     *         m_pendingRestoreQueues' QHash.
      */
     int pruneExcludedPendingRestores(const QStringList& exclusionPatterns);
 

--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -479,6 +479,34 @@ public:
      */
     bool consumePendingAssignment(const QString& windowId) override;
 
+    /**
+     * @brief Drop pending-restore queues whose appId matches any exclusion
+     *        pattern.
+     *
+     * The snap engine already refuses to honor a pending restore for an
+     * excluded app at runtime (see resolveWindowRestore in
+     * phosphor-snap-engine/lifecycle.cpp), so the entries are functionally
+     * dead. They still live on disk in PendingRestoreQueues until the next
+     * save cycle, generating one "pending snap:" log line per entry at every
+     * daemon startup and bloating session state with values that can never
+     * be replayed. This method walks the queues, removes appIds that match
+     * any pattern via PhosphorIdentity::WindowId::appIdMatches (the same
+     * predicate the engine uses), and marks DirtyPendingRestores when any
+     * removal happened so the next debounced save persists the pruned set.
+     *
+     * Called from the daemon adaptor at startup (after loadState) and on
+     * every excludedApplicationsChanged / excludedWindowClassesChanged
+     * signal, so freshly excluded apps don't strand their old queues.
+     *
+     * @param exclusionPatterns combined list of excludedApplications and
+     *                          excludedWindowClasses entries; empty
+     *                          patterns and an empty list are no-ops.
+     * @return number of appId entries fully removed (the queue may have
+     *         contained multiple PendingRestores for one appId; one removal
+     *         counts once, mirroring m_pendingRestoreQueues' QHash shape).
+     */
+    int pruneExcludedPendingRestores(const QStringList& exclusionPatterns);
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Navigation Helpers
     // ═══════════════════════════════════════════════════════════════════════════

--- a/libs/phosphor-placement/src/snap.cpp
+++ b/libs/phosphor-placement/src/snap.cpp
@@ -101,4 +101,37 @@ bool WindowTrackingService::consumePendingAssignment(const QString& windowId)
     return true;
 }
 
+int WindowTrackingService::pruneExcludedPendingRestores(const QStringList& exclusionPatterns)
+{
+    if (exclusionPatterns.isEmpty() || m_pendingRestoreQueues.isEmpty()) {
+        return 0;
+    }
+    int removed = 0;
+    for (auto it = m_pendingRestoreQueues.begin(); it != m_pendingRestoreQueues.end();) {
+        const QString& appId = it.key();
+        bool matched = false;
+        for (const QString& pattern : exclusionPatterns) {
+            if (pattern.isEmpty()) {
+                continue;
+            }
+            if (PhosphorIdentity::WindowId::appIdMatches(appId, pattern)) {
+                matched = true;
+                break;
+            }
+        }
+        if (matched) {
+            qCInfo(lcPlacement) << "Pruning pending-restore queue for excluded appId:" << appId << "("
+                                << it.value().size() << "entries)";
+            it = m_pendingRestoreQueues.erase(it);
+            ++removed;
+        } else {
+            ++it;
+        }
+    }
+    if (removed > 0) {
+        markDirty(DirtyPendingRestores);
+    }
+    return removed;
+}
+
 } // namespace PhosphorPlacement

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -480,19 +480,21 @@ public:
      * so the disk-pruning verdict here matches what the runtime would already do.
      *
      * The existing ShouldPersistRestorePredicate filters entries by disabled
-     * (screen, desktop, activity) context but is blind to the exclusion-list
-     * axis, so entries authored before the user excluded an app remain on disk
-     * and bloat AutotilePendingRestores until the next save with this method
-     * called in between.
+     * context across screen, desktop, and activity but is blind to the
+     * exclusion-list axis. Entries authored before the user excluded an app
+     * remain on disk and bloat AutotilePendingRestores until this method
+     * runs at the next save.
      *
-     * Settings-agnostic by design (LGPL boundary): the engine takes plain
-     * patterns and does NOT mark dirty. The WTA caller wraps this and calls
-     * service()->markDirty(DirtyAutotilePending) when the return value is > 0
-     * so the next debounced save persists the prune.
+     * The engine is settings-agnostic by design to keep the LGPL boundary
+     * clean. It takes plain patterns and does NOT mark dirty. The WTA caller
+     * wraps this and calls service()->markDirty(DirtyAutotilePending) when
+     * the return value is greater than zero, so the next debounced save
+     * persists the prune.
      *
      * @param exclusionPatterns combined list of excludedApplications and
-     *                          excludedWindowClasses entries; empty patterns
-     *                          are skipped, an empty list is a no-op.
+     *                          excludedWindowClasses entries. Empty
+     *                          patterns are skipped. An empty list is a
+     *                          no-op.
      * @return number of appId entries fully removed.
      */
     int pruneExcludedPendingRestores(const QStringList& exclusionPatterns);

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -471,6 +471,32 @@ public:
     void deserializePendingRestores(const QJsonObject& obj) override;
 
     /**
+     * @brief Drop pending-restore queues whose appId matches any exclusion pattern.
+     *
+     * Mirror of PhosphorPlacement::WindowTrackingService::pruneExcludedPendingRestores
+     * for the autotile side. Patterns are compared via
+     * PhosphorIdentity::WindowId::appIdMatches — the same predicate the snap
+     * engine uses to gate runtime restores against the user's exclusion lists.
+     *
+     * The existing ShouldPersistRestorePredicate filters entries by disabled
+     * (screen, desktop, activity) context but is blind to the exclusion-list
+     * axis, so entries authored before the user excluded an app remain on disk
+     * and bloat AutotilePendingRestores until the next save with this method
+     * called in between.
+     *
+     * Settings-agnostic by design (LGPL boundary): the engine takes plain
+     * patterns and does NOT mark dirty. The WTA caller wraps this and calls
+     * service()->markDirty(DirtyAutotilePending) when the return value is > 0
+     * so the next debounced save persists the prune.
+     *
+     * @param exclusionPatterns combined list of excludedApplications and
+     *                          excludedWindowClasses entries; empty patterns
+     *                          are skipped, an empty list is a no-op.
+     * @return number of appId entries fully removed.
+     */
+    int pruneExcludedPendingRestores(const QStringList& exclusionPatterns);
+
+    /**
      * @brief Predicate consulted before persisting or honoring a pending restore.
      *
      * Returns true to keep the entry, false to drop it. Mirrors the snap-side

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -475,8 +475,9 @@ public:
      *
      * Mirror of PhosphorPlacement::WindowTrackingService::pruneExcludedPendingRestores
      * for the autotile side. Patterns are compared via
-     * PhosphorIdentity::WindowId::appIdMatches — the same predicate the snap
-     * engine uses to gate runtime restores against the user's exclusion lists.
+     * PhosphorIdentity::WindowId::appIdMatches. The snap engine uses the same
+     * predicate when it gates runtime restores against the user's exclusion lists,
+     * so the disk-pruning verdict here matches what the runtime would already do.
      *
      * The existing ShouldPersistRestorePredicate filters entries by disabled
      * (screen, desktop, activity) context but is blind to the exclusion-list

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -1555,6 +1555,37 @@ void AutotileEngine::deserializePendingRestores(const QJsonObject& queuesObj)
     qCInfo(PhosphorTileEngine::lcTileEngine) << "Autotile pending restores: loaded" << restoredEntries << "entries";
 }
 
+int AutotileEngine::pruneExcludedPendingRestores(const QStringList& exclusionPatterns)
+{
+    if (exclusionPatterns.isEmpty() || m_pendingAutotileRestores.isEmpty()) {
+        return 0;
+    }
+    int removed = 0;
+    for (auto it = m_pendingAutotileRestores.begin(); it != m_pendingAutotileRestores.end();) {
+        const QString& appId = it.key();
+        bool matched = false;
+        for (const QString& pattern : exclusionPatterns) {
+            if (pattern.isEmpty()) {
+                continue;
+            }
+            if (PhosphorIdentity::WindowId::appIdMatches(appId, pattern)) {
+                matched = true;
+                break;
+            }
+        }
+        if (matched) {
+            qCInfo(PhosphorTileEngine::lcTileEngine)
+                << "Pruning autotile pending-restore queue for excluded appId:" << appId << "(" << it.value().size()
+                << "entries)";
+            it = m_pendingAutotileRestores.erase(it);
+            ++removed;
+        } else {
+            ++it;
+        }
+    }
+    return removed;
+}
+
 void AutotileEngine::scheduleRetileForScreen(const QString& screenId)
 {
     m_pendingRetileScreens.insert(screenId);

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -714,6 +714,16 @@ void Daemon::finalizeStartup()
         m_autotileEngine->loadState();
     }
 
+    // Now that AutotileEngine::loadState has deserialized m_pendingAutotileRestores,
+    // re-run the exclusion-list prune so any persisted entries for apps the user has
+    // since excluded are dropped here too. WTA's constructor already pruned the snap
+    // side; this call also touches the autotile queues that didn't exist at constructor
+    // time. The same prune is invoked live on excludedApplicationsChanged /
+    // excludedWindowClassesChanged via the WTA constructor's signal hookups.
+    if (m_windowTrackingAdaptor) {
+        m_windowTrackingAdaptor->pruneExcludedPendingRestoresFromSettings();
+    }
+
     // Signal that daemon is fully initialized and ready for queries
     Q_EMIT m_layoutAdaptor->daemonReady();
 

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -717,9 +717,9 @@ void Daemon::finalizeStartup()
     // Now that AutotileEngine::loadState has deserialized m_pendingAutotileRestores,
     // re-run the exclusion-list prune so any persisted entries for apps the user has
     // since excluded are dropped here too. WTA's constructor already pruned the snap
-    // side; this call also touches the autotile queues that didn't exist at constructor
-    // time. The same prune is invoked live on excludedApplicationsChanged /
-    // excludedWindowClassesChanged via the WTA constructor's signal hookups.
+    // side. This call also touches the autotile queues that didn't exist at
+    // constructor time. The same prune is invoked live on excludedApplicationsChanged
+    // or excludedWindowClassesChanged via the WTA constructor's signal hookups.
     if (m_windowTrackingAdaptor) {
         m_windowTrackingAdaptor->pruneExcludedPendingRestoresFromSettings();
     }

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -167,6 +167,20 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(PhosphorZones::LayoutRegistry* layo
     // Load persisted window tracking state from previous session
     loadState();
 
+    // Prune any pending-restore queues for appIds that are now on the user's
+    // exclusion list. Snap-engine's resolveWindowRestore already refuses to
+    // honor them at runtime, but they live on disk until pruned and spam one
+    // "pending snap:" log line per entry at every startup. One-shot at boot
+    // catches entries authored before the user added the class to exclusions;
+    // the signal hookups cover live additions for the running session. The
+    // autotile-side prune happens again from the daemon's finalizeStartup
+    // after AutotileEngine::loadState populates m_pendingAutotileRestores.
+    pruneExcludedPendingRestoresFromSettings();
+    connect(m_settings, &ISettings::excludedApplicationsChanged, this,
+            &WindowTrackingAdaptor::pruneExcludedPendingRestoresFromSettings);
+    connect(m_settings, &ISettings::excludedWindowClassesChanged, this,
+            &WindowTrackingAdaptor::pruneExcludedPendingRestoresFromSettings);
+
     // If we have pending restores but missed activeLayoutChanged (layout was set before we
     // connected), set the flag so tryEmitPendingRestoresAvailable will emit when panel
     // geometry is ready. Fixes daemon restart: windows that were snapped before stop
@@ -223,6 +237,40 @@ void WindowTrackingAdaptor::setTilingPendingRestoreDelegates(std::function<QJson
 {
     m_serializePendingRestoresFn = std::move(serializeFn);
     m_deserializePendingRestoresFn = std::move(deserializeFn);
+}
+
+void WindowTrackingAdaptor::pruneExcludedPendingRestoresFromSettings()
+{
+    if (!m_settings) {
+        return;
+    }
+    QStringList patterns = m_settings->excludedApplications();
+    patterns += m_settings->excludedWindowClasses();
+    if (patterns.isEmpty()) {
+        return;
+    }
+
+    int snapRemoved = 0;
+    if (m_service) {
+        snapRemoved = m_service->pruneExcludedPendingRestores(patterns);
+    }
+
+    int autotileRemoved = 0;
+    if (auto* autotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(m_autotileEngine.data())) {
+        autotileRemoved = autotile->pruneExcludedPendingRestores(patterns);
+        // The engine is settings-agnostic and does NOT mark dirty itself —
+        // flip the autotile-pending bit on WTS so the next debounced save
+        // rewrites AutotilePendingRestores. Mirror of what
+        // pruneExcludedPendingRestores does internally on the snap side.
+        if (autotileRemoved > 0 && m_service) {
+            m_service->markDirty(PhosphorPlacement::WindowTrackingService::DirtyAutotilePending);
+        }
+    }
+
+    if (snapRemoved > 0 || autotileRemoved > 0) {
+        qCInfo(lcDbusWindow) << "Pruned pending-restore queues for excluded apps — snap:" << snapRemoved
+                             << "autotile:" << autotileRemoved;
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -171,8 +171,8 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(PhosphorZones::LayoutRegistry* layo
     // exclusion list. Snap-engine's resolveWindowRestore already refuses to
     // honor them at runtime, but they live on disk until pruned and spam one
     // "pending snap:" log line per entry at every startup. One-shot at boot
-    // catches entries authored before the user added the class to exclusions;
-    // the signal hookups cover live additions for the running session. The
+    // catches entries authored before the user added the class to exclusions.
+    // The signal hookups cover live additions for the running session. The
     // autotile-side prune happens again from the daemon's finalizeStartup
     // after AutotileEngine::loadState populates m_pendingAutotileRestores.
     pruneExcludedPendingRestoresFromSettings();

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -258,18 +258,18 @@ void WindowTrackingAdaptor::pruneExcludedPendingRestoresFromSettings()
     int autotileRemoved = 0;
     if (auto* autotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(m_autotileEngine.data())) {
         autotileRemoved = autotile->pruneExcludedPendingRestores(patterns);
-        // The engine is settings-agnostic and does NOT mark dirty itself —
-        // flip the autotile-pending bit on WTS so the next debounced save
-        // rewrites AutotilePendingRestores. Mirror of what
-        // pruneExcludedPendingRestores does internally on the snap side.
+        // The engine is settings-agnostic and does NOT mark dirty itself.
+        // Flip the autotile-pending bit on WTS so the next debounced save
+        // rewrites AutotilePendingRestores. The snap-side
+        // pruneExcludedPendingRestores method does this internally.
         if (autotileRemoved > 0 && m_service) {
             m_service->markDirty(PhosphorPlacement::WindowTrackingService::DirtyAutotilePending);
         }
     }
 
     if (snapRemoved > 0 || autotileRemoved > 0) {
-        qCInfo(lcDbusWindow) << "Pruned pending-restore queues for excluded apps — snap:" << snapRemoved
-                             << "autotile:" << autotileRemoved;
+        qCInfo(lcDbusWindow) << "Pruned pending-restore queues for excluded apps. snap" << snapRemoved << "autotile"
+                             << autotileRemoved;
     }
 }
 

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -562,7 +562,7 @@ public Q_SLOTS:
      *
      * Reads the current snap-side exclusion lists from m_settings, combines
      * them, and asks both engines to walk their pending-restore queues and
-     * remove any appId matching a pattern. Marks DirtyPendingRestores /
+     * remove any appId matching a pattern. Marks DirtyPendingRestores or
      * DirtyAutotilePending as appropriate so the next debounced save persists
      * the pruned state.
      *

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -558,6 +558,27 @@ public Q_SLOTS:
     void loadState();
 
     /**
+     * @brief Drop pending-restore queues (snap + autotile) for excluded appIds.
+     *
+     * Reads the current snap-side exclusion lists from m_settings, combines
+     * them, and asks both engines to walk their pending-restore queues and
+     * remove any appId matching a pattern. Marks DirtyPendingRestores /
+     * DirtyAutotilePending as appropriate so the next debounced save persists
+     * the pruned state.
+     *
+     * Called from:
+     *   - WTA's own constructor (after loadState — snap queues populated, autotile not yet),
+     *   - the excludedApplicationsChanged / excludedWindowClassesChanged signal handlers wired
+     *     in the constructor,
+     *   - the daemon's finalizeStartup after AutotileEngine::loadState runs, so the
+     *     autotile-side queue (deserialized into the engine inside loadState) is also pruned.
+     *
+     * Safe to call before either engine is wired — engines that are missing
+     * simply contribute zero removals.
+     */
+    void pruneExcludedPendingRestoresFromSettings();
+
+    /**
      * @brief Emit reapplyWindowGeometriesRequested (called by daemon after geometry settles)
      *
      * Not a D-Bus method; used internally so the daemon timer can trigger the signal.

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -558,7 +558,7 @@ public Q_SLOTS:
     void loadState();
 
     /**
-     * @brief Drop pending-restore queues (snap + autotile) for excluded appIds.
+     * @brief Drop snap and autotile pending-restore queues for excluded appIds.
      *
      * Reads the current snap-side exclusion lists from m_settings, combines
      * them, and asks both engines to walk their pending-restore queues and

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -566,15 +566,17 @@ public Q_SLOTS:
      * DirtyAutotilePending as appropriate so the next debounced save persists
      * the pruned state.
      *
-     * Called from:
-     *   - WTA's own constructor (after loadState — snap queues populated, autotile not yet),
-     *   - the excludedApplicationsChanged / excludedWindowClassesChanged signal handlers wired
-     *     in the constructor,
-     *   - the daemon's finalizeStartup after AutotileEngine::loadState runs, so the
-     *     autotile-side queue (deserialized into the engine inside loadState) is also pruned.
+     * Called from three sites.
+     *   1. WTA's own constructor, right after loadState. The snap queues are
+     *      populated by then but the autotile queue is not.
+     *   2. The excludedApplicationsChanged and excludedWindowClassesChanged signal
+     *      handlers wired in the constructor.
+     *   3. The daemon's finalizeStartup, after AutotileEngine::loadState runs. By
+     *      then the autotile queue has also been deserialized into the engine,
+     *      so it gets pruned too.
      *
-     * Safe to call before either engine is wired — engines that are missing
-     * simply contribute zero removals.
+     * Calling this before either engine is wired is safe. Engines that are
+     * missing contribute zero removals.
      */
     void pruneExcludedPendingRestoresFromSettings();
 


### PR DESCRIPTION
## Summary

Two follow-ups to discussion #461 that surfaced from krakerz's latest report + attached logs.

### 1. Pause focus-follows-mouse while an excluded window is active

3.0.10 stabilised FFM for the common case, but missed the scenario where an excluded popup (emoji picker, notification, krunner, etc.) is the active window inside a zone. Moving the cursor across the underlying tiled window's visible area would still activate that tile, sending the just-opened popup straight to the background. krakerz's logs show this cleanly: `Window activated: opera` immediately precedes every `windowClosed: org.kde.plasma.emojier` event on their HKC ultrawide.

The existing under-cursor guard in `AutotileHandler::handleCursorMoved` only inspects the window the cursor is over. New active-window guard at the top mirrors the same `isTileableWindow` / `shouldHandleWindow` / min-size predicates and short-circuits FFM while a non-tileable window has focus on the same screen as the cursor. Resumes naturally on the next cursor move once a tileable window becomes active (e.g. the user clicks one). Skips own-overlay class so the editor never freezes FFM. Scoped to same-screen so a focused popup on another monitor doesn't block FFM on this one.

### 2. Prune pending-restore queues for excluded apps from disk

`resolveWindowRestore` (snap) and `ShouldPersistRestorePredicate` (autotile) already refuse to honor pending restores for excluded apps at runtime, but dead entries lived in `PendingRestoreQueues` / `AutotilePendingRestores` until pruned. Every daemon start logged one `pending snap:` line per stale entry (krakerz's log shows 9 for `steam`) and bloated `session.json`.

Add a parallel `pruneExcludedPendingRestores(QStringList)` on both engines. Both use `PhosphorIdentity::WindowId::appIdMatches` (the same predicate the runtime gates use). Snap-side marks `DirtyPendingRestores` internally; autotile-side stays settings-agnostic and lets the WTA caller flip `DirtyAutotilePending`.

`WindowTrackingAdaptor::pruneExcludedPendingRestoresFromSettings()` combines `excludedApplications + excludedWindowClasses` and drives both engines. Trigger points:

- WTA constructor after `loadState()` — catches stale snap entries.
- `excludedApplicationsChanged` / `excludedWindowClassesChanged` signal handlers — covers live additions for the running session.
- `Daemon::finalizeStartup()` right after `AutotileEngine::loadState()` — catches stale autotile entries (autotile queue isn't loaded yet at WTA-constructor time).

With krakerz's config (steam + abdownloadmanager + opensnitch_ui + gamescope all on the exclusion list), the next start emits one `Pruned pending-restore queues for excluded apps — snap: N autotile: M` line and writes a clean `session.json`.

## Test plan

- [x] All 189 unit tests pass (`ctest --output-on-failure`)
- [x] Build clean on KF6 / Qt6.11.1
- [ ] Manual reproduction of FFM scenario: open emoji picker over tiled window on autotile screen, sweep cursor across the tile's visible area — picker must stay foreground; clicking any tiled window resumes FFM
- [ ] Verify the `Pruned pending-restore queues for excluded apps` log line appears once at startup on a config with on-disk stale entries and that `session.json` is rewritten without those entries
- [ ] Verify live-add to exclusion list immediately prunes corresponding queues (no daemon restart needed)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)