### PR TITLE
feat: default daemon overlay show/hide to the fade shader

### DIFF
--- a/libs/phosphor-animation/include/PhosphorAnimation/ProfilePaths.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/ProfilePaths.h
@@ -139,9 +139,11 @@ PHOSPHORANIMATION_EXPORT QString parentPath(const QString& path);
 /// families default to a shader:
 ///   • Window MOVE/RESIZE (snap, tile, layout-switch, move, resize) →
 ///     "window-morph" (geometry cross-fade), run by the kwin-effect.
-///   • Overlay show/hide (osd.*, popup.{zoneSelector,layoutPicker,snapAssist}.*)
-///     → "fade" (fade-and-scale), run by the daemon SurfaceAnimator instead of
-///     its C++ opacity/scale legs.
+///   • Overlay show/hide leaves (osd.{show,hide},
+///     popup.{zoneSelector,layoutPicker,snapAssist}.{show,hide}) → "fade"
+///     (fade-and-scale), run by the daemon SurfaceAnimator instead of its C++
+///     opacity/scale legs. The category roots (osd, popup, osd.pop) carry no
+///     default.
 /// Every other event defaults to none. The default applies only when the user
 /// has set no override for the path or an ancestor (an explicit "None" is an
 /// override and is respected) — see `resolveShaderWithDefault` in

--- a/libs/phosphor-animation/include/PhosphorAnimation/ProfilePaths.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/ProfilePaths.h
@@ -135,15 +135,19 @@ PHOSPHORANIMATION_EXPORT QString parentPath(const QString& path);
 
 /// Built-in default shader effect id for an event @p path, or empty for none.
 ///
-/// SSOT for "what shader does this event animate with out of the box". The
-/// window MOVE/RESIZE events (snap, tile, layout-switch, move, resize) default
-/// to the geometry-morph shader ("window-morph") so a window snapping into a
-/// zone animates via shader cross-fade by default; every other event defaults
-/// to none. The default applies only when the user has set no override for the
-/// path or an ancestor (an explicit "None" is an override and is respected) —
-/// see `resolveShaderWithDefault` in ShaderProfileTree.h. Consumed by both the
-/// kwin-effect resolution and the settings UI so the default both plays at
-/// runtime and shows as the current value in settings.
+/// SSOT for "what shader does this event animate with out of the box". Two
+/// families default to a shader:
+///   • Window MOVE/RESIZE (snap, tile, layout-switch, move, resize) →
+///     "window-morph" (geometry cross-fade), run by the kwin-effect.
+///   • Overlay show/hide (osd.*, popup.{zoneSelector,layoutPicker,snapAssist}.*)
+///     → "fade" (fade-and-scale), run by the daemon SurfaceAnimator instead of
+///     its C++ opacity/scale legs.
+/// Every other event defaults to none. The default applies only when the user
+/// has set no override for the path or an ancestor (an explicit "None" is an
+/// override and is respected) — see `resolveShaderWithDefault` in
+/// ShaderProfileTree.h. Consumed by the kwin-effect resolution, the daemon
+/// overlay resolution (animation_config), and the settings UI so the default
+/// both plays at runtime and shows as the current value in settings.
 PHOSPHORANIMATION_EXPORT QString defaultShaderEffectIdForPath(const QString& path);
 
 } // namespace ProfilePaths

--- a/libs/phosphor-animation/src/profilepaths.cpp
+++ b/libs/phosphor-animation/src/profilepaths.cpp
@@ -187,12 +187,22 @@ QString parentPath(const QString& path)
 QString defaultShaderEffectIdForPath(const QString& path)
 {
     // Window move/resize events default to the geometry-morph shader so a
-    // window animates via shader cross-fade when it snaps/tiles/reflows. Every
-    // other event defaults to no shader.
+    // window animates via shader cross-fade when it snaps/tiles/reflows.
     if (path == WindowMove || path == WindowResize || path == WindowSnapIn || path == WindowSnapOut
         || path == WindowSnapResize || path == WindowLayoutSwitch) {
         return QStringLiteral("window-morph");
     }
+    // Overlay surface show/hide (OSD + popups) default to the fade-and-scale
+    // shader so the daemon animates them via shader instead of the C++
+    // opacity/scale legs in SurfaceAnimator (which stay as the fallback when a
+    // shader is unavailable or the user picks "None"). Per-surface scale feel is
+    // preserved by seeding fade's `scaleAmount` daemon-side (animation_config).
+    if (path == OsdShow || path == OsdHide || path == PopupZoneSelectorShow || path == PopupZoneSelectorHide
+        || path == PopupLayoutPickerShow || path == PopupLayoutPickerHide || path == PopupSnapAssistShow
+        || path == PopupSnapAssistHide) {
+        return QStringLiteral("fade");
+    }
+    // Every other event defaults to no shader.
     return QString();
 }
 

