### PR TITLE
fix(settings): align condition operator dropdowns to a uniform width

### DIFF
--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -33,6 +33,12 @@ RowLayout {
     // Operator options depend on the current field's enum value.
     readonly property var _operatorOptions: leaf._fieldEntry !== undefined ? controller.operatorsForField(leaf._fieldEntry.value) : []
     readonly property string _valueKind: leaf._fieldEntry !== undefined ? leaf._fieldEntry.valueKind : "string"
+    // Widest operator label across the FULL operator vocabulary, in pixels —
+    // the operator dropdown is sized to this (not to the current field's
+    // operator subset) so the operator column lines up on every condition row
+    // and doesn't resize when the field changes. Recomputed by
+    // _recalcOperatorWidth() on load and whenever the measuring font changes.
+    property real _widestOperatorTextWidth: 0
 
     signal leafChanged(var updatedLeaf)
     signal removeRequested
@@ -62,6 +68,19 @@ RowLayout {
             "op": op,
             "value": value
         });
+    }
+
+    /// Measure every operator label (the full vocabulary, via
+    /// controller.allOperators()) and cache the widest in pixels. The label
+    /// set is static, so this only needs to run on load and on font change.
+    function _recalcOperatorWidth() {
+        var ops = leaf.controller ? leaf.controller.allOperators() : [];
+        var maxW = 0;
+        for (var i = 0; i < ops.length; ++i) {
+            opMetrics.text = ops[i].label || "";
+            maxW = Math.max(maxW, opMetrics.advanceWidth);
+        }
+        leaf._widestOperatorTextWidth = maxW;
     }
 
     /// True when the running-windows picker has a mode that fills @p wire
