### PR TITLE
fix(ffm): restore floating-window focus-pause for autotile AND snapping

### DIFF
--- a/kwin-effect/snaphandler.cpp
+++ b/kwin-effect/snaphandler.cpp
@@ -337,30 +337,24 @@ void SnapHandler::handleCursorMoved(const QPointF& pos, const QString& screenId)
         return;
     }
 
-    // Pause FFM while a transient/popup/special window is active so hovering a
-    // snapped window beneath it does not dismiss it — e.g. an emoji picker or
-    // notification opened over a snapped window, where moving the cursor across
-    // the underlying window's exposed area would otherwise activate it and send
-    // the popup to the background. A snapped or normal tileable active window
-    // does not pause FFM. Scoped to the cursor's screen (mirrors
-    // AutotileHandler::handleCursorMoved, discussion #461): a transient window
-    // active on another monitor must not freeze FFM on the monitor the cursor is
-    // on. Our own full-screen overlays never count as the kind of active window
-    // worth protecting.
+    // Pause FFM whenever the active window is NOT snapped into a zone. Any
+    // non-snapped active window — a popup/dialog/excluded app, a window the user
+    // deliberately floated, or a free window they simply have not snapped — is
+    // one the user is working in on top of the snap stack; wandering the cursor
+    // over a snapped window beneath it must not steal its focus. FFM resumes
+    // (follows the cursor between snapped windows) once a snapped window is
+    // active. Scoped to the cursor's screen (mirrors AutotileHandler::
+    // handleCursorMoved, discussion #461 + follow-up): a window active on another
+    // monitor must not freeze FFM on the monitor the cursor is on. Our own
+    // full-screen overlays never count as the kind of active window worth
+    // protecting. (Autotile pauses on the same principle — floated/popup/under-
+    // min-size — but everything else there is tiled, so it has no never-managed
+    // "free" case; snap does, hence the single not-snapped predicate.)
     if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
         // Cheap overlay-class check first, then the heavier screen resolution
-        // (mirrors the autotile guard's predicate ordering). The predicate is
-        // deliberately wider than the under-cursor occlusion guard below: there
-        // we only look *through* a snapped window, but here a normal tileable
-        // active window (a regular app the user is working in, not a popup) must
-        // not pause FFM either. Only a non-snapped, non-tileable active window
-        // (dialog/popup/excluded app) is worth protecting. Both of autotile's
-        // guards key off the same tileable/shouldHandle membership; snap's managed
-        // set (snapped) is narrower than tileable, so here the pause guard accepts
-        // the extra isTileableWindow case the occlusion guard below does not.
+        // (mirrors the autotile guard's predicate ordering).
         if (!PlasmaZonesEffect::isOwnOverlayClass(active->windowClass())
-            && m_effect->getWindowScreenId(active) == screenId && !isTiledWindow(m_effect->getWindowId(active))
-            && !m_effect->isTileableWindow(active)) {
+            && m_effect->getWindowScreenId(active) == screenId && !isTiledWindow(m_effect->getWindowId(active))) {
             return;
         }
     }

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -860,6 +860,16 @@ void WindowTrackingAdaptor::pruneStaleWindows(const QStringList& aliveWindowIds)
             ++it;
         }
     }
