### PR TITLE
feat(windowrule): add LockContext rule action to lock a context's layout

### DIFF
--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/RuleAction.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/RuleAction.h
@@ -240,6 +240,13 @@ inline constexpr QLatin1StringView SetEngineMode{"setEngineMode"};
 inline constexpr QLatin1StringView SetSnappingLayout{"setSnappingLayout"};
 inline constexpr QLatin1StringView SetTilingAlgorithm{"setTilingAlgorithm"};
 inline constexpr QLatin1StringView DisableEngine{"disableEngine"};
+/// Lock the active layout for the matched screen/desktop/activity context so
+/// it can't be switched — the rule-driven equivalent of the manual
+/// ToggleLayoutLock shortcut. Context domain (matches only context fields);
+/// mode-agnostic (a `true` lock applies to both the snapping and tiling
+/// engines). The daemon resolves it LIVE on the context-lock path and never
+/// persists it, so rule locks and manual toggles never overwrite each other.
+inline constexpr QLatin1StringView LockContext{"lockContext"};
 inline constexpr QLatin1StringView Exclude{"exclude"};
 inline constexpr QLatin1StringView Float{"float"};
 inline constexpr QLatin1StringView OverrideAnimationShader{"overrideAnimationShader"};
@@ -365,6 +372,9 @@ namespace ActionSlot {
 inline constexpr QLatin1StringView EngineMode{"engine-mode"};
 inline constexpr QLatin1StringView Layout{"layout"};
 inline constexpr QLatin1StringView EngineEnable{"engine-enable"};
+/// Context-domain layout-lock slot — filled by `ActionType::LockContext`.
+/// A single boolean: a winning rule with `value == true` locks the context.
+inline constexpr QLatin1StringView Locked{"locked"};
 inline constexpr QLatin1StringView Manage{"manage"};
 inline constexpr QLatin1StringView Float{"float"};
 inline constexpr QLatin1StringView Opacity{"opacity"};

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/RuleAction.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/RuleAction.h
@@ -339,6 +339,20 @@ inline bool isEffectRuleAction(const QString& type)
 {
     return isAnimationOverrideAction(type) || type == SetOpacity || isBorderAppearanceAction(type);
 }
+
+/// True when @p type is one of the five context-domain layout/engine actions
+/// that pin a screen/desktop/activity's layout behaviour — engine mode,
+/// snapping layout, tiling algorithm, disable-engine, or the layout lock. The
+/// settings layer clusters these into the "Layout & engine" picker category and
+/// treats any of them as marking a Monitor & Layout rule; keeping the list in
+/// one place stops those call-sites from drifting when a sixth such action is
+/// added. (Gap overrides are also context-domain but cluster separately, so
+/// they are intentionally excluded here.)
+inline bool isLayoutEngineContextAction(const QString& type)
+{
+    return type == SetEngineMode || type == SetSnappingLayout || type == SetTilingAlgorithm || type == DisableEngine
+        || type == LockContext;
+}
 } // namespace ActionType
 
 // ── Action param keys — canonical wire strings ──

--- a/libs/phosphor-windowrule/src/ruleaction.cpp
+++ b/libs/phosphor-windowrule/src/ruleaction.cpp
@@ -366,6 +366,27 @@ void ActionRegistry::registerBuiltins()
                      .enumWireValues = engineModeOptions()}},
     });
 
+    // ── locked slot — context-domain layout lock ──
+    // A matched context rule pins the active layout for its screen/desktop/
+    // activity so it can't be switched, mirroring the manual ToggleLayoutLock
+    // shortcut. Boolean `value`: true locks (the meaningful default for a
+    // freshly-authored action, hence `defaultDisplay = 1.0`), false is an
+    // explicit no-op overlay. Mode-agnostic — the daemon's lock check ORs the
+    // resolved value across both engine modes — and live-resolved, never
+    // persisted, so rule locks and manual toggles do not fight.
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::LockContext),
+        .slotFor = constantSlot(ActionSlot::Locked),
+        .validate =
+            [](const QJsonObject& p) {
+                return hasBool(p, ActionParam::Value);
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value), .kind = QStringLiteral("bool"), .defaultDisplay = 1.0}},
+    });
+
     // ── manage slot — terminal. Exclude is intentionally free-form: an empty
     //    `allowedKeys` opts out of the strict-key check so a future Exclude
     //    reason/scope param can be added without a schema bump. ──

--- a/libs/phosphor-windowrule/src/ruleaction.cpp
+++ b/libs/phosphor-windowrule/src/ruleaction.cpp
@@ -371,9 +371,10 @@ void ActionRegistry::registerBuiltins()
     // activity so it can't be switched, mirroring the manual ToggleLayoutLock
     // shortcut. Boolean `value`: true locks (the meaningful default for a
     // freshly-authored action, hence `defaultDisplay = 1.0`), false is an
-    // explicit no-op overlay. Mode-agnostic — the daemon's lock check ORs the
-    // resolved value across both engine modes — and live-resolved, never
-    // persisted, so rule locks and manual toggles do not fight.
+    // explicit no-op overlay. Mode-agnostic — the rule query ignores the Mode
+    // axis, so the same lock surfaces for whichever engine mode is asked — and
+    // live-resolved: the daemon ORs it with (never replaces) the manual
+    // ToggleLayoutLock store, so rule locks and manual toggles do not fight.
     registerAction(ActionDescriptor{
         .type = QString(ActionType::LockContext),
         .slotFor = constantSlot(ActionSlot::Locked),

--- a/libs/phosphor-windowrule/src/ruleaction.cpp
+++ b/libs/phosphor-windowrule/src/ruleaction.cpp
@@ -370,8 +370,11 @@ void ActionRegistry::registerBuiltins()
     // A matched context rule pins the active layout for its screen/desktop/
     // activity so it can't be switched, mirroring the manual ToggleLayoutLock
     // shortcut. Boolean `value`: true locks (the meaningful default for a
-    // freshly-authored action, hence `defaultDisplay = 1.0`), false is an
-    // explicit no-op overlay. Mode-agnostic — the rule query ignores the Mode
+    // freshly-authored action, hence `defaultDisplay = 1.0`); false fills the
+    // Locked slot with not-locked — a no-op against the manual lock store (the
+    // daemon ORs, so it never unlocks a manual lock), but as a single-winner
+    // slot a higher-priority false rule overrides a lower-priority true one.
+    // Mode-agnostic — the rule query ignores the Mode
     // axis, so the same lock surfaces for whichever engine mode is asked — and
     // live-resolved: the daemon ORs it with (never replaces) the manual
     // ToggleLayoutLock store, so rule locks and manual toggles do not fight.

--- a/libs/phosphor-windowrule/tests/test_actionregistry.cpp
+++ b/libs/phosphor-windowrule/tests/test_actionregistry.cpp
@@ -50,6 +50,7 @@ private Q_SLOTS:
         QVERIFY(reg.isRegistered(QString(ActionType::OverrideAnimationCurve)));
         QVERIFY(reg.isRegistered(QString(ActionType::SetOpacity)));
         QVERIFY(reg.isRegistered(QString(ActionType::RestorePosition)));
+        QVERIFY(reg.isRegistered(QString(ActionType::LockContext)));
     }
 
     void testSlots()
@@ -111,6 +112,7 @@ private Q_SLOTS:
         QVERIFY(!reg.isTerminal(makeAction(ActionType::OverrideAnimationCurve)));
         QVERIFY(!reg.isTerminal(makeAction(ActionType::SetOpacity)));
         QVERIFY(!reg.isTerminal(makeAction(ActionType::RestorePosition)));
+        QVERIFY(!reg.isTerminal(makeAction(ActionType::LockContext)));
     }
 
     void testValidateAcceptsWellFormedRegisteredAction()

--- a/libs/phosphor-windowrule/tests/test_actionregistry.cpp
+++ b/libs/phosphor-windowrule/tests/test_actionregistry.cpp
@@ -20,14 +20,14 @@ RuleAction makeAction(QLatin1StringView type, const QJsonObject& params = {})
 
 } // namespace
 
-// `ActionRegistry` is a process-global singleton. It now exposes
-// `unregisterAction` (added in the audit pass), so symmetric cleanup is
-// possible — but this test suite predates that API and `testRegisterCustomAction`
-// does not yet RAII-clean up its sentinel. To keep cross-test independence
-// without rewriting every test, no test here asserts an *absolute*
-// `registeredTypes().size()` — that count is not stable across the suite.
-// Builtins are asserted individually instead. `testBuiltinsRegistered` must
-// stay declared FIRST so it observes the registry before any test mutates it.
+// `ActionRegistry` is a process-global singleton. `testRegisterCustomAction`
+// registers a sentinel and unregisters it again (via `unregisterAction`) so it
+// leaves the singleton pristine. As defence in depth against any future test
+// that mutates the registry without cleaning up, no test here asserts an
+// *absolute* `registeredTypes().size()` — that count is not guaranteed stable
+// across the suite. Builtins are asserted individually instead, and
+// `testBuiltinsRegistered` stays declared FIRST so it observes the registry
+// before any test mutates it.
 class TestActionRegistry : public QObject
 {
     Q_OBJECT

--- a/libs/phosphor-windowrule/tests/test_actionregistry.cpp
+++ b/libs/phosphor-windowrule/tests/test_actionregistry.cpp
@@ -166,6 +166,32 @@ private Q_SLOTS:
         QVERIFY2(!reg.validate(makeAction(ActionType::RestorePosition, notBool)), "non-bool value must fail");
     }
 
+    void testLockContextAction()
+    {
+        const ActionRegistry& reg = ActionRegistry::instance();
+        QVERIFY(reg.isRegistered(QString(ActionType::LockContext)));
+
+        QJsonObject on;
+        on.insert(QStringLiteral("value"), true);
+        QJsonObject off;
+        off.insert(QStringLiteral("value"), false);
+
+        // Context-domain boolean action filling the dedicated locked slot.
+        // Non-terminal: a lock-only context rule composes with other context
+        // slots (e.g. a separate gap rule) rather than short-circuiting.
+        QCOMPARE(reg.slotFor(makeAction(ActionType::LockContext, on)), QString(ActionSlot::Locked));
+        QCOMPARE(reg.domainFor(makeAction(ActionType::LockContext, on)), ActionDomain::Context);
+        QVERIFY(!reg.isTerminal(makeAction(ActionType::LockContext, on)));
+
+        // Requires a boolean `value`; both true and false are well-formed.
+        QVERIFY(reg.validate(makeAction(ActionType::LockContext, on)));
+        QVERIFY(reg.validate(makeAction(ActionType::LockContext, off)));
+        QVERIFY2(!reg.validate(makeAction(ActionType::LockContext)), "missing value must fail validation");
+        QJsonObject notBool;
+        notBool.insert(QStringLiteral("value"), 1);
+        QVERIFY2(!reg.validate(makeAction(ActionType::LockContext, notBool)), "non-bool value must fail");
+    }
+
     void testRegisterCustomAction()
     {
         ActionRegistry& reg = ActionRegistry::instance();

--- a/libs/phosphor-windowrule/tests/test_actionregistry.cpp
+++ b/libs/phosphor-windowrule/tests/test_actionregistry.cpp
@@ -200,10 +200,10 @@ private Q_SLOTS:
         // `_zz_` prefix so the type-id sorts to the end if anyone iterates
         // `registeredTypes()` in lexicographic order, and the underscore-led
         // name visually separates it from the production wire identifiers.
-        // This test predates the `unregisterAction` API; the sentinel
-        // remains registered for the rest of the test binary's lifetime —
-        // see the file-level comment for the cross-test independence
-        // pattern.
+        // The sentinel is unregistered at the end of the test so it does not
+        // leak into the process-global singleton for the rest of the binary's
+        // lifetime — see the file-level comment for the cross-test
+        // independence pattern.
         const QString customType = QStringLiteral("_zz_pwrTestCustomAction");
         QVERIFY(!reg.isRegistered(customType));
 
@@ -219,6 +219,11 @@ private Q_SLOTS:
                                             .terminal = false});
         QVERIFY(reg.isRegistered(customType));
         QCOMPARE(reg.slotFor(makeAction(QLatin1StringView("_zz_pwrTestCustomAction"))), QStringLiteral("custom-slot"));
