### PR TITLE
refactor(window-rule): unify active/inactive border into IsFocused match condition

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -597,6 +597,13 @@ private:
 
     QHash<QString, WindowBorder> m_windowBorders; // windowId → border
 
+    // The window most recently passed to slotWindowActivated — i.e. the
+    // "previously active" window on the next focus change. Used to repaint the
+    // window that just lost focus so a focus-scoped (IsFocused) SetOpacity rule
+    // re-resolves on it; the window gaining focus is repainted via the slot's
+    // own argument. QPointer auto-nulls on window destruction.
+    QPointer<KWin::EffectWindow> m_lastActivatedWindow;
+
     // Windows whose server-side title bar a per-window-rule SetHideTitleBar
     // override hid (distinct from the snap/autotile borderless sets). Tracked
     // so reconcileRuleHiddenTitleBar can restore the decoration when the rule

--- a/kwin-effect/plasmazoneseffect/borders.cpp
+++ b/kwin-effect/plasmazoneseffect/borders.cpp
@@ -123,20 +123,22 @@ void PlasmaZonesEffect::updateWindowBorder(const QString& windowId, KWin::Effect
         return;
     }
 
-    // Choose color: active for focused window, inactive for others.
-    const QColor activeColor = (ovr && ovr->borderColor) ? *ovr->borderColor : (state ? state->color : QColor());
-    // Inactive falls back to the active rule colour when a rule supplies only
-    // an active colour AND the window has no owning mode (floating): without
-    // this a rule-bordered floating window would lose its border entirely when
-    // it loses focus (invalid inactiveColor → early-return below). A snapped
-    // window still inherits its mode's inactive colour.
-    const QColor inactiveColor = (ovr && ovr->inactiveBorderColor) ? *ovr->inactiveBorderColor
-        : state                                                    ? state->inactiveColor
-        : (ovr && ovr->borderColor)                                ? *ovr->borderColor
-                                                                   : QColor();
-    KWin::EffectWindow* active = KWin::effects->activeWindow();
-    const bool isFocused = (w == active);
-    const QColor bc = isFocused ? activeColor : inactiveColor;
+    // Choose color. The owning mode (autotile / snap) carries separate active
+    // and inactive border colours — global appearance settings, not rules — so
+    // pick the one matching the window's current focus state. A per-window
+    // SetBorderColor rule, when matched, overrides it. Focus-dependence of the
+    // RULE colour is expressed in the rule itself via the IsFocused match
+    // condition: `windowRuleQueryFor` set the query's isFocused flag, so a
+    // focus-scoped rule (`WHEN focused`/`WHEN NOT focused`) only fills the
+    // border-colour slot in its matching state, while a focus-agnostic rule
+    // applies in both. Either way `ovr->borderColor` already holds the colour
+    // appropriate to this window's current focus — no post-resolution switch.
+    // A floating window (no owning mode) whose only rule is focus-scoped thus
+    // correctly shows no border in the unmatched state; author a focus-agnostic
+    // rule to keep a border in both states.
+    const bool isFocused = (w == KWin::effects->activeWindow());
+    const QColor modeColor = state ? (isFocused ? state->color : state->inactiveColor) : QColor();
+    const QColor bc = (ovr && ovr->borderColor) ? *ovr->borderColor : modeColor;
     if (!bc.isValid() || bc.alpha() == 0) {
         return;
     }

