### PR TITLE
fix(kwin-effect): close screenAdded/Removed race in DPMS-wake autotile guard (#527)

### DIFF
--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -491,6 +491,22 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     // In KWin 6, use virtualScreenGeometryChanged (not per-screen signal)
     connect(KWin::effects, &KWin::EffectsHandler::virtualScreenGeometryChanged, m_screenChangeHandler.get(),
             &ScreenChangeHandler::slotScreenGeometryChanged);
+
+    // Discussion #527 follow-up: latch the screen-change flag the instant KWin
+    // tells us an output appeared or disappeared. KWin fires screenAdded /
+    // screenRemoved BEFORE the per-window outputChanged signals it emits for
+    // windows it reassigns as part of the layout change, so this beats the
+    // race where outputChanged would reach the autotile-delegation guard in
+    // window_lifecycle.cpp without isScreenChangeInProgress() set — and
+    // when KWin shifts a remaining monitor's x-offset on the second add
+    // (DPMS wake of a dual-monitor setup), oldScreenStillConnected returns
+    // true and is no help on its own. slotScreenLayoutChanged sets the same
+    // pending flag + debounce that virtualScreenGeometryChanged eventually
+    // would, so the existing settle path is unchanged once it catches up.
+    connect(KWin::effects, &KWin::EffectsHandler::screenAdded, m_screenChangeHandler.get(),
+            &ScreenChangeHandler::slotScreenLayoutChanged);
+    connect(KWin::effects, &KWin::EffectsHandler::screenRemoved, m_screenChangeHandler.get(),
+            &ScreenChangeHandler::slotScreenLayoutChanged);
     // Invalidate screen ID cache and refresh virtual screen definitions on screen changes
     // (connector names may be reassigned, physical screen geometry changes invalidate
     // virtual screen absolute geometry)

--- a/kwin-effect/screenchangehandler.cpp
+++ b/kwin-effect/screenchangehandler.cpp
@@ -119,6 +119,29 @@ void ScreenChangeHandler::applyScreenGeometryChange()
     fetchAndApplyWindowGeometries();
 }
 
+void ScreenChangeHandler::slotScreenLayoutChanged()
+{
+    // KWin emits screenAdded / screenRemoved before per-window outputChanged
+    // signals for windows it reassigns when an output appears or disappears.
+    // virtualScreenGeometryChanged — which the geometry-debounce slot above
+    // listens for — fires later in the same cascade, leaving a window where
+    // outputChanged can be processed with no screen-change flag set. The
+    // guard in PlasmaZonesEffect's outputChanged lambda (window_lifecycle.cpp)
+    // depends on isScreenChangeInProgress() to recognize involuntary moves
+    // when oldScreenStillConnected is true (DPMS-wake layout shift onto a
+    // monitor that simply moved to a new x-offset rather than disappearing),
+    // so latch the flag at the earliest point KWin tells us anything is
+    // happening to the output set.
+    m_pendingScreenChange = true;
+    m_screenChangeDebounce.start();
+
+    // A real layout change also moves panels — re-push the work area for the
+    // same reason slotScreenGeometryChanged does. Coalesces via the queued
+    // continuation, so a burst of screenAdded / screenRemoved + a trailing
+    // virtualScreenGeometryChanged collapse into one client-area report.
+    scheduleClientAreaReport();
+}
+
 void ScreenChangeHandler::slotReapplyWindowGeometriesRequested()
 {
     qCInfo(lcScreenChange) << "Daemon requested re-apply of window geometries (e.g. after panel editor close)";

--- a/kwin-effect/screenchangehandler.h
+++ b/kwin-effect/screenchangehandler.h
@@ -71,6 +71,17 @@ public Q_SLOTS:
     void slotScreenGeometryChanged();
     void slotReapplyWindowGeometriesRequested();
 
+    /// Latch the screen-change-in-progress flag as soon as KWin emits
+    /// screenAdded / screenRemoved, before the per-window outputChanged
+    /// signals it fires for windows reassigned by the layout change can
+    /// reach @ref isScreenChangeInProgress checks elsewhere. Closes the
+    /// race between outputChanged and virtualScreenGeometryChanged
+    /// (discussion #527 follow-up). The 500 ms debounce + client-area
+    /// report scheduling mirror @ref slotScreenGeometryChanged so the
+    /// usual settle path still runs once virtualScreenGeometryChanged
+    /// catches up.
+    void slotScreenLayoutChanged();
+
     /// Connected to `EffectsHandler::windowClosed` — schedules a work-area
     /// report when @p w is a panel (dock) so the strut it freed reaches the
     /// daemon. A no-op for non-dock windows.


### PR DESCRIPTION
## Summary

- Follow-up to #528 / 3.0.13. krakerz's testing in [discussion #527 comment-17069880](https://github.com/fuddlesworth/PlasmaZones/discussions/527#discussioncomment-17069880) shows the orphan-reassignment-into-autotile still fires intermittently on DPMS wake.
- Root cause is a signal-order race: KWin emits the per-window `outputChanged` before `virtualScreenGeometryChanged`, so when the orphan reaches the guard in `window_lifecycle.cpp` outputChanged lambda, `isScreenChangeInProgress()` is still false. When the second monitor's wake-up only *shifts* the first monitor's x-offset (no output is removed), `oldScreenStillConnected` is true and the autotile path runs.
- Fix: also wire `screenAdded` / `screenRemoved` — which fire *before* the per-window `outputChanged` they cause — into a new `ScreenChangeHandler::slotScreenLayoutChanged()` that latches `m_pendingScreenChange` and starts the existing 500ms debounce. Settle path is unchanged.

## Test plan

- [x] Build passes (`cmake --build build --parallel`)
- [x] All 184 unit tests pass (`ctest`)
- [ ] User (krakerz) re-runs the discussion-#527 repro on a 3.0.14 build with this patch — single-monitor wake, dual-monitor wake, varied mouse positions
- [ ] Verify normal "Move to Screen" shortcut still routes through the snapping/autotile paths (involuntaryMove stays false when no screen actually changed)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)