### PR TITLE
fix(kwin-effect): pause FFM while floating/overflow window is active (discussion #461)

### DIFF
--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -66,6 +66,17 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
             if (!m_effect->isTileableWindow(active) || !m_effect->shouldHandleWindow(active)) {
                 return;
             }
+            // Also pause for floating active windows. FloatingCache covers
+            // both manually-floated windows and overflow windows that the
+            // daemon auto-floated past the maxWindows cap (applyFloatCleanup
+            // path). Either kind is perched on top of the tiled stack while
+            // the user works in it, so activating an underlying tiled window
+            // on cursor wander sends the floating one straight to the
+            // background — the same regression the excluded-active guard
+            // above fixes (discussion #461 follow-up).
+            if (m_effect->isWindowFloating(m_effect->getWindowId(active))) {
+                return;
+            }
             const QRectF aframe = active->frameGeometry();
             if ((m_effect->m_cachedMinWindowWidth > 0 && aframe.width() < m_effect->m_cachedMinWindowWidth)
                 || (m_effect->m_cachedMinWindowHeight > 0 && aframe.height() < m_effect->m_cachedMinWindowHeight)) {


### PR DESCRIPTION
## Summary
- Extends the existing FFM-pause-on-excluded-active guard in `AutotileHandler::handleCursorMoved` to also pause when the active window is floating
- `isWindowFloating()` (FloatingCache) covers **both** scenarios krakerz raised in [discussion #461 comment 17047873](https://github.com/fuddlesworth/PlasmaZones/discussions/461#discussioncomment-17047873): manually-floated windows AND overflow / extra-limit windows (the daemon auto-floats overflow via `applyFloatCleanup` in `kwin-effect/autotilehandler/tiling.cpp:113`), so one predicate handles both
- Mirrors the pattern shipped in PR #521 (3.0.11) for excluded windows; placement matches the cheap-first ordering established by audit pass commit `4267ed576`

## Why
A manually-floated window or an overflow window sits on top of the tiled stack while the user works in it. Moving the cursor across an underlying tiled window's visible edge currently steals focus away and sends the floating one straight to the background — same regression class the 3.0.11 excluded-window fix solved.

## Test plan
- [x] `cmake --build build --target kwin_effect_plasmazones` succeeds
- [x] `ctest` — 191/191 pass, including `test_floating_cache`, `test_autotile_engine_overflow`, `test_overflow_manager`
- [ ] Manual: open a floating window over a tiled stack, drag cursor across an underlying tiled window — floating window should stay focused
- [ ] Manual: spawn windows past `maxWindows` cap (Float overflow behaviour) — the overflow window should retain focus when the cursor wanders onto a tiled window
- [ ] Confirm the existing excluded-window FFM pause (3.0.11 behaviour) is unchanged
- [ ] Confirm FFM resumes naturally after clicking a tiled window