### PR TITLE
feat(animation): per-shader event-class capability gating

### DIFF
--- a/data/animations/window-morph/metadata.json
+++ b/data/animations/window-morph/metadata.json
@@ -5,6 +5,7 @@
     "author": "PlasmaZones",
     "version": "1.0",
     "category": "Distortion",
+    "appliesTo": ["geometry"],
     "fragmentShader": "effect.frag",
     "vertexShader": "effect.vert",
     "fboExtent": "surface",

--- a/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderEffect.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderEffect.h
@@ -61,6 +61,23 @@ struct PHOSPHORANIMATION_EXPORT AnimationShaderEffect
     /// Category for settings-UI grouping (e.g. "Fade", "Geometric", "Glitch").
     QString category;
 
+    /// Event-class tokens this effect is meaningful on. Each token is one
+    /// of `PhosphorAnimation::ProfilePaths::EventClassAppearance`
+    /// ("appearance" — open/close/minimize/focus + OSD/popup show/hide) or
+    /// `EventClassGeometry` ("geometry" — move/resize/snap*/layoutSwitch/
+    /// maximize). EMPTY (the default) means "universal" — the effect applies
+    /// to every event class, which is the right answer for the bulk of
+    /// transitions (fade, glitch, dissolve …) that operate on a single
+    /// surface and need no before/after geometry.
+    ///
+    /// A geometry-only effect like `window-morph` cross-fades an old rect
+    /// into a new rect (`iFromRect → iToRect`); that pair only exists on
+    /// geometry legs, so on an appearance event it would render nothing.
+    /// Declaring `["geometry"]` lets the settings picker dim the effect on
+    /// appearance rows with an explanatory tooltip instead of letting a
+    /// user assign a silent no-op. See `shaderEffectAppliesToEventPath`.
+    QStringList appliesTo;
+
     /// Path to the fragment shader (relative to the effect dir). The same
     /// source is used on both QtQuick and KWin paths — ShaderNodeRhi
     /// handles backend differences at the RHI level.
@@ -246,6 +263,23 @@ struct PHOSPHORANIMATION_EXPORT AnimationShaderEffect
         return !(*this == other);
     }
 };
+
+/// True iff @p effect may meaningfully run on event @p path.
+///
+/// An effect with an empty `appliesTo` is universal and always returns
+/// true. Otherwise the predicate maps @p path to its event class via
+/// `PhosphorAnimation::ProfilePaths::eventClassForPath` and checks
+/// membership. A path with no determinable class (a mixed ancestor like
+/// `window`, or a non-window/overlay path) also returns true — the
+/// predicate only reports false when it can PROVE a mismatch, so it never
+/// over-restricts a row whose class is ambiguous.
+///
+/// This is the (effect × path) analogue of
+/// `PlasmaZones::eventPathSupportsShaderLeg(path)`, which gates whether a
+/// path can run ANY shader. Both the settings picker (to dim incompatible
+/// effects) and any future runtime verification consult this one predicate
+/// so the policy has a single source of truth.
+PHOSPHORANIMATION_EXPORT bool shaderEffectAppliesToEventPath(const AnimationShaderEffect& effect, const QString& path);
 
 } // namespace PhosphorAnimationShaders
 

--- a/libs/phosphor-animation/include/PhosphorAnimation/ProfilePaths.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/ProfilePaths.h
@@ -148,9 +148,10 @@ PHOSPHORANIMATION_EXPORT extern const QString EventClassAppearance;
 
 /// Classify @p path into an event class, or empty string when the path has
 /// no single class (a mixed ancestor like `window`, or a path outside the
-/// window/OSD/popup families). Resolution is leaf-aware: the OSD and popup
-/// roots and all their descendants are `appearance`; the window leaves split
-/// by motion-vs-lifecycle; the `window` root itself is mixed → empty.
+/// window/OSD/popup families — editor / panel / widget / cursor / shader /
+/// global). Resolution is leaf-aware: the OSD and popup roots and all their
+/// descendants are `appearance`; the window leaves split by
+/// motion-vs-lifecycle; the `window` root itself is mixed → empty.
 PHOSPHORANIMATION_EXPORT QString eventClassForPath(const QString& path);
 
 /// Full list of built-in paths in taxonomy order.

--- a/libs/phosphor-animation/include/PhosphorAnimation/ProfilePaths.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/ProfilePaths.h
@@ -127,6 +127,32 @@ PHOSPHORANIMATION_EXPORT extern const QString WidgetZoneHighlightBorder;
 // content effect on the overlay, not a per-zone animation.
 PHOSPHORANIMATION_EXPORT extern const QString WidgetZoneOverlayFlash;
 
+// ── Event classes ───────────────────────────────────────────────────────
+// A coarse capability axis layered over the path taxonomy: an animation
+// either reshapes a window's GEOMETRY (it has a before-rect and an
+// after-rect) or it changes a surface's APPEARANCE (a single surface fading
+// / scaling / glitching in or out). A geometry-only shader such as
+// window-morph cross-fades `iFromRect → iToRect` and is a silent no-op on an
+// appearance event, so a shader can declare which classes it supports
+// (AnimationShaderEffect::appliesTo) and the settings UI dims the rows it
+// can't drive. These string tokens are the SSOT for that vocabulary —
+// matched verbatim against `appliesTo` entries and `eventClassForPath`.
+
+/// Geometry transitions: move, resize, snapIn/snapOut/snapResize,
+/// layoutSwitch, maximize — every leg that carries an old and new rect.
+PHOSPHORANIMATION_EXPORT extern const QString EventClassGeometry;
+
+/// Appearance transitions: open, close, minimize, focus, and every OSD /
+/// popup show/hide — a single surface materialising or dissolving.
+PHOSPHORANIMATION_EXPORT extern const QString EventClassAppearance;
+
+/// Classify @p path into an event class, or empty string when the path has
+/// no single class (a mixed ancestor like `window`, or a path outside the
+/// window/OSD/popup families). Resolution is leaf-aware: the OSD and popup
+/// roots and all their descendants are `appearance`; the window leaves split
+/// by motion-vs-lifecycle; the `window` root itself is mixed → empty.
+PHOSPHORANIMATION_EXPORT QString eventClassForPath(const QString& path);
+
 /// Full list of built-in paths in taxonomy order.
 PHOSPHORANIMATION_EXPORT QStringList allBuiltInPaths();
 

