### PR TITLE
fix(build): make the tree compile with CMAKE_UNITY_BUILD=OFF

### DIFF
--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "../plasmazoneseffect.h"
+#include "../compositorclock.h"
 #include "shader_internal.h"
+#include "shader_resolve.h"
 #include "window_query.h"
 
 #include <effect/effecthandler.h>

--- a/libs/phosphor-animation/CMakeLists.txt
+++ b/libs/phosphor-animation/CMakeLists.txt
@@ -290,6 +290,15 @@ target_include_directories(PhosphorAnimationQml
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
         $<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR}>
+    PRIVATE
+        # The generated <module>_qmltyperegistrations.cpp guards each registered
+        # type with `#if __has_include(<PhosphorCurve.h>)` using the BARE header
+        # name, so the header's own directory must be on the include path for the
+        # registration to resolve it. A non-unity build compiles that generated
+        # TU alone (no batch-mate to declare the type), so without this it fails
+        # with "PhosphorAnimation … not declared". PRIVATE — consumers still use
+        # the <PhosphorAnimation/…> spelling via the PUBLIC include dir above.
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/PhosphorAnimation>
 )
 
 target_compile_features(PhosphorAnimationQml PUBLIC cxx_std_20)
@@ -331,6 +340,10 @@ if(PHOSPHOR_ANIMATION_QML_INSTALL)
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
             $<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR}>
+        PRIVATE
+            # Same bare-`__has_include(<PhosphorCurve.h>)` resolution as the
+            # PhosphorAnimationQml target above — see the comment there.
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/PhosphorAnimation>
     )
 
     # The SHARED variant compiles the same sources under a different target

--- a/libs/phosphor-placement/src/resnap.cpp
+++ b/libs/phosphor-placement/src/resnap.cpp
@@ -11,6 +11,7 @@
 #include <PhosphorZones/LayoutUtils.h>
 #include <PhosphorSnapEngine/SnapState.h>
 #include <PhosphorScreens/Manager.h>
+#include <PhosphorWorkspaces/VirtualDesktopManager.h>
 #include <PhosphorZones/Zone.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorIdentity/WindowId.h>

--- a/libs/phosphor-settings-ui/CMakeLists.txt
+++ b/libs/phosphor-settings-ui/CMakeLists.txt
@@ -283,6 +283,13 @@ target_include_directories(PhosphorSettingsUiQml
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
         $<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR}>
+    PRIVATE
+        # The generated <module>_qmltyperegistrations.cpp guards each registered
+        # type with `#if __has_include(<Header.h>)` using the BARE header name,
+        # so the header's own directory must be on the include path for a
+        # non-unity build (which compiles that TU alone) to resolve it. PRIVATE —
+        # consumers still use the <PhosphorSettingsUi/…> spelling above.
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/PhosphorSettingsUi>
 )
 
 target_compile_features(PhosphorSettingsUiQml PUBLIC cxx_std_20)
@@ -362,6 +369,10 @@ if(PHOSPHOR_SETTINGS_UI_QML_INSTALL)
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
             $<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR}>
+        PRIVATE
+            # Same bare-`__has_include(<Header.h>)` resolution as the
+            # PhosphorSettingsUiQml target above.
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/PhosphorSettingsUi>
     )
 
     # The SHARED variant compiles the same sources under a different

--- a/libs/phosphor-snap-engine/src/commit.cpp
+++ b/libs/phosphor-snap-engine/src/commit.cpp
@@ -3,6 +3,7 @@
 
 #include <PhosphorSnapEngine/SnapEngine.h>
 #include <PhosphorSnapEngine/SnapState.h>
+#include <PhosphorScreens/Manager.h>
 #include <PhosphorScreens/ScreenIdentity.h>
 #include "snapenginelogging.h"
 

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
@@ -5,6 +5,7 @@
 
 #include <phosphortileengine_export.h>
 #include <PhosphorEngine/PerScreenKeys.h>
+#include <PhosphorLayoutApi/EdgeGaps.h>
 #include <QHash>
 #include <QString>
 #include <QVariantMap>

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -37,6 +37,7 @@
 #include <array>
 
 #include "overlayservice.h"
+#include "unifiedlayoutcontroller.h"
 #include "modetracker.h"
 #include "shortcutmanager.h"
 #include "rendering/zoneshadernoderhi.h"

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -15,6 +15,7 @@
 #include "../../core/constants.h"
 #include "../../core/utils.h"
 #include <PhosphorPlacement/WindowTrackingService.h>
