### PR TITLE
feat(snapping): focus new windows and focus follows mouse

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -475,7 +475,7 @@ private:
      * so a dialog/popup floating over a snapped window keeps focus (occlusion guard,
      * mirroring AutotileHandler::handleCursorMoved).
      */
-    void handleSnapCursorMoved(const QPointF& pos);
+    void handleSnapCursorMoved(const QPointF& pos, const QString& screenId);
 
     void notifyWindowClosed(KWin::EffectWindow* w);
     void notifyWindowActivated(KWin::EffectWindow* w);

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -468,6 +468,15 @@ private:
         return PhosphorCompositor::AutotileStateHelpers::isBorderlessWindow(m_snapBorder, windowId);
     }
 
+    /**
+     * @brief Snapping focus-follows-mouse: activate the topmost snapped window under
+     * the cursor. Gated by m_snappingFocusFollowsMouse and called from slotMouseChanged
+     * when not dragging. No-op unless the window directly under the cursor is snapped,
+     * so a dialog/popup floating over a snapped window keeps focus (occlusion guard,
+     * mirroring AutotileHandler::handleCursorMoved).
+     */
+    void handleSnapCursorMoved(const QPointF& pos);
+
     void notifyWindowClosed(KWin::EffectWindow* w);
     void notifyWindowActivated(KWin::EffectWindow* w);
     KWin::EffectWindow* findWindowById(const QString& windowId) const;
@@ -901,6 +910,10 @@ private:
     bool m_cachedToggleActivation = false;
     bool m_cachedAutotileDragInsertToggle = false;
     bool m_cachedZoneSpanToggleMode = false;
+    // Snapping focus-follows-mouse (Snapping.Behavior.FocusFollowsMouse). When on,
+    // moving the cursor over a snapped window activates it. Mirrors autotile FFM but
+    // scoped to the snap BorderState tiled set instead of autotile screens.
+    bool m_snappingFocusFollowsMouse = false;
     // AutotileDragBehavior cached so the synchronous drag-start fast path can
     // decide whether to skip the handleDragToFloat(immediate=true) call.
     // Refreshed by loadCachedSettings on every settingsChanged D-Bus

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -699,6 +699,10 @@ void PlasmaZonesEffect::loadCachedSettings()
         m_autotileHandler->setFocusFollowsMouse(v.toBool());
     });
 
+    loadSettingAsync(QStringLiteral("snappingFocusFollowsMouse"), [this](const QVariant& v) {
+        m_snappingFocusFollowsMouse = v.toBool();
+    });
+
     // Snapped-window border settings — feed the effect's parallel snap
     // BorderState (m_snapBorder), mirroring the autotile* block above. When
     // snapWindowUseSystemBorderColors is on the daemon writes the resolved

