### PR TITLE
fix(editor): render autotile layout previews with correct zone geometry

### DIFF
--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -18,6 +18,7 @@
 #include <PhosphorWorkspaces/VirtualDesktopManager.h>
 #include <PhosphorWorkspaces/ActivityManager.h>
 #include <PhosphorZones/LayoutRegistry.h>
+#include <PhosphorZones/ZoneJsonKeys.h>
 #include "../core/logging.h"
 #include "../core/shaderregistry.h"
 #include <PhosphorScreens/Manager.h>
@@ -32,8 +33,51 @@
 #include <QScreen>
 #include <QThread>
 #include <PhosphorScreens/ScreenIdentity.h>
+#include <QUuid>
 
 namespace PlasmaZones {
+
+namespace {
+
+// `getLayout` is contractually a *Layout*-schema endpoint: its sole consumer
+// (the editor's loadLayout parser, DBusLayoutService::loadLayout → getLayout)
+// reads the layout name under `name` and each zone's geometry nested under
+// `relativeGeometry`. Autotile "layouts" are synthesized on the fly from a
+// LayoutPreview, whose own wire shape (PlasmaZones::toJson) is the *flat*
+// preview schema consumed by the layout picker / OSD (getLayoutPreview*).
+// Returning that flat shape from getLayout left the editor parsing every zone
+// to a (0,0,0,0) rect — a blank canvas in preview mode. Project the preview
+// into the Layout schema the editor expects instead.
+QJsonObject autotilePreviewToLayoutJson(const PhosphorLayout::LayoutPreview& preview)
+{
+    QJsonObject layout;
+    layout[::PhosphorZones::ZoneJsonKeys::Id] = preview.id;
+    layout[::PhosphorZones::ZoneJsonKeys::Name] = preview.displayName;
+
+    QJsonArray zones;
+    for (int i = 0; i < preview.zones.size(); ++i) {
+        const QRectF& r = preview.zones.at(i);
+        QJsonObject relGeo;
+        relGeo[::PhosphorZones::ZoneJsonKeys::X] = r.x();
+        relGeo[::PhosphorZones::ZoneJsonKeys::Y] = r.y();
+        relGeo[::PhosphorZones::ZoneJsonKeys::Width] = r.width();
+        relGeo[::PhosphorZones::ZoneJsonKeys::Height] = r.height();
+
+        QJsonObject zone;
+        // Synthetic per-zone id: autotile previews are read-only in the editor
+        // (previewMode is forced for autotile ids), but the editor's zone model
+        // and QML key zones by id, never index — so each needs a stable id.
+        zone[::PhosphorZones::ZoneJsonKeys::Id] = QUuid::createUuid().toString();
+        zone[::PhosphorZones::ZoneJsonKeys::ZoneNumber] =
+            (i < preview.zoneNumbers.size()) ? preview.zoneNumbers.at(i) : (i + 1);
+        zone[::PhosphorZones::ZoneJsonKeys::RelativeGeometry] = relGeo;
+        zones.append(zone);
+    }
+    layout[::PhosphorZones::ZoneJsonKeys::Zones] = zones;
+    return layout;
+}
+
+} // namespace
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Constructor and Signal Setup
@@ -298,7 +342,9 @@ QString LayoutAdaptor::getLayout(const QString& id)
         // non-positive windowCount, so no adapter helper is needed here.
         PhosphorLayout::LayoutPreview preview =
             PhosphorTiles::previewFromAlgorithm(algoId, algo, -1, m_algorithmRegistry);
-        QJsonObject json = PlasmaZones::toJson(preview);
+        // getLayout returns a Layout-schema document (editor parser contract);
+        // the flat preview schema belongs to getLayoutPreview*, not here.
+        QJsonObject json = autotilePreviewToLayoutJson(preview);
         // Apply stored per-algorithm overrides (gaps, visibility, shader)
         QJsonObject overrides = m_layoutManager->loadAutotileOverrides(algoId);
         for (auto it = overrides.constBegin(); it != overrides.constEnd(); ++it) {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -743,7 +743,8 @@ add_test(NAME test_dbus_validation COMMAND test_dbus_validation)
 # Pins the rule: property mutations emit layoutChanged only, NEVER
 # layoutListChanged - the list hasn't changed.
 add_executable(test_layout_adaptor_signals dbus/test_layout_adaptor_signals.cpp)
-target_link_libraries(test_layout_adaptor_signals PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core)
+target_link_libraries(test_layout_adaptor_signals PRIVATE Qt6::Test Qt6::Core Qt6::DBus plasmazones_core
+                      PhosphorTiles::PhosphorTiles)
 add_test(NAME test_layout_adaptor_signals COMMAND test_layout_adaptor_signals)
 
 # Micro-benchmarks for D-Bus adaptor hot paths. Drives the

--- a/tests/unit/dbus/test_layout_adaptor_signals.cpp
+++ b/tests/unit/dbus/test_layout_adaptor_signals.cpp
@@ -25,11 +25,46 @@
 #include <PhosphorZones/LayoutRegistry.h>
 #include "config/configbackends.h"
 #include <PhosphorZones/Zone.h>
+#include <PhosphorZones/ZoneJsonKeys.h>
 #include "../helpers/IsolatedConfigGuard.h"
 #include "../helpers/LayoutRegistryTestHelpers.h"
 
+#include <PhosphorTiles/AlgorithmRegistry.h>
+#include <PhosphorTiles/TilingAlgorithm.h>
+#include <PhosphorTiles/TilingParams.h>
+#include <PhosphorLayoutApi/LayoutId.h>
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+
 using namespace PlasmaZones;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
+
+namespace {
+// Minimal stub algorithm producing two side-by-side zones. Lets the
+// autotile getLayout() path run end-to-end without depending on the Luau
+// engine (whose geometry is independently covered by test_luau_parity); this
+// test pins the *serialization contract* getLayout() owes the editor.
+class TwoColumnStubAlgorithm : public PhosphorTiles::TilingAlgorithm
+{
+public:
+    QString name() const override
+    {
+        return QStringLiteral("Two Column Stub");
+    }
+    QString description() const override
+    {
+        return QStringLiteral("Test stub");
+    }
+    QVector<QRect> calculateZones(const PhosphorTiles::TilingParams& params) const override
+    {
+        const QRect a = params.screenGeometry;
+        const int halfW = a.width() / 2;
+        return {QRect(a.x(), a.y(), halfW, a.height()), QRect(a.x() + halfW, a.y(), a.width() - halfW, a.height())};
+    }
+};
+} // namespace
 
 class TestLayoutAdaptorSignals : public QObject
 {
@@ -220,6 +255,51 @@ private Q_SLOTS:
         QSignalSpy propertyChanged(m_adaptor, &LayoutAdaptor::layoutPropertyChanged);
         m_adaptor->setLayoutAspectRatioClass(m_layoutId, 2);
         QCOMPARE(propertyChanged.count(), 0);
+    }
+
+    // Regression guard: getLayout() is the editor's load endpoint
+    // (DBusLayoutService::loadLayout → getLayout). Its sole consumer parses
+    // the canonical Layout schema — top-level `name`, and each zone's geometry
+    // nested under `relativeGeometry`. The autotile branch must emit that
+    // schema, NOT the flat preview schema (zones[].x/width at top level) used
+    // by getLayoutPreview*/OSD. Emitting the flat shape silently parsed every
+    // editor zone to (0,0,0,0) — a blank canvas in preview mode.
+    void testGetLayout_autotile_emitsLayoutSchemaNotPreviewSchema()
+    {
+        namespace K = ::PhosphorZones::ZoneJsonKeys;
+
+        PhosphorTiles::AlgorithmRegistry registry;
+        registry.registerAlgorithm(QStringLiteral("twocol"), new TwoColumnStubAlgorithm);
+        m_adaptor->setAlgorithmRegistry(&registry);
+
+        const QString autotileId = PhosphorLayout::LayoutId::makeAutotileId(QStringLiteral("twocol"));
+        const QString jsonStr = m_adaptor->getLayout(autotileId);
+        QVERIFY2(!jsonStr.isEmpty(), "getLayout returned empty JSON for a registered autotile algorithm");
+
+        const QJsonObject obj = QJsonDocument::fromJson(jsonStr.toUtf8()).object();
+        QCOMPARE(obj.value(K::Id).toString(), autotileId);
+        // Editor reads the layout title from `name`, not the preview's `displayName`.
+        QCOMPARE(obj.value(K::Name).toString(), QStringLiteral("Two Column Stub"));
+
+        const QJsonArray zones = obj.value(K::Zones).toArray();
+        QCOMPARE(zones.size(), 2);
+
+        const QJsonObject zone0 = zones.at(0).toObject();
+        // Must be the nested Layout schema...
+        QVERIFY2(zone0.contains(K::RelativeGeometry), "zone missing relativeGeometry — editor would parse (0,0,0,0)");
+        // ...and NOT the flat preview schema the bug emitted.
+        QVERIFY2(!zone0.contains(K::Width), "zone leaked flat preview-schema width key");
+        QVERIFY2(!zone0.contains(K::X), "zone leaked flat preview-schema x key");
+
+        const QJsonObject relGeo = zone0.value(K::RelativeGeometry).toObject();
+        QVERIFY(relGeo.value(K::Width).toDouble() > 0.0);
+        QVERIFY(relGeo.value(K::Height).toDouble() > 0.0);
+        QCOMPARE(relGeo.value(K::Width).toDouble(), 0.5);
+        QCOMPARE(zone0.value(K::ZoneNumber).toInt(), 1);
+        QVERIFY2(!zone0.value(K::Id).toString().isEmpty(), "zone needs a stable id (editor keys zones by id)");
+
+        // Clear the dangling local-registry pointer before it goes out of scope.
+        m_adaptor->setAlgorithmRegistry(nullptr);
     }
 
 private:


### PR DESCRIPTION
## Problem

Opening an **autotile layout** in the layout editor showed a blank / degenerate canvas — every zone collapsed to `0×0` instead of the algorithm's tiled zones.

## Root cause

The editor loads a layout over D-Bus via `LayoutRegistry.getLayout`. Its sole consumer — the editor's `loadLayout` parser — expects the canonical **Layout schema**: the title under `name`, and each zone's geometry nested under `relativeGeometry`.

The autotile branch of `LayoutAdaptor::getLayout` instead returned the **flat preview schema** (`PlasmaZones::toJson`: `zones[].x/y/width/height` at the zone's top level, title under `displayName`) — the shape intended for the layout picker / OSD via `getLayoutPreview*`. The editor parser found no `relativeGeometry`, so every zone parsed to `(0,0,0,0)`.

The Luau geometry engine itself is correct (`test_luau_parity` confirms byte-identical output to the prior JS engine) — this was purely a serialization-schema mismatch on the editor's autotile-open path.

## Fix

- Add `autotilePreviewToLayoutJson()` in `layoutadaptor.cpp` to project a `LayoutPreview` into the Layout schema the editor expects: top-level `name` plus zones with nested `relativeGeometry` and stable per-zone ids.
- `getLayout(autotileId)` now uses it. `getLayout` is **editor-only**, so the flat preview schema used by the picker / OSD (`getLayoutPreview*`) is unaffected.

## Tests

- New regression test `testGetLayout_autotile_emitsLayoutSchemaNotPreviewSchema` pins the contract: `getLayout(autotile)` emits nested `relativeGeometry` (and explicitly *not* the flat zone keys).
- Full Luau / autotile / layout-source suite passes (`test_luau_parity`, `test_autotile_engine_core`, `test_layout_source_bundle`, `test_layout_adaptor_signals`).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)