@@ -133,6 +152,18 @@ RowLayout {
 
     spacing: Kirigami.Units.smallSpacing
 
+    Component.onCompleted: leaf._recalcOperatorWidth()
+
+    // Non-visual measurer for _recalcOperatorWidth(). Matches the operator
+    // combo's font so the cached widths are pixel-accurate; re-measures if the
+    // font changes (e.g. a theme/scale switch).
+    TextMetrics {
+        id: opMetrics
+
+        font: opCombo.font
+        onFontChanged: leaf._recalcOperatorWidth()
+    }
+
     Kirigami.Icon {
         source: "dialog-information"
         Layout.preferredWidth: Kirigami.Units.iconSizes.small
@@ -188,6 +219,13 @@ RowLayout {
     WideComboBox {
         id: opCombo
 
+        // Fixed to the widest operator label across ALL fields' operator sets
+        // (plus chrome for the dropdown indicator + padding) instead of the
+        // WideComboBox auto-width, which keys off the CURRENT field's operator
+        // subset and so renders a different width per field (e.g. Desktop's
+        // numeric operators vs Monitor's string operators). The gridUnit * 3
+        // chrome allowance mirrors WideComboBox's own popup-width formula.
+        Layout.preferredWidth: leaf._widestOperatorTextWidth + Kirigami.Units.gridUnit * 3
         textRole: "label"
         valueRole: "wire"
         model: leaf._operatorOptions

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -410,6 +410,23 @@ QVariantList operatorsForField(int fieldValue)
     return out;
 }
 
+QVariantList allOperators()
+{
+    // Iterate the whole Operator enum via OperatorCount rather than a
+    // hand-maintained list — a new operator auto-surfaces here (and so widens
+    // the leaf editor's operator-column sizing) the moment it's added.
+    QVariantList out;
+    for (int i = 0; i < PhosphorWindowRule::OperatorCount; ++i) {
+        const auto op = static_cast<Operator>(i);
+        QVariantMap entry;
+        entry[QStringLiteral("value")] = i;
+        entry[QStringLiteral("wire")] = PhosphorWindowRule::operatorToString(op);
+        entry[QStringLiteral("label")] = operatorLabelImpl(op);
+        out.append(entry);
+    }
+    return out;
+}
+
 QVariantList actionTypes()
 {
     // The picker order is meaningful (engine-mode first, then layout-shaping,

--- a/src/settings/windowruleauthoring.h
+++ b/src/settings/windowruleauthoring.h
@@ -20,6 +20,13 @@ QVariantList matchFields();
 /// Each entry: `{ value: int (Operator enum), wire: QString, label }`.
 QVariantList operatorsForField(int fieldValue);
 
+/// Every operator with its translated label, independent of any field. Same
+/// entry shape as operatorsForField. The leaf editor sizes the operator
+/// dropdown to the widest of these so the operator column lines up across
+/// condition rows and doesn't resize when the field — and thus its valid
+/// operator subset — changes.
+QVariantList allOperators();
+
 /// Registered action types for the action-editor dropdown. Each entry:
 /// `{ value: QString (action type id), label, params: [ ... ],
 ///    domain: "context"|"window" }`. See `WindowRuleController::actionTypes`

--- a/src/settings/windowrulecontroller.h
+++ b/src/settings/windowrulecontroller.h
@@ -292,6 +292,12 @@ public:
     /// `{ value: int (Operator enum), wire: QString (JSON wire string), label }`.
     Q_INVOKABLE QVariantList operatorsForField(int fieldValue) const;
 
+    /// Every operator with its translated label, independent of any field —
+    /// the leaf editor uses this to size the operator dropdown to the widest
+    /// possible label so the operator column lines up across condition rows.
+    /// Same entry shape as operatorsForField.
+    Q_INVOKABLE QVariantList allOperators() const;
+
     /// Registered action types for the action-editor dropdown. Each entry:
     /// `{ value: QString (action type id), label, params: [ ... ],
     ///   domain: "context"|"window" }` where each param descriptor is

--- a/src/settings/windowrulecontroller_views.cpp
+++ b/src/settings/windowrulecontroller_views.cpp
@@ -297,6 +297,11 @@ QVariantList WindowRuleController::operatorsForField(int fieldValue) const
     return WindowRuleAuthoring::operatorsForField(fieldValue);
 }
 
+QVariantList WindowRuleController::allOperators() const
+{
+    return WindowRuleAuthoring::allOperators();
+}
+
 QVariantList WindowRuleController::actionTypes() const
 {
     return WindowRuleAuthoring::actionTypes();

--- a/tests/unit/settings/test_window_rule_controller.cpp
+++ b/tests/unit/settings/test_window_rule_controller.cpp
@@ -21,6 +21,7 @@
 
 #include <QJSEngine>
 #include <QJsonObject>
+#include <QSet>
 #include <QSignalSpy>
 #include <QTest>
 #include <QUuid>
@@ -511,6 +512,29 @@ void TestWindowRuleController::authoringMetadata()
     // AppId (Field enum 0) supports the AppIdMatches operator.
     const QVariantList appOps = controller.operatorsForField(0);
     QVERIFY(!appOps.isEmpty());
+
+    // allOperators() surfaces the FULL operator vocabulary (not a field
+    // subset). The leaf editor sizes the operator dropdown to the widest
+    // allOperators() label so the operator column lines up across condition
+    // rows — that sizing is only correct if allOperators() is a SUPERSET of
+    // every field's operator set (otherwise a field operator wider than any
+    // measured label would size the column too narrow and elide). Assert the
+    // {value, wire, label} shape with non-empty labels and the superset
+    // relationship so a regression that drops an operator is caught.
+    const QVariantList allOps = controller.allOperators();
+    QVERIFY(!allOps.isEmpty());
+    QSet<QString> allOperatorWires;
+    for (const QVariant& v : allOps) {
+        const QVariantMap m = v.toMap();
+        QVERIFY(m.contains(QStringLiteral("value")));
+        QVERIFY(!m.value(QStringLiteral("wire")).toString().isEmpty());
+        QVERIFY(!m.value(QStringLiteral("label")).toString().isEmpty());
+        allOperatorWires.insert(m.value(QStringLiteral("wire")).toString());
+    }
+    for (const QVariant& v : appOps) {
+        QVERIFY2(allOperatorWires.contains(v.toMap().value(QStringLiteral("wire")).toString()),
+                 "operatorsForField returned an operator absent from allOperators()");
+    }
 
     const QVariantList actions = controller.actionTypes();
     QVERIFY(!actions.isEmpty());


### PR DESCRIPTION
## Problem

In the window-rule condition editor (**WHEN … of** rows), the middle **operator** dropdown (the "is" combo) rendered at a different width on the **Desktop** row than on the **Monitor** and **Activity** rows.

![condition rows with mismatched operator dropdowns](https://example/screenshot)

## Root cause

The operator combo is a `WideComboBox`, which auto-sizes its closed width to the widest label **in its current model**. The valid-operator set differs per field:

- **Desktop** (numeric): `is`, `greater than`, `less than`, `is one of`
- **Monitor / Activity** (string): `is`, `contains`, `starts with`, `ends with`, `matches regex`, `is one of`

Different widest-label ⇒ different combo width. The same combo would also visibly resize when a row's field changed.

## Fix

Size every operator combo to the widest label across the **entire** operator vocabulary instead of the current field's subset, so the operator column lines up on every condition row and stays stable across field changes.

- `windowruleauthoring.{h,cpp}` — add `allOperators()` (iterates `OperatorCount`, so a future operator automatically widens the column)
- `windowrulecontroller.{h,cpp}` — `Q_INVOKABLE` forwarder
- `MatchLeafEditor.qml` — measure all operator labels via `TextMetrics` and pin the operator combo's `Layout.preferredWidth` (chrome allowance mirrors `WideComboBox`'s own popup-width formula)

## Testing

- `cmake --build build` — clean
- `ctest` — **273/273 passing**

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)