--- a/libs/phosphor-animation/src/animationshadereffect.cpp
+++ b/libs/phosphor-animation/src/animationshadereffect.cpp
@@ -4,6 +4,7 @@
 #include <PhosphorAnimation/AnimationShaderEffect.h>
 
 #include <PhosphorAnimation/AnimationShaderContract.h>
+#include <PhosphorAnimation/ProfilePaths.h>
 
 #include <QJsonArray>
 #include <QJsonValue>
@@ -70,6 +71,15 @@ QJsonObject AnimationShaderEffect::toJson() const
         obj.insert(QLatin1String("version"), version);
     if (!category.isEmpty())
         obj.insert(QLatin1String("category"), category);
+    // Emit `appliesTo` only when the effect constrains itself — the empty
+    // (universal) default stays omitted so the bulk of metadata.json files
+    // are unchanged, same terse-by-default idiom as fboExtent/multipass.
+    if (!appliesTo.isEmpty()) {
+        QJsonArray arr;
+        for (const auto& c : appliesTo)
+            arr.append(c);
+        obj.insert(QLatin1String("appliesTo"), arr);
+    }
     if (!fragmentShaderPath.isEmpty())
         obj.insert(QLatin1String("fragmentShader"), fragmentShaderPath);
     if (!vertexShaderPath.isEmpty())
@@ -190,6 +200,28 @@ AnimationShaderEffect AnimationShaderEffect::fromJson(const QJsonObject& obj)
     e.author = obj.value(QLatin1String("author")).toString();
     e.version = obj.value(QLatin1String("version")).toString();
     e.category = obj.value(QLatin1String("category")).toString();
+    // `appliesTo` (array of event-class tokens). Only the documented
+    // vocabulary — "geometry" / "appearance" — is accepted; an unknown
+    // token is a typo or a foreign import and is dropped with a warning so
+    // it neither restricts the picker on a class that doesn't exist nor
+    // round-trips the typo back to disk via toJson. An array that validates
+    // down to empty is indistinguishable from "universal", which is the
+    // correct fallback (the effect applies everywhere).
+    {
+        namespace PP = PhosphorAnimation::ProfilePaths;
+        const QJsonArray appliesArr = obj.value(QLatin1String("appliesTo")).toArray();
+        for (const QJsonValue& v : appliesArr) {
+            const QString token = v.toString().trimmed();
+            if (token == PP::EventClassGeometry || token == PP::EventClassAppearance) {
+                if (!e.appliesTo.contains(token))
+                    e.appliesTo.append(token);
+            } else if (!token.isEmpty()) {
+                qCWarning(lcAnimationShader)
+                    << "AnimationShaderEffect::fromJson: unknown appliesTo token" << token << "for effect" << e.id
+                    << "— accepted values are \"geometry\" and \"appearance\"; dropping.";
+            }
+        }
+    }
     e.fragmentShaderPath = obj.value(QLatin1String("fragmentShader")).toString();
     e.vertexShaderPath = obj.value(QLatin1String("vertexShader")).toString();
     e.previewPath = obj.value(QLatin1String("preview")).toString();
@@ -327,6 +359,8 @@ bool AnimationShaderEffect::operator==(const AnimationShaderEffect& other) const
         return false;
     if (author != other.author || version != other.version || category != other.category)
         return false;
+    if (appliesTo != other.appliesTo)
+        return false;
     if (fragmentShaderPath != other.fragmentShaderPath || vertexShaderPath != other.vertexShaderPath)
         return false;
     if (sourceDir != other.sourceDir || isUserEffect != other.isUserEffect)
@@ -360,6 +394,21 @@ bool AnimationShaderEffect::operator==(const AnimationShaderEffect& other) const
     if (textures != other.textures)
         return false;
     return true;
+}
+
+bool shaderEffectAppliesToEventPath(const AnimationShaderEffect& effect, const QString& path)
+{
+    // Universal effect (no declared constraint) runs everywhere.
+    if (effect.appliesTo.isEmpty())
+        return true;
+    // Only report false on a PROVABLE mismatch: the path resolves to a
+    // concrete class AND the effect doesn't list it. An ambiguous row
+    // (mixed ancestor / non-window path → empty class) is left compatible
+    // so the picker never dims an effect on a row it can't classify.
+    const QString cls = PhosphorAnimation::ProfilePaths::eventClassForPath(path);
+    if (cls.isEmpty())
+        return true;
+    return effect.appliesTo.contains(cls);
 }
 
 } // namespace PhosphorAnimationShaders

