### PR TITLE
chore(release): bump version to 3.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.14] - 2026-05-27
+
+### Fixed
+
+- **DPMS-wake autotile orphan reassignment still triggered intermittently** ([#527](https://github.com/fuddlesworth/PlasmaZones/discussions/527), [#536](https://github.com/fuddlesworth/PlasmaZones/pull/536)): 3.0.13 closed the dropped-monitor case but missed the dual-monitor wake-up where the second output coming back simply shifts the first output's x-offset. With no output actually removed, `oldScreenStillConnected` stayed true, and `isScreenChangeInProgress()` hadn't flipped on yet because KWin emits the per-window `outputChanged` *before* the `virtualScreenGeometryChanged` that the screen-change debounce listens for — the orphan reached the autotile-delegation guard with both legs of the check false. `screenAdded` and `screenRemoved` are now also wired into the screen-change handler, latching the pending-change flag at the earliest point KWin tells us the output set is changing. The settle path that runs once `virtualScreenGeometryChanged` catches up is unchanged.
+
 ## [3.0.13] - 2026-05-26
 
 ### Fixed
@@ -1425,7 +1431,8 @@ Initial packaged release. Wayland-only (X11 support removed). Requires KDE Plasm
 - Session restoration and rotation after login ([#66])
 - Window tracking: snap/restore behavior, zone clearing, startup timing, rotation zone ID matching, floating window exclusion ([#67])
 
-[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.13...HEAD
+[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.14...HEAD
+[3.0.14]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.13...v3.0.14
 [3.0.13]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.12...v3.0.13
 [3.0.12]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.11...v3.0.12
 [3.0.11]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.10...v3.0.11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(PlasmaZones VERSION 3.0.13 LANGUAGES C CXX)
+project(PlasmaZones VERSION 3.0.14 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/data/whatsnew.json
+++ b/data/whatsnew.json
@@ -1,6 +1,13 @@
 {
     "releases": [
         {
+            "version": "3.0.14",
+            "date": "2026-05-27",
+            "highlights": [
+                "Fixed intermittent DPMS-wake autotile orphan reassignment on dual-monitor setups — KWin's screenAdded/screenRemoved signals now latch the screen-change-in-progress flag early enough to catch the per-window outputChanged race (#527, #536)"
+            ]
+        },
+        {
             "version": "3.0.13",
             "date": "2026-05-26",
             "highlights": [


### PR DESCRIPTION
## Summary

- Releases the discussion-#527 follow-up shipped in #536 (`fix(kwin-effect): latch screen-change flag on screenAdded/screenRemoved`).
- Bumps `CMakeLists.txt`, `CHANGELOG.md` (new section + footer ref), and `data/whatsnew.json`.

## Test plan

- [x] Build clean (`cmake --build build --parallel`)
- [x] Tests pass (`ctest`) on the merged main + bump
- [ ] Tag and publish `v3.0.14` after merge

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)