### PR TITLE
feat(phosphor-service-polkit): Phase 2.6 PolicyKit authentication agent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,6 +453,7 @@ if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(libs/phosphor-service-bluetooth) # BlueZ adapters / devices / pairing (Phase 2.3)
     add_subdirectory(libs/phosphor-service-brightness) # display / keyboard backlight brightness (Phase 2.4)
     add_subdirectory(libs/phosphor-service-notifications) # org.freedesktop.Notifications server (Phase 2.5)
+    add_subdirectory(libs/phosphor-service-polkit)        # PolicyKit authentication agent (Phase 2.6)
 endif()
 
 # Source directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -713,6 +713,14 @@ if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(examples/phosphor-service-notifications-cli)
 endif()
 
+# phosphor-service-polkit-cli. Acceptance harness for the phosphor-service-polkit
+# library (Phase 2.6). Runs as the session's PolicyKit authentication agent and
+# answers PAM prompts (trigger with `pkexec true`). Gated like the lib: when
+# BUILD_PHOSPHOR_SHELL is OFF the lib target does not exist, so the CLI can't link.
+if(BUILD_PHOSPHOR_SHELL)
+    add_subdirectory(examples/phosphor-service-polkit-cli)
+endif()
+
 # phosphor-registry-plugin-demo. Sibling of phosphor-registry-demo
 # that exercises the PluginLoader + hot-reload path. The third
 # (CPU-meter) widget builds as a separate .so + manifest.json and

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -506,7 +506,7 @@ Three structural firsts versus the prior service libs:
 
 ---
 
-### 2.6: `phosphor-service-polkit` *(in progress: milestones 1+2, 3 landed)*
+### 2.6: `phosphor-service-polkit` *(in progress: milestones 1+2, 3, 4 landed)*
 
 > Note: milestone 2 (the `Listener` subclass + registration lifecycle) shipped
 > inside the milestone-1 commit; the registration plumbing is inseparable from

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -506,11 +506,11 @@ Three structural firsts versus the prior service libs:
 
 ---
 
-### 2.6: `phosphor-service-polkit` *(in progress: milestones 1+2, 3, 4, 5, 6, 7 landed)*
+### 2.6: `phosphor-service-polkit` *(shipped)*
 
 > Note: milestone 2 (the `Listener` subclass + registration lifecycle) shipped
 > inside the milestone-1 commit; the registration plumbing is inseparable from
-> the skeleton. The commit series runs 1 → 3.
+> the skeleton. The commit series runs 1 → 3 → 4 → 5 → 6 → 7 → 8.
 
 
 A PolicyKit **authentication agent** via the `polkit-qt6` binding. Namespace `PhosphorServicePolkit`, export macro `PHOSPHORSERVICEPOLKIT_EXPORT`, LGPL-2.1-or-later, QML URI `Phosphor.Service.Polkit 1.0`. Table effort **M**. Unlike the data-source service libs (2.1-2.4), and like 2.5, this one is a callback target: `polkitd` calls into us when an app requests a privileged action, and we drive the PAM conversation that authenticates the user.

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -506,7 +506,7 @@ Three structural firsts versus the prior service libs:
 
 ---
 
-### 2.6: `phosphor-service-polkit` *(in progress: milestones 1+2, 3, 4, 5 landed)*
+### 2.6: `phosphor-service-polkit` *(in progress: milestones 1+2, 3, 4, 5, 6 landed)*
 
 > Note: milestone 2 (the `Listener` subclass + registration lifecycle) shipped
 > inside the milestone-1 commit; the registration plumbing is inseparable from

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -506,7 +506,7 @@ Three structural firsts versus the prior service libs:
 
 ---
 
-### 2.6: `phosphor-service-polkit` *(in progress: milestones 1+2, 3, 4 landed)*
+### 2.6: `phosphor-service-polkit` *(in progress: milestones 1+2, 3, 4, 5 landed)*
 
 > Note: milestone 2 (the `Listener` subclass + registration lifecycle) shipped
 > inside the milestone-1 commit; the registration plumbing is inseparable from

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -506,6 +506,65 @@ Three structural firsts versus the prior service libs:
 
 ---
 
+### 2.6: `phosphor-service-polkit` *(planned)*
+
+A PolicyKit **authentication agent** via the `polkit-qt6` binding. Namespace `PhosphorServicePolkit`, export macro `PHOSPHORSERVICEPOLKIT_EXPORT`, LGPL-2.1-or-later, QML URI `Phosphor.Service.Polkit 1.0`. Table effort **M**. Unlike the data-source service libs (2.1-2.4), and like 2.5, this one is a callback target: `polkitd` calls into us when an app requests a privileged action, and we drive the PAM conversation that authenticates the user.
+
+Two structural notes versus the prior service libs:
+
+- **Single active request, no model.** polkit serialises authentication: the agent handles one request at a time. So the facade exposes a single *active* `AuthRequest` plus signals, not a `QAbstractListModel` (the notifications-style list shape does not apply). The closest precedent is 2.3's `Agent1` (a callback object with interactive, deferred responses keyed to a request), not 2.5's server-with-a-model.
+- **Security-sensitive.** This library handles authentication. It surfaces the request and a `respond(password)` path but never stores, logs, or echoes the password; the password flows straight into `Agent::Session::setResponse`. The plan-table's "accepts a hardcoded password" is strictly a CLI-demo convenience, fenced behind an explicit flag and never in the library.
+
+The `polkit-qt6` API we build on:
+- `PolkitQt1::Agent::Listener` (abstract): subclass it, override `initiateAuthentication(actionId, message, iconName, Details, cookie, Identity::List, AsyncResult*)`, `initiateAuthenticationFinish()`, `cancelAuthentication()`; register with `registerListener(subject, objectPath)` for the session `Subject`. The `AsyncResult*` MUST be completed when the flow ends.
+- `PolkitQt1::Agent::Session`: drives one PAM conversation. `initiate()` starts it; the `request(prompt, echo)` signal carries each PAM prompt; `setResponse(password)` answers; `completed(gainedAuthorization)` / `showError` / `showInfo` report progress; `cancel()` aborts. Constructed with the chosen `Identity`, the `cookie`, and the `AsyncResult`.
+
+**Decisions taken up front** (see Unknowns for the rest):
+
+- **DI for testability.** The agent takes an injectable `Subject` (default: the current session) and an injectable object path, so registration can be exercised without owning the real session, and the request/response state machine can be driven without a live `polkitd`.
+- **Inert on registration failure.** Exactly one agent serves a session; if the desktop's agent (KDE / GNOME / `polkit-gnome`) already holds it, `registerListener` fails and the agent surfaces `registered() == false` and stays inert, mirroring 2.5's name-conflict-is-inert shape. Taking over (stopping the desktop agent) is the operator's choice, surfaced in the CLI demo, not forced.
+- **Surface the request, never the secret.** `AuthRequest` carries actionId / message / iconName / details / the chosen identity / the current PAM prompt + echo flag. `respond(password)` and `cancel()` are `Q_INVOKABLE` for a UI; the password is passed straight through and never retained.
+- **Link Core + Agent, not Gui.** `PolkitQt6-1::Core` + `::Agent` only; the `::Gui` action-button widgets are a different (Phase 3/4 UI) concern. (`Qt6::Gui` still arrives transitively via the agent lib.)
+
+**Milestones**
+
+1. **Skeleton + CMake plumbing (S, ~1 day).** `libs/phosphor-service-polkit/` mirroring the 2.5 shape (`CMakeLists.txt`, `PhosphorServicePolkitConfig.cmake.in`, `include/PhosphorServicePolkit/`, `src/`, `tests/`, `examples/phosphor-service-polkit-cli/`). `find_package(PolkitQt6-1 REQUIRED)`; link `PolkitQt6-1::Core` + `PolkitQt6-1::Agent`. Imperative `qmlregistration.cpp`, `std::call_once`-guarded, called from `src/shell/main.cpp` alongside the nine existing services. `BUILD_PHOSPHOR_SHELL`-gated.
+2. **`PolkitAgent` listener + registration (M, ~2-3 days).** Subclass `Listener`. Build on an injectable `(Subject, objectPath)`; `registerListener` for the session subject, expose `registered`. Implement the three overrides as a skeleton (store the `AsyncResult` + `cookie`, complete immediately or reject) so the lib links and registers; inert + `registered() == false` when another agent owns the session.
+3. **`initiateAuthentication` ingestion + typed `AuthRequest` (M, ~2-3 days).** Decode the callback into an `AuthRequest` (actionId, message, iconName, `Details` → `QVariantMap`, cookie, identities → typed list), store the pending `AsyncResult` keyed by cookie (the 2.3 keyed-request precedent), and surface the active request via signals. Identity selection (default: first identity; multi-identity selection is a UI affordance).
+4. **`Session` / PAM conversation (M, ~2-3 days).** Wrap `Agent::Session`: `initiate()` on accept; relay `request(prompt, echo)` as a Qt signal; `respond(password)` → `setResponse`; `completed(gained)` → complete the `AsyncResult` + emit result + clear the active request; `cancel()` and `showError` / `showInfo` paths. `cancelAuthentication()` from polkit tears down the in-flight session.
+5. **QML facade (S, ~1 day).** `Phosphor.Service.Polkit 1.0`: the agent host instantiable (plain type, not a singleton), `AuthRequest` `qmlRegisterUncreatableType`. `respond` / `cancel` `Q_INVOKABLE`, never exported on any bus (the 2.3 / 2.5 isolation pattern).
+6. **CLI demo `examples/phosphor-service-polkit-cli/` (M, ~3 days).** Runs as the standalone agent: registers, logs each incoming request (action, message, identities, PAM prompt), and with an explicit `--password <pw>` (demo only, loudly documented) auto-answers. `pkexec true` (or any polkit action) from another terminal exercises the full path end to end; `--replace`-style guidance when the desktop agent owns the session.
+7. **Tests: smoke (S-M, ~1-2 days).** No live `polkitd` on CI. Pin what is deterministic: inert construction (no crash when registration fails / no daemon), the `Details` → `QVariantMap` decode, `AuthRequest` field surfaces and identity selection, and the session state machine where it can be driven without PAM (`request` → `respond` → `completed` wiring via a fake/injected session seam). `QSKIP` the daemon-dependent registration + real-PAM paths.
+8. **README + Status (S, ~half day).** Sibling convention; "Phase 2.6: shipped" on gate pass; cross-reference §2.3 for the agent-callback precedent and §2.5 for the inert-on-conflict shape.
+
+**Total effort:** M (≈ 2-3 weeks). Milestones 3-4 (the request decode + the PAM session relay) hold the wall-clock; 1, 5, 7, 8 are mechanical given the 2.5 templates.
+
+**Dependencies**
+
+- `polkit-qt6` ≥ the distro's PolkitQt6-1 (Core + Agent), discovered via `find_package(PolkitQt6-1)`. A running `polkitd` on the system bus for the live path (the lib loads inert without it).
+- Qt6 ≥ 6.6 Core / Qml (Gui arrives transitively via `PolkitQt6-1::Agent`). No `phosphor-dbus` (polkit-qt owns its D-Bus).
+
+**Risks**
+
+- **Agent-conflict.** A desktop session almost always already has an agent (KDE / GNOME). Registration then fails; the lib must stay inert, never crash or busy-loop, and the demo documents stopping the desktop agent to test. The inert path is the common case on a real desktop.
+- **AsyncResult lifetime.** Every `initiateAuthentication` MUST eventually complete its `AsyncResult` (success, error, or cancel) or polkit's auth dialog hangs; a dropped or double completion corrupts the flow. Key it by cookie, complete exactly once, with explicit `cancelAuthentication` handling (the 2.3 delayed-reply discipline).
+- **Password handling.** The secret must never be retained, logged, or echoed; it flows straight into `setResponse`. The `request(prompt, echo)` echo flag is honoured by the UI, not the lib. Audit this surface specifically.
+- **PAM in tests.** Real authentication needs PAM + a daemon, untestable on CI. Keep the testable seam (request decode, state machine) injectable; `QSKIP` the rest, validated manually through the CLI against a real `pkexec`.
+
+**Unknowns to resolve before / during implementation**
+
+| # | Question | Lean |
+|---|----------|------|
+| U1 | `Subject` for registration: `UnixSessionSubject` from the session id, or from the process pid? | Lean session-id (the agent serves the whole session); injectable so tests pass a synthetic subject. Confirm against a polkit-qt example. |
+| U2 | Object path for the exported agent. | A Phosphor-namespaced path (e.g. `/org/phosphor/PolicyKit1/AuthenticationAgent`), constant + injectable. |
+| U3 | Multi-identity handling: pick the first, or surface the list for selection? | Surface the list on `AuthRequest`; default-select the first; the Phase-3/4 dialog can offer a chooser. |
+| U4 | Also expose the **client** side (`Authority::checkAuthorization`) for the shell to gate its own privileged actions, or agent-only? | Agent-only for 2.6 (the table's scope); a thin `Authority` query wrapper can land later if a consumer needs it. |
+| U5 | Registration-failure policy when a desktop agent owns the session: inert, or offer takeover? | Inert by default (cannot force-replace a polkit agent the way a bus name allows); the CLI documents stopping the desktop agent. |
+
+**Out of scope for 2.6.** The authentication **dialog UI** (Phase 3/4: the agent only surfaces the request + prompt a dialog binds), client-side `checkAuthorization` gating (U4), temporary-authorization management, and any credential storage. The agent drives the PAM conversation; it draws nothing and remembers nothing.
+
+---
+
 ## Phase 3: UI primitives + first visible examples
 
 **Goal:** end-user-visible building blocks that we'll glue together in Phase 4. Each is a runnable demo, not a real shell surface yet.

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -506,7 +506,7 @@ Three structural firsts versus the prior service libs:
 
 ---
 
-### 2.6: `phosphor-service-polkit` *(in progress: milestones 1+2, 3, 4, 5, 6 landed)*
+### 2.6: `phosphor-service-polkit` *(in progress: milestones 1+2, 3, 4, 5, 6, 7 landed)*
 
 > Note: milestone 2 (the `Listener` subclass + registration lifecycle) shipped
 > inside the milestone-1 commit; the registration plumbing is inseparable from

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -529,7 +529,7 @@ The `polkit-qt6` API we build on:
 - **DI for testability.** The agent takes an injectable `Subject` (default: the current session) and an injectable object path, so registration can be exercised without owning the real session, and the request/response state machine can be driven without a live `polkitd`.
 - **Inert on registration failure.** Exactly one agent serves a session; if the desktop's agent (KDE / GNOME / `polkit-gnome`) already holds it, `registerListener` fails and the agent surfaces `registered() == false` and stays inert, mirroring 2.5's name-conflict-is-inert shape. Taking over (stopping the desktop agent) is the operator's choice, surfaced in the CLI demo, not forced.
 - **Surface the request, never the secret.** `AuthRequest` carries actionId / message / iconName / details / the chosen identity / the current PAM prompt + echo flag. `respond(password)` and `cancel()` are `Q_INVOKABLE` for a UI; the password is passed straight through and never retained.
-- **Link Core + Agent, not Gui.** `PolkitQt6-1::Core` + `::Agent` only; the `::Gui` action-button widgets are a different (Phase 3/4 UI) concern. (`Qt6::Gui` still arrives transitively via the agent lib.)
+- **Link Core + Agent, not Gui.** `PolkitQt6-1::Core` + `::Agent` only; the `::Gui` action-button widgets are a different (Phase 3/4 UI) concern. No Qt Gui type is used, and `PolkitQt6-1::Agent` does not pull `Qt6::Gui` transitively, so Gui is not a dependency.
 
 **Milestones**
 
@@ -547,7 +547,7 @@ The `polkit-qt6` API we build on:
 **Dependencies**
 
 - `polkit-qt6` ≥ the distro's PolkitQt6-1 (Core + Agent), discovered via `find_package(PolkitQt6-1)`. A running `polkitd` on the system bus for the live path (the lib loads inert without it).
-- Qt6 ≥ 6.6 Core / Qml (Gui arrives transitively via `PolkitQt6-1::Agent`). No `phosphor-dbus` (polkit-qt owns its D-Bus).
+- Qt6 ≥ 6.6 Core / Qml. No `phosphor-dbus` (polkit-qt owns its D-Bus).
 
 **Risks**
 

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -506,7 +506,12 @@ Three structural firsts versus the prior service libs:
 
 ---
 
-### 2.6: `phosphor-service-polkit` *(planned)*
+### 2.6: `phosphor-service-polkit` *(in progress: milestones 1+2, 3 landed)*
+
+> Note: milestone 2 (the `Listener` subclass + registration lifecycle) shipped
+> inside the milestone-1 commit; the registration plumbing is inseparable from
+> the skeleton. The commit series runs 1 → 3.
+
 
 A PolicyKit **authentication agent** via the `polkit-qt6` binding. Namespace `PhosphorServicePolkit`, export macro `PHOSPHORSERVICEPOLKIT_EXPORT`, LGPL-2.1-or-later, QML URI `Phosphor.Service.Polkit 1.0`. Table effort **M**. Unlike the data-source service libs (2.1-2.4), and like 2.5, this one is a callback target: `polkitd` calls into us when an app requests a privileged action, and we drive the PAM conversation that authenticates the user.
 

--- a/examples/phosphor-service-polkit-cli/CMakeLists.txt
+++ b/examples/phosphor-service-polkit-cli/CMakeLists.txt
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# phosphor-service-polkit-cli: headless driver for the phosphor-service-polkit
+# library. See main.cpp's usage() for the flags. Runs as the session's PolicyKit
+# authentication agent and answers PAM prompts; trigger a request with e.g.
+# `pkexec true` from another terminal. Doubles as the worked C++ example for
+# callers learning the lib. Pinned to Qt6 6.6 so it builds stand-alone from this
+# directory too.
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core)
+
+add_executable(phosphor-service-polkit-cli
+    main.cpp
+)
+
+target_link_libraries(phosphor-service-polkit-cli
+    PRIVATE
+        Qt6::Core
+        PhosphorServicePolkit::PhosphorServicePolkit
+)
+
+# Intentionally no `install(TARGETS ...)` rule. This CLI is the acceptance
+# harness + worked example for phosphor-service-polkit, not a user-facing tool.
+# Keeping it build-tree-only avoids polluting distro paths with a developer
+# binary.

