### PR TITLE
fix(kwin-effect): window-rule SetOpacity rendering — survives idle + animations

### DIFF
--- a/data/animations/shared/animation_uniforms.glsl
+++ b/data/animations/shared/animation_uniforms.glsl
@@ -141,6 +141,18 @@ uniform vec2 iAnchorSize;
 // consumes it.
 uniform vec2 iAnchorPosInFbo;
 
+// Window's effective rule-resolved opacity in [0, 1] — compositor path
+// only. A `SetOpacity` window rule must dim the window for the whole
+// transition, but the custom transition shader is compiled
+// `MapTexture`-only (no `Modulate` trait), so KWin never applies
+// `data.opacity()` to it. `surfaceColor()` below multiplies the
+// premultiplied surface sample by this uniform so the dim holds across
+// the animation instead of snapping in only after it ends. The
+// kwin-effect pushes 1.0 for windows with no matching rule, so the
+// multiply is a no-op in the common case. Daemon-only animations have no
+// window-rule opacity, so the UBO branch omits this field entirely.
+uniform float iWindowOpacity;
+
 // Card's UV sub-rect within `uTexture0`, as (x, y, width, height) in
 // the texture's [0, 1] space. Both runtimes capture more than the bare
 // card: KWin's OffscreenEffect redirects the whole window item —
@@ -324,10 +336,21 @@ layout(binding = 10) uniform sampler2D uTexture3;
 vec4 surfaceColor(vec2 uv) {
     vec2 t = iAnchorRectInTexture.xy + uv * iAnchorRectInTexture.zw;
 #ifdef PLASMAZONES_KWIN
-    // KWin's FBO is bottom-origin (Y-up) — flip last.
-    return texture(uTexture0, vec2(t.x, 1.0 - t.y));
+    // KWin's FBO is bottom-origin (Y-up) — flip last. Then scale by the
+    // window-rule opacity: uTexture0 is premultiplied, so multiplying the
+    // whole sample by the [0, 1] `iWindowOpacity` is the correct
+    // premultiplied-alpha dim. This is what makes a `SetOpacity` rule hold
+    // throughout a transition (the MapTexture-only shader can't see
+    // `data.opacity()`); the effect feeds 1.0 when no rule matches, so the
+    // common case is unchanged. Every window-content shader reads the
+    // surface through this helper (directly or via bmw_compat's
+    // `getInputColor`), so the dim propagates uniformly without per-shader
+    // edits.
+    return texture(uTexture0, vec2(t.x, 1.0 - t.y)) * iWindowOpacity;
 #else
-    // The daemon's Qt-RHI texture is top-origin (Y-down) — no flip.
+    // The daemon's Qt-RHI texture is top-origin (Y-down) — no flip. The
+    // daemon path has no window-rule opacity (SetOpacity is a compositor
+    // window-rule feature), so there is no iWindowOpacity multiply here.
     return texture(uTexture0, t);
 #endif
 }

--- a/kwin-effect/plasmazoneseffect.cpp
+++ b/kwin-effect/plasmazoneseffect.cpp
@@ -63,7 +63,24 @@ bool PlasmaZonesEffect::isActive() const
     // maximize/resize) installs a shader transition only — without this
     // clause those events would resolve cleanly, redirect the window,
     // and then sit unrendered until the timer-driven teardown fired.