--- a/libs/phosphor-animation/src/profilepaths.cpp
+++ b/libs/phosphor-animation/src/profilepaths.cpp
@@ -223,6 +223,10 @@ QString defaultShaderEffectIdForPath(const QString& path)
 {
     // Window move/resize events default to the geometry-morph shader so a
     // window animates via shader cross-fade when it snaps/tiles/reflows.
+    // This is the same geometry leg set `eventClassForPath` classes as
+    // EventClassGeometry, MINUS maximize (maximize is geometry-classed so
+    // morph is selectable there, but it isn't a built-in default) — keep the
+    // two lists in sync if a new geometry leg is added.
     if (path == WindowMove || path == WindowResize || path == WindowSnapIn || path == WindowSnapOut
         || path == WindowSnapResize || path == WindowLayoutSwitch) {
         return QStringLiteral("window-morph");

--- a/libs/phosphor-animation/src/profilepaths.cpp
+++ b/libs/phosphor-animation/src/profilepaths.cpp
@@ -9,6 +9,11 @@ namespace ProfilePaths {
 // Root
 const QString Global = QStringLiteral("global");
 
+// Event-class tokens (see ProfilePaths.h). Kept as QStringLiteral so they
+// compare cheaply against AnimationShaderEffect::appliesTo entries.
+const QString EventClassGeometry = QStringLiteral("geometry");
+const QString EventClassAppearance = QStringLiteral("appearance");
+
 // window.*
 const QString Window = QStringLiteral("window");
 const QString WindowOpen = QStringLiteral("window.open");
@@ -182,6 +187,36 @@ QString parentPath(const QString& path)
         return Global;
     }
     return path.left(dotIdx);
+}
+
+QString eventClassForPath(const QString& path)
+{
+    // Geometry legs carry an old rect and a new rect (move/resize/snap/
+    // tile/layoutSwitch/maximize). Mirrors the geometry set that
+    // defaultShaderEffectIdForPath seeds with window-morph, plus maximize
+    // (a maximize IS a geometry change with a before/after rect — morph can
+    // drive it even though it isn't a built-in default there).
+    if (path == WindowMove || path == WindowResize || path == WindowSnapIn || path == WindowSnapOut
+        || path == WindowSnapResize || path == WindowLayoutSwitch || path == WindowMaximize) {
+        return EventClassGeometry;
+    }
+    // Appearance legs animate a single surface in or out. Window lifecycle
+    // leaves (open/close/minimize/focus) plus every OSD and popup surface —
+    // the osd/popup roots and all their show/hide/pop descendants. A
+    // `startsWith` on the family roots keeps future popup sub-surfaces
+    // classified without touching this list.
+    if (path == WindowOpen || path == WindowClose || path == WindowMinimize || path == WindowFocus) {
+        return EventClassAppearance;
+    }
+    if (path == Osd || path == Popup || path.startsWith(Osd + QLatin1Char('.'))
+        || path.startsWith(Popup + QLatin1Char('.'))) {
+        return EventClassAppearance;
+    }
+    // `window` root (mixed: spans both classes), `global`, and the
+    // editor/panel/widget/cursor/shader families have no single class — the
+    // predicate treats empty as "don't dim" so an ambiguous row never
+    // suppresses a compatible effect.
+    return QString();
 }
 
 QString defaultShaderEffectIdForPath(const QString& path)

--- a/libs/phosphor-animation/tests/test_animationshadereffect.cpp
+++ b/libs/phosphor-animation/tests/test_animationshadereffect.cpp
@@ -107,6 +107,14 @@ private Q_SLOTS:
 
         b.id = QStringLiteral("morph");
         QVERIFY(a != b);
+
+        // operator== must observe appliesTo: two effects differing ONLY in
+        // their declared event classes are not equal. Without the dedicated
+        // branch this would falsely compare equal.
+        AnimationShaderEffect c = a;
+        AnimationShaderEffect d = a;
+        d.appliesTo = QStringList{QStringLiteral("geometry")};
+        QVERIFY(c != d);
     }
 
     /// Multipass / wallpaper / depth / buffer fields survive a full
@@ -258,6 +266,22 @@ private Q_SLOTS:
         bad.append(QStringLiteral("nonsense"));
         allBad.insert(QLatin1String("appliesTo"), bad);
         QVERIFY(AnimationShaderEffect::fromJson(allBad).appliesTo.isEmpty());
+
+        // A non-array value (scalar where an array is expected) and non-string
+        // array elements are both hand-authoring mistakes — neither should
+        // throw or smuggle garbage in; the field reduces to universal/valid.
+        QJsonObject scalar = obj;
+        scalar.insert(QLatin1String("appliesTo"), QStringLiteral("geometry"));
+        QVERIFY(AnimationShaderEffect::fromJson(scalar).appliesTo.isEmpty());
+
+        QJsonObject mixed;
+        mixed.insert(QLatin1String("id"), QStringLiteral("y"));
+        mixed.insert(QLatin1String("fragmentShader"), QStringLiteral("effect.frag"));
+        QJsonArray mixedArr;
+        mixedArr.append(QStringLiteral("geometry"));
+        mixedArr.append(7); // numeric element silently skipped
+        mixed.insert(QLatin1String("appliesTo"), mixedArr);
+        QCOMPARE(AnimationShaderEffect::fromJson(mixed).appliesTo, (QStringList{QStringLiteral("geometry")}));
     }
 
     /// The (effect × path) predicate: a geometry-only effect is compatible
@@ -273,19 +297,38 @@ private Q_SLOTS:
         morph.fragmentShaderPath = QStringLiteral("effect.frag");
         morph.appliesTo = QStringList{QStringLiteral("geometry")};
 
