### PR TITLE
feat(window-rule): animate row expansion + THEN pill + thinner tree guides

### DIFF
--- a/src/settings/qml/ActionListView.qml
+++ b/src/settings/qml/ActionListView.qml
@@ -257,7 +257,11 @@ ColumnLayout {
                 // Per-parameter LABEL + value pill pairs. First param's
                 // label sits at the same absolute x as WHEN's operator
                 // column (because the type-label minWidth above
-                // matches WHEN's depth-1 field width).
+                // matches WHEN's depth-1 field width). Subsequent params
+                // (`index > 0`) drop the 8 gridUnit floor and flow at
+                // their text width so a short label like "SHADER EFFECT"
+                // doesn't push its value pill into dead space — see the
+                // index-gated `Layout.minimumWidth` on the inner Label.
                 Repeater {
                     model: actionDelegate._params
 

--- a/src/settings/qml/ActionListView.qml
+++ b/src/settings/qml/ActionListView.qml
@@ -47,7 +47,9 @@ ColumnLayout {
     /// look like one consistent tree visualisation.
     readonly property real _indentStep: Kirigami.Units.gridUnit * 1.5
     readonly property color _guideColor: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.75)
-    readonly property int _guideThickness: Math.max(2, Math.round(Screen.devicePixelRatio * 1.5))
+    // 1 physical pixel — matches MatchExpressionView's revised guide
+    // thickness. See the rationale comment there.
+    readonly property int _guideThickness: Math.max(1, Math.round(Screen.devicePixelRatio))
 
     /// Look up the `{ value, label, params }` entry for a wire type
     /// string, or null when the type isn't in the registry.

--- a/src/settings/qml/ActionListView.qml
+++ b/src/settings/qml/ActionListView.qml
@@ -265,12 +265,23 @@ ColumnLayout {
                         id: paramRow
 
                         required property var modelData
+                        required property int index
 
                         spacing: Kirigami.Units.largeSpacing
 
                         Label {
                             Layout.alignment: Qt.AlignVCenter
-                            Layout.minimumWidth: Kirigami.Units.gridUnit * 8
+                            // First param keeps the 8-gridUnit floor so its
+                            // value pill lands in the same column as WHEN's
+                            // value pills (visual alignment with the operator
+                            // column above). Subsequent params shrink to
+                            // their text width — leaving the 8 gu floor on
+                            // every param turned the gap between a short
+                            // label like "SHADER EFFECT" and its value pill
+                            // into dead space because the label box itself
+                            // padded out to 8 gu before the largeSpacing to
+                            // the pill kicked in.
+                            Layout.minimumWidth: paramRow.index === 0 ? Kirigami.Units.gridUnit * 8 : 0
                             text: paramRow.modelData.label
                             font.capitalization: Font.AllUppercase
                             font.pointSize: Kirigami.Theme.smallFont.pointSize

--- a/src/settings/qml/MatchExpressionView.qml
+++ b/src/settings/qml/MatchExpressionView.qml
@@ -225,17 +225,16 @@ ColumnLayout {
             /// closer to the intended affordance than another low-alpha
             /// attempt — they should read as tree lines, not whispers.
             readonly property color _guideColor: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.75)
-            /// Solid 2px lines on every dpr. Math.max(2, ...) so even on
-            /// non-hidpi the stroke is two physical pixels — single-pixel
-            /// strokes disappear into anti-aliased edges on dark
-            /// surfaces.
-            // 1 physical pixel — the prior `Math.max(2, Math.round(Screen
-            // .devicePixelRatio * 1.5))` was tuned against the broken
-            // `Kirigami.Units.devicePixelRatio` (which evaluated to NaN and
-            // fell through to the floor of 2). Once the underlying ratio
-            // started returning the real value, the `* 1.5` made the
-            // connectors noticeably thicker than the original visual
-            // baseline. Same one-physical-pixel hairline as borders.
+            /// One-physical-pixel hairline (`Math.max(1, ...)` so even when
+            /// devicePixelRatio rounds to zero we still draw something).
+            /// Matches the rest of the chrome's hairline conventions —
+            /// borders, separators, hover strokes. The earlier
+            /// `Math.max(2, Math.round(... * 1.5))` shape was tuned against
+            /// the broken `Kirigami.Units.devicePixelRatio` (which evaluated
+            /// to NaN and fell through to the floor of 2); once the
+            /// underlying ratio started returning the real value the
+            /// `* 1.5` made the connectors noticeably thicker than the
+            /// original visual baseline.
             readonly property int _guideThickness: Math.max(1, Math.round(Screen.devicePixelRatio))
 
             // Size delegate to the tree's available width so the

--- a/src/settings/qml/MatchExpressionView.qml
+++ b/src/settings/qml/MatchExpressionView.qml
@@ -229,7 +229,14 @@ ColumnLayout {
             /// non-hidpi the stroke is two physical pixels — single-pixel
             /// strokes disappear into anti-aliased edges on dark
             /// surfaces.
-            readonly property int _guideThickness: Math.max(2, Math.round(Screen.devicePixelRatio * 1.5))
+            // 1 physical pixel — the prior `Math.max(2, Math.round(Screen
+            // .devicePixelRatio * 1.5))` was tuned against the broken
+            // `Kirigami.Units.devicePixelRatio` (which evaluated to NaN and
+            // fell through to the floor of 2). Once the underlying ratio
+            // started returning the real value, the `* 1.5` made the
+            // connectors noticeably thicker than the original visual
+            // baseline. Same one-physical-pixel hairline as borders.
+            readonly property int _guideThickness: Math.max(1, Math.round(Screen.devicePixelRatio))
 
             // Size delegate to the tree's available width so the
             // rightmost spacer pushes content into a clean column.

--- a/src/settings/qml/WindowRuleRow.qml
+++ b/src/settings/qml/WindowRuleRow.qml
@@ -421,7 +421,13 @@ ItemDelegate {
                     Layout.alignment: Qt.AlignLeft
                     Layout.topMargin: Kirigami.Units.smallSpacing
                     implicitWidth: thenLabel.implicitWidth + Kirigami.Units.largeSpacing * 2
-                    implicitHeight: thenLabel.implicitHeight + Kirigami.Units.smallSpacing
+                    // `smallSpacing * 2` matches the ALL/ANY/NONE pills in
+                    // MatchExpressionView so the THEN header and the WHEN
+                    // group pills carry the same vertical weight — both pill
+                    // styles use highlightColor-family tints + 0.4 fill + 0.9
+                    // border, and the matching padding keeps them readable
+                    // as one design.
+                    implicitHeight: thenLabel.implicitHeight + Kirigami.Units.smallSpacing * 2
                     radius: implicitHeight / 2
                     color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.4)
                     border.width: Math.max(1, Math.round(Screen.devicePixelRatio))

--- a/src/settings/qml/WindowRuleRow.qml
+++ b/src/settings/qml/WindowRuleRow.qml
@@ -4,6 +4,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Window
 import org.kde.kirigami as Kirigami
 import org.phosphor.animation
 import org.plasmazones.settings
@@ -80,9 +81,9 @@ ItemDelegate {
     /// and the expansion is a peek, not a persistent view mode).
     property bool expanded: false
 
-    signal editRequested()
-    signal duplicateRequested()
-    signal deleteRequested()
+    signal editRequested
+    signal duplicateRequested
+    signal deleteRequested
     // Parameter named `ruleEnabled` for symmetry with the `ruleEnabled`
     // property — using the bare name `enabled` would shadow the row's own
     // `enabled` in any handler that relies on implicit-argument scope.
@@ -102,7 +103,6 @@ ItemDelegate {
     onClicked: {
         if (row.expandable)
             row.expanded = !row.expanded;
-
     }
 
     contentItem: ColumnLayout {
@@ -123,7 +123,7 @@ ItemDelegate {
                 Layout.alignment: Qt.AlignVCenter
                 checked: row.ruleEnabled
                 accessibleName: row.ruleEnabled ? i18n("Disable rule %1", row.ruleName) : i18n("Enable rule %1", row.ruleName)
-                onToggled: function(newValue) {
+                onToggled: function (newValue) {
                     row.toggleRequested(newValue);
                 }
             }
@@ -146,7 +146,6 @@ ItemDelegate {
                 HoverHandler {
                     id: warningHover
                 }
-
             }
 
             ColumnLayout {
@@ -168,7 +167,6 @@ ItemDelegate {
                     elide: Text.ElideRight
                     visible: row.ruleName.length > 0
                 }
-
             }
 
             // "Composite" badge — paired with the conditions count for composite
@@ -195,7 +193,6 @@ ItemDelegate {
                     font.pointSize: Kirigami.Theme.smallFont.pointSize
                     opacity: 0.7
                 }
-
             }
 
             // Condition-count badge for composite rules.
@@ -215,7 +212,6 @@ ItemDelegate {
                     font.pointSize: Kirigami.Theme.smallFont.pointSize
                     opacity: 0.7
                 }
-
             }
 
             // Action-count badge — shown for rules carrying more than one action.
@@ -235,7 +231,6 @@ ItemDelegate {
                     font.pointSize: Kirigami.Theme.smallFont.pointSize
                     opacity: 0.7
                 }
-
             }
 
             // Priority badge — sits with the other metadata badges (Composite,
@@ -261,7 +256,6 @@ ItemDelegate {
                     font.pointSize: Kirigami.Theme.smallFont.pointSize
                     opacity: 0.7
                 }
-
             }
 
             // Doubles as the expand-state indicator: rotates 90° clockwise when
@@ -283,9 +277,7 @@ ItemDelegate {
                         profile: "widget.hover"
                         durationOverride: Kirigami.Units.shortDuration
                     }
-
                 }
-
             }
 
             // Action summary — wraps to two lines before eliding so multi-action
@@ -334,30 +326,76 @@ ItemDelegate {
                 Accessible.name: i18n("Delete rule %1", row.ruleName)
                 onClicked: row.deleteRequested()
             }
-
         }
         // ── Expansion area ───────────────────────────────────────────────
 
-        // Lazy-loaded read-only preview of the rule's full match tree.
-        // `active` gates instantiation on the row actually being expanded
-        // — collapsed rows pay zero cost. The controller's `ruleJson`
-        // returns a deep copy of the rule, so the View walks its own data
-        // and a controller-side mutation won't yank the tree mid-render.
-        Loader {
+        // Clipped container that animates the expansion in/out instead of
+        // snapping height between 0 and the full body. Mirrors SettingsCard's
+        // expand/collapse pattern: clip:true keeps the loaded body from
+        // bleeding above the row during the height interpolation, and
+        // PhosphorMotionAnimation on `Layout.preferredHeight` + `opacity`
+        // hands the timing off to the project's motion profile (so
+        // animation-speed and reduce-motion preferences propagate without
+        // a hardcoded duration). The Loader stays `active` for one extra
+        // animation cycle when collapsing so the body can fade out
+        // gracefully instead of being torn down mid-transition.
+        Item {
+            id: expansionClip
+
+            // `_active` lags `row.expanded` through the collapse animation by
+            // also gating on `Layout.preferredHeight > 0` — Qt's animation
+            // updates the height property directly during the transition,
+            // so the value is positive while interpolating from full→0 and
+            // only reaches 0 when the animation lands. Without this lag the
+            // Loader would unload synchronously on collapse-start and the
+            // user would see the viewport blank before the height finished
+            // shrinking. Re-expanding mid-collapse keeps the Loader active
+            // (no reload thrash) because the height never reaches 0.
+            property bool _active: row.expandable && row.controller !== null && (row.expanded || Layout.preferredHeight > 0)
+
             Layout.fillWidth: true
             Layout.leftMargin: Kirigami.Units.gridUnit * 2
-            Layout.bottomMargin: row.expanded ? Kirigami.Units.smallSpacing : 0
-            active: row.expandable && row.expanded && row.controller !== null
-            visible: active
-            sourceComponent: expansionComponent
+            Layout.preferredHeight: row.expanded ? expansionLoader.implicitHeight + Kirigami.Units.smallSpacing : 0
+            clip: true
+            opacity: row.expanded ? 1 : 0
+            visible: Layout.preferredHeight > 0 || opacity > 0
+
+            Behavior on Layout.preferredHeight {
+                PhosphorMotionAnimation {
+                    profile: row.expanded ? "widget.accordionExpand" : "widget.accordionCollapse"
+                    durationOverride: Kirigami.Units.shortDuration
+                }
+            }
+
+            Behavior on opacity {
+                PhosphorMotionAnimation {
+                    profile: row.expanded ? "widget.fadeIn" : "widget.fadeOut"
+                    durationOverride: Kirigami.Units.veryShortDuration * 2
+                }
+            }
+
+            // Lazy-loaded read-only preview of the rule's full match tree.
+            // `active` gates instantiation on the row actually being expanded
+            // — collapsed rows pay zero cost. The controller's `ruleJson`
+            // returns a deep copy of the rule, so the View walks its own data
+            // and a controller-side mutation won't yank the tree mid-render.
+            Loader {
+                id: expansionLoader
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                active: expansionClip._active
+                visible: active
+                sourceComponent: expansionComponent
+            }
         }
 
         Component {
             id: expansionComponent
 
             ColumnLayout {
-                readonly property var _ruleJson: row.controller ? row.controller.ruleJson(row.ruleId) : ({
-                })
+                readonly property var _ruleJson: row.controller ? row.controller.ruleJson(row.ruleId) : ({})
 
                 spacing: Kirigami.Units.smallSpacing
 
@@ -372,20 +410,33 @@ ItemDelegate {
                 MatchExpressionView {
                     Layout.fillWidth: true
                     matchJson: parent._ruleJson.match || ({
-                        "all": []
-                    })
+                            "all": []
+                        })
                     controller: row.controller
                     matchFieldOptions: row.matchFieldOptions
                     appSettings: row.appSettings
                 }
 
-                Label {
-                    text: i18n("THEN")
-                    font.bold: true
-                    opacity: 0.7
-                    font.capitalization: Font.AllUppercase
-                    font.pointSize: Kirigami.Theme.smallFont.pointSize
+                Rectangle {
+                    Layout.alignment: Qt.AlignLeft
                     Layout.topMargin: Kirigami.Units.smallSpacing
+                    implicitWidth: thenLabel.implicitWidth + Kirigami.Units.largeSpacing * 2
+                    implicitHeight: thenLabel.implicitHeight + Kirigami.Units.smallSpacing
+                    radius: implicitHeight / 2
+                    color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.4)
+                    border.width: Math.max(1, Math.round(Screen.devicePixelRatio))
+                    border.color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.9)
+
+                    Label {
+                        id: thenLabel
+
+                        anchors.centerIn: parent
+                        text: i18n("THEN")
+                        font.bold: true
+                        font.capitalization: Font.AllUppercase
+                        font.pointSize: Kirigami.Theme.smallFont.pointSize
+                        color: Kirigami.Theme.textColor
+                    }
                 }
 
                 ActionListView {
@@ -394,11 +445,7 @@ ItemDelegate {
                     actionTypeOptions: row.actionTypeOptions
                     appSettings: row.appSettings
                 }
-
             }
-
         }
-
     }
-
 }