--- a/examples/phosphor-service-polkit-cli/main.cpp
+++ b/examples/phosphor-service-polkit-cli/main.cpp
@@ -13,8 +13,8 @@
 //   --password <pw>   DEMO ONLY: auto-answer every PAM prompt with <pw>. The
 //                     password is visible in the process list, so this exists
 //                     purely to make the demo scriptable; a real shell collects
-//                     the secret in a secure dialog. Without it, prompts are
-//                     read from stdin.
+//                     the secret in a secure dialog. Without it, prompts are read
+//                     from stdin (terminal echo suppressed for secret prompts).
 //
 // Exactly one agent serves a session. If your desktop already runs one (KDE /
 // GNOME), registration fails and the demo prints guidance; stop that agent first
@@ -27,6 +27,10 @@
 #include <QObject>
 #include <QStringList>
 #include <QTextStream>
+
+#include <termios.h>
+
+#include <cstdio>
 
 using namespace PhosphorServicePolkit;
 
@@ -53,11 +57,38 @@ int usage()
           << "  PAM prompts for each request. Trigger one with e.g. `pkexec true` from\n"
           << "  another terminal.\n\n"
           << "  --password <pw>   DEMO ONLY: auto-answer every prompt with <pw> (visible in\n"
-          << "                    the process list). Without it, prompts are read from stdin.\n\n"
+          << "                    the process list). Without it, prompts are read from stdin\n"
+          << "                    (terminal echo suppressed for secret prompts).\n\n"
           << "  Exactly one agent serves a session; if your desktop already runs one\n"
           << "  (KDE / GNOME) registration fails. Stop it first to test this demo.\n";
     err().flush();
     return kUsage;
+}
+
+// Read one line from stdin. When @p echo is false (a secret), terminal echo is
+// suppressed so the password is not printed to the screen, honouring the
+// AuthRequest::echo flag. NOTE: this blocks the event loop until the user
+// answers, so a cancellation arriving mid-input is not processed until Enter;
+// the agent's respond() safely no-ops if the request was settled meanwhile.
+QString readResponse(bool echo)
+{
+    QTextStream in(stdin);
+    if (echo)
+        return in.readLine();
+
+    const int fd = fileno(stdin);
+    termios original{};
+    if (tcgetattr(fd, &original) != 0)
+        return in.readLine(); // not a tty: nothing to suppress
+
+    termios masked = original;
+    masked.c_lflag &= ~static_cast<tcflag_t>(ECHO);
+    tcsetattr(fd, TCSANOW, &masked);
+    const QString line = in.readLine();
+    tcsetattr(fd, TCSANOW, &original);
+    out() << "\n"; // the user's (un-echoed) newline
+    out().flush();
+    return line;
 }
 } // namespace
 
@@ -92,37 +123,34 @@ int main(int argc, char** argv)
           << "trigger an action (e.g. `pkexec true`) from another terminal. Ctrl+C to stop.\n";
     out().flush();
 