--- a/libs/phosphor-animation/tests/test_shaderprofiletree.cpp
+++ b/libs/phosphor-animation/tests/test_shaderprofiletree.cpp
@@ -239,6 +239,38 @@ private Q_SLOTS:
         QVERIFY(PP::defaultShaderEffectIdForPath(PP::WindowClose).isEmpty());
     }
 
+    void testDefaultShaderForPathOverlayEvents()
+    {
+        // OSD + popup show/hide events default to the fade shader; others none.
+        QCOMPARE(PP::defaultShaderEffectIdForPath(PP::OsdShow), QStringLiteral("fade"));
+        QCOMPARE(PP::defaultShaderEffectIdForPath(PP::OsdHide), QStringLiteral("fade"));
+        QCOMPARE(PP::defaultShaderEffectIdForPath(PP::PopupZoneSelectorShow), QStringLiteral("fade"));
+        QCOMPARE(PP::defaultShaderEffectIdForPath(PP::PopupZoneSelectorHide), QStringLiteral("fade"));
+        QCOMPARE(PP::defaultShaderEffectIdForPath(PP::PopupLayoutPickerShow), QStringLiteral("fade"));
+        QCOMPARE(PP::defaultShaderEffectIdForPath(PP::PopupLayoutPickerHide), QStringLiteral("fade"));
+        QCOMPARE(PP::defaultShaderEffectIdForPath(PP::PopupSnapAssistShow), QStringLiteral("fade"));
+        QCOMPARE(PP::defaultShaderEffectIdForPath(PP::PopupSnapAssistHide), QStringLiteral("fade"));
+        // The category roots and the OSD "pop" event carry no built-in default.
+        QVERIFY(PP::defaultShaderEffectIdForPath(PP::Osd).isEmpty());
+        QVERIFY(PP::defaultShaderEffectIdForPath(PP::Popup).isEmpty());
+        QVERIFY(PP::defaultShaderEffectIdForPath(PP::OsdPop).isEmpty());
+    }
+
+    void testResolveWithDefaultUnsetOverlayEventGetsFade()
+    {
+        // Truly-unset overlay show/hide resolves to the built-in fade default;
+        // an explicit per-event "None" is still respected.
+        ShaderProfileTree tree;
+        QCOMPARE(PhosphorAnimationShaders::resolveShaderWithDefault(tree, PP::OsdShow).effectiveEffectId(),
+                 QStringLiteral("fade"));
+        QCOMPARE(PhosphorAnimationShaders::resolveShaderWithDefault(tree, PP::PopupSnapAssistHide).effectiveEffectId(),
+                 QStringLiteral("fade"));
+        ShaderProfile none;
+        none.effectId = QString();
+        tree.setOverride(PP::OsdShow, none);
+        QVERIFY(PhosphorAnimationShaders::resolveShaderWithDefault(tree, PP::OsdShow).effectiveEffectId().isEmpty());
+    }
+
     void testResolveWithDefaultUnsetMoveEventGetsMorph()
     {
         // Truly-unset move event resolves to the built-in default.

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -901,10 +901,12 @@ private:
      * lookups - surfaces mid-animation keep the config they bound at
      * beginShow/beginHide. That mirrors motion-tree live-reload semantics.
      *
-     * A default-constructed tree (empty baseline + no overrides) silently
-     * resolves every path to an empty effect id - same end result as the
-     * pre-shader-wireup motion-only behaviour. Used during the initial
-     * @c setupSurfaceAnimator pass before @c m_settings is wired.
+     * A default-constructed tree (empty baseline + no overrides) resolves each
+     * path to its built-in default shader (via @c resolveShaderWithDefault):
+     * overlay show/hide paths to "fade", paths without a default to empty
+     * (motion-only). Used during the initial @c setupSurfaceAnimator pass
+     * before @c m_settings is wired; the live tree later applies user
+     * overrides on top.
      */
     void applyShaderProfilesToAnimator(const PhosphorAnimationShaders::ShaderProfileTree& tree);
 

--- a/src/daemon/overlayservice/animation_config.cpp
+++ b/src/daemon/overlayservice/animation_config.cpp
@@ -82,11 +82,12 @@ namespace {
 namespace PAL = PhosphorAnimationLayer;
 namespace PAS = PhosphorAnimationShaders;
 
-/// Resolve a path against the shader profile tree. A default-constructed
-/// tree (empty baseline + no overrides) resolves every path to an empty
-/// effect id, equivalent to "no shader leg" - motion runs alone, identical
-/// to the pre-shader-wireup behaviour. The setSettings() handler later
-/// re-registers configs with the live tree once settings exist.
+/// Resolve a path's shader effect id, applying the built-in per-event default
+/// via `resolveShaderWithDefault`. A default-constructed tree (empty baseline +
+/// no overrides) therefore resolves overlay show/hide paths to their default
+/// ("fade") and every other path to empty ("no shader leg" - motion runs
+/// alone). The setSettings() handler later re-registers configs with the live
+/// tree once settings exist, applying any user overrides on top.
 ///
 /// **Source-of-truth note.** The settings UI gates its shader picker on
 /// `src/core/animationshadersupportedpaths.h::shaderSupportedEventPaths`,
@@ -140,19 +141,24 @@ PAL::SurfaceAnimator::Config buildDefaultConfig()
 PAL::SurfaceAnimator::Config buildOsdConfig(const PAS::ShaderProfileTree& tree)
 {
     namespace PP = PhosphorAnimation::ProfilePaths;
-    return PAL::SurfaceAnimator::Config{.showProfile = PP::OsdShow,
-                                        .hideProfile = PP::OsdHide,
-                                        .showScaleProfile = PP::OsdShow,
-                                        .hideScaleProfile = PP::OsdHide,
-                                        .showScaleFrom = 0.92,
-                                        .hideScaleTo = 0.96,
-                                        .showShaderEffectId = resolveShaderEffect(tree, PP::OsdShow),
-                                        .hideShaderEffectId = resolveShaderEffect(tree, PP::OsdHide),
-                                        .showShaderProfile = PP::OsdShow,
-                                        .hideShaderProfile = PP::OsdHide,
-                                        // fade scaleAmount = 1 - showScaleFrom (0.92) / 1 - hideScaleTo (0.96)
-                                        .showShaderParameters = resolveShaderParameters(tree, PP::OsdShow, 0.08),
-                                        .hideShaderParameters = resolveShaderParameters(tree, PP::OsdHide, 0.04)};
+    // Scale envelope, shared by the C++ scale-leg fallback (showScaleFrom /
+    // hideScaleTo) and the fade shader's scaleAmount seed (1 - the scale value),
+    // so retuning the envelope keeps both in lockstep.
+    constexpr double kShowScaleFrom = 0.92;
+    constexpr double kHideScaleTo = 0.96;
+    return PAL::SurfaceAnimator::Config{
+        .showProfile = PP::OsdShow,
+        .hideProfile = PP::OsdHide,
+        .showScaleProfile = PP::OsdShow,
+        .hideScaleProfile = PP::OsdHide,
+        .showScaleFrom = kShowScaleFrom,
+        .hideScaleTo = kHideScaleTo,
+        .showShaderEffectId = resolveShaderEffect(tree, PP::OsdShow),
+        .hideShaderEffectId = resolveShaderEffect(tree, PP::OsdHide),
+        .showShaderProfile = PP::OsdShow,
+        .hideShaderProfile = PP::OsdHide,
+        .showShaderParameters = resolveShaderParameters(tree, PP::OsdShow, 1.0 - kShowScaleFrom),
+        .hideShaderParameters = resolveShaderParameters(tree, PP::OsdHide, 1.0 - kHideScaleTo)};
 }
 
 /// LayoutPicker: OSD-style fade-and-pop shape with a softer scale
@@ -174,20 +180,23 @@ PAL::SurfaceAnimator::Config buildOsdConfig(const PAS::ShaderProfileTree& tree)
 PAL::SurfaceAnimator::Config buildLayoutPickerConfig(const PAS::ShaderProfileTree& tree)
 {
     namespace PP = PhosphorAnimation::ProfilePaths;
+    // Scale envelope (softer than the OSD's 0.92→1 since the picker is larger),
+    // shared by the C++ scale-leg fallback and the fade scaleAmount seed.
+    constexpr double kShowScaleFrom = 0.94;
+    constexpr double kHideScaleTo = 0.97;
     return PAL::SurfaceAnimator::Config{
         .showProfile = PP::PopupLayoutPickerShow,
         .hideProfile = PP::PopupLayoutPickerHide,
         .showScaleProfile = PP::PopupLayoutPickerShow,
         .hideScaleProfile = PP::PopupLayoutPickerHide,
-        .showScaleFrom = 0.94,
-        .hideScaleTo = 0.97,
+        .showScaleFrom = kShowScaleFrom,
+        .hideScaleTo = kHideScaleTo,
         .showShaderEffectId = resolveShaderEffect(tree, PP::PopupLayoutPickerShow),
         .hideShaderEffectId = resolveShaderEffect(tree, PP::PopupLayoutPickerHide),
         .showShaderProfile = PP::PopupLayoutPickerShow,
         .hideShaderProfile = PP::PopupLayoutPickerHide,
-        // fade scaleAmount = 1 - showScaleFrom (0.94) / 1 - hideScaleTo (0.97)
-        .showShaderParameters = resolveShaderParameters(tree, PP::PopupLayoutPickerShow, 0.06),
-        .hideShaderParameters = resolveShaderParameters(tree, PP::PopupLayoutPickerHide, 0.03)};
+        .showShaderParameters = resolveShaderParameters(tree, PP::PopupLayoutPickerShow, 1.0 - kShowScaleFrom),
+        .hideShaderParameters = resolveShaderParameters(tree, PP::PopupLayoutPickerHide, 1.0 - kHideScaleTo)};
 }
 
 /// ZoneSelector: opacity-only show/hide. `keepMappedOnHide=true` so the
@@ -318,14 +327,15 @@ void OverlayService::setupSurfaceAnimator(PhosphorAnimation::PhosphorProfileRegi
     // the passive-shell surface scope does not collide with this config.
     //
     // Initial registration runs with an empty tree - m_settings is wired
-    // later via setSettings(). A default-constructed tree resolves every
-    // path to an empty effect id, so this pass installs motion-only
-    // configs (identical to the pre-shader-wireup behaviour). Once
-    // settings exist, setSettings calls applyShaderProfilesToAnimator
-    // again with the live tree, and connects shaderProfileTreeChanged
-    // for live-reload. This keeps the constructor's invariant ("animator
-    // is ready before any Surface is created") while deferring the
-    // shader wiring to the moment settings are available.
+    // later via setSettings(). A default-constructed tree resolves each
+    // path to its built-in default (overlay show/hide → "fade"; paths with
+    // no default → motion-only), so this pass installs the default shader
+    // configs. Once settings exist, setSettings calls
+    // applyShaderProfilesToAnimator again with the live tree (applying any
+    // user overrides), and connects shaderProfileTreeChanged for
+    // live-reload. This keeps the constructor's invariant ("animator is
+    // ready before any Surface is created") while deferring the live-tree
+    // wiring to the moment settings are available.
     applyShaderProfilesToAnimator(PAS::ShaderProfileTree{});
 }
 

--- a/src/daemon/overlayservice/animation_config.cpp
+++ b/src/daemon/overlayservice/animation_config.cpp
@@ -96,15 +96,27 @@ namespace PAS = PhosphorAnimationShaders;
 /// settings UI starts surfacing the picker on the new path.
 QString resolveShaderEffect(const PAS::ShaderProfileTree& tree, const QString& path)
 {
-    return tree.resolve(path).effectiveEffectId();
+    // Route through the SSOT so overlay show/hide paths pick up their built-in
+    // default ("fade") when the user has set no override — and a per-app/tree
+    // "None" is still respected (empty id → SurfaceAnimator's C++ legs run).
+    return PAS::resolveShaderWithDefault(tree, path).effectiveEffectId();
 }
 
-/// Resolve a path against the shader profile tree and extract the per-event
-/// parameter overrides. Empty map when the profile didn't override anything
-/// - the shader runs with its declared defaults from metadata.json.
-QVariantMap resolveShaderParameters(const PAS::ShaderProfileTree& tree, const QString& path)
+/// Resolve a path against the shader profile tree (via the built-in default)
+/// and extract the per-event parameter overrides. When the resolved shader is
+/// the built-in "fade" overlay default and the user left `scaleAmount` unset,
+/// seed it from @p fadeScaleAmount — the surface's prior C++ scale depth
+/// (1 - showScaleFrom on show, 1 - hideScaleTo on hide; 0.0 for opacity-only
+/// surfaces) — so the shader reproduces the surface's existing pop feel. A user
+/// override of the shader (to anything but fade) or of scaleAmount itself wins.
+QVariantMap resolveShaderParameters(const PAS::ShaderProfileTree& tree, const QString& path, double fadeScaleAmount)
 {
-    return tree.resolve(path).effectiveParameters();
+    const PAS::ShaderProfile resolved = PAS::resolveShaderWithDefault(tree, path);
+    QVariantMap params = resolved.effectiveParameters();
+    if (resolved.effectiveEffectId() == QLatin1String("fade") && !params.contains(QLatin1String("scaleAmount"))) {
+        params.insert(QStringLiteral("scaleAmount"), fadeScaleAmount);
+    }
+    return params;
 }
 
 /// Default config - empty. Surfaces that route through the animator
@@ -138,8 +150,9 @@ PAL::SurfaceAnimator::Config buildOsdConfig(const PAS::ShaderProfileTree& tree)
                                         .hideShaderEffectId = resolveShaderEffect(tree, PP::OsdHide),
                                         .showShaderProfile = PP::OsdShow,
                                         .hideShaderProfile = PP::OsdHide,
-                                        .showShaderParameters = resolveShaderParameters(tree, PP::OsdShow),
-                                        .hideShaderParameters = resolveShaderParameters(tree, PP::OsdHide)};
+                                        // fade scaleAmount = 1 - showScaleFrom (0.92) / 1 - hideScaleTo (0.96)
+                                        .showShaderParameters = resolveShaderParameters(tree, PP::OsdShow, 0.08),
+                                        .hideShaderParameters = resolveShaderParameters(tree, PP::OsdHide, 0.04)};
 }
 
 /// LayoutPicker: OSD-style fade-and-pop shape with a softer scale