-    return m_dragTracker->isDragging() || m_windowAnimator->hasActiveAnimations() || !m_shaderManager.empty();
+    //
+    // `m_shaderManager.hasOpacityRules()` is included for the same
+    // chain-exclusion reason, but the failure mode is the opposite of a
+    // one-shot transition: a SetOpacity rule is a PERSISTENT per-window
+    // appearance change that prePaintWindow/paintWindow must apply on
+    // every frame the matched window is painted. The transient triggers
+    // above only hold isActive() true while a drag/animation/transition
+    // is in flight; the instant they settle KWin drops the effect from
+    // the chain and `data.setOpacity()` stops running, so the window
+    // snaps back to full opacity until the next interaction spins a
+    // transition back up. Gating on hasOpacityRules() keeps the effect
+    // in the chain for as long as any enabled opacity rule exists, so
+    // the dim survives idle. This does not force continuous repaints —
+    // KWin still only composites on damage; isActive() merely keeps the
+    // effect consulted (and the window composited rather than
+    // direct-scanned-out) when a frame is produced.
+    return m_dragTracker->isDragging() || m_windowAnimator->hasActiveAnimations() || !m_shaderManager.empty()
+        || m_shaderManager.hasOpacityRules();
 }
 
 void PlasmaZonesEffect::grabbedKeyboardEvent(QKeyEvent* e)

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -234,7 +234,9 @@ void PlasmaZonesEffect::postPaintScreen()
 void PlasmaZonesEffect::prePaintWindow(KWin::RenderView* view, KWin::EffectWindow* w, KWin::WindowPrePaintData& data,
                                        std::chrono::milliseconds presentTime)
 {
-    if (w && (m_windowAnimator->hasAnimation(w) || m_shaderManager.hasTransition(w) || m_restoreSuppress.contains(w))) {
+    const bool transformDriven =
+        w && (m_windowAnimator->hasAnimation(w) || m_shaderManager.hasTransition(w) || m_restoreSuppress.contains(w));
+    if (transformDriven) {
         // Mark as transformed so paintWindow applies our translate+scale, and
         // so the OffscreenEffect redirect drives full-window repaints for the
         // shader leg's iTime advance even when the underlying window content
@@ -260,30 +262,35 @@ void PlasmaZonesEffect::prePaintWindow(KWin::RenderView* view, KWin::EffectWindo
         // the whole animation. setTranslucent() clears the opaque region
         // so every frame fully recomposites under the window.
         data.setTranslucent();
-    } else if (w && m_shaderManager.hasOpacityRules()) {
-        // SetOpacity-only case: a rule may dim this window via
-        // `data.setOpacity()` in paintWindow below, but with neither an
-        // animation, shader transition, nor restore suppression in
-        // flight the branch above didn't fire setTranslucent(). Without
-        // it, KWin keeps the window's deviceOpaque region and skips
-        // recompositing whatever sits behind it — stale background
-        // pixels show through the dimmed window the moment anything
-        // behind it moves. Probe the rule cascade for an opacity < 1.0
-        // and clear the opaque region. Geometry is untouched
-        // (setTransformed deliberately NOT called) since SetOpacity is
-        // a pure alpha change.
-        //
-        // Resolve once per frame and cache: paintWindow below re-uses
-        // the same `(window, frame)` lookup, and walking the rule
-        // cascade twice per visible window per frame is wasted work
-        // for a hot path the project explicitly tracks. The cache is
-        // dropped at postPaintScreen.
+    }
+
+    // Resolve + cache the rule-resolved opacity for ANY window with
+    // SetOpacity rules, independent of whether a transition is in flight.
+    // Two consumers in paintWindow read this cache: the `data.setOpacity()`
+    // path (plain dimmed window) and the shader-transition draw, which
+    // pushes the value into the `iWindowOpacity` uniform so surfaceColor()
+    // dims the surface for the whole animation — a MapTexture-only custom
+    // shader can't see `data.opacity()`. This was previously an `else if`
+    // gated off the transform-driven branch above, so a window mid-
+    // transition never cached its opacity and the transition shader
+    // rendered it fully opaque until the animation settled, then snapped to
+    // the rule opacity. Resolve once per frame and cache (the cascade walk
+    // is the hot-path cost the project tracks); the cache drops at
+    // postPaintScreen.
+    if (w && m_shaderManager.hasOpacityRules()) {
         const QString winClass = w->windowClass();
         if (!isOwnOverlayClass(winClass) && !isPlasmaShellSurface(winClass)) {
             const auto opacity = resolveWindowOpacity(m_shaderManager.animationRuleEvaluator(),
                                                       windowRuleQueryFor(w, getWindowScreenId(w)), getWindowId(w));
             m_shaderManager.cacheFrameOpacity(w, opacity);
-            if (opacity && *opacity < 1.0) {
+            // Clear the deviceOpaque region so KWin recomposites whatever
+            // sits behind a dimmed window — without it, stale background
+            // pixels show through the moment anything behind moves. The
+            // transform-driven branch already did this for windows mid-
+            // transition; only the SetOpacity-only case needs it here.
+            // Geometry is untouched (no setTransformed) — SetOpacity is a
+            // pure alpha change.
+            if (!transformDriven && opacity && *opacity < 1.0) {
                 data.setTranslucent();
             }
         }
@@ -701,6 +708,25 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                     // converts surface-UV back to anchor-space — matching
                     // the daemon's surface-sized-FBO path.
                     shader->setUniform(cached->iAnchorPosInFboLoc, anchorUniforms.anchorPosInFbo);
+                }
+                if (cached->iWindowOpacityLoc >= 0) {
+                    // Feed the rule-resolved opacity so surfaceColor() dims
+                    // the surface for the entire transition. prePaintWindow
+                    // cached it this frame for any window with SetOpacity
+                    // rules; a nullopt entry (or no rules at all) means "no
+                    // rule matched this window" → full opacity. The custom
+                    // shader is compiled MapTexture-only and can't observe
+                    // data.opacity(), so this uniform is the only path that
+                    // applies the dim while the transition runs — without it
+                    // the window flashes fully opaque until the animation
+                    // settles, then snaps to the rule opacity.
+                    float winOpacity = 1.0f;
+                    if (m_shaderManager.frameOpacityCached(w)) {
+                        if (const auto cachedOpacity = m_shaderManager.cachedFrameOpacity(w)) {
+                            winOpacity = static_cast<float>(*cachedOpacity);
+                        }
+                    }
+                    shader->setUniform(cached->iWindowOpacityLoc, winOpacity);
                 }
                 if (cached->iAnchorRectInTextureLoc >= 0) {
                     // The anchor's UV sub-rect within uTexture0 (KWin's

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -747,6 +747,8 @@ bool PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
             shader->uniformLocation(PhosphorAnimationShaders::AnimationShaderContract::kIAnchorPosInFbo);
         cached.iAnchorRectInTextureLoc =
             shader->uniformLocation(PhosphorAnimationShaders::AnimationShaderContract::kIAnchorRectInTexture);
+        cached.iWindowOpacityLoc =
+            shader->uniformLocation(PhosphorAnimationShaders::AnimationShaderContract::kIWindowOpacity);
         // Cache element locations for the per-effect declared parameter
         // slots: `customParams[0..kMaxCustomParams-1]` for float / int /
         // bool params, and `customColors[0..kMaxCustomColors-1]` for color

--- a/kwin-effect/plasmazoneseffect/types.h
+++ b/kwin-effect/plasmazoneseffect/types.h
@@ -75,6 +75,12 @@ struct CachedShader
     int iAnchorSizeLoc = -1;
     int iAnchorPosInFboLoc = -1;
     int iAnchorRectInTextureLoc = -1;
+    /// `iWindowOpacity` location — -1 when the shader never reads
+    /// `surfaceColor()` (so the GLSL linker dropped the uniform). paintWindow
+    /// pushes the rule-resolved opacity here every frame so a SetOpacity rule
+    /// dims the surface throughout the transition; the MapTexture-only shader
+    /// can't see `data.opacity()`.
+    int iWindowOpacityLoc = -1;
     // Slot counts sourced from AnimationShaderContract so a future change to
     // the contract (e.g. growing the customParams budget) can't silently
     // desync this cache from the translation + upload sites in

--- a/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
@@ -308,6 +308,21 @@ inline constexpr const char* kIAnchorPosInFbo = "iAnchorPosInFbo";
 /// via classic-GL `setUniform`.
 inline constexpr const char* kIAnchorRectInTexture = "iAnchorRectInTexture";
 
+/// `float iWindowOpacity` — the window's effective rule-resolved opacity
+/// in [0.0, 1.0], COMPOSITOR PATH ONLY. A `SetOpacity` window rule must
+/// dim the window for the whole duration of a transition, but the custom
+/// transition shader is compiled `MapTexture`-only (no `Modulate` trait),
+/// so KWin never applies `data.opacity()` to it — `surfaceColor()`
+/// multiplies the premultiplied surface sample by this uniform instead.
+/// The kwin-effect pushes it every frame via classic-GL `setUniform`,
+/// defaulting to `1.0` for windows with no matching rule (a no-op dim).
+///
+/// Absent on the daemon path: overlay-surface animations have no
+/// window-rule opacity (`SetOpacity` is a compositor window-rule feature),
+/// so the canonical header declares this uniform — and folds it into
+/// `surfaceColor()` — only inside the `#ifdef PLASMAZONES_KWIN` branch.
+inline constexpr const char* kIWindowOpacity = "iWindowOpacity";
+
 /// Maximum number of user-declared textures per animation effect.
 ///
 /// Each declared texture binds to one of the canonical samplers


### PR DESCRIPTION
## Problem

The window-transparency window-rule effect (`SetOpacity`) "sort of worked but frequently stopped being transparent." Two distinct root causes in the KWin effect's paint pipeline:

1. **Dim didn't survive idle.** `isActive()` only returned `true` while a drag, animation, or shader transition was in flight. A `SetOpacity` rule is a *persistent* per-window appearance change, but the instant all transitions settled KWin dropped the effect from the paint chain and `data.setOpacity()` stopped running — the window snapped back to full opacity until the next interaction spun a transition up.

2. **Dim didn't survive animations.** A window with both a `SetOpacity` rule and an active animation-shader transition rendered at full opacity for the whole animation, then snapped to the rule opacity once it ended. During a transition the window is drawn by a custom shader compiled with only `KWin::ShaderTrait::MapTexture` (no `Modulate` trait), so KWin never applies `data.opacity()` to it.

## Fix

**Commit 1 — keep the effect active while opacity rules exist.** Add `hasOpacityRules()` to the `isActive()` predicate so the effect stays in the chain for as long as any enabled opacity rule exists. This does not force continuous repaints (KWin still composites only on damage); it just keeps the effect consulted — and the window composited rather than direct-scanned-out — whenever a frame is produced.

**Commit 2 — apply the rule opacity during transitions.** Route the rule opacity into the shader through its one universal window-content seam, `surfaceColor()`:
- New `iWindowOpacity` uniform (compositor path only) that `surfaceColor()` multiplies into the premultiplied surface sample. Every transition shader reads the surface through `surfaceColor()` (directly or via `bmw_compat`'s `getInputColor`), so the dim propagates to **all** shaders with no per-shader edits.
- The daemon UBO branch is untouched (no window-rule opacity there), so std140 layout and the shader bake test are unaffected.
- `prePaintWindow` now resolves and caches the rule opacity whenever `hasOpacityRules()` — not only when no transition is active (the old `else if` skipped caching mid-transition, leaving the shader nothing to read). `paintWindow` pushes the cached value into `iWindowOpacity`, defaulting to `1.0` when no rule matches (a no-op for the common case).

The two fixes are complementary: the first keeps the dim alive at idle, the second keeps it alive during animations.

## Testing

- `cmake --build build` clean (incl. the KWin effect plugin).
- `ctest` — 214/214 pass (incl. `test_animation_shader_bake` and the `phosphorwindowrule` suite).
- Manually verified by the author: windows with a `SetOpacity` rule now stay dimmed at idle and animate in already at the rule opacity instead of flashing fully opaque.

Note: effect-*generated* overdraw (glows/particles) is not dimmed by design, since the rule targets the window content.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)