### PR TITLE
fix(settings): stop combo-popup rows running under the scrollbar

### DIFF
--- a/src/settings/qml/LayoutComboBox.qml
+++ b/src/settings/qml/LayoutComboBox.qml
@@ -373,13 +373,17 @@ ComboBox {
         }
 
         contentItem: ListView {
+            id: popupList
+
             clip: true
             implicitHeight: contentHeight
             model: root.delegateModel
             currentIndex: root.highlightedIndex
             highlightMoveDuration: 0
 
-            ScrollBar.vertical: ScrollBar {}
+            ScrollBar.vertical: ScrollBar {
+                policy: ScrollBar.AsNeeded
+            }
         }
 
         background: Rectangle {
@@ -399,7 +403,12 @@ ComboBox {
         readonly property bool isCurrentSelection: root.currentIndex === index
 
         Accessible.name: modelData.text || ""
-        width: root.popup.availableWidth
+        // Reserve the scrollbar's gutter so the row content ends at the
+        // scrollbar's left edge instead of running underneath it — otherwise
+        // the seam between the full-width delegate and the floating scrollbar
+        // shows as a stray vertical line beside the handle (mirrors the
+        // FontPickerDialog list pattern).
+        width: popupList.width - (popupList.ScrollBar.vertical.visible ? popupList.ScrollBar.vertical.width : 0)
         implicitHeight: Kirigami.Units.gridUnit * 6
         // Only highlight the hovered/keyboard-navigated item (standard ComboBox UX).
         // The current selection is shown with a checkmark, not a second highlight

--- a/src/settings/qml/WideComboBox.qml
+++ b/src/settings/qml/WideComboBox.qml
@@ -145,13 +145,17 @@ ComboBox {
         padding: 1
 
         contentItem: ListView {
+            id: popupList
+
             clip: true
             implicitHeight: contentHeight
             model: root.delegateModel
             currentIndex: root.highlightedIndex
             highlightMoveDuration: 0
 
-            ScrollBar.vertical: ScrollBar {}
+            ScrollBar.vertical: ScrollBar {
+                policy: ScrollBar.AsNeeded
+            }
         }
 
         background: Rectangle {
@@ -167,7 +171,10 @@ ComboBox {
         required property int index
         readonly property bool isCurrentSelection: root.currentIndex === index
 
-        width: root.popup.availableWidth
+        // Reserve the scrollbar's gutter so the row content ends at the
+        // scrollbar's left edge instead of running underneath it (avoids the
+        // stray vertical-line seam beside the handle when the list scrolls).
+        width: popupList.width - (popupList.ScrollBar.vertical.visible ? popupList.ScrollBar.vertical.width : 0)
         highlighted: root.highlightedIndex === index
 
         background: Rectangle {


### PR DESCRIPTION
## Summary
Fixes the stray vertical line in the layout selector dropdown (and any other custom combo popup that scrolls).

The custom `ComboBox` popups (`LayoutComboBox`, `WideComboBox`) sized each row to the full popup width (`root.popup.availableWidth`). When the list was long enough to show a scrollbar, the rows ran **underneath** the floating scrollbar, and the seam between the full-width delegate and the scrollbar rendered as a thin vertical line just left of the handle.

This was most visible in the **Set snapping layout** selector — the one combo whose list reliably scrolls.

## Fix
Reserve the scrollbar's gutter so rows end at the scrollbar's left edge:
`width: popupList.width - (ScrollBar.visible ? ScrollBar.width : 0)`

This matches the existing `FontPickerDialog` list pattern (which never showed the line). `WideComboBox` carried the same latent bug (its event/shader pickers in the rule editor can get long enough to scroll), so both popups are fixed and the scrollbar policy is made explicit (`AsNeeded`).

## Testing
- `cmake --build` green (QML module compiles; `popupList` id references resolve)
- Verified visually in the running settings app: line gone, rows stop cleanly at the scrollbar.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)