-    QObject::connect(
-        agent, &PolkitAgent::authenticationRequested, &app, [agent, havePassword, password](AuthRequest* request) {
-            out() << "+ auth request: action=" << request->actionId() << "\n"
-                  << "    message: " << request->message() << "\n"
-                  << "    identities: " << request->identities().join(QLatin1String(", ")) << "\n";
-            out().flush();
+    QObject::connect(agent, &PolkitAgent::authenticationRequested, &app, [agent](AuthRequest* request) {
+        out() << "+ auth request: action=" << request->actionId() << "\n"
+              << "    message: " << request->message() << "\n"
+              << "    identities: " << request->identities().join(QLatin1String(", ")) << "\n";
+        out().flush();
+        // Start the PAM conversation for the (default-selected) identity; its
+        // prompts arrive via promptRequested below.
+        agent->authenticate();
+    });
 
-            // Print and answer each PAM prompt as the conversation progresses.
-            QObject::connect(request, &AuthRequest::promptChanged, agent, [agent, havePassword, password, request]() {
-                const QString prompt = request->prompt();
-                if (prompt.isEmpty())
-                    return;
-                out() << "    prompt: " << prompt;
-                out().flush();
-
-                QString response;
-                if (havePassword) {
-                    response = password;
-                    out() << "(answered from --password)\n";
-                } else {
-                    QTextStream in(stdin);
-                    response = in.readLine();
-                }
-                out().flush();
-                // Straight to PAM; the response is not retained here.
-                agent->respond(response);
-            });
-
-            // Start the PAM conversation for the (default-selected) identity.
-            agent->authenticate();
-        });
+    // PAM asked for input. promptRequested is an event (fires per prompt, incl.
+    // a same-text retry after a wrong answer), so answering it here is exactly
+    // once per request.
+    QObject::connect(agent, &PolkitAgent::promptRequested, &app,
+                     [agent, havePassword, password](const QString& prompt, bool echo) {
+                         out() << "    prompt: " << prompt;
+                         out().flush();
+                         QString response;
+                         if (havePassword) {
+                             response = password;
+                             out() << "(answered from --password)\n";
+                             out().flush();
+                         } else {
+                             response = readResponse(echo);
+                         }
+                         // Straight to PAM; the response is not retained here.
+                         agent->respond(response);
+                     });
 
     QObject::connect(agent, &PolkitAgent::authenticationCompleted, &app, [](bool gained) {
         out() << (gained ? "- authenticated\n" : "- authentication failed\n");

--- a/examples/phosphor-service-polkit-cli/main.cpp
+++ b/examples/phosphor-service-polkit-cli/main.cpp
@@ -25,6 +25,7 @@
 
 #include <QCoreApplication>
 #include <QObject>
+#include <QScopeGuard>
 #include <QStringList>
 #include <QTextStream>
 
@@ -84,8 +85,12 @@ QString readResponse(bool echo)
     termios masked = original;
     masked.c_lflag &= ~static_cast<tcflag_t>(ECHO);
     tcsetattr(fd, TCSANOW, &masked);
+    // Restore the terminal on every exit path so a future early return can never
+    // leave echo disabled.
+    const auto restore = qScopeGuard([fd, &original] {
+        tcsetattr(fd, TCSANOW, &original);
+    });
     const QString line = in.readLine();
-    tcsetattr(fd, TCSANOW, &original);
     out() << "\n"; // the user's (un-echoed) newline
     out().flush();
     return line;

--- a/examples/phosphor-service-polkit-cli/main.cpp
+++ b/examples/phosphor-service-polkit-cli/main.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// phosphor-service-polkit-cli: headless acceptance harness + worked example for
+// the phosphor-service-polkit library. It runs as the session's PolicyKit
+// authentication agent: it registers, logs each authentication request, drives
+// the PAM conversation, and answers the prompts.
+//
+// Trigger a request from another terminal with e.g. `pkexec true`. This is the
+// only way to exercise the full register -> request -> prompt -> respond ->
+// completed path, since it requires a live polkitd + PAM calling back into us.
+//
+//   --password <pw>   DEMO ONLY: auto-answer every PAM prompt with <pw>. The
+//                     password is visible in the process list, so this exists
+//                     purely to make the demo scriptable; a real shell collects
+//                     the secret in a secure dialog. Without it, prompts are
+//                     read from stdin.
+//
+// Exactly one agent serves a session. If your desktop already runs one (KDE /
+// GNOME), registration fails and the demo prints guidance; stop that agent first
+// to test.
+
+#include <PhosphorServicePolkit/AuthRequest.h>
+#include <PhosphorServicePolkit/PolkitAgent.h>
+
+#include <QCoreApplication>
+#include <QObject>
+#include <QStringList>
+#include <QTextStream>
+
+using namespace PhosphorServicePolkit;
+
+namespace {
+QTextStream& out()
+{
+    static QTextStream s(stdout);
+    return s;
+}
+QTextStream& err()
+{
+    static QTextStream s(stderr);
+    return s;
+}
+
+constexpr int kOk = 0;
+constexpr int kUsage = 64;
+constexpr int kRuntime = 1;
+
+int usage()
+{
+    err() << "usage: phosphor-service-polkit-cli [--password <pw>]\n\n"
+          << "  Registers as the session's PolicyKit authentication agent and answers the\n"
+          << "  PAM prompts for each request. Trigger one with e.g. `pkexec true` from\n"
+          << "  another terminal.\n\n"
+          << "  --password <pw>   DEMO ONLY: auto-answer every prompt with <pw> (visible in\n"
+          << "                    the process list). Without it, prompts are read from stdin.\n\n"
+          << "  Exactly one agent serves a session; if your desktop already runs one\n"
+          << "  (KDE / GNOME) registration fails. Stop it first to test this demo.\n";
+    err().flush();
+    return kUsage;
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+    const QStringList args = app.arguments();
+
+    QString password;
+    bool havePassword = false;
+    for (int i = 1; i < args.size(); ++i) {
+        const QString& a = args.at(i);
+        if (a == QLatin1String("--password") && i + 1 < args.size()) {
+            password = args.at(++i);
+            havePassword = true;
+        } else if (a == QLatin1String("--help") || a == QLatin1String("-h")) {
+            usage();
+            return kOk;
+        } else {
+            return usage();
+        }
+    }
+
+    auto* agent = new PolkitAgent(&app);
+    if (!agent->registerAgent()) {
+        err() << "could not register as the authentication agent: another agent owns this\n"
+              << "session. Stop your desktop's polkit agent first to test this demo.\n";
+        err().flush();
+        return kRuntime;
+    }
+    out() << "phosphor polkit agent registered at " << PolkitAgent::defaultObjectPath() << "\n"
+          << "trigger an action (e.g. `pkexec true`) from another terminal. Ctrl+C to stop.\n";
+    out().flush();
+
+    QObject::connect(
+        agent, &PolkitAgent::authenticationRequested, &app, [agent, havePassword, password](AuthRequest* request) {
+            out() << "+ auth request: action=" << request->actionId() << "\n"
+                  << "    message: " << request->message() << "\n"
+                  << "    identities: " << request->identities().join(QLatin1String(", ")) << "\n";
+            out().flush();
+
+            // Print and answer each PAM prompt as the conversation progresses.
+            QObject::connect(request, &AuthRequest::promptChanged, agent, [agent, havePassword, password, request]() {
+                const QString prompt = request->prompt();
+                if (prompt.isEmpty())
+                    return;
+                out() << "    prompt: " << prompt;
+                out().flush();
+
+                QString response;
+                if (havePassword) {
+                    response = password;
+                    out() << "(answered from --password)\n";
+                } else {
+                    QTextStream in(stdin);
+                    response = in.readLine();
+                }
+                out().flush();
+                // Straight to PAM; the response is not retained here.
+                agent->respond(response);
+            });
+
+            // Start the PAM conversation for the (default-selected) identity.
+            agent->authenticate();
+        });
+
+    QObject::connect(agent, &PolkitAgent::authenticationCompleted, &app, [](bool gained) {
+        out() << (gained ? "- authenticated\n" : "- authentication failed\n");
+        out().flush();
+    });
+    QObject::connect(agent, &PolkitAgent::authenticationError, &app, [](const QString& text) {
+        out() << "    error: " << text << "\n";
+        out().flush();
+    });
+    QObject::connect(agent, &PolkitAgent::authenticationInfo, &app, [](const QString& text) {
+        out() << "    info: " << text << "\n";
+        out().flush();
+    });
+    QObject::connect(agent, &PolkitAgent::authenticationCancelled, &app, []() {
+        out() << "- request cancelled\n";
+        out().flush();
+    });
+
+    return app.exec();
+}

--- a/libs/phosphor-service-polkit/CMakeLists.txt
+++ b/libs/phosphor-service-polkit/CMakeLists.txt
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# PhosphorServicePolkit: a PolicyKit authentication agent for Phosphor-based
+# desktop shells, via the polkit-qt6 binding. Phase 2.6 of the service-library
+# split (see docs/phosphor-shell-design/04-implementation-plan.md). polkitd
+# calls into the registered agent when an app requests a privileged action, and
+# the agent drives the PAM conversation that authenticates the user. polkit-qt6
+# is wrapped privately, so it does not appear in the public link interface.
+
+cmake_minimum_required(VERSION 3.16)
+
+set(PHOSPHORSERVICEPOLKIT_VERSION "0.1.0")
+
+if(NOT PROJECT_VERSION)
+    project(PhosphorServicePolkit VERSION ${PHOSPHORSERVICEPOLKIT_VERSION} LANGUAGES CXX)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+    set(CMAKE_AUTOMOC ON)
+endif()
+
+include(GenerateExportHeader)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dependencies
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Core / Qml: the QObject + QML surface. PolkitQt6-1 (Core + Agent) is the
+# backend; it is PRIVATE because the polkit-qt types are wrapped inside the .cpp
+# (the public PolkitAgent header is a plain QObject with no polkit-qt types), so
+# consumers neither include nor link polkit-qt. Qt6::Gui is pulled transitively
+# by PolkitQt6-1::Agent but is not part of our interface. The polkit-qt6 GUI
+# action-button widgets (PolkitQt6-1::Gui) are a Phase 3/4 UI concern and are
+# NOT linked.
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Qml Gui)
+find_package(PolkitQt6-1 REQUIRED)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Library
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set(phosphorservicepolkit_public_HDRS
+    include/PhosphorServicePolkit/PhosphorServicePolkit.h
+    include/PhosphorServicePolkit/QmlRegistration.h
+    include/PhosphorServicePolkit/PolkitAgent.h
+)
+
+set(phosphorservicepolkit_SRCS
+    src/qmlregistration.cpp
+    src/polkitagent.cpp
+)
+
+add_library(PhosphorServicePolkit SHARED
+    ${phosphorservicepolkit_public_HDRS}
+    ${phosphorservicepolkit_SRCS}
+)
+
+add_library(PhosphorServicePolkit::PhosphorServicePolkit ALIAS PhosphorServicePolkit)
+
+generate_export_header(PhosphorServicePolkit
+    EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/PhosphorServicePolkit/phosphorservicepolkit_export.h
+    EXPORT_MACRO_NAME PHOSPHORSERVICEPOLKIT_EXPORT
+)
+
+if(NOT DEFINED KDE_INSTALL_INCLUDEDIR)
+    include(GNUInstallDirs)
+    set(KDE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
+    set(KDE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+    set(KDE_INSTALL_BINDIR ${CMAKE_INSTALL_BINDIR})
+endif()
+
+target_include_directories(PhosphorServicePolkit
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(PhosphorServicePolkit PUBLIC cxx_std_20)
+
+target_link_libraries(PhosphorServicePolkit
+    PUBLIC
+        Qt6::Core
+        Qt6::Qml
+    PRIVATE
+        PolkitQt6-1::Core
+        PolkitQt6-1::Agent
+)
+
+set_target_properties(PhosphorServicePolkit PROPERTIES
+    VERSION ${PHOSPHORSERVICEPOLKIT_VERSION}
+    SOVERSION 0
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+    UNITY_BUILD OFF
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Install
+# ═══════════════════════════════════════════════════════════════════════════════
+
+install(TARGETS PhosphorServicePolkit
+    EXPORT PhosphorServicePolkitTargets
+    RUNTIME DESTINATION ${KDE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${KDE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${KDE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${KDE_INSTALL_INCLUDEDIR}
+)
+
+install(FILES ${phosphorservicepolkit_public_HDRS}
+    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/PhosphorServicePolkit
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PhosphorServicePolkit/phosphorservicepolkit_export.h
+    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/PhosphorServicePolkit
+)
+
+install(EXPORT PhosphorServicePolkitTargets
+    FILE PhosphorServicePolkitTargets.cmake
+    NAMESPACE PhosphorServicePolkit::
+    DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorServicePolkit
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/PhosphorServicePolkitConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorServicePolkitConfig.cmake"
+    INSTALL_DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorServicePolkit
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorServicePolkitConfigVersion.cmake"
+    VERSION ${PHOSPHORSERVICEPOLKIT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorServicePolkitConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorServicePolkitConfigVersion.cmake"
+    DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorServicePolkit
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+if(CMAKE_PROJECT_NAME STREQUAL "PhosphorServicePolkit" OR BUILD_TESTING)
+    enable_testing()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt")
+        add_subdirectory(tests)
+    endif()
+endif()

--- a/libs/phosphor-service-polkit/CMakeLists.txt
+++ b/libs/phosphor-service-polkit/CMakeLists.txt
@@ -46,11 +46,13 @@ set(phosphorservicepolkit_public_HDRS
     include/PhosphorServicePolkit/PhosphorServicePolkit.h
     include/PhosphorServicePolkit/QmlRegistration.h
     include/PhosphorServicePolkit/PolkitAgent.h
+    include/PhosphorServicePolkit/AuthRequest.h
 )
 
 set(phosphorservicepolkit_SRCS
     src/qmlregistration.cpp
     src/polkitagent.cpp
+    src/authrequest.cpp
 )
 
 add_library(PhosphorServicePolkit SHARED

--- a/libs/phosphor-service-polkit/CMakeLists.txt
+++ b/libs/phosphor-service-polkit/CMakeLists.txt
@@ -29,11 +29,11 @@ include(GenerateExportHeader)
 # Core / Qml: the QObject + QML surface. PolkitQt6-1 (Core + Agent) is the
 # backend; it is PRIVATE because the polkit-qt types are wrapped inside the .cpp
 # (the public PolkitAgent header is a plain QObject with no polkit-qt types), so
-# consumers neither include nor link polkit-qt. Qt6::Gui is pulled transitively
-# by PolkitQt6-1::Agent but is not part of our interface. The polkit-qt6 GUI
-# action-button widgets (PolkitQt6-1::Gui) are a Phase 3/4 UI concern and are
-# NOT linked.
-find_package(Qt6 6.6 REQUIRED COMPONENTS Core Qml Gui)
+# consumers neither include nor link polkit-qt. No Qt Gui type is used, and
+# PolkitQt6-1::Agent does not pull Qt6::Gui transitively, so Gui is not a
+# dependency. The polkit-qt6 GUI action-button widgets (PolkitQt6-1::Gui) are a
+# Phase 3/4 UI concern and are NOT linked.
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Qml)
 find_package(PolkitQt6-1 REQUIRED)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/libs/phosphor-service-polkit/PhosphorServicePolkitConfig.cmake.in
+++ b/libs/phosphor-service-polkit/PhosphorServicePolkitConfig.cmake.in
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Mirror the PUBLIC link set in CMakeLists.txt. (PolkitQt6-1 is a PRIVATE link:
+# the polkit-qt types are wrapped inside the .cpp and never appear in the public
+# headers, so consumers neither include nor link it.)
+find_dependency(Qt6 6.6 COMPONENTS Core Qml)
+
+include("${CMAKE_CURRENT_LIST_DIR}/PhosphorServicePolkitTargets.cmake")
+
+check_required_components(PhosphorServicePolkit)

--- a/libs/phosphor-service-polkit/README.md
+++ b/libs/phosphor-service-polkit/README.md
@@ -103,7 +103,7 @@ pkexec true
 - `polkit-qt6` (Core + Agent), discovered via `find_package(PolkitQt6-1)`. A
   running `polkitd` on the system bus for the live path (the lib loads inert
   without it). The polkit-qt6 GUI action-button widgets are not used.
-- Qt6 ≥ 6.6 (Core, Qml). Gui arrives transitively via polkit-qt6's agent library.
+- Qt6 ≥ 6.6 (Core, Qml).
 
 ## Status
 

--- a/libs/phosphor-service-polkit/README.md
+++ b/libs/phosphor-service-polkit/README.md
@@ -59,5 +59,6 @@ registration plumbing; the listener-registration work folded into the
 milestone-1 commit), 3 (the `initiateAuthentication` → `AuthRequest` decode,
 surfaced as the active request), and 4 (the `Agent::Session` PAM conversation:
 `authenticate()` / `respond()` / `cancel()` driving the prompt → answer →
-completed flow) landed; milestones 5-8 (the QML facade, the CLI agent demo,
-tests, and README finalisation) follow per the plan.
+completed flow), and 5 (the QML facade, verified by a real QQmlEngine load test)
+landed; milestones 6-8 (the CLI agent demo, tests, and README finalisation)
+follow per the plan.

--- a/libs/phosphor-service-polkit/README.md
+++ b/libs/phosphor-service-polkit/README.md
@@ -56,7 +56,8 @@ The authentication dialog itself is a Phase 3 / 4 consumer of this library.
 
 Phase 2.6: in progress. Milestones 1+2 (skeleton + CMake + the `PolkitAgent`
 registration plumbing; the listener-registration work folded into the
-milestone-1 commit) and 3 (the `initiateAuthentication` → `AuthRequest` decode,
-surfaced as the active request) landed; milestones 4-8 (the `Agent::Session` PAM
-conversation, the QML facade, the CLI agent demo, tests, and README
-finalisation) follow per the plan.
+milestone-1 commit), 3 (the `initiateAuthentication` → `AuthRequest` decode,
+surfaced as the active request), and 4 (the `Agent::Session` PAM conversation:
+`authenticate()` / `respond()` / `cancel()` driving the prompt → answer →
+completed flow) landed; milestones 5-8 (the QML facade, the CLI agent demo,
+tests, and README finalisation) follow per the plan.

--- a/libs/phosphor-service-polkit/README.md
+++ b/libs/phosphor-service-polkit/README.md
@@ -27,8 +27,7 @@ The authentication dialog itself is a Phase 3 / 4 consumer of this library.
 | Type          | Role                                                                                     |
 |---------------|------------------------------------------------------------------------------------------|
 | `PolkitAgent` | Registers as the session's authentication agent and surfaces the active request + a respond / cancel path. Wraps `polkit-qt6`'s `Agent::Listener` privately, so its public surface carries no polkit-qt types. |
-
-*(The typed `AuthRequest` object joins this table in milestone 3.)*
+| `AuthRequest` | One decoded authentication request polkit is waiting on (action / message / icon / details / identities + the selected identity). |
 
 ## Design notes
 
@@ -55,8 +54,9 @@ The authentication dialog itself is a Phase 3 / 4 consumer of this library.
 
 ## Status
 
-Phase 2.6: in progress. Milestone 1 (skeleton + CMake + the `PolkitAgent`
-registration plumbing) landed; milestones 2-8 (listener registration lifecycle,
-the `initiateAuthentication` → `AuthRequest` decode, the `Agent::Session` PAM
+Phase 2.6: in progress. Milestones 1+2 (skeleton + CMake + the `PolkitAgent`
+registration plumbing; the listener-registration work folded into the
+milestone-1 commit) and 3 (the `initiateAuthentication` → `AuthRequest` decode,
+surfaced as the active request) landed; milestones 4-8 (the `Agent::Session` PAM
 conversation, the QML facade, the CLI agent demo, tests, and README
 finalisation) follow per the plan.

--- a/libs/phosphor-service-polkit/README.md
+++ b/libs/phosphor-service-polkit/README.md
@@ -60,5 +60,6 @@ milestone-1 commit), 3 (the `initiateAuthentication` → `AuthRequest` decode,
 surfaced as the active request), and 4 (the `Agent::Session` PAM conversation:
 `authenticate()` / `respond()` / `cancel()` driving the prompt → answer →
 completed flow), 5 (the QML facade, verified by a real QQmlEngine load test),
-and 6 (the `examples/phosphor-service-polkit-cli` standalone-agent demo) landed;
-milestones 7-8 (tests and README finalisation) follow per the plan.
+6 (the `examples/phosphor-service-polkit-cli` standalone-agent demo), and 7 (the
+decode unit test over real polkit-qt `Details` / `Identity` values) landed;
+milestone 8 (README finalisation) follows per the plan.

--- a/libs/phosphor-service-polkit/README.md
+++ b/libs/phosphor-service-polkit/README.md
@@ -3,8 +3,8 @@
 
 # phosphor-service-polkit
 
-A PolicyKit authentication agent for Phosphor-based desktop shells, via the
-`polkit-qt6` binding.
+A PolicyKit authentication agent, built on the `polkit-qt6` binding, for
+Phosphor-based desktop shells.
 
 ## Responsibility
 

--- a/libs/phosphor-service-polkit/README.md
+++ b/libs/phosphor-service-polkit/README.md
@@ -59,6 +59,6 @@ registration plumbing; the listener-registration work folded into the
 milestone-1 commit), 3 (the `initiateAuthentication` → `AuthRequest` decode,
 surfaced as the active request), and 4 (the `Agent::Session` PAM conversation:
 `authenticate()` / `respond()` / `cancel()` driving the prompt → answer →
-completed flow), and 5 (the QML facade, verified by a real QQmlEngine load test)
-landed; milestones 6-8 (the CLI agent demo, tests, and README finalisation)
-follow per the plan.
+completed flow), 5 (the QML facade, verified by a real QQmlEngine load test),
+and 6 (the `examples/phosphor-service-polkit-cli` standalone-agent demo) landed;
+milestones 7-8 (tests and README finalisation) follow per the plan.

--- a/libs/phosphor-service-polkit/README.md
+++ b/libs/phosphor-service-polkit/README.md
@@ -29,6 +29,54 @@ The authentication dialog itself is a Phase 3 / 4 consumer of this library.
 | `PolkitAgent` | Registers as the session's authentication agent and surfaces the active request + a respond / cancel path. Wraps `polkit-qt6`'s `Agent::Listener` privately, so its public surface carries no polkit-qt types. |
 | `AuthRequest` | One decoded authentication request polkit is waiting on (action / message / icon / details / identities + the selected identity). |
 
+## Typical use
+
+C++ shell composition root:
+
+```cpp
+#include <PhosphorServicePolkit/QmlRegistration.h>
+
+int main(int argc, char** argv)
+{
+    QGuiApplication app(argc, argv);
+    PhosphorServicePolkit::registerQmlTypes();
+    // ... load shell.qml
+}
+```
+
+QML authentication dialog (drives one request to completion):
+
+```qml
+import Phosphor.Service.Polkit 1.0
+
+PolkitAgent {
+    id: agent
+    Component.onCompleted: registerAgent()
+
+    onAuthenticationRequested: (request) => authDialog.show(request)
+    onAuthenticationCompleted: (gained) => authDialog.finish(gained)
+}
+
+AuthDialog {
+    id: authDialog
+    // request.message + request.identities choose who; request.prompt is the
+    // PAM prompt (e.g. "Password: "), request.echo whether to show the input.
+    onAuthenticate: agent.authenticate()
+    onAnswered: (text) => agent.respond(text)   // straight to PAM, never stored
+    onDismissed: agent.cancel()
+}
+```
+
+The CLI doubles as the worked example and the acceptance harness; it runs as the
+agent itself:
+
+```sh
+# register as the session agent and answer prompts (stop the desktop agent first)
+phosphor-service-polkit-cli
+# in another terminal, trigger an action:
+pkexec true
+```
+
 ## Design notes
 
 - **Wraps polkit-qt privately.** `PolkitAgent` is a plain `QObject`; the
@@ -54,12 +102,17 @@ The authentication dialog itself is a Phase 3 / 4 consumer of this library.
 
 ## Status
 
-Phase 2.6: in progress. Milestones 1+2 (skeleton + CMake + the `PolkitAgent`
-registration plumbing; the listener-registration work folded into the
-milestone-1 commit), 3 (the `initiateAuthentication` → `AuthRequest` decode,
-surfaced as the active request), and 4 (the `Agent::Session` PAM conversation:
-`authenticate()` / `respond()` / `cancel()` driving the prompt → answer →
-completed flow), 5 (the QML facade, verified by a real QQmlEngine load test),
-6 (the `examples/phosphor-service-polkit-cli` standalone-agent demo), and 7 (the
-decode unit test over real polkit-qt `Details` / `Identity` values) landed;
-milestone 8 (README finalisation) follows per the plan.
+Phase 2.6: shipped. The `PolkitAgent` registers as the session's authentication
+agent (explicit, inert when another agent owns the session), decodes polkit's
+`initiateAuthentication` into a typed `AuthRequest` (action / message / icon /
+details / identities), and drives the `polkit-qt6` `Agent::Session` PAM
+conversation: `authenticate()` starts it, the PAM prompt surfaces on
+`AuthRequest`, `respond()` answers it straight to PAM without retaining the
+secret, and `completed` / `cancel` resolve polkit's result exactly once. The
+`examples/phosphor-service-polkit-cli` standalone-agent demo covers the Phase-2
+gate (run as the agent, log requests, answer prompts) and exercises the live
+path against `pkexec`. Three test binaries pin the deterministic surface with no
+`polkitd`: the C++ smoke harness (inert construction, registration-fail, the
+active-request / authenticate / respond / cancel guards), the QML-engine facade
+load test, and the decode unit test over real polkit-qt `Details` / `Identity`
+values. The authentication dialog UI is a Phase 3 / 4 consumer.

--- a/libs/phosphor-service-polkit/README.md
+++ b/libs/phosphor-service-polkit/README.md
@@ -54,13 +54,18 @@ PolkitAgent {
     Component.onCompleted: registerAgent()
 
     onAuthenticationRequested: (request) => authDialog.show(request)
+    // promptRequested is an EVENT, not a property change: it fires once per PAM
+    // prompt INCLUDING a same-text retry after a wrong answer. Drive the dialog's
+    // input field from it (not from a binding on request.prompt, which a
+    // same-text retry would not re-notify). echo is false for secrets.
+    onPromptRequested: (prompt, echo) => authDialog.askFor(prompt, echo)
     onAuthenticationCompleted: (gained) => authDialog.finish(gained)
 }
 
 AuthDialog {
     id: authDialog
-    // request.message + request.identities choose who; request.prompt is the
-    // PAM prompt (e.g. "Password: "), request.echo whether to show the input.
+    // request.message + request.identities choose who; askFor() shows each PAM
+    // prompt as it arrives.
     onAuthenticate: agent.authenticate()
     onAnswered: (text) => agent.respond(text)   // straight to PAM, never stored
     onDismissed: agent.cancel()

--- a/libs/phosphor-service-polkit/README.md
+++ b/libs/phosphor-service-polkit/README.md
@@ -1,0 +1,62 @@
+<!-- SPDX-FileCopyrightText: 2026 fuddlesworth -->
+<!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
+
+# phosphor-service-polkit
+
+A PolicyKit authentication agent for Phosphor-based desktop shells, via the
+`polkit-qt6` binding.
+
+## Responsibility
+
+When an application requests a privileged action, `polkitd` calls into the
+authentication agent registered for the session; the agent drives the PAM
+conversation that authenticates the user. This library is that agent. No UI; it
+surfaces the request and a respond / cancel path, and a shell renders the
+authentication dialog.
+
+- Register with `polkitd` as the session's authentication agent (opt-in, since
+  becoming the agent intercepts every authentication).
+- Surface the active authentication request (action, message, identities, and
+  each PAM prompt) and drive the `polkit-qt6` `Agent::Session` that answers it.
+- Pass the user's response straight through to PAM without retaining it.
+
+The authentication dialog itself is a Phase 3 / 4 consumer of this library.
+
+## Key types
+
+| Type          | Role                                                                                     |
+|---------------|------------------------------------------------------------------------------------------|
+| `PolkitAgent` | Registers as the session's authentication agent and surfaces the active request + a respond / cancel path. Wraps `polkit-qt6`'s `Agent::Listener` privately, so its public surface carries no polkit-qt types. |
+
+*(The typed `AuthRequest` object joins this table in milestone 3.)*
+
+## Design notes
+
+- **Wraps polkit-qt privately.** `PolkitAgent` is a plain `QObject`; the
+  `PolkitQt1::Agent::Listener` it subclasses lives in the `.cpp`. polkit-qt6 is
+  a private link, so consumers neither include nor link it.
+- **Registration is explicit.** `registerAgent()` opts into becoming the
+  session's agent; the constructor has no side effects. Exactly one agent serves
+  a session, so when the desktop's agent (KDE / GNOME) already holds it,
+  registration fails and the object stays inert (`registered() == false`).
+- **Surface the request, never the secret.** The user's response flows straight
+  into `Agent::Session::setResponse`; the library never stores, logs, or echoes
+  it.
+- **Dependency injection for tests.** The agent takes an injectable session id +
+  object path, so registration is exercised against a synthetic session with no
+  real `polkitd` and no chance of intercepting the tester's authentications.
+
+## Dependencies
+
+- `polkit-qt6` (Core + Agent), discovered via `find_package(PolkitQt6-1)`. A
+  running `polkitd` on the system bus for the live path (the lib loads inert
+  without it). The polkit-qt6 GUI action-button widgets are not used.
+- Qt6 ≥ 6.6 (Core, Qml). Gui arrives transitively via polkit-qt6's agent library.
+
+## Status
+
+Phase 2.6: in progress. Milestone 1 (skeleton + CMake + the `PolkitAgent`
+registration plumbing) landed; milestones 2-8 (listener registration lifecycle,
+the `initiateAuthentication` → `AuthRequest` decode, the `Agent::Session` PAM
+conversation, the QML facade, the CLI agent demo, tests, and README
+finalisation) follow per the plan.

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/AuthRequest.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/AuthRequest.h
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorServicePolkit/phosphorservicepolkit_export.h>
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QVariantMap>
+
+namespace PhosphorServicePolkit {
+
+class ListenerImpl;
+
+/**
+ * @brief One active PolicyKit authentication request, decoded from polkit's
+ * `initiateAuthentication` callback.
+ *
+ * Owned by `PolkitAgent` (its parent). polkit serialises authentication, so at
+ * most one of these is active at a time. The descriptive fields are fixed for
+ * the life of the request (`CONSTANT`); only `selectedIdentity` is writable, so
+ * a dialog can offer a chooser when the user may authenticate as more than one
+ * identity (usually just themselves, sometimes root).
+ *
+ * The PAM prompt and the response path land on this object / the agent in
+ * milestone 4; milestone 3 surfaces the request's description and identities.
+ */
+class PHOSPHORSERVICEPOLKIT_EXPORT AuthRequest : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString actionId READ actionId CONSTANT)
+    Q_PROPERTY(QString message READ message CONSTANT)
+    Q_PROPERTY(QString iconName READ iconName CONSTANT)
+    Q_PROPERTY(QVariantMap details READ details CONSTANT)
+    Q_PROPERTY(QString cookie READ cookie CONSTANT)
+    Q_PROPERTY(QStringList identities READ identities CONSTANT)
+    Q_PROPERTY(int selectedIdentity READ selectedIdentity WRITE setSelectedIdentity NOTIFY selectedIdentityChanged)
+
+public:
+    [[nodiscard]] QString actionId() const
+    {
+        return m_actionId;
+    }
+    [[nodiscard]] QString message() const
+    {
+        return m_message;
+    }
+    [[nodiscard]] QString iconName() const
+    {
+        return m_iconName;
+    }
+    [[nodiscard]] QVariantMap details() const
+    {
+        return m_details;
+    }
+    /// The opaque polkit cookie that ties this request to its authentication.
+    [[nodiscard]] QString cookie() const
+    {
+        return m_cookie;
+    }
+    /// Display strings for the identities the user may authenticate as.
+    [[nodiscard]] QStringList identities() const
+    {
+        return m_identities;
+    }
+    /// Index into `identities` of the identity the user will authenticate as
+    /// (default 0). The agent uses it to build the PAM session in milestone 4.
+    [[nodiscard]] int selectedIdentity() const
+    {
+        return m_selectedIdentity;
+    }
+    /// Clamped to a valid index; out-of-range values are ignored.
+    void setSelectedIdentity(int index);
+
+Q_SIGNALS:
+    void selectedIdentityChanged();
+
+private:
+    Q_DISABLE_COPY_MOVE(AuthRequest)
+    friend class ListenerImpl;
+
+    AuthRequest(QString actionId, QString message, QString iconName, QVariantMap details, QString cookie,
+                QStringList identities, QObject* parent);
+
+    QString m_actionId;
+    QString m_message;
+    QString m_iconName;
+    QVariantMap m_details;
+    QString m_cookie;
+    QStringList m_identities;
+    int m_selectedIdentity = 0;
+};
+
+} // namespace PhosphorServicePolkit

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/AuthRequest.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/AuthRequest.h
@@ -13,6 +13,7 @@
 namespace PhosphorServicePolkit {
 
 class ListenerImpl;
+class PolkitAgent;
 
 /**
  * @brief One active PolicyKit authentication request, decoded from polkit's
@@ -37,6 +38,8 @@ class PHOSPHORSERVICEPOLKIT_EXPORT AuthRequest : public QObject
     Q_PROPERTY(QString cookie READ cookie CONSTANT)
     Q_PROPERTY(QStringList identities READ identities CONSTANT)
     Q_PROPERTY(int selectedIdentity READ selectedIdentity WRITE setSelectedIdentity NOTIFY selectedIdentityChanged)
+    Q_PROPERTY(QString prompt READ prompt NOTIFY promptChanged)
+    Q_PROPERTY(bool echo READ echo NOTIFY promptChanged)
 
 public:
     [[nodiscard]] QString actionId() const
@@ -74,12 +77,27 @@ public:
     /// Clamped to a valid index; out-of-range values are ignored.
     void setSelectedIdentity(int index);
 
+    /// The current PAM prompt to show the user (e.g. "Password: "), updated by
+    /// the agent as the conversation progresses. Empty until authentication
+    /// starts.
+    [[nodiscard]] QString prompt() const
+    {
+        return m_prompt;
+    }
+    /// Whether the response to `prompt` should be echoed (false for passwords).
+    [[nodiscard]] bool echo() const
+    {
+        return m_echo;
+    }
+
 Q_SIGNALS:
     void selectedIdentityChanged();
+    void promptChanged();
 
 private:
     Q_DISABLE_COPY_MOVE(AuthRequest)
     friend class ListenerImpl;
+    friend class PolkitAgent;
 
     AuthRequest(QString actionId, QString message, QString iconName, QVariantMap details, QString cookie,
                 QStringList identities, QObject* parent);
@@ -91,6 +109,8 @@ private:
     QString m_cookie;
     QStringList m_identities;
     int m_selectedIdentity = 0;
+    QString m_prompt;
+    bool m_echo = false;
 };
 
 } // namespace PhosphorServicePolkit

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/AuthRequest.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/AuthRequest.h
@@ -75,7 +75,7 @@ public:
     {
         return m_selectedIdentity;
     }
-    /// Clamped to a valid index; out-of-range values are ignored.
+    /// Out-of-range indices are ignored (the current selection is kept).
     void setSelectedIdentity(int index);
 
     /// The current PAM prompt to show the user (e.g. "Password: "), updated by

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/AuthRequest.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/AuthRequest.h
@@ -25,8 +25,9 @@ class PolkitAgent;
  * a dialog can offer a chooser when the user may authenticate as more than one
  * identity (usually just themselves, sometimes root).
  *
- * The PAM prompt and the response path land on this object / the agent in
- * milestone 4; milestone 3 surfaces the request's description and identities.
+ * The request's description and identities are decoded here; the live PAM
+ * `prompt` / `echo` are updated on this object by the agent as the conversation
+ * progresses, and the response goes back through `PolkitAgent::respond()`.
  */
 class PHOSPHORSERVICEPOLKIT_EXPORT AuthRequest : public QObject
 {

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/AuthRequest.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/AuthRequest.h
@@ -40,7 +40,7 @@ class PHOSPHORSERVICEPOLKIT_EXPORT AuthRequest : public QObject
     Q_PROPERTY(QStringList identities READ identities CONSTANT)
     Q_PROPERTY(int selectedIdentity READ selectedIdentity WRITE setSelectedIdentity NOTIFY selectedIdentityChanged)
     Q_PROPERTY(QString prompt READ prompt NOTIFY promptChanged)
-    Q_PROPERTY(bool echo READ echo NOTIFY promptChanged)
+    Q_PROPERTY(bool echo READ echo NOTIFY echoChanged)
 
 public:
     [[nodiscard]] QString actionId() const
@@ -70,7 +70,7 @@ public:
         return m_identities;
     }
     /// Index into `identities` of the identity the user will authenticate as
-    /// (default 0). The agent uses it to build the PAM session in milestone 4.
+    /// (default 0). `authenticate()` uses it to build the PAM session.
     [[nodiscard]] int selectedIdentity() const
     {
         return m_selectedIdentity;
@@ -94,6 +94,7 @@ public:
 Q_SIGNALS:
     void selectedIdentityChanged();
     void promptChanged();
+    void echoChanged();
 
 private:
     Q_DISABLE_COPY_MOVE(AuthRequest)

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PhosphorServicePolkit.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PhosphorServicePolkit.h
@@ -18,11 +18,13 @@
  * Shells consume:
  *   - `PolkitAgent`: registers as the session's authentication agent and
  *     surfaces the active request + a respond / cancel path.
- * (The typed `AuthRequest` object joins this umbrella header in milestone 3.)
+ *   - `AuthRequest`: one decoded authentication request (action / message /
+ *     icon / details / identities) polkit is waiting on.
  *
  * Phase 2.6 of the service-library plan documented in
  * `docs/phosphor-shell-design/04-implementation-plan.md`.
  */
 
+#include <PhosphorServicePolkit/AuthRequest.h>
 #include <PhosphorServicePolkit/PolkitAgent.h>
 #include <PhosphorServicePolkit/QmlRegistration.h>

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PhosphorServicePolkit.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PhosphorServicePolkit.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+/**
+ * @file PhosphorServicePolkit.h
+ * @brief Umbrella header for the PhosphorServicePolkit library.
+ *
+ * PhosphorServicePolkit is a PolicyKit authentication agent for Phosphor-based
+ * desktop shells, built on the `polkit-qt6` binding. When an application
+ * requests a privileged action, `polkitd` calls into the registered agent,
+ * which drives the PAM conversation that authenticates the user. The library
+ * wraps polkit-qt privately, so its public surface is a clean Qt/QML type with
+ * no polkit-qt types leaking out; it has no UI of its own (the authentication
+ * dialog is a Phase 3 / 4 consumer).
+ *
+ * Shells consume:
+ *   - `PolkitAgent`: registers as the session's authentication agent and
+ *     surfaces the active request + a respond / cancel path.
+ * (The typed `AuthRequest` object joins this umbrella header in milestone 3.)
+ *
+ * Phase 2.6 of the service-library plan documented in
+ * `docs/phosphor-shell-design/04-implementation-plan.md`.
+ */
+
+#include <PhosphorServicePolkit/PolkitAgent.h>
+#include <PhosphorServicePolkit/QmlRegistration.h>

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PolkitAgent.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PolkitAgent.h
@@ -12,6 +12,9 @@
 
 namespace PhosphorServicePolkit {
 
+class AuthRequest;
+class ListenerImpl;
+
 /**
  * @brief A PolicyKit authentication agent for Phosphor-based desktop shells.
  *
@@ -37,6 +40,7 @@ class PHOSPHORSERVICEPOLKIT_EXPORT PolkitAgent : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(bool registered READ registered NOTIFY registeredChanged)
+    Q_PROPERTY(PhosphorServicePolkit::AuthRequest* activeRequest READ activeRequest NOTIFY activeRequestChanged)
 
 public:
     /// Agent for the current session, at the default object path.
@@ -61,11 +65,27 @@ public:
     /// opt in from QML.
     Q_INVOKABLE bool registerAgent();
 
+    /// The authentication request polkit is currently waiting on, or null. A
+    /// dialog binds this; at most one is active (polkit serialises).
+    [[nodiscard]] AuthRequest* activeRequest() const;
+
+    /// Decline the active request: it completes without authorization and clears.
+    /// The authenticate path (answering the PAM prompt) lands in milestone 4.
+    /// Q_INVOKABLE for a UI / CLI; never exported on any bus.
+    Q_INVOKABLE void cancel();
+
 Q_SIGNALS:
     void registeredChanged();
+    void activeRequestChanged();
+    /// A new authentication request arrived (also reflected in `activeRequest`).
+    void authenticationRequested(PhosphorServicePolkit::AuthRequest* request);
+    /// The active request ended with none remaining (declined here, or withdrawn
+    /// by polkit).
+    void authenticationCancelled();
 
 private:
     Q_DISABLE_COPY_MOVE(PolkitAgent)
+    friend class ListenerImpl;
     class Private;
     std::unique_ptr<Private> d;
 };

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PolkitAgent.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PolkitAgent.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorServicePolkit/phosphorservicepolkit_export.h>
+
+#include <QObject>
+#include <QString>
+
+#include <memory>
+
+namespace PhosphorServicePolkit {
+
+/**
+ * @brief A PolicyKit authentication agent for Phosphor-based desktop shells.
+ *
+ * When an application requests a privileged action, `polkitd` calls into the
+ * agent registered for the session; the agent drives the PAM conversation that
+ * authenticates the user. This class is that agent. It wraps `polkit-qt6`'s
+ * `Agent::Listener` privately, so the public surface stays a clean `QObject`
+ * with no polkit-qt types: a consumer binds the request + a `respond` path and
+ * never touches polkit-qt directly.
+ *
+ * Registration is explicit (`registerAgent()`), not done in the constructor:
+ * becoming the session's agent intercepts every authentication, so it is an
+ * opt-in step a shell or the CLI demo takes deliberately. Exactly one agent
+ * serves a session, so when the desktop's agent (KDE / GNOME) already holds it
+ * `registerAgent()` fails and the object stays inert (`registered() == false`),
+ * mirroring the name-conflict-is-inert shape of `phosphor-service-notifications`.
+ *
+ * Milestone 1 lands the registration plumbing. The request decode into a typed
+ * `AuthRequest` (milestone 3) and the `Agent::Session` PAM conversation that
+ * actually authenticates (milestone 4) follow.
+ */
+class PHOSPHORSERVICEPOLKIT_EXPORT PolkitAgent : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool registered READ registered NOTIFY registeredChanged)
+
+public:
+    /// Agent for the current session, at the default object path.
+    explicit PolkitAgent(QObject* parent = nullptr);
+    /// Dependency-injected: register for an explicit session id at an explicit
+    /// object path (tests pass a synthetic session so registration is exercised
+    /// without owning the real one). An empty @p sessionId means the current
+    /// session, resolved at registration time.
+    PolkitAgent(QString sessionId, QString objectPath, QObject* parent = nullptr);
+    ~PolkitAgent() override;
+
+    /// True once this process is the registered authentication agent for its
+    /// session. False until `registerAgent()` succeeds, or when another agent
+    /// already holds the session (see class docs).
+    [[nodiscard]] bool registered() const;
+
+    /// The default D-Bus object path the agent exports at.
+    [[nodiscard]] static QString defaultObjectPath();
+
+    /// Register with `polkitd` as the session's authentication agent. Returns
+    /// `registered()`. A no-op once registered. Q_INVOKABLE so a shell/CLI can
+    /// opt in from QML.
+    Q_INVOKABLE bool registerAgent();
+
+Q_SIGNALS:
+    void registeredChanged();
+
+private:
+    Q_DISABLE_COPY_MOVE(PolkitAgent)
+    class Private;
+    std::unique_ptr<Private> d;
+};
+
+} // namespace PhosphorServicePolkit

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PolkitAgent.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PolkitAgent.h
@@ -69,9 +69,19 @@ public:
     /// dialog binds this; at most one is active (polkit serialises).
     [[nodiscard]] AuthRequest* activeRequest() const;
 
-    /// Decline the active request: it completes without authorization and clears.
-    /// The authenticate path (answering the PAM prompt) lands in milestone 4.
-    /// Q_INVOKABLE for a UI / CLI; never exported on any bus.
+    /// Begin authenticating the active request as its `selectedIdentity`: starts
+    /// the PAM conversation, after which `activeRequest`'s `prompt` updates and
+    /// the user's answer goes back via `respond()`. A no-op with no active
+    /// request or once a conversation is already running. Q_INVOKABLE for a UI.
+    Q_INVOKABLE void authenticate();
+
+    /// Answer the active PAM prompt. The response is passed straight to PAM and
+    /// is never stored, logged, or echoed by this library. Q_INVOKABLE for a UI.
+    Q_INVOKABLE void respond(const QString& response);
+
+    /// Decline the active request: it completes without authorization and clears
+    /// (aborting any running PAM conversation). Q_INVOKABLE for a UI / CLI; never
+    /// exported on any bus.
     Q_INVOKABLE void cancel();
 
 Q_SIGNALS:
@@ -79,6 +89,13 @@ Q_SIGNALS:
     void activeRequestChanged();
     /// A new authentication request arrived (also reflected in `activeRequest`).
     void authenticationRequested(PhosphorServicePolkit::AuthRequest* request);
+    /// The PAM conversation finished; @p gainedAuthorization is true when the
+    /// user authenticated successfully.
+    void authenticationCompleted(bool gainedAuthorization);
+    /// PAM reported an error (e.g. "Authentication failure") to show the user.
+    void authenticationError(const QString& text);
+    /// PAM reported an informational message to show the user.
+    void authenticationInfo(const QString& text);
     /// The active request ended with none remaining (declined here, or withdrawn
     /// by polkit).
     void authenticationCancelled();
@@ -86,6 +103,13 @@ Q_SIGNALS:
 private:
     Q_DISABLE_COPY_MOVE(PolkitAgent)
     friend class ListenerImpl;
+
+    /// Complete the PAM conversation: complete polkit's result and clear.
+    void onSessionCompleted(bool gainedAuthorization);
+    /// Drop the active request + session (deleting both) and notify; does NOT
+    /// complete polkit's result (the caller decides whether to).
+    void teardownActive();
+
     class Private;
     std::unique_ptr<Private> d;
 };

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PolkitAgent.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PolkitAgent.h
@@ -90,6 +90,11 @@ Q_SIGNALS:
     void activeRequestChanged();
     /// A new authentication request arrived (also reflected in `activeRequest`).
     void authenticationRequested(PhosphorServicePolkit::AuthRequest* request);
+    /// PAM is asking for input: answer it with `respond()`. This is an EVENT, not
+    /// a property change, so it fires once per request including a same-text
+    /// retry after a wrong answer (which `activeRequest`'s change-guarded `prompt`
+    /// would not re-notify). @p echo is false for secrets (do not echo input).
+    void promptRequested(const QString& prompt, bool echo);
     /// The PAM conversation finished; @p gainedAuthorization is true when the
     /// user authenticated successfully.
     void authenticationCompleted(bool gainedAuthorization);

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PolkitAgent.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/PolkitAgent.h
@@ -32,9 +32,10 @@ class ListenerImpl;
  * `registerAgent()` fails and the object stays inert (`registered() == false`),
  * mirroring the name-conflict-is-inert shape of `phosphor-service-notifications`.
  *
- * Milestone 1 lands the registration plumbing. The request decode into a typed
- * `AuthRequest` (milestone 3) and the `Agent::Session` PAM conversation that
- * actually authenticates (milestone 4) follow.
+ * `initiateAuthentication` from polkit is decoded into a typed `AuthRequest`
+ * surfaced as `activeRequest`; `authenticate()` then drives the `Agent::Session`
+ * PAM conversation (prompt -> `respond()` -> `completed`), with `cancel()` and
+ * polkit's withdrawal both resolving polkit's result exactly once.
  */
 class PHOSPHORSERVICEPOLKIT_EXPORT PolkitAgent : public QObject
 {
@@ -104,11 +105,15 @@ private:
     Q_DISABLE_COPY_MOVE(PolkitAgent)
     friend class ListenerImpl;
 
-    /// Complete the PAM conversation: complete polkit's result and clear.
+    /// The PAM session finished: settle the active request (completing polkit's
+    /// result) and emit authenticationCompleted.
     void onSessionCompleted(bool gainedAuthorization);
-    /// Drop the active request + session (deleting both) and notify; does NOT
-    /// complete polkit's result (the caller decides whether to).
-    void teardownActive();
+    /// Resolve the active request exactly once: capture-and-clear the state first
+    /// (so re-entrant calls become no-ops), disconnect + delete the session
+    /// (aborting PAM), optionally complete polkit's result, and emit
+    /// activeRequestChanged. @p completeResult is false only when polkit itself
+    /// withdrew the request and owns the result's teardown.
+    void settleActive(bool completeResult);
 
     class Private;
     std::unique_ptr<Private> d;

--- a/libs/phosphor-service-polkit/include/PhosphorServicePolkit/QmlRegistration.h
+++ b/libs/phosphor-service-polkit/include/PhosphorServicePolkit/QmlRegistration.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorServicePolkit/phosphorservicepolkit_export.h>
+
+namespace PhosphorServicePolkit {
+
+/// Register every PhosphorServicePolkit QML type under the
+/// `Phosphor.Service.Polkit` module at version 1.0. Idempotent on repeat calls:
+/// internally guarded by `std::call_once` so a hot-reloading shell that builds a
+/// fresh `QQmlEngine` per reload can safely call this from every engine setup
+/// without triggering Qt's duplicate-registration warning.
+///
+/// Called from the consuming binary (typically `src/shell/main.cpp`) before any
+/// `QQmlEngine` loads a `.qml` file.
+PHOSPHORSERVICEPOLKIT_EXPORT void registerQmlTypes();
+
+} // namespace PhosphorServicePolkit

--- a/libs/phosphor-service-polkit/src/authrequest.cpp
+++ b/libs/phosphor-service-polkit/src/authrequest.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorServicePolkit/AuthRequest.h>
+
+namespace PhosphorServicePolkit {
+
+AuthRequest::AuthRequest(QString actionId, QString message, QString iconName, QVariantMap details, QString cookie,
+                         QStringList identities, QObject* parent)
+    : QObject(parent)
+    , m_actionId(std::move(actionId))
+    , m_message(std::move(message))
+    , m_iconName(std::move(iconName))
+    , m_details(std::move(details))
+    , m_cookie(std::move(cookie))
+    , m_identities(std::move(identities))
+{
+}
+
+void AuthRequest::setSelectedIdentity(int index)
+{
+    if (index < 0 || index >= m_identities.size() || index == m_selectedIdentity)
+        return;
+    m_selectedIdentity = index;
+    Q_EMIT selectedIdentityChanged();
+}
+
+} // namespace PhosphorServicePolkit

--- a/libs/phosphor-service-polkit/src/polkitagent.cpp
+++ b/libs/phosphor-service-polkit/src/polkitagent.cpp
@@ -157,9 +157,19 @@ void PolkitAgent::authenticate()
     connect(session, &PolkitQt1::Agent::Session::request, this, [this](const QString& prompt, bool echo) {
         if (!d->request)
             return;
-        d->request->m_prompt = prompt;
-        d->request->m_echo = echo;
-        Q_EMIT d->request->promptChanged();
+        // Update the display properties with change-guarded notifies, then emit
+        // the answer-now EVENT. The event fires every time (including a same-text
+        // retry after a wrong answer), which the change-guarded prompt property
+        // would not re-notify.
+        if (d->request->m_prompt != prompt) {
+            d->request->m_prompt = prompt;
+            Q_EMIT d->request->promptChanged();
+        }
+        if (d->request->m_echo != echo) {
+            d->request->m_echo = echo;
+            Q_EMIT d->request->echoChanged();
+        }
+        Q_EMIT promptRequested(prompt, echo);
     });
     connect(session, &PolkitQt1::Agent::Session::completed, this, [this](bool gained) {
         onSessionCompleted(gained);

--- a/libs/phosphor-service-polkit/src/polkitagent.cpp
+++ b/libs/phosphor-service-polkit/src/polkitagent.cpp
@@ -93,7 +93,15 @@ PolkitAgent::PolkitAgent(QString sessionId, QString objectPath, QObject* parent)
 // Out-of-line: the Private dtor needs ListenerImpl complete, and ~Listener
 // unregisters the agent (there is no explicit unregister API), so destroying
 // this object releases the session.
-PolkitAgent::~PolkitAgent() = default;
+PolkitAgent::~PolkitAgent()
+{
+    // Complete any in-flight polkit result so a pending authentication does not
+    // dangle when the agent is destroyed mid-conversation. The Session +
+    // AuthRequest are QObject children, reclaimed by ~QObject; we deliberately do
+    // not run the signal-emitting settleActive() from the destructor.
+    if (d->result)
+        d->result->setCompleted();
+}
 
 bool PolkitAgent::registered() const
 {

--- a/libs/phosphor-service-polkit/src/polkitagent.cpp
+++ b/libs/phosphor-service-polkit/src/polkitagent.cpp
@@ -3,6 +3,8 @@
 
 #include <PhosphorServicePolkit/PolkitAgent.h>
 
+#include <PhosphorServicePolkit/AuthRequest.h>
+
 #include <polkitqt1-agent-listener.h>
 #include <polkitqt1-agent-session.h>
 #include <polkitqt1-details.h>
@@ -11,18 +13,39 @@
 
 #include <QCoreApplication>
 #include <QLoggingCategory>
+#include <QStringList>
+#include <QVariantMap>
 
 namespace {
 constexpr auto kDefaultObjectPath = "/org/phosphor/PolicyKit1/AuthenticationAgent";
 
 Q_LOGGING_CATEGORY(lcPolkitAgent, "phosphor.service.polkit")
+
+QVariantMap detailsToMap(const PolkitQt1::Details& details)
+{
+    QVariantMap map;
+    const QStringList keys = details.keys();
+    for (const QString& key : keys)
+        map.insert(key, details.lookup(key));
+    return map;
+}
+
+QStringList identityNames(const PolkitQt1::Identity::List& identities)
+{
+    QStringList names;
+    names.reserve(identities.size());
+    for (const PolkitQt1::Identity& identity : identities)
+        names << identity.toString();
+    return names;
+}
 } // namespace
 
 namespace PhosphorServicePolkit {
 
 // Internal polkit Listener. Wraps the polkit-qt agent callback surface so the
 // public PolkitAgent stays a clean QObject with no polkit-qt types in its
-// header. It overrides regular virtuals (not slots), so it needs no Q_OBJECT.
+// header. A friend of PolkitAgent (to reach its Private) and of AuthRequest (to
+// build one). It overrides regular virtuals, so it needs no Q_OBJECT.
 class ListenerImpl : public PolkitQt1::Agent::Listener
 {
 public:
@@ -34,31 +57,12 @@ public:
     void initiateAuthentication(const QString& actionId, const QString& message, const QString& iconName,
                                 const PolkitQt1::Details& details, const QString& cookie,
                                 const PolkitQt1::Identity::List& identities,
-                                PolkitQt1::Agent::AsyncResult* result) override
-    {
-        // Milestone 1 is registration plumbing only. Decoding the request into a
-        // typed AuthRequest (milestone 3) and driving the Agent::Session PAM
-        // conversation that actually authenticates (milestone 4) follow. Until
-        // then, complete the result without authorization (a clean denial)
-        // rather than leaving polkit's auth dialog waiting on us.
-        Q_UNUSED(actionId)
-        Q_UNUSED(message)
-        Q_UNUSED(iconName)
-        Q_UNUSED(details)
-        Q_UNUSED(cookie)
-        Q_UNUSED(identities)
-        if (result)
-            result->setCompleted();
-    }
-
+                                PolkitQt1::Agent::AsyncResult* result) override;
     bool initiateAuthenticationFinish() override
     {
         return true;
     }
-
-    void cancelAuthentication() override
-    {
-    }
+    void cancelAuthentication() override;
 
 private:
     PolkitAgent* m_facade;
@@ -71,6 +75,14 @@ public:
     QString objectPath;
     bool registered = false;
     ListenerImpl listener;
+
+    // Active request state. polkit serialises authentication, so at most one is
+    // live. The AsyncResult is owned by polkit (we complete it, never delete it);
+    // the Identity::List is kept so milestone 4 can build the PAM session for the
+    // selected identity.
+    AuthRequest* request = nullptr;
+    PolkitQt1::Identity::List identities;
+    PolkitQt1::Agent::AsyncResult* result = nullptr;
 
     Private(PolkitAgent* facade, QString sid, QString path)
         : sessionId(std::move(sid))
@@ -126,6 +138,69 @@ bool PolkitAgent::registerAgent()
         Q_EMIT registeredChanged();
     }
     return d->registered;
+}
+
+AuthRequest* PolkitAgent::activeRequest() const
+{
+    return d->request;
+}
+
+void PolkitAgent::cancel()
+{
+    if (!d->request)
+        return;
+    // Completing the result without the user authenticating is a clean decline.
+    if (d->result) {
+        d->result->setCompleted();
+        d->result = nullptr;
+    }
+    AuthRequest* request = d->request;
+    d->request = nullptr;
+    d->identities.clear();
+    Q_EMIT activeRequestChanged();
+    Q_EMIT authenticationCancelled();
+    request->deleteLater();
+}
+
+void ListenerImpl::initiateAuthentication(const QString& actionId, const QString& message, const QString& iconName,
+                                          const PolkitQt1::Details& details, const QString& cookie,
+                                          const PolkitQt1::Identity::List& identities,
+                                          PolkitQt1::Agent::AsyncResult* result)
+{
+    PolkitAgent::Private* d = m_facade->d.get();
+
+    // polkit serialises, but defend against a lingering prior request: decline it
+    // before taking the new one so its AsyncResult is not orphaned.
+    if (d->request)
+        m_facade->cancel();
+
+    auto* request = new AuthRequest(actionId, message, iconName, detailsToMap(details), cookie,
+                                    identityNames(identities), m_facade);
+    d->request = request;
+    d->identities = identities;
+    d->result = result;
+
+    // Milestone 3 surfaces the decoded request. Answering it (the Agent::Session
+    // PAM conversation driven by respond(password)) lands in milestone 4; until
+    // then a consumer can read the request and decline it via cancel().
+    Q_EMIT m_facade->activeRequestChanged();
+    Q_EMIT m_facade->authenticationRequested(request);
+}
+
+void ListenerImpl::cancelAuthentication()
+{
+    PolkitAgent::Private* d = m_facade->d.get();
+    if (!d->request)
+        return;
+    // polkit is withdrawing the request and owns the result's teardown, so we
+    // drop our state and notify without completing the result ourselves.
+    AuthRequest* request = d->request;
+    d->request = nullptr;
+    d->result = nullptr;
+    d->identities.clear();
+    Q_EMIT m_facade->activeRequestChanged();
+    Q_EMIT m_facade->authenticationCancelled();
+    request->deleteLater();
 }
 
 } // namespace PhosphorServicePolkit

--- a/libs/phosphor-service-polkit/src/polkitagent.cpp
+++ b/libs/phosphor-service-polkit/src/polkitagent.cpp
@@ -5,6 +5,8 @@
 
 #include <PhosphorServicePolkit/AuthRequest.h>
 
+#include "polkitdecode.h"
+
 #include <polkitqt1-agent-listener.h>
 #include <polkitqt1-agent-session.h>
 #include <polkitqt1-details.h>
@@ -20,24 +22,6 @@ namespace {
 constexpr auto kDefaultObjectPath = "/org/phosphor/PolicyKit1/AuthenticationAgent";
 
 Q_LOGGING_CATEGORY(lcPolkitAgent, "phosphor.service.polkit")
-
-QVariantMap detailsToMap(const PolkitQt1::Details& details)
-{
-    QVariantMap map;
-    const QStringList keys = details.keys();
-    for (const QString& key : keys)
-        map.insert(key, details.lookup(key));
-    return map;
-}
-
-QStringList identityNames(const PolkitQt1::Identity::List& identities)
-{
-    QStringList names;
-    names.reserve(identities.size());
-    for (const PolkitQt1::Identity& identity : identities)
-        names << identity.toString();
-    return names;
-}
 } // namespace
 
 namespace PhosphorServicePolkit {
@@ -248,8 +232,8 @@ void ListenerImpl::initiateAuthentication(const QString& actionId, const QString
     if (d->request)
         m_facade->cancel();
 
-    auto* request = new AuthRequest(actionId, message, iconName, detailsToMap(details), cookie,
-                                    identityNames(identities), m_facade);
+    auto* request = new AuthRequest(actionId, message, iconName, detail::detailsToMap(details), cookie,
+                                    detail::identityNames(identities), m_facade);
     d->request = request;
     d->identities = identities;
     d->result = result;

--- a/libs/phosphor-service-polkit/src/polkitagent.cpp
+++ b/libs/phosphor-service-polkit/src/polkitagent.cpp
@@ -83,6 +83,7 @@ public:
     AuthRequest* request = nullptr;
     PolkitQt1::Identity::List identities;
     PolkitQt1::Agent::AsyncResult* result = nullptr;
+    PolkitQt1::Agent::Session* session = nullptr;
 
     Private(PolkitAgent* facade, QString sid, QString path)
         : sessionId(std::move(sid))
@@ -145,21 +146,94 @@ AuthRequest* PolkitAgent::activeRequest() const
     return d->request;
 }
 
+void PolkitAgent::authenticate()
+{
+    if (!d->request || d->session)
+        return;
+    const int index = d->request->selectedIdentity();
+    if (index < 0 || index >= d->identities.size())
+        return;
+
+    // The Session is constructed with polkit's AsyncResult and drives the PAM
+    // conversation for the chosen identity. We complete the result on completed()
+    // (the documented contract), never the Session.
+    auto* session = new PolkitQt1::Agent::Session(d->identities.at(index), d->request->cookie(), d->result, this);
+    d->session = session;
+
+    connect(session, &PolkitQt1::Agent::Session::request, this, [this](const QString& prompt, bool echo) {
+        if (!d->request)
+            return;
+        d->request->m_prompt = prompt;
+        d->request->m_echo = echo;
+        Q_EMIT d->request->promptChanged();
+    });
+    connect(session, &PolkitQt1::Agent::Session::completed, this, [this](bool gained) {
+        onSessionCompleted(gained);
+    });
+    connect(session, &PolkitQt1::Agent::Session::showError, this, [this](const QString& text) {
+        Q_EMIT authenticationError(text);
+    });
+    connect(session, &PolkitQt1::Agent::Session::showInfo, this, [this](const QString& text) {
+        Q_EMIT authenticationInfo(text);
+    });
+
+    session->initiate();
+}
+
+void PolkitAgent::respond(const QString& response)
+{
+    // Straight through to PAM; never retained, logged, or echoed.
+    if (d->session)
+        d->session->setResponse(response);
+}
+
 void PolkitAgent::cancel()
 {
     if (!d->request)
         return;
-    // Completing the result without the user authenticating is a clean decline.
+    if (d->session) {
+        // A running PAM conversation: cancelling it emits completed(false), which
+        // completes the result and tears down via onSessionCompleted.
+        d->session->cancel();
+        return;
+    }
+    // No conversation started yet: decline the request directly (completing the
+    // result without authorization).
     if (d->result) {
         d->result->setCompleted();
         d->result = nullptr;
     }
-    AuthRequest* request = d->request;
-    d->request = nullptr;
-    d->identities.clear();
-    Q_EMIT activeRequestChanged();
+    teardownActive();
     Q_EMIT authenticationCancelled();
-    request->deleteLater();
+}
+
+void PolkitAgent::onSessionCompleted(bool gainedAuthorization)
+{
+    if (d->result) {
+        d->result->setCompleted();
+        d->result = nullptr;
+    }
+    teardownActive();
+    Q_EMIT authenticationCompleted(gainedAuthorization);
+}
+
+void PolkitAgent::teardownActive()
+{
+    if (d->session) {
+        // Stop further signals before deleting, so a teardown triggered from
+        // within a session signal (completed) does not re-enter.
+        d->session->disconnect(this);
+        d->session->deleteLater();
+        d->session = nullptr;
+    }
+    d->result = nullptr;
+    d->identities.clear();
+    if (d->request) {
+        AuthRequest* request = d->request;
+        d->request = nullptr;
+        request->deleteLater();
+    }
+    Q_EMIT activeRequestChanged();
 }
 
 void ListenerImpl::initiateAuthentication(const QString& actionId, const QString& message, const QString& iconName,
@@ -193,14 +267,11 @@ void ListenerImpl::cancelAuthentication()
     if (!d->request)
         return;
     // polkit is withdrawing the request and owns the result's teardown, so we
-    // drop our state and notify without completing the result ourselves.
-    AuthRequest* request = d->request;
-    d->request = nullptr;
+    // drop our state (result first) and notify without completing it ourselves.
+    // teardownActive disconnects + deletes any running session, aborting PAM.
     d->result = nullptr;
-    d->identities.clear();
-    Q_EMIT m_facade->activeRequestChanged();
+    m_facade->teardownActive();
     Q_EMIT m_facade->authenticationCancelled();
-    request->deleteLater();
 }
 
 } // namespace PhosphorServicePolkit

--- a/libs/phosphor-service-polkit/src/polkitagent.cpp
+++ b/libs/phosphor-service-polkit/src/polkitagent.cpp
@@ -99,8 +99,15 @@ PolkitAgent::~PolkitAgent()
     // dangle when the agent is destroyed mid-conversation. The Session +
     // AuthRequest are QObject children, reclaimed by ~QObject; we deliberately do
     // not run the signal-emitting settleActive() from the destructor.
-    if (d->result)
-        d->result->setCompleted();
+    //
+    // Sever the session first so its asynchronous completed() can never re-enter
+    // onSessionCompleted() during teardown, and clear the result as we complete
+    // it so "polkit's result is completed exactly once" holds by construction
+    // rather than by trusting ~Session to stay silent.
+    if (d->session)
+        d->session->disconnect(this);
+    if (auto* result = std::exchange(d->result, nullptr))
+        result->setCompleted();
 }
 
 bool PolkitAgent::registered() const

--- a/libs/phosphor-service-polkit/src/polkitagent.cpp
+++ b/libs/phosphor-service-polkit/src/polkitagent.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorServicePolkit/PolkitAgent.h>
+
+#include <polkitqt1-agent-listener.h>
+#include <polkitqt1-agent-session.h>
+#include <polkitqt1-details.h>
+#include <polkitqt1-identity.h>
+#include <polkitqt1-subject.h>
+
+#include <QCoreApplication>
+#include <QLoggingCategory>
+
+namespace {
+constexpr auto kDefaultObjectPath = "/org/phosphor/PolicyKit1/AuthenticationAgent";
+
+Q_LOGGING_CATEGORY(lcPolkitAgent, "phosphor.service.polkit")
+} // namespace
+
+namespace PhosphorServicePolkit {
+
+// Internal polkit Listener. Wraps the polkit-qt agent callback surface so the
+// public PolkitAgent stays a clean QObject with no polkit-qt types in its
+// header. It overrides regular virtuals (not slots), so it needs no Q_OBJECT.
+class ListenerImpl : public PolkitQt1::Agent::Listener
+{
+public:
+    explicit ListenerImpl(PolkitAgent* facade)
+        : m_facade(facade)
+    {
+    }
+
+    void initiateAuthentication(const QString& actionId, const QString& message, const QString& iconName,
+                                const PolkitQt1::Details& details, const QString& cookie,
+                                const PolkitQt1::Identity::List& identities,
+                                PolkitQt1::Agent::AsyncResult* result) override
+    {
+        // Milestone 1 is registration plumbing only. Decoding the request into a
+        // typed AuthRequest (milestone 3) and driving the Agent::Session PAM
+        // conversation that actually authenticates (milestone 4) follow. Until
+        // then, complete the result without authorization (a clean denial)
+        // rather than leaving polkit's auth dialog waiting on us.
+        Q_UNUSED(actionId)
+        Q_UNUSED(message)
+        Q_UNUSED(iconName)
+        Q_UNUSED(details)
+        Q_UNUSED(cookie)
+        Q_UNUSED(identities)
+        if (result)
+            result->setCompleted();
+    }
+
+    bool initiateAuthenticationFinish() override
+    {
+        return true;
+    }
+
+    void cancelAuthentication() override
+    {
+    }
+
+private:
+    PolkitAgent* m_facade;
+};
+
+class PolkitAgent::Private
+{
+public:
+    QString sessionId; // empty -> current session (resolved from pid at register time)
+    QString objectPath;
+    bool registered = false;
+    ListenerImpl listener;
+
+    Private(PolkitAgent* facade, QString sid, QString path)
+        : sessionId(std::move(sid))
+        , objectPath(std::move(path))
+        , listener(facade)
+    {
+    }
+};
+
+PolkitAgent::PolkitAgent(QObject* parent)
+    : PolkitAgent(QString(), defaultObjectPath(), parent)
+{
+}
+
+PolkitAgent::PolkitAgent(QString sessionId, QString objectPath, QObject* parent)
+    : QObject(parent)
+    , d(std::make_unique<Private>(this, std::move(sessionId), std::move(objectPath)))
+{
+}
+
+// Out-of-line: the Private dtor needs ListenerImpl complete, and ~Listener
+// unregisters the agent (there is no explicit unregister API), so destroying
+// this object releases the session.
+PolkitAgent::~PolkitAgent() = default;
+
+bool PolkitAgent::registered() const
+{
+    return d->registered;
+}
+
+QString PolkitAgent::defaultObjectPath()
+{
+    return QLatin1String(kDefaultObjectPath);
+}
+
+bool PolkitAgent::registerAgent()
+{
+    if (d->registered)
+        return true;
+
+    // An empty session id means "this process's session", resolved from the pid.
+    const PolkitQt1::UnixSessionSubject subject = d->sessionId.isEmpty()
+        ? PolkitQt1::UnixSessionSubject(static_cast<qint64>(QCoreApplication::applicationPid()))
+        : PolkitQt1::UnixSessionSubject(d->sessionId);
+
+    const bool ok = d->listener.registerListener(subject, d->objectPath);
+    if (!ok) {
+        qCInfo(lcPolkitAgent) << "could not register as the authentication agent for the session"
+                              << "(another agent likely owns it) - staying inert";
+    }
+    if (ok != d->registered) {
+        d->registered = ok;
+        Q_EMIT registeredChanged();
+    }
+    return d->registered;
+}
+
+} // namespace PhosphorServicePolkit

--- a/libs/phosphor-service-polkit/src/polkitagent.cpp
+++ b/libs/phosphor-service-polkit/src/polkitagent.cpp
@@ -18,6 +18,8 @@
 #include <QStringList>
 #include <QVariantMap>
 
+#include <utility>
+
 namespace {
 constexpr auto kDefaultObjectPath = "/org/phosphor/PolicyKit1/AuthenticationAgent";
 
@@ -62,8 +64,8 @@ public:
 
     // Active request state. polkit serialises authentication, so at most one is
     // live. The AsyncResult is owned by polkit (we complete it, never delete it);
-    // the Identity::List is kept so milestone 4 can build the PAM session for the
-    // selected identity.
+    // the Identity::List is kept so authenticate() can build the PAM session for
+    // the selected identity.
     AuthRequest* request = nullptr;
     PolkitQt1::Identity::List identities;
     PolkitQt1::Agent::AsyncResult* result = nullptr;
@@ -175,49 +177,49 @@ void PolkitAgent::cancel()
 {
     if (!d->request)
         return;
-    if (d->session) {
-        // A running PAM conversation: cancelling it emits completed(false), which
-        // completes the result and tears down via onSessionCompleted.
-        d->session->cancel();
-        return;
-    }
-    // No conversation started yet: decline the request directly (completing the
-    // result without authorization).
-    if (d->result) {
-        d->result->setCompleted();
-        d->result = nullptr;
-    }
-    teardownActive();
+    // Decline: complete polkit's result without authorization and tear down.
+    // Synchronous and deterministic even mid-conversation; it does not wait on
+    // the session's asynchronous completed() signal.
+    settleActive(/*completeResult=*/true);
     Q_EMIT authenticationCancelled();
 }
 
 void PolkitAgent::onSessionCompleted(bool gainedAuthorization)
 {
-    if (d->result) {
-        d->result->setCompleted();
-        d->result = nullptr;
-    }
-    teardownActive();
+    // The session finished; complete polkit's result exactly once and tear down.
+    settleActive(/*completeResult=*/true);
     Q_EMIT authenticationCompleted(gainedAuthorization);
 }
 
-void PolkitAgent::teardownActive()
+void PolkitAgent::settleActive(bool completeResult)
 {
-    if (d->session) {
-        // Stop further signals before deleting, so a teardown triggered from
-        // within a session signal (completed) does not re-enter.
-        d->session->disconnect(this);
-        d->session->deleteLater();
-        d->session = nullptr;
-    }
-    d->result = nullptr;
+    if (!d->request)
+        return;
+
+    // Capture and clear the active state FIRST, so any re-entrant call (a slot on
+    // activeRequestChanged, or a synchronous session signal) sees no active
+    // request and returns. This makes the result completion exactly-once and the
+    // teardown idempotent regardless of polkit-qt's signal-emission timing
+    // (Session::completed is asynchronous, fired when the PAM helper exits).
+    AuthRequest* request = std::exchange(d->request, nullptr);
+    PolkitQt1::Agent::Session* session = std::exchange(d->session, nullptr);
+    PolkitQt1::Agent::AsyncResult* result = std::exchange(d->result, nullptr);
     d->identities.clear();
-    if (d->request) {
-        AuthRequest* request = d->request;
-        d->request = nullptr;
-        request->deleteLater();
+
+    if (session) {
+        // Disconnect before deleting so the session's pending/asynchronous
+        // completed() can never re-enter this path; ~Session aborts the PAM
+        // helper.
+        session->disconnect(this);
+        session->deleteLater();
     }
+    // Complete polkit's result unless the daemon withdrew the request, in which
+    // case polkit owns the result's teardown and completing it would double-free.
+    if (completeResult && result)
+        result->setCompleted();
+
     Q_EMIT activeRequestChanged();
+    request->deleteLater();
 }
 
 void ListenerImpl::initiateAuthentication(const QString& actionId, const QString& message, const QString& iconName,
@@ -227,10 +229,15 @@ void ListenerImpl::initiateAuthentication(const QString& actionId, const QString
 {
     PolkitAgent::Private* d = m_facade->d.get();
 
-    // polkit serialises, but defend against a lingering prior request: decline it
-    // before taking the new one so its AsyncResult is not orphaned.
-    if (d->request)
-        m_facade->cancel();
+    // polkit serialises authentication, but defend against a lingering prior
+    // request: decline it synchronously (completing its result) before adopting
+    // the new one, so its AsyncResult is never orphaned. settleActive does NOT
+    // rely on the old session's asynchronous completed(), so the state is fully
+    // cleared before the assignments below.
+    if (d->request) {
+        m_facade->settleActive(/*completeResult=*/true);
+        Q_EMIT m_facade->authenticationCancelled();
+    }
 
     auto* request = new AuthRequest(actionId, message, iconName, detail::detailsToMap(details), cookie,
                                     detail::identityNames(identities), m_facade);
@@ -238,9 +245,8 @@ void ListenerImpl::initiateAuthentication(const QString& actionId, const QString
     d->identities = identities;
     d->result = result;
 
-    // Milestone 3 surfaces the decoded request. Answering it (the Agent::Session
-    // PAM conversation driven by respond(password)) lands in milestone 4; until
-    // then a consumer can read the request and decline it via cancel().
+    // Surface the decoded request. A consumer calls authenticate() to begin the
+    // PAM conversation, or cancel() to decline.
     Q_EMIT m_facade->activeRequestChanged();
     Q_EMIT m_facade->authenticationRequested(request);
 }
@@ -250,11 +256,10 @@ void ListenerImpl::cancelAuthentication()
     PolkitAgent::Private* d = m_facade->d.get();
     if (!d->request)
         return;
-    // polkit is withdrawing the request and owns the result's teardown, so we
-    // drop our state (result first) and notify without completing it ourselves.
-    // teardownActive disconnects + deletes any running session, aborting PAM.
-    d->result = nullptr;
-    m_facade->teardownActive();
+    // polkit is withdrawing the request and owns the result's teardown, so settle
+    // WITHOUT completing the result ourselves (completing it would double-free).
+    // settleActive disconnects + deletes any running session, aborting PAM.
+    m_facade->settleActive(/*completeResult=*/false);
     Q_EMIT m_facade->authenticationCancelled();
 }
 

--- a/libs/phosphor-service-polkit/src/polkitdecode.h
+++ b/libs/phosphor-service-polkit/src/polkitdecode.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+// Internal (not installed) decode helpers shared between the agent and its unit
+// test. They convert polkit-qt's request data into the plain Qt types the
+// AuthRequest exposes. Inline so they need no separate translation unit.
+
+#include <polkitqt1-details.h>
+#include <polkitqt1-identity.h>
+
+#include <QStringList>
+#include <QVariantMap>
+
+namespace PhosphorServicePolkit::detail {
+
+/// polkit `Details` (a string→string map) to a `QVariantMap`.
+inline QVariantMap detailsToMap(const PolkitQt1::Details& details)
+{
+    QVariantMap map;
+    const QStringList keys = details.keys();
+    for (const QString& key : keys)
+        map.insert(key, details.lookup(key));
+    return map;
+}
+
+/// The identities the user may authenticate as, as display strings (e.g.
+/// `unix-user:alice`).
+inline QStringList identityNames(const PolkitQt1::Identity::List& identities)
+{
+    QStringList names;
+    names.reserve(identities.size());
+    for (const PolkitQt1::Identity& identity : identities)
+        names << identity.toString();
+    return names;
+}
+
+} // namespace PhosphorServicePolkit::detail

--- a/libs/phosphor-service-polkit/src/qmlregistration.cpp
+++ b/libs/phosphor-service-polkit/src/qmlregistration.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorServicePolkit/QmlRegistration.h>
+
+#include <PhosphorServicePolkit/PolkitAgent.h>
+
+#include <QQmlEngine>
+
+#include <mutex>
+
+namespace PhosphorServicePolkit {
+
+namespace {
+constexpr int kModuleVersionMajor = 1;
+constexpr int kModuleVersionMinor = 0;
+constexpr const char* kModule = "Phosphor.Service.Polkit";
+} // namespace
+
+void registerQmlTypes()
+{
+    // qmlRegister* is process-global, not per-engine. Repeat calls overwrite the
+    // previous registration and Qt logs a duplicate-registration warning. A
+    // hot-reloading shell builds a fresh QQmlEngine per reload and would call
+    // this every time; the call_once guard makes the function safe to invoke
+    // from every engine setup, matching the sibling service-lib pattern.
+    static std::once_flag once;
+    std::call_once(once, [] {
+        // Instantiable entry point. The shell constructs the agent in QML and
+        // calls registerAgent() to opt into becoming the session's agent; a
+        // plain type, NOT a singleton. AuthRequest joins this registration in
+        // milestone 3.
+        qmlRegisterType<PolkitAgent>(kModule, kModuleVersionMajor, kModuleVersionMinor, "PolkitAgent");
+    });
+}
+
+} // namespace PhosphorServicePolkit

--- a/libs/phosphor-service-polkit/src/qmlregistration.cpp
+++ b/libs/phosphor-service-polkit/src/qmlregistration.cpp
@@ -3,6 +3,7 @@
 
 #include <PhosphorServicePolkit/QmlRegistration.h>
 
+#include <PhosphorServicePolkit/AuthRequest.h>
 #include <PhosphorServicePolkit/PolkitAgent.h>
 
 #include <QQmlEngine>
@@ -28,9 +29,15 @@ void registerQmlTypes()
     std::call_once(once, [] {
         // Instantiable entry point. The shell constructs the agent in QML and
         // calls registerAgent() to opt into becoming the session's agent; a
-        // plain type, NOT a singleton. AuthRequest joins this registration in
-        // milestone 3.
+        // plain type, NOT a singleton.
         qmlRegisterType<PolkitAgent>(kModule, kModuleVersionMajor, kModuleVersionMinor, "PolkitAgent");
+
+        // Pointer-receivable type. Exposed as a Q_PROPERTY / signal arg from the
+        // agent, never constructed in QML; uncreatable makes its metatype known
+        // so QML can read its properties and set selectedIdentity.
+        qmlRegisterUncreatableType<AuthRequest>(
+            kModule, kModuleVersionMajor, kModuleVersionMinor, "AuthRequest",
+            QStringLiteral("AuthRequest is owned by PolkitAgent; bind via the agent's activeRequest"));
     });
 }
 

--- a/libs/phosphor-service-polkit/tests/CMakeLists.txt
+++ b/libs/phosphor-service-polkit/tests/CMakeLists.txt
@@ -26,7 +26,8 @@ _phosphorservicepolkit_test(test_phosphorservicepolkit_smoke test_smoke.cpp)
 
 # QML facade test: a real QQmlEngine imports the module and proves the
 # imperative registration yields a usable facade (PolkitAgent instantiates and
-# binds; the AuthRequest-typed activeRequest property is readable).
+# binds; its registered / activeRequest properties read through QML, with
+# activeRequest null on a bare agent).
 _phosphorservicepolkit_test(test_phosphorservicepolkit_qmlfacade test_qmlfacade.cpp)
 
 # Decode unit test: drives the internal Details/Identity -> Qt-types decode with

--- a/libs/phosphor-service-polkit/tests/CMakeLists.txt
+++ b/libs/phosphor-service-polkit/tests/CMakeLists.txt
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Test)
+
+function(_phosphorservicepolkit_test target source)
+    add_executable(${target} ${source})
+    target_link_libraries(${target}
+        PRIVATE
+            Qt6::Test
+            PhosphorServicePolkit::PhosphorServicePolkit
+    )
+    add_test(NAME ${target} COMMAND ${target})
+    set_tests_properties(${target}
+        PROPERTIES
+            ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+            LABELS "phosphorservicepolkit"
+    )
+endfunction()
+
+# Smoke test: exercises the milestone-1 contract (QML-registration idempotency,
+# the default object path, and inert construction / registration against a
+# bogus session so no real polkitd registration can occur).
+_phosphorservicepolkit_test(test_phosphorservicepolkit_smoke test_smoke.cpp)

--- a/libs/phosphor-service-polkit/tests/CMakeLists.txt
+++ b/libs/phosphor-service-polkit/tests/CMakeLists.txt
@@ -18,9 +18,10 @@ function(_phosphorservicepolkit_test target source)
     )
 endfunction()
 
-# Smoke test: exercises the milestone-1 contract (QML-registration idempotency,
-# the default object path, and inert construction / registration against a
-# bogus session so no real polkitd registration can occur).
+# Smoke test: exercises the deterministic facade contract (QML-registration
+# idempotency, the default object path, inert construction / registration against
+# a bogus session so no real polkitd registration can occur, and the
+# cancel / authenticate / respond no-op guards).
 _phosphorservicepolkit_test(test_phosphorservicepolkit_smoke test_smoke.cpp)
 
 # QML facade test: a real QQmlEngine imports the module and proves the

--- a/libs/phosphor-service-polkit/tests/CMakeLists.txt
+++ b/libs/phosphor-service-polkit/tests/CMakeLists.txt
@@ -22,3 +22,8 @@ endfunction()
 # the default object path, and inert construction / registration against a
 # bogus session so no real polkitd registration can occur).
 _phosphorservicepolkit_test(test_phosphorservicepolkit_smoke test_smoke.cpp)
+
+# QML facade test: a real QQmlEngine imports the module and proves the
+# imperative registration yields a usable facade (PolkitAgent instantiates and
+# binds; the AuthRequest-typed activeRequest property is readable).
+_phosphorservicepolkit_test(test_phosphorservicepolkit_qmlfacade test_qmlfacade.cpp)

--- a/libs/phosphor-service-polkit/tests/CMakeLists.txt
+++ b/libs/phosphor-service-polkit/tests/CMakeLists.txt
@@ -27,3 +27,12 @@ _phosphorservicepolkit_test(test_phosphorservicepolkit_smoke test_smoke.cpp)
 # imperative registration yields a usable facade (PolkitAgent instantiates and
 # binds; the AuthRequest-typed activeRequest property is readable).
 _phosphorservicepolkit_test(test_phosphorservicepolkit_qmlfacade test_qmlfacade.cpp)
+
+# Decode unit test: drives the internal Details/Identity -> Qt-types decode with
+# real polkit-qt values. It links PolkitQt6-1::Core directly (the lib links it
+# PRIVATE, so it is not transitive) and includes the lib's src/ for the internal
+# polkitdecode.h header.
+find_package(PolkitQt6-1 REQUIRED)
+_phosphorservicepolkit_test(test_phosphorservicepolkit_decode test_decode.cpp)
+target_link_libraries(test_phosphorservicepolkit_decode PRIVATE PolkitQt6-1::Core)
+target_include_directories(test_phosphorservicepolkit_decode PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)

--- a/libs/phosphor-service-polkit/tests/test_decode.cpp
+++ b/libs/phosphor-service-polkit/tests/test_decode.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Decode unit test for phosphor-service-polkit (milestone 7). The agent's
+// register / request / PAM lifecycle needs a live polkitd to exercise (covered
+// by the CLI demo in milestone 6), but the pure transformation it applies to
+// polkit's request data is testable in isolation: this constructs real
+// PolkitQt1::Details + Identity values and asserts they decode into the plain Qt
+// types AuthRequest exposes.
+
+#include "polkitdecode.h"
+
+#include <polkitqt1-details.h>
+#include <polkitqt1-identity.h>
+
+#include <QStringList>
+#include <QTest>
+#include <QVariantMap>
+
+#include <sys/types.h>
+
+using namespace PhosphorServicePolkit;
+
+class PolkitDecodeTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void detailsDecodeToVariantMap();
+    void emptyDetailsDecodeToEmptyMap();
+    void identitiesDecodeToDisplayStrings();
+    void emptyIdentitiesDecodeToEmptyList();
+};
+
+void PolkitDecodeTest::detailsDecodeToVariantMap()
+{
+    PolkitQt1::Details details;
+    details.insert(QStringLiteral("polkit.message"), QStringLiteral("Authentication is required"));
+    details.insert(QStringLiteral("org.example.path"), QStringLiteral("/usr/bin/thing"));
+
+    const QVariantMap map = detail::detailsToMap(details);
+    QCOMPARE(map.size(), 2);
+    QCOMPARE(map.value(QStringLiteral("polkit.message")).toString(), QStringLiteral("Authentication is required"));
+    QCOMPARE(map.value(QStringLiteral("org.example.path")).toString(), QStringLiteral("/usr/bin/thing"));
+}
+
+void PolkitDecodeTest::emptyDetailsDecodeToEmptyMap()
+{
+    const PolkitQt1::Details details;
+    QVERIFY(detail::detailsToMap(details).isEmpty());
+}
+
+void PolkitDecodeTest::identitiesDecodeToDisplayStrings()
+{
+    // uid 0 always exists, so its identity is valid and toString() is non-empty
+    // (e.g. "unix-user:0" / "unix-user:root").
+    PolkitQt1::Identity::List identities;
+    identities << PolkitQt1::UnixUserIdentity(static_cast<uid_t>(0));
+
+    const QStringList names = detail::identityNames(identities);
+    QCOMPARE(names.size(), 1);
+    QVERIFY(!names.at(0).isEmpty());
+    QVERIFY(names.at(0).contains(QStringLiteral("unix-user")));
+}
+
+void PolkitDecodeTest::emptyIdentitiesDecodeToEmptyList()
+{
+    const PolkitQt1::Identity::List identities;
+    QVERIFY(detail::identityNames(identities).isEmpty());
+}
+
+QTEST_GUILESS_MAIN(PolkitDecodeTest)
+#include "test_decode.moc"

--- a/libs/phosphor-service-polkit/tests/test_decode.cpp
+++ b/libs/phosphor-service-polkit/tests/test_decode.cpp
@@ -59,8 +59,9 @@ void PolkitDecodeTest::identitiesDecodeToDisplayStrings()
 
     const QStringList names = detail::identityNames(identities);
     QCOMPARE(names.size(), 1);
-    QVERIFY(!names.at(0).isEmpty());
-    QVERIFY(names.at(0).contains(QStringLiteral("unix-user")));
+    // toString() is "unix-user:<uid>" for a UnixUserIdentity across polkit-qt6
+    // versions; assert the stable prefix rather than the NSS-dependent name form.
+    QVERIFY(names.at(0).startsWith(QStringLiteral("unix-user:")));
 }
 
 void PolkitDecodeTest::emptyIdentitiesDecodeToEmptyList()

--- a/libs/phosphor-service-polkit/tests/test_decode.cpp
+++ b/libs/phosphor-service-polkit/tests/test_decode.cpp
@@ -60,8 +60,10 @@ void PolkitDecodeTest::identitiesDecodeToDisplayStrings()
     const QStringList names = detail::identityNames(identities);
     QCOMPARE(names.size(), 1);
     // toString() is "unix-user:<uid>" for a UnixUserIdentity across polkit-qt6
-    // versions; assert the stable prefix rather than the NSS-dependent name form.
+    // versions; assert the stable prefix (not the NSS-dependent name form) plus a
+    // non-empty uid suffix, so a bare "unix-user:" could not pass.
     QVERIFY(names.at(0).startsWith(QStringLiteral("unix-user:")));
+    QVERIFY(names.at(0).size() > QStringLiteral("unix-user:").size());
 }
 
 void PolkitDecodeTest::emptyIdentitiesDecodeToEmptyList()

--- a/libs/phosphor-service-polkit/tests/test_qmlfacade.cpp
+++ b/libs/phosphor-service-polkit/tests/test_qmlfacade.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// QML facade test for phosphor-service-polkit (milestone 5). Proves the
+// imperative registration produces a usable QML module: a real QQmlEngine
+// imports Phosphor.Service.Polkit 1.0, instantiates a PolkitAgent (whose ctor
+// is side-effect-free, so this does NOT register as the session agent), and
+// reads its `registered` and `activeRequest` properties through QML.
+//
+// Instantiating PolkitAgent in QML is safe precisely because registration is
+// explicit (registerAgent()); a bare `PolkitAgent {}` never touches polkitd.
+
+#include <PhosphorServicePolkit/QmlRegistration.h>
+
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QTest>
+
+#include <memory>
+
+using namespace PhosphorServicePolkit;
+
+namespace {
+constexpr auto kQml = R"(
+import QtQml
+import Phosphor.Service.Polkit 1.0
+
+QtObject {
+    id: root
+    property PolkitAgent agent: PolkitAgent {}
+    readonly property bool agentRegistered: root.agent.registered
+    readonly property bool hasActiveRequest: root.agent.activeRequest !== null
+}
+)";
+} // namespace
+
+class PolkitQmlFacadeTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        registerQmlTypes();
+    }
+    void moduleLoadsAndAgentBinds();
+};
+
+void PolkitQmlFacadeTest::moduleLoadsAndAgentBinds()
+{
+    QQmlEngine engine;
+    QQmlComponent component(&engine);
+    component.setData(kQml, QUrl(QStringLiteral("qrc:/test_polkit_facade.qml")));
+    std::unique_ptr<QObject> root(component.create());
+    QVERIFY2(root != nullptr, qPrintable(component.errorString())); // module + types resolved
+
+    // A bare agent has not registered and has no active request: confirms both
+    // properties (and the AuthRequest-typed activeRequest property) are readable
+    // through QML.
+    QCOMPARE(root->property("agentRegistered").toBool(), false);
+    QCOMPARE(root->property("hasActiveRequest").toBool(), false);
+}
+
+QTEST_GUILESS_MAIN(PolkitQmlFacadeTest)
+#include "test_qmlfacade.moc"

