### PR TITLE
fix(settings): use the custom SettingsSwitch for rule-editor toggles

### DIFF
--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -406,12 +406,28 @@ ColumnLayout {
     }
 
     _boolParamEditor: Component {
-        Switch {
+        // SettingsSwitch is a fixed-size custom Item whose track fills its
+        // bounds, but the hosting Loader is `Layout.fillWidth` (for the text /
+        // combo editors), which would stretch the toggle into a full-width pill.
+        // Host it in a fill wrapper and keep the toggle at its implicit size,
+        // left- and vertically-centered — matching the compact placement the
+        // stock Switch produced.
+        Item {
             readonly property var _param: parent.modelData
 
-            checked: row.action[_param.key] === true
-            Accessible.name: _param.label
-            onToggled: row.actionEdited(row._withParam(_param.key, checked))
+            implicitHeight: boolToggle.implicitHeight
+
+            SettingsSwitch {
+                id: boolToggle
+
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                checked: row.action[_param.key] === true
+                accessibleName: _param.label
+                onToggled: function (newValue) {
+                    row.actionEdited(row._withParam(_param.key, newValue));
+                }
+            }
         }
     }
 

--- a/src/settings/qml/RuleEditorBody.qml
+++ b/src/settings/qml/RuleEditorBody.qml
@@ -184,11 +184,13 @@ ColumnLayout {
             onEditingFinished: root._patch("name", text)
         }
 
-        Switch {
+        SettingsSwitch {
             Kirigami.FormData.label: i18n("Enabled:")
             checked: root.workingRule.enabled !== false
-            Accessible.name: i18n("Rule enabled")
-            onToggled: root._patch("enabled", checked)
+            accessibleName: i18n("Rule enabled")
+            onToggled: function (newValue) {
+                root._patch("enabled", newValue);
+            }
         }
 
         // Priority + band-name hint. Bare integers like "610" are


### PR DESCRIPTION
## Summary
The window-rule editor used stock QtQuick `Switch` controls instead of the app's custom animated `SettingsSwitch` (the control the rest of the settings app uses for boolean toggles).

- **`ActionRow.qml`** — the per-action boolean param editor (Lock layout, Hide title bar, Border visible, Per-side gaps) now uses `SettingsSwitch`. It's hosted in a fill wrapper so the toggle keeps its implicit size and left/vertical-center placement instead of being stretched into a full-width pill by the `Layout.fillWidth` Loader.
- **`RuleEditorBody.qml`** — the rule's "Enabled:" form field switches from a raw `Switch` to `SettingsSwitch` for consistency.

Both adapt to `SettingsSwitch`'s API: `accessibleName` (vs `Accessible.name`) and `toggled(newValue)` (vs the no-arg `Switch.toggled()` + post-flip `checked`).

## Testing
- `cmake --build` green (QML module compiles)
- `ctest` 279/279 pass
- pre-commit hooks (qmlformat) clean

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)