+
+        // Clean up: unregister the sentinel so the singleton is left pristine
+        // for any later test (and so the binary does not carry a bespoke type).
+        QVERIFY(reg.unregisterAction(customType));
+        QVERIFY(!reg.isRegistered(customType));
     }
 
     void testValidateRejectsUnregistered()

--- a/libs/phosphor-windowrule/tests/test_ruleaction.cpp
+++ b/libs/phosphor-windowrule/tests/test_ruleaction.cpp
@@ -30,6 +30,9 @@ const QList<QLatin1StringView> kContextDomainTypes = {
     ActionType::SetSnappingLayout,
     ActionType::SetTilingAlgorithm,
     ActionType::DisableEngine,
+    // Layout lock — context-domain, resolved during the screen/desktop/
+    // activity pass (mode-agnostic) like the other context actions.
+    ActionType::LockContext,
     // Gap overrides are context-domain — resolved during the
     // screen/desktop/activity pass, never per-window.
     ActionType::SetZonePadding,

--- a/libs/phosphor-windowrule/tests/test_ruleaction.cpp
+++ b/libs/phosphor-windowrule/tests/test_ruleaction.cpp
@@ -418,6 +418,31 @@ private Q_SLOTS:
         rejectsStray(ActionType::SetBorderColor, QJsonValue(QStringLiteral("#FF0000")));
         rejectsStray(ActionType::SetOuterGapTop, QJsonValue(8));
         rejectsStray(ActionType::SetUsePerSideOuterGap, QJsonValue(true));
+        rejectsStray(ActionType::LockContext, QJsonValue(true));
+    }
+
+    void testLockContext_fromJsonRoundTrip()
+    {
+        // LockContext is a context-domain boolean: it must validate through the
+        // public fromJson boundary (not just the registry), require a bool
+        // `value`, and round-trip both true and the explicit-false no-op overlay
+        // losslessly. Mirrors testSetHideTitleBarFalse_isValidAndPreserved.
+        QJsonObject bad;
+        bad.insert(QStringLiteral("type"), QString(ActionType::LockContext));
+        bad.insert(QStringLiteral("value"), 1); // a number is not a bool
+        QVERIFY(!RuleAction::fromJson(bad).has_value());
+
+        for (const bool v : {true, false}) {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString(ActionType::LockContext));
+            o.insert(QStringLiteral("value"), v);
+            const auto action = RuleAction::fromJson(o);
+            QVERIFY(action.has_value());
+            QCOMPARE(action->params.value(QStringLiteral("value")), QJsonValue(v));
+            const auto roundTripped = RuleAction::fromJson(action->toJson());
+            QVERIFY(roundTripped.has_value());
+            QCOMPARE(roundTripped->params.value(QStringLiteral("value")), QJsonValue(v));
+        }
     }
 };
 

--- a/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
@@ -141,6 +141,23 @@ public:
         return {};
     }
 
+    /// Resolve whether window rules lock the active layout for the
+    /// (@p screenId, @p virtualDesktop, @p activity) context — the rule-driven
+    /// counterpart to the manual ToggleLayoutLock shortcut. A context rule
+    /// carrying an `ActionType::LockContext` action whose `value` is true locks
+    /// the context; the daemon ORs this into its context-lock check (across
+    /// both engine modes) so a locked context refuses layout switches. Mode-
+    /// agnostic and never persisted. The default returns false (no rule lock); a
+    /// registry that does not model context rules — e.g. a fixture stub — keeps
+    /// only the persisted manual-lock behaviour.
+    virtual bool resolveContextLocked(const QString& screenId, int virtualDesktop, const QString& activity) const
+    {
+        Q_UNUSED(screenId);
+        Q_UNUSED(virtualDesktop);
+        Q_UNUSED(activity);
+        return false;
+    }
+
 Q_SIGNALS:
     // Catalog mutation. @c addLayout / @c duplicateLayout fire `layoutAdded`;
     // @c removeLayout / @c removeLayoutById fire `layoutRemoved`.

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -645,6 +645,39 @@ private:
         return h;
     }
 
+    /// Shared revision-invalidated memoization for the three context resolvers
+    /// (@ref resolveAssignmentEntry, @ref resolveContextGaps,
+    /// @ref resolveContextLocked). Drops @p cache wholesale whenever the rule
+    /// set's monotonic revision moves past @p cacheRevision, returns a cached
+    /// hit, else runs @p compute, then soft-caps the cache at 256 entries —
+    /// dropping the whole cache on overflow rather than evicting one key, which
+    /// keeps the structure simple and lets the next walk re-seed cleanly — and
+    /// stores the result (a @c nullopt / false value is cached too, so a genuine
+    /// miss pays the walk once per revision, not on every cursor frame). Callers
+    /// that must short-circuit on a null evaluator do so BEFORE calling this.
+    template<typename V, typename ComputeFn>
+    V resolveCachedContext(QHash<ContextResolveKey, V>& cache, quint64& cacheRevision, const QString& screenId,
+                           int virtualDesktop, const QString& activity, ComputeFn&& compute) const
+    {
+        const quint64 revision = m_ruleStore->ruleSet().revision();
+        if (revision != cacheRevision) {
+            cache.clear();
+            cacheRevision = revision;
+        }
+        const ContextResolveKey key{screenId, virtualDesktop, activity};
+        const auto cached = cache.constFind(key);
+        if (cached != cache.constEnd()) {
+            return cached.value();
+        }
+        V value = compute();
+        constexpr qsizetype kMaxEntries = 256;
+        if (cache.size() >= kMaxEntries) {
+            cache.clear();
+        }
+        cache.insert(key, value);
+        return value;
+    }
+
     /// Cache of @ref resolveAssignmentEntry results keyed by context tuple.
     /// A @c nullopt value caches a genuine cascade miss (no pinned context
     /// rule wins) — so a missed lookup pays the linear walk exactly once per

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -534,7 +534,8 @@ private:
     /// linear walk. No explicit signal-time clear is required: a real edit
     /// bumps the revision (see @c WindowRuleSet::setRules), so the next
     /// resolve sees the bump and re-populates. A soft cap (256 entries — see
-    /// the @c kMaxEntries constant in @c layoutregistry_assignments.cpp)
+    /// the per-cache @c kMaxEntries constant in
+    /// @c layoutregistry_assignments.cpp; each context cache declares its own)
     /// guards against pathological growth from clients probing unique
     /// non-existent tuples; on overflow the cache is cleared entirely (the
     /// next walk re-seeds it cleanly). 256 sits comfortably above any

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -314,6 +314,14 @@ public:
     ContextGapOverride resolveContextGaps(const QString& screenId, int virtualDesktop,
                                           const QString& activity) const override;
 
+    /// Resolve whether a context rule locks the active layout for the
+    /// (screen, desktop, activity) context by evaluating a windowless
+    /// WindowQuery through the RuleEvaluator and reading the
+    /// `ActionSlot::Locked` slot. Mode-agnostic per-slot read (mirrors @ref
+    /// resolveContextGaps); returns true iff the winning Locked-slot action's
+    /// `value` is true. Same owner-thread affinity as the rest of the registry.
+    bool resolveContextLocked(const QString& screenId, int virtualDesktop, const QString& activity) const override;
+
     Q_INVOKABLE void clearAssignment(const QString& screenId, int virtualDesktop = 0,
                                      const QString& activity = QString());
     /// True iff a context-assignment rule whose match is exactly this
@@ -656,6 +664,14 @@ private:
     /// so memoizing collapses those repeats to one walk per rule-set revision.
     mutable QHash<ContextResolveKey, ContextGapOverride> m_contextGapCache;
     mutable quint64 m_contextGapCacheRevision = 0;
+
+    /// Hot-path cache for @ref resolveContextLocked, keyed and
+    /// revision-invalidated exactly like @c m_contextGapCache. The lock check
+    /// runs on overlay/selector updates (per cursor-move while a selector is
+    /// open) as well as every layout-switch attempt, so memoizing the per-slot
+    /// walk collapses repeats to one walk per rule-set revision.
+    mutable QHash<ContextResolveKey, bool> m_contextLockCache;
+    mutable quint64 m_contextLockCacheRevision = 0;
 
     std::function<QString()> m_defaultLayoutIdProvider; ///< Empty = provider disabled; falls back to first layout
     /// Empty = provider disabled. Returns the user's default autotile

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -166,6 +166,45 @@ ContextGapOverride LayoutRegistry::resolveContextGaps(const QString& screenId, i
     return gaps;
 }
 