@@ -172,8 +185,9 @@ PAL::SurfaceAnimator::Config buildLayoutPickerConfig(const PAS::ShaderProfileTre
         .hideShaderEffectId = resolveShaderEffect(tree, PP::PopupLayoutPickerHide),
         .showShaderProfile = PP::PopupLayoutPickerShow,
         .hideShaderProfile = PP::PopupLayoutPickerHide,
-        .showShaderParameters = resolveShaderParameters(tree, PP::PopupLayoutPickerShow),
-        .hideShaderParameters = resolveShaderParameters(tree, PP::PopupLayoutPickerHide)};
+        // fade scaleAmount = 1 - showScaleFrom (0.94) / 1 - hideScaleTo (0.97)
+        .showShaderParameters = resolveShaderParameters(tree, PP::PopupLayoutPickerShow, 0.06),
+        .hideShaderParameters = resolveShaderParameters(tree, PP::PopupLayoutPickerHide, 0.03)};
 }
 
 /// ZoneSelector: opacity-only show/hide. `keepMappedOnHide=true` so the
@@ -198,8 +212,9 @@ PAL::SurfaceAnimator::Config buildZoneSelectorConfig(const PAS::ShaderProfileTre
         .hideShaderEffectId = resolveShaderEffect(tree, PP::PopupZoneSelectorHide),
         .showShaderProfile = PP::PopupZoneSelectorShow,
         .hideShaderProfile = PP::PopupZoneSelectorHide,
-        .showShaderParameters = resolveShaderParameters(tree, PP::PopupZoneSelectorShow),
-        .hideShaderParameters = resolveShaderParameters(tree, PP::PopupZoneSelectorHide)};
+        // Opacity-only surface (no scale leg) → fade scaleAmount 0.0 (pure fade).
+        .showShaderParameters = resolveShaderParameters(tree, PP::PopupZoneSelectorShow, 0.0),
+        .hideShaderParameters = resolveShaderParameters(tree, PP::PopupZoneSelectorHide, 0.0)};
 }
 
 /// SnapAssist: full show/hide pair. Pre-unified-shell, snap-assist