--- a/kwin-effect/plasmazoneseffect/shader_resolve.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.cpp
@@ -300,7 +300,6 @@ std::optional<ResolvedWindowAppearance> resolveWindowAppearance(const PhosphorWi
     out.borderWidth = intSlot(PhosphorWindowRule::ActionSlot::BorderWidth, kMaxBorderWidth);
     out.borderRadius = intSlot(PhosphorWindowRule::ActionSlot::BorderRadius, kMaxBorderRadius);
     out.borderColor = colorSlot(PhosphorWindowRule::ActionSlot::BorderColor);
-    out.inactiveBorderColor = colorSlot(PhosphorWindowRule::ActionSlot::InactiveBorderColor);
     if (!out.any()) {
         return std::nullopt;
     }

--- a/kwin-effect/plasmazoneseffect/shader_resolve.h
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.h
@@ -156,12 +156,14 @@ struct ResolvedWindowAppearance
     std::optional<bool> showBorder;
     std::optional<int> borderWidth;
     std::optional<int> borderRadius;
+    // Focus-dependent colour is resolved by the rule cascade itself: the
+    // WindowQuery carries the window's live `isFocused` state, so a
+    // focus-scoped colour rule only fills this slot in its matching state.
     std::optional<QColor> borderColor;
-    std::optional<QColor> inactiveBorderColor;
 
     bool any() const
     {
-        return hideTitleBar || showBorder || borderWidth || borderRadius || borderColor || inactiveBorderColor;
+        return hideTitleBar || showBorder || borderWidth || borderRadius || borderColor;
     }
 };
 

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -430,6 +430,23 @@ void PlasmaZonesEffect::slotWindowActivated(KWin::EffectWindow* w)
     // Filtering (e.g. shouldHandleWindow) is done inside notifyWindowActivated
     notifyWindowActivated(w);
 
+    // Focus is a window-rule match input (Field::IsFocused), and both the
+    // border-appearance and opacity resolvers go through the evaluator's
+    // per-window match cache (resolveCached), which is keyed on
+    // (windowId, ruleSet revision) — neither of which moves on a focus
+    // change. Without dropping the cache, a window keeps the actions it
+    // resolved at its FIRST focus state forever (a `WHEN focused` border
+    // colour would never revert when the window loses focus). Mirror the
+    // windowClass / desktopFile invalidation: drop the whole cache so the
+    // re-resolve below (and the next per-frame opacity resolve) sees the new
+    // focus state. Gated on a non-empty rule set so the no-rules case pays
+    // nothing. The per-frame opacity cache clears every frame at
+    // prePaintScreen, so opacity-when-unfocused rules pick up the change on
+    // the activation repaint without extra work here.
+    if (!m_shaderManager.animationRuleSet().isEmpty()) {
+        m_shaderManager.animationRuleEvaluator().clearCache();
+    }
+
     // Recreate all borders so the active window gets the active color
     // and inactive windows get the inactive color.  A full recreate is
     // used instead of in-place setOutline() because the latter may not

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -441,11 +441,32 @@ void PlasmaZonesEffect::slotWindowActivated(KWin::EffectWindow* w)
     // re-resolve below (and the next per-frame opacity resolve) sees the new
     // focus state. Gated on a non-empty rule set so the no-rules case pays
     // nothing. The per-frame opacity cache clears every frame at
-    // prePaintScreen, so opacity-when-unfocused rules pick up the change on
-    // the activation repaint without extra work here.
+    // postPaintScreen, so a focus-scoped opacity re-resolves on the next paint.
     if (!m_shaderManager.animationRuleSet().isEmpty()) {
         m_shaderManager.animationRuleEvaluator().clearCache();
+
+        // A focus-scoped SetOpacity rule changes a window's resolved opacity
+        // when it gains or loses focus. updateAllBorders() below repaints any
+        // window that carries a border item, but an opacity-only (borderless)
+        // window has nothing to recreate — so without an explicit repaint its
+        // re-resolved opacity would not reach the screen until some unrelated
+        // damage happened to repaint it. Force a repaint of both the window
+        // gaining focus (w) and the one losing it (m_lastActivatedWindow).
+        // Gated on hasOpacityRules() because pure border-colour changes are
+        // already covered by updateAllBorders()'s item recreate.
+        if (m_shaderManager.hasOpacityRules()) {
+            if (w) {
+                w->addRepaintFull();
+            }
+            if (m_lastActivatedWindow && m_lastActivatedWindow != w) {
+                m_lastActivatedWindow->addRepaintFull();
+            }
+        }
     }
+    // Track the now-active window as the next focus change's "previously
+    // active" window. Updated unconditionally (even with no rules yet) so the
+    // pointer is correct if opacity rules are added before the next activation.
+    m_lastActivatedWindow = w;
 
     // Recreate all borders so the active window gets the active color
     // and inactive windows get the inactive color.  A full recreate is

