### PR TITLE
Feat: Cross-Surface Window Focus/Swap/Move

### DIFF
--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -505,6 +505,15 @@
                 <annotation name="org.gtk.GDBus.DocString" value="Window to activate."/>
             </arg>
         </signal>
+        <signal name="windowDesktopMoveRequested">
+            <annotation name="org.gtk.GDBus.DocString" value="Daemon requests KWin to move a window to another virtual desktop."/>
+            <arg name="windowId" type="s">
+                <annotation name="org.gtk.GDBus.DocString" value="Window to move."/>
+            </arg>
+            <arg name="desktop" type="i">
+                <annotation name="org.gtk.GDBus.DocString" value="1-based virtual desktop number."/>
+            </arg>
+        </signal>
         <signal name="applyGeometriesBatch">
             <annotation name="org.gtk.GDBus.DocString" value="Daemon requests compositor to apply geometries for a batch of windows."/>
             <arg name="geometries" type="a(siiiis)">

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -342,6 +342,69 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
 
     m_autotileScreens = newScreens;
 
+    if (isDesktopSwitch && added.isEmpty() && removed.isEmpty() && !m_autotileScreens.isEmpty()) {
+        // Desktop switch between desktops with the same autotile screen set.
+        // The daemon still retiles, but without an autotileScreensChanged
+        // notification the effect-side bookkeeping can leave a window moved
+        // across desktops untracked here after windowDesktopsChanged removed
+        // it from m_notifiedWindows on the source desktop.
+        qCInfo(lcEffect) << "slotScreensChanged: same-screen desktop return for screens:" << m_autotileScreens;
+        for (const QString& screenId : m_autotileScreens) {
+            for (KWin::EffectWindow* w : windows) {
+                if (!w || !m_effect->shouldHandleWindow(w) || !w->isOnCurrentDesktop() || !w->isOnCurrentActivity()
+                    || w->isMinimized()) {
+                    continue;
+                }
+                if (m_effect->getWindowScreenId(w) != screenId) {
+                    continue;
+                }
+                const QString windowId = m_effect->getWindowId(w);
+                if (!m_notifiedWindows.contains(windowId)) {
+                    auto savedIt = m_savedPreAutotileForDesktopMove.find(windowId);
+                    if (savedIt != m_savedPreAutotileForDesktopMove.end()) {
+                        if (savedIt.value().first == screenId) {
+                            m_preAutotileGeometries[screenId][windowId] = savedIt.value().second;
+                        } else {
+                            qCDebug(lcEffect) << "Desktop switch: dropping cross-screen pre-autotile rect for"
+                                              << windowId << "source=" << savedIt.value().first << "dest=" << screenId;
+                        }
+                        m_savedPreAutotileForDesktopMove.erase(savedIt);
+                    }
+                    qCInfo(lcEffect) << "Desktop switch: re-adding moved window to autotile:" << windowId << "on"
+                                     << screenId;
+                    notifyWindowAdded(w);
+                }
+            }
+        }
+
+        if (m_border.hideTitleBars) {
+            for (const QString& screenId : m_autotileScreens) {
+                for (KWin::EffectWindow* w : windows) {
+                    if (!w || !m_effect->shouldHandleWindow(w) || !w->isOnCurrentDesktop() || !w->isOnCurrentActivity()
+                        || w->isMinimized()) {
+                        continue;
+                    }
+                    if (m_effect->getWindowScreenId(w) != screenId) {
+                        continue;
+                    }
+                    const QString windowId = m_effect->getWindowId(w);
+                    if (m_effect->isWindowFloating(windowId)) {
+                        continue;
+                    }
+                    if (AutotileStateHelpers::borderlessOnScreen(m_border, screenId).contains(windowId)) {
+                        KWin::Window* kw = w->window();
+                        if (kw && !kw->noBorder()) {
+                            kw->setNoBorder(true);
+                            qCDebug(lcEffect) << "Desktop return: re-applied setNoBorder for" << windowId;
+                        }
+                    }
+                }
+            }
+        }
+
+        m_effect->updateAllBorders();
+    }
+
     if (!added.isEmpty()) {
         if (isDesktopSwitch) {
             // Desktop/activity return: windows are already tiled on this desktop.

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -148,6 +148,7 @@ private Q_SLOTS:
     void slotApplyGeometryRequested(const QString& windowId, int x, int y, int width, int height, const QString& zoneId,
                                     const QString& screenId, bool sizeOnly);
     void slotActivateWindowRequested(const QString& windowId);
+    void slotWindowDesktopMoveRequested(const QString& windowId, int desktop);
 
     // Float toggle is entirely daemon-local — no effect-side slot needed.
 

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -130,6 +130,31 @@ void PlasmaZonesEffect::slotMoveSpecificWindowToZoneRequested(const QString& win
 // locally against its active-window + frame-geometry shadow and emits
 // applyGeometryRequested directly. See WindowTrackingAdaptor::toggleWindowFloat.
 
+void PlasmaZonesEffect::slotWindowDesktopMoveRequested(const QString& windowId, int desktop)
+{
+    if (desktop < 1) {
+        qCDebug(lcEffect) << "slotWindowDesktopMoveRequested: invalid desktop" << desktop;
+        return;
+    }
+
+    KWin::EffectWindow* w = findWindowById(windowId);
+    if (!w) {
+        qCDebug(lcEffect) << "slotWindowDesktopMoveRequested: window not found" << windowId;
+        return;
+    }
+
+    const auto desktops = KWin::effects->desktops();
+    if (desktop > desktops.size()) {
+        qCDebug(lcEffect) << "slotWindowDesktopMoveRequested: desktop out of range" << desktop;
+        return;
+    }
+
+    auto targetDesktops = desktops;
+    targetDesktops.clear();
+    targetDesktops.append(desktops.at(desktop - 1));
+    KWin::effects->windowToDesktops(w, targetDesktops);
+}
+
 void PlasmaZonesEffect::slotApplyGeometryRequested(const QString& windowId, int x, int y, int width, int height,
                                                    const QString& zoneId, const QString& screenId, bool sizeOnly)
 {

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -699,6 +699,12 @@ void PlasmaZonesEffect::connectNavigationSignals()
                                           QStringLiteral("activateWindowRequested"), this,
                                           SLOT(slotActivateWindowRequested(QString)));
 
+    // Daemon-driven virtual-desktop move: daemon updates tiling state, effect updates KWin membership.
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowTracking,
+                                          QStringLiteral("windowDesktopMoveRequested"), this,
+                                          SLOT(slotWindowDesktopMoveRequested(QString, int)));
+
     // Float toggle is entirely daemon-local: the daemon reads the active
     // window from its own shadow, calls toggleFloatForWindow internally, and
     // emits applyGeometryRequested to paint the outcome. The effect no longer

--- a/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
@@ -408,6 +408,19 @@ public:
     {
         Q_UNUSED(desktop)
     }
+    virtual void setCurrentDesktopForScreen(const QString& screenId, int desktop)
+    {
+        Q_UNUSED(screenId)
+        Q_UNUSED(desktop)
+    }
+    virtual void setDesktopCount(int count)
+    {
+        Q_UNUSED(count)
+    }
+    virtual void setDesktopRows(int rows)
+    {
+        Q_UNUSED(rows)
+    }
     virtual void setCurrentActivity(const QString& activity)
     {
         Q_UNUSED(activity)

--- a/libs/phosphor-engine/include/PhosphorEngine/PlacementEngineBase.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/PlacementEngineBase.h
@@ -105,6 +105,18 @@ Q_SIGNALS:
     void windowFloatingChanged(const QString& windowId, bool floating, const QString& screenId);
     void activateWindowRequested(const QString& windowId);
 
+    /// Emitted when navigation moves a managed window to another virtual desktop.
+    void windowDesktopMoveRequested(const QString& windowId, int desktop);
+
+    /// Emitted when navigation should switch the active virtual desktop.
+    void currentDesktopChangeRequested(int desktop);
+
+    /// Emitted when navigation should switch the active virtual desktop for a specific output/screen.
+    /// Current KWin releases expose a global current desktop, so the daemon maps this to the
+    /// global setter. The screen argument keeps the navigation policy ready for per-output
+    /// virtual desktops.
+    void currentDesktopChangeRequestedForScreen(const QString& screenId, int desktop);
+
     /// Emitted to sync floating state without restoring geometry.
     /// Passive state-sync: engine-internal divergence correction.
     void windowFloatingStateSynced(const QString& windowId, bool floating, const QString& screenId);

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -268,6 +268,16 @@ public:
     void setCurrentDesktop(int desktop) override;
 
     /**
+     * @brief Update the number of KWin virtual desktops known to navigation.
+     */
+    void setDesktopCount(int count) override;
+
+    /**
+     * @brief Update the number of virtual desktop rows known to navigation.
+     */
+    void setDesktopRows(int rows) override;
+
+    /**
      * @brief Set the current activity for per-activity tiling state
      *
      * Swaps the active PhosphorTiles::TilingState set without releasing windows. Must be
@@ -317,6 +327,21 @@ public:
     {
         return m_currentDesktop;
     }
+
+    /**
+     * @brief Get the current virtual desktop for a specific screen/output.
+     *
+     * Current KDE releases keep every output on the same desktop, so all
+     * screens are synchronized by setCurrentDesktop(). The per-screen map is
+     * used by navigation so KDE's upcoming per-output virtual desktop mode can
+     * preserve each output's visible desktop independently.
+     */
+    int currentDesktopForScreen(const QString& screenId) const noexcept;
+
+    /**
+     * @brief Set the current virtual desktop for a specific screen/output.
+     */
+    void setCurrentDesktopForScreen(const QString& screenId, int desktop) override;
 
     /**
      * @brief Get the current activity tracked by the engine
@@ -1145,7 +1170,7 @@ private:
     PhosphorEngine::TilingStateKey currentKeyForScreen(const QString& screenId) const
     {
         auto it = m_screenDesktopOverride.constFind(screenId);
-        int desktop = (it != m_screenDesktopOverride.constEnd()) ? it.value() : m_currentDesktop;
+        int desktop = (it != m_screenDesktopOverride.constEnd()) ? it.value() : currentDesktopForScreen(screenId);
         return PhosphorEngine::TilingStateKey{screenId, desktop, m_currentActivity};
     }
 
@@ -1382,6 +1407,9 @@ private:
     // TilingStateKey. Updated by setCurrentDesktop()/setCurrentActivity() BEFORE
     // updateAutotileScreens() runs on desktop/activity switch.
     int m_currentDesktop = 1;
+    QHash<QString, int> m_screenCurrentDesktop;
+    int m_desktopCount = 1;
+    int m_desktopRows = 1;
     QString m_currentActivity;
     bool m_isDesktopContextSwitch = false;
 

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/NavigationController.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/NavigationController.h
@@ -55,7 +55,8 @@ public:
     /// engine's per-state focusedWindow tracker is stale.
     void swapFocusedInDirection(const QString& direction, const QString& action,
                                 const QString& explicitWindowId = QString());
-    void focusInDirection(const QString& direction, const QString& action, const QString& explicitWindowId = QString());
+    void focusInDirection(const QString& direction, const QString& action, const QString& explicitWindowId = QString(),
+                          const QString& explicitScreenId = QString());
     void moveFocusedToPosition(int position, const QString& explicitWindowId = QString());
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -83,6 +84,11 @@ private:
     QString resolveActiveScreen() const;
 
     /**
+     * @brief Resolve a screen for navigation when the current desktop has no focused tiled window.
+     */
+    QString resolveFallbackScreenId(const QString& explicitScreenId = QString()) const;
+
+    /**
      * @brief Resolve the PhosphorTiles::TilingState for the currently focused screen
      *
      * Returns nullptr if no active screen or no state exists for it.
@@ -105,6 +111,34 @@ private:
      */
     QStringList tiledWindowsForFocusedScreen(QString& outScreenId, PhosphorTiles::TilingState*& outState,
                                              const QString& explicitWindowId = QString());
+
+    /**
+     * @brief Return the neighboring autotile screen in a keyboard-navigation direction.
+     */
+    QString neighborAutotileScreenInDirection(const QString& sourceScreenId, const QString& direction) const;
+
+    /**
+     * @brief Return the neighboring virtual desktop for a keyboard-navigation direction.
+     */
+    int neighborDesktopInDirection(const QString& sourceScreenId, const QString& direction) const;
+
+    /**
+     * @brief Move a tiled window into another screen/desktop state at its entry edge.
+     */
+    bool moveFocusedToBoundaryTarget(const QString& focused, const QString& sourceScreenId,
+                                     PhosphorTiles::TilingState* sourceState, const QString& targetScreenId,
+                                     int targetDesktop, const QString& direction);
+
+    /**
+     * @brief Handle focus crossing to an output that has no tiled window on its visible desktop.
+     */
+    bool focusEmptyScreenBoundaryTarget(const QString& targetScreenId, const QString& direction, const QString& action);
+
+    /**
+     * @brief Focus the edge window in a neighboring screen/desktop state.
+     */
+    bool focusBoundaryTarget(const QString& targetScreenId, int targetDesktop, const QString& direction,
+                             const QString& action, const QString& feedbackScreenId);
 
     /**
      * @brief Helper to apply an operation to all screen states

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -3,6 +3,7 @@
 
 // Qt headers
 #include <algorithm>
+#include <utility>
 #include <QDebug>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -179,7 +180,8 @@ void AutotileEngine::onWindowZoneChanged(const QString& windowId, const QString&
         return;
     if (zoneId.isEmpty()) {
         for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-            if (it.key().desktop != m_currentDesktop || it.key().activity != m_currentActivity) {
+            if (it.key().desktop != currentDesktopForScreen(it.key().screenId)
+                || it.key().activity != m_currentActivity) {
                 continue;
             }
             if (it.value() && it.value()->isFloating(windowId)) {
@@ -399,11 +401,21 @@ void AutotileEngine::moveToPosition(const QString& windowId, int position, const
 
 void AutotileEngine::setCurrentDesktop(int desktop)
 {
-    if (desktop == m_currentDesktop) {
+    desktop = qMax(1, desktop);
+
+    bool changed = (desktop != m_currentDesktop);
+    for (auto it = m_screenCurrentDesktop.constBegin(); it != m_screenCurrentDesktop.constEnd(); ++it) {
+        if (it.value() != desktop) {
+            changed = true;
+            break;
+        }
+    }
+    if (!changed) {
         return;
     }
+
     qCInfo(PhosphorTileEngine::lcTileEngine)
-        << "Switching autotile context: desktop" << m_currentDesktop << "->" << desktop;
+        << "Switching autotile context globally: desktop" << m_currentDesktop << "->" << desktop;
     // Only flag as desktop switch if we already had a valid context (desktop > 0).
     // Initial setup (desktop 0 → 1 during daemon startup) is NOT a switch — the
     // effect must receive the normal enabledChanged/autotileScreensChanged sequence
@@ -414,7 +426,63 @@ void AutotileEngine::setCurrentDesktop(int desktop)
     // desktop AND activity change simultaneously (e.g., activity-per-desktop).
     m_isDesktopContextSwitch |= (m_currentDesktop > 0);
     m_currentDesktop = desktop;
+
+    // Current KWin exposes a global current desktop. Model that as every output
+    // having the same visible desktop, while keeping navigation keyed by
+    // (screen, desktop) so per-output virtual desktops can diverge later.
+    for (auto it = m_screenCurrentDesktop.begin(); it != m_screenCurrentDesktop.end(); ++it) {
+        it.value() = desktop;
+    }
+    for (const QString& screenId : std::as_const(m_autotileScreens)) {
+        m_screenCurrentDesktop.insert(screenId, desktop);
+    }
+
     schedulePromoteSavedWindowOrders();
+}
+
+int AutotileEngine::currentDesktopForScreen(const QString& screenId) const noexcept
+{
+    if (screenId.isEmpty()) {
+        return m_currentDesktop;
+    }
+    return m_screenCurrentDesktop.value(screenId, m_currentDesktop);
+}
+
+void AutotileEngine::setCurrentDesktopForScreen(const QString& screenId, int desktop)
+{
+    if (screenId.isEmpty()) {
+        setCurrentDesktop(desktop);
+        return;
+    }
+
+    desktop = qMax(1, desktop);
+    const int previous = currentDesktopForScreen(screenId);
+    if (previous == desktop) {
+        return;
+    }
+
+    qCInfo(PhosphorTileEngine::lcTileEngine)
+        << "Switching autotile context for screen" << screenId << ": desktop" << previous << "->" << desktop;
+
+    m_isDesktopContextSwitch |= (previous > 0);
+    m_screenCurrentDesktop.insert(screenId, desktop);
+    m_currentDesktop = desktop;
+    schedulePromoteSavedWindowOrders();
+}
+
+void AutotileEngine::setDesktopCount(int count)
+{
+    m_desktopCount = qMax(1, count);
+    m_desktopRows = qBound(1, m_desktopRows, m_desktopCount);
+    m_currentDesktop = qBound(1, m_currentDesktop, m_desktopCount);
+    for (auto it = m_screenCurrentDesktop.begin(); it != m_screenCurrentDesktop.end(); ++it) {
+        it.value() = qBound(1, it.value(), m_desktopCount);
+    }
+}
+
+void AutotileEngine::setDesktopRows(int rows)
+{
+    m_desktopRows = qBound(1, rows, m_desktopCount);
 }
 
 void AutotileEngine::setCurrentActivity(const QString& activity)
@@ -482,9 +550,10 @@ void AutotileEngine::updateStickyScreenPins(const std::function<bool(const QStri
                     << "Unpinning screen" << screenId << "from desktop" << pinnedDesktop;
 
                 // Migrate PhosphorTiles::TilingState from pinned key to current desktop key
-                if (pinnedDesktop != m_currentDesktop) {
+                const int targetDesktop = currentDesktopForScreen(screenId);
+                if (pinnedDesktop != targetDesktop) {
                     TilingStateKey oldKey{screenId, pinnedDesktop, m_currentActivity};
-                    TilingStateKey newKey{screenId, m_currentDesktop, m_currentActivity};
+                    TilingStateKey newKey{screenId, targetDesktop, m_currentActivity};
 
                     auto oldIt = m_screenStates.find(oldKey);
                     if (oldIt != m_screenStates.end()) {
@@ -516,7 +585,7 @@ void AutotileEngine::updateStickyScreenPins(const std::function<bool(const QStri
 
                         qCInfo(PhosphorTileEngine::lcTileEngine)
                             << "Migrated screen" << screenId << "state from desktop" << pinnedDesktop << "to"
-                            << m_currentDesktop;
+                            << targetDesktop;
                     }
                 }
             }
@@ -532,7 +601,11 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
         // autotile screen set leaves the flag set. The NEXT setAutotileScreens
         // call (e.g. from a toggle OFF) then incorrectly reports isDesktopSwitch=true,
         // causing the effect to skip geometry/border restore on toggle OFF.
+        const bool wasDesktopSwitch = m_isDesktopContextSwitch;
         m_isDesktopContextSwitch = false;
+        if (wasDesktopSwitch) {
+            Q_EMIT autotileScreensChanged(QStringList(m_autotileScreens.begin(), m_autotileScreens.end()), true);
+        }
         return;
     }
 
@@ -554,6 +627,9 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
     }
 
     m_autotileScreens = screens;
+    for (const QString& screenId : added) {
+        m_screenCurrentDesktop.insert(screenId, m_currentDesktop);
+    }
 
     // R1 fix: Retile newly-added screens without requiring pre-existing state.
     // tilingStateForScreen() creates the PhosphorTiles::TilingState lazily, so windows that arrive
@@ -631,7 +707,7 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
         // Only prune states that match the current desktop/activity AND whose
         // screen is no longer in the autotile set. States for other desktops
         // are left untouched — they'll be pruned when that desktop is current.
-        if (key.desktop != m_currentDesktop || key.activity != m_currentActivity) {
+        if (key.desktop != currentDesktopForScreen(key.screenId) || key.activity != m_currentActivity) {
             continue;
         }
         if (!removed.contains(key.screenId)) {
@@ -1443,7 +1519,7 @@ void AutotileEngine::deserializeWindowOrders(const QJsonArray& orders)
         const QString activity = entry[QLatin1String("activity")].toString();
         TilingStateKey loadKey;
         loadKey.screenId = screenId;
-        loadKey.desktop = (desktop > 0) ? desktop : m_currentDesktop;
+        loadKey.desktop = (desktop > 0) ? desktop : currentDesktopForScreen(screenId);
         loadKey.activity = !activity.isEmpty() ? activity : m_currentActivity;
         const QString compositeKey =
             QStringLiteral("%1/%2/%3").arg(loadKey.screenId).arg(loadKey.desktop).arg(loadKey.activity);
@@ -1462,7 +1538,7 @@ void AutotileEngine::deserializeWindowOrders(const QJsonArray& orders)
         }
         if (!windowOrder.isEmpty()) {
             m_savedWindowOrders[loadKey] = windowOrder;
-            const bool isCurrentContext = loadKey.desktop == m_currentDesktop
+            const bool isCurrentContext = loadKey.desktop == currentDesktopForScreen(screenId)
                 && (loadKey.activity.isEmpty() || loadKey.activity == m_currentActivity);
             if (isCurrentContext) {
                 m_pendingInitialOrders[screenId] = windowOrder;
@@ -1902,7 +1978,8 @@ void AutotileEngine::toggleFocusedWindowFloat()
     }
     if (!state) {
         for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-            if (it.value() && !it.value()->focusedWindow().isEmpty() && it.key().desktop == m_currentDesktop
+            if (it.value() && !it.value()->focusedWindow().isEmpty()
+                && it.key().desktop == currentDesktopForScreen(it.key().screenId)
                 && it.key().activity == m_currentActivity) {
                 screenId = it.key().screenId;
                 state = it.value();
@@ -1964,7 +2041,8 @@ void AutotileEngine::toggleWindowFloat(const QString& rawWindowId, const QString
     // states only — states for other desktops should not be considered.
     if (!state) {
         for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-            if (it.key().desktop != m_currentDesktop || it.key().activity != m_currentActivity) {
+            if (it.key().desktop != currentDesktopForScreen(it.key().screenId)
+                || it.key().activity != m_currentActivity) {
                 continue;
             }
             if (it.value() && it.value()->containsWindow(windowId)) {
@@ -3561,7 +3639,7 @@ void AutotileEngine::propagateGlobalSplitRatio()
     // Only propagate to current desktop/activity states — per-desktop split
     // ratio adjustments (via increaseMasterRatio) are preserved on other desktops.
     for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-        if (it.key().desktop != m_currentDesktop || it.key().activity != m_currentActivity) {
+        if (it.key().desktop != currentDesktopForScreen(it.key().screenId) || it.key().activity != m_currentActivity) {
             continue;
         }
         if (it.value() && !hasPerScreenOverride(it.key().screenId, PerScreenKeys::SplitRatio)) {
@@ -3575,7 +3653,7 @@ void AutotileEngine::propagateGlobalMasterCount()
     // Only propagate to current desktop/activity states — per-desktop master
     // count adjustments are preserved on other desktops.
     for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-        if (it.key().desktop != m_currentDesktop || it.key().activity != m_currentActivity) {
+        if (it.key().desktop != currentDesktopForScreen(it.key().screenId) || it.key().activity != m_currentActivity) {
             continue;
         }
         if (it.value() && !hasPerScreenOverride(it.key().screenId, PerScreenKeys::MasterCount)) {
@@ -3605,7 +3683,7 @@ void AutotileEngine::backfillWindows()
         // (insertWindow calls m_windowToStateKey.insert which is unsafe during const iteration)
         QStringList candidates;
         for (auto it = m_windowToStateKey.constBegin(); it != m_windowToStateKey.constEnd(); ++it) {
-            if (it.value().screenId == screenId && it.value().desktop == m_currentDesktop
+            if (it.value().screenId == screenId && it.value().desktop == currentDesktopForScreen(screenId)
                 && it.value().activity == m_currentActivity && !state->containsWindow(it.key())
                 && shouldTileWindow(it.key())) {
                 candidates.append(it.key());
@@ -3871,8 +3949,8 @@ void AutotileEngine::promoteSavedWindowOrders()
     // is replaced by desktop 2's order when switching to desktop 2).
     for (auto it = m_savedWindowOrders.begin(); it != m_savedWindowOrders.end();) {
         const TilingStateKey& key = it.key();
-        const bool matchesContext =
-            key.desktop == m_currentDesktop && (key.activity.isEmpty() || key.activity == m_currentActivity);
+        const bool matchesContext = key.desktop == currentDesktopForScreen(key.screenId)
+            && (key.activity.isEmpty() || key.activity == m_currentActivity);
 
         if (matchesContext) {
             m_pendingInitialOrders[key.screenId] = it.value();
@@ -3960,7 +4038,8 @@ void AutotileEngine::focusInDirection(const QString& direction, const Navigation
     // tracker, which can drift when focus moves through floating, snapped, or
     // never-tracked windows that don't update it (same root cause as the
     // toggleFocusedFloat fix).
-    m_navigation->focusInDirection(direction, QStringLiteral("focus"), canonicalizeForLookup(ctx.windowId));
+    m_navigation->focusInDirection(direction, QStringLiteral("focus"), canonicalizeForLookup(ctx.windowId),
+                                   ctx.screenId);
 }
 
 void AutotileEngine::moveFocusedInDirection(const QString& direction, const NavigationContext& ctx)
@@ -4020,7 +4099,7 @@ void AutotileEngine::toggleFocusedFloat(const NavigationContext& ctx)
 void AutotileEngine::cycleFocus(bool forward, const NavigationContext& ctx)
 {
     const QString dir = forward ? QStringLiteral("right") : QStringLiteral("left");
-    m_navigation->focusInDirection(dir, QStringLiteral("cycle"), canonicalizeForLookup(ctx.windowId));
+    m_navigation->focusInDirection(dir, QStringLiteral("cycle"), canonicalizeForLookup(ctx.windowId), ctx.screenId);
 }
 
 void AutotileEngine::pushToEmptyZone(const NavigationContext& /*ctx*/)

--- a/libs/phosphor-tile-engine/src/NavigationController.cpp
+++ b/libs/phosphor-tile-engine/src/NavigationController.cpp
@@ -11,12 +11,52 @@
 #include <PhosphorScreens/Manager.h>
 
 #include <QScreen>
+#include <QRect>
 #include <algorithm>
+#include <limits>
+#include <utility>
 #include <PhosphorScreens/ScreenIdentity.h>
 
 namespace PhosphorTileEngine {
 
 namespace PerScreenKeys = PhosphorEngine::PerScreenKeys;
+
+namespace {
+
+bool isForwardDirection(const QString& direction)
+{
+    return direction == QLatin1String("right") || direction == QLatin1String("down");
+}
+
+bool isHorizontalDirection(const QString& direction)
+{
+    return direction == QLatin1String("left") || direction == QLatin1String("right");
+}
+
+int entryIndexForDirection(const QString& direction, int windowCount)
+{
+    if (windowCount <= 0) {
+        return 0;
+    }
+    // Moving right/down enters a target screen/desktop at its first tiled slot;
+    // moving left/up enters at the opposite edge.
+    return isForwardDirection(direction) ? 0 : windowCount - 1;
+}
+
+int axisOverlap(const QRect& a, const QRect& b, bool horizontalNavigation)
+{
+    if (horizontalNavigation) {
+        return qMax(0, qMin(a.bottom(), b.bottom()) - qMax(a.top(), b.top()) + 1);
+    }
+    return qMax(0, qMin(a.right(), b.right()) - qMax(a.left(), b.left()) + 1);
+}
+
+int orthogonalCenterDistance(const QRect& a, const QRect& b, bool horizontalNavigation)
+{
+    return horizontalNavigation ? qAbs(a.center().y() - b.center().y()) : qAbs(a.center().x() - b.center().x());
+}
+
+} // namespace
 
 NavigationController::NavigationController(AutotileEngine* engine)
     : m_engine(engine)
@@ -119,13 +159,13 @@ void NavigationController::rotateWindowOrder(bool clockwise)
 void NavigationController::swapFocusedInDirection(const QString& direction, const QString& action,
                                                   const QString& explicitWindowId)
 {
-    const bool forward = (direction == QLatin1String("right") || direction == QLatin1String("down"));
+    const bool forward = isForwardDirection(direction);
 
     QString screenId;
     PhosphorTiles::TilingState* state = nullptr;
     const QStringList windows = tiledWindowsForFocusedScreen(screenId, state, explicitWindowId);
 
-    if (windows.size() < 2 || !state) {
+    if (windows.isEmpty() || !state) {
         Q_EMIT m_engine->navigationFeedback(false, action, QStringLiteral("nothing_to_swap"), QString(), QString(),
                                             screenId);
         return;
@@ -143,8 +183,34 @@ void NavigationController::swapFocusedInDirection(const QString& direction, cons
         return;
     }
 
+    const bool atBoundary = forward ? (currentIndex == windows.size() - 1) : (currentIndex == 0);
+    if (atBoundary) {
+        const QString targetScreen = neighborAutotileScreenInDirection(screenId, direction);
+        if (!targetScreen.isEmpty()
+            && moveFocusedToBoundaryTarget(focused, screenId, state, targetScreen,
+                                           m_engine->currentDesktopForScreen(targetScreen), direction)) {
+            Q_EMIT m_engine->navigationFeedback(true, action, QStringLiteral("screen:%1").arg(direction), QString(),
+                                                QString(), targetScreen);
+            return;
+        }
+
+        const int targetDesktop = neighborDesktopInDirection(screenId, direction);
+        if (targetDesktop > 0
+            && moveFocusedToBoundaryTarget(focused, screenId, state, screenId, targetDesktop, direction)) {
+            Q_EMIT m_engine->navigationFeedback(true, action, QStringLiteral("desktop:%1").arg(targetDesktop),
+                                                QString(), QString(), screenId);
+            return;
+        }
+    }
+
+    if (windows.size() < 2) {
+        Q_EMIT m_engine->navigationFeedback(false, action, QStringLiteral("nothing_to_swap"), QString(), QString(),
+                                            screenId);
+        return;
+    }
+
     int targetIndex = forward ? currentIndex + 1 : currentIndex - 1;
-    // Wrap around
+    // Preserve the existing local wrap behavior when there is no boundary target.
     if (targetIndex < 0) {
         targetIndex = windows.size() - 1;
     } else if (targetIndex >= windows.size()) {
@@ -159,22 +225,83 @@ void NavigationController::swapFocusedInDirection(const QString& direction, cons
 }
 
 void NavigationController::focusInDirection(const QString& direction, const QString& action,
-                                            const QString& explicitWindowId)
+                                            const QString& explicitWindowId, const QString& explicitScreenId)
 {
-    const bool forward = (direction == QLatin1String("right") || direction == QLatin1String("down"));
+    const bool forward = isForwardDirection(direction);
 
     QString screenId;
     PhosphorTiles::TilingState* state = nullptr;
     const QStringList windows = tiledWindowsForFocusedScreen(screenId, state, explicitWindowId);
 
     if (windows.isEmpty() || !state) {
+        const QString fallbackScreenId = screenId.isEmpty() ? resolveFallbackScreenId(explicitScreenId) : screenId;
+
+        const QString targetScreen = neighborAutotileScreenInDirection(fallbackScreenId, direction);
+        if (!targetScreen.isEmpty()) {
+            if (focusBoundaryTarget(targetScreen, m_engine->currentDesktopForScreen(targetScreen), direction, action,
+                                    targetScreen)) {
+                return;
+            }
+            if (focusEmptyScreenBoundaryTarget(targetScreen, direction, action)) {
+                return;
+            }
+        }
+
+        const int targetDesktop = neighborDesktopInDirection(fallbackScreenId, direction);
+        if (targetDesktop > 0 && !fallbackScreenId.isEmpty()) {
+            Q_EMIT m_engine->currentDesktopChangeRequestedForScreen(fallbackScreenId, targetDesktop);
+            m_engine->setCurrentDesktopForScreen(fallbackScreenId, targetDesktop);
+            if (focusBoundaryTarget(fallbackScreenId, targetDesktop, direction, action, fallbackScreenId)) {
+                return;
+            }
+
+            // With no tiled window on the source desktop, there is no local
+            // boundary index to inspect. Treat the empty desktop itself as
+            // the boundary: switch desktops and stop rather than reporting
+            // no_windows or wrapping to stale focus state from another context.
+            Q_EMIT m_engine->navigationFeedback(true, action, QStringLiteral("desktop:%1").arg(targetDesktop),
+                                                QString(), QString(), fallbackScreenId);
+            return;
+        }
+
         Q_EMIT m_engine->navigationFeedback(false, action, QStringLiteral("no_windows"), QString(), QString(),
-                                            screenId);
+                                            fallbackScreenId);
         return;
     }
 
     const QString focused = !explicitWindowId.isEmpty() ? explicitWindowId : state->focusedWindow();
     const int currentIndex = qMax(0, windows.indexOf(focused));
+    const bool atBoundary = forward ? (currentIndex == windows.size() - 1) : (currentIndex == 0);
+    if (atBoundary) {
+        const QString targetScreen = neighborAutotileScreenInDirection(screenId, direction);
+        if (!targetScreen.isEmpty()) {
+            if (focusBoundaryTarget(targetScreen, m_engine->currentDesktopForScreen(targetScreen), direction, action,
+                                    targetScreen)) {
+                return;
+            }
+            if (focusEmptyScreenBoundaryTarget(targetScreen, direction, action)) {
+                return;
+            }
+        }
+
+        const int targetDesktop = neighborDesktopInDirection(screenId, direction);
+        if (targetDesktop > 0) {
+            Q_EMIT m_engine->currentDesktopChangeRequestedForScreen(screenId, targetDesktop);
+            m_engine->setCurrentDesktopForScreen(screenId, targetDesktop);
+            if (focusBoundaryTarget(screenId, targetDesktop, direction, action, screenId)) {
+                return;
+            }
+
+            // Desktop traversal should still cross the
+            // boundary when the target desktop currently has no tiled
+            // windows. Switch desktops and stop instead of wrapping focus
+            // back to another window on the source desktop.
+            Q_EMIT m_engine->navigationFeedback(true, action, QStringLiteral("desktop:%1").arg(targetDesktop),
+                                                QString(), QString(), screenId);
+            return;
+        }
+    }
+
     const int targetIndex = (currentIndex + (forward ? 1 : -1) + windows.size()) % windows.size();
 
     Q_EMIT m_engine->activateWindowRequested(windows.at(targetIndex));
@@ -350,6 +477,22 @@ QString NavigationController::resolveActiveScreen() const
     return QString();
 }
 
+QString NavigationController::resolveFallbackScreenId(const QString& explicitScreenId) const
+{
+    if (!explicitScreenId.isEmpty()) {
+        return explicitScreenId;
+    }
+
+    const QString activeScreen = resolveActiveScreen();
+    if (!activeScreen.isEmpty()) {
+        return activeScreen;
+    }
+
+    const Phosphor::Screens::PhysicalScreen primaryScreen =
+        m_engine->m_screenManager ? m_engine->m_screenManager->primaryScreen() : Phosphor::Screens::PhysicalScreen{};
+    return primaryScreen.isValid() ? primaryScreen.identifier : QString();
+}
+
 void NavigationController::emitFocusRequestAtIndex(int indexOffset, bool useFirst)
 {
     QString screenId;
@@ -382,7 +525,8 @@ QStringList NavigationController::tiledWindowsForFocusedScreen(QString& outScree
     // it — using the daemon's value avoids operating on the wrong window.
     if (!explicitWindowId.isEmpty()) {
         for (auto it = m_engine->m_screenStates.constBegin(); it != m_engine->m_screenStates.constEnd(); ++it) {
-            if (it.key().desktop != m_engine->m_currentDesktop || it.key().activity != m_engine->m_currentActivity) {
+            if (it.key().desktop != m_engine->currentDesktopForScreen(it.key().screenId)
+                || it.key().activity != m_engine->m_currentActivity) {
                 continue;
             }
             PhosphorTiles::TilingState* state = it.value();
@@ -413,7 +557,8 @@ QStringList NavigationController::tiledWindowsForFocusedScreen(QString& outScree
 
     // Fallback: scan states for current desktop/activity (e.g., if m_activeScreen is stale)
     for (auto it = m_engine->m_screenStates.constBegin(); it != m_engine->m_screenStates.constEnd(); ++it) {
-        if (it.key().desktop != m_engine->m_currentDesktop || it.key().activity != m_engine->m_currentActivity) {
+        if (it.key().desktop != m_engine->currentDesktopForScreen(it.key().screenId)
+            || it.key().activity != m_engine->m_currentActivity) {
             continue;
         }
         PhosphorTiles::TilingState* state = it.value();
@@ -441,6 +586,232 @@ QStringList NavigationController::tiledWindowsForFocusedScreen(QString& outScree
     return {};
 }
 
+QString NavigationController::neighborAutotileScreenInDirection(const QString& sourceScreenId,
+                                                                const QString& direction) const
+{
+    if (!m_engine || !m_engine->m_screenManager || sourceScreenId.isEmpty()) {
+        return QString();
+    }
+
+    const QRect sourceGeometry = m_engine->screenGeometry(sourceScreenId);
+    if (!sourceGeometry.isValid()) {
+        return QString();
+    }
+
+    const bool horizontal = isHorizontalDirection(direction);
+    QString bestScreen;
+    int bestDistance = std::numeric_limits<int>::max();
+    int bestCenterDistance = std::numeric_limits<int>::max();
+
+    for (const QString& candidate : std::as_const(m_engine->m_autotileScreens)) {
+        if (candidate == sourceScreenId) {
+            continue;
+        }
+
+        const QRect candidateGeometry = m_engine->screenGeometry(candidate);
+        if (!candidateGeometry.isValid() || axisOverlap(sourceGeometry, candidateGeometry, horizontal) <= 0) {
+            continue;
+        }
+
+        int distance = -1;
+        if (direction == QLatin1String("right")) {
+            if (candidateGeometry.left() <= sourceGeometry.right()) {
+                continue;
+            }
+            distance = candidateGeometry.left() - sourceGeometry.right();
+        } else if (direction == QLatin1String("left")) {
+            if (candidateGeometry.right() >= sourceGeometry.left()) {
+                continue;
+            }
+            distance = sourceGeometry.left() - candidateGeometry.right();
+        } else if (direction == QLatin1String("down")) {
+            if (candidateGeometry.top() <= sourceGeometry.bottom()) {
+                continue;
+            }
+            distance = candidateGeometry.top() - sourceGeometry.bottom();
+        } else if (direction == QLatin1String("up")) {
+            if (candidateGeometry.bottom() >= sourceGeometry.top()) {
+                continue;
+            }
+            distance = sourceGeometry.top() - candidateGeometry.bottom();
+        }
+
+        if (distance < 0) {
+            continue;
+        }
+
+        const int centerDistance = orthogonalCenterDistance(sourceGeometry, candidateGeometry, horizontal);
+        if (distance < bestDistance || (distance == bestDistance && centerDistance < bestCenterDistance)) {
+            bestDistance = distance;
+            bestCenterDistance = centerDistance;
+            bestScreen = candidate;
+        }
+    }
+
+    return bestScreen;
+}
+
+int NavigationController::neighborDesktopInDirection(const QString& sourceScreenId, const QString& direction) const
+{
+    if (!m_engine) {
+        return 0;
+    }
+
+    const int count = qMax(1, m_engine->m_desktopCount);
+    const int rows = qBound(1, m_engine->m_desktopRows, count);
+    const int columns = qMax(1, (count + rows - 1) / rows);
+
+    const int sourceDesktop = m_engine->currentDesktopForScreen(sourceScreenId);
+    const int sourceIndex = sourceDesktop - 1; // desktop numbers are 1-based
+    if (sourceIndex < 0 || sourceIndex >= count) {
+        return 0;
+    }
+
+    const int sourceRow = sourceIndex / columns;
+    const int sourceColumn = sourceIndex % columns;
+    int targetIndex = -1;
+
+    if (direction == QLatin1String("left")) {
+        if (sourceColumn == 0) {
+            return 0;
+        }
+        targetIndex = sourceIndex - 1;
+    } else if (direction == QLatin1String("right")) {
+        if (sourceColumn == columns - 1) {
+            return 0;
+        }
+        targetIndex = sourceIndex + 1;
+    } else if (direction == QLatin1String("up")) {
+        if (sourceRow == 0) {
+            return 0;
+        }
+        targetIndex = sourceIndex - columns;
+    } else if (direction == QLatin1String("down")) {
+        if (sourceRow == rows - 1) {
+            return 0;
+        }
+        targetIndex = sourceIndex + columns;
+    }
+
+    if (targetIndex < 0 || targetIndex >= count) {
+        return 0;
+    }
+
+    // Avoid horizontal movement wrapping across rows on partial grids.
+    if ((direction == QLatin1String("left") || direction == QLatin1String("right"))
+        && targetIndex / columns != sourceRow) {
+        return 0;
+    }
+
+    return targetIndex + 1;
+}
+
+bool NavigationController::moveFocusedToBoundaryTarget(const QString& focused, const QString& sourceScreenId,
+                                                       PhosphorTiles::TilingState* sourceState,
+                                                       const QString& targetScreenId, int targetDesktop,
+                                                       const QString& direction)
+{
+    if (!m_engine || focused.isEmpty() || !sourceState || targetScreenId.isEmpty() || targetDesktop < 1) {
+        return false;
+    }
+
+    PhosphorEngine::TilingStateKey targetKey{targetScreenId, targetDesktop, m_engine->m_currentActivity};
+    PhosphorTiles::TilingState* targetState = nullptr;
+    if (targetDesktop == m_engine->currentDesktopForScreen(targetScreenId)) {
+        targetState = m_engine->tilingStateForScreen(targetScreenId);
+    } else {
+        targetState = m_engine->stateForKey(targetKey);
+    }
+    if (!targetState) {
+        return false;
+    }
+
+    const int sourceDesktop = m_engine->currentDesktopForScreen(sourceScreenId);
+    const bool crossDesktop = targetDesktop != sourceDesktop;
+    const bool crossScreen = targetScreenId != sourceScreenId;
+    const int insertPosition = isForwardDirection(direction) ? 0 : -1;
+
+    if (!sourceState->removeWindow(focused)) {
+        return false;
+    }
+    if (!targetState->addWindow(focused, insertPosition)) {
+        sourceState->addWindow(focused);
+        return false;
+    }
+
+    m_engine->m_windowToStateKey[focused] = targetKey;
+    targetState->setFocusedWindow(focused);
+    m_engine->m_activeScreen = targetScreenId;
+
+    m_engine->retileAfterOperation(sourceScreenId, true);
+    if (crossDesktop) {
+        Q_EMIT m_engine->windowDesktopMoveRequested(focused, targetDesktop);
+        if (!crossScreen) {
+            Q_EMIT m_engine->currentDesktopChangeRequestedForScreen(sourceScreenId, targetDesktop);
+            m_engine->setCurrentDesktopForScreen(sourceScreenId, targetDesktop);
+            // The daemon's desktop-change path will retile the new desktop after
+            // the compositor moves the window's desktop membership.
+        } else {
+            // Per-output desktop semantics: crossing onto another output targets
+            // that output's already-visible desktop. There is no desktop switch
+            // to wait for, so retile the destination surface immediately.
+            m_engine->retileAfterOperation(targetScreenId, true);
+        }
+    } else {
+        m_engine->retileAfterOperation(targetScreenId, true);
+    }
+
+    Q_EMIT m_engine->activateWindowRequested(focused);
+    return true;
+}
+
+bool NavigationController::focusBoundaryTarget(const QString& targetScreenId, int targetDesktop,
+                                               const QString& direction, const QString& action,
+                                               const QString& feedbackScreenId)
+{
+    if (!m_engine || targetScreenId.isEmpty() || targetDesktop < 1) {
+        return false;
+    }
+
+    const PhosphorEngine::TilingStateKey targetKey{targetScreenId, targetDesktop, m_engine->m_currentActivity};
+    auto it = m_engine->m_screenStates.constFind(targetKey);
+    if (it == m_engine->m_screenStates.constEnd() || !it.value()) {
+        return false;
+    }
+
+    const QStringList targetWindows = it.value()->tiledWindows();
+    if (targetWindows.isEmpty()) {
+        return false;
+    }
+
+    const int targetIndex = entryIndexForDirection(direction, targetWindows.size());
+    Q_EMIT m_engine->activateWindowRequested(targetWindows.at(targetIndex));
+    Q_EMIT m_engine->navigationFeedback(true, action,
+                                        targetDesktop == m_engine->currentDesktopForScreen(targetScreenId)
+                                            ? QStringLiteral("screen:%1").arg(direction)
+                                            : QStringLiteral("desktop:%1").arg(targetDesktop),
+                                        QString(), QString(), feedbackScreenId);
+    return true;
+}
+
+bool NavigationController::focusEmptyScreenBoundaryTarget(const QString& targetScreenId, const QString& direction,
+                                                          const QString& action)
+{
+    if (!m_engine || targetScreenId.isEmpty()) {
+        return false;
+    }
+
+    // Outputs have priority over virtual desktops at a boundary. If the
+    // neighboring output has no tiled windows on its visible desktop, remember
+    // it as the active navigation surface and stop instead of falling through
+    // to a virtual-desktop transition on the source output. There is no KWin
+    // window to activate in this case.
+    m_engine->m_activeScreen = targetScreenId;
+    Q_EMIT m_engine->navigationFeedback(true, action, QStringLiteral("screen:%1").arg(direction), QString(), QString(),
+                                        targetScreenId);
+    return true;
+}
+
 void NavigationController::applyToAllStates(const std::function<void(PhosphorTiles::TilingState*)>& operation)
 {
     if (m_engine->m_screenStates.isEmpty()) {
@@ -449,8 +820,8 @@ void NavigationController::applyToAllStates(const std::function<void(PhosphorTil
 
     // Only apply to states for the current desktop/activity
     for (auto it = m_engine->m_screenStates.begin(); it != m_engine->m_screenStates.end(); ++it) {
-        if (it.key().desktop == m_engine->m_currentDesktop && it.key().activity == m_engine->m_currentActivity
-            && it.value()) {
+        if (it.key().desktop == m_engine->currentDesktopForScreen(it.key().screenId)
+            && it.key().activity == m_engine->m_currentActivity && it.value()) {
             operation(it.value());
         }
     }

--- a/libs/phosphor-workspaces/include/PhosphorWorkspaces/VirtualDesktopManager.h
+++ b/libs/phosphor-workspaces/include/PhosphorWorkspaces/VirtualDesktopManager.h
@@ -26,17 +26,22 @@ public:
     void stop();
 
     int currentDesktop() const override;
+    int currentDesktopForScreen(const QString& screenId) const;
     void setCurrentDesktop(int desktop);
+    void setCurrentDesktopForScreen(const QString& screenId, int desktop);
     int desktopCount() const;
+    int desktopRows() const;
     QStringList desktopNames() const;
 
 Q_SIGNALS:
     void currentDesktopChanged(int desktop);
     void desktopCountChanged(int count);
+    void desktopRowsChanged(int rows);
 
 private Q_SLOTS:
     void onCurrentDesktopChanged(int desktop);
     void onNumberOfDesktopsChanged(int count);
+    void onDesktopRowsChanged(uint rows);
     void refreshFromKWin();
     void onKWinCurrentChanged(const QString& desktopId);
     void onKWinDesktopCreated();
@@ -51,6 +56,7 @@ private:
     bool m_useKWinDBus = false;
     int m_currentDesktop = 1;
     int m_desktopCount = 1;
+    int m_desktopRows = 1;
     QStringList m_desktopNames;
     QStringList m_desktopIds;
     uint m_refreshGeneration = 0;

--- a/libs/phosphor-workspaces/src/VirtualDesktopManager.cpp
+++ b/libs/phosphor-workspaces/src/VirtualDesktopManager.cpp
@@ -53,6 +53,10 @@ void VirtualDesktopManager::initKWinDBus()
 
         QDBusConnection::sessionBus().connect(QStringLiteral("org.kde.KWin"), QStringLiteral("/VirtualDesktopManager"),
                                               QStringLiteral("org.kde.KWin.VirtualDesktopManager"),
+                                              QStringLiteral("rowsChanged"), this, SLOT(onDesktopRowsChanged(uint)));
+
+        QDBusConnection::sessionBus().connect(QStringLiteral("org.kde.KWin"), QStringLiteral("/VirtualDesktopManager"),
+                                              QStringLiteral("org.kde.KWin.VirtualDesktopManager"),
                                               QStringLiteral("desktopCreated"), this, SLOT(onKWinDesktopCreated()));
 
         QDBusConnection::sessionBus().connect(QStringLiteral("org.kde.KWin"), QStringLiteral("/VirtualDesktopManager"),
@@ -112,6 +116,7 @@ void VirtualDesktopManager::applyDesktopListReply(const QDBusMessage& reply, con
 
     if (!m_desktopIds.isEmpty() && m_desktopIds.size() != m_desktopCount) {
         m_desktopCount = m_desktopIds.size();
+        m_desktopRows = qBound(1, m_desktopRows, m_desktopCount);
     }
 
     if (!currentId.isEmpty() && !m_desktopIds.isEmpty()) {
@@ -134,7 +139,12 @@ void VirtualDesktopManager::refreshFromKWin()
 
     QVariant countVar = m_kwinVDInterface->property("count");
     if (countVar.isValid()) {
-        m_desktopCount = countVar.toInt();
+        m_desktopCount = qMax(1, countVar.toInt());
+    }
+
+    QVariant rowsVar = m_kwinVDInterface->property("rows");
+    if (rowsVar.isValid()) {
+        m_desktopRows = qBound(1, rowsVar.toInt(), m_desktopCount);
     }
 
     QVariant currentVar = m_kwinVDInterface->property("current");
@@ -222,18 +232,47 @@ int VirtualDesktopManager::currentDesktop() const
     return m_useKWinDBus ? m_currentDesktop : 1;
 }
 
+int VirtualDesktopManager::currentDesktopForScreen(const QString& screenId) const
+{
+    Q_UNUSED(screenId)
+    // Plasma versions through the current global-desktop model expose one
+    // active desktop for the session. Keep the output-scoped accessor as the
+    // daemon/engine integration point for KDE's per-output virtual desktops.
+    return currentDesktop();
+}
+
 void VirtualDesktopManager::setCurrentDesktop(int desktop)
 {
     if (desktop < 1 || desktop > m_desktopCount) {
         return;
     }
 
+    bool requestSent = false;
     if (m_useKWinDBus && m_kwinVDInterface) {
         int idx = desktop - 1;
         if (idx >= 0 && idx < m_desktopIds.size()) {
             m_kwinVDInterface->setProperty("current", m_desktopIds.at(idx));
+            requestSent = true;
         }
     }
+
+    // The KWin property change notification is asynchronous. Navigation uses
+    // the daemon's desktop shadow immediately after requesting a boundary
+    // crossing, so update it optimistically for valid requests. When the real
+    // KWin signal arrives, onCurrentDesktopChanged() will no-op if the value
+    // already matches.
+    if (requestSent || !m_useKWinDBus) {
+        onCurrentDesktopChanged(desktop);
+    }
+}
+
+void VirtualDesktopManager::setCurrentDesktopForScreen(const QString& screenId, int desktop)
+{
+    Q_UNUSED(screenId)
+    // Fallback for current KWin: changing one output's desktop is equivalent
+    // to changing the global desktop. Future KWin per-output support should
+    // replace only this method, leaving callers keyed by screenId.
+    setCurrentDesktop(desktop);
 }
 
 void VirtualDesktopManager::onCurrentDesktopChanged(int desktop)
@@ -248,11 +287,13 @@ void VirtualDesktopManager::onCurrentDesktopChanged(int desktop)
 
 void VirtualDesktopManager::onNumberOfDesktopsChanged(int count)
 {
+    count = qMax(1, count);
     if (m_desktopCount == count) {
         return;
     }
 
     m_desktopCount = count;
+    m_desktopRows = qBound(1, m_desktopRows, m_desktopCount);
 
     if (m_useKWinDBus) {
         refreshFromKWin();
@@ -266,9 +307,25 @@ void VirtualDesktopManager::onNumberOfDesktopsChanged(int count)
     Q_EMIT desktopCountChanged(count);
 }
 
+void VirtualDesktopManager::onDesktopRowsChanged(uint rows)
+{
+    const int clampedRows = qBound(1, static_cast<int>(rows), m_desktopCount);
+    if (m_desktopRows == clampedRows) {
+        return;
+    }
+
+    m_desktopRows = clampedRows;
+    Q_EMIT desktopRowsChanged(m_desktopRows);
+}
+
 int VirtualDesktopManager::desktopCount() const
 {
     return m_useKWinDBus ? m_desktopCount : 1;
+}
+
+int VirtualDesktopManager::desktopRows() const
+{
+    return m_useKWinDBus ? m_desktopRows : 1;
 }
 
 QStringList VirtualDesktopManager::desktopNames() const

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -46,17 +46,23 @@ void Daemon::updateAutotileScreens()
 
     const int desktop = currentDesktop();
     const QString activity = currentActivity();
+    const auto desktopForScreen = [this, desktop](const QString& screenId) {
+        return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : desktop;
+    };
 
     QSet<QString> autotileScreens;
     QHash<QString, QString> screenAlgorithms;
     const QStringList effectiveIds = m_screenManager->effectiveScreenIds();
     for (const QString& screenId : effectiveIds) {
+        const int screenDesktop = desktopForScreen(screenId);
+        m_autotileEngine->setCurrentDesktopForScreen(screenId, screenDesktop);
+
         // Skip screens/desktops/activities where PlasmaZones is disabled
-        if (isContextDisabled(m_settings.get(), PhosphorZones::AssignmentEntry::Autotile, screenId, desktop,
+        if (isContextDisabled(m_settings.get(), PhosphorZones::AssignmentEntry::Autotile, screenId, screenDesktop,
                               activity)) {
             continue;
         }
-        QString assignmentId = m_layoutManager->assignmentIdForScreen(screenId, desktop, activity);
+        QString assignmentId = m_layoutManager->assignmentIdForScreen(screenId, screenDesktop, activity);
         if (PhosphorLayout::LayoutId::isAutotile(assignmentId)) {
             autotileScreens.insert(screenId);
             QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(assignmentId);
@@ -75,7 +81,7 @@ void Daemon::updateAutotileScreens()
     for (const QString& screenId : removedScreens) {
         QStringList order = m_autotileEngine->managedWindowOrder(screenId);
         if (!order.isEmpty()) {
-            m_lastAutotileOrders[TilingStateKey{screenId, desktop, activity}] = order;
+            m_lastAutotileOrders[TilingStateKey{screenId, desktopForScreen(screenId), activity}] = order;
         }
     }
 
@@ -340,9 +346,11 @@ QHash<TilingStateKey, QStringList> Daemon::captureAutotileOrders() const
     const int desktop = currentDesktop();
     const QString activity = currentActivity();
     for (const QString& screenId : m_autotileEngine->activeScreens()) {
+        const int screenDesktop =
+            m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : desktop;
         QStringList order = m_autotileEngine->managedWindowOrder(screenId);
         if (!order.isEmpty()) {
-            orders[TilingStateKey{screenId, desktop, activity}] = order;
+            orders[TilingStateKey{screenId, screenDesktop, activity}] = order;
         }
     }
     return orders;
@@ -459,7 +467,9 @@ void Daemon::seedAutotileOrderForScreen(const QString& screenId)
     // Prefer saved autotile order from last mode toggle (deterministic re-entry).
     // Falls back to zone-ordered window list when no saved order exists (first
     // activation, or windows changed between toggles).
-    TilingStateKey orderKey{screenId, currentDesktop(), currentActivity()};
+    const int desktop =
+        m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : currentDesktop();
+    TilingStateKey orderKey{screenId, desktop, currentActivity()};
     QStringList order = m_lastAutotileOrders.value(orderKey);
     if (order.isEmpty()) {
         PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -239,9 +239,29 @@ void Daemon::connectDesktopActivity()
                 showDesktopSwitchOsd(desktop, currentActivity());
             });
 
+    // Autotile keyboard navigation may request a desktop boundary crossing.
+    if (m_autotileEngine) {
+        connect(m_autotileEngine.get(), &PhosphorEngine::PlacementEngineBase::currentDesktopChangeRequested, this,
+                [this](int desktop) {
+                    if (m_virtualDesktopManager) {
+                        m_virtualDesktopManager->setCurrentDesktop(desktop);
+                    }
+                });
+        connect(m_autotileEngine.get(), &PhosphorEngine::PlacementEngineBase::currentDesktopChangeRequestedForScreen,
+                this, [this](const QString& screenId, int desktop) {
+                    if (m_virtualDesktopManager) {
+                        m_virtualDesktopManager->setCurrentDesktopForScreen(screenId, desktop);
+                    }
+                });
+    }
+
     // Prune stale PhosphorTiles::TilingState entries and disabled-desktop numbers when desktops are removed
     connect(m_virtualDesktopManager.get(), &PhosphorWorkspaces::VirtualDesktopManager::desktopCountChanged, this,
             [this](int newCount) {
+                if (m_autotileEngine) {
+                    m_autotileEngine->setDesktopCount(newCount);
+                    m_autotileEngine->setDesktopRows(m_virtualDesktopManager->desktopRows());
+                }
                 // Prune stale disabled-desktop entries (desktop numbers > newCount no longer exist).
                 // NOTE: KDE Plasma renumbers desktops when one in the middle is removed (e.g.
                 // removing desktop 2 of 4 shifts 3→2 and 4→3). We only prune out-of-range
@@ -282,12 +302,21 @@ void Daemon::connectDesktopActivity()
                 pruneContextMapsForDesktop(newCount);
             });
 
+    connect(m_virtualDesktopManager.get(), &PhosphorWorkspaces::VirtualDesktopManager::desktopRowsChanged, this,
+            [this](int rows) {
+                if (m_autotileEngine) {
+                    m_autotileEngine->setDesktopRows(rows);
+                }
+            });
+
     // Set initial virtual desktop on components that maintain their own copy
     // (WindowDragAdaptor reads from PhosphorZones::LayoutRegistry directly via resolveLayoutForScreen())
     const int initialDesktop = m_virtualDesktopManager->currentDesktop();
     m_overlayService->setCurrentVirtualDesktop(initialDesktop);
     m_layoutManager->setCurrentVirtualDesktop(initialDesktop);
     if (m_autotileEngine) {
+        m_autotileEngine->setDesktopCount(m_virtualDesktopManager->desktopCount());
+        m_autotileEngine->setDesktopRows(m_virtualDesktopManager->desktopRows());
         m_autotileEngine->setCurrentDesktop(initialDesktop);
     }
 

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -690,6 +690,15 @@ Q_SIGNALS:
     void activateWindowRequested(const QString& windowId);
 
     /**
+     * @brief Request KWin effect to move a window to another virtual desktop.
+     *
+     * Used by autotile keyboard navigation when a move/swap crosses a desktop
+     * boundary. The daemon owns tiling state; the compositor owns actual
+     * window-desktop membership.
+     */
+    void windowDesktopMoveRequested(const QString& windowId, int desktop);
+
+    /**
      * @brief Daemon requests KWin to apply geometries for a batch of windows
      * @param geometries List of window geometry entries to apply
      * @param action Navigation action type ("rotate", "resnap", "snap_all") for feedback

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -31,6 +31,7 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
     // Disconnect previous autotile engine nav feedback (the only signal connected here)
     if (m_autotileEngine) {
         disconnect(m_autotileEngine, &PhosphorEngine::PlacementEngineBase::navigationFeedback, this, nullptr);
+        disconnect(m_autotileEngine, &PhosphorEngine::PlacementEngineBase::windowDesktopMoveRequested, this, nullptr);
     }
 
     // Detach the restore predicates from the outgoing engines before dropping
@@ -122,6 +123,8 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
     if (m_autotileEngine) {
         connect(m_autotileEngine, &PhosphorEngine::PlacementEngineBase::navigationFeedback, this,
                 &WindowTrackingAdaptor::navigationFeedback);
+        connect(m_autotileEngine, &PhosphorEngine::PlacementEngineBase::windowDesktopMoveRequested, this,
+                &WindowTrackingAdaptor::windowDesktopMoveRequested);
 
         // Disabled-context gate for autotile pending restores (discussion
         // #461 item 2). Mirror of the snap-side ShouldTrackPredicate wired


### PR DESCRIPTION
Implements COSMIC-like (technically more close to what we have over in the Krohnkite project) window navigation allowing one to easily move, swap, or focus windows across both virtual desktops and outputs.

In principle, this implementation should also work for when KDE 6.7 releases with per-output virtual desktops, but this will need further testing when available. 

This feature has been tested against all current tests, all passing. I have not added tests as of yet (as the implementation isn't too fancy I don't think and works as far as I have manually tested). 

I did not add attribution to myself in the headers (as I don't really care, I just wanted this feature brought over from Krohnkite), but if you require it, I can add to the changed files. 

(Probably) unrelated issue I noticed: the directionality of the focus/move/swap keybinds isn't always followed. For example, with the binary split layout, if I have three windows tiled with the top left focused and I try to move it or focus right, it instead moves/focuses to the window below. This isn't a major issue _per se_, but it makes things a little less intuitive with regards to cross-surface navigation. I can make a separate issue for this if you would like.

AI usage/disclaimer:
AI was used to understand the project structure and for suggestions of minimal entry points necessary for the included changes. AI was used as fancy autocomplete. AI was used for some debugging as well. I went through any generated code and found nothing suspect, but this was my first time working on the C++ side of qt development so reviews are appreciated. 

As a side note, if you have recommendations for how to make clangd not complain about everything, that would be appreciated. I generated compile_commands.json with bear and also tried to craft a .clangd file, but nothing seemed to make it happy...

Edit: 
This should address #307.