### PR TITLE
feat(phosphor-service-lock): Phase 2.9 PAM auth + ext-session-lock-v1 service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,6 +462,7 @@ if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(libs/phosphor-service-polkit)        # PolicyKit authentication agent (Phase 2.6)
     add_subdirectory(libs/phosphor-service-idle)          # Wayland idle monitoring + inhibition (Phase 2.7)
     add_subdirectory(libs/phosphor-service-clipboard)     # Wayland clipboard history (data-control) (Phase 2.8)
+    add_subdirectory(libs/phosphor-service-lock)          # PAM auth + ext-session-lock-v1 coordination (Phase 2.9)
 endif()
 
 # Source directories
@@ -745,6 +746,14 @@ endif()
 # BUILD_PHOSPHOR_SHELL is OFF the lib target does not exist, so the CLI can't link.
 if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(examples/phosphor-service-clipboard-cli)
+endif()
+
+# phosphor-service-lock-cli. Acceptance harness for the phosphor-service-lock
+# library (Phase 2.9). Authenticates the user (PAM) and drives the session lock.
+# Gated like the lib: when BUILD_PHOSPHOR_SHELL is OFF the lib target does not
+# exist, so the CLI can't link.
+if(BUILD_PHOSPHOR_SHELL)
+    add_subdirectory(examples/phosphor-service-lock-cli)
 endif()
 
 # phosphor-registry-plugin-demo. Sibling of phosphor-registry-demo

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -724,9 +724,9 @@ Third **Wayland-client** service lib (after 2.7 idle and 2.8 clipboard), and the
 **Decisions taken up front.**
 
 - **Foundation client in phosphor-wayland, policy in the service.** The raw `ext-session-lock-v1` client is a `phosphor-wayland` primitive (like `ClipboardDevice`); the service is the PAM + state-machine layer over it, linked PRIVATE so no Wayland types leak from the public surface.
-- **Authenticate off the GUI thread.** PAM is blocking (faildelay, network modules); the transaction runs on the thread pool and the result is delivered on the GUI thread. The authenticator sits behind an `IAuthenticator` seam, so the lock policy is unit-tested with a fake — no real PAM, no valid credentials.
+- **Authenticate off the GUI thread.** PAM is blocking (faildelay, network modules); the transaction runs on the thread pool and the result is delivered on the GUI thread. The authenticator sits behind an `IAuthenticator` seam, so the lock policy is unit-tested with a fake: no real PAM, no valid credentials.
 - **Single state, not a model.** The lock is one active state (a `State` enum), the single-active shape of 2.6 / 2.7, not the list-model shape of 2.5 / 2.8.
-- **Lock surfaces are a later phase.** The per-output `ext_session_lock_surface_v1` graphics shown while locked need rendering / output enumeration; that is shell work (Phase 4). This lib owns authentication and the lock lifecycle, not rendering — so the CLI exposes `authenticate` (the gate criterion) and a `supported` check, not an interactive screen-lock that would blank the outputs with no visible prompt.
+- **Lock surfaces are a later phase.** The per-output `ext_session_lock_surface_v1` graphics shown while locked need rendering / output enumeration; that is shell work (Phase 4). This lib owns authentication and the lock lifecycle, not rendering, so the CLI exposes `authenticate` (the gate criterion) and a `supported` check, not an interactive screen-lock that would blank the outputs with no visible prompt.
 
 **Milestones (as landed).**
 

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -704,6 +704,64 @@ Second **Wayland-client** service lib (after 2.7), with two structural firsts:
 
 **Out of scope for 2.8.** The clipboard-manager UI (a Phase 3 / 4 popup / picker consumer), image thumbnail rendering, primary-selection history (U4), cross-device sync, and any D-Bus clipboard interface. The service watches, stores, and re-applies; the shell renders the picker.
 