--- a/kwin-effect/plasmazoneseffect/window_query.cpp
+++ b/kwin-effect/plasmazoneseffect/window_query.cpp
@@ -136,6 +136,13 @@ PhosphorWindowRule::WindowQuery windowRuleQueryFor(KWin::EffectWindow* w, const 
     if (kw) {
         query.isMaximized = (kw->maximizeMode() == KWin::MaximizeFull);
     }
+    // isFocused mirrors the live active-window state so a rule like
+    // "isFocused=false ⇒ SetBorderColor(gray)" resolves correctly. The
+    // evaluator's per-window match cache is keyed on (windowId, ruleSet
+    // revision) — neither moves on focus change — so callers MUST invalidate
+    // it on KWin's windowActivated signal (see slotWindowActivated), exactly
+    // as they already do for windowClass / desktopFile changes.
+    query.isFocused = (w == KWin::effects->activeWindow());
     // virtualDesktop: first desktop's 1-based x11 number (0 = all/unknown).
     // activity: first activity UUID (empty = all/unknown). Both mirror the
     // daemon-side setWindowMetadata derivation in window_identity.cpp so a

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/MatchTypes.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/MatchTypes.h
@@ -36,12 +36,13 @@ enum class Field : int {
     Activity = 12,
     // Window state (appended — keeping enum values stable across versions)
     IsMaximized = 13,
+    IsFocused = 14, ///< true when the window is the focused / active window
 };
 
 /// The number of distinct `Field` enumerators. `Field` is a contiguous range
 /// `[0, FieldCount)`; bump this whenever an enumerator is added — round-trip
 /// tests iterate the range using it as the upper bound.
-inline constexpr int FieldCount = static_cast<int>(Field::IsMaximized) + 1;
+inline constexpr int FieldCount = static_cast<int>(Field::IsFocused) + 1;
 
 /// Match operators. Not every operator is valid against every field —
 /// validity is enforced by Predicate::isValid(), not the parser.
@@ -93,6 +94,8 @@ inline QString fieldToString(Field field)
         return QStringLiteral("activity");
     case Field::IsMaximized:
         return QStringLiteral("isMaximized");
+    case Field::IsFocused:
+        return QStringLiteral("isFocused");
     }
     return QStringLiteral("appId");
 }
@@ -116,6 +119,7 @@ inline std::optional<Field> fieldFromString(QStringView s)
         {QLatin1StringView("virtualDesktop"), Field::VirtualDesktop},
         {QLatin1StringView("activity"), Field::Activity},
         {QLatin1StringView("isMaximized"), Field::IsMaximized},
