### PR TITLE
fix(editor): use live screen for canvas reference, not fixed-zone bbox (#593)

### DIFF
--- a/src/editor/controller/layout.cpp
+++ b/src/editor/controller/layout.cpp
@@ -416,18 +416,34 @@ void EditorController::loadLayout(const QString& layoutId)
     m_layoutId = layoutObj[QLatin1String(::PhosphorZones::ZoneJsonKeys::Id)].toString();
     m_layoutName = layoutObj[QLatin1String(::PhosphorZones::ZoneJsonKeys::Name)].toString();
 
-    // Resolve the final reference size before building zones. Fixed-geometry
-    // layouts normalize against their own zone bounding box (which may differ
-    // from the current screen — e.g. a 3840x2160 layout shown on a 3840x2126
-    // panel-reduced screen). Use a throwaway Layout to ask the canonical
-    // helper rather than re-walking the JSON here. Relative-only layouts
-    // clear the override so targetScreenSize() falls back to the screen
-    // geometry setTargetScreen already cached — no extra D-Bus call.
+    // Resolve the final reference size before building zones. The editor
+    // canvas fills the live screen, and EditorZone scales each fixed zone by
+    // targetScreenSize (fixedPixels / targetScreenSize.width * canvasWidth),
+    // so the reference MUST share the live screen's aspect ratio or fixed
+    // zones stretch. The raw fixed-zone bounding box is the wrong reference
+    // whenever the zones don't span the full screen — a 16:9 layout whose
+    // fixed zones only reach 2560px wide yields a 2560x2160 bbox and renders
+    // 1.5x too wide (discussion #593).
+    //
+    // Clear the override first so targetScreenSize() reports the live
+    // screen/VS size, then re-pin only when the layout's fixed zones
+    // genuinely exceed that size (e.g. a 3840x2160 layout on a 3840x2126
+    // panel-reduced screen). fixedZoneReferenceGeometry() encodes exactly
+    // this "use the recalc geometry unless the bbox overflows it" rule, the
+    // same helper the preview path uses — seed it by recalculating the
+    // throwaway Layout against the live screen first.
     const QSize prevSize = targetScreenSize();
     {
+        m_layoutBoundsOverride = QSize();
+        const QSize screenSize = targetScreenSize();
         std::unique_ptr<PhosphorZones::Layout> tmp(PhosphorZones::Layout::fromJson(layoutObj));
-        const QRectF bbox = tmp ? tmp->fixedZoneBoundingBox() : QRectF();
-        m_layoutBoundsOverride = bbox.isEmpty() ? QSize() : QSize(qRound(bbox.width()), qRound(bbox.height()));
+        if (tmp && screenSize.isValid()) {
+            tmp->recalculateZoneGeometries(QRectF(QPointF(), screenSize));
+            const QRectF refGeo = tmp->fixedZoneReferenceGeometry();
+            if (!refGeo.isEmpty() && refGeo.size().toSize() != screenSize) {
+                m_layoutBoundsOverride = refGeo.size().toSize();
+            }
+        }
     }
     const QSize newSize = targetScreenSize();
     if (newSize != prevSize) {

--- a/tests/unit/core/test_layout_core.cpp
+++ b/tests/unit/core/test_layout_core.cpp
@@ -406,6 +406,65 @@ private Q_SLOTS:
         QCOMPARE(copy.minAspectRatio(), 0.3);
         QCOMPARE(copy.maxAspectRatio(), 0.9);
     }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Fixed-zone reference geometry (editor canvas reference — discussion #593)
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    // The editor canvas scales fixed zones by its reference size, so the
+    // reference must match the live screen unless the fixed zones overflow it.
+    // fixedZoneReferenceGeometry() encodes that rule: keep the recalc
+    // (screen) geometry when the fixed-zone bounding box fits inside it.
+    void testLayout_fixedZoneReference_partialZonesKeepScreen()
+    {
+        // A 16:9 layout whose two fixed zones only reach 2560px wide on a
+        // 3840x2160 screen (the discussion #593 "4K" layout). The raw bbox is
+        // 2560x2160 (near-square); pinning to it would stretch the canvas 1.5x
+        // horizontally. The reference must stay the full 3840x2160 screen.
+        PhosphorZones::Layout layout(QStringLiteral("4K"));
+        auto* z1 = new PhosphorZones::Zone();
+        z1->setGeometryMode(PhosphorZones::ZoneGeometryMode::Fixed);
+        z1->setFixedGeometry(QRectF(0, 1080, 1920, 1080));
+        layout.addZone(z1);
+        auto* z2 = new PhosphorZones::Zone();
+        z2->setGeometryMode(PhosphorZones::ZoneGeometryMode::Fixed);
+        z2->setFixedGeometry(QRectF(0, 720, 2560, 1440));
+        layout.addZone(z2);
+
+        QCOMPARE(layout.fixedZoneBoundingBox(), QRectF(0, 0, 2560, 2160));
+
+        layout.recalculateZoneGeometries(QRectF(0, 0, 3840, 2160));
+        QCOMPARE(layout.fixedZoneReferenceGeometry(), QRectF(0, 0, 3840, 2160));
+    }
+
+    // When the fixed zones genuinely exceed the live screen (a 3840x2160
+    // layout on a 3840x2126 panel-reduced screen), the reference keeps the
+    // authored bounding box so fixed pixels stay accurate.
+    void testLayout_fixedZoneReference_overflowKeepsBbox()
+    {
+        PhosphorZones::Layout layout(QStringLiteral("FullScreen"));
+        auto* z = new PhosphorZones::Zone();
+        z->setGeometryMode(PhosphorZones::ZoneGeometryMode::Fixed);
+        z->setFixedGeometry(QRectF(0, 0, 3840, 2160));
+        layout.addZone(z);
+
+        layout.recalculateZoneGeometries(QRectF(0, 0, 3840, 2126));
+        QCOMPARE(layout.fixedZoneReferenceGeometry(), QRectF(0, 0, 3840, 2160));
+    }
+
+    // Relative-only layouts have no fixed-zone bounding box, so the editor
+    // falls back to the live screen (empty reference → no canvas override).
+    void testLayout_fixedZoneReference_relativeOnlyIsEmpty()
+    {
+        PhosphorZones::Layout layout(QStringLiteral("Relative"));
+        auto* z = new PhosphorZones::Zone();
+        z->setRelativeGeometry(QRectF(0, 0, 0.5, 1.0));
+        layout.addZone(z);
+
+        QVERIFY(layout.fixedZoneBoundingBox().isEmpty());
+        layout.recalculateZoneGeometries(QRectF(0, 0, 3840, 2160));
+        QVERIFY(layout.fixedZoneReferenceGeometry().isEmpty());
+    }
 };
 
 QTEST_MAIN(TestLayoutCore)


### PR DESCRIPTION
## Summary

Fixes [discussion #593](https://github.com/fuddlesworth/PlasmaZones/discussions/593): editing a layout on a 4K (16:9) screen renders it stretched ("still ultrawide"), while creating a new layout renders correctly.

## Root cause

The editor canvas fills the live screen, and `EditorZone.qml` sizes each fixed zone as `(fixedPixelWidth / targetScreenSize.width) * canvasWidth`. So the canvas reference (`targetScreenSize()`) must share the live screen's aspect ratio.

`loadLayout()` pinned the reference to the raw `fixedZoneBoundingBox()` — the union of fixed-zone rects anchored at (0,0). That has the wrong aspect whenever the fixed zones don't span the full screen.

Confirmed against the reporter's support report (their "4K" layout, tagged `standard`/16:9): its fixed zones reach only 2560px wide on a 3840×2160 screen → bbox `2560×2160` → every zone scaled **1.5× horizontally**. Creating worked because `createNewLayout()` clears the override and uses the live screen.

## Fix

`loadLayout()` now defaults the reference to the live screen and re-pins **only** when the fixed zones genuinely overflow it (e.g. a 3840×2160 layout on a 3840×2126 panel-reduced screen), via `fixedZoneReferenceGeometry()` — the same helper the preview path already uses. This is the "accurate placement" behavior.

`aspectRatioClass` is unchanged: it is only a picker/matching tag and never drove the canvas, so changing it would not have fixed the bug.

## Tests

Adds regression tests in `tests/unit/core/test_layout_core.cpp` for:
- partial-coverage fixed zones → reference stays the live screen
- fixed zones overflowing the screen → reference keeps the authored bbox
- relative-only layouts → empty reference (falls back to live screen)

Build clean; full suite 274/274 passing.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)