### PR TITLE
fix(kwin-effect): capture kName in loadSettingAsync lambdas for clang builds

### DIFF
--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -83,7 +83,7 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
     auto handled = std::make_shared<bool>(false);
     QTimer* timeoutTimer = new QTimer(this);
     timeoutTimer->setSingleShot(true);
-    connect(timeoutTimer, &QTimer::timeout, this, [this, windowId, handled, watcher, timeoutTimer]() {
+    connect(timeoutTimer, &QTimer::timeout, this, [windowId, handled, watcher, timeoutTimer]() {
         if (*handled) {
             return;
         }

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -1457,7 +1457,7 @@ void PlasmaZonesEffect::tryBeginShaderForEvent(KWin::EffectWindow* window, const
 void PlasmaZonesEffect::loadShaderProfileFromDbus()
 {
     constexpr QLatin1String kName = PhosphorProtocol::Service::SettingProperty::ShaderProfileTree;
-    PhosphorProtocol::ClientHelpers::loadSettingAsync(this, kName, [this](const QVariant& v) {
+    PhosphorProtocol::ClientHelpers::loadSettingAsync(this, kName, [this, kName](const QVariant& v) {
         dispatchJsonSetting(kName, v,
                             [this](const QJsonObject& obj) {
                                 auto& tree = m_shaderManager.profileTree();
@@ -1473,7 +1473,7 @@ void PlasmaZonesEffect::loadShaderProfileFromDbus()
 void PlasmaZonesEffect::loadAnimationAppRulesFromDbus()
 {
     constexpr QLatin1String kName = PhosphorProtocol::Service::SettingProperty::AnimationAppRules;
-    PhosphorProtocol::ClientHelpers::loadSettingAsync(this, kName, [this](const QVariant& v) {
+    PhosphorProtocol::ClientHelpers::loadSettingAsync(this, kName, [this, kName](const QVariant& v) {
         dispatchJsonSetting(kName, v,
                             /*objectSink=*/{}, [this](const QJsonArray& arr) {
                                 auto& rules = m_shaderManager.appRules();
@@ -1486,7 +1486,7 @@ void PlasmaZonesEffect::loadAnimationAppRulesFromDbus()
 void PlasmaZonesEffect::loadMotionProfileTreeFromDbus()
 {
     constexpr QLatin1String kName = PhosphorProtocol::Service::SettingProperty::MotionProfileTree;
-    PhosphorProtocol::ClientHelpers::loadSettingAsync(this, kName, [this](const QVariant& v) {
+    PhosphorProtocol::ClientHelpers::loadSettingAsync(this, kName, [this, kName](const QVariant& v) {
         dispatchJsonSetting(kName, v,
                             [this](const QJsonObject& obj) {
                                 // ProfileTree::fromJson resolves the optional `curve`
@@ -1520,7 +1520,7 @@ void PlasmaZonesEffect::slotMotionProfileTreeChanged()
 void PlasmaZonesEffect::loadShaderRegistryFromDbus()
 {
     constexpr QLatin1String kName = PhosphorProtocol::Service::SettingProperty::AnimationShaderSearchPaths;
-    PhosphorProtocol::ClientHelpers::loadSettingAsync(this, kName, [this](const QVariant& v) {
+    PhosphorProtocol::ClientHelpers::loadSettingAsync(this, kName, [this, kName](const QVariant& v) {
         dispatchJsonSetting(kName, v,
                             /*objectSink=*/{}, [this](const QJsonArray& arr) {
                                 QStringList paths;


### PR DESCRIPTION
## Problem

Building PlasmaZones with **clang** fails to compile `kwin-effect/plasmazoneseffect/shader_transitions.cpp` (GCC accepts it, which is why CI never caught it). Reported building the **v3.0.15** release tarball with clang on AerynOS:

```
error: variable 'kName' cannot be implicitly captured in a lambda with no capture-default specified
 1461 |         dispatchJsonSetting(kName, v,
 1459 |     constexpr QLatin1String kName = PhosphorProtocol::Service::SettingProperty::ShaderProfileTree;
```

## Root cause

The outer `loadSettingAsync` completion lambdas capture only `[this]` but ODR-use the `constexpr QLatin1String kName` when forwarding it to `dispatchJsonSetting()`:

```cpp
constexpr QLatin1String kName = ...;
loadSettingAsync(this, kName, [this](const QVariant& v) {
    dispatchJsonSetting(kName, v, ...);   // kName ODR-used but not captured
});
```

Passing the class-typed `kName` into a function inside the lambda is an ODR-use, so clang correctly requires it in the capture list. GCC is lenient here, so the project's GCC-based CI never flagged it.

## Fix

Capture `kName` by value (`[this, kName]`) at all four sites — `loadShaderProfileFromDbus`, `loadAnimationAppRulesFromDbus`, `loadMotionProfileTreeFromDbus`, `loadShaderRegistryFromDbus`. `QLatin1String` is a cheap pointer+size value.

## Verification

- `clang -fsyntax-only` (real build flags): fails at all four sites before, **0 errors** after.
- GCC build of `kwin_effect_plasmazones`: still links clean.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)