+#include <PhosphorContext/ContextResolver.h>
 #include "../config/settings.h"
 #include "../../dbus/windowtrackingadaptor.h"
 #include <PhosphorEngine/PlacementEngineBase.h>

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -5,6 +5,7 @@
 #include "../overlayservice.h"
 #include "../unifiedlayoutcontroller.h"
 #include "../modetracker.h"
+#include "../../core/screenmoderouter.h"
 #include <PhosphorContext/ContextResolver.h>
 #include <PhosphorZones/AssignmentEntry.h>
 #include <PhosphorZones/LayoutRegistry.h>

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -18,6 +18,7 @@
 #include "../../core/utils.h"
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include "../../dbus/layoutadaptor.h"
+#include "../../dbus/settingsadaptor.h"
 #include "../../dbus/windowtrackingadaptor.h"
 #include "../../dbus/zonedetectionadaptor.h"
 

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -9,6 +9,7 @@
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorZones/LayoutComputeService.h>
 #include <PhosphorScreens/Manager.h>
+#include <PhosphorContext/ContextResolver.h>
 #include <PhosphorWorkspaces/VirtualDesktopManager.h>
 #include <PhosphorWorkspaces/ActivityManager.h>
 #include "../../core/geometryutils.h"
@@ -31,6 +32,7 @@
 #include <PhosphorTiles/TilingAlgorithm.h>
 #include <PhosphorTiles/ScriptedAlgorithmLoader.h>
 #include "../../core/shaderregistry.h"
+#include "../../config/settingsconfigstore.h"
 #include <PhosphorZones/ZoneDetector.h>
 #include <QProcess>
 #include <QPointer>

--- a/src/daemon/enginefactory.cpp
+++ b/src/daemon/enginefactory.cpp
@@ -6,6 +6,10 @@
 // Concrete engine includes — only this TU needs them.
 #include <PhosphorTileEngine/AutotileEngine.h>
 #include <PhosphorSnapEngine/SnapEngine.h>
+#include <PhosphorEngine/WindowRegistry.h>
+#include <PhosphorPlacement/WindowTrackingService.h>
+#include <PhosphorWorkspaces/VirtualDesktopManager.h>
+#include "../core/isettings.h"
 #include "../core/screenmoderouter.h"
 
 namespace PlasmaZones {

--- a/src/daemon/overlayservice/settings.cpp
+++ b/src/daemon/overlayservice/settings.cpp
@@ -5,6 +5,7 @@
 #include "../overlayservice.h"
 #include "qml_property_names.h"
 #include <PhosphorAudio/IAudioSpectrumProvider.h>
+#include <PhosphorAnimation/SurfaceAnimator.h>
 #include <PhosphorRendering/ShaderCompiler.h>
 #include "../../core/logging.h"
 #include <PhosphorTiles/ITileAlgorithmRegistry.h>

--- a/src/daemon/vulkan_support.h
+++ b/src/daemon/vulkan_support.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <QtCore/qglobal.h> // Ensure QT_CONFIG is defined regardless of include order
+#include <QtGui/qtguiglobal.h> // Ensure QT_CONFIG(vulkan)/QT_FEATURE_vulkan is defined regardless of include order
 
 #include <QVersionNumber>
 

--- a/src/settings/animations_controller_detail.h
+++ b/src/settings/animations_controller_detail.h
@@ -10,10 +10,17 @@
 // QML consumption. Inline definitions here ensure both TUs get their own
 // copy without relying on unity-build TU merging for cross-TU linkage.
 
+#include "../core/logging.h"
+
 #include <PhosphorAnimation/AnimationShaderEffect.h>
+#include <PhosphorAnimation/Easing.h>
+#include <PhosphorAnimation/Profile.h>
 #include <PhosphorAnimation/ShaderProfile.h>
 #include <PhosphorAnimation/ShaderProfileTree.h>
 
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QLatin1Char>
 #include <QLatin1String>
 #include <QString>
@@ -129,6 +136,90 @@ inline QString humanizeSegment(const QString& segment)
         out.append(cur);
     }
     return out;