-        QVERIFY(shaderEffectAppliesToEventPath(morph, QStringLiteral("window.move")));
-        QVERIFY(shaderEffectAppliesToEventPath(morph, QStringLiteral("window.snapIn")));
-        QVERIFY(shaderEffectAppliesToEventPath(morph, QStringLiteral("window.maximize")));
-        QVERIFY(!shaderEffectAppliesToEventPath(morph, QStringLiteral("window.open")));
-        QVERIFY(!shaderEffectAppliesToEventPath(morph, QStringLiteral("popup.layoutPicker.show")));
-        // Mixed ancestor → unclassified → not provably incompatible.
+        // Every geometry leg eventClassForPath classifies must be compatible
+        // with a geometry-only effect — pin the full disjunction so dropping
+        // any leg from the classifier is caught.
+        for (const char* geo : {"window.move", "window.resize", "window.snapIn", "window.snapOut", "window.snapResize",
+                                "window.layoutSwitch", "window.maximize"}) {
+            QVERIFY2(shaderEffectAppliesToEventPath(morph, QString::fromLatin1(geo)), geo);
+        }
+        // Every appearance leg must be incompatible with a geometry-only effect.
+        for (const char* app : {"window.open", "window.close", "window.minimize", "window.focus", "osd.show",
+                                "osd.hide", "popup.layoutPicker.show", "popup.zoneSelector.hide"}) {
+            QVERIFY2(!shaderEffectAppliesToEventPath(morph, QString::fromLatin1(app)), app);
+        }
+        // Unclassified paths (mixed `window` root, non-window families) are
+        // never provably incompatible — the predicate stays permissive.
         QVERIFY(shaderEffectAppliesToEventPath(morph, QStringLiteral("window")));
+        QVERIFY(shaderEffectAppliesToEventPath(morph, QStringLiteral("editor.snapIn")));
+        QVERIFY(shaderEffectAppliesToEventPath(morph, QStringLiteral("panel.slideIn")));
 
         AnimationShaderEffect fade; // universal (no appliesTo)
         fade.id = QStringLiteral("fade");
         fade.fragmentShaderPath = QStringLiteral("effect.frag");
         QVERIFY(shaderEffectAppliesToEventPath(fade, QStringLiteral("window.open")));
         QVERIFY(shaderEffectAppliesToEventPath(fade, QStringLiteral("window.move")));
+
+        // Appearance-only effect: mirror image — incompatible on geometry legs,
+        // compatible on appearance legs.
+        AnimationShaderEffect appearanceOnly;
+        appearanceOnly.id = QStringLiteral("aretha-materialize");
+        appearanceOnly.fragmentShaderPath = QStringLiteral("effect.frag");
+        appearanceOnly.appliesTo = QStringList{QStringLiteral("appearance")};
+        QVERIFY(shaderEffectAppliesToEventPath(appearanceOnly, QStringLiteral("window.open")));
+        QVERIFY(!shaderEffectAppliesToEventPath(appearanceOnly, QStringLiteral("window.move")));
     }
 };
 

--- a/libs/phosphor-animation/tests/test_animationshadereffect.cpp
+++ b/libs/phosphor-animation/tests/test_animationshadereffect.cpp
@@ -3,6 +3,7 @@
 
 #include <PhosphorAnimation/AnimationShaderEffect.h>
 
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QTest>
 
@@ -212,6 +213,79 @@ private Q_SLOTS:
 
         const AnimationShaderEffect restored = AnimationShaderEffect::fromJson(original.toJson());
         QCOMPARE(restored.fboExtentKind, AnimationShaderEffect::FboExtentKind::Surface);
+    }
+
+    /// `appliesTo` round-trips through JSON, and an unset list stays empty
+    /// (universal) without emitting the key.
+    void testAppliesToRoundTrip()
+    {
+        AnimationShaderEffect original;
+        original.id = QStringLiteral("window-morph");
+        original.fragmentShaderPath = QStringLiteral("effect.frag");
+        original.appliesTo = QStringList{QStringLiteral("geometry")};
+
+        const QJsonObject json = original.toJson();
+        QVERIFY(json.contains(QLatin1String("appliesTo")));
+        const AnimationShaderEffect restored = AnimationShaderEffect::fromJson(json);
+        QCOMPARE(restored.appliesTo, original.appliesTo);
+
+        // Universal (empty) effect omits the key entirely.
+        AnimationShaderEffect universal;
+        universal.id = QStringLiteral("fade");
+        universal.fragmentShaderPath = QStringLiteral("effect.frag");
+        QVERIFY(!universal.toJson().contains(QLatin1String("appliesTo")));
+        QVERIFY(AnimationShaderEffect::fromJson(universal.toJson()).appliesTo.isEmpty());
+    }
+
+    /// Unknown / duplicate tokens are dropped at parse time; a list that
+    /// validates down to empty is treated as universal.
+    void testAppliesToValidation()
+    {
+        QJsonObject obj;
+        obj.insert(QLatin1String("id"), QStringLiteral("x"));
+        obj.insert(QLatin1String("fragmentShader"), QStringLiteral("effect.frag"));
+        QJsonArray arr;
+        arr.append(QStringLiteral("geometry"));
+        arr.append(QStringLiteral("geometry")); // duplicate
+        arr.append(QStringLiteral("teleport")); // unknown
+        obj.insert(QLatin1String("appliesTo"), arr);
+
+        const AnimationShaderEffect e = AnimationShaderEffect::fromJson(obj);
+        QCOMPARE(e.appliesTo, (QStringList{QStringLiteral("geometry")}));
+
+        QJsonObject allBad = obj;
+        QJsonArray bad;
+        bad.append(QStringLiteral("nonsense"));
+        allBad.insert(QLatin1String("appliesTo"), bad);
+        QVERIFY(AnimationShaderEffect::fromJson(allBad).appliesTo.isEmpty());
+    }
+
+    /// The (effect × path) predicate: a geometry-only effect is compatible
+    /// with geometry legs, incompatible with appearance legs, and a
+    /// universal effect is compatible everywhere. An ambiguous row (the
+    /// mixed `window` root) is never reported incompatible.
+    void testShaderEffectAppliesToEventPath()
+    {
+        using PhosphorAnimationShaders::shaderEffectAppliesToEventPath;
+
+        AnimationShaderEffect morph;
+        morph.id = QStringLiteral("window-morph");
+        morph.fragmentShaderPath = QStringLiteral("effect.frag");
+        morph.appliesTo = QStringList{QStringLiteral("geometry")};
+
+        QVERIFY(shaderEffectAppliesToEventPath(morph, QStringLiteral("window.move")));
+        QVERIFY(shaderEffectAppliesToEventPath(morph, QStringLiteral("window.snapIn")));
+        QVERIFY(shaderEffectAppliesToEventPath(morph, QStringLiteral("window.maximize")));
+        QVERIFY(!shaderEffectAppliesToEventPath(morph, QStringLiteral("window.open")));
+        QVERIFY(!shaderEffectAppliesToEventPath(morph, QStringLiteral("popup.layoutPicker.show")));
+        // Mixed ancestor → unclassified → not provably incompatible.
+        QVERIFY(shaderEffectAppliesToEventPath(morph, QStringLiteral("window")));
+
+        AnimationShaderEffect fade; // universal (no appliesTo)
+        fade.id = QStringLiteral("fade");
+        fade.fragmentShaderPath = QStringLiteral("effect.frag");
+        QVERIFY(shaderEffectAppliesToEventPath(fade, QStringLiteral("window.open")));
+        QVERIFY(shaderEffectAppliesToEventPath(fade, QStringLiteral("window.move")));
     }
 };
 