+### 2.9: `phosphor-service-lock` *(shipped)*
+
+A session-lock + authentication service: it authenticates the session user through PAM and coordinates the `ext-session-lock-v1` lock state with the compositor. Namespace `PhosphorServiceLock`, export macro `PHOSPHORSERVICELOCK_EXPORT`, LGPL-2.1-or-later, QML URI `Phosphor.Service.Lock 1.0`. Table effort **M**.
+
+Third **Wayland-client** service lib (after 2.7 idle and 2.8 clipboard), and the first to do **authentication**: it is the first lib to link PAM, and the first whose correctness is genuinely security-critical in the authentication sense (2.6 polkit and 2.8 clipboard guard *secrets*; this lib decides whether to *unlock the session*).
+
+**What already exists (foundation tier).**
+
+- `phosphor-wayland` binds Wayland globals in `LayerShellIntegration::registryHandler`. An `ext_session_lock_manager_v1` global binds the same way as the other managers, and a `phosphor-wayland` client class wraps the lock object, mirroring `IdleNotifier` / `ClipboardDevice`.
+- `ext-session-lock-v1.xml` was **not yet vendored**. 2.9 vendors it (the freedesktop staging protocol) under `libs/phosphor-wayland/protocols/` and code-generates it there, the established pattern.
+
+**What the service adds.**
+
+- **A foundation session-lock client** (lands in `phosphor-wayland`): bind `ext_session_lock_manager_v1`, request a lock, surface the compositor's `locked` / `finished` reply, and `unlock_and_destroy` on success. Protocol-correct teardown (never destroy a locked session; honour the must-stay-locked-if-the-client-dies guarantee) lives here.
+- **A PAM authenticator**: `pam_authenticate` + `pam_acct_mgmt` run on the global thread pool and the result is marshalled back to the GUI thread, so a sleeping PAM module never blocks the loop. Configurable service name (default `login`); the password answers only the echo-off prompt, is moved to a sole owner, and is wiped after the transaction.
+- **A QML / CLI facade** (`LockService` + a lock state machine): `Unlocked → Locking → Locked → Authenticating`, with auth-failure retry and compositor-driven teardown. Plus a public `PamAuthenticator` for standalone credential checks.
+
+**Decisions taken up front.**
+
+- **Foundation client in phosphor-wayland, policy in the service.** The raw `ext-session-lock-v1` client is a `phosphor-wayland` primitive (like `ClipboardDevice`); the service is the PAM + state-machine layer over it, linked PRIVATE so no Wayland types leak from the public surface.
+- **Authenticate off the GUI thread.** PAM is blocking (faildelay, network modules); the transaction runs on the thread pool and the result is delivered on the GUI thread. The authenticator sits behind an `IAuthenticator` seam, so the lock policy is unit-tested with a fake — no real PAM, no valid credentials.
+- **Single state, not a model.** The lock is one active state (a `State` enum), the single-active shape of 2.6 / 2.7, not the list-model shape of 2.5 / 2.8.
+- **Lock surfaces are a later phase.** The per-output `ext_session_lock_surface_v1` graphics shown while locked need rendering / output enumeration; that is shell work (Phase 4). This lib owns authentication and the lock lifecycle, not rendering — so the CLI exposes `authenticate` (the gate criterion) and a `supported` check, not an interactive screen-lock that would blank the outputs with no visible prompt.
+
+**Milestones (as landed).**
+
+1. **Foundation `SessionLock` client in `phosphor-wayland` (M).** Vendor `ext-session-lock-v1.xml`; bind `ext_session_lock_manager_v1` in `LayerShellIntegration` (the `strcmp` branch + a `sessionLockManager()` accessor); `SessionLock` class with `lock()` / `unlockAndDestroy()` / `locked` / `finished` / `isSupported()`. Inert when the compositor lacks the global.
+2. **Service skeleton + CMake plumbing (S).** `libs/phosphor-service-lock/` mirroring the 2.8 shape. Link `PhosphorWayland` (PRIVATE) + Qt6 Core / Qml. Imperative `qmlregistration.cpp`, `std::call_once`-guarded, called from `src/shell/main.cpp`. `BUILD_PHOSPHOR_SHELL`-gated.
+3. **PAM authenticator (M).** `IAuthenticator` seam + `PamAuthenticator` (off-thread `pam_authenticate` + `pam_acct_mgmt`, configurable service, password wiped). Unit-tested for the credential-free contract.
+4. **Lock state machine + QML facade (M).** `ISessionLock` seam + `WaylandSessionLock` adapter; `LockStateMachine` (DI'd with both seams, unit-tested with fakes); `LockService` exposing the QML surface.
+5. **CLI demo (S-M).** `examples/phosphor-service-lock-cli/`: `authenticate [user] [--service NAME]` (PAM, prints success/failure, no compositor) and `supported` (under the phosphorwayland QPA).
+6. **Tests (M).** Smoke, QML facade load, PAM authenticator, and the lock state machine.
+7. **README + Status (S).** Sibling convention; "Phase 2.9: shipped".
+
+**Dependencies**
+
+- `phosphor-wayland` (PRIVATE link; provides the new session-lock client + the vendored protocol code).
+- PAM (`libpam`, PRIVATE link).
+- Qt6 ≥ 6.6 Core / Qml; Qt6 Concurrent (PRIVATE) for the off-thread PAM transaction. The CLI additionally links Gui for `QGuiApplication`.
+- A compositor implementing `ext-session-lock-v1` for the live lock path (the lib loads inert without it; authentication still works).
+
+**Risks**
+
+- **Authentication correctness.** A bug that accepts a wrong password, or unlocks on the wrong signal, defeats the lock. The state machine gates unlock strictly on `IAuthenticator::succeeded` while `Authenticating`, and `pam_acct_mgmt` gates success alongside `pam_authenticate`.
+- **Blocking the loop.** PAM can sleep; the transaction must stay off the GUI thread (it does, via the thread pool + `QFutureWatcher`).
+- **Password in memory.** Minimised: the password answers only the echo-off prompt, is moved to a single owner, and is wiped (`explicit_bzero`) after `pam_end`; never logged. Full secure-input handling is an input-layer concern.
+- **Locking with no prompt.** Without lock surfaces the compositor blanks the outputs; the CLI therefore does not offer an interactive lock, and the interactive screen-lock waits on Phase 4 surfaces.
+
+**Unknowns resolved during implementation**
+
+| # | Question | Resolution |
+|---|----------|------------|
+| U1 | How much of `ext-session-lock-v1` to build now? | Foundation client (`SessionLock`) + PAM + state machine; defer per-output lock *surfaces* to the Phase 4 shell. |
+| U2 | Which PAM service name? | Configurable, default `login` (present on every system, so the demo authenticates out of the box); a shell points it at its own stack. |
+| U3 | PAM threading model? | Blocking transaction on the global thread pool (`QtConcurrent::run`), result marshalled to the GUI thread via `QFutureWatcher`. |
+
+**Out of scope for 2.9.** The per-output lock surfaces and the lock-screen UI (Phase 4 consumers), fingerprint / smartcard / other PAM-driven factors beyond password, screensaver / DPMS coupling, and any D-Bus lock interface. The service authenticates and drives the lock lifecycle; the shell renders the lock screen.
+
 ---
 
 ## Phase 3: UI primitives + first visible examples

--- a/examples/phosphor-service-lock-cli/CMakeLists.txt
+++ b/examples/phosphor-service-lock-cli/CMakeLists.txt
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # phosphor-service-lock-cli: headless driver + worked example for the
-# phosphor-service-lock library. The Phase 2.9 milestone-2 skeleton just reports
-# whether the compositor advertises the session-lock protocol; the full
-# authenticate / lock demo lands with the later milestones (the authenticate
-# subcommand runs anywhere, the lock subcommand under the shell's Wayland
-# platform). Pinned to Qt6 6.6 so it builds stand-alone from this directory too.
-find_package(Qt6 6.6 REQUIRED COMPONENTS Core)
+# phosphor-service-lock library. `authenticate` verifies a password through PAM
+# and prints success/failure (no compositor needed); `supported` reports whether
+# the compositor advertises ext-session-lock-v1, queried under the phosphorwayland
+# QPA shell integration (registerLayerShellPlugin, before QGuiApplication). Pinned
+# to Qt6 6.6 so it builds stand-alone from this directory too.
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui)
 
 add_executable(phosphor-service-lock-cli
     main.cpp
@@ -16,7 +16,9 @@ add_executable(phosphor-service-lock-cli
 target_link_libraries(phosphor-service-lock-cli
     PRIVATE
         Qt6::Core
+        Qt6::Gui
         PhosphorServiceLock::PhosphorServiceLock
+        PhosphorWayland::PhosphorWayland
 )
 
 # Intentionally no `install(TARGETS ...)` rule. This CLI is the acceptance

--- a/examples/phosphor-service-lock-cli/CMakeLists.txt
+++ b/examples/phosphor-service-lock-cli/CMakeLists.txt
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# phosphor-service-lock-cli: headless driver + worked example for the
+# phosphor-service-lock library. The Phase 2.9 milestone-2 skeleton just reports
+# whether the compositor advertises the session-lock protocol; the full
+# authenticate / lock demo lands with the later milestones (the authenticate
+# subcommand runs anywhere, the lock subcommand under the shell's Wayland
+# platform). Pinned to Qt6 6.6 so it builds stand-alone from this directory too.
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core)
+
+add_executable(phosphor-service-lock-cli
+    main.cpp
+)
+
+target_link_libraries(phosphor-service-lock-cli
+    PRIVATE
+        Qt6::Core
+        PhosphorServiceLock::PhosphorServiceLock
+)
+
+# Intentionally no `install(TARGETS ...)` rule. This CLI is the acceptance
+# harness + worked example for phosphor-service-lock, not a user-facing tool.
+# Keeping it build-tree-only avoids polluting distro paths with a developer
+# binary.

--- a/examples/phosphor-service-lock-cli/main.cpp
+++ b/examples/phosphor-service-lock-cli/main.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// phosphor-service-lock-cli: headless driver + worked example for the
+// phosphor-service-lock library.
+//
+// Phase 2.9 milestone-2 skeleton: it constructs the LockService and reports
+// whether session-lock support is available, then exits. The live demo
+// (authenticate the user and print success/failure; lock/unlock the session)
+// lands with the later milestones. The authenticate path needs no compositor;
+// the lock path runs under the shell's Wayland platform where the
+// ext-session-lock-v1 protocol is advertised. Under a plain QCoreApplication
+// there is no Wayland platform integration, so `supported` reads false here by
+// construction.
+
+#include <PhosphorServiceLock/LockService.h>
+
+#include <QCoreApplication>
+#include <QTextStream>
+
+using namespace PhosphorServiceLock;
+
+int main(int argc, char** argv)
+{
+    QCoreApplication app(argc, argv);
+
+    LockService service;
+
+    QTextStream out(stdout);
+    out << "phosphor-service-lock skeleton\n"
+        << "  session-lock support (this process): " << (service.isSupported() ? "yes" : "no") << "\n"
+        << "  (the live authenticate / lock demo arrives with the later Phase 2.9 milestones;\n"
+        << "   authenticate runs anywhere, lock runs under the shell's Wayland platform.)\n";
+    out.flush();
+
+    return 0;
+}

--- a/examples/phosphor-service-lock-cli/main.cpp
+++ b/examples/phosphor-service-lock-cli/main.cpp
@@ -4,34 +4,170 @@
 // phosphor-service-lock-cli: headless driver + worked example for the
 // phosphor-service-lock library.
 //
-// Phase 2.9 milestone-2 skeleton: it constructs the LockService and reports
-// whether session-lock support is available, then exits. The live demo
-// (authenticate the user and print success/failure; lock/unlock the session)
-// lands with the later milestones. The authenticate path needs no compositor;
-// the lock path runs under the shell's Wayland platform where the
-// ext-session-lock-v1 protocol is advertised. Under a plain QCoreApplication
-// there is no Wayland platform integration, so `supported` reads false here by
-// construction.
+//   authenticate [user]   Verify a password for the user (default: the current
+//                         user) through PAM and print success/failure. Needs no
+//                         compositor, so it runs anywhere. --service NAME selects
+//                         the /etc/pam.d stack (default "login").
+//   supported             Report whether the compositor advertises
+//                         ext-session-lock-v1, queried under the live
+//                         phosphorwayland QPA.
+//
+// There is deliberately no interactive "lock" command yet: locking the session
+// without the per-output lock surfaces (a Phase 4 shell concern) would blank the
+// outputs with no visible password prompt. Until the surfaces land, the lock
+// lifecycle is exercised by the unit tests; this CLI covers the authentication
+// path the plan's acceptance criterion calls for.
 
 #include <PhosphorServiceLock/LockService.h>
+#include <PhosphorServiceLock/PamAuthenticator.h>
+#include <PhosphorWayland/LayerShellPluginLoader.h>
 
 #include <QCoreApplication>
+#include <QGuiApplication>
+#include <QString>
+#include <QStringList>
 #include <QTextStream>
+
+#include <pwd.h>
+#include <termios.h>
+#include <unistd.h>
 
 using namespace PhosphorServiceLock;
 
-int main(int argc, char** argv)
+namespace {
+
+// sysexits-style return codes.
+constexpr int kOk = 0;
+constexpr int kFailure = 1;
+constexpr int kUsage = 64;
+
+QString currentUser()
 {
-    QCoreApplication app(argc, argv);
+    if (const struct passwd* pw = getpwuid(getuid()); pw && pw->pw_name)
+        return QString::fromLocal8Bit(pw->pw_name);
+    return qEnvironmentVariable("USER");
+}
 
-    LockService service;
-
-    QTextStream out(stdout);
-    out << "phosphor-service-lock skeleton\n"
-        << "  session-lock support (this process): " << (service.isSupported() ? "yes" : "no") << "\n"
-        << "  (the live authenticate / lock demo arrives with the later Phase 2.9 milestones;\n"
-        << "   authenticate runs anywhere, lock runs under the shell's Wayland platform.)\n";
+// Read one line from stdin with terminal echo disabled when stdin is a TTY, so
+// the password is never shown. Falls back to a plain read when stdin is piped.
+QString readPassword(QTextStream& out, const QString& prompt)
+{
+    out << prompt;
     out.flush();
 
-    return 0;
+    const bool tty = ::isatty(STDIN_FILENO) == 1;
+    struct termios saved{};
+    if (tty) {
+        ::tcgetattr(STDIN_FILENO, &saved);
+        struct termios hidden = saved;
+        hidden.c_lflag &= ~static_cast<tcflag_t>(ECHO);
+        ::tcsetattr(STDIN_FILENO, TCSANOW, &hidden);
+    }
+
+    QTextStream in(stdin);
+    const QString line = in.readLine();
+
+    if (tty) {
+        ::tcsetattr(STDIN_FILENO, TCSANOW, &saved);
+        out << '\n';
+        out.flush();
+    }
+    return line;
+}
+
+int runAuthenticate(int argc, char** argv, const QString& service, const QString& requestedUser)
+{
+    QCoreApplication app(argc, argv);
+    QTextStream out(stdout);
+    QTextStream err(stderr);
+
+    const QString username = requestedUser.isEmpty() ? currentUser() : requestedUser;
+    if (username.isEmpty()) {
+        err << "could not determine the user to authenticate\n";
+        return kUsage;
+    }
+
+    PamAuthenticator authenticator(service);
+    const QString password = readPassword(out, QStringLiteral("Password for %1: ").arg(username));
+
+    int rc = kFailure;
+    QObject::connect(&authenticator, &PamAuthenticator::succeeded, &app, [&] {
+        out << "authentication succeeded\n";
+        out.flush();
+        rc = kOk;
+        app.quit();
+    });
+    QObject::connect(&authenticator, &PamAuthenticator::failed, &app, [&](const QString& reason) {
+        out << "authentication failed: " << reason << '\n';
+        out.flush();
+        rc = kFailure;
+        app.quit();
+    });
+
+    authenticator.authenticate(username, password);
+    app.exec();
+    return rc;
+}
+
+int runSupported(int argc, char** argv)
+{
+    // Bring up the phosphorwayland QPA so the session-lock global can be detected.
+    PhosphorWayland::registerLayerShellPlugin();
+    QGuiApplication app(argc, argv);
+    QTextStream out(stdout);
+
+    LockService service;
+    const bool supported = service.isSupported();
+    out << "ext-session-lock-v1 supported: " << (supported ? "yes" : "no") << '\n';
+    out.flush();
+    return supported ? kOk : kFailure;
+}
+
+void printUsage(QTextStream& out)
+{
+    out << "usage: phosphor-service-lock-cli <command> [args]\n"
+        << "  authenticate [user] [--service NAME]  verify a password through PAM (default user: current)\n"
+        << "  supported                             report ext-session-lock-v1 availability\n";
+    out.flush();
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    // Inspect the command before constructing the application: `authenticate`
+    // needs no compositor (QCoreApplication), `supported` runs under the Wayland
+    // QPA (QGuiApplication + registerLayerShellPlugin, which must precede it).
+    const QString command = (argc > 1) ? QString::fromLocal8Bit(argv[1]) : QStringLiteral("authenticate");
+
+    QTextStream out(stdout);
+    if (command == QLatin1String("-h") || command == QLatin1String("--help") || command == QLatin1String("help")) {
+        printUsage(out);
+        return kOk;
+    }
+
+    if (command == QLatin1String("supported"))
+        return runSupported(argc, argv);
+
+    if (command == QLatin1String("authenticate")) {
+        // Parse the remaining args: an optional positional user and --service NAME.
+        QString service = QStringLiteral("login");
+        QString user;
+        for (int i = 2; i < argc; ++i) {
+            const QString arg = QString::fromLocal8Bit(argv[i]);
+            if (arg == QLatin1String("--service") && i + 1 < argc) {
+                service = QString::fromLocal8Bit(argv[++i]);
+            } else if (!arg.startsWith(QLatin1Char('-')) && user.isEmpty()) {
+                user = arg;
+            } else {
+                QTextStream(stderr) << "unrecognised argument: " << arg << '\n';
+                return kUsage;
+            }
+        }
+        return runAuthenticate(argc, argv, service, user);
+    }
+
+    QTextStream(stderr) << "unknown command: " << command << "\n\n";
+    printUsage(out);
+    return kUsage;
 }

--- a/libs/phosphor-service-lock/CMakeLists.txt
+++ b/libs/phosphor-service-lock/CMakeLists.txt
@@ -41,8 +41,8 @@ if(NOT TARGET PhosphorWayland::PhosphorWayland)
     find_package(PhosphorWayland REQUIRED)
 endif()
 
-# PAM: the authentication backend. Linked PRIVATE — security/pam_appl.h and the
-# PAM handle never appear in the public headers (the IAuthenticator seam hides
+# PAM: the authentication backend. Linked PRIVATE (security/pam_appl.h and the
+# PAM handle never appear in the public headers; the IAuthenticator seam hides
 # them). PAM ships no CMake/pkg-config module, so locate it directly.
 find_path(PAM_INCLUDE_DIR NAMES security/pam_appl.h)
 find_library(PAM_LIBRARY NAMES pam)

--- a/libs/phosphor-service-lock/CMakeLists.txt
+++ b/libs/phosphor-service-lock/CMakeLists.txt
@@ -28,16 +28,26 @@ include(GenerateExportHeader)
 # Dependencies
 # ═══════════════════════════════════════════════════════════════════════════════
 #
-# Core / Qml: the QObject + QML surface. PhosphorWayland is the backend; it is
-# PRIVATE because the foundation SessionLock client is used inside the .cpp and
-# never appears in the public headers, so consumers neither include nor link
-# phosphor-wayland.
-find_package(Qt6 6.6 REQUIRED COMPONENTS Core Qml)
+# Core / Qml: the QObject + QML surface. Concurrent runs the blocking PAM
+# transaction off the GUI thread. PhosphorWayland is the backend; it is PRIVATE
+# because the foundation SessionLock client is used inside the .cpp and never
+# appears in the public headers, so consumers neither include nor link
+# phosphor-wayland. Concurrent and PAM are likewise private.
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Qml Concurrent)
 
 # phosphor-wayland is an in-tree sibling under BUILD_PHOSPHOR_SHELL; only
 # find_package it when building this lib stand-alone.
 if(NOT TARGET PhosphorWayland::PhosphorWayland)
     find_package(PhosphorWayland REQUIRED)
+endif()
+
+# PAM: the authentication backend. Linked PRIVATE — security/pam_appl.h and the
+# PAM handle never appear in the public headers (the IAuthenticator seam hides
+# them). PAM ships no CMake/pkg-config module, so locate it directly.
+find_path(PAM_INCLUDE_DIR NAMES security/pam_appl.h)
+find_library(PAM_LIBRARY NAMES pam)
+if(NOT PAM_INCLUDE_DIR OR NOT PAM_LIBRARY)
+    message(FATAL_ERROR "phosphor-service-lock requires PAM (libpam + security/pam_appl.h)")
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -55,6 +65,8 @@ set(phosphorservicelock_public_HDRS
 set(phosphorservicelock_SRCS
     src/qmlregistration.cpp
     src/lockservice.cpp
+    src/iauthenticator.cpp
+    src/pamauthenticator.cpp
 )
 
 add_library(PhosphorServiceLock SHARED
@@ -90,8 +102,12 @@ target_link_libraries(PhosphorServiceLock
         Qt6::Core
         Qt6::Qml
     PRIVATE
+        Qt6::Concurrent
         PhosphorWayland::PhosphorWayland
+        ${PAM_LIBRARY}
 )
+
+target_include_directories(PhosphorServiceLock PRIVATE ${PAM_INCLUDE_DIR})
 
 set_target_properties(PhosphorServiceLock PROPERTIES
     VERSION ${PHOSPHORSERVICELOCK_VERSION}

--- a/libs/phosphor-service-lock/CMakeLists.txt
+++ b/libs/phosphor-service-lock/CMakeLists.txt
@@ -60,6 +60,8 @@ set(phosphorservicelock_public_HDRS
     include/PhosphorServiceLock/PhosphorServiceLock.h
     include/PhosphorServiceLock/QmlRegistration.h
     include/PhosphorServiceLock/LockService.h
+    include/PhosphorServiceLock/IAuthenticator.h
+    include/PhosphorServiceLock/PamAuthenticator.h
 )
 
 set(phosphorservicelock_SRCS

--- a/libs/phosphor-service-lock/CMakeLists.txt
+++ b/libs/phosphor-service-lock/CMakeLists.txt
@@ -65,8 +65,11 @@ set(phosphorservicelock_public_HDRS
 set(phosphorservicelock_SRCS
     src/qmlregistration.cpp
     src/lockservice.cpp
+    src/lockstatemachine.cpp
     src/iauthenticator.cpp
     src/pamauthenticator.cpp
+    src/isessionlock.cpp
+    src/waylandsessionlock.cpp
 )
 
 add_library(PhosphorServiceLock SHARED

--- a/libs/phosphor-service-lock/CMakeLists.txt
+++ b/libs/phosphor-service-lock/CMakeLists.txt
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# PhosphorServiceLock: a session-lock + authentication service for Phosphor-based
+# desktop shells. Phase 2.9 of the service-library split (see
+# docs/phosphor-shell-design/04-implementation-plan.md). It authenticates the
+# user through PAM and coordinates the ext-session-lock-v1 lock state with the
+# compositor. It is the policy layer over the raw protocol client that already
+# lives in phosphor-wayland (SessionLock), so it does not re-vendor protocols;
+# phosphor-wayland is wrapped privately and does not appear in the public link
+# interface.
+
+cmake_minimum_required(VERSION 3.16)
+
+set(PHOSPHORSERVICELOCK_VERSION "0.1.0")
+
+if(NOT PROJECT_VERSION)
+    project(PhosphorServiceLock VERSION ${PHOSPHORSERVICELOCK_VERSION} LANGUAGES CXX)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+    set(CMAKE_AUTOMOC ON)
+endif()
+
+include(GenerateExportHeader)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dependencies
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Core / Qml: the QObject + QML surface. PhosphorWayland is the backend; it is
+# PRIVATE because the foundation SessionLock client is used inside the .cpp and
+# never appears in the public headers, so consumers neither include nor link
+# phosphor-wayland.
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Qml)
+
+# phosphor-wayland is an in-tree sibling under BUILD_PHOSPHOR_SHELL; only
+# find_package it when building this lib stand-alone.
+if(NOT TARGET PhosphorWayland::PhosphorWayland)
+    find_package(PhosphorWayland REQUIRED)
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Library
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set(phosphorservicelock_public_HDRS
+    include/PhosphorServiceLock/PhosphorServiceLock.h
+    include/PhosphorServiceLock/QmlRegistration.h
+    include/PhosphorServiceLock/LockService.h
+)
+
+set(phosphorservicelock_SRCS
+    src/qmlregistration.cpp
+    src/lockservice.cpp
+)
+
+add_library(PhosphorServiceLock SHARED
+    ${phosphorservicelock_public_HDRS}
+    ${phosphorservicelock_SRCS}
+)
+
+add_library(PhosphorServiceLock::PhosphorServiceLock ALIAS PhosphorServiceLock)
+
+generate_export_header(PhosphorServiceLock
+    EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/PhosphorServiceLock/phosphorservicelock_export.h
+    EXPORT_MACRO_NAME PHOSPHORSERVICELOCK_EXPORT
+)
+
+if(NOT DEFINED KDE_INSTALL_INCLUDEDIR)
+    include(GNUInstallDirs)
+    set(KDE_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
+    set(KDE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+    set(KDE_INSTALL_BINDIR ${CMAKE_INSTALL_BINDIR})
+endif()
+
+target_include_directories(PhosphorServiceLock
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<INSTALL_INTERFACE:${KDE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_features(PhosphorServiceLock PUBLIC cxx_std_20)
+
+target_link_libraries(PhosphorServiceLock
+    PUBLIC
+        Qt6::Core
+        Qt6::Qml
+    PRIVATE
+        PhosphorWayland::PhosphorWayland
+)
+
+set_target_properties(PhosphorServiceLock PROPERTIES
+    VERSION ${PHOSPHORSERVICELOCK_VERSION}
+    SOVERSION 0
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+    UNITY_BUILD OFF
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Install
+# ═══════════════════════════════════════════════════════════════════════════════
+
+install(TARGETS PhosphorServiceLock
+    EXPORT PhosphorServiceLockTargets
+    RUNTIME DESTINATION ${KDE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${KDE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${KDE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${KDE_INSTALL_INCLUDEDIR}
+)
+
+install(FILES ${phosphorservicelock_public_HDRS}
+    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/PhosphorServiceLock
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PhosphorServiceLock/phosphorservicelock_export.h
+    DESTINATION ${KDE_INSTALL_INCLUDEDIR}/PhosphorServiceLock
+)
+
+install(EXPORT PhosphorServiceLockTargets
+    FILE PhosphorServiceLockTargets.cmake
+    NAMESPACE PhosphorServiceLock::
+    DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorServiceLock
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/PhosphorServiceLockConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorServiceLockConfig.cmake"
+    INSTALL_DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorServiceLock
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorServiceLockConfigVersion.cmake"
+    VERSION ${PHOSPHORSERVICELOCK_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorServiceLockConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/PhosphorServiceLockConfigVersion.cmake"
+    DESTINATION ${KDE_INSTALL_LIBDIR}/cmake/PhosphorServiceLock
+)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+if(CMAKE_PROJECT_NAME STREQUAL "PhosphorServiceLock" OR BUILD_TESTING)
+    enable_testing()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt")
+        add_subdirectory(tests)
+    endif()
+endif()

--- a/libs/phosphor-service-lock/PhosphorServiceLockConfig.cmake.in
+++ b/libs/phosphor-service-lock/PhosphorServiceLockConfig.cmake.in
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Mirror the PUBLIC link set in CMakeLists.txt. (PhosphorWayland is a PRIVATE
+# link: the foundation SessionLock client is used inside the .cpp and never
+# appears in the public headers, so consumers neither include nor link it. PAM
+# is likewise a private link.)
+find_dependency(Qt6 6.6 COMPONENTS Core Qml)
+
+include("${CMAKE_CURRENT_LIST_DIR}/PhosphorServiceLockTargets.cmake")
+
+check_required_components(PhosphorServiceLock)

--- a/libs/phosphor-service-lock/README.md
+++ b/libs/phosphor-service-lock/README.md
@@ -1,0 +1,131 @@
+<!-- SPDX-FileCopyrightText: 2026 fuddlesworth -->
+<!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
+
+# phosphor-service-lock
+
+A session-lock + authentication service for Phosphor-based desktop shells.
+
+## Responsibility
+
+Authenticates the session user through PAM and coordinates the
+`ext-session-lock-v1` lock state with the compositor. It is the policy /
+state-machine layer over `phosphor-wayland`'s `SessionLock` client (an
+`ext-session-lock-v1` client) and a PAM authentication backend; it composes them
+rather than binding the protocol or talking to PAM in its public surface, so its
+public types are clean Qt/QML types with no Wayland or PAM types leaking out.
+
+- Verify the session user's password through PAM, off the GUI thread.
+- Ask the compositor to lock the session and track the lock lifecycle.
+- Release the lock once authentication succeeds.
+
+The lock *surfaces* (the per-output graphics shown while the session is locked)
+are a shell concern wired in a later phase; this service owns authentication and
+the lock lifecycle, not rendering.
+
+## Key types
+
+| Type             | Role                                                                                  |
+|------------------|---------------------------------------------------------------------------------------|
+| `LockService`    | The lock host. `lock()` asks the compositor to lock (state `Locking` → `Locked`); `unlock(password)` authenticates the session user (`Authenticating`) and, on success, releases the lock (`Unlocked`, `unlocked()`); on failure `authenticationFailed()` fires and the state returns to `Locked`. Exposes `supported`, `state`, and `locked`. A plain instantiable QML type, not a singleton. |
+| `PamAuthenticator` / `IAuthenticator` | The standalone credential-check surface: `authenticate(user, password)` runs PAM off the GUI thread and reports `succeeded()` / `failed(reason)`. The PAM service name is configurable (default `login`). Use it to verify a password independently of the compositor lock. |
+
+## Typical use
+
+C++ shell composition root:
+
+```cpp
+#include <PhosphorServiceLock/QmlRegistration.h>
+
+int main(int argc, char** argv)
+{
+    QGuiApplication app(argc, argv);
+    PhosphorServiceLock::registerQmlTypes();
+    // ... load shell.qml
+}
+```
+
+QML lock screen (a later-phase lock surface drives the service):
+
+```qml
+import Phosphor.Service.Lock 1.0
+
+LockService {
+    id: lock
+    onUnlocked: console.log("session unlocked")
+    onAuthenticationFailed: (reason) => console.log("denied:", reason)
+}
+
+// request the lock when the session should be secured
+Component.onCompleted: lock.lock()
+
+// the password field submits an unlock attempt
+TextField {
+    echoMode: TextInput.Password
+    onAccepted: lock.unlock(text)
+}
+```
+
+The CLI doubles as the worked example and the acceptance harness:
+
+```sh
+# verify a password for the current user through PAM (prompts; echo disabled)
+phosphor-service-lock-cli authenticate
+# authenticate a specific user against a specific PAM stack
+phosphor-service-lock-cli authenticate alice --service phosphor-lock
+# report whether the compositor advertises ext-session-lock-v1
+phosphor-service-lock-cli supported
+```
+
+## Design notes
+
+- **Composes the foundation primitive.** The `ext-session-lock-v1` client lives
+  in `phosphor-wayland` (`SessionLock`); this library links it privately and
+  builds the authentication + lock state machine on top. It binds no protocols
+  itself. The protocol-correct teardown rules (never destroy a locked session;
+  honour the must-stay-locked-if-the-client-dies guarantee) live in the client.
+- **Authenticates off the GUI thread.** `PamAuthenticator` runs the blocking PAM
+  transaction (`pam_authenticate` + `pam_acct_mgmt`) on the global thread pool
+  and marshals the result back to the GUI thread, so a PAM module that sleeps
+  (faildelay, a network backend) never stalls the event loop. One transaction at
+  a time. The password answers only PAM's echo-off prompt, is moved to a sole
+  owner, and is wiped (`explicit_bzero`) after the transaction; it is never
+  logged.
+- **Seams for testability.** The lock state machine is driven through an
+  `ISessionLock` seam and the `IAuthenticator` seam, so the whole lock policy
+  (request → locked → authenticate → unlock, with auth-failure retry and
+  compositor-driven teardown) is unit-tested with fakes and no live compositor or
+  PAM stack.
+- **A single active lock, not a model.** Like `phosphor-service-polkit` /
+  `phosphor-service-idle` and unlike `phosphor-service-clipboard`, the lock is a
+  single state, exposed as a `State` enum rather than a list model.
+- **Lock surfaces are deferred.** A real lock screen must create an
+  `ext_session_lock_surface_v1` per output before the compositor presents the
+  locked frame; that rendering layer is a shell concern for a later phase. Until
+  then the compositor decides, per its own policy, when to confirm the lock.
+
+## Dependencies
+
+- `phosphor-wayland` (private link; provides the `SessionLock`
+  `ext-session-lock-v1` client and the vendored protocol code). No separate
+  `wayland-protocols` dependency.
+- PAM (`libpam`, private link) for authentication.
+- Qt6 >= 6.6 (Core, Qml; Concurrent privately for the off-thread PAM
+  transaction). The CLI additionally uses Qt6 Gui for `QGuiApplication`.
+- A compositor advertising `ext-session-lock-v1` for the live lock path (the
+  library loads inert without it; authentication still works).
+
+## Status
+
+Phase 2.9: shipped. `LockService` authenticates the session user through
+`PamAuthenticator` (PAM, off the GUI thread, configurable service, default
+`login`) and coordinates the lock state with the compositor through
+`PhosphorWayland::SessionLock` (`ext-session-lock-v1`): `Unlocked → Locking →
+Locked → Authenticating`, releasing the lock on a successful unlock and staying
+locked on a failed attempt. The `examples/phosphor-service-lock-cli` demo
+provides `authenticate` (PAM, prints success/failure) and `supported` against a
+live session. Four test binaries pin the deterministic surface with no compositor
+or valid credentials: the smoke harness (registration idempotency, inert
+construction), the QML-engine load test, the PAM authenticator test (configured
+service, fast-fail, the concurrency guard, real-PAM rejection of a nonexistent
+user), and the state-machine test (the full lock policy on fakes). The per-output
+lock surfaces and the lock-screen UI are a Phase 4 consumer of this library.

--- a/libs/phosphor-service-lock/include/PhosphorServiceLock/IAuthenticator.h
+++ b/libs/phosphor-service-lock/include/PhosphorServiceLock/IAuthenticator.h
@@ -3,19 +3,23 @@
 
 #pragma once
 
-// Internal (not installed) seam for verifying a user's credentials. Production
-// wraps PAM (PamAuthenticator); tests substitute a fake that resolves a result
-// directly. Keeping the lock state machine behind this interface is what lets it
-// be unit-tested without a real PAM stack or valid credentials.
+#include <PhosphorServiceLock/phosphorservicelock_export.h>
 
 #include <QObject>
 #include <QString>
 
 namespace PhosphorServiceLock {
 
-/// The authentication surface the lock state machine drives: it verifies a
-/// password for a user and reports the outcome asynchronously.
-class IAuthenticator : public QObject
+/**
+ * @brief The credential-verification surface a lock UI (and the lock state
+ *        machine) drives.
+ *
+ * Verifies a password for a user and reports the outcome asynchronously. The
+ * production implementation is PamAuthenticator; tests and the state machine can
+ * substitute a fake, so the lock policy is exercisable without a real PAM stack
+ * or valid credentials.
+ */
+class PHOSPHORSERVICELOCK_EXPORT IAuthenticator : public QObject
 {
     Q_OBJECT
 
@@ -24,8 +28,6 @@ public:
         : QObject(parent)
     {
     }
-    // Out-of-line (defined in iauthenticator.cpp) so it anchors the vtable and
-    // gives AUTOMOC a translation unit for the Q_OBJECT metaobject.
     ~IAuthenticator() override;
 
     /// Asynchronously verify @p password for @p username.

--- a/libs/phosphor-service-lock/include/PhosphorServiceLock/LockService.h
+++ b/libs/phosphor-service-lock/include/PhosphorServiceLock/LockService.h
@@ -6,38 +6,84 @@
 #include <PhosphorServiceLock/phosphorservicelock_export.h>
 
 #include <QObject>
+#include <QString>
+
+#include <memory>
 
 namespace PhosphorServiceLock {
 
 /**
  * @brief Session-lock + authentication host for Phosphor-based desktop shells.
  *
- * Authenticates the user through PAM and coordinates the `ext-session-lock-v1`
- * lock state with the compositor through `phosphor-wayland`'s `SessionLock`
- * client. It is the policy / state-machine layer over the raw client and the
- * authentication backend; it composes them rather than binding the protocol or
- * talking to PAM in its public surface, so the host is a clean Qt/QML type with
- * no Wayland or PAM types leaking out.
+ * Authenticates the session user through PAM and coordinates the
+ * `ext-session-lock-v1` lock state with the compositor through `phosphor-wayland`'s
+ * `SessionLock` client. It is the policy / state-machine layer over the raw
+ * client and the authentication backend; it composes them rather than binding
+ * the protocol or talking to PAM in its public surface, so the host is a clean
+ * Qt/QML type with no Wayland or PAM types leaking out.
  *
- * Phase 2.9 milestone 2 is the skeleton: the host constructs and reports whether
- * the compositor advertises the session-lock protocol this service needs. The
- * PAM authenticator, the lock state machine, and the full QML facade arrive in
- * the following milestones.
+ * Flow: `lock()` asks the compositor to lock (state `Locking`); the compositor
+ * confirms (`Locked`). `unlock(password)` authenticates the session user
+ * (`Authenticating`); on success the lock is released (`Unlocked`, `unlocked()`),
+ * on failure the state returns to `Locked` and `authenticationFailed()` fires.
+ *
+ * Lock *surfaces* (the per-output graphics shown while locked) are a shell
+ * concern wired in a later phase; this service owns authentication and the lock
+ * lifecycle, not rendering.
  */
 class PHOSPHORSERVICELOCK_EXPORT LockService : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(bool supported READ isSupported CONSTANT)
+    Q_PROPERTY(State state READ state NOTIFY stateChanged)
+    Q_PROPERTY(bool locked READ isLocked NOTIFY stateChanged)
 
 public:
+    /// The lock lifecycle.
+    enum class State {
+        Unlocked, ///< No lock; the session is usable.
+        Locking, ///< lock() issued; awaiting the compositor's reply.
+        Locked, ///< The compositor locked the session; awaiting authentication.
+        Authenticating, ///< An unlock() attempt is verifying credentials.
+    };
+    Q_ENUM(State)
+
     explicit LockService(QObject* parent = nullptr);
+    ~LockService() override;
 
     /// Whether the compositor advertises the `ext-session-lock-v1` protocol this
     /// service builds on. When false the service constructs but cannot lock.
     [[nodiscard]] bool isSupported() const;
 
+    /// The current lock state.
+    [[nodiscard]] State state() const;
+
+    /// True while the session is locked (whether idle or authenticating).
+    [[nodiscard]] bool isLocked() const;
+
+    /// Request that the compositor lock the session. A no-op unless currently
+    /// `Unlocked`.
+    Q_INVOKABLE void lock();
+
+    /// Attempt to unlock by authenticating the session user with @p password. A
+    /// no-op unless currently `Locked`. On success the session unlocks; on
+    /// failure `authenticationFailed()` fires and the state returns to `Locked`.
+    Q_INVOKABLE void unlock(const QString& password);
+
+Q_SIGNALS:
+    /// `state()` changed.
+    void stateChanged();
+    /// An `unlock()` attempt was rejected; @p reason is a human-readable,
+    /// non-sensitive explanation. The session stays locked.
+    void authenticationFailed(const QString& reason);
+    /// The session was successfully unlocked after authentication.
+    void unlocked();
+
 private:
     Q_DISABLE_COPY_MOVE(LockService)
+
+    class Private;
+    std::unique_ptr<Private> d;
 };
 
 } // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/include/PhosphorServiceLock/LockService.h
+++ b/libs/phosphor-service-lock/include/PhosphorServiceLock/LockService.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorServiceLock/phosphorservicelock_export.h>
+
+#include <QObject>
+
+namespace PhosphorServiceLock {
+
+/**
+ * @brief Session-lock + authentication host for Phosphor-based desktop shells.
+ *
+ * Authenticates the user through PAM and coordinates the `ext-session-lock-v1`
+ * lock state with the compositor through `phosphor-wayland`'s `SessionLock`
+ * client. It is the policy / state-machine layer over the raw client and the
+ * authentication backend; it composes them rather than binding the protocol or
+ * talking to PAM in its public surface, so the host is a clean Qt/QML type with
+ * no Wayland or PAM types leaking out.
+ *
+ * Phase 2.9 milestone 2 is the skeleton: the host constructs and reports whether
+ * the compositor advertises the session-lock protocol this service needs. The
+ * PAM authenticator, the lock state machine, and the full QML facade arrive in
+ * the following milestones.
+ */
+class PHOSPHORSERVICELOCK_EXPORT LockService : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool supported READ isSupported CONSTANT)
+
+public:
+    explicit LockService(QObject* parent = nullptr);
+
+    /// Whether the compositor advertises the `ext-session-lock-v1` protocol this
+    /// service builds on. When false the service constructs but cannot lock.
+    [[nodiscard]] bool isSupported() const;
+
+private:
+    Q_DISABLE_COPY_MOVE(LockService)
+};
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/include/PhosphorServiceLock/PamAuthenticator.h
+++ b/libs/phosphor-service-lock/include/PhosphorServiceLock/PamAuthenticator.h
@@ -3,20 +3,14 @@
 
 #pragma once
 
-#include "iauthenticator.h"
+#include <PhosphorServiceLock/IAuthenticator.h>
+#include <PhosphorServiceLock/phosphorservicelock_export.h>
 
-#include <QFutureWatcher>
 #include <QString>
 
-namespace PhosphorServiceLock {
+#include <memory>
 
-/// Result of one PAM transaction, marshalled from the worker thread back to the
-/// GUI thread by the QFutureWatcher.
-struct PamResult
-{
-    bool success = false;
-    QString reason;
-};
+namespace PhosphorServiceLock {
 
 /**
  * @brief IAuthenticator backed by PAM (`pam_authenticate` + `pam_acct_mgmt`).
@@ -28,12 +22,12 @@ struct PamResult
  *
  * The PAM service name (which `/etc/pam.d/<service>` stack validates the
  * password) is configurable; it defaults to `login`, which exists on every
- * system so the demo authenticates out of the box. A shell would point this at
- * its own stack.
+ * system so the service authenticates out of the box. A shell would point this
+ * at its own stack.
  *
  * Threading: construct and call from the GUI thread.
  */
-class PamAuthenticator : public IAuthenticator
+class PHOSPHORSERVICELOCK_EXPORT PamAuthenticator : public IAuthenticator
 {
     Q_OBJECT
     Q_DISABLE_COPY_MOVE(PamAuthenticator)
@@ -49,8 +43,8 @@ public:
     void authenticate(const QString& username, const QString& password) override;
 
 private:
-    QString m_service;
-    QFutureWatcher<PamResult> m_watcher;
+    class Private;
+    std::unique_ptr<Private> d;
 };
 
 } // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/include/PhosphorServiceLock/PhosphorServiceLock.h
+++ b/libs/phosphor-service-lock/include/PhosphorServiceLock/PhosphorServiceLock.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+/**
+ * @file PhosphorServiceLock.h
+ * @brief Umbrella header for the PhosphorServiceLock library.
+ *
+ * PhosphorServiceLock is a session-lock + authentication service for
+ * Phosphor-based desktop shells. It authenticates the user through PAM and
+ * coordinates the `ext-session-lock-v1` lock state with the compositor through
+ * `phosphor-wayland`'s `SessionLock` client. It is the policy layer over the raw
+ * protocol client, composing it rather than binding the protocol itself, so its
+ * public surface is a clean Qt/QML type with no Wayland (or PAM) types leaking
+ * out.
+ *
+ * Shells consume:
+ *   - `LockService`: the lock host (lock state machine + authenticate path).
+ *
+ * Lock *surfaces* (the per-output graphics shown while locked) are a shell
+ * concern wired in a later phase; this service owns authentication and the lock
+ * lifecycle, not rendering.
+ *
+ * Phase 2.9 of the service-library plan documented in
+ * `docs/phosphor-shell-design/04-implementation-plan.md`.
+ */
+
+#include <PhosphorServiceLock/LockService.h>
+#include <PhosphorServiceLock/QmlRegistration.h>

--- a/libs/phosphor-service-lock/include/PhosphorServiceLock/PhosphorServiceLock.h
+++ b/libs/phosphor-service-lock/include/PhosphorServiceLock/PhosphorServiceLock.h
@@ -17,6 +17,8 @@
  *
  * Shells consume:
  *   - `LockService`: the lock host (lock state machine + authenticate path).
+ *   - `PamAuthenticator` / `IAuthenticator`: the standalone credential-check
+ *     surface, for verifying the user's password independently of the lock.
  *
  * Lock *surfaces* (the per-output graphics shown while locked) are a shell
  * concern wired in a later phase; this service owns authentication and the lock
@@ -26,5 +28,7 @@
  * `docs/phosphor-shell-design/04-implementation-plan.md`.
  */
 
+#include <PhosphorServiceLock/IAuthenticator.h>
 #include <PhosphorServiceLock/LockService.h>
+#include <PhosphorServiceLock/PamAuthenticator.h>
 #include <PhosphorServiceLock/QmlRegistration.h>

--- a/libs/phosphor-service-lock/include/PhosphorServiceLock/QmlRegistration.h
+++ b/libs/phosphor-service-lock/include/PhosphorServiceLock/QmlRegistration.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorServiceLock/phosphorservicelock_export.h>
+
+namespace PhosphorServiceLock {
+
+/// Register every PhosphorServiceLock QML type under the `Phosphor.Service.Lock`
+/// module at version 1.0. Idempotent on repeat calls: internally guarded by
+/// `std::call_once` so a hot-reloading shell that builds a fresh `QQmlEngine`
+/// per reload can safely call this from every engine setup without triggering
+/// Qt's duplicate-registration warning.
+///
+/// Called from the consuming binary (typically `src/shell/main.cpp`) before any
+/// `QQmlEngine` loads a `.qml` file.
+PHOSPHORSERVICELOCK_EXPORT void registerQmlTypes();
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/iauthenticator.cpp
+++ b/libs/phosphor-service-lock/src/iauthenticator.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "iauthenticator.h"
+#include <PhosphorServiceLock/IAuthenticator.h>
 
 namespace PhosphorServiceLock {
 

--- a/libs/phosphor-service-lock/src/iauthenticator.cpp
+++ b/libs/phosphor-service-lock/src/iauthenticator.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "iauthenticator.h"
+
+namespace PhosphorServiceLock {
+
+IAuthenticator::~IAuthenticator() = default;
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/iauthenticator.h
+++ b/libs/phosphor-service-lock/src/iauthenticator.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+// Internal (not installed) seam for verifying a user's credentials. Production
+// wraps PAM (PamAuthenticator); tests substitute a fake that resolves a result
+// directly. Keeping the lock state machine behind this interface is what lets it
+// be unit-tested without a real PAM stack or valid credentials.
+
+#include <QObject>
+#include <QString>
+
+namespace PhosphorServiceLock {
+
+/// The authentication surface the lock state machine drives: it verifies a
+/// password for a user and reports the outcome asynchronously.
+class IAuthenticator : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit IAuthenticator(QObject* parent = nullptr)
+        : QObject(parent)
+    {
+    }
+    // Out-of-line (defined in iauthenticator.cpp) so it anchors the vtable and
+    // gives AUTOMOC a translation unit for the Q_OBJECT metaobject.
+    ~IAuthenticator() override;
+
+    /// Asynchronously verify @p password for @p username.
+    ///
+    /// Contract: every authenticate() MUST eventually emit exactly one
+    /// `succeeded` or `failed`. The check runs off the GUI thread so a slow
+    /// authentication stack never blocks the event loop, and the result signal
+    /// is delivered on the GUI thread. Implementations should reject (as a
+    /// `failed`) a call made while a previous one is still outstanding rather
+    /// than run two transactions concurrently.
+    virtual void authenticate(const QString& username, const QString& password) = 0;
+
+Q_SIGNALS:
+    /// The credentials were accepted.
+    void succeeded();
+    /// The credentials were rejected (or the attempt could not complete);
+    /// @p reason is a human-readable, non-sensitive explanation.
+    void failed(const QString& reason);
+};
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/isessionlock.cpp
+++ b/libs/phosphor-service-lock/src/isessionlock.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "isessionlock.h"
+
+namespace PhosphorServiceLock {
+
+ISessionLock::~ISessionLock() = default;
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/isessionlock.h
+++ b/libs/phosphor-service-lock/src/isessionlock.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+// Internal (not installed) seam for the compositor session lock the state
+// machine drives. Production wraps PhosphorWayland::SessionLock
+// (WaylandSessionLock); tests substitute a fake that drives the locked /
+// finished edges directly. Keeping the state machine behind this interface is
+// what lets the lock policy be unit-tested without a live compositor.
+
+#include <QObject>
+
+namespace PhosphorServiceLock {
+
+/// The session-lock surface the state machine drives: request a lock, observe
+/// whether the compositor granted (`locked`) or refused / ended it (`finished`),
+/// and release it after a successful authentication.
+class ISessionLock : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ISessionLock(QObject* parent = nullptr)
+        : QObject(parent)
+    {
+    }
+    // Out-of-line (defined in isessionlock.cpp) so it anchors the vtable and
+    // gives AUTOMOC a translation unit for the Q_OBJECT metaobject.
+    ~ISessionLock() override;
+
+    /// Request that the compositor lock the session. The compositor replies with
+    /// exactly one of `locked` or `finished`.
+    virtual void lock() = 0;
+
+    /// Release the lock after a successful authentication. Valid only after
+    /// `locked`; a no-op otherwise.
+    virtual void unlockAndDestroy() = 0;
+
+    /// True between `locked` and release (or a compositor-driven `finished`).
+    [[nodiscard]] virtual bool isLocked() const = 0;
+
+Q_SIGNALS:
+    /// The compositor granted the lock; the session is now locked.
+    void locked();
+    /// The compositor refused the lock, or ended an active one. The lock object
+    /// is over; a new `lock()` is required to try again.
+    void finished();
+};
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/lockservice.cpp
+++ b/libs/phosphor-service-lock/src/lockservice.cpp
@@ -4,9 +4,9 @@
 #include <PhosphorServiceLock/LockService.h>
 
 #include "lockstatemachine.h"
-#include "pamauthenticator.h"
 #include "waylandsessionlock.h"
 
+#include <PhosphorServiceLock/PamAuthenticator.h>
 #include <PhosphorWayland/SessionLock.h>
 
 #include <utility>

--- a/libs/phosphor-service-lock/src/lockservice.cpp
+++ b/libs/phosphor-service-lock/src/lockservice.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorServiceLock/LockService.h>
+
+#include <PhosphorWayland/SessionLock.h>
+
+namespace PhosphorServiceLock {
+
+LockService::LockService(QObject* parent)
+    : QObject(parent)
+{
+}
+
+bool LockService::isSupported() const
+{
+    // The compositor must advertise ext-session-lock-v1 (surfaced by
+    // PhosphorWayland::SessionLock) for the service to lock the session.
+    return PhosphorWayland::SessionLock::isSupported();
+}
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/lockservice.cpp
+++ b/libs/phosphor-service-lock/src/lockservice.cpp
@@ -3,20 +3,81 @@
 
 #include <PhosphorServiceLock/LockService.h>
 
+#include "lockstatemachine.h"
+#include "pamauthenticator.h"
+#include "waylandsessionlock.h"
+
 #include <PhosphorWayland/SessionLock.h>
+
+#include <utility>
+
+#include <pwd.h>
+#include <unistd.h>
 
 namespace PhosphorServiceLock {
 
+namespace {
+// The session user authenticated on an unlock attempt: the owner of this
+// process. Resolved from the real uid, falling back to $USER.
+QString currentUser()
+{
+    if (const struct passwd* pw = getpwuid(getuid()); pw && pw->pw_name)
+        return QString::fromLocal8Bit(pw->pw_name);
+    return qEnvironmentVariable("USER");
+}
+} // namespace
+
+class LockService::Private
+{
+public:
+    explicit Private(QString username)
+        : machine(&sessionLock, &authenticator, std::move(username))
+    {
+    }
+
+    // Declaration order matters: the state machine borrows the two backends, so
+    // they must be constructed before (and destroyed after) it.
+    WaylandSessionLock sessionLock;
+    PamAuthenticator authenticator;
+    LockStateMachine machine;
+};
+
 LockService::LockService(QObject* parent)
     : QObject(parent)
+    , d(std::make_unique<Private>(currentUser()))
 {
+    connect(&d->machine, &LockStateMachine::stateChanged, this, &LockService::stateChanged);
+    connect(&d->machine, &LockStateMachine::authenticationFailed, this, &LockService::authenticationFailed);
+    connect(&d->machine, &LockStateMachine::unlocked, this, &LockService::unlocked);
 }
+
+LockService::~LockService() = default;
 
 bool LockService::isSupported() const
 {
     // The compositor must advertise ext-session-lock-v1 (surfaced by
     // PhosphorWayland::SessionLock) for the service to lock the session.
     return PhosphorWayland::SessionLock::isSupported();
+}
+
+LockService::State LockService::state() const
+{
+    return d->machine.state();
+}
+
+bool LockService::isLocked() const
+{
+    return state() == State::Locked || state() == State::Authenticating;
+}
+
+void LockService::lock()
+{
+    d->machine.requestLock();
+}
+
+void LockService::unlock(const QString& password)
+{
+    d->machine.authenticate(password);
 }
 
 } // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/lockstatemachine.cpp
+++ b/libs/phosphor-service-lock/src/lockstatemachine.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "lockstatemachine.h"
+
+#include "iauthenticator.h"
+#include "isessionlock.h"
+
+#include <utility>
+
+namespace PhosphorServiceLock {
+
+LockStateMachine::LockStateMachine(ISessionLock* lock, IAuthenticator* authenticator, QString username, QObject* parent)
+    : QObject(parent)
+    , m_lock(lock)
+    , m_authenticator(authenticator)
+    , m_username(std::move(username))
+{
+    connect(m_lock, &ISessionLock::locked, this, &LockStateMachine::onLocked);
+    connect(m_lock, &ISessionLock::finished, this, &LockStateMachine::onFinished);
+    connect(m_authenticator, &IAuthenticator::succeeded, this, &LockStateMachine::onAuthSucceeded);
+    connect(m_authenticator, &IAuthenticator::failed, this, &LockStateMachine::onAuthFailed);
+}
+
+LockService::State LockStateMachine::state() const
+{
+    return m_state;
+}
+
+void LockStateMachine::setState(LockService::State state)
+{
+    if (m_state == state)
+        return;
+    m_state = state;
+    Q_EMIT stateChanged();
+}
+
+void LockStateMachine::requestLock()
+{
+    if (m_state != LockService::State::Unlocked)
+        return;
+    setState(LockService::State::Locking);
+    m_lock->lock();
+}
+
+void LockStateMachine::onLocked()
+{
+    // The compositor granted the lock we requested.
+    if (m_state == LockService::State::Locking)
+        setState(LockService::State::Locked);
+}
+
+void LockStateMachine::onFinished()
+{
+    // The compositor refused the lock (while Locking) or ended an active one
+    // (while Locked / Authenticating). Either way the lock object is gone and we
+    // are back to an unlocked session; a fresh requestLock() is needed to retry.
+    if (m_state != LockService::State::Unlocked)
+        setState(LockService::State::Unlocked);
+}
+
+void LockStateMachine::authenticate(const QString& password)
+{
+    // Only meaningful from a settled Locked state: not before the compositor has
+    // confirmed the lock, and not while another attempt is already in flight.
+    if (m_state != LockService::State::Locked)
+        return;
+    setState(LockService::State::Authenticating);
+    m_authenticator->authenticate(m_username, password);
+}
+
+void LockStateMachine::onAuthSucceeded()
+{
+    if (m_state != LockService::State::Authenticating)
+        return;
+    // Release the compositor lock and return to a usable session.
+    m_lock->unlockAndDestroy();
+    setState(LockService::State::Unlocked);
+    Q_EMIT unlocked();
+}
+
+void LockStateMachine::onAuthFailed(const QString& reason)
+{
+    if (m_state != LockService::State::Authenticating)
+        return;
+    // Wrong password (or the attempt could not complete): stay locked, let the
+    // user try again.
+    setState(LockService::State::Locked);
+    Q_EMIT authenticationFailed(reason);
+}
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/lockstatemachine.cpp
+++ b/libs/phosphor-service-lock/src/lockstatemachine.cpp
@@ -3,8 +3,9 @@
 
 #include "lockstatemachine.h"
 
-#include "iauthenticator.h"
 #include "isessionlock.h"
+
+#include <PhosphorServiceLock/IAuthenticator.h>
 
 #include <utility>
 

--- a/libs/phosphor-service-lock/src/lockstatemachine.h
+++ b/libs/phosphor-service-lock/src/lockstatemachine.h
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+// Internal (not installed) lock state machine. It coordinates a session lock
+// (ISessionLock) and an authenticator (IAuthenticator) behind seams, so the
+// whole lock policy (request -> locked -> authenticate -> unlock, with
+// auth-failure retry and compositor-driven teardown) is unit-tested with fakes
+// and no live compositor or PAM stack. LockService composes the real backends
+// over it.
+
+#include <PhosphorServiceLock/LockService.h>
+
+#include <QObject>
+#include <QString>
+
+namespace PhosphorServiceLock {
+
+class ISessionLock;
+class IAuthenticator;
+
+class LockStateMachine : public QObject
+{
+    Q_OBJECT
+
+public:
+    /// @p lock and @p authenticator are borrowed (not owned); they must outlive
+    /// this machine. @p username is the user authenticated on an unlock attempt.
+    LockStateMachine(ISessionLock* lock, IAuthenticator* authenticator, QString username, QObject* parent = nullptr);
+
+    [[nodiscard]] LockService::State state() const;
+
+    /// Request a lock. A no-op unless currently Unlocked.
+    void requestLock();
+    /// Verify @p password for the session user. A no-op unless currently Locked.
+    void authenticate(const QString& password);
+
+Q_SIGNALS:
+    void stateChanged();
+    void authenticationFailed(const QString& reason);
+    void unlocked();
+
+private:
+    void setState(LockService::State state);
+    void onLocked();
+    void onFinished();
+    void onAuthSucceeded();
+    void onAuthFailed(const QString& reason);
+
+    ISessionLock* m_lock;
+    IAuthenticator* m_authenticator;
+    QString m_username;
+    LockService::State m_state = LockService::State::Unlocked;
+};
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/pamauthenticator.cpp
+++ b/libs/phosphor-service-lock/src/pamauthenticator.cpp
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#include "pamauthenticator.h"
+#include <PhosphorServiceLock/PamAuthenticator.h>
 
+#include <QFutureWatcher>
 #include <QtConcurrent>
 
 #include <security/pam_appl.h>
@@ -14,6 +15,14 @@
 namespace PhosphorServiceLock {
 
 namespace {
+
+// Result of one PAM transaction, marshalled from the worker thread back to the
+// GUI thread by the QFutureWatcher.
+struct PamResult
+{
+    bool success = false;
+    QString reason;
+};
 
 // Payload handed to the PAM conversation callback: a pointer to the (still
 // owned, null-terminated) password bytes to answer the module's echo-off prompt
@@ -125,16 +134,24 @@ PamResult runPamTransaction(const QString& service, const QString& username, QBy
 
 } // namespace
 
+class PamAuthenticator::Private
+{
+public:
+    QString service;
+    QFutureWatcher<PamResult> watcher;
+};
+
 PamAuthenticator::PamAuthenticator(QString service, QObject* parent)
     : IAuthenticator(parent)
-    , m_service(std::move(service))
+    , d(std::make_unique<Private>())
 {
+    d->service = std::move(service);
     // QFutureWatcher::finished is delivered on this (the GUI) thread, so reading
     // the result and emitting here is thread-safe.
-    connect(&m_watcher, &QFutureWatcher<PamResult>::finished, this, [this] {
-        if (m_watcher.future().resultCount() == 0)
+    connect(&d->watcher, &QFutureWatcher<PamResult>::finished, this, [this] {
+        if (d->watcher.future().resultCount() == 0)
             return; // cancelled / no result
-        const PamResult result = m_watcher.result();
+        const PamResult result = d->watcher.result();
         if (result.success)
             Q_EMIT succeeded();
         else
@@ -146,12 +163,12 @@ PamAuthenticator::~PamAuthenticator() = default;
 
 QString PamAuthenticator::service() const
 {
-    return m_service;
+    return d->service;
 }
 
 void PamAuthenticator::authenticate(const QString& username, const QString& password)
 {
-    if (m_watcher.isRunning()) {
+    if (d->watcher.isRunning()) {
         // One transaction at a time: never run two PAM stacks concurrently.
         Q_EMIT failed(QStringLiteral("authentication already in progress"));
         return;
@@ -161,14 +178,14 @@ void PamAuthenticator::authenticate(const QString& username, const QString& pass
         return;
     }
 
-    const QString service = m_service;
+    const QString service = d->service;
     QByteArray pw = password.toUtf8();
     // The worker captures only value copies (service, user, and the moved-in
     // password buffer) — never `this` — so destroying the authenticator
     // mid-transaction cannot dangle: the watcher disconnects and the detached
     // task finishes harmlessly. The password buffer is moved through to
     // runPamTransaction, which is its sole owner and wipes it.
-    m_watcher.setFuture(QtConcurrent::run([service, user = username, pw = std::move(pw)]() mutable -> PamResult {
+    d->watcher.setFuture(QtConcurrent::run([service, user = username, pw = std::move(pw)]() mutable -> PamResult {
         return runPamTransaction(service, user, std::move(pw));
     }));
 }

--- a/libs/phosphor-service-lock/src/pamauthenticator.cpp
+++ b/libs/phosphor-service-lock/src/pamauthenticator.cpp
@@ -119,6 +119,9 @@ PamResult runPamTransaction(const QString& service, const QString& username, QBy
         return {false, reason};
     }
 
+    // This is an unlock (verify-only): the session and its credentials already
+    // exist, so the transaction deliberately runs pam_authenticate + pam_acct_mgmt
+    // and omits pam_setcred / pam_open_session, which belong to fresh login flows.
     const int authRet = pam_authenticate(handle, 0);
     // Even with correct credentials the account may be unusable (expired,
     // locked, password-change required); gate success on acct_mgmt too.

--- a/libs/phosphor-service-lock/src/pamauthenticator.cpp
+++ b/libs/phosphor-service-lock/src/pamauthenticator.cpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "pamauthenticator.h"
+
+#include <QtConcurrent>
+
+#include <security/pam_appl.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <utility>
+
+namespace PhosphorServiceLock {
+
+namespace {
+
+// Payload handed to the PAM conversation callback: a pointer to the (still
+// owned, null-terminated) password bytes to answer the module's echo-off prompt
+// with. Valid for the synchronous duration of pam_authenticate().
+struct ConvData
+{
+    const char* password = nullptr;
+};
+
+void wipe(QByteArray& bytes)
+{
+    if (!bytes.isEmpty())
+        explicit_bzero(bytes.data(), static_cast<size_t>(bytes.size()));
+}
+
+// PAM conversation callback. PAM drives authentication by sending prompts; for
+// password auth it asks once with PAM_PROMPT_ECHO_OFF, which we answer with the
+// supplied password. PAM takes ownership of (and frees) every `resp` string, so
+// each must be a fresh malloc'd copy.
+int pamConversation(int numMsg, const struct pam_message** msg, struct pam_response** resp, void* appdataPtr)
+{
+    if (numMsg <= 0 || numMsg > PAM_MAX_NUM_MSG || !msg || !resp || !appdataPtr)
+        return PAM_CONV_ERR;
+
+    auto* data = static_cast<ConvData*>(appdataPtr);
+    auto* replies = static_cast<struct pam_response*>(calloc(static_cast<size_t>(numMsg), sizeof(struct pam_response)));
+    if (!replies)
+        return PAM_BUF_ERR;
+
+    const auto unwind = [&](int upTo) {
+        for (int j = 0; j < upTo; ++j) {
+            if (replies[j].resp) {
+                explicit_bzero(replies[j].resp, strlen(replies[j].resp));
+                free(replies[j].resp);
+            }
+        }
+        free(replies);
+    };
+
+    for (int i = 0; i < numMsg; ++i) {
+        switch (msg[i]->msg_style) {
+        case PAM_PROMPT_ECHO_OFF: {
+            // The password prompt. strdup so PAM can free it; on OOM unwind.
+            char* answer = strdup(data->password ? data->password : "");
+            if (!answer) {
+                unwind(i);
+                return PAM_BUF_ERR;
+            }
+            replies[i].resp = answer;
+            replies[i].resp_retcode = 0;
+            break;
+        }
+        case PAM_PROMPT_ECHO_ON:
+            // A visible prompt (e.g. a re-asked username). The user is already
+            // fixed via pam_start, so answer empty.
+            replies[i].resp = strdup("");
+            replies[i].resp_retcode = 0;
+            break;
+        case PAM_ERROR_MSG:
+        case PAM_TEXT_INFO:
+            // Informational; no response. The module may log these itself.
+            replies[i].resp = nullptr;
+            replies[i].resp_retcode = 0;
+            break;
+        default:
+            unwind(i + 1);
+            return PAM_CONV_ERR;
+        }
+    }
+
+    *resp = replies;
+    return PAM_SUCCESS;
+}
+
+QString pamError(pam_handle_t* handle, int code)
+{
+    return QString::fromUtf8(pam_strerror(handle, code));
+}
+
+// Run one full PAM transaction. Takes sole ownership of @p password and wipes
+// its buffer before returning. Never logs the password.
+PamResult runPamTransaction(const QString& service, const QString& username, QByteArray password)
+{
+    ConvData convData{password.constData()}; // constData() does not detach: sole owner is preserved
+    const struct pam_conv conv = {pamConversation, &convData};
+
+    pam_handle_t* handle = nullptr;
+    int ret = pam_start(service.toLocal8Bit().constData(), username.toLocal8Bit().constData(), &conv, &handle);
+    if (ret != PAM_SUCCESS) {
+        const QString reason = pamError(handle, ret);
+        if (handle)
+            pam_end(handle, ret);
+        wipe(password);
+        return {false, reason};
+    }
+
+    const int authRet = pam_authenticate(handle, 0);
+    // Even with correct credentials the account may be unusable (expired,
+    // locked, password-change required); gate success on acct_mgmt too.
+    const int acctRet = (authRet == PAM_SUCCESS) ? pam_acct_mgmt(handle, 0) : authRet;
+
+    const bool success = (authRet == PAM_SUCCESS && acctRet == PAM_SUCCESS);
+    const QString reason = success ? QString() : pamError(handle, authRet != PAM_SUCCESS ? authRet : acctRet);
+
+    pam_end(handle, success ? PAM_SUCCESS : authRet);
+    wipe(password);
+    return {success, reason};
+}
+
+} // namespace
+
+PamAuthenticator::PamAuthenticator(QString service, QObject* parent)
+    : IAuthenticator(parent)
+    , m_service(std::move(service))
+{
+    // QFutureWatcher::finished is delivered on this (the GUI) thread, so reading
+    // the result and emitting here is thread-safe.
+    connect(&m_watcher, &QFutureWatcher<PamResult>::finished, this, [this] {
+        if (m_watcher.future().resultCount() == 0)
+            return; // cancelled / no result
+        const PamResult result = m_watcher.result();
+        if (result.success)
+            Q_EMIT succeeded();
+        else
+            Q_EMIT failed(result.reason);
+    });
+}
+
+PamAuthenticator::~PamAuthenticator() = default;
+
+QString PamAuthenticator::service() const
+{
+    return m_service;
+}
+
+void PamAuthenticator::authenticate(const QString& username, const QString& password)
+{
+    if (m_watcher.isRunning()) {
+        // One transaction at a time: never run two PAM stacks concurrently.
+        Q_EMIT failed(QStringLiteral("authentication already in progress"));
+        return;
+    }
+    if (username.isEmpty()) {
+        Q_EMIT failed(QStringLiteral("no user to authenticate"));
+        return;
+    }
+
+    const QString service = m_service;
+    QByteArray pw = password.toUtf8();
+    // The worker captures only value copies (service, user, and the moved-in
+    // password buffer) — never `this` — so destroying the authenticator
+    // mid-transaction cannot dangle: the watcher disconnects and the detached
+    // task finishes harmlessly. The password buffer is moved through to
+    // runPamTransaction, which is its sole owner and wipes it.
+    m_watcher.setFuture(QtConcurrent::run([service, user = username, pw = std::move(pw)]() mutable -> PamResult {
+        return runPamTransaction(service, user, std::move(pw));
+    }));
+}
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/pamauthenticator.cpp
+++ b/libs/phosphor-service-lock/src/pamauthenticator.cpp
@@ -125,9 +125,13 @@ PamResult runPamTransaction(const QString& service, const QString& username, QBy
     const int acctRet = (authRet == PAM_SUCCESS) ? pam_acct_mgmt(handle, 0) : authRet;
 
     const bool success = (authRet == PAM_SUCCESS && acctRet == PAM_SUCCESS);
-    const QString reason = success ? QString() : pamError(handle, authRet != PAM_SUCCESS ? authRet : acctRet);
+    const int terminalRet = authRet != PAM_SUCCESS ? authRet : acctRet;
+    const QString reason = success ? QString() : pamError(handle, terminalRet);
 
-    pam_end(handle, success ? PAM_SUCCESS : authRet);
+    // pam_end's status should reflect the actual terminal result so modules'
+    // cleanup sees the real outcome (an acct_mgmt failure after a successful
+    // authenticate must not be reported as PAM_SUCCESS).
+    pam_end(handle, terminalRet);
     wipe(password);
     return {success, reason};
 }
@@ -181,7 +185,7 @@ void PamAuthenticator::authenticate(const QString& username, const QString& pass
     const QString service = d->service;
     QByteArray pw = password.toUtf8();
     // The worker captures only value copies (service, user, and the moved-in
-    // password buffer) — never `this` — so destroying the authenticator
+    // password buffer), never `this`, so destroying the authenticator
     // mid-transaction cannot dangle: the watcher disconnects and the detached
     // task finishes harmlessly. The password buffer is moved through to
     // runPamTransaction, which is its sole owner and wipes it.

--- a/libs/phosphor-service-lock/src/pamauthenticator.h
+++ b/libs/phosphor-service-lock/src/pamauthenticator.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include "iauthenticator.h"
+
+#include <QFutureWatcher>
+#include <QString>
+
+namespace PhosphorServiceLock {
+
+/// Result of one PAM transaction, marshalled from the worker thread back to the
+/// GUI thread by the QFutureWatcher.
+struct PamResult
+{
+    bool success = false;
+    QString reason;
+};
+
+/**
+ * @brief IAuthenticator backed by PAM (`pam_authenticate` + `pam_acct_mgmt`).
+ *
+ * Runs the blocking PAM transaction on the global thread pool and delivers the
+ * outcome on the GUI thread, so an authentication stack that sleeps (faildelay,
+ * a network module) never stalls the event loop. One transaction at a time: a
+ * call made while another is outstanding fails fast rather than racing two.
+ *
+ * The PAM service name (which `/etc/pam.d/<service>` stack validates the
+ * password) is configurable; it defaults to `login`, which exists on every
+ * system so the demo authenticates out of the box. A shell would point this at
+ * its own stack.
+ *
+ * Threading: construct and call from the GUI thread.
+ */
+class PamAuthenticator : public IAuthenticator
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(PamAuthenticator)
+
+public:
+    explicit PamAuthenticator(QString service = QStringLiteral("login"), QObject* parent = nullptr);
+    ~PamAuthenticator() override;
+
+    /// The PAM service name (the `/etc/pam.d/<service>` stack) this authenticator
+    /// validates against.
+    [[nodiscard]] QString service() const;
+
+    void authenticate(const QString& username, const QString& password) override;
+
+private:
+    QString m_service;
+    QFutureWatcher<PamResult> m_watcher;
+};
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/qmlregistration.cpp
+++ b/libs/phosphor-service-lock/src/qmlregistration.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorServiceLock/QmlRegistration.h>
+
+#include <PhosphorServiceLock/LockService.h>
+
+#include <QQmlEngine>
+
+#include <mutex>
+
+namespace PhosphorServiceLock {
+
+namespace {
+constexpr int kModuleVersionMajor = 1;
+constexpr int kModuleVersionMinor = 0;
+constexpr const char* kModule = "Phosphor.Service.Lock";
+} // namespace
+
+void registerQmlTypes()
+{
+    // qmlRegister* is process-global, not per-engine. Repeat calls overwrite the
+    // previous registration and Qt logs a duplicate-registration warning. A
+    // hot-reloading shell builds a fresh QQmlEngine per reload and would call
+    // this every time; the call_once guard makes the function safe to invoke
+    // from every engine setup, matching the sibling service-lib pattern.
+    static std::once_flag once;
+    std::call_once(once, [] {
+        // Instantiable host. The shell constructs the service in QML and drives
+        // the lock lifecycle; a plain type, NOT a singleton.
+        qmlRegisterType<LockService>(kModule, kModuleVersionMajor, kModuleVersionMinor, "LockService");
+    });
+}
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/waylandsessionlock.cpp
+++ b/libs/phosphor-service-lock/src/waylandsessionlock.cpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "waylandsessionlock.h"
+
+namespace PhosphorServiceLock {
+
+WaylandSessionLock::WaylandSessionLock(QObject* parent)
+    : ISessionLock(parent)
+{
+    // The device's signals carry the same (empty) payloads as the seam's, so
+    // forward them directly rather than through relay lambdas.
+    connect(&m_lock, &PhosphorWayland::SessionLock::locked, this, &ISessionLock::locked);
+    connect(&m_lock, &PhosphorWayland::SessionLock::finished, this, &ISessionLock::finished);
+}
+
+void WaylandSessionLock::lock()
+{
+    m_lock.lock();
+}
+
+void WaylandSessionLock::unlockAndDestroy()
+{
+    m_lock.unlockAndDestroy();
+}
+
+bool WaylandSessionLock::isLocked() const
+{
+    return m_lock.isLocked();
+}
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/src/waylandsessionlock.h
+++ b/libs/phosphor-service-lock/src/waylandsessionlock.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+// Internal (not installed) ISessionLock backed by the foundation
+// ext-session-lock-v1 client. The production state machine wires this to the
+// compositor; it forwards PhosphorWayland::SessionLock's locked / finished
+// signals into the seam and delegates the lock / unlock requests.
+
+#include "isessionlock.h"
+
+#include <PhosphorWayland/SessionLock.h>
+
+namespace PhosphorServiceLock {
+
+class WaylandSessionLock : public ISessionLock
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(WaylandSessionLock)
+
+public:
+    explicit WaylandSessionLock(QObject* parent = nullptr);
+
+    void lock() override;
+    void unlockAndDestroy() override;
+    [[nodiscard]] bool isLocked() const override;
+
+private:
+    PhosphorWayland::SessionLock m_lock;
+};
+
+} // namespace PhosphorServiceLock

--- a/libs/phosphor-service-lock/tests/CMakeLists.txt
+++ b/libs/phosphor-service-lock/tests/CMakeLists.txt
@@ -24,33 +24,12 @@ endfunction()
 # CLI demo as they land.
 _phosphorservicelock_test(test_phosphorservicelock_smoke test_smoke.cpp)
 
-# PAM authenticator unit test: compiles the internal authenticator sources
-# directly (they are not exported) and links PAM + Concurrent, so it needs no
-# compositor and the internal classes stay unexported. Exercises the
-# credential-free contract; authenticating a valid user is left to the CLI demo.
-add_executable(test_phosphorservicelock_pam
-    test_pamauthenticator.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../src/pamauthenticator.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../src/iauthenticator.cpp
-)
-target_include_directories(test_phosphorservicelock_pam
-    PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../src
-        ${CMAKE_CURRENT_BINARY_DIR}/..
-        ${PAM_INCLUDE_DIR}
-)
-target_link_libraries(test_phosphorservicelock_pam
-    PRIVATE
-        Qt6::Test
-        Qt6::Concurrent
-        ${PAM_LIBRARY}
-)
-add_test(NAME test_phosphorservicelock_pam COMMAND test_phosphorservicelock_pam)
-set_tests_properties(test_phosphorservicelock_pam
-    PROPERTIES
-        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
-        LABELS "phosphorservicelock"
-)
+# PAM authenticator unit test: links the lib and exercises the public
+# PamAuthenticator's credential-free contract (configured service, fast-fail on
+# bad input, the concurrency guard, and that a nonexistent user is rejected
+# through the real off-thread PAM path). Authenticating a valid user needs real
+# credentials and is left to the CLI demo.
+_phosphorservicelock_test(test_phosphorservicelock_pam test_pamauthenticator.cpp)
 
 # Lock state-machine unit test: compiles the internal state machine + seams
 # directly (no lib link, no PAM, no compositor) and drives them with fakes, so
@@ -60,6 +39,9 @@ add_executable(test_phosphorservicelock_statemachine
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/lockstatemachine.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/isessionlock.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/iauthenticator.cpp
+    # Listed so AUTOMOC generates the IAuthenticator metaobject: its source file
+    # name (iauthenticator.cpp) does not match the public header (IAuthenticator.h).
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/PhosphorServiceLock/IAuthenticator.h
 )
 target_include_directories(test_phosphorservicelock_statemachine
     PRIVATE

--- a/libs/phosphor-service-lock/tests/CMakeLists.txt
+++ b/libs/phosphor-service-lock/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 fuddlesworth
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-find_package(Qt6 6.6 REQUIRED COMPONENTS Test)
+find_package(Qt6 6.6 REQUIRED COMPONENTS Test Concurrent)
 
 function(_phosphorservicelock_test target source)
     add_executable(${target} ${source})
@@ -23,3 +23,31 @@ endfunction()
 # authenticator and lock state machine are exercised by the unit tests and the
 # CLI demo as they land.
 _phosphorservicelock_test(test_phosphorservicelock_smoke test_smoke.cpp)
+
+# PAM authenticator unit test: compiles the internal authenticator sources
+# directly (they are not exported) and links PAM + Concurrent, so it needs no
+# compositor and the internal classes stay unexported. Exercises the
+# credential-free contract; authenticating a valid user is left to the CLI demo.
+add_executable(test_phosphorservicelock_pam
+    test_pamauthenticator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/pamauthenticator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/iauthenticator.cpp
+)
+target_include_directories(test_phosphorservicelock_pam
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src
+        ${CMAKE_CURRENT_BINARY_DIR}/..
+        ${PAM_INCLUDE_DIR}
+)
+target_link_libraries(test_phosphorservicelock_pam
+    PRIVATE
+        Qt6::Test
+        Qt6::Concurrent
+        ${PAM_LIBRARY}
+)
+add_test(NAME test_phosphorservicelock_pam COMMAND test_phosphorservicelock_pam)
+set_tests_properties(test_phosphorservicelock_pam
+    PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+        LABELS "phosphorservicelock"
+)

--- a/libs/phosphor-service-lock/tests/CMakeLists.txt
+++ b/libs/phosphor-service-lock/tests/CMakeLists.txt
@@ -24,6 +24,11 @@ endfunction()
 # CLI demo as they land.
 _phosphorservicelock_test(test_phosphorservicelock_smoke test_smoke.cpp)
 
+# QML facade test: a real QQmlEngine imports the module and proves the imperative
+# registration yields a usable facade (LockService instantiates, its supported /
+# state / locked surface reads through QML, and the invokables run).
+_phosphorservicelock_test(test_phosphorservicelock_qmlfacade test_qmlfacade.cpp)
+
 # PAM authenticator unit test: links the lib and exercises the public
 # PamAuthenticator's credential-free contract (configured service, fast-fail on
 # bad input, the concurrency guard, and that a nonexistent user is rejected

--- a/libs/phosphor-service-lock/tests/CMakeLists.txt
+++ b/libs/phosphor-service-lock/tests/CMakeLists.txt
@@ -51,3 +51,26 @@ set_tests_properties(test_phosphorservicelock_pam
         ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
         LABELS "phosphorservicelock"
 )
+
+# Lock state-machine unit test: compiles the internal state machine + seams
+# directly (no lib link, no PAM, no compositor) and drives them with fakes, so
+# the lock policy is exercised deterministically.
+add_executable(test_phosphorservicelock_statemachine
+    test_statemachine.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/lockstatemachine.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/isessionlock.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/iauthenticator.cpp
+)
+target_include_directories(test_phosphorservicelock_statemachine
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src
+        ${CMAKE_CURRENT_SOURCE_DIR}/../include
+        ${CMAKE_CURRENT_BINARY_DIR}/..
+)
+target_link_libraries(test_phosphorservicelock_statemachine PRIVATE Qt6::Test)
+add_test(NAME test_phosphorservicelock_statemachine COMMAND test_phosphorservicelock_statemachine)
+set_tests_properties(test_phosphorservicelock_statemachine
+    PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+        LABELS "phosphorservicelock"
+)

--- a/libs/phosphor-service-lock/tests/CMakeLists.txt
+++ b/libs/phosphor-service-lock/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 fuddlesworth
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-find_package(Qt6 6.6 REQUIRED COMPONENTS Test Concurrent)
+find_package(Qt6 6.6 REQUIRED COMPONENTS Test)
 
 function(_phosphorservicelock_test target source)
     add_executable(${target} ${source})

--- a/libs/phosphor-service-lock/tests/CMakeLists.txt
+++ b/libs/phosphor-service-lock/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Test)
+
+function(_phosphorservicelock_test target source)
+    add_executable(${target} ${source})
+    target_link_libraries(${target}
+        PRIVATE
+            Qt6::Test
+            PhosphorServiceLock::PhosphorServiceLock
+    )
+    add_test(NAME ${target} COMMAND ${target})
+    set_tests_properties(${target}
+        PROPERTIES
+            ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+            LABELS "phosphorservicelock"
+    )
+endfunction()
+
+# Smoke test: exercises the deterministic facade contract (QML-registration
+# idempotency and inert construction with no live compositor). The PAM
+# authenticator and lock state machine are exercised by the unit tests and the
+# CLI demo as they land.
+_phosphorservicelock_test(test_phosphorservicelock_smoke test_smoke.cpp)

--- a/libs/phosphor-service-lock/tests/test_pamauthenticator.cpp
+++ b/libs/phosphor-service-lock/tests/test_pamauthenticator.cpp
@@ -69,6 +69,10 @@ void PamAuthenticatorTest::busyRejectsConcurrentCall()
 
     // The first call starts a real (bogus-user) transaction; the second, issued
     // before it completes, must fail fast rather than run two PAM stacks at once.
+    // QtConcurrent::run marks the future Running synchronously at setFuture(), so
+    // the busy guard (isRunning()) sees it on the immediately-following second
+    // call regardless of how fast the worker runs; PAM's faildelay only widens
+    // the window further.
     const QString user = QStringLiteral("phosphor-no-such-user-2f1a9c");
     auth.authenticate(user, QStringLiteral("x"));
 

--- a/libs/phosphor-service-lock/tests/test_pamauthenticator.cpp
+++ b/libs/phosphor-service-lock/tests/test_pamauthenticator.cpp
@@ -21,6 +21,7 @@ class PamAuthenticatorTest : public QObject
 private Q_SLOTS:
     void exposesConfiguredService();
     void emptyUsernameFailsImmediately();
+    void emptyPasswordStillReachesPam();
     void busyRejectsConcurrentCall();
     void nonexistentUserIsRejected();
 };
@@ -46,6 +47,21 @@ void PamAuthenticatorTest::emptyUsernameFailsImmediately()
     QCOMPARE(okSpy.count(), 0);
 }
 
+void PamAuthenticatorTest::emptyPasswordStillReachesPam()
+{
+    PamAuthenticator auth;
+    QSignalSpy okSpy(&auth, &IAuthenticator::succeeded);
+    QSignalSpy failSpy(&auth, &IAuthenticator::failed);
+
+    // A non-empty username with an empty password is NOT short-circuited (only an
+    // empty username is): it reaches the real PAM stack and is rejected there.
+    auth.authenticate(QStringLiteral("phosphor-no-such-user-1c4e"), QString());
+    QVERIFY(failSpy.wait(20000));
+    QCOMPARE(okSpy.count(), 0);
+    QCOMPARE(failSpy.count(), 1);
+    QVERIFY(!failSpy.at(0).at(0).toString().isEmpty());
+}
+
 void PamAuthenticatorTest::busyRejectsConcurrentCall()
 {
     PamAuthenticator auth;
@@ -55,10 +71,13 @@ void PamAuthenticatorTest::busyRejectsConcurrentCall()
     // before it completes, must fail fast rather than run two PAM stacks at once.
     const QString user = QStringLiteral("phosphor-no-such-user-2f1a9c");
     auth.authenticate(user, QStringLiteral("x"));
-    auth.authenticate(user, QStringLiteral("y"));
 
-    // The synchronous "already in progress" rejection is the first failure seen.
-    QVERIFY(failSpy.count() >= 1);
+    // The second call is rejected synchronously (the worker is still running, held
+    // by PAM's faildelay), so exactly one new failure appears immediately and it
+    // carries the in-progress reason.
+    QCOMPARE(failSpy.count(), 0);
+    auth.authenticate(user, QStringLiteral("y"));
+    QCOMPARE(failSpy.count(), 1);
     QCOMPARE(failSpy.at(0).at(0).toString(), QStringLiteral("authentication already in progress"));
 
     // Drain the async result of the first call so the watcher is idle at teardown.

--- a/libs/phosphor-service-lock/tests/test_pamauthenticator.cpp
+++ b/libs/phosphor-service-lock/tests/test_pamauthenticator.cpp
@@ -7,7 +7,7 @@
 // rejected (never accepted) through the real off-thread PAM path. Authenticating
 // a VALID user needs real credentials and is exercised by the CLI demo.
 
-#include "pamauthenticator.h"
+#include <PhosphorServiceLock/PamAuthenticator.h>
 
 #include <QSignalSpy>
 #include <QTest>

--- a/libs/phosphor-service-lock/tests/test_pamauthenticator.cpp
+++ b/libs/phosphor-service-lock/tests/test_pamauthenticator.cpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Unit test for the PAM-backed authenticator. The deterministic, credential-free
+// contract is exercised here: configured service name, fast-fail on bad input,
+// the one-transaction-at-a-time guard, and that a definitely-nonexistent user is
+// rejected (never accepted) through the real off-thread PAM path. Authenticating
+// a VALID user needs real credentials and is exercised by the CLI demo.
+
+#include "pamauthenticator.h"
+
+#include <QSignalSpy>
+#include <QTest>
+
+using namespace PhosphorServiceLock;
+
+class PamAuthenticatorTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void exposesConfiguredService();
+    void emptyUsernameFailsImmediately();
+    void busyRejectsConcurrentCall();
+    void nonexistentUserIsRejected();
+};
+
+void PamAuthenticatorTest::exposesConfiguredService()
+{
+    PamAuthenticator defaulted;
+    QCOMPARE(defaulted.service(), QStringLiteral("login")); // documented default
+
+    PamAuthenticator custom(QStringLiteral("phosphor-lock"));
+    QCOMPARE(custom.service(), QStringLiteral("phosphor-lock"));
+}
+
+void PamAuthenticatorTest::emptyUsernameFailsImmediately()
+{
+    PamAuthenticator auth;
+    QSignalSpy okSpy(&auth, &IAuthenticator::succeeded);
+    QSignalSpy failSpy(&auth, &IAuthenticator::failed);
+
+    // No user: rejected synchronously, no PAM transaction started.
+    auth.authenticate(QString(), QStringLiteral("irrelevant"));
+    QCOMPARE(failSpy.count(), 1);
+    QCOMPARE(okSpy.count(), 0);
+}
+
+void PamAuthenticatorTest::busyRejectsConcurrentCall()
+{
+    PamAuthenticator auth;
+    QSignalSpy failSpy(&auth, &IAuthenticator::failed);
+
+    // The first call starts a real (bogus-user) transaction; the second, issued
+    // before it completes, must fail fast rather than run two PAM stacks at once.
+    const QString user = QStringLiteral("phosphor-no-such-user-2f1a9c");
+    auth.authenticate(user, QStringLiteral("x"));
+    auth.authenticate(user, QStringLiteral("y"));
+
+    // The synchronous "already in progress" rejection is the first failure seen.
+    QVERIFY(failSpy.count() >= 1);
+    QCOMPARE(failSpy.at(0).at(0).toString(), QStringLiteral("authentication already in progress"));
+
+    // Drain the async result of the first call so the watcher is idle at teardown.
+    QTRY_VERIFY_WITH_TIMEOUT(failSpy.count() >= 2, 20000);
+}
+
+void PamAuthenticatorTest::nonexistentUserIsRejected()
+{
+    PamAuthenticator auth;
+    QSignalSpy okSpy(&auth, &IAuthenticator::succeeded);
+    QSignalSpy failSpy(&auth, &IAuthenticator::failed);
+
+    // A user that cannot exist is rejected through the real off-thread PAM path:
+    // exactly one failed(), never succeeded(), and the event loop is never
+    // blocked while PAM (with its faildelay) runs.
+    auth.authenticate(QStringLiteral("phosphor-no-such-user-8b3d07e"), QStringLiteral("whatever"));
+    QVERIFY(failSpy.wait(20000));
+    QCOMPARE(okSpy.count(), 0);
+    QCOMPARE(failSpy.count(), 1);
+    QVERIFY(!failSpy.at(0).at(0).toString().isEmpty()); // a non-empty, human-readable reason
+}
+
+QTEST_GUILESS_MAIN(PamAuthenticatorTest)
+#include "test_pamauthenticator.moc"

--- a/libs/phosphor-service-lock/tests/test_qmlfacade.cpp
+++ b/libs/phosphor-service-lock/tests/test_qmlfacade.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// QML facade test for phosphor-service-lock. Proves the imperative registration
+// produces a usable QML module: a real QQmlEngine imports Phosphor.Service.Lock
+// 1.0, instantiates a LockService, reads its supported / state / locked surface,
+// and drives its invokables. With no live compositor (offscreen QPA) the service
+// is unsupported; the compositor-driven lock path is exercised by the state
+// machine test and the CLI demo.
+
+#include <PhosphorServiceLock/LockService.h>
+#include <PhosphorServiceLock/QmlRegistration.h>
+
+#include <QMetaObject>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QTest>
+
+#include <memory>
+
+using namespace PhosphorServiceLock;
+using State = LockService::State;
+
+namespace {
+constexpr auto kQml = R"(
+import QtQml
+import Phosphor.Service.Lock 1.0
+
+QtObject {
+    id: root
+    property LockService service: LockService {}
+    readonly property bool serviceSupported: root.service.supported
+    readonly property int serviceState: root.service.state
+    readonly property bool serviceLocked: root.service.locked
+}
+)";
+
+int n(State s)
+{
+    return static_cast<int>(s);
+}
+} // namespace
+
+class LockQmlFacadeTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        registerQmlTypes();
+    }
+    void moduleLoadsAndServiceBinds();
+    void invokablesAreCallable();
+
+private:
+    static std::unique_ptr<QObject> create(QQmlComponent& component)
+    {
+        component.setData(kQml, QUrl(QStringLiteral("qrc:/test_lock_facade.qml")));
+        return std::unique_ptr<QObject>(component.create());
+    }
+};
+
+void LockQmlFacadeTest::moduleLoadsAndServiceBinds()
+{
+    QQmlEngine engine;
+    QQmlComponent component(&engine);
+    std::unique_ptr<QObject> root = create(component);
+    QVERIFY2(root != nullptr, qPrintable(component.errorString())); // module + types resolved
+
+    // Under the offscreen platform there is no compositor, so the service is
+    // unsupported and starts in the Unlocked state.
+    QCOMPARE(root->property("serviceSupported").toBool(), false);
+    QCOMPARE(root->property("serviceState").toInt(), n(State::Unlocked));
+    QCOMPARE(root->property("serviceLocked").toBool(), false);
+}
+
+void LockQmlFacadeTest::invokablesAreCallable()
+{
+    QQmlEngine engine;
+    QQmlComponent component(&engine);
+    std::unique_ptr<QObject> root = create(component);
+    QVERIFY2(root != nullptr, qPrintable(component.errorString()));
+
+    QObject* service = qvariant_cast<QObject*>(root->property("service"));
+    QVERIFY(service != nullptr);
+
+    // unlock() before the session is locked is a safe no-op: no authentication
+    // is attempted and the state is unchanged.
+    QVERIFY(QMetaObject::invokeMethod(service, "unlock", Q_ARG(QString, QStringLiteral("irrelevant"))));
+    QCOMPARE(service->property("state").toInt(), n(State::Unlocked));
+    QCOMPARE(service->property("locked").toBool(), false);
+
+    // lock() requests a lock; with no compositor to reply, the service settles in
+    // Locking (and is not yet "locked", which only holds from Locked onward).
+    QVERIFY(QMetaObject::invokeMethod(service, "lock"));
+    QCOMPARE(service->property("state").toInt(), n(State::Locking));
+    QCOMPARE(service->property("locked").toBool(), false);
+}
+
+QTEST_GUILESS_MAIN(LockQmlFacadeTest)
+#include "test_qmlfacade.moc"

--- a/libs/phosphor-service-lock/tests/test_smoke.cpp
+++ b/libs/phosphor-service-lock/tests/test_smoke.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Smoke test for phosphor-service-lock. Pins the deterministic plumbing
+// contract: QML-registration idempotency and inert construction. With no live
+// compositor (offscreen QPA) the session-lock protocol is unavailable, so the
+// service constructs, reports unsupported, and never crashes. The PAM
+// authentication and the lock state machine are unit-tested separately; the live
+// lock path needs a real compositor and is exercised via the CLI demo.
+
+#include <PhosphorServiceLock/LockService.h>
+#include <PhosphorServiceLock/QmlRegistration.h>
+
+#include <QTest>
+
+using namespace PhosphorServiceLock;
+
+class LockSmokeTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void registerQmlTypesIsIdempotent();
+    void constructsInert();
+    void supportedIsQueryableWithoutCompositor();
+};
+
+void LockSmokeTest::registerQmlTypesIsIdempotent()
+{
+    // The std::call_once guard must make a second call a no-op (no crash, no
+    // duplicate-registration fault). A hot-reloading shell relies on this.
+    registerQmlTypes();
+    registerQmlTypes();
+}
+
+void LockSmokeTest::constructsInert()
+{
+    // Constructing without a live compositor must not crash; the service simply
+    // cannot lock.
+    LockService service;
+    Q_UNUSED(service);
+}
+
+void LockSmokeTest::supportedIsQueryableWithoutCompositor()
+{
+    // Under the offscreen platform there is no Wayland session, so the
+    // session-lock protocol is unavailable and the query reports false.
+    LockService service;
+    QVERIFY(!service.isSupported());
+}
+
+QTEST_GUILESS_MAIN(LockSmokeTest)
+#include "test_smoke.moc"

--- a/libs/phosphor-service-lock/tests/test_statemachine.cpp
+++ b/libs/phosphor-service-lock/tests/test_statemachine.cpp
@@ -10,8 +10,9 @@
 
 #include "lockstatemachine.h"
 
-#include "iauthenticator.h"
 #include "isessionlock.h"
+
+#include <PhosphorServiceLock/IAuthenticator.h>
 
 #include <QSignalSpy>
 #include <QTest>

--- a/libs/phosphor-service-lock/tests/test_statemachine.cpp
+++ b/libs/phosphor-service-lock/tests/test_statemachine.cpp
@@ -24,7 +24,7 @@ namespace {
 
 // QCOMPARE on the scoped Q_ENUM State would instantiate
 // QMetaEnum::fromType<LockService::State>, which needs LockService's metaobject
-// — not linked into this seam-only test. Compare the underlying values instead.
+// (not linked into this seam-only test). Compare the underlying values instead.
 int n(State s)
 {
     return static_cast<int>(s);
@@ -105,6 +105,8 @@ private Q_SLOTS:
     void successfulAuthUnlocks();
     void failedAuthReturnsToLocked();
     void compositorEndWhileLockedUnlocks();
+    void compositorEndWhileAuthenticatingUnlocks();
+    void staleAuthResultAfterResetIsIgnored();
     void concurrentAuthenticateIgnored();
 };
 
@@ -244,10 +246,55 @@ void LockStateMachineTest::concurrentAuthenticateIgnored()
     QCOMPARE(n(machine.state()), n(State::Authenticating));
     QCOMPARE(auth.calls, 1);
 
-    // A second attempt while one is outstanding must not start another.
+    QSignalSpy stateSpy(&machine, &LockStateMachine::stateChanged);
+    // A second attempt while one is outstanding must not start another, nor emit
+    // a spurious state change.
     machine.authenticate(QStringLiteral("second"));
     QCOMPARE(auth.calls, 1);
     QCOMPARE(n(machine.state()), n(State::Authenticating));
+    QCOMPARE(stateSpy.count(), 0);
+}
+
+void LockStateMachineTest::compositorEndWhileAuthenticatingUnlocks()
+{
+    FakeSessionLock lock;
+    FakeAuthenticator auth;
+    LockStateMachine machine(&lock, &auth, QStringLiteral("testuser"));
+
+    machine.requestLock();
+    lock.grant();
+    machine.authenticate(QStringLiteral("pw"));
+    QCOMPARE(n(machine.state()), n(State::Authenticating));
+
+    // The compositor ends the lock mid-authentication (its own recovery path):
+    // the session returns to Unlocked even with an attempt outstanding.
+    lock.end();
+    QCOMPARE(n(machine.state()), n(State::Unlocked));
+    QCOMPARE(lock.unlockCalls, 0); // finished() tore the lock down; we don't unlock_and_destroy
+}
+
+void LockStateMachineTest::staleAuthResultAfterResetIsIgnored()
+{
+    FakeSessionLock lock;
+    FakeAuthenticator auth;
+    LockStateMachine machine(&lock, &auth, QStringLiteral("testuser"));
+    QSignalSpy unlockedSpy(&machine, &LockStateMachine::unlocked);
+
+    machine.requestLock();
+    lock.grant();
+    machine.authenticate(QStringLiteral("pw"));
+    QCOMPARE(n(machine.state()), n(State::Authenticating));
+
+    // The compositor ends the lock first, resetting to Unlocked.
+    lock.end();
+    QCOMPARE(n(machine.state()), n(State::Unlocked));
+
+    // A now-stale success from the in-flight attempt must NOT unlock a session
+    // that is already unlocked: the Authenticating guard drops it.
+    auth.resolveSuccess();
+    QCOMPARE(n(machine.state()), n(State::Unlocked));
+    QCOMPARE(lock.unlockCalls, 0);
+    QCOMPARE(unlockedSpy.count(), 0);
 }
 
 QTEST_GUILESS_MAIN(LockStateMachineTest)

--- a/libs/phosphor-service-lock/tests/test_statemachine.cpp
+++ b/libs/phosphor-service-lock/tests/test_statemachine.cpp
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Unit test for the lock state machine. It drives the machine with a fake
+// session lock and a fake authenticator that deliver the locked / finished /
+// succeeded / failed edges directly, so the whole policy (request -> locked ->
+// authenticate -> unlock, with auth-failure retry, the locked-only authenticate
+// guard, and compositor-driven teardown) is exercised deterministically with no
+// live compositor and no PAM stack.
+
+#include "lockstatemachine.h"
+
+#include "iauthenticator.h"
+#include "isessionlock.h"
+
+#include <QSignalSpy>
+#include <QTest>
+
+using namespace PhosphorServiceLock;
+using State = LockService::State;
+
+namespace {
+
+// QCOMPARE on the scoped Q_ENUM State would instantiate
+// QMetaEnum::fromType<LockService::State>, which needs LockService's metaobject
+// — not linked into this seam-only test. Compare the underlying values instead.
+int n(State s)
+{
+    return static_cast<int>(s);
+}
+
+class FakeSessionLock : public ISessionLock
+{
+public:
+    void lock() override
+    {
+        ++lockCalls;
+    }
+    void unlockAndDestroy() override
+    {
+        ++unlockCalls;
+        m_locked = false;
+    }
+    [[nodiscard]] bool isLocked() const override
+    {
+        return m_locked;
+    }
+
+    // Test drivers simulating the compositor.
+    void grant()
+    {
+        m_locked = true;
+        Q_EMIT locked();
+    }
+    void end()
+    {
+        m_locked = false;
+        Q_EMIT finished();
+    }
+
+    int lockCalls = 0;
+    int unlockCalls = 0;
+
+private:
+    bool m_locked = false;
+};
+
+class FakeAuthenticator : public IAuthenticator
+{
+public:
+    void authenticate(const QString& username, const QString& password) override
+    {
+        ++calls;
+        lastUser = username;
+        lastPassword = password;
+    }
+
+    // Test drivers resolving the outstanding attempt.
+    void resolveSuccess()
+    {
+        Q_EMIT succeeded();
+    }
+    void resolveFailure(const QString& reason = QStringLiteral("incorrect password"))
+    {
+        Q_EMIT failed(reason);
+    }
+
+    int calls = 0;
+    QString lastUser;
+    QString lastPassword;
+};
+
+} // namespace
+
+class LockStateMachineTest : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void startsUnlocked();
+    void requestLockReachesLocked();
+    void lockRefusalReturnsToUnlocked();
+    void authenticateIgnoredUntilLocked();
+    void successfulAuthUnlocks();
+    void failedAuthReturnsToLocked();
+    void compositorEndWhileLockedUnlocks();
+    void concurrentAuthenticateIgnored();
+};
+
+void LockStateMachineTest::startsUnlocked()
+{
+    FakeSessionLock lock;
+    FakeAuthenticator auth;
+    LockStateMachine machine(&lock, &auth, QStringLiteral("testuser"));
+    QCOMPARE(n(machine.state()), n(State::Unlocked));
+}
+
+void LockStateMachineTest::requestLockReachesLocked()
+{
+    FakeSessionLock lock;
+    FakeAuthenticator auth;
+    LockStateMachine machine(&lock, &auth, QStringLiteral("testuser"));
+    QSignalSpy stateSpy(&machine, &LockStateMachine::stateChanged);
+
+    machine.requestLock();
+    QCOMPARE(n(machine.state()), n(State::Locking));
+    QCOMPARE(lock.lockCalls, 1);
+
+    lock.grant();
+    QCOMPARE(n(machine.state()), n(State::Locked));
+    QCOMPARE(stateSpy.count(), 2); // Unlocked->Locking->Locked
+
+    // A second requestLock while locked is a no-op.
+    machine.requestLock();
+    QCOMPARE(lock.lockCalls, 1);
+    QCOMPARE(stateSpy.count(), 2);
+}
+
+void LockStateMachineTest::lockRefusalReturnsToUnlocked()
+{
+    FakeSessionLock lock;
+    FakeAuthenticator auth;
+    LockStateMachine machine(&lock, &auth, QStringLiteral("testuser"));
+
+    machine.requestLock();
+    QCOMPARE(n(machine.state()), n(State::Locking));
+    // The compositor refuses (another locker owns the session).
+    lock.end();
+    QCOMPARE(n(machine.state()), n(State::Unlocked));
+}
+
+void LockStateMachineTest::authenticateIgnoredUntilLocked()
+{
+    FakeSessionLock lock;
+    FakeAuthenticator auth;
+    LockStateMachine machine(&lock, &auth, QStringLiteral("testuser"));
+
+    // Unlocked: nothing to authenticate against.
+    machine.authenticate(QStringLiteral("pw"));
+    QCOMPARE(auth.calls, 0);
+    QCOMPARE(n(machine.state()), n(State::Unlocked));
+
+    // Locking (awaiting the compositor): still too early.
+    machine.requestLock();
+    machine.authenticate(QStringLiteral("pw"));
+    QCOMPARE(auth.calls, 0);
+    QCOMPARE(n(machine.state()), n(State::Locking));
+}
+
+void LockStateMachineTest::successfulAuthUnlocks()
+{
+    FakeSessionLock lock;
+    FakeAuthenticator auth;
+    LockStateMachine machine(&lock, &auth, QStringLiteral("testuser"));
+    QSignalSpy unlockedSpy(&machine, &LockStateMachine::unlocked);
+
+    machine.requestLock();
+    lock.grant();
+    QCOMPARE(n(machine.state()), n(State::Locked));
+
+    machine.authenticate(QStringLiteral("hunter2"));
+    QCOMPARE(n(machine.state()), n(State::Authenticating));
+    QCOMPARE(auth.calls, 1);
+    QCOMPARE(auth.lastUser, QStringLiteral("testuser")); // the session user, not the password
+    QCOMPARE(auth.lastPassword, QStringLiteral("hunter2"));
+
+    auth.resolveSuccess();
+    QCOMPARE(n(machine.state()), n(State::Unlocked));
+    QCOMPARE(lock.unlockCalls, 1); // the compositor lock was released
+    QCOMPARE(unlockedSpy.count(), 1);
+}
+
+void LockStateMachineTest::failedAuthReturnsToLocked()
+{
+    FakeSessionLock lock;
+    FakeAuthenticator auth;
+    LockStateMachine machine(&lock, &auth, QStringLiteral("testuser"));
+    QSignalSpy failSpy(&machine, &LockStateMachine::authenticationFailed);
+    QSignalSpy unlockedSpy(&machine, &LockStateMachine::unlocked);
+
+    machine.requestLock();
+    lock.grant();
+    machine.authenticate(QStringLiteral("wrong"));
+    QCOMPARE(n(machine.state()), n(State::Authenticating));
+
+    auth.resolveFailure(QStringLiteral("incorrect password"));
+    QCOMPARE(n(machine.state()), n(State::Locked)); // stays locked, ready to retry
+    QCOMPARE(lock.unlockCalls, 0); // the session was NOT unlocked
+    QCOMPARE(unlockedSpy.count(), 0);
+    QCOMPARE(failSpy.count(), 1);
+    QCOMPARE(failSpy.at(0).at(0).toString(), QStringLiteral("incorrect password"));
+
+    // A retry after failure is accepted.
+    machine.authenticate(QStringLiteral("hunter2"));
+    QCOMPARE(n(machine.state()), n(State::Authenticating));
+    QCOMPARE(auth.calls, 2);
+}
+
+void LockStateMachineTest::compositorEndWhileLockedUnlocks()
+{
+    FakeSessionLock lock;
+    FakeAuthenticator auth;
+    LockStateMachine machine(&lock, &auth, QStringLiteral("testuser"));
+
+    machine.requestLock();
+    lock.grant();
+    QCOMPARE(n(machine.state()), n(State::Locked));
+
+    // The compositor ends the lock itself (its own secure recovery path).
+    lock.end();
+    QCOMPARE(n(machine.state()), n(State::Unlocked));
+}
+
+void LockStateMachineTest::concurrentAuthenticateIgnored()
+{
+    FakeSessionLock lock;
+    FakeAuthenticator auth;
+    LockStateMachine machine(&lock, &auth, QStringLiteral("testuser"));
+
+    machine.requestLock();
+    lock.grant();
+    machine.authenticate(QStringLiteral("first"));
+    QCOMPARE(n(machine.state()), n(State::Authenticating));
+    QCOMPARE(auth.calls, 1);
+
+    // A second attempt while one is outstanding must not start another.
+    machine.authenticate(QStringLiteral("second"));
+    QCOMPARE(auth.calls, 1);
+    QCOMPARE(n(machine.state()), n(State::Authenticating));
+}
+
+QTEST_GUILESS_MAIN(LockStateMachineTest)
+#include "test_statemachine.moc"

--- a/libs/phosphor-wayland/CMakeLists.txt
+++ b/libs/phosphor-wayland/CMakeLists.txt
@@ -144,6 +144,19 @@ add_custom_command(
     COMMENT "PhosphorWayland: generating wlr-data-control protocol code"
 )
 
+add_custom_command(
+    OUTPUT ${_ps_gen_dir}/ext-session-lock-v1-client-protocol.h
+           ${_ps_gen_dir}/ext-session-lock-v1-protocol.c
+    COMMAND ${WAYLAND_SCANNER} client-header
+            ${_ps_proto_dir}/ext-session-lock-v1.xml
+            ${_ps_gen_dir}/ext-session-lock-v1-client-protocol.h
+    COMMAND ${WAYLAND_SCANNER} private-code
+            ${_ps_proto_dir}/ext-session-lock-v1.xml
+            ${_ps_gen_dir}/ext-session-lock-v1-protocol.c
+    DEPENDS ${_ps_proto_dir}/ext-session-lock-v1.xml
+    COMMENT "PhosphorWayland: generating ext-session-lock protocol code"
+)
+
 # Generated C code: skip PCH and unity build
 set_source_files_properties(
     ${_ps_gen_dir}/wlr-layer-shell-unstable-v1-protocol.c
@@ -153,6 +166,7 @@ set_source_files_properties(
     ${_ps_gen_dir}/wlr-foreign-toplevel-management-unstable-v1-protocol.c
     ${_ps_gen_dir}/zwp-idle-inhibit-v1-protocol.c
     ${_ps_gen_dir}/wlr-data-control-unstable-v1-protocol.c
+    ${_ps_gen_dir}/ext-session-lock-v1-protocol.c
     src/qpa/xdg_popup_stub.c
     src/qpa/xdg_toplevel_stub.c
     PROPERTIES
@@ -174,6 +188,7 @@ set(phosphorwayland_public_HDRS
     include/PhosphorWayland/IdleInhibitor.h
     include/PhosphorWayland/CompositorLost.h
     include/PhosphorWayland/ClipboardDevice.h
+    include/PhosphorWayland/SessionLock.h
 )
 
 # --- Layer-shell sources ---
@@ -185,6 +200,7 @@ set(phosphorwayland_layershell_SRCS
     src/foreigntoplevel.cpp
     src/idleinhibitor.cpp
     src/clipboarddevice.cpp
+    src/sessionlock.cpp
     src/compositorlost.cpp
     src/compositorlost_internal.h
     src/qpa/layershellintegration.cpp
@@ -200,6 +216,7 @@ set(phosphorwayland_layershell_SRCS
     ${_ps_gen_dir}/wlr-foreign-toplevel-management-unstable-v1-protocol.c
     ${_ps_gen_dir}/zwp-idle-inhibit-v1-protocol.c
     ${_ps_gen_dir}/wlr-data-control-unstable-v1-protocol.c
+    ${_ps_gen_dir}/ext-session-lock-v1-protocol.c
 )
 
 add_library(PhosphorWayland SHARED

--- a/libs/phosphor-wayland/include/PhosphorWayland/PhosphorWayland.h
+++ b/libs/phosphor-wayland/include/PhosphorWayland/PhosphorWayland.h
@@ -15,5 +15,6 @@
 #include <PhosphorWayland/CompositorLost.h>
 #include <PhosphorWayland/IdleNotifier.h>
 #include <PhosphorWayland/LayerSurface.h>
+#include <PhosphorWayland/SessionLock.h>
 #include <PhosphorWayland/SinglePixelBuffer.h>
 #include <PhosphorWayland/ToplevelDrag.h>

--- a/libs/phosphor-wayland/include/PhosphorWayland/SessionLock.h
+++ b/libs/phosphor-wayland/include/PhosphorWayland/SessionLock.h
@@ -22,7 +22,7 @@ namespace PhosphorWayland {
  * session). On a successful authentication the owner calls `unlockAndDestroy()`.
  *
  * This is the foundation primitive a lock service composes; it carries no
- * authentication, no UI, and — deliberately — no lock *surfaces*. Per the
+ * authentication, no UI, and (deliberately) no lock *surfaces*. Per the
  * protocol a real lock screen must create an `ext_session_lock_surface_v1` for
  * every output before the compositor presents the locked frame and sends
  * `locked()`; that rendering layer is a shell concern wired in a later phase.
@@ -32,7 +32,7 @@ namespace PhosphorWayland {
  * Security guarantee (from the protocol): if the client dies while the session
  * is locked, the compositor must NOT unlock. Accordingly this object never
  * destroys a lock for which `locked()` was received without going through
- * `unlockAndDestroy()` — a bare destroy in that state is a protocol error and
+ * `unlockAndDestroy()`: a bare destroy in that state is a protocol error and
  * would also defeat the guarantee.
  *
  * Construct one per process. Threading: every method MUST be called from the

--- a/libs/phosphor-wayland/include/PhosphorWayland/SessionLock.h
+++ b/libs/phosphor-wayland/include/PhosphorWayland/SessionLock.h
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <phosphorwayland_export.h>
+
+#include <QObject>
+
+#include <memory>
+
+namespace PhosphorWayland {
+
+/**
+ * @brief Client-side wrapper around `ext_session_lock_manager_v1` /
+ *        `ext_session_lock_v1`.
+ *
+ * Requests that the compositor lock the session and observes the outcome: the
+ * compositor replies with either `locked()` (this client now owns the locked
+ * session and is responsible for authenticating and releasing it) or
+ * `finished()` (the request was denied, or an existing lock already owns the
+ * session). On a successful authentication the owner calls `unlockAndDestroy()`.
+ *
+ * This is the foundation primitive a lock service composes; it carries no
+ * authentication, no UI, and — deliberately — no lock *surfaces*. Per the
+ * protocol a real lock screen must create an `ext_session_lock_surface_v1` for
+ * every output before the compositor presents the locked frame and sends
+ * `locked()`; that rendering layer is a shell concern wired in a later phase.
+ * Until surfaces are added the compositor decides, per its own policy and time
+ * limit, when (or whether) to emit `locked()`.
+ *
+ * Security guarantee (from the protocol): if the client dies while the session
+ * is locked, the compositor must NOT unlock. Accordingly this object never
+ * destroys a lock for which `locked()` was received without going through
+ * `unlockAndDestroy()` — a bare destroy in that state is a protocol error and
+ * would also defeat the guarantee.
+ *
+ * Construct one per process. Threading: every method MUST be called from the
+ * GUI thread.
+ */
+class PHOSPHORWAYLAND_EXPORT SessionLock : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(SessionLock)
+    Q_PROPERTY(bool locked READ isLocked NOTIFY lockedChanged)
+
+public:
+    explicit SessionLock(QObject* parent = nullptr);
+    ~SessionLock() override;
+
+    /// True iff the compositor advertises `ext_session_lock_manager_v1`. The
+    /// constructor still succeeds when unsupported, but `lock()` is a no-op.
+    static bool isSupported();
+
+    /// Request that the session be locked. The compositor replies with exactly
+    /// one of `locked()` or `finished()`. A no-op if a lock is already in
+    /// progress, the session is already locked by this object, or the protocol
+    /// is unsupported.
+    void lock();
+
+    /// Release the lock after a successful authentication: sends
+    /// `unlock_and_destroy` and flushes. Valid only after `locked()` was
+    /// emitted; a no-op otherwise. Emits `lockedChanged()`.
+    void unlockAndDestroy();
+
+    /// True between `locked()` and `unlockAndDestroy()` (or a compositor-driven
+    /// `finished()`).
+    [[nodiscard]] bool isLocked() const;
+
+Q_SIGNALS:
+    /// The session is now locked; this client owns the lock and must call
+    /// `unlockAndDestroy()` to release it.
+    void locked();
+
+    /// The compositor will not (or will no longer) lock the session: the lock
+    /// object has been torn down and the request is over. Emitted at most once
+    /// per `lock()`.
+    void finished();
+
+    /// `isLocked()` changed.
+    void lockedChanged();
+
+private:
+    class Private;
+    std::unique_ptr<Private> d;
+};
+
+} // namespace PhosphorWayland

--- a/libs/phosphor-wayland/include/PhosphorWayland/SessionLock.h
+++ b/libs/phosphor-wayland/include/PhosphorWayland/SessionLock.h
@@ -60,7 +60,10 @@ public:
 
     /// Release the lock after a successful authentication: sends
     /// `unlock_and_destroy` and flushes. Valid only after `locked()` was
-    /// emitted; a no-op otherwise. Emits `lockedChanged()`.
+    /// emitted; a no-op otherwise. Emits `lockedChanged()` but NOT `finished()`:
+    /// `finished()` signals a compositor-driven end of the lock, whereas this is
+    /// the client-driven unlock, so a consumer must model unlock success off this
+    /// call (or `lockedChanged()`), not off `finished()`.
     void unlockAndDestroy();
 
     /// True between `locked()` and `unlockAndDestroy()` (or a compositor-driven

--- a/libs/phosphor-wayland/protocols/ext-session-lock-v1.xml
+++ b/libs/phosphor-wayland/protocols/ext-session-lock-v1.xml
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="ext_session_lock_v1">
+  <copyright>
+    Copyright 2021 Isaac Freund
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+  </copyright>
+
+  <description summary="secure session locking with arbitrary graphics">
+    This protocol allows for a privileged Wayland client to lock the session
+    and display arbitrary graphics while the session is locked.
+
+    The compositor may choose to restrict this protocol to a special client
+    launched by the compositor itself or expose it to all privileged clients,
+    this is compositor policy.
+
+    The client is responsible for performing authentication and informing the
+    compositor when the session should be unlocked. If the client dies while
+    the session is locked the session remains locked, possibly permanently
+    depending on compositor policy.
+
+    The key words "must", "must not", "required", "shall", "shall not",
+    "should", "should not", "recommended",  "may", and "optional" in this
+    document are to be interpreted as described in IETF RFC 2119.
+
+    Warning! The protocol described in this file is currently in the
+    testing phase. Backward compatible changes may be added together with
+    the corresponding interface version bump. Backward incompatible changes
+    can only be done by creating a new major version of the extension.
+  </description>
+
+  <interface name="ext_session_lock_manager_v1" version="1">
+    <description summary="used to lock the session">
+      This interface is used to request that the session be locked.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the session lock manager object">
+        This informs the compositor that the session lock manager object will
+        no longer be used. Existing objects created through this interface
+        remain valid.
+      </description>
+    </request>
+
+    <request name="lock">
+      <description summary="attempt to lock the session">
+        This request creates a session lock and asks the compositor to lock the
+        session. The compositor will send either the ext_session_lock_v1.locked
+        or ext_session_lock_v1.finished event on the created object in
+        response to this request.
+      </description>
+      <arg name="id" type="new_id" interface="ext_session_lock_v1"/>
+    </request>
+  </interface>
+
+  <interface name="ext_session_lock_v1" version="1">
+    <description summary="manage lock state and create lock surfaces">
+      In response to the creation of this object the compositor must send
+      either the locked or finished event.
+
+      The locked event indicates that the session is locked. This means
+      that the compositor must stop rendering and providing input to normal
+      clients. Instead the compositor must blank all outputs with an opaque
+      color such that their normal content is fully hidden.
+
+      The only surfaces that should be rendered while the session is locked
+      are the lock surfaces created through this interface and optionally,
+      at the compositor's discretion, special privileged surfaces such as
+      input methods or portions of desktop shell UIs.
+
+      The locked event must not be sent until a new "locked" frame (either
+      from a session lock surface or the compositor blanking the output) has
+      been presented on all outputs and no security sensitive normal/unlocked
+      content is possibly visible.
+
+      The finished event should be sent immediately on creation of this
+      object if the compositor decides that the locked event will not be sent.
+
+      The compositor may wait for the client to create and render session lock
+      surfaces before sending the locked event to avoid displaying intermediate
+      blank frames. However, it must impose a reasonable time limit if
+      waiting and send the locked event as soon as the hard requirements
+      described above can be met if the time limit expires. Clients should
+      immediately create lock surfaces for all outputs on creation of this
+      object to make this possible.
+
+      This behavior of the locked event is required in order to prevent
+      possible race conditions with clients that wish to suspend the system
+      or similar after locking the session. Without these semantics, clients
+      triggering a suspend after receiving the locked event would race with
+      the first "locked" frame being presented and normal/unlocked frames
+      might be briefly visible as the system is resumed if the suspend
+      operation wins the race.
+
+      If the client dies while the session is locked, the compositor must not
+      unlock the session in response. It is acceptable for the session to be
+      permanently locked if this happens. The compositor may choose to continue
+      to display the lock surfaces the client had mapped before it died or
+      alternatively fall back to a solid color, this is compositor policy.
+
+      Compositors may also allow a secure way to recover the session, the
+      details of this are compositor policy. Compositors may allow a new
+      client to create a ext_session_lock_v1 object and take responsibility
+      for unlocking the session, they may even start a new lock client
+      instance automatically.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_destroy" value="0"
+        summary="attempted to destroy session lock while locked"/>
+      <entry name="invalid_unlock" value="1"
+        summary="unlock requested but locked event was never sent"/>
+      <entry name="role" value="2"
+        summary="given wl_surface already has a role"/>
+      <entry name="duplicate_output" value="3"
+        summary="given output already has a lock surface"/>
+      <entry name="already_constructed" value="4"
+        summary="given wl_surface has a buffer attached or committed"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the session lock">
+        This informs the compositor that the lock object will no longer be
+        used. Existing objects created through this interface remain valid.
+
+        After this request is made, lock surfaces created through this object
+        should be destroyed by the client as they will no longer be used by
+        the compositor.
+
+        It is a protocol error to make this request if the locked event was
+        sent, the unlock_and_destroy request must be used instead.
+      </description>
+    </request>
+
+    <event name="locked">
+      <description summary="session successfully locked">
+        This client is now responsible for displaying graphics while the
+        session is locked and deciding when to unlock the session.
+
+        The locked event must not be sent until a new "locked" frame has been
+        presented on all outputs and no security sensitive normal/unlocked
+        content is possibly visible.
+
+        If this event is sent, making the destroy request is a protocol error,
+        the lock object must be destroyed using the unlock_and_destroy request.
+      </description>
+    </event>
+
+    <event name="finished">
+      <description summary="the session lock object should be destroyed">
+        The compositor has decided that the session lock should be destroyed
+        as it will no longer be used by the compositor. Exactly when this
+        event is sent is compositor policy, but it must never be sent more
+        than once for a given session lock object.
+
+        This might be sent because there is already another ext_session_lock_v1
+        object held by a client, or the compositor has decided to deny the
+        request to lock the session for some other reason. This might also
+        be sent because the compositor implements some alternative, secure
+        way to authenticate and unlock the session.
+
+        The finished event should be sent immediately on creation of this
+        object if the compositor decides that the locked event will not
+        be sent.
+
+        If the locked event is sent on creation of this object the finished
+        event may still be sent at some later time in this object's
+        lifetime. This is compositor policy.
+
+        Upon receiving this event, the client should make either the destroy
+        request or the unlock_and_destroy request, depending on whether or
+        not the locked event was received on this object.
+      </description>
+    </event>
+
+    <request name="get_lock_surface">
+      <description summary="create a lock surface for a given output">
+        The client is expected to create lock surfaces for all outputs
+        currently present and any new outputs as they are advertised. These
+        won't be displayed by the compositor unless the lock is successful
+        and the locked event is sent.
+
+        Providing a wl_surface which already has a role or already has a buffer
+        attached or committed is a protocol error, as is attaching/committing
+        a buffer before the first ext_session_lock_surface_v1.configure event.
+
+        Attempting to create more than one lock surface for a given output
+        is a duplicate_output protocol error.
+      </description>
+      <arg name="id" type="new_id" interface="ext_session_lock_surface_v1"/>
+      <arg name="surface" type="object" interface="wl_surface"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="unlock_and_destroy" type="destructor">
+      <description summary="unlock the session, destroying the object">
+        This request indicates that the session should be unlocked, for
+        example because the user has entered their password and it has been
+        verified by the client.
+
+        This request also informs the compositor that the lock object will
+        no longer be used and should be destroyed. Existing objects created
+        through this interface remain valid.
+
+        After this request is made, lock surfaces created through this object
+        should be destroyed by the client as they will no longer be used by
+        the compositor.
+
+        It is a protocol error to make this request if the locked event has
+        not been sent. In that case, the lock object must be destroyed using
+        the destroy request.
+
+        Note that a correct client that wishes to exit directly after unlocking
+        the session must use the wl_display.sync request to ensure the server
+        receives and processes the unlock_and_destroy request. Otherwise
+        there is no guarantee that the server has unlocked the session due
+        to the asynchronous nature of the Wayland protocol. For example,
+        the server might terminate the client with a protocol error before
+        it processes the unlock_and_destroy request.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="ext_session_lock_surface_v1" version="1">
+    <description summary="a surface displayed while the session is locked">
+      The client may use lock surfaces to display a screensaver, render a
+      dialog to enter a password and unlock the session, or however else it
+      sees fit.
+
+      On binding this interface the compositor will immediately send the
+      first configure event. After making the ack_configure request in
+      response to this event the client should attach and commit the first
+      buffer. Committing the surface before acking the first configure is a
+      protocol error. Committing the surface with a null buffer at any time
+      is a protocol error.
+
+      The compositor is free to handle keyboard/pointer focus for lock
+      surfaces however it chooses. A reasonable way to do this would be to
+      give the first lock surface created keyboard focus and change keyboard
+      focus if the user clicks on other surfaces.
+    </description>
+
+    <enum name="error">
+      <entry name="commit_before_first_ack" value="0"
+        summary="surface committed before first ack_configure request"/>
+      <entry name="null_buffer" value="1"
+        summary="surface committed with a null buffer"/>
+      <entry name="dimensions_mismatch" value="2"
+        summary="failed to match ack'd width/height"/>
+      <entry name="invalid_serial" value="3"
+        summary="serial provided in ack_configure is invalid"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the lock surface object">
+        This informs the compositor that the lock surface object will no
+        longer be used.
+
+        It is recommended for a lock client to destroy lock surfaces if
+        their corresponding wl_output global is removed.
+
+        If a lock surface on an active output is destroyed before the
+        ext_session_lock_v1.unlock_and_destroy event is sent, the compositor
+        must fall back to rendering a solid color.
+      </description>
+    </request>
+
+    <request name="ack_configure">
+      <description summary="ack a configure event">
+        When a configure event is received, if a client commits the surface
+        in response to the configure event, then the client must make an
+        ack_configure request sometime before the commit request, passing
+        along the serial of the configure event.
+
+        If the client receives multiple configure events before it can
+        respond to one, it only has to ack the last configure event.
+
+        A client is not required to commit immediately after sending an
+        ack_configure request - it may even ack_configure several times
+        before its next surface commit.
+
+        A client may send multiple ack_configure requests before committing,
+        but only the last request sent before a commit indicates which
+        configure event the client really is responding to.
+
+        Sending an ack_configure request consumes the configure event
+        referenced by the given serial, as well as all older configure events
+        sent on this object.
+
+        It is a protocol error to issue multiple ack_configure requests
+        referencing the same configure event or to issue an ack_configure
+        request referencing a configure event older than the last configure
+        event acked for a given lock surface.
+      </description>
+      <arg name="serial" type="uint" summary="serial from the configure event"/>
+    </request>
+
+    <event name="configure">
+      <description summary="the client should resize its surface">
+        This event is sent once on binding the interface and may be sent again
+        at the compositor's discretion, for example if output geometry changes.
+
+        The width and height are in surface-local coordinates and are exact
+        requirements. Failing to match these surface dimensions in the next
+        commit after acking a configure is a protocol error.
+      </description>
+      <arg name="serial" type="uint" summary="serial for use in ack_configure"/>
+      <arg name="width" type="uint"/>
+      <arg name="height" type="uint"/>
+    </event>
+  </interface>
+</protocol>

--- a/libs/phosphor-wayland/src/qpa/layershellintegration.cpp
+++ b/libs/phosphor-wayland/src/qpa/layershellintegration.cpp
@@ -63,6 +63,9 @@ LayerShellIntegration::~LayerShellIntegration()
     if (m_dataControlManager) {
         zwlr_data_control_manager_v1_destroy(m_dataControlManager);
     }
+    if (m_sessionLockManager) {
+        ext_session_lock_manager_v1_destroy(m_sessionLockManager);
+    }
     if (m_layerShell) {
         if (m_boundVersion >= 3) {
             // Protocol-level destroy request (added in v3)
@@ -275,6 +278,17 @@ void LayerShellIntegration::registryHandler(void* data, struct wl_registry* regi
         self->m_dataControlManagerId = id;
         self->m_dataControlManagerAvailable = true;
         qCDebug(lcLayerShellIntegration).nospace() << "Bound zwlr_data_control_manager_v1 v" << bindVersion;
+    } else if (strcmp(interface, ext_session_lock_manager_v1_interface.name) == 0) {
+        if (self->m_sessionLockManager && self->m_sessionLockManagerAvailable)
+            return;
+        self->m_sessionLockManager = nullptr;
+        static constexpr uint32_t kMaxVersion = 1;
+        uint32_t bindVersion = qMin(version, kMaxVersion);
+        self->m_sessionLockManager = static_cast<struct ext_session_lock_manager_v1*>(
+            wl_registry_bind(registry, id, &ext_session_lock_manager_v1_interface, bindVersion));
+        self->m_sessionLockManagerId = id;
+        self->m_sessionLockManagerAvailable = true;
+        qCDebug(lcLayerShellIntegration).nospace() << "Bound ext_session_lock_manager_v1 v" << bindVersion;
     }
 }
 
@@ -306,6 +320,10 @@ void LayerShellIntegration::registryRemoveHandler(void* data, struct wl_registry
         self->m_dataControlManagerAvailable = false;
         self->m_dataControlManagerId = 0;
         qCDebug(lcLayerShellIntegration) << "zwlr_data_control_manager_v1 global removed";
+    } else if (id == self->m_sessionLockManagerId) {
+        self->m_sessionLockManagerAvailable = false;
+        self->m_sessionLockManagerId = 0;
+        qCDebug(lcLayerShellIntegration) << "ext_session_lock_manager_v1 global removed";
     } else if (id == self->m_layerShellId) {
         qCWarning(lcLayerShellIntegration) << "zwlr_layer_shell_v1 global removed (id" << id << ") —"
                                            << "new layer surface creation will fail."

--- a/libs/phosphor-wayland/src/qpa/layershellintegration.h
+++ b/libs/phosphor-wayland/src/qpa/layershellintegration.h
@@ -18,6 +18,7 @@
 #include "xdg_toplevel_drag_protocol.h"
 #include "foreign_toplevel_protocol.h"
 #include "data_control_protocol.h"
+#include "session_lock_protocol.h"
 
 namespace PhosphorWayland {
 
@@ -149,6 +150,13 @@ public:
         return m_dataControlManagerAvailable ? m_dataControlManager : nullptr;
     }
 
+    /// Client-side session-lock manager (`ext_session_lock_manager_v1`). Bound at
+    /// version 1. Returns nullptr when the compositor does not advertise it.
+    struct ext_session_lock_manager_v1* sessionLockManager() const
+    {
+        return m_sessionLockManagerAvailable ? m_sessionLockManager : nullptr;
+    }
+
     /// Access the Wayland display for explicit flushing after surface creation.
     QtWaylandClient::QWaylandDisplay* display() const
     {
@@ -191,6 +199,10 @@ private:
     struct zwlr_data_control_manager_v1* m_dataControlManager = nullptr;
     uint32_t m_dataControlManagerId = 0;
     bool m_dataControlManagerAvailable = false;
+
+    struct ext_session_lock_manager_v1* m_sessionLockManager = nullptr;
+    uint32_t m_sessionLockManagerId = 0;
+    bool m_sessionLockManagerAvailable = false;
 
     std::vector<std::pair<CallbackId, GlobalRemovedCallback>> m_globalRemovedCallbacks;
     CallbackId m_nextCallbackId = 1;

--- a/libs/phosphor-wayland/src/qpa/session_lock_protocol.h
+++ b/libs/phosphor-wayland/src/qpa/session_lock_protocol.h
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+extern "C" {
+#include "ext-session-lock-v1-client-protocol.h"
+}

--- a/libs/phosphor-wayland/src/sessionlock.cpp
+++ b/libs/phosphor-wayland/src/sessionlock.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <PhosphorWayland/SessionLock.h>
+
+#include "qpa/layershellintegration.h"
+#include "qpa/session_lock_protocol.h"
+
+#include <QLoggingCategory>
+
+#include <QtWaylandClient/private/qwaylanddisplay_p.h>
+
+Q_LOGGING_CATEGORY(lcSessionLock, "phosphorwayland.sessionlock")
+
+namespace PhosphorWayland {
+
+class SessionLock::Private
+{
+public:
+    SessionLock* owner = nullptr;
+
+    // The active lock object, or null when no lock is in flight / locked.
+    struct ext_session_lock_v1* lockObj = nullptr;
+    // True between the `locked` event and release (unlock_and_destroy or a
+    // compositor-driven `finished`). Distinguishes the two teardown paths:
+    // a locked object must be released with unlock_and_destroy; an unlocked
+    // (in-flight) object with destroy.
+    bool isLocked = false;
+
+    void flush()
+    {
+        auto* integration = LayerShellIntegration::instance();
+        if (integration && integration->display())
+            integration->display()->flushRequests();
+    }
+
+    static void handleLocked(void* data, struct ext_session_lock_v1*)
+    {
+        auto* self = static_cast<Private*>(data);
+        if (!self || self->isLocked)
+            return;
+        self->isLocked = true;
+        Q_EMIT self->owner->lockedChanged();
+        Q_EMIT self->owner->locked();
+    }
+
+    static void handleFinished(void* data, struct ext_session_lock_v1*)
+    {
+        auto* self = static_cast<Private*>(data);
+        if (!self)
+            return;
+        // The compositor is done with this lock object; tear it down with the
+        // protocol-correct destructor (unlock_and_destroy iff `locked` was
+        // sent, destroy otherwise) so the proxy is freed exactly once.
+        if (self->lockObj) {
+            if (self->isLocked)
+                ext_session_lock_v1_unlock_and_destroy(self->lockObj);
+            else
+                ext_session_lock_v1_destroy(self->lockObj);
+            self->lockObj = nullptr;
+            self->flush();
+        }
+        if (self->isLocked) {
+            self->isLocked = false;
+            Q_EMIT self->owner->lockedChanged();
+        }
+        Q_EMIT self->owner->finished();
+    }
+};
+
+SessionLock::SessionLock(QObject* parent)
+    : QObject(parent)
+    , d(std::make_unique<Private>())
+{
+    d->owner = this;
+}
+
+SessionLock::~SessionLock()
+{
+    if (d->lockObj) {
+        // Sever the listener's back-pointer so any still-queued locked/finished
+        // event dispatches with data == nullptr and is dropped (the Private is
+        // being freed). We deliberately do NOT destroy the proxy: if the
+        // session is locked, destroying is an invalid_destroy protocol error
+        // and would break the protocol's must-stay-locked-if-the-client-dies
+        // guarantee; if a lock is still in flight, a destroy could race the
+        // locked event into the same error. The proxy is reclaimed when the
+        // wl_display tears down.
+        wl_proxy_set_user_data(reinterpret_cast<struct wl_proxy*>(d->lockObj), nullptr);
+    }
+}
+
+bool SessionLock::isSupported()
+{
+    auto* integration = LayerShellIntegration::instance();
+    return integration && integration->sessionLockManager();
+}
+
+void SessionLock::lock()
+{
+    if (d->lockObj)
+        return; // a lock is already in flight or held.
+    auto* integration = LayerShellIntegration::instance();
+    if (!integration)
+        return;
+    auto* manager = integration->sessionLockManager();
+    if (!manager) {
+        qCWarning(lcSessionLock) << "Compositor does not advertise ext_session_lock_manager_v1; cannot lock";
+        return;
+    }
+    d->lockObj = ext_session_lock_manager_v1_lock(manager);
+    if (!d->lockObj) {
+        qCWarning(lcSessionLock) << "Failed to create the session lock object";
+        return;
+    }
+    static const struct ext_session_lock_v1_listener listener = {
+        .locked = Private::handleLocked,
+        .finished = Private::handleFinished,
+    };
+    ext_session_lock_v1_add_listener(d->lockObj, &listener, d.get());
+    d->flush();
+}
+
+void SessionLock::unlockAndDestroy()
+{
+    if (!d->lockObj || !d->isLocked)
+        return; // unlock_and_destroy is a protocol error before `locked`.
+    ext_session_lock_v1_unlock_and_destroy(d->lockObj);
+    d->lockObj = nullptr;
+    d->isLocked = false;
+    d->flush();
+    Q_EMIT lockedChanged();
+}
+
+bool SessionLock::isLocked() const
+{
+    return d->isLocked;
+}
+
+} // namespace PhosphorWayland

--- a/libs/phosphor-wayland/src/sessionlock.cpp
+++ b/libs/phosphor-wayland/src/sessionlock.cpp
@@ -37,6 +37,8 @@ public:
     static void handleLocked(void* data, struct ext_session_lock_v1*)
     {
         auto* self = static_cast<Private*>(data);
+        // self is null when the listener was severed at teardown; the isLocked
+        // guard drops a spurious repeat (the protocol sends `locked` at most once).
         if (!self || self->isLocked)
             return;
         self->isLocked = true;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -563,6 +563,7 @@ if(BUILD_PHOSPHOR_SHELL)
             PhosphorServicePolkit::PhosphorServicePolkit
             PhosphorServiceIdle::PhosphorServiceIdle
             PhosphorServiceClipboard::PhosphorServiceClipboard
+            PhosphorServiceLock::PhosphorServiceLock
             PhosphorLayer::PhosphorLayer
             PhosphorWayland::PhosphorWayland
             PhosphorRendering::PhosphorRendering

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -6,6 +6,7 @@
 #include <PhosphorServiceClipboard/QmlRegistration.h>
 #include <PhosphorServiceIconTheme/QmlRegistration.h>
 #include <PhosphorServiceIdle/QmlRegistration.h>
+#include <PhosphorServiceLock/QmlRegistration.h>
 #include <PhosphorServiceMpris/QmlRegistration.h>
 #include <PhosphorServiceNetwork/QmlRegistration.h>
 #include <PhosphorServiceNotifications/QmlRegistration.h>
@@ -119,6 +120,7 @@ int main(int argc, char* argv[])
     PhosphorServicePolkit::registerQmlTypes();
     PhosphorServiceIdle::registerQmlTypes();
     PhosphorServiceClipboard::registerQmlTypes();
+    PhosphorServiceLock::registerQmlTypes();
 
     auto screenProvider = std::make_unique<PhosphorLayer::DefaultScreenProvider>();
     auto transport = std::make_unique<PhosphorLayer::PhosphorWaylandTransport>();


### PR DESCRIPTION
## Phase 2.9: `phosphor-service-lock`

A session-lock + authentication service for Phosphor-based shells. It authenticates the session user through PAM and coordinates the `ext-session-lock-v1` lock state with the compositor. Namespace `PhosphorServiceLock`, LGPL-2.1-or-later, QML URI `Phosphor.Service.Lock 1.0`.

Scope was confirmed up front: foundation client + state machine now, per-output lock surfaces deferred to the Phase 4 shell; PAM service name configurable, default `login`.

## What landed (7 milestones, commit + build/test green per milestone)

1. **Foundation `SessionLock` client in `phosphor-wayland`.** Vendored `ext-session-lock-v1.xml` (freedesktop staging), bound `ext_session_lock_manager_v1` in `LayerShellIntegration`, and added a `SessionLock` client: `lock()`, `unlockAndDestroy()`, `locked()`/`finished()`, `isSupported()`. Protocol-correct teardown: it never destroys a locked session (an `invalid_destroy` error that also breaks the must-stay-locked-if-the-client-dies guarantee); the destructor severs the listener back-pointer rather than risk a racing destroy.
2. **Service skeleton + CMake plumbing.** Mirrors the 2.8 shape (Config.cmake.in, export header, umbrella, QML registration), wired under `BUILD_PHOSPHOR_SHELL` and registered in `src/shell/main.cpp`. phosphor-wayland is a PRIVATE link.
3. **PAM authenticator.** `IAuthenticator` seam + `PamAuthenticator`: `pam_authenticate` + `pam_acct_mgmt` run on the global thread pool and the result is marshalled back via `QFutureWatcher`, so a sleeping PAM module never blocks the loop. One transaction at a time. The password answers only PAM's echo-off prompt, is moved to a sole owner, and is wiped (`explicit_bzero`) after `pam_end`; never logged.
4. **Lock state machine + QML facade.** `ISessionLock` seam + `WaylandSessionLock` adapter; `LockStateMachine` (`Unlocked -> Locking -> Locked -> Authenticating`, with auth-failure retry and compositor-driven teardown), driven behind both seams so the policy is unit-tested with fakes. `LockService` exposes the QML surface (`State` enum, `supported`/`state`/`locked`, `lock()`/`unlock(pw)`).
5. **CLI demo + public authenticator.** `IAuthenticator`/`PamAuthenticator` promoted to the public API (PamAuthenticator pimpl'd, so QtConcurrent stays a private dep). `examples/phosphor-service-lock-cli`: `authenticate [user] [--service NAME]` (PAM, prints success/failure, terminal echo disabled, no compositor needed) and `supported` (under the phosphorwayland QPA). No interactive lock command: without the Phase 4 lock surfaces it would blank the outputs with no visible prompt.
6. **QML facade test.**
7. **README + plan-doc 2.9 section + shipped status.**

## Verification

- Build green; full suite passes (260 tests).
- Four lock test binaries: smoke (registration idempotency, inert construction), QML facade load, PAM authenticator (configured service, fast-fail, concurrency guard, real-PAM rejection of a nonexistent user), and the lock state machine (8 cases on fakes).
- The CLI was exercised end-to-end: a wrong password for the real session user and an unknown user are both rejected through real off-thread PAM (exit 1); `supported` reports correctly.

## Notes for review (security-critical)

- Unlock is gated strictly on `IAuthenticator::succeeded` while `Authenticating`, and `pam_acct_mgmt` gates success alongside `pam_authenticate` (a valid password on an expired/locked account does not unlock).
- The blocking PAM call stays off the GUI thread; the worker captures only value copies (never `this`), so destroying the authenticator mid-transaction cannot dangle.
- Lock-object lifetime in `SessionLock` follows the protocol's destructor rules exactly; see `libs/phosphor-wayland/src/sessionlock.cpp`.

## Out of scope (Phase 4 consumers)

Per-output `ext_session_lock_surface_v1` graphics and the lock-screen UI, non-password PAM factors, screensaver/DPMS coupling, and any D-Bus lock interface.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)