### PR TITLE
fix(daemon): exit cleanly when WAYLAND_DISPLAY is empty/unset

### DIFF
--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -12,6 +12,7 @@
 #include "rendering/zoneshaderitem.h"
 #include "version.h"
 #include "vulkan_support.h"
+#include "waylandsessioncheck.h"
 
 #include <PhosphorProtocol/Registration.h>
 #include <PhosphorProtocol/ServiceConstants.h>
@@ -55,28 +56,28 @@ void signalHandler(int /*signal*/)
 
 int main(int argc, char* argv[])
 {
-    // Exit cleanly (code 0) if the Wayland socket is already gone — avoids
-    // a SIGABRT → Restart=on-failure loop. See queryPlasmaWorkspaceState()
-    // in daemon.cpp for the full phantom-session analysis.
+    // Exit cleanly (code 0) if there is no usable Wayland display — avoids a
+    // SIGABRT → Restart=on-failure loop. When systemd respawns us during the
+    // logout → SDDM handoff (or autostarts us in a session that has no live
+    // wl_display), Qt's wayland QPA can't create a wl_display, the xcb fallback
+    // also fails, and QGuiApplication's constructor calls qFatal() → abort.
+    // This is a Wayland-only daemon, so "no wayland socket" means "nothing to
+    // do". Resolving the socket path handles the empty/unset WAYLAND_DISPLAY
+    // case too (Qt's default "wayland-0"), which previously bypassed this guard
+    // and let Qt abort. See queryPlasmaWorkspaceState() in daemon.cpp for the
+    // full phantom-session analysis.
     {
         const QByteArray waylandDisplay = qgetenv("WAYLAND_DISPLAY");
-        if (!waylandDisplay.isEmpty()) {
-            QByteArray socketPath;
-            if (waylandDisplay.startsWith('/')) {
-                socketPath = waylandDisplay;
-            } else {
-                const QByteArray runtimeDir = qgetenv("XDG_RUNTIME_DIR");
-                if (!runtimeDir.isEmpty()) {
-                    socketPath = runtimeDir + '/' + waylandDisplay;
-                }
-            }
-            if (!socketPath.isEmpty() && !QFile::exists(QString::fromLocal8Bit(socketPath))) {
-                std::fprintf(stderr,
-                             "plasmazones: WAYLAND_DISPLAY=%s but socket %s missing — "
-                             "wayland session not available, exiting cleanly to avoid restart loop\n",
-                             waylandDisplay.constData(), socketPath.constData());
-                return 0;
-            }
+        const QByteArray runtimeDir = qgetenv("XDG_RUNTIME_DIR");
+        const QString socketPath = resolveWaylandSocketPath(waylandDisplay, runtimeDir);
+        if (socketPath.isEmpty() || !QFile::exists(socketPath)) {
+            std::fprintf(stderr,
+                         "plasmazones: no usable Wayland display (WAYLAND_DISPLAY=\"%s\", "
+                         "resolved socket \"%s\") — wayland session not available, "
+                         "exiting cleanly to avoid restart loop\n",
+                         waylandDisplay.constData(),
+                         socketPath.isEmpty() ? "<none>" : socketPath.toLocal8Bit().constData());
+            return 0;
         }
     }
 

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -66,7 +66,13 @@ int main(int argc, char* argv[])
     // case too (Qt's default "wayland-0"), which previously bypassed this guard
     // and let Qt abort. See queryPlasmaWorkspaceState() in daemon.cpp for the
     // full phantom-session analysis.
-    {
+    //
+    // Skip the probe entirely when WAYLAND_SOCKET is set: libwayland (and thus
+    // Qt's wayland QPA) connects via that inherited fd and ignores
+    // WAYLAND_DISPLAY, so there is a live connection even though no socket path
+    // resolves. Probing a path in that case would make us exit on a perfectly
+    // usable session.
+    if (qEnvironmentVariableIsEmpty("WAYLAND_SOCKET")) {
         const QByteArray waylandDisplay = qgetenv("WAYLAND_DISPLAY");
         const QByteArray runtimeDir = qgetenv("XDG_RUNTIME_DIR");
         const QString socketPath = resolveWaylandSocketPath(waylandDisplay, runtimeDir);

--- a/src/daemon/waylandsessioncheck.h
+++ b/src/daemon/waylandsessioncheck.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QByteArray>
+#include <QString>
+
+namespace PlasmaZones {
+
+// Resolve the filesystem path of the Wayland display socket that Qt's wayland
+// QPA plugin would attempt to connect to, given the WAYLAND_DISPLAY and
+// XDG_RUNTIME_DIR environment values.
+//
+//   - An absolute WAYLAND_DISPLAY (starts with '/') is used verbatim;
+//     XDG_RUNTIME_DIR is irrelevant.
+//   - A relative WAYLAND_DISPLAY resolves against XDG_RUNTIME_DIR.
+//   - An empty/unset WAYLAND_DISPLAY falls back to Qt's default "wayland-0"
+//     display name (also resolved against XDG_RUNTIME_DIR). This is the case
+//     that previously slipped past the startup guard in main(): with no
+//     WAYLAND_DISPLAY the guard did nothing, Qt's wayland QPA failed to create
+//     a wl_display, the xcb fallback also failed, and QGuiApplication's
+//     constructor called qFatal() → SIGABRT → core dump (see the crash analysis
+//     and queryPlasmaWorkspaceState() in daemon.cpp).
+//
+// Returns an empty QString when no path can be formed — a relative or empty
+// display name with no XDG_RUNTIME_DIR — which means there is no Wayland
+// session for this process to connect to.
+inline QString resolveWaylandSocketPath(const QByteArray& waylandDisplay, const QByteArray& runtimeDir)
+{
+    if (waylandDisplay.startsWith('/')) {
+        return QString::fromLocal8Bit(waylandDisplay);
+    }
+
+    const QByteArray displayName = waylandDisplay.isEmpty() ? QByteArrayLiteral("wayland-0") : waylandDisplay;
+    if (runtimeDir.isEmpty()) {
+        return QString();
+    }
+    return QString::fromLocal8Bit(runtimeDir + '/' + displayName);
+}
+
+} // namespace PlasmaZones

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -258,6 +258,14 @@ target_link_libraries(test_animation_profile_publication
     PRIVATE Qt6::Test Qt6::Core plasmazones_core PhosphorAnimation::PhosphorAnimation)
 add_test(NAME test_animation_profile_publication COMMAND test_animation_profile_publication)
 
+# Startup Wayland-display guard (main.cpp). Pins resolveWaylandSocketPath()
+# so an empty/unset WAYLAND_DISPLAY resolves to Qt's default "wayland-0" and
+# the guard exits cleanly instead of letting QGuiApplication qFatal() →
+# SIGABRT → core dump. Header-only logic, so links Qt6::Core only.
+add_executable(test_wayland_session_check daemon/test_wayland_session_check.cpp)
+target_link_libraries(test_wayland_session_check PRIVATE Qt6::Test Qt6::Core)
+add_test(NAME test_wayland_session_check COMMAND test_wayland_session_check)
+
 # Phase-5 SurfaceAnimator scope-prefix policy. Pins down the
 # per-instance scope construction in osd.cpp / selector.cpp /
 # snapassist.cpp so a divergence from the PzRoles base scopePrefix

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -261,7 +261,8 @@ add_test(NAME test_animation_profile_publication COMMAND test_animation_profile_
 # Startup Wayland-display guard (main.cpp). Pins resolveWaylandSocketPath()
 # so an empty/unset WAYLAND_DISPLAY resolves to Qt's default "wayland-0" and
 # the guard exits cleanly instead of letting QGuiApplication qFatal() →
-# SIGABRT → core dump. Header-only logic, so links Qt6::Core only.
+# SIGABRT → core dump. Header-only logic, so links Qt6::Test + Qt6::Core
+# only (no plasmazones_core).
 add_executable(test_wayland_session_check daemon/test_wayland_session_check.cpp)
 target_link_libraries(test_wayland_session_check PRIVATE Qt6::Test Qt6::Core)
 add_test(NAME test_wayland_session_check COMMAND test_wayland_session_check)

--- a/tests/unit/daemon/test_wayland_session_check.cpp
+++ b/tests/unit/daemon/test_wayland_session_check.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_wayland_session_check.cpp
+ * @brief Regression: the daemon startup guard in main() must resolve the
+ *        Wayland socket path for an empty/unset WAYLAND_DISPLAY too.
+ *
+ * Why this exists: plasmazonesd is Wayland-only. When systemd respawns it
+ * during a logout → SDDM handoff (or autostarts it in a session with no live
+ * wl_display), Qt's wayland QPA aborts in the QGuiApplication constructor via
+ * qFatal() → SIGABRT → core dump. The guard in main() returns 0 early when no
+ * usable Wayland socket exists, turning the crash into a clean exit so
+ * Restart=on-failure does not loop.
+ *
+ * The original guard only acted when WAYLAND_DISPLAY was *set but its socket
+ * was missing*. Observed crashes (CachyOS bug report) showed WAYLAND_DISPLAY
+ * *empty* ("could not connect to display "), which bypassed the guard entirely
+ * and let Qt abort. resolveWaylandSocketPath() now resolves the empty case to
+ * Qt's default "wayland-0" so the guard's file-existence check can fire. These
+ * tests pin that resolution so the gap cannot silently reopen.
+ */
+
+#include "daemon/waylandsessioncheck.h"
+
+#include <QTest>
+
+using namespace PlasmaZones;
+
+class TestWaylandSessionCheck : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    // An absolute WAYLAND_DISPLAY is used verbatim, ignoring XDG_RUNTIME_DIR.
+    void absoluteDisplayUsedVerbatim()
+    {
+        QCOMPARE(resolveWaylandSocketPath("/custom/run/wayland-9", "/run/user/1000"),
+                 QStringLiteral("/custom/run/wayland-9"));
+        // Even with no runtime dir, an absolute path stands on its own.
+        QCOMPARE(resolveWaylandSocketPath("/custom/run/wayland-9", QByteArray()),
+                 QStringLiteral("/custom/run/wayland-9"));
+    }
+
+    // A relative WAYLAND_DISPLAY resolves against XDG_RUNTIME_DIR.
+    void relativeDisplayResolvesAgainstRuntimeDir()
+    {
+        QCOMPARE(resolveWaylandSocketPath("wayland-1", "/run/user/1000"), QStringLiteral("/run/user/1000/wayland-1"));
+    }
+
+    // THE REGRESSION: an empty/unset WAYLAND_DISPLAY must fall back to Qt's
+    // default "wayland-0" display name so the guard probes a real path instead
+    // of doing nothing and letting QGuiApplication abort.
+    void emptyDisplayFallsBackToWayland0()
+    {
+        QCOMPARE(resolveWaylandSocketPath(QByteArray(), "/run/user/952"), QStringLiteral("/run/user/952/wayland-0"));
+        // Explicitly-empty (set to "") behaves identically to unset.
+        QCOMPARE(resolveWaylandSocketPath(QByteArray(""), "/run/user/952"), QStringLiteral("/run/user/952/wayland-0"));
+    }
+
+    // With a relative/empty display name and no XDG_RUNTIME_DIR there is no
+    // session — an empty path tells the guard to exit cleanly.
+    void noRuntimeDirYieldsEmptyForRelativeOrEmptyDisplay()
+    {
+        QVERIFY(resolveWaylandSocketPath(QByteArray(), QByteArray()).isEmpty());
+        QVERIFY(resolveWaylandSocketPath("wayland-0", QByteArray()).isEmpty());
+    }
+};
+
+QTEST_MAIN(TestWaylandSessionCheck)
+#include "test_wayland_session_check.moc"


### PR DESCRIPTION
## Problem

`plasmazonesd` is a Wayland-only daemon. When systemd respawns it during a logout → SDDM handoff (or autostarts it in a session with no live `wl_display`), Qt's wayland QPA can't create a `wl_display`, the xcb fallback also fails, and `QGuiApplication`'s constructor calls `qFatal()` → SIGABRT → core dump. With `Restart=on-failure`, this becomes a restart loop.

The previous startup guard only acted when `WAYLAND_DISPLAY` was **set but its socket was missing**. Observed crashes (CachyOS bug report) had `WAYLAND_DISPLAY` **empty** (`"could not connect to display "`), which bypassed the guard entirely and let Qt abort.

## Fix

- Extract `resolveWaylandSocketPath()` into `src/daemon/waylandsessioncheck.h`. It resolves the socket path Qt's wayland QPA would attempt:
  - Absolute `WAYLAND_DISPLAY` → used verbatim.
  - Relative `WAYLAND_DISPLAY` → resolved against `XDG_RUNTIME_DIR`.
  - **Empty/unset `WAYLAND_DISPLAY` → falls back to Qt's default `"wayland-0"`** (the previously-missed case).
  - No path formable → empty string (no session).
- `main()` now exits cleanly (`return 0`) whenever no usable Wayland socket exists, turning the crash into a clean exit so `Restart=on-failure` does not loop.
- Add `test_wayland_session_check` pinning all four resolution cases so the gap cannot silently reopen.

## Testing

- `cmake --build build` — clean.
- `ctest -R test_wayland_session_check` — **1/1 passed**.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)