### PR TITLE
fix(settings): show connector + primary in monitor labels

### DIFF
--- a/libs/phosphor-screens/src/screeninfo.cpp
+++ b/libs/phosphor-screens/src/screeninfo.cpp
@@ -92,13 +92,19 @@ QVariantList screenInfoListToVariantList(const QList<ScreenInfo>& screens)
         if (s.width > 0 && s.height > 0) {
             label += QStringLiteral(" (%1×%2)").arg(s.width).arg(s.height);
         }
-        // Disambiguate identical physical monitors by their connector — two
-        // "LG Ultra HD" panels become "… · DP-1" / "… · HDMI-A-1". Skip virtual
-        // screens (their VS index already disambiguates) and the case where the
-        // label already IS the connector (no make/model and name == connector),
-        // which would read "DP-2 · DP-2".
-        if (!s.isVirtualScreen && !s.connectorName.isEmpty() && !(parts.isEmpty() && s.name == s.connectorName)) {
-            label += QStringLiteral(" · ") + s.connectorName;
+        // Disambiguate monitors that share a make/model by appending the
+        // physical connector — two "LG Ultra HD" panels become "… · DP-1" /
+        // "… · HDMI-A-1". This matters for virtual screens too: virtualIndex is
+        // per-physical-monitor (VS1/VS2 repeat on every monitor — see
+        // ScreenInfo.h), so the connector is what distinguishes "VS1 — LG Ultra
+        // HD" on DP-1 from the same on DP-2. Skip only when the connector is
+        // already the label's monitor name (no make/model): a virtual screen
+        // then reads "VS1 — DP-2" and a physical one "DP-2", so "· DP-2" would
+        // be redundant.
+        if (!s.connectorName.isEmpty()) {
+            const bool connectorAlreadyShown = parts.isEmpty() && (s.isVirtualScreen || s.name == s.connectorName);
+            if (!connectorAlreadyShown)
+                label += QStringLiteral(" · ") + s.connectorName;
         }
         map[QStringLiteral("displayLabel")] = label;
 

--- a/libs/phosphor-screens/src/screeninfo.cpp
+++ b/libs/phosphor-screens/src/screeninfo.cpp
@@ -80,18 +80,25 @@ QVariantList screenInfoListToVariantList(const QList<ScreenInfo>& screens)
         // selectors, etc.). Single source of truth — avoids duplicating
         // label-building logic in QML.
         QString label;
+        const QStringList parts = vendorModelParts(s);
         if (s.isVirtualScreen) {
             const QString vsName =
                 s.virtualDisplayName.isEmpty() ? QStringLiteral("VS%1").arg(s.virtualIndex + 1) : s.virtualDisplayName;
-            const QStringList parts = vendorModelParts(s);
             const QString monitorName = parts.isEmpty() ? s.connectorName : parts.join(QLatin1Char(' '));
             label = monitorName.isEmpty() ? vsName : vsName + QStringLiteral(" — ") + monitorName;
         } else {
-            const QStringList parts = vendorModelParts(s);
             label = parts.isEmpty() ? s.name : parts.join(QLatin1Char(' '));
         }
         if (s.width > 0 && s.height > 0) {
             label += QStringLiteral(" (%1×%2)").arg(s.width).arg(s.height);
+        }
+        // Disambiguate identical physical monitors by their connector — two
+        // "LG Ultra HD" panels become "… · DP-1" / "… · HDMI-A-1". Skip virtual
+        // screens (their VS index already disambiguates) and the case where the
+        // label already IS the connector (no make/model and name == connector),
+        // which would read "DP-2 · DP-2".
+        if (!s.isVirtualScreen && !s.connectorName.isEmpty() && !(parts.isEmpty() && s.name == s.connectorName)) {
+            label += QStringLiteral(" · ") + s.connectorName;
         }
         map[QStringLiteral("displayLabel")] = label;
 

--- a/libs/phosphor-screens/tests/CMakeLists.txt
+++ b/libs/phosphor-screens/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ function(ps_add_test _name)
 endfunction()
 
 ps_add_test(ps_test_virtualscreen test_virtualscreen.cpp)
+ps_add_test(ps_test_screeninfo_variantlist test_screeninfo_variantlist.cpp)
 ps_add_test(ps_test_inmemoryconfigstore test_inmemoryconfigstore.cpp)
 ps_add_test(ps_test_swapper test_swapper.cpp)
 ps_add_test(ps_test_screenidentity_variants test_screenidentity_variants.cpp)

--- a/libs/phosphor-screens/tests/test_screeninfo_variantlist.cpp
+++ b/libs/phosphor-screens/tests/test_screeninfo_variantlist.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/**
+ * @file test_screeninfo_variantlist.cpp
+ * @brief Coverage for @c screenInfoListToVariantList — specifically the
+ *        pre-computed @c displayLabel and the connector-disambiguation
+ *        branch (two identical panels become "… · DP-1" / "… · HDMI-A-1").
+ *
+ * The label builder has four interacting axes — virtual vs physical,
+ * make/model present vs absent, connector present vs absent, and the
+ * "connector already shown" skip — so each combination is locked here.
+ * The skip is what prevents a redundant "DP-1 · DP-1" (physical, no
+ * make/model, name == connector) and "VS1 — DP-2 · DP-2" (virtual, no
+ * make/model); both are regression-guarded below.
+ */
+
+#include <PhosphorScreens/ScreenInfo.h>
+
+#include <QTest>
+#include <QVariantList>
+#include <QVariantMap>
+
+using namespace PhosphorScreens;
+
+namespace {
+QString labelAt(const QVariantList& list, int index)
+{
+    return list.at(index).toMap().value(QStringLiteral("displayLabel")).toString();
+}
+}
+
+class TestScreenInfoVariantList : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    void physical_makeModelResolution_appendsConnector()
+    {
+        ScreenInfo s;
+        s.name = QStringLiteral("DP-1");
+        s.manufacturer = QStringLiteral("LG");
+        s.model = QStringLiteral("Ultra HD");
+        s.width = 3840;
+        s.height = 2160;
+        s.connectorName = QStringLiteral("DP-1");
+
+        const QVariantList out = screenInfoListToVariantList({s});
+        QCOMPARE(labelAt(out, 0), QStringLiteral("LG Ultra HD (3840×2160) · DP-1"));
+    }
+
+    void physical_makeModelNoResolution_appendsConnector()
+    {
+        ScreenInfo s;
+        s.name = QStringLiteral("DP-1");
+        s.manufacturer = QStringLiteral("LG");
+        s.model = QStringLiteral("Ultra HD");
+        s.connectorName = QStringLiteral("DP-1");
+
+        const QVariantList out = screenInfoListToVariantList({s});
+        QCOMPARE(labelAt(out, 0), QStringLiteral("LG Ultra HD · DP-1"));
+    }
+
+    void physical_noMakeModel_nameEqualsConnector_skipsRedundantConnector()
+    {
+        // The regression the PR fixes: previously QML appended the connector
+        // unconditionally, yielding "DP-1 · DP-1". The label IS the connector
+        // here, so nothing is appended.
+        ScreenInfo s;
+        s.name = QStringLiteral("DP-1");
+        s.connectorName = QStringLiteral("DP-1");
+
+        const QVariantList out = screenInfoListToVariantList({s});
+        QCOMPARE(labelAt(out, 0), QStringLiteral("DP-1"));
+    }
+
+    void physical_noMakeModel_nameDiffersFromConnector_appendsConnector()
+    {
+        // No make/model, but the name is an EDID-derived id distinct from the
+        // connector — the connector still disambiguates, so it is appended.
+        ScreenInfo s;
+        s.name = QStringLiteral("Dell:U2722D:115107");
+        s.connectorName = QStringLiteral("DP-2");
+
+        const QVariantList out = screenInfoListToVariantList({s});
+        QCOMPARE(labelAt(out, 0), QStringLiteral("Dell:U2722D:115107 · DP-2"));
+    }
+
+    void physical_noConnector_noTrailingSeparator()
+    {
+        ScreenInfo s;
+        s.name = QStringLiteral("DP-1");
+        s.manufacturer = QStringLiteral("LG");
+        s.model = QStringLiteral("Ultra HD");
+
+        const QVariantList out = screenInfoListToVariantList({s});
+        QCOMPARE(labelAt(out, 0), QStringLiteral("LG Ultra HD"));
+    }
+
+    void virtual_makeModel_appendsConnector()
+    {
+        // virtualIndex 0 → "VS1"; connector distinguishes the same virtual
+        // screen on two different physical monitors.
+        ScreenInfo s;
+        s.name = QStringLiteral("Dell:U2722D:115107/vs:0");
+        s.manufacturer = QStringLiteral("LG");
+        s.model = QStringLiteral("Ultra HD");
+        s.isVirtualScreen = true;
+        s.virtualIndex = 0;
+        s.connectorName = QStringLiteral("DP-1");
+
+        const QVariantList out = screenInfoListToVariantList({s});
+        QCOMPARE(labelAt(out, 0), QStringLiteral("VS1 — LG Ultra HD · DP-1"));
+    }
+
+    void virtual_noMakeModel_connectorIsMonitorName_skipsRedundantConnector()
+    {
+        // With no make/model the monitor-name slot falls back to the
+        // connector, so the label reads "VS1 — DP-2"; appending "· DP-2"
+        // again would be redundant and is skipped.
+        ScreenInfo s;
+        s.name = QStringLiteral("DP-2/vs:0");
+        s.isVirtualScreen = true;
+        s.virtualIndex = 0;
+        s.connectorName = QStringLiteral("DP-2");
+
+        const QVariantList out = screenInfoListToVariantList({s});
+        QCOMPARE(labelAt(out, 0), QStringLiteral("VS1 — DP-2"));
+    }
+
+    void virtual_displayName_makeModel_appendsConnector()
+    {
+        ScreenInfo s;
+        s.name = QStringLiteral("Dell:U2722D:115107/vs:1");
+        s.manufacturer = QStringLiteral("LG");
+        s.model = QStringLiteral("Ultra HD");
+        s.isVirtualScreen = true;
+        s.virtualIndex = 1;
+        s.virtualDisplayName = QStringLiteral("Left");
+        s.connectorName = QStringLiteral("DP-1");
+
+        const QVariantList out = screenInfoListToVariantList({s});
+        QCOMPARE(labelAt(out, 0), QStringLiteral("Left — LG Ultra HD · DP-1"));
+    }
+
+    void payloadKeys_alwaysEmitFlagsAndConnector()
+    {
+        ScreenInfo s;
+        s.name = QStringLiteral("DP-1");
+        s.isPrimary = true;
+        s.connectorName = QStringLiteral("DP-1");
+
+        const QVariantMap m = screenInfoListToVariantList({s}).at(0).toMap();
+        // isVirtualScreen is always present (physical screens read `false`,
+        // not `undefined`); isPrimary round-trips; connectorName is emitted
+        // because it is non-empty.
+        QVERIFY(m.contains(QStringLiteral("isVirtualScreen")));
+        QCOMPARE(m.value(QStringLiteral("isVirtualScreen")).toBool(), false);
+        QCOMPARE(m.value(QStringLiteral("isPrimary")).toBool(), true);
+        QCOMPARE(m.value(QStringLiteral("connectorName")).toString(), QStringLiteral("DP-1"));
+    }
+};
+
+QTEST_MAIN(TestScreenInfoVariantList)
+#include "test_screeninfo_variantlist.moc"

