### PR TITLE
perf(daemon): reduce idle memory usage in overlay + snap-assist

### DIFF
--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -671,6 +671,13 @@ private:
     // rather than relying on the single-threaded teardown invariant.
     std::unique_ptr<SnapAssistThumbnailProvider> m_thumbnailProviderOwned;
     std::atomic<SnapAssistThumbnailProvider*> m_thumbnailProvider{nullptr};
+    // Single-shot idle-grace timer: started on every hideSnapAssist and
+    // stopped on showSnapAssist. If snap-assist stays dismissed long enough
+    // for it to fire, it clears the thumbnail cache so its bounded (~6 MB
+    // worst-case) pixel buffers don't sit resident for the rest of the
+    // session. Rapid dismiss/re-show continuations restart it before it
+    // fires, keeping the warm cache. Lazily created (parented to this).
+    QTimer* m_snapAssistCacheTrimTimer = nullptr;
     // Layout Picker (interactive layout browser). Post-shell-migration
     // the picker is an Item slot inside the per-screen passive shell;
     // these track which screen's shell currently shows it (singleton

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -34,11 +34,15 @@ namespace PlasmaZones {
 
 namespace {
 
-// Collapse a dismissed overlay slot's full-screen texture buffers to a 1x1
-// placeholder so the labels (and wallpaper) QImages - up to tens of MB per
-// shader-enabled screen at 4K - are released while the overlay is hidden
-// rather than pinned on the persistent slot property for the whole session.
-// The next show() rebuilds them via createOverlayWindow ->
+// Collapse a dismissed overlay slot's full-screen labels texture to a 1x1
+// placeholder so the labels QImage - up to tens of MB per shader-enabled
+// screen at 4K - is released while the overlay is hidden rather than pinned
+// on the persistent slot property for the whole session. The wallpaperTexture
+// is reset for symmetry and to drop the slot's stale reference across a
+// wallpaper change, but the bulk wallpaper image is owned by ShaderRegistry's
+// static cache (s_cachedWallpaperImage / crops) and is COW-shared, so that
+// reset reclaims little RSS on its own - the labels release is the real win.
+// The next show() rebuilds both via createOverlayWindow ->
 // updateLabelsTextureForWindow / applyShaderInfoToWindow. Callers MUST also
 // reset PerScreenOverlayState::labelsTextureHash to 0 so the hash compare in
 // updateLabelsTextureForWindow does not short-circuit the rebuild and leave
@@ -602,9 +606,11 @@ void OverlayService::dismissOverlayWindow(const QString& screenId)
             sit->overlayGeomConnection = {};
             sit->overlayPhysScreen = nullptr;
             sit->overlayGeometry = QRect();
-            // Release the full-screen labels/wallpaper QImage buffers the
-            // persistent slot property would otherwise keep resident for the
-            // whole session while hidden. Zeroing labelsTextureHash forces
+            // Release the full-screen labels QImage the persistent slot
+            // property would otherwise keep resident for the whole session
+            // while hidden (the wallpaper reset is symmetric only - its image
+            // is pinned by ShaderRegistry's static cache; see
+            // releaseOverlaySlotTextures). Zeroing labelsTextureHash forces
             // updateLabelsTextureForWindow to rebuild on the next show()
             // instead of short-circuiting on the now-1x1 placeholder (which
             // would render no labels). The trade is one ZoneLabelTextureBuilder
@@ -658,6 +664,14 @@ void OverlayService::destroyOverlayWindow(const QString& screenId)
     it->overlayPhysScreen = nullptr;
     it->overlayGeometry = QRect();
     it->overlayGeomConnection = {};
+    // Release the slot's full-screen labels buffer too. A shader->non-shader
+    // type flip routes through here (destroyIfTypeMismatch) and the
+    // non-shader createOverlayWindow reload does NOT overwrite labelsTexture,
+    // so without this the slot would pin the last shader-mode QImage for the
+    // screen's whole non-shader session. The screen-teardown callers
+    // immediately destroyPassiveShell, where this is a harmless no-op on an
+    // about-to-be-freed slot. Mirrors dismissOverlayWindow's release.
+    releaseOverlaySlotTextures(it->mainOverlaySlot());
     it->labelsTextureHash = 0;
 }
 

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -20,6 +20,7 @@
 #include <QScreen>
 #include <QQmlEngine>
 #include <QQmlComponent>
+#include <QImage>
 #include <QMutexLocker>
 #include <QPointer>
 
@@ -30,6 +31,31 @@
 #include <PhosphorScreens/ScreenIdentity.h>
 
 namespace PlasmaZones {
+
+namespace {
+
+// Collapse a dismissed overlay slot's full-screen texture buffers to a 1x1
+// placeholder so the labels (and wallpaper) QImages - up to tens of MB per
+// shader-enabled screen at 4K - are released while the overlay is hidden
+// rather than pinned on the persistent slot property for the whole session.
+// The next show() rebuilds them via createOverlayWindow ->
+// updateLabelsTextureForWindow / applyShaderInfoToWindow. Callers MUST also
+// reset PerScreenOverlayState::labelsTextureHash to 0 so the hash compare in
+// updateLabelsTextureForWindow does not short-circuit the rebuild and leave
+// the 1x1 placeholder showing with no labels.
+void releaseOverlaySlotTextures(QQuickItem* slot)
+{
+    if (!slot) {
+        return;
+    }
+    QImage placeholder(1, 1, QImage::Format_ARGB32);
+    placeholder.fill(Qt::transparent);
+    const QVariant placeholderVar = QVariant::fromValue(placeholder);
+    writeQmlProperty(slot, QStringLiteral("labelsTexture"), placeholderVar);
+    writeQmlProperty(slot, QStringLiteral("wallpaperTexture"), placeholderVar);
+}
+
+} // namespace
 
 void OverlayService::destroyIfTypeMismatch(const QString& screenId)
 {
@@ -576,13 +602,17 @@ void OverlayService::dismissOverlayWindow(const QString& screenId)
             sit->overlayGeomConnection = {};
             sit->overlayPhysScreen = nullptr;
             sit->overlayGeometry = QRect();
-            // labelsTextureHash is intentionally NOT cleared - the
-            // QML labelsTexture property still holds the previously-
-            // built image, and updateLabelsTextureForWindow's hash
-            // compare on the next show() will detect any genuine
-            // input change and rebuild only then. Zeroing the hash
-            // would force a redundant 23 MB QImage rebuild on every
-            // hide/show cycle even for unchanged zone inputs.
+            // Release the full-screen labels/wallpaper QImage buffers the
+            // persistent slot property would otherwise keep resident for the
+            // whole session while hidden. Zeroing labelsTextureHash forces
+            // updateLabelsTextureForWindow to rebuild on the next show()
+            // instead of short-circuiting on the now-1x1 placeholder (which
+            // would render no labels). The trade is one ZoneLabelTextureBuilder
+            // rebuild per drag-start vs. tens of MB held idle per screen; the
+            // warm drag-pause path (setIdleForDragPause) is untouched and keeps
+            // the texture warm mid-drag.
+            releaseOverlaySlotTextures(sit->mainOverlaySlot());
+            sit->labelsTextureHash = 0;
             writeQmlProperty(sit->mainOverlaySlot(), QStringLiteral("loaded"), false);
             sit->mainOverlaySlot()->setVisible(false);
             syncPassiveShellSurfaceState(screenIdCopy);
@@ -595,6 +625,10 @@ void OverlayService::dismissOverlayWindow(const QString& screenId)
         it->overlayGeomConnection = {};
         it->overlayPhysScreen = nullptr;
         it->overlayGeometry = QRect();
+        // Mirror the shell-surface path: release the full-screen texture
+        // buffers and reset the hash so the next show() rebuilds correctly.
+        releaseOverlaySlotTextures(slot);
+        it->labelsTextureHash = 0;
         writeQmlProperty(slot, QStringLiteral("loaded"), false);
         slot->setVisible(false);
         syncPassiveShellSurfaceState(screenId);

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -31,6 +31,13 @@ namespace PlasmaZones {
 
 namespace {
 
+/// Grace period before a dismissed snap-assist's thumbnail cache is trimmed.
+/// Long enough that any interactive continuation (dismiss → re-trigger,
+/// multi-zone fill, cross-screen move) restarts the timer first and keeps the
+/// warm cache; short enough that the bounded cache doesn't linger for the rest
+/// of the session after the user is done snapping.
+constexpr int SnapAssistCacheTrimDelayMs = 30000;
+
 /// Convert PhosphorProtocol::EmptyZoneList to QVariantList for QML property push
 QVariantList emptyZonesToVariantList(const PhosphorProtocol::EmptyZoneList& zones)
 {
@@ -146,6 +153,12 @@ void OverlayService::showSnapAssist(const QString& screenId, const PhosphorProto
 
     m_snapAssistScreenId = screenId;
     m_snapAssistVisible = true;
+
+    // Snap-assist is in active use again - cancel any pending cache trim so
+    // the continuation lookups below (urlFor) hit the warm cache.
+    if (m_snapAssistCacheTrimTimer) {
+        m_snapAssistCacheTrimTimer->stop();
+    }
 
     // Hide the zone selector for the specific virtual screen where snap
     // assist is showing - selectors on adjacent VS of the same physical
@@ -349,6 +362,24 @@ void OverlayService::hideSnapAssist()
     // showZoneSelectorSlotOnScreen short-circuit (which checks
     // slot->isVisible() - true mid-animation), risking visible
     // overlap or missed re-shows.
+
+    // Schedule a delayed trim of the thumbnail cache. A rapid re-show
+    // (continuation / multi-zone fill / cross-screen move) restarts this
+    // timer in showSnapAssist before it fires, preserving the warm cache;
+    // a genuine end-of-use lets it fire and release the cached pixels. The
+    // cross-screen handoff path routes through onSnapAssistSlotHideCompleted
+    // (not here), so monitor switches never start the trim.
+    if (!m_snapAssistCacheTrimTimer) {
+        m_snapAssistCacheTrimTimer = new QTimer(this);
+        m_snapAssistCacheTrimTimer->setSingleShot(true);
+        m_snapAssistCacheTrimTimer->setInterval(SnapAssistCacheTrimDelayMs);
+        connect(m_snapAssistCacheTrimTimer, &QTimer::timeout, this, [this]() {
+            if (auto* provider = m_thumbnailProvider.load(std::memory_order_acquire)) {
+                provider->clear();
+            }
+        });
+    }
+    m_snapAssistCacheTrimTimer->start();
 }
 
 bool OverlayService::isSnapAssistVisible() const

--- a/src/daemon/snapassistthumbnailprovider.cpp
+++ b/src/daemon/snapassistthumbnailprovider.cpp
@@ -71,6 +71,12 @@ QString SnapAssistThumbnailProvider::urlFor(const QString& compositorHandle) con
     return cached ? cached->url : QString();
 }
 
+void SnapAssistThumbnailProvider::clear()
+{
+    QMutexLocker lock(&m_mutex);
+    m_cache.clear();
+}
+
 QString SnapAssistThumbnailProvider::makeUrl(const QString& handle, quint32 generation)
 {
     return QStringLiteral("image://%1/%2/%3").arg(QString::fromLatin1(ProviderId)).arg(handle).arg(generation);

--- a/src/daemon/snapassistthumbnailprovider.h
+++ b/src/daemon/snapassistthumbnailprovider.h
@@ -83,6 +83,18 @@ public:
      */
     QString urlFor(const QString& compositorHandle) const;
 
+    /**
+     * @brief Drop every cached thumbnail, releasing their pixel buffers.
+     *
+     * The cache is already hard-capped and LRU-evicting, but after the final
+     * snap-assist of a session its (≈6 MB worst-case) images would otherwise
+     * sit resident until daemon exit. OverlayService calls this on a short
+     * idle-grace timer after snap-assist stays dismissed, so rapid
+     * continuations keep the warm cache while a genuine end-of-use reclaims
+     * it; the next snap-assist repopulates from fresh kwin-effect captures.
+     */
+    void clear();
+
 private:
     /// Cache entry — image plus the URL that names this generation. Storing
     /// the URL inside the entry means LRU eviction reclaims the URL state


### PR DESCRIPTION
## Summary

Reduces the daemon's resident memory while idle by releasing two categories of full-screen image buffers that were previously pinned for the whole desktop session. Both changes came out of a memory audit of the daemon subsystems; each finding was verified against the code before implementing.

The daemon is already lean for default (no-shader) users — these target the cases where buffers were retained needlessly after the overlay/snap-assist were dismissed.

## Changes

### 1. Release overlay label/wallpaper textures on dismiss (`972531c6a`)
In shader overlay mode the per-screen labels (and wallpaper) full-screen `QImage` was stored on the **persistent** shell slot property and deliberately kept across hide/dismiss as a warm-cache optimization. Because the slot Item outlives the Loader content for the whole session, this pinned **tens of MB per shader-enabled screen (~33 MB at 4K)** resident even while no drag was in progress.

`dismissOverlayWindow` now collapses the slot's `labelsTexture`/`wallpaperTexture` to a 1×1 transparent placeholder and zeros `labelsTextureHash` so the next `show()` rebuilds correctly instead of short-circuiting on the stale hash.

- The warm **drag-pause** idle path (`setIdleForDragPause`) is untouched — texture stays warm mid-drag.
- Cost: one `ZoneLabelTextureBuilder` rebuild per drag-start.
- Also removes a latent risk where a retained placeholder + matching hash could have rendered no labels.

### 2. Trim snap-assist thumbnail cache after idle (`52c2e3781`)
The snap-assist thumbnail `QCache` (hard-capped at 24 entries, **~6 MB worst-case**) was never released once snap-assist closed, so its pixel buffers sat resident until daemon exit even though snap-assist is a transient, rarely-shown overlay.

Adds `SnapAssistThumbnailProvider::clear()` driven by a single-shot 30s idle-grace timer — started on `hideSnapAssist`, stopped on `showSnapAssist`.

- A rapid dismiss/re-show (continuation, multi-zone fill) restarts the timer before it fires, preserving the warm cache.
- The cross-screen handoff path routes through `onSnapAssistSlotHideCompleted` (not `hideSnapAssist`), so monitor switches never trigger a trim and keep reusing cached thumbnails.

## Out of scope (intentionally not included)
- **Per-screen Vulkan swapchain residency** (largest absolute cost): needs a dedicated change with visual regression testing — it risks reintroducing the NVIDIA teardown stall the keep-mapped design avoids on purpose.
- **`ShaderRegistry` static wallpaper cache eviction**: the cache is shared between overlay zone-shaders and SurfaceAnimator transition effects (two independent toggles), so any forced eviction risks an expensive disk re-decode on the shared animation path. A correct fix needs refcounted lifetime across all consumers — not justified for this bounded, mtime-self-refreshing, low-impact cache.

## Testing
- `cmake --build build --parallel` — clean
- `ctest` — **212/212 pass**

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)