--- a/libs/phosphor-service-polkit/tests/test_qmlfacade.cpp
+++ b/libs/phosphor-service-polkit/tests/test_qmlfacade.cpp
@@ -55,8 +55,9 @@ void PolkitQmlFacadeTest::moduleLoadsAndAgentBinds()
     QVERIFY2(root != nullptr, qPrintable(component.errorString())); // module + types resolved
 
     // A bare agent has not registered and has no active request: confirms both
-    // properties (and the AuthRequest-typed activeRequest property) are readable
-    // through QML.
+    // properties are readable through QML and that activeRequest is null on a
+    // bare agent. Binding a live AuthRequest needs polkitd, exercised via the CLI
+    // demo against pkexec.
     QCOMPARE(root->property("agentRegistered").toBool(), false);
     QCOMPARE(root->property("hasActiveRequest").toBool(), false);
 }

--- a/libs/phosphor-service-polkit/tests/test_smoke.cpp
+++ b/libs/phosphor-service-polkit/tests/test_smoke.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Milestone-1 smoke test for phosphor-service-polkit. Pins the plumbing
+// contract: QML-registration idempotency, the default object path, and inert
+// construction. registerAgent() is exercised against a deliberately bogus
+// session id so the test can never register as the real session's agent (which
+// would intercept the tester's authentications); it must fail and leave the
+// object inert. The request decode + PAM session paths need a live polkitd and
+// are exercised manually via the CLI demo in milestone 6.
+
+#include <PhosphorServicePolkit/PolkitAgent.h>
+#include <PhosphorServicePolkit/QmlRegistration.h>
+
+#include <QString>
+#include <QTest>
+
+#include <memory>
+
+using namespace PhosphorServicePolkit;
+
+class PolkitSmokeTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void registerQmlTypesIsIdempotent();
+    void defaultObjectPath();
+    void constructsInert();
+    void registerWithBogusSessionStaysInert();
+
+private:
+    // A session id that cannot resolve to a real logind session, so
+    // registerListener can only fail. Guarantees the test never becomes the
+    // tester's authentication agent.
+    static QString bogusSession()
+    {
+        return QStringLiteral("phosphor-test-nonexistent-session");
+    }
+};
+
+void PolkitSmokeTest::registerQmlTypesIsIdempotent()
+{
+    // The std::call_once guard must make a second call a no-op (no crash, no
+    // duplicate-registration fault). A hot-reloading shell relies on this.
+    registerQmlTypes();
+    registerQmlTypes();
+}
+
+void PolkitSmokeTest::defaultObjectPath()
+{
+    QCOMPARE(PolkitAgent::defaultObjectPath(), QStringLiteral("/org/phosphor/PolicyKit1/AuthenticationAgent"));
+}
+
+void PolkitSmokeTest::constructsInert()
+{
+    // A freshly constructed agent has not registered yet.
+    PolkitAgent agent(bogusSession(), PolkitAgent::defaultObjectPath());
+    QVERIFY(!agent.registered());
+}
+
+void PolkitSmokeTest::registerWithBogusSessionStaysInert()
+{
+    PolkitAgent agent(bogusSession(), PolkitAgent::defaultObjectPath());
+    // Registering for a session that does not exist cannot succeed; the agent
+    // reports failure and stays inert rather than crashing.
+    const bool ok = agent.registerAgent();
+    QVERIFY(!ok);
+    QVERIFY(!agent.registered());
+}
+
+QTEST_GUILESS_MAIN(PolkitSmokeTest)
+#include "test_smoke.moc"