+    // Same defensive sweep for the last-broadcast floating shadow: an entry
+    // would otherwise leak if the window died without a windowClosed signal.
+    // Not persisted, so it does not feed the save-scheduling decision below.
+    for (auto it = m_broadcastFloating.begin(); it != m_broadcastFloating.end();) {
+        if (!alive.contains(it.key())) {
+            it = m_broadcastFloating.erase(it);
+        } else {
+            ++it;
+        }
+    }
     const int totalPruned = persistedPruned + frameGeoPruned;
     if (totalPruned > 0) {
         qCInfo(lcDbusWindow) << "Pruned" << totalPruned << "stale window assignments (not in KWin)";

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -571,6 +571,8 @@ void WindowTrackingAdaptor::windowClosed(const QString& windowId, int windowKind
 
     // Drop frame-geometry shadow entry for this window.
     m_frameGeometry.remove(windowId);
+    // Drop the last-broadcast floating state for this window.
+    m_broadcastFloating.remove(windowId);
 
     m_service->windowClosed(windowId, kind);
 

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -899,7 +899,8 @@ private:
     // engine flips its float bit BEFORE the daemon's sync slot reaches the
     // writer, so a re-query already reports the post-transition value and would
     // suppress every autotile float broadcast. Absent entry == not-floating.
-    // Entries are removed on windowClosed.
+    // Entries are removed on windowClosed and swept by pruneStaleWindows
+    // (defensive, for a window that died without a close signal).
     QHash<QString, bool> m_broadcastFloating;
 
     // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -893,6 +893,15 @@ private:
     // fresh geometry without round-tripping through the effect.
     QHash<QString, QRect> m_frameGeometry;
 
+    // Last floating value broadcast via windowFloatingChanged, per window. The
+    // setWindowFloating broadcast gate compares against THIS, not a re-query of
+    // the service's float state: with the per-engine float model the owning
+    // engine flips its float bit BEFORE the daemon's sync slot reaches the
+    // writer, so a re-query already reports the post-transition value and would
+    // suppress every autotile float broadcast. Absent entry == not-floating.
+    // Entries are removed on windowClosed.
+    QHash<QString, bool> m_broadcastFloating;
+
     // ═══════════════════════════════════════════════════════════════════════════════
     // Dependencies (kept for signal connections and settings access)
     // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -100,16 +100,22 @@ void WindowTrackingAdaptor::setWindowFloating(const QString& windowId, bool floa
     if (!validateWindowId(windowId, QStringLiteral("set float state"))) {
         return;
     }
-    // Gate the signal emissions on a real state change. WTS::setWindowFloating
-    // is itself a no-op on unchanged input, but the two signal emits below
-    // would otherwise fire on every redundant call — violating the project's
-    // "only emit signals when value actually changes" rule and waking up
-    // every D-Bus subscriber for no reason.
-    const bool wasFloating = m_service->isWindowFloating(windowId);
     m_service->setWindowFloating(windowId, floating);
-    if (floating == wasFloating) {
+    // Gate the signal emissions on a real change in what we last BROADCAST, not
+    // on a re-query of the service's float state. Under the per-engine float
+    // model the owning engine flips its float bit BEFORE the daemon's sync slot
+    // reaches this writer (e.g. AutotileEngine::performToggleFloat toggles then
+    // emits windowFloatingChanged, which Daemon::syncAutotileFloatState relays
+    // here), so m_service->isWindowFloating() already reports the post-transition
+    // value — the old `floating == wasFloating` gate then suppressed every
+    // autotile float broadcast, leaving subscribers (the effect's float cache,
+    // which the autotile FFM float-pause depends on) permanently stale.
+    // Tracking the last-broadcast value detects the real edge regardless of when
+    // the engine updated its bit, and still honours "only emit when changed".
+    if (m_broadcastFloating.value(windowId, false) == floating) {
         return;
     }
+    m_broadcastFloating[windowId] = floating;
     qCInfo(lcDbusWindow) << "Window" << windowId << "is now" << (floating ? "floating" : "not floating");
     // Notify effect so it can update its local cache (use full windowId for per-instance tracking).
     // Use the window's tracked screen if available, otherwise fall back to last active screen.

--- a/tests/unit/dbus/test_wta_convenience.cpp
+++ b/tests/unit/dbus/test_wta_convenience.cpp
@@ -634,6 +634,44 @@ private Q_SLOTS:
         QVERIFY(foundFloated);
     }
 
+    // Regression: under the per-engine float model the owning engine flips its
+    // float bit BEFORE the daemon's sync slot reaches WTA::setWindowFloating
+    // (e.g. AutotileEngine::performToggleFloat toggles then emits
+    // windowFloatingChanged → Daemon::syncAutotileFloatState → here). A re-query
+    // of the service therefore already reports floating==true, so the old
+    // broadcast gate (which compared against m_service->isWindowFloating())
+    // suppressed EVERY autotile float broadcast — leaving the effect's float
+    // cache stale and silently breaking the autotile FFM float-pause. The gate
+    // must instead compare against the last value WTA broadcast.
+    void testSetWindowFloating_broadcastsWhenServiceAlreadyReportsFloating()
+    {
+        const QString windowId = QStringLiteral("firefox|12345");
+
+        // Simulate the engine having ALREADY set the float bit: the resolver
+        // (consulted by m_service->isWindowFloating) reports floating regardless
+        // of WTS's own set.
+        m_wta->service()->setEngineFloatResolver([windowId](const QString& id) {
+            return id == windowId;
+        });
+
+        QSignalSpy spy(m_wta, &WindowTrackingAdaptor::windowFloatingChanged);
+
+        // The real float edge must broadcast even though a re-query says true.
+        m_wta->setWindowFloating(windowId, true);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.first().at(0).toString(), windowId);
+        QCOMPARE(spy.first().at(1).toBool(), true);
+
+        // Dedup still holds: setting the same broadcast value again is a no-op.
+        m_wta->setWindowFloating(windowId, true);
+        QCOMPARE(spy.count(), 1);
+
+        // The unfloat edge broadcasts.
+        m_wta->setWindowFloating(windowId, false);
+        QCOMPARE(spy.count(), 2);
+        QCOMPARE(spy.at(1).at(1).toBool(), false);
+    }
+
 private:
     std::unique_ptr<IsolatedConfigGuard> m_guard;
     PhosphorZones::LayoutRegistry* m_layoutManager = nullptr;


### PR DESCRIPTION
## Symptom

The focus-follows-mouse pause for windows the user is working in stopped working: FFM kept wandering off a floating window (autotile) and off floating/free windows (snapping) onto managed windows under the cursor, stealing their focus.

## Two parts

### 1. Daemon: restore the float broadcast (fixes autotile)

`WindowTrackingAdaptor::setWindowFloating` gated its `windowFloatingChanged` broadcast on `floating == m_service->isWindowFloating(windowId)`. The unified per-engine float model rerouted `isWindowFloating` through the engine float resolver, and the autotile engine flips its float bit **before** the daemon's sync slot reaches this writer (`AutotileEngine::performToggleFloat` toggles → emits → `Daemon::syncAutotileFloatState` → `setWindowFloating`). So the re-query already reported the post-transition value, the gate always tripped, and the broadcast was suppressed — leaving the effect's `FloatingCache` (which the autotile FFM float-pause reads) permanently stale. Snap was unaffected (it relays the engine signal directly).

**Fix:** gate the broadcast on the last value the adaptor actually broadcast (`m_broadcastFloating`), not on a re-query of engine-owned state. Cleaned up in `windowClosed`. Regression test in `test_wta_convenience` injects the engine-pre-set condition and asserts the broadcast still fires (verified it fails against the old gate).

Autotile already has the `isWindowFloating` guard (`autotilehandler.cpp`), so this alone restores autotile's behavior.

### 2. Effect: pause snap FFM for any non-snapped active window

The snap FFM added in the SnapHandler work (`SnapHandler::handleCursorMoved`) only paused for non-snapped, non-tileable popups — so a floated window OR a free window the user simply hadn't snapped kept losing focus. Replace that narrow check with a single predicate: **pause whenever the active window is not snapped into a zone** (popup, floated, or free). That's the true parity with autotile, which pauses for everything-not-tiled; snap additionally has a never-managed "free" case that autotile does not.

## Result

Both autotile and snapping now hold focus on a window the user is working in (floating in autotile; floating or free in snapping) while the cursor moves over managed windows beneath it. FFM resumes following once a managed (tiled/snapped) window is active again. Build green, all 274 tests pass.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)