+}
+
+// ProfileLoader's envelope helper reads the top-level `name` field to
+// assign the registry path (and strips it from the returned root). We
+// add it on write so the file is recognised. JSON keys are
+// QLatin1String per the project's Qt6 string-literal rule. `inline`
+// (external linkage, one definition) so the sibling TUs that consume
+// these helpers (animationspagecontroller{,_overrides,_shaders}.cpp)
+// all share one definition without relying on unity-build TU merging.
+inline constexpr QLatin1String JsonNameKey{"name"};
+
+/// Convert a `Profile` value to its `toJson()` shape as a QVariantMap.
+/// Sparse — only engaged fields appear, matching the wire format.
+inline QVariantMap profileToVariantMap(const PhosphorAnimation::Profile& profile)
+{
+    return profile.toJson().toVariantMap();
+}
+
+/// Read the JSON object at @p path. Returns an empty object on missing
+/// file / parse error / non-object root. The `name` field is stripped so
+/// the returned map matches the QML-facing Profile shape. Parse errors
+/// are logged so silent corruption surfaces in journalctl.
+inline QJsonObject readProfileJson(const QString& path)
+{
+    QFile file(path);
+    if (!file.exists())
+        return {};
+    if (!file.open(QIODevice::ReadOnly)) {
+        qCWarning(lcConfig) << "AnimationsPageController: cannot open profile" << path;
+        return {};
+    }
+    QJsonParseError err{};
+    const auto doc = QJsonDocument::fromJson(file.readAll(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        qCWarning(lcConfig) << "AnimationsPageController: failed to parse" << path << ":" << err.errorString();
+        return {};
+    }
+    QJsonObject obj = doc.object();
+    obj.remove(JsonNameKey);
+    return obj;
+}
+
+/// Merge fields from @p source into @p target without overwriting keys
+/// already present in @p target. Implements ProfileTree-style "deeper
+/// path wins" inheritance when called from leaf to root.
+inline void mergeMissingFields(QVariantMap& target, const QVariantMap& source)
+{
+    for (auto it = source.cbegin(); it != source.cend(); ++it) {
+        if (!target.contains(it.key())) {
+            target.insert(it.key(), it.value());
+        }
+    }
+}
+
+/// Fill any unset fields in @p profile with the `Profile::Default*`
+/// library constants so the QML side always reads a populated map.
+inline void fillLibraryDefaults(QVariantMap& profile)
+{
+    using P = PhosphorAnimation::Profile;
+    if (!profile.contains(QLatin1String(P::JsonFieldDuration))) {
+        profile.insert(QLatin1String(P::JsonFieldDuration), P::DefaultDuration);
+    }
+    if (!profile.contains(QLatin1String(P::JsonFieldMinDistance))) {
+        profile.insert(QLatin1String(P::JsonFieldMinDistance), P::DefaultMinDistance);
+    }
+    if (!profile.contains(QLatin1String(P::JsonFieldSequenceMode))) {
+        profile.insert(QLatin1String(P::JsonFieldSequenceMode), int(P::DefaultSequenceMode));
+    }
+    if (!profile.contains(QLatin1String(P::JsonFieldStaggerInterval))) {
+        profile.insert(QLatin1String(P::JsonFieldStaggerInterval), P::DefaultStaggerInterval);
+    }
+    // `curve` left unset → fill with the canonical library default
+    // (default-constructed `Easing` is OutCubic, matching
+    // `Profile::withDefaults()` and `AnimatedValue::defaultFallbackCurve()`).
+    // Without this, QML cards crashed with "Cannot read property of
+    // undefined" when no parent supplied a curve.
+    if (!profile.contains(QLatin1String(P::JsonFieldCurve))) {
+        // Cache the canonical default curve string. Constructing a fresh
+        // PhosphorAnimation::Easing() per call just to read its toString()
+        // is wasteful — the function-local static is initialised once,
+        // thread-safely under C++11.
+        static const QString kDefaultCurve = PhosphorAnimation::Easing().toString();
+        profile.insert(QLatin1String(P::JsonFieldCurve), kDefaultCurve);
+    }
 }
 
 } // namespace animations_controller_detail