--- a/libs/phosphor-service-polkit/tests/test_smoke.cpp
+++ b/libs/phosphor-service-polkit/tests/test_smoke.cpp
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
-// Milestone-1 smoke test for phosphor-service-polkit. Pins the plumbing
-// contract: QML-registration idempotency, the default object path, and inert
+// Smoke test for phosphor-service-polkit. Pins the plumbing contract:
+// QML-registration idempotency, the default object path, and inert
 // construction. registerAgent() is exercised against a deliberately bogus
 // session id so the test can never register as the real session's agent (which
 // would intercept the tester's authentications); it must fail and leave the
-// object inert. The request decode + PAM session paths need a live polkitd and
-// are exercised manually via the CLI demo in milestone 6.
+// object inert. The pure request decode is unit-tested in test_decode.cpp; the
+// full PAM session lifecycle needs a live polkitd and is exercised via the CLI
+// demo against pkexec.
 
 #include <PhosphorServicePolkit/AuthRequest.h>
 #include <PhosphorServicePolkit/PolkitAgent.h>

--- a/libs/phosphor-service-polkit/tests/test_smoke.cpp
+++ b/libs/phosphor-service-polkit/tests/test_smoke.cpp
@@ -18,8 +18,6 @@
 #include <QString>
 #include <QTest>
 
