### PR TITLE
fix(zone-selector): stop hover-driven layout switches during snap-assist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
     branches: [main, develop, v3]
   pull_request:
     branches: [main, v3]
+  # `workflow_dispatch` so we can hand-fire the draft-arch packaging job
+  # against an arbitrary ref (e.g. a back-ported hot-fix branch that
+  # isn't yet in a PR). The build / lint / nix jobs ignore this trigger
+  # because they're keyed off PR file diffs and push events.
+  workflow_dispatch:
 
 # Default workflow token is read-only; jobs that need writes opt in.
 permissions:
@@ -234,3 +239,332 @@ jobs:
 
       - name: Verify devShell
         run: nix develop -c echo "devShell OK"
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # Draft Arch Package (PR builds)
+  # ─────────────────────────────────────────────────────────────────────────
+  # On every PR (and on hand-fired workflow_dispatch), build a .pkg.tar.zst
+  # from the PR head and publish:
+  #   1) the built package (artifact `arch-draft-package`)
+  #   2) a hand-off PKGBUILD that pulls the PR branch via `git+#branch=…`
+  #      so testers without binary trust can `makepkg -si` instead
+  #      (artifact `arch-draft-pkgbuild`)
+  #   3) a sticky PR comment with one-line install commands for both paths
+  #
+  # The package uses pkgname=plasmazones-pr with provides+conflicts on
+  # plasmazones, so a tester can swap between any PR build and the stable
+  # release with a single `pacman -U` / `pacman -S plasmazones` round-trip.
+  # Version derives from the upstream pkgver + PR number + commit count +
+  # short SHA so successive force-pushes to the same PR sort monotonically.
+  # ═══════════════════════════════════════════════════════════════════════════
+  build-arch-draft:
+    name: Draft Arch package
+    # Skips other event types (push to main, scheduled, etc). pull_request
+    # covers branch updates on the PR head; workflow_dispatch covers manual
+    # ad-hoc builds against any ref.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    container:
+      image: archlinux:latest
+    permissions:
+      contents: read
+      # Required so the sticky-comment step at the end can post / edit the
+      # comment on the PR. No other write surfaces are needed.
+      pull-requests: write
+
+    steps:
+      - name: Setup build environment
+        run: |
+          set -euo pipefail
+          # Full -Syu to avoid partial-upgrade state (same reasoning as
+          # the `build` job above).
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm --needed \
+            base-devel git sudo namcap \
+            cmake ninja extra-cmake-modules \
+            qt6-base qt6-declarative qt6-tools qt6-shadertools qt6-svg \
+            qt6-wayland wayland \
+            kwin \
+            kconfig kconfigwidgets kcmutils kglobalaccel kirigami \
+            plasma-activities \
+            vulkan-headers vulkan-icd-loader
+
+          # makepkg refuses to run as root.
+          useradd -m builder
+          echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history so pkgver() can do `git rev-list --count HEAD`
+          # and produce a sortable version.
+          fetch-depth: 0
+          # On PRs, default checkout is the synthetic merge ref. We want
+          # the PR head commit so the draft package mirrors what a tester
+          # would clone from the branch.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Resolve build metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+          CMAKE_VER=$(sed -n 's/^project(PlasmaZones VERSION \([^ )]*\).*/\1/p' CMakeLists.txt)
+          : "${CMAKE_VER:=0.0.0}"
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          # workflow_dispatch has no PR number — fall back to "ref" tag
+          # so the version still sorts but is recognisable as a manual run.
+          : "${PR_NUMBER:=manual}"
+
+          BRANCH_REF="${{ github.head_ref || github.ref_name }}"
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          COMMIT_COUNT=$(git rev-list --count HEAD)
+          # pkgver schema: <cmake>.pr<num>.r<count>.g<sha>
+          # Sorts above plain <cmake> stable (more dot-components) and
+          # monotonically across force-pushes (count + sha bump).
+          PKGVER="${CMAKE_VER}.pr${PR_NUMBER}.r${COMMIT_COUNT}.g${SHORT_SHA}"
+
+          # KWin pin must match the version available in the build env so
+          # the kwin-effect plugin's IID matches the tester's KWin at
+          # install time. CI's Arch image always has the latest, which is
+          # also what most rolling-release testers will have.
+          KWIN_VER=$(pacman -Q kwin | awk '{print $2}' | cut -d- -f1)
+
+          {
+            echo "pkgver=$PKGVER"
+            echo "pr_number=$PR_NUMBER"
+            echo "branch_ref=$BRANCH_REF"
+            echo "short_sha=$SHORT_SHA"
+            echo "kwin_ver=$KWIN_VER"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Building plasmazones-pr $PKGVER against KWin $KWIN_VER"
+
+      - name: Generate draft PKGBUILD (local-source, CI build)
+        # The PKGBUILD makepkg consumes inside CI builds from the
+        # already-checked-out tree so we don't pay a second clone. Mirrors
+        # release.yml's PKGBUILD.ci pattern but with the PR-aware pkgname,
+        # version, and provides/conflicts so a tester can install on top
+        # of stable cleanly.
+        run: |
+          set -euo pipefail
+          mkdir -p ci-pkgbuild
+          cat > ci-pkgbuild/PKGBUILD <<'PKGBUILD_EOF'
+          # PlasmaZones draft build — generated by .github/workflows/ci.yml
+          # SPDX-FileCopyrightText: 2026 fuddlesworth
+          # SPDX-License-Identifier: GPL-3.0-or-later
+          pkgname=plasmazones-pr
+          pkgver=__PKGVER__
+          pkgrel=1
+          pkgdesc="PlasmaZones — draft build for PR #__PR_NUMBER__ (__BRANCH__@__SHORT_SHA__)"
+          arch=('x86_64')
+          url="https://github.com/fuddlesworth/PlasmaZones"
+          license=('GPL-3.0-or-later' 'LGPL-2.1-or-later')
+          depends=(
+              'qt6-base' 'qt6-declarative' 'qt6-shadertools' 'qt6-svg'
+              'kconfig' 'kconfigwidgets' 'kirigami'
+              'kcmutils' 'kglobalaccel' 'qt6-wayland'
+              "kwin=__KWIN_VER__"
+          )
+          makedepends=('cmake' 'extra-cmake-modules' 'qt6-tools' 'ninja')
+          optdepends=('plasma-activities: activity-based layouts')
+          provides=("plasmazones=$pkgver")
+          conflicts=('plasmazones' 'plasmazones-git' 'plasmazones-bin')
+          source=()
+          sha256sums=()
+          install=plasmazones.install
+
+          build() {
+              cd "$startdir/.."
+              cmake -B build -G Ninja \
+                  -DCMAKE_BUILD_TYPE=Release \
+                  -DCMAKE_INSTALL_PREFIX=/usr \
+                  -DCMAKE_INSTALL_LIBDIR=lib \
+                  -DBUILD_TESTING=OFF \
+                  -Wno-dev
+              cmake --build build --parallel
+          }
+
+          package() {
+              cd "$startdir/.."
+              DESTDIR="$pkgdir" cmake --install build
+              install -Dm644 packaging/arch/kbuildsycoca.hook \
+                  "$pkgdir/usr/share/libalpm/hooks/plasmazones-kbuildsycoca.hook"
+              install -Dm755 packaging/arch/plasmazones-refresh-sycoca \
+                  "$pkgdir/usr/share/libalpm/scripts/plasmazones-refresh-sycoca"
+              install -Dm644 LICENSE        "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+              install -Dm644 COPYING.LESSER "$pkgdir/usr/share/licenses/$pkgname/COPYING.LESSER"
+          }
+          PKGBUILD_EOF
+
+          # Substitute the placeholders out-of-band (heredoc 'EOF' is
+          # quoted to keep $startdir / $pkgdir literal for makepkg).
+          sed -i \
+              -e "s|__PKGVER__|${{ steps.meta.outputs.pkgver }}|" \
+              -e "s|__PR_NUMBER__|${{ steps.meta.outputs.pr_number }}|" \
+              -e "s|__BRANCH__|${{ steps.meta.outputs.branch_ref }}|" \
+              -e "s|__SHORT_SHA__|${{ steps.meta.outputs.short_sha }}|" \
+              -e "s|__KWIN_VER__|${{ steps.meta.outputs.kwin_ver }}|" \
+              ci-pkgbuild/PKGBUILD
+
+          # The pacman install hook is reused verbatim from the stable
+          # packaging tree.
+          cp packaging/arch/plasmazones.install ci-pkgbuild/
+
+      - name: Build .pkg.tar.zst
+        run: |
+          set -euo pipefail
+          chown -R builder:builder .
+          cd ci-pkgbuild
+          su builder -c "makepkg --noconfirm -sf"
+          mv ./*.pkg.tar.zst ../
+        # Surfaces non-zero exit from makepkg (e.g. cmake failure inside
+        # build()) as a job failure rather than silently producing no
+        # artifact.
+
+      - name: namcap validation
+        # Non-fatal — namcap warnings (e.g. about unrecognised licence
+        # strings or missing changelog entries on a draft build) shouldn't
+        # block the artifact, but we surface them in the job log.
+        continue-on-error: true
+        run: namcap ./*.pkg.tar.zst
+
+      - name: Generate hand-off PKGBUILD (git-source, for makepkg users)
+        # Companion PKGBUILD that pulls the PR branch directly via
+        # `git+…#branch=…`. Anyone who doesn't trust the prebuilt binary
+        # can drop this + plasmazones.install into a folder and
+        # `makepkg -si` to build from source. The pkgver() function
+        # produces a sortable version on every rebuild so a later
+        # force-push to the PR re-installs cleanly.
+        run: |
+          set -euo pipefail
+          mkdir -p draft-pkgbuild
+          BRANCH="${{ steps.meta.outputs.branch_ref }}"
+          cat > draft-pkgbuild/PKGBUILD <<PKGBUILD_EOF
+          # PlasmaZones — draft build for PR #${{ steps.meta.outputs.pr_number }}
+          # Pulls the branch directly from GitHub. To rebuild against new
+          # commits on the branch, run \`makepkg -fC -si\` in this folder.
+          # SPDX-FileCopyrightText: 2026 fuddlesworth
+          # SPDX-License-Identifier: GPL-3.0-or-later
+          pkgname=plasmazones-pr
+          # pkgver() overwrites this on every build — placeholder must
+          # already sort above the canonical stable release so a shallow
+          # clone that breaks describe still upgrades cleanly.
+          pkgver=${{ steps.meta.outputs.pkgver }}
+          pkgrel=1
+          pkgdesc="PlasmaZones — draft build for PR #${{ steps.meta.outputs.pr_number }} (${BRANCH})"
+          arch=('x86_64')
+          url="https://github.com/fuddlesworth/PlasmaZones"
+          license=('GPL-3.0-or-later' 'LGPL-2.1-or-later')
+          _kwin_ver=\$(pacman -Q kwin 2>/dev/null | awk '{print \$2}' | cut -d- -f1)
+          depends=(
+              'qt6-base' 'qt6-declarative' 'qt6-shadertools' 'qt6-svg'
+              'kconfig' 'kconfigwidgets' 'kirigami'
+              'kcmutils' 'kglobalaccel' 'qt6-wayland'
+              "kwin\${_kwin_ver:+=}\${_kwin_ver}"
+          )
+          makedepends=('git' 'cmake' 'extra-cmake-modules' 'qt6-tools' 'ninja' 'kwin' 'wayland')
+          optdepends=('plasma-activities: activity-based layouts')
+          provides=("plasmazones=\$pkgver")
+          conflicts=('plasmazones' 'plasmazones-git' 'plasmazones-bin')
+          source=("\$pkgname::git+\$url.git#branch=${BRANCH}")
+          sha256sums=('SKIP')
+          install=plasmazones.install
+
+          pkgver() {
+              cd "\$pkgname"
+              local cmake_version describe
+              cmake_version=\$(sed -n 's/^project(PlasmaZones VERSION \([^ )]*\).*/\1/p' CMakeLists.txt)
+              : "\${cmake_version:=0.0.0}"
+              if describe=\$(git describe --long --tags 2>/dev/null) && [[ -n "\$describe" ]]; then
+                  printf '%s\n' "\$describe" | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+              else
+                  printf "%s.pr${{ steps.meta.outputs.pr_number }}.r%s.g%s" "\$cmake_version" "\$(git rev-list --count HEAD)" "\$(git rev-parse --short HEAD)"
+              fi
+          }
+
+          build() {
+              cmake -B build -S "\$pkgname" -G Ninja \\
+                  -DCMAKE_BUILD_TYPE=Release \\
+                  -DCMAKE_INSTALL_PREFIX=/usr \\
+                  -DCMAKE_INSTALL_LIBDIR=lib \\
+                  -DBUILD_TESTING=OFF -Wno-dev
+              cmake --build build --parallel
+          }
+
+          package() {
+              DESTDIR="\$pkgdir" cmake --install build
+              install -Dm644 "\$pkgname/packaging/arch/kbuildsycoca.hook" \\
+                  "\$pkgdir/usr/share/libalpm/hooks/plasmazones-kbuildsycoca.hook"
+              install -Dm755 "\$pkgname/packaging/arch/plasmazones-refresh-sycoca" \\
+                  "\$pkgdir/usr/share/libalpm/scripts/plasmazones-refresh-sycoca"
+              install -Dm644 "\$pkgname/LICENSE"        "\$pkgdir/usr/share/licenses/\$pkgname/LICENSE"
+              install -Dm644 "\$pkgname/COPYING.LESSER" "\$pkgdir/usr/share/licenses/\$pkgname/COPYING.LESSER"
+          }
+          PKGBUILD_EOF
+          cp packaging/arch/plasmazones.install draft-pkgbuild/
+
+      - name: Upload .pkg.tar.zst
+        uses: actions/upload-artifact@v7
+        with:
+          name: arch-draft-package
+          path: plasmazones-pr-*.pkg.tar.zst
+          # 14 days is enough for any reviewer to grab a binary; the next
+          # push to the PR re-builds anyway.
+          retention-days: 14
+
+      - name: Upload hand-off PKGBUILD
+        uses: actions/upload-artifact@v7
+        with:
+          name: arch-draft-pkgbuild
+          path: draft-pkgbuild/
+          retention-days: 14
+
+      - name: Post sticky PR comment with install instructions
+        # Only for PR events — workflow_dispatch has no PR to comment on.
+        if: github.event_name == 'pull_request'
+        # marocchino/sticky-pull-request-comment v3.0.4 — SHA-pinned for
+        # the same supply-chain reason ccache-action is pinned above.
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+        with:
+          # `header` keys the sticky comment so re-runs update in place
+          # instead of stacking new comments per build.
+          header: arch-draft-build
+          message: |
+            ### Draft Arch build for this PR
+
+            **Built against:** KWin `${{ steps.meta.outputs.kwin_ver }}` • commit [`${{ steps.meta.outputs.short_sha }}`](${{ github.event.pull_request.head.repo.html_url }}/commit/${{ github.event.pull_request.head.sha }}) • run [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            **`pkgname=plasmazones-pr` `pkgver=${{ steps.meta.outputs.pkgver }}`** — provides+conflicts with `plasmazones`, so it cleanly replaces a stable install. Roll back with `sudo pacman -S plasmazones` (or `-git` / `-bin`).
+
+            ---
+
+            #### Option A — prebuilt binary (KWin `${{ steps.meta.outputs.kwin_ver }}` only)
+
+            The kwin-effect plugin's IID embeds KWin's upstream version, so this prebuilt only loads on systems with **`kwin=${{ steps.meta.outputs.kwin_ver }}`**.
+
+            1. Download **`arch-draft-package`** from [the run's artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) and extract the `.pkg.tar.zst`.
+            2. Install:
+               ```
+               sudo pacman -U plasmazones-pr-*.pkg.tar.zst
+               systemctl --user restart plasmazones.service
+               kwin_wayland --replace &   # or just log out / back in
+               ```
+
+            #### Option B — rebuild from source (any KWin)
+
+            1. Download **`arch-draft-pkgbuild`** from [the run's artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) and extract.
+            2. `cd` into the folder and:
+               ```
+               makepkg -si
+               systemctl --user restart plasmazones.service
+               kwin_wayland --replace &
+               ```
+               The PKGBUILD git-clones this PR branch and rebuilds locally, so the KWin pin auto-matches your installed version.
+
+            ---
+
+            <sub>Posted by `.github/workflows/ci.yml` → `build-arch-draft`. Each push to this PR rebuilds and updates this comment in place.</sub>
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,26 +545,39 @@ jobs:
 
             The kwin-effect plugin's IID embeds KWin's upstream version, so this prebuilt only loads on systems with **`kwin=${{ steps.meta.outputs.kwin_ver }}`**.
 
-            1. Download **`arch-draft-package`** from [the run's artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) and extract the `.pkg.tar.zst`.
-            2. Install:
-               ```
-               sudo pacman -U plasmazones-pr-*.pkg.tar.zst
-               systemctl --user restart plasmazones.service
-               kwin_wayland --replace &   # or just log out / back in
-               ```
+            **Anonymous download (no GitHub account needed)** via [nightly.link](https://nightly.link/), which proxies the workflow artifact:
+
+            - <https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/arch-draft-package.zip>
+
+            Or, signed in to GitHub, grab `arch-draft-package` directly from [the run's artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts).
+
+            Then:
+            ```
+            unzip arch-draft-package.zip
+            sudo pacman -U plasmazones-pr-*.pkg.tar.zst
+            systemctl --user restart plasmazones.service
+            kwin_wayland --replace &   # or just log out / back in
+            ```
 
             #### Option B — rebuild from source (any KWin)
 
-            1. Download **`arch-draft-pkgbuild`** from [the run's artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts) and extract.
-            2. `cd` into the folder and:
-               ```
-               makepkg -si
-               systemctl --user restart plasmazones.service
-               kwin_wayland --replace &
-               ```
-               The PKGBUILD git-clones this PR branch and rebuilds locally, so the KWin pin auto-matches your installed version.
+            Anonymous download via nightly.link:
+
+            - <https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/arch-draft-pkgbuild.zip>
+
+            Or, signed in: `arch-draft-pkgbuild` from the [run's artifacts](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts).
+
+            Then:
+            ```
+            unzip arch-draft-pkgbuild.zip -d plasmazones-pr-draft
+            cd plasmazones-pr-draft
+            makepkg -si
+            systemctl --user restart plasmazones.service
+            kwin_wayland --replace &
+            ```
+            The PKGBUILD git-clones this PR branch and rebuilds locally, so the KWin pin auto-matches your installed version.
 
             ---
 
-            <sub>Posted by `.github/workflows/ci.yml` → `build-arch-draft`. Each push to this PR rebuilds and updates this comment in place.</sub>
+            <sub>Posted by `.github/workflows/ci.yml` → `build-arch-draft`. Each push to this PR rebuilds and updates this comment in place. nightly.link is a public third-party proxy; it has no special access — it reads the same artifact GitHub serves and exposes it without auth.</sub>
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,10 +302,30 @@ jobs:
           # On PRs, default checkout is the synthetic merge ref. We want
           # the PR head commit so the draft package mirrors what a tester
           # would clone from the branch.
+          # `head.sha` is supplied by GitHub from the head repo's API state
+          # (40-char hex), not from anything the PR author can write — safe
+          # to interpolate. The `|| github.sha` fallback covers
+          # workflow_dispatch where no PR exists.
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Resolve build metadata
         id: meta
+        # Route every attacker-controllable input (branch ref) through env
+        # vars instead of `${{ }}` template substitution. Git ref-format
+        # allows `$`, `(`, `)`, backticks, `&`, `|` in branch names, so a
+        # malicious PR with `branch=fix$(rm -rf /)` would inject the
+        # substitution into bash when `${{ github.head_ref }}` is pasted
+        # into a double-quoted shell string. The job grants
+        # `pull-requests: write` to post the sticky comment, so a
+        # successful injection could exfiltrate GITHUB_TOKEN and abuse it
+        # against the PR. Environment variables are read by bash without
+        # re-parsing — `$BRANCH_REF` is safe even when the value contains
+        # shell metacharacters. Documented as a GHA hardening best
+        # practice; see github.com/github/actions-runner-controller#security.
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+          PR_NUMBER_RAW: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -313,12 +333,26 @@ jobs:
           CMAKE_VER=$(sed -n 's/^project(PlasmaZones VERSION \([^ )]*\).*/\1/p' CMakeLists.txt)
           : "${CMAKE_VER:=0.0.0}"
 
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          # workflow_dispatch has no PR number — fall back to "ref" tag
-          # so the version still sorts but is recognisable as a manual run.
-          : "${PR_NUMBER:=manual}"
+          # workflow_dispatch has no PR number — fall back to "manual" so
+          # the version still sorts but is recognisable as a manual run.
+          PR_NUMBER="${PR_NUMBER_RAW:-manual}"
 
-          BRANCH_REF="${{ github.head_ref || github.ref_name }}"
+          # Prefer HEAD_REF (PR source branch); fall back to REF_NAME for
+          # workflow_dispatch. Both come from env (no GHA interpolation
+          # into the shell source).
+          BRANCH_REF="${HEAD_REF:-$REF_NAME}"
+
+          # Sanity-validate the branch name against the conservative
+          # subset of git ref-format we want to flow through pkgver/
+          # source URLs. Reject anything outside [A-Za-z0-9._/-]; the
+          # injection vector is closed above by env-passing, but a
+          # malformed value here would still poison pkgver and the
+          # source URL passed to `git+#branch=...`. Belt-and-suspenders.
+          if [[ ! "$BRANCH_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::Refusing to build with branch ref containing unsupported characters: $BRANCH_REF"
+            exit 1
+          fi
+
           SHORT_SHA=$(git rev-parse --short HEAD)
           COMMIT_COUNT=$(git rev-list --count HEAD)
           # pkgver schema: <cmake>.pr<num>.r<count>.g<sha>

--- a/src/core/ioverlayservice.h
+++ b/src/core/ioverlayservice.h
@@ -135,14 +135,6 @@ Q_SIGNALS:
     void zoneActivated(PhosphorZones::Zone* zone);
     void multiZoneActivated(const QVector<PhosphorZones::Zone*>& zones);
     void zoneSelectorVisibilityChanged(bool visible);
-    void zoneSelectorZoneSelected(int zoneIndex);
-
-    /**
-     * @brief Emitted when a manual layout is selected from the zone selector
-     * @param layoutId The UUID of the selected manual layout
-     * @param screenId The screen where the selection was made
-     */
-    void manualLayoutSelected(const QString& layoutId, const QString& screenId);
 
     /**
      * @brief Emitted when user selects a window from Snap Assist to snap to a zone
@@ -184,13 +176,6 @@ Q_SIGNALS:
      * registration that was active for the picker's lifetime.
      */
     void layoutPickerDismissed();
-
-    /**
-     * @brief Emitted when an autotile algorithm layout is selected from the zone selector
-     * @param algorithmId The algorithm identifier (e.g. "master-stack")
-     * @param screenId The screen where the selection was made
-     */
-    void autotileLayoutSelected(const QString& algorithmId, const QString& screenId);
 };
 
 } // namespace PlasmaZones

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -479,9 +479,10 @@ void Daemon::connectLayoutSignals()
     // (e.g., from D-Bus, layout picker, unified controller).
     // Also sync the unified controller's cycling index when the assignment
     // affects the current desktop — needed for D-Bus/KCM batch operations.
-    // Do NOT touch setActiveLayout here — applyEntry/manualLayoutSelected
-    // handle active layout themselves, and calling it here with QSignalBlocker
-    // steals the activeLayoutChanged transition, leaving the resnap buffer
+    // Do NOT touch setActiveLayout here — applyEntry and the drop-time
+    // cross-layout switch in WindowDragAdaptor (drop.cpp) handle active
+    // layout themselves, and calling it here with QSignalBlocker steals
+    // the activeLayoutChanged transition, leaving the resnap buffer
     // empty. Desktop switches sync active layout via syncModeFromAssignments().
     connect(m_layoutManager.get(), &PhosphorZones::LayoutRegistry::layoutAssigned, this,
             [this](const QString& screenId, int virtualDesktop, PhosphorZones::Layout* /*layout*/) {
@@ -578,52 +579,24 @@ void Daemon::connectLayoutSignals()
     // Record manual layout only when user explicitly selects one via zone selector
     // or unified layout controller — NOT on every internal layout change.
 
-    // Connect zone selector manual layout selection (drop on zone)
-    // Screen name comes directly from the zone selector window.
-    // Routes through UnifiedLayoutController::applyLayoutById() + resnapIfManualMode(),
-    // the same path as cycle/quick-layout shortcuts, for consistent resnap behavior.
-    connect(m_overlayService.get(), &OverlayService::manualLayoutSelected, this,
-            [this](const QString& layoutId, const QString& screenId) {
-                if (!m_layoutManager || !m_unifiedLayoutController) {
-                    return;
-                }
-                // Check if snapping layout is locked
-                // screenId is already a virtual-aware ID from the zone selector
-                if (!screenId.isEmpty() && isCurrentContextLockedForMode(screenId, 0)) {
-                    showLockedPreviewOsd(screenId);
-                    return;
-                }
-                if (!screenId.isEmpty()) {
-                    m_unifiedLayoutController->setCurrentScreenName(screenId);
-                }
-                if (!m_unifiedLayoutController->applyLayoutById(layoutId)) {
-                    return;
-                }
-                qCInfo(lcDaemon) << "Zone selector: manual layout selected, layout=" << layoutId
-                                 << "screen=" << screenId;
-                resnapIfManualMode();
-            });
+    // No handler for OverlayService::manualLayoutSelected: the zone-selector
+    // slot is input-transparent by design (ZoneSelectorContent's
+    // `interactive: false`) and the QML hover path that used to emit this is
+    // gone. Cross-layout commits happen at drop time inside WindowDragAdaptor
+    // (drop.cpp), which calls assignLayout + setActiveLayout directly when
+    // the user releases the drag on a zone in a different layout. Routing
+    // through a hover-driven handler would resnap mid-interaction, which is
+    // what produced the "layouts changing when holding alt" bug.
 }
 
 void Daemon::connectOverlaySignals()
 {
-    // Connect zone selector autotile layout selection — route through UnifiedLayoutController
-    // to avoid duplicate activation logic (the controller handles enable + algorithm + OSD)
-    connect(m_overlayService.get(), &IOverlayService::autotileLayoutSelected, this,
-            [this](const QString& algorithmId, const QString& screenId) {
-                // Check if tiling algorithm is locked
-                // screenId is already a virtual-aware ID from the zone selector
-                if (!screenId.isEmpty() && isCurrentContextLockedForMode(screenId, 1)) {
-                    showLockedPreviewOsd(screenId);
-                    return;
-                }
-                if (m_unifiedLayoutController) {
-                    if (!screenId.isEmpty()) {
-                        m_unifiedLayoutController->setCurrentScreenName(screenId);
-                    }
-                    m_unifiedLayoutController->applyLayoutById(PhosphorLayout::LayoutId::makeAutotileId(algorithmId));
-                }
-            });
+    // No autotileLayoutSelected handler: the zone-selector slot is input-
+    // transparent by design (see ZoneSelectorContent's `interactive: false`),
+    // so QML never emits a hover-driven selection. Switching the autotile
+    // algorithm via the zone-selector popup is gone — users have keyboard
+    // shortcuts (NextLayout / QuickLayoutN) and the explicit Layout Picker
+    // (Meta+Alt+Space by default) for that.
 
     // Connect Snap Assist selection: fetch authoritative zone geometry from service (same as
     // keyboard navigation) to avoid overlay coordinate drift/overlap bugs, then forward to effect

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -400,7 +400,6 @@ public Q_SLOTS:
     // teardown that the warm-surface design is meant to avoid. Pre-warmed
     // OSD windows are reused for the daemon's entire lifetime.
     void hideLayoutPicker() override;
-    void onZoneSelected(const QString& layoutId, int zoneIndex, const QVariant& relativeGeometry);
 
     // Shader error reporting from QML
     void onShaderError(const QString& errorLog);

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -485,8 +485,8 @@ void OverlayService::createZoneSelectorWindow(const QString& screenId, QScreen* 
     writeQmlProperty(slot, QStringLiteral("previewWidth"), config.previewWidth);
     writeQmlProperty(slot, QStringLiteral("previewHeight"), config.previewHeight);
     writeQmlProperty(slot, QStringLiteral("previewLockAspect"), config.previewLockAspect);
-    // zoneSelected signal wiring lives in ensurePassiveShellFor so it's
-    // installed once per shell rather than per screen-state init pass.
+    // No signal wiring: the slot is input-transparent by design — hit-testing
+    // and commit both happen in C++ (updateSelectorPosition + drop.cpp).
 }
 
 void OverlayService::destroyZoneSelectorWindow(const QString& screenId)
@@ -688,51 +688,6 @@ QRect OverlayService::getSelectedZoneGeometry(const QString& screenId) const
                 areaGeom.y() + m_selectedZoneRelGeo.y() * areaGeom.height(),
                 m_selectedZoneRelGeo.width() * areaGeom.width(), m_selectedZoneRelGeo.height() * areaGeom.height());
     return GeometryUtils::snapToRect(geom);
-}
-
-void OverlayService::onZoneSelected(const QString& layoutId, int zoneIndex, const QVariant& relativeGeometry)
-{
-    m_selectedLayoutId = layoutId;
-    m_selectedZoneIndex = zoneIndex;
-
-    // Convert QVariant to QVariantMap and extract relative geometry
-    QVariantMap relGeoMap = relativeGeometry.toMap();
-    qreal x = relGeoMap.value(QStringLiteral("x"), 0.0).toReal();
-    qreal y = relGeoMap.value(QStringLiteral("y"), 0.0).toReal();
-    qreal width = relGeoMap.value(QStringLiteral("width"), 0.0).toReal();
-    qreal height = relGeoMap.value(QStringLiteral("height"), 0.0).toReal();
-    m_selectedZoneRelGeo = QRectF(x, y, width, height);
-
-    // Determine which screen the zone selector is on from the sender window
-    // Primary: look up in our window-to-screen map (authoritative assignment)
-    // Fallback: use Qt's screen assignment on the window itself
-    // The zoneSelected signal is forwarded by the shell window, so
-    // sender() is the shell QQuickWindow. The shell hosts every
-    // kbd-None overlay slot for one screen; matching to its
-    // shell->shellWindow() yields the screen id.
-    QString screenId;
-    auto* senderWindow = qobject_cast<QQuickWindow*>(sender());
-    if (senderWindow) {
-        for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-            if (it.value().shell && it.value().shell->shellWindow() == senderWindow) {
-                screenId = it.key();
-                break;
-            }
-        }
-        if (screenId.isEmpty() && senderWindow->screen()) {
-            screenId = Phosphor::Screens::ScreenIdentity::identifierFor(senderWindow->screen());
-        }
-    }
-
-    // Route to the correct signal based on whether this is an autotile algorithm or manual layout
-    if (PhosphorLayout::LayoutId::isAutotile(layoutId)) {
-        const QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(layoutId);
-        qCInfo(lcOverlay) << "Zone selector: autotile algorithm selected, algoId=" << algoId << "screen=" << screenId;
-        Q_EMIT autotileLayoutSelected(algoId, screenId);
-    } else {
-        qCInfo(lcOverlay) << "Zone selector: layout selected, layoutId=" << layoutId << "screen=" << screenId;
-        Q_EMIT manualLayoutSelected(layoutId, screenId);
-    }
 }
 
 void OverlayService::scrollZoneSelector(int angleDeltaY)

--- a/src/daemon/overlayservice/shellhost_bridge.cpp
+++ b/src/daemon/overlayservice/shellhost_bridge.cpp
@@ -184,8 +184,10 @@ void OverlayService::wirePassiveShellSlots(const QString& screenId, PhosphorOver
                      SLOT(onSnapAssistWindowSelected(QString, QString, QString)));
     QObject::connect(window, SIGNAL(layoutPickerSelected(QString)), this, SLOT(onLayoutPickerSelected(QString)));
     QObject::connect(window, SIGNAL(layoutPickerDismissRequested()), this, SLOT(onLayoutPickerDismissRequested()));
-    QObject::connect(window, SIGNAL(zoneSelectorZoneSelected(QString, int, QVariant)), this,
-                     SLOT(onZoneSelected(QString, int, QVariant)));
+    // No zoneSelectorZoneSelected wiring: the zone-selector slot is input-
+    // transparent by design and hit-testing runs in C++ via
+    // updateSelectorPosition. See ZoneSelectorContent's `interactive: false`
+    // for the matching QML-side enforcement.
 
     // Prime the wl_surface map + Vulkan swapchain init + first-frame
     // render so the very first user-triggered slot show doesn't race

--- a/src/daemon/zoneselectorcontroller.cpp
+++ b/src/daemon/zoneselectorcontroller.cpp
@@ -387,11 +387,11 @@ void ZoneSelectorController::selectLayout(const QString& layoutId)
     Q_EMIT layoutSelected(layoutId);
 
     // PhosphorZones::Layout application is handled by whoever connects to layoutSelected().
-    // The primary path is QML zoneSelected → OverlayService::onZoneSelected →
-    // manualLayoutSelected → daemon handler, which routes through the unified
-    // layout pipeline (per-screen assignments, mode tracking, resnap).
-    // Do NOT call m_layoutManager->setActiveLayout() here — it bypasses that
-    // pipeline and leaves per-screen state, mode tracking, and resnap out of sync.
+    // For zone-selector drag-drop the commit happens in WindowDragAdaptor's drop path
+    // (drop.cpp), which calls assignLayout + setActiveLayout directly using
+    // OverlayService::selectedLayoutId()/selectedZoneIndex(). Do NOT call
+    // m_layoutManager->setActiveLayout() here — it bypasses the unified layout
+    // pipeline (per-screen assignments, mode tracking, resnap).
 #ifdef QT_DEBUG
     if (!QObject::receivers(SIGNAL(layoutSelected(QString)))) {
         qCWarning(lcOverlay) << "selectLayout(): no receivers connected to layoutSelected signal"

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -259,13 +259,17 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
                     // This prevents auto-snapping windows that were never manually snapped by user
                     m_windowTracking->service()->recordSnapIntent(windowId, true);
 
-                    // Neither the C++ updateSelectorPosition path nor the QML hover path
-                    // emits manualLayoutSelected — both only update m_selectedLayoutId /
-                    // m_selectedZoneIndex (see selector.cpp). This branch is the sole
-                    // commit point for a cross-layout zone-selector drop, so activate
-                    // the selected layout directly here. (Doing this earlier on hover
-                    // would resnap every other window mid-drag — the "layouts changing
-                    // when holding alt to move window" bug.)
+                    // The QML hover commit path is gone — ZoneSelectorContent is
+                    // `interactive: false`, so the slot's MouseAreas never fire and
+                    // selector.cpp::onZoneSelected was removed along with the
+                    // manualLayoutSelected signal it used to emit. Selection state
+                    // (m_selectedLayoutId / m_selectedZoneIndex) is now written
+                    // exclusively by the C++ updateSelectorPosition hit-test during
+                    // drag (selector.cpp). This branch is therefore the sole commit
+                    // point for a cross-layout zone-selector drop, so activate the
+                    // selected layout directly here. Doing the activation earlier on
+                    // hover would resnap every other window mid-drag — the "layouts
+                    // changing when holding alt to move window" bug.
                     if (selectedLayout) {
                         // Check lock before applying layout change from drag-drop
                         int layoutChangeDesktop = m_layoutManager->currentVirtualDesktop();

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -259,12 +259,13 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
                     // This prevents auto-snapping windows that were never manually snapped by user
                     m_windowTracking->service()->recordSnapIntent(windowId, true);
 
-                    // During drag, the C++ updateSelectorPosition path updates selection
-                    // state but does NOT emit manualLayoutSelected (only the QML hover
-                    // path does, which doesn't fire during drag). Activate the selected
-                    // layout directly so snap assist uses the correct layout's empty zones.
-                    // We intentionally skip manualLayoutSelected to avoid a layout OSD
-                    // flashing briefly before snap assist appears.
+                    // Neither the C++ updateSelectorPosition path nor the QML hover path
+                    // emits manualLayoutSelected — both only update m_selectedLayoutId /
+                    // m_selectedZoneIndex (see selector.cpp). This branch is the sole
+                    // commit point for a cross-layout zone-selector drop, so activate
+                    // the selected layout directly here. (Doing this earlier on hover
+                    // would resnap every other window mid-drag — the "layouts changing
+                    // when holding alt to move window" bug.)
                     if (selectedLayout) {
                         // Check lock before applying layout change from drag-drop
                         int layoutChangeDesktop = m_layoutManager->currentVirtualDesktop();

--- a/src/ui/PassiveOverlayShell.qml
+++ b/src/ui/PassiveOverlayShell.qml
@@ -79,20 +79,17 @@ Window {
     /// Forwarded from the loaded OSD content. C++ side connects this to
     /// the slot-hide animation start (not Surface::hide() — the shell
     /// stays mapped permanently, only the slot's opacity animates).
-    signal osdDismissRequested()
+    signal osdDismissRequested
     /// Forwarded from snap-assist's `windowSelected` signal — host wires
     /// to onSnapAssistWindowSelected.
     signal snapAssistWindowSelected(string windowId, string zoneId, string geometryJson)
     /// Forwarded from snap-assist's backdrop click / dismiss request.
-    signal snapAssistDismissRequested()
+    signal snapAssistDismissRequested
     /// Forwarded from picker's `layoutSelected`.
     signal layoutPickerSelected(string layoutId)
     /// Forwarded from picker's `dismissRequested` (backdrop click /
     /// supplemental dismiss path; primary Escape goes via global accel).
-    signal layoutPickerDismissRequested()
-    /// Forwarded from zone-selector's `zoneSelected` — host wires to
-    /// onZoneSelected.
-    signal zoneSelectorZoneSelected(string layoutId, int zoneIndex, var relativeGeometry)
+    signal layoutPickerDismissRequested
 
     // Qt::WindowTransparentForInput is driven imperatively by C++ from
     // syncPassiveShellSurfaceState (via Surface::show()/hide() with
@@ -196,7 +193,6 @@ Window {
         onModeChanged: {
             if (mode !== "" && mode !== "layout-osd" && mode !== "navigation-osd")
                 console.warn("PassiveOverlayShell osdSlot: unknown mode =", mode);
-
         }
 
         Loader {
@@ -219,7 +215,6 @@ Window {
             onLoaded: {
                 if (osdLoader.item)
                     osdLoader.item.dismissRequested.connect(root.osdDismissRequested);
-
             }
         }
 
@@ -252,7 +247,6 @@ Window {
                 disabled: osdSlot.disabled
                 disabledReason: osdSlot.disabledReason
             }
-
         }
 
         Component {
@@ -271,9 +265,7 @@ Window {
                 windowCount: osdSlot.windowCount
                 errorColor: osdSlot.errorColor
             }
-
         }
-
     }
 
     Item {
@@ -341,9 +333,7 @@ Window {
                 borderWidth: snapAssistSlot.borderWidth
                 borderRadius: snapAssistSlot.borderRadius
             }
-
         }
-
     }
 
     Item {
@@ -381,13 +371,11 @@ Window {
         function moveSelection(dx, dy) {
             if (layoutPickerLoader.item)
                 layoutPickerLoader.item.moveSelection(dx, dy);
-
         }
 
         function confirmSelection() {
             if (layoutPickerLoader.item)
                 layoutPickerLoader.item.confirmSelection();
-
         }
 
         anchors.fill: parent
@@ -442,9 +430,7 @@ Window {
                 fontStrikeout: layoutPickerSlot.fontStrikeout
                 locked: layoutPickerSlot.locked
             }
-
         }
-
     }
 
     Item {
@@ -523,7 +509,6 @@ Window {
         function applyScrollDelta(angleDeltaY) {
             if (zoneSelectorLoader.item)
                 zoneSelectorLoader.item.applyScrollDelta(angleDeltaY);
-
         }
 
         function resetCursorState() {
@@ -549,11 +534,10 @@ Window {
             active: zoneSelectorSlot.loaded
             asynchronous: true
             sourceComponent: zoneSelectorContentComp
-            onLoaded: {
-                if (zoneSelectorLoader.item)
-                    zoneSelectorLoader.item.zoneSelected.connect(root.zoneSelectorZoneSelected);
-
-            }
+            // No signal wiring: the zone-selector slot is input-transparent by
+            // design (see ZoneSelectorContent's `interactive: false`). Cursor
+            // tracking and commit both go through C++ (updateSelectorPosition
+            // + drop.cpp), so QML never needs to forward a selection event.
         }
 
         Component {
@@ -626,9 +610,7 @@ Window {
                 activeOpacity: zoneSelectorSlot.activeOpacity
                 inactiveOpacity: zoneSelectorSlot.inactiveOpacity
             }
-
         }
-
     }
 
     Item {
@@ -669,8 +651,7 @@ Window {
         property string bufferWrap: "clamp"
         property int zoneCount: 0
         property int highlightedCount: 0
-        property var shaderParams: ({
-        })
+        property var shaderParams: ({})
         property int zoneDataVersion: 0
         property real iTime: 0
         property real iTimeDelta: 0
@@ -688,31 +669,26 @@ Window {
         function flash() {
             if (mainOverlayLoader.item && mainOverlayLoader.item.flash)
                 mainOverlayLoader.item.flash();
-
         }
 
         function highlightZone(zoneId) {
             if (mainOverlayLoader.item && mainOverlayLoader.item.highlightZone)
                 mainOverlayLoader.item.highlightZone(zoneId);
-
         }
 
         function highlightZones(zoneIds) {
             if (mainOverlayLoader.item && mainOverlayLoader.item.highlightZones)
                 mainOverlayLoader.item.highlightZones(zoneIds);
-
         }
 
         function clearHighlight() {
             if (mainOverlayLoader.item && mainOverlayLoader.item.clearHighlight)
                 mainOverlayLoader.item.clearHighlight();
-
         }
 
         function reloadShader() {
             if (mainOverlayLoader.item && mainOverlayLoader.item.reloadShader)
                 mainOverlayLoader.item.reloadShader();
-
         }
 
         anchors.fill: parent
@@ -757,7 +733,6 @@ Window {
                 borderRadius: mainOverlaySlot.borderRadius
                 _idled: mainOverlaySlot._idled
             }
-
         }
 
         Component {
@@ -806,9 +781,6 @@ Window {
                 borderRadius: mainOverlaySlot.borderRadius
                 _idled: mainOverlaySlot._idled
             }
-
         }
-
     }
-
 }

--- a/src/ui/ZoneSelectorContent.qml
+++ b/src/ui/ZoneSelectorContent.qml
@@ -117,8 +117,6 @@ Item {
     property real inactiveOpacity: 0.3
     readonly property color fadeColor: Qt.rgba(backgroundColor.r, backgroundColor.g, backgroundColor.b, autoScrollConstants.fadeOpacity)
 
-    signal zoneSelected(string layoutId, int zoneIndex, var relativeGeometry)
-
     function applyScrollDelta(angleDeltaY) {
         var step = angleDeltaY / 120 * 0.1;
         if (root.needsScrolling) {
@@ -244,7 +242,6 @@ Item {
                     anchors.topMargin: root.effectiveTopMargin
                     anchors.leftMargin: root.effectiveSideMargin
                 }
-
             },
             State {
                 name: "top"
@@ -263,7 +260,6 @@ Item {
                     target: container
                     anchors.topMargin: root.effectiveTopMargin
                 }
-
             },
             State {
                 name: "topRight"
@@ -283,7 +279,6 @@ Item {
                     anchors.topMargin: root.effectiveTopMargin
                     anchors.rightMargin: root.effectiveSideMargin
                 }
-
             },
             State {
                 name: "left"
@@ -302,7 +297,6 @@ Item {
                     target: container
                     anchors.leftMargin: root.effectiveSideMargin
                 }
-
             },
             State {
                 name: "center"
@@ -316,7 +310,6 @@ Item {
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
-
             },
             State {
                 name: "right"
@@ -335,7 +328,6 @@ Item {
                     target: container
                     anchors.rightMargin: root.effectiveSideMargin
                 }
-
             },
             State {
                 name: "bottomLeft"
@@ -355,7 +347,6 @@ Item {
                     anchors.bottomMargin: root.effectiveTopMargin
                     anchors.leftMargin: root.effectiveSideMargin
                 }
-
             },
             State {
                 name: "bottom"
@@ -374,7 +365,6 @@ Item {
                     target: container
                     anchors.bottomMargin: root.effectiveTopMargin
                 }
-
             },
             State {
                 name: "bottomRight"
@@ -394,7 +384,6 @@ Item {
                     anchors.bottomMargin: root.effectiveTopMargin
                     anchors.rightMargin: root.effectiveSideMargin
                 }
-
             }
         ]
 
@@ -446,7 +435,18 @@ Item {
                             previewWidth: root.indicatorWidth
                             previewHeight: root.indicatorHeight
                             showCardBackground: true
-                            interactive: !(root.locked && !indicator.isActive)
+                            // The zone-selector slot is supposed to be input-transparent —
+                            // OverlayService::updateSelectorPosition pushes cursor coords from
+                            // the D-Bus drag stream and writes `selectedLayoutId` /
+                            // `selectedZoneIndex` back; the commit happens at drag-end in
+                            // WindowDragAdaptor's drop path (drop.cpp). The shared shell
+                            // surface only flips to input-grabbing when snap-assist / layout-
+                            // picker is up, and during that window the still-hiding zone-
+                            // selector slot was leaking hover events into these MouseAreas,
+                            // which switched the active layout out from under the user. Hard-
+                            // disabling interactivity here matches the design contract and is
+                            // defense in depth against any future input-grab regression.
+                            interactive: false
                             selectedZoneIndex: indicator.hasSelectedZone ? root.selectedZoneIndex : -1
                             zonePadding: root.scaledPadding
                             edgeGap: root.scaledPadding
@@ -469,22 +469,10 @@ Item {
                             animationDuration: animationConstants.normalDuration
                             shortAnimationDuration: animationConstants.shortDuration
                             labelTopMargin: root.labelTopMargin
-                            onZoneHovered: function(zoneIndex) {
-                                if (root.locked && !indicator.isActive)
-                                    return ;
-
-                                if (root.selectedLayoutId === indicator.layoutId && root.selectedZoneIndex === zoneIndex)
-                                    return ;
-
-                                root.selectedLayoutId = indicator.layoutId;
-                                root.selectedZoneIndex = zoneIndex;
-                                var zones = indicator.modelData.zones || [];
-                                var zone = zones[zoneIndex];
-                                var relGeo = zone ? (zone.relativeGeometry || {
-                                }) : {
-                                };
-                                root.zoneSelected(indicator.layoutId, root.selectedZoneIndex, relGeo);
-                            }
+                            // No onZoneHovered: interactive=false above means the inner
+                            // MouseArea never fires. `selectedLayoutId` / `selectedZoneIndex`
+                            // are written from C++ (selector.cpp::updateSelectorPosition) so
+                            // the highlight still tracks the cursor.
                         }
 
                         Rectangle {
@@ -507,22 +495,17 @@ Item {
                                 hoverEnabled: true
                                 cursorShape: Qt.ForbiddenCursor
                                 Accessible.name: i18nc("@info:whatsthis zone selector lock overlay", "Layout is locked — switch to this layout before selecting a zone")
-                                onClicked: function(mouse) {
+                                onClicked: function (mouse) {
                                     mouse.accepted = true;
                                 }
-                                onPressed: function(mouse) {
+                                onPressed: function (mouse) {
                                     mouse.accepted = true;
                                 }
                             }
-
                         }
-
                     }
-
                 }
-
             }
-
         }
 
         Rectangle {
@@ -543,9 +526,7 @@ Item {
                     position: 1
                     color: "transparent"
                 }
-
             }
-
         }
 
         Rectangle {
@@ -566,9 +547,7 @@ Item {
                     position: 1
                     color: root.fadeColor
                 }
-
             }
-
         }
 
         Rectangle {
@@ -591,9 +570,7 @@ Item {
                     position: 1
                     color: "transparent"
                 }
-
             }
-
         }
 
         Rectangle {
@@ -616,9 +593,7 @@ Item {
                     position: 1
                     color: root.fadeColor
                 }
-
             }
-
         }
 
         Label {
@@ -627,7 +602,5 @@ Item {
             color: Kirigami.Theme.disabledTextColor
             visible: root.layouts.length === 0
         }
-
     }
-
 }


### PR DESCRIPTION
## Summary

- Removes the QML `onZoneHovered → zoneSelected → manualLayoutSelected` chain that was committing layout switches whenever the cursor crossed a layout card in the zone-selector popup.
- Restores the design contract that the zone-selector slot is input-transparent (`ZoneSelectorContent` now hard-set to `interactive: false`).
- Cross-layout switching on drop is unchanged — `WindowDragAdaptor::drop.cpp` still calls `assignLayout` + `setActiveLayout` when the user releases the drag on a zone in a different layout.

## Bug

User report: \"layouts change when I drag windows up — they switch to layouts with more or fewer windows.\" Logs (in #issue thread) show bursts of `Zone selector: layout selected` events firing in the second after a drag ended, each followed by `assignLayout` + `Resnapping N windows to new layout`.

Root cause: the zone-selector slot is *supposed* to be input-transparent, per the contract documented in `shellhost_bridge.cpp::syncPassiveShellSurfaceState` (\"D-Bus updateSelectorPosition pushes cursor coords; the zone is committed via drag-end-on-hovered-zone, not a Qt click\"). But:

- The shell surface flips to input-grabbing the instant snap-assist becomes visible (`anyInputGrabbing = isVisible(snapAssistSlot) || isVisible(layoutPickerSlot)`).
- The zone-selector slot's hide is animated (asynchronous), so when snap-assist comes up right after drag-end the still-hiding selector slot is briefly visible-and-on-an-input-grabbing-surface.
- Its QML `MouseArea.onEntered` then fires `zoneSelected`, which the daemon was handling by calling `applyLayoutById` + `resnapIfManualMode` — resnapping every tiled window into a different layout under the user.

## Fix (defense in depth)

**1. Daemon-side:** remove the `manualLayoutSelected` signal, its sole emitter in `selector.cpp::onZoneSelected`, and the daemon handler in `signals.cpp`. Cross-layout drop is already handled at drop time in `drop.cpp:268-289`, which reads `m_selectedLayoutId` from the C++ `updateSelectorPosition` hit-test (no QML round-trip needed).

**2. QML-side:** hard-set `LayoutCard.interactive: false` in `ZoneSelectorContent.qml` and remove the now-dead `onZoneHovered` handler, the `zoneSelected` signal, the `PassiveOverlayShell` forward, the `shellhost_bridge.cpp` `SIGNAL/SLOT` connect, and the `OverlayService::onZoneSelected` slot. Even if a future surface-grab regression reaches the slot, no hover fires.

## Trade-off

Switching the **autotile** algorithm by hovering over an autotile preview in the zone-selector popup is gone — `drop.cpp` resolves `selectedLayoutId` as a UUID and skips non-UUID (autotile) ids, so the hover path was the only commit point for autotile-via-zone-selector. Users have keyboard shortcuts (`NextLayout`, `QuickLayoutN`) and the explicit Layout Picker (`Meta+Alt+Space` by default) for algorithm swaps. The `autotileLayoutSelected` signal + handler are removed as dead code.

## Net diff

```
9 files changed, 62 insertions(+), 202 deletions(-)
```

Most of that is signal/slot wiring + comments going away.

## Test plan

- [ ] Build clean (`cmake --build build`) and full test suite passes (`ctest` — 184/184 locally).
- [ ] Tester (Discord #527-ish): reproduce the original bug on stable 3.0.14 — drag window up, drop, move cursor across top while snap-assist is up, observe layout change.
- [ ] Install this branch's build, repeat the steps, confirm layout no longer changes.
- [ ] Sanity-check intentional cross-layout drop still works: alt+drag a window, drop on a zone in a different layout, confirm the layout switches to match and the window snaps to the targeted zone.
- [ ] Sanity-check snap-assist still works (click a candidate, snaps to that zone).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)