### PR TITLE
refactor(settings): extract IAnimationSettings sub-interface

### DIFF
--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -15,8 +15,6 @@
 #include "enums.h"
 #include "settings_interfaces.h"
 
-#include <PhosphorAnimation/ShaderProfileTree.h>
-
 #include <QColor>
 #include <QObject>
 #include <QString>
@@ -67,7 +65,8 @@ class PLASMAZONES_EXPORT ISettings : public QObject,
                                      public IZoneSelectorSettings,
                                      public IWindowBehaviorSettings,
                                      public IDefaultLayoutSettings,
-                                     public IOrderingSettings
+                                     public IOrderingSettings,
+                                     public IAnimationSettings
 {
     Q_OBJECT
 
@@ -125,53 +124,21 @@ public:
     //   - IZoneSelectorSettings: zone selector UI configuration
     //   - IWindowBehaviorSettings: snap restore, sticky handling
     //   - IDefaultLayoutSettings: default layout ID
+    //   - IAnimationSettings: animation/shader-profile state + window filtering
     //
     // See settings_interfaces.h for the full API.
     // ═══════════════════════════════════════════════════════════════════════════
 
-    // Animation settings (global — applies to snapping and autotiling)
+    // Animation + shader-profile settings are segregated into
+    // IAnimationSettings (mixed in above). The matching NOTIFY signals stay on
+    // this QObject (see Q_SIGNALS below): Qt forbids multiple QObject
+    // inheritance, so a consumer that needs an animation signal depends on
+    // ISettings, not IAnimationSettings alone.
     //
-    // FIXME(audit): consider extracting IAnimationSettings sub-interface —
-    // every method between here and `setShaderProfileTree` is purely about
-    // animation/shader-profile state. A focused sub-interface would let
-    // consumers (kwin-effect's animator, AnimationsPageController) depend on
-    // exactly that surface and remove the cross-cutting include of the full
-    // ISettings header. Deferred because it touches a large number of files;
-    // do not roll into an unrelated audit pass.
-    virtual bool animationsEnabled() const = 0;
-    virtual void setAnimationsEnabled(bool enabled) = 0;
-    virtual int animationDuration() const = 0;
-    virtual void setAnimationDuration(int duration) = 0;
-    virtual QString animationEasingCurve() const = 0;
-    virtual void setAnimationEasingCurve(const QString& curve) = 0;
-    virtual int animationMinDistance() const = 0;
-    virtual void setAnimationMinDistance(int distance) = 0;
-    virtual int animationSequenceMode() const = 0;
-    virtual void setAnimationSequenceMode(int mode) = 0;
-    virtual int animationStaggerInterval() const = 0;
-    virtual void setAnimationStaggerInterval(int ms) = 0;
-    virtual PhosphorAnimationShaders::ShaderProfileTree shaderProfileTree() const = 0;
-    virtual void setShaderProfileTree(const PhosphorAnimationShaders::ShaderProfileTree& tree) = 0;
-
-    // Animation window filtering — gates animations BEFORE the app-rule
-    // cascade. A class-pattern rule whose pattern matches the window's
-    // class overrides the filter at the resolver layer, so users can
-    // re-enable animations for a specific app even when it'd otherwise
-    // be excluded. Mirrors the snapping/tiling Exclusion settings but
-    // lives in its own namespace so the two filter sets can diverge.
-    virtual bool animationExcludeTransientWindows() const = 0;
-    virtual void setAnimationExcludeTransientWindows(bool exclude) = 0;
-    virtual bool animationExcludeNotificationsAndOsd() const = 0;
-    virtual void setAnimationExcludeNotificationsAndOsd(bool exclude) = 0;
-    virtual int animationMinimumWindowWidth() const = 0;
-    virtual void setAnimationMinimumWindowWidth(int width) = 0;
-    virtual int animationMinimumWindowHeight() const = 0;
-    virtual void setAnimationMinimumWindowHeight(int height) = 0;
-    // animationExcludedApplications / animationExcludedWindowClasses
-    // virtuals retired in v4 — the lists folded into ExcludeAnimations
-    // WindowRules; the KWin effect now derives its
-    // m_animationExclusionRuleSet from the unified rule store via
-    // PhosphorWindowRule::ExclusionRules::excludeAnimationsRulesFrom.
+    // animationExcludedApplications / animationExcludedWindowClasses virtuals
+    // retired in v4 — the lists folded into ExcludeAnimations WindowRules; the
+    // KWin effect now derives its m_animationExclusionRuleSet from the unified
+    // rule store via PhosphorWindowRule::ExclusionRules::excludeAnimationsRulesFrom.
 
     // Autotile decoration settings (fetched by KWin effect via D-Bus)
     virtual bool autotileFocusFollowsMouse() const = 0;
@@ -421,11 +388,11 @@ Q_SIGNALS:
     void excludeTransientWindowsChanged();
     void minimumWindowWidthChanged();
     void minimumWindowHeightChanged();
-    // Animation window filtering — paired with the virtuals at the top
-    // of this interface. Same shape as the snapping/tiling exclusion
-    // signals; lives in its own change-set so animation-only consumers
-    // (the kwin-effect, the AnimationsPageController) don't have to
-    // discriminate when filtering NOTIFY traffic.
+    // Animation window filtering — paired with the IAnimationSettings
+    // virtuals. Same shape as the snapping/tiling exclusion signals; lives
+    // in its own change-set so animation-only consumers (the kwin-effect,
+    // the AnimationsPageController) don't have to discriminate when
+    // filtering NOTIFY traffic.
     void animationExcludeTransientWindowsChanged();
     void animationExcludeNotificationsAndOsdChanged();
     void animationMinimumWindowWidthChanged();

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -5,6 +5,7 @@
 
 #include "plasmazones_export.h"
 #include "enums.h"
+#include <PhosphorAnimation/ShaderProfileTree.h>
 #include <PhosphorEngine/IGeometrySettings.h>
 #include <PhosphorZones/AssignmentEntry.h>
 #include <QString>
@@ -392,6 +393,55 @@ public:
 
     virtual QString defaultLayoutId() const = 0;
     virtual void setDefaultLayoutId(const QString& layoutId) = 0;
+};
+
+/**
+ * @brief Settings related to window animations and shader profiles
+ *        (global — applies to snapping and autotiling).
+ *
+ * Used by: KWin Effect (via D-Bus), the daemon overlay animator, and
+ * AnimationsPageController.
+ *
+ * NOTE: the matching NOTIFY signals (animationsEnabledChanged,
+ * shaderProfileTreeChanged, …) live on ISettings, the QObject that mixes this
+ * interface in — Qt forbids multiple QObject inheritance, so a consumer that
+ * needs an animation signal still depends on ISettings, not this interface
+ * alone.
+ */
+class PLASMAZONES_EXPORT IAnimationSettings
+{
+public:
+    virtual ~IAnimationSettings() = default;
+
+    virtual bool animationsEnabled() const = 0;
+    virtual void setAnimationsEnabled(bool enabled) = 0;
+    virtual int animationDuration() const = 0;
+    virtual void setAnimationDuration(int duration) = 0;
+    virtual QString animationEasingCurve() const = 0;
+    virtual void setAnimationEasingCurve(const QString& curve) = 0;
+    virtual int animationMinDistance() const = 0;
+    virtual void setAnimationMinDistance(int distance) = 0;
+    virtual int animationSequenceMode() const = 0;
+    virtual void setAnimationSequenceMode(int mode) = 0;
+    virtual int animationStaggerInterval() const = 0;
+    virtual void setAnimationStaggerInterval(int ms) = 0;
+    virtual PhosphorAnimationShaders::ShaderProfileTree shaderProfileTree() const = 0;
+    virtual void setShaderProfileTree(const PhosphorAnimationShaders::ShaderProfileTree& tree) = 0;
+
+    // Animation window filtering — gates animations BEFORE the app-rule
+    // cascade. A class-pattern rule whose pattern matches the window's class
+    // overrides the filter at the resolver layer, so users can re-enable
+    // animations for a specific app even when it'd otherwise be excluded.
+    // Mirrors the snapping/tiling Exclusion settings but lives in its own
+    // namespace so the two filter sets can diverge.
+    virtual bool animationExcludeTransientWindows() const = 0;
+    virtual void setAnimationExcludeTransientWindows(bool exclude) = 0;
+    virtual bool animationExcludeNotificationsAndOsd() const = 0;
+    virtual void setAnimationExcludeNotificationsAndOsd(bool exclude) = 0;
+    virtual int animationMinimumWindowWidth() const = 0;
+    virtual void setAnimationMinimumWindowWidth(int width) = 0;
+    virtual int animationMinimumWindowHeight() const = 0;
+    virtual void setAnimationMinimumWindowHeight(int height) = 0;
 };
 
 /**


### PR DESCRIPTION
Resolves scoping-doc item **#5** — the `IAnimationSettings` `FIXME` on `ISettings`.

## What

Move the 11 animation/shader-profile getter+setter pairs out of `ISettings`' inline block into a new **non-QObject** `IAnimationSettings` sub-interface in `settings_interfaces.h`, matching the existing 8 segregated interfaces (`IZoneActivationSettings`, `IZoneVisualizationSettings`, …). `ISettings` now mixes it in as a 9th base.

- `settings_interfaces.h`: new `IAnimationSettings` (animation enable/duration/easing/min-distance/sequence-mode/stagger/shader-profile-tree + the animation window-filtering accessors); moved the `ShaderProfileTree` include here.
- `isettings.h`: `ISettings` inherits `IAnimationSettings`; the inline animation block + `FIXME` removed; dropped the now-unused `ShaderProfileTree` include; segregated-interface list updated.

## Honest scope note

Investigation showed the `FIXME`'s headline benefit — letting consumers depend on the narrow interface and drop the cross-cutting `ISettings` include — **does not materialize**, and the change is **structural-consistency only**:

- The **animation NOTIFY signals stay on `ISettings`** (the QObject) — Qt forbids multiple QObject inheritance, so the sub-interfaces are signal-less.
- The **kwin-effect doesn't use `ISettings`** at all (D-Bus), and the two in-process consumers (`overlayservice/settings.cpp`, `AnimationsPageController`) both **connect to animation signals**, so both must keep depending on `ISettings`.

So no consumer narrows; the value is a uniform, segregated interface surface (and a future *method-only* animation consumer could depend on `IAnimationSettings`). This direction was chosen deliberately.

## Behaviour

None changed — this is a compile-time interface reorganization. Concrete `Settings` and `StubSettings` are untouched (`override` resolves through the new base).

## Testing
- `cmake --build build` → clean; `ctest` → **214/214 pass**.

## Audit
Ran `/code-audit` (3 passes). 2 findings fixed (1 LOW stale comment, 1 NIT include order); final pass CLEAN.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)