--- a/src/settings/animationspagecontroller.cpp
+++ b/src/settings/animationspagecontroller.cpp
@@ -44,93 +44,16 @@ namespace PlasmaZones {
 
 namespace animations_controller_detail {
 
-// ProfileLoader's envelope helper reads the top-level `name` field to
-// assign the registry path (and strips it from the returned root). We
-// add it on write so the file is recognised. JSON keys are
-// QLatin1String per the project's Qt6 string-literal rule. `static`
-// (internal linkage) keeps unity-build merging safe even though sibling
-// TUs declare the same symbol name in their own detail namespaces.
-static constexpr QLatin1String JsonNameKey{"name"};
-
-/// `humanizeSegment` (segment title-casing for label display) lives in
+/// `JsonNameKey`, `profileToVariantMap`, `readProfileJson`,
+/// `mergeMissingFields`, and `fillLibraryDefaults` live in
+/// `animations_controller_detail.h` so sibling TUs
+/// (animationspagecontroller_overrides.cpp, _shaders.cpp) share the exact
+/// same implementations without relying on unity-build TU merging.
+///
+/// `humanizeSegment` (segment title-casing for label display) also lives in
 /// `animations_controller_detail.h` so animationspagecontroller_paths.cpp
 /// shares the exact same implementation. Both `eventSections` (this TU)
 /// and `eventLabel` (paths TU) call through to the header version.
-
-/// Convert a `Profile` value to its `toJson()` shape as a QVariantMap.
-/// Sparse — only engaged fields appear, matching the wire format.
-static QVariantMap profileToVariantMap(const PhosphorAnimation::Profile& profile)
-{
-    return profile.toJson().toVariantMap();
-}
-
-/// Read the JSON object at @p path. Returns an empty object on missing
-/// file / parse error / non-object root. The `name` field is stripped so
-/// the returned map matches the QML-facing Profile shape. Parse errors
-/// are logged so silent corruption surfaces in journalctl.
-static QJsonObject readProfileJson(const QString& path)
-{
-    QFile file(path);
-    if (!file.exists())
-        return {};
-    if (!file.open(QIODevice::ReadOnly)) {
-        qCWarning(lcConfig) << "AnimationsPageController: cannot open profile" << path;
-        return {};
-    }
-    QJsonParseError err{};
-    const auto doc = QJsonDocument::fromJson(file.readAll(), &err);
-    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
-        qCWarning(lcConfig) << "AnimationsPageController: failed to parse" << path << ":" << err.errorString();
-        return {};
-    }
-    QJsonObject obj = doc.object();
-    obj.remove(JsonNameKey);
-    return obj;
-}
-
-/// Merge fields from @p source into @p target without overwriting keys
-/// already present in @p target. Implements ProfileTree-style "deeper
-/// path wins" inheritance when called from leaf to root.
-static void mergeMissingFields(QVariantMap& target, const QVariantMap& source)
-{
-    for (auto it = source.cbegin(); it != source.cend(); ++it) {
-        if (!target.contains(it.key())) {
-            target.insert(it.key(), it.value());
-        }
-    }
-}
-
-/// Fill any unset fields in @p profile with the `Profile::Default*`
-/// library constants so the QML side always reads a populated map.
-static void fillLibraryDefaults(QVariantMap& profile)
-{
-    using P = PhosphorAnimation::Profile;
-    if (!profile.contains(QLatin1String(P::JsonFieldDuration))) {
-        profile.insert(QLatin1String(P::JsonFieldDuration), P::DefaultDuration);
-    }
-    if (!profile.contains(QLatin1String(P::JsonFieldMinDistance))) {
-        profile.insert(QLatin1String(P::JsonFieldMinDistance), P::DefaultMinDistance);
-    }
-    if (!profile.contains(QLatin1String(P::JsonFieldSequenceMode))) {
-        profile.insert(QLatin1String(P::JsonFieldSequenceMode), int(P::DefaultSequenceMode));
-    }
-    if (!profile.contains(QLatin1String(P::JsonFieldStaggerInterval))) {
-        profile.insert(QLatin1String(P::JsonFieldStaggerInterval), P::DefaultStaggerInterval);
-    }
-    // `curve` left unset → fill with the canonical library default
-    // (default-constructed `Easing` is OutCubic, matching
-    // `Profile::withDefaults()` and `AnimatedValue::defaultFallbackCurve()`).
-    // Without this, QML cards crashed with "Cannot read property of
-    // undefined" when no parent supplied a curve.
-    if (!profile.contains(QLatin1String(P::JsonFieldCurve))) {
-        // Cache the canonical default curve string. Constructing a fresh
-        // PhosphorAnimation::Easing() per call just to read its toString()
-        // is wasteful — the function-local static is initialised once,
-        // thread-safely under C++11.
-        static const QString kDefaultCurve = PhosphorAnimation::Easing().toString();
-        profile.insert(QLatin1String(P::JsonFieldCurve), kDefaultCurve);
-    }
-}
 
 } // namespace animations_controller_detail
 