--- a/src/settings/animations_controller_detail.h
+++ b/src/settings/animations_controller_detail.h
@@ -64,6 +64,11 @@ inline QVariantMap effectToMap(const PhosphorAnimationShaders::AnimationShaderEf
     m.insert(QLatin1String("author"), effect.author);
     m.insert(QLatin1String("version"), effect.version);
     m.insert(QLatin1String("category"), effect.category);
+    // Declared event-class capability (empty = universal). Surfaced so the
+    // shader gallery can show a capability badge; the per-event picker uses
+    // the controller's path-aware `availableShaderEffectsForPath` instead,
+    // which folds this into ready-made `dimmed`/`dimReason` flags.
+    m.insert(QLatin1String("appliesTo"), QVariant::fromValue(effect.appliesTo));
     m.insert(QLatin1String("isUserEffect"), effect.isUserEffect);
     // `previewPath` is resolved to an absolute path by the registry's
     // `parseEffect`, so QML can pass it directly to `Image.source` (with

--- a/src/settings/animationspagecontroller.h
+++ b/src/settings/animationspagecontroller.h
@@ -220,9 +220,24 @@ public:
     Q_INVOKABLE bool supportsShaderLeg(const QString& path) const;
 
     /// Installed `AnimationShaderEffect`s flattened to a QML-friendly list.
-    /// Each row: id / name / description / author / version / category /
-    /// isUserEffect / parameters (QVariantList of ParameterInfo maps).
+    /// Each row mirrors `animations_controller_detail::effectToMap`:
+    /// id / name / description / author / version / category / appliesTo
+    /// (QStringList of event-class tokens, empty = universal) / isUserEffect /
+    /// previewPath / parameters (QVariantList of ParameterInfo maps).
     Q_INVOKABLE QVariantList availableShaderEffects() const;
+
+    /// Path-aware variant of @c availableShaderEffects: the same rows, each
+    /// additionally carrying `dimmed` (bool) and `dimReason` (string) for
+    /// the event @p path. An effect whose declared `appliesTo` class can't
+    /// drive @p path (e.g. the geometry-only window-morph on a window.open
+    /// row) comes back `dimmed: true` with a human-readable reason. The
+    /// per-event shader picker feeds this straight to the cascading
+    /// category menu, which renders dimmed items with a warning tooltip —
+    /// the same affordance the window-rule action picker uses for actions
+    /// that can't fire against the current match. Mirrors that pattern:
+    /// dimmed items stay SELECTABLE; the UI surfaces the consequence rather
+    /// than hard-blocking the choice.
+    Q_INVOKABLE QVariantList availableShaderEffectsForPath(const QString& path) const;
 
     /// Single-effect lookup. Empty map when @p effectId is unknown.
     Q_INVOKABLE QVariantMap shaderEffectInfo(const QString& effectId) const;

--- a/src/settings/animationspagecontroller_shaders.cpp
+++ b/src/settings/animationspagecontroller_shaders.cpp
@@ -96,13 +96,10 @@ QString shaderPathMismatchReason(const PhosphorAnimationShaders::AnimationShader
     namespace PP = PhosphorAnimation::ProfilePaths;
     if (pathClass == PP::EventClassAppearance) {
         // Effect is geometry-only (e.g. window-morph) on an appearance row.
-        return PhosphorI18n::tr(
-                   "“%1” needs an old and new geometry — it only applies to move, resize, snap and tile events.")
-            .arg(effect.name);
+        return PhosphorI18n::tr("“%1” only applies to move, resize, snap, and tile events.").arg(effect.name);
     }
     // pathClass == geometry: effect is appearance-only on a geometry row.
-    return PhosphorI18n::tr(
-               "“%1” animates a surface fading in or out — it has no effect on move, resize, snap or tile events.")
+    return PhosphorI18n::tr("“%1” only applies to show and hide events, not move, resize, snap, or tile.")
         .arg(effect.name);
 }
 } // namespace

--- a/src/settings/animationspagecontroller_shaders.cpp
+++ b/src/settings/animationspagecontroller_shaders.cpp
@@ -82,6 +82,27 @@ struct MutatingShaderTreeScope
     MutatingShaderTreeScope(const MutatingShaderTreeScope&) = delete;
     MutatingShaderTreeScope& operator=(const MutatingShaderTreeScope&) = delete;
 };
