### PR TITLE
fix(overlay): downgrade PassiveShell from Overlay to Top layer (issue #516)

### DIFF
--- a/src/daemon/overlayservice/pz_roles.h
+++ b/src/daemon/overlayservice/pz_roles.h
@@ -61,6 +61,16 @@ inline const PhosphorLayer::Role Osd = PhosphorShellPatterns::Hud().withScopePre
 /// is moot since per-content slots toggle visibility within the shared
 /// scene graph rather than the wl_surface itself unmapping.
 ///
+/// Layer downgrade from Overlay to Top is deliberate (issue #516). A
+/// fullscreen wlr Overlay-layer surface above the active toplevel masks
+/// KWin's Translucency-while-moving effect, and on hybrid Intel+NVIDIA
+/// systems forces a slower compositional path that produces visible drag
+/// artifacts and post-snap flicker. Top still draws the zone preview
+/// above normal toplevels (it is what KDE's own panel uses) but lets
+/// KWin keep the translucency render path and the fast composition
+/// route. Fullscreen apps on Overlay still draw above the zone preview,
+/// which is the correct behaviour anyway.
+///
 /// Each per-content slot is animated by the SurfaceAnimator keyed on
 /// (PassiveShell surface, slot QQuickItem). Per-content motion / shader
 /// configs are resolved via the role-override `beginShow`/`beginHide`
@@ -70,8 +80,9 @@ inline const PhosphorLayer::Role Osd = PhosphorShellPatterns::Hud().withScopePre
 ///
 /// See `PassiveOverlayShell.qml` for the QML side and the unified-shell
 /// migration commits for the per-consumer rewrite.
-inline const PhosphorLayer::Role PassiveShell =
-    PhosphorShellPatterns::Hud().withScopePrefix(QStringLiteral("plasmazones-passive-shell"));
+inline const PhosphorLayer::Role PassiveShell = PhosphorShellPatterns::Hud()
+                                                    .withLayer(PhosphorLayer::Layer::Top)
+                                                    .withScopePrefix(QStringLiteral("plasmazones-passive-shell"));
 
 /// Snap-assist config-only role. The wl_surface lifetime moved to the
 /// unified PassiveShell post-shell-migration; this role is preserved


### PR DESCRIPTION
## Summary

3.0.10 stopped the always-on prewarm and the idle-no-slots-mapped state of the PassiveShell so effects-off users no longer paid for a permanently composited wlr Overlay-layer wl_surface. The remaining gap that issue #516 reports is during the drag itself, when zone preview slots are live: the shell maps on the first dragMoved tick and stays mapped for the whole drag, on the Overlay layer, fullscreen.

A fullscreen Overlay-layer surface above the active toplevel masks KWin's Translucency-while-moving effect. KWin elides the translucency render path when something on Overlay is going to draw over the toplevel anyway. On hybrid Intel+NVIDIA setups it also forces a slower compositional path that produces the visible drag artifacts, post-snap flicker, and gray decoration ring the reporter (CachyOS, Plasma 6.6.5, NVIDIA 595) filmed in the issue's IMG20260523101118 attachment.

## The change

Downgrade the PassiveShell role from Overlay to Top in `src/daemon/overlayservice/pz_roles.h`. One added `.withLayer(PhosphorLayer::Layer::Top)` call on the role builder chain, plus a comment block citing the issue and the hybrid-GPU rationale.

The Hud pattern still supplies AnchorAll, click-through, no-keyboard, and an ignored exclusive zone. The only behavioural change is the wlr-layer-shell layer the shell sits on.

## Why Top is correct here

Top still draws the zone preview above normal toplevels. It is the same layer KDE's own panel uses. KWin's translucency effect coexists with Top-layer surfaces. Fullscreen apps on Overlay still draw above the zone preview on Top, which is the correct compositional ordering: a fullscreen video should not be obscured by a drag overlay.

## Test plan

- [x] All 189 unit tests pass (`ctest --output-on-failure`)
- [x] Clean build on KF6 / Qt 6.11.1
- [ ] Reporter retests on CachyOS + Plasma 6.6.5 + NVIDIA 595 hybrid. The three symptoms to verify are gone:
  1. KDE Translucency-while-moving effect is respected (set in System Settings → Desktop Effects).
  2. No visual artifacts during the move.
  3. No flickering once the window snaps.
  4. No gray decoration ring around the moving/snapped window.
- [ ] Zone preview still appears above all normal toplevels during a drag.
- [ ] A fullscreen video app correctly draws above the zone preview when the user drags another window.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)