### PR TITLE
fix(settings): unify WHEN/THEN preview headers as matching pills

### DIFF
--- a/src/settings/qml/WindowRuleRow.qml
+++ b/src/settings/qml/WindowRuleRow.qml
@@ -85,6 +85,32 @@ ItemDelegate {
     // `enabled` in any handler that relies on implicit-argument scope.
     signal toggleRequested(bool ruleEnabled)
 
+    // Section-header pill shared by the WHEN and THEN halves of the expanded
+    // preview. Both headers use one capsule style — highlightColor family,
+    // 0.4 fill + 0.9 border — so the two sections read as one design and line
+    // up on the same left edge. Mirrors the fill/border recipe of the
+    // ALL/ANY/NONE group pills in MatchExpressionView.
+    component SectionHeaderPill: Rectangle {
+        property alias text: pillLabel.text
+
+        implicitWidth: pillLabel.implicitWidth + Kirigami.Units.largeSpacing * 2
+        implicitHeight: pillLabel.implicitHeight + Kirigami.Units.smallSpacing * 2
+        radius: implicitHeight / 2
+        color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.4)
+        border.width: Math.max(1, Math.round(Screen.devicePixelRatio))
+        border.color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.9)
+
+        Label {
+            id: pillLabel
+
+            anchors.centerIn: parent
+            font.bold: true
+            font.capitalization: Font.AllUppercase
+            font.pointSize: Kirigami.Theme.smallFont.pointSize
+            color: Kirigami.Theme.textColor
+        }
+    }
+
     // Instantiated inside a Repeater/ColumnLayout — `Layout.fillWidth: true`
     // (set by the delegate's parent) drives the width; there is no enclosing
     // ListView, so no `ListView.view` branch.
@@ -392,12 +418,9 @@ ItemDelegate {
 
                 spacing: Kirigami.Units.smallSpacing
 
-                Label {
+                SectionHeaderPill {
+                    Layout.alignment: Qt.AlignLeft
                     text: i18n("WHEN")
-                    font.bold: true
-                    opacity: 0.7
-                    font.capitalization: Font.AllUppercase
-                    font.pointSize: Kirigami.Theme.smallFont.pointSize
                 }
 
                 MatchExpressionView {
@@ -410,32 +433,10 @@ ItemDelegate {
                     appSettings: row.appSettings
                 }
 
-                Rectangle {
+                SectionHeaderPill {
                     Layout.alignment: Qt.AlignLeft
                     Layout.topMargin: Kirigami.Units.smallSpacing
-                    implicitWidth: thenLabel.implicitWidth + Kirigami.Units.largeSpacing * 2
-                    // `smallSpacing * 2` matches the ALL/ANY/NONE pills in
-                    // MatchExpressionView so the THEN header and the WHEN
-                    // group pills carry the same vertical weight — both pill
-                    // styles use highlightColor-family tints + 0.4 fill + 0.9
-                    // border, and the matching padding keeps them readable
-                    // as one design.
-                    implicitHeight: thenLabel.implicitHeight + Kirigami.Units.smallSpacing * 2
-                    radius: implicitHeight / 2
-                    color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.4)
-                    border.width: Math.max(1, Math.round(Screen.devicePixelRatio))
-                    border.color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.9)
-
-                    Label {
-                        id: thenLabel
-
-                        anchors.centerIn: parent
-                        text: i18n("THEN")
-                        font.bold: true
-                        font.capitalization: Font.AllUppercase
-                        font.pointSize: Kirigami.Theme.smallFont.pointSize
-                        color: Kirigami.Theme.textColor
-                    }
+                    text: i18n("THEN")
                 }
 
                 ActionListView {


### PR DESCRIPTION
## Problem

In the expanded read-only rule preview, the **WHEN** section header was plain bold text while **THEN** was a tinted capsule pill. The two headers had inconsistent styling, and because the pill carries internal padding its label sat further right than the flush "WHEN" text — so the headers didn't line up either.

## Change

`src/settings/qml/WindowRuleRow.qml`:

- Factor the header pill into a shared `SectionHeaderPill` inline component (highlightColor family, 0.4 fill + 0.9 border, capsule radius — the same recipe as the ALL/ANY/NONE group pills in `MatchExpressionView`).
- Use it for **both** WHEN and THEN headers, each `Layout.alignment: Qt.AlignLeft` so they share one left edge.

Both halves of the preview now read as one design:

```
╭──────╮
│ WHEN │
╰──────╯
  (ALL of)
  ├ • Window class   CONTAINS   [steam]
  └ (NONE of)
      └ • Title   IS   [Steam]
╭──────╮
│ THEN │
╰──────╯
  └ • Exclude window
```

Net effect is DRY: one pill definition replaces the previously-inline THEN `Rectangle` and the plain WHEN `Label`.

### Note
The pill's child `id` deliberately avoids a leading underscore — qmlformat 6.11.1 fails to format a leading-underscore `id` declared inside an inline `component` (the runtime QML compiler and qmllint accept it, but the pre-commit qmlformat hook would block).

## Testing

- Portable Qt-only build (`-DUSE_KDE_FRAMEWORKS=OFF`) of `plasmazones-settings` — **green** (native KF6 build is blocked by an unrelated half-applied `KF6ColorScheme` system upgrade).
- `qmlformat` parses clean; `qmllint` reports no errors (only the file's pre-existing unqualified-access style warnings).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)