+bool LayoutRegistry::resolveContextLocked(const QString& screenId, int virtualDesktop, const QString& activity) const
+{
+    // Mirror resolveContextGaps: a per-slot read off the evaluator's
+    // ResolvedActions, not the single-winner assignment walk. The Locked slot
+    // is filled by the highest-priority matching context rule carrying a
+    // LockContext action; we report its boolean value. No engine-mode gate —
+    // a lock-only context rule is a first-class overlay.
+    if (!m_evaluator) {
+        return false;
+    }
+
+    const quint64 revision = m_ruleStore->ruleSet().revision();
+    if (revision != m_contextLockCacheRevision) {
+        m_contextLockCache.clear();
+        m_contextLockCacheRevision = revision;
+    }
+    const ContextResolveKey key{screenId, virtualDesktop, activity};
+    const auto cached = m_contextLockCache.constFind(key);
+    if (cached != m_contextLockCache.constEnd()) {
+        return cached.value();
+    }
+
+    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+    const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
+    bool locked = false;
+    if (const auto action = resolved.slot(QString(PWR::ActionSlot::Locked))) {
+        locked = action->params.value(PWR::ActionParam::Value).toBool();
+    }
+
+    // Soft cap mirroring m_contextGapCache (see resolveAssignmentEntry): drop
+    // the whole cache on overflow rather than evicting one key.
+    constexpr qsizetype kMaxEntries = 256;
+    if (m_contextLockCache.size() >= kMaxEntries) {
+        m_contextLockCache.clear();
+    }
+    m_contextLockCache.insert(key, locked);
+    return locked;
+}
+
 bool LayoutRegistry::hasExactContextRule(const QString& screenId, int virtualDesktop, const QString& activity) const
 {
     return findExactContextRule(screenId, virtualDesktop, activity) != nullptr;

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -64,46 +64,23 @@ std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QStr
     // mode-toggle losslessness invariant (an entry keeps BOTH snappingLayout
     // and tilingAlgorithm regardless of active mode).
     //
-    // Hot-path cache. The linear walk is O(N rules × M predicates per match);
-    // overlay/OSD callers issue it per cursor-move, and the connector +
-    // virtual-screen fallback chain in the public resolvers triples that on a
-    // miss. Memoize the (screenId, virtualDesktop, activity) result, keyed
-    // against the rule set's monotonic revision so any real edit invalidates
-    // lazily. A @c nullopt is cached too — a genuine miss must not re-walk
-    // three times per cursor frame.
-    const quint64 revision = m_ruleStore->ruleSet().revision();
-    if (revision != m_contextResolveCacheRevision) {
-        m_contextResolveCache.clear();
-        m_contextResolveCacheRevision = revision;
-    }
-    const ContextResolveKey key{screenId, virtualDesktop, activity};
-    const auto cached = m_contextResolveCache.constFind(key);
-    if (cached != m_contextResolveCache.constEnd()) {
-        return cached.value();
-    }
-
-    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
-    const PWR::WindowRule* winner = m_evaluator->highestPriorityMatch(query, [](const PWR::WindowRule& rule) {
-        return hasEngineModeAction(rule) && !rule.match.isCatchAll();
-    });
-    std::optional<AssignmentEntry> result;
-    if (winner != nullptr) {
-        result = entryFromRuleMatchActions(*winner);
-    }
-    // Soft cap. The header claims the cache is bounded by live
-    // (screens × desktops × activities) — order-of-1000 in the worst case —
-    // but a pathological client poking unique non-existent tuples could grow
-    // it unbounded. 256 is comfortably above any realistic live footprint and
-    // far below any heap-pressure concern; on overflow drop the whole cache
-    // rather than evicting one key, which keeps the data-structure simple
-    // and the next walk seeds it cleanly. The walk itself stays O(N), so the
-    // miss cost is bounded.
-    constexpr qsizetype kMaxEntries = 256;
-    if (m_contextResolveCache.size() >= kMaxEntries) {
-        m_contextResolveCache.clear();
-    }
-    m_contextResolveCache.insert(key, result);
-    return result;
+    // Hot-path cache via the shared revision-invalidated memoizer. The linear
+    // walk is O(N rules × M predicates per match); overlay/OSD callers issue it
+    // per cursor-move, and the connector + virtual-screen fallback chain in the
+    // public resolvers triples that on a miss. A @c nullopt is cached too — a
+    // genuine miss must not re-walk three times per cursor frame.
+    return resolveCachedContext(m_contextResolveCache, m_contextResolveCacheRevision, screenId, virtualDesktop,
+                                activity, [&]() -> std::optional<AssignmentEntry> {
+                                    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+                                    const PWR::WindowRule* winner =
+                                        m_evaluator->highestPriorityMatch(query, [](const PWR::WindowRule& rule) {
+                                            return hasEngineModeAction(rule) && !rule.match.isCatchAll();
+                                        });
+                                    if (winner != nullptr) {
+                                        return entryFromRuleMatchActions(*winner);
+                                    }
+                                    return std::nullopt;
+                                });
 }
 
 ContextGapOverride LayoutRegistry::resolveContextGaps(const QString& screenId, int virtualDesktop,
@@ -115,55 +92,38 @@ ContextGapOverride LayoutRegistry::resolveContextGaps(const QString& screenId, i
     // compose — and two gap rules touching different slots both apply. No
     // engine-mode gate and no isValid() filter: a gap-only context rule is a
     // first-class override here.
-    ContextGapOverride gaps;
     if (!m_evaluator) {
-        return gaps;
+        return ContextGapOverride{};
     }
 
-    // Hot-path cache, mirroring resolveAssignmentEntry: the geometry path
-    // resolves the same context twice per op (zone padding + outer gaps) and
-    // N× inside a multi-zone snap, all with identical arguments. Memoize keyed
-    // by the rule set's monotonic revision so any edit invalidates lazily.
-    const quint64 revision = m_ruleStore->ruleSet().revision();
-    if (revision != m_contextGapCacheRevision) {
-        m_contextGapCache.clear();
-        m_contextGapCacheRevision = revision;
-    }
-    const ContextResolveKey key{screenId, virtualDesktop, activity};
-    const auto cached = m_contextGapCache.constFind(key);
-    if (cached != m_contextGapCache.constEnd()) {
-        return cached.value();
-    }
+    // Hot-path cache via the shared revision-invalidated memoizer: the geometry
+    // path resolves the same context twice per op (zone padding + outer gaps)
+    // and N× inside a multi-zone snap, all with identical arguments.
+    return resolveCachedContext(
+        m_contextGapCache, m_contextGapCacheRevision, screenId, virtualDesktop, activity, [&]() -> ContextGapOverride {
+            ContextGapOverride gaps;
+            const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+            const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
 
-    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
-    const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
-
-    const auto readInt = [&resolved](QLatin1StringView slot, std::optional<int>& out) {
-        if (const auto action = resolved.slot(QString(slot))) {
-            out = action->params.value(PWR::ActionParam::Value).toInt();
-        }
-    };
-    const auto readBool = [&resolved](QLatin1StringView slot, std::optional<bool>& out) {
-        if (const auto action = resolved.slot(QString(slot))) {
-            out = action->params.value(PWR::ActionParam::Value).toBool();
-        }
-    };
-    readInt(PWR::ActionSlot::ZonePadding, gaps.zonePadding);
-    readInt(PWR::ActionSlot::OuterGap, gaps.outerGap);
-    readBool(PWR::ActionSlot::UsePerSideOuterGap, gaps.usePerSideOuterGap);
-    readInt(PWR::ActionSlot::OuterGapTop, gaps.outerGapTop);
-    readInt(PWR::ActionSlot::OuterGapBottom, gaps.outerGapBottom);
-    readInt(PWR::ActionSlot::OuterGapLeft, gaps.outerGapLeft);
-    readInt(PWR::ActionSlot::OuterGapRight, gaps.outerGapRight);
-
-    // Soft cap mirroring m_contextResolveCache (see resolveAssignmentEntry):
-    // drop the whole cache on overflow rather than evicting one key.
-    constexpr qsizetype kMaxEntries = 256;
-    if (m_contextGapCache.size() >= kMaxEntries) {
-        m_contextGapCache.clear();
-    }
-    m_contextGapCache.insert(key, gaps);
-    return gaps;
+            const auto readInt = [&resolved](QLatin1StringView slot, std::optional<int>& out) {
+                if (const auto action = resolved.slot(QString(slot))) {
+                    out = action->params.value(PWR::ActionParam::Value).toInt();
+                }
+            };
+            const auto readBool = [&resolved](QLatin1StringView slot, std::optional<bool>& out) {
+                if (const auto action = resolved.slot(QString(slot))) {
+                    out = action->params.value(PWR::ActionParam::Value).toBool();
+                }
+            };
+            readInt(PWR::ActionSlot::ZonePadding, gaps.zonePadding);
+            readInt(PWR::ActionSlot::OuterGap, gaps.outerGap);
+            readBool(PWR::ActionSlot::UsePerSideOuterGap, gaps.usePerSideOuterGap);
+            readInt(PWR::ActionSlot::OuterGapTop, gaps.outerGapTop);
+            readInt(PWR::ActionSlot::OuterGapBottom, gaps.outerGapBottom);
+            readInt(PWR::ActionSlot::OuterGapLeft, gaps.outerGapLeft);
+            readInt(PWR::ActionSlot::OuterGapRight, gaps.outerGapRight);
+            return gaps;
+        });
 }
 
 bool LayoutRegistry::resolveContextLocked(const QString& screenId, int virtualDesktop, const QString& activity) const
@@ -177,32 +137,18 @@ bool LayoutRegistry::resolveContextLocked(const QString& screenId, int virtualDe
         return false;
     }
 
-    const quint64 revision = m_ruleStore->ruleSet().revision();
-    if (revision != m_contextLockCacheRevision) {
-        m_contextLockCache.clear();
-        m_contextLockCacheRevision = revision;
-    }
-    const ContextResolveKey key{screenId, virtualDesktop, activity};
-    const auto cached = m_contextLockCache.constFind(key);
-    if (cached != m_contextLockCache.constEnd()) {
-        return cached.value();
-    }
-
-    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
-    const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
-    bool locked = false;
-    if (const auto action = resolved.slot(QString(PWR::ActionSlot::Locked))) {
-        locked = action->params.value(PWR::ActionParam::Value).toBool();
-    }
-
-    // Soft cap mirroring m_contextGapCache (see resolveAssignmentEntry): drop
-    // the whole cache on overflow rather than evicting one key.
-    constexpr qsizetype kMaxEntries = 256;
-    if (m_contextLockCache.size() >= kMaxEntries) {
-        m_contextLockCache.clear();
-    }
-    m_contextLockCache.insert(key, locked);
-    return locked;
+    // Hot-path cache via the shared revision-invalidated memoizer: the lock
+    // check runs per cursor-move while a selector is open and on every
+    // layout-switch attempt.
+    return resolveCachedContext(m_contextLockCache, m_contextLockCacheRevision, screenId, virtualDesktop, activity,
+                                [&]() -> bool {
+                                    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+                                    const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
+                                    if (const auto action = resolved.slot(QString(PWR::ActionSlot::Locked))) {
+                                        return action->params.value(PWR::ActionParam::Value).toBool();
+                                    }
+                                    return false;
+                                });
 }
 
 bool LayoutRegistry::hasExactContextRule(const QString& screenId, int virtualDesktop, const QString& activity) const