@@ -222,21 +237,23 @@ PAL::SurfaceAnimator::Config buildZoneSelectorConfig(const PAS::ShaderProfileTre
 PAL::SurfaceAnimator::Config buildSnapAssistConfig(const PAS::ShaderProfileTree& tree)
 {
     namespace PP = PhosphorAnimation::ProfilePaths;
-    return PAL::SurfaceAnimator::Config{// Popup surface family - dedicated path. A user editing
-                                        // `popup.snapAssist.show.json` affects ONLY the snap
-                                        // assist; siblings are unaffected. Built-in default mirrors the
-                                        // prior `popup` (150 ms widget-out) so behaviour is
-                                        // preserved.
-                                        .showProfile = PP::PopupSnapAssistShow,
-                                        .hideProfile = PP::PopupSnapAssistHide,
-                                        .showScaleProfile = {},
-                                        .hideScaleProfile = {},
-                                        .showShaderEffectId = resolveShaderEffect(tree, PP::PopupSnapAssistShow),
-                                        .hideShaderEffectId = resolveShaderEffect(tree, PP::PopupSnapAssistHide),
-                                        .showShaderProfile = PP::PopupSnapAssistShow,
-                                        .hideShaderProfile = PP::PopupSnapAssistHide,
-                                        .showShaderParameters = resolveShaderParameters(tree, PP::PopupSnapAssistShow),
-                                        .hideShaderParameters = resolveShaderParameters(tree, PP::PopupSnapAssistHide)};
+    return PAL::SurfaceAnimator::Config{
+        // Popup surface family - dedicated path. A user editing
+        // `popup.snapAssist.show.json` affects ONLY the snap
+        // assist; siblings are unaffected. Built-in default mirrors the
+        // prior `popup` (150 ms widget-out) so behaviour is
+        // preserved.
+        .showProfile = PP::PopupSnapAssistShow,
+        .hideProfile = PP::PopupSnapAssistHide,
+        .showScaleProfile = {},
+        .hideScaleProfile = {},
+        .showShaderEffectId = resolveShaderEffect(tree, PP::PopupSnapAssistShow),
+        .hideShaderEffectId = resolveShaderEffect(tree, PP::PopupSnapAssistHide),
+        .showShaderProfile = PP::PopupSnapAssistShow,
+        .hideShaderProfile = PP::PopupSnapAssistHide,
+        // Opacity-only surface (no scale leg) → fade scaleAmount 0.0 (pure fade).
+        .showShaderParameters = resolveShaderParameters(tree, PP::PopupSnapAssistShow, 0.0),
+        .hideShaderParameters = resolveShaderParameters(tree, PP::PopupSnapAssistHide, 0.0)};
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

Moves the daemon's **OSD + popup show/hide** transitions onto the **shader path**: they now animate via the existing `fade` shader by default, instead of `SurfaceAnimator`'s manual C++ opacity/scale legs. This is the overlay-side counterpart to the window-morph default (PR #572) — both now express their default animation as a shader through the same SSOT.

Follow-up to the audit finding that the daemon `SurfaceAnimator` opacity+scale legs were the main remaining C++-driven (non-shader) window/surface animation.

## Why it's a small change

`SurfaceAnimator` already makes the shader leg **exclusive** when one resolves: `hasScaleLeg = !scaleProfile.isEmpty() && !hasShaderLeg`, and opacity *snaps* under `shaderExclusive`. So the C++ legs are already the fallback — wiring a default shader id makes them bypass themselves. No `SurfaceAnimator` changes were needed.

## Changes

- **`profilepaths.cpp`** — `defaultShaderEffectIdForPath()` returns `"fade"` for the eight consumed overlay paths: `osd.{show,hide}` + `popup.{zoneSelector,layoutPicker,snapAssist}.{show,hide}`.
- **`animation_config.cpp`** (daemon) — `resolveShaderEffect`/`resolveShaderParameters` now route through `resolveShaderWithDefault` (the same SSOT helper as the morph PR). Each surface's prior pop feel is preserved by seeding fade's `scaleAmount` from its existing C++ scale depth (`1 − showScaleFrom` / `1 − hideScaleTo`): OSD `0.08`/`0.04`, layout picker `0.06`/`0.03`, zone selector & snap assist `0.0` (opacity-only).
- **`ProfilePaths.h`** — doc updated to describe both default families (window-morph + fade).
- Reuses the existing `fade` shader (already a fade-and-scale transition) rather than authoring a duplicate.

## Behavior

- Default (no user config): OSD/popups fade+scale via shader; the C++ opacity/scale legs no longer run.
- The C++ legs **remain the fallback** when the user sets the event shader to "None" or animations are gated off.
- Per-event overrides still win (different shader, custom `scaleAmount`, or "None"); the settings UI already shows `fade` as the current default via the same SSOT.

## Testing

- All 216 ctests pass, incl. new `test_shaderprofiletree` coverage: overlay default-map, resolve-with-default for overlay paths, and explicit per-event "None" respected.
- `fade` bakes via the shader bake test (pre-existing shader, no new GLSL).
- Hardware-validated (daemon, not headless-testable): layout-switch OSD, zone selector, layout picker, snap assist — show and hide.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)