+        {QLatin1StringView("isFocused"), Field::IsFocused},
     };
     for (const auto& [token, field] : kTable) {
         if (s.compare(token, Qt::CaseInsensitive) == 0) {
@@ -193,6 +197,7 @@ inline bool fieldIsString(Field field)
     case Field::IsFullscreen:
     case Field::IsMinimized:
     case Field::IsMaximized:
+    case Field::IsFocused:
         return false;
     }
     return false;
@@ -208,7 +213,7 @@ inline bool fieldIsNumeric(Field field)
 inline bool fieldIsBool(Field field)
 {
     return field == Field::IsSticky || field == Field::IsFullscreen || field == Field::IsMinimized
-        || field == Field::IsMaximized;
+        || field == Field::IsMaximized || field == Field::IsFocused;
 }
 
 /// True if @p field describes the **context** a window appears in

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/RuleAction.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/RuleAction.h
@@ -269,8 +269,10 @@ inline constexpr QLatin1StringView SetHideTitleBar{"setHideTitleBar"};
 inline constexpr QLatin1StringView SetBorderVisible{"setBorderVisible"};
 inline constexpr QLatin1StringView SetBorderWidth{"setBorderWidth"};
 inline constexpr QLatin1StringView SetBorderRadius{"setBorderRadius"};
+// Focus-dependent colours are expressed by matching on `Field::IsFocused`
+// (e.g. a rule `WHEN NOT focused ⇒ SetBorderColor(gray)`) rather than a
+// separate inactive-colour action — see the effect's updateWindowBorder.
 inline constexpr QLatin1StringView SetBorderColor{"setBorderColor"};
-inline constexpr QLatin1StringView SetInactiveBorderColor{"setInactiveBorderColor"};
 
 // ── Per-context gap overrides (domain Context) ──
 // Resolved daemon-side at zone-geometry time as the highest-precedence gap
@@ -301,7 +303,7 @@ inline bool isAnimationOverrideAction(const QString& type)
 inline bool isBorderAppearanceAction(const QString& type)
 {
     return type == SetHideTitleBar || type == SetBorderVisible || type == SetBorderWidth || type == SetBorderRadius
-        || type == SetBorderColor || type == SetInactiveBorderColor;
+        || type == SetBorderColor;
 }
 
 /// True when @p type is one of the actions the KWin effect's **shader
@@ -363,7 +365,6 @@ inline constexpr QLatin1StringView BorderVisible{"border-visible"};
 inline constexpr QLatin1StringView BorderWidth{"border-width"};
 inline constexpr QLatin1StringView BorderRadius{"border-radius"};
 inline constexpr QLatin1StringView BorderColor{"border-color"};
-inline constexpr QLatin1StringView InactiveBorderColor{"inactive-border-color"};
 // Per-context gap slots (mirror the PerScreenSnappingKey set).
 inline constexpr QLatin1StringView ZonePadding{"zone-padding"};
 inline constexpr QLatin1StringView OuterGap{"outer-gap"};

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/RuleAction.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/RuleAction.h
@@ -296,10 +296,10 @@ inline bool isAnimationOverrideAction(const QString& type)
     return type == OverrideAnimationShader || type == OverrideAnimationTiming || type == OverrideAnimationCurve;
 }
 
-/// True when @p type is one of the six per-window border / title-bar
+/// True when @p type is one of the five per-window border / title-bar
 /// appearance override actions. Grouped here so `isEffectRuleAction` (which
 /// admits these to the effect's rule set) has one definition to delegate to —