@@ -238,8 +184,8 @@ const PhosphorWindowRule::WindowRule* LayoutRegistry::findExactContextRule(const
     // the settings UI (windowruletemplates.cpp's `QUuid::createUuid()`
     // path). The shape fallback gates on `isPureAssignmentRule` — a
     // user rule that ALSO carries SetOpacity / OverrideAnimation* /
-    // Float / Exclude alongside the assignment slots is intentionally
-    // NOT claimed here. Admitting it would feed it through
+    // Float / Exclude / LockContext alongside the assignment slots is
+    // intentionally NOT claimed here. Admitting it would feed it through
     // upsertAssignmentRule / assignLayout / applyBatchAssignments which
     // rebuild via makeAssignmentActions and emit only the three slot
     // actions — silently stripping the user's other actions. Falling
@@ -364,9 +310,9 @@ bool LayoutRegistry::purgeSnappingLayoutFromAssignments(const QString& layoutId)
         // Gate on isPureAssignmentRule (not isContextAssignmentRule) — the
         // Shape-1 rebuild path emits ONLY the three assignment slot actions
         // via makeAssignmentActions, so a mixed context rule carrying
-        // SetOpacity / OverrideAnimation* / Float / Exclude alongside its
-        // assignment actions would silently lose those non-assignment
-        // actions on rebuild. Mixed rules fall through to Shape 2's
+        // SetOpacity / OverrideAnimation* / Float / Exclude / LockContext
+        // alongside its assignment actions would silently lose those
+        // non-assignment actions on rebuild. Mixed rules fall through to Shape 2's
         // surgical SetSnappingLayout removal, which preserves every
         // other action verbatim.
         if (isContextAssignmentRule(rule) && isPureAssignmentRule(rule)) {

--- a/src/daemon/contextresolverwiring.cpp
+++ b/src/daemon/contextresolverwiring.cpp
@@ -7,6 +7,8 @@
 #include "../core/screenmoderouter.h"
 #include "../core/utils.h"
 
+#include <PhosphorZones/LayoutRegistry.h>
+
 #include <PhosphorWorkspaces/ActivityManager.h>
 #include <PhosphorWorkspaces/VirtualDesktopManager.h>
 
@@ -59,8 +61,9 @@ PhosphorZones::AssignmentEntry::Mode DaemonScreenModeAdapter::modeFor(const QStr
 
 // ── DaemonSettingsGateAdapter ───────────────────────────────────────────
 
-DaemonSettingsGateAdapter::DaemonSettingsGateAdapter(ISettings* settings)
+DaemonSettingsGateAdapter::DaemonSettingsGateAdapter(ISettings* settings, PhosphorZones::LayoutRegistry* layoutRegistry)
     : m_settings(settings)
+    , m_layoutRegistry(layoutRegistry)
 {
 }
 
@@ -97,6 +100,14 @@ bool DaemonSettingsGateAdapter::isActivityDisabled(PhosphorZones::AssignmentEntr
 bool DaemonSettingsGateAdapter::isContextLocked(PhosphorZones::AssignmentEntry::Mode mode, const QString& screenId,
                                                 int desktop, const QString& activity) const
 {
+    // Rule-driven lock first: a `LockContext` context rule locks the active
+    // layout live, regardless of engine mode, and is never written to the
+    // persisted lock store — so it OR-s with (never replaces) the manual
+    // ToggleLayoutLock state below. Mode-agnostic: the rule query ignores the
+    // Mode axis, so the same rule lock surfaces for whichever mode is asked.
+    if (m_layoutRegistry && m_layoutRegistry->resolveContextLocked(screenId, desktop, activity))
+        return true;
+
     if (!m_settings)
         return false;
     // Fold the Mode into the screen-key the way every pre-migration call

--- a/src/daemon/contextresolverwiring.h
+++ b/src/daemon/contextresolverwiring.h
@@ -12,6 +12,10 @@ class ActivityManager;
 class VirtualDesktopManager;
 } // namespace PhosphorWorkspaces
 
+namespace PhosphorZones {
+class LayoutRegistry;
+} // namespace PhosphorZones
+
 namespace PlasmaZones {
 
 class ISettings;
@@ -97,16 +101,19 @@ private:
  * composes the Mode into the screen-key string via `Utils::contextLockKey`
  * before calling `ISettings::isContextLocked`, mirroring the call shape
  * every migrated site used before (`isContextLocked(contextLockKey(modeInt,
- * screenId), desktop, activity)`).
+ * screenId), desktop, activity)`), then ORs in the rule-driven lock resolved
+ * by `LayoutRegistry::resolveContextLocked` so a `LockContext` window rule
+ * locks the context live without ever touching the persisted lock store.
  *
- * Null `ISettings*` is permitted for headless-test wiring; every predicate
- * returns `false` in that case (the "no settings → nothing is gated"
- * fallback that the daemon's existing code already exercises).
+ * Null `ISettings*` / `LayoutRegistry*` are permitted for headless-test
+ * wiring; every predicate returns `false` in that case (the "no settings →
+ * nothing is gated" fallback that the daemon's existing code already
+ * exercises).
  */
 class DaemonSettingsGateAdapter : public PhosphorContext::IContextGateSource
 {
 public:
-    explicit DaemonSettingsGateAdapter(ISettings* settings);
+    DaemonSettingsGateAdapter(ISettings* settings, PhosphorZones::LayoutRegistry* layoutRegistry);
     ~DaemonSettingsGateAdapter() override = default;
 
     bool isMonitorDisabled(PhosphorZones::AssignmentEntry::Mode mode, const QString& screenId) const override;
@@ -119,6 +126,10 @@ public:
 
 private:
     ISettings* m_settings; ///< Non-owning; outlives this adapter.
+    /// Non-owning; outlives this adapter (the daemon declares the registry
+    /// before this adapter, so it tears down after). Source of the live,
+    /// never-persisted rule-driven context lock OR-ed into `isContextLocked`.
+    PhosphorZones::LayoutRegistry* m_layoutRegistry;
 };
 
 } // namespace PlasmaZones

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1097,7 +1097,7 @@ bool Daemon::init()
     m_workspaceStateAdapter =
         std::make_unique<DaemonWorkspaceStateAdapter>(m_virtualDesktopManager.get(), m_activityManager.get());
     m_screenModeAdapter = std::make_unique<DaemonScreenModeAdapter>(m_screenModeRouter.get());
-    m_settingsGateAdapter = std::make_unique<DaemonSettingsGateAdapter>(m_settings.get());
+    m_settingsGateAdapter = std::make_unique<DaemonSettingsGateAdapter>(m_settings.get(), m_layoutManager.get());
     m_contextResolver = std::make_unique<PhosphorContext::ContextResolver>(
         m_workspaceStateAdapter.get(), m_screenModeAdapter.get(), m_settingsGateAdapter.get());
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1214,6 +1214,19 @@ bool Daemon::init()
                 refilterExcludeRules();
             });
 
+    // A rule edit can change the live context-lock state (e.g. toggling,
+    // re-prioritising or re-matching a LockContext rule) without touching the
+    // manual lock store, so the ISettings::settingsChanged refresh that keeps
+    // open zone selectors / the layout picker in sync would miss it. Re-push
+    // the lock state to any open overlay on every rule change. QPointer guards
+    // the shutdown window (overlay reset before ~Daemon disconnects).
+    connect(m_windowRuleStore.get(), &PhosphorWindowRule::WindowRuleStore::rulesChanged, this,
+            [overlay = QPointer(m_overlayService.get())](bool /*persisted*/) {
+                if (overlay) {
+                    overlay->refreshContextLockState();
+                }
+            });
+
     // Wire persistence delegate — SnapEngine delegates save/load to WTA's KConfig layer.
     // QPointer guards against late calls during shutdown if WTA is destroyed first.
     snapEngine->setPersistenceDelegate(

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -391,6 +391,16 @@ public:
     void pickerMoveSelection(int dx, int dy);
     void pickerConfirmSelection();
 
+    /// Re-push the context lock state to any open zone selector and the layout
+    /// picker. Called when window rules change at runtime (e.g. a `LockContext`
+    /// rule is toggled, re-prioritised or re-matched) so an already-visible
+    /// overlay's lock affordance updates in place instead of waiting for the
+    /// next show — mirroring how `ISettings::settingsChanged` refreshes the
+    /// selectors for manual-lock edits. The authoritative block is still the
+    /// live re-check at commit (the selector hit-test and `isScreenLocked`);
+    /// this only keeps the visual in sync.
+    void refreshContextLockState();
+
 public Q_SLOTS:
     // hideLayoutOsd / hideNavigationOsd intentionally absent. Phase-5
     // dismiss path: QML auto-dismiss timer → loaded content's

--- a/src/daemon/overlayservice/internal.h
+++ b/src/daemon/overlayservice/internal.h
@@ -16,10 +16,9 @@
 #include <PhosphorLayer/Role.h>
 #include <PhosphorScreens/Manager.h>
 #include <PhosphorScreens/ScreenIdentity.h>
+#include <PhosphorZones/IZoneLayoutRegistry.h>
 
 #include "overlay_helpers.h"
-#include <PhosphorScreens/Manager.h>
-#include <PhosphorZones/IZoneLayoutRegistry.h>
 #include "../../core/settings_interfaces.h"
 #include "../../core/interfaces.h"
 #include "../../core/shaderregistry.h"

--- a/src/daemon/overlayservice/internal.h
+++ b/src/daemon/overlayservice/internal.h
@@ -5,6 +5,18 @@
 
 #include <optional>
 
+#include "overlay_helpers.h"
+#include "../../core/settings_interfaces.h"
+#include "../../core/interfaces.h"
+#include "../../core/shaderregistry.h"
+#include "../../core/utils.h"
+#include "../config/configdefaults.h"
+
+#include <PhosphorLayer/Role.h>
+#include <PhosphorScreens/Manager.h>
+#include <PhosphorScreens/ScreenIdentity.h>
+#include <PhosphorZones/IZoneLayoutRegistry.h>
+
 #include <QFont>
 #include <QGuiApplication>
 #include <QMargins>
@@ -12,18 +24,6 @@
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QScreen>
-
-#include <PhosphorLayer/Role.h>
-#include <PhosphorScreens/Manager.h>
-#include <PhosphorScreens/ScreenIdentity.h>
-#include <PhosphorZones/IZoneLayoutRegistry.h>
-
-#include "overlay_helpers.h"
-#include "../../core/settings_interfaces.h"
-#include "../../core/interfaces.h"
-#include "../../core/shaderregistry.h"
-#include "../../core/utils.h"
-#include "../config/configdefaults.h"
 
 namespace PlasmaZones {
 

--- a/src/daemon/overlayservice/internal.h
+++ b/src/daemon/overlayservice/internal.h
@@ -19,6 +19,7 @@
 
 #include "overlay_helpers.h"
 #include <PhosphorScreens/Manager.h>
+#include <PhosphorZones/IZoneLayoutRegistry.h>
 #include "../../core/settings_interfaces.h"
 #include "../../core/interfaces.h"
 #include "../../core/shaderregistry.h"
@@ -257,11 +258,20 @@ inline void applyShaderInfoToWindow(QObject* window, const ShaderRegistry::Shade
 /// Previously, ZoneSelectorController only checked the current mode, causing inconsistencies when the
 /// overlay reported a lock but the selector did not.
 ///
+/// A rule-driven `LockContext` lock is checked FIRST, ahead of the persisted per-mode store: it is
+/// mode-agnostic (locks regardless of @p currentMode) and live-resolved, exactly mirroring the
+/// daemon's resolver-routed `IContextGateSource::isContextLocked`. Without this, a `LockContext`
+/// window rule would block the layout-switch gate but leave the selector/overlay reporting unlocked —
+/// the same overlay-vs-selector split PR #247 eliminated for manual locks.
+///
 /// Pass the current mode explicitly when only the active mode's lock is relevant.
 // contextLockKey is defined in Utils:: (src/core/utils.h)
-inline bool isAnyModeLocked(ISettings* settings, const QString& screenId, int desktop, const QString& activity,
-                            int currentMode = -1)
+inline bool isAnyModeLocked(ISettings* settings, PhosphorZones::IZoneLayoutRegistry* layoutRegistry,
+                            const QString& screenId, int desktop, const QString& activity, int currentMode = -1)
 {
+    if (layoutRegistry && layoutRegistry->resolveContextLocked(screenId, desktop, activity)) {
+        return true;
+    }
     if (!settings) {
         return false;
     }

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -365,7 +365,7 @@ void OverlayService::updateSelectorPosition(int cursorX, int cursorY)
                 if (m_settings && m_layoutManager) {
                     int curDesktop = m_layoutManager->currentVirtualDesktop();
                     QString curActivity = m_layoutManager->currentActivity();
-                    bool locked = isAnyModeLocked(m_settings, cursorScreenId, curDesktop, curActivity);
+                    bool locked = isAnyModeLocked(m_settings, m_layoutManager, cursorScreenId, curDesktop, curActivity);
                     if (locked) {
                         // Only allow zone selection from the active layout
                         PhosphorZones::Layout* activeLayout = m_layoutManager->resolveLayoutForScreen(cursorScreenId);

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -361,7 +361,8 @@ void OverlayService::updateSelectorPosition(int cursorX, int cursorY)
                 QVariantMap layoutMap = layouts[i].toMap();
                 QString layoutId = layoutMap[QStringLiteral("id")].toString();
 
-                // Skip non-active layouts when screen is locked (either mode)
+                // Skip non-active layouts when screen is locked — a LockContext
+                // rule (checked first) or a manual lock on either mode.
                 if (m_settings && m_layoutManager) {
                     int curDesktop = m_layoutManager->currentVirtualDesktop();
                     QString curActivity = m_layoutManager->currentActivity();

--- a/src/daemon/overlayservice/selector_update.cpp
+++ b/src/daemon/overlayservice/selector_update.cpp
@@ -175,8 +175,9 @@ void OverlayService::updateZoneSelectorWindow(const QString& screenId)
     }
     writeQmlProperty(window, QStringLiteral("activeLayoutId"), activeLayoutId);
 
-    // Push lock state so QML disables non-active layout interaction
-    // Check both modes - zone selector appears during drag for the current mode
+    // Push lock state so QML disables non-active layout interaction.
+    // isAnyModeLocked checks a LockContext rule first, then both manual modes -
+    // the zone selector appears during drag for the current mode.
     bool locked = false;
     if (m_settings && m_layoutManager) {
         int curDesktop = m_layoutManager->currentVirtualDesktop();

--- a/src/daemon/overlayservice/selector_update.cpp
+++ b/src/daemon/overlayservice/selector_update.cpp
@@ -229,4 +229,39 @@ void OverlayService::updateZoneSelectorWindow(const QString& screenId)
     }
 }
 
+void OverlayService::refreshContextLockState()
+{
+    // Targeted re-push of just the `locked` QML property (not a full
+    // updateZoneSelectorWindow — only the lock state can change here). Both the
+    // zone selector and the layout picker compute `locked` via isAnyModeLocked,
+    // which folds the rule-driven LockContext lock over the manual lock store,
+    // so re-resolving picks up a runtime rule edit. Without settings/registry we
+    // cannot resolve a lock, and every overlay already defaults to unlocked.
+    if (!m_settings || !m_layoutManager) {
+        return;
+    }
+    const int curDesktop = m_layoutManager->currentVirtualDesktop();
+    const QString curActivity = m_layoutManager->currentActivity();
+
+    // Open zone selectors: one entry per screen with a live slot.
+    for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
+        auto* window = it.value().zoneSelectorSlot();
+        if (!window) {
+            continue;
+        }
+        const bool locked = isAnyModeLocked(m_settings, m_layoutManager, it.key(), curDesktop, curActivity);
+        writeQmlProperty(window, QStringLiteral("locked"), locked);
+    }
+
+    // Open layout picker (re-running showLayoutPicker would rebuild/re-animate
+    // it, so push just the lock state to the live slot).
+    if (m_layoutPickerVisible && !m_layoutPickerScreenId.isEmpty()) {
+        if (auto* slot = m_screenStates.value(m_layoutPickerScreenId).layoutPickerSlot()) {
+            const bool locked =
+                isAnyModeLocked(m_settings, m_layoutManager, m_layoutPickerScreenId, curDesktop, curActivity);
+            writeQmlProperty(slot, QStringLiteral("locked"), locked);
+        }
+    }
+}
+
 } // namespace PlasmaZones

--- a/src/daemon/overlayservice/selector_update.cpp
+++ b/src/daemon/overlayservice/selector_update.cpp
@@ -181,7 +181,7 @@ void OverlayService::updateZoneSelectorWindow(const QString& screenId)
     if (m_settings && m_layoutManager) {
         int curDesktop = m_layoutManager->currentVirtualDesktop();
         QString curActivity = m_layoutManager->currentActivity();
-        locked = isAnyModeLocked(m_settings, screenId, curDesktop, curActivity);
+        locked = isAnyModeLocked(m_settings, m_layoutManager, screenId, curDesktop, curActivity);
     }
     writeQmlProperty(window, QStringLiteral("locked"), locked);
 

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -573,7 +573,7 @@ void OverlayService::showLayoutPicker(const QString& screenId)
     if (m_settings && m_layoutManager) {
         int curDesktop = m_layoutManager->currentVirtualDesktop();
         QString curActivity = m_layoutManager->currentActivity();
-        locked = isAnyModeLocked(m_settings, resolvedId, curDesktop, curActivity);
+        locked = isAnyModeLocked(m_settings, m_layoutManager, resolvedId, curDesktop, curActivity);
     }
     writeQmlProperty(slot, QStringLiteral("locked"), locked);
     writeColorSettings(slot, m_settings);

--- a/src/daemon/zoneselectorcontroller.cpp
+++ b/src/daemon/zoneselectorcontroller.cpp
@@ -408,7 +408,7 @@ bool ZoneSelectorController::isScreenLocked() const
         // Check both modes (0 = manual, 1 = autotile) to match OverlayService behavior.
         // A lock on either mode should block the zone selector regardless of which mode
         // is currently active, preventing inconsistency with overlay lock checks.
-        return isAnyModeLocked(m_settings, m_screenId, desktop, activity);
+        return isAnyModeLocked(m_settings, m_layoutManager, m_screenId, desktop, activity);
     }
     return false;
 }

--- a/src/daemon/zoneselectorcontroller.cpp
+++ b/src/daemon/zoneselectorcontroller.cpp
@@ -405,9 +405,10 @@ bool ZoneSelectorController::isScreenLocked() const
     if (m_layoutManager && m_settings && m_screen) {
         const int desktop = m_layoutManager->currentVirtualDesktop();
         const QString activity = m_layoutManager->currentActivity();
-        // Check both modes (0 = manual, 1 = autotile) to match OverlayService behavior.
-        // A lock on either mode should block the zone selector regardless of which mode
-        // is currently active, preventing inconsistency with overlay lock checks.
+        // Match OverlayService behavior: a rule-driven LockContext lock is checked first,
+        // then both manual modes (0 = manual, 1 = autotile). A lock from any of these
+        // sources should block the zone selector regardless of which mode is currently
+        // active, preventing inconsistency with overlay lock checks.
         return isAnyModeLocked(m_settings, m_layoutManager, m_screenId, desktop, activity);
     }
     return false;

--- a/src/settings/qml/MonitorOverviewTile.qml
+++ b/src/settings/qml/MonitorOverviewTile.qml
@@ -26,9 +26,10 @@ Rectangle {
     /// connectorName, isPrimary, width/height, etc.).
     required property var screenData
     /// Rule-related data: `{ screenId, layoutName, tilingEnabled, ruleCount,
-    /// assigned }` from `WindowRuleController.monitorOverview(screens)`, which
-    /// emits a tile for every screen. A screen with no pinned rules carries
-    /// `assigned: false` and renders a "Not assigned" caption; the property only
+    /// assigned, locked }` from `WindowRuleController.monitorOverview(screens)`,
+    /// which emits a tile for every screen. A screen with no pinned rules carries
+    /// `assigned: false` and renders a "Not assigned" caption; `locked` is true
+    /// when a LockContext rule pins the monitor's layout; the property only
     /// stays `undefined` if no overview payload is supplied at all.
     property var tileData: undefined
     /// True when this tile is the active monitor filter.
@@ -40,6 +41,8 @@ Rectangle {
     // "NaN rules" in the caption.
     readonly property int _ruleCount: (tile.tileData !== undefined && tile.tileData.ruleCount !== undefined ? Number(tile.tileData.ruleCount) : 0) || 0
     readonly property bool _isPrimary: tile.screenData.isPrimary === true
+    /// True when a LockContext rule pins this monitor's layout — drives the lock badge.
+    readonly property bool _locked: tile.tileData !== undefined && tile.tileData.locked === true
 
     signal clicked
 
@@ -116,6 +119,18 @@ Rectangle {
         RowLayout {
             Layout.alignment: Qt.AlignHCenter
             spacing: Kirigami.Units.smallSpacing
+
+            // Lock badge — shown when a LockContext rule pins this monitor's
+            // layout, mirroring the "object-locked" icon used by the lock-layout
+            // rule template and the overlay lock affordances.
+            Kirigami.Icon {
+                source: "object-locked"
+                visible: tile._locked
+                Layout.preferredWidth: Kirigami.Units.iconSizes.small
+                Layout.preferredHeight: Kirigami.Units.iconSizes.small
+                opacity: 0.7
+                Accessible.name: i18nc("@info:accessibility monitor tile", "Layout locked")
+            }
 
             Kirigami.Icon {
                 source: tile._assigned ? (tile.tileData.tilingEnabled ? "view-grid" : "dialog-cancel") : "edit-none"

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -124,7 +124,8 @@ QString fieldDescription(Field f)
 PickerCategory actionCategory(const QString& type)
 {
     if (type == ActionType::SetEngineMode || type == ActionType::SetSnappingLayout
-        || type == ActionType::SetTilingAlgorithm || type == ActionType::DisableEngine) {
+        || type == ActionType::SetTilingAlgorithm || type == ActionType::DisableEngine
+        || type == ActionType::LockContext) {
         return {PhosphorI18n::tr("Layout & engine"), 0};
     }
     if (type == ActionType::SetZonePadding || type == ActionType::SetOuterGap
@@ -205,6 +206,11 @@ QString paramLabel(const QString& type, const QString& key)
     }
     if (type == ActionType::SetUsePerSideOuterGap && key == ActionParam::Value) {
         return PhosphorI18n::tr("Per-side outer gaps");
+    }
+    if (type == ActionType::LockContext && key == ActionParam::Value) {
+        // The action is the rule-driven counterpart to the ToggleLayoutLock
+        // shortcut: on = the matched context's active layout can't be switched.
+        return PhosphorI18n::tr("Lock the layout (off = no change)");
     }
     if (type == ActionType::SetOuterGapTop && key == ActionParam::Value) {
         return PhosphorI18n::tr("Top gap (px)");
@@ -318,6 +324,9 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::DisableEngine) {
         return PhosphorI18n::tr("Disable engine");
+    }
+    if (type == ActionType::LockContext) {
+        return PhosphorI18n::tr("Lock layout");
     }
     if (type == ActionType::Exclude) {
         return PhosphorI18n::tr("Exclude window");
@@ -589,6 +598,7 @@ QVariantList actionTypes()
         ActionType::SetSnappingLayout,
         ActionType::SetTilingAlgorithm,
         ActionType::DisableEngine,
+        ActionType::LockContext,
         // Per-context gap overrides (context-domain, grouped with the other
         // context actions above).
         ActionType::SetZonePadding,

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -210,7 +210,9 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::LockContext && key == ActionParam::Value) {
         // The action is the rule-driven counterpart to the ToggleLayoutLock
         // shortcut: on = the matched context's active layout can't be switched.
-        return PhosphorI18n::tr("Lock the layout (off = no change)");
+        // off is "don't lock" (not "no change"): the Locked slot is single-winner
+        // by priority, so a higher-priority off rule cancels a lower-priority on.
+        return PhosphorI18n::tr("Lock the layout (off = don't lock)");
     }
     if (type == ActionType::SetOuterGapTop && key == ActionParam::Value) {
         return PhosphorI18n::tr("Top gap (px)");

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -123,9 +123,7 @@ QString fieldDescription(Field f)
 /// management, appearance, animation.
 PickerCategory actionCategory(const QString& type)
 {
-    if (type == ActionType::SetEngineMode || type == ActionType::SetSnappingLayout
-        || type == ActionType::SetTilingAlgorithm || type == ActionType::DisableEngine
-        || type == ActionType::LockContext) {
+    if (ActionType::isLayoutEngineContextAction(type)) {
         return {PhosphorI18n::tr("Layout & engine"), 0};
     }
     if (type == ActionType::SetZonePadding || type == ActionType::SetOuterGap

--- a/src/settings/windowrulecontroller.h
+++ b/src/settings/windowrulecontroller.h
@@ -260,9 +260,11 @@ public:
     // ── Authoring metadata for the QML editors ────────────────────────────
 
     /// Match fields suitable for the leaf-editor field dropdown. Each entry:
-    /// `{ value: int (Field enum), wire: QString (JSON wire string),
-    ///    label, valueKind: "string"|"number"|"bool" }`. QML keys off `wire`
-    /// so it never has to reconstruct the enum↔wire-string table.
+    /// `{ value: int (Field enum), wire: QString (JSON wire string), label,
+    ///    valueKind: "string"|"number"|"bool"|"windowType"|"screen"|"activity" }`
+    /// (the latter three drive dedicated pickers; "windowType" also carries an
+    /// `options` list). QML keys off `wire` so it never has to reconstruct the
+    /// enum↔wire-string table.
     Q_INVOKABLE QVariantList matchFields() const;
 
     /// Operators valid for @p fieldValue (a `Field` enum int). Each entry:

--- a/src/settings/windowrulecontroller.h
+++ b/src/settings/windowrulecontroller.h
@@ -249,7 +249,8 @@ public:
     // ── Monitor overview strip ────────────────────────────────────────────
 
     /// Read-only per-monitor summary for the overview strip. Each entry:
-    /// `{ screenId, layoutName, tilingEnabled, ruleCount, assigned }`.
+    /// `{ screenId, layoutName, tilingEnabled, ruleCount, assigned, locked }`
+    /// (`locked` is true when a LockContext rule pins the monitor's layout).
     /// @p screens is the `SettingsController::screens` list (each a map with a
     /// `name` field, and a `screenId` fallback) so the overview can list every
     /// connected monitor — including ones with no rule at all (the "Not

--- a/src/settings/windowrulecontroller_views.cpp
+++ b/src/settings/windowrulecontroller_views.cpp
@@ -127,6 +127,14 @@ QVariantList WindowRuleController::monitorOverview(const QVariantList& screens) 
         QString engineMode;
         QString snappingLayout;
         QString tilingAlgorithm;
+        // Layout-lock state from the highest-priority matching `LockContext`
+        // rule on this screen. `lockResolved` is the first-wins guard (indices
+        // are priority-DESC, so the first LockContext rule seen is the winner of
+        // the daemon's single-winner Locked slot); `locked` is that rule's
+        // boolean value — a higher-priority `value:false` rule reports unlocked
+        // even when a lower one says lock, mirroring `resolveContextLocked`.
+        bool lockResolved = false;
+        bool locked = false;
     };
     QHash<QString, Summary> byScreen;
 
@@ -183,6 +191,12 @@ QVariantList WindowRuleController::monitorOverview(const QVariantList& screens) 
                     s.disabledEngineMode = a.params.value(PhosphorWindowRule::ActionParam::Mode).toString();
                 else if (a.type == ActionType::SetEngineMode)
                     ruleHasEngineMode = true;
+                else if (a.type == ActionType::LockContext && !s.lockResolved) {
+                    // First-wins on the single Locked slot (priority-DESC): the
+                    // highest-priority LockContext rule decides, value and all.
+                    s.lockResolved = true;
+                    s.locked = a.params.value(PhosphorWindowRule::ActionParam::Value).toBool();
+                }
             }
             // Engine/layout: capture from the FIRST rule (highest priority) that
             // carries a SetEngineMode action — the assignment winner. Read its
@@ -277,6 +291,9 @@ QVariantList WindowRuleController::monitorOverview(const QVariantList& screens) 
         tile[QStringLiteral("tilingEnabled")] = !engineDisabled;
         tile[QStringLiteral("ruleCount")] = summary.ruleCount;
         tile[QStringLiteral("assigned")] = assigned;
+        // True when a LockContext rule pins this monitor's layout (the
+        // highest-priority matching rule's value). The tile shows a lock badge.
+        tile[QStringLiteral("locked")] = summary.locked;
         out.append(tile);
     }
     return out;

--- a/src/settings/windowrulecontroller_views.cpp
+++ b/src/settings/windowrulecontroller_views.cpp
@@ -133,6 +133,10 @@ QVariantList WindowRuleController::monitorOverview(const QVariantList& screens) 
         // the daemon's single-winner Locked slot); `locked` is that rule's
         // boolean value — a higher-priority `value:false` rule reports unlocked
         // even when a lower one says lock, mirroring `resolveContextLocked`.
+        // Like the engine/disable slots above, this does NOT model terminal-
+        // action (Exclude) cascade termination — but Exclude is window-domain
+        // and these accumulators only see context-only rules, which never carry
+        // it, so the omission is unreachable here.
         bool lockResolved = false;
         bool locked = false;
     };

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -42,9 +42,7 @@ bool hasAnimationAction(const QList<RuleAction>& actions)
 bool hasContextAction(const QList<RuleAction>& actions)
 {
     for (const RuleAction& a : actions) {
-        if (a.type == ActionType::SetEngineMode || a.type == ActionType::SetSnappingLayout
-            || a.type == ActionType::SetTilingAlgorithm || a.type == ActionType::DisableEngine
-            || a.type == ActionType::LockContext) {
+        if (ActionType::isLayoutEngineContextAction(a.type)) {
             return true;
         }
     }

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -38,12 +38,13 @@ bool hasAnimationAction(const QList<RuleAction>& actions)
 }
 
 /// True if @p actions carry a context-targeting action (layout / engine /
-/// disable) — the kind a Monitor & Layout rule produces.
+/// disable / lock) — the kind a Monitor & Layout rule produces.
 bool hasContextAction(const QList<RuleAction>& actions)
 {
     for (const RuleAction& a : actions) {
         if (a.type == ActionType::SetEngineMode || a.type == ActionType::SetSnappingLayout
-            || a.type == ActionType::SetTilingAlgorithm || a.type == ActionType::DisableEngine) {
+            || a.type == ActionType::SetTilingAlgorithm || a.type == ActionType::DisableEngine
+            || a.type == ActionType::LockContext) {
             return true;
         }
     }
@@ -311,6 +312,9 @@ QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup
         }
         if (action.type == ActionType::SetHideTitleBar) {
             return raw.toBool() ? PhosphorI18n::tr("Hide title bars") : PhosphorI18n::tr("Show title bars");
+        }
+        if (action.type == ActionType::LockContext) {
+            return raw.toBool() ? PhosphorI18n::tr("Lock layout") : PhosphorI18n::tr("Don't lock layout");
         }
         if (action.type == ActionType::SetBorderVisible) {
             return raw.toBool() ? PhosphorI18n::tr("Show border") : PhosphorI18n::tr("Hide border");

--- a/src/settings/windowruletemplates.cpp
+++ b/src/settings/windowruletemplates.cpp
@@ -95,6 +95,10 @@ QVariantList ruleTemplates()
     out.append(entry(QLatin1String("algorithmOnMonitor"), PhosphorI18n::tr("Set a tiling algorithm on a monitor"),
                      PhosphorI18n::tr("Pick an autotile algorithm to use on one monitor."),
                      QLatin1String("view-list-tree")));
+    out.append(entry(QLatin1String("lockLayoutOnMonitor"), PhosphorI18n::tr("Lock the layout on a monitor"),
+                     PhosphorI18n::tr("Pin the active layout on one monitor so it can't be switched — the rule-driven "
+                                      "version of the lock-layout shortcut."),
+                     QLatin1String("object-locked")));
     out.append(entry(QLatin1String("excludeApp"), PhosphorI18n::tr("Exclude an app from tiling"),
                      PhosphorI18n::tr("Keep one application's windows out of the snap and autotile engines entirely."),
                      QLatin1String("edit-delete-remove")));
@@ -144,6 +148,17 @@ QVariantMap newRuleFromTemplate(const QString& templateId)
         algoAction.type = QString::fromLatin1(ActionType::SetTilingAlgorithm);
         algoAction.params.insert(ActionParam::Algorithm, QString());
         rule.actions.append(algoAction);
+    } else if (templateId == QLatin1String("lockLayoutOnMonitor")) {
+        rule.name = PhosphorI18n::tr("Lock layout on monitor");
+        rule.priority = kContextBandBase;
+        rule.match = MatchExpression::makeLeaf(Field::ScreenId, Operator::Equals, QString());
+        // Single LockContext action seeded to lock (value = true) — the user
+        // fills in the screen picker. Mode-agnostic and live-resolved, so it
+        // pins whichever layout is active on that monitor without persisting.
+        RuleAction lockAction;
+        lockAction.type = QString::fromLatin1(ActionType::LockContext);
+        lockAction.params.insert(ActionParam::Value, true);
+        rule.actions.append(lockAction);
     } else if (templateId == QLatin1String("excludeApp")) {
         rule.name = PhosphorI18n::tr("Exclude an app from tiling");
         rule.priority = kApplicationBandBase;

--- a/tests/unit/core/test_windowrule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_windowrule_cascade_fidelity.cpp
@@ -678,6 +678,56 @@ private Q_SLOTS:
         // A context the rules do not pin → no override (cascade falls through).
         QVERIFY(f.registry->resolveContextGaps(QStringLiteral("DP-2"), 0, QString()).isEmpty());
     }
+
+    // ─── Context lock resolution (ActionSlot::Locked) ─────────────────────
+    // resolveContextLocked reads the boolean Locked slot off a matching
+    // context rule. Mode-agnostic, never persisted — the daemon's
+    // isContextLocked ORs it over the manual lock store.
+
+    void testContextLock_resolution()
+    {
+        const auto lockRule = [](const QString& name, PWR::Field field, const QVariant& value, bool locked) {
+            PWR::RuleAction a;
+            a.type = QString(PWR::ActionType::LockContext);
+            a.params.insert(QString(PWR::ActionParam::Value), locked);
+            PWR::WindowRule r;
+            r.id = QUuid::createUuid();
+            r.name = name;
+            r.enabled = true;
+            r.priority = 400;
+            r.match = PWR::MatchExpression::makeLeaf(field, PWR::Operator::Equals, value);
+            r.actions = {a};
+            return r;
+        };
+
+        RegistryFixture f = makeRegistryFixture();
+        // A monitor lock (value = true) on DP-1, and an activity lock scoped to
+        // "work". An explicit value = false lock on DP-3 must NOT lock.
+        const PWR::WindowRule lockMonitor =
+            lockRule(QStringLiteral("lock DP-1"), PWR::Field::ScreenId, QStringLiteral("DP-1"), true);
+        const PWR::WindowRule lockActivity =
+            lockRule(QStringLiteral("lock work"), PWR::Field::Activity, QStringLiteral("work-uuid"), true);
+        const PWR::WindowRule unlockMonitor =
+            lockRule(QStringLiteral("unlock DP-3"), PWR::Field::ScreenId, QStringLiteral("DP-3"), false);
+        QVERIFY(f.store->setAllRules({lockMonitor, lockActivity, unlockMonitor}));
+
+        // DP-1 is locked regardless of desktop/activity (screen-only match).
+        QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-1"), 0, QString()));
+        QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-1"), 3, QStringLiteral("anything")));
+        // The activity lock fires only inside "work".
+        QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-2"), 0, QStringLiteral("work-uuid")));
+        QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-2"), 0, QStringLiteral("play-uuid")));
+        // value = false resolves to not-locked (explicit no-op overlay).
+        QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-3"), 0, QString()));
+        // A context no rule pins → not locked.
+        QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("HDMI-1"), 0, QString()));
+
+        // Disabling the lock rule drops the lock (revision-invalidated cache).
+        PWR::WindowRule disabled = lockMonitor;
+        disabled.enabled = false;
+        QVERIFY(f.store->setAllRules({disabled, lockActivity, unlockMonitor}));
+        QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-1"), 0, QString()));
+    }
 };
 
 QTEST_MAIN(TestWindowRuleCascadeFidelity)

--- a/tests/unit/core/test_windowrule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_windowrule_cascade_fidelity.cpp
@@ -757,6 +757,10 @@ private Q_SLOTS:
         disabled.enabled = false;
         QVERIFY(f.store->setAllRules({disabled, lockActivity, unlockMonitor, lockDesktop, mixedLock}));
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-1"), 0, QString()));
+        // The eviction is a whole-cache drop, not a zeroing: a lock left intact
+        // (lockDesktop, also primed above) must still resolve true after the
+        // revision bump rebuilds the cache.
+        QVERIFY(f.registry->resolveContextLocked(QStringLiteral("HDMI-2"), 2, QString()));
     }
 
     // ─── Context lock — slot conflict resolution ──────────────────────────

--- a/tests/unit/core/test_windowrule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_windowrule_cascade_fidelity.cpp
@@ -728,6 +728,49 @@ private Q_SLOTS:
         QVERIFY(f.store->setAllRules({disabled, lockActivity, unlockMonitor}));
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-1"), 0, QString()));
     }
+
+    // ─── Context lock — slot conflict resolution ──────────────────────────
+    // When two LockContext rules pin the SAME context with opposing values,
+    // the single Locked slot is won by the highest-priority rule (then list
+    // order on a tie), exactly like the layout slot (testTieBreakIsListOrder).
+    // The value itself does not bias the contest — proven by running it both
+    // directions so neither "true always wins" nor "false always wins" passes.
+
+    void testContextLock_priorityResolution()
+    {
+        const auto lockRuleAt = [](const QString& name, const QString& screenId, bool locked, int priority) {
+            PWR::RuleAction a;
+            a.type = QString(PWR::ActionType::LockContext);
+            a.params.insert(QString(PWR::ActionParam::Value), locked);
+            PWR::WindowRule r;
+            r.id = QUuid::createUuid();
+            r.name = name;
+            r.enabled = true;
+            r.priority = priority;
+            r.match = PWR::MatchExpression::makeLeaf(PWR::Field::ScreenId, PWR::Operator::Equals, screenId);
+            r.actions = {a};
+            return r;
+        };
+
+        RegistryFixture f = makeRegistryFixture();
+        // DP-9: higher-priority rule says NOT locked → wins over a lower one
+        // that says locked.
+        const PWR::WindowRule dp9High = lockRuleAt(QStringLiteral("dp9 unlock"), QStringLiteral("DP-9"), false, 500);
+        const PWR::WindowRule dp9Low = lockRuleAt(QStringLiteral("dp9 lock"), QStringLiteral("DP-9"), true, 400);
+        // DP-10: the inverse — higher-priority rule says locked → wins.
+        const PWR::WindowRule dp10High = lockRuleAt(QStringLiteral("dp10 lock"), QStringLiteral("DP-10"), true, 500);
+        const PWR::WindowRule dp10Low = lockRuleAt(QStringLiteral("dp10 unlock"), QStringLiteral("DP-10"), false, 400);
+        // DP-11: equal priority — first-listed rule wins the slot (stable sort).
+        const PWR::WindowRule dp11First = lockRuleAt(QStringLiteral("dp11 a"), QStringLiteral("DP-11"), true, 400);
+        const PWR::WindowRule dp11Second = lockRuleAt(QStringLiteral("dp11 b"), QStringLiteral("DP-11"), false, 400);
+        QVERIFY(f.store->setAllRules({dp9High, dp9Low, dp10High, dp10Low, dp11First, dp11Second}));
+
+        // Highest priority wins regardless of the value it carries.
+        QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-9"), 0, QString()));
+        QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-10"), 0, QString()));
+        // Equal priority → first-listed (lock=true) wins.
+        QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-11"), 0, QString()));
+    }
 };
 
 QTEST_MAIN(TestWindowRuleCascadeFidelity)

--- a/tests/unit/core/test_windowrule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_windowrule_cascade_fidelity.cpp
@@ -713,7 +713,24 @@ private Q_SLOTS:
         // screen/activity, proving the desktop axis of the context match.
         const PWR::WindowRule lockDesktop =
             lockRule(QStringLiteral("lock desktop 2"), PWR::Field::VirtualDesktop, 2, true);
-        QVERIFY(f.store->setAllRules({lockMonitor, lockActivity, unlockMonitor, lockDesktop}));
+        // A mixed (context + window-property) lock rule: All{ScreenId == DP-4,
+        // AppId == firefox} carrying a LockContext action at a far-above band.
+        // Against the windowless context query the AppId leaf evaluates false,
+        // so the All{} fails and DP-4 must NOT lock — symmetric to the
+        // assignment-path mixed-rule inertness proof (testMixedRule* above).
+        PWR::RuleAction mixedLockAction;
+        mixedLockAction.type = QString(PWR::ActionType::LockContext);
+        mixedLockAction.params.insert(QString(PWR::ActionParam::Value), true);
+        PWR::WindowRule mixedLock;
+        mixedLock.id = QUuid::createUuid();
+        mixedLock.name = QStringLiteral("mixed lock DP-4");
+        mixedLock.enabled = true;
+        mixedLock.priority = 999;
+        mixedLock.match = PWR::MatchExpression::makeAll(
+            {PWR::MatchExpression::makeLeaf(PWR::Field::ScreenId, PWR::Operator::Equals, QStringLiteral("DP-4")),
+             PWR::MatchExpression::makeLeaf(PWR::Field::AppId, PWR::Operator::Equals, QStringLiteral("firefox"))});
+        mixedLock.actions = {mixedLockAction};
+        QVERIFY(f.store->setAllRules({lockMonitor, lockActivity, unlockMonitor, lockDesktop, mixedLock}));
 
         // DP-1 is locked regardless of desktop/activity (screen-only match).
         QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-1"), 0, QString()));
@@ -727,6 +744,9 @@ private Q_SLOTS:
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("HDMI-2"), 1, QString()));
         // value = false resolves to not-locked (explicit no-op overlay).
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-3"), 0, QString()));
+        // The mixed rule's AppId leaf can't match a windowless query → DP-4 not
+        // locked, even though its band (999) would dominate if it leaked.
+        QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-4"), 0, QString()));
         // A context no rule pins → not locked.
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("HDMI-1"), 0, QString()));
 
