### PR TITLE
feat(settings): align snapping and tiling settings (naming, sections, prefix parity)

### DIFF
--- a/docs/per-mode-window-appearance-impl-plan.md
+++ b/docs/per-mode-window-appearance-impl-plan.md
@@ -66,7 +66,7 @@ current code, so nothing is missed during implementation.
 | Surface | UI title | Config group | C++ accessors |
 |---|---|---|---|
 | Zone overlay (existing) | **Zones** (was "Appearance") | `Snapping.Zones.{Colors,Opacity,Border,Labels}` (migrated from `Snapping.Appearance.*`) | unchanged (`borderWidth()`, `activeOpacity()`, …) — only the *group* accessor renames |
-| Snap window appearance (new) | **Window Appearance** | `Snapping.Appearance.{Colors,Decorations,Borders}` (freed by the migration) | `snapWindow*` (parallel to `autotile*`) |
+| Snap window appearance (new) | **Window Appearance** | `Snapping.Appearance.{Colors,Decorations,Borders}` (freed by the migration) | `snapping*` (parallel to `autotile*`) |
 | Tiling window appearance (existing) | **Window Appearance** (was "Appearance") | `Tiling.Appearance.*` (unchanged) | `autotile*` (unchanged) |
 
 Rationale: moving the zone overlay to `Snapping.Zones.*` makes `Snapping.Appearance.*` mean
@@ -166,13 +166,13 @@ Move the zone-overlay sub-groups `Snapping.Appearance.*` → `Snapping.Zones.*` 
 
 ## 6. Phase 1b — Snap window-appearance config keys
 
-Add 7 `snapWindow*` keys under the freed `Snapping.Appearance.{Colors,Decorations,Borders}`,
+Add 7 `snapping*` keys under the freed `Snapping.Appearance.{Colors,Decorations,Borders}`,
 full add-a-setting chain mirroring `autotile*`.
 
 ### Keys
-`snapWindowHideTitleBars` (bool), `snapWindowShowBorder` (bool), `snapWindowBorderWidth`
-(+Min/Max), `snapWindowBorderRadius` (+Min/Max), `snapWindowBorderColor`,
-`snapWindowInactiveBorderColor`, `snapWindowUseSystemBorderColors`.
+`snappingHideTitleBars` (bool), `snappingShowBorder` (bool), `snappingBorderWidth`
+(+Min/Max), `snappingBorderRadius` (+Min/Max), `snappingBorderColor`,
+`snappingInactiveBorderColor`, `snappingUseSystemBorderColors`.
 
 ### Tasks (ordered)
 1. `configkeys.h`: new `Snapping.Appearance.{Colors,Decorations,Borders}` groups; reuse generic
@@ -181,7 +181,7 @@ full add-a-setting chain mirroring `autotile*`.
 2. `configdefaults.h`: default + bounds accessors (mirror `autotile*` defaults).
 3. `isettings.h`: 7 virtuals + NOTIFY signals.
 4. `settings.{h,cpp}`: Q_PROPERTY/getter/setter/member via `P_STORE_*`;
-   `applySnapWindowBorderSystemColor()` accent helper; load/save/reset.
+   `applySnappingBorderSystemColor()` accent helper; load/save/reset.
 5. `settingsadaptor.cpp`: `REGISTER_*_SETTING` entries (D-Bus by-name).
 6. `tests/unit/helpers/StubSettings.h`: add the 7 overrides.
 
@@ -191,7 +191,7 @@ full add-a-setting chain mirroring `autotile*`.
 
 ### Top gotchas
 - Config KEY strings are generic (group disambiguates); only the **C++ accessor names** are
-  `snapWindow*`-prefixed to stay distinct from zone (`borderWidth`) and autotile (`autotileBorderWidth`).
+  `snapping*`-prefixed to stay distinct from zone (`borderWidth`) and autotile (`autotileBorderWidth`).
 
 ---
 
@@ -199,7 +199,7 @@ full add-a-setting chain mirroring `autotile*`.
 
 ### Tasks (ordered)
 1. New `src/settings/qml/SnappingWindowAppearancePage.qml` — Colors / Decorations / Borders cards
-   binding `appSettings.snapWindow*`, mirroring `TilingAppearancePage.qml`.
+   binding `appSettings.snapping*`, mirroring `TilingAppearancePage.qml`.
 2. New `SnappingWindowAppearanceController` (bounds facade like `TilingAppearanceController`).
 3. `settingscontroller.{h,cpp}`: member + getter + `Q_PROPERTY CONSTANT` + ctor construction.
 4. Register `snapping-window-appearance` under `snapping-visual-cat` (regPage); update
@@ -210,7 +210,7 @@ full add-a-setting chain mirroring `autotile*`.
   `settingscontroller.{h,cpp}`, `settingscontroller_pageregistration.cpp`, `CMakeLists.txt`.
 
 ### Tests / verify
-- Build + run: new page edits persist to the `snapWindow*` keys (effect consumption lands in Phase 3).
+- Build + run: new page edits persist to the `snapping*` keys (effect consumption lands in Phase 3).
 
 ---
 
