### PR TITLE
feat(snapping): add zone span toggle mode option (#563)

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -900,6 +900,7 @@ private:
         false; // false until D-Bus reply arrives — permissive default bypasses trigger gating (#175)
     bool m_cachedToggleActivation = false;
     bool m_cachedAutotileDragInsertToggle = false;
+    bool m_cachedZoneSpanToggleMode = false;
     // AutotileDragBehavior cached so the synchronous drag-start fast path can
     // decide whether to skip the handleDragToFloat(immediate=true) call.
     // Refreshed by loadCachedSettings on every settingsChanged D-Bus

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -620,6 +620,9 @@ void PlasmaZonesEffect::loadCachedSettings()
     loadSettingAsync(QStringLiteral("autotileDragInsertToggle"), [this](const QVariant& v) {
         m_cachedAutotileDragInsertToggle = v.toBool();
     });
+    loadSettingAsync(QStringLiteral("zoneSpanToggleMode"), [this](const QVariant& v) {
+        m_cachedZoneSpanToggleMode = v.toBool();
+    });
     loadSettingAsync(QStringLiteral("autotileDragBehavior"), [this](const QVariant& v) {
         // Clamp unknown values to the safe default (Float) rather than the
         // highest known value — an older effect build against a newer daemon
@@ -783,7 +786,12 @@ bool PlasmaZonesEffect::detectActivationAndGrab()
     // started on a non-autotile screen and the user hasn't held any snap
     // trigger. Without this, the cross-to-autotile policy flip never fires
     // because the gate below (drag lambda, slotMouseChanged) swallows ticks.
-    if (anyLocalTriggerHeld() || m_cachedToggleActivation || m_cachedAutotileDragInsertToggle) {
+    // Zone-span toggle mode (#563) forces activation for the same reason: the
+    // daemon's span rising-edge latch needs the release→press ticks even when
+    // no key is currently held (e.g. activation itself is toggled on and the
+    // user tapped, then released, the activation trigger).
+    if (anyLocalTriggerHeld() || m_cachedToggleActivation || m_cachedAutotileDragInsertToggle
+        || m_cachedZoneSpanToggleMode) {
         m_dragActivationDetected = true;
         if (!m_keyboardGrabbed) {
             KWin::effects->grabKeyboard(this);

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -91,6 +91,10 @@ public:
     {
         return makeSingleTriggerList(zoneSpanModifier());
     }
+    static bool zoneSpanToggleMode()
+    {
+        return false;
+    }
     static QVariantList autotileDragInsertTriggers()
     {
         // Held while dragging a window to dynamically insert it into the

--- a/src/config/configkeys.h
+++ b/src/config/configkeys.h
@@ -194,7 +194,7 @@ public:
     P_CONFIG_KEY(toggleActivationKey, "ToggleActivation")
 
     // Snapping.Behavior.ZoneSpan
-    // (uses enabledKey and triggersKey)
+    // (uses enabledKey, modifierKey, triggersKey and toggleActivationKey)
 
     // Snapping.Behavior.SnapAssist
     P_CONFIG_KEY(featureEnabledKey, "FeatureEnabled")

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -1856,6 +1856,8 @@ P_STORE_GET(bool, snappingEnabled, snappingGroup, enabledKey, bool)
 P_STORE_SET_BOOL(setSnappingEnabled, snappingGroup, enabledKey, snappingEnabledChanged)
 P_STORE_GET(bool, toggleActivation, snappingBehaviorGroup, toggleActivationKey, bool)
 P_STORE_SET_BOOL(setToggleActivation, snappingBehaviorGroup, toggleActivationKey, toggleActivationChanged)
+P_STORE_GET(bool, zoneSpanToggleMode, snappingBehaviorZoneSpanGroup, toggleActivationKey, bool)
+P_STORE_SET_BOOL(setZoneSpanToggleMode, snappingBehaviorZoneSpanGroup, toggleActivationKey, zoneSpanToggleModeChanged)
 
 // Shared helper for the three "plain" trigger-list setters (activation,
 // snap-assist, autotile-insert). Post-write compare — the schema's

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -99,6 +99,8 @@ public:
         int zoneSpanModifier READ zoneSpanModifierInt WRITE setZoneSpanModifierInt NOTIFY zoneSpanModifierChanged)
     Q_PROPERTY(
         QVariantList zoneSpanTriggers READ zoneSpanTriggers WRITE setZoneSpanTriggers NOTIFY zoneSpanTriggersChanged)
+    Q_PROPERTY(
+        bool zoneSpanToggleMode READ zoneSpanToggleMode WRITE setZoneSpanToggleMode NOTIFY zoneSpanToggleModeChanged)
     Q_PROPERTY(bool toggleActivation READ toggleActivation WRITE setToggleActivation NOTIFY toggleActivationChanged)
     Q_PROPERTY(bool snappingEnabled READ snappingEnabled WRITE setSnappingEnabled NOTIFY snappingEnabledChanged)
 
@@ -531,6 +533,8 @@ public:
     void setZoneSpanModifierInt(int modifier);
     QVariantList zoneSpanTriggers() const override;
     void setZoneSpanTriggers(const QVariantList& triggers) override;
+    bool zoneSpanToggleMode() const override;
+    void setZoneSpanToggleMode(bool enable) override;
     bool toggleActivation() const override;
     void setToggleActivation(bool enable) override;
     bool snappingEnabled() const override;

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -708,6 +708,7 @@ void appendActivationSchema(PhosphorConfig::Schema& schema)
                      static_cast<int>(DragModifier::CtrlAltMeta)},
                     static_cast<int>(DragModifier::Disabled))},
         {CD::triggersKey(), CD::zoneSpanTriggers(), QMetaType::QVariantList, {}, canonicalTriggerList},
+        {CD::toggleActivationKey(), CD::zoneSpanToggleMode(), QMetaType::Bool},
     };
 }
 

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -327,6 +327,7 @@ Q_SIGNALS:
     void zoneSpanEnabledChanged();
     void zoneSpanModifierChanged();
     void zoneSpanTriggersChanged();
+    void zoneSpanToggleModeChanged();
     void toggleActivationChanged();
     void snappingEnabledChanged();
     void showZonesOnAllMonitorsChanged();

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -128,6 +128,8 @@ public:
     virtual void setZoneSpanModifier(DragModifier modifier) = 0;
     virtual QVariantList zoneSpanTriggers() const = 0;
     virtual void setZoneSpanTriggers(const QVariantList& triggers) = 0;
+    virtual bool zoneSpanToggleMode() const = 0;
+    virtual void setZoneSpanToggleMode(bool enable) = 0;
     virtual bool toggleActivation() const = 0;
     virtual void setToggleActivation(bool enable) = 0;
     virtual bool snappingEnabled() const = 0;

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -325,6 +325,7 @@ void SettingsAdaptor::initializeRegistry()
 
     REGISTER_BOOL_SETTING("autotileDragInsertToggle", autotileDragInsertToggle, setAutotileDragInsertToggle)
     REGISTER_BOOL_SETTING("toggleActivation", toggleActivation, setToggleActivation)
+    REGISTER_BOOL_SETTING("zoneSpanToggleMode", zoneSpanToggleMode, setZoneSpanToggleMode)
     REGISTER_BOOL_SETTING("snappingEnabled", snappingEnabled, setSnappingEnabled)
 
     // Display settings

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -492,6 +492,8 @@ private:
     bool m_prevTriggerHeld = false; // Previous frame's trigger state for edge detection
     bool m_autotileDragInsertToggled = false; // Current toggle state for autotile drag-insert
     bool m_prevAutotileDragInsertHeld = false; // Previous frame's autotile drag-insert trigger state
+    bool m_zoneSpanToggled = false; // Current toggle state for zone span (toggle mode)
+    bool m_prevZoneSpanTriggerHeld = false; // Previous frame's zone span trigger state for edge detection
     // Drag-to-reorder mode is active for the current drag: cached at beginDrag
     // time so per-tick dragMoved work (60+ Hz) doesn't have to re-query the
     // settings + engine on every cursor update. Requires (a) autotile-bypass

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -83,11 +83,10 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
     // and is also commonly the configured snap activation trigger). The user
     // must perform a real release→press cycle to toggle.
     m_prevTriggerHeld = true;
-    // Zone span toggle latch (#563) follows the same reset/seed contract as the
-    // activation latch above: cleared each drag, prev seeded true so a span
-    // trigger already held at drag start isn't read as a rising edge.
-    m_zoneSpanToggled = false;
-    m_prevZoneSpanTriggerHeld = true;
+    // Zone span toggle latch (#563) reset lives in beginDrag, not here — the
+    // bypass path (autotile-only) never calls dragStarted, so resetting it
+    // here would leave the latch stale across bypass drags (same hazard the
+    // autotile drag-insert latch and m_modifierConflictWarned avoid).
     m_overlayShown = false;
     // m_overlayIdled is NOT reset here. The previous drag's end sets it:
     // a normal drop (hideOverlayAndSelector) leaves it true because the

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -83,6 +83,11 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
     // and is also commonly the configured snap activation trigger). The user
     // must perform a real release→press cycle to toggle.
     m_prevTriggerHeld = true;
+    // Zone span toggle latch (#563) follows the same reset/seed contract as the
+    // activation latch above: cleared each drag, prev seeded true so a span
+    // trigger already held at drag start isn't read as a rising edge.
+    m_zoneSpanToggled = false;
+    m_prevZoneSpanTriggerHeld = true;
     m_overlayShown = false;
     // m_overlayIdled is NOT reset here. The previous drag's end sets it:
     // a normal drop (hideOverlayAndSelector) leaves it true because the
@@ -624,8 +629,20 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
         m_overlayIdled = false;
     }
 
