### PR TITLE
perf(settings): fix slow first-visit page loads

### DIFF
--- a/libs/phosphor-settings-ui/qml/PageHost.qml
+++ b/libs/phosphor-settings-ui/qml/PageHost.qml
@@ -9,15 +9,22 @@ import org.phosphor.settings.ui
 import "LoaderHelpers.js" as PhosphorLoaderHelpers
 
 /**
- * Loads the QML page for ApplicationController.currentPageId.
+ * Hosts the QML page for ApplicationController.currentPageId, KDE
+ * System-Settings style: each visited page is built once and KEPT ALIVE
+ * (hidden), so navigating back to it is an instant visibility flip rather
+ * than a rebuild. This mirrors how `systemsettings` caches loaded KCMs.
  *
- * Sets two context properties on the loaded item if they exist:
- *   - controller: the registered PageController for the current id
+ * Two cost-reduction mechanisms work together:
+ *   - Compile warm-up: shortly after startup every page's component is
+ *     compiled (not instantiated) on the background type-loader thread and
+ *     held, so the first navigation to a page pays instance construction
+ *     only, not first-time QML compilation + type resolution.
+ *   - Instance cache: a page, once built, stays in the cache and is shown
+ *     / hidden on navigation instead of destroyed and rebuilt.
+ *
+ * Each loaded item gets two injections if it declares them:
+ *   - controller: the registered PageController for that page id
  *   - settingsApp: the ApplicationController, for cross-page access
- *
- * Each loaded page is faded in via a 180 ms widget.fadeIn motion
- * profile so navigating between pages reads as a soft transition
- * rather than an instantaneous swap.
  */
 Item {
     id: root
@@ -27,16 +34,14 @@ Item {
      *  (cards, rows, breadcrumb-aligned headers) has breathing room
      *  instead of running flush to the chrome separators / window
      *  edge. Defaults to largeSpacing to match the UnsavedChangesFooter
-     *  content inset and the breadcrumb row, so the breadcrumb, page
-     *  body, and footer all share one left/right gutter. Consumers can
-     *  override (e.g. a full-bleed page host) by reassigning. */
+     *  content inset and the breadcrumb row. */
     property real contentMargins: Kirigami.Units.largeSpacing
+
     // `pageData()` returns an empty QVariantMap when the id is unknown
-    // (e.g. mid-startup before registration completes, or a stale id
-    // restored from disk). An empty map marshals to a non-null JS
-    // object — so we must check for a valid `id` field to fall
-    // through to the placeholder rather than rendering an empty
-    // viewport with no page and no fallback message.
+    // (mid-startup before registration, or a stale id restored from disk).
+    // An empty map marshals to a non-null JS object, so check for a valid
+    // `id` field to fall through to the placeholder rather than rendering
+    // an empty viewport.
     readonly property var currentEntry: {
         if (root.controller.currentPageId === "")
             return null;
@@ -45,84 +50,120 @@ Item {
         return (data && data.id) ? data : null;
     }
 
-    Loader {
-        id: pageLoader
-
-        anchors.fill: parent
-        anchors.margins: root.contentMargins
-        active: root.currentEntry !== null
-        // Async loading lets the chrome stay responsive during page
-        // instantiation — important for heavy pages (motion-set list,
-        // shader catalog) whose synchronous instantiation would
-        // hitch the UI thread mid-navigation. The Loader.status gate
-        // on opacity (below) keeps the previous page hidden while
-        // the new one is still constructing instead of flashing an
-        // empty viewport.
-        asynchronous: true
-        source: root.currentEntry ? root.currentEntry.qmlSource : ""
-        // Fade is on the LOADER's opacity, not the loaded item's. The
-        // prior shape did `item.opacity = 0` from onLoaded — an
-        // imperative assignment that broke any declarative `opacity`
-        // binding the page declared on its root (e.g. an
-        // enabled-state opacity dim). Animating the Loader keeps the
-        // loaded item's own binding intact while still producing the
-        // page-swap fade.
-        //
-        // Opacity is pinned to 0 at construction. Source changes snap
-        // it back to 0 imperatively (onSourceChanged below) so the
-        // outgoing page disappears synchronously rather than waiting
-        // for the new page to fade in over the top of it. The
-        // pageFadeIn animation below restores opacity to 1 once
-        // onLoaded fires. Combined with `asynchronous: true`, that
-        // gives a symmetric fade: outgoing page goes invisible the
-        // instant the source changes, viewport stays empty while the
-        // new page constructs in the background, then the new page
-        // fades up.
-        opacity: 0
-        onSourceChanged: {
-            // Imperative reset, overriding the live `pageFadeIn`
-            // animation if one is in-flight. Without this, swapping
-            // from a fully visible page to a new source would leave
-            // opacity at 1 until onLoaded fires — long enough on an
-            // async page to read as a frozen-old-page flash.
-            opacity = 0;
+    // ── First-navigation compile warm-up ─────────────────────────────
+    // Page hosting is a lazy, URL-loaded Loader, so the first navigation
+    // to each page would otherwise pay a one-time QML compilation +
+    // type-resolution cost (hundreds of ms for content-heavy pages) that
+    // the previous inline-component chrome paid once at startup. Compile
+    // every registered page in the background just after startup — via
+    // Qt.createComponent WITHOUT instantiating, so no page `onCompleted`
+    // side effects run — and hold the Components so the engine keeps the
+    // compiled units cached. Asynchronous: compilation runs on the
+    // type-loader thread, never blocking the UI thread.
+    property var _warmComponents: []
+    function _warmAllPages() {
+        const all = root.controller.registry.allPagesData();
+        for (let i = 0; i < all.length; ++i) {
+            if (all[i].hasQmlSource === true && all[i].qmlSource)
+                root._warmComponents.push(Qt.createComponent(all[i].qmlSource, Component.Asynchronous));
         }
-        onLoaded: {
-            if (!item)
-                return;
+    }
 
-            const pageController = root.controller.registry.controller(root.controller.currentPageId);
-            // Pages that already have their own readonly `controller`
-            // binding (e.g. `readonly property var controller:
-            // settingsController.windowRulesPage`) reject the
-            // assignment under Qt 6.11. That's fine — the page
-            // already has a controller; PageHost's injection is
-            // redundant. Try/catch swallows the TypeError so the
-            // page still loads instead of failing to mount entirely.
-            // Both injections go through the shared helper so the
-            // hasOwnProperty + try-catch dance lives in one place.
-            // Pages that bind their own readonly `controller` /
-            // `settingsApp` Q_PROPERTY survive the assignment via the
-            // helper's catch block.
-            PhosphorLoaderHelpers.injectIfAssignable(item, "controller", pageController);
-            PhosphorLoaderHelpers.injectIfAssignable(item, "settingsApp", root.controller);
+    // ── Instance cache ───────────────────────────────────────────────
+    // Ordered list of page ids that have a live (built, cached) Loader.
+    // Appended to the first time each page becomes current; the Repeater
+    // below maps it to one persistent Loader per id. Never reordered, so a
+    // page's Loader index is stable for the host's lifetime.
+    property var cachedPageIds: []
 
-            // Fade in the freshly-loaded page. The Loader's own
-            // opacity (pinned at 0 above) is what we animate — the
-            // loaded item's opacity is untouched so its declarative
-            // bindings survive.
-            pageFadeIn.restart();
+    // Append `id` to the cache list if it names a real registered page and
+    // is not already cached. slice()+push()+reassign so the change is a new
+    // array reference — a plain in-place push would not notify the Repeater
+    // model binding.
+    function cachePage(id) {
+        if (!id)
+            return;
+        const data = root.controller.registry.pageData(id);
+        if (!data || !data.id)
+            return;
+        if (root.cachedPageIds.indexOf(id) !== -1)
+            return;
+        const next = root.cachedPageIds.slice();
+        next.push(id);
+        root.cachedPageIds = next;
+    }
+
+    Component.onCompleted: {
+        root.cachePage(root.controller.currentPageId);
+        // Defer the warm-up so the first real page + chrome paint before
+        // we start compiling the rest in the background.
+        Qt.callLater(root._warmAllPages);
+    }
+
+    // Cache the page the instant it becomes current (covers normal
+    // navigation, restored-on-startup ids, programmatic switches).
+    Connections {
+        function onCurrentPageIdChanged() {
+            root.cachePage(root.controller.currentPageId);
         }
 
-        PhosphorMotionAnimation {
-            id: pageFadeIn
+        target: root.controller
+    }
 
-            target: pageLoader
-            properties: "opacity"
-            from: 0
-            to: 1
-            profile: "widget.fadeIn"
-            durationOverride: 180
+    Repeater {
+        id: pageRepeater
+
+        model: root.cachedPageIds
+
+        delegate: Loader {
+            id: pageLoader
+
+            required property string modelData
+            readonly property string pageId: pageLoader.modelData
+            readonly property bool isCurrent: root.controller.currentPageId === pageLoader.pageId
+
+            anchors.fill: parent
+            anchors.margins: root.contentMargins
+            // Built once when this page first becomes current; the compiled
+            // unit is already warm, so construction is the only cost. Async
+            // so even a heavy first build never hitches the UI thread.
+            asynchronous: true
+            active: true
+            source: {
+                const data = root.controller.registry.pageData(pageLoader.pageId);
+                return (data && data.id) ? data.qmlSource : "";
+            }
+            // Only the current page is shown + interactive. Hidden cached
+            // pages stay built but are not painted and take no input.
+            visible: pageLoader.isCurrent
+            enabled: pageLoader.isCurrent
+            z: pageLoader.isCurrent ? 1 : 0
+
+            // Fade the current page up. Bound to isCurrent so a cached
+            // re-show fades exactly like a first build; the Behavior is the
+            // only per-page animation object, so the cache stays cheap.
+            opacity: pageLoader.isCurrent ? 1 : 0
+            Behavior on opacity {
+                enabled: pageLoader.isCurrent
+                PhosphorMotionAnimation {
+                    profile: "widget.fadeIn"
+                    durationOverride: 180
+                }
+            }
+
+            onLoaded: {
+                if (!pageLoader.item)
+                    return;
+
+                const pageController = root.controller.registry.controller(pageLoader.pageId);
+                // Pages that bind their own readonly `controller` /
+                // `settingsApp` Q_PROPERTY reject the assignment under
+                // Qt 6.11; the helper's try/catch swallows that so the page
+                // still mounts. PageHost's injection is authoritative for
+                // the rest.
+                PhosphorLoaderHelpers.injectIfAssignable(pageLoader.item, "controller", pageController);
+                PhosphorLoaderHelpers.injectIfAssignable(pageLoader.item, "settingsApp", root.controller);
+            }
         }
     }
 
@@ -134,28 +175,25 @@ Item {
         icon.name: "settings-configure"
     }
 
-    // If a page gets re-registered (dynamic registration after
-    // startup) with a different controller, the already-loaded
-    // page keeps the stale pointer. Listen for pageRegistered and
-    // re-inject the controller when it matches the active page.
+    // If a page is re-registered (dynamic registration after startup) with
+    // a different controller, its already-built cached Loader keeps the
+    // stale pointer. Re-inject into whichever cached Loader matches.
     Connections {
         function onPageRegistered(id) {
-            if (id !== root.controller.currentPageId)
-                return;
-            if (!pageLoader.item)
-                return;
             const pageController = root.controller.registry.controller(id);
             // A registration that explicitly passes a null controller
-            // ("detach the controller" path) leaves the previously
-            // injected pointer in place rather than clobbering it
-            // with null — re-using a stale controller is preferable
-            // to a runtime "TypeError: cannot read property of null"
-            // in the page body. Consumers wanting the detach
-            // behaviour should re-register with a placeholder
-            // controller instead.
+            // ("detach" path) leaves the previously injected pointer in
+            // place rather than clobbering it with null — a stale
+            // controller beats a runtime null-deref in the page body.
             if (!pageController)
                 return;
-            PhosphorLoaderHelpers.injectIfAssignable(pageLoader.item, "controller", pageController);
+            for (let i = 0; i < pageRepeater.count; ++i) {
+                const ld = pageRepeater.itemAt(i);
+                if (ld && ld.pageId === id && ld.item) {
+                    PhosphorLoaderHelpers.injectIfAssignable(ld.item, "controller", pageController);
+                    return;
+                }
+            }
         }
 
         target: root.controller.registry

--- a/libs/phosphor-settings-ui/qml/PageHost.qml
+++ b/libs/phosphor-settings-ui/qml/PageHost.qml
@@ -14,13 +14,12 @@ import "LoaderHelpers.js" as PhosphorLoaderHelpers
  * (hidden), so navigating back to it is an instant visibility flip rather
  * than a rebuild. This mirrors how `systemsettings` caches loaded KCMs.
  *
- * Two cost-reduction mechanisms work together:
- *   - Compile warm-up: shortly after startup every page's component is
- *     compiled (not instantiated) on the background type-loader thread and
- *     held, so the first navigation to a page pays instance construction
- *     only, not first-time QML compilation + type resolution.
- *   - Instance cache: a page, once built, stays in the cache and is shown
- *     / hidden on navigation instead of destroyed and rebuilt.
+ * First-visit construction cost is reduced elsewhere — the settings app's
+ * composition root (main.cpp) background-compiles every settings QML unit
+ * (pages AND their child component types) after startup, so the first
+ * navigation here pays instance construction only, not first-time
+ * compilation of the page and its children. This Item only handles the
+ * instance cache.
  *
  * Each loaded item gets two injections if it declares them:
  *   - controller: the registered PageController for that page id
@@ -50,25 +49,6 @@ Item {
         return (data && data.id) ? data : null;
     }
 
-    // ── First-navigation compile warm-up ─────────────────────────────
-    // Page hosting is a lazy, URL-loaded Loader, so the first navigation
-    // to each page would otherwise pay a one-time QML compilation +
-    // type-resolution cost (hundreds of ms for content-heavy pages) that
-    // the previous inline-component chrome paid once at startup. Compile
-    // every registered page in the background just after startup — via
-    // Qt.createComponent WITHOUT instantiating, so no page `onCompleted`
-    // side effects run — and hold the Components so the engine keeps the
-    // compiled units cached. Asynchronous: compilation runs on the
-    // type-loader thread, never blocking the UI thread.
-    property var _warmComponents: []
-    function _warmAllPages() {
-        const all = root.controller.registry.allPagesData();
-        for (let i = 0; i < all.length; ++i) {
-            if (all[i].hasQmlSource === true && all[i].qmlSource)
-                root._warmComponents.push(Qt.createComponent(all[i].qmlSource, Component.Asynchronous));
-        }
-    }
-
     // ── Instance cache ───────────────────────────────────────────────
     // Ordered list of page ids that have a live (built, cached) Loader.
     // Appended to the first time each page becomes current; the Repeater
@@ -93,12 +73,7 @@ Item {
         root.cachedPageIds = next;
     }
 
-    Component.onCompleted: {
-        root.cachePage(root.controller.currentPageId);
-        // Defer the warm-up so the first real page + chrome paint before
-        // we start compiling the rest in the background.
-        Qt.callLater(root._warmAllPages);
-    }
+    Component.onCompleted: root.cachePage(root.controller.currentPageId)
 
     // Cache the page the instant it becomes current (covers normal
     // navigation, restored-on-startup ids, programmatic switches).

--- a/libs/phosphor-settings-ui/qml/PageHost.qml
+++ b/libs/phosphor-settings-ui/qml/PageHost.qml
@@ -114,16 +114,36 @@ Item {
             enabled: pageLoader.isCurrent
             z: pageLoader.isCurrent ? 1 : 0
 
-            // Fade the current page up. Bound to isCurrent so a cached
-            // re-show fades exactly like a first build; the Behavior is the
-            // only per-page animation object, so the cache stays cheap.
-            opacity: pageLoader.isCurrent ? 1 : 0
-            Behavior on opacity {
-                enabled: pageLoader.isCurrent
-                PhosphorMotionAnimation {
-                    profile: "widget.fadeIn"
-                    durationOverride: 180
+            // Fade the page up when it becomes the current one. Pinned to 0
+            // and driven imperatively (not `opacity: isCurrent ? 1 : 0` with
+            // a `Behavior`): a Behavior never animates the INITIAL value, so
+            // the first build — whose Loader is created already-current —
+            // would snap to 1 with no fade; and on a cached re-show the
+            // unspecified eval order of the opacity binding vs the Behavior's
+            // `enabled` would drop the animation. Restarting the animation
+            // from the state transition covers first load (onLoaded), cached
+            // re-show (onIsCurrentChanged while already Ready), and resets to
+            // 0 on hide so the next show fades again.
+            opacity: 0
+            onIsCurrentChanged: {
+                if (pageLoader.isCurrent) {
+                    if (pageLoader.status === Loader.Ready)
+                        pageFadeIn.restart();
+                } else {
+                    pageFadeIn.stop();
+                    pageLoader.opacity = 0;
                 }
+            }
+
+            PhosphorMotionAnimation {
+                id: pageFadeIn
+
+                target: pageLoader
+                properties: "opacity"
+                from: 0
+                to: 1
+                profile: "widget.fadeIn"
+                durationOverride: 180
             }
 
             onLoaded: {
@@ -138,6 +158,11 @@ Item {
                 // the rest.
                 PhosphorLoaderHelpers.injectIfAssignable(pageLoader.item, "controller", pageController);
                 PhosphorLoaderHelpers.injectIfAssignable(pageLoader.item, "settingsApp", root.controller);
+
+                // Fade in if this page is the one being shown (covers the
+                // common first-visit case: built async while current).
+                if (pageLoader.isCurrent)
+                    pageFadeIn.restart();
             }
         }
     }

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -299,6 +299,7 @@ qt_add_qml_module(plasmazones-settings
         # consumed by every Animations sub-page and the editor dialog.
         qml/AnimatedBoxTrack.qml
         qml/AnimationEventCard.qml
+        qml/AnimationEventCardList.qml
         qml/AnimationProfileEditor.qml
         qml/AnimationsWindowsPage.qml
         qml/AnimationsEditorPage.qml

--- a/src/settings/main.cpp
+++ b/src/settings/main.cpp
@@ -19,13 +19,19 @@
 #include <PhosphorAnimation/PhosphorCurve.h>
 #include <PhosphorAnimation/QtQuickClockManager.h>
 
+#include <QDir>
+#include <QDirIterator>
 #include <QGuiApplication>
 #include <QCommandLineParser>
 #include <QIcon>
 #include <QQmlApplicationEngine>
+#include <QQmlComponent>
 #include <QQmlContext>
 #include <QQuickStyle>
 #include <QScopeGuard>
+
+#include <memory>
+#include <vector>
 
 namespace {
 
@@ -175,6 +181,32 @@ int main(int argc, char* argv[])
     if (engine.rootObjects().isEmpty()) {
         qCCritical(PlasmaZones::lcCore) << "Failed to load settings QML";
         return 1;
+    }
+
+    // Background-compile every settings QML unit — the pages AND the shared
+    // child component types they use (SettingsCard, AnimationEventCard,
+    // AnimationProfileEditor, CurveThumbnail, …). A page's child component
+    // types compile LAZILY on first instantiation, not when the page's own
+    // unit compiles, so the first navigation to a page otherwise pays that
+    // first-time child compilation — which measurement showed dominates
+    // first-visit cost (e.g. Window Rules' first build was ~1560 ms, ~1300 ms
+    // of it child compilation; warmed it drops to ~260 ms). Compiling here,
+    // asynchronously (on the type-loader thread, never blocking the UI) and
+    // holding the components so the engine keeps the compiled units cached,
+    // means PageHost's Loader pays construction only on first visit.
+    //
+    // `warmComponents` is declared after `engine` so it is destroyed BEFORE
+    // the engine (the components reference it). Compilation only — no
+    // instantiation — so no page `onCompleted` side effects run here.
+    std::vector<std::unique_ptr<QQmlComponent>> warmComponents;
+    {
+        QDirIterator qmlIt(QStringLiteral(":/qt/qml/org/plasmazones/settings/qml"),
+                           QStringList{QStringLiteral("*.qml")}, QDir::Files, QDirIterator::Subdirectories);
+        while (qmlIt.hasNext()) {
+            qmlIt.next();
+            const QUrl url(QStringLiteral("qrc") + qmlIt.filePath());
+            warmComponents.push_back(std::make_unique<QQmlComponent>(&engine, url, QQmlComponent::Asynchronous));
+        }
     }
 
     return app.exec();

--- a/src/settings/qml/AnimationEventCardList.qml
+++ b/src/settings/qml/AnimationEventCardList.qml
@@ -70,7 +70,13 @@ SettingsFlickable {
                 property bool _everInView: false
 
                 Layout.fillWidth: true
-                Layout.preferredHeight: active && item ? item.implicitHeight : page.placeholderHeight
+                // Reserve the real card height once built (a Loader's
+                // implicitHeight reflects its loaded item's implicitHeight),
+                // placeholder otherwise. Reading `cardLoader.implicitHeight`
+                // rather than `item.implicitHeight` keeps the access typed —
+                // `Loader.item` is an untyped QtObject. `> 0` covers the
+                // async window where active is true but item not yet built.
+                Layout.preferredHeight: cardLoader.active && cardLoader.implicitHeight > 0 ? cardLoader.implicitHeight : page.placeholderHeight
                 active: _everInView
                 asynchronous: true
                 visible: active

--- a/src/settings/qml/AnimationEventCardList.qml
+++ b/src/settings/qml/AnimationEventCardList.qml
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+import QtQuick
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+/**
+ * A SettingsFlickable that renders a list of AnimationEventCards with
+ * viewport-gated lazy construction: only cards whose slot intersects the
+ * visible viewport (plus a build-ahead buffer) are instantiated. Each
+ * AnimationEventCard embeds a heavy AnimationProfileEditor (curve Canvas,
+ * shader picker, sliders, dialogs), so building a whole page of them
+ * eagerly was the dominant first-visit cost on the animation-event pages.
+ *
+ * The root stays a SettingsFlickable so the Kirigami.WheelHandler (Plasma
+ * wheel-scroll speed, bug 385836) is preserved untouched — no ListView,
+ * no re-derived wheel math. Cards are recycle-safe: AnimationEventCard
+ * holds no persistent state of its own (its Component.onCompleted re-reads
+ * from settingsController.animationsPage), so a freshly-built card always
+ * shows the committed tree state. Each Loader LATCHES active once it
+ * enters the viewport and never unloads, so no transient UI (open dialogs,
+ * focus, master-toggle collapse state) is lost on scroll.
+ *
+ * Consumers provide `eventModel` (and an Accessible.name):
+ *
+ *   AnimationEventCardList {
+ *       Accessible.name: i18n("Window animation events")
+ *       eventModel: [ { eventPath, eventLabel, isParentNode }, ... ]
+ *   }
+ */
+SettingsFlickable {
+    id: page
+
+    /// Ordered list of `{ eventPath: string, eventLabel: string,
+    /// isParentNode: bool }` — one AnimationEventCard per entry, in order.
+    property var eventModel: []
+
+    // Build-ahead margin above/below the visible viewport so a card is
+    // built slightly before it scrolls into view — keeps a fast flick from
+    // landing on an un-built placeholder.
+    readonly property real buildBuffer: Kirigami.Units.gridUnit * 20
+    // Placeholder height a not-yet-built card reserves in the layout so
+    // contentHeight (and scroll position) stays stable until the real card
+    // materialises. Sized to a collapsed card (header + inheritance banner
+    // + "Current:" line).
+    readonly property real placeholderHeight: Kirigami.Units.gridUnit * 7
+
+    contentHeight: col.implicitHeight
+    clip: true
+
+    ColumnLayout {
+        id: col
+
+        width: page.width
+        spacing: Kirigami.Units.smallSpacing
+
+        Repeater {
+            model: page.eventModel
+
+            // One latching, viewport-gated Loader per event. The Loader is
+            // the layout participant — it carries the placeholder height
+            // until built, then tracks the card's real height.
+            Loader {
+                id: cardLoader
+
+                required property var modelData
+
+                // Latch: once the card has entered the viewport it stays
+                // built. `_everInView` flips true and never back.
+                property bool _everInView: false
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: active && item ? item.implicitHeight : page.placeholderHeight
+                active: _everInView
+                asynchronous: true
+                visible: active
+
+                // Imperative one-shot latch. A declarative `Binding { when:
+                // <reads y> }` loops: building the card changes
+                // Layout.preferredHeight, which makes the ColumnLayout
+                // re-assign every child's `y` in the same pass, re-firing
+                // the `when` that reads `y` — Qt flags that as a binding
+                // loop. Checking imperatively on the relevant change signals
+                // and returning once latched breaks the cycle. `y` is read
+                // live but never bound; placeholderHeight (constant)
+                // estimates the slot's bottom so the build height never
+                // feeds back in. A ColumnLayout derives a child's `y` from
+                // the items ABOVE it, never from this Loader's own
+                // height/active, so reading `y` here is safe.
+                function _checkInView() {
+                    if (cardLoader._everInView)
+                        return;
+                    const top = cardLoader.y;
+                    if ((top + page.placeholderHeight) >= (page.contentY - page.buildBuffer) && top <= (page.contentY + page.height + page.buildBuffer))
+                        cardLoader._everInView = true;
+                }
+                onYChanged: cardLoader._checkInView()
+                Component.onCompleted: cardLoader._checkInView()
+
+                Connections {
+                    target: page
+                    function onContentYChanged() {
+                        cardLoader._checkInView();
+                    }
+                    function onHeightChanged() {
+                        cardLoader._checkInView();
+                    }
+                }
+
+                sourceComponent: AnimationEventCard {
+                    // Width is driven by the Loader (Layout.fillWidth →
+                    // Loader.width → item.width); the card's implicitHeight
+                    // drives Layout.preferredHeight above.
+                    eventPath: cardLoader.modelData.eventPath
+                    eventLabel: cardLoader.modelData.eventLabel
+                    isParentNode: cardLoader.modelData.isParentNode === true
+                }
+            }
+        }
+    }
+}

--- a/src/settings/qml/AnimationEventCardList.qml
+++ b/src/settings/qml/AnimationEventCardList.qml
@@ -79,7 +79,16 @@ SettingsFlickable {
                 Layout.preferredHeight: cardLoader.active && cardLoader.implicitHeight > 0 ? cardLoader.implicitHeight : page.placeholderHeight
                 active: _everInView
                 asynchronous: true
-                visible: active
+                // Deliberately NOT `visible: active`. QtQuick.Layouts
+                // excludes invisible items from layout entirely, so an
+                // inactive (not-yet-built) Loader marked invisible would
+                // reserve ZERO height instead of `placeholderHeight`. Every
+                // card's `y` would then collapse toward 0, the viewport test
+                // below would see them all on-screen, and the whole page
+                // would build at once — defeating the virtualization. An
+                // inactive Loader has no `item`, so it paints nothing while
+                // visible; leaving it visible keeps it a layout participant
+                // that carries the placeholder height.
 
                 // Imperative one-shot latch. A declarative `Binding { when:
                 // <reads y> }` loops: building the card changes
@@ -101,7 +110,14 @@ SettingsFlickable {
                         cardLoader._everInView = true;
                 }
                 onYChanged: cardLoader._checkInView()
-                Component.onCompleted: cardLoader._checkInView()
+                // Deferred one tick: a ColumnLayout assigns child `y` on a
+                // polish pass AFTER Component.onCompleted runs, so a check
+                // here would read the pre-layout `y` (0 for every card) and
+                // latch the whole page in-view. Qt.callLater runs the first
+                // check once layout has positioned this Loader, so the
+                // viewport test sees the real slot position. Later re-checks
+                // come from onYChanged / the page Connections below.
+                Component.onCompleted: Qt.callLater(cardLoader._checkInView)
 
                 Connections {
                     target: page

--- a/src/settings/qml/AnimationsEditorPage.qml
+++ b/src/settings/qml/AnimationsEditorPage.qml
@@ -1,49 +1,35 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Layouts
-import org.kde.kirigami as Kirigami
 
 // Layout-editor zone-manipulation animations. Fires only inside the
-// PlasmaZones layout editor (fill-preview, snap-resize-preview).
-// Runtime window snapping is KWin's compositor-level domain and is
-// NOT controlled here.
-SettingsFlickable {
-    contentHeight: col.implicitHeight
-    clip: true
+// PlasmaZones layout editor (fill-preview, snap-resize-preview). Runtime
+// window snapping is KWin's compositor-level domain and is NOT controlled
+// here.
+//
+// Card list is viewport-virtualized by AnimationEventCardList.
+AnimationEventCardList {
     Accessible.name: i18n("Layout editor animation events")
-
-    ColumnLayout {
-        id: col
-
-        width: parent.width
-        spacing: Kirigami.Units.smallSpacing
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "editor"
-            eventLabel: i18n("All Editor Events")
-            isParentNode: true
+    eventModel: [
+        {
+            "eventPath": "editor",
+            "eventLabel": i18n("All Editor Events"),
+            "isParentNode": true
+        },
+        {
+            "eventPath": "editor.snapIn",
+            "eventLabel": i18n("Snap Into Zone (Fill Preview)"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "editor.snapOut",
+            "eventLabel": i18n("Snap Out of Zone"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "editor.snapResize",
+            "eventLabel": i18n("Snap Resize (Drag Preview)"),
+            "isParentNode": false
         }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "editor.snapIn"
-            eventLabel: i18n("Snap Into Zone (Fill Preview)")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "editor.snapOut"
-            eventLabel: i18n("Snap Out of Zone")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "editor.snapResize"
-            eventLabel: i18n("Snap Resize (Drag Preview)")
-        }
-
-    }
-
+    ]
 }

--- a/src/settings/qml/AnimationsOsdsPage.qml
+++ b/src/settings/qml/AnimationsOsdsPage.qml
@@ -1,46 +1,32 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
-
 import QtQuick
-import QtQuick.Layouts
-import org.kde.kirigami as Kirigami
 
-// OSDs animation page: the `osd.*` resolver subtree (both LayoutOsd
-// and NavigationOsd modes). The "All OSDs" parent is a parent-node
-// card whose override cascades to `osd.show` and `osd.hide` via
-// ShaderProfileTree::resolve's walk-up. Transient overlays (zone
-// selector, layout picker, snap assist) live under `popup.*` and have
-// their own dedicated Overlays page.
-SettingsFlickable {
-    contentHeight: col.implicitHeight
-    clip: true
+// OSDs animation page: the `osd.*` resolver subtree (both LayoutOsd and
+// NavigationOsd modes). The "All OSDs" parent is a parent-node card whose
+// override cascades to `osd.show` and `osd.hide` via
+// ShaderProfileTree::resolve's walk-up. Transient overlays (zone selector,
+// layout picker, snap assist) live under `popup.*` and have their own
+// dedicated Overlays page.
+//
+// Card list is viewport-virtualized by AnimationEventCardList.
+AnimationEventCardList {
     Accessible.name: i18n("OSD animation events")
-
-    ColumnLayout {
-        id: col
-
-        width: parent.width
-        spacing: Kirigami.Units.smallSpacing
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "osd"
-            eventLabel: i18n("All OSDs")
-            isParentNode: true
+    eventModel: [
+        {
+            "eventPath": "osd",
+            "eventLabel": i18n("All OSDs"),
+            "isParentNode": true
+        },
+        {
+            "eventPath": "osd.show",
+            "eventLabel": i18n("Show"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "osd.hide",
+            "eventLabel": i18n("Hide"),
+            "isParentNode": false
         }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "osd.show"
-            eventLabel: i18n("Show")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "osd.hide"
-            eventLabel: i18n("Hide")
-        }
-
-    }
-
+    ]
 }

--- a/src/settings/qml/AnimationsOverlaysPage.qml
+++ b/src/settings/qml/AnimationsOverlaysPage.qml
@@ -1,73 +1,54 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
-
 import QtQuick
-import QtQuick.Layouts
-import org.kde.kirigami as Kirigami
 
-// Overlays animation page: the `popup.*` resolver subtree (zone
-// selector, layout picker, snap assist; the resolver path keeps the
-// historical name). The "All Overlays" parent is a parent-node card
-// whose override cascades to `popup.zoneSelector.*`,
-// `popup.layoutPicker.*` and `popup.snapAssist.*` via
-// ShaderProfileTree::resolve's walk-up (`popup` is the closest common
-// ancestor of all three surfaces). In-app side panels (settings nav
-// rail, editor property panel) live under `panel.*` and have their
-// own dedicated Side Panels page.
-SettingsFlickable {
-    contentHeight: col.implicitHeight
-    clip: true
+// Overlays animation page: the `popup.*` resolver subtree (zone selector,
+// layout picker, snap assist; the resolver path keeps the historical
+// name). The "All Overlays" parent is a parent-node card whose override
+// cascades to `popup.zoneSelector.*`, `popup.layoutPicker.*` and
+// `popup.snapAssist.*` via ShaderProfileTree::resolve's walk-up (`popup`
+// is the closest common ancestor of all three surfaces). In-app side
+// panels (settings nav rail, editor property panel) live under `panel.*`
+// and have their own dedicated Side Panels page.
+//
+// Card list is viewport-virtualized by AnimationEventCardList.
+AnimationEventCardList {
     Accessible.name: i18n("Overlay animation events")
-
-    ColumnLayout {
-        id: col
-
-        width: parent.width
-        spacing: Kirigami.Units.smallSpacing
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "popup"
-            eventLabel: i18n("All Overlays")
-            isParentNode: true
+    eventModel: [
+        {
+            "eventPath": "popup",
+            "eventLabel": i18n("All Overlays"),
+            "isParentNode": true
+        },
+        {
+            "eventPath": "popup.zoneSelector.show",
+            "eventLabel": i18n("Zone Selector: Show"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "popup.zoneSelector.hide",
+            "eventLabel": i18n("Zone Selector: Hide"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "popup.layoutPicker.show",
+            "eventLabel": i18n("Layout Picker: Show"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "popup.layoutPicker.hide",
+            "eventLabel": i18n("Layout Picker: Hide"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "popup.snapAssist.show",
+            "eventLabel": i18n("Snap Assist: Show"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "popup.snapAssist.hide",
+            "eventLabel": i18n("Snap Assist: Hide"),
+            "isParentNode": false
         }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "popup.zoneSelector.show"
-            eventLabel: i18n("Zone Selector: Show")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "popup.zoneSelector.hide"
-            eventLabel: i18n("Zone Selector: Hide")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "popup.layoutPicker.show"
-            eventLabel: i18n("Layout Picker: Show")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "popup.layoutPicker.hide"
-            eventLabel: i18n("Layout Picker: Hide")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "popup.snapAssist.show"
-            eventLabel: i18n("Snap Assist: Show")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "popup.snapAssist.hide"
-            eventLabel: i18n("Snap Assist: Hide")
-        }
-
-    }
-
+    ]
 }

--- a/src/settings/qml/AnimationsSidePanelsPage.qml
+++ b/src/settings/qml/AnimationsSidePanelsPage.qml
@@ -1,60 +1,43 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
-
 import QtQuick
-import QtQuick.Layouts
-import org.kde.kirigami as Kirigami
 
 // Side panels animation page: the `panel.*` resolver subtree (the
-// resolver path keeps the historical name). Covers in-app side
-// surfaces that slide in from an edge (settings nav rail, editor
-// property panel). Slide is size/translate motion; fade is opacity.
-// Renamed from "Panels" to disambiguate from system panels (Plasma
-// taskbar, etc.) which we do not animate. Transient overlays (zone
-// selector, layout picker, snap assist) live under `popup.*` and
-// have their own dedicated Overlays page.
-SettingsFlickable {
-    contentHeight: col.implicitHeight
-    clip: true
+// resolver path keeps the historical name). Covers in-app side surfaces
+// that slide in from an edge (settings nav rail, editor property panel).
+// Slide is size/translate motion; fade is opacity. Renamed from "Panels"
+// to disambiguate from system panels (Plasma taskbar, etc.) which we do
+// not animate. Transient overlays (zone selector, layout picker, snap
+// assist) live under `popup.*` and have their own dedicated Overlays page.
+//
+// Card list is viewport-virtualized by AnimationEventCardList.
+AnimationEventCardList {
     Accessible.name: i18n("Side panel animation events")
-
-    ColumnLayout {
-        id: col
-
-        width: parent.width
-        spacing: Kirigami.Units.smallSpacing
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "panel"
-            eventLabel: i18n("All Side Panels")
-            isParentNode: true
+    eventModel: [
+        {
+            "eventPath": "panel",
+            "eventLabel": i18n("All Side Panels"),
+            "isParentNode": true
+        },
+        {
+            "eventPath": "panel.slideIn",
+            "eventLabel": i18n("Slide In"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "panel.slideOut",
+            "eventLabel": i18n("Slide Out"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "panel.fadeIn",
+            "eventLabel": i18n("Fade In"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "panel.fadeOut",
+            "eventLabel": i18n("Fade Out"),
+            "isParentNode": false
         }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "panel.slideIn"
-            eventLabel: i18n("Slide In")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "panel.slideOut"
-            eventLabel: i18n("Slide Out")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "panel.fadeIn"
-            eventLabel: i18n("Fade In")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "panel.fadeOut"
-            eventLabel: i18n("Fade Out")
-        }
-
-    }
-
+    ]
 }

--- a/src/settings/qml/AnimationsWidgetsPage.qml
+++ b/src/settings/qml/AnimationsWidgetsPage.qml
@@ -1,25 +1,12 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Layouts
-import org.kde.kirigami as Kirigami
 
-SettingsFlickable {
-    id: page
-
-    // Viewport-gated lazy build: only AnimationEventCards whose y-range
-    // intersects the visible viewport (plus a buffer) are instantiated.
-    // Each card embeds a heavy AnimationProfileEditor (curve Canvas,
-    // shader picker, sliders, dialogs); this page lists ~22 events, so
-    // building them all eagerly was the dominant first-visit cost. The
-    // page stays a SettingsFlickable so the Kirigami.WheelHandler (Plasma
-    // wheel-scroll speed, bug 385836) is preserved untouched. Cards are
-    // recycle-safe: AnimationEventCard holds no persistent state of its
-    // own (Component.onCompleted re-reads from settingsController.
-    // animationsPage), and each Loader latches active once it enters the
-    // viewport and never unloads — so no transient UI is lost on scroll.
-    // See AnimationsWindowsPage.qml for the same pattern + rationale.
-    readonly property var eventModel: [
+// Widget animation events. Viewport-virtualized via AnimationEventCardList
+// (only visible AnimationEventCards build) — see that component.
+AnimationEventCardList {
+    Accessible.name: i18n("Widget animation events")
+    eventModel: [
         {
             "eventPath": "widget",
             "eventLabel": i18n("All Widget Events"),
@@ -137,73 +124,4 @@ SettingsFlickable {
             "isParentNode": false
         }
     ]
-    // Build-ahead margin above/below the viewport so a card is built
-    // slightly before it scrolls into view.
-    readonly property real buildBuffer: Kirigami.Units.gridUnit * 20
-    // Placeholder height a not-yet-built card reserves so contentHeight
-    // (and scroll position) stays stable until the real card materialises.
-    readonly property real placeholderHeight: Kirigami.Units.gridUnit * 7
-
-    contentHeight: col.implicitHeight
-    clip: true
-    Accessible.name: i18n("Widget animation events")
-
-    ColumnLayout {
-        id: col
-
-        width: page.width
-        spacing: Kirigami.Units.smallSpacing
-
-        Repeater {
-            model: page.eventModel
-
-            // One latching, viewport-gated Loader per event.
-            Loader {
-                id: cardLoader
-
-                required property var modelData
-
-                // Latch: once the card has entered the viewport it stays
-                // built. `_everInView` flips true and never back.
-                property bool _everInView: false
-
-                Layout.fillWidth: true
-                Layout.preferredHeight: active && item ? item.implicitHeight : page.placeholderHeight
-                active: _everInView
-                asynchronous: true
-                visible: active
-
-                // Imperative one-shot latch — see AnimationsWindowsPage.qml
-                // for why a declarative `Binding { when: <reads y> }` forms a
-                // binding loop here. `y` read live but never bound;
-                // placeholderHeight (constant) estimates the slot bottom so
-                // the build height never feeds back in.
-                function _checkInView() {
-                    if (cardLoader._everInView)
-                        return;
-                    const top = cardLoader.y;
-                    if ((top + page.placeholderHeight) >= (page.contentY - page.buildBuffer) && top <= (page.contentY + page.height + page.buildBuffer))
-                        cardLoader._everInView = true;
-                }
-                onYChanged: cardLoader._checkInView()
-                Component.onCompleted: cardLoader._checkInView()
-
-                Connections {
-                    target: page
-                    function onContentYChanged() {
-                        cardLoader._checkInView();
-                    }
-                    function onHeightChanged() {
-                        cardLoader._checkInView();
-                    }
-                }
-
-                sourceComponent: AnimationEventCard {
-                    eventPath: cardLoader.modelData.eventPath
-                    eventLabel: cardLoader.modelData.eventLabel
-                    isParentNode: cardLoader.modelData.isParentNode === true
-                }
-            }
-        }
-    }
 }

--- a/src/settings/qml/AnimationsWidgetsPage.qml
+++ b/src/settings/qml/AnimationsWidgetsPage.qml
@@ -5,6 +5,145 @@ import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
 
 SettingsFlickable {
+    id: page
+
+    // Viewport-gated lazy build: only AnimationEventCards whose y-range
+    // intersects the visible viewport (plus a buffer) are instantiated.
+    // Each card embeds a heavy AnimationProfileEditor (curve Canvas,
+    // shader picker, sliders, dialogs); this page lists ~22 events, so
+    // building them all eagerly was the dominant first-visit cost. The
+    // page stays a SettingsFlickable so the Kirigami.WheelHandler (Plasma
+    // wheel-scroll speed, bug 385836) is preserved untouched. Cards are
+    // recycle-safe: AnimationEventCard holds no persistent state of its
+    // own (Component.onCompleted re-reads from settingsController.
+    // animationsPage), and each Loader latches active once it enters the
+    // viewport and never unloads — so no transient UI is lost on scroll.
+    // See AnimationsWindowsPage.qml for the same pattern + rationale.
+    readonly property var eventModel: [
+        {
+            "eventPath": "widget",
+            "eventLabel": i18n("All Widget Events"),
+            "isParentNode": true
+        },
+        {
+            "eventPath": "widget.hover",
+            "eventLabel": i18n("Hover"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.press",
+            "eventLabel": i18n("Press"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.toggleOn",
+            "eventLabel": i18n("Toggle On"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.toggleOff",
+            "eventLabel": i18n("Toggle Off"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.badgeShow",
+            "eventLabel": i18n("Show (badge)"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.badgeHide",
+            "eventLabel": i18n("Hide (badge)"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.badgePulse",
+            "eventLabel": i18n("Pulse (badge)"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.tint",
+            "eventLabel": i18n("Tint"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.dim",
+            "eventLabel": i18n("Dim"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.fadeIn",
+            "eventLabel": i18n("Fade In"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.fadeOut",
+            "eventLabel": i18n("Fade Out"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.reorder",
+            "eventLabel": i18n("Reorder"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.accordionExpand",
+            "eventLabel": i18n("Expand (accordion)"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.accordionCollapse",
+            "eventLabel": i18n("Collapse (accordion)"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.progress",
+            "eventLabel": i18n("Progress"),
+            "isParentNode": false
+        },
+        // Zone-rect widget. Embedded across the runtime overlay, settings
+        // dialogs, layout thumbnails, the new-layout dialog, shared
+        // previews. The animation lives with the widget; the surface
+        // hosting it is incidental.
+        {
+            "eventPath": "widget.zoneHighlight",
+            "eventLabel": i18n("Zone Highlight"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.zoneHighlight.pop",
+            "eventLabel": i18n("Zone Highlight: Pop"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "widget.zoneHighlight.border",
+            "eventLabel": i18n("Zone Highlight: Border"),
+            "isParentNode": false
+        },
+        // One-shot flash on the main zone-overlay surface when the active
+        // layout switches mid-drag.
+        {
+            "eventPath": "widget.zoneOverlayFlash",
+            "eventLabel": i18n("Zone Overlay: Layout-Switch Flash"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "cursor.hover",
+            "eventLabel": i18n("Cursor Hover"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "cursor.click",
+            "eventLabel": i18n("Cursor Click"),
+            "isParentNode": false
+        }
+    ]
+    // Build-ahead margin above/below the viewport so a card is built
+    // slightly before it scrolls into view.
+    readonly property real buildBuffer: Kirigami.Units.gridUnit * 20
+    // Placeholder height a not-yet-built card reserves so contentHeight
+    // (and scroll position) stays stable until the real card materialises.
+    readonly property real placeholderHeight: Kirigami.Units.gridUnit * 7
+
     contentHeight: col.implicitHeight
     clip: true
     Accessible.name: i18n("Widget animation events")
@@ -12,146 +151,59 @@ SettingsFlickable {
     ColumnLayout {
         id: col
 
-        width: parent.width
+        width: page.width
         spacing: Kirigami.Units.smallSpacing
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget"
-            eventLabel: i18n("All Widget Events")
-            isParentNode: true
-        }
+        Repeater {
+            model: page.eventModel
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.hover"
-            eventLabel: i18n("Hover")
-        }
+            // One latching, viewport-gated Loader per event.
+            Loader {
+                id: cardLoader
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.press"
-            eventLabel: i18n("Press")
-        }
+                required property var modelData
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.toggleOn"
-            eventLabel: i18n("Toggle On")
-        }
+                // Latch: once the card has entered the viewport it stays
+                // built. `_everInView` flips true and never back.
+                property bool _everInView: false
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.toggleOff"
-            eventLabel: i18n("Toggle Off")
-        }
+                Layout.fillWidth: true
+                Layout.preferredHeight: active && item ? item.implicitHeight : page.placeholderHeight
+                active: _everInView
+                asynchronous: true
+                visible: active
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.badgeShow"
-            eventLabel: i18n("Show (badge)")
-        }
+                // Imperative one-shot latch — see AnimationsWindowsPage.qml
+                // for why a declarative `Binding { when: <reads y> }` forms a
+                // binding loop here. `y` read live but never bound;
+                // placeholderHeight (constant) estimates the slot bottom so
+                // the build height never feeds back in.
+                function _checkInView() {
+                    if (cardLoader._everInView)
+                        return;
+                    const top = cardLoader.y;
+                    if ((top + page.placeholderHeight) >= (page.contentY - page.buildBuffer) && top <= (page.contentY + page.height + page.buildBuffer))
+                        cardLoader._everInView = true;
+                }
+                onYChanged: cardLoader._checkInView()
+                Component.onCompleted: cardLoader._checkInView()
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.badgeHide"
-            eventLabel: i18n("Hide (badge)")
-        }
+                Connections {
+                    target: page
+                    function onContentYChanged() {
+                        cardLoader._checkInView();
+                    }
+                    function onHeightChanged() {
+                        cardLoader._checkInView();
+                    }
+                }
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.badgePulse"
-            eventLabel: i18n("Pulse (badge)")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.tint"
-            eventLabel: i18n("Tint")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.dim"
-            eventLabel: i18n("Dim")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.fadeIn"
-            eventLabel: i18n("Fade In")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.fadeOut"
-            eventLabel: i18n("Fade Out")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.reorder"
-            eventLabel: i18n("Reorder")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.accordionExpand"
-            eventLabel: i18n("Expand (accordion)")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.accordionCollapse"
-            eventLabel: i18n("Collapse (accordion)")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.progress"
-            eventLabel: i18n("Progress")
-        }
-
-        // Zone-rect widget. Embedded across the runtime overlay,
-        // settings dialogs, layout thumbnails, the new-layout dialog,
-        // shared previews. The animation lives with the widget; the
-        // surface hosting it is incidental.
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.zoneHighlight"
-            eventLabel: i18n("Zone Highlight")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.zoneHighlight.pop"
-            eventLabel: i18n("Zone Highlight: Pop")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.zoneHighlight.border"
-            eventLabel: i18n("Zone Highlight: Border")
-        }
-
-        // One-shot flash on the main zone-overlay surface when the
-        // active layout switches mid-drag.
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "widget.zoneOverlayFlash"
-            eventLabel: i18n("Zone Overlay: Layout-Switch Flash")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "cursor.hover"
-            eventLabel: i18n("Cursor Hover")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "cursor.click"
-            eventLabel: i18n("Cursor Click")
+                sourceComponent: AnimationEventCard {
+                    eventPath: cardLoader.modelData.eventPath
+                    eventLabel: cardLoader.modelData.eventLabel
+                    isParentNode: cardLoader.modelData.isParentNode === true
+                }
+            }
         }
     }
 }

--- a/src/settings/qml/AnimationsWindowsPage.qml
+++ b/src/settings/qml/AnimationsWindowsPage.qml
@@ -1,40 +1,18 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Layouts
-import org.kde.kirigami as Kirigami
 
-SettingsFlickable {
-    id: page
-
-    // Viewport-gated lazy build: only AnimationEventCards whose y-range
-    // intersects the visible viewport (plus a buffer) are instantiated.
-    // Each card embeds a heavy AnimationProfileEditor (curve Canvas,
-    // shader picker, sliders, dialogs); building all ~22 eagerly is the
-    // first-visit cost this page is optimising away.
-    //
-    // The page stays a SettingsFlickable so the Kirigami.WheelHandler
-    // (Plasma wheel-scroll speed, bug 385836) is preserved untouched —
-    // no ListView, no re-derived wheel math.
-    //
-    // Cards are recycle-safe: AnimationEventCard holds no persistent
-    // state of its own. Its Component.onCompleted re-reads everything
-    // from settingsController.animationsPage (refreshFromTree +
-    // refreshShaderFromTree), so a freshly-built card always shows the
-    // committed tree state. We therefore LATCH each Loader active once
-    // it enters the viewport and never unload it — this avoids losing
-    // transient UI (open dialogs, focus, the master toggle's collapse
-    // state) on scroll and avoids rebuild churn, while keeping the
-    // first-paint cost proportional to what's visible.
-
-    // Model for the event cards. Order matches the on-screen order; the
-    // parent node ("All Window Events") leads, then the per-event leaves.
-    //
-    // `window.snapResize` (resize-only branch of applySnapGeometry) is
-    // intentionally NOT listed: no kwin-effect callsite routes a
-    // resize-only event through tryBeginShaderForEvent today, so a card
-    // here would be runtime-dead.
-    readonly property var eventModel: [
+// Window animation events. The card list is viewport-virtualized by
+// AnimationEventCardList (only visible AnimationEventCards build) — see
+// that component for the rationale.
+//
+// `window.snapResize` (resize-only branch of applySnapGeometry) is
+// intentionally NOT listed: no kwin-effect callsite routes a resize-only
+// event through tryBeginShaderForEvent today, so a card here would be
+// runtime-dead.
+AnimationEventCardList {
+    Accessible.name: i18n("Window animation events")
+    eventModel: [
         {
             "eventPath": "window",
             "eventLabel": i18n("All Window Events"),
@@ -75,9 +53,9 @@ SettingsFlickable {
             "eventLabel": i18n("Focus"),
             "isParentNode": false
         },
-        // Snap-into-zone window animations driven by the kwin-effect.
-        // The window quad animates when it snaps into / out of a zone
-        // or when a layout switch repositions it.
+        // Snap-into-zone window animations driven by the kwin-effect. The
+        // window quad animates when it snaps into / out of a zone or when a
+        // layout switch repositions it.
         {
             "eventPath": "window.snapIn",
             "eventLabel": i18n("Snap Into Zone"),
@@ -94,93 +72,4 @@ SettingsFlickable {
             "isParentNode": false
         }
     ]
-    // Build-ahead margin above and below the visible viewport so a card
-    // is instantiated slightly before it scrolls into view — keeps the
-    // edge of a fast flick from showing an un-built placeholder.
-    readonly property real buildBuffer: Kirigami.Units.gridUnit * 20
-    // Placeholder height a not-yet-built card reserves in the layout so
-    // contentHeight (and therefore scroll position) stays stable before
-    // the real card materialises. Sized to a collapsed card (header +
-    // inheritance banner + "Current:" line). Cards that build above the
-    // viewport replace this with their real height, so cumulative offset
-    // for already-passed cards is always exact and scrolling never
-    // jumps.
-    readonly property real placeholderHeight: Kirigami.Units.gridUnit * 7
-
-    contentHeight: col.implicitHeight
-    clip: true
-    Accessible.name: i18n("Window animation events")
-
-    ColumnLayout {
-        id: col
-
-        width: page.width
-        spacing: Kirigami.Units.smallSpacing
-
-        Repeater {
-            model: page.eventModel
-
-            // One latching, viewport-gated Loader per event. The Loader
-            // is the layout participant — it carries the placeholder
-            // height until built, then tracks the card's real height.
-            Loader {
-                id: cardLoader
-
-                required property var modelData
-
-                // Latch: once the card has entered the viewport it stays
-                // built. `_everInView` flips true and never back.
-                property bool _everInView: false
-
-                Layout.fillWidth: true
-                // Reserve the real card height once built, placeholder
-                // otherwise. ColumnLayout lays children out top-to-
-                // bottom, so this Loader's `y` is already in flickable
-                // content-space.
-                Layout.preferredHeight: active && item ? item.implicitHeight : page.placeholderHeight
-                active: _everInView
-                asynchronous: true
-                visible: active
-
-                // Imperative one-shot latch. A declarative `Binding { when:
-                // <reads y> }` loops: building the card changes
-                // Layout.preferredHeight, which makes the ColumnLayout
-                // re-assign every child's `y` in the same pass, re-firing the
-                // `when` that reads `y` — Qt flags that as a binding loop.
-                // Checking imperatively on the relevant change signals and
-                // returning once latched breaks the cycle (no binding over
-                // the layout geometry the build perturbs). `y` is read live
-                // but never bound. placeholderHeight (constant) estimates the
-                // slot's bottom so the build height never feeds back in.
-                function _checkInView() {
-                    if (cardLoader._everInView)
-                        return;
-                    const top = cardLoader.y;
-                    if ((top + page.placeholderHeight) >= (page.contentY - page.buildBuffer) && top <= (page.contentY + page.height + page.buildBuffer))
-                        cardLoader._everInView = true;
-                }
-                onYChanged: cardLoader._checkInView()
-                Component.onCompleted: cardLoader._checkInView()
-
-                Connections {
-                    target: page
-                    function onContentYChanged() {
-                        cardLoader._checkInView();
-                    }
-                    function onHeightChanged() {
-                        cardLoader._checkInView();
-                    }
-                }
-
-                sourceComponent: AnimationEventCard {
-                    // Width is driven by the Loader (Layout.fillWidth on
-                    // the Loader → Loader.width → item.width); the card's
-                    // implicitHeight drives Layout.preferredHeight above.
-                    eventPath: cardLoader.modelData.eventPath
-                    eventLabel: cardLoader.modelData.eventLabel
-                    isParentNode: cardLoader.modelData.isParentNode === true
-                }
-            }
-        }
-    }
 }

--- a/src/settings/qml/AnimationsWindowsPage.qml
+++ b/src/settings/qml/AnimationsWindowsPage.qml
@@ -5,91 +5,182 @@ import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
 
 SettingsFlickable {
+    id: page
+
+    // Viewport-gated lazy build: only AnimationEventCards whose y-range
+    // intersects the visible viewport (plus a buffer) are instantiated.
+    // Each card embeds a heavy AnimationProfileEditor (curve Canvas,
+    // shader picker, sliders, dialogs); building all ~22 eagerly is the
+    // first-visit cost this page is optimising away.
+    //
+    // The page stays a SettingsFlickable so the Kirigami.WheelHandler
+    // (Plasma wheel-scroll speed, bug 385836) is preserved untouched —
+    // no ListView, no re-derived wheel math.
+    //
+    // Cards are recycle-safe: AnimationEventCard holds no persistent
+    // state of its own. Its Component.onCompleted re-reads everything
+    // from settingsController.animationsPage (refreshFromTree +
+    // refreshShaderFromTree), so a freshly-built card always shows the
+    // committed tree state. We therefore LATCH each Loader active once
+    // it enters the viewport and never unload it — this avoids losing
+    // transient UI (open dialogs, focus, the master toggle's collapse
+    // state) on scroll and avoids rebuild churn, while keeping the
+    // first-paint cost proportional to what's visible.
+
+    // Model for the event cards. Order matches the on-screen order; the
+    // parent node ("All Window Events") leads, then the per-event leaves.
+    //
+    // `window.snapResize` (resize-only branch of applySnapGeometry) is
+    // intentionally NOT listed: no kwin-effect callsite routes a
+    // resize-only event through tryBeginShaderForEvent today, so a card
+    // here would be runtime-dead.
+    readonly property var eventModel: [
+        {
+            "eventPath": "window",
+            "eventLabel": i18n("All Window Events"),
+            "isParentNode": true
+        },
+        {
+            "eventPath": "window.open",
+            "eventLabel": i18n("Open"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "window.close",
+            "eventLabel": i18n("Close"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "window.minimize",
+            "eventLabel": i18n("Minimize"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "window.maximize",
+            "eventLabel": i18n("Maximize"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "window.move",
+            "eventLabel": i18n("Move"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "window.resize",
+            "eventLabel": i18n("Resize"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "window.focus",
+            "eventLabel": i18n("Focus"),
+            "isParentNode": false
+        },
+        // Snap-into-zone window animations driven by the kwin-effect.
+        // The window quad animates when it snaps into / out of a zone
+        // or when a layout switch repositions it.
+        {
+            "eventPath": "window.snapIn",
+            "eventLabel": i18n("Snap Into Zone"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "window.snapOut",
+            "eventLabel": i18n("Snap Out of Zone"),
+            "isParentNode": false
+        },
+        {
+            "eventPath": "window.layoutSwitch",
+            "eventLabel": i18n("Layout Switch"),
+            "isParentNode": false
+        }
+    ]
+    // Build-ahead margin above and below the visible viewport so a card
+    // is instantiated slightly before it scrolls into view — keeps the
+    // edge of a fast flick from showing an un-built placeholder.
+    readonly property real buildBuffer: Kirigami.Units.gridUnit * 20
+    // Placeholder height a not-yet-built card reserves in the layout so
+    // contentHeight (and therefore scroll position) stays stable before
+    // the real card materialises. Sized to a collapsed card (header +
+    // inheritance banner + "Current:" line). Cards that build above the
+    // viewport replace this with their real height, so cumulative offset
+    // for already-passed cards is always exact and scrolling never
+    // jumps.
+    readonly property real placeholderHeight: Kirigami.Units.gridUnit * 7
+
     contentHeight: col.implicitHeight
     clip: true
     Accessible.name: i18n("Window animation events")
 
     ColumnLayout {
-        // `window.snapResize` (resize-only branch of applySnapGeometry)
-        // is intentionally NOT exposed here: no kwin-effect callsite
-        // routes a resize-only event through tryBeginShaderForEvent
-        // today, so a card here would be runtime-dead.
-
         id: col
 
-        width: parent.width
+        width: page.width
         spacing: Kirigami.Units.smallSpacing
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window"
-            eventLabel: i18n("All Window Events")
-            isParentNode: true
-        }
+        Repeater {
+            model: page.eventModel
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.open"
-            eventLabel: i18n("Open")
-        }
+            // One latching, viewport-gated Loader per event. The Loader
+            // is the layout participant — it carries the placeholder
+            // height until built, then tracks the card's real height.
+            Loader {
+                id: cardLoader
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.close"
-            eventLabel: i18n("Close")
-        }
+                required property var modelData
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.minimize"
-            eventLabel: i18n("Minimize")
-        }
+                // Latch: once the card has entered the viewport it stays
+                // built. `_everInView` flips true and never back.
+                property bool _everInView: false
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.maximize"
-            eventLabel: i18n("Maximize")
-        }
+                Layout.fillWidth: true
+                // Reserve the real card height once built, placeholder
+                // otherwise. ColumnLayout lays children out top-to-
+                // bottom, so this Loader's `y` is already in flickable
+                // content-space.
+                Layout.preferredHeight: active && item ? item.implicitHeight : page.placeholderHeight
+                active: _everInView
+                asynchronous: true
+                visible: active
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.move"
-            eventLabel: i18n("Move")
-        }
+                // Imperative one-shot latch. A declarative `Binding { when:
+                // <reads y> }` loops: building the card changes
+                // Layout.preferredHeight, which makes the ColumnLayout
+                // re-assign every child's `y` in the same pass, re-firing the
+                // `when` that reads `y` — Qt flags that as a binding loop.
+                // Checking imperatively on the relevant change signals and
+                // returning once latched breaks the cycle (no binding over
+                // the layout geometry the build perturbs). `y` is read live
+                // but never bound. placeholderHeight (constant) estimates the
+                // slot's bottom so the build height never feeds back in.
+                function _checkInView() {
+                    if (cardLoader._everInView)
+                        return;
+                    const top = cardLoader.y;
+                    if ((top + page.placeholderHeight) >= (page.contentY - page.buildBuffer) && top <= (page.contentY + page.height + page.buildBuffer))
+                        cardLoader._everInView = true;
+                }
+                onYChanged: cardLoader._checkInView()
+                Component.onCompleted: cardLoader._checkInView()
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.resize"
-            eventLabel: i18n("Resize")
-        }
+                Connections {
+                    target: page
+                    function onContentYChanged() {
+                        cardLoader._checkInView();
+                    }
+                    function onHeightChanged() {
+                        cardLoader._checkInView();
+                    }
+                }
 
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.focus"
-            eventLabel: i18n("Focus")
+                sourceComponent: AnimationEventCard {
+                    // Width is driven by the Loader (Layout.fillWidth on
+                    // the Loader → Loader.width → item.width); the card's
+                    // implicitHeight drives Layout.preferredHeight above.
+                    eventPath: cardLoader.modelData.eventPath
+                    eventLabel: cardLoader.modelData.eventLabel
+                    isParentNode: cardLoader.modelData.isParentNode === true
+                }
+            }
         }
-
-        // Snap-into-zone window animations driven by the kwin-effect.
-        // The window quad animates when it snaps into / out of a zone
-        // or when a layout switch repositions it.
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.snapIn"
-            eventLabel: i18n("Snap Into Zone")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.snapOut"
-            eventLabel: i18n("Snap Out of Zone")
-        }
-
-        AnimationEventCard {
-            Layout.fillWidth: true
-            eventPath: "window.layoutSwitch"
-            eventLabel: i18n("Layout Switch")
-        }
-
     }
-
 }


### PR DESCRIPTION
## Problem

Since page hosting moved into the `phosphor-settings-ui` library, settings pages were slow on **first visit** (revisits were fine). Headless measurement (`QT_QPA_PLATFORM=offscreen`, compile-vs-instantiate split, min of many samples — single-run wall-clock timers proved 3x noisy and misleading) settled the cause: first-visit cost is **instantiation, not compilation**, in two distinct forms:

| page | sub-cards | compile | first-instantiate | warm-instantiate |
|---|---|---|---|---|
| animations-widgets | 22 | ~45 ms | 5885 ms | 5002 ms |
| animations-windows | 11 | ~50 ms | 818–3216 | 1732 ms |
| window-rules | – | ~45 ms | 1560 ms | 264 ms |
| layouts | – | ~58 ms | 937 ms | 383 ms |
| animations-general | 1 | ~91 ms | 764 ms | 51 ms |

1. **`inst_first` ≫ `warm`** on most pages = the page's **child component types compiling lazily on first instantiation** (the page's own unit compiling doesn't compile its children).
2. **Huge `warm` floor** on the animation card pages, ~200 ms per `AnimationEventCard` (each embeds a full `AnimationProfileEditor`).

## Fixes

- **Instance cache** (`PageHost.qml`): visited pages are built once and kept alive, shown/hidden on navigation like System Settings caches KCMs → revisits instant. Single `Loader` → `Repeater` of per-page Loaders.
- **Child-component compile-warm** (`main.cpp`): after startup, background-compile **every** settings QML unit (pages *and* their shared child component types) via `QQmlComponent(Asynchronous)`, held so the engine keeps the units cached. Compilation only — no instantiation, no page `onCompleted` side effects. Closes the `inst_first → warm` gap (non-card pages ~1.5 s → ~0.25 s first visit).
- **Virtualize all six animation-event pages** via a new reusable `AnimationEventCardList`: a `SettingsFlickable` (preserving the `WheelHandler` scroll) that renders one viewport-gated, latching `Loader` per `eventModel` entry — only cards near the viewport instantiate. The in-view latch is imperative, not a `Binding{when:}` (building a card relayouts the column and re-assigns child `y` in the same pass → binding loop).
- **fade-in fix** (review-found): the cached-page delegate's fade is driven imperatively so it survives both first-build and cached re-show.

## Out of scope (follow-ups)
- **Presets** (Canvas curve thumbnails) and **Motion Sets** (short saved-list) have a different structure and were not in the measured-heavy set. Presets could later defer its Canvas painting.
- **Hidden cached pages keep live signal connections** — bounded (cards early-return on a path check unless the edited path matches; no observed lag), but a future `isCurrent` gate would eliminate the fan-out entirely.

## Verification
Full build + 274 tests green. Verified in the running app: no binding-loop warnings, virtualized pages scroll cleanly, first-visit notably faster. A `/code-review` pass (high effort) ran over the diff; the one real regression it found (fade-in) is fixed in this branch.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)