--- a/kwin-effect/plasmazoneseffect/mouse_drag.cpp
+++ b/kwin-effect/plasmazoneseffect/mouse_drag.cpp
@@ -144,7 +144,15 @@ void PlasmaZonesEffect::handleSnapCursorMoved(const QPointF& pos, const QString&
     // worth protecting.
     if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
         // Cheap overlay-class check first, then the heavier screen resolution
-        // (mirrors the autotile guard's predicate ordering).
+        // (mirrors the autotile guard's predicate ordering). The predicate is
+        // deliberately wider than the under-cursor occlusion guard below: there
+        // we only look *through* a snapped window, but here a normal tileable
+        // active window (a regular app the user is working in, not a popup) must
+        // not pause FFM either. Only a non-snapped, non-tileable active window
+        // (dialog/popup/excluded app) is worth protecting. Both of autotile's
+        // guards key off the same tileable/shouldHandle membership; snap's managed
+        // set (snapped) is narrower than tileable, so here the pause guard accepts
+        // the extra isTileableWindow case the occlusion guard below does not.
         if (!isOwnOverlayClass(active->windowClass()) && getWindowScreenId(active) == screenId
             && !isWindowMarkedSnapped(getWindowId(active)) && !isTileableWindow(active)) {
             return;

--- a/kwin-effect/plasmazoneseffect/mouse_drag.cpp
+++ b/kwin-effect/plasmazoneseffect/mouse_drag.cpp
@@ -122,11 +122,11 @@ void PlasmaZonesEffect::slotMouseChanged(const QPointF& pos, const QPointF& oldp
         // bails when the cursor screen is not an autotile screen, and snapping FFM only
         // acts on windows in the snap tiled set (which live on snapping-mode screens), so
         // at most one of them activates a window for any given cursor position.
-        handleSnapCursorMoved(pos);
+        handleSnapCursorMoved(pos, effectiveScreenId);
     }
 }
 
-void PlasmaZonesEffect::handleSnapCursorMoved(const QPointF& pos)
+void PlasmaZonesEffect::handleSnapCursorMoved(const QPointF& pos, const QString& screenId)
 {
     if (!m_snappingFocusFollowsMouse) {
         return;
@@ -137,12 +137,14 @@ void PlasmaZonesEffect::handleSnapCursorMoved(const QPointF& pos)
     // notification opened over a snapped window, where moving the cursor across
     // the underlying window's exposed area would otherwise activate it and send
     // the popup to the background. A snapped or normal tileable active window
-    // does not pause FFM. Mirrors AutotileHandler::handleCursorMoved's
-    // active-window guard (discussion #461). Our own full-screen overlays never
-    // count as the kind of active window worth protecting.
+    // does not pause FFM. Scoped to the cursor's screen (mirrors
+    // AutotileHandler::handleCursorMoved, discussion #461): a transient window
+    // active on another monitor must not freeze FFM on the monitor the cursor is
+    // on. Our own full-screen overlays never count as the kind of active window
+    // worth protecting.
     if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
-        if (!isOwnOverlayClass(active->windowClass()) && !isWindowMarkedSnapped(getWindowId(active))
-            && !isTileableWindow(active)) {
+        if (getWindowScreenId(active) == screenId && !isOwnOverlayClass(active->windowClass())
+            && !isWindowMarkedSnapped(getWindowId(active)) && !isTileableWindow(active)) {
             return;
         }
     }

--- a/kwin-effect/plasmazoneseffect/mouse_drag.cpp
+++ b/kwin-effect/plasmazoneseffect/mouse_drag.cpp
@@ -143,7 +143,9 @@ void PlasmaZonesEffect::handleSnapCursorMoved(const QPointF& pos, const QString&
     // on. Our own full-screen overlays never count as the kind of active window
     // worth protecting.
     if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
-        if (getWindowScreenId(active) == screenId && !isOwnOverlayClass(active->windowClass())
+        // Cheap overlay-class check first, then the heavier screen resolution
+        // (mirrors the autotile guard's predicate ordering).
+        if (!isOwnOverlayClass(active->windowClass()) && getWindowScreenId(active) == screenId
             && !isWindowMarkedSnapped(getWindowId(active)) && !isTileableWindow(active)) {
             return;
         }

--- a/kwin-effect/plasmazoneseffect/mouse_drag.cpp
+++ b/kwin-effect/plasmazoneseffect/mouse_drag.cpp
@@ -118,6 +118,49 @@ void PlasmaZonesEffect::slotMouseChanged(const QPointF& pos, const QPointF& oldp
     // Reuse effectiveScreenId computed above to avoid redundant resolveEffectiveScreenId call.
     if (!m_dragTracker->isDragging() && output) {
         m_autotileHandler->handleCursorMoved(pos, effectiveScreenId);
+        // Snapping FFM runs alongside autotile FFM. The two are disjoint: autotile FFM
+        // bails when the cursor screen is not an autotile screen, and snapping FFM only
+        // acts on windows in the snap tiled set (which live on snapping-mode screens), so
+        // at most one of them activates a window for any given cursor position.
+        handleSnapCursorMoved(pos);
+    }
+}
+
+void PlasmaZonesEffect::handleSnapCursorMoved(const QPointF& pos)
+{
+    if (!m_snappingFocusFollowsMouse) {
+        return;
+    }
+
+    // Find the topmost snapped window under the cursor (stacking order top → bottom).
+    const auto windows = KWin::effects->stackingOrder();
+    for (int i = windows.size() - 1; i >= 0; --i) {
+        KWin::EffectWindow* w = windows[i];
+        if (!w || w->isMinimized() || !w->isOnCurrentDesktop() || !w->isOnCurrentActivity()) {
+            continue;
+        }
+        // Cheap geometry test before the windowClass()/windowId allocations below.
+        if (!w->frameGeometry().contains(pos)) {
+            continue;
+        }
+        // Look through our own overlay/editor layer-shell surfaces — they are full-screen
+        // and always topmost, so a bail here would kill FFM whenever an overlay is up
+        // (mirrors the autotile FFM guard).
+        if (isOwnOverlayClass(w->windowClass())) {
+            continue;
+        }
+        // The window directly under the cursor is not snapped (a floating dialog, popup,
+        // or excluded app occluding a snapped window beneath). Don't look through it to
+        // focus the snapped window — that would steal focus from what the user is pointing
+        // at. Mirrors AutotileHandler::handleCursorMoved's occlusion guard.
+        if (!isWindowMarkedSnapped(getWindowId(w))) {
+            return;
+        }
+        if (w == KWin::effects->activeWindow()) {
+            return; // Already focused — no-op.
+        }
+        KWin::effects->activateWindow(w);
+        return;
     }
 }
 

--- a/kwin-effect/plasmazoneseffect/mouse_drag.cpp
+++ b/kwin-effect/plasmazoneseffect/mouse_drag.cpp
@@ -132,6 +132,21 @@ void PlasmaZonesEffect::handleSnapCursorMoved(const QPointF& pos)
         return;
     }
 
+    // Pause FFM while a transient/popup/special window is active so hovering a
+    // snapped window beneath it does not dismiss it — e.g. an emoji picker or
+    // notification opened over a snapped window, where moving the cursor across
+    // the underlying window's exposed area would otherwise activate it and send
+    // the popup to the background. A snapped or normal tileable active window
+    // does not pause FFM. Mirrors AutotileHandler::handleCursorMoved's
+    // active-window guard (discussion #461). Our own full-screen overlays never
+    // count as the kind of active window worth protecting.
+    if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
+        if (!isOwnOverlayClass(active->windowClass()) && !isWindowMarkedSnapped(getWindowId(active))
+            && !isTileableWindow(active)) {
+            return;
+        }
+    }
+
     // Find the topmost snapped window under the cursor (stacking order top → bottom).
     const auto windows = KWin::effects->stackingOrder();
     for (int i = windows.size() - 1; i >= 0; --i) {

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
@@ -31,6 +31,13 @@ public:
     virtual bool moveNewWindowsToLastZone() const = 0;
     virtual bool restoreWindowsToZonesOnLogin() const = 0;
 
+    // When true, a window that is auto-placed into a zone on open (session
+    // restore, app rule, empty-zone auto-assign, last-used-zone) is given focus.
+    // Read only on the AutoRestored commit path in SnapEngine::commitSnapImpl, so
+    // it never affects manual drag or keyboard snaps (those use UserInitiated).
+    // Mirrors AutotileConfig::focusNewWindows. Default false.
+    virtual bool focusNewWindows() const = 0;
+
     // Force-on master toggle: when true, every layout reaching the snap-to-
     // empty-zone path auto-assigns new windows to its first empty zone
     // regardless of its individual `autoAssign` flag. Effective behavior is

--- a/libs/phosphor-snap-engine/src/commit.cpp
+++ b/libs/phosphor-snap-engine/src/commit.cpp
@@ -61,6 +61,19 @@ void SnapEngine::commitSnapImpl(const QString& windowId, const QStringList& zone
     Q_EMIT windowSnapStateChanged(windowId,
                                   PhosphorProtocol::WindowStateEntry{windowId, primaryZoneId, screenId, false,
                                                                      QStringLiteral("snapped"), zoneIds, false});
+
+    // Focus-new-windows: activate a window that was just auto-placed into a zone on
+    // open. AutoRestored is used only by the auto-snap-on-open paths (windowOpened and
+    // the D-Bus resolveWindowRestore facade); manual drag, keyboard snap, snap-all,
+    // unfloat, and navigation all use UserInitiated, so they keep KWin's normal focus.
+    // Mirrors AutotileEngine, which emits activateWindowRequested for newly-inserted
+    // windows when focusNewWindows is set. Single chokepoint for both single- and
+    // multi-zone auto-restored commits.
+    if (intent == SnapIntent::AutoRestored) {
+        if (auto* settings = snapSettings(); settings && settings->focusNewWindows()) {
+            Q_EMIT activateWindowRequested(windowId);
+        }
+    }
 }
 
 void SnapEngine::commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId, SnapIntent intent)

--- a/libs/phosphor-snap-engine/src/commit.cpp
+++ b/libs/phosphor-snap-engine/src/commit.cpp
@@ -66,9 +66,13 @@ void SnapEngine::commitSnapImpl(const QString& windowId, const QStringList& zone
     // open. AutoRestored is used only by the auto-snap-on-open paths (windowOpened and
     // the D-Bus resolveWindowRestore facade); manual drag, keyboard snap, snap-all,
     // unfloat, and navigation all use UserInitiated, so they keep KWin's normal focus.
-    // Mirrors AutotileEngine, which emits activateWindowRequested for newly-inserted
-    // windows when focusNewWindows is set. Single chokepoint for both single- and
-    // multi-zone auto-restored commits.
+    // This matches AutotileEngine's focusNewWindows intent-gating, but emits
+    // immediately rather than deferring like autotile does. Autotile defers focus to
+    // after its windowsTiled reflow because its post-commit raise-in-tiling-order loop
+    // would otherwise bury an early-focused window. Snap has no such batch raise — each
+    // window's geometry is applied independently — so activating now is safe and lets
+    // this stay the single chokepoint for both single- and multi-zone auto-restored
+    // commits.
     if (intent == SnapIntent::AutoRestored) {
         if (auto* settings = snapSettings(); settings && settings->focusNewWindows()) {
             Q_EMIT activateWindowRequested(windowId);

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -1010,6 +1010,17 @@ public:
     {
         return false;
     }
+    // Snapping focus behavior. Both default off: snapping is more manual than
+    // autotile, and auto-focusing windows that the daemon places on open (e.g.
+    // a session restore that opens many windows at once) would thrash focus.
+    static bool snappingFocusNewWindows()
+    {
+        return false;
+    }
+    static bool snappingFocusFollowsMouse()
+    {
+        return false;
+    }
     static bool autotileRespectMinimumSize()
     {
         return true;

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -2213,6 +2213,13 @@ P_STORE_SET_BOOL(setSnappingFocusNewWindows, snappingBehaviorGroup, focusNewWind
 P_STORE_GET(bool, snappingFocusFollowsMouse, snappingBehaviorGroup, focusFollowsMouseKey, bool)
 P_STORE_SET_BOOL(setSnappingFocusFollowsMouse, snappingBehaviorGroup, focusFollowsMouseKey,
                  snappingFocusFollowsMouseChanged)
+
+// ISnapSettings hook for the snap engine — same Snapping.Behavior value, surfaced
+// under the interface name the engine consults on AutoRestored commits.
+bool Settings::focusNewWindows() const
+{
+    return snappingFocusNewWindows();
+}
 P_STORE_GET(bool, autotileRespectMinimumSize, tilingBehaviorGroup, respectMinimumSizeKey, bool)
 P_STORE_SET_BOOL(setAutotileRespectMinimumSize, tilingBehaviorGroup, respectMinimumSizeKey,
                  autotileRespectMinimumSizeChanged)

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -2208,6 +2208,11 @@ P_STORE_SET_BOOL(setAutotileFocusNewWindows, tilingBehaviorGroup, focusNewWindow
 P_STORE_GET(bool, autotileFocusFollowsMouse, tilingBehaviorGroup, focusFollowsMouseKey, bool)
 P_STORE_SET_BOOL(setAutotileFocusFollowsMouse, tilingBehaviorGroup, focusFollowsMouseKey,
                  autotileFocusFollowsMouseChanged)
+P_STORE_GET(bool, snappingFocusNewWindows, snappingBehaviorGroup, focusNewWindowsKey, bool)
+P_STORE_SET_BOOL(setSnappingFocusNewWindows, snappingBehaviorGroup, focusNewWindowsKey, snappingFocusNewWindowsChanged)
+P_STORE_GET(bool, snappingFocusFollowsMouse, snappingBehaviorGroup, focusFollowsMouseKey, bool)
+P_STORE_SET_BOOL(setSnappingFocusFollowsMouse, snappingBehaviorGroup, focusFollowsMouseKey,
+                 snappingFocusFollowsMouseChanged)
 P_STORE_GET(bool, autotileRespectMinimumSize, tilingBehaviorGroup, respectMinimumSizeKey, bool)
 P_STORE_SET_BOOL(setAutotileRespectMinimumSize, tilingBehaviorGroup, respectMinimumSizeKey,
                  autotileRespectMinimumSizeChanged)

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -302,6 +302,10 @@ public:
     // Autotile Behavior and Visual Settings
     Q_PROPERTY(bool autotileFocusFollowsMouse READ autotileFocusFollowsMouse WRITE setAutotileFocusFollowsMouse NOTIFY
                    autotileFocusFollowsMouseChanged)
+    Q_PROPERTY(bool snappingFocusNewWindows READ snappingFocusNewWindows WRITE setSnappingFocusNewWindows NOTIFY
+                   snappingFocusNewWindowsChanged)
+    Q_PROPERTY(bool snappingFocusFollowsMouse READ snappingFocusFollowsMouse WRITE setSnappingFocusFollowsMouse NOTIFY
+                   snappingFocusFollowsMouseChanged)
     Q_PROPERTY(bool autotileRespectMinimumSize READ autotileRespectMinimumSize WRITE setAutotileRespectMinimumSize
                    NOTIFY autotileRespectMinimumSizeChanged)
     Q_PROPERTY(bool autotileHideTitleBars READ autotileHideTitleBars WRITE setAutotileHideTitleBars NOTIFY
@@ -864,6 +868,10 @@ public:
     // Additional Autotiling Settings — PhosphorConfig::Store-backed.
     bool autotileFocusFollowsMouse() const override;
     void setAutotileFocusFollowsMouse(bool focus) override;
+    bool snappingFocusNewWindows() const override;
+    void setSnappingFocusNewWindows(bool focus) override;
+    bool snappingFocusFollowsMouse() const override;
+    void setSnappingFocusFollowsMouse(bool focus) override;
     bool autotileRespectMinimumSize() const override;
     void setAutotileRespectMinimumSize(bool respect);
     bool autotileHideTitleBars() const override;

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -643,6 +643,10 @@ public:
     bool keepWindowsInZonesOnResolutionChange() const override;
     void setKeepWindowsInZonesOnResolutionChange(bool keep) override;
     bool moveNewWindowsToLastZone() const override;
+    // ISnapSettings::focusNewWindows() — delegates to the Snapping.Behavior store
+    // value (snappingFocusNewWindows). The snap engine reads this on AutoRestored
+    // commits to focus auto-placed-on-open windows.
+    bool focusNewWindows() const override;
     void setMoveNewWindowsToLastZone(bool move) override;
     bool restoreOriginalSizeOnUnsnap() const override;
     void setRestoreOriginalSizeOnUnsnap(bool restore) override;

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -686,6 +686,8 @@ void appendActivationSchema(PhosphorConfig::Schema& schema)
     schema.groups[CD::snappingBehaviorGroup()] = {
         {CD::triggersKey(), CD::dragActivationTriggers(), QMetaType::QVariantList, {}, canonicalTriggerList},
         {CD::toggleActivationKey(), CD::toggleActivation(), QMetaType::Bool},
+        {CD::focusNewWindowsKey(), CD::snappingFocusNewWindows(), QMetaType::Bool},
+        {CD::focusFollowsMouseKey(), CD::snappingFocusFollowsMouse(), QMetaType::Bool},
     };
     schema.groups[CD::snappingBehaviorZoneSpanGroup()] = {
         {CD::enabledKey(), CD::zoneSpanEnabled(), QMetaType::Bool},

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -143,6 +143,13 @@ public:
     // Autotile decoration settings (fetched by KWin effect via D-Bus)
     virtual bool autotileFocusFollowsMouse() const = 0;
     virtual void setAutotileFocusFollowsMouse(bool enabled) = 0;
+    // Snapping focus behavior. focusNewWindows is read daemon-side by SnapAdaptor
+    // to activate auto-placed-on-open windows; focusFollowsMouse is fetched by the
+    // KWin effect via D-Bus.
+    virtual bool snappingFocusNewWindows() const = 0;
+    virtual void setSnappingFocusNewWindows(bool enabled) = 0;
+    virtual bool snappingFocusFollowsMouse() const = 0;
+    virtual void setSnappingFocusFollowsMouse(bool enabled) = 0;
     virtual bool autotileHideTitleBars() const = 0;
     virtual void setAutotileHideTitleBars(bool hide) = 0;
     virtual bool autotileShowBorder() const = 0;
@@ -525,6 +532,8 @@ Q_SIGNALS:
     void autotileInsertPositionChanged();
     void autotileRespectMinimumSizeChanged();
     void autotileFocusFollowsMouseChanged();
+    void snappingFocusNewWindowsChanged();
+    void snappingFocusFollowsMouseChanged();
     void autotileHideTitleBarsChanged();
     void autotileShowBorderChanged();
     void autotileBorderWidthChanged();

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -461,6 +461,8 @@ void SettingsAdaptor::initializeRegistry()
     REGISTER_BOOL_SETTING("autoAssignAllLayouts", autoAssignAllLayouts, setAutoAssignAllLayouts)
     REGISTER_BOOL_SETTING("snapAssistFeatureEnabled", snapAssistFeatureEnabled, setSnapAssistFeatureEnabled)
     REGISTER_BOOL_SETTING("snapAssistEnabled", snapAssistEnabled, setSnapAssistEnabled)
+    REGISTER_BOOL_SETTING("snappingFocusNewWindows", snappingFocusNewWindows, setSnappingFocusNewWindows)
+    REGISTER_BOOL_SETTING("snappingFocusFollowsMouse", snappingFocusFollowsMouse, setSnappingFocusFollowsMouse)
 
     // Snap assist triggers (when always-enabled is off, hold any trigger at drop to enable)
     m_getters[QStringLiteral("snapAssistTriggers")] = [this]() {

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -265,6 +265,15 @@ bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
     } else {
         m_engine->commitSnap(windowId, zoneIds.first(), result.screenId, SnapIntent::AutoRestored);
     }
+
+    // Focus-new-windows for snapping. Only the auto-snap-on-open path funnels
+    // through applySnapResult (SnapIntent::AutoRestored), so this never fires for
+    // manual drag or keyboard snap-to-zone (SnapIntent::UserInitiated) — those
+    // keep KWin's normal focus handling. The effect handles activateWindowRequested
+    // by calling KWin::effects->activateWindow(), the same path autotile uses.
+    if (m_settings && m_settings->snappingFocusNewWindows()) {
+        Q_EMIT m_adaptor->activateWindowRequested(windowId);
+    }
     return true;
 }
 

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -265,15 +265,9 @@ bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
     } else {
         m_engine->commitSnap(windowId, zoneIds.first(), result.screenId, SnapIntent::AutoRestored);
     }
-
-    // Focus-new-windows for snapping. Only the auto-snap-on-open path funnels
-    // through applySnapResult (SnapIntent::AutoRestored), so this never fires for
-    // manual drag or keyboard snap-to-zone (SnapIntent::UserInitiated) — those
-    // keep KWin's normal focus handling. The effect handles activateWindowRequested
-    // by calling KWin::effects->activateWindow(), the same path autotile uses.
-    if (m_settings && m_settings->snappingFocusNewWindows()) {
-        Q_EMIT m_adaptor->activateWindowRequested(windowId);
-    }
+    // Focus-new-windows is handled inside SnapEngine::commitSnapImpl on the
+    // AutoRestored path (mirrors AutotileEngine), so it covers every auto-snap-on-open
+    // entry point in one place — not just this D-Bus facade.
     return true;
 }
 

--- a/src/settings/qml/SnappingWindowBehaviorPage.qml
+++ b/src/settings/qml/SnappingWindowBehaviorPage.qml
@@ -209,5 +209,53 @@ SettingsFlickable {
                 }
             }
         }
+
+        // =================================================================
+        // FOCUS
+        // =================================================================
+        Item {
+            Layout.fillWidth: true
+            implicitHeight: focusCard.implicitHeight
+
+            SettingsCard {
+                id: focusCard
+
+                anchors.fill: parent
+                headerText: i18n("Focus")
+                collapsible: true
+
+                contentItem: ColumnLayout {
+                    spacing: Kirigami.Units.smallSpacing
+
+                    SettingsRow {
+                        title: i18n("Focus new windows")
+                        description: i18n("Focus a window when it is automatically placed into a zone on open")
+
+                        SettingsSwitch {
+                            checked: appSettings.snappingFocusNewWindows
+                            accessibleName: i18n("Focus newly placed windows")
+                            onToggled: function (newValue) {
+                                appSettings.snappingFocusNewWindows = newValue;
+                            }
+                        }
+                    }
+
+                    SettingsSeparator {}
+
+                    SettingsRow {
+                        title: i18n("Focus follows mouse")
+                        description: i18n("Moving the mouse pointer over a snapped window gives it focus")
+
+                        SettingsSwitch {
+                            checked: appSettings.snappingFocusFollowsMouse
+                            accessibleName: i18n("Snapped window focus follows mouse pointer")
+                            onToggled: function (newValue) {
+                                appSettings.snappingFocusFollowsMouse = newValue;
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/tests/unit/config/test_settings_core.cpp
+++ b/tests/unit/config/test_settings_core.cpp
@@ -154,6 +154,32 @@ private Q_SLOTS:
     }
 
     /**
+     * Snapping focus-behavior settings default off and return to the default on
+     * reset(). Both gate runtime focus changes (the daemon focus-new-windows emit
+     * and the effect focus-follows-mouse), so a flipped default would silently
+     * change focus behavior for every user.
+     */
+    void testSnappingFocusSettings_defaultsAndReset()
+    {
+        IsolatedConfigGuard guard;
+
+        Settings settings;
+        QCOMPARE(settings.snappingFocusNewWindows(), ConfigDefaults::snappingFocusNewWindows());
+        QCOMPARE(settings.snappingFocusFollowsMouse(), ConfigDefaults::snappingFocusFollowsMouse());
+        QCOMPARE(settings.snappingFocusNewWindows(), false);
+        QCOMPARE(settings.snappingFocusFollowsMouse(), false);
+
+        settings.setSnappingFocusNewWindows(true);
+        settings.setSnappingFocusFollowsMouse(true);
+        QCOMPARE(settings.snappingFocusNewWindows(), true);
+        QCOMPARE(settings.snappingFocusFollowsMouse(), true);
+
+        settings.reset();
+        QCOMPARE(settings.snappingFocusNewWindows(), ConfigDefaults::snappingFocusNewWindows());
+        QCOMPARE(settings.snappingFocusFollowsMouse(), ConfigDefaults::snappingFocusFollowsMouse());
+    }
+
+    /**
      * After save() then load(), every property must equal what was set.
      * This validates the full round-trip for a representative subset of settings
      * across all config groups.
@@ -177,6 +203,8 @@ private Q_SLOTS:
         settings.setInactiveOpacity(0.2);
         settings.setShowZoneNumbers(false);
         settings.setToggleActivation(true);
+        settings.setSnappingFocusNewWindows(true);
+        settings.setSnappingFocusFollowsMouse(true);
         settings.setZoneSpanToggleMode(true);
         settings.setZoneSelectorEnabled(false);
         settings.setZoneSelectorTriggerDistance(100);
@@ -233,6 +261,8 @@ private Q_SLOTS:
         {
             auto behavior = backend->group(ConfigDefaults::snappingBehaviorGroup());
             QCOMPARE(behavior->readBool(ConfigDefaults::toggleActivationKey(), false), true);
+            QCOMPARE(behavior->readBool(ConfigDefaults::focusNewWindowsKey(), false), true);
+            QCOMPARE(behavior->readBool(ConfigDefaults::focusFollowsMouseKey(), false), true);
         }
 
         {

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -936,6 +936,24 @@ private Q_SLOTS:
         m_wts->setSnapState(nullptr);
     }
 
+    void testFocusNewWindows_multiZone_autoRestored_emitsOnce()
+    {
+        // A multi-zone auto-restore (zone span) routes through the same
+        // commitSnapImpl chokepoint, so it must request focus exactly once.
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+        m_settings->setSnappingFocusNewWindows(true);
+
+        QSignalSpy spy(&engine, &SnapEngine::activateWindowRequested);
+        engine.commitMultiZoneSnap(QStringLiteral("win-focus-4"), {QStringLiteral("zone-1"), QStringLiteral("zone-2")},
+                                   QStringLiteral("DP-1"), PhosphorEngine::SnapIntent::AutoRestored);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.first().first().toString(), QStringLiteral("win-focus-4"));
+        m_wts->setSnapState(nullptr);
+    }
+
     // =========================================================================
     // resolveWindowRestore — disabled-context gate (ShouldRestorePredicate,
     // discussion #461 item 7)

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -883,6 +883,60 @@ private Q_SLOTS:
     }
 
     // =========================================================================
+    // focus-new-windows — commitSnapImpl emits activateWindowRequested only for
+    // AutoRestored commits when ISnapSettings::focusNewWindows() is on. Manual
+    // (UserInitiated) commits never request focus, regardless of the setting.
+    // =========================================================================
+
+    void testFocusNewWindows_autoRestored_emitsWhenEnabled()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+        m_settings->setSnappingFocusNewWindows(true);
+
+        QSignalSpy spy(&engine, &SnapEngine::activateWindowRequested);
+        engine.commitSnap(QStringLiteral("win-focus-1"), QStringLiteral("zone-1"), QStringLiteral("DP-1"),
+                          PhosphorEngine::SnapIntent::AutoRestored);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.first().first().toString(), QStringLiteral("win-focus-1"));
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testFocusNewWindows_autoRestored_silentWhenDisabled()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+        m_settings->setSnappingFocusNewWindows(false);
+
+        QSignalSpy spy(&engine, &SnapEngine::activateWindowRequested);
+        engine.commitSnap(QStringLiteral("win-focus-2"), QStringLiteral("zone-1"), QStringLiteral("DP-1"),
+                          PhosphorEngine::SnapIntent::AutoRestored);
+
+        QCOMPARE(spy.count(), 0);
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testFocusNewWindows_userInitiated_neverEmits()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+        // Even with the setting on, a user-initiated snap (drag, keyboard) must
+        // not steal focus — the window is already where the user put it.
+        m_settings->setSnappingFocusNewWindows(true);
+
+        QSignalSpy spy(&engine, &SnapEngine::activateWindowRequested);
+        engine.commitSnap(QStringLiteral("win-focus-3"), QStringLiteral("zone-1"), QStringLiteral("DP-1"),
+                          PhosphorEngine::SnapIntent::UserInitiated);
+
+        QCOMPARE(spy.count(), 0);
+        m_wts->setSnapState(nullptr);
+    }
+
+    // =========================================================================
     // resolveWindowRestore — disabled-context gate (ShouldRestorePredicate,
     // discussion #461 item 7)
     //

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -752,6 +752,22 @@ public:
     void setAutotileFocusFollowsMouse(bool) override
     {
     }
+    bool snappingFocusNewWindows() const override
+    {
+        return m_snappingFocusNewWindows;
+    }
+    void setSnappingFocusNewWindows(bool v) override
+    {
+        m_snappingFocusNewWindows = v;
+    }
+    bool snappingFocusFollowsMouse() const override
+    {
+        return m_snappingFocusFollowsMouse;
+    }
+    void setSnappingFocusFollowsMouse(bool v) override
+    {
+        m_snappingFocusFollowsMouse = v;
+    }
     bool autotileHideTitleBars() const override
     {
         return false;
@@ -1105,6 +1121,8 @@ private:
     bool m_snapAssistFeatureEnabled = false;
     bool m_snapAssistEnabled = false;
     bool m_autoAssignAllLayouts = false;
+    bool m_snappingFocusNewWindows = false;
+    bool m_snappingFocusFollowsMouse = false;
     QStringList m_snappingLayoutOrder;
     QStringList m_tilingAlgorithmOrder;
     QVariantList m_dragActivationTriggers;

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -595,6 +595,12 @@ public:
     void setMoveNewWindowsToLastZone(bool) override
     {
     }
+    // ISnapSettings::focusNewWindows() — shares the ISettings snappingFocusNewWindows
+    // member so a test can drive the snap engine's focus-new path.
+    bool focusNewWindows() const override
+    {
+        return m_snappingFocusNewWindows;
+    }
     bool restoreOriginalSizeOnUnsnap() const override
     {
         return true;


### PR DESCRIPTION
Brings the two autotile focus behaviors to the snapping subsystem, with matching architecture.

## Behaviors (both default off)

**Focus follows mouse** (KWin effect). Moving the cursor over a snapped window activates it. `handleSnapCursorMoved` runs from the same dispatch as autotile FFM, scoped to the effect's live snapped-window set (`isWindowMarkedSnapped`). It uses the same occlusion guard as autotile (a non-snapped window under the cursor keeps focus) plus an active-popup guard so an emoji picker or dialog opened over a snapped window is not dismissed when the cursor crosses the window beneath it.

**Focus new windows** (snap engine). When a window is automatically placed into a zone on open (remembered `WindowPlacements` restore, or a window rule targeting a zone), it is given focus. Emitted from `SnapEngine::commitSnapImpl` gated on `SnapIntent::AutoRestored`, which is used only by the two auto-snap-on-open paths. Manual drag, keyboard snap-to-zone, snap-all, unfloat, and navigation use `UserInitiated` and keep KWin's normal focus.

## Architecture parity with autotile

| Behavior | Autotile | Snapping |
|---|---|---|
| Focus follows mouse | KWin effect (`AutotileHandler`) | KWin effect (`handleSnapCursorMoved`) |
| Focus new windows | LGPL engine (`AutotileEngine`, gated by config) | LGPL engine (`SnapEngine::commitSnapImpl`, gated by `ISnapSettings::focusNewWindows()`) |

`commitSnapImpl` is the single chokepoint for both auto-snap-on-open entry points (the D-Bus `resolveWindowRestore` facade and `SnapEngine::windowOpened`), so the engine placement covers every path, not just the D-Bus one.

## Settings

New `snappingFocusNewWindows` and `snappingFocusFollowsMouse` keys in the `Snapping.Behavior` config group, wired through `ConfigDefaults`, the schema, `ISettings`, the `Settings` store accessors, and the D-Bus `getSetting`/`setSetting` registry. `Settings::focusNewWindows()` (the `ISnapSettings` surface the engine reads) delegates to `snappingFocusNewWindows()`, the same dual-surface split autotile uses. A new Focus card on Snapping > Window > Behavior exposes both toggles.

Defaults are off: snapping is more manual than autotile, and auto-focusing on a multi-window session restore would thrash focus.

## Testing

`test_snap_engine` covers the focus-new gate via `QSignalSpy`: AutoRestored-enabled emits once, AutoRestored-disabled is silent, UserInitiated never emits. `test_settings_core` covers the settings round-trip and defaults/reset. Full build clean, 274/274 ctest pass.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)