### PR TITLE
refactor(screens): split PhosphorScreensCore into Core (POD) + Runtime

### DIFF
--- a/libs/phosphor-placement/CMakeLists.txt
+++ b/libs/phosphor-placement/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(PhosphorPlacement
         PhosphorZones::PhosphorZones
         PhosphorProtocol::Types
     PRIVATE
-        PhosphorScreens::Core
+        PhosphorScreens::Runtime  # WindowTrackingService drives a ScreenManager*
         PhosphorIdentity::PhosphorIdentity
         PhosphorWorkspaces::PhosphorWorkspaces
         PhosphorLayoutApi::PhosphorLayoutApi

--- a/libs/phosphor-screens/CHANGES.md
+++ b/libs/phosphor-screens/CHANGES.md
@@ -8,6 +8,37 @@ shape changes) so consumers can audit their binding code on upgrade. Library
 SOVERSION still follows semver; entries here flag the kind of behaviour
 churn that won't be caught by an ABI break.
 
+## Phase: Core split into Core (POD) + Runtime (ScreenManager)
+
+`PhosphorScreens::Core` previously bundled the pure POD/serialiser surface
+(`ScreenInfo`, `ScreenIdentity`, `Swapper`, `QtScreenProvider`, `VirtualScreen`,
+the config/panel interfaces) together with the live `ScreenManager`, whose
+LayerSurface-backed geometry sensors pull in `PhosphorWayland`. Every consumer
+that linked `::Core` therefore acquired `PhosphorWayland` at runtime even if it
+only touched POD types.
+
+### New target layering
+
+`ScreenManager` (and its header `Manager.h`) moved to a new
+`PhosphorScreens::Runtime` target. `::Core` is now pure POD — Qt6::Core/Gui only,
+no Wayland.
+
+| Consumer need                                              | Link target                |
+|------------------------------------------------------------|----------------------------|
+| Only POD types (ScreenInfo/ScreenIdentity/VirtualScreen/…) | `PhosphorScreens::Core`     |
+| Drives a `ScreenManager` (`Manager.h`)                     | `PhosphorScreens::Runtime`  |
+| D-Bus surface (DBusScreenAdaptor/Resolver/PlasmaPanelSource)| `PhosphorScreens::PhosphorScreens` |
+
+`Runtime` PUBLIC-links `Core`, and the umbrella `PhosphorScreens` now links
+`Runtime`, so existing consumers of those two targets are unaffected.
+
+**Action for downstream consumers:** a target that previously linked
+`PhosphorScreens::Core` *and* constructs/calls a `ScreenManager` must re-point to
+`PhosphorScreens::Runtime`. Consumers that only use POD types stay on `::Core`
+and shed the `PhosphorWayland` dependency. `Manager.h`'s export macro changed
+from `PHOSPHORSCREENSCORE_EXPORT` to `PHOSPHORSCREENSRUNTIME_EXPORT` (this macro
+name is internal to the header — no source change at call sites).
+
 ## Phase: phosphor-settings-ui scaffolding
 
 Context: lift-and-shift refactor extracting common QML/Qt6 settings

--- a/libs/phosphor-screens/CMakeLists.txt
+++ b/libs/phosphor-screens/CMakeLists.txt
@@ -93,7 +93,7 @@ if(NOT DEFINED KDE_INSTALL_INCLUDEDIR)
     set(KDE_INSTALL_BINDIR ${CMAKE_INSTALL_BINDIR})
 endif()
 