-#include <memory>
-
 using namespace PhosphorServicePolkit;
 
 class PolkitSmokeTest : public QObject

--- a/libs/phosphor-service-polkit/tests/test_smoke.cpp
+++ b/libs/phosphor-service-polkit/tests/test_smoke.cpp
@@ -9,9 +9,11 @@
 // object inert. The request decode + PAM session paths need a live polkitd and
 // are exercised manually via the CLI demo in milestone 6.
 
+#include <PhosphorServicePolkit/AuthRequest.h>
 #include <PhosphorServicePolkit/PolkitAgent.h>
 #include <PhosphorServicePolkit/QmlRegistration.h>
 
+#include <QSignalSpy>
 #include <QString>
 #include <QTest>
 
@@ -28,6 +30,8 @@ private Q_SLOTS:
     void defaultObjectPath();
     void constructsInert();
     void registerWithBogusSessionStaysInert();
+    void activeRequestStartsNull();
+    void cancelWithNoRequestIsNoop();
 
 private:
     // A session id that cannot resolve to a real logind session, so
@@ -67,6 +71,26 @@ void PolkitSmokeTest::registerWithBogusSessionStaysInert()
     const bool ok = agent.registerAgent();
     QVERIFY(!ok);
     QVERIFY(!agent.registered());