### PR DESCRIPTION
## Summary

- Animate the rule-row expansion/collapse (`Layout.preferredHeight` + `opacity` via `PhosphorMotionAnimation`, direction-bound on `row.expanded`; Loader survives the collapse through `(expanded || preferredHeight > 0)` so the body fades out gracefully).
- Style the `THEN` section header as a highlight-blue capsule pill so the boundary reads cleanly on dark themes (it was a bare uppercase label that fell into the expansion surface).
- Drop the WHEN/THEN tree-guide thickness from `Math.max(2, Math.round(dpr * 1.5))` back to `Math.max(1, Math.round(dpr))`. The `* 1.5` and the floor of 2 were tuned against the broken `Kirigami.Units.devicePixelRatio` (which evaluated to NaN); once #533 made the ratio real, the guides got visibly thicker than the original baseline — this restores the 1-physical-pixel hairline.

## Test plan
- [ ] Open Settings → Window Rules, expand a composite rule, confirm the expansion animates smoothly (no pop, no blank-viewport flash).
- [ ] Collapse mid-animation by re-clicking the row — no Loader reload thrash.
- [ ] The `THEN` header now reads as a distinct blue capsule pill alongside `Float window` / `Override animation shader`.
- [ ] WHEN/THEN tree connectors are hairlines again (1 px on standard DPI, 2 px on HiDPI).
- [ ] All other badges, pills, and chrome unchanged from v3.1 baseline (Composite / Conditions / Actions / Priority badges and the WHEN / value pills).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)