@@ -735,7 +755,7 @@ private Q_SLOTS:
         // true here — the post-mutation false proves the revision bump evicts.
         PWR::WindowRule disabled = lockMonitor;
         disabled.enabled = false;
-        QVERIFY(f.store->setAllRules({disabled, lockActivity, unlockMonitor, lockDesktop}));
+        QVERIFY(f.store->setAllRules({disabled, lockActivity, unlockMonitor, lockDesktop, mixedLock}));
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-1"), 0, QString()));
     }
 

--- a/tests/unit/core/test_windowrule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_windowrule_cascade_fidelity.cpp
@@ -709,7 +709,11 @@ private Q_SLOTS:
             lockRule(QStringLiteral("lock work"), PWR::Field::Activity, QStringLiteral("work-uuid"), true);
         const PWR::WindowRule unlockMonitor =
             lockRule(QStringLiteral("unlock DP-3"), PWR::Field::ScreenId, QStringLiteral("DP-3"), false);
-        QVERIFY(f.store->setAllRules({lockMonitor, lockActivity, unlockMonitor}));
+        // A desktop-scoped lock: fires on virtual desktop 2 regardless of
+        // screen/activity, proving the desktop axis of the context match.
+        const PWR::WindowRule lockDesktop =
+            lockRule(QStringLiteral("lock desktop 2"), PWR::Field::VirtualDesktop, 2, true);
+        QVERIFY(f.store->setAllRules({lockMonitor, lockActivity, unlockMonitor, lockDesktop}));
 
         // DP-1 is locked regardless of desktop/activity (screen-only match).
         QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-1"), 0, QString()));