-/// adding a seventh appearance override only updates this helper.
+/// adding a sixth appearance override only updates this helper.
 inline bool isBorderAppearanceAction(const QString& type)
 {
     return type == SetHideTitleBar || type == SetBorderVisible || type == SetBorderWidth || type == SetBorderRadius

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/WindowQuery.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/WindowQuery.h
@@ -40,6 +40,7 @@ struct WindowQuery
     std::optional<bool> isFullscreen;
     std::optional<bool> isMinimized;
     std::optional<bool> isMaximized;
+    std::optional<bool> isFocused;
 
     // ── Context attributes — always present ──
     QString screenId;
@@ -52,7 +53,7 @@ struct WindowQuery
     {
         return appId.has_value() || windowClass.has_value() || title.has_value() || windowRole.has_value()
             || desktopFile.has_value() || pid.has_value() || windowType.has_value() || isSticky.has_value()
-            || isFullscreen.has_value() || isMinimized.has_value() || isMaximized.has_value();
+            || isFullscreen.has_value() || isMinimized.has_value() || isMaximized.has_value() || isFocused.has_value();
     }
 
     /**
@@ -97,6 +98,8 @@ struct WindowQuery
             return std::optional<QVariant>(activity);
         case Field::IsMaximized:
             return isMaximized ? std::optional<QVariant>(*isMaximized) : std::nullopt;
+        case Field::IsFocused:
+            return isFocused ? std::optional<QVariant>(*isFocused) : std::nullopt;
         }
         return std::nullopt;
     }

--- a/libs/phosphor-windowrule/src/ruleaction.cpp
+++ b/libs/phosphor-windowrule/src/ruleaction.cpp
@@ -585,18 +585,6 @@ void ActionRegistry::registerBuiltins()
         // defaultPayloadFor "color" branch, not via defaultDisplay (double).
         .params = {P{.key = QString(ActionParam::Value), .kind = QStringLiteral("color")}},
     });
-    registerAction(ActionDescriptor{
-        .type = QString(ActionType::SetInactiveBorderColor),
-        .slotFor = constantSlot(ActionSlot::InactiveBorderColor),
-        .validate =
-            [](const QJsonObject& p) {
-                return hasHexColor(p, ActionParam::Value);
-            },
-        .terminal = false,
-        .allowedKeys = {QString(ActionParam::Value)},
-        .domain = ActionDomain::Window,
-        .params = {P{.key = QString(ActionParam::Value), .kind = QStringLiteral("color")}},
-    });
 
     // ── per-context gap slots (domain Context) ──
     // Resolved daemon-side at zone-geometry time (DaemonGeometryResolver) as

--- a/libs/phosphor-windowrule/tests/test_matchtypes.cpp
+++ b/libs/phosphor-windowrule/tests/test_matchtypes.cpp
@@ -18,7 +18,7 @@ private Q_SLOTS:
         // Canary: the loop bound is derived from FieldCount, not hard-coded.
         // If this fails, an enumerator was added/removed without updating
         // FieldCount in MatchTypes.h.
-        QCOMPARE(FieldCount, 14);
+        QCOMPARE(FieldCount, 15);
         QTest::addColumn<int>("fieldValue");
         for (int v = 0; v < FieldCount; ++v) {
             QTest::addRow("field-%d", v) << v;
@@ -120,6 +120,7 @@ private Q_SLOTS:
         QVERIFY(!fieldIsContext(Field::IsFullscreen));
         QVERIFY(!fieldIsContext(Field::IsMinimized));
         QVERIFY(!fieldIsContext(Field::IsMaximized));
+        QVERIFY(!fieldIsContext(Field::IsFocused));
     }
 
     void testFieldIsContext_coversAllFields_data()

--- a/libs/phosphor-windowrule/tests/test_ruleaction.cpp
+++ b/libs/phosphor-windowrule/tests/test_ruleaction.cpp
@@ -57,6 +57,21 @@ private Q_SLOTS:
         QVERIFY(!RuleAction::fromJson(o).has_value());
     }
 
+    void testJson_rejectsRemovedInactiveBorderColor()
+    {
+        // `setInactiveBorderColor` was a valid action type until focus-dependent
+        // colour was folded into the IsFocused match condition (a `WHEN NOT
+        // focused ⇒ setBorderColor` rule replaces it). It is now unregistered,
+        // so a saved rule carrying it must drop the action on load — even with
+        // an otherwise-valid hex payload. Pins the removal's drop-on-load
+        // contract to the specific retired token, not just the generic
+        // unknown-type path (testJson_rejectsUnregisteredType).
+        QJsonObject o;
+        o.insert(QStringLiteral("type"), QStringLiteral("setInactiveBorderColor"));
+        o.insert(QStringLiteral("value"), QStringLiteral("#FF0000"));
+        QVERIFY(!RuleAction::fromJson(o).has_value());
+    }
+
     void testJson_rejectsInvalidParams()
     {
         // setEngineMode requires a non-empty `mode` string.

--- a/libs/phosphor-windowrule/tests/test_ruleaction.cpp
+++ b/libs/phosphor-windowrule/tests/test_ruleaction.cpp
@@ -141,7 +141,6 @@ private Q_SLOTS:
             ActionType::SetBorderWidth,
             ActionType::SetBorderRadius,
             ActionType::SetBorderColor,
-            ActionType::SetInactiveBorderColor,
         };
         for (const QLatin1StringView type : windowTypes) {
             const auto descriptor = ActionRegistry::instance().descriptor(QString::fromLatin1(type));
@@ -258,7 +257,7 @@ private Q_SLOTS:
 
     void testBorderColorActions_requireHex()
     {
-        for (const QLatin1StringView type : {ActionType::SetBorderColor, ActionType::SetInactiveBorderColor}) {
+        for (const QLatin1StringView type : {ActionType::SetBorderColor}) {
             QJsonObject o;
             o.insert(QStringLiteral("type"), QString::fromLatin1(type));
             o.insert(QStringLiteral("value"), QStringLiteral("red")); // named colour — hex-only boundary rejects

--- a/libs/phosphor-windowrule/tests/test_windowquery.cpp
+++ b/libs/phosphor-windowrule/tests/test_windowquery.cpp
@@ -59,12 +59,14 @@ private Q_SLOTS:
         q.pid = 4242;
         q.windowType = WindowType::Dialog;
         q.isFullscreen = true;
+        q.isFocused = true;
 
         QCOMPARE(q.valueForField(Field::AppId)->toString(), QStringLiteral("firefox"));
         QCOMPARE(q.valueForField(Field::Pid)->toInt(), 4242);
         // WindowType resolves to its underlying int.
         QCOMPARE(q.valueForField(Field::WindowType)->toInt(), static_cast<int>(WindowType::Dialog));
         QCOMPARE(q.valueForField(Field::IsFullscreen)->toBool(), true);
+        QCOMPARE(q.valueForField(Field::IsFocused)->toBool(), true);
     }
 
     void testValueForField_falseBoolIsStillPresent()

--- a/libs/phosphor-windowrule/tests/test_windowquery.cpp
+++ b/libs/phosphor-windowrule/tests/test_windowquery.cpp
@@ -50,6 +50,7 @@ private Q_SLOTS:
         QVERIFY(!q.valueForField(Field::Pid).has_value());
         QVERIFY(!q.valueForField(Field::WindowType).has_value());
         QVERIFY(!q.valueForField(Field::IsSticky).has_value());
+        QVERIFY(!q.valueForField(Field::IsFocused).has_value());
     }
 
     void testValueForField_presentWindowAttribute()

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -131,14 +131,14 @@ ColumnLayout {
     // Toggle editor for `kind == "bool"` params (SetHideTitleBar / SetBorderVisible
     // / SetUsePerSideOuterGap). Stores a JSON bool.
     property Component _boolParamEditor
-    // Colour swatch + picker for `kind == "color"` params (SetBorderColor /
-    // SetInactiveBorderColor). Stores a `#RRGGBB` wire string — the validator
+    // Colour swatch + picker for `kind == "color"` params (SetBorderColor).
+    // Stores a `#RRGGBB` wire string — the validator
     // rejects anything else, so the dialog's selectedColor is encoded to 6-hex
     // via `_toHex6` (QML color.toString() includes the alpha byte).
     property Component _colorParamEditor
 
     /// Encode a QML color to a `#RRGGBB` wire string (no alpha) — the form the
-    /// SetBorderColor / SetInactiveBorderColor validators accept.
+    /// SetBorderColor validator accepts.
     function _toHex6(c) {
         function h(v) {
             var s = Math.round(v * 255).toString(16);

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -68,9 +68,6 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::SetBorderColor && key == ActionParam::Value) {
         return PzI18n::tr("Border color");
     }
-    if (type == ActionType::SetInactiveBorderColor && key == ActionParam::Value) {
-        return PzI18n::tr("Inactive border color");
-    }
     // Per-context gap overrides (all single-value, keyed ActionParam::Value).
     if (type == ActionType::SetZonePadding && key == ActionParam::Value) {
         return PzI18n::tr("Zone padding (px)");
@@ -229,9 +226,6 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::SetBorderColor) {
         return PzI18n::tr("Set border color");
-    }
-    if (type == ActionType::SetInactiveBorderColor) {
-        return PzI18n::tr("Set inactive border color");
     }
     if (type == ActionType::SetZonePadding) {
         return PzI18n::tr("Set zone padding");
@@ -449,7 +443,6 @@ QVariantList actionTypes()
         ActionType::SetBorderWidth,
         ActionType::SetBorderRadius,
         ActionType::SetBorderColor,
-        ActionType::SetInactiveBorderColor,
         ActionType::OverrideAnimationShader,
         ActionType::OverrideAnimationCurve,
         ActionType::OverrideAnimationTiming,
@@ -576,8 +569,8 @@ QVariantMap defaultPayloadFor(const QString& typeWire)
         } else if (kind == QLatin1String("color")) {
             // Colour kind has no numeric `defaultDisplay` (that field is a
             // double); seed a valid `#RRGGBB` so a fresh rule passes the
-            // SetBorderColor / SetInactiveBorderColor validator before the user
-            // opens the picker. Neutral KDE accent blue.
+            // SetBorderColor validator before the user opens the picker.
+            // Neutral KDE accent blue.
             payload[key] = QStringLiteral("#3daee9");
         } else {
             // Picker kinds (snappingLayout, tilingAlgorithm, animationEvent,

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -315,9 +315,6 @@ QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup
         if (action.type == ActionType::SetBorderColor) {
             return PzI18n::tr("Border: %1").arg(raw.toString().toUpper());
         }
-        if (action.type == ActionType::SetInactiveBorderColor) {
-            return PzI18n::tr("Inactive border: %1").arg(raw.toString().toUpper());
-        }
         // ── per-context gap overrides ──
         if (action.type == ActionType::SetZonePadding) {
             return PzI18n::tr("Zone padding: %1 px").arg(raw.toInt());
@@ -638,6 +635,8 @@ QString WindowRuleModel::fieldLabel(Field field)
         return PzI18n::tr("Maximized");
     case Field::IsMinimized:
         return PzI18n::tr("Minimized");
+    case Field::IsFocused:
+        return PzI18n::tr("Focused");
     case Field::ScreenId:
         return PzI18n::tr("Monitor");
     case Field::VirtualDesktop:


### PR DESCRIPTION
## Summary

Active/inactive border colour was modelled as **two parallel action types** — `SetBorderColor` and `SetInactiveBorderColor`. That's a one-concept-two-actions wart that didn't scale: any other focus-dependent property (opacity, border width, …) would have needed its own `Inactive*` variant.

Meanwhile `minimized`/`maximized` were already proper **match conditions**. This PR closes that asymmetry by making focus a first-class match condition too.

## What changed

- **New `Field::IsFocused`** — a boolean WHEN condition parallel to `IsMinimized`/`IsMaximized`. Plumbed through the enum, wire serialization (`"isFocused"`), classification helpers, `WindowQuery`, and `valueForField`. It auto-surfaces in the rule picker as "Focused" with a checkbox/Equals editor (the authoring UI is generic over the `Field` enum).
- **`SetInactiveBorderColor` deleted entirely** — action id, `ActionSlot`, descriptor, `ResolvedWindowAppearance::inactiveBorderColor`, UI labels/summary/ordering, QML comments, and test references.
- **Effect resolution rewritten** — `windowRuleQueryFor` sets `query.isFocused = (w == activeWindow())`, so a focus-scoped rule (`WHEN focused` / `WHEN NOT focused → SetBorderColor`) only fills the border-colour slot in its matching state, while a focus-agnostic rule applies in both. `borders.cpp` picks the mode's active/inactive base colour by focus and lets a matched rule override it — no more post-resolution colour switch.
- **Cache invalidation on `windowActivated`** — both the border and opacity resolvers go through the evaluator's per-window match cache, keyed on `(windowId, ruleSet revision)`, neither of which moves on a focus change. Drop the cache on activation (gated on a non-empty rule set), mirroring the existing `windowClass`/`desktopFile` invalidation, so a focus-scoped rule re-resolves instead of freezing at its first-resolved state.

## Emergent win

Any window-domain action is now focus-scopable for free. "Dim unfocused windows" is just `WHEN NOT focused → SetOpacity(0.8)` — no `SetInactiveOpacity` action needed.

## Out of scope (intentionally untouched)

The global snap/autotile inactive-border **settings** (`autotileInactiveBorderColor`, `snapWindowInactiveBorderColor`) — those are the mode's default border, a separate concept from per-window rules.

## Migration

None. Window rules ship in this same unreleased `v3.1` branch, so old `setInactiveBorderColor` rules are dropped on load via the existing unregistered-action-type drop path (an action with other valid actions keeps those; an inactive-colour-only rule drops entirely). Consistent with the "No Ad-Hoc Backwards Compatibility" rule.

## Testing

- Full tree builds clean (daemon, editor, KWin effect).
- `214/214` ctest pass, including the 14 `phosphorwindowrule` suites (`FieldCount` canary bumped to 15, round-trip + classification + `WindowQuery` coverage updated).
- Runtime behaviour (border colours flipping on focus/alt-tab, focus-scoped rules) should be sanity-checked on a live session.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)