### PR TITLE
refactor(settings): low-risk cleanups — animations page-id split + ScreenInfo alias drop

### DIFF
--- a/src/settings/animationspagecontroller.cpp
+++ b/src/settings/animationspagecontroller.cpp
@@ -140,16 +140,14 @@ using namespace animations_controller_detail;
 
 AnimationsPageController::AnimationsPageController(PhosphorAnimationShaders::AnimationShaderRegistry* shaderRegistry,
                                                    ISettings* settings, QObject* parent)
-    // FIXME(audit): PageController id "animations" is ALSO the navigation
-    // parent id that SettingsController::parentPageRedirects() maps to
-    // "animations-general". The dual-purpose id works today (setActivePage
-    // resolves the parent before storing it) but obscures the distinction
-    // between "navigate to the parent" and "address the staging
-    // controller". See the matching FIXME(audit) in
-    // settingscontroller_pageregistration.cpp at the regPage(m_animationsPage,
-    // …) site for the proposed fix (rename the staging controller's id to
-    // "animations-staging" so the two surfaces are independent).
-    : PhosphorSettingsUi::PageController(QStringLiteral("animations"), parent)
+    // Id is the headless staging-domain identity, deliberately distinct from
+    // the "animations" sidebar nav-parent. The controller is wired into the
+    // framework via registerDomain() (NOT registerPage) — see the
+    // registration site in settingscontroller_pageregistration.cpp. Keeping
+    // the two ids separate means QML / D-Bus callers can address the nav
+    // parent ("animations", which redirects to "animations-general") without
+    // colliding with this staging controller's own identity.
+    : PhosphorSettingsUi::PageController(QStringLiteral("animations-staging"), parent)
     , m_shaderRegistry(shaderRegistry)
     , m_settings(settings)
 {

--- a/src/settings/screenprovider.cpp
+++ b/src/settings/screenprovider.cpp
@@ -18,9 +18,9 @@
 
 namespace PlasmaZones {
 
-QList<ScreenInfo> fetchScreens(bool* daemonUnavailable)
+QList<PhosphorScreens::ScreenInfo> fetchScreens(bool* daemonUnavailable)
 {
-    QList<ScreenInfo> result;
+    QList<PhosphorScreens::ScreenInfo> result;
     if (daemonUnavailable)
         *daemonUnavailable = false;
 
@@ -47,7 +47,7 @@ QList<ScreenInfo> fetchScreens(bool* daemonUnavailable)
         const QStringList screenNames = screenReply.arguments().first().toStringList();
 
         for (const QString& screenName : screenNames) {
-            ScreenInfo info;
+            PhosphorScreens::ScreenInfo info;
             info.name = screenName;
             // Compare physical parent for virtual screens (primary is always a physical ID)
             QString physName = PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenName);
@@ -142,7 +142,7 @@ QList<ScreenInfo> fetchScreens(bool* daemonUnavailable)
         result.clear();
         QScreen* primaryScreen = QGuiApplication::primaryScreen();
         for (QScreen* screen : QGuiApplication::screens()) {
-            ScreenInfo info;
+            PhosphorScreens::ScreenInfo info;
             info.name = screen->name();
             info.isPrimary = (screen == primaryScreen);
             info.manufacturer = screen->manufacturer();

--- a/src/settings/screenprovider.h
+++ b/src/settings/screenprovider.h
@@ -16,21 +16,14 @@ namespace PlasmaZones {
 
 class ISettings;
 
-/// Re-export of the lib's POD so PlasmaZones-internal callers don't need the
-/// `PhosphorScreens::` prefix. Single update-site for any future renames.
-// TODO(post-merge): drop this alias once the phosphor-settings-ui lift-and-
-// shift settles. Keeping it for now buys migration ergonomics — call sites
-// can adopt the lib-qualified spelling incrementally rather than in lockstep
-// with this header's churn.
-using ScreenInfo = PhosphorScreens::ScreenInfo;
-
 /**
  * @brief Fetch the list of connected screens via D-Bus (daemon) with Qt fallback
  *
- * Each ScreenInfo contains connector name, primary flag, manufacturer, model,
- * resolution, and the stable EDID-based screenId from the daemon. This call
- * stays in PlasmaZones because it speaks the PlasmaZones daemon's specific
- * D-Bus protocol; the generic ScreenInfo POD itself lives in phosphor-screens.
+ * Each PhosphorScreens::ScreenInfo contains connector name, primary flag,
+ * manufacturer, model, resolution, and the stable EDID-based screenId from the
+ * daemon. This call stays in PlasmaZones because it speaks the PlasmaZones
+ * daemon's specific D-Bus protocol; the generic ScreenInfo POD itself lives in
+ * phosphor-screens.
  *
  * @param daemonUnavailable  Optional out-pointer. When non-null, set to true
  *                           if the daemon path failed (empty getScreens reply
@@ -39,7 +32,7 @@ using ScreenInfo = PhosphorScreens::ScreenInfo;
  *                           use this to render a degraded-fallback banner
  *                           without re-doing the D-Bus probing.
  */
-QList<ScreenInfo> fetchScreens(bool* daemonUnavailable = nullptr);
+QList<PhosphorScreens::ScreenInfo> fetchScreens(bool* daemonUnavailable = nullptr);
 
 /**
  * @brief Check whether a given monitor is disabled in settings for the given mode

--- a/src/settings/settingscontroller_lifecycle.cpp
+++ b/src/settings/settingscontroller_lifecycle.cpp
@@ -119,9 +119,9 @@ void SettingsController::save()
     // controller to m_domains): WindowRuleController via regPage(...) →
     // ApplicationController::registerPage(...), and AnimationsPageController
     // via an explicit registerDomain(...) call (it is a headless staging
-    // controller, distinct from the "animations" nav-parent node). Their own apply()
-    // methods drive the async D-Bus push (windowrules) and the
-    // snapshot clear (animations). Calling commit/commitPending here
+    // controller, distinct from the "animations" nav-parent node).
+    // Their own apply() methods drive the async D-Bus push (windowrules)
+    // and the snapshot clear (animations). Calling commit/commitPending here
     // would double-dispatch (and for window rules, ALSO send a
     // synchronous setAllRules over D-Bus *before* the async one
     // returned, hitting the daemon twice in the same save tick). The

--- a/src/settings/settingscontroller_lifecycle.cpp
+++ b/src/settings/settingscontroller_lifecycle.cpp
@@ -113,12 +113,13 @@ void SettingsController::save()
 
     // WindowRuleController and AnimationsPageController are registered
     // as their own StagingDomains and the framework's applyAllAsync
-    // walks them directly. The registration happens in
-    // settingscontroller_pageregistration.cpp via regPage(...) →
-    // ApplicationController::registerPage(...) → trackDomain(...),
-    // which connects dirtyChanged + appends the controller to
-    // m_domains. No explicit registerDomain() call on these two —
-    // their PageController identity is sufficient. Their own apply()
+    // walks them directly. Both registrations happen in
+    // settingscontroller_pageregistration.cpp and route through
+    // trackDomain() (which connects dirtyChanged + appends the
+    // controller to m_domains): WindowRuleController via regPage(...) →
+    // ApplicationController::registerPage(...), and AnimationsPageController
+    // via an explicit registerDomain(...) call (it is a headless staging
+    // controller, distinct from the "animations" nav-parent node). Their own apply()
     // methods drive the async D-Bus push (windowrules) and the
     // snapshot clear (animations). Calling commit/commitPending here
     // would double-dispatch (and for window rules, ALSO send a

--- a/src/settings/settingscontroller_pageregistration.cpp
+++ b/src/settings/settingscontroller_pageregistration.cpp
@@ -93,18 +93,20 @@ void SettingsController::buildApplicationController()
     // Animations / Window Rules pages that follow.
     regVirtual(QStringLiteral("placement"), QString(), PzI18n::tr("Placement"), QString(),
                QStringLiteral("preferences-system-windows"), /*collapsible=*/true, /*divider=*/true);
-    // DESIGN-NOTE: m_animationsPage carries PageController id "animations"
-    // (see the AnimationsPageController ctor in animationspagecontroller.cpp)
-    // which is ALSO the navigation-parent id we redirect to
-    // "animations-general" via parentPageRedirects(). The round-trip works
-    // today because setActivePage resolves the parent before storing
-    // m_activePage, but the dual role means QML or D-Bus callers can't
-    // distinguish "navigate to the Animations parent (and land on its first
-    // child)" from "address the staging controller's own id". Consider
-    // splitting: keep the parent navigation handle as "animations" and
-    // rename the controller id to something like "animations-staging" so
-    // the two surfaces are independent.
-    regPage(m_animationsPage, QString(), PzI18n::tr("Animations"), QString(), QStringLiteral("media-playback-start"));
+    // "animations" is a no-QML drill-down parent — register it as a virtual
+    // navigation node (like display / placement / snapping / tiling), NOT as
+    // m_animationsPage's own id. The AnimationsPageController is the staging
+    // controller for animation edits; it carries the distinct id
+    // "animations-staging" and is wired into the framework's dirty/apply
+    // machinery as a headless domain below. Splitting the two means the nav
+    // handle ("animations", redirected to "animations-general") and the
+    // staging controller are independently addressable by QML / D-Bus.
+    regVirtual(QStringLiteral("animations"), QString(), PzI18n::tr("Animations"), QString(),
+               QStringLiteral("media-playback-start"));
+    // Headless staging domain — trackDomain() connects dirtyChanged + appends
+    // to m_domains so applyAllAsync walks it, exactly as registerPage would
+    // have, but without claiming a sidebar/registry id of its own.
+    m_app->registerDomain(m_animationsPage);
     // Window Rules is a top-level leaf (its old "Rules" parent retired after
     // the v4 fold left a single rule surface). Divider after it closes the
     // feature block and opens the tools-and-meta block below.


### PR DESCRIPTION
Two low-risk, self-contained cleanups resolving deferred `FIXME`/`TODO` markers on `v3.1`. No functional/behavioural change intended; build is clean and all 213 tests pass.

## 1. Split the animations staging-controller id from the nav-parent

The string `"animations"` was doing double duty:
- the `AnimationsPageController`'s framework/registry id, **and**
- the sidebar navigation-parent id (redirected to `"animations-general"` via `parentPageRedirects()`).

So QML/D-Bus callers couldn't address one role without colliding with the other (the original `FIXME(audit)`).

**Fix:** register `"animations"` as a virtual nav-parent — consistent with every other no-QML parent (`display`/`placement`/`snapping`/`tiling`, which all use `regVirtual`) — and wire the `AnimationsPageController` into the framework's dirty/apply machinery as a **headless staging domain** (`registerDomain`) under the distinct id `"animations-staging"`. The two surfaces are now independently addressable.

Why it's safe:
- The controller is exposed to QML via the `animationsPage` Q_PROPERTY, **not** by registry id → zero QML impact.
- `"animations-staging"` isn't in `validPageNames()`, so `setActivePage` rejects it → it can never become the active page, keeping the `startsWith("animations-")` dirty-target fallback safe.
- `registerDomain` runs the same `trackDomain()` wiring `registerPage` did, so `applyAllAsync` still walks the controller.

Touches: `animationspagecontroller.cpp`, `settingscontroller_pageregistration.cpp`, `settingscontroller_lifecycle.cpp` (stale comment corrected).

## 2. Drop the `ScreenInfo` re-export alias

Removed the PlasmaZones-internal `using ScreenInfo = PhosphorScreens::ScreenInfo;` convenience alias (and its `TODO(post-merge)`) and spelled out the fully-qualified type at its five call sites in `screenprovider.{h,cpp}`. Pure cosmetic rename — the header already includes the POD header and the sole `fetchScreens()` caller doesn't name the type. The unrelated `Snapshot::ScreenInfo` nested struct in `supportreport.h` is left untouched.

> Note: this alias's `TODO` was gated on the phosphor-settings-ui lift-and-shift settling. The removal is mechanical and safe regardless, but flagging in case it should wait for that milestone.

## Testing
- `cmake --build build` → clean (exit 0)
- `ctest` → 213/213 pass, incl. `test_animations_page_controller` and the 9 `phosphorscreens` tests

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)