### PR TITLE
feat(shaders): validate animation packs offline (shader-API Tier-1 residual)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -786,17 +786,23 @@ target_link_libraries(plasmazones-shader-validate
         plasmazones_rendering
         PhosphorRendering::PhosphorRendering
         PhosphorShaders::PhosphorShaders
+        PhosphorAnimation::PhosphorAnimation
         Qt6::Core
         Qt6::GuiPrivate
         Qt6::ShaderToolsPrivate
 )
 install(TARGETS plasmazones-shader-validate DESTINATION ${KDE_INSTALL_BINDIR})
 
-# CI gate: every bundled zone pack must parse + bake clean. Headless glslang, so
-# this runs in CI with no GPU/Wayland — exactly like luau-analyze for algorithms.
+# CI gate: every bundled pack must parse + bake clean. Headless glslang, so this
+# runs in CI with no GPU/Wayland — exactly like luau-analyze for algorithms. Zone
+# packs (data/shaders) and animation packs (--animation, data/animations) are
+# distinct authoring models with different entry conventions, so each gets its own
+# invocation.
 if(BUILD_TESTING)
     add_test(NAME shader_validate_bundled
-             COMMAND plasmazones-shader-validate ${PROJECT_SOURCE_DIR}/data/shaders)
+             COMMAND plasmazones-shader-validate --overlay ${PROJECT_SOURCE_DIR}/data/shaders)
+    add_test(NAME shader_validate_animations
+             COMMAND plasmazones-shader-validate --animation ${PROJECT_SOURCE_DIR}/data/animations)
 endif()
 
 # Standalone settings app (no KDE Frameworks required)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -778,8 +778,9 @@ install(TARGETS plasmazones-editor DESTINATION ${KDE_INSTALL_BINDIR})
 # T1.2 — offline shader-pack validator. Parses metadata.json with the daemon's
 # parser, reproduces the runtime GLSL assembly (entry scaffold + p_<id> preamble
 # + includes) and bakes every stage through headless glslang (QShaderBaker — CPU