@@ -717,15 +721,21 @@ private Q_SLOTS:
         // The activity lock fires only inside "work".
         QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-2"), 0, QStringLiteral("work-uuid")));
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-2"), 0, QStringLiteral("play-uuid")));
+        // The desktop lock fires on desktop 2 (any screen, no activity) and
+        // not on other desktops.
+        QVERIFY(f.registry->resolveContextLocked(QStringLiteral("HDMI-2"), 2, QString()));
+        QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("HDMI-2"), 1, QString()));
         // value = false resolves to not-locked (explicit no-op overlay).
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-3"), 0, QString()));
         // A context no rule pins → not locked.
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("HDMI-1"), 0, QString()));
 
-        // Disabling the lock rule drops the lock (revision-invalidated cache).
+        // Disabling the lock rule drops the lock (revision-invalidated cache):
+        // DP-1 was primed locked above, so a stale cache would keep returning
+        // true here — the post-mutation false proves the revision bump evicts.
         PWR::WindowRule disabled = lockMonitor;
         disabled.enabled = false;
-        QVERIFY(f.store->setAllRules({disabled, lockActivity, unlockMonitor}));
+        QVERIFY(f.store->setAllRules({disabled, lockActivity, unlockMonitor, lockDesktop}));
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-1"), 0, QString()));
     }
 
