### PR TITLE
fix(kwin-effect): stop focus-follows-mouse stealing focus from the interactive editor

### DIFF
--- a/kwin-effect/autotilehandler.cpp
+++ b/kwin-effect/autotilehandler.cpp
@@ -73,7 +73,7 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
     // active. Scoped to the same screen as the cursor so an unrelated focused
     // window on another monitor never freezes FFM here.
     if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
-        if (!PlasmaZonesEffect::isOwnOverlayClass(active->windowClass())
+        if (!PlasmaZonesEffect::isOwnPassthroughOverlayClass(active->windowClass())
             && m_effect->getWindowScreenId(active) == screenId) {
             // Filter first, then size-check. This mirrors the under-cursor
             // guard below so the two predicates stay structurally aligned.
@@ -115,10 +115,13 @@ void AutotileHandler::handleCursorMoved(const QPointF& pos, const QString& scree
         if (!w->frameGeometry().contains(pos)) {
             continue;
         }
-        // Look through our own overlay/editor layer-shell surfaces — they are
+        // Look through the daemon's own passthrough overlay surface — it is
         // full-screen and always topmost on the autotile monitor, so the bail
-        // below would otherwise kill FFM forever (discussion #461 #3).
-        if (PlasmaZonesEffect::isOwnOverlayClass(w->windowClass())) {
+        // below would otherwise kill FFM forever (discussion #461 #3). The
+        // editor is deliberately NOT looked through here: it is an interactive
+        // fullscreen window, so it falls to the occluder bail below and FFM
+        // leaves focus on it rather than stealing to the tiled window beneath.
+        if (PlasmaZonesEffect::isOwnPassthroughOverlayClass(w->windowClass())) {
             continue;
         }
         // A non-autotile window (excluded app, keep-above overlay, popup, dialog,

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -343,17 +343,31 @@ private:
     static bool isPlasmaShellSurface(const QString& windowClass);
 
     /**
-     * @brief Recognise the daemon's own overlay / editor layer-shell surfaces
+     * @brief Recognise the daemon's own overlay surface AND the editor window
      *        by window class.
      *
-     * The shouldHandleWindow filter rejects these as "own overlay/editor
-     * window class" so the snap/tile pipeline never targets them. Other paths
-     * (focus-follows-mouse stacking-order walks) need to *look through* them
-     * to the real user window beneath, rather than treating them as legitimate
-     * occluders the way they'd treat an emoji picker or xdg-desktop-portal
-     * surface. Sharing one substring match keeps both call sites in lockstep.
+     * The shouldHandleWindow filter rejects both as "own overlay/editor window
+     * class" so the snap/tile pipeline never targets them — that is the right
+     * scope for tiling exclusion: neither the daemon overlay nor the editor may
+     * ever be tiled.
+     *
+     * Do NOT use this for the focus-follows-mouse look-through — the editor is
+     * an interactive window that must keep its focus. Use
+     * isOwnPassthroughOverlayClass() there instead.
      */
     static bool isOwnOverlayClass(const QString& windowClass);
+
+    /**
+     * @brief Recognise only the daemon's non-interactive passthrough overlay
+     *        surface ("plasmazonesd") by window class.
+     *
+     * The focus-follows-mouse stacking walks look THROUGH this surface to the
+     * real user window beneath, because it is full-screen, permanently topmost,
+     * and never holds keyboard focus (PR #517 / discussion #461 #3). The
+     * interactive editor is intentionally excluded so FFM treats it as a real
+     * occluder and leaves focus on it.
+     */
+    static bool isOwnPassthroughOverlayClass(const QString& windowClass);
 
     /**
      * @brief Reject XDG desktop portal surfaces by window class.

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -176,6 +176,25 @@ bool PlasmaZonesEffect::isOwnOverlayClass(const QString& windowClass)
         || windowClass.contains(QLatin1String("plasmazones-editor"), Qt::CaseInsensitive);
 }
 
+bool PlasmaZonesEffect::isOwnPassthroughOverlayClass(const QString& windowClass)
+{
+    // The daemon's overlay layer-shell surface (windowClass "plasmazonesd")
+    // covers the whole autotile monitor and is permanently topmost, but it is a
+    // non-interactive passthrough surface that never holds keyboard focus. The
+    // focus-follows-mouse stacking walk must look THROUGH it to the real window
+    // beneath, or FFM bails on every cursor move once any OSD/snap-preview/
+    // layout-picker has been shown (discussion #461 #3 / PR #517).
+    //
+    // The editor (windowClass "plasmazones-editor") is deliberately NOT here:
+    // it is an interactive fullscreen xdg-shell toplevel the user works in, not
+    // a passthrough overlay. Looking through it stole the editor's focus to the
+    // tiled window beneath on every cursor move — that is what this predicate
+    // exists to prevent. It is still rejected from tiling by isOwnOverlayClass()
+    // (shouldHandleWindow), so FFM treats it as a genuine occluder and pauses,
+    // leaving focus on the editor.
+    return windowClass.contains(QLatin1String("plasmazonesd"), Qt::CaseInsensitive);
+}
+
 bool PlasmaZonesEffect::isXdgDesktopPortalSurface(const QString& windowClass)
 {
     // Substring match on "xdg-desktop-portal" covers every brokered portal

--- a/kwin-effect/snaphandler.cpp
+++ b/kwin-effect/snaphandler.cpp
@@ -277,9 +277,11 @@ void SnapHandler::handleCursorMoved(const QPointF& pos, const QString& screenId)
     // (follows the cursor between snapped windows) once a snapped window is
     // active. Scoped to the cursor's screen (mirrors AutotileHandler::
     // handleCursorMoved, discussion #461 + follow-up): a window active on another
-    // monitor must not freeze FFM on the monitor the cursor is on. Our own
-    // full-screen overlays never count as the kind of active window worth
-    // protecting. (Autotile pauses on the same principle — floated/popup/under-
+    // monitor must not freeze FFM on the monitor the cursor is on. The daemon's
+    // own passthrough overlay surface never counts as the kind of active window
+    // worth protecting; the interactive editor DOES (it is not a passthrough
+    // overlay, so it falls through to the not-snapped pause below and keeps
+    // focus). (Autotile pauses on the same principle — floated/popup/under-
     // min-size — but everything else there is tiled, so it has no never-managed
     // "free" case; snap does, hence the single not-snapped predicate.)
     if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {

--- a/kwin-effect/snaphandler.cpp
+++ b/kwin-effect/snaphandler.cpp
@@ -285,7 +285,7 @@ void SnapHandler::handleCursorMoved(const QPointF& pos, const QString& screenId)
     if (KWin::EffectWindow* active = KWin::effects->activeWindow()) {
         // Cheap overlay-class check first, then the heavier screen resolution
         // (mirrors the autotile guard's predicate ordering).
-        if (!PlasmaZonesEffect::isOwnOverlayClass(active->windowClass())
+        if (!PlasmaZonesEffect::isOwnPassthroughOverlayClass(active->windowClass())
             && m_effect->getWindowScreenId(active) == screenId && !isTiledWindow(m_effect->getWindowId(active))) {
             return;
         }
@@ -304,10 +304,12 @@ void SnapHandler::handleCursorMoved(const QPointF& pos, const QString& screenId)
         if (!w->frameGeometry().contains(pos)) {
             continue;
         }
-        // Look through our own overlay/editor layer-shell surfaces — they are full-screen
-        // and always topmost, so a bail here would kill FFM whenever an overlay is up
-        // (mirrors the autotile FFM guard).
-        if (PlasmaZonesEffect::isOwnOverlayClass(w->windowClass())) {
+        // Look through the daemon's own passthrough overlay surface — it is
+        // full-screen and always topmost, so a bail here would kill FFM whenever
+        // an overlay is up (mirrors the autotile FFM guard). The interactive
+        // editor is NOT looked through: it falls to the not-snapped bail below,
+        // so FFM leaves focus on it instead of stealing to a snapped window.
+        if (PlasmaZonesEffect::isOwnPassthroughOverlayClass(w->windowClass())) {
             continue;
         }
         // The window directly under the cursor is not snapped (a floating dialog, popup,


### PR DESCRIPTION
## Problem

With focus-follows-mouse enabled, fullscreen/exclusive windows like **`plasmazones-editor`** don't keep focus: moving the cursor over the editor immediately activates the tiled/snapped window beneath it, yanking focus away from the editor the user is working in.

## Root cause

PR #517 (discussion #461 #3) made the FFM stacking-order walk look **through** our own full-screen surfaces, so a permanently-topmost overlay couldn't kill FFM forever. That fix was only ever about the **daemon's passthrough overlay surface** (windowClass `plasmazonesd`) — the commit message says so explicitly.

But the predicate it reused, `isOwnOverlayClass()`, *also* matches `plasmazones-editor`, on the mistaken assumption the editor is "our own overlay/editor layer-shell surface." It isn't — the editor is an **interactive fullscreen xdg-shell toplevel** (`EditorWindow.qml` is a plain `Window` shown via `showFullScreenOnTargetScreen`). Looking through it means FFM finds the tiled window underneath and activates it on every cursor move.

## Fix

Split the two concerns that were conflated:

- **`isOwnOverlayClass()`** (matches daemon overlay **and** editor) — still drives the tiling exclusion in `shouldHandleWindow()`. Correct: neither may ever be tiled.
- **`isOwnPassthroughOverlayClass()`** (new; matches **only** `plasmazonesd`) — drives the FFM look-through. The editor now falls to the existing occluder bail, so FFM **pauses** and leaves focus on it — exactly how it already treats an emoji picker or a portal dialog.

Applied at all four FFM sites: under-cursor walk + active-window guard, in both `autotilehandler.cpp` and `snaphandler.cpp`. The daemon overlay is still looked through, so #517 / #461 #3 stays fixed.

## Verification

- Build: clean (`kwin_effect_plasmazones.so` links).
- Tests: 277/279 pass. The 2 failures are unrelated live-hardware tests (`pipewire smoke` — talks to the real pipewire daemon; `surface animator` — timing) that this change does not even rebuild; they're independent of the diff.
- The FFM walk runs against the live KWin compositor and has no unit harness, so the behavioural confirmation is: open the editor on an autotile/snap monitor with FFM on, move the cursor over it — focus stays on the editor.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)