--- a/src/settings/animationspagecontroller_overrides.cpp
+++ b/src/settings/animationspagecontroller_overrides.cpp
@@ -21,9 +21,11 @@
 #include "../core/logging.h"
 #include "animations_controller_detail.h"
 
+#include <PhosphorAnimation/PhosphorProfileRegistry.h>
 #include <PhosphorAnimation/Profile.h>
 #include <PhosphorAnimation/ProfilePaths.h>
 
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QJsonDocument>

--- a/src/settings/animationspagecontroller_shaders.cpp
+++ b/src/settings/animationspagecontroller_shaders.cpp
@@ -20,6 +20,7 @@
 
 #include "../config/configdefaults.h"
 #include "../core/animationshadersupportedpaths.h"
+#include "../core/isettings.h"
 #include "../core/logging.h"
 #include "../core/utils.h"
 #include "../pz_i18n.h"

--- a/src/settings/settingscontroller_lifecycle.cpp
+++ b/src/settings/settingscontroller_lifecycle.cpp
@@ -24,6 +24,7 @@
 #include "../config/configdefaults.h"
 #include "../config/configmigration.h"
 #include "../core/utils.h"
+#include "dbusutils.h"
 
 #include <PhosphorProtocol/ClientHelpers.h>
 

--- a/src/settings/settingscontroller_virtualscreens.cpp
+++ b/src/settings/settingscontroller_virtualscreens.cpp
@@ -16,6 +16,9 @@
 #include "settingscontroller.h"
 
 #include "../core/logging.h"
+#include "virtualscreenutils.h"
+
+#include "dbusutils.h"
 
 #include <PhosphorProtocol/ClientHelpers.h>
 #include <PhosphorProtocol/ServiceConstants.h>


### PR DESCRIPTION
## What

Makes the entire project (libs + daemon + settings app + kwin effect + tests) compile with `-DCMAKE_UNITY_BUILD=OFF`.

## Why

Unity (jumbo) builds concatenate ~16 `.cpp` into a single TU, so a file can compile by riding a batch-mate's `#include`s. That masked a layer of **include-what-you-use** debt: ~20 files relied on transitive/batch-mate includes and failed to compile standalone. Turning unity off surfaced them all. No behavioural change — purely making each TU self-contained.

## Fixes by category

- **Plain missing includes** for incomplete types / undeclared symbols across the daemon, settings app, and the snap/tile/placement libs and kwin effect: `ContextResolver`, `ScreenModeRouter`, `SettingsAdaptor`, `SettingsConfigStore`, `WindowRegistry`, `SurfaceAnimator`, `ISettings`, `DaemonDBus`, `VirtualScreenUtils`, `PhosphorProfileRegistry`, `QDir`, etc.
- **`enginefactory.cpp`** — the engine ctors take `IWindowTrackingService*` / `IVirtualDesktopManager*`, but the factory passes the concrete `WindowTrackingService*` / `VirtualDesktopManager*`. The derived→base pointer conversion needs the **complete** types, so their headers are now included.
- **`daemon.cpp`** — `unique_ptr<UnifiedLayoutController>` destructor needs the complete type; include the controller header.
- **`vulkan_support.h`** — `QT_CONFIG(vulkan)` depends on `QT_FEATURE_vulkan`, a Qt **GUI** feature. Switched `<QtCore/qglobal.h>` → `<QtGui/qtguiglobal.h>` so the `#if` resolves standalone (was *"division by zero in #if"* in non-unity builds).
- **`animations_controller_detail.h`** — `readProfileJson` / `profileToVariantMap` / `mergeMissingFields` / `fillLibraryDefaults` / `JsonNameKey` were `static` in `animationspagecontroller.cpp` but used by sibling TUs (`_overrides.cpp`, `_shaders.cpp`) — only linkable under unity merging. Moved to the shared detail header as `inline`.
- **`PhosphorAnimationQml` / `PhosphorSettingsUiQml`** — the generated `<module>_qmltyperegistrations.cpp` guards each type with a bare `#if __has_include(<Header.h>)`, so the header's own `include/<Subdir>` is now on the (PRIVATE) include path for the non-unity TU to resolve it.

## Verification

- `CMAKE_UNITY_BUILD=ON` build: clean (0 errors)
- `CMAKE_UNITY_BUILD=OFF` build: clean (0 errors, 0 undefined references)
- All **214** unit tests pass

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)