-    // Check all configured zone span triggers (multi-bind support)
-    const bool zoneSpanModifierHeld = anyTriggerHeld(m_cachedZoneSpanTriggers, mods, mouseButtons);
+    // Check all configured zone span triggers (multi-bind support). In toggle
+    // mode the raw held-state is resolved through the same rising-edge latch as
+    // activation (#563): tap the span modifier once to start spanning, tap
+    // again to stop, instead of holding it. alwaysActiveOnDrag is always false
+    // here — zone span has no always-active sentinel. The latch is evaluated
+    // every tick (not just when the overlay is active) so a release→press while
+    // the overlay is off is still seen on the next active tick.
+    const bool rawZoneSpanHeld = anyTriggerHeld(m_cachedZoneSpanTriggers, mods, mouseButtons);
+    const ActivationDecision zoneSpanDecision =
+        resolveActivationActive(rawZoneSpanHeld, m_settings->zoneSpanToggleMode(), /*alwaysActiveOnDrag=*/false,
+                                m_prevZoneSpanTriggerHeld, m_zoneSpanToggled);
+    m_prevZoneSpanTriggerHeld = zoneSpanDecision.nextPrevTriggerHeld;
+    m_zoneSpanToggled = zoneSpanDecision.nextActivationToggled;
+    const bool zoneSpanModifierHeld = zoneSpanDecision.active;
 
     // Conflict detection: warn once per drag when activation and zone span
     // can both fire on the same physical input. Runtime semantics are AND

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -115,6 +115,13 @@ PhosphorProtocol::DragPolicy WindowDragAdaptor::beginDrag(const QString& windowI
     // release and re-press to toggle.
     m_autotileDragInsertToggled = false;
     m_prevAutotileDragInsertHeld = true;
+    // Zone span toggle latch (#563), same rationale and seed contract as the
+    // autotile drag-insert latch above: reset on every beginDrag so it covers
+    // both the bypass path (dragStarted never runs) and the snap path. Prev is
+    // seeded true so a span trigger already held at drag start is not read as a
+    // rising edge on the first dragMoved tick.
+    m_zoneSpanToggled = false;
+    m_prevZoneSpanTriggerHeld = true;
     // Reset the modifier-conflict warning latch on every beginDrag,
     // not just the snap-path dragStarted further down. Bypass-path drags
     // never call dragStarted, so without this reset a previously latched

--- a/src/settings/qml/SnappingOverlayBehaviorPage.qml
+++ b/src/settings/qml/SnappingOverlayBehaviorPage.qml
@@ -150,6 +150,21 @@ SettingsFlickable {
                     SettingsSeparator {}
 
                     SettingsRow {
+                        title: i18n("Toggle mode")
+                        description: i18n("Tap the span modifier once to start spanning, tap again to stop, instead of holding it")
+
+                        SettingsSwitch {
+                            checked: appSettings.zoneSpanToggleMode
+                            accessibleName: i18n("Zone span toggle mode")
+                            onToggled: function (newValue) {
+                                appSettings.zoneSpanToggleMode = newValue;
+                            }
+                        }
+                    }
+
+                    SettingsSeparator {}
+
+                    SettingsRow {
                         title: i18n("Edge threshold")
                         description: i18n("Distance from zone edge for multi-zone selection")
 

--- a/tests/unit/config/test_configdefaults.cpp
+++ b/tests/unit/config/test_configdefaults.cpp
@@ -193,6 +193,15 @@ private Q_SLOTS:
     }
 
     /**
+     * Zone span toggle mode (#563) is opt-in: the default must be false so the
+     * span modifier keeps its hold-to-span behaviour unless the user enables it.
+     */
+    void testZoneSpanToggleMode_default_isFalse()
+    {
+        QCOMPARE(ConfigDefaults::zoneSpanToggleMode(), false);
+    }
+
+    /**
      * Snapped-window appearance defaults must be IDENTICAL to the autotile*
      * window appearance defaults — the two modes start a window from the same
      * chrome (every snapWindow* default delegates to its autotile* counterpart).

--- a/tests/unit/config/test_settings_core.cpp
+++ b/tests/unit/config/test_settings_core.cpp
@@ -177,6 +177,7 @@ private Q_SLOTS:
         settings.setInactiveOpacity(0.2);
         settings.setShowZoneNumbers(false);
         settings.setToggleActivation(true);
+        settings.setZoneSpanToggleMode(true);
         settings.setZoneSelectorEnabled(false);
         settings.setZoneSelectorTriggerDistance(100);
         settings.setZoneSelectorGridColumns(3);
@@ -232,6 +233,11 @@ private Q_SLOTS:
         {
             auto behavior = backend->group(ConfigDefaults::snappingBehaviorGroup());
             QCOMPARE(behavior->readBool(ConfigDefaults::toggleActivationKey(), false), true);
+        }
+
+        {
+            auto zoneSpan = backend->group(ConfigDefaults::snappingBehaviorZoneSpanGroup());
+            QCOMPARE(zoneSpan->readBool(ConfigDefaults::toggleActivationKey(), false), true);
         }
 
         {

--- a/tests/unit/dbus/test_settings_adaptor_batch.cpp
+++ b/tests/unit/dbus/test_settings_adaptor_batch.cpp
@@ -296,6 +296,43 @@ private Q_SLOTS:
     }
 
     // ─────────────────────────────────────────────────────────────────────
+    // Drag-activation toggle keys. The KWin effect fetches these three bools
+    // (via loadSettingAsync → getSetting, the singular form of this batch) to
+    // decide whether to keep streaming drag-cursor ticks while no trigger is
+    // physically held, so the daemon's rising-edge toggle latches still fire.
+    // If the adaptor registry drops any registration the effect silently reads
+    // false and that toggle feature dies — zoneSpanToggleMode shipped
+    // unregistered until PR #595's audit caught it, so pin the whole set here
+    // to break the test gate on any future omission. Mirrors the snap-window
+    // batch test above: every requested key must come back, valid, Bool-typed,
+    // and wired to its own ISettings accessor.
+    // ─────────────────────────────────────────────────────────────────────
+    void testGetSettings_dragToggleKeys_allReturnedWithTypes()
+    {
+        const QStringList keys{
+            QStringLiteral("toggleActivation"),
+            QStringLiteral("autotileDragInsertToggle"),
+            QStringLiteral("zoneSpanToggleMode"),
+        };
+
+        const QVariantMap result = m_adaptor->getSettings(keys);
+
+        QCOMPARE(result.size(), keys.size());
+        for (const QString& k : keys) {
+            QVERIFY2(result.contains(k), qPrintable(QStringLiteral("missing key: %1").arg(k)));
+            QVERIFY2(result.value(k).isValid(), qPrintable(QStringLiteral("invalid variant for: %1").arg(k)));
+            QCOMPARE(result.value(k).metaType().id(), QMetaType::Bool);
+        }
+
+        // Each key resolves to its own ISettings accessor rather than collapsing
+        // onto a neighbour.
+        QCOMPARE(result.value(QStringLiteral("toggleActivation")).toBool(), m_settings->toggleActivation());
+        QCOMPARE(result.value(QStringLiteral("autotileDragInsertToggle")).toBool(),
+                 m_settings->autotileDragInsertToggle());
+        QCOMPARE(result.value(QStringLiteral("zoneSpanToggleMode")).toBool(), m_settings->zoneSpanToggleMode());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
     // Phase 5: setPerScreenSettings batch surface.
     //
     // The contract mirrors setSettings (global batch): empty map returns

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -97,6 +97,13 @@ public:
     void setZoneSpanTriggers(const QVariantList&) override
     {
     }
+    bool zoneSpanToggleMode() const override
+    {
+        return false;
+    }
+    void setZoneSpanToggleMode(bool) override
+    {
+    }
     bool toggleActivation() const override
     {
         return false;


### PR DESCRIPTION
## Summary

Implements the feature requested in discussion #563: an opt-in option to make the **zone span modifier a toggle** instead of a hold. Tap the span modifier once to start spanning across zones, tap again to stop, instead of holding it down throughout the drag.

Default is off, so existing hold-to-span behavior is unchanged. Motivated by accessibility: some mice make holding a second button (e.g. middle mouse mapped to span) awkward, and toggling is easier than a sustained hold.

## How it works

The runtime reuses the existing, tested `resolveActivationActive()` rising-edge latch (`alwaysActiveOnDrag=false`), mirroring how drag activation and autotile drag-insert already implement toggle mode. The latch resets at snap-drag start with `prev` seeded true, so a span trigger already held when the drag begins is not read as a rising edge.

Storage follows the established pattern: a bool under `Snapping.Behavior.ZoneSpan` reusing the `ToggleActivation` key, with the default registered in the settings schema. No schema-version bump and no migration: an absent key falls back to `false` (per the project's no-ad-hoc-migration rule).

### KWin effect wiring

The effect gates the daemon's drag-cursor tick stream through `detectActivationAndGrab()` to avoid flooding D-Bus when no trigger is held. That gate already force-passes for `toggleActivation` and `autotileDragInsertToggle` so their daemon-side rising-edge latches keep receiving release→press ticks. Zone span toggle needed the same treatment, otherwise the daemon never sees the span trigger edge in the fully hands-free case (activation toggled on, all keys released) and spanning silently fails to latch. The effect now caches `zoneSpanToggleMode` (loaded + refreshed via the same `settingsChanged` path as the other toggles) and includes it in the gate, giving span toggle parity with the overlay activation toggle.

## Changes

- **Config/settings**: new `zoneSpanToggleMode` setting (ConfigDefaults default, schema entry, Q_PROPERTY, interface getter/setter + signal)
- **Daemon runtime**: span trigger resolved through `resolveActivationActive()` in the `dragMoved` hot path; latch reset at drag start
- **KWin effect**: cache the setting and add it to the activation/tick-forwarding gate
- **UI**: "Toggle mode" switch in the Zone Span card of the snapping overlay behavior page
- **Tests**: default-value + persistence coverage; stub override

## Testing

- `cmake --build` succeeds (including `kwin_effect_plasmazones.so`)
- `ctest`: **274/274 passed**
- clang-format / qmlformat / conventional-commit pre-commit hooks pass

Closes #563

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)