@@ -760,16 +770,63 @@ private Q_SLOTS:
         // DP-10: the inverse — higher-priority rule says locked → wins.
         const PWR::WindowRule dp10High = lockRuleAt(QStringLiteral("dp10 lock"), QStringLiteral("DP-10"), true, 500);
         const PWR::WindowRule dp10Low = lockRuleAt(QStringLiteral("dp10 unlock"), QStringLiteral("DP-10"), false, 400);
-        // DP-11: equal priority — first-listed rule wins the slot (stable sort).
+        // DP-11: equal priority, lock=true first — first-listed rule wins.
         const PWR::WindowRule dp11First = lockRuleAt(QStringLiteral("dp11 a"), QStringLiteral("DP-11"), true, 400);
         const PWR::WindowRule dp11Second = lockRuleAt(QStringLiteral("dp11 b"), QStringLiteral("DP-11"), false, 400);
-        QVERIFY(f.store->setAllRules({dp9High, dp9Low, dp10High, dp10Low, dp11First, dp11Second}));
+        // DP-12: the inverse tie-break — lock=false first at the same priority.
+        // Run both directions so the tie-break is proven to be list-order, not
+        // value-bias: a "true always wins on a tie" bug would pass DP-11 alone.
+        const PWR::WindowRule dp12First = lockRuleAt(QStringLiteral("dp12 a"), QStringLiteral("DP-12"), false, 400);
+        const PWR::WindowRule dp12Second = lockRuleAt(QStringLiteral("dp12 b"), QStringLiteral("DP-12"), true, 400);
+        QVERIFY(
+            f.store->setAllRules({dp9High, dp9Low, dp10High, dp10Low, dp11First, dp11Second, dp12First, dp12Second}));
 
         // Highest priority wins regardless of the value it carries.
         QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-9"), 0, QString()));
         QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-10"), 0, QString()));
-        // Equal priority → first-listed (lock=true) wins.
+        // Equal priority → first-listed wins, in both directions.
         QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-11"), 0, QString()));
+        QVERIFY(!f.registry->resolveContextLocked(QStringLiteral("DP-12"), 0, QString()));
+    }
+
+    // ─── Context lock composes with a layout/engine assignment ────────────
+    // LockContext is terminal=false and fills the dedicated Locked slot, so a
+    // lock-only rule must co-exist with a separate context-assignment rule on
+    // the SAME context: the lock surfaces via resolveContextLocked AND the
+    // layout still surfaces via assignmentEntryForScreen. Neither slot shadows
+    // the other — the whole reason the action is non-terminal.
+
+    void testContextLock_composesWithAssignment()
+    {
+        RegistryFixture f = makeRegistryFixture();
+
+        // A lock-only rule (Locked slot) and a separate layout-assignment rule
+        // (engine/layout slots), both pinned to DP-7 (screen-only match).
+        PWR::RuleAction lockAction;
+        lockAction.type = QString(PWR::ActionType::LockContext);
+        lockAction.params.insert(QString(PWR::ActionParam::Value), true);
+        PWR::WindowRule lock;
+        lock.id = QUuid::createUuid();
+        lock.name = QStringLiteral("lock DP-7");
+        lock.enabled = true;
+        lock.priority = 400;
+        lock.match =
+            PWR::MatchExpression::makeLeaf(PWR::Field::ScreenId, PWR::Operator::Equals, QStringLiteral("DP-7"));
+        lock.actions = {lockAction};
+
+        const PWR::WindowRule assign =
+            CRB::makeAssignmentRule(QStringLiteral("layout DP-7"), QStringLiteral("DP-7"), 0, QString(),
+                                    QStringLiteral("snapping"), QStringLiteral("{ctx-layout}"), QString());
+        QVERIFY(f.store->setAllRules({lock, assign}));
+
+        // The lock surfaces (Locked slot) ...
+        QVERIFY(f.registry->resolveContextLocked(QStringLiteral("DP-7"), 1, QString()));
+        // ... and the layout assignment still surfaces (engine/layout slots),
+        // unshadowed by the non-terminal lock rule.
+        const PhosphorZones::AssignmentEntry entry =
+            f.registry->assignmentEntryForScreen(QStringLiteral("DP-7"), 1, QString());
+        QCOMPARE(entry.mode, PhosphorZones::AssignmentEntry::Snapping);
+        QCOMPARE(entry.snappingLayout, QStringLiteral("{ctx-layout}"));
     }
 };
 

--- a/tests/unit/settings/test_window_rule_controller.cpp
+++ b/tests/unit/settings/test_window_rule_controller.cpp
@@ -279,17 +279,25 @@ void TestWindowRuleController::monitorOverviewLockPriorityResolution()
     const QVariantList overview = controller.monitorOverview(screens);
     QCOMPARE(overview.size(), 2);
 
+    bool sawA = false;
+    bool sawB = false;
     for (const QVariant& v : overview) {
         const QVariantMap tile = v.toMap();
         const QString id = tile.value(QStringLiteral("screenId")).toString();
         // Both screens carry two pinned lock rules.
         QCOMPARE(tile.value(QStringLiteral("ruleCount")).toInt(), 2);
         if (id == QLatin1String("DP-A")) {
+            sawA = true;
             QCOMPARE(tile.value(QStringLiteral("locked")).toBool(), true);
         } else if (id == QLatin1String("DP-B")) {
+            sawB = true;
             QCOMPARE(tile.value(QStringLiteral("locked")).toBool(), false);
         }
     }
+    // Pin identity: an unexpected screenId would otherwise skip both branches
+    // and pass having verified no lock value.
+    QVERIFY(sawA);
+    QVERIFY(sawB);
 }
 
 void TestWindowRuleController::monitorOverviewIgnoresDisabledRules()

--- a/tests/unit/settings/test_window_rule_controller.cpp
+++ b/tests/unit/settings/test_window_rule_controller.cpp
@@ -51,6 +51,7 @@ private Q_SLOTS:
     void monitorOverviewIgnoresBareLayoutRules();
     void monitorOverviewLayoutFromSingleWinningRule();
     void monitorOverviewDisableEngineMatchesEffectiveMode();
+    void monitorOverviewReportsLock();
     void engineModePickerExposesAllVocabularyTokens();
     void userAuthorableFilterHidesInternalActions();
     void moveRuleReorders();
@@ -192,6 +193,55 @@ void TestWindowRuleController::monitorOverviewSummarises()
     }
     QVERIFY(sawDp2);
     QVERIFY(sawEdp1);