+
+/// Human-readable tooltip for an effect that can't drive an event row of
+/// class @p pathClass. Only called when a mismatch is proven, so @p
+/// pathClass is always a concrete class and the effect supports the OTHER
+/// one. The two messages name the events the effect DOES apply to so the
+/// user knows where to use it instead.
+QString shaderPathMismatchReason(const PhosphorAnimationShaders::AnimationShaderEffect& effect,
+                                 const QString& pathClass)
+{
+    namespace PP = PhosphorAnimation::ProfilePaths;
+    if (pathClass == PP::EventClassAppearance) {
+        // Effect is geometry-only (e.g. window-morph) on an appearance row.
+        return PhosphorI18n::tr(
+                   "“%1” needs an old and new geometry — it only applies to move, resize, snap and tile events.")
+            .arg(effect.name);
+    }
+    // pathClass == geometry: effect is appearance-only on a geometry row.
+    return PhosphorI18n::tr(
+               "“%1” animates a surface fading in or out — it has no effect on move, resize, snap or tile events.")
+        .arg(effect.name);
+}
 } // namespace
 
 bool AnimationsPageController::supportsShaderLeg(const QString& path) const
@@ -98,6 +119,29 @@ QVariantList AnimationsPageController::availableShaderEffects() const
     result.reserve(effects.size());
     for (const auto& effect : effects)
         result.append(effectToMap(effect));
+    return result;
+}
+
+QVariantList AnimationsPageController::availableShaderEffectsForPath(const QString& path) const
+{
+    QVariantList result;
+    if (!m_shaderRegistry)
+        return result;
+
+    // Class of this event row — drives the dim reason. Computed once; empty
+    // for an ambiguous row, in which case nothing dims (the predicate
+    // returns true for every effect).
+    const QString pathClass = PhosphorAnimation::ProfilePaths::eventClassForPath(path);
+
+    const auto effects = m_shaderRegistry->availableEffects();
+    result.reserve(effects.size());
+    for (const auto& effect : effects) {
+        QVariantMap m = effectToMap(effect);
+        const bool compatible = PhosphorAnimationShaders::shaderEffectAppliesToEventPath(effect, path);
+        m.insert(QLatin1String("dimmed"), !compatible);
+        m.insert(QLatin1String("dimReason"), compatible ? QString() : shaderPathMismatchReason(effect, pathClass));
+        result.append(m);
+    }
     return result;
 }
 

--- a/src/settings/animationspagecontroller_shaders.cpp
+++ b/src/settings/animationspagecontroller_shaders.cpp
@@ -3,11 +3,13 @@
 
 // Shader-leg methods for AnimationsPageController:
 //   * Available-shader enumeration (availableShaderEffects,
-//     shaderParameters, supportsShaderLeg).
+//     availableShaderEffectsForPath, shaderEffectInfo, shaderParameters,
+//     supportsShaderLeg).
 //   * User shader directory + shader-pack install
 //     (userShaderDirectoryPath, ensureUserShaderDirectory,
 //     openUserShaderDirectory, installShaderPack).