--- a/src/settings/qml/MatchExpressionView.qml
+++ b/src/settings/qml/MatchExpressionView.qml
@@ -115,8 +115,14 @@ ColumnLayout {
             var screens = root.appSettings.screens;
             if (screens) {
                 for (var i = 0; i < screens.length; ++i) {
-                    if (screens[i].name === value)
-                        return screens[i].displayLabel || String(value);
+                    if (screens[i].name === value) {
+                        // displayLabel carries make/model/resolution + connector;
+                        // mark the primary monitor to match the editor's picker.
+                        var label = screens[i].displayLabel || String(value);
+                        if (screens[i].isPrimary)
+                            label += " · " + i18n("Primary");
+                        return label;
+                    }
                 }
             }
         }

--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -295,20 +295,30 @@ RowLayout {
         id: screenValueEditor
 
         WideComboBox {
+            id: screenCombo
+
             // Drive the picker off `appSettings.screens` so the user picks
             // "LG Ultra HD · DP-2" while the wire value remains the raw
-            // connector / virtual-screen id.
-            model: leaf.appSettings ? leaf.appSettings.screens : []
-            textRole: "displayLabel"
+            // connector / virtual-screen id. displayLabel already carries the
+            // connector; append a Primary marker here (a plain ComboBox has no
+            // badge surface like the monitor tiles do) so the user can tell the
+            // primary monitor and which port each entry is on.
+            readonly property var _screens: leaf.appSettings ? leaf.appSettings.screens : []
+            model: _screens.map(function (s) {
+                var label = s.displayLabel || s.name || "";
+                if (s.isPrimary)
+                    label += " · " + i18n("Primary");
+                return {
+                    "label": label,
+                    "name": s.name
+                };
+            })
+            textRole: "label"
             valueRole: "name"
             currentIndex: {
-                if (!leaf.appSettings)
-                    return -1;
-
                 var target = leaf.node.value;
-                var list = leaf.appSettings.screens;
-                for (var i = 0; i < list.length; ++i) {
-                    if (list[i].name === target)
+                for (var i = 0; i < screenCombo._screens.length; ++i) {
+                    if (screenCombo._screens[i].name === target)
                         return i;
                 }
                 return -1;

--- a/src/settings/qml/MonitorOverviewTile.qml
+++ b/src/settings/qml/MonitorOverviewTile.qml
@@ -80,11 +80,10 @@ Rectangle {
                 // `Unknown monitor` placeholder guards against the every-
                 // field-empty case so the tile (and the Accessible.name
                 // interpolation that reads this label) never becomes blank.
-                let label = tile.screenData.displayLabel || tile.screenData.name || (tile.tileData ? tile.tileData.screenId : "") || i18n("Unknown monitor");
-                if (tile.screenData.connectorName)
-                    label += " · " + tile.screenData.connectorName;
-
-                return label;
+                // displayLabel already carries the connector (see
+                // screenInfoListToVariantList) — the primary badge below covers
+                // the primary indicator.
+                return tile.screenData.displayLabel || tile.screenData.name || (tile.tileData ? tile.tileData.screenId : "") || i18n("Unknown monitor");
             }
             font: Kirigami.Theme.smallFont
             Layout.alignment: Qt.AlignHCenter

--- a/src/settings/qml/MonitorSelectorSection.qml
+++ b/src/settings/qml/MonitorSelectorSection.qml
@@ -76,9 +76,11 @@ ColumnLayout {
                         label += " (" + entry.resolution + ")";
 
                     // Mirror screenInfoListToVariantList(): append the connector
-                    // so identical panels stay distinguishable, unless the label
-                    // already IS the connector.
-                    if (entry.connectorName && entry.connectorName !== physId)
+                    // so identical panels stay distinguishable. Skip only when
+                    // the label already IS the connector (no make/model, so the
+                    // base label fell back to physId == connector) — otherwise
+                    // it must be appended even when connector == physId.
+                    if (entry.connectorName && !(parts.length === 0 && entry.connectorName === physId))
                         label += " · " + entry.connectorName;
 
                     entry["displayLabel"] = label;

--- a/src/settings/qml/MonitorSelectorSection.qml
+++ b/src/settings/qml/MonitorSelectorSection.qml
@@ -75,6 +75,12 @@ ColumnLayout {
                     if (entry.resolution)
                         label += " (" + entry.resolution + ")";
 
+                    // Mirror screenInfoListToVariantList(): append the connector
+                    // so identical panels stay distinguishable, unless the label
+                    // already IS the connector.
+                    if (entry.connectorName && entry.connectorName !== physId)
+                        label += " · " + entry.connectorName;
+
                     entry["displayLabel"] = label;
                 }
                 result.push(entry);
@@ -228,12 +234,9 @@ ColumnLayout {
 
                             text: {
                                 let s = modelData;
-                                // Use pre-computed displayLabel, append connector name for detail
-                                let label = s.displayLabel || s.name || screenName;
-                                if (s.connectorName)
-                                    label += " · " + s.connectorName;
-
-                                return label;
+                                // displayLabel already carries the connector (see
+                                // screenInfoListToVariantList / the rebuild above).
+                                return s.displayLabel || s.name || screenName;
                             }
                             font: Kirigami.Theme.smallFont
                             Layout.alignment: Qt.AlignHCenter


### PR DESCRIPTION
## Problem

In the window-rule editor's monitor picker, identical monitors (same make/model/resolution) all rendered as the **same** string — e.g. two `LG Electronics LG Ultra HD (3200×1800)` entries — so there was no way to tell **which physical port** each entry was on, or **which monitor is primary**.

![before](https://github.com/fuddlesworth/PlasmaZones/pull/530) <!-- reported from the window rule editor screen dropdown -->

## Fix

`displayLabel` is the documented single source of truth for monitor labels (built in `screenInfoListToVariantList()`), but it omitted the connector and the primary flag, forcing several consumers to patch it by hand.

- **`displayLabel` now carries the connector** for physical screens:
  `LG Electronics LG Ultra HD (3200×1800) · DP-1` / `· HDMI-A-1`.
  Guarded so it never produces `DP-2 · DP-2`, and skips virtual screens (their `VS#` already disambiguates).
- **Removed the now-redundant manual connector appends** in the monitor tiles (`MonitorOverviewTile`) and selector (`MonitorSelectorSection`), and added the connector to `MonitorSelectorSection`'s local physical-remap rebuild so it stays consistent.
- **Primary indicator** where there's no badge surface — the window-rule picker (`MatchLeafEditor`) and the read-only rule preview (`MatchExpressionView`) append ` · Primary`. The overview/selector tiles keep their existing green **Primary** badge.

Result for two identical panels:

```
LG Electronics LG Ultra HD (3200×1800) · DP-1
LG Electronics LG Ultra HD (3200×1800) · DP-2 · Primary
```

## Verification

- `PhosphorScreens` + `plasmazones-settings` build clean.
- `phosphorscreens`, `phosphorwindowrule`, and `phosphor-settings-ui` test labels pass (27 tests).
- Confirmed `connectorName`/`isPrimary` are populated end-to-end (daemon `getScreenInfo` → `screen->name()` → `ScreenInfo.connectorName`).

## Notes

- Targets `v3.1` because the window-rule editor (`MatchLeafEditor` / `MatchExpressionView`) is a v3.1-only feature.
- Separator is `·` (matches existing `MonitorOverviewTile` / rule-summary conventions) for both connector and primary.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)