+}
+
+void TestWindowRuleController::monitorOverviewReportsLock()
+{
+    // A LockContext rule pinning a monitor surfaces `locked: true` on its tile
+    // (drives the lock badge), independent of any layout assignment — a
+    // lock-only rule carries no SetEngineMode, so the tile has no layoutName,
+    // yet it is locked. A rule whose lock value is false reports
+    // `locked: false`, proving the tile reads the action's value (not mere
+    // presence), mirroring resolveContextLocked.
+    WindowRuleController controller;
+
+    const auto lockRule = [&](const QString& screenId, bool locked) {
+        QVariantMap rule = controller.newEmptyRule(QStringLiteral("monitor"));
+        QVariantMap match = rule.value(QStringLiteral("match")).toMap();
+        match[QStringLiteral("value")] = screenId;
+        rule[QStringLiteral("match")] = match;
+        rule[QStringLiteral("actions")] = QVariantList{
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("lockContext")}, {QStringLiteral("value"), locked}}};
+        QVERIFY(!controller.addRuleFromJson(rule).isEmpty());
+    };
+    lockRule(QStringLiteral("DP-2"), true);
+    lockRule(QStringLiteral("DP-3"), false);
+
+    const QVariantList screens{QVariantMap{{QStringLiteral("name"), QStringLiteral("DP-2")}},
+                               QVariantMap{{QStringLiteral("name"), QStringLiteral("DP-3")}},
+                               QVariantMap{{QStringLiteral("name"), QStringLiteral("eDP-1")}}};
+    const QVariantList overview = controller.monitorOverview(screens);
+    QCOMPARE(overview.size(), 3);
+
+    for (const QVariant& v : overview) {
+        const QVariantMap tile = v.toMap();
+        const QString id = tile.value(QStringLiteral("screenId")).toString();
+        if (id == QLatin1String("DP-2")) {
+            // Lock-only rule: locked, counts as a pinned rule (assigned = has
+            // any rule), and surfaces no layoutName (no engine-mode action).
+            QCOMPARE(tile.value(QStringLiteral("locked")).toBool(), true);
+            QCOMPARE(tile.value(QStringLiteral("assigned")).toBool(), true);
+            QCOMPARE(tile.value(QStringLiteral("ruleCount")).toInt(), 1);
+            QVERIFY(tile.value(QStringLiteral("layoutName")).toString().isEmpty());
+        } else if (id == QLatin1String("DP-3")) {
+            // value:false → not locked (the tile reads the value, not presence).
+            QCOMPARE(tile.value(QStringLiteral("locked")).toBool(), false);
+            QCOMPARE(tile.value(QStringLiteral("ruleCount")).toInt(), 1);
+        } else if (id == QLatin1String("eDP-1")) {
+            // No rule → not locked.
+            QCOMPARE(tile.value(QStringLiteral("locked")).toBool(), false);
+        }
+    }
 }
 
 void TestWindowRuleController::monitorOverviewIgnoresDisabledRules()

--- a/tests/unit/settings/test_window_rule_controller.cpp
+++ b/tests/unit/settings/test_window_rule_controller.cpp
@@ -52,6 +52,7 @@ private Q_SLOTS:
     void monitorOverviewLayoutFromSingleWinningRule();
     void monitorOverviewDisableEngineMatchesEffectiveMode();
     void monitorOverviewReportsLock();
+    void monitorOverviewLockPriorityResolution();
     void engineModePickerExposesAllVocabularyTokens();
     void userAuthorableFilterHidesInternalActions();
     void moveRuleReorders();
@@ -239,6 +240,53 @@ void TestWindowRuleController::monitorOverviewReportsLock()
             QCOMPARE(tile.value(QStringLiteral("ruleCount")).toInt(), 1);
         } else if (id == QLatin1String("eDP-1")) {
             // No rule → not locked.
+            QCOMPARE(tile.value(QStringLiteral("locked")).toBool(), false);
+        }
+    }
+}
+
+void TestWindowRuleController::monitorOverviewLockPriorityResolution()
+{
+    // When two opposing LockContext rules pin the SAME monitor, the tile must
+    // report the HIGHEST-PRIORITY rule's value (first-wins), not last-wins and
+    // not mere presence — mirroring resolveContextLocked's single-winner Locked
+    // slot (cf. testContextLock_priorityResolution at the registry level).
+    // addRuleFromJson appends and renormalizePriorities makes the earlier-added
+    // rule the higher-priority one within the Context band, so the FIRST rule
+    // added for a screen is its winner. Run both value directions so a
+    // "true-always-wins" / "false-always-wins" bug fails one of the two.
+    WindowRuleController controller;
+
+    const auto lockRule = [&](const QString& screenId, bool locked) {
+        QVariantMap rule = controller.newEmptyRule(QStringLiteral("monitor"));
+        QVariantMap match = rule.value(QStringLiteral("match")).toMap();
+        match[QStringLiteral("value")] = screenId;
+        rule[QStringLiteral("match")] = match;
+        rule[QStringLiteral("actions")] = QVariantList{
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("lockContext")}, {QStringLiteral("value"), locked}}};
+        QVERIFY(!controller.addRuleFromJson(rule).isEmpty());
+    };
+    // DP-A: lock=true added FIRST (higher priority) over a later unlock → locked.
+    lockRule(QStringLiteral("DP-A"), true);
+    lockRule(QStringLiteral("DP-A"), false);
+    // DP-B: the inverse — unlock added first (higher priority) over a later
+    // lock → not locked. Proves the winner is priority, not the value.
+    lockRule(QStringLiteral("DP-B"), false);
+    lockRule(QStringLiteral("DP-B"), true);
+
+    const QVariantList screens{QVariantMap{{QStringLiteral("name"), QStringLiteral("DP-A")}},
+                               QVariantMap{{QStringLiteral("name"), QStringLiteral("DP-B")}}};
+    const QVariantList overview = controller.monitorOverview(screens);
+    QCOMPARE(overview.size(), 2);
+
+    for (const QVariant& v : overview) {
+        const QVariantMap tile = v.toMap();
+        const QString id = tile.value(QStringLiteral("screenId")).toString();
+        // Both screens carry two pinned lock rules.
+        QCOMPARE(tile.value(QStringLiteral("ruleCount")).toInt(), 2);
+        if (id == QLatin1String("DP-A")) {
+            QCOMPARE(tile.value(QStringLiteral("locked")).toBool(), true);
+        } else if (id == QLatin1String("DP-B")) {
             QCOMPARE(tile.value(QStringLiteral("locked")).toBool(), false);
         }
     }

--- a/tests/unit/settings/test_window_rule_controller.cpp
+++ b/tests/unit/settings/test_window_rule_controller.cpp
@@ -847,6 +847,20 @@ void TestWindowRuleController::templatesProduceSeededRules()
     QCOMPARE(smallActions.size(), 1);
     QCOMPARE(smallActions.at(0).toMap().value(QStringLiteral("type")).toString(), QStringLiteral("excludeAnimations"));
 
+    // `lockLayoutOnMonitor` is the lock template: ScreenId leaf + a single
+    // LockContext action seeded to lock (value == true). The seeded value is
+    // the contract — a regression that drops/inverts it would author a rule
+    // that silently doesn't lock, or doesn't surface in the picker's
+    // value-on default.
+    const QVariantMap lockRule = controller.newRuleFromTemplate(QStringLiteral("lockLayoutOnMonitor"));
+    QVERIFY(!lockRule.value(QStringLiteral("id")).toString().isEmpty());
+    QCOMPARE(lockRule.value(QStringLiteral("match")).toMap().value(QStringLiteral("field")).toString(),
+             QStringLiteral("screenId"));
+    const QVariantList lockActions = lockRule.value(QStringLiteral("actions")).toList();
+    QCOMPARE(lockActions.size(), 1);
+    QCOMPARE(lockActions.at(0).toMap().value(QStringLiteral("type")).toString(), QStringLiteral("lockContext"));
+    QCOMPARE(lockActions.at(0).toMap().value(QStringLiteral("value")).toBool(), true);
+
     // An unknown id must return an empty map — the AddRuleSheet would
     // otherwise commit a UUID-less rule on a typo in the template id.
     const QVariantMap bogus = controller.newRuleFromTemplate(QStringLiteral("nonexistentTemplate"));

--- a/tests/unit/settings/test_window_rule_controller.cpp
+++ b/tests/unit/settings/test_window_rule_controller.cpp
@@ -1023,6 +1023,16 @@ void TestWindowRuleController::defaultPayloadForSeedsParams()
     QCOMPARE(borderColorPayload.value(QStringLiteral("type")).toString(), QStringLiteral("setBorderColor"));
     QCOMPARE(borderColorPayload.value(QStringLiteral("value")).toString(), QStringLiteral("#FF3DAEE9"));
 
+    // LockContext's `value` is a bool with defaultDisplay=1.0, so a freshly
+    // type-switched lock action seeds to `value: true` — the picker opens
+    // value-on (the meaningful "lock" default). A descriptor regression that
+    // dropped defaultDisplay would seed `false` here, silently authoring a
+    // lock action that doesn't lock.
+    const QVariantMap lockPayload = controller.defaultPayloadFor(QStringLiteral("lockContext"));
+    QCOMPARE(lockPayload.value(QStringLiteral("type")).toString(), QStringLiteral("lockContext"));
+    QVERIFY(lockPayload.contains(QStringLiteral("value")));
+    QCOMPARE(lockPayload.value(QStringLiteral("value")).toBool(), true);
+
     // Unknown type → bare `{type: X}` map. The QML side will never call this
     // with an unknown wire (the picker only offers registered types), but
     // returning a sane shape keeps the contract total.

--- a/tests/unit/settings/test_window_rule_controller.cpp
+++ b/tests/unit/settings/test_window_rule_controller.cpp
@@ -891,6 +891,7 @@ void TestWindowRuleController::actionTypesCarryDomain()
     QCOMPARE(domainOf.value(QStringLiteral("setSnappingLayout")), QStringLiteral("context"));
     QCOMPARE(domainOf.value(QStringLiteral("setTilingAlgorithm")), QStringLiteral("context"));
     QCOMPARE(domainOf.value(QStringLiteral("disableEngine")), QStringLiteral("context"));
+    QCOMPARE(domainOf.value(QStringLiteral("lockContext")), QStringLiteral("context"));
     QCOMPARE(domainOf.value(QStringLiteral("float")), QStringLiteral("window"));
     QCOMPARE(domainOf.value(QStringLiteral("exclude")), QStringLiteral("window"));
 }


### PR DESCRIPTION
## Summary

Window rules could set a context's engine mode, layout, algorithm, and gaps, but there was no way to express a layout **lock** as a rule — locking was reachable only through the manual **ToggleLayoutLock** shortcut. This adds a context-domain `LockContext` action so a rule like *"WHEN Activity == Work ⇒ Lock layout"* pins the active layout for that screen/desktop/activity.

Semantics (per design decisions): locks the **active layout** (same effect as ToggleLayoutLock), applies to **both engine modes**, and is a **live-resolved overlay** — never persisted, so rule locks and manual toggles never overwrite each other.

## How it flows

1. A context rule fills a new boolean `ActionSlot::Locked`.
2. `LayoutRegistry::resolveContextLocked()` reads that slot via the `RuleEvaluator` (mirrors `resolveContextGaps`, with the same revision-keyed hot-path cache).
3. `DaemonSettingsGateAdapter::isContextLocked()` ORs the rule-resolved lock over the manual `lockedScreens` store — so a rule-locked context shows the lock badge and refuses layout switches exactly like a manual lock.

## Changes (13 files)

- **phosphor-windowrule** (LGPL): `ActionType::LockContext` + `ActionSlot::Locked`; Context-domain boolean descriptor (defaults to locked).
- **phosphor-zones** (LGPL): `resolveContextLocked` on `IZoneLayoutRegistry` (default `false`) + `LayoutRegistry` impl with cache.
- **daemon** (GPL): threaded `LayoutRegistry` into the gate adapter; OR'd the rule lock into `isContextLocked`.
- **settings** (GPL): "Lock layout" picker entry/label/category + one-click **"Lock the layout on a monitor"** template.
- **tests**: action-registry round-trip, domain-canary pinning, and a `resolveContextLocked` cascade test (screen/activity scoping, `value=false` no-op, disabled-rule cache invalidation).

## Testing

- `cmake --build build` — clean, no warnings.
- `ctest` — **100% (279/279) passed**.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)