+}
+
+void PolkitSmokeTest::activeRequestStartsNull()
+{
+    // No authentication is in flight until polkit calls initiateAuthentication.
+    PolkitAgent agent(bogusSession(), PolkitAgent::defaultObjectPath());
+    QVERIFY(agent.activeRequest() == nullptr);
+}
+
+void PolkitSmokeTest::cancelWithNoRequestIsNoop()
+{
+    // Declining when nothing is active is a safe no-op: no crash, no signal, the
+    // active request stays null. (The decode of a real request into an
+    // AuthRequest needs a live polkitd calling back, and is exercised through
+    // the CLI demo against pkexec in milestone 6.)
+    PolkitAgent agent(bogusSession(), PolkitAgent::defaultObjectPath());
+    QSignalSpy cancelledSpy(&agent, &PolkitAgent::authenticationCancelled);
+    agent.cancel();
+    QCOMPARE(cancelledSpy.count(), 0);
+    QVERIFY(agent.activeRequest() == nullptr);
 }
 
 QTEST_GUILESS_MAIN(PolkitSmokeTest)

--- a/libs/phosphor-service-polkit/tests/test_smoke.cpp
+++ b/libs/phosphor-service-polkit/tests/test_smoke.cpp
@@ -32,6 +32,8 @@ private Q_SLOTS:
     void registerWithBogusSessionStaysInert();
     void activeRequestStartsNull();
     void cancelWithNoRequestIsNoop();