-//   * Per-event shader override (setShaderOverride, clearShaderOverride,
+//   * Per-event shader read + override (rawShaderProfile,
+//     resolvedShaderProfile, setShaderOverride, clearShaderOverride,
 //     shaderOverrideDescendantCount, clearShaderOverrideDescendants,
 //     shaderEffectUsages).
 //

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -664,28 +664,35 @@ ColumnLayout {
     }
 
     _shaderEffectEditor: Component {
-        WideComboBox {
+        // Cascading category menu (same widget as the action-type picker above
+        // and the animations page's shader picker) instead of a flat combo, so
+        // shaders group by category. The list is path-aware: each effect
+        // carries `dimmed`/`dimReason` for this action's target event, so a
+        // geometry-only shader (window-morph) is greyed out with a warning
+        // tooltip on a show/hide event — matching the animations page and the
+        // WHEN/THEN pickers in this same editor.
+        PZCommon.CategoryMenuButton {
             readonly property var _param: parent.modelData
+            // Reading `row.action.event` makes the dim state re-evaluate when
+            // the user changes the action's target event. Empty event → the
+            // controller leaves every shader compatible (nothing to dim yet).
             readonly property var _effects: {
                 var controller = row.appSettings ? row.appSettings.animationsController : null;
-                return controller ? controller.availableShaderEffects() : [];
+                if (!controller)
+                    return [];
+
+                return controller.availableShaderEffectsForPath(row.action.event || "");
             }
 
-            model: _effects
-            textRole: "name"
-            valueRole: "id"
-            currentIndex: {
-                var target = row.action[_param.key];
-                for (var i = 0; i < _effects.length; ++i) {
-                    if (_effects[i].id === target)
-                        return i;
-                }
-                return -1;
-            }
-            displayText: currentIndex >= 0 ? currentText : (row.action[_param.key] || i18n("Choose a shader…"))
-            Accessible.name: _param.label
-            onActivated: function (index) {
-                row.actionEdited(row._withParam(_param.key, currentValue));
+            items: _effects
+            currentId: row.action[_param.key] || ""
+            // Surface a stale / uninstalled shader id verbatim rather than
+            // collapsing the closed picker to a blank — mirrors the old combo's
+            // displayText fallback.
+            placeholderText: row.action[_param.key] || i18n("Choose a shader…")
+            Accessible.description: _param.label
+            onSelected: function (id) {
+                row.actionEdited(row._withParam(_param.key, id));
             }
         }
     }

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -116,9 +116,10 @@ ColumnLayout {
     // Parse decides which mode to seed the dialog with; Apply encodes the
     // dialog's working state back into one of those forms.
     property Component _curveEditorEditor
-    // Shader-effect picker — `availableShaderEffects()` returns rows with
-    // `{id, name, …}`. Wire value is the effect id; the dropdown shows the
-    // friendly name.
+    // Shader-effect picker — a cascading category menu fed by the path-aware
+    // `availableShaderEffectsForPath(event)`, so shaders group by category and
+    // ones incompatible with the action's target event render dimmed. Wire
+    // value is the effect id.
     property Component _shaderEffectEditor
     // Inline shader-uniform editor for OverrideAnimationShader actions. The
     // action stores a nested `params` object (the shader uniform values);
@@ -686,10 +687,10 @@ ColumnLayout {
 
             items: _effects
             currentId: row.action[_param.key] || ""
-            // Surface a stale / uninstalled shader id verbatim rather than
-            // collapsing the closed picker to a blank — mirrors the old combo's
-            // displayText fallback.
-            placeholderText: row.action[_param.key] || i18n("Choose a shader…")
+            // CategoryMenuButton renders "(missing: <id>)" on its own for a
+            // stale / uninstalled shader id, so the placeholder is only seen
+            // when nothing is selected.
+            placeholderText: i18n("Choose a shader…")
             Accessible.description: _param.label
             onSelected: function (id) {
                 row.actionEdited(row._withParam(_param.key, id));

--- a/src/settings/qml/AnimationEventCard.qml
+++ b/src/settings/qml/AnimationEventCard.qml
@@ -85,8 +85,7 @@ Item {
         // (mid-warmup, malformed path) so downstream `r.curve` /
         // `r.duration` reads don't throw and the bindings fall back
         // cleanly to the curve / duration defaults below.
-        return settingsController.animationsPage.resolvedProfile(root.eventPath) || ({
-        });
+        return settingsController.animationsPage.resolvedProfile(root.eventPath) || ({});
     }
     // True only for event paths the daemon's overlay service actually
     // consumes as a shader-leg surface. Gates the shader picker, the
@@ -171,7 +170,7 @@ Item {
     // silently retarget the write at a different effect's param map.
     function _writeShaderParam(effectId, paramId, value) {
         if (!effectId)
-            return ;
+            return;
 
         // Bail if the user navigated to a different effect while the
         // dialog (color picker / etc.) was open. Calling
@@ -180,11 +179,9 @@ Item {
         // navigation and reviving a dropped param map. Better to drop the
         // late accept than to clobber state the user explicitly changed.
         if (effectId !== root.currentShaderEffectId)
-            return ;
+            return;
 
-        var next = Object.assign({
-        }, root.currentShaderParams || {
-        });
+        var next = Object.assign({}, root.currentShaderParams || {});
         next[paramId] = value;
         root.currentShaderParams = next;
         settingsController.animationsPage.setShaderOverride(root.eventPath, effectId, next);
@@ -195,7 +192,7 @@ Item {
     /// `_writeShaderParam`.
     function _writeAllShaderParams(effectId, allParams) {
         if (!effectId || effectId !== root.currentShaderEffectId)
-            return ;
+            return;
 
         root.currentShaderParams = allParams;
         settingsController.animationsPage.setShaderOverride(root.eventPath, effectId, allParams);
@@ -207,12 +204,10 @@ Item {
         // Stale-lock clear on effect switch — same-named ids in
         // different shaders are unrelated.
         if (nextEffectId !== root.currentShaderEffectId)
-            root.lockedShaderParams = ({
-        });
+            root.lockedShaderParams = ({});
 
         root.currentShaderEffectId = nextEffectId;
-        root.currentShaderParams = (resolved && resolved.parameters) ? resolved.parameters : ({
-        });
+        root.currentShaderParams = (resolved && resolved.parameters) ? resolved.parameters : ({});
         // Recompute deeper-override count on every shader-tree update —
         // the warning banner below depends on it. Cheap (O(N) over
         // overriddenPaths). Only meaningful for parent-node cards but
@@ -272,7 +267,6 @@ Item {
             root.currentTimingMode = CurvePresets.timingModeEasing;
             if (typeof curve === "string" && curve.length > 0)
                 root.currentEasingCurve = curve;
-
         }
         root.currentDuration = effective.duration !== undefined ? effective.duration : CurvePresets.defaultDurationMs;
     }
@@ -315,7 +309,7 @@ Item {
             // a single check covers both per-path filtering and the
             // global-broadcast carve-out.
             if (!root._pathAffectsThisCard(path))
-                return ;
+                return;
 
             root.refreshFromTree();
             // The signal is per-path but the resolved profile depends on
@@ -336,7 +330,7 @@ Item {
             // every card refreshes for it; per-path emits still get
             // the prefix filter.
             if (!root._pathAffectsThisCard(path))
-                return ;
+                return;
 
             root.refreshShaderFromTree();
             // The card's "Override" toggle now reflects whether either
@@ -406,7 +400,7 @@ Item {
         showToggle: !root.alwaysEnabled
         toggleChecked: root.alwaysEnabled || root.overrideEnabled
         collapsible: root.collapsible
-        onToggleClicked: function(checked) {
+        onToggleClicked: function (checked) {
             if (checked) {
                 root.commitOverride();
             } else {
@@ -420,8 +414,7 @@ Item {
                 // The reverse order would record neither on a partial
                 // failure, dropping the disable intent entirely.
                 if (root._shaderLegSupported)
-                    settingsController.animationsPage.setShaderOverride(root.eventPath, "", ({
-                }));
+                    settingsController.animationsPage.setShaderOverride(root.eventPath, "", ({}));
 
                 settingsController.animationsPage.clearOverride(root.eventPath);
             }
@@ -507,16 +500,20 @@ Item {
                 onValueChanged: {
                     if (root.alwaysEnabled || root.overrideEnabled)
                         root.commitOverride();
-
                 }
                 // Picker model fed via the registry-tick dependency
                 // so the binding re-evaluates on
                 // `shaderEffectsChanged`.
+                // Path-aware list: each effect carries `dimmed`/`dimReason`
+                // for this event, so the category picker greys out shaders
+                // that can't drive this row (e.g. the geometry-only
+                // window-morph on a show/hide event) with a warning tooltip —
+                // the same affordance the window-rule action picker uses.
                 availableShaders: {
                     void (root._shaderRegistryRev);
-                    return settingsController.animationsPage.availableShaderEffects();
+                    return settingsController.animationsPage.availableShaderEffectsForPath(root.eventPath);
                 }
-                onShaderEffectActivated: function(id) {
+                onShaderEffectActivated: function (id) {
                     var sid = id || "";
                     var rawShader = settingsController.animationsPage.rawShaderProfile(root.eventPath);
                     var directEffectId = (rawShader && typeof rawShader.effectId === "string") ? rawShader.effectId : "";
@@ -526,24 +523,22 @@ Item {
                         // path already holds it.
                         var alreadyDisabled = rawShader && typeof rawShader.effectId === "string" && rawShader.effectId === "";
                         if (alreadyDisabled)
-                            return ;
+                            return;
 
-                        settingsController.animationsPage.setShaderOverride(root.eventPath, "", ({
-                        }));
-                        return ;
+                        settingsController.animationsPage.setShaderOverride(root.eventPath, "", ({}));
+                        return;
                     }
                     // No-op when the user re-picks the value already
                     // sitting at this path's DIRECT override.
                     if (sid === directEffectId)
-                        return ;
+                        return;
 
                     // Switching effect (or promoting an inherited
                     // value to a direct override): drop the previous
                     // effect's parameter map.
-                    settingsController.animationsPage.setShaderOverride(root.eventPath, sid, ({
-                    }));
+                    settingsController.animationsPage.setShaderOverride(root.eventPath, sid, ({}));
                 }
-                onShaderParamWriteRequested: function(effectId, paramId, value) {
+                onShaderParamWriteRequested: function (effectId, paramId, value) {
                     root._writeShaderParam(effectId, paramId, value);
                 }
                 // Lock-toggle handlers are no-ops here —
@@ -553,7 +548,7 @@ Item {
                 // re-assign here would be idempotent. The signals
                 // remain connect-free until / unless the lock state
                 // becomes persistent (today it's working-state only).
-                onRandomizeRequested: function(rolled) {
+                onRandomizeRequested: function (rolled) {
                     // Editor already staged `rolled` onto its
                     // `shaderParams`; this card's persistence is
                     // through the controller, so route the rolled map
@@ -562,9 +557,6 @@ Item {
                     root._writeAllShaderParams(root.currentShaderEffectId, rolled);
                 }
             }
-
         }
-
     }
-
 }


### PR DESCRIPTION
## Problem

Some shaders only make sense on certain event types. `window-morph` cross-fades an old rect into a new rect (`iFromRect → iToRect`), so on a show/hide event — where there is no before/after geometry — it renders **nothing**. Yet the per-event shader pickers happily let you assign it there, producing a silent no-op.

We already gate **which paths** can run any shader (`eventPathSupportsShaderLeg`). This adds the orthogonal axis: **which shader** is valid on **which event**.

## Approach

A capability declaration on the shader plus one SSOT predicate that the UI consults — the (effect × path) analogue of the existing path gate. Modeled on the window-rule action picker, which already dims incompatible actions: dimmed items stay **selectable** (warns, doesn't hard-block).

- **`AnimationShaderEffect.appliesTo`** — optional metadata field of event-class tokens (`"geometry"` / `"appearance"`). Empty = universal, so every existing shader keeps applying everywhere (back-compat). Parsed/emitted/compared with token validation (unknown tokens dropped with a warning).
- **`ProfilePaths::eventClassForPath` + `EventClassGeometry`/`EventClassAppearance`** — the path→class policy: geometry = move/resize/snap\*/layoutSwitch/maximize; appearance = open/close/minimize/focus + all OSD/popup show·hide; mixed ancestors (`window`) → unclassified, never dimmed.
- **`shaderEffectAppliesToEventPath(effect, path)`** — the predicate, SSOT in `phosphor-animation`; only reports `false` on a *provable* mismatch.
- **`AnimationsPageController::availableShaderEffectsForPath(path)`** — effect rows with ready-made `dimmed`/`dimReason` for an event.
- **Both per-event pickers** consume it:
  - Animations page (`AnimationEventCard`) feeds the path-aware list to its `CategoryMenuButton`.
  - Window-rule action editor (`ActionRow`) — the shader dropdown is **converted from a flat `WideComboBox` to the cascading `CategoryMenuButton`**, so it now groups by category (matching the WHEN/THEN pickers) *and* dims incompatible shaders.
- **`window-morph`** declares `"appliesTo": ["geometry"]` (the only shader that structurally needs it).

## UX

In any per-event shader picker, a shader that can't drive the selected event renders greyed-out with a tooltip (e.g. *"Window Morph needs an old and new geometry — it only applies to move, resize, snap and tile events"*). Consistent with the window-rule action picker; the shader still stays selectable.

## Tests

New lib coverage in `test_animationshadereffect`: `appliesTo` JSON round-trip, token validation (unknown/duplicate dropped), and the predicate (geometry vs appearance vs universal vs mixed-ancestor). Full suite: **280/280 pass**. `shader_validate_animations` confirms the updated `window-morph` metadata parses.

## Notes

- Base branch is `v3.1` (this branch forked from it).
- Reviewed via `/code-audit` (3 passes, CLEAN) — one dead invokable removed, one stale doc comment fixed; the window-rule dropdown gap surfaced there is the `ActionRow` conversion included here.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)