@@ -229,7 +229,7 @@ settings of the **mode that manages it** (snap vs autotile). Reuse `OutlinedBord
    commit/release path.
 3. Make `shouldShowBorderForWindow` / `updateWindowBorder` (`borders.cpp`) mode-parameterised:
    resolve the window's managing mode, then read that mode's width/radius/colour/show/hide.
-4. Extend `daemon_bringup.cpp::loadCachedSettings()` to fetch the `snapWindow*` keys into the
+4. Extend `daemon_bringup.cpp::loadCachedSettings()` to fetch the `snapping*` keys into the
    snap border state (same shape as the `autotile*` block; re-run on `settingsChanged`).
 5. Title-bar hiding for snapped windows via `setNoBorder`, mirroring `setWindowBorderless`.
 

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -706,47 +706,47 @@ void PlasmaZonesEffect::loadCachedSettings()
 
     // Snapped-window border settings — feed SnapHandler's parallel snap
     // BorderState, mirroring the autotile* block above. When
-    // snapWindowUseSystemBorderColors is on the daemon writes the resolved
+    // snappingUseSystemBorderColors is on the daemon writes the resolved
     // accent into the colour keys, so (like autotile) the effect only reads the
     // resolved colours and never the use-system flag.
     // Each setter guards on a changed value before re-walking the stacking
     // order in updateAllBorders / re-toggling title bars — matching the
     // "only act on change" convention the autotile width/radius setters use.
-    loadSettingAsync(QStringLiteral("snapWindowHideTitleBars"), [this](const QVariant& v) {
+    loadSettingAsync(QStringLiteral("snappingHideTitleBars"), [this](const QVariant& v) {
         const bool hide = v.toBool();
         if (m_snapHandler->hideTitleBars() != hide) {
             m_snapHandler->updateSnapHideTitleBars(hide);
         }
     });
-    loadSettingAsync(QStringLiteral("snapWindowShowBorder"), [this](const QVariant& v) {
+    loadSettingAsync(QStringLiteral("snappingShowBorder"), [this](const QVariant& v) {
         const bool show = v.toBool();
         if (m_snapHandler->showBorder() != show) {
             m_snapHandler->setShowBorder(show);
             updateAllBorders();
         }
     });
-    loadSettingAsync(QStringLiteral("snapWindowBorderWidth"), [this](const QVariant& v) {
+    loadSettingAsync(QStringLiteral("snappingBorderWidth"), [this](const QVariant& v) {
         const int bw = qBound(0, v.toInt(), 10);
         if (m_snapHandler->borderWidth() != bw) {
             m_snapHandler->setBorderWidth(bw);
             updateAllBorders();
         }
     });
-    loadSettingAsync(QStringLiteral("snapWindowBorderRadius"), [this](const QVariant& v) {
+    loadSettingAsync(QStringLiteral("snappingBorderRadius"), [this](const QVariant& v) {
         const int br = qBound(0, v.toInt(), 20);
         if (m_snapHandler->borderRadius() != br) {
             m_snapHandler->setBorderRadius(br);
             updateAllBorders();
         }
     });
-    loadSettingAsync(QStringLiteral("snapWindowBorderColor"), [this](const QVariant& v) {
+    loadSettingAsync(QStringLiteral("snappingBorderColor"), [this](const QVariant& v) {
         const QColor c(v.toString());
         if (m_snapHandler->borderColor() != c) {
             m_snapHandler->setBorderColor(c);
             updateAllBorders();
         }
     });
-    loadSettingAsync(QStringLiteral("snapWindowInactiveBorderColor"), [this](const QVariant& v) {
+    loadSettingAsync(QStringLiteral("snappingInactiveBorderColor"), [this](const QVariant& v) {
         const QColor c(v.toString());
         if (m_snapHandler->inactiveBorderColor() != c) {
             m_snapHandler->setInactiveBorderColor(c);

--- a/kwin-effect/snaphandler.h
+++ b/kwin-effect/snaphandler.h
@@ -72,7 +72,7 @@ public:
     /// bar if we hid it, and remove its border.
     void clearWindowSnapped(const QString& windowId);
     /// Apply/restore title-bar hiding across all currently snap-committed
-    /// windows when the snapWindowHideTitleBars setting toggles.
+    /// windows when the snappingHideTitleBars setting toggles.
     void updateSnapHideTitleBars(bool hide);
     /// Restore every snap-hidden title bar and drop the snap border set.
     /// Called on daemon loss / effect teardown (symmetric with

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
@@ -27,7 +27,7 @@ public:
     // SnapEngine via `setExcludeRuleSet`; consumers that previously called
     // these accessors evaluate against the rule set instead.
 
-    virtual StickyWindowHandling stickyWindowHandling() const = 0;
+    virtual StickyWindowHandling snappingStickyWindowHandling() const = 0;
     virtual bool moveNewWindowsToLastZone() const = 0;
     virtual bool restoreWindowsToZonesOnLogin() const = 0;
 

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -39,7 +39,7 @@ SnapResult SnapEngine::calculateSnapToAppRule(const QString& windowId, const QSt
 
     // Check sticky window handling
     if (auto* s = snapSettings(); isSticky && s) {
-        auto handling = s->stickyWindowHandling();
+        auto handling = s->snappingStickyWindowHandling();
         if (handling == PhosphorEngine::StickyWindowHandling::IgnoreAll) {
             return SnapResult::noSnap();
         }
@@ -182,7 +182,7 @@ SnapResult SnapEngine::calculateSnapToLastZone(const QString& windowId, const QS
 
     // Check sticky window handling
     if (isSticky) {
-        auto handling = s->stickyWindowHandling();
+        auto handling = s->snappingStickyWindowHandling();
         if (handling == PhosphorEngine::StickyWindowHandling::IgnoreAll
             || handling == PhosphorEngine::StickyWindowHandling::RestoreOnly) {
             return SnapResult::noSnap();
@@ -246,7 +246,7 @@ SnapResult SnapEngine::calculateSnapToEmptyZone(const QString& windowId, const Q
 
     // Check sticky window handling (auto-assign is an auto-snap, not a restore)
     if (auto* s = snapSettings(); isSticky && s) {
-        auto handling = s->stickyWindowHandling();
+        auto handling = s->snappingStickyWindowHandling();
         if (handling == PhosphorEngine::StickyWindowHandling::IgnoreAll
             || handling == PhosphorEngine::StickyWindowHandling::RestoreOnly) {
             qCDebug(PhosphorSnapEngine::lcSnapEngine)

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -1074,47 +1074,47 @@ public:
     // decoration (stored under Snapping.Appearance.*). Every default delegates to
     // its autotile* counterpart so the two modes start from identical window
     // appearance: a single edit to the autotile default moves both in lockstep.
-    static bool snapWindowHideTitleBars()
+    static bool snappingHideTitleBars()
     {
         return autotileHideTitleBars();
     }
-    static bool snapWindowShowBorder()
+    static bool snappingShowBorder()
     {
         return autotileShowBorder();
     }
-    static int snapWindowBorderWidth()
+    static int snappingBorderWidth()
     {
         return autotileBorderWidth();
     }
-    static constexpr int snapWindowBorderWidthMin()
+    static constexpr int snappingBorderWidthMin()
     {
         return autotileBorderWidthMin();
     }
-    static constexpr int snapWindowBorderWidthMax()
+    static constexpr int snappingBorderWidthMax()
     {
         return autotileBorderWidthMax();
     }
-    static int snapWindowBorderRadius()
+    static int snappingBorderRadius()
     {
         return autotileBorderRadius();
     }
-    static constexpr int snapWindowBorderRadiusMin()
+    static constexpr int snappingBorderRadiusMin()
     {
         return autotileBorderRadiusMin();
     }
-    static constexpr int snapWindowBorderRadiusMax()
+    static constexpr int snappingBorderRadiusMax()
     {
         return autotileBorderRadiusMax();
     }
-    static QColor snapWindowBorderColor()
+    static QColor snappingBorderColor()
     {
         return autotileBorderColor();
     }
-    static QColor snapWindowInactiveBorderColor()
+    static QColor snappingInactiveBorderColor()
     {
         return autotileInactiveBorderColor();
     }
-    static bool snapWindowUseSystemBorderColors()
+    static bool snappingUseSystemBorderColors()
     {
         return autotileUseSystemBorderColors();
     }

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -426,7 +426,7 @@ public:
     {
         return true;
     }
-    static int stickyWindowHandling()
+    static int snappingStickyWindowHandling()
     {
         return 0;
     }

--- a/src/config/configmigration.h
+++ b/src/config/configmigration.h
@@ -46,7 +46,7 @@ namespace PlasmaZones {
 ///     Additionally renames the drag-time zone-overlay groups
 ///     Snapping.Appearance.{Colors,Opacity,Border,Labels} → Snapping.Zones.*,
 ///     freeing the Snapping.Appearance.* namespace for the new per-window
-///     snapped-window decoration settings (snapWindow*). See moveGroupAtPath
+///     snapped-window decoration settings (snapping*). See moveGroupAtPath
 ///     in configmigration.cpp.
 inline constexpr int ConfigSchemaVersion = 4;
 

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -229,8 +229,8 @@ void Settings::load()
     if (autotileUseSystemBorderColors()) {
         applyAutotileBorderSystemColor();
     }
-    if (snapWindowUseSystemBorderColors()) {
-        applySnapWindowBorderSystemColor();
+    if (snappingUseSystemBorderColors()) {
+        applySnappingBorderSystemColor();
     }
 
     qCInfo(lcConfig) << "Settings loaded";
@@ -2479,35 +2479,35 @@ P_STORE_SET_INT(setAutotileBorderRadius, tilingAppearanceBordersGroup, radiusKey
 
 // Snapping.Appearance — the snapped window's border / title-bar (parallel to
 // Tiling.Appearance above; distinct from the Snapping.Zones.* drag overlay).
-P_STORE_GET(QColor, snapWindowBorderColor, snappingAppearanceColorsGroup, activeKey, QColor)
-P_STORE_SET_COLOR(setSnapWindowBorderColor, snappingAppearanceColorsGroup, activeKey, snapWindowBorderColorChanged)
-P_STORE_GET(QColor, snapWindowInactiveBorderColor, snappingAppearanceColorsGroup, inactiveKey, QColor)
-P_STORE_SET_COLOR(setSnapWindowInactiveBorderColor, snappingAppearanceColorsGroup, inactiveKey,
-                  snapWindowInactiveBorderColorChanged)
+P_STORE_GET(QColor, snappingBorderColor, snappingAppearanceColorsGroup, activeKey, QColor)
+P_STORE_SET_COLOR(setSnappingBorderColor, snappingAppearanceColorsGroup, activeKey, snappingBorderColorChanged)
+P_STORE_GET(QColor, snappingInactiveBorderColor, snappingAppearanceColorsGroup, inactiveKey, QColor)
+P_STORE_SET_COLOR(setSnappingInactiveBorderColor, snappingAppearanceColorsGroup, inactiveKey,
+                  snappingInactiveBorderColorChanged)
 
-P_STORE_GET(bool, snapWindowUseSystemBorderColors, snappingAppearanceColorsGroup, useSystemKey, bool)
-void Settings::setSnapWindowUseSystemBorderColors(bool use)
+P_STORE_GET(bool, snappingUseSystemBorderColors, snappingAppearanceColorsGroup, useSystemKey, bool)
+void Settings::setSnappingUseSystemBorderColors(bool use)
 {
-    if (snapWindowUseSystemBorderColors() == use) {
+    if (snappingUseSystemBorderColors() == use) {
         return;
     }
     m_store->write(ConfigDefaults::snappingAppearanceColorsGroup(), ConfigDefaults::useSystemKey(), use);
     if (use) {
-        applySnapWindowBorderSystemColor();
+        applySnappingBorderSystemColor();
     }
-    Q_EMIT snapWindowUseSystemBorderColorsChanged();
+    Q_EMIT snappingUseSystemBorderColorsChanged();
     Q_EMIT settingsChanged();
 }
 
-P_STORE_GET(bool, snapWindowHideTitleBars, snappingAppearanceDecorationsGroup, hideTitleBarsKey, bool)
-P_STORE_SET_BOOL(setSnapWindowHideTitleBars, snappingAppearanceDecorationsGroup, hideTitleBarsKey,
-                 snapWindowHideTitleBarsChanged)
-P_STORE_GET(bool, snapWindowShowBorder, snappingAppearanceBordersGroup, showBorderKey, bool)
-P_STORE_SET_BOOL(setSnapWindowShowBorder, snappingAppearanceBordersGroup, showBorderKey, snapWindowShowBorderChanged)
-P_STORE_GET(int, snapWindowBorderWidth, snappingAppearanceBordersGroup, widthKey, int)
-P_STORE_SET_INT(setSnapWindowBorderWidth, snappingAppearanceBordersGroup, widthKey, snapWindowBorderWidthChanged)
-P_STORE_GET(int, snapWindowBorderRadius, snappingAppearanceBordersGroup, radiusKey, int)
-P_STORE_SET_INT(setSnapWindowBorderRadius, snappingAppearanceBordersGroup, radiusKey, snapWindowBorderRadiusChanged)
+P_STORE_GET(bool, snappingHideTitleBars, snappingAppearanceDecorationsGroup, hideTitleBarsKey, bool)
+P_STORE_SET_BOOL(setSnappingHideTitleBars, snappingAppearanceDecorationsGroup, hideTitleBarsKey,
+                 snappingHideTitleBarsChanged)
+P_STORE_GET(bool, snappingShowBorder, snappingAppearanceBordersGroup, showBorderKey, bool)
+P_STORE_SET_BOOL(setSnappingShowBorder, snappingAppearanceBordersGroup, showBorderKey, snappingShowBorderChanged)
+P_STORE_GET(int, snappingBorderWidth, snappingAppearanceBordersGroup, widthKey, int)
+P_STORE_SET_INT(setSnappingBorderWidth, snappingAppearanceBordersGroup, widthKey, snappingBorderWidthChanged)
+P_STORE_GET(int, snappingBorderRadius, snappingAppearanceBordersGroup, radiusKey, int)
+P_STORE_SET_INT(setSnappingBorderRadius, snappingAppearanceBordersGroup, radiusKey, snappingBorderRadiusChanged)
 
 // ── reset / color helpers ────────────────────────────────────────────────────
 
@@ -2934,14 +2934,14 @@ void Settings::applyAutotileBorderSystemColor()
     setAutotileInactiveBorderColor(inactiveColor());
 }
 
-void Settings::applySnapWindowBorderSystemColor()
+void Settings::applySnappingBorderSystemColor()
 {
     // Mirror applyAutotileBorderSystemColor: adopt the zone highlight/inactive
     // colors (which themselves track the system accent) so the snapped-window
     // border follows the system accent. Route through the setters so the Store
     // stays the source of truth and NOTIFY signals fire.
-    setSnapWindowBorderColor(highlightColor());
-    setSnapWindowInactiveBorderColor(inactiveColor());
+    setSnappingBorderColor(highlightColor());
+    setSnappingInactiveBorderColor(inactiveColor());
 }
 
 #undef P_STORE_GET

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -2040,16 +2040,16 @@ P_STORE_GET(bool, restoreOriginalSizeOnUnsnap, snappingBehaviorWindowHandlingGro
 P_STORE_SET_BOOL(setRestoreOriginalSizeOnUnsnap, snappingBehaviorWindowHandlingGroup, restoreOnUnsnapKey,
                  restoreOriginalSizeOnUnsnapChanged)
 
-StickyWindowHandling Settings::stickyWindowHandling() const
+StickyWindowHandling Settings::snappingStickyWindowHandling() const
 {
     return static_cast<StickyWindowHandling>(m_store->read<int>(ConfigDefaults::snappingBehaviorWindowHandlingGroup(),
                                                                 ConfigDefaults::stickyWindowHandlingKey()));
 }
-int Settings::stickyWindowHandlingInt() const
+int Settings::snappingStickyWindowHandlingInt() const
 {
-    return static_cast<int>(stickyWindowHandling());
+    return static_cast<int>(snappingStickyWindowHandling());
 }
-void Settings::setStickyWindowHandling(StickyWindowHandling handling)
+void Settings::setSnappingStickyWindowHandling(StickyWindowHandling handling)
 {
     const int before = m_store->read<int>(ConfigDefaults::snappingBehaviorWindowHandlingGroup(),
                                           ConfigDefaults::stickyWindowHandlingKey());
@@ -2060,14 +2060,14 @@ void Settings::setStickyWindowHandling(StickyWindowHandling handling)
     if (after == before) {
         return;
     }
-    Q_EMIT stickyWindowHandlingChanged();
+    Q_EMIT snappingStickyWindowHandlingChanged();
     Q_EMIT settingsChanged();
 }
-void Settings::setStickyWindowHandlingInt(int handling)
+void Settings::setSnappingStickyWindowHandlingInt(int handling)
 {
     if (handling >= static_cast<int>(StickyWindowHandling::TreatAsNormal)
         && handling <= static_cast<int>(StickyWindowHandling::IgnoreAll)) {
-        setStickyWindowHandling(static_cast<StickyWindowHandling>(handling));
+        setSnappingStickyWindowHandling(static_cast<StickyWindowHandling>(handling));
     }
 }
 

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -168,8 +168,8 @@ public:
                    moveNewWindowsToLastZoneChanged)
     Q_PROPERTY(bool restoreOriginalSizeOnUnsnap READ restoreOriginalSizeOnUnsnap WRITE setRestoreOriginalSizeOnUnsnap
                    NOTIFY restoreOriginalSizeOnUnsnapChanged)
-    Q_PROPERTY(int stickyWindowHandling READ stickyWindowHandlingInt WRITE setStickyWindowHandlingInt NOTIFY
-                   stickyWindowHandlingChanged)
+    Q_PROPERTY(int snappingStickyWindowHandling READ snappingStickyWindowHandlingInt WRITE
+                   setSnappingStickyWindowHandlingInt NOTIFY snappingStickyWindowHandlingChanged)
     Q_PROPERTY(bool restoreWindowsToZonesOnLogin READ restoreWindowsToZonesOnLogin WRITE setRestoreWindowsToZonesOnLogin
                    NOTIFY restoreWindowsToZonesOnLoginChanged)
     Q_PROPERTY(bool autoAssignAllLayouts READ autoAssignAllLayouts WRITE setAutoAssignAllLayouts NOTIFY
@@ -650,10 +650,10 @@ public:
     void setMoveNewWindowsToLastZone(bool move) override;
     bool restoreOriginalSizeOnUnsnap() const override;
     void setRestoreOriginalSizeOnUnsnap(bool restore) override;
-    StickyWindowHandling stickyWindowHandling() const override;
-    void setStickyWindowHandling(StickyWindowHandling handling) override;
-    int stickyWindowHandlingInt() const;
-    void setStickyWindowHandlingInt(int handling);
+    StickyWindowHandling snappingStickyWindowHandling() const override;
+    void setSnappingStickyWindowHandling(StickyWindowHandling handling) override;
+    int snappingStickyWindowHandlingInt() const;
+    void setSnappingStickyWindowHandlingInt(int handling);
     bool restoreWindowsToZonesOnLogin() const override;
     void setRestoreWindowsToZonesOnLogin(bool restore) override;
     bool autoAssignAllLayouts() const override;

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -322,20 +322,20 @@ public:
                    NOTIFY autotileInactiveBorderColorChanged)
     Q_PROPERTY(bool autotileUseSystemBorderColors READ autotileUseSystemBorderColors WRITE
                    setAutotileUseSystemBorderColors NOTIFY autotileUseSystemBorderColorsChanged)
-    Q_PROPERTY(bool snapWindowHideTitleBars READ snapWindowHideTitleBars WRITE setSnapWindowHideTitleBars NOTIFY
-                   snapWindowHideTitleBarsChanged)
-    Q_PROPERTY(bool snapWindowShowBorder READ snapWindowShowBorder WRITE setSnapWindowShowBorder NOTIFY
-                   snapWindowShowBorderChanged)
-    Q_PROPERTY(int snapWindowBorderWidth READ snapWindowBorderWidth WRITE setSnapWindowBorderWidth NOTIFY
-                   snapWindowBorderWidthChanged)
-    Q_PROPERTY(int snapWindowBorderRadius READ snapWindowBorderRadius WRITE setSnapWindowBorderRadius NOTIFY
-                   snapWindowBorderRadiusChanged)
-    Q_PROPERTY(QColor snapWindowBorderColor READ snapWindowBorderColor WRITE setSnapWindowBorderColor NOTIFY
-                   snapWindowBorderColorChanged)
-    Q_PROPERTY(QColor snapWindowInactiveBorderColor READ snapWindowInactiveBorderColor WRITE
-                   setSnapWindowInactiveBorderColor NOTIFY snapWindowInactiveBorderColorChanged)
-    Q_PROPERTY(bool snapWindowUseSystemBorderColors READ snapWindowUseSystemBorderColors WRITE
-                   setSnapWindowUseSystemBorderColors NOTIFY snapWindowUseSystemBorderColorsChanged)
+    Q_PROPERTY(bool snappingHideTitleBars READ snappingHideTitleBars WRITE setSnappingHideTitleBars NOTIFY
+                   snappingHideTitleBarsChanged)
+    Q_PROPERTY(
+        bool snappingShowBorder READ snappingShowBorder WRITE setSnappingShowBorder NOTIFY snappingShowBorderChanged)
+    Q_PROPERTY(
+        int snappingBorderWidth READ snappingBorderWidth WRITE setSnappingBorderWidth NOTIFY snappingBorderWidthChanged)
+    Q_PROPERTY(int snappingBorderRadius READ snappingBorderRadius WRITE setSnappingBorderRadius NOTIFY
+                   snappingBorderRadiusChanged)
+    Q_PROPERTY(QColor snappingBorderColor READ snappingBorderColor WRITE setSnappingBorderColor NOTIFY
+                   snappingBorderColorChanged)
+    Q_PROPERTY(QColor snappingInactiveBorderColor READ snappingInactiveBorderColor WRITE setSnappingInactiveBorderColor
+                   NOTIFY snappingInactiveBorderColorChanged)
+    Q_PROPERTY(bool snappingUseSystemBorderColors READ snappingUseSystemBorderColors WRITE
+                   setSnappingUseSystemBorderColors NOTIFY snappingUseSystemBorderColorsChanged)
     Q_PROPERTY(int autotileStickyWindowHandling READ autotileStickyWindowHandlingInt WRITE
                    setAutotileStickyWindowHandlingInt NOTIFY autotileStickyWindowHandlingChanged)
     Q_PROPERTY(int autotileDragBehavior READ autotileDragBehaviorInt WRITE setAutotileDragBehaviorInt NOTIFY
@@ -892,20 +892,20 @@ public:
     void setAutotileInactiveBorderColor(const QColor& color) override;
     bool autotileUseSystemBorderColors() const override;
     void setAutotileUseSystemBorderColors(bool use) override;
-    bool snapWindowHideTitleBars() const override;
-    void setSnapWindowHideTitleBars(bool hide) override;
-    bool snapWindowShowBorder() const override;
-    void setSnapWindowShowBorder(bool show) override;
-    int snapWindowBorderWidth() const override;
-    void setSnapWindowBorderWidth(int width) override;
-    int snapWindowBorderRadius() const override;
-    void setSnapWindowBorderRadius(int radius) override;
-    QColor snapWindowBorderColor() const override;
-    void setSnapWindowBorderColor(const QColor& color) override;
-    QColor snapWindowInactiveBorderColor() const override;
-    void setSnapWindowInactiveBorderColor(const QColor& color) override;
-    bool snapWindowUseSystemBorderColors() const override;
-    void setSnapWindowUseSystemBorderColors(bool use) override;
+    bool snappingHideTitleBars() const override;
+    void setSnappingHideTitleBars(bool hide) override;
+    bool snappingShowBorder() const override;
+    void setSnappingShowBorder(bool show) override;
+    int snappingBorderWidth() const override;
+    void setSnappingBorderWidth(int width) override;
+    int snappingBorderRadius() const override;
+    void setSnappingBorderRadius(int radius) override;
+    QColor snappingBorderColor() const override;
+    void setSnappingBorderColor(const QColor& color) override;
+    QColor snappingInactiveBorderColor() const override;
+    void setSnappingInactiveBorderColor(const QColor& color) override;
+    bool snappingUseSystemBorderColors() const override;
+    void setSnappingUseSystemBorderColors(bool use) override;
     StickyWindowHandling autotileStickyWindowHandling() const override;
     void setAutotileStickyWindowHandling(StickyWindowHandling handling) override;
     int autotileStickyWindowHandlingInt() const;
@@ -1123,7 +1123,7 @@ public:
     Q_INVOKABLE QString loadColorsFromFile(const QString& filePath) override;
     Q_INVOKABLE void applySystemColorScheme();
     void applyAutotileBorderSystemColor();
-    void applySnapWindowBorderSystemColor();
+    void applySnappingBorderSystemColor();
 
 Q_SIGNALS:
     /// Emitted when the whole animation Profile blob is replaced via

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -231,35 +231,31 @@ void appendAppearanceSchema(PhosphorConfig::Schema& schema)
     // decoration (parallel to Tiling.Appearance.* in appendAutotilingSchema;
     // defaults via snapWindow* in ConfigDefaults).
     schema.groups[CD::snappingAppearanceColorsGroup()] = {
-        {CD::activeKey(),
-         CD::snapWindowBorderColor(),
-         QMetaType::QColor,
-         {},
-         validColorOr(CD::snapWindowBorderColor())},
+        {CD::activeKey(), CD::snappingBorderColor(), QMetaType::QColor, {}, validColorOr(CD::snappingBorderColor())},
         {CD::inactiveKey(),
-         CD::snapWindowInactiveBorderColor(),
+         CD::snappingInactiveBorderColor(),
          QMetaType::QColor,
          {},
-         validColorOr(CD::snapWindowInactiveBorderColor())},
-        {CD::useSystemKey(), CD::snapWindowUseSystemBorderColors(), QMetaType::Bool},
+         validColorOr(CD::snappingInactiveBorderColor())},
+        {CD::useSystemKey(), CD::snappingUseSystemBorderColors(), QMetaType::Bool},
     };
 
     schema.groups[CD::snappingAppearanceDecorationsGroup()] = {
-        {CD::hideTitleBarsKey(), CD::snapWindowHideTitleBars(), QMetaType::Bool},
+        {CD::hideTitleBarsKey(), CD::snappingHideTitleBars(), QMetaType::Bool},
     };
 
     schema.groups[CD::snappingAppearanceBordersGroup()] = {
-        {CD::showBorderKey(), CD::snapWindowShowBorder(), QMetaType::Bool},
+        {CD::showBorderKey(), CD::snappingShowBorder(), QMetaType::Bool},
         {CD::widthKey(),
-         CD::snapWindowBorderWidth(),
+         CD::snappingBorderWidth(),
          QMetaType::Int,
          {},
-         clampInt(CD::snapWindowBorderWidthMin(), CD::snapWindowBorderWidthMax())},
+         clampInt(CD::snappingBorderWidthMin(), CD::snappingBorderWidthMax())},
         {CD::radiusKey(),
-         CD::snapWindowBorderRadius(),
+         CD::snappingBorderRadius(),
          QMetaType::Int,
          {},
-         clampInt(CD::snapWindowBorderRadiusMin(), CD::snapWindowBorderRadiusMax())},
+         clampInt(CD::snappingBorderRadiusMin(), CD::snappingBorderRadiusMax())},
     };
 }
 

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -722,7 +722,7 @@ void appendBehaviorSchema(PhosphorConfig::Schema& schema)
         {CD::moveNewToLastZoneKey(), CD::moveNewWindowsToLastZone(), QMetaType::Bool},
         {CD::restoreOnUnsnapKey(), CD::restoreOriginalSizeOnUnsnap(), QMetaType::Bool},
         {CD::stickyWindowHandlingKey(),
-         CD::stickyWindowHandling(),
+         CD::snappingStickyWindowHandling(),
          QMetaType::Int,
          {},
          clampInt(static_cast<int>(StickyWindowHandling::TreatAsNormal),

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -229,7 +229,7 @@ void appendAppearanceSchema(PhosphorConfig::Schema& schema)
 
     // Snapping.Appearance.* — the snapped window's border / title-bar
     // decoration (parallel to Tiling.Appearance.* in appendAutotilingSchema;
-    // defaults via snapWindow* in ConfigDefaults).
+    // defaults via snapping* in ConfigDefaults).
     schema.groups[CD::snappingAppearanceColorsGroup()] = {
         {CD::activeKey(), CD::snappingBorderColor(), QMetaType::QColor, {}, validColorOr(CD::snappingBorderColor())},
         {CD::inactiveKey(),

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -167,20 +167,20 @@ public:
 
     // Snapping window decoration settings (fetched by KWin effect via D-Bus).
     // Parallel to autotile* — the snapped window's border / title-bar.
-    virtual bool snapWindowHideTitleBars() const = 0;
-    virtual void setSnapWindowHideTitleBars(bool hide) = 0;
-    virtual bool snapWindowShowBorder() const = 0;
-    virtual void setSnapWindowShowBorder(bool show) = 0;
-    virtual int snapWindowBorderWidth() const = 0;
-    virtual void setSnapWindowBorderWidth(int width) = 0;
-    virtual int snapWindowBorderRadius() const = 0;
-    virtual void setSnapWindowBorderRadius(int radius) = 0;
-    virtual QColor snapWindowBorderColor() const = 0;
-    virtual void setSnapWindowBorderColor(const QColor& color) = 0;
-    virtual QColor snapWindowInactiveBorderColor() const = 0;
-    virtual void setSnapWindowInactiveBorderColor(const QColor& color) = 0;
-    virtual bool snapWindowUseSystemBorderColors() const = 0;
-    virtual void setSnapWindowUseSystemBorderColors(bool use) = 0;
+    virtual bool snappingHideTitleBars() const = 0;
+    virtual void setSnappingHideTitleBars(bool hide) = 0;
+    virtual bool snappingShowBorder() const = 0;
+    virtual void setSnappingShowBorder(bool show) = 0;
+    virtual int snappingBorderWidth() const = 0;
+    virtual void setSnappingBorderWidth(int width) = 0;
+    virtual int snappingBorderRadius() const = 0;
+    virtual void setSnappingBorderRadius(int radius) = 0;
+    virtual QColor snappingBorderColor() const = 0;
+    virtual void setSnappingBorderColor(const QColor& color) = 0;
+    virtual QColor snappingInactiveBorderColor() const = 0;
+    virtual void setSnappingInactiveBorderColor(const QColor& color) = 0;
+    virtual bool snappingUseSystemBorderColors() const = 0;
+    virtual void setSnappingUseSystemBorderColors(bool use) = 0;
 
     virtual StickyWindowHandling autotileStickyWindowHandling() const = 0;
     virtual void setAutotileStickyWindowHandling(StickyWindowHandling handling) = 0;
@@ -541,13 +541,13 @@ Q_SIGNALS:
     void autotileBorderColorChanged();
     void autotileInactiveBorderColorChanged();
     void autotileUseSystemBorderColorsChanged();
-    void snapWindowHideTitleBarsChanged();
-    void snapWindowShowBorderChanged();
-    void snapWindowBorderWidthChanged();
-    void snapWindowBorderRadiusChanged();
-    void snapWindowBorderColorChanged();
-    void snapWindowInactiveBorderColorChanged();
-    void snapWindowUseSystemBorderColorsChanged();
+    void snappingHideTitleBarsChanged();
+    void snappingShowBorderChanged();
+    void snappingBorderWidthChanged();
+    void snappingBorderRadiusChanged();
+    void snappingBorderColorChanged();
+    void snappingInactiveBorderColorChanged();
+    void snappingUseSystemBorderColorsChanged();
     void autotileStickyWindowHandlingChanged();
     void autotileDragBehaviorChanged();
     void autotileOverflowBehaviorChanged();

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -381,7 +381,7 @@ Q_SIGNALS:
     void keepWindowsInZonesOnResolutionChangeChanged();
     void moveNewWindowsToLastZoneChanged();
     void restoreOriginalSizeOnUnsnapChanged();
-    void stickyWindowHandlingChanged();
+    void snappingStickyWindowHandlingChanged();
     void restoreWindowsToZonesOnLoginChanged();
     void autoAssignAllLayoutsChanged();
     void snapAssistFeatureEnabledChanged();

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -350,8 +350,8 @@ public:
     virtual void setMoveNewWindowsToLastZone(bool move) = 0;
     virtual bool restoreOriginalSizeOnUnsnap() const = 0;
     virtual void setRestoreOriginalSizeOnUnsnap(bool restore) = 0;
-    virtual StickyWindowHandling stickyWindowHandling() const = 0;
-    virtual void setStickyWindowHandling(StickyWindowHandling handling) = 0;
+    virtual StickyWindowHandling snappingStickyWindowHandling() const = 0;
+    virtual void setSnappingStickyWindowHandling(StickyWindowHandling handling) = 0;
     virtual bool restoreWindowsToZonesOnLogin() const = 0;
     virtual void setRestoreWindowsToZonesOnLogin(bool restore) = 0;
     virtual bool autoAssignAllLayouts() const = 0;

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -444,19 +444,19 @@ void SettingsAdaptor::initializeRegistry()
                           setKeepWindowsInZonesOnResolutionChange)
     REGISTER_BOOL_SETTING("moveNewWindowsToLastZone", moveNewWindowsToLastZone, setMoveNewWindowsToLastZone)
     REGISTER_BOOL_SETTING("restoreOriginalSizeOnUnsnap", restoreOriginalSizeOnUnsnap, setRestoreOriginalSizeOnUnsnap)
-    // stickyWindowHandling: enum (0=TreatAsNormal, 1=RestoreOnly, 2=IgnoreAll)
-    m_getters[QStringLiteral("stickyWindowHandling")] = [this]() {
-        return static_cast<int>(m_settings->stickyWindowHandling());
+    // snappingStickyWindowHandling: enum (0=TreatAsNormal, 1=RestoreOnly, 2=IgnoreAll)
+    m_getters[QStringLiteral("snappingStickyWindowHandling")] = [this]() {
+        return static_cast<int>(m_settings->snappingStickyWindowHandling());
     };
-    m_setters[QStringLiteral("stickyWindowHandling")] = [this](const QVariant& v) {
+    m_setters[QStringLiteral("snappingStickyWindowHandling")] = [this](const QVariant& v) {
         int val = v.toInt();
         if (val >= 0 && val <= 2) {
-            m_settings->setStickyWindowHandling(static_cast<StickyWindowHandling>(val));
+            m_settings->setSnappingStickyWindowHandling(static_cast<StickyWindowHandling>(val));
             return true;
         }
         return false;
     };
-    m_schemas[QStringLiteral("stickyWindowHandling")] = QStringLiteral("int");
+    m_schemas[QStringLiteral("snappingStickyWindowHandling")] = QStringLiteral("int");
     REGISTER_BOOL_SETTING("restoreWindowsToZonesOnLogin", restoreWindowsToZonesOnLogin, setRestoreWindowsToZonesOnLogin)
     REGISTER_BOOL_SETTING("autoAssignAllLayouts", autoAssignAllLayouts, setAutoAssignAllLayouts)
     REGISTER_BOOL_SETTING("snapAssistFeatureEnabled", snapAssistFeatureEnabled, setSnapAssistFeatureEnabled)

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -685,15 +685,14 @@ void SettingsAdaptor::initializeRegistry()
                           setAutotileUseSystemBorderColors)
 
     // Snapping window decoration settings (on ISettings interface)
-    REGISTER_BOOL_SETTING("snapWindowHideTitleBars", snapWindowHideTitleBars, setSnapWindowHideTitleBars)
-    REGISTER_BOOL_SETTING("snapWindowShowBorder", snapWindowShowBorder, setSnapWindowShowBorder)
-    REGISTER_INT_SETTING("snapWindowBorderWidth", snapWindowBorderWidth, setSnapWindowBorderWidth)
-    REGISTER_INT_SETTING("snapWindowBorderRadius", snapWindowBorderRadius, setSnapWindowBorderRadius)
-    REGISTER_COLOR_SETTING("snapWindowBorderColor", snapWindowBorderColor, setSnapWindowBorderColor)
-    REGISTER_COLOR_SETTING("snapWindowInactiveBorderColor", snapWindowInactiveBorderColor,
-                           setSnapWindowInactiveBorderColor)
-    REGISTER_BOOL_SETTING("snapWindowUseSystemBorderColors", snapWindowUseSystemBorderColors,
-                          setSnapWindowUseSystemBorderColors)
+    REGISTER_BOOL_SETTING("snappingHideTitleBars", snappingHideTitleBars, setSnappingHideTitleBars)
+    REGISTER_BOOL_SETTING("snappingShowBorder", snappingShowBorder, setSnappingShowBorder)
+    REGISTER_INT_SETTING("snappingBorderWidth", snappingBorderWidth, setSnappingBorderWidth)
+    REGISTER_INT_SETTING("snappingBorderRadius", snappingBorderRadius, setSnappingBorderRadius)
+    REGISTER_COLOR_SETTING("snappingBorderColor", snappingBorderColor, setSnappingBorderColor)
+    REGISTER_COLOR_SETTING("snappingInactiveBorderColor", snappingInactiveBorderColor, setSnappingInactiveBorderColor)
+    REGISTER_BOOL_SETTING("snappingUseSystemBorderColors", snappingUseSystemBorderColors,
+                          setSnappingUseSystemBorderColors)
 
     REGISTER_BOOL_SETTING("autotileFocusFollowsMouse", autotileFocusFollowsMouse, setAutotileFocusFollowsMouse)
     m_getters[QStringLiteral("autotileStickyWindowHandling")] = [this]() {

--- a/src/settings/qml/QuickLayoutSlotsCard.qml
+++ b/src/settings/qml/QuickLayoutSlotsCard.qml
@@ -27,7 +27,7 @@ SettingsCard {
             appSettings.setQuickLayoutSlot(slotNumber, value);
     }
 
-    headerText: root.viewMode === 1 ? i18n("Tiling Quick Shortcuts") : i18n("Quick Layout Shortcuts")
+    headerText: root.viewMode === 1 ? i18n("Tiling Quick Shortcuts") : i18n("Snapping Quick Shortcuts")
     collapsible: true
 
     contentItem: ColumnLayout {
@@ -67,7 +67,7 @@ SettingsCard {
                         spacing: Kirigami.Units.smallSpacing / 2
 
                         Label {
-                            text: root.viewMode === 1 ? i18n("Quick Tiling %1", slotDelegate.slotNumber) : i18n("Quick Layout %1", slotDelegate.slotNumber)
+                            text: root.viewMode === 1 ? i18n("Quick Tiling %1", slotDelegate.slotNumber) : i18n("Quick Snapping %1", slotDelegate.slotNumber)
                             Layout.fillWidth: true
                             elide: Text.ElideRight
                         }

--- a/src/settings/qml/SnappingWindowAppearancePage.qml
+++ b/src/settings/qml/SnappingWindowAppearancePage.qml
@@ -62,10 +62,10 @@ SettingsFlickable {
                     SettingsSwitch {
                         id: useSystemColorsSwitch
 
-                        checked: appSettings.snapWindowUseSystemBorderColors
+                        checked: appSettings.snappingUseSystemBorderColors
                         accessibleName: i18n("Use system accent color")
                         onToggled: function (newValue) {
-                            appSettings.snapWindowUseSystemBorderColors = newValue;
+                            appSettings.snappingUseSystemBorderColors = newValue;
                         }
                     }
                 }
@@ -80,9 +80,9 @@ SettingsFlickable {
                     description: i18n("Border color for the focused snapped window")
 
                     ColorSwatchRow {
-                        color: appSettings.snapWindowBorderColor
+                        color: appSettings.snappingBorderColor
                         onClicked: {
-                            activeBorderColorDialog.selectedColor = appSettings.snapWindowBorderColor;
+                            activeBorderColorDialog.selectedColor = appSettings.snappingBorderColor;
                             activeBorderColorDialog.open();
                         }
                     }
@@ -98,9 +98,9 @@ SettingsFlickable {
                     description: i18n("Border color for unfocused snapped windows")
 
                     ColorSwatchRow {
-                        color: appSettings.snapWindowInactiveBorderColor
+                        color: appSettings.snappingInactiveBorderColor
                         onClicked: {
-                            inactiveBorderColorDialog.selectedColor = appSettings.snapWindowInactiveBorderColor;
+                            inactiveBorderColorDialog.selectedColor = appSettings.snappingInactiveBorderColor;
                             inactiveBorderColorDialog.open();
                         }
                     }
@@ -124,10 +124,10 @@ SettingsFlickable {
                     description: i18n("Remove window title bars while snapped, restored when floating")
 
                     SettingsSwitch {
-                        checked: appSettings.snapWindowHideTitleBars
+                        checked: appSettings.snappingHideTitleBars
                         accessibleName: i18n("Hide title bars on snapped windows")
                         onToggled: function (newValue) {
-                            appSettings.snapWindowHideTitleBars = newValue;
+                            appSettings.snappingHideTitleBars = newValue;
                         }
                     }
                 }
@@ -141,9 +141,9 @@ SettingsFlickable {
             Layout.fillWidth: true
             headerText: i18n("Borders")
             showToggle: true
-            toggleChecked: appSettings.snapWindowShowBorder
+            toggleChecked: appSettings.snappingShowBorder
             onToggleClicked: checked => {
-                return appSettings.snapWindowShowBorder = checked;
+                return appSettings.snappingShowBorder = checked;
             }
             collapsible: true
 
@@ -155,11 +155,11 @@ SettingsFlickable {
                     description: i18n("Thickness of colored borders around snapped windows")
 
                     SettingsSpinBox {
-                        from: root.settingsBridge.snapWindowBorderWidthMin
-                        to: root.settingsBridge.snapWindowBorderWidthMax
-                        value: appSettings.snapWindowBorderWidth
+                        from: root.settingsBridge.snappingBorderWidthMin
+                        to: root.settingsBridge.snappingBorderWidthMax
+                        value: appSettings.snappingBorderWidth
                         onValueModified: value => {
-                            return appSettings.snapWindowBorderWidth = value;
+                            return appSettings.snappingBorderWidth = value;
                         }
                     }
                 }
@@ -171,11 +171,11 @@ SettingsFlickable {
                     description: i18n("Roundness of border corners (0 for square)")
 
                     SettingsSpinBox {
-                        from: root.settingsBridge.snapWindowBorderRadiusMin
-                        to: root.settingsBridge.snapWindowBorderRadiusMax
-                        value: appSettings.snapWindowBorderRadius
+                        from: root.settingsBridge.snappingBorderRadiusMin
+                        to: root.settingsBridge.snappingBorderRadiusMax
+                        value: appSettings.snappingBorderRadius
                         onValueModified: value => {
-                            return appSettings.snapWindowBorderRadius = value;
+                            return appSettings.snappingBorderRadius = value;
                         }
                     }
                 }
@@ -257,13 +257,13 @@ SettingsFlickable {
         id: activeBorderColorDialog
 
         title: i18n("Choose Active Border Color")
-        onAccepted: appSettings.snapWindowBorderColor = selectedColor
+        onAccepted: appSettings.snappingBorderColor = selectedColor
     }
 
     ColorDialog {
         id: inactiveBorderColorDialog
 
         title: i18n("Choose Inactive Border Color")
-        onAccepted: appSettings.snapWindowInactiveBorderColor = selectedColor
+        onAccepted: appSettings.snappingInactiveBorderColor = selectedColor
     }
 }

--- a/src/settings/qml/SnappingWindowAppearancePage.qml
+++ b/src/settings/qml/SnappingWindowAppearancePage.qml
@@ -192,12 +192,13 @@ SettingsFlickable {
             scopeAppSettings: settingsController
             scopeHasOverridesMethod: "hasPerScreenSnappingGapsSettings"
             scopeClearerMethod: "clearPerScreenSnappingGapsSettings"
-            // Snapping uses "Zone padding" / "Edge gap" labels and has no Smart
-            // gaps. Zone-padding bounds come from zonePaddingMin/Max; the edge /
-            // per-side gaps from gapMin/Max — each matching its validator clamp.
-            primaryGapLabel: i18n("Zone padding")
+            // Snapping shares the "Inner gap" / "Outer gap" labels with tiling
+            // (consistent cross-mode wording) but has no Smart gaps. Inner-gap
+            // bounds come from zonePaddingMin/Max; the outer / per-side gaps from
+            // gapMin/Max — each matching its validator clamp.
+            primaryGapLabel: i18n("Inner gap")
             primaryGapDescription: i18n("Space between snapped windows")
-            outerGapLabel: i18n("Edge gap")
+            outerGapLabel: i18n("Outer gap")
             outerGapDescription: i18n("Space from screen edges to snapped windows")
             showSmartGaps: false
             gapMin: root.settingsBridge.gapMin

--- a/src/settings/qml/SnappingWindowBehaviorPage.qml
+++ b/src/settings/qml/SnappingWindowBehaviorPage.qml
@@ -202,8 +202,8 @@ SettingsFlickable {
                                     "value": 2
                                 }
                             ]
-                            currentIndex: Math.max(0, indexOfValue(appSettings.stickyWindowHandling))
-                            onActivated: appSettings.stickyWindowHandling = currentValue
+                            currentIndex: Math.max(0, indexOfValue(appSettings.snappingStickyWindowHandling))
+                            onActivated: appSettings.snappingStickyWindowHandling = currentValue
                         }
                     }
                 }

--- a/src/settings/qml/TilingBehaviorPage.qml
+++ b/src/settings/qml/TilingBehaviorPage.qml
@@ -43,15 +43,13 @@ SettingsFlickable {
 
                         checked: root.settingsBridge.alwaysReinsertIntoStack
                         accessibleName: i18n("Always re-insert into stack on drag")
-                        onToggled: function(newValue) {
+                        onToggled: function (newValue) {
                             root.settingsBridge.alwaysReinsertIntoStack = newValue;
                         }
                     }
-
                 }
 
-                SettingsSeparator {
-                }
+                SettingsSeparator {}
 
                 SettingsRow {
                     title: i18n("Hold to re-insert into stack")
@@ -66,15 +64,13 @@ SettingsFlickable {
                         triggers: root.settingsBridge.autotileDragInsertTriggers
                         defaultTriggers: root.settingsBridge.defaultAutotileDragInsertTriggers
                         tooltipEnabled: false
-                        onTriggersModified: (triggers) => {
+                        onTriggersModified: triggers => {
                             root.settingsBridge.autotileDragInsertTriggers = triggers;
                         }
                     }
-
                 }
 
-                SettingsSeparator {
-                }
+                SettingsSeparator {}
 
                 SettingsRow {
                     title: i18n("Toggle mode")
@@ -85,23 +81,20 @@ SettingsFlickable {
                     SettingsSwitch {
                         checked: appSettings.autotileDragInsertToggle
                         accessibleName: i18n("Toggle mode for re-insert into stack")
-                        onToggled: function(newValue) {
+                        onToggled: function (newValue) {
                             appSettings.autotileDragInsertToggle = newValue;
                         }
                     }
-
                 }
-
             }
-
         }
 
         // =================================================================
-        // Behavior Card
+        // Window Handling Card
         // =================================================================
         SettingsCard {
             Layout.fillWidth: true
-            headerText: i18n("Behavior")
+            headerText: i18n("Window Handling")
             collapsible: true
 
             contentItem: ColumnLayout {
@@ -116,58 +109,26 @@ SettingsFlickable {
                         Accessible.name: i18n("New window placement")
                         textRole: "text"
                         valueRole: "value"
-                        model: [{
-                            "text": i18n("After existing"),
-                            "value": 0
-                        }, {
-                            "text": i18n("After focused"),
-                            "value": 1
-                        }, {
-                            "text": i18n("As main window"),
-                            "value": 2
-                        }]
+                        model: [
+                            {
+                                "text": i18n("After existing"),
+                                "value": 0
+                            },
+                            {
+                                "text": i18n("After focused"),
+                                "value": 1
+                            },
+                            {
+                                "text": i18n("As main window"),
+                                "value": 2
+                            }
+                        ]
                         currentIndex: Math.max(0, indexOfValue(appSettings.autotileInsertPosition))
                         onActivated: appSettings.autotileInsertPosition = currentValue
                     }
-
                 }
 
-                SettingsSeparator {
-                }
-
-                SettingsRow {
-                    title: i18n("Focus new windows")
-                    description: i18n("Automatically focus windows when they open")
-
-                    SettingsSwitch {
-                        checked: appSettings.autotileFocusNewWindows
-                        accessibleName: i18n("Focus newly opened windows")
-                        onToggled: function(newValue) {
-                            appSettings.autotileFocusNewWindows = newValue;
-                        }
-                    }
-
-                }
-
-                SettingsSeparator {
-                }
-
-                SettingsRow {
-                    title: i18n("Focus follows mouse")
-                    description: i18n("Moving the mouse pointer over a window gives it focus")
-
-                    SettingsSwitch {
-                        checked: appSettings.autotileFocusFollowsMouse
-                        accessibleName: i18n("Focus follows mouse pointer")
-                        onToggled: function(newValue) {
-                            appSettings.autotileFocusFollowsMouse = newValue;
-                        }
-                    }
-
-                }
-
-                SettingsSeparator {
-                }
+                SettingsSeparator {}
 
                 SettingsRow {
                     title: i18n("Respect minimum size")
@@ -176,15 +137,13 @@ SettingsFlickable {
                     SettingsSwitch {
                         checked: appSettings.autotileRespectMinimumSize
                         accessibleName: i18n("Respect window minimum size")
-                        onToggled: function(newValue) {
+                        onToggled: function (newValue) {
                             appSettings.autotileRespectMinimumSize = newValue;
                         }
                     }
-
                 }
 
-                SettingsSeparator {
-                }
+                SettingsSeparator {}
 
                 SettingsRow {
                     title: i18n("Sticky windows")
@@ -194,24 +153,26 @@ SettingsFlickable {
                         Accessible.name: i18n("Sticky windows")
                         textRole: "text"
                         valueRole: "value"
-                        model: [{
-                            "text": i18n("Treat as normal"),
-                            "value": 0
-                        }, {
-                            "text": i18n("Restore only"),
-                            "value": 1
-                        }, {
-                            "text": i18n("Ignore all"),
-                            "value": 2
-                        }]
+                        model: [
+                            {
+                                "text": i18n("Treat as normal"),
+                                "value": 0
+                            },
+                            {
+                                "text": i18n("Restore only"),
+                                "value": 1
+                            },
+                            {
+                                "text": i18n("Ignore all"),
+                                "value": 2
+                            }
+                        ]
                         currentIndex: Math.max(0, indexOfValue(appSettings.autotileStickyWindowHandling))
                         onActivated: appSettings.autotileStickyWindowHandling = currentValue
                     }
-
                 }
 
-                SettingsSeparator {
-                }
+                SettingsSeparator {}
 
                 SettingsRow {
                     title: i18n("Drag behavior")
@@ -222,21 +183,22 @@ SettingsFlickable {
                         Accessible.description: i18n("Selects how dragging a tiled window on an autotile screen behaves: Float converts it to free-floating, Reorder keeps it tiled and swaps it into the drop slot.")
                         textRole: "text"
                         valueRole: "value"
-                        model: [{
-                            "text": i18n("Float on drag"),
-                            "value": 0
-                        }, {
-                            "text": i18n("Reorder on drag"),
-                            "value": 1
-                        }]
+                        model: [
+                            {
+                                "text": i18n("Float on drag"),
+                                "value": 0
+                            },
+                            {
+                                "text": i18n("Reorder on drag"),
+                                "value": 1
+                            }
+                        ]
                         currentIndex: Math.max(0, indexOfValue(appSettings.autotileDragBehavior))
                         onActivated: appSettings.autotileDragBehavior = currentValue
                     }
-
                 }
 
-                SettingsSeparator {
-                }
+                SettingsSeparator {}
 
                 SettingsRow {
                     title: i18n("Overflow behavior")
@@ -247,23 +209,62 @@ SettingsFlickable {
                         Accessible.description: i18n("Selects how windows beyond the max-windows cap are handled: Float excess windows, or Unlimited to tile every window regardless of count.")
                         textRole: "text"
                         valueRole: "value"
-                        model: [{
-                            "text": i18n("Float excess"),
-                            "value": 0
-                        }, {
-                            "text": i18n("Unlimited"),
-                            "value": 1
-                        }]
+                        model: [
+                            {
+                                "text": i18n("Float excess"),
+                                "value": 0
+                            },
+                            {
+                                "text": i18n("Unlimited"),
+                                "value": 1
+                            }
+                        ]
                         currentIndex: Math.max(0, indexOfValue(appSettings.autotileOverflowBehavior))
                         onActivated: appSettings.autotileOverflowBehavior = currentValue
                     }
-
                 }
-
             }
-
         }
 
-    }
+        // =================================================================
+        // Focus Card
+        // =================================================================
+        SettingsCard {
+            Layout.fillWidth: true
+            headerText: i18n("Focus")
+            collapsible: true
 
+            contentItem: ColumnLayout {
+                spacing: Kirigami.Units.smallSpacing
+
+                SettingsRow {
+                    title: i18n("Focus new windows")
+                    description: i18n("Focus a window when it opens")
+
+                    SettingsSwitch {
+                        checked: appSettings.autotileFocusNewWindows
+                        accessibleName: i18n("Focus newly opened windows")
+                        onToggled: function (newValue) {
+                            appSettings.autotileFocusNewWindows = newValue;
+                        }
+                    }
+                }
+
+                SettingsSeparator {}
+
+                SettingsRow {
+                    title: i18n("Focus follows mouse")
+                    description: i18n("Moving the mouse pointer over a window gives it focus")
+
+                    SettingsSwitch {
+                        checked: appSettings.autotileFocusFollowsMouse
+                        accessibleName: i18n("Focus follows mouse pointer")
+                        onToggled: function (newValue) {
+                            appSettings.autotileFocusFollowsMouse = newValue;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/src/settings/snappingwindowappearancecontroller.h
+++ b/src/settings/snappingwindowappearancecontroller.h
@@ -14,16 +14,16 @@ namespace PlasmaZones {
 ///
 /// CONSTANT bounds for the snapped-window border-width / border-radius sliders
 /// (parallel to TilingAppearanceController). Live border values are on Settings
-/// (Q_PROPERTY) and bind via `appSettings.snapWindowBorderWidth` /
-/// `appSettings.snapWindowBorderRadius`.
+/// (Q_PROPERTY) and bind via `appSettings.snappingBorderWidth` /
+/// `appSettings.snappingBorderRadius`.
 class SnappingWindowAppearanceController : public PhosphorSettingsUi::PageController
 {
     Q_OBJECT
 
-    Q_PROPERTY(int snapWindowBorderWidthMin READ snapWindowBorderWidthMin CONSTANT)
-    Q_PROPERTY(int snapWindowBorderWidthMax READ snapWindowBorderWidthMax CONSTANT)
-    Q_PROPERTY(int snapWindowBorderRadiusMin READ snapWindowBorderRadiusMin CONSTANT)
-    Q_PROPERTY(int snapWindowBorderRadiusMax READ snapWindowBorderRadiusMax CONSTANT)
+    Q_PROPERTY(int snappingBorderWidthMin READ snappingBorderWidthMin CONSTANT)
+    Q_PROPERTY(int snappingBorderWidthMax READ snappingBorderWidthMax CONSTANT)
+    Q_PROPERTY(int snappingBorderRadiusMin READ snappingBorderRadiusMin CONSTANT)
+    Q_PROPERTY(int snappingBorderRadiusMax READ snappingBorderRadiusMax CONSTANT)
     // Snapping gaps (zone padding + outer/edge gaps) moved onto Window →
     // Appearance (per-screen, beside the global border/title-bar cards). Each
     // field is bounded by the SAME ConfigDefaults accessor the per-screen
@@ -52,21 +52,21 @@ public:
     {
     }
 
-    int snapWindowBorderWidthMin() const
+    int snappingBorderWidthMin() const
     {
-        return ConfigDefaults::snapWindowBorderWidthMin();
+        return ConfigDefaults::snappingBorderWidthMin();
     }
-    int snapWindowBorderWidthMax() const
+    int snappingBorderWidthMax() const
     {
-        return ConfigDefaults::snapWindowBorderWidthMax();
+        return ConfigDefaults::snappingBorderWidthMax();
     }
-    int snapWindowBorderRadiusMin() const
+    int snappingBorderRadiusMin() const
     {
-        return ConfigDefaults::snapWindowBorderRadiusMin();
+        return ConfigDefaults::snappingBorderRadiusMin();
     }
-    int snapWindowBorderRadiusMax() const
+    int snappingBorderRadiusMax() const
     {
-        return ConfigDefaults::snapWindowBorderRadiusMax();
+        return ConfigDefaults::snappingBorderRadiusMax();
     }
     int zonePaddingMin() const
     {

--- a/tests/unit/config/test_configdefaults.cpp
+++ b/tests/unit/config/test_configdefaults.cpp
@@ -103,8 +103,8 @@ private Q_SLOTS:
         QVERIFY(ConfigDefaults::minimumZoneDisplaySizePx() <= ConfigDefaults::minimumZoneDisplaySizePxMax());
 
         // Behavior
-        QVERIFY(ConfigDefaults::stickyWindowHandling() >= 0);
-        QVERIFY(ConfigDefaults::stickyWindowHandling() <= 2);
+        QVERIFY(ConfigDefaults::snappingStickyWindowHandling() >= 0);
+        QVERIFY(ConfigDefaults::snappingStickyWindowHandling() <= 2);
         QVERIFY(ConfigDefaults::minimumWindowWidth() >= ConfigDefaults::minimumWindowWidthMin());
         QVERIFY(ConfigDefaults::minimumWindowWidth() <= ConfigDefaults::minimumWindowWidthMax());
         QVERIFY(ConfigDefaults::minimumWindowHeight() >= ConfigDefaults::minimumWindowHeightMin());

--- a/tests/unit/config/test_configdefaults.cpp
+++ b/tests/unit/config/test_configdefaults.cpp
@@ -204,7 +204,7 @@ private Q_SLOTS:
     /**
      * Snapped-window appearance defaults must be IDENTICAL to the autotile*
      * window appearance defaults — the two modes start a window from the same
-     * chrome (every snapWindow* default delegates to its autotile* counterpart).
+     * chrome (every snapping* default delegates to its autotile* counterpart).
      * Assert each pair is equal rather than pinning literals so a single change
      * to an autotile default moves both in lockstep without staling this test.
      * The concrete shipped values are pinned separately below.

--- a/tests/unit/config/test_configdefaults.cpp
+++ b/tests/unit/config/test_configdefaults.cpp
@@ -152,10 +152,10 @@ private Q_SLOTS:
         QVERIFY(ConfigDefaults::autotileBorderWidth() <= ConfigDefaults::autotileBorderWidthMax());
         QVERIFY(ConfigDefaults::autotileBorderRadius() >= ConfigDefaults::autotileBorderRadiusMin());
         QVERIFY(ConfigDefaults::autotileBorderRadius() <= ConfigDefaults::autotileBorderRadiusMax());
-        QVERIFY(ConfigDefaults::snapWindowBorderWidth() >= ConfigDefaults::snapWindowBorderWidthMin());
-        QVERIFY(ConfigDefaults::snapWindowBorderWidth() <= ConfigDefaults::snapWindowBorderWidthMax());
-        QVERIFY(ConfigDefaults::snapWindowBorderRadius() >= ConfigDefaults::snapWindowBorderRadiusMin());
-        QVERIFY(ConfigDefaults::snapWindowBorderRadius() <= ConfigDefaults::snapWindowBorderRadiusMax());
+        QVERIFY(ConfigDefaults::snappingBorderWidth() >= ConfigDefaults::snappingBorderWidthMin());
+        QVERIFY(ConfigDefaults::snappingBorderWidth() <= ConfigDefaults::snappingBorderWidthMax());
+        QVERIFY(ConfigDefaults::snappingBorderRadius() >= ConfigDefaults::snappingBorderRadiusMin());
+        QVERIFY(ConfigDefaults::snappingBorderRadius() <= ConfigDefaults::snappingBorderRadiusMax());
         QVERIFY(ConfigDefaults::autotileOuterGapTop() >= ConfigDefaults::autotileOuterGapTopMin());
         QVERIFY(ConfigDefaults::autotileOuterGapTop() <= ConfigDefaults::autotileOuterGapTopMax());
         QVERIFY(ConfigDefaults::autotileOuterGapBottom() >= ConfigDefaults::autotileOuterGapBottomMin());
@@ -209,25 +209,25 @@ private Q_SLOTS:
      * to an autotile default moves both in lockstep without staling this test.
      * The concrete shipped values are pinned separately below.
      */
-    void testSnapWindowAppearance_defaults()
+    void testSnappingWindowAppearance_defaults()
     {
-        QCOMPARE(ConfigDefaults::snapWindowHideTitleBars(), ConfigDefaults::autotileHideTitleBars());
-        QCOMPARE(ConfigDefaults::snapWindowShowBorder(), ConfigDefaults::autotileShowBorder());
-        QCOMPARE(ConfigDefaults::snapWindowUseSystemBorderColors(), ConfigDefaults::autotileUseSystemBorderColors());
-        QCOMPARE(ConfigDefaults::snapWindowBorderColor(), ConfigDefaults::autotileBorderColor());
-        QCOMPARE(ConfigDefaults::snapWindowInactiveBorderColor(), ConfigDefaults::autotileInactiveBorderColor());
-        QCOMPARE(ConfigDefaults::snapWindowBorderWidth(), ConfigDefaults::autotileBorderWidth());
-        QCOMPARE(ConfigDefaults::snapWindowBorderRadius(), ConfigDefaults::autotileBorderRadius());
+        QCOMPARE(ConfigDefaults::snappingHideTitleBars(), ConfigDefaults::autotileHideTitleBars());
+        QCOMPARE(ConfigDefaults::snappingShowBorder(), ConfigDefaults::autotileShowBorder());
+        QCOMPARE(ConfigDefaults::snappingUseSystemBorderColors(), ConfigDefaults::autotileUseSystemBorderColors());
+        QCOMPARE(ConfigDefaults::snappingBorderColor(), ConfigDefaults::autotileBorderColor());
+        QCOMPARE(ConfigDefaults::snappingInactiveBorderColor(), ConfigDefaults::autotileInactiveBorderColor());
+        QCOMPARE(ConfigDefaults::snappingBorderWidth(), ConfigDefaults::autotileBorderWidth());
+        QCOMPARE(ConfigDefaults::snappingBorderRadius(), ConfigDefaults::autotileBorderRadius());
 
         // Pin the concrete shipped defaults (shared by both modes): title bars
         // and the border are OFF, width 2, radius 8. Colors are compared against
         // the zone color accessors so a palette change can't stale the test.
-        QCOMPARE(ConfigDefaults::snapWindowHideTitleBars(), false);
-        QCOMPARE(ConfigDefaults::snapWindowShowBorder(), false);
-        QCOMPARE(ConfigDefaults::snapWindowBorderColor(), ConfigDefaults::highlightColor());
-        QCOMPARE(ConfigDefaults::snapWindowInactiveBorderColor(), ConfigDefaults::inactiveColor());
-        QCOMPARE(ConfigDefaults::snapWindowBorderWidth(), ::PhosphorZones::ZoneDefaults::BorderWidth);
-        QCOMPARE(ConfigDefaults::snapWindowBorderRadius(), ::PhosphorZones::ZoneDefaults::BorderRadius);
+        QCOMPARE(ConfigDefaults::snappingHideTitleBars(), false);
+        QCOMPARE(ConfigDefaults::snappingShowBorder(), false);
+        QCOMPARE(ConfigDefaults::snappingBorderColor(), ConfigDefaults::highlightColor());
+        QCOMPARE(ConfigDefaults::snappingInactiveBorderColor(), ConfigDefaults::inactiveColor());
+        QCOMPARE(ConfigDefaults::snappingBorderWidth(), ::PhosphorZones::ZoneDefaults::BorderWidth);
+        QCOMPARE(ConfigDefaults::snappingBorderRadius(), ::PhosphorZones::ZoneDefaults::BorderRadius);
     }
 };
 

--- a/tests/unit/config/test_migration_v3_to_v4.cpp
+++ b/tests/unit/config/test_migration_v3_to_v4.cpp
@@ -2049,10 +2049,10 @@ private Q_SLOTS:
         // End-state collision check: the NEW snap-window appearance settings reuse the
         // freed Snapping.Appearance.Colors namespace. The v3 zone-overlay value
         // (UseSystem=false) was relocated to Snapping.Zones above, so a Settings loaded
-        // from the migrated config must read snapWindowUseSystemBorderColors() as the
+        // from the migrated config must read snappingUseSystemBorderColors() as the
         // SHIPPED DEFAULT — proving no stale v3 zone value bleeds into the new key.
         Settings settings;
-        QCOMPARE(settings.snapWindowUseSystemBorderColors(), ConfigDefaults::snapWindowUseSystemBorderColors());
+        QCOMPARE(settings.snappingUseSystemBorderColors(), ConfigDefaults::snappingUseSystemBorderColors());
     }
 
     void testZoneRename_absentSourceIsNoOp()

--- a/tests/unit/config/test_settings_core.cpp
+++ b/tests/unit/config/test_settings_core.cpp
@@ -127,7 +127,7 @@ private Q_SLOTS:
 
         Settings settings;
 
-        // Drive every snapWindow* setting away from its default.
+        // Drive every snapping* setting away from its default.
         settings.setSnappingHideTitleBars(!ConfigDefaults::snappingHideTitleBars());
         settings.setSnappingShowBorder(!ConfigDefaults::snappingShowBorder());
         settings.setSnappingUseSystemBorderColors(!ConfigDefaults::snappingUseSystemBorderColors());
@@ -328,7 +328,7 @@ private Q_SLOTS:
 
         {
             // Load-side getter round-trip: a freshly-constructed Settings must
-            // read every snapWindow* value back through its OWN getter. The
+            // read every snapping* value back through its OWN getter. The
             // on-disk assertions above only prove save() wrote the right keys;
             // a getter wired to the wrong group/key would still pass them.
             // Reading through the getters pins the read path too.

--- a/tests/unit/config/test_settings_core.cpp
+++ b/tests/unit/config/test_settings_core.cpp
@@ -121,36 +121,36 @@ private Q_SLOTS:
      * value. reset() reverts them via its group-delete + reload path (like every
      * other store-backed setting), so this pins dedicated reset coverage for them.
      */
-    void testReset_restoresSnapWindowAppearanceDefaults()
+    void testReset_restoresSnappingWindowAppearanceDefaults()
     {
         IsolatedConfigGuard guard;
 
         Settings settings;
 
         // Drive every snapWindow* setting away from its default.
-        settings.setSnapWindowHideTitleBars(!ConfigDefaults::snapWindowHideTitleBars());
-        settings.setSnapWindowShowBorder(!ConfigDefaults::snapWindowShowBorder());
-        settings.setSnapWindowUseSystemBorderColors(!ConfigDefaults::snapWindowUseSystemBorderColors());
-        settings.setSnapWindowBorderWidth(ConfigDefaults::snapWindowBorderWidth() + 1);
-        settings.setSnapWindowBorderRadius(ConfigDefaults::snapWindowBorderRadius() + 1);
-        settings.setSnapWindowBorderColor(QColor(10, 20, 30));
-        settings.setSnapWindowInactiveBorderColor(QColor(40, 50, 60));
+        settings.setSnappingHideTitleBars(!ConfigDefaults::snappingHideTitleBars());
+        settings.setSnappingShowBorder(!ConfigDefaults::snappingShowBorder());
+        settings.setSnappingUseSystemBorderColors(!ConfigDefaults::snappingUseSystemBorderColors());
+        settings.setSnappingBorderWidth(ConfigDefaults::snappingBorderWidth() + 1);
+        settings.setSnappingBorderRadius(ConfigDefaults::snappingBorderRadius() + 1);
+        settings.setSnappingBorderColor(QColor(10, 20, 30));
+        settings.setSnappingInactiveBorderColor(QColor(40, 50, 60));
 
         settings.reset();
 
-        QCOMPARE(settings.snapWindowHideTitleBars(), ConfigDefaults::snapWindowHideTitleBars());
-        QCOMPARE(settings.snapWindowShowBorder(), ConfigDefaults::snapWindowShowBorder());
-        QCOMPARE(settings.snapWindowUseSystemBorderColors(), ConfigDefaults::snapWindowUseSystemBorderColors());
-        QCOMPARE(settings.snapWindowBorderWidth(), ConfigDefaults::snapWindowBorderWidth());
-        QCOMPARE(settings.snapWindowBorderRadius(), ConfigDefaults::snapWindowBorderRadius());
-        // The default snapWindowUseSystemBorderColors is true, so reset()'s
+        QCOMPARE(settings.snappingHideTitleBars(), ConfigDefaults::snappingHideTitleBars());
+        QCOMPARE(settings.snappingShowBorder(), ConfigDefaults::snappingShowBorder());
+        QCOMPARE(settings.snappingUseSystemBorderColors(), ConfigDefaults::snappingUseSystemBorderColors());
+        QCOMPARE(settings.snappingBorderWidth(), ConfigDefaults::snappingBorderWidth());
+        QCOMPARE(settings.snappingBorderRadius(), ConfigDefaults::snappingBorderRadius());
+        // The default snappingUseSystemBorderColors is true, so reset()'s
         // reload drives the snap border colors to the (also-reset) zone
-        // highlight/inactive colors via applySnapWindowBorderSystemColor().
+        // highlight/inactive colors via applySnappingBorderSystemColor().
         // Assert against the live zone colors — the actual contract when
         // system colors are enabled — rather than the static ConfigDefaults
         // border colors, which only apply when system colors are off.
-        QCOMPARE(settings.snapWindowBorderColor(), settings.highlightColor());
-        QCOMPARE(settings.snapWindowInactiveBorderColor(), settings.inactiveColor());
+        QCOMPARE(settings.snappingBorderColor(), settings.highlightColor());
+        QCOMPARE(settings.snappingInactiveBorderColor(), settings.inactiveColor());
     }
 
     /**
@@ -218,13 +218,13 @@ private Q_SLOTS:
         // Snapped-window appearance (Snapping.Appearance.{Borders,Decorations,Colors}).
         // useSystemBorderColors=false so the explicit colors persist instead of
         // being overwritten by the accent-derived system colors on load.
-        settings.setSnapWindowShowBorder(false);
-        settings.setSnapWindowHideTitleBars(false);
-        settings.setSnapWindowBorderWidth(4);
-        settings.setSnapWindowBorderRadius(8);
-        settings.setSnapWindowUseSystemBorderColors(false);
-        settings.setSnapWindowBorderColor(QColor(10, 20, 30));
-        settings.setSnapWindowInactiveBorderColor(QColor(40, 50, 60));
+        settings.setSnappingShowBorder(false);
+        settings.setSnappingHideTitleBars(false);
+        settings.setSnappingBorderWidth(4);
+        settings.setSnappingBorderRadius(8);
+        settings.setSnappingUseSystemBorderColors(false);
+        settings.setSnappingBorderColor(QColor(10, 20, 30));
+        settings.setSnappingInactiveBorderColor(QColor(40, 50, 60));
 
         settings.save();
 
@@ -333,13 +333,13 @@ private Q_SLOTS:
             // a getter wired to the wrong group/key would still pass them.
             // Reading through the getters pins the read path too.
             Settings reloaded;
-            QCOMPARE(reloaded.snapWindowShowBorder(), false);
-            QCOMPARE(reloaded.snapWindowHideTitleBars(), false);
-            QCOMPARE(reloaded.snapWindowBorderWidth(), 4);
-            QCOMPARE(reloaded.snapWindowBorderRadius(), 8);
-            QCOMPARE(reloaded.snapWindowUseSystemBorderColors(), false);
-            QCOMPARE(reloaded.snapWindowBorderColor(), QColor(10, 20, 30));
-            QCOMPARE(reloaded.snapWindowInactiveBorderColor(), QColor(40, 50, 60));
+            QCOMPARE(reloaded.snappingShowBorder(), false);
+            QCOMPARE(reloaded.snappingHideTitleBars(), false);
+            QCOMPARE(reloaded.snappingBorderWidth(), 4);
+            QCOMPARE(reloaded.snappingBorderRadius(), 8);
+            QCOMPARE(reloaded.snappingUseSystemBorderColors(), false);
+            QCOMPARE(reloaded.snappingBorderColor(), QColor(10, 20, 30));
+            QCOMPARE(reloaded.snappingInactiveBorderColor(), QColor(40, 50, 60));
         }
     }
 
@@ -407,28 +407,28 @@ private Q_SLOTS:
     }
 
     /**
-     * The hand-written setSnapWindowUseSystemBorderColors setter (not
+     * The hand-written setSnappingUseSystemBorderColors setter (not
      * macro-generated) must emit both its specific
-     * snapWindowUseSystemBorderColorsChanged signal and settingsChanged() on a
+     * snappingUseSystemBorderColorsChanged signal and settingsChanged() on a
      * real change, and stay silent on a no-op (set to the same value twice).
      */
-    void testSetSnapWindowUseSystemBorderColors_emitsAndGuards()
+    void testSetSnappingUseSystemBorderColors_emitsAndGuards()
     {
         IsolatedConfigGuard guard;
 
         Settings settings;
 
-        const bool current = settings.snapWindowUseSystemBorderColors();
+        const bool current = settings.snappingUseSystemBorderColors();
         const bool toggled = !current;
-        settings.setSnapWindowUseSystemBorderColors(current); // force known value
+        settings.setSnappingUseSystemBorderColors(current); // force known value
 
         QSignalSpy generalSpy(&settings, &Settings::settingsChanged);
-        QSignalSpy specificSpy(&settings, &Settings::snapWindowUseSystemBorderColorsChanged);
+        QSignalSpy specificSpy(&settings, &Settings::snappingUseSystemBorderColorsChanged);
         QVERIFY(generalSpy.isValid());
         QVERIFY(specificSpy.isValid());
 
         // Real change emits both signals.
-        settings.setSnapWindowUseSystemBorderColors(toggled);
+        settings.setSnappingUseSystemBorderColors(toggled);
         QCOMPARE(specificSpy.count(), 1);
         QVERIFY(generalSpy.count() >= 1);
 
@@ -436,7 +436,7 @@ private Q_SLOTS:
         const int generalBefore = generalSpy.count();
 
         // No-op (same value again) emits nothing.
-        settings.setSnapWindowUseSystemBorderColors(toggled);
+        settings.setSnappingUseSystemBorderColors(toggled);
         QCOMPARE(specificSpy.count(), specificBefore);
         QCOMPARE(generalSpy.count(), generalBefore);
     }

--- a/tests/unit/config/test_settings_validation.cpp
+++ b/tests/unit/config/test_settings_validation.cpp
@@ -76,68 +76,68 @@ private Q_SLOTS:
      * shape as the autotile border keys but can regress independently, so they
      * get their own coverage.
      */
-    void testReadValidatedInt_snapWindowBorderWidth_outOfRange_returnsMax()
+    void testReadValidatedInt_snappingBorderWidth_outOfRange_returnsMax()
     {
         IsolatedConfigGuard guard;
 
         {
             auto backend = PlasmaZones::createDefaultConfigBackend();
             auto borders = backend->group(ConfigDefaults::snappingAppearanceBordersGroup());
-            borders->writeInt(ConfigDefaults::widthKey(), 999); // clamp max is snapWindowBorderWidthMax()
+            borders->writeInt(ConfigDefaults::widthKey(), 999); // clamp max is snappingBorderWidthMax()
             borders.reset();
             backend->sync();
         }
 
         Settings settings;
-        QCOMPARE(settings.snapWindowBorderWidth(), ConfigDefaults::snapWindowBorderWidthMax());
+        QCOMPARE(settings.snappingBorderWidth(), ConfigDefaults::snappingBorderWidthMax());
     }
 
-    void testReadValidatedInt_snapWindowBorderRadius_outOfRange_returnsMax()
+    void testReadValidatedInt_snappingBorderRadius_outOfRange_returnsMax()
     {
         IsolatedConfigGuard guard;
 
         {
             auto backend = PlasmaZones::createDefaultConfigBackend();
             auto borders = backend->group(ConfigDefaults::snappingAppearanceBordersGroup());
-            borders->writeInt(ConfigDefaults::radiusKey(), 999); // clamp max is snapWindowBorderRadiusMax()
+            borders->writeInt(ConfigDefaults::radiusKey(), 999); // clamp max is snappingBorderRadiusMax()
             borders.reset();
             backend->sync();
         }
 
         Settings settings;
-        QCOMPARE(settings.snapWindowBorderRadius(), ConfigDefaults::snapWindowBorderRadiusMax());
+        QCOMPARE(settings.snappingBorderRadius(), ConfigDefaults::snappingBorderRadiusMax());
     }
 
-    void testReadValidatedInt_snapWindowBorderWidth_negative_returnsMin()
+    void testReadValidatedInt_snappingBorderWidth_negative_returnsMin()
     {
         IsolatedConfigGuard guard;
 
         {
             auto backend = PlasmaZones::createDefaultConfigBackend();
             auto borders = backend->group(ConfigDefaults::snappingAppearanceBordersGroup());
-            borders->writeInt(ConfigDefaults::widthKey(), -5); // clamp min is snapWindowBorderWidthMin()
+            borders->writeInt(ConfigDefaults::widthKey(), -5); // clamp min is snappingBorderWidthMin()
             borders.reset();
             backend->sync();
         }
 
         Settings settings;
-        QCOMPARE(settings.snapWindowBorderWidth(), ConfigDefaults::snapWindowBorderWidthMin());
+        QCOMPARE(settings.snappingBorderWidth(), ConfigDefaults::snappingBorderWidthMin());
     }
 
-    void testReadValidatedInt_snapWindowBorderRadius_negative_returnsMin()
+    void testReadValidatedInt_snappingBorderRadius_negative_returnsMin()
     {
         IsolatedConfigGuard guard;
 
         {
             auto backend = PlasmaZones::createDefaultConfigBackend();
             auto borders = backend->group(ConfigDefaults::snappingAppearanceBordersGroup());
-            borders->writeInt(ConfigDefaults::radiusKey(), -5); // clamp min is snapWindowBorderRadiusMin()
+            borders->writeInt(ConfigDefaults::radiusKey(), -5); // clamp min is snappingBorderRadiusMin()
             borders.reset();
             backend->sync();
         }
 
         Settings settings;
-        QCOMPARE(settings.snapWindowBorderRadius(), ConfigDefaults::snapWindowBorderRadiusMin());
+        QCOMPARE(settings.snappingBorderRadius(), ConfigDefaults::snappingBorderRadiusMin());
     }
 
     /**
@@ -147,7 +147,7 @@ private Q_SLOTS:
      * Settings::load() doesn't overwrite the validated value with the
      * accent-derived system color.
      */
-    void testReadValidatedColor_snapWindowBorderColor_invalidColor_returnsDefault()
+    void testReadValidatedColor_snappingBorderColor_invalidColor_returnsDefault()
     {
         IsolatedConfigGuard guard;
 
@@ -161,7 +161,7 @@ private Q_SLOTS:
         }
 
         Settings settings;
-        QCOMPARE(settings.snapWindowBorderColor(), ConfigDefaults::snapWindowBorderColor());
+        QCOMPARE(settings.snappingBorderColor(), ConfigDefaults::snappingBorderColor());
     }
 
     /**
@@ -172,7 +172,7 @@ private Q_SLOTS:
      * its own coverage. useSystemBorderColors is disabled so Settings::load()
      * doesn't overwrite the validated value with the accent-derived color.
      */
-    void testReadValidatedColor_snapWindowInactiveBorderColor_invalidColor_returnsDefault()
+    void testReadValidatedColor_snappingInactiveBorderColor_invalidColor_returnsDefault()
     {
         IsolatedConfigGuard guard;
 
@@ -186,18 +186,18 @@ private Q_SLOTS:
         }
 
         Settings settings;
-        QCOMPARE(settings.snapWindowInactiveBorderColor(), ConfigDefaults::snapWindowInactiveBorderColor());
+        QCOMPARE(settings.snappingInactiveBorderColor(), ConfigDefaults::snappingInactiveBorderColor());
     }
 
     /**
      * The inverse of the validator tests above: with useSystemBorderColors ENABLED,
-     * Settings::load() routes through applySnapWindowBorderSystemColor(), overriding the
+     * Settings::load() routes through applySnappingBorderSystemColor(), overriding the
      * stored Active color with the accent-derived highlight color. A hand-seeded
      * explicit Active color must NOT survive the load — proving the system-color
      * override fires for the snap-window border (the load path the disabled tests
      * deliberately avoid).
      */
-    void testReadValidatedColor_snapWindowBorderColor_systemColorsEnabled_overridesStored()
+    void testReadValidatedColor_snappingBorderColor_systemColorsEnabled_overridesStored()
     {
         IsolatedConfigGuard guard;
 
@@ -211,8 +211,8 @@ private Q_SLOTS:
         }
 
         Settings settings;
-        QCOMPARE(settings.snapWindowBorderColor(), settings.highlightColor());
-        QVERIFY(settings.snapWindowBorderColor() != QColor(QStringLiteral("#010203")));
+        QCOMPARE(settings.snappingBorderColor(), settings.highlightColor());
+        QVERIFY(settings.snappingBorderColor() != QColor(QStringLiteral("#010203")));
     }
 
     // =========================================================================

--- a/tests/unit/dbus/test_settings_adaptor_batch.cpp
+++ b/tests/unit/dbus/test_settings_adaptor_batch.cpp
@@ -250,10 +250,10 @@ private Q_SLOTS:
     void testGetSettings_snapWindowKeys_allReturnedWithTypes()
     {
         const QStringList keys{
-            QStringLiteral("snapWindowHideTitleBars"),         QStringLiteral("snapWindowShowBorder"),
-            QStringLiteral("snapWindowBorderWidth"),           QStringLiteral("snapWindowBorderRadius"),
-            QStringLiteral("snapWindowBorderColor"),           QStringLiteral("snapWindowInactiveBorderColor"),
-            QStringLiteral("snapWindowUseSystemBorderColors"),
+            QStringLiteral("snappingHideTitleBars"),         QStringLiteral("snappingShowBorder"),
+            QStringLiteral("snappingBorderWidth"),           QStringLiteral("snappingBorderRadius"),
+            QStringLiteral("snappingBorderColor"),           QStringLiteral("snappingInactiveBorderColor"),
+            QStringLiteral("snappingUseSystemBorderColors"),
         };
 
         const QVariantMap result = m_adaptor->getSettings(keys);
@@ -265,13 +265,13 @@ private Q_SLOTS:
         }
         // Bool / int / color wire types — color keys serialize to a string via
         // the REGISTER_COLOR_SETTING getter (QColor::name(HexArgb)).
-        QCOMPARE(result.value(QStringLiteral("snapWindowHideTitleBars")).metaType().id(), QMetaType::Bool);
-        QCOMPARE(result.value(QStringLiteral("snapWindowShowBorder")).metaType().id(), QMetaType::Bool);
-        QCOMPARE(result.value(QStringLiteral("snapWindowUseSystemBorderColors")).metaType().id(), QMetaType::Bool);
-        QCOMPARE(result.value(QStringLiteral("snapWindowBorderWidth")).metaType().id(), QMetaType::Int);
-        QCOMPARE(result.value(QStringLiteral("snapWindowBorderRadius")).metaType().id(), QMetaType::Int);
-        QCOMPARE(result.value(QStringLiteral("snapWindowBorderColor")).metaType().id(), QMetaType::QString);
-        QCOMPARE(result.value(QStringLiteral("snapWindowInactiveBorderColor")).metaType().id(), QMetaType::QString);
+        QCOMPARE(result.value(QStringLiteral("snappingHideTitleBars")).metaType().id(), QMetaType::Bool);
+        QCOMPARE(result.value(QStringLiteral("snappingShowBorder")).metaType().id(), QMetaType::Bool);
+        QCOMPARE(result.value(QStringLiteral("snappingUseSystemBorderColors")).metaType().id(), QMetaType::Bool);
+        QCOMPARE(result.value(QStringLiteral("snappingBorderWidth")).metaType().id(), QMetaType::Int);
+        QCOMPARE(result.value(QStringLiteral("snappingBorderRadius")).metaType().id(), QMetaType::Int);
+        QCOMPARE(result.value(QStringLiteral("snappingBorderColor")).metaType().id(), QMetaType::QString);
+        QCOMPARE(result.value(QStringLiteral("snappingInactiveBorderColor")).metaType().id(), QMetaType::QString);
 
         // Values mirror the stub's snapWindow* getters, proving each key is
         // wired to its own accessor rather than collapsed onto a neighbour. The
@@ -282,17 +282,16 @@ private Q_SLOTS:
         // bool mirrors catch any swap involving showBorder; a hideTitleBars↔
         // useSystem swap is instead pinned by the verified-correct production
         // registration and the per-key metaType assertions above.
-        QCOMPARE(result.value(QStringLiteral("snapWindowBorderWidth")).toInt(), m_settings->snapWindowBorderWidth());
-        QCOMPARE(result.value(QStringLiteral("snapWindowBorderRadius")).toInt(), m_settings->snapWindowBorderRadius());
-        QCOMPARE(QColor(result.value(QStringLiteral("snapWindowBorderColor")).toString()),
-                 m_settings->snapWindowBorderColor());
-        QCOMPARE(QColor(result.value(QStringLiteral("snapWindowInactiveBorderColor")).toString()),
-                 m_settings->snapWindowInactiveBorderColor());
-        QCOMPARE(result.value(QStringLiteral("snapWindowHideTitleBars")).toBool(),
-                 m_settings->snapWindowHideTitleBars());
-        QCOMPARE(result.value(QStringLiteral("snapWindowShowBorder")).toBool(), m_settings->snapWindowShowBorder());
-        QCOMPARE(result.value(QStringLiteral("snapWindowUseSystemBorderColors")).toBool(),
-                 m_settings->snapWindowUseSystemBorderColors());
+        QCOMPARE(result.value(QStringLiteral("snappingBorderWidth")).toInt(), m_settings->snappingBorderWidth());
+        QCOMPARE(result.value(QStringLiteral("snappingBorderRadius")).toInt(), m_settings->snappingBorderRadius());
+        QCOMPARE(QColor(result.value(QStringLiteral("snappingBorderColor")).toString()),
+                 m_settings->snappingBorderColor());
+        QCOMPARE(QColor(result.value(QStringLiteral("snappingInactiveBorderColor")).toString()),
+                 m_settings->snappingInactiveBorderColor());
+        QCOMPARE(result.value(QStringLiteral("snappingHideTitleBars")).toBool(), m_settings->snappingHideTitleBars());
+        QCOMPARE(result.value(QStringLiteral("snappingShowBorder")).toBool(), m_settings->snappingShowBorder());
+        QCOMPARE(result.value(QStringLiteral("snappingUseSystemBorderColors")).toBool(),
+                 m_settings->snappingUseSystemBorderColors());
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/tests/unit/dbus/test_settings_adaptor_batch.cpp
+++ b/tests/unit/dbus/test_settings_adaptor_batch.cpp
@@ -247,7 +247,7 @@ private Q_SLOTS:
     // test above: every requested key must come back, valid, with the right
     // wire type (color keys serialize to a HexArgb string).
     // ─────────────────────────────────────────────────────────────────────
-    void testGetSettings_snapWindowKeys_allReturnedWithTypes()
+    void testGetSettings_snappingKeys_allReturnedWithTypes()
     {
         const QStringList keys{
             QStringLiteral("snappingHideTitleBars"),         QStringLiteral("snappingShowBorder"),
@@ -446,7 +446,7 @@ private:
     std::unique_ptr<IsolatedConfigGuard> m_guard;
     CountingStubSettings* m_settings = nullptr;
     // CountingStubSettings publicly inherits StubSettings, whose snapping*
-    // getters back the value assertions in testGetSettings_snapWindowKeys_*.
+    // getters back the value assertions in testGetSettings_snappingKeys_*.
     QObject* m_parent = nullptr;
     SettingsAdaptor* m_adaptor = nullptr;
 };

--- a/tests/unit/dbus/test_settings_adaptor_batch.cpp
+++ b/tests/unit/dbus/test_settings_adaptor_batch.cpp
@@ -273,7 +273,7 @@ private Q_SLOTS:
         QCOMPARE(result.value(QStringLiteral("snappingBorderColor")).metaType().id(), QMetaType::QString);
         QCOMPARE(result.value(QStringLiteral("snappingInactiveBorderColor")).metaType().id(), QMetaType::QString);
 
-        // Values mirror the stub's snapWindow* getters, proving each key is
+        // Values mirror the stub's snapping* getters, proving each key is
         // wired to its own accessor rather than collapsed onto a neighbour. The
         // int (width 2 / radius 0) and color (white / black) keys hold mutually
         // distinct values, so any swap among them flips a mirror. Among the three
@@ -445,7 +445,7 @@ private Q_SLOTS:
 private:
     std::unique_ptr<IsolatedConfigGuard> m_guard;
     CountingStubSettings* m_settings = nullptr;
-    // CountingStubSettings publicly inherits StubSettings, whose snapWindow*
+    // CountingStubSettings publicly inherits StubSettings, whose snapping*
     // getters back the value assertions in testGetSettings_snapWindowKeys_*.
     QObject* m_parent = nullptr;
     SettingsAdaptor* m_adaptor = nullptr;

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -823,58 +823,58 @@ public:
     void setAutotileUseSystemBorderColors(bool) override
     {
     }
-    bool snapWindowHideTitleBars() const override
+    bool snappingHideTitleBars() const override
     {
-        // Distinct from snapWindowShowBorder so the D-Bus batch test can detect a
+        // Distinct from snappingShowBorder so the D-Bus batch test can detect a
         // registration swap between the two adjacent bool keys via value-mirroring.
         return true;
     }
-    void setSnapWindowHideTitleBars(bool) override
+    void setSnappingHideTitleBars(bool) override
     {
     }
-    bool snapWindowShowBorder() const override
+    bool snappingShowBorder() const override
     {
         return false;
     }
-    void setSnapWindowShowBorder(bool) override
+    void setSnappingShowBorder(bool) override
     {
     }
-    int snapWindowBorderWidth() const override
+    int snappingBorderWidth() const override
     {
         return 2;
     }
-    void setSnapWindowBorderWidth(int) override
+    void setSnappingBorderWidth(int) override
     {
     }
-    int snapWindowBorderRadius() const override
+    int snappingBorderRadius() const override
     {
         return 0;
     }
-    void setSnapWindowBorderRadius(int) override
+    void setSnappingBorderRadius(int) override
     {
     }
-    QColor snapWindowBorderColor() const override
+    QColor snappingBorderColor() const override
     {
         return Qt::white;
     }
-    void setSnapWindowBorderColor(const QColor&) override
+    void setSnappingBorderColor(const QColor&) override
     {
     }
-    QColor snapWindowInactiveBorderColor() const override
+    QColor snappingInactiveBorderColor() const override
     {
         // A distinct, valid color (active is white) so the D-Bus batch test can
         // round-trip it through HexArgb and catch an active/inactive swap.
         return Qt::black;
     }
-    void setSnapWindowInactiveBorderColor(const QColor&) override
+    void setSnappingInactiveBorderColor(const QColor&) override
     {
     }
-    bool snapWindowUseSystemBorderColors() const override
+    bool snappingUseSystemBorderColors() const override
     {
-        // Distinct from snapWindowShowBorder for the same batch-test swap detection.
+        // Distinct from snappingShowBorder for the same batch-test swap detection.
         return true;
     }
-    void setSnapWindowUseSystemBorderColors(bool) override
+    void setSnappingUseSystemBorderColors(bool) override
     {
     }
     StickyWindowHandling autotileStickyWindowHandling() const override

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -21,7 +21,7 @@ namespace PlasmaZones {
  * Also inherits PhosphorEngine::ISnapSettings so SnapEngine's
  * dynamic_cast<ISnapSettings*>(engineSettings()) succeeds when a stub is wired
  * via setEngineSettings(). The remaining ISnapSettings methods
- * (stickyWindowHandling, moveNewWindowsToLastZone,
+ * (snappingStickyWindowHandling, moveNewWindowsToLastZone,
  * restoreWindowsToZonesOnLogin, autoAssignAllLayouts) are already
  * implemented for ISettings — the multiple inheritance just registers
  * the second base so the cast resolves.
@@ -608,11 +608,11 @@ public:
     void setRestoreOriginalSizeOnUnsnap(bool) override
     {
     }
-    StickyWindowHandling stickyWindowHandling() const override
+    StickyWindowHandling snappingStickyWindowHandling() const override
     {
         return StickyWindowHandling::TreatAsNormal;
     }
-    void setStickyWindowHandling(StickyWindowHandling) override
+    void setSnappingStickyWindowHandling(StickyWindowHandling) override
     {
     }
     bool restoreWindowsToZonesOnLogin() const override


### PR DESCRIPTION
## Summary

Snapping and tiling exposed similar settings under inconsistent names, in differently-named sections, and with a divergent C++ property prefix. This makes the two modes follow the same patterns across the settings app and the backing config code.

The Colors / Decorations / Borders sections were already consistent; the work concentrated on the gaps, focus, sticky, border-prefix, and quick-shortcuts divergences.

## Changes (per milestone)

- **M1 — UI structure (labels/sections only).** Tiling's Behavior page gains a dedicated **Focus** card (Focus new windows + Focus follows mouse), pulled out of the catch-all card; that card is renamed **"Behavior" → "Window Handling"** so Sticky windows sits in a same-named section in both modes (and avoids a card named the same as its page). Snapping gap labels **"Zone padding"/"Edge gap" → "Inner gap"/"Outer gap"** to match tiling (shared `GapsSettingsCard` already defaults to these). Tiling's "Focus new windows" description aligned to a parallel phrasing.
- **M3 — sticky property rename.** `stickyWindowHandling` → `snappingStickyWindowHandling` (mirrors tiling's `autotileStickyWindowHandling`). Crosses the snap-specific LGPL `ISnapSettings` virtual + its `SnapEngine` consumer.
- **M4 — border family rename.** `snapWindow*` → `snapping*` for the 7 snapping window-appearance settings (border color/width/radius, show-border, hide-title-bars, system colors), mirroring `autotile*`.
- **M5 — quick-shortcuts naming.** Snapping's "Quick Layout Shortcuts" / "Quick Layout N" → **"Snapping Quick Shortcuts" / "Quick Snapping N"**, parallel to tiling's existing "Tiling Quick Shortcuts" / "Quick Tiling N".

After this, all snapping window settings share one `snapping*` prefix (`snappingFocus*`, `snappingStickyWindowHandling`, `snapping{Border*,ShowBorder,HideTitleBars,UseSystemBorderColors}`), mirroring tiling's `autotile*`.

## Deliberately NOT changed

- **Gap getters.** `IGeometrySettings::zonePadding()` / `outerGap()` are generic zone-geometry methods on an LGPL interface (also used by the resolver, `Layout`, window rules), and the global gap config keys were already consistent across modes — so only the labels were unified (M1), no getter rename.
- **No config-key changes / no user-config reset.** All renames are C++ property/symbol renames; stored keys are group-scoped short keys independent of the property name. Existing user settings are preserved.
- The unrelated `snapWindowToZone` navigation method, the shared `stickyWindowHandlingKey` accessor, the `StickyWindowHandling` enum, and tiling's `autotileStickyWindowHandling` are intentionally untouched.

## Testing & review

- Build green and 274/274 tests pass at every milestone.
- D-Bus property names verified consistent end-to-end (effect `loadSettingAsync` reads ↔ daemon adaptor registrations).
- Ran a partitioned multi-pass code audit (4 partitions × 3 passes): 7 LOW findings, all stale `snapWindow*` comment/doc/test-name remnants of the rename, all fixed. Final verdict CLEAN.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)