-# Properties shared by both library targets.
+# Properties shared by all three library targets (Core, Runtime, umbrella).
 function(_phosphorscreens_target_defaults _target)
     set_target_properties(${_target} PROPERTIES
         VERSION ${PHOSPHORSCREENS_VERSION}
@@ -103,13 +103,13 @@ function(_phosphorscreens_target_defaults _target)
         UNITY_BUILD OFF
         AUTOMOC ON
         POSITION_INDEPENDENT_CODE ON
-        # PhosphorScreens.so links PhosphorScreensCore.so via its public
-        # interface. On distros that don't add KDE_INSTALL_LIBDIR to the
-        # default loader search path (e.g. /usr/local/lib), runtime load
-        # of PhosphorScreens.so would fail with "PhosphorScreensCore.so:
-        # cannot open shared object file". $ORIGIN tells the dynamic
-        # linker to look beside the loading .so first, which is exactly
-        # where both shipped libs live. BUILD_WITH_INSTALL_RPATH lets
+        # The shipped libraries link in a chain via their public interfaces:
+        # PhosphorScreens.so → PhosphorScreensRuntime.so → PhosphorScreensCore.so.
+        # On distros that don't add KDE_INSTALL_LIBDIR to the default loader
+        # search path (e.g. /usr/local/lib), runtime load of a downstream .so
+        # would fail with "...Core.so: cannot open shared object file". $ORIGIN
+        # tells the dynamic linker to look beside the loading .so first, which is
+        # exactly where all three shipped libs live. BUILD_WITH_INSTALL_RPATH lets
         # ctest dlopen the in-tree binaries without an explicit
         # LD_LIBRARY_PATH — without it, in-tree consumers (the demo,
         # the test runner) inherit CMake's empty build-tree rpath and

--- a/libs/phosphor-screens/CMakeLists.txt
+++ b/libs/phosphor-screens/CMakeLists.txt
@@ -3,18 +3,25 @@
 #
 # PhosphorScreens — domain-free screen-topology library for Qt6 Wayland.
 #
-# Two targets, layered so the screen-topology core does not drag QtDBus
-# into pure-compute consumers:
+# Three targets, layered so pure-compute consumers don't drag in the Wayland
+# or QtDBus surface they never use:
 #
-#   PhosphorScreens::Core  — physical-screen monitoring, virtual-screen
-#                            subdivision, identity helpers, pluggable
-#                            config/panel backends. Qt6::Core/Gui only.
-#                            Domain libraries (zones, snap/tile engines,
-#                            placement) link this.
+#   PhosphorScreens::Core     — pure POD/serialiser surface: ScreenInfo,
+#                               ScreenIdentity, Swapper, QtScreenProvider,
+#                               VirtualScreen, and the IConfigStore /
+#                               IPanelSource interfaces. Qt6::Core/Gui only —
+#                               NO Wayland. POD-only consumers (zones, overlay)
+#                               link this and avoid the PhosphorWayland .so.
+#   PhosphorScreens::Runtime  — the live ScreenManager (physical-screen
+#                               monitoring + virtual-screen subdivision) whose
+#                               LayerSurface-backed geometry sensors need
+#                               Wayland. Depends on ::Core + PhosphorWayland.
+#                               Consumers that drive a ScreenManager (the
+#                               daemon, snap/tile engines, placement) link this.
 #   PhosphorScreens::PhosphorScreens
-#                          — adds the D-Bus surface: DBusScreenAdaptor,
-#                            the Plasma panel source, and the resolver.
-#                            Depends on ::Core + Qt6::DBus.
+#                             — adds the D-Bus surface: DBusScreenAdaptor,
+#                               the Plasma panel source, and the resolver.
+#                               Depends on ::Runtime + Qt6::DBus.
 
 cmake_minimum_required(VERSION 3.16)
 
@@ -65,8 +72,9 @@ if(NOT TARGET PhosphorIdentity::PhosphorIdentity)
     find_package(PhosphorIdentity CONFIG REQUIRED)
 endif()
 
-# PhosphorWayland ships the wlr-layer-shell QPA integration. ScreenManager
-# consumes it for the per-screen geometry sensor windows.
+# PhosphorWayland ships the wlr-layer-shell QPA integration. Only the Runtime
+# target's ScreenManager consumes it (per-screen geometry sensor windows); the
+# pure-POD Core target deliberately does NOT link it.
 if(NOT TARGET PhosphorWayland::PhosphorWayland)
     find_package(PhosphorWayland CONFIG REQUIRED)
 endif()
@@ -113,7 +121,7 @@ function(_phosphorscreens_target_defaults _target)
 endfunction()
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# PhosphorScreens::Core — QtDBus-free screen-topology core
+# PhosphorScreens::Core — pure-POD/serialiser surface (no Wayland, no QtDBus)
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set(phosphorscreenscore_public_HDRS
@@ -121,7 +129,6 @@ set(phosphorscreenscore_public_HDRS
     include/PhosphorScreens/InMemoryConfigStore.h
     include/PhosphorScreens/IPanelSource.h
     include/PhosphorScreens/IScreenProvider.h
-    include/PhosphorScreens/Manager.h
     include/PhosphorScreens/NoOpPanelSource.h
     include/PhosphorScreens/PhysicalScreen.h
     include/PhosphorScreens/QtScreenProvider.h
@@ -134,8 +141,6 @@ set(phosphorscreenscore_public_HDRS
 add_library(PhosphorScreensCore SHARED
     ${phosphorscreenscore_public_HDRS}
     src/screenslogging.h
-    src/manager.cpp
-    src/manager_virtualscreens.cpp
     src/qtscreenprovider.cpp
     src/screenidentity.cpp
     src/screeninfo.cpp
@@ -165,20 +170,61 @@ target_link_libraries(PhosphorScreensCore
         Qt6::Core
         Qt6::Gui   # QRect / QRectF / QScreen in public headers
         PhosphorIdentity::PhosphorIdentity
-    PRIVATE
-        # FIXME(audit): screeninfo.cpp + several other Core TUs are pure
-        # POD/serialiser code and don't need Wayland; only the
-        # LayerSurface-backed geometry sensor in ScreenManager does.
-        # Splitting Core into a pure-POD sub-target + a CoreRuntime
-        # sub-target (with Wayland) would let consumers that only need
-        # ScreenInfo / ScreenIdentity / IConfigStore avoid pulling in
-        # PhosphorWayland. Deferred — splitting is API-breaking and
-        # warrants its own audit-pass commit. See
-        # libs/phosphor-screens/CHANGES.md for namespace history.
-        PhosphorWayland::PhosphorWayland  # LayerSurface for geometry sensors
 )
 
 _phosphorscreens_target_defaults(PhosphorScreensCore)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PhosphorScreens::Runtime — the live ScreenManager (needs Wayland)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# ScreenManager is one class split across two TUs (manager.cpp +
+# manager_virtualscreens.cpp); only manager.cpp's geometry-sensor lifecycle
+# touches PhosphorWayland (LayerSurface), but the class travels whole here so
+# its symbols live in a single .so. Manager.h's public surface is Wayland-free
+# (Qt types only), so Core consumers that never construct a ScreenManager don't
+# need this target at all.
+
+set(phosphorscreensruntime_public_HDRS
+    include/PhosphorScreens/Manager.h
+)
+
+add_library(PhosphorScreensRuntime SHARED
+    ${phosphorscreensruntime_public_HDRS}
+    src/manager.cpp
+    src/manager_virtualscreens.cpp
+)
+
+add_library(PhosphorScreens::Runtime ALIAS PhosphorScreensRuntime)
+
+generate_export_header(PhosphorScreensRuntime
+    BASE_NAME PhosphorScreensRuntime
+    EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/phosphorscreensruntime_export.h
+    EXPORT_MACRO_NAME PHOSPHORSCREENSRUNTIME_EXPORT
+)
+
+target_include_directories(PhosphorScreensRuntime
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR}>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_link_libraries(PhosphorScreensRuntime
+    PUBLIC
+        # Manager.h surfaces QtScreenProvider / IConfigStore / VirtualScreen
+        # (all Core POD types), so Core is a PUBLIC dependency.
+        PhosphorScreens::Core
+        Qt6::Core
+        Qt6::Gui
+    PRIVATE
+        # LayerSurface geometry sensors — confined to manager.cpp, hence PRIVATE.
+        PhosphorWayland::PhosphorWayland
+)
+
+_phosphorscreens_target_defaults(PhosphorScreensRuntime)
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # PhosphorScreens — D-Bus adaptor + Plasma panel source + resolver
@@ -217,7 +263,9 @@ target_include_directories(PhosphorScreens
 
 target_link_libraries(PhosphorScreens
     PUBLIC
-        PhosphorScreens::Core
+        # DBusScreenAdaptor holds a ScreenManager* and connects its signals,
+        # so the umbrella needs Runtime (which re-exports Core).
+        PhosphorScreens::Runtime
         Qt6::DBus  # QDBusAbstractAdaptor in DBusScreenAdaptor.h public surface
         PhosphorProtocol::Types  # Service::* constants in Resolver.h
 )
@@ -228,7 +276,7 @@ _phosphorscreens_target_defaults(PhosphorScreens)
 # Install
 # ═══════════════════════════════════════════════════════════════════════════════
 
-install(TARGETS PhosphorScreensCore PhosphorScreens
+install(TARGETS PhosphorScreensCore PhosphorScreensRuntime PhosphorScreens
     EXPORT PhosphorScreensTargets
     LIBRARY DESTINATION ${KDE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${KDE_INSTALL_LIBDIR}
@@ -265,6 +313,7 @@ install(DIRECTORY include/PhosphorScreens/
 
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/phosphorscreenscore_export.h
+    ${CMAKE_CURRENT_BINARY_DIR}/phosphorscreensruntime_export.h
     ${CMAKE_CURRENT_BINARY_DIR}/phosphorscreens_export.h
     DESTINATION ${KDE_INSTALL_INCLUDEDIR}/PhosphorScreens
 )

--- a/libs/phosphor-screens/PhosphorScreensConfig.cmake.in
+++ b/libs/phosphor-screens/PhosphorScreensConfig.cmake.in
@@ -35,4 +35,15 @@ if(TARGET PhosphorScreens::PhosphorScreensCore AND NOT TARGET PhosphorScreens::C
     add_library(PhosphorScreens::Core ALIAS PhosphorScreens_CoreAliasWrapper)
 endif()
 
+# Same in-tree-alias re-creation for the Runtime target (ScreenManager +
+# Wayland), so downstream `find_package(PhosphorScreens)` consumers can spell
+# `PhosphorScreens::Runtime` exactly as in-tree add_subdirectory consumers do.
+if(TARGET PhosphorScreens::PhosphorScreensRuntime AND NOT TARGET PhosphorScreens::Runtime)
+    if(NOT TARGET PhosphorScreens_RuntimeAliasWrapper)
+        add_library(PhosphorScreens_RuntimeAliasWrapper INTERFACE)
+        target_link_libraries(PhosphorScreens_RuntimeAliasWrapper INTERFACE PhosphorScreens::PhosphorScreensRuntime)
+    endif()
+    add_library(PhosphorScreens::Runtime ALIAS PhosphorScreens_RuntimeAliasWrapper)
+endif()
+
 check_required_components(PhosphorScreens)

--- a/libs/phosphor-screens/include/PhosphorScreens/Manager.h
+++ b/libs/phosphor-screens/include/PhosphorScreens/Manager.h
@@ -5,7 +5,7 @@
 
 #include "PhosphorScreens/PhysicalScreen.h"
 #include "VirtualScreen.h"
-#include "phosphorscreenscore_export.h"
+#include "phosphorscreensruntime_export.h"
 
 #include <QHash>
 #include <QMap>
@@ -71,7 +71,7 @@ struct ScreenManagerConfig
  * that need a process-wide ScreenManager (the PlasmaZones daemon does)
  * provide their own thin service-locator outside this class.
  */
-class PHOSPHORSCREENSCORE_EXPORT ScreenManager : public QObject
+class PHOSPHORSCREENSRUNTIME_EXPORT ScreenManager : public QObject
 {
     Q_OBJECT
 public:

--- a/libs/phosphor-screens/tests/CMakeLists.txt
+++ b/libs/phosphor-screens/tests/CMakeLists.txt
@@ -45,6 +45,12 @@ ps_add_test(ps_test_resolver test_resolver.cpp)
 ps_add_test(ps_test_plasma_panel_source test_plasma_panel_source.cpp)
 ps_add_test(ps_test_dbusscreenadaptor test_dbusscreenadaptor.cpp)
 
+# These construct/exercise ScreenManager, which lives in the Runtime target
+# (its geometry sensors need PhosphorWayland); the pure-POD Core no longer
+# carries ScreenManager. Runtime re-exports Core, so the POD types stay available.
+target_link_libraries(ps_test_manager_lifecycle PRIVATE PhosphorScreens::Runtime)
+target_link_libraries(ps_test_screenmanager_geometry PRIVATE PhosphorScreens::Runtime)
+
 # These exercise the D-Bus surface (DBusScreenAdaptor, PlasmaPanelSource,
 # Resolver), so they link the full PhosphorScreens target rather than the
 # QtDBus-free core. PhosphorScreens carries Qt6::DBus PUBLIC.

--- a/libs/phosphor-snap-engine/CMakeLists.txt
+++ b/libs/phosphor-snap-engine/CMakeLists.txt
@@ -65,7 +65,7 @@ target_link_libraries(PhosphorSnapEngine
         PhosphorZones::PhosphorZones
         PhosphorProtocol::Types
     PRIVATE
-        PhosphorScreens::Core
+        PhosphorScreens::Runtime  # SnapEngine queries screen geometry via ScreenManager
         PhosphorIdentity::PhosphorIdentity
         PhosphorWindowRule::PhosphorWindowRule
 )

--- a/libs/phosphor-tile-engine/CMakeLists.txt
+++ b/libs/phosphor-tile-engine/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(PhosphorTileEngine
         PhosphorEngine::PhosphorEngine
         PhosphorTiles::PhosphorTiles
     PRIVATE
-        PhosphorScreens::Core
+        PhosphorScreens::Runtime  # AutotileEngine queries screen geometry via ScreenManager
         PhosphorIdentity::PhosphorIdentity
         PhosphorZones::PhosphorZones
 )

--- a/libs/phosphor-zones/CMakeLists.txt
+++ b/libs/phosphor-zones/CMakeLists.txt
@@ -44,10 +44,12 @@ if(NOT TARGET PhosphorLayoutApi::PhosphorLayoutApi)
     find_package(PhosphorLayoutApi CONFIG REQUIRED)
 endif()
 
-# PhosphorScreens supplies ScreenIdentity (canonical id ↔ connector name)
-# and VirtualScreen helpers used by LayoutRegistry's assignment cascade.
-# PRIVATE because no public header leaks the type.
-if(NOT TARGET PhosphorScreens::Core)
+# PhosphorScreens supplies ScreenIdentity / VirtualScreen (LayoutRegistry's
+# assignment cascade) and ScreenManager geometry queries (GeometryUtils, whose
+# public GeometryUtils.h surfaces a ScreenManager*) — so this links the Runtime
+# target. PRIVATE: callers of the ScreenManager-taking GeometryUtils functions
+# own and link their own PhosphorScreens, so the dep need not propagate.
+if(NOT TARGET PhosphorScreens::Runtime)
     find_package(PhosphorScreens CONFIG REQUIRED)
 endif()
 

--- a/libs/phosphor-zones/CMakeLists.txt
+++ b/libs/phosphor-zones/CMakeLists.txt
@@ -166,10 +166,13 @@ target_link_libraries(PhosphorZones
         # composite window-id parsing; PRIVATE because the dep doesn't
         # leak through any public PhosphorZones header.
         PhosphorIdentity::PhosphorIdentity
-        # LayoutRegistry impl uses ScreenIdentity / VirtualScreen for
-        # the assignment-cascade screen-id normalisation. PRIVATE — no
-        # public header surfaces these types.
-        PhosphorScreens::Core
+        # GeometryUtils calls ScreenManager geometry queries, and LayoutRegistry
+        # uses ScreenIdentity / VirtualScreen for assignment-cascade screen-id
+        # normalisation — so this links the Runtime target (ScreenManager), which
+        # re-exports Core's POD types. PRIVATE: callers of the GeometryUtils
+        # functions that take a ScreenManager* pass one they already own and link
+        # PhosphorScreens themselves, so the dep need not propagate.
+        PhosphorScreens::Runtime
 )
 
 set_target_properties(PhosphorZones PROPERTIES


### PR DESCRIPTION
Resolves scoping-doc item **#6** — the `PhosphorScreensCore` POD/Runtime split FIXME. This is the **last** of the six deferred items.

## Problem

`PhosphorScreens::Core` bundled the pure POD/serialiser surface (`ScreenInfo`, `ScreenIdentity`, `Swapper`, `QtScreenProvider`, `VirtualScreen`, the config/panel interfaces) together with the live `ScreenManager`, whose LayerSurface-backed geometry sensors pull in `PhosphorWayland`. So **every** consumer that linked `::Core` acquired `PhosphorWayland` at runtime — even ones that only touch POD types.

## The split

| Target | Contents | Links |
|---|---|---|
| `PhosphorScreens::Core` | pure POD/serialiser surface | Qt6::Core/Gui + PhosphorIdentity — **no Wayland** |
| `PhosphorScreens::Runtime` (new) | the whole `ScreenManager` (`manager.cpp` + `manager_virtualscreens.cpp` + `Manager.h`) | `::Core` (PUBLIC) + PhosphorWayland (PRIVATE) |
| `PhosphorScreens::PhosphorScreens` | D-Bus surface | now `::Runtime` (DBusScreenAdaptor holds a `ScreenManager*`) |

`ScreenManager` travels whole into Runtime (its only Wayland coupling is in `manager.cpp`); `Manager.h`'s public surface is Wayland-free. `Manager.h` export macro → `PHOSPHORSCREENSRUNTIME_EXPORT`. Added a `CHANGES.md` entry + a `::Runtime` package-config alias for downstream `find_package`.

## Consumers re-pointed (`Core` → `Runtime`)

They construct/call a `ScreenManager`: `phosphor-placement`, `phosphor-snap-engine`, `phosphor-tile-engine`, `phosphor-zones`, and the 2 `ScreenManager` tests. POD-only consumers (`phosphor-overlay`, the POD tests) stay on `Core` and shed `PhosphorWayland`. `src/` is untouched — the umbrella pulls Runtime transitively.

## Verified the goal (`ldd`)

- `libPhosphorScreensCore.so` **no longer links** `PhosphorWayland` — it's no longer a Wayland propagation vector.
- The 4 POD-only test binaries (link *only* Core) are now **Wayland-free** (they pulled it before).
- Runtime consumers still get Wayland; the `ScreenManager` test correctly has it.

## Notes

- **The static consumer map had one miss the build caught:** `phosphor-zones` looked POD-only, but `GeometryUtils.h` exposes `ScreenManager*` and `geometryutils.cpp` calls its methods — it's a Runtime consumer. The link error surfaced it; re-pointed + corrected its stale "no public header surfaces these types" comment.
- `phosphor-overlay` still pulls Wayland, but via its **own** `PhosphorLayer` dependency (it's a layer-shell overlay renderer) — orthogonal to this split, not a regression.

## Testing
- `cmake --build build` → clean; `ctest` → **214/214 pass**.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)