+    void authenticateWithNoRequestIsNoop();
+    void respondWithNoSessionIsNoop();
 
 private:
     // A session id that cannot resolve to a real logind session, so
@@ -91,6 +93,27 @@ void PolkitSmokeTest::cancelWithNoRequestIsNoop()
     agent.cancel();
     QCOMPARE(cancelledSpy.count(), 0);
     QVERIFY(agent.activeRequest() == nullptr);
+}
+
+void PolkitSmokeTest::authenticateWithNoRequestIsNoop()
+{
+    // Starting a PAM conversation with nothing to authenticate is a safe no-op.
+    // The real authenticate -> prompt -> respond -> completed flow needs a live
+    // polkitd + PAM and is exercised via the CLI demo against pkexec (milestone 6).
+    PolkitAgent agent(bogusSession(), PolkitAgent::defaultObjectPath());
+    QSignalSpy completedSpy(&agent, &PolkitAgent::authenticationCompleted);
+    agent.authenticate();
+    QCOMPARE(completedSpy.count(), 0);
+    QVERIFY(agent.activeRequest() == nullptr);
+}
+
+void PolkitSmokeTest::respondWithNoSessionIsNoop()
+{
+    // Answering when no conversation is running must not crash or emit anything.
+    PolkitAgent agent(bogusSession(), PolkitAgent::defaultObjectPath());
+    QSignalSpy errorSpy(&agent, &PolkitAgent::authenticationError);
+    agent.respond(QStringLiteral("not-a-real-password"));
+    QCOMPARE(errorSpy.count(), 0);
 }
 
 QTEST_GUILESS_MAIN(PolkitSmokeTest)

--- a/libs/phosphor-service-polkit/tests/test_smoke.cpp
+++ b/libs/phosphor-service-polkit/tests/test_smoke.cpp
@@ -108,11 +108,19 @@ void PolkitSmokeTest::authenticateWithNoRequestIsNoop()
 
 void PolkitSmokeTest::respondWithNoSessionIsNoop()
 {
-    // Answering when no conversation is running must not crash or emit anything.
+    // Answering when no conversation is running must not crash, mutate the active
+    // request, or emit any conversation signal.
     PolkitAgent agent(bogusSession(), PolkitAgent::defaultObjectPath());
     QSignalSpy errorSpy(&agent, &PolkitAgent::authenticationError);
+    QSignalSpy completedSpy(&agent, &PolkitAgent::authenticationCompleted);
+    QSignalSpy promptSpy(&agent, &PolkitAgent::promptRequested);
+    QSignalSpy cancelledSpy(&agent, &PolkitAgent::authenticationCancelled);
     agent.respond(QStringLiteral("not-a-real-password"));
     QCOMPARE(errorSpy.count(), 0);
+    QCOMPARE(completedSpy.count(), 0);
+    QCOMPARE(promptSpy.count(), 0);
+    QCOMPARE(cancelledSpy.count(), 0);
+    QVERIFY(agent.activeRequest() == nullptr);
 }
 
 QTEST_GUILESS_MAIN(PolkitSmokeTest)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -503,6 +503,7 @@ if(BUILD_PHOSPHOR_SHELL)
             PhosphorServiceBluetooth::PhosphorServiceBluetooth
             PhosphorServiceBrightness::PhosphorServiceBrightness
             PhosphorServiceNotifications::PhosphorServiceNotifications
+            PhosphorServicePolkit::PhosphorServicePolkit
             PhosphorLayer::PhosphorLayer
             PhosphorWayland::PhosphorWayland
             PhosphorRendering::PhosphorRendering

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -7,6 +7,7 @@
 #include <PhosphorServiceMpris/QmlRegistration.h>
 #include <PhosphorServiceNetwork/QmlRegistration.h>
 #include <PhosphorServiceNotifications/QmlRegistration.h>
+#include <PhosphorServicePolkit/QmlRegistration.h>
 #include <PhosphorServicePipeWire/QmlRegistration.h>
 #include <PhosphorServiceSni/QmlRegistration.h>
 #include <PhosphorServiceUPower/QmlRegistration.h>
@@ -113,6 +114,7 @@ int main(int argc, char* argv[])
     PhosphorServiceBluetooth::registerQmlTypes();
     PhosphorServiceBrightness::registerQmlTypes();
     PhosphorServiceNotifications::registerQmlTypes();
+    PhosphorServicePolkit::registerQmlTypes();
 
     auto screenProvider = std::make_unique<PhosphorLayer::DefaultScreenProvider>();
     auto transport = std::make_unique<PhosphorLayer::PhosphorWaylandTransport>();

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -7,8 +7,8 @@
 #include <PhosphorServiceMpris/QmlRegistration.h>
 #include <PhosphorServiceNetwork/QmlRegistration.h>
 #include <PhosphorServiceNotifications/QmlRegistration.h>
-#include <PhosphorServicePolkit/QmlRegistration.h>
 #include <PhosphorServicePipeWire/QmlRegistration.h>
+#include <PhosphorServicePolkit/QmlRegistration.h>
 #include <PhosphorServiceSni/QmlRegistration.h>
 #include <PhosphorServiceUPower/QmlRegistration.h>
 #include <PhosphorShell/ShellEngine.h>


### PR DESCRIPTION
Phase 2.6 of the service-library plan (`docs/phosphor-shell-design/04-implementation-plan.md`): a PolicyKit authentication agent via the `polkit-qt6` binding. When an app requests a privileged action, `polkitd` calls into the session's agent; this library is that agent, driving the PAM conversation that authenticates the user. No UI (the auth dialog is a Phase 3/4 consumer).

Targets `feat/phosphor-shell`, matching how 2.5 (#576) landed. 8 commits, one per milestone, each building and testing green before commit.

## What shipped

- **`PolkitAgent`** wraps `polkit-qt6`'s `Agent::Listener` **privately** (the subclass lives in the `.cpp`), so the public header carries no polkit-qt types and `PolkitQt6-1` is a PRIVATE link. Registration is **explicit** (`registerAgent()`), since becoming the session agent intercepts every authentication; inert (`registered() == false`) when another agent (KDE / GNOME) owns the session.
- **`AuthRequest`** is the decoded request (action / message / icon / details→`QVariantMap` / cookie / identities→display strings / selected identity / PAM prompt + echo).
- **PAM conversation**: `authenticate()` starts an `Agent::Session` for the selected identity, relays `request(prompt, echo)` onto `AuthRequest` and `showError`/`showInfo` as signals; `respond()` passes the answer straight to `Session::setResponse`; `completed(gained)` completes polkit's `AsyncResult` exactly once (the documented contract) and emits `authenticationCompleted`. `cancel()` / polkit's `cancelAuthentication` tear down cleanly.
- **Security discipline**: the password is passed straight to PAM and is never stored, logged, or echoed by this library.
- **CLI demo** (`examples/phosphor-service-polkit-cli`): runs as the standalone agent, logs requests, answers prompts (`--password` demo-only, otherwise stdin).

## Structural notes vs the sibling service libs

- Single active request (polkit serialises), so a `activeRequest` facade + signals rather than a `QAbstractListModel`. Closest precedent is 2.3's `Agent1`, not 2.5's server-with-a-model.
- First service lib that is purely a callback target wrapping a third-party Qt binding (polkit-qt6), kept entirely out of the public interface.

## Verification

- Three test binaries, all green with no `polkitd`: the C++ smoke harness (inert construction, registration-fail, active-request / authenticate / respond / cancel guards), the QML-engine facade load test, and the decode unit test over real polkit-qt `Details` / `Identity` values.
- Lib, CLI, and the shell binary build and link.
- The registration-failure path (the common real-desktop case) is validated end to end: on this KDE desktop the agent correctly detects KDE's agent owns the session, prints guidance, and exits inert without entering the loop.

## Known manual test

The full success path (`register → pkexec → prompt → respond → completed`), including settling whether the `Session` double-completes the `AsyncResult` vs. us, requires stopping the desktop's polkit agent and is the documented manual test, not run in CI.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)