### PR TITLE
chore(release): 3.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [3.0.15] - 2026-05-28
+
+### Fixed
+
+- **Zone-selector popup at the screen edge switched the active layout on hover, resnapping every tiled window** ([#542](https://github.com/fuddlesworth/PlasmaZones/pull/542)): the zone-selector slot was supposed to be input-transparent during drag — cursor coordinates come in via the D-Bus `updateSelectorPosition` path and the snap commits at drag-end via `drop.cpp`, never via a Qt hover event. But the slot's QML `MouseArea`s still fired `zoneSelected` on every pointer-enter, and once snap-assist became visible the shared shell surface flipped to input-grabbing (`anyInputGrabbing = isVisible(snapAssistSlot) || isVisible(layoutPickerSlot)` in `syncPassiveShellSurfaceState`) — those leaked hover events committed `manualLayoutSelected`, which immediately resnapped every other tiled window into the new layout's zones. Visible as "my layout changes to one with more or fewer windows whenever I drag windows up". The QML hover commit path is gone (`ZoneSelectorContent` is now `interactive: false` and the daemon's `manualLayoutSelected` handler / signal are removed); cross-layout switching on drop still works because `WindowDragAdaptor::dragStopped` reads `m_selectedLayoutId` from the C++ hit-test and applies the layout when the user actually releases the drag on a zone in a different layout.
+
+### Removed
+
+- **Switching the autotile algorithm by hovering an autotile preview in the zone-selector popup** ([#542](https://github.com/fuddlesworth/PlasmaZones/pull/542)): the autotile-hover commit path went away with the input-contract fix above (`drop.cpp` resolves the selected id as a UUID and skips non-UUID autotile ids, so the hover path was the only commit point for autotile-via-zone-selector). Algorithm swaps still work through the existing on-by-default routes: `NextLayout` / `PreviousLayout`, `QuickLayout1`–`QuickLayout9`, and the Layout Picker (`Meta+Alt+Space` by default). The `IOverlayService::autotileLayoutSelected` signal and its daemon handler were removed as dead code.
+
 ## [3.0.14] - 2026-05-27
 
 ### Fixed
@@ -1431,7 +1441,8 @@ Initial packaged release. Wayland-only (X11 support removed). Requires KDE Plasm
 - Session restoration and rotation after login ([#66])
 - Window tracking: snap/restore behavior, zone clearing, startup timing, rotation zone ID matching, floating window exclusion ([#67])
 
-[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.14...HEAD
+[Unreleased]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.15...HEAD
+[3.0.15]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.14...v3.0.15
 [3.0.14]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.13...v3.0.14
 [3.0.13]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.12...v3.0.13
 [3.0.12]: https://github.com/fuddlesworth/PlasmaZones/compare/v3.0.11...v3.0.12

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-project(PlasmaZones VERSION 3.0.14 LANGUAGES C CXX)
+project(PlasmaZones VERSION 3.0.15 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/data/whatsnew.json
+++ b/data/whatsnew.json
@@ -1,6 +1,14 @@
 {
     "releases": [
         {
+            "version": "3.0.15",
+            "date": "2026-05-28",
+            "highlights": [
+                "Fixed the zone-selector popup switching the active layout on hover when snap-assist was up — dragging a window past the top of the screen no longer resnaps every other tiled window into a different layout (#542)",
+                "Removed: switching the autotile algorithm by hovering the zone-selector popup. Use NextLayout / QuickLayout1–9 / Layout Picker (Meta+Alt+Space) instead (#542)"
+            ]
+        },
+        {
             "version": "3.0.14",
             "date": "2026-05-27",
             "highlights": [


### PR DESCRIPTION
## Summary

Ships the zone-selector hover-commit fix (PR #542) as **3.0.15**.

- `CMakeLists.txt`: `3.0.14` → `3.0.15`
- `CHANGELOG.md`: new `[3.0.15] - 2026-05-28` section + compare-link refresh
- `data/whatsnew.json`: prepend the 3.0.15 entry (KCM Settings → About → What's New picks this up)

### Highlights

**Fixed:** the zone-selector popup at the screen edge no longer switches the active layout on hover when snap-assist is up. Dragging a window past the top of the screen used to resnap every other tiled window into a different layout — visible as "my layout changes to one with more or fewer windows whenever I drag windows up". `ZoneSelectorContent` is now `interactive: false` and the daemon's `manualLayoutSelected` handler is gone; cross-layout switching on actual drop still works through `drop.cpp`. Full rationale in PR #542 and the changelog entry.

**Removed:** the autotile-hover-switch path that lived inside the zone-selector popup. Use `NextLayout` / `PreviousLayout` / `QuickLayout1`–`9` / Layout Picker (`Meta+Alt+Space` by default) for algorithm swaps — all already on by default.

## Test plan

- [x] `cmake --build build --parallel` clean
- [x] `ctest --output-on-failure` — 184/184 pass
- [x] `CMakeLists.txt` reports `VERSION 3.0.15`
- [x] `data/whatsnew.json` parses as valid JSON
- [ ] After merge: tag `v3.0.15` to trigger `release.yml` (Arch / Debian / Fedora / openSUSE / generic-tarball builds + GitHub Release)
- [ ] Smoke-test the released `.pkg.tar.zst` on a clean KDE Plasma Wayland session — drag a window up to the top edge while snap-assist is visible and confirm the layout no longer changes
- [ ] KCM Settings → About → What's New shows the 3.0.15 entry on first launch after install

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)