-# only, no GPU/Wayland). The CI gate for the bundled set; pre-commit-friendly for
-# pack authors. Links plasmazones_rendering for the zone entry scaffold.
+# only, no GPU/Wayland). The CI gate for the bundled sets; pre-commit-friendly for
+# pack authors. Links plasmazones_rendering for the zone entry scaffold and
+# PhosphorAnimation for the animation effect parser + entry scaffold.
 add_executable(plasmazones-shader-validate shadervalidate/main.cpp)
 target_link_libraries(plasmazones-shader-validate
     PRIVATE

--- a/src/shadervalidate/main.cpp
+++ b/src/shadervalidate/main.cpp
@@ -293,7 +293,10 @@ int validatePack(const QString& packDir, QTextStream& out)
     const QString preamble = ShaderRegistry::paramPreamble(info);
 
     if (QFile::exists(info.sourcePath)) {
-        errors += compileStage(out, QStringLiteral("effect.frag"), info.sourcePath, QShader::FragmentStage,
+        // Label by the actual fragment filename — parsePackMetadata honours a
+        // custom `fragmentShader` field (default effect.frag), so the stage label
+        // tracks the real file rather than assuming effect.frag.
+        errors += compileStage(out, QFileInfo(info.sourcePath).fileName(), info.sourcePath, QShader::FragmentStage,
                                includePaths, /*useScaffold=*/true, preamble, info);
     }
     // Only multipass packs bake buffer passes — parseShaderMetadata seeds a

--- a/src/shadervalidate/main.cpp
+++ b/src/shadervalidate/main.cpp
@@ -1,23 +1,36 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
-// plasmazones-shader-validate — offline validator for zone shader packs (T1.2).
+// plasmazones-shader-validate — offline validator for shader packs (T1.2).
 //
 // A `luau-analyze` equivalent for GLSL packs: it parses metadata.json with the
-// SAME parser the daemon uses (ShaderRegistry::parsePackMetadata, T1.1 auto-slot
-// included), reproduces the runtime's GLSL assembly (entry scaffold + generated
-// p_<id> preamble + include expansion), and bakes every stage through headless
-// glslang (QShaderBaker, CPU-only — no GPU, no Wayland, no compositor). It is the
-// CI gate for the bundled set and a pre-commit-friendly tool for pack authors.
+// SAME parser the runtime uses, reproduces the runtime's GLSL assembly (entry
+// scaffold + generated p_<id> preamble + include expansion), and bakes every
+// stage through headless glslang (QShaderBaker, CPU-only — no GPU, no Wayland,
+// no compositor). It is the CI gate for the bundled sets and a pre-commit-
+// friendly tool for pack authors.
+//
+// Two authoring models, selected by --overlay (default) / --animation:
+//   • zone/overlay packs (--overlay, the default, data/shaders/*):
+//     ShaderRegistry::parsePackMetadata + the zone entry scaffold (pZone/pImage);
+//     validates the frag, multipass buffer passes, and the vertex stage on the
+//     daemon Qt-RHI path.
+//   • animation/transition packs (--animation, data/animations/*):
+//     AnimationShaderEffect + the animation entry scaffold (pTransition / pIn+pOut)
+//     + paramPreamble; validates effect.frag on the daemon Qt-RHI path. (The
+//     kwin-effect classic-GL branch is not baked — see validateAnimationPack.)
 //
 // Usage:
-//   plasmazones-shader-validate <path> [<path> ...]
+//   plasmazones-shader-validate [--quiet] [--overlay|--animation] <path> [<path> ...]
 // where each <path> is either a pack directory (contains metadata.json) or a
 // root that holds pack subdirectories. Exits non-zero if any pack has an error.
 
 #include "../daemon/rendering/zoneentryscaffold.h"
 
+#include <PhosphorAnimation/AnimationShaderEffect.h>
+#include <PhosphorAnimation/AnimationShaderRegistry.h>
 #include <PhosphorRendering/ShaderCompiler.h>
+#include <PhosphorShaders/ShaderEntryPoint.h>
 #include <PhosphorShaders/ShaderIncludeResolver.h>
 #include <PhosphorShaders/ShaderParamPreamble.h>
 #include <PhosphorShaders/ShaderRegistry.h>
@@ -35,6 +48,8 @@
 
 #include <rhi/qshader.h>
 
+using PhosphorAnimationShaders::AnimationShaderEffect;
+using PhosphorAnimationShaders::AnimationShaderRegistry;
 using PhosphorRendering::ShaderCompiler;
 using PhosphorShaders::ShaderIncludeResolver;
 using PhosphorShaders::ShaderRegistry;
@@ -79,13 +94,10 @@ int editDistance(const QString& a, const QString& b)
 
 // If the glslang diagnostic names an undeclared `p_<x>` and a declared param is
 // a near match, surface the suggestion — the friction T1.2 exists to remove.
-void appendDidYouMean(QTextStream& out, const QString& diagnostic, const ShaderRegistry::ShaderInfo& info)
+// @p declared is the list of generated `p_<id>` names (zone or animation).
+void appendDidYouMean(QTextStream& out, const QString& diagnostic, const QStringList& declared)
 {
     static const QRegularExpression re(QStringLiteral("'(p_[A-Za-z0-9_]+)' : undeclared identifier"));
-    QStringList declared;
-    for (const ShaderRegistry::ParameterInfo& p : info.parameters) {
-        declared << QStringLiteral("p_") + p.id;
-    }
     auto it = re.globalMatch(diagnostic);
     while (it.hasNext()) {
         const QString used = it.next().captured(1);
@@ -108,7 +120,51 @@ void appendDidYouMean(QTextStream& out, const QString& diagnostic, const ShaderR
     }
 }
 
-// Compile one stage through the exact runtime assembly and print OK/ERROR.
+// Report a compiled stage's outcome: "OK", or "ERROR" with the glslang
+// diagnostics mapped to the author's file/line (T1.3 #line) plus the
+// did-you-mean hint. @p declared is the list of generated `p_<id>` names.
+// Returns 1 on failure, 0 on success. Shared by the zone and animation paths.
+int reportCompile(QTextStream& out, const QString& label, const ShaderCompiler::Result& result,
+                  const QStringList& declared)
+{
+    if (result.success) {
+        out << "  " << label.leftJustified(14) << "OK\n";
+        return 0;
+    }
+    out << "  " << label.leftJustified(14) << "ERROR\n";
+    const QStringList diagLines = result.error.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
+    for (const QString& line : diagLines) {
+        // glslang names the root source (file id 0, via the T1.3 #line directives)
+        // with an empty filename — `ERROR: :58:`. Substitute the stage label so the
+        // author sees `effect.frag:58`. Include errors keep their numeric file id.
+        QString shown = line.trimmed();
+        shown.replace(QStringLiteral("ERROR: :"), QStringLiteral("ERROR: ") + label + QStringLiteral(":"));
+        shown.replace(QStringLiteral("WARNING: :"), QStringLiteral("WARNING: ") + label + QStringLiteral(":"));
+        out << "    " << shown << "\n";
+    }
+    appendDidYouMean(out, result.error, declared);
+    return 1;
+}
+
+// Build the `p_<id>` name list a pack declares, for the did-you-mean hint.
+QStringList declaredParamNames(const QList<ShaderRegistry::ParameterInfo>& params)
+{
+    QStringList declared;
+    for (const ShaderRegistry::ParameterInfo& p : params) {
+        declared << QStringLiteral("p_") + p.id;
+    }
+    return declared;
+}
+QStringList declaredParamNames(const QList<AnimationShaderEffect::ParameterInfo>& params)
+{
+    QStringList declared;
+    for (const AnimationShaderEffect::ParameterInfo& p : params) {
+        declared << QStringLiteral("p_") + p.id;
+    }
+    return declared;
+}
+
+// Compile one ZONE stage through the exact runtime assembly and print OK/ERROR.
 // Returns 1 on failure, 0 on success.
 int compileStage(QTextStream& out, const QString& label, const QString& path, QShader::Stage stage,
                  const QStringList& includePaths, bool useScaffold, const QString& preamble,
@@ -140,23 +196,7 @@ int compileStage(QTextStream& out, const QString& label, const QString& path, QS
     }
 
     const ShaderCompiler::Result result = ShaderCompiler::compile(expanded.toUtf8(), stage);
-    if (result.success) {
-        out << "  " << label.leftJustified(14) << "OK\n";
-        return 0;
-    }
-    out << "  " << label.leftJustified(14) << "ERROR\n";
-    const QStringList diagLines = result.error.split(QLatin1Char('\n'), Qt::SkipEmptyParts);
-    for (const QString& line : diagLines) {
-        // glslang names the root source (file id 0, via the T1.3 #line directives)
-        // with an empty filename — `ERROR: :58:`. Substitute the stage label so the
-        // author sees `effect.frag:58`. Include errors keep their numeric file id.
-        QString shown = line.trimmed();
-        shown.replace(QStringLiteral("ERROR: :"), QStringLiteral("ERROR: ") + label + QStringLiteral(":"));
-        shown.replace(QStringLiteral("WARNING: :"), QStringLiteral("WARNING: ") + label + QStringLiteral(":"));
-        out << "    " << shown << "\n";
-    }
-    appendDidYouMean(out, result.error, info);
-    return 1;
+    return reportCompile(out, label, result, declaredParamNames(info.parameters));
 }
 
 // Validate one pack directory. Returns the number of errors found.
@@ -285,6 +325,117 @@ int validatePack(const QString& packDir, QTextStream& out)
     return errors;
 }
 
+// Validate one ANIMATION pack directory (data/animations/*). Reproduces the
+// animation runtime's fragment assembly on the daemon (Qt-RHI) path — the entry
+// scaffold (pTransition / pIn+pOut, or a pass-through main()), the generated
+// p_<id> preamble, and include expansion — then bakes through headless glslang.
+// Returns the number of errors found.
+//
+// The kwin-effect classic-GL path (`#define PLASMAZONES_KWIN`, default-block
+// uniforms) is NOT baked here: QShaderBaker compiles Vulkan-dialect GLSL and
+// rejects default-block uniforms, so the kwin branch needs a separate
+// OpenGL-target compiler. The PLASMAZONES_KWIN uniform plumbing lives entirely
+// in the shared animation_uniforms.glsl — identical for every pack — while each
+// pack's authored body is fully covered by the daemon bake here.
+int validateAnimationPack(const QString& packDir, QTextStream& out)
+{
+    const QString name = QFileInfo(packDir).fileName();
+
+    QFile metaFile(QDir(packDir).filePath(QStringLiteral("metadata.json")));
+    if (!metaFile.open(QIODevice::ReadOnly)) {
+        out << name << "\n  metadata      ERROR\n    cannot read metadata.json\n  → 1 error\n\n";
+        return 1;
+    }
+    QJsonParseError perr{};
+    const QJsonDocument doc = QJsonDocument::fromJson(metaFile.readAll(), &perr);
+    if (doc.isNull() || !doc.isObject()) {
+        out << name << "\n  metadata      ERROR\n    invalid JSON: " << perr.errorString() << "\n  → 1 error\n\n";
+        return 1;
+    }
+
+    AnimationShaderEffect eff = AnimationShaderEffect::fromJson(doc.object());
+    eff.sourceDir = QDir(packDir).absolutePath();
+    eff.fragmentShaderPath = QDir(packDir).filePath(QStringLiteral("effect.frag"));
+    if (!eff.isValid()) {
+        out << name << "\n  metadata      ERROR\n    missing required field (id / effect.frag)\n  → 1 error\n\n";
+        return 1;
+    }
+
+    out << name << "  (" << eff.parameters.size() << " param" << (eff.parameters.size() == 1 ? "" : "s") << ", "
+        << eff.textures.size() << " texture" << (eff.textures.size() == 1 ? "" : "s") << ")\n";
+
+    int errors = 0;
+
+    // ── metadata lints ──
+    // Animation params are always auto-slot (declaration order per pool), so
+    // there are no explicit-slot collisions to detect; lint the param types and
+    // ids that gate whether a p_<id> define is emitted at all.
+    static const QStringList kAnimParamTypes = {QStringLiteral("float"), QStringLiteral("int"), QStringLiteral("bool"),
+                                                QStringLiteral("color")};
+    QStringList lints;
+    for (const AnimationShaderEffect::ParameterInfo& p : eff.parameters) {
+        if (!kAnimParamTypes.contains(p.type)) {
+            lints << QStringLiteral(
+                         "unknown param type '%1' for '%2' (animation params are float/int/bool/color; "
+                         "images are textures, not params)")
+                         .arg(p.type, p.id);
+        }
+        if (!PhosphorShaders::isValidParamId(p.id)) {
+            lints
+                << QStringLiteral("invalid parameter id '%1' (not a GLSL identifier; skipped, no p_ define)").arg(p.id);
+        }
+    }
+    if (!QFile::exists(eff.fragmentShaderPath)) {
+        lints << QStringLiteral("fragment shader missing: effect.frag");
+    }
+
+    if (lints.isEmpty()) {
+        out << "  metadata      OK\n";
+    } else {
+        out << "  metadata      ERROR\n";
+        for (const QString& l : lints) {
+            out << "    " << l << "\n";
+            ++errors;
+        }
+    }
+
+    // ── stage compile (reproduce the daemon runtime fragment assembly) ──
+    if (QFile::exists(eff.fragmentShaderPath)) {
+        QFile frag(eff.fragmentShaderPath);
+        if (!frag.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            out << "  effect.frag    ERROR\n    cannot read " << eff.fragmentShaderPath << "\n";
+            ++errors;
+        } else {
+            const QString raw = QString::fromUtf8(frag.readAll());
+            // An entry-only pack (pTransition / pIn+pOut) gets a generated main();
+            // a traditional main() pack passes through — exactly as both runtimes do.
+            const QString assembled =
+                PhosphorShaders::assembleEntryPoint(raw, AnimationShaderRegistry::animationEntryPrologue(),
+                                                    AnimationShaderRegistry::animationEntryCandidates());
+            const QStringList includePaths = {QFileInfo(packDir).absolutePath() + QStringLiteral("/shared")};
+            QString err;
+            const QString expanded = ShaderCompiler::expandSource(
+                assembled, QFileInfo(eff.fragmentShaderPath).absolutePath(), includePaths, &err);
+            if (expanded.isEmpty()) {
+                out << "  effect.frag    ERROR\n    include expansion failed: " << err << "\n";
+                ++errors;
+            } else {
+                const QString spliced =
+                    PhosphorShaders::spliceAfterVersion(expanded, AnimationShaderRegistry::paramPreamble(eff));
+                const ShaderCompiler::Result result = ShaderCompiler::compile(spliced.toUtf8(), QShader::FragmentStage);
+                errors += reportCompile(out, QStringLiteral("effect.frag"), result, declaredParamNames(eff.parameters));
+            }
+        }
+    }
+
+    if (errors == 0) {
+        out << "  → OK\n\n";
+    } else {
+        out << "  → " << errors << (errors == 1 ? " error\n\n" : " errors\n\n");
+    }
+    return errors;
+}
+
 bool isPackDir(const QString& dir)
 {
     return QFile::exists(QDir(dir).filePath(QStringLiteral("metadata.json")));
@@ -299,16 +450,26 @@ int main(int argc, char** argv)
 
     QStringList args;
     bool quiet = false; // --quiet/-q: print only failing packs (clean pre-commit output)
+    // System selection: --overlay (default) vs --animation. Two distinct
+    // authoring models (different metadata schema + entry convention), so the
+    // mode is explicit and symmetric; later flag wins if both are given.
+    bool animationMode = false;
     for (int i = 1; i < argc; ++i) {
         const QString a = QString::fromLocal8Bit(argv[i]);
         if (a == QLatin1String("--quiet") || a == QLatin1String("-q")) {
             quiet = true;
+        } else if (a == QLatin1String("--animation") || a == QLatin1String("-a")) {
+            animationMode = true;
+        } else if (a == QLatin1String("--overlay") || a == QLatin1String("-o")) {
+            animationMode = false;
         } else {
             args << a;
         }
     }
     if (args.isEmpty()) {
-        errStream << "usage: plasmazones-shader-validate [--quiet] <pack-dir-or-root> [...]\n";
+        errStream << "usage: plasmazones-shader-validate [--quiet] [--overlay|--animation] <pack-dir-or-root> [...]\n"
+                  << "  --overlay    zone/overlay packs (data/shaders/*)        [default]\n"
+                  << "  --animation  transition/animation packs (data/animations/*)\n";
         return 2;
     }
 
@@ -344,7 +505,7 @@ int main(int argc, char** argv)
     for (const QString& pack : packs) {
         QString report;
         QTextStream reportStream(&report);
-        const int e = validatePack(pack, reportStream);
+        const int e = animationMode ? validateAnimationPack(pack, reportStream) : validatePack(pack, reportStream);
         reportStream.flush();
         totalErrors += e;
         if (e > 0) {

--- a/src/shadervalidate/main.cpp
+++ b/src/shadervalidate/main.cpp
@@ -27,6 +27,7 @@
 
 #include "../daemon/rendering/zoneentryscaffold.h"
 
+#include <PhosphorAnimation/AnimationShaderContract.h>
 #include <PhosphorAnimation/AnimationShaderEffect.h>
 #include <PhosphorAnimation/AnimationShaderRegistry.h>
 #include <PhosphorRendering/ShaderCompiler.h>
@@ -355,11 +356,19 @@ int validateAnimationPack(const QString& packDir, QTextStream& out)
 
     AnimationShaderEffect eff = AnimationShaderEffect::fromJson(doc.object());
     eff.sourceDir = QDir(packDir).absolutePath();
-    eff.fragmentShaderPath = QDir(packDir).filePath(QStringLiteral("effect.frag"));
+    // Mirror AnimationShaderRegistry::parseEffect: the fragment path comes from
+    // the metadata `fragmentShader` field, resolved relative to the pack dir
+    // (QDir::filePath returns an absolute input unchanged). The runtime does NOT
+    // default to effect.frag — a pack that omits the field is unreachable, so an
+    // empty path stays empty and is caught by isValid() below.
+    if (!eff.fragmentShaderPath.isEmpty()) {
+        eff.fragmentShaderPath = QDir(packDir).filePath(eff.fragmentShaderPath);
+    }
     if (!eff.isValid()) {
-        out << name << "\n  metadata      ERROR\n    missing required field (id / effect.frag)\n  → 1 error\n\n";
+        out << name << "\n  metadata      ERROR\n    missing required field (id / fragmentShader)\n  → 1 error\n\n";
         return 1;
     }
+    const QString fragLabel = QFileInfo(eff.fragmentShaderPath).fileName();
 
     out << name << "  (" << eff.parameters.size() << " param" << (eff.parameters.size() == 1 ? "" : "s") << ", "
         << eff.textures.size() << " texture" << (eff.textures.size() == 1 ? "" : "s") << ")\n";
@@ -385,8 +394,22 @@ int validateAnimationPack(const QString& packDir, QTextStream& out)
                 << QStringLiteral("invalid parameter id '%1' (not a GLSL identifier; skipped, no p_ define)").arg(p.id);
         }
     }
+    // Texture lints mirror parseEffect's parse-time journal warnings. fromJson
+    // silently drops these from the in-memory struct, so read the RAW metadata
+    // textures array (same as parseEffect) rather than eff.textures.
+    const QJsonArray declaredTextures = doc.object().value(QLatin1String("textures")).toArray();
+    if (declaredTextures.size() > PhosphorAnimationShaders::AnimationShaderContract::kMaxUserTextureSlots) {
+        lints << QStringLiteral("too many textures: %1 declared, cap is %2 (surplus dropped at load)")
+                     .arg(static_cast<int>(declaredTextures.size()))
+                     .arg(PhosphorAnimationShaders::AnimationShaderContract::kMaxUserTextureSlots);
+    }
+    for (const QJsonValue& v : declaredTextures) {
+        if (v.toObject().value(QLatin1String("path")).toString().isEmpty()) {
+            lints << QStringLiteral("texture entry with empty `path` (dropped at load)");
+        }
+    }
     if (!QFile::exists(eff.fragmentShaderPath)) {
-        lints << QStringLiteral("fragment shader missing: effect.frag");
+        lints << QStringLiteral("fragment shader missing: %1").arg(fragLabel);
     }
 
     if (lints.isEmpty()) {
@@ -403,7 +426,7 @@ int validateAnimationPack(const QString& packDir, QTextStream& out)
     if (QFile::exists(eff.fragmentShaderPath)) {
         QFile frag(eff.fragmentShaderPath);
         if (!frag.open(QIODevice::ReadOnly | QIODevice::Text)) {
-            out << "  effect.frag    ERROR\n    cannot read " << eff.fragmentShaderPath << "\n";
+            out << "  " << fragLabel.leftJustified(14) << "ERROR\n    cannot read " << eff.fragmentShaderPath << "\n";
             ++errors;
         } else {
             const QString raw = QString::fromUtf8(frag.readAll());
@@ -417,13 +440,13 @@ int validateAnimationPack(const QString& packDir, QTextStream& out)
             const QString expanded = ShaderCompiler::expandSource(
                 assembled, QFileInfo(eff.fragmentShaderPath).absolutePath(), includePaths, &err);
             if (expanded.isEmpty()) {
-                out << "  effect.frag    ERROR\n    include expansion failed: " << err << "\n";
+                out << "  " << fragLabel.leftJustified(14) << "ERROR\n    include expansion failed: " << err << "\n";
                 ++errors;
             } else {
                 const QString spliced =
                     PhosphorShaders::spliceAfterVersion(expanded, AnimationShaderRegistry::paramPreamble(eff));
                 const ShaderCompiler::Result result = ShaderCompiler::compile(spliced.toUtf8(), QShader::FragmentStage);
-                errors += reportCompile(out, QStringLiteral("effect.frag"), result, declaredParamNames(eff.parameters));
+                errors += reportCompile(out, fragLabel, result, declaredParamNames(eff.parameters));
             }
         }
     }


### PR DESCRIPTION
Closes the shader-API **A4 "animation CLI mode"** gap: `plasmazones-shader-validate` now validates animation/transition packs, not just zone/overlay packs. Previously animation packs had no CLI check — only the `test_animation_shader_preamble_bake` unit test gated them.

## What changed
- **`--animation`/`-a`** reproduces the animation runtime's daemon (Qt-RHI) fragment assembly — `AnimationShaderEffect` metadata, the entry scaffold (`pTransition` / `pIn`+`pOut`, or a pass-through `main()`), the generated `p_<id>` preamble, and include expansion — then bakes through headless glslang. Diagnostics map to `effect.frag:line` (T1.3 `#line`) and carry the did-you-mean hint, same as the zone path.
- **`--overlay`/`-o`** is the explicit form of the default zone/overlay mode, so the two authoring systems are named symmetrically rather than one being the unnamed default (default stays overlay for back-compat).
- New CI gate **`shader_validate_animations`** (`--animation data/animations`); the zone gate now passes `--overlay` for symmetry.
- Shared the compile-result reporting (`reportCompile`) + did-you-mean across both modes; `appendDidYouMean` now takes the declared `p_<id>` list directly.

## Verification
- All **26 zone** + **53 animation** packs validate clean.
- Error injection (a typo'd `p_` reference inside `data/animations`) is caught with the correct `effect.frag:NN` and the `did you mean 'p_…'` hint.
- Full build green; suite **272/272** (271 + the new gate).

## Out of scope (documented in `validateAnimationPack`)
The kwin-effect classic-GL branch (`#define PLASMAZONES_KWIN`, default-block uniforms) is **not** baked: QShaderBaker compiles Vulkan-dialect GLSL and rejects default-block uniforms, so that branch needs a separate OpenGL-target compiler. Its incremental value is low — the `PLASMAZONES_KWIN` plumbing lives entirely in the shared `animation_uniforms.glsl` (identical for every pack), while each pack's authored body is fully covered by the daemon bake.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)