### PR TITLE
feat(windowrule): fix Float action + add KWin-property and PlasmaZones-state match fields

### DIFF
--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -356,6 +356,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
             <arg name="windowType" type="i" direction="in">
                 <annotation name="org.gtk.GDBus.DocString" value="PhosphorProtocol::WindowType underlying value; out-of-range values are clamped to Unknown."/>
             </arg>
+            <arg name="extended" type="a{sv}" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Extended window-property snapshot (state flags, geometry, accessory flags, captionNormal) keyed by PhosphorProtocol::Service::WindowMetadataKey. A key is present only when the value is known, so absent keys leave the derived window-rule field disengaged. Lets the daemon's Float/RestorePosition resolvers match the same KWin-property fields the effect path resolves live."/>
+            </arg>
         </method>
         <method name="windowClosed">
             <annotation name="org.gtk.GDBus.DocString" value="Notify daemon that a window was closed (cleanup). The window's structural kind is captured into the PendingRestore entry if one is recorded, so the consume path can refuse to assign that entry to a window of a different kind on reopen."/>

--- a/kwin-effect/navigationhandler.cpp
+++ b/kwin-effect/navigationhandler.cpp
@@ -106,14 +106,15 @@ void NavigationHandler::syncZonesFromDaemon()
 
         // Authoritative refresh: clear, then seed every snapped window's zone.
         // A window with an empty zoneId (floating / unmanaged) carries no entry.
-        m_zoneByWindow.clear();
+        // setWindowZone keys by the stable instanceId (see header).
+        clearAllZoneState();
         const PhosphorProtocol::WindowStateList states = reply.value();
         for (const PhosphorProtocol::WindowStateEntry& state : states) {
             if (!state.zoneId.isEmpty()) {
-                m_zoneByWindow.insert(state.windowId, state.zoneId);
+                setWindowZone(state.windowId, state.zoneId);
             }
         }
-        qCDebug(lcEffect) << "Synced" << m_zoneByWindow.size() << "snapped-window zones from daemon";
+        qCDebug(lcEffect) << "Synced" << zoneEntryCount() << "snapped-window zones from daemon";
     });
 }
 

--- a/kwin-effect/navigationhandler.cpp
+++ b/kwin-effect/navigationhandler.cpp
@@ -122,6 +122,11 @@ void NavigationHandler::syncZonesFromDaemon()
             }
         }
         qCDebug(lcEffect) << "Synced" << zoneEntryCount() << "snapped-window zones from daemon";
+        // Re-seeding the zone cache changes the IsSnapped / Zone match inputs; drop
+        // the stale placement-scoped opacity verdicts so a `WHEN isSnapped` /
+        // `Zone(...)` SetOpacity rule re-resolves against the fresh state on the
+        // next frame (mirrors the daemon-loss invalidation).
+        m_effect->invalidateAllRuleCaches();
     });
 }
 

--- a/kwin-effect/navigationhandler.cpp
+++ b/kwin-effect/navigationhandler.cpp
@@ -98,16 +98,20 @@ void NavigationHandler::syncZonesFromDaemon()
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
         w->deleteLater();
 
+        // Authoritative refresh: drop any stale entries from a prior daemon session
+        // up front — this is the ONLY place daemon-ready clears the zone cache, so a
+        // failed reply leaves it empty (no stale matches) rather than keeping last
+        // session's zones, and there is no clear racing the seed below.
+        clearAllZoneState();
+
         QDBusPendingReply<PhosphorProtocol::WindowStateList> reply = *w;
         if (!reply.isValid()) {
             qCDebug(lcEffect) << "Failed to get window states from daemon";
             return;
         }
 
-        // Authoritative refresh: clear, then seed every snapped window's zone.
-        // A window with an empty zoneId (floating / unmanaged) carries no entry.
-        // setWindowZone keys by the stable instanceId (see header).
-        clearAllZoneState();
+        // Seed every snapped window's zone. A window with an empty zoneId (floating
+        // / unmanaged) carries no entry. setWindowZone keys by instanceId (see header).
         const PhosphorProtocol::WindowStateList states = reply.value();
         for (const PhosphorProtocol::WindowStateEntry& state : states) {
             if (!state.zoneId.isEmpty()) {

--- a/kwin-effect/navigationhandler.cpp
+++ b/kwin-effect/navigationhandler.cpp
@@ -52,7 +52,10 @@ void NavigationHandler::syncFloatingWindowsFromDaemon()
             m_floatingCache.insert(id);
         }
 
-        qCDebug(lcEffect) << "Synced" << m_floatingCache.size() << "floating windows from daemon";
+        // Report the count of synced entries, not m_floatingCache.size() — the
+        // latter sums the instance and app-wide keyspaces and would misreport when
+        // both carry entries for the same app.
+        qCDebug(lcEffect) << "Synced" << floatingIds.size() << "floating windows from daemon";
     });
 }
 

--- a/kwin-effect/navigationhandler.cpp
+++ b/kwin-effect/navigationhandler.cpp
@@ -85,4 +85,36 @@ void NavigationHandler::syncFloatingStateForWindow(const QString& windowId)
     });
 }
 
+void NavigationHandler::syncZonesFromDaemon()
+{
+    if (!m_effect->isDaemonReady("sync window zones")) {
+        return;
+    }
+
+    QDBusPendingCall pendingCall = PhosphorProtocol::ClientHelpers::asyncCall(
+        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getAllWindowStates"));
+    auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
+
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+        w->deleteLater();
+
+        QDBusPendingReply<PhosphorProtocol::WindowStateList> reply = *w;
+        if (!reply.isValid()) {
+            qCDebug(lcEffect) << "Failed to get window states from daemon";
+            return;
+        }
+
+        // Authoritative refresh: clear, then seed every snapped window's zone.
+        // A window with an empty zoneId (floating / unmanaged) carries no entry.
+        m_zoneByWindow.clear();
+        const PhosphorProtocol::WindowStateList states = reply.value();
+        for (const PhosphorProtocol::WindowStateEntry& state : states) {
+            if (!state.zoneId.isEmpty()) {
+                m_zoneByWindow.insert(state.windowId, state.zoneId);
+            }
+        }
+        qCDebug(lcEffect) << "Synced" << m_zoneByWindow.size() << "snapped-window zones from daemon";
+    });
+}
+
 } // namespace PlasmaZones

--- a/kwin-effect/navigationhandler.h
+++ b/kwin-effect/navigationhandler.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <PhosphorCompositor/FloatingCache.h>
+#include <PhosphorCompositor/ZoneCache.h>
 
-#include <QHash>
 #include <QObject>
 #include <QString>
 
@@ -16,6 +16,7 @@ namespace PlasmaZones {
 // Targeted using-declaration, not a namespace-wide directive: headers must
 // not leak the whole PhosphorCompositor namespace into every includer.
 using PhosphorCompositor::FloatingCache;
+using PhosphorCompositor::ZoneCache;
 
 class PlasmaZonesEffect;
 
@@ -55,43 +56,43 @@ public:
 
     // Snap-zone tracking — synced from the daemon's windowStateChanged signal,
     // queried by the rule-query builder for the IsSnapped / Zone match fields.
-    // Keyed by the full composite windowId. A window is "snapped" iff it has a
-    // non-empty zone entry (snap mode only — autotile tiles carry no zone UUID
-    // and never appear here). Floating state is tracked separately above.
+    // Delegates to the shared ZoneCache (sibling of FloatingCache), which keys by
+    // the stable instanceId so a class-mutating snapped window stays resolvable.
 
     /// The snap-zone UUID @p windowId occupies, or empty if it occupies none.
     QString zoneForWindow(const QString& windowId) const
     {
-        return m_zoneByWindow.value(windowId);
+        return m_zoneCache.zoneForWindow(windowId);
     }
-    /// True iff @p windowId is snapped into a zone (has a non-empty zone entry).
+    /// True iff @p windowId is snapped into a zone (snap mode only — autotile
+    /// tiles carry no zone UUID and never appear here).
     bool isWindowSnapped(const QString& windowId) const
     {
-        return !m_zoneByWindow.value(windowId).isEmpty();
+        return m_zoneCache.isSnapped(windowId);
     }
     /// Record @p windowId's zone. An empty @p zoneId removes the entry (the
     /// window left its zone — unsnapped / floated / screen-changed).
     void setWindowZone(const QString& windowId, const QString& zoneId)
     {
-        if (zoneId.isEmpty()) {
-            m_zoneByWindow.remove(windowId);
-        } else {
-            m_zoneByWindow.insert(windowId, zoneId);
-        }
+        m_zoneCache.setZone(windowId, zoneId);
     }
     void clearWindowZone(const QString& windowId)
     {
-        m_zoneByWindow.remove(windowId);
+        m_zoneCache.remove(windowId);
     }
     void clearAllZoneState()
     {
-        m_zoneByWindow.clear();
+        m_zoneCache.clear();
+    }
+    int zoneEntryCount() const
+    {
+        return m_zoneCache.size();
     }
 
 private:
     PlasmaZonesEffect* m_effect;
     FloatingCache m_floatingCache;
-    QHash<QString, QString> m_zoneByWindow; ///< composite windowId → snap-zone UUID
+    ZoneCache m_zoneCache;
 };
 
 } // namespace PlasmaZones

--- a/kwin-effect/navigationhandler.h
+++ b/kwin-effect/navigationhandler.h
@@ -5,6 +5,7 @@
 
 #include <PhosphorCompositor/FloatingCache.h>
 
+#include <QHash>
 #include <QObject>
 #include <QString>
 
@@ -50,10 +51,47 @@ public:
     }
     void syncFloatingWindowsFromDaemon();
     void syncFloatingStateForWindow(const QString& windowId);
+    void syncZonesFromDaemon();
+
+    // Snap-zone tracking — synced from the daemon's windowStateChanged signal,
+    // queried by the rule-query builder for the IsSnapped / Zone match fields.
+    // Keyed by the full composite windowId. A window is "snapped" iff it has a
+    // non-empty zone entry (snap mode only — autotile tiles carry no zone UUID
+    // and never appear here). Floating state is tracked separately above.
+
+    /// The snap-zone UUID @p windowId occupies, or empty if it occupies none.
+    QString zoneForWindow(const QString& windowId) const
+    {
+        return m_zoneByWindow.value(windowId);
+    }
+    /// True iff @p windowId is snapped into a zone (has a non-empty zone entry).
+    bool isWindowSnapped(const QString& windowId) const
+    {
+        return !m_zoneByWindow.value(windowId).isEmpty();
+    }
+    /// Record @p windowId's zone. An empty @p zoneId removes the entry (the
+    /// window left its zone — unsnapped / floated / screen-changed).
+    void setWindowZone(const QString& windowId, const QString& zoneId)
+    {
+        if (zoneId.isEmpty()) {
+            m_zoneByWindow.remove(windowId);
+        } else {
+            m_zoneByWindow.insert(windowId, zoneId);
+        }
+    }
+    void clearWindowZone(const QString& windowId)
+    {
+        m_zoneByWindow.remove(windowId);
+    }
+    void clearAllZoneState()
+    {
+        m_zoneByWindow.clear();
+    }
 
 private:
     PlasmaZonesEffect* m_effect;
     FloatingCache m_floatingCache;
+    QHash<QString, QString> m_zoneByWindow; ///< composite windowId → snap-zone UUID
 };
 
 } // namespace PlasmaZones

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -183,6 +183,7 @@ private Q_SLOTS:
     void slotRaiseWindowsRequested(const QStringList& windowIds);
 
     void slotWindowFloatingChanged(const QString& windowId, bool isFloating, const QString& screenId);
+    void slotWindowStateChanged(const QString& windowId, const PhosphorProtocol::WindowStateEntry& state);
     void slotRunningWindowsRequested();
     void slotRestoreSizeDuringDrag(const QString& windowId, int width, int height);
 
@@ -441,6 +442,18 @@ private:
      * @return true if window is floating
      */
     bool isWindowFloating(const QString& windowId) const;
+    /// True iff @p windowId is snapped into a zone (snap mode; delegates to the
+    /// NavigationHandler zone cache). Autotile tiles carry no zone and are not
+    /// snapped under this definition.
+    bool isWindowSnapped(const QString& windowId) const;
+    /// The snap-zone UUID @p windowId occupies, or empty when it occupies none.
+    QString zoneForWindow(const QString& windowId) const;
+    /// Build a window-rule match query for @p w with the effect's runtime
+    /// placement state (floating / snapped / zone) threaded into the free
+    /// `windowRuleQueryFor` builder. Use this at EVERY rule-evaluation site so
+    /// IsFloating / IsSnapped / Zone resolve uniformly; the free builder stays
+    /// KWin-only and can't reach the effect's caches.
+    PhosphorWindowRule::WindowQuery windowRuleQuery(KWin::EffectWindow* w) const;
 
     /**
      * @brief True if the window is currently snap-managed (tiled into a snap zone).
@@ -654,6 +667,14 @@ private:
     void removeWindowBorder(const QString& windowId);
     void updateAllBorders();
     void clearAllBorders();
+
+    /// Drop the per-window rule match cache and refresh @p windowId's border /
+    /// opacity after its placement state (snapped / floating / zone) changed.
+    /// Those are rule MATCH inputs now, so without this a window stays resolved
+    /// at its prior state (e.g. a `WHEN isSnapped` border never reverting on
+    /// unsnap). Mirrors slotWindowActivated's focus invalidation; no-op when
+    /// there are no animation rules.
+    void invalidateRuleCacheForStateChange(const QString& windowId);
 
     /// Resolve which mode's BorderState manages @p windowId — autotile first,
     /// then snap — or nullptr if neither draws a border for it.

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -467,6 +467,16 @@ private:
     /// KWin-only and can't reach the effect's caches.
     PhosphorWindowRule::WindowQuery windowRuleQuery(KWin::EffectWindow* w) const;
 
+    /// Resolve the animation rule-action verdict for @p w, skipping the per-frame
+    /// `windowRuleQuery(w)` build (≈30 KWin accessor reads) when the evaluator
+    /// already has a cached verdict for @p windowId. Peek-then-build: a cache hit
+    /// returns the memoised actions directly; a miss builds the query and resolves
+    /// (caching the result). An empty windowId or a windowless query yields empty
+    /// actions (no slots) WITHOUT caching, matching the resolvers' old
+    /// short-circuit (avoids churning the cache for sub-surfaces / proxies). The
+    /// per-frame opacity / border resolvers consume the returned ResolvedActions.
+    PhosphorWindowRule::ResolvedActions resolveWindowRuleActions(KWin::EffectWindow* w, const QString& windowId) const;
+
     /**
      * @brief True if the window is currently snap-managed (tiled into a snap zone).
      * Its frame geometry is the zone rect, NOT a free-floating position — callers

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -251,8 +251,18 @@ private:
      * Safe to call unconditionally on every observation — the daemon de-dupes.
      * Called from slotWindowAdded for initial registration, and from
      * windowClassChanged / desktopFileNameChanged handlers for live updates.
+     *
+     * @param includeExtended When false, the extended-property snapshot (the
+     * trailing a{sv}: state flags, geometry, accessory flags, captionNormal) is
+     * NOT rebuilt or sent — the daemon preserves whatever it already has. Used by
+     * the captionChanged handler: terminals/browsers rewrite their title every
+     * frame, and the rule-relevant extended fields don't change on a title tick,
+     * so rebuilding/marshalling a ~20-entry map per frame is pure waste. The
+     * extended snapshot is captured at window-open and refreshed on identity
+     * changes (class/desktop/activity), which is when it matters for the daemon's
+     * open-path Float / RestorePosition resolvers.
      */
-    void pushWindowMetadata(KWin::EffectWindow* w);
+    void pushWindowMetadata(KWin::EffectWindow* w, bool includeExtended = true);
 
     /**
      * @brief Snapping/zone-management window filter.
@@ -690,6 +700,14 @@ private:
     /// restore / rebuild path. No-op when there are no animation rules.
     void invalidateAllRuleCaches();
 
+    /// Flush coalesced per-window rule-cache invalidations queued by
+    /// invalidateRuleCacheForStateChange within one event-loop turn: drops the
+    /// match cache once and re-resolves the border / opacity of each affected
+    /// window. Posted via a queued single-shot so a float toggle (which emits
+    /// both windowFloatingChanged AND windowStateChanged) clears the cache once
+    /// instead of twice.
+    void flushPendingRuleInvalidations();
+
     /// Resolve which mode's BorderState manages @p windowId — autotile first,
     /// then snap — or nullptr if neither draws a border for it.
     const PhosphorCompositor::BorderState* resolveBorderStateFor(const QString& windowId) const;
@@ -962,6 +980,11 @@ private:
     // Entries are consumed (removed) when slotApplyGeometryRequested skips
     // the geometry restore for a drag-floated window.
     QSet<QString> m_dragFloatedWindowIds;
+
+    // Per-window rule-cache invalidations accumulated within one event-loop turn,
+    // flushed once by flushPendingRuleInvalidations(). Coalesces the double
+    // invalidation a float toggle triggers (windowFloatingChanged + windowStateChanged).
+    QSet<QString> m_pendingRuleInvalidations;
 
     // Cached daemon D-Bus service registration state.
     // Updated via QDBusServiceWatcher signals (registration/unregistration) to avoid

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -678,6 +678,18 @@ private:
     /// there are no animation rules.
     void invalidateRuleCacheForStateChange(const QString& windowId);
 
+    /// Bulk analog of invalidateRuleCacheForStateChange for placement changes that
+    /// affect EVERY window at once — daemon loss (the zone / floating caches are
+    /// cleared) and the daemon-ready re-seed (they are repopulated). The match
+    /// cache is keyed (windowId, ruleSet revision); neither moves on a bulk
+    /// placement change, so a placement-scoped opacity verdict would otherwise
+    /// stay cached (e.g. a `WHEN isSnapped` SetOpacity window staying dimmed after
+    /// the cache that made it "snapped" was cleared). Drops the whole match cache
+    /// and forces a full repaint so opacity rules re-resolve against the current
+    /// IsSnapped / IsFloating / Zone state. Borders recover via their own
+    /// restore / rebuild path. No-op when there are no animation rules.
+    void invalidateAllRuleCaches();
+
     /// Resolve which mode's BorderState manages @p windowId — autotile first,
     /// then snap — or nullptr if neither draws a border for it.
     const PhosphorCompositor::BorderState* resolveBorderStateFor(const QString& windowId) const;

--- a/kwin-effect/plasmazoneseffect/borders.cpp
+++ b/kwin-effect/plasmazoneseffect/borders.cpp
@@ -125,8 +125,7 @@ void PlasmaZonesEffect::updateWindowBorder(const QString& windowId, KWin::Effect
     // with no rules pay nothing.
     std::optional<ResolvedWindowAppearance> ovr;
     if (w && !m_shaderManager.animationRuleSet().isEmpty()) {
-        ovr = resolveWindowAppearance(m_shaderManager.animationRuleEvaluator(),
-                                      windowRuleQueryFor(w, getWindowScreenId(w)), windowId);
+        ovr = resolveWindowAppearance(m_shaderManager.animationRuleEvaluator(), windowRuleQuery(w), windowId);
     }
 
     // Merge: a rule field wins; otherwise fall back to the owning mode's value
@@ -310,8 +309,8 @@ void PlasmaZonesEffect::reconcileRuleHiddenTitleBar(const QString& windowId, KWi
     // The manager owns the capability gate, the mode-ownership coordination
     // the old m_ruleHiddenTitleBars/modeBorderless dance approximated, and
     // the geometry re-assert across veto-driven decoration flips.
-    const std::optional<ResolvedWindowAppearance> ovr = resolveWindowAppearance(
-        m_shaderManager.animationRuleEvaluator(), windowRuleQueryFor(w, getWindowScreenId(w)), windowId);
+    const std::optional<ResolvedWindowAppearance> ovr =
+        resolveWindowAppearance(m_shaderManager.animationRuleEvaluator(), windowRuleQuery(w), windowId);
     m_decorationManager->setRuleOverride(windowId, ovr ? ovr->hideTitleBar : std::nullopt);
 }
 

--- a/kwin-effect/plasmazoneseffect/borders.cpp
+++ b/kwin-effect/plasmazoneseffect/borders.cpp
@@ -125,7 +125,7 @@ void PlasmaZonesEffect::updateWindowBorder(const QString& windowId, KWin::Effect
     // with no rules pay nothing.
     std::optional<ResolvedWindowAppearance> ovr;
     if (w && !m_shaderManager.animationRuleSet().isEmpty()) {
-        ovr = resolveWindowAppearance(m_shaderManager.animationRuleEvaluator(), windowRuleQuery(w), windowId);
+        ovr = resolveWindowAppearance(resolveWindowRuleActions(w, windowId));
     }
 
     // Merge: a rule field wins; otherwise fall back to the owning mode's value
@@ -309,8 +309,7 @@ void PlasmaZonesEffect::reconcileRuleHiddenTitleBar(const QString& windowId, KWi
     // The manager owns the capability gate, the mode-ownership coordination
     // the old m_ruleHiddenTitleBars/modeBorderless dance approximated, and
     // the geometry re-assert across veto-driven decoration flips.
-    const std::optional<ResolvedWindowAppearance> ovr =
-        resolveWindowAppearance(m_shaderManager.animationRuleEvaluator(), windowRuleQuery(w), windowId);
+    const std::optional<ResolvedWindowAppearance> ovr = resolveWindowAppearance(resolveWindowRuleActions(w, windowId));
     m_decorationManager->setRuleOverride(windowId, ovr ? ovr->hideTitleBar : std::nullopt);
 }
 

--- a/kwin-effect/plasmazoneseffect/borders.cpp
+++ b/kwin-effect/plasmazoneseffect/borders.cpp
@@ -151,7 +151,7 @@ void PlasmaZonesEffect::updateWindowBorder(const QString& windowId, KWin::Effect
     // pick the one matching the window's current focus state. A per-window
     // SetBorderColor rule, when matched, overrides it. Focus-dependence of the
     // RULE colour is expressed in the rule itself via the IsFocused match
-    // condition: `windowRuleQueryFor` set the query's isFocused flag, so a
+    // condition: `windowRuleQuery` sets the query's isFocused flag, so a
     // focus-scoped rule (`WHEN focused`/`WHEN NOT focused`) only fills the
     // border-colour slot in its matching state, while a focus-agnostic rule
     // applies in both. Either way `ovr->borderColor` already holds the colour

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -440,8 +440,9 @@ void PlasmaZonesEffect::slotWindowStateChanged(const QString& windowId, const Ph
 {
     // Keep the effect-side zone cache current so the IsSnapped / Zone rule-match
     // fields resolve against the live placement. An empty zoneId (unsnapped /
-    // floated / screen-changed) removes the entry. isFloating flows through the
-    // separate windowFloatingChanged path, so it is not duplicated here.
+    // floated / screen-changed) removes the entry. The isFloating cache WRITE lives
+    // on the separate windowFloatingChanged path, so it is not duplicated here; the
+    // rule-cache invalidation below may still run on both paths (it is idempotent).
     m_navigationHandler->setWindowZone(windowId, state.zoneId);
     invalidateRuleCacheForStateChange(windowId);
 }

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -513,6 +513,23 @@ void PlasmaZonesEffect::invalidateRuleCacheForStateChange(const QString& windowI
     }
 }
 
+void PlasmaZonesEffect::invalidateAllRuleCaches()
+{
+    if (m_shaderManager.animationRuleSet().isEmpty()) {
+        return;
+    }
+    // A bulk placement change (daemon loss clears the zone/floating caches; the
+    // daemon-ready re-seed repopulates them) moves neither the windowId nor the
+    // ruleSet revision the match cache is keyed on, so every placement-scoped
+    // verdict would survive stale. Drop the whole cache; the full repaint makes
+    // every opacity-only window re-resolve against the current placement on the
+    // next frame (border windows recover through their own restore/rebuild path).
+    m_shaderManager.animationRuleEvaluator().clearCache();
+    if (KWin::effects && m_shaderManager.hasOpacityRules()) {
+        KWin::effects->addRepaintFull();
+    }
+}
+
 void PlasmaZonesEffect::slotWindowMinimizedChanged(KWin::EffectWindow* w)
 {
     if (!w || !shouldHandleWindow(w) || !isTileableWindow(w)) {

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -431,6 +431,40 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
         // appId to survive the window's identity change across close/reopen.
         m_snapHandler->invalidateRestore(::PhosphorIdentity::WindowId::extractAppId(windowId));
     }
+    // isFloating is now a rule MATCH field — re-resolve appearance / animation
+    // rules for this window so a `WHEN isFloating` border / opacity re-applies.
+    invalidateRuleCacheForStateChange(windowId);
+}
+
+void PlasmaZonesEffect::slotWindowStateChanged(const QString& windowId, const PhosphorProtocol::WindowStateEntry& state)
+{
+    // Keep the effect-side zone cache current so the IsSnapped / Zone rule-match
+    // fields resolve against the live placement. An empty zoneId (unsnapped /
+    // floated / screen-changed) removes the entry. isFloating flows through the
+    // separate windowFloatingChanged path, so it is not duplicated here.
+    m_navigationHandler->setWindowZone(windowId, state.zoneId);
+    invalidateRuleCacheForStateChange(windowId);
+}
+
+void PlasmaZonesEffect::invalidateRuleCacheForStateChange(const QString& windowId)
+{
+    if (m_shaderManager.animationRuleSet().isEmpty()) {
+        return;
+    }
+    // The match cache is keyed on (windowId, ruleSet revision); neither moves on
+    // a placement-state change, so drop it so border / opacity rules re-resolve
+    // against the new snapped / floating / zone state.
+    m_shaderManager.animationRuleEvaluator().clearCache();
+    KWin::EffectWindow* w = findWindowById(windowId);
+    if (w) {
+        // Recreate this window's border so a state-scoped border colour re-applies.
+        updateWindowBorder(windowId, w);
+        // An opacity-only (borderless) window needs an explicit repaint for its
+        // re-resolved opacity to reach the screen (mirrors slotWindowActivated).
+        if (m_shaderManager.hasOpacityRules()) {
+            w->addRepaintFull();
+        }
+    }
 }
 
 void PlasmaZonesEffect::slotWindowMinimizedChanged(KWin::EffectWindow* w)

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -26,6 +26,9 @@
 #include <QScopeGuard>
 #include <QSet>
 #include <QStringList>
+#include <QTimer>
+
+#include <utility>
 
 #include "../autotilehandler.h"
 #include "../navigationhandler.h"
@@ -477,11 +480,19 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
 
 void PlasmaZonesEffect::slotWindowStateChanged(const QString& windowId, const PhosphorProtocol::WindowStateEntry& state)
 {
+    // Validate the daemon payload at the boundary, mirroring the other
+    // daemon-data slots (DragPolicy / BridgeRegistrationResult). A garbled entry
+    // naming no window must not write a zone keyed by an empty/garbage id.
+    if (const QString err = state.validationError(); !err.isEmpty()) {
+        qCWarning(lcEffect) << "slotWindowStateChanged: rejecting invalid entry —" << err;
+        return;
+    }
     // Keep the effect-side zone cache current so the IsSnapped / Zone rule-match
     // fields resolve against the live placement. An empty zoneId (unsnapped /
     // floated / screen-changed) removes the entry. The isFloating cache WRITE lives
     // on the separate windowFloatingChanged path, so it is not duplicated here; the
-    // rule-cache invalidation below may still run on both paths (it is idempotent).
+    // rule-cache invalidation below coalesces with the floating path's (a float
+    // toggle emits both signals — see flushPendingRuleInvalidations).
     m_navigationHandler->setWindowZone(windowId, state.zoneId);
     invalidateRuleCacheForStateChange(windowId);
 }
@@ -491,23 +502,49 @@ void PlasmaZonesEffect::invalidateRuleCacheForStateChange(const QString& windowI
     if (m_shaderManager.animationRuleSet().isEmpty()) {
         return;
     }
-    // The match cache is keyed on (windowId, ruleSet revision); neither moves on
-    // a placement-state change, so drop it so border / opacity rules re-resolve
-    // against the new snapped / floating / zone state.
+    // Coalesce: a single float toggle emits BOTH windowFloatingChanged and
+    // windowStateChanged, so this runs twice per logical change. Accumulate the
+    // affected windowIds and flush once at the end of the event-loop turn — the
+    // match-cache clear is global (running it per call is wasteful) and the
+    // per-window border rebuild is otherwise repeated. The flush before the next
+    // paint keeps the re-resolved border / opacity visually immediate.
     //
-    // Only the CACHED verdicts (border / opacity) need explicit invalidation here.
-    // shouldHandleWindow's exclusion query is evaluated on-demand every time it is
-    // consulted (drag start, lifecycle filtering), so a snap/float/zone change is
-    // picked up at the next natural call without eager re-filtering — re-running it
-    // for every window on every state change would be a needless hot-path cost.
+    // Only the CACHED verdicts (border / opacity) need invalidation. shouldHandleWindow's
+    // exclusion query is evaluated on-demand every time it is consulted (drag start,
+    // lifecycle filtering), so a snap/float/zone change is picked up at the next natural
+    // call without eager re-filtering.
+    const bool wasEmpty = m_pendingRuleInvalidations.isEmpty();
+    m_pendingRuleInvalidations.insert(windowId);
+    if (wasEmpty) {
+        // `this` as the context object cancels the callback if the effect is torn
+        // down before the turn ends.
+        QTimer::singleShot(0, this, [this] {
+            flushPendingRuleInvalidations();
+        });
+    }
+}
+
+void PlasmaZonesEffect::flushPendingRuleInvalidations()
+{
+    const QSet<QString> windowIds = std::exchange(m_pendingRuleInvalidations, {});
+    if (windowIds.isEmpty() || m_shaderManager.animationRuleSet().isEmpty()) {
+        return;
+    }
+    // The match cache is keyed on (windowId, ruleSet revision); neither moves on a
+    // placement-state change, so drop it once so border / opacity rules re-resolve
+    // against the new snapped / floating / zone state.
     m_shaderManager.animationRuleEvaluator().clearCache();
-    KWin::EffectWindow* w = findWindowById(windowId);
-    if (w) {
+    const bool hasOpacity = m_shaderManager.hasOpacityRules();
+    for (const QString& windowId : windowIds) {
+        KWin::EffectWindow* w = findWindowById(windowId);
+        if (!w) {
+            continue;
+        }
         // Recreate this window's border so a state-scoped border colour re-applies.
         updateWindowBorder(windowId, w);
         // An opacity-only (borderless) window needs an explicit repaint for its
         // re-resolved opacity to reach the screen (mirrors slotWindowActivated).
-        if (m_shaderManager.hasOpacityRules()) {
+        if (hasOpacity) {
             w->addRepaintFull();
         }
     }

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -455,6 +455,12 @@ void PlasmaZonesEffect::invalidateRuleCacheForStateChange(const QString& windowI
     // The match cache is keyed on (windowId, ruleSet revision); neither moves on
     // a placement-state change, so drop it so border / opacity rules re-resolve
     // against the new snapped / floating / zone state.
+    //
+    // Only the CACHED verdicts (border / opacity) need explicit invalidation here.
+    // shouldHandleWindow's exclusion query is evaluated on-demand every time it is
+    // consulted (drag start, lifecycle filtering), so a snap/float/zone change is
+    // picked up at the next natural call without eager re-filtering — re-running it
+    // for every window on every state change would be a needless hot-path cost.
     m_shaderManager.animationRuleEvaluator().clearCache();
     KWin::EffectWindow* w = findWindowById(windowId);
     if (w) {

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -244,6 +244,9 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
             QDBusPendingReply<QStringList> reply = *w;
             if (reply.isValid()) {
                 m_navigationHandler->clearAllFloatingState();
+                // Drop stale snap-zone entries from a prior daemon session too;
+                // syncZonesFromDaemon() below repopulates them authoritatively.
+                m_navigationHandler->clearAllZoneState();
                 QStringList floatingIds = reply.value();
                 for (const QString& id : floatingIds) {
                     m_navigationHandler->setWindowFloating(id, true);
@@ -252,6 +255,11 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
             }
         });
     }
+
+    // Repopulate the snap-zone cache from the daemon's authoritative state so
+    // windows snapped before this effect / daemon started are matchable by the
+    // IsSnapped / Zone rule fields without waiting for their next state change.
+    m_navigationHandler->syncZonesFromDaemon();
 
     // One-shot WindowRules subscription. The daemon emits rulesChanged per
     // per-rule mutation; slotWindowRulesChanged debounces via a 50ms timer to
@@ -913,6 +921,14 @@ void PlasmaZonesEffect::connectNavigationSignals()
                                           PhosphorProtocol::Service::Interface::WindowTracking,
                                           QStringLiteral("windowFloatingChanged"), this,
                                           SLOT(slotWindowFloatingChanged(QString, bool, QString)));
+
+    // Snap-zone state sync — feeds the effect-side zone cache the IsSnapped /
+    // Zone rule-match fields read. Carries the per-window WindowStateEntry
+    // (zoneId / changeType) on every snap / unsnap / float / screen-change.
+    QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,
+                                          PhosphorProtocol::Service::Interface::WindowTracking,
+                                          QStringLiteral("windowStateChanged"), this,
+                                          SLOT(slotWindowStateChanged(QString, PhosphorProtocol::WindowStateEntry)));
 
     // Settings: window picker for KCM exclusion list
     QDBusConnection::sessionBus().connect(PhosphorProtocol::Service::Name, PhosphorProtocol::Service::ObjectPath,

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -244,9 +244,6 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
             QDBusPendingReply<QStringList> reply = *w;
             if (reply.isValid()) {
                 m_navigationHandler->clearAllFloatingState();
-                // Drop stale snap-zone entries from a prior daemon session too;
-                // syncZonesFromDaemon() below repopulates them authoritatively.
-                m_navigationHandler->clearAllZoneState();
                 QStringList floatingIds = reply.value();
                 for (const QString& id : floatingIds) {
                     m_navigationHandler->setWindowFloating(id, true);

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -249,6 +249,11 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
                     m_navigationHandler->setWindowFloating(id, true);
                 }
                 qCDebug(lcEffect) << "Synced" << floatingIds.size() << "floating windows from daemon";
+                // Re-seeding the float cache changes the IsFloating match input for
+                // these windows; drop the stale placement-scoped opacity verdicts so
+                // a `WHEN isFloating` SetOpacity rule re-resolves against the fresh
+                // state on the next frame (mirrors the daemon-loss invalidation).
+                invalidateAllRuleCaches();
             }
         });
     }

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -535,7 +535,7 @@ void PlasmaZonesEffect::applySnapGeometry(KWin::EffectWindow* window, const QRec
         // resolver call below — matches the shape `shouldAnimateWindow`
         // uses for its rule-override gate, so a rule that gates the
         // animation also resolves its curve / timing / shader slots.
-        const PhosphorWindowRule::WindowQuery query = windowRuleQueryFor(window, getWindowScreenId(window));
+        const PhosphorWindowRule::WindowQuery query = windowRuleQuery(window);
         const auto& baseProfile = m_windowAnimator->profile();
         const PhosphorAnimation::Profile* motionOverridePtr = nullptr;
         PhosphorAnimation::Profile motionProfile;

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -764,6 +764,13 @@ PlasmaZonesEffect::PlasmaZonesEffect()
         // authoritatively repopulated on daemon-ready.
         m_navigationHandler->clearAllZoneState();
         m_navigationHandler->clearAllFloatingState();
+        // The placement caches above feed placement-scoped rule match inputs. A
+        // SetOpacity rule keyed on IsSnapped/IsFloating/Zone caches its verdict
+        // per (windowId, ruleSet revision) — neither moves here — so without this
+        // the window keeps its stale opacity (borders revert via restoreAll /
+        // clearAllBorders below, but opacity would not). Re-resolve every opacity
+        // window against the now-cleared placement, matching the border teardown.
+        invalidateAllRuleCaches();
         m_decorationManager->restoreAll();
         m_autotileHandler->restoreAllMonocleMaximized();
         clearAllBorders();

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -754,6 +754,16 @@ PlasmaZonesEffect::PlasmaZonesEffect()
         // suppressing the handler across the burst.
         m_autotileHandler->clearTiledTracking();
         m_snapHandler->clearSnapTracking();
+        // Drop the zone / floating caches that feed the IsSnapped / Zone /
+        // IsFloating rule-match fields. Unlike the exclusion / animation rule
+        // sets (deliberately preserved below), these caches mirror per-window
+        // PLACEMENT state owned by the now-dead daemon session. Keeping them
+        // would let a `WHEN IsSnapped` / `Zone(...)` / `IsFloating` rule match
+        // against stale state during the bringup race until the async
+        // syncZonesFromDaemon / getFloatingWindows re-seed lands. Both are
+        // authoritatively repopulated on daemon-ready.
+        m_navigationHandler->clearAllZoneState();
+        m_navigationHandler->clearAllFloatingState();
         m_decorationManager->restoreAll();
         m_autotileHandler->restoreAllMonocleMaximized();
         clearAllBorders();

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -288,8 +288,8 @@ void PlasmaZonesEffect::prePaintWindow(KWin::RenderView* view, KWin::EffectWindo
     if (w && m_shaderManager.hasOpacityRules()) {
         const QString winClass = w->windowClass();
         if (!isOwnOverlayClass(winClass) && !isPlasmaShellSurface(winClass)) {
-            const auto opacity = resolveWindowOpacity(m_shaderManager.animationRuleEvaluator(),
-                                                      windowRuleQueryFor(w, getWindowScreenId(w)), getWindowId(w));
+            const auto opacity =
+                resolveWindowOpacity(m_shaderManager.animationRuleEvaluator(), windowRuleQuery(w), getWindowId(w));
             m_shaderManager.cacheFrameOpacity(w, opacity);
             // Clear the deviceOpaque region so KWin recomposites whatever
             // sits behind a dimmed window — without it, stale background
@@ -407,8 +407,8 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
             if (m_shaderManager.frameOpacityCached(w)) {
                 opacity = m_shaderManager.cachedFrameOpacity(w);
             } else {
-                opacity = resolveWindowOpacity(m_shaderManager.animationRuleEvaluator(),
-                                               windowRuleQueryFor(w, getWindowScreenId(w)), getWindowId(w));
+                opacity =
+                    resolveWindowOpacity(m_shaderManager.animationRuleEvaluator(), windowRuleQuery(w), getWindowId(w));
                 m_shaderManager.cacheFrameOpacity(w, opacity);
             }
             if (opacity) {

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -288,8 +288,7 @@ void PlasmaZonesEffect::prePaintWindow(KWin::RenderView* view, KWin::EffectWindo
     if (w && m_shaderManager.hasOpacityRules()) {
         const QString winClass = w->windowClass();
         if (!isOwnOverlayClass(winClass) && !isPlasmaShellSurface(winClass)) {
-            const auto opacity =
-                resolveWindowOpacity(m_shaderManager.animationRuleEvaluator(), windowRuleQuery(w), getWindowId(w));
+            const auto opacity = resolveWindowOpacity(resolveWindowRuleActions(w, getWindowId(w)));
             m_shaderManager.cacheFrameOpacity(w, opacity);
             // Clear the deviceOpaque region so KWin recomposites whatever
             // sits behind a dimmed window — without it, stale background
@@ -407,8 +406,7 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
             if (m_shaderManager.frameOpacityCached(w)) {
                 opacity = m_shaderManager.cachedFrameOpacity(w);
             } else {
-                opacity =
-                    resolveWindowOpacity(m_shaderManager.animationRuleEvaluator(), windowRuleQuery(w), getWindowId(w));
+                opacity = resolveWindowOpacity(resolveWindowRuleActions(w, getWindowId(w)));
                 m_shaderManager.cacheFrameOpacity(w, opacity);
             }
             if (opacity) {

--- a/kwin-effect/plasmazoneseffect/shader_resolve.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.cpp
@@ -166,19 +166,8 @@ PhosphorAnimation::Profile resolveAnimationMotionProfile(const PhosphorWindowRul
     return out;
 }
 
-std::optional<qreal> resolveWindowOpacity(const PhosphorWindowRule::RuleEvaluator& evaluator,
-                                          const PhosphorWindowRule::WindowQuery& query, const QString& windowId)
+std::optional<qreal> resolveWindowOpacity(const PhosphorWindowRule::ResolvedActions& resolved)
 {
-    // Empty inputs short-circuit — a windowless query can't match any
-    // window-side predicate, and windowId keys the evaluator's per-window
-    // cache. Either being absent means there is nothing to resolve, and
-    // avoiding the cached walk here keeps the paint hot path from churning
-    // the cache on every paint of a window with no rule-side attributes
-    // (sub-surfaces, drop shadows, screen-edge proxies).
-    if (!query.hasWindow() || windowId.isEmpty()) {
-        return std::nullopt;
-    }
-    const PhosphorWindowRule::ResolvedActions resolved = evaluator.resolveCached(windowId, query);
     // The opacity-slot id is a constant; hoist its QString materialisation
     // out of the per-paint hot path so each `resolveWindowOpacity` call
     // reuses the same heap allocation. `static const` is thread-safe under
@@ -233,17 +222,8 @@ std::optional<qreal> resolveWindowOpacity(const PhosphorWindowRule::RuleEvaluato
     return value;
 }
 
-std::optional<ResolvedWindowAppearance> resolveWindowAppearance(const PhosphorWindowRule::RuleEvaluator& evaluator,
-                                                                const PhosphorWindowRule::WindowQuery& query,
-                                                                const QString& windowId)
+std::optional<ResolvedWindowAppearance> resolveWindowAppearance(const PhosphorWindowRule::ResolvedActions& resolved)
 {
-    // Same short-circuit rationale as resolveWindowOpacity: a windowless query
-    // can't match a window predicate, and windowId keys the per-window cache.
-    if (!query.hasWindow() || windowId.isEmpty()) {
-        return std::nullopt;
-    }
-    const PhosphorWindowRule::ResolvedActions resolved = evaluator.resolveCached(windowId, query);
-
     // Each reader re-validates the param type even though the load-time
     // descriptor validators already did — defence in depth against a
     // programmatically-built / hand-edited payload that bypassed the parser

--- a/kwin-effect/plasmazoneseffect/shader_resolve.h
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.h
@@ -41,9 +41,8 @@ namespace PlasmaZones {
  * WindowType / Pid / state flags / placement state), built once per window by
  * the GPL-side caller via `PlasmaZonesEffect::windowRuleQuery(w)`, which threads
  * the effect's floating / snapped / zone caches into the free `windowRuleQueryFor`
- * builder. Pre-PR the resolvers
- * took a bare `windowClass` and the rule layer matched exclusively on
- * `WindowClass Contains <pattern>`; v4 widened the match shape so a
+ * builder. Pre-PR the resolvers took a bare `windowClass` and the rule layer
+ * matched exclusively on `WindowClass Contains <pattern>`; v4 widened the match shape so a
  * user-authored rule may pin to `AppId` / `DesktopFile` / `Title` / etc.
  * Routing the full query through to the resolver keeps the rule-override
  * gate (which already builds the full query) and the slot resolution in

--- a/kwin-effect/plasmazoneseffect/shader_resolve.h
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.h
@@ -38,8 +38,10 @@ namespace PlasmaZones {
  *
  * Every resolver takes a `PhosphorWindowRule::WindowQuery` carrying the FULL
  * window context (AppId / WindowClass / Title / WindowRole / DesktopFile /
- * WindowType / Pid / state flags), built once per window by the GPL-side
- * caller via `windowRuleQueryFor(KWin::EffectWindow*)`. Pre-PR the resolvers
+ * WindowType / Pid / state flags / placement state), built once per window by
+ * the GPL-side caller via `PlasmaZonesEffect::windowRuleQuery(w)`, which threads
+ * the effect's floating / snapped / zone caches into the free `windowRuleQueryFor`
+ * builder. Pre-PR the resolvers
  * took a bare `windowClass` and the rule layer matched exclusively on
  * `WindowClass Contains <pattern>`; v4 widened the match shape so a
  * user-authored rule may pin to `AppId` / `DesktopFile` / `Title` / etc.

--- a/kwin-effect/plasmazoneseffect/shader_resolve.h
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.h
@@ -19,6 +19,7 @@ class CurveRegistry;
 
 namespace PhosphorWindowRule {
 class RuleEvaluator;
+class ResolvedActions;
 }
 
 namespace PlasmaZones {
@@ -117,36 +118,33 @@ PhosphorAnimation::Profile resolveAnimationMotionProfile(const PhosphorWindowRul
  * @brief Per-window opacity cascade — the runtime consumer for
  *        `SetOpacity` rules.
  *
- * Returns the rule-resolved opacity in `[0.0, 1.0]` when an enabled rule
- * whose match expression resolves for @p query fills the `opacity` slot
- * with a valid `value` param, or `std::nullopt` when no rule matches / the
- * param is missing / the value falls outside the documented range. Caller
- * applies the returned value via `KWin::WindowPaintData::setOpacity`
- * (absolute set, not multiplicative — SetOpacity semantics are "make the
- * window THIS opaque," not "scale by this factor").
+ * Returns the rule-resolved opacity in `[0.0, 1.0]` when an enabled rule fills
+ * the `opacity` slot of @p resolved with a valid `value` param, or `std::nullopt`
+ * when no rule filled it / the param is missing / the value falls outside the
+ * documented range. Caller applies the returned value via
+ * `KWin::WindowPaintData::setOpacity` (absolute set, not multiplicative —
+ * SetOpacity semantics are "make the window THIS opaque," not "scale by this
+ * factor").
  *
- * Windowless @p query (`hasWindow()` false) or empty @p windowId
- * short-circuit to `nullopt` — a windowless query can't match any
- * window-side predicate, and an empty windowId can't key the cache.
- *
- * Caller is the effect's `paintWindow` hook. The resolver does NOT cache
- * across calls — the evaluator's per-window cache (`resolveCached`) is
- * the right cache scope for this lookup, and the resolver consumes it.
+ * @p resolved comes from the effect's `resolveWindowRuleActions` helper, which
+ * peeks the evaluator's per-window cache and only builds the WindowQuery on a
+ * miss — so this pure extractor stays off the per-frame query-build hot path. An
+ * empty `resolved` (windowless / unmatched window) simply has no opacity slot →
+ * `nullopt`.
  */
-std::optional<qreal> resolveWindowOpacity(const PhosphorWindowRule::RuleEvaluator& evaluator,
-                                          const PhosphorWindowRule::WindowQuery& query, const QString& windowId);
+std::optional<qreal> resolveWindowOpacity(const PhosphorWindowRule::ResolvedActions& resolved);
 
 /**
  * @brief Per-window border / title-bar appearance override — the runtime
  *        consumer for the SetBorder* / SetHideTitleBar rules.
  *
- * Each field is set only when an enabled rule whose match resolves for
- * @p query fills the corresponding slot with a valid param (bool for
- * hideTitleBar/showBorder, an int in the descriptor range for width/radius, a
- * parseable `#AARRGGBB` for the colours). Unset fields mean "no override — fall
- * back to the global snap/autotile border state." Returns `std::nullopt` when
- * @p query is windowless / @p windowId is empty / no rule fills any slot, so
- * the caller can skip the merge entirely.
+ * Each field is set only when an enabled rule fills the corresponding slot of
+ * @p resolved with a valid param (bool for hideTitleBar/showBorder, an int in
+ * the descriptor range for width/radius, a parseable `#AARRGGBB` for the
+ * colours). Unset fields mean "no override — fall back to the global
+ * snap/autotile border state." Returns `std::nullopt` when no rule fills any
+ * slot (including the windowless / empty `resolved` case), so the caller can
+ * skip the merge entirely.
  *
  * Applies to ANY matched window (snapped OR floating), mirroring
  * `resolveWindowOpacity`. The bool/int re-reads here mirror the load-time
@@ -174,8 +172,6 @@ struct ResolvedWindowAppearance
     }
 };
 
-std::optional<ResolvedWindowAppearance> resolveWindowAppearance(const PhosphorWindowRule::RuleEvaluator& evaluator,
-                                                                const PhosphorWindowRule::WindowQuery& query,
-                                                                const QString& windowId);
+std::optional<ResolvedWindowAppearance> resolveWindowAppearance(const PhosphorWindowRule::ResolvedActions& resolved);
 
 } // namespace PlasmaZones

--- a/kwin-effect/plasmazoneseffect/shader_resolve.h
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.h
@@ -42,8 +42,8 @@ namespace PlasmaZones {
  * the GPL-side caller via `PlasmaZonesEffect::windowRuleQuery(w)`, which threads
  * the effect's floating / snapped / zone caches into the free `windowRuleQueryFor`
  * builder. Pre-PR the resolvers took a bare `windowClass` and the rule layer
- * matched exclusively on `WindowClass Contains <pattern>`; v4 widened the match shape so a
- * user-authored rule may pin to `AppId` / `DesktopFile` / `Title` / etc.
+ * matched exclusively on `WindowClass Contains <pattern>`; v4 widened the match
+ * shape so a user-authored rule may pin to `AppId` / `DesktopFile` / `Title` / etc.
  * Routing the full query through to the resolver keeps the rule-override
  * gate (which already builds the full query) and the slot resolution in
  * lockstep — a rule that passes the gate also resolves its slot.

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -1436,7 +1436,7 @@ void PlasmaZonesEffect::tryBeginShaderForEvent(KWin::EffectWindow* window, const
     // also resolves its slot. Caching across resolver calls is built
     // into the evaluator's `resolveCached(windowId, …)` path; the query
     // here is only the match input, not the cache key.
-    const PhosphorWindowRule::WindowQuery query = windowRuleQueryFor(window, getWindowScreenId(window));
+    const PhosphorWindowRule::WindowQuery query = windowRuleQuery(window);
     const QString windowId = getWindowId(window);
     const auto& profileTree = m_shaderManager.profileTree();
     // Per-event base duration. The daemon mirrors its motion

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -69,6 +69,23 @@ bool PlasmaZonesEffect::isWindowFloating(const QString& windowId) const
     return m_navigationHandler->isWindowFloating(windowId);
 }
 
+bool PlasmaZonesEffect::isWindowSnapped(const QString& windowId) const
+{
+    return m_navigationHandler->isWindowSnapped(windowId);
+}
+
+QString PlasmaZonesEffect::zoneForWindow(const QString& windowId) const
+{
+    return m_navigationHandler->zoneForWindow(windowId);
+}
+
+PhosphorWindowRule::WindowQuery PlasmaZonesEffect::windowRuleQuery(KWin::EffectWindow* w) const
+{
+    const QString windowId = getWindowId(w);
+    return windowRuleQueryFor(w, getWindowScreenId(w), isWindowFloating(windowId), isWindowSnapped(windowId),
+                              zoneForWindow(windowId));
+}
+
 bool PlasmaZonesEffect::isStructurallyUnmanageableWindowType(KWin::EffectWindow* w, QString* rejectReason) const
 {
     // Single source of truth for the window-TYPE rejection set shared by
@@ -159,7 +176,7 @@ bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w, QString* rejec
     // `!isEmpty()` fast path keeps a no-exclusions user at two pointer
     // reads — same cost as the prior list-derived check.
     if (!m_snappingExclusionRuleSet.isEmpty()) {
-        if (m_snappingExclusionEvaluator.resolve(windowRuleQueryFor(w, getWindowScreenId(w))).isExcluded()) {
+        if (m_snappingExclusionEvaluator.resolve(windowRuleQuery(w)).isExcluded()) {
             return rejectedBecause(rejectReason, "user exclusion rule match");
         }
     }
@@ -212,7 +229,7 @@ bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
     std::optional<PhosphorWindowRule::WindowQuery> cachedQuery;
     auto query = [&]() -> const PhosphorWindowRule::WindowQuery& {
         if (!cachedQuery) {
-            cachedQuery = windowRuleQueryFor(w, getWindowScreenId(w));
+            cachedQuery = windowRuleQuery(w);
         }
         return *cachedQuery;
     };

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -86,6 +86,30 @@ PhosphorWindowRule::WindowQuery PlasmaZonesEffect::windowRuleQuery(KWin::EffectW
                               zoneForWindow(windowId));
 }
 
+PhosphorWindowRule::ResolvedActions PlasmaZonesEffect::resolveWindowRuleActions(KWin::EffectWindow* w,
+                                                                                const QString& windowId) const
+{
+    const PhosphorWindowRule::RuleEvaluator& evaluator = m_shaderManager.animationRuleEvaluator();
+    // An empty windowId can't key the per-window cache; nothing to resolve.
+    if (windowId.isEmpty()) {
+        return {};
+    }
+    // Cache hit → skip the ≈30-accessor windowRuleQuery(w) build entirely. The
+    // cached verdict already reflects whatever query produced it, and resolveCached
+    // ignores the query on a hit anyway.
+    if (std::optional<PhosphorWindowRule::ResolvedActions> cached = evaluator.resolveCachedIfPresent(windowId)) {
+        return std::move(*cached);
+    }
+    // Miss → build the query once and resolve (caching the result). A windowless
+    // query (sub-surface / drop shadow / proxy) can't fill any slot; return empty
+    // actions WITHOUT caching, so the paint hot path doesn't churn the cache for it.
+    const PhosphorWindowRule::WindowQuery query = windowRuleQuery(w);
+    if (!query.hasWindow()) {
+        return {};
+    }
+    return evaluator.resolveCached(windowId, query);
+}
+
 bool PlasmaZonesEffect::isStructurallyUnmanageableWindowType(KWin::EffectWindow* w, QString* rejectReason) const
 {
     // Single source of truth for the window-TYPE rejection set shared by

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -100,9 +100,11 @@ PhosphorWindowRule::ResolvedActions PlasmaZonesEffect::resolveWindowRuleActions(
     if (std::optional<PhosphorWindowRule::ResolvedActions> cached = evaluator.resolveCachedIfPresent(windowId)) {
         return std::move(*cached);
     }
-    // Miss → build the query once and resolve (caching the result). A windowless
-    // query (sub-surface / drop shadow / proxy) can't fill any slot; return empty
-    // actions WITHOUT caching, so the paint hot path doesn't churn the cache for it.
+    // Miss → build the query once and resolve (caching the result). Defensive guard
+    // against a windowless query (no engaged window attribute): it can't fill any
+    // slot, so return empty actions WITHOUT caching to avoid a useless cache entry.
+    // In practice a non-null w always engages placement/state attributes, so this
+    // only ever covers the already-handled empty-windowId case — kept as a belt.
     const PhosphorWindowRule::WindowQuery query = windowRuleQuery(w);
     if (!query.hasWindow()) {
         return {};

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -130,10 +130,83 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w)
 
     const int windowType = static_cast<int>(windowTypeFor(w));
 
+    // Extended window-property snapshot. Built via the SAME windowRuleQueryFor the
+    // effect's live rule path uses, so the daemon resolves byte-identical values —
+    // no second, drift-prone accessor copy here. Placement state (isFloating /
+    // isSnapped / zone) is intentionally NOT carried: those are resolved at
+    // window-open before any placement exists, so the daemon's open-path resolvers
+    // must see them absent (a predicate over an unplaced window stays inert). Only
+    // the present (engaged) optionals are inserted, so an unknown field (e.g. no
+    // underlying KWin::Window) leaves the daemon-side WindowQuery field disengaged,
+    // mirroring the engage-only-when-known contract on both ends.
+    const PhosphorWindowRule::WindowQuery props = windowRuleQueryFor(w, QString(), false, false, QString());
+    namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
+    QVariantMap extended;
+    if (props.isMinimized) {
+        extended.insert(Key::IsMinimized, *props.isMinimized);
+    }
+    if (props.isFullscreen) {
+        extended.insert(Key::IsFullscreen, *props.isFullscreen);
+    }
+    if (props.isSticky) {
+        extended.insert(Key::IsSticky, *props.isSticky);
+    }
+    if (props.isMaximized) {
+        extended.insert(Key::IsMaximized, *props.isMaximized);
+    }
+    if (props.isFocused) {
+        extended.insert(Key::IsFocused, *props.isFocused);
+    }
+    if (props.isTransient) {
+        extended.insert(Key::IsTransient, *props.isTransient);
+    }
+    if (props.isNotification) {
+        extended.insert(Key::IsNotification, *props.isNotification);
+    }
+    if (props.keepAbove) {
+        extended.insert(Key::KeepAbove, *props.keepAbove);
+    }
+    if (props.keepBelow) {
+        extended.insert(Key::KeepBelow, *props.keepBelow);
+    }
+    if (props.skipTaskbar) {
+        extended.insert(Key::SkipTaskbar, *props.skipTaskbar);
+    }
+    if (props.skipPager) {
+        extended.insert(Key::SkipPager, *props.skipPager);
+    }
+    if (props.skipSwitcher) {
+        extended.insert(Key::SkipSwitcher, *props.skipSwitcher);
+    }
+    if (props.isModal) {
+        extended.insert(Key::IsModal, *props.isModal);
+    }
+    if (props.hasDecoration) {
+        extended.insert(Key::HasDecoration, *props.hasDecoration);
+    }
+    if (props.isResizable) {
+        extended.insert(Key::IsResizable, *props.isResizable);
+    }
+    if (props.width) {
+        extended.insert(Key::Width, *props.width);
+    }
+    if (props.height) {
+        extended.insert(Key::Height, *props.height);
+    }
+    if (props.positionX) {
+        extended.insert(Key::PositionX, *props.positionX);
+    }
+    if (props.positionY) {
+        extended.insert(Key::PositionY, *props.positionY);
+    }
+    if (props.captionNormal) {
+        extended.insert(Key::CaptionNormal, *props.captionNormal);
+    }
+
     // Fire-and-forget — the daemon side is idempotent.
     PhosphorProtocol::ClientHelpers::fireAndForget(
         this, PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("setWindowMetadata"),
-        {instanceId, appId, desktopFile, title, windowRole, pid, virtualDesktop, activity, windowType},
+        {instanceId, appId, desktopFile, title, windowRole, pid, virtualDesktop, activity, windowType, extended},
         QStringLiteral("setWindowMetadata"));
 }
 

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -79,7 +79,7 @@ QString PlasmaZonesEffect::getWindowAppId(KWin::EffectWindow* w) const
     return ::PhosphorIdentity::WindowId::normalizeAppId(window->desktopFileName(), w->windowClass());
 }
 
-void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w)
+void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w, bool includeExtended)
 {
     if (!w) {
         return;
@@ -139,68 +139,74 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w)
     // the present (engaged) optionals are inserted, so an unknown field (e.g. no
     // underlying KWin::Window) leaves the daemon-side WindowQuery field disengaged,
     // mirroring the engage-only-when-known contract on both ends.
-    const PhosphorWindowRule::WindowQuery props = windowRuleQueryFor(w, QString(), false, false, QString());
-    namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
+    //
+    // Skipped entirely on a caption-only refresh (@p includeExtended false): the
+    // map stays empty and the daemon preserves the existing extended snapshot,
+    // avoiding a per-frame query build + a{sv} marshal for chatty-title windows.
     QVariantMap extended;
-    if (props.isMinimized) {
-        extended.insert(Key::IsMinimized, *props.isMinimized);
-    }
-    if (props.isFullscreen) {
-        extended.insert(Key::IsFullscreen, *props.isFullscreen);
-    }
-    if (props.isSticky) {
-        extended.insert(Key::IsSticky, *props.isSticky);
-    }
-    if (props.isMaximized) {
-        extended.insert(Key::IsMaximized, *props.isMaximized);
-    }
-    if (props.isFocused) {
-        extended.insert(Key::IsFocused, *props.isFocused);
-    }
-    if (props.isTransient) {
-        extended.insert(Key::IsTransient, *props.isTransient);
-    }
-    if (props.isNotification) {
-        extended.insert(Key::IsNotification, *props.isNotification);
-    }
-    if (props.keepAbove) {
-        extended.insert(Key::KeepAbove, *props.keepAbove);
-    }
-    if (props.keepBelow) {
-        extended.insert(Key::KeepBelow, *props.keepBelow);
-    }
-    if (props.skipTaskbar) {
-        extended.insert(Key::SkipTaskbar, *props.skipTaskbar);
-    }
-    if (props.skipPager) {
-        extended.insert(Key::SkipPager, *props.skipPager);
-    }
-    if (props.skipSwitcher) {
-        extended.insert(Key::SkipSwitcher, *props.skipSwitcher);
-    }
-    if (props.isModal) {
-        extended.insert(Key::IsModal, *props.isModal);
-    }
-    if (props.hasDecoration) {
-        extended.insert(Key::HasDecoration, *props.hasDecoration);
-    }
-    if (props.isResizable) {
-        extended.insert(Key::IsResizable, *props.isResizable);
-    }
-    if (props.width) {
-        extended.insert(Key::Width, *props.width);
-    }
-    if (props.height) {
-        extended.insert(Key::Height, *props.height);
-    }
-    if (props.positionX) {
-        extended.insert(Key::PositionX, *props.positionX);
-    }
-    if (props.positionY) {
-        extended.insert(Key::PositionY, *props.positionY);
-    }
-    if (props.captionNormal) {
-        extended.insert(Key::CaptionNormal, *props.captionNormal);
+    if (includeExtended) {
+        const PhosphorWindowRule::WindowQuery props = windowRuleQueryFor(w, QString(), false, false, QString());
+        namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
+        if (props.isMinimized) {
+            extended.insert(Key::IsMinimized, *props.isMinimized);
+        }
+        if (props.isFullscreen) {
+            extended.insert(Key::IsFullscreen, *props.isFullscreen);
+        }
+        if (props.isSticky) {
+            extended.insert(Key::IsSticky, *props.isSticky);
+        }
+        if (props.isMaximized) {
+            extended.insert(Key::IsMaximized, *props.isMaximized);
+        }
+        if (props.isFocused) {
+            extended.insert(Key::IsFocused, *props.isFocused);
+        }
+        if (props.isTransient) {
+            extended.insert(Key::IsTransient, *props.isTransient);
+        }
+        if (props.isNotification) {
+            extended.insert(Key::IsNotification, *props.isNotification);
+        }
+        if (props.keepAbove) {
+            extended.insert(Key::KeepAbove, *props.keepAbove);
+        }
+        if (props.keepBelow) {
+            extended.insert(Key::KeepBelow, *props.keepBelow);
+        }
+        if (props.skipTaskbar) {
+            extended.insert(Key::SkipTaskbar, *props.skipTaskbar);
+        }
+        if (props.skipPager) {
+            extended.insert(Key::SkipPager, *props.skipPager);
+        }
+        if (props.skipSwitcher) {
+            extended.insert(Key::SkipSwitcher, *props.skipSwitcher);
+        }
+        if (props.isModal) {
+            extended.insert(Key::IsModal, *props.isModal);
+        }
+        if (props.hasDecoration) {
+            extended.insert(Key::HasDecoration, *props.hasDecoration);
+        }
+        if (props.isResizable) {
+            extended.insert(Key::IsResizable, *props.isResizable);
+        }
+        if (props.width) {
+            extended.insert(Key::Width, *props.width);
+        }
+        if (props.height) {
+            extended.insert(Key::Height, *props.height);
+        }
+        if (props.positionX) {
+            extended.insert(Key::PositionX, *props.positionX);
+        }
+        if (props.positionY) {
+            extended.insert(Key::PositionY, *props.positionY);
+        }
+        if (props.captionNormal) {
+            extended.insert(Key::CaptionNormal, *props.captionNormal);
+        }
     }
 
     // Fire-and-forget — the daemon side is idempotent.

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -271,9 +271,12 @@ void PlasmaZonesEffect::slotWindowClosed(KWin::EffectWindow* w)
     // Delegate to helpers
     m_dragTracker->handleWindowClosed(w);
 
-    // Clear floating state — floating is runtime-only and resets on window close.
-    // The daemon clears its side in windowClosed().
+    // Clear floating and snap-zone state — both are runtime-only and reset on
+    // window close. The daemon clears its side in windowClosed(). Done here while
+    // getWindowId(w) still resolves (before the windowId cache drops the entry),
+    // so a reused id can't inherit a stale zone.
     m_navigationHandler->setWindowFloating(getWindowId(w), false);
+    m_navigationHandler->clearWindowZone(getWindowId(w));
 
     // Tear down any in-flight zone.* shader transition first — this window
     // is going away and we don't want a half-faded zone shader fighting the

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -275,8 +275,9 @@ void PlasmaZonesEffect::slotWindowClosed(KWin::EffectWindow* w)
     // window close. The daemon clears its side in windowClosed(). Done here while
     // getWindowId(w) still resolves (before the windowId cache drops the entry),
     // so a reused id can't inherit a stale zone.
-    m_navigationHandler->setWindowFloating(getWindowId(w), false);
-    m_navigationHandler->clearWindowZone(getWindowId(w));
+    const QString closingWindowId = getWindowId(w);
+    m_navigationHandler->setWindowFloating(closingWindowId, false);
+    m_navigationHandler->clearWindowZone(closingWindowId);
 
     // Tear down any in-flight zone.* shader transition first — this window
     // is going away and we don't want a half-faded zone shader fighting the

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -597,6 +597,16 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
                 pushWindowMetadata(safeW);
             }
         };
+        // Caption changes fire every frame for terminals / browsers; the extended
+        // property snapshot (geometry / state flags) doesn't change on a title tick,
+        // so refresh the registry's core metadata (title) WITHOUT rebuilding and
+        // marshalling the ~20-entry a{sv} each frame. The daemon preserves the
+        // existing extended fields when none are sent.
+        auto pushCaptionOnly = [this, safeW]() {
+            if (safeW && !safeW->isDeleted()) {
+                pushWindowMetadata(safeW, /*includeExtended=*/false);
+            }
+        };
         // Class / desktop-file mutations invalidate the animation rule
         // evaluator's per-window match cache. The cache is keyed on the
         // window's frozen composite id but the cascade resolves against
@@ -614,7 +624,7 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
         connect(kw, &KWin::Window::windowClassChanged, this, invalidateRuleCache);
         connect(kw, &KWin::Window::desktopFileNameChanged, this, pushLatest);
         connect(kw, &KWin::Window::desktopFileNameChanged, this, invalidateRuleCache);
-        connect(kw, &KWin::Window::captionChanged, this, pushLatest);
+        connect(kw, &KWin::Window::captionChanged, this, pushCaptionOnly);
         // Per-window virtual-desktop / activity / role changes also refresh the
         // registry so context-aware rule resolution sees current values. Same
         // record-only contract: no retroactive re-evaluation of committed state.

--- a/kwin-effect/plasmazoneseffect/window_query.cpp
+++ b/kwin-effect/plasmazoneseffect/window_query.cpp
@@ -56,11 +56,21 @@ PhosphorProtocol::WindowType windowTypeFor(KWin::EffectWindow* w)
     return WindowType::Unknown;
 }
 
-PhosphorWindowRule::WindowQuery windowRuleQueryFor(KWin::EffectWindow* w, const QString& screenId)
+PhosphorWindowRule::WindowQuery windowRuleQueryFor(KWin::EffectWindow* w, const QString& screenId, bool isFloating,
+                                                   bool isSnapped, const QString& zoneId)
 {
     PhosphorWindowRule::WindowQuery query;
     if (!w) {
         return query;
+    }
+    // PlasmaZones placement state — caller-supplied from the effect's runtime
+    // caches (see header). Bools are always engaged when the window exists; the
+    // zone UUID is gated on non-empty so a non-snapped window stays a non-match
+    // (the engaged-empty foot-gun the string fields below also avoid).
+    query.isFloating = isFloating;
+    query.isSnapped = isSnapped;
+    if (!zoneId.isEmpty()) {
+        query.zone = zoneId;
     }
     // Context fields — let a window-domain rule pin screen / desktop / activity
     // (e.g. "red border on monitor 2"). screenId is resolved by the caller (the

--- a/kwin-effect/plasmazoneseffect/window_query.cpp
+++ b/kwin-effect/plasmazoneseffect/window_query.cpp
@@ -135,6 +135,18 @@ PhosphorWindowRule::WindowQuery windowRuleQueryFor(KWin::EffectWindow* w, const 
     // surprise rules that target "is the window maximized."
     if (kw) {
         query.isMaximized = (kw->maximizeMode() == KWin::MaximizeFull);
+        // KWin::Window-only accessory / capability flags (not exposed on
+        // EffectWindow). Always engaged when the underlying window exists.
+        query.skipTaskbar = kw->skipTaskbar();
+        query.skipPager = kw->skipPager();
+        query.isResizable = kw->isResizable();
+        // captionNormal is the raw WM_NAME without the WM-added " — App" suffix
+        // that caption() (used for Title above) includes. Gate non-empty like
+        // the other string fields so a disengaged optional stays a non-match.
+        const QString captionNormal = kw->captionNormal();
+        if (!captionNormal.isEmpty()) {
+            query.captionNormal = captionNormal;
+        }
     }
     // isFocused mirrors the live active-window state so a rule like
     // "isFocused=false ⇒ SetBorderColor(gray)" resolves correctly. The
@@ -157,9 +169,19 @@ PhosphorWindowRule::WindowQuery windowRuleQueryFor(KWin::EffectWindow* w, const 
     query.isTransient = w->isDialog() || w->isUtility() || w->isPopupWindow() || w->isPopupMenu() || w->isDropdownMenu()
         || w->isTooltip() || w->isMenu() || w->isSplash() || w->transientFor() != nullptr;
     query.isNotification = w->isNotification() || w->isCriticalNotification() || w->isOnScreenDisplay();
+    // Stacking / accessory flags read straight off EffectWindow. Always engaged
+    // when the window exists, like the other bool flags above.
+    query.keepAbove = w->keepAbove();
+    query.keepBelow = w->keepBelow();
+    query.isModal = w->isModal();
+    query.hasDecoration = w->hasDecoration();
+    query.skipSwitcher = w->isSkipSwitcher();
     const QRectF frame = w->frameGeometry();
     query.width = static_cast<int>(frame.width());
     query.height = static_cast<int>(frame.height());
+    // Frame position — from the same frameGeometry() already read for the size.
+    query.positionX = static_cast<int>(frame.x());
+    query.positionY = static_cast<int>(frame.y());
     // virtualDesktop: first desktop's 1-based x11 number (0 = all/unknown).
     // activity: first activity UUID (empty = all/unknown). Both mirror the
     // daemon-side setWindowMetadata derivation in window_identity.cpp so a

--- a/kwin-effect/plasmazoneseffect/window_query.h
+++ b/kwin-effect/plasmazoneseffect/window_query.h
@@ -50,7 +50,10 @@ PhosphorProtocol::WindowType windowTypeFor(KWin::EffectWindow* w);
 ///     `setWindowMetadata` derivation). `screenId` requires the effect's
 ///     output→stable-id resolution, which is not available to this free
 ///     helper, so the caller passes it via @p screenId (typically
-///     `getWindowScreenId(w)`); left empty it stays disengaged. NOTE: a window
+///     `getWindowScreenId(w)`). Unlike the window string fields, `screenId` is a
+///     non-optional context field that is always present; passing it empty
+///     resolves as the empty/unknown screen value (the all/unknown convention),
+///     not a disengaged optional. NOTE: a window
 ///     query carrying a populated context only ENABLES context-pinned
 ///     window-domain rules to match — it does not affect the windowless
 ///     context cascade, which routes through `ContextRuleBridge`.

--- a/kwin-effect/plasmazoneseffect/window_query.h
+++ b/kwin-effect/plasmazoneseffect/window_query.h
@@ -55,8 +55,17 @@ PhosphorProtocol::WindowType windowTypeFor(KWin::EffectWindow* w);
 ///     window-domain rules to match — it does not affect the windowless
 ///     context cascade, which routes through `ContextRuleBridge`.
 ///
+/// PlasmaZones placement state (@p isFloating / @p isSnapped / @p zoneId) is
+/// supplied by the caller because it lives in the effect's runtime caches
+/// (NavigationHandler), not on the KWin window. The caller passes
+/// `isWindowFloating(wid)`, `isWindowSnapped(wid)`, `zoneForWindow(wid)`. These
+/// are REQUIRED (no defaults) so every call site is compiler-forced to supply
+/// them — a site that silently omitted them would leave IsFloating / IsSnapped /
+/// Zone unmatched in that resolver path only.
+///
 /// Confined to the effect translation unit so the LGPL phosphor-windowrule
 /// library never sees a KWin type.
-PhosphorWindowRule::WindowQuery windowRuleQueryFor(KWin::EffectWindow* w, const QString& screenId = {});
+PhosphorWindowRule::WindowQuery windowRuleQueryFor(KWin::EffectWindow* w, const QString& screenId, bool isFloating,
+                                                   bool isSnapped, const QString& zoneId);
 
 } // namespace PlasmaZones

--- a/libs/phosphor-compositor/CMakeLists.txt
+++ b/libs/phosphor-compositor/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(PhosphorCompositor SHARED
     include/PhosphorCompositor/DecorationDefaults.h
     include/PhosphorCompositor/DecorationManager.h
     include/PhosphorCompositor/FloatingCache.h
+    include/PhosphorCompositor/ZoneCache.h
     include/PhosphorCompositor/DebouncedAction.h
     include/PhosphorCompositor/GeometryHelpers.h
     include/PhosphorCompositor/SnapAssistFilter.h

--- a/libs/phosphor-compositor/CMakeLists.txt
+++ b/libs/phosphor-compositor/CMakeLists.txt
@@ -4,7 +4,7 @@
 # PhosphorCompositor — Compositor-plugin SDK for Phosphor.
 #
 # Provides ICompositorBridge interface, shared types (WindowInfo,
-# AutotileState, FloatingCache), trigger parsing, and snap-assist
+# AutotileState, FloatingCache, ZoneCache), trigger parsing, and snap-assist
 # candidate filtering. Compositor plugins implement ICompositorBridge
 # and talk to the Phosphor daemon over D-Bus.
 

--- a/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
@@ -5,6 +5,7 @@
 
 #include <PhosphorIdentity/WindowId.h>
 
+#include <QHash>
 #include <QSet>
 #include <QString>
 
@@ -13,60 +14,72 @@ namespace PhosphorCompositor {
 /**
  * @brief Compositor-agnostic floating window state cache
  *
- * Tracks which windows are floating using full windowId with appId fallback.
- * Shared by all compositor plugins to avoid duplicating the lookup logic.
+ * Tracks which windows are floating, dual-keyed so both float kinds resolve:
+ *   - Instance-specific floats (a single window the user/rule floated) are keyed
+ *     by the STABLE instanceId, like @c ZoneCache. A window's appId can mutate
+ *     mid-session (Electron / CEF apps rename their window class), changing the
+ *     composite `appId|instanceId` but never the instanceId — keying by it keeps
+ *     a floated window resolvable across that rename.
+ *   - App-wide floats (a bare appId, e.g. a rule floating every instance of an
+ *     app) are keyed by appId and match every instance via the fallback below.
  *
- * setFloating(false) removes the exact windowId and only removes the bare
- * appId key if no other full-ID entry shares it. This ensures clearing
- * "firefox|1" does not affect "firefox|2"'s float state via the appId
- * fallback in isFloating().
+ * setFloating(false) on a specific instance also clears the app-wide entry once
+ * no sibling instance remains floating, so the app-wide fallback does not keep
+ * reporting a window as floating after its last instance was unfloated.
  */
 class FloatingCache
 {
 public:
     bool isFloating(const QString& windowId) const
     {
-        if (m_floatingWindows.contains(windowId)) {
+        // Instance-specific float — survives appId (class) mutation.
+        if (m_byInstance.contains(::PhosphorIdentity::WindowId::extractInstanceId(windowId))) {
             return true;
         }
-        QString appId = ::PhosphorIdentity::WindowId::extractAppId(windowId);
-        return (appId != windowId && m_floatingWindows.contains(appId));
+        // App-wide float — a bare appId matches every instance of that app.
+        return m_byAppId.contains(::PhosphorIdentity::WindowId::extractAppId(windowId));
     }
 
     void setFloating(const QString& windowId, bool floating)
     {
+        const QString appId = ::PhosphorIdentity::WindowId::extractAppId(windowId);
+        const bool isComposite = (appId != windowId); // bare appId has no separator
         if (floating) {
-            m_floatingWindows.insert(windowId);
-        } else {
-            m_floatingWindows.remove(windowId);
-            QString appId = ::PhosphorIdentity::WindowId::extractAppId(windowId);
-            if (appId != windowId) {
-                // Only remove bare appId key if no other full-ID entry shares it.
-                // Without this guard, clearing "firefox|1" would also clear the bare
-                // "firefox" key, making isFloating("firefox|2") return false via the
-                // appId fallback even though "firefox|2" is still floating.
-                bool otherFullIdExists = false;
-                for (const QString& entry : m_floatingWindows) {
-                    if (entry != appId && ::PhosphorIdentity::WindowId::extractAppId(entry) == appId) {
-                        otherFullIdExists = true;
-                        break;
-                    }
-                }
-                if (!otherFullIdExists) {
-                    m_floatingWindows.remove(appId);
+            if (isComposite) {
+                m_byInstance.insert(::PhosphorIdentity::WindowId::extractInstanceId(windowId), appId);
+            } else {
+                m_byAppId.insert(windowId);
+            }
+        } else if (isComposite) {
+            m_byInstance.remove(::PhosphorIdentity::WindowId::extractInstanceId(windowId));
+            // Drop the app-wide entry only once no sibling instance is still
+            // floating, mirroring the old single-set guard: without this, clearing
+            // "firefox|1" would orphan a bare "firefox" that keeps isFloating()
+            // true for every other instance via the fallback.
+            bool otherInstanceFloating = false;
+            for (const QString& entryAppId : m_byInstance) {
+                if (entryAppId == appId) {
+                    otherInstanceFloating = true;
+                    break;
                 }
             }
+            if (!otherInstanceFloating) {
+                m_byAppId.remove(appId);
+            }
+        } else {
+            m_byAppId.remove(windowId);
         }
     }
 
     void clear()
     {
-        m_floatingWindows.clear();
+        m_byInstance.clear();
+        m_byAppId.clear();
     }
 
     int size() const
     {
-        return m_floatingWindows.size();
+        return m_byInstance.size() + m_byAppId.size();
     }
 
     /// Convenience alias for setFloating(windowId, true). Kept symmetric
@@ -83,7 +96,8 @@ public:
     }
 
 private:
-    QSet<QString> m_floatingWindows;
+    QHash<QString, QString> m_byInstance; ///< stable instanceId → appId (instance floats)
+    QSet<QString> m_byAppId; ///< app-wide floats, keyed by appId
 };
 
 } // namespace PhosphorCompositor

--- a/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
@@ -5,7 +5,6 @@
 
 #include <PhosphorIdentity/WindowId.h>
 
-#include <QHash>
 #include <QSet>
 #include <QString>
 
@@ -20,12 +19,16 @@ namespace PhosphorCompositor {
  *     mid-session (Electron / CEF apps rename their window class), changing the
  *     composite `appId|instanceId` but never the instanceId — keying by it keeps
  *     a floated window resolvable across that rename.
- *   - App-wide floats (a bare appId, e.g. a rule floating every instance of an
- *     app) are keyed by appId and match every instance via the fallback below.
+ *   - App-wide floats (a bare appId, e.g. a session-restore marker floating every
+ *     instance of an app) are keyed by appId and match every instance via the
+ *     fallback in @c isFloating.
  *
- * setFloating(false) on a specific instance also clears the app-wide entry once
- * no sibling instance remains floating, so the app-wide fallback does not keep
- * reporting a window as floating after its last instance was unfloated.
+ * Mirrors the authoritative @c WindowTrackingService::setFloating: unfloating a
+ * specific instance ALSO drops the coarse app-wide (bare appId) entry. Still-
+ * floating siblings keep their own instance entries, so this never clears them;
+ * it only removes the session-restore appId marker (matching the daemon, which
+ * removes the appId entry unconditionally on instance unfloat — no sibling scan,
+ * which would not survive a mid-session class rename anyway).
  */
 class FloatingCache
 {
@@ -44,28 +47,25 @@ public:
     {
         const QString appId = ::PhosphorIdentity::WindowId::extractAppId(windowId);
         const bool isComposite = (appId != windowId); // bare appId has no separator
-        if (floating) {
-            if (isComposite) {
-                m_byInstance.insert(::PhosphorIdentity::WindowId::extractInstanceId(windowId), appId);
+        if (isComposite) {
+            const QString instanceId = ::PhosphorIdentity::WindowId::extractInstanceId(windowId);
+            // A composite with an empty instanceId ("appId|") is malformed: keying
+            // it would alias every other empty-instance window onto one wildcard
+            // slot. Reject rather than corrupt the cache.
+            if (instanceId.isEmpty()) {
+                return;
+            }
+            if (floating) {
+                m_byInstance.insert(instanceId);
             } else {
-                m_byAppId.insert(windowId);
-            }
-        } else if (isComposite) {
-            m_byInstance.remove(::PhosphorIdentity::WindowId::extractInstanceId(windowId));
-            // Drop the app-wide entry only once no sibling instance is still
-            // floating, mirroring the old single-set guard: without this, clearing
-            // "firefox|1" would orphan a bare "firefox" that keeps isFloating()
-            // true for every other instance via the fallback.
-            bool otherInstanceFloating = false;
-            for (const QString& entryAppId : m_byInstance) {
-                if (entryAppId == appId) {
-                    otherInstanceFloating = true;
-                    break;
-                }
-            }
-            if (!otherInstanceFloating) {
+                m_byInstance.remove(instanceId);
+                // Mirror WindowTrackingService::setFloating: an explicit instance
+                // unfloat also drops the coarse app-wide fallback. Siblings keep
+                // their own instance entries, so this only clears the appId marker.
                 m_byAppId.remove(appId);
             }
+        } else if (floating) {
+            m_byAppId.insert(windowId);
         } else {
             m_byAppId.remove(windowId);
         }
@@ -96,7 +96,7 @@ public:
     }
 
 private:
-    QHash<QString, QString> m_byInstance; ///< stable instanceId → appId (instance floats)
+    QSet<QString> m_byInstance; ///< instance floats, keyed by stable instanceId
     QSet<QString> m_byAppId; ///< app-wide floats, keyed by appId
 };
 

--- a/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
@@ -77,6 +77,11 @@ public:
         m_byAppId.clear();
     }
 
+    /// Total entries across BOTH keyspaces (instance floats + app-wide floats).
+    /// Not a window count: an app floated both app-wide and per-instance counts
+    /// in each. Diagnostics that want "how many windows did the daemon report
+    /// floating" should log the source list size, not this (see
+    /// NavigationHandler::syncFloatingWindowsFromDaemon).
     int size() const
     {
         return m_byInstance.size() + m_byAppId.size();

--- a/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
@@ -21,7 +21,11 @@ namespace PhosphorCompositor {
  *     a floated window resolvable across that rename.
  *   - App-wide floats (a bare appId, e.g. a session-restore marker floating every
  *     instance of an app) are keyed by appId and match every instance via the
- *     fallback in @c isFloating.
+ *     fallback in @c isFloating. Unlike the instanceId keyspace, this one is NOT
+ *     class-mutation-safe: a bare-appId entry inserted as `slack` is not resolved
+ *     by a later `Slack`. This matches the authoritative daemon's own appId-keyed
+ *     markers (same exposure); the rename-robustness guarantee covers only the
+ *     instance keyspace above.
  *
  * Mirrors the authoritative @c WindowTrackingService::setFloating: unfloating a
  * specific instance ALSO drops the coarse app-wide (bare appId) entry. Still-

--- a/libs/phosphor-compositor/include/PhosphorCompositor/ZoneCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/ZoneCache.h
@@ -18,7 +18,8 @@ namespace PhosphorCompositor {
  * Sibling of @c FloatingCache — together the two describe a window's placement
  * for the IsSnapped / Zone / IsFloating window-rule match fields. Both caches key
  * per-instance state by the stable instanceId (below); FloatingCache additionally
- * carries an app-wide appId keyspace for rules that float every instance of an app.
+ * carries an app-wide appId keyspace (a bare appId, e.g. a session-restore marker
+ * floating every instance of an app).
  *
  * Keyed by the STABLE instanceId, not the full composite windowId. A window's
  * appId can mutate mid-session (Electron / CEF apps rename their window class),
@@ -41,7 +42,7 @@ public:
     /// True iff @p windowId is snapped into a zone (has a non-empty entry).
     bool isSnapped(const QString& windowId) const
     {
-        return !m_byInstance.value(::PhosphorIdentity::WindowId::extractInstanceId(windowId)).isEmpty();
+        return !zoneForWindow(windowId).isEmpty();
     }
 
     /// Record @p windowId's zone. An empty @p zoneId removes the entry (the
@@ -49,6 +50,11 @@ public:
     void setZone(const QString& windowId, const QString& zoneId)
     {
         const QString instanceId = ::PhosphorIdentity::WindowId::extractInstanceId(windowId);
+        // A composite with an empty instanceId ("appId|") is malformed: keying it
+        // would alias every empty-instance window onto one wildcard slot. Ignore.
+        if (instanceId.isEmpty()) {
+            return;
+        }
         if (zoneId.isEmpty()) {
             m_byInstance.remove(instanceId);
         } else {

--- a/libs/phosphor-compositor/include/PhosphorCompositor/ZoneCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/ZoneCache.h
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <PhosphorIdentity/WindowId.h>
+
+#include <QHash>
+#include <QString>
+
+namespace PhosphorCompositor {
+
+/**
+ * @brief Compositor-agnostic snap-zone state cache.
+ *
+ * Maps a window to the snap-zone UUID it occupies. A window is "snapped" iff it
+ * has a non-empty zone entry; a floating or unmanaged window carries no entry.
+ * Sibling of @c FloatingCache — together the two describe a window's placement
+ * for the IsSnapped / Zone / IsFloating window-rule match fields.
+ *
+ * Keyed by the STABLE instanceId, not the full composite windowId. A window's
+ * appId can mutate mid-session (Electron / CEF apps rename their window class),
+ * which changes the composite `appId|instanceId` but never the instanceId.
+ * Keying by instanceId keeps a snapped window's zone resolvable across that
+ * rename, so a Zone / IsSnapped rule keeps matching it. All accessors take the
+ * composite windowId and extract the instanceId internally, so callers stay
+ * composite-id-based. A bare appId (no `|` separator) is its own instanceId per
+ * @c extractInstanceId, so it degrades gracefully.
+ */
+class ZoneCache
+{
+public:
+    /// The snap-zone UUID @p windowId occupies, or empty if it occupies none.
+    QString zoneForWindow(const QString& windowId) const
+    {
+        return m_byInstance.value(::PhosphorIdentity::WindowId::extractInstanceId(windowId));
+    }
+
+    /// True iff @p windowId is snapped into a zone (has a non-empty entry).
+    bool isSnapped(const QString& windowId) const
+    {
+        return !m_byInstance.value(::PhosphorIdentity::WindowId::extractInstanceId(windowId)).isEmpty();
+    }
+
+    /// Record @p windowId's zone. An empty @p zoneId removes the entry (the
+    /// window left its zone — unsnapped / floated / screen-changed).
+    void setZone(const QString& windowId, const QString& zoneId)
+    {
+        const QString instanceId = ::PhosphorIdentity::WindowId::extractInstanceId(windowId);
+        if (zoneId.isEmpty()) {
+            m_byInstance.remove(instanceId);
+        } else {
+            m_byInstance.insert(instanceId, zoneId);
+        }
+    }
+
+    void remove(const QString& windowId)
+    {
+        m_byInstance.remove(::PhosphorIdentity::WindowId::extractInstanceId(windowId));
+    }
+
+    void clear()
+    {
+        m_byInstance.clear();
+    }
+
+    int size() const
+    {
+        return m_byInstance.size();
+    }
+
+private:
+    QHash<QString, QString> m_byInstance; ///< stable instanceId → snap-zone UUID
+};
+
+} // namespace PhosphorCompositor

--- a/libs/phosphor-compositor/include/PhosphorCompositor/ZoneCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/ZoneCache.h
@@ -16,7 +16,9 @@ namespace PhosphorCompositor {
  * Maps a window to the snap-zone UUID it occupies. A window is "snapped" iff it
  * has a non-empty zone entry; a floating or unmanaged window carries no entry.
  * Sibling of @c FloatingCache — together the two describe a window's placement
- * for the IsSnapped / Zone / IsFloating window-rule match fields.
+ * for the IsSnapped / Zone / IsFloating window-rule match fields. Both caches key
+ * per-instance state by the stable instanceId (below); FloatingCache additionally
+ * carries an app-wide appId keyspace for rules that float every instance of an app.
  *
  * Keyed by the STABLE instanceId, not the full composite windowId. A window's
  * appId can mutate mid-session (Electron / CEF apps rename their window class),

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -27,11 +27,46 @@ struct WindowMetadata
     QString activity{}; ///< activity UUID; empty = all activities / unknown
     PhosphorProtocol::WindowType windowType = PhosphorProtocol::WindowType::Unknown;
 
+    // ── Extended window properties. The kwin-effect snapshots these at metadata-push
+    // time so the daemon's window-rule resolvers (shouldFloatByRule /
+    // shouldRestoreFloatedPosition) can match the same KWin-property / geometry
+    // fields the effect path resolves live. std::optional so an absent value (the
+    // compositor could not report it — e.g. no underlying KWin::Window) leaves the
+    // corresponding WindowQuery field disengaged, keeping a predicate over it inert,
+    // mirroring window_query.cpp's engage-only-when-known contract. ──
+    std::optional<bool> isMinimized;
+    std::optional<bool> isFullscreen;
+    std::optional<bool> isSticky; ///< on all virtual desktops
+    std::optional<bool> isMaximized; ///< MaximizeFull (both axes)
+    std::optional<bool> isFocused; ///< the active window at snapshot time
+    std::optional<bool> isTransient; ///< dialog/utility/popup/menu/tooltip/splash family or has a transient parent
+    std::optional<bool> isNotification; ///< notification / critical-notification / on-screen-display
+    std::optional<bool> keepAbove;
+    std::optional<bool> keepBelow;
+    std::optional<bool> skipTaskbar;
+    std::optional<bool> skipPager;
+    std::optional<bool> skipSwitcher;
+    std::optional<bool> isModal;
+    std::optional<bool> hasDecoration; ///< server-side title-bar / border
+    std::optional<bool> isResizable;
+    std::optional<int> width; ///< frame width in px
+    std::optional<int> height; ///< frame height in px
+    std::optional<int> positionX; ///< frame left edge X in px
+    std::optional<int> positionY; ///< frame top edge Y in px
+    std::optional<QString> captionNormal; ///< title without the WM-added app-name suffix
+
     bool operator==(const WindowMetadata& other) const
     {
         return appId == other.appId && desktopFile == other.desktopFile && title == other.title
             && windowRole == other.windowRole && pid == other.pid && virtualDesktop == other.virtualDesktop
-            && activity == other.activity && windowType == other.windowType;
+            && activity == other.activity && windowType == other.windowType && isMinimized == other.isMinimized
+            && isFullscreen == other.isFullscreen && isSticky == other.isSticky && isMaximized == other.isMaximized
+            && isFocused == other.isFocused && isTransient == other.isTransient
+            && isNotification == other.isNotification && keepAbove == other.keepAbove && keepBelow == other.keepBelow
+            && skipTaskbar == other.skipTaskbar && skipPager == other.skipPager && skipSwitcher == other.skipSwitcher
+            && isModal == other.isModal && hasDecoration == other.hasDecoration && isResizable == other.isResizable
+            && width == other.width && height == other.height && positionX == other.positionX
+            && positionY == other.positionY && captionNormal == other.captionNormal;
     }
     bool operator!=(const WindowMetadata& other) const
     {

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -38,7 +38,11 @@ struct WindowMetadata
     std::optional<bool> isFullscreen;
     std::optional<bool> isSticky; ///< on all virtual desktops
     std::optional<bool> isMaximized; ///< MaximizeFull (both axes)
-    std::optional<bool> isFocused; ///< the active window at snapshot time
+    std::optional<bool> isFocused; ///< focused at metadata-push time (point-in-time, NOT
+                                   ///< refreshed on focus change) — the open-path Float /
+                                   ///< RestorePosition resolvers read it at window-open, where
+                                   ///< it is fresh; the effect path reads live isFocused for
+                                   ///< continuously-evaluated border / opacity rules.
     std::optional<bool> isTransient; ///< dialog/utility/popup/menu/tooltip/splash family or has a transient parent
     std::optional<bool> isNotification; ///< notification / critical-notification / on-screen-display
     std::optional<bool> keepAbove;

--- a/libs/phosphor-protocol/include/PhosphorProtocol/ServiceConstants.h
+++ b/libs/phosphor-protocol/include/PhosphorProtocol/ServiceConstants.h
@@ -50,6 +50,35 @@ inline constexpr QLatin1String MotionProfileTree("motionProfileTree");
 inline constexpr QLatin1String AnimationShaderSearchPaths("animationShaderSearchPaths");
 }
 
+/// Keys for the extended-window-property QVariantMap (the trailing a{sv} argument
+/// of setWindowMetadata). The kwin-effect packs the live KWin-property / geometry
+/// snapshot under these keys; the daemon unpacks them into WindowMetadata so its
+/// window-rule resolvers match the same fields the effect path resolves. A key is
+/// PRESENT only when the value is known — absence leaves the WindowQuery field
+/// disengaged, mirroring window_query.cpp's engage-only-when-known contract.
+namespace WindowMetadataKey {
+inline constexpr QLatin1String IsMinimized("isMinimized");
+inline constexpr QLatin1String IsFullscreen("isFullscreen");
+inline constexpr QLatin1String IsSticky("isSticky");
+inline constexpr QLatin1String IsMaximized("isMaximized");
+inline constexpr QLatin1String IsFocused("isFocused");
+inline constexpr QLatin1String IsTransient("isTransient");
+inline constexpr QLatin1String IsNotification("isNotification");
+inline constexpr QLatin1String KeepAbove("keepAbove");
+inline constexpr QLatin1String KeepBelow("keepBelow");
+inline constexpr QLatin1String SkipTaskbar("skipTaskbar");
+inline constexpr QLatin1String SkipPager("skipPager");
+inline constexpr QLatin1String SkipSwitcher("skipSwitcher");
+inline constexpr QLatin1String IsModal("isModal");
+inline constexpr QLatin1String HasDecoration("hasDecoration");
+inline constexpr QLatin1String IsResizable("isResizable");
+inline constexpr QLatin1String Width("width");
+inline constexpr QLatin1String Height("height");
+inline constexpr QLatin1String PositionX("positionX");
+inline constexpr QLatin1String PositionY("positionY");
+inline constexpr QLatin1String CaptionNormal("captionNormal");
+}
+
 /// Single-instance app identities. Each Phosphor sub-process (settings,
 /// editor) advertises its own service name and a small controller object so
 /// the launcher can detect "already running" without scanning the bus.
@@ -87,10 +116,13 @@ inline constexpr QLatin1String Interface("org.plasmazones.EditorController");
 //       peers fail the bridge handshake instead of producing
 //       method-not-found at first thumbnail post.
 //   v4: setWindowMetadata widened from 4 args (instanceId, appId,
-//       desktopFile, title) to 9 (adds windowRole, pid, virtualDesktop,
-//       activity, windowType). A stale effect sending the old 4-arg form
-//       would fail marshalling, so the bridge handshake rejects mismatched
-//       peers up front.
+//       desktopFile, title) to 10: adds windowRole, pid, virtualDesktop,
+//       activity, windowType, plus a trailing a{sv} (QVariantMap) carrying the
+//       extended window-property snapshot (state flags, geometry, accessory
+//       flags, captionNormal — see WindowMetadataKey) so the daemon's
+//       window-rule resolvers match the same KWin-property fields the effect
+//       path resolves live. A stale effect sending an older form would fail
+//       marshalling, so the bridge handshake rejects mismatched peers up front.
 //
 inline constexpr int ApiVersion = 4;
 inline constexpr int MinPeerApiVersion = 4;

--- a/libs/phosphor-protocol/include/PhosphorProtocol/WindowTypes.h
+++ b/libs/phosphor-protocol/include/PhosphorProtocol/WindowTypes.h
@@ -82,6 +82,19 @@ struct WindowStateEntry
     QString changeType; ///< "snapped", "unsnapped", "floated", "unfloated", "screen_changed"
     QStringList zoneIds; ///< D-Bus type 'as' — all zone IDs for multi-zone span (query only)
     bool isSticky = false; ///< Whether window is on all virtual desktops (query only)
+
+    /// Returns empty QString if valid, else a human-readable description of the
+    /// invariant violation. Called at the windowStateChanged unmarshal site (like
+    /// DragPolicy / BridgeRegistrationResult on their paths) so a garbled entry —
+    /// one naming no window — can't perturb the effect's zone cache. zoneId is
+    /// intentionally unchecked: empty is the valid "unsnapped / floated" signal.
+    QString validationError() const
+    {
+        if (windowId.isEmpty()) {
+            return QStringLiteral("WindowStateEntry: empty windowId");
+        }
+        return QString();
+    }
 };
 
 using WindowStateList = QList<WindowStateEntry>;

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -175,6 +175,22 @@ public:
         m_restorePositionPredicate = std::move(predicate);
     }
 
+    /**
+     * @brief Predicate deciding whether an opening window should start FLOATING
+     *        because a "Float this app" window rule matched it. Daemon-injected,
+     *        keyed by the live windowId, evaluated on the window-open path. When
+     *        UNSET (default) no window is rule-floated and the engine keeps its
+     *        historical open behaviour (path unit tests rely on this). Same
+     *        lifetime contract as setRestorePositionPredicate — clear with `{}`
+     *        before destroying any state the closure captured.
+     */
+    using FloatPredicate = std::function<bool(const QString& windowId)>;
+
+    void setFloatPredicate(FloatPredicate predicate)
+    {
+        m_floatPredicate = std::move(predicate);
+    }
+
     void windowClosed(const QString& windowId) override;
     void windowFocused(const QString& windowId, const QString& screenId) override;
     void toggleWindowFloat(const QString& windowId, const QString& screenId) override;
@@ -725,6 +741,10 @@ private:
     // only on the reopening screen — the historical behaviour unit tests rely on.
     // See RestorePositionPredicate doc above.
     RestorePositionPredicate m_restorePositionPredicate{};
+
+    // Rule-driven open-floating gate. Empty until the daemon wires it; while
+    // empty no window is rule-floated. See FloatPredicate doc above.
+    FloatPredicate m_floatPredicate{};
 };
 
 } // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -424,8 +424,10 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
 
     // A matched "Float this app" window rule opens the window floating, exactly
     // as if the user had toggled float. Runs after the exclusion gate (excluded
-    // windows return earlier) and the already-floating guard, before the
-    // auto-snap chain — so a rule-floated window never auto-snaps to a zone.
+    // windows return earlier), the already-floating guard, and the persisted-
+    // placement restore (a window the user previously snapped reopens snapped —
+    // that restore returns before reaching here), but before the auto-snap chain —
+    // so a rule-floated window never auto-snaps to a zone.
     // Mirrors the no-match default-float terminal at the end of this function.
     if (m_floatPredicate && m_floatPredicate(windowId)) {
         m_snapState->setFloatingOnScreen(windowId, screenId, currentVirtualDesktop());

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -422,6 +422,18 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
         return SnapResult::noSnap();
     }
 
+    // A matched "Float this app" window rule opens the window floating, exactly
+    // as if the user had toggled float. Runs after the exclusion gate (excluded
+    // windows return earlier) and the already-floating guard, before the
+    // auto-snap chain — so a rule-floated window never auto-snaps to a zone.
+    // Mirrors the no-match default-float terminal at the end of this function.
+    if (m_floatPredicate && m_floatPredicate(windowId)) {
+        m_snapState->setFloatingOnScreen(windowId, screenId, currentVirtualDesktop());
+        Q_EMIT windowFloatingChanged(windowId, true, screenId);
+        qCInfo(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore:" << windowId << "floated by rule";
+        return SnapResult::noSnap();
+    }
+
     // 1. App rules (highest priority). May cross-screen migrate.
     {
         SnapResult result = calculateSnapToAppRule(windowId, screenId, sticky);

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -449,6 +449,21 @@ public:
         m_restorePositionPredicate = std::move(predicate);
     }
 
+    /**
+     * Predicate deciding whether an opening window should start FLOATING because a
+     * "Float this app" window rule matched it. Daemon-injected, keyed by the live
+     * windowId. The window is still inserted (so it stays managed and Meta+F can
+     * re-tile it); it is just marked floating, identical to a manual float. When
+     * UNSET (default) no window is rule-floated. Clear with `{}` before destroying
+     * any state the closure captured.
+     */
+    using FloatPredicate = std::function<bool(const QString& windowId)>;
+
+    void setFloatPredicate(FloatPredicate predicate)
+    {
+        m_floatPredicate = std::move(predicate);
+    }
+
     // Cross-engine handoff (see PhosphorEngine/IPlacementEngine.h for contract)
     QString engineId() const override
     {
@@ -1311,6 +1326,10 @@ private:
     // the engine always re-applies a floated window's recorded position (historical
     // behaviour). See RestorePositionPredicate doc above.
     RestorePositionPredicate m_restorePositionPredicate{};
+
+    // Rule-driven open-floating gate. Empty until the daemon wires it; while empty
+    // no window is rule-floated. See FloatPredicate doc above.
+    FloatPredicate m_floatPredicate{};
 
     QSet<QString> m_autotileScreens;
     QString m_algorithmId;

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1047,6 +1047,11 @@ private Q_SLOTS:
 private:
     void connectSignals();
     bool insertWindow(const QString& windowId, const QString& screenId);
+    // Passive float-state sync after insertWindow() places a window: notify the
+    // daemon it opened floating (matched Float rule / restored saved float), or
+    // clear a stale WTS float when it was placed tiled. Shared by onWindowAdded
+    // and backfillWindows so the two cannot diverge.
+    void emitInsertFloatStateSync(const QString& windowId, const QString& screenId);
     void removeWindow(const QString& windowId);
 
     /// Algorithm lifecycle REMOVE hook + state removal for a tracked window,

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -2489,23 +2489,8 @@ void AutotileEngine::onWindowAdded(const QString& windowId)
 
     const bool inserted = insertWindow(windowId, screenId);
 
-    // Sync floating state to daemon. Float state is per-mode:
-    // - Restored as floating from autotile's saved set → notify daemon to set WTS floating
-    // - Inserted as tiled but WTS says floating (stale snap-mode float) → clear WTS floating
-    //
-    // Use windowFloatingStateSynced (not windowFloatingChanged): this is a
-    // passive state-sync on window insertion, not a user float toggle. The
-    // daemon must NOT restore pre-tile geometry here — the window was just
-    // added (e.g. dropped onto an autotile VS from a snap VS) and already
-    // has a valid position. Routing through windowFloatingChanged causes
-    // syncAutotileFloatState to call applyGeometryForFloat, which teleports
-    // the window to a cross-screen-adjusted rect and resizes it.
-    if (inserted && state) {
-        if (state->isFloating(windowId)) {
-            Q_EMIT windowFloatingStateSynced(windowId, true, screenId);
-        } else if (m_windowTracker && m_windowTracker->isWindowFloating(windowId)) {
-            Q_EMIT windowFloatingStateSynced(windowId, false, screenId);
-        }
+    if (inserted) {
+        emitInsertFloatStateSync(windowId, screenId);
     }
 
     if (inserted && m_config && m_config->focusNewWindows) {
@@ -2621,6 +2606,30 @@ void AutotileEngine::onLayoutChanged(PhosphorZones::Layout* layout)
 // ═══════════════════════════════════════════════════════════════════════════════
 // Internal implementation
 // ═══════════════════════════════════════════════════════════════════════════════
+
+void AutotileEngine::emitInsertFloatStateSync(const QString& windowId, const QString& screenId)
+{
+    PhosphorTiles::TilingState* state = tilingStateForScreen(screenId);
+    if (!state) {
+        return;
+    }
+    // Sync floating state to daemon. Float state is per-mode:
+    // - Restored as floating from autotile's saved set → notify daemon to set WTS floating
+    // - Inserted as tiled but WTS says floating (stale snap-mode float) → clear WTS floating
+    //
+    // Use windowFloatingStateSynced (not windowFloatingChanged): this is a
+    // passive state-sync on window insertion, not a user float toggle. The
+    // daemon must NOT restore pre-tile geometry here — the window was just
+    // added (e.g. dropped onto an autotile VS from a snap VS) and already
+    // has a valid position. Routing through windowFloatingChanged causes
+    // syncAutotileFloatState to call applyGeometryForFloat, which teleports
+    // the window to a cross-screen-adjusted rect and resizes it.
+    if (state->isFloating(windowId)) {
+        Q_EMIT windowFloatingStateSynced(windowId, true, screenId);
+    } else if (m_windowTracker && m_windowTracker->isWindowFloating(windowId)) {
+        Q_EMIT windowFloatingStateSynced(windowId, false, screenId);
+    }
+}
 
 bool AutotileEngine::insertWindow(const QString& windowId, const QString& screenId)
 {
@@ -3701,7 +3710,17 @@ void AutotileEngine::backfillWindows()
             }
         }
         for (const QString& windowId : candidates) {
-            insertWindow(windowId, screenId);
+            const bool inserted = insertWindow(windowId, screenId);
+            // Same passive float-state sync onWindowAdded does: a window that
+            // insertWindow floats here (matched Float rule / restored saved float)
+            // — or whose stale WTS float must be cleared because it was placed
+            // tiled — would otherwise desync from the daemon until its next add.
+            // emitInsertFloatStateSync uses windowFloatingStateSynced (NOT
+            // windowFloatingChanged), so it applies no geometry and cannot drive
+            // the mid-transition feedback loop the overflow-recovery note warns of.
+            if (inserted) {
+                emitInsertFloatStateSync(windowId, screenId);
+            }
             if (state->tiledWindowCount() >= maxWin) {
                 break;
             }

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -2832,6 +2832,16 @@ bool AutotileEngine::insertWindow(const QString& windowId, const QString& screen
     // parallel saved-floating set — the WindowPlacement record is the single
     // source of truth for cross-mode float state.
 
+    // A matched "Float this app" window rule opens the window floating: it is
+    // inserted above (so it stays managed and Meta+F can re-tile it), then marked
+    // floating here, identical to a manual float toggle. Guarded on not-already-
+    // floating so the placement-record float-restore branch above is not
+    // re-applied. onWindowAdded then emits windowFloatingStateSynced so the daemon
+    // mirrors the state.
+    if (m_floatPredicate && !state->isFloating(windowId) && m_floatPredicate(windowId)) {
+        state->setFloating(windowId, true);
+    }
+
     m_windowToStateKey.insert(windowId, currentKey);
     return true;
 }

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -2476,7 +2476,13 @@ void AutotileEngine::onWindowAdded(const QString& windowId)
 
     PhosphorTiles::TilingState* state = tilingStateForScreen(screenId);
     const int maxWin = effectiveMaxWindows(screenId);
-    if (state && state->tiledWindowCount() >= maxWin) {
+    // A window matched by a "Float this app" rule must bypass the tiled-window
+    // cap: it opens floating and so consumes no tile slot (tiledWindowCount
+    // excludes floats), and insertWindow marks it floating once inserted. Dropping
+    // it here would leave it untracked — neither floating in autotile (so the
+    // IsFloating match field stays false) nor re-tileable via Meta+F.
+    const bool ruleWillFloat = m_floatPredicate && m_floatPredicate(windowId);
+    if (state && state->tiledWindowCount() >= maxWin && !ruleWillFloat) {
         qCDebug(PhosphorTileEngine::lcTileEngine)
             << "Max window limit reached for screen" << screenId << "(max=" << maxWin << ")";
         // Purge this window from pending initial orders so the order doesn't
@@ -2609,7 +2615,10 @@ void AutotileEngine::onLayoutChanged(PhosphorZones::Layout* layout)
 
 void AutotileEngine::emitInsertFloatStateSync(const QString& windowId, const QString& screenId)
 {
-    PhosphorTiles::TilingState* state = tilingStateForScreen(screenId);
+    // Read-only lookup — must NOT lazily materialize a state. tilingStateForScreen
+    // would create one for a known-but-stateless screen; this method only reads
+    // isFloating right after a successful insertWindow, so the state already exists.
+    PhosphorTiles::TilingState* state = m_screenStates.value(currentKeyForScreen(screenId));
     if (!state) {
         return;
     }

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/MatchTypes.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/MatchTypes.h
@@ -42,12 +42,26 @@ enum class Field : int {
     // Window geometry (numeric)
     Width = 17, ///< frame width in px
     Height = 18, ///< frame height in px
+    // Window stacking / accessory state (appended — append-only for value stability)
+    KeepAbove = 19, ///< window set to stay above others (always on top)
+    KeepBelow = 20, ///< window set to stay below others
+    SkipTaskbar = 21, ///< hidden from the taskbar
+    SkipPager = 22, ///< hidden from the pager
+    SkipSwitcher = 23, ///< hidden from the window switcher (Alt+Tab)
+    IsModal = 24, ///< modal dialog
+    HasDecoration = 25, ///< has a server-side title-bar / border
+    IsResizable = 26, ///< window can be resized
+    // Window geometry (numeric) — position
+    PositionX = 27, ///< frame left edge X in px
+    PositionY = 28, ///< frame top edge Y in px
+    // Window content
+    CaptionNormal = 29, ///< title without the WM-added application-name suffix
 };
 
 /// The number of distinct `Field` enumerators. `Field` is a contiguous range
 /// `[0, FieldCount)`; bump this whenever an enumerator is added — round-trip
 /// tests iterate the range using it as the upper bound.
-inline constexpr int FieldCount = static_cast<int>(Field::Height) + 1;
+inline constexpr int FieldCount = static_cast<int>(Field::CaptionNormal) + 1;
 
 /// Match operators. Not every operator is valid against every field —
 /// validity is enforced by Predicate::isValid(), not the parser.
@@ -109,6 +123,28 @@ inline QString fieldToString(Field field)
         return QStringLiteral("width");
     case Field::Height:
         return QStringLiteral("height");
+    case Field::KeepAbove:
+        return QStringLiteral("keepAbove");
+    case Field::KeepBelow:
+        return QStringLiteral("keepBelow");
+    case Field::SkipTaskbar:
+        return QStringLiteral("skipTaskbar");
+    case Field::SkipPager:
+        return QStringLiteral("skipPager");
+    case Field::SkipSwitcher:
+        return QStringLiteral("skipSwitcher");
+    case Field::IsModal:
+        return QStringLiteral("isModal");
+    case Field::HasDecoration:
+        return QStringLiteral("hasDecoration");
+    case Field::IsResizable:
+        return QStringLiteral("isResizable");
+    case Field::PositionX:
+        return QStringLiteral("positionX");
+    case Field::PositionY:
+        return QStringLiteral("positionY");
+    case Field::CaptionNormal:
+        return QStringLiteral("captionNormal");
     }
     return QStringLiteral("appId");
 }
@@ -137,6 +173,17 @@ inline std::optional<Field> fieldFromString(QStringView s)
         {QLatin1StringView("isNotification"), Field::IsNotification},
         {QLatin1StringView("width"), Field::Width},
         {QLatin1StringView("height"), Field::Height},
+        {QLatin1StringView("keepAbove"), Field::KeepAbove},
+        {QLatin1StringView("keepBelow"), Field::KeepBelow},
+        {QLatin1StringView("skipTaskbar"), Field::SkipTaskbar},
+        {QLatin1StringView("skipPager"), Field::SkipPager},
+        {QLatin1StringView("skipSwitcher"), Field::SkipSwitcher},
+        {QLatin1StringView("isModal"), Field::IsModal},
+        {QLatin1StringView("hasDecoration"), Field::HasDecoration},
+        {QLatin1StringView("isResizable"), Field::IsResizable},
+        {QLatin1StringView("positionX"), Field::PositionX},
+        {QLatin1StringView("positionY"), Field::PositionY},
+        {QLatin1StringView("captionNormal"), Field::CaptionNormal},
     };
     for (const auto& [token, field] : kTable) {
         if (s.compare(token, Qt::CaseInsensitive) == 0) {
@@ -206,6 +253,7 @@ inline bool fieldIsString(Field field)
     case Field::Title:
     case Field::ScreenId:
     case Field::Activity:
+    case Field::CaptionNormal:
         return true;
     case Field::Pid:
     case Field::VirtualDesktop:
@@ -219,6 +267,16 @@ inline bool fieldIsString(Field field)
     case Field::IsNotification:
     case Field::Width:
     case Field::Height:
+    case Field::KeepAbove:
+    case Field::KeepBelow:
+    case Field::SkipTaskbar:
+    case Field::SkipPager:
+    case Field::SkipSwitcher:
+    case Field::IsModal:
+    case Field::HasDecoration:
+    case Field::IsResizable:
+    case Field::PositionX:
+    case Field::PositionY:
         return false;
     }
     return false;
@@ -227,7 +285,8 @@ inline bool fieldIsString(Field field)
 /// True if @p field carries a numeric value (Pid / VirtualDesktop / Width / Height).
 inline bool fieldIsNumeric(Field field)
 {
-    return field == Field::Pid || field == Field::VirtualDesktop || field == Field::Width || field == Field::Height;
+    return field == Field::Pid || field == Field::VirtualDesktop || field == Field::Width || field == Field::Height
+        || field == Field::PositionX || field == Field::PositionY;
 }
 
 /// True if @p field carries a boolean value (window-state flags).
@@ -235,7 +294,9 @@ inline bool fieldIsBool(Field field)
 {
     return field == Field::IsSticky || field == Field::IsFullscreen || field == Field::IsMinimized
         || field == Field::IsMaximized || field == Field::IsFocused || field == Field::IsTransient
-        || field == Field::IsNotification;
+        || field == Field::IsNotification || field == Field::KeepAbove || field == Field::KeepBelow
+        || field == Field::SkipTaskbar || field == Field::SkipPager || field == Field::SkipSwitcher
+        || field == Field::IsModal || field == Field::HasDecoration || field == Field::IsResizable;
 }
 
 /// True if @p field describes the **context** a window appears in

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/MatchTypes.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/MatchTypes.h
@@ -80,8 +80,8 @@ enum class Operator : int {
     Regex = 4, ///< QRegularExpression, precompiled & cached per predicate
     AppIdMatches = 5, ///< segment-aware reverse-DNS match (AppId only)
     In = 6, ///< value is a set; membership test
-    GreaterThan = 7, ///< numeric compare (Pid / VirtualDesktop / Width / Height)
-    LessThan = 8, ///< numeric compare (Pid / VirtualDesktop / Width / Height)
+    GreaterThan = 7, ///< numeric compare (Pid / VirtualDesktop / Width / Height / PositionX / PositionY)
+    LessThan = 8, ///< numeric compare (Pid / VirtualDesktop / Width / Height / PositionX / PositionY)
 };
 
 /// The number of distinct `Operator` enumerators. `Operator` is a contiguous
@@ -301,7 +301,8 @@ inline bool fieldIsString(Field field)
     return false;
 }
 
-/// True if @p field carries a numeric value (Pid / VirtualDesktop / Width / Height).
+/// True if @p field carries a numeric value
+/// (Pid / VirtualDesktop / Width / Height / PositionX / PositionY).
 inline bool fieldIsNumeric(Field field)
 {
     return field == Field::Pid || field == Field::VirtualDesktop || field == Field::Width || field == Field::Height

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/MatchTypes.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/MatchTypes.h
@@ -56,12 +56,19 @@ enum class Field : int {
     PositionY = 28, ///< frame top edge Y in px
     // Window content
     CaptionNormal = 29, ///< title without the WM-added application-name suffix
+    // PlasmaZones placement state (snap-mode semantics; see WindowQuery population).
+    // IsFloating covers both snap- and autotile-floated windows; IsSnapped / Zone
+    // reflect snap-mode zone membership only — autotile tiles carry no persistent
+    // zone UUID, so they are neither IsSnapped nor matched by Zone.
+    IsFloating = 30, ///< window floated out of tiling (snap or autotile)
+    IsSnapped = 31, ///< window occupies a snap zone
+    Zone = 32, ///< the snap zone's UUID the window occupies
 };
 
 /// The number of distinct `Field` enumerators. `Field` is a contiguous range
 /// `[0, FieldCount)`; bump this whenever an enumerator is added — round-trip
 /// tests iterate the range using it as the upper bound.
-inline constexpr int FieldCount = static_cast<int>(Field::CaptionNormal) + 1;
+inline constexpr int FieldCount = static_cast<int>(Field::Zone) + 1;
 
 /// Match operators. Not every operator is valid against every field —
 /// validity is enforced by Predicate::isValid(), not the parser.
@@ -145,6 +152,12 @@ inline QString fieldToString(Field field)
         return QStringLiteral("positionY");
     case Field::CaptionNormal:
         return QStringLiteral("captionNormal");
+    case Field::IsFloating:
+        return QStringLiteral("isFloating");
+    case Field::IsSnapped:
+        return QStringLiteral("isSnapped");
+    case Field::Zone:
+        return QStringLiteral("zone");
     }
     return QStringLiteral("appId");
 }
@@ -184,6 +197,9 @@ inline std::optional<Field> fieldFromString(QStringView s)
         {QLatin1StringView("positionX"), Field::PositionX},
         {QLatin1StringView("positionY"), Field::PositionY},
         {QLatin1StringView("captionNormal"), Field::CaptionNormal},
+        {QLatin1StringView("isFloating"), Field::IsFloating},
+        {QLatin1StringView("isSnapped"), Field::IsSnapped},
+        {QLatin1StringView("zone"), Field::Zone},
     };
     for (const auto& [token, field] : kTable) {
         if (s.compare(token, Qt::CaseInsensitive) == 0) {
@@ -254,6 +270,7 @@ inline bool fieldIsString(Field field)
     case Field::ScreenId:
     case Field::Activity:
     case Field::CaptionNormal:
+    case Field::Zone:
         return true;
     case Field::Pid:
     case Field::VirtualDesktop:
@@ -277,6 +294,8 @@ inline bool fieldIsString(Field field)
     case Field::IsResizable:
     case Field::PositionX:
     case Field::PositionY:
+    case Field::IsFloating:
+    case Field::IsSnapped:
         return false;
     }
     return false;
@@ -296,7 +315,8 @@ inline bool fieldIsBool(Field field)
         || field == Field::IsMaximized || field == Field::IsFocused || field == Field::IsTransient
         || field == Field::IsNotification || field == Field::KeepAbove || field == Field::KeepBelow
         || field == Field::SkipTaskbar || field == Field::SkipPager || field == Field::SkipSwitcher
-        || field == Field::IsModal || field == Field::HasDecoration || field == Field::IsResizable;
+        || field == Field::IsModal || field == Field::HasDecoration || field == Field::IsResizable
+        || field == Field::IsFloating || field == Field::IsSnapped;
 }
 
 /// True if @p field describes the **context** a window appears in

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/RuleEvaluator.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/RuleEvaluator.h
@@ -149,6 +149,15 @@ public:
     /// is bounded — see the class doc for the eviction policy.
     ResolvedActions resolveCached(const QString& windowId, const WindowQuery& query) const;
 
+    /// Peek the match cache without resolving: returns the cached verdict for
+    /// @p windowId iff one exists at the CURRENT rule-set revision, else nullopt.
+    /// Lets a hot-path caller (per-frame paint resolvers) skip building the
+    /// WindowQuery entirely on a cache hit — the cached verdict already reflects
+    /// whatever query produced it, and the query is ignored by resolveCached on a
+    /// hit anyway. A stale-revision entry reads as a miss (nullopt) here; it is
+    /// pruned lazily on the next resolveCached call, not by this read-only peek.
+    std::optional<ResolvedActions> resolveCachedIfPresent(const QString& windowId) const;
+
     /// True if at least one enabled rule matches @p query — an existence
     /// test that does not allocate a ResolvedActions. Used by hot paths that
     /// only need a yes/no ("does any rule re-enable this class"). Iterates in

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/WindowQuery.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/WindowQuery.h
@@ -45,6 +45,17 @@ struct WindowQuery
     std::optional<bool> isNotification; ///< notification / critical-notification / on-screen-display surface
     std::optional<int> width; ///< frame width in px
     std::optional<int> height; ///< frame height in px
+    std::optional<bool> keepAbove; ///< window set to stay above others
+    std::optional<bool> keepBelow; ///< window set to stay below others
+    std::optional<bool> skipTaskbar; ///< hidden from the taskbar
+    std::optional<bool> skipPager; ///< hidden from the pager
+    std::optional<bool> skipSwitcher; ///< hidden from the window switcher
+    std::optional<bool> isModal; ///< modal dialog
+    std::optional<bool> hasDecoration; ///< has a server-side title-bar / border
+    std::optional<bool> isResizable; ///< window can be resized
+    std::optional<int> positionX; ///< frame left edge X in px
+    std::optional<int> positionY; ///< frame top edge Y in px
+    std::optional<QString> captionNormal; ///< title without the WM-added app-name suffix
 
     // ── Context attributes — always present ──
     QString screenId;
@@ -58,7 +69,10 @@ struct WindowQuery
         return appId.has_value() || windowClass.has_value() || title.has_value() || windowRole.has_value()
             || desktopFile.has_value() || pid.has_value() || windowType.has_value() || isSticky.has_value()
             || isFullscreen.has_value() || isMinimized.has_value() || isMaximized.has_value() || isFocused.has_value()
-            || isTransient.has_value() || isNotification.has_value() || width.has_value() || height.has_value();
+            || isTransient.has_value() || isNotification.has_value() || width.has_value() || height.has_value()
+            || keepAbove.has_value() || keepBelow.has_value() || skipTaskbar.has_value() || skipPager.has_value()
+            || skipSwitcher.has_value() || isModal.has_value() || hasDecoration.has_value() || isResizable.has_value()
+            || positionX.has_value() || positionY.has_value() || captionNormal.has_value();
     }
 
     /**
@@ -113,6 +127,28 @@ struct WindowQuery
             return width ? std::optional<QVariant>(*width) : std::nullopt;
         case Field::Height:
             return height ? std::optional<QVariant>(*height) : std::nullopt;
+        case Field::KeepAbove:
+            return keepAbove ? std::optional<QVariant>(*keepAbove) : std::nullopt;
+        case Field::KeepBelow:
+            return keepBelow ? std::optional<QVariant>(*keepBelow) : std::nullopt;
+        case Field::SkipTaskbar:
+            return skipTaskbar ? std::optional<QVariant>(*skipTaskbar) : std::nullopt;
+        case Field::SkipPager:
+            return skipPager ? std::optional<QVariant>(*skipPager) : std::nullopt;
+        case Field::SkipSwitcher:
+            return skipSwitcher ? std::optional<QVariant>(*skipSwitcher) : std::nullopt;
+        case Field::IsModal:
+            return isModal ? std::optional<QVariant>(*isModal) : std::nullopt;
+        case Field::HasDecoration:
+            return hasDecoration ? std::optional<QVariant>(*hasDecoration) : std::nullopt;
+        case Field::IsResizable:
+            return isResizable ? std::optional<QVariant>(*isResizable) : std::nullopt;
+        case Field::PositionX:
+            return positionX ? std::optional<QVariant>(*positionX) : std::nullopt;
+        case Field::PositionY:
+            return positionY ? std::optional<QVariant>(*positionY) : std::nullopt;
+        case Field::CaptionNormal:
+            return captionNormal ? std::optional<QVariant>(*captionNormal) : std::nullopt;
         }
         return std::nullopt;
     }

--- a/libs/phosphor-windowrule/include/PhosphorWindowRule/WindowQuery.h
+++ b/libs/phosphor-windowrule/include/PhosphorWindowRule/WindowQuery.h
@@ -56,6 +56,9 @@ struct WindowQuery
     std::optional<int> positionX; ///< frame left edge X in px
     std::optional<int> positionY; ///< frame top edge Y in px
     std::optional<QString> captionNormal; ///< title without the WM-added app-name suffix
+    std::optional<bool> isFloating; ///< floated out of tiling (snap or autotile)
+    std::optional<bool> isSnapped; ///< occupies a snap zone (snap mode only)
+    std::optional<QString> zone; ///< the snap zone's UUID the window occupies
 
     // ── Context attributes — always present ──
     QString screenId;
@@ -72,7 +75,8 @@ struct WindowQuery
             || isTransient.has_value() || isNotification.has_value() || width.has_value() || height.has_value()
             || keepAbove.has_value() || keepBelow.has_value() || skipTaskbar.has_value() || skipPager.has_value()
             || skipSwitcher.has_value() || isModal.has_value() || hasDecoration.has_value() || isResizable.has_value()
-            || positionX.has_value() || positionY.has_value() || captionNormal.has_value();
+            || positionX.has_value() || positionY.has_value() || captionNormal.has_value() || isFloating.has_value()
+            || isSnapped.has_value() || zone.has_value();
     }
 
     /**
@@ -149,6 +153,12 @@ struct WindowQuery
             return positionY ? std::optional<QVariant>(*positionY) : std::nullopt;
         case Field::CaptionNormal:
             return captionNormal ? std::optional<QVariant>(*captionNormal) : std::nullopt;
+        case Field::IsFloating:
+            return isFloating ? std::optional<QVariant>(*isFloating) : std::nullopt;
+        case Field::IsSnapped:
+            return isSnapped ? std::optional<QVariant>(*isSnapped) : std::nullopt;
+        case Field::Zone:
+            return zone ? std::optional<QVariant>(*zone) : std::nullopt;
         }
         return std::nullopt;
     }

--- a/libs/phosphor-windowrule/src/matchexpression.cpp
+++ b/libs/phosphor-windowrule/src/matchexpression.cpp
@@ -350,7 +350,7 @@ bool MatchExpression::evaluateLeaf(const WindowQuery& query) const
         return subject.toBool() == value.toBool();
     }
 
-    // ── Numeric fields (Pid / VirtualDesktop / Width / Height) ──
+    // ── Numeric fields (Pid / VirtualDesktop / Width / Height / PositionX / PositionY) ──
     if (fieldIsNumeric(m_predicate.field)) {
         const int lhs = subject.toInt();
         const int rhs = value.toInt();

--- a/libs/phosphor-windowrule/src/ruleevaluator.cpp
+++ b/libs/phosphor-windowrule/src/ruleevaluator.cpp
@@ -215,6 +215,15 @@ ResolvedActions RuleEvaluator::resolveCached(const QString& windowId, const Wind
     return result;
 }
 
+std::optional<ResolvedActions> RuleEvaluator::resolveCachedIfPresent(const QString& windowId) const
+{
+    const auto it = m_cache.constFind(windowId);
+    if (it != m_cache.constEnd() && it->revision == m_ruleSet.revision()) {
+        return it->actions;
+    }
+    return std::nullopt;
+}
+
 void RuleEvaluator::clearCache() const
 {
     m_cache.clear();

--- a/libs/phosphor-windowrule/tests/test_matchexpression.cpp
+++ b/libs/phosphor-windowrule/tests/test_matchexpression.cpp
@@ -182,6 +182,52 @@ private Q_SLOTS:
         QVERIFY(!MatchExpression::makeLeaf(Field::Width, Operator::Contains, QStringLiteral("25")).isValid());
     }
 
+    // Leaf evaluation for the KWin-property / geometry / placement-state fields
+    // added in this PR — confirms each routes through the right operator branch
+    // (bool Equals-only, numeric GT/LT/Equals incl. a negative coordinate, string
+    // ops) and that an absent field stays inert (the windowless-context contract).
+    void testNewMatchFields_evaluateLeaf()
+    {
+        WindowQuery q;
+        q.appId = QStringLiteral("firefox");
+        q.positionX = 1920;
+        q.positionY = -40; // monitor stacked above the primary
+        q.isModal = true;
+        q.keepAbove = false;
+        q.captionNormal = QStringLiteral("Save As");
+        q.zone = QStringLiteral("{a1b2c3d4-0000-0000-0000-000000000001}");
+        q.isFloating = true;
+        q.isSnapped = false;
+
+        // Numeric position fields (including a negative coordinate).
+        QVERIFY(MatchExpression::makeLeaf(Field::PositionX, Operator::GreaterThan, 1000).evaluate(q));
+        QVERIFY(MatchExpression::makeLeaf(Field::PositionX, Operator::Equals, 1920).evaluate(q));
+        QVERIFY(MatchExpression::makeLeaf(Field::PositionY, Operator::LessThan, 0).evaluate(q));
+
+        // Bool state / accessory / placement fields — only Equals is meaningful.
+        QVERIFY(MatchExpression::makeLeaf(Field::IsModal, Operator::Equals, true).evaluate(q));
+        QVERIFY(!MatchExpression::makeLeaf(Field::IsModal, Operator::Equals, false).evaluate(q));
+        QVERIFY(MatchExpression::makeLeaf(Field::KeepAbove, Operator::Equals, false).evaluate(q));
+        QVERIFY(MatchExpression::makeLeaf(Field::IsFloating, Operator::Equals, true).evaluate(q));
+        QVERIFY(MatchExpression::makeLeaf(Field::IsSnapped, Operator::Equals, false).evaluate(q));
+
+        // String fields.
+        QVERIFY(
+            MatchExpression::makeLeaf(Field::CaptionNormal, Operator::Contains, QStringLiteral("Save")).evaluate(q));
+        QVERIFY(MatchExpression::makeLeaf(Field::Zone, Operator::Equals,
+                                          QStringLiteral("{a1b2c3d4-0000-0000-0000-000000000001}"))
+                    .evaluate(q));
+
+        // Absent field → predicate inert (false), even though appId is present.
+        WindowQuery bare;
+        bare.appId = QStringLiteral("firefox");
+        QVERIFY(!MatchExpression::makeLeaf(Field::IsModal, Operator::Equals, true).evaluate(bare));
+        QVERIFY(!MatchExpression::makeLeaf(Field::PositionX, Operator::GreaterThan, 0).evaluate(bare));
+        QVERIFY(!MatchExpression::makeLeaf(Field::Zone, Operator::Equals,
+                                           QStringLiteral("{a1b2c3d4-0000-0000-0000-000000000001}"))
+                     .evaluate(bare));
+    }
+
     void testWindowTypeField()
     {
         const auto expr =

--- a/libs/phosphor-windowrule/tests/test_matchtypes.cpp
+++ b/libs/phosphor-windowrule/tests/test_matchtypes.cpp
@@ -18,7 +18,7 @@ private Q_SLOTS:
         // Canary: the loop bound is derived from FieldCount, not hard-coded.
         // If this fails, an enumerator was added/removed without updating
         // FieldCount in MatchTypes.h.
-        QCOMPARE(FieldCount, 19);
+        QCOMPARE(FieldCount, 30);
         QTest::addColumn<int>("fieldValue");
         for (int v = 0; v < FieldCount; ++v) {
             QTest::addRow("field-%d", v) << v;

--- a/libs/phosphor-windowrule/tests/test_matchtypes.cpp
+++ b/libs/phosphor-windowrule/tests/test_matchtypes.cpp
@@ -18,7 +18,7 @@ private Q_SLOTS:
         // Canary: the loop bound is derived from FieldCount, not hard-coded.
         // If this fails, an enumerator was added/removed without updating
         // FieldCount in MatchTypes.h.
-        QCOMPARE(FieldCount, 30);
+        QCOMPARE(FieldCount, 33);
         QTest::addColumn<int>("fieldValue");
         for (int v = 0; v < FieldCount; ++v) {
             QTest::addRow("field-%d", v) << v;

--- a/libs/phosphor-windowrule/tests/test_matchtypes.cpp
+++ b/libs/phosphor-windowrule/tests/test_matchtypes.cpp
@@ -125,6 +125,20 @@ private Q_SLOTS:
         QVERIFY(!fieldIsContext(Field::IsNotification));
         QVERIFY(!fieldIsContext(Field::Width));
         QVERIFY(!fieldIsContext(Field::Height));
+        QVERIFY(!fieldIsContext(Field::KeepAbove));
+        QVERIFY(!fieldIsContext(Field::KeepBelow));
+        QVERIFY(!fieldIsContext(Field::SkipTaskbar));
+        QVERIFY(!fieldIsContext(Field::SkipPager));
+        QVERIFY(!fieldIsContext(Field::SkipSwitcher));
+        QVERIFY(!fieldIsContext(Field::IsModal));
+        QVERIFY(!fieldIsContext(Field::HasDecoration));
+        QVERIFY(!fieldIsContext(Field::IsResizable));
+        QVERIFY(!fieldIsContext(Field::PositionX));
+        QVERIFY(!fieldIsContext(Field::PositionY));
+        QVERIFY(!fieldIsContext(Field::CaptionNormal));
+        QVERIFY(!fieldIsContext(Field::IsFloating));
+        QVERIFY(!fieldIsContext(Field::IsSnapped));
+        QVERIFY(!fieldIsContext(Field::Zone));
     }
 
     void testFieldIsContext_coversAllFields_data()

--- a/libs/phosphor-windowrule/tests/test_ruleevaluator.cpp
+++ b/libs/phosphor-windowrule/tests/test_ruleevaluator.cpp
@@ -336,6 +336,34 @@ private Q_SLOTS:
         QCOMPARE(eval.cacheSize(), 1);
     }
 
+    // The read-only peek used by the effect's per-frame paint path to skip the
+    // (expensive) WindowQuery build on a cache hit. It must be revision-gated and
+    // must not mutate the cache.
+    void testResolveCachedIfPresent_peeksWithoutResolving()
+    {
+        WindowRuleSet set;
+        set.addRule(makeRule(QStringLiteral("a"), 100, MatchExpression{}, {floatAction()}));
+        RuleEvaluator eval(set);
+        const QString winId = QStringLiteral("org.kde.konsole|abc");
+
+        // (a) Unseeded cache → miss (nullopt), no entry created by the peek.
+        QVERIFY(!eval.resolveCachedIfPresent(winId).has_value());
+        QCOMPARE(eval.cacheSize(), 0);
+
+        // (b) After resolveCached seeds the entry, the peek returns the SAME verdict
+        //     and does NOT grow the cache.
+        const ResolvedActions resolved = eval.resolveCached(winId, konsoleQuery());
+        const std::optional<ResolvedActions> peeked = eval.resolveCachedIfPresent(winId);
+        QVERIFY(peeked.has_value());
+        QVERIFY(*peeked == resolved);
+        QCOMPARE(eval.cacheSize(), 1);
+
+        // (c) A rule-set mutation bumps the revision, so the now-stale entry reads as
+        //     a miss — the peek is revision-gated exactly like resolveCached.
+        set.addRule(makeRule(QStringLiteral("b"), 50, MatchExpression{}, {floatAction()}));
+        QVERIFY(!eval.resolveCachedIfPresent(winId).has_value());
+    }
+
     void testResolveCached_invalidatedByRevisionBump()
     {
         WindowRuleSet set;

--- a/libs/phosphor-windowrule/tests/test_windowquery.cpp
+++ b/libs/phosphor-windowrule/tests/test_windowquery.cpp
@@ -145,6 +145,27 @@ private Q_SLOTS:
         QCOMPARE(q.valueForField(Field::CaptionNormal)->toString(), QStringLiteral("Firefox"));
         QVERIFY(q.hasWindow());
     }
+
+    void testValueForField_pzStateFields()
+    {
+        WindowQuery q;
+        // Absent by default — inert during windowless context resolution.
+        QVERIFY(!q.valueForField(Field::IsFloating).has_value());
+        QVERIFY(!q.valueForField(Field::IsSnapped).has_value());
+        QVERIFY(!q.valueForField(Field::Zone).has_value());
+        QVERIFY(!q.hasWindow());
+
+        q.isFloating = false;
+        q.isSnapped = true;
+        q.zone = QStringLiteral("{a1b2c3d4-0000-0000-0000-000000000001}");
+
+        // Present even though false (the bool-field contract).
+        QVERIFY(q.valueForField(Field::IsFloating).has_value());
+        QCOMPARE(q.valueForField(Field::IsFloating)->toBool(), false);
+        QCOMPARE(q.valueForField(Field::IsSnapped)->toBool(), true);
+        QCOMPARE(q.valueForField(Field::Zone)->toString(), QStringLiteral("{a1b2c3d4-0000-0000-0000-000000000001}"));
+        QVERIFY(q.hasWindow());
+    }
 };
 
 QTEST_GUILESS_MAIN(TestWindowQuery)

--- a/libs/phosphor-windowrule/tests/test_windowquery.cpp
+++ b/libs/phosphor-windowrule/tests/test_windowquery.cpp
@@ -100,6 +100,51 @@ private Q_SLOTS:
         QCOMPARE(q.valueForField(Field::Height)->toInt(), 240);
         QVERIFY(q.hasWindow());
     }
+
+    void testValueForField_kwinPropertyFields()
+    {
+        WindowQuery q;
+        // Absent by default — inert during windowless context resolution.
+        QVERIFY(!q.valueForField(Field::KeepAbove).has_value());
+        QVERIFY(!q.valueForField(Field::KeepBelow).has_value());
+        QVERIFY(!q.valueForField(Field::SkipTaskbar).has_value());
+        QVERIFY(!q.valueForField(Field::SkipPager).has_value());
+        QVERIFY(!q.valueForField(Field::SkipSwitcher).has_value());
+        QVERIFY(!q.valueForField(Field::IsModal).has_value());
+        QVERIFY(!q.valueForField(Field::HasDecoration).has_value());
+        QVERIFY(!q.valueForField(Field::IsResizable).has_value());
+        QVERIFY(!q.valueForField(Field::PositionX).has_value());
+        QVERIFY(!q.valueForField(Field::PositionY).has_value());
+        QVERIFY(!q.valueForField(Field::CaptionNormal).has_value());
+        QVERIFY(!q.hasWindow());
+
+        q.keepAbove = true;
+        q.keepBelow = false;
+        q.skipTaskbar = true;
+        q.skipPager = false;
+        q.skipSwitcher = true;
+        q.isModal = false;
+        q.hasDecoration = true;
+        q.isResizable = false;
+        q.positionX = -50; // a negative X is valid (window straddling the left edge)
+        q.positionY = 100;
+        q.captionNormal = QStringLiteral("Firefox");
+
+        QCOMPARE(q.valueForField(Field::KeepAbove)->toBool(), true);
+        // Present even though false (the bool-field contract).
+        QVERIFY(q.valueForField(Field::KeepBelow).has_value());
+        QCOMPARE(q.valueForField(Field::KeepBelow)->toBool(), false);
+        QCOMPARE(q.valueForField(Field::SkipTaskbar)->toBool(), true);
+        QCOMPARE(q.valueForField(Field::SkipPager)->toBool(), false);
+        QCOMPARE(q.valueForField(Field::SkipSwitcher)->toBool(), true);
+        QCOMPARE(q.valueForField(Field::IsModal)->toBool(), false);
+        QCOMPARE(q.valueForField(Field::HasDecoration)->toBool(), true);
+        QCOMPARE(q.valueForField(Field::IsResizable)->toBool(), false);
+        QCOMPARE(q.valueForField(Field::PositionX)->toInt(), -50);
+        QCOMPARE(q.valueForField(Field::PositionY)->toInt(), 100);
+        QCOMPARE(q.valueForField(Field::CaptionNormal)->toString(), QStringLiteral("Firefox"));
+        QVERIFY(q.hasWindow());
+    }
 };
 
 QTEST_GUILESS_MAIN(TestWindowQuery)

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -740,45 +740,73 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
     }
     meta.windowType = PhosphorProtocol::windowTypeFromInt(windowType);
 
-    // Extended window-property snapshot (the trailing a{sv}). Each key is present
-    // only when the effect could observe the value, so an absent key leaves the
-    // optional disengaged and the derived WindowQuery field inert — mirroring the
+    // Extended window-property snapshot (the trailing a{sv}). An EMPTY map is a
+    // caption-only refresh (the effect skips the snapshot on chatty title ticks):
+    // carry forward the registry's existing extended fields so a per-frame title
+    // update does not wipe geometry/state. A non-empty map fully replaces them —
+    // each key present only when the effect could observe the value, so an absent
+    // key disengages the optional (and its derived WindowQuery field), mirroring the
     // effect-side engage-only-when-known contract in window_query.cpp. Lenient
     // QVariant conversions are the boundary policy here, matching the pid /
     // windowType clamping above (a malformed caller cannot corrupt placement).
-    namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
-    const auto optBool = [&extended](QLatin1String key) -> std::optional<bool> {
-        const auto it = extended.constFind(QString(key));
-        return it != extended.constEnd() ? std::optional<bool>(it.value().toBool()) : std::nullopt;
-    };
-    const auto optInt = [&extended](QLatin1String key) -> std::optional<int> {
-        const auto it = extended.constFind(QString(key));
-        return it != extended.constEnd() ? std::optional<int>(it.value().toInt()) : std::nullopt;
-    };
-    const auto optString = [&extended](QLatin1String key) -> std::optional<QString> {
-        const auto it = extended.constFind(QString(key));
-        return it != extended.constEnd() ? std::optional<QString>(it.value().toString()) : std::nullopt;
-    };
-    meta.isMinimized = optBool(Key::IsMinimized);
-    meta.isFullscreen = optBool(Key::IsFullscreen);
-    meta.isSticky = optBool(Key::IsSticky);
-    meta.isMaximized = optBool(Key::IsMaximized);
-    meta.isFocused = optBool(Key::IsFocused);
-    meta.isTransient = optBool(Key::IsTransient);
-    meta.isNotification = optBool(Key::IsNotification);
-    meta.keepAbove = optBool(Key::KeepAbove);
-    meta.keepBelow = optBool(Key::KeepBelow);
-    meta.skipTaskbar = optBool(Key::SkipTaskbar);
-    meta.skipPager = optBool(Key::SkipPager);
-    meta.skipSwitcher = optBool(Key::SkipSwitcher);
-    meta.isModal = optBool(Key::IsModal);
-    meta.hasDecoration = optBool(Key::HasDecoration);
-    meta.isResizable = optBool(Key::IsResizable);
-    meta.width = optInt(Key::Width);
-    meta.height = optInt(Key::Height);
-    meta.positionX = optInt(Key::PositionX);
-    meta.positionY = optInt(Key::PositionY);
-    meta.captionNormal = optString(Key::CaptionNormal);
+    if (extended.isEmpty()) {
+        if (const std::optional<PhosphorEngine::WindowMetadata> existing = m_windowRegistry->metadata(instanceId)) {
+            meta.isMinimized = existing->isMinimized;
+            meta.isFullscreen = existing->isFullscreen;
+            meta.isSticky = existing->isSticky;
+            meta.isMaximized = existing->isMaximized;
+            meta.isFocused = existing->isFocused;
+            meta.isTransient = existing->isTransient;
+            meta.isNotification = existing->isNotification;
+            meta.keepAbove = existing->keepAbove;
+            meta.keepBelow = existing->keepBelow;
+            meta.skipTaskbar = existing->skipTaskbar;
+            meta.skipPager = existing->skipPager;
+            meta.skipSwitcher = existing->skipSwitcher;
+            meta.isModal = existing->isModal;
+            meta.hasDecoration = existing->hasDecoration;
+            meta.isResizable = existing->isResizable;
+            meta.width = existing->width;
+            meta.height = existing->height;
+            meta.positionX = existing->positionX;
+            meta.positionY = existing->positionY;
+            meta.captionNormal = existing->captionNormal;
+        }
+    } else {
+        namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
+        const auto optBool = [&extended](QLatin1String key) -> std::optional<bool> {
+            const auto it = extended.constFind(QString(key));
+            return it != extended.constEnd() ? std::optional<bool>(it.value().toBool()) : std::nullopt;
+        };
+        const auto optInt = [&extended](QLatin1String key) -> std::optional<int> {
+            const auto it = extended.constFind(QString(key));
+            return it != extended.constEnd() ? std::optional<int>(it.value().toInt()) : std::nullopt;
+        };
+        const auto optString = [&extended](QLatin1String key) -> std::optional<QString> {
+            const auto it = extended.constFind(QString(key));
+            return it != extended.constEnd() ? std::optional<QString>(it.value().toString()) : std::nullopt;
+        };
+        meta.isMinimized = optBool(Key::IsMinimized);
+        meta.isFullscreen = optBool(Key::IsFullscreen);
+        meta.isSticky = optBool(Key::IsSticky);
+        meta.isMaximized = optBool(Key::IsMaximized);
+        meta.isFocused = optBool(Key::IsFocused);
+        meta.isTransient = optBool(Key::IsTransient);
+        meta.isNotification = optBool(Key::IsNotification);
+        meta.keepAbove = optBool(Key::KeepAbove);
+        meta.keepBelow = optBool(Key::KeepBelow);
+        meta.skipTaskbar = optBool(Key::SkipTaskbar);
+        meta.skipPager = optBool(Key::SkipPager);
+        meta.skipSwitcher = optBool(Key::SkipSwitcher);
+        meta.isModal = optBool(Key::IsModal);
+        meta.hasDecoration = optBool(Key::HasDecoration);
+        meta.isResizable = optBool(Key::IsResizable);
+        meta.width = optInt(Key::Width);
+        meta.height = optInt(Key::Height);
+        meta.positionX = optInt(Key::PositionX);
+        meta.positionY = optInt(Key::PositionY);
+        meta.captionNormal = optString(Key::CaptionNormal);
+    }
 
     m_windowRegistry->upsert(instanceId, meta);
 }

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -24,7 +24,7 @@
 #include "../core/types.h"
 #include <PhosphorEngine/WindowRegistry.h>
 // Complete type required where ~WindowTrackingAdaptor destroys the
-// unique_ptr<RuleEvaluator> member (m_restorePositionEvaluator).
+// unique_ptr<RuleEvaluator> member (m_windowRuleEvaluator).
 #include <PhosphorWindowRule/RuleEvaluator.h>
 #include <QJsonArray>
 #include <QJsonDocument>

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -26,6 +26,7 @@
 // Complete type required where ~WindowTrackingAdaptor destroys the
 // unique_ptr<RuleEvaluator> member (m_windowRuleEvaluator).
 #include <PhosphorWindowRule/RuleEvaluator.h>
+#include <PhosphorProtocol/ServiceConstants.h>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -693,7 +694,7 @@ void WindowTrackingAdaptor::setWindowRegistry(PhosphorEngine::WindowRegistry* re
 void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const QString& appId,
                                               const QString& desktopFile, const QString& title,
                                               const QString& windowRole, int pid, int virtualDesktop,
-                                              const QString& activity, int windowType)
+                                              const QString& activity, int windowType, const QVariantMap& extended)
 {
     if (!m_windowRegistry) {
         // Registry not wired yet — during daemon startup the kwin-effect may
@@ -738,6 +739,47 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
                                 << instanceId << "— treating as Unknown";
     }
     meta.windowType = PhosphorProtocol::windowTypeFromInt(windowType);
+
+    // Extended window-property snapshot (the trailing a{sv}). Each key is present
+    // only when the effect could observe the value, so an absent key leaves the
+    // optional disengaged and the derived WindowQuery field inert — mirroring the
+    // effect-side engage-only-when-known contract in window_query.cpp. Lenient
+    // QVariant conversions are the boundary policy here, matching the pid /
+    // windowType clamping above (a malformed caller cannot corrupt placement).
+    namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
+    const auto optBool = [&extended](QLatin1String key) -> std::optional<bool> {
+        const auto it = extended.constFind(QString(key));
+        return it != extended.constEnd() ? std::optional<bool>(it.value().toBool()) : std::nullopt;
+    };
+    const auto optInt = [&extended](QLatin1String key) -> std::optional<int> {
+        const auto it = extended.constFind(QString(key));
+        return it != extended.constEnd() ? std::optional<int>(it.value().toInt()) : std::nullopt;
+    };
+    const auto optString = [&extended](QLatin1String key) -> std::optional<QString> {
+        const auto it = extended.constFind(QString(key));
+        return it != extended.constEnd() ? std::optional<QString>(it.value().toString()) : std::nullopt;
+    };
+    meta.isMinimized = optBool(Key::IsMinimized);
+    meta.isFullscreen = optBool(Key::IsFullscreen);
+    meta.isSticky = optBool(Key::IsSticky);
+    meta.isMaximized = optBool(Key::IsMaximized);
+    meta.isFocused = optBool(Key::IsFocused);
+    meta.isTransient = optBool(Key::IsTransient);
+    meta.isNotification = optBool(Key::IsNotification);
+    meta.keepAbove = optBool(Key::KeepAbove);
+    meta.keepBelow = optBool(Key::KeepBelow);
+    meta.skipTaskbar = optBool(Key::SkipTaskbar);
+    meta.skipPager = optBool(Key::SkipPager);
+    meta.skipSwitcher = optBool(Key::SkipSwitcher);
+    meta.isModal = optBool(Key::IsModal);
+    meta.hasDecoration = optBool(Key::HasDecoration);
+    meta.isResizable = optBool(Key::IsResizable);
+    meta.width = optInt(Key::Width);
+    meta.height = optInt(Key::Height);
+    meta.positionX = optInt(Key::PositionX);
+    meta.positionY = optInt(Key::PositionY);
+    meta.captionNormal = optString(Key::CaptionNormal);
+
     m_windowRegistry->upsert(instanceId, meta);
 }
 

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -17,6 +17,7 @@
 #include <QString>
 #include <QStringList>
 #include <QHash>
+#include <QVariantMap>
 #include <QJsonArray>
 #include <QQueue>
 #include <QRect>
@@ -242,6 +243,14 @@ public Q_SLOTS:
      * @param activity       Activity UUID (empty = all activities / unknown)
      * @param windowType     PhosphorProtocol::WindowType underlying value; out-of-range
      *                       values are clamped to WindowType::Unknown
+     * @param extended       Extended window-property snapshot keyed by
+     *                       PhosphorProtocol::Service::WindowMetadataKey (state flags,
+     *                       geometry, accessory flags, captionNormal). A key is
+     *                       present only when the value is known; absent keys leave
+     *                       the corresponding WindowMetadata optional disengaged so a
+     *                       window-rule predicate over it stays inert. Lets the
+     *                       daemon's resolvers match the same KWin-property fields the
+     *                       effect path resolves live (window_query.cpp).
      *
      * Emits no D-Bus signal. Populates the daemon's WindowRegistry; consumers
      * subscribe to the registry's Qt signals directly.
@@ -251,7 +260,7 @@ public Q_SLOTS:
      */
     void setWindowMetadata(const QString& instanceId, const QString& appId, const QString& desktopFile,
                            const QString& title, const QString& windowRole, int pid, int virtualDesktop,
-                           const QString& activity, int windowType);
+                           const QString& activity, int windowType, const QVariantMap& extended);
 
     // windowSnapped, windowSnappedMultiZone, windowUnsnapped, windowsSnappedBatch,
     // recordSnapIntent moved to SnapAdaptor (org.plasmazones.Snap D-Bus interface).

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -619,6 +619,14 @@ public:
     /// per-engine `*RestoreFloatedWindowsOnLogin` setting decides. Builds a
     /// WindowQuery from the window registry metadata.
     bool shouldRestoreFloatedPosition(const QString& windowId, PhosphorZones::AssignmentEntry::Mode mode);
+
+    /// Resolve whether an opening window should start FLOATING because a "Float
+    /// this app" window rule matched it. Consulted by the float predicate the
+    /// daemon injects into BOTH engines (in-process, not via D-Bus). Unlike
+    /// RestorePosition there is no global default — Float is purely rule-driven,
+    /// so the answer is false unless a Float rule matches. The Float action's
+    /// params are free-form, so the verdict is the presence of the filled slot.
+    bool shouldFloatByRule(const QString& windowId);
     /**
      * @brief Drop unified WindowPlacement records for excluded appIds.
      *
@@ -999,12 +1007,14 @@ private:
     QPointer<PhosphorEngine::WindowRegistry> m_windowRegistry;
 
     // Unified window-rule store (daemon-owned, not owned here) + a lazily-built
-    // evaluator over its full rule set, used only by shouldRestoreFloatedPosition.
-    // The evaluator self-invalidates on in-place rule edits via the set revision,
-    // so it is built once on first use. Reset in setWindowRuleStore only when the
-    // store pointer actually changes (a same-store rebind keeps the evaluator).
+    // evaluator over its full rule set, shared by shouldRestoreFloatedPosition
+    // and shouldFloatByRule (resolveCached returns every matched slot, so one
+    // evaluator serves both per-window resolvers). The evaluator self-invalidates
+    // on in-place rule edits via the set revision, so it is built once on first
+    // use. Reset in setWindowRuleStore only when the store pointer actually
+    // changes (a same-store rebind keeps the evaluator).
     PhosphorWindowRule::WindowRuleStore* m_windowRuleStore = nullptr;
-    std::unique_ptr<PhosphorWindowRule::RuleEvaluator> m_restorePositionEvaluator;
+    std::unique_ptr<PhosphorWindowRule::RuleEvaluator> m_windowRuleEvaluator;
 
     // ═══════════════════════════════════════════════════════════════════════════════
     // Persistence (adaptor responsibility: session.json save/load)

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -416,6 +416,11 @@ bool WindowTrackingAdaptor::shouldRestoreFloatedPosition(const QString& windowId
     if (!m_windowRuleEvaluator) {
         m_windowRuleEvaluator = std::make_unique<PhosphorWindowRule::RuleEvaluator>(m_windowRuleStore->ruleSet());
     }
+    // Shares m_windowRuleEvaluator with shouldFloatByRule; resolveCached is keyed on
+    // (windowId, ruleSet revision) and ignores the query on a hit. Safe because both
+    // are open-path (resolved once per window lifetime — see shouldFloatByRule) and
+    // the effect pushes the window's full metadata before the engine's open-path
+    // resolve, so the first (and only) resolve for a window sees complete metadata.
     const PhosphorWindowRule::ResolvedActions resolved = m_windowRuleEvaluator->resolveCached(windowId, *query);
     if (const std::optional<PhosphorWindowRule::RuleAction> action =
             resolved.slot(QString(PhosphorWindowRule::ActionSlot::RestorePosition))) {

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -239,7 +239,13 @@ namespace {
 // one place. windowClass is not tracked daemon-side (the compositor reports
 // appId, which is class-derived), so rules match on appId / title / role / type
 // / desktop / pid plus the recorded desktop / activity context; screenId stays
-// empty (a window-domain rule does not pin a screen).
+// empty (a window-domain rule does not pin a screen). The extended window
+// properties (state flags, geometry, accessory flags, captionNormal) are carried
+// straight through from the effect's snapshot (setWindowMetadata's a{sv}), so a
+// Float / RestorePosition rule keyed on e.g. IsModal or Width matches the same
+// values the effect path resolves live. Placement state (IsFloating / IsSnapped /
+// Zone) is deliberately absent: these resolvers run at window-open, before any
+// placement exists, so a predicate over them must stay inert.
 std::optional<PhosphorWindowRule::WindowQuery>
 buildRuleQueryForWindow(const QPointer<PhosphorEngine::WindowRegistry>& registry, const QString& windowId)
 {
@@ -272,6 +278,28 @@ buildRuleQueryForWindow(const QPointer<PhosphorEngine::WindowRegistry>& registry
     query.windowType = meta->windowType;
     query.virtualDesktop = meta->virtualDesktop;
     query.activity = meta->activity;
+    // Extended properties — optional→optional copy preserves engagement exactly,
+    // so a field the effect could not observe stays disengaged and inert here too.
+    query.isMinimized = meta->isMinimized;
+    query.isFullscreen = meta->isFullscreen;
+    query.isSticky = meta->isSticky;
+    query.isMaximized = meta->isMaximized;
+    query.isFocused = meta->isFocused;
+    query.isTransient = meta->isTransient;
+    query.isNotification = meta->isNotification;
+    query.keepAbove = meta->keepAbove;
+    query.keepBelow = meta->keepBelow;
+    query.skipTaskbar = meta->skipTaskbar;
+    query.skipPager = meta->skipPager;
+    query.skipSwitcher = meta->skipSwitcher;
+    query.isModal = meta->isModal;
+    query.hasDecoration = meta->hasDecoration;
+    query.isResizable = meta->isResizable;
+    query.width = meta->width;
+    query.height = meta->height;
+    query.positionX = meta->positionX;
+    query.positionY = meta->positionY;
+    query.captionNormal = meta->captionNormal;
     return query;
 }
 } // namespace
@@ -323,6 +351,12 @@ bool WindowTrackingAdaptor::shouldFloatByRule(const QString& windowId)
     if (!m_windowRuleEvaluator) {
         m_windowRuleEvaluator = std::make_unique<PhosphorWindowRule::RuleEvaluator>(m_windowRuleStore->ruleSet());
     }
+    // resolveCached is keyed on (windowId, ruleSet revision); on a cache hit the
+    // freshly built `query` is ignored. That is safe because windowId is both
+    // lifetime-stable AND unique: a reopened window gets a fresh instanceId (new
+    // key → miss) and a mid-session appId rename changes the composite key too, so
+    // a cached verdict can never outlive the metadata it was built from. Both the
+    // float and restore predicates are open-path (resolved once per lifetime).
     const PhosphorWindowRule::ResolvedActions resolved = m_windowRuleEvaluator->resolveCached(windowId, *query);
     // The Float action carries free-form params (no Value key), so the verdict is
     // the PRESENCE of the filled slot, not a bool payload.

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -56,9 +56,11 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
     if (m_cachedSnapEngine) {
         m_cachedSnapEngine->setShouldRestorePredicate({});
         m_cachedSnapEngine->setRestorePositionPredicate({});
+        m_cachedSnapEngine->setFloatPredicate({});
     }
     if (m_cachedAutotileEngine) {
         m_cachedAutotileEngine->setRestorePositionPredicate({});
+        m_cachedAutotileEngine->setFloatPredicate({});
     }
 
     m_snapEngine = snapEngine;
@@ -113,6 +115,13 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
         // `snappingRestoreFloatedWindowsOnLogin` setting (Mode::Snapping here).
         snap->setRestorePositionPredicate([this](const QString& windowId) -> bool {
             return shouldRestoreFloatedPosition(windowId, PhosphorZones::AssignmentEntry::Mode::Snapping);
+        });
+
+        // Open-floating gate (snap). A matched "Float this app" rule opens the
+        // window floating instead of auto-snapping it. Purely rule-driven (no
+        // global default), so the same resolver serves both engines.
+        snap->setFloatPredicate([this](const QString& windowId) -> bool {
+            return shouldFloatByRule(windowId);
         });
 
         // Snap-specific signal: carries PhosphorProtocol::WindowStateEntry which is snap-mode-only.
@@ -176,6 +185,11 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
             m_cachedAutotileEngine->setRestorePositionPredicate([this](const QString& windowId) -> bool {
                 return shouldRestoreFloatedPosition(windowId, PhosphorZones::AssignmentEntry::Mode::Autotile);
             });
+            // Open-floating gate (autotile). Same rule-driven resolver as snap; the
+            // window is inserted then marked floating so it stays managed.
+            m_cachedAutotileEngine->setFloatPredicate([this](const QString& windowId) -> bool {
+                return shouldFloatByRule(windowId);
+            });
         }
     }
 
@@ -214,41 +228,33 @@ void WindowTrackingAdaptor::setWindowRuleStore(PhosphorWindowRule::WindowRuleSto
     }
     m_windowRuleStore = store;
     // Drop the evaluator bound to the previous set; it rebuilds lazily against
-    // the new one on the next shouldRestoreFloatedPosition call.
-    m_restorePositionEvaluator.reset();
+    // the new one on the next per-window resolve.
+    m_windowRuleEvaluator.reset();
 }
 
-bool WindowTrackingAdaptor::shouldRestoreFloatedPosition(const QString& windowId,
-                                                         PhosphorZones::AssignmentEntry::Mode mode)
+namespace {
+// Build a per-window rule query from the registry metadata, or nullopt when no
+// metadata is tracked (the caller falls back to its own default). Shared by the
+// RestorePosition and Float resolvers so the metadata→query derivation lives in
+// one place. windowClass is not tracked daemon-side (the compositor reports
+// appId, which is class-derived), so rules match on appId / title / role / type
+// / desktop / pid plus the recorded desktop / activity context; screenId stays
+// empty (a window-domain rule does not pin a screen).
+std::optional<PhosphorWindowRule::WindowQuery>
+buildRuleQueryForWindow(const QPointer<PhosphorEngine::WindowRegistry>& registry, const QString& windowId)
 {
-    // m_settings is a hard ctor dependency (qFatal on null), so it is non-null
-    // here — deref unguarded like every other method in this class. The global
-    // default is per-engine (snap-floated vs autotile-floated); the RestorePosition
-    // rule override below is engine-neutral.
-    const bool globalDefault = mode == PhosphorZones::AssignmentEntry::Mode::Autotile
-        ? m_settings->autotileRestoreFloatedWindowsOnLogin()
-        : m_settings->snappingRestoreFloatedWindowsOnLogin();
-
-    // No rule store / metadata → the global setting is the whole policy.
-    if (!m_windowRuleStore || m_windowRegistry.isNull()) {
-        return globalDefault;
+    if (registry.isNull()) {
+        return std::nullopt;
     }
     // WindowRegistry is keyed by the BARE instance id; the engine hands us the
     // composite `appId|instanceId`. Extract first — every other registry reader
     // (currentAppIdFor, windowClosed, AutotileEngine) does the same. Looking up by
-    // the composite id always misses, which would silently make RestorePosition
-    // rules inert and collapse the feature to the global setting.
+    // the composite id always misses, which would silently make the rule inert.
     const QString instanceId = PhosphorIdentity::WindowId::extractInstanceId(windowId);
-    const std::optional<PhosphorEngine::WindowMetadata> meta = m_windowRegistry->metadata(instanceId);
+    const std::optional<PhosphorEngine::WindowMetadata> meta = registry->metadata(instanceId);
     if (!meta) {
-        return globalDefault;
+        return std::nullopt;
     }
-
-    // Build a per-window query from the registry metadata. windowClass is not
-    // tracked daemon-side (the compositor reports appId, which is class-derived),
-    // so RestorePosition rules match on appId / title / role / type — the common
-    // per-app case. Context fields come from the window's recorded desktop /
-    // activity; screenId stays empty (a window-domain rule does not pin a screen).
     PhosphorWindowRule::WindowQuery query;
     query.appId = meta->appId;
     if (!meta->title.isEmpty()) {
@@ -266,17 +272,61 @@ bool WindowTrackingAdaptor::shouldRestoreFloatedPosition(const QString& windowId
     query.windowType = meta->windowType;
     query.virtualDesktop = meta->virtualDesktop;
     query.activity = meta->activity;
+    return query;
+}
+} // namespace
 
-    if (!m_restorePositionEvaluator) {
-        m_restorePositionEvaluator = std::make_unique<PhosphorWindowRule::RuleEvaluator>(m_windowRuleStore->ruleSet());
+bool WindowTrackingAdaptor::shouldRestoreFloatedPosition(const QString& windowId,
+                                                         PhosphorZones::AssignmentEntry::Mode mode)
+{
+    // m_settings is a hard ctor dependency (qFatal on null), so it is non-null
+    // here — deref unguarded like every other method in this class. The global
+    // default is per-engine (snap-floated vs autotile-floated); the RestorePosition
+    // rule override below is engine-neutral.
+    const bool globalDefault = mode == PhosphorZones::AssignmentEntry::Mode::Autotile
+        ? m_settings->autotileRestoreFloatedWindowsOnLogin()
+        : m_settings->snappingRestoreFloatedWindowsOnLogin();
+
+    // No rule store / metadata → the global setting is the whole policy.
+    if (!m_windowRuleStore) {
+        return globalDefault;
     }
-    const PhosphorWindowRule::ResolvedActions resolved = m_restorePositionEvaluator->resolveCached(windowId, query);
+    const std::optional<PhosphorWindowRule::WindowQuery> query = buildRuleQueryForWindow(m_windowRegistry, windowId);
+    if (!query) {
+        return globalDefault;
+    }
+
+    if (!m_windowRuleEvaluator) {
+        m_windowRuleEvaluator = std::make_unique<PhosphorWindowRule::RuleEvaluator>(m_windowRuleStore->ruleSet());
+    }
+    const PhosphorWindowRule::ResolvedActions resolved = m_windowRuleEvaluator->resolveCached(windowId, *query);
     if (const std::optional<PhosphorWindowRule::RuleAction> action =
             resolved.slot(QString(PhosphorWindowRule::ActionSlot::RestorePosition))) {
         // A matched RestorePosition rule overrides the global setting.
         return action->params.value(QString(PhosphorWindowRule::ActionParam::Value)).toBool();
     }
     return globalDefault;
+}
+
+bool WindowTrackingAdaptor::shouldFloatByRule(const QString& windowId)
+{
+    // Float is purely rule-driven: there is no global "float on open" setting, so
+    // absent a matching rule the answer is "do not float".
+    if (!m_windowRuleStore) {
+        return false;
+    }
+    const std::optional<PhosphorWindowRule::WindowQuery> query = buildRuleQueryForWindow(m_windowRegistry, windowId);
+    if (!query) {
+        return false;
+    }
+
+    if (!m_windowRuleEvaluator) {
+        m_windowRuleEvaluator = std::make_unique<PhosphorWindowRule::RuleEvaluator>(m_windowRuleStore->ruleSet());
+    }
+    const PhosphorWindowRule::ResolvedActions resolved = m_windowRuleEvaluator->resolveCached(windowId, *query);
+    // The Float action carries free-form params (no Value key), so the verdict is
+    // the PRESENCE of the filled slot, not a bool payload.
+    return resolved.slot(QString(PhosphorWindowRule::ActionSlot::Float)).has_value();
 }
 
 } // namespace PlasmaZones

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -118,6 +118,7 @@ SettingsController::~SettingsController()
     if (m_windowRulesPage) {
         m_windowRulesPage->setScreenLookup({});
         m_windowRulesPage->setActivityLookup({});
+        m_windowRulesPage->setZoneLookup({});
         m_windowRulesPage->setSnappingLayoutLookup({});
         m_windowRulesPage->setTilingAlgorithmLookup({});
         // The shader resolver captures `this` and reaches m_animationShaderRegistry;
@@ -541,6 +542,32 @@ SettingsController::SettingsController(QObject* parent)
             }
         }
         return activityId;
+    });
+    // Zone (snap-zone UUID) → friendly "<layout> — <zone>" label, walking the
+    // local manual layouts for the zone whose id matches. Resolved live so a
+    // later layout/zone rename surfaces on the next refreshLabels(). The zone-name
+    // data is not in the LayoutPreview list (it carries geometry + numbers, not
+    // UUIDs), so this reads the registry's actual Zone objects directly. Unknown
+    // ids (deleted layout, hand-edited rule) round-trip verbatim.
+    m_windowRulesPage->setZoneLookup([this](const QString& zoneId) -> QString {
+        if (zoneId.isEmpty() || !m_localLayoutManager) {
+            return zoneId;
+        }
+        for (PhosphorZones::Layout* layout : m_localLayoutManager->layouts()) {
+            if (!layout) {
+                continue;
+            }
+            for (PhosphorZones::Zone* zone : layout->zones()) {
+                if (!zone || zone->id().toString() != zoneId) {
+                    continue;
+                }
+                const QString zoneName =
+                    zone->name().isEmpty() ? PhosphorI18n::tr("Zone %1").arg(zone->zoneNumber()) : zone->name();
+                const QString layoutName = layout->name();
+                return layoutName.isEmpty() ? zoneName : PhosphorI18n::tr("%1 — %2").arg(layoutName, zoneName);
+            }
+        }
+        return zoneId;
     });
     // SettingsController::layouts() is the union of snapping layouts
     // (UUID-keyed) and autotile entries (algorithm-token-keyed via the

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -48,6 +48,7 @@ PickerCategory fieldCategory(Field f)
     case Field::WindowRole:
     case Field::Pid:
     case Field::Title:
+    case Field::CaptionNormal:
         return {PhosphorI18n::tr("Identity"), 0};
     case Field::WindowType:
     case Field::IsSticky:
@@ -57,9 +58,19 @@ PickerCategory fieldCategory(Field f)
     case Field::IsFocused:
     case Field::IsTransient:
     case Field::IsNotification:
+    case Field::KeepAbove:
+    case Field::KeepBelow:
+    case Field::SkipTaskbar:
+    case Field::SkipPager:
+    case Field::SkipSwitcher:
+    case Field::IsModal:
+    case Field::HasDecoration:
+    case Field::IsResizable:
         return {PhosphorI18n::tr("State"), 1};
     case Field::Width:
     case Field::Height:
+    case Field::PositionX:
+    case Field::PositionY:
         return {PhosphorI18n::tr("Size"), 2};
     case Field::ScreenId:
     case Field::VirtualDesktop:
@@ -108,6 +119,28 @@ QString fieldDescription(Field f)
         return PhosphorI18n::tr("The window's width in pixels.");
     case Field::Height:
         return PhosphorI18n::tr("The window's height in pixels.");
+    case Field::KeepAbove:
+        return PhosphorI18n::tr("Whether the window is set to stay above other windows (always on top).");
+    case Field::KeepBelow:
+        return PhosphorI18n::tr("Whether the window is set to stay below other windows.");
+    case Field::SkipTaskbar:
+        return PhosphorI18n::tr("Whether the window is hidden from the taskbar.");
+    case Field::SkipPager:
+        return PhosphorI18n::tr("Whether the window is hidden from the pager.");
+    case Field::SkipSwitcher:
+        return PhosphorI18n::tr("Whether the window is hidden from the window switcher (Alt+Tab).");
+    case Field::IsModal:
+        return PhosphorI18n::tr("Whether the window is a modal dialog.");
+    case Field::HasDecoration:
+        return PhosphorI18n::tr("Whether the window has a server-side title-bar and border.");
+    case Field::IsResizable:
+        return PhosphorI18n::tr("Whether the window can be resized.");
+    case Field::PositionX:
+        return PhosphorI18n::tr("The window's left-edge X position in pixels.");
+    case Field::PositionY:
+        return PhosphorI18n::tr("The window's top-edge Y position in pixels.");
+    case Field::CaptionNormal:
+        return PhosphorI18n::tr("The window's title without the application-name suffix the window manager adds.");
     case Field::ScreenId:
         return PhosphorI18n::tr("The monitor the window is on.");
     case Field::VirtualDesktop:

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -145,7 +145,7 @@ QString fieldDescription(Field f)
     case Field::CaptionNormal:
         return PhosphorI18n::tr("The window's title without the application-name suffix the window manager adds.");
     case Field::IsFloating:
-        return PhosphorI18n::tr("Whether the window is floating (not snapped or tiled).");
+        return PhosphorI18n::tr("Whether the window has been floated out of tiling (snap or autotile).");
     case Field::IsSnapped:
         return PhosphorI18n::tr(
             "Whether the window is snapped into a zone (manual-zone mode; tiled windows are not snapped).");

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -66,6 +66,9 @@ PickerCategory fieldCategory(Field f)
     case Field::IsModal:
     case Field::HasDecoration:
     case Field::IsResizable:
+    case Field::IsFloating:
+    case Field::IsSnapped:
+    case Field::Zone:
         return {PhosphorI18n::tr("State"), 1};
     case Field::Width:
     case Field::Height:
@@ -141,6 +144,13 @@ QString fieldDescription(Field f)
         return PhosphorI18n::tr("The window's top-edge Y position in pixels.");
     case Field::CaptionNormal:
         return PhosphorI18n::tr("The window's title without the application-name suffix the window manager adds.");
+    case Field::IsFloating:
+        return PhosphorI18n::tr("Whether the window is floating (not snapped or tiled).");
+    case Field::IsSnapped:
+        return PhosphorI18n::tr(
+            "Whether the window is snapped into a zone (manual-zone mode; tiled windows are not snapped).");
+    case Field::Zone:
+        return PhosphorI18n::tr("The zone the window is snapped into (manual-zone mode only).");
     case Field::ScreenId:
         return PhosphorI18n::tr("The monitor the window is on.");
     case Field::VirtualDesktop:

--- a/src/settings/windowrulecontroller.h
+++ b/src/settings/windowrulecontroller.h
@@ -87,6 +87,8 @@ public:
     /// registration via the typed snappingLayout/tilingAlgorithm pair.
     void setScreenLookup(WindowRuleModel::LabelLookup fn);
     void setActivityLookup(WindowRuleModel::LabelLookup fn);
+    /// zone UUID → zone-name resolver for `Zone` match-leaf labels.
+    void setZoneLookup(WindowRuleModel::LabelLookup fn);
     /// layoutId UUID → display label resolver for SetSnappingLayout actions.
     void setSnappingLayoutLookup(WindowRuleModel::LabelLookup fn);
     /// Algorithm token ("bsp", …) → display label resolver for SetTilingAlgorithm actions.

--- a/src/settings/windowrulecontroller_lookups.cpp
+++ b/src/settings/windowrulecontroller_lookups.cpp
@@ -21,6 +21,11 @@ void WindowRuleController::setActivityLookup(WindowRuleModel::LabelLookup fn)
     m_model.setActivityLabelLookup(std::move(fn));
 }
 
+void WindowRuleController::setZoneLookup(WindowRuleModel::LabelLookup fn)
+{
+    m_model.setZoneLabelLookup(std::move(fn));
+}
+
 void WindowRuleController::setSnappingLayoutLookup(WindowRuleModel::LabelLookup fn)
 {
     m_snappingLayoutLookup = std::move(fn);

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -684,6 +684,12 @@ QString WindowRuleModel::fieldLabel(Field field)
         return PhosphorI18n::tr("Position Y");
     case Field::CaptionNormal:
         return PhosphorI18n::tr("Title (no suffix)");
+    case Field::IsFloating:
+        return PhosphorI18n::tr("Floating");
+    case Field::IsSnapped:
+        return PhosphorI18n::tr("Snapped");
+    case Field::Zone:
+        return PhosphorI18n::tr("Zone");
     }
     return QString();
 }

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -134,7 +134,7 @@ bool matchIsSimpleConjunction(const MatchExpression& match)
 /// "identity" so the function stays usable in code paths that have not yet
 /// wired the SettingsController-backed resolvers.
 QString leafLabel(const MatchExpression::Predicate& predicate, const WindowRuleModel::LabelLookup& screenLookup,
-                  const WindowRuleModel::LabelLookup& activityLookup)
+                  const WindowRuleModel::LabelLookup& activityLookup, const WindowRuleModel::LabelLookup& zoneLookup)
 {
     // Pick the lookup matching the leaf's field. An empty lookup degenerates
     // to identity so this stays usable from code paths that have not yet
@@ -144,6 +144,8 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const WindowRuleM
         lookup = &screenLookup;
     } else if (predicate.field == Field::Activity) {
         lookup = &activityLookup;
+    } else if (predicate.field == Field::Zone) {
+        lookup = &zoneLookup;
     }
     const auto resolveOne = [lookup](const QString& raw) {
         if (!lookup || !*lookup) {
@@ -700,14 +702,14 @@ QString WindowRuleModel::matchSummary(const MatchExpression& match) const
         return PhosphorI18n::tr("Any window");
     }
     if (match.isLeaf()) {
-        return leafLabel(match.predicate(), m_screenLookup, m_activityLookup);
+        return leafLabel(match.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup);
     }
     // A simple AND renders its leaves joined by " · ".
     if (match.kind() == MatchExpression::Kind::All) {
         QStringList parts;
         for (const MatchExpression& child : match.children()) {
             if (child.isLeaf()) {
-                parts.append(leafLabel(child.predicate(), m_screenLookup, m_activityLookup));
+                parts.append(leafLabel(child.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup));
             } else {
                 parts.append(PhosphorI18n::tr("(condition group)"));
             }
@@ -768,6 +770,11 @@ void WindowRuleModel::setScreenLabelLookup(LabelLookup fn)
 void WindowRuleModel::setActivityLabelLookup(LabelLookup fn)
 {
     m_activityLookup = std::move(fn);
+}
+
+void WindowRuleModel::setZoneLabelLookup(LabelLookup fn)
+{
+    m_zoneLookup = std::move(fn);
 }
 
 void WindowRuleModel::setSnappingLayoutLabelLookup(LabelLookup fn)

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -662,6 +662,28 @@ QString WindowRuleModel::fieldLabel(Field field)
         return PhosphorI18n::tr("Width");
     case Field::Height:
         return PhosphorI18n::tr("Height");
+    case Field::KeepAbove:
+        return PhosphorI18n::tr("Keep above");
+    case Field::KeepBelow:
+        return PhosphorI18n::tr("Keep below");
+    case Field::SkipTaskbar:
+        return PhosphorI18n::tr("Skip taskbar");
+    case Field::SkipPager:
+        return PhosphorI18n::tr("Skip pager");
+    case Field::SkipSwitcher:
+        return PhosphorI18n::tr("Skip switcher");
+    case Field::IsModal:
+        return PhosphorI18n::tr("Modal");
+    case Field::HasDecoration:
+        return PhosphorI18n::tr("Decorated");
+    case Field::IsResizable:
+        return PhosphorI18n::tr("Resizable");
+    case Field::PositionX:
+        return PhosphorI18n::tr("Position X");
+    case Field::PositionY:
+        return PhosphorI18n::tr("Position Y");
+    case Field::CaptionNormal:
+        return PhosphorI18n::tr("Title (no suffix)");
     }
     return QString();
 }

--- a/src/settings/windowrulemodel.h
+++ b/src/settings/windowrulemodel.h
@@ -210,6 +210,13 @@ public:
     /// call @ref refreshLabels.
     void setActivityLabelLookup(LabelLookup fn);
 
+    /// Inject the zone-uuid → zone-name resolver used when rendering `Zone` leaf
+    /// predicates, so a snap-zone rule renders "Right column" rather than a raw
+    /// `{uuid}`. Install-once setter; lookups are read live every time `data()` is
+    /// invoked. To refresh visible labels after a lookup-source change, call
+    /// @ref refreshLabels.
+    void setZoneLabelLookup(LabelLookup fn);
+
     /// Inject the layoutId / algorithm-token → display-name resolvers used by
     /// the action summary so `SetSnappingLayout` and `SetTilingAlgorithm`
     /// render "Binary Split" rather than the wire token / UUID. Split into a
@@ -268,6 +275,7 @@ private:
     QList<PhosphorWindowRule::WindowRule> m_rules;
     LabelLookup m_screenLookup;
     LabelLookup m_activityLookup;
+    LabelLookup m_zoneLookup;
     // Split so a SetSnappingLayout action whose layoutId happens to
     // tokenise (e.g. matches an algorithm token by coincidence) and a
     // SetTilingAlgorithm action with a UUID-shaped algorithm name

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -804,7 +804,7 @@ set_tests_properties(bench_dbus_adaptors PROPERTIES LABELS "bench")
 # ═══════════════════════════════════════════════════════════════════════════════
 # compositor-common/ - Shared Library Types Tests (split for <800-line limit)
 #   test_wire_types: D-Bus wire type signature/roundtrip tests
-#   test_floating_cache: FloatingCache + TriggerParser tests
+#   test_floating_cache: FloatingCache + ZoneCache + TriggerParser tests
 #   test_autotile_state: AutotileStateHelpers + WindowId tests
 #   test_decoration_manager: DecorationManager ownership/veto behavioral spec
 #   test_decoration_manager_timers: DecorationManager deferred-drain/fallback timers

--- a/tests/unit/autotile/test_autotile_ext_startup_float.cpp
+++ b/tests/unit/autotile/test_autotile_ext_startup_float.cpp
@@ -201,6 +201,92 @@ private Q_SLOTS:
         engine.floatWindow(QStringLiteral("win1"));
         QCOMPARE(floatSpy.count(), 0);
     }
+
+    // =========================================================================
+    // Float-on-open rule predicate (FloatPredicate)
+    //
+    // The daemon injects a predicate that returns true when a "Float this app"
+    // rule matched the opening window. onWindowAdded must then insert it FLOATING
+    // (so it stays managed and IsFloating reflects it) and emit
+    // windowFloatingStateSynced so the daemon mirrors the state. Autotile tiles
+    // carry no zone, so these windows are floating-but-tracked, never snapped.
+    // =========================================================================
+
+    void testFloatPredicate_opensMatchedWindowFloating()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("eDP-1");
+        engine.setAutotileScreens({screen});
+
+        engine.setFloatPredicate([](const QString& id) {
+            return id == QStringLiteral("float-me");
+        });
+
+        QSignalSpy syncSpy(&engine, &PhosphorEngine::PlacementEngineBase::windowFloatingStateSynced);
+
+        engine.windowOpened(QStringLiteral("float-me"), screen);
+        QCoreApplication::processEvents();
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        QVERIFY(state->containsWindow(QStringLiteral("float-me")));
+        QVERIFY(state->isFloating(QStringLiteral("float-me")));
+
+        bool foundSync = false;
+        for (const auto& args : syncSpy) {
+            if (args.at(0).toString() == QStringLiteral("float-me") && args.at(1).toBool()) {
+                foundSync = true;
+                break;
+            }
+        }
+        QVERIFY2(foundSync, "rule-floated window must emit windowFloatingStateSynced(true)");
+    }
+
+    void testFloatPredicate_unsetOpensWindowTiled()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("eDP-1");
+        engine.setAutotileScreens({screen});
+
+        // No predicate set — the gate is inert and the window tiles normally.
+        engine.windowOpened(QStringLiteral("win1"), screen);
+        QCoreApplication::processEvents();
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        QVERIFY(state->containsWindow(QStringLiteral("win1")));
+        QVERIFY(!state->isFloating(QStringLiteral("win1")));
+    }
+
+    void testFloatPredicate_bypassesTiledWindowCap()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("eDP-1");
+        engine.config()->maxWindows = 1;
+        engine.setAutotileScreens({screen});
+
+        engine.setFloatPredicate([](const QString& id) {
+            return id == QStringLiteral("float-me");
+        });
+
+        // Fill the single tile slot.
+        engine.windowOpened(QStringLiteral("tiled-1"), screen);
+        QCoreApplication::processEvents();
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        QVERIFY(state);
+        QCOMPARE(state->tiledWindowCount(), 1);
+
+        // A rule-floated window opening while the screen is already at the tiled
+        // cap must NOT be dropped: a floating window consumes no tile slot, so the
+        // cap does not apply. It is inserted floating and stays tracked.
+        engine.windowOpened(QStringLiteral("float-me"), screen);
+        QCoreApplication::processEvents();
+
+        QVERIFY(state->containsWindow(QStringLiteral("float-me")));
+        QVERIFY(state->isFloating(QStringLiteral("float-me")));
+        QCOMPARE(state->tiledWindowCount(), 1);
+    }
 };
 
 QTEST_MAIN(TestAutotileExtStartupFloat)

--- a/tests/unit/compositor-common/test_floating_cache.cpp
+++ b/tests/unit/compositor-common/test_floating_cache.cpp
@@ -116,6 +116,23 @@ private Q_SLOTS:
     }
 
     // =================================================================
+    // FloatingCache: malformed composite with empty instanceId is rejected
+    // =================================================================
+
+    void testFloatingCacheRejectsEmptyInstanceId()
+    {
+        PhosphorCompositor::FloatingCache cache;
+        // A composite "app|" (trailing separator → empty instanceId) is malformed.
+        // It must be rejected, not inserted under an empty-string key — otherwise
+        // every empty-instance window would alias onto one wildcard slot.
+        cache.setFloating(QStringLiteral("app|"), true);
+        QCOMPARE(cache.size(), 0);
+        QVERIFY(!cache.isFloating(QStringLiteral("app|")));
+        // A different malformed id must not resolve as floating via a shared key.
+        QVERIFY(!cache.isFloating(QStringLiteral("other|")));
+    }
+
+    // =================================================================
     // ZoneCache: basic set / get / unsnap
     // =================================================================
 
@@ -177,6 +194,22 @@ private Q_SLOTS:
 
         cache.clear();
         QCOMPARE(cache.size(), 0);
+    }
+
+    // =================================================================
+    // ZoneCache: malformed composite with empty instanceId is rejected
+    // =================================================================
+
+    void testZoneCacheRejectsEmptyInstanceId()
+    {
+        PhosphorCompositor::ZoneCache cache;
+        // A composite "app|" (trailing separator → empty instanceId) is malformed
+        // and must be ignored, not keyed under an empty string (which would alias
+        // every empty-instance window onto one wildcard slot).
+        cache.setZone(QStringLiteral("app|"), QStringLiteral("{z}"));
+        QCOMPARE(cache.size(), 0);
+        QVERIFY(!cache.isSnapped(QStringLiteral("app|")));
+        QVERIFY(!cache.isSnapped(QStringLiteral("other|")));
     }
 
     // =================================================================

--- a/tests/unit/compositor-common/test_floating_cache.cpp
+++ b/tests/unit/compositor-common/test_floating_cache.cpp
@@ -13,6 +13,7 @@
 
 #include <PhosphorCompositor/FloatingCache.h>
 #include <PhosphorCompositor/TriggerParser.h>
+#include <PhosphorCompositor/ZoneCache.h>
 
 class TestFloatingCache : public QObject
 {
@@ -83,6 +84,70 @@ private Q_SLOTS:
         QVERIFY(!cache.isFloating(QStringLiteral("firefox|1")));
         // "firefox|2" was never individually floating, and bare appId is gone:
         QVERIFY(!cache.isFloating(QStringLiteral("firefox|2")));
+    }
+
+    // =================================================================
+    // ZoneCache: basic set / get / unsnap
+    // =================================================================
+
+    void testZoneCacheBasic()
+    {
+        PhosphorCompositor::ZoneCache cache;
+        QVERIFY(!cache.isSnapped(QStringLiteral("app|1")));
+        QVERIFY(cache.zoneForWindow(QStringLiteral("app|1")).isEmpty());
+
+        cache.setZone(QStringLiteral("app|1"), QStringLiteral("{z1}"));
+        QVERIFY(cache.isSnapped(QStringLiteral("app|1")));
+        QCOMPARE(cache.zoneForWindow(QStringLiteral("app|1")), QStringLiteral("{z1}"));
+        QCOMPARE(cache.size(), 1);
+
+        // An empty zoneId removes the entry (unsnapped / floated / screen-changed).
+        cache.setZone(QStringLiteral("app|1"), QString());
+        QVERIFY(!cache.isSnapped(QStringLiteral("app|1")));
+        QCOMPARE(cache.size(), 0);
+    }
+
+    // =================================================================
+    // ZoneCache: keyed by instanceId — survives appId (class) mutation
+    // =================================================================
+
+    void testZoneCacheClassMutationRobustness()
+    {
+        PhosphorCompositor::ZoneCache cache;
+        // Snap recorded under the original appId.
+        cache.setZone(QStringLiteral("slack|uuid-1"), QStringLiteral("{zone-a}"));
+        QVERIFY(cache.isSnapped(QStringLiteral("slack|uuid-1")));
+
+        // The app renames its window class mid-session (Electron / CEF): the
+        // composite id's appId changes, but the instanceId is unchanged — the
+        // zone must still resolve because the cache keys by instanceId.
+        QVERIFY(cache.isSnapped(QStringLiteral("Slack|uuid-1")));
+        QCOMPARE(cache.zoneForWindow(QStringLiteral("Slack|uuid-1")), QStringLiteral("{zone-a}"));
+
+        // A different INSTANCE of the same app is not snapped (distinct instanceId).
+        QVERIFY(!cache.isSnapped(QStringLiteral("slack|uuid-2")));
+    }
+
+    // =================================================================
+    // ZoneCache: remove / clear
+    // =================================================================
+
+    void testZoneCacheRemoveAndClear()
+    {
+        PhosphorCompositor::ZoneCache cache;
+        // Distinct instanceIds — real instanceIds are unique per window. Two ids
+        // sharing an instanceId would (correctly) collide on the instanceId key.
+        cache.setZone(QStringLiteral("a|uuid-1"), QStringLiteral("{z}"));
+        cache.setZone(QStringLiteral("b|uuid-2"), QStringLiteral("{z}"));
+        QCOMPARE(cache.size(), 2);
+
+        cache.remove(QStringLiteral("a|uuid-1"));
+        QVERIFY(!cache.isSnapped(QStringLiteral("a|uuid-1")));
+        QVERIFY(cache.isSnapped(QStringLiteral("b|uuid-2")));
+        QCOMPARE(cache.size(), 1);
+
+        cache.clear();
+        QCOMPARE(cache.size(), 0);
     }
 
     // =================================================================

--- a/tests/unit/compositor-common/test_floating_cache.cpp
+++ b/tests/unit/compositor-common/test_floating_cache.cpp
@@ -3,9 +3,10 @@
 
 /**
  * @file test_floating_cache.cpp
- * @brief Unit tests for FloatingCache and TriggerParser
+ * @brief Unit tests for FloatingCache, ZoneCache and TriggerParser
  *
- * Tests FloatingCache set/get/clear/appId-fallback logic and
+ * Tests FloatingCache set/get/clear/appId-fallback and class-mutation
+ * robustness, ZoneCache snap-zone tracking and class-mutation robustness, and
  * TriggerParser modifier checking and anyTriggerHeld.
  */
 

--- a/tests/unit/compositor-common/test_floating_cache.cpp
+++ b/tests/unit/compositor-common/test_floating_cache.cpp
@@ -62,10 +62,38 @@ private Q_SLOTS:
     void testFloatingCacheClear()
     {
         PhosphorCompositor::FloatingCache cache;
-        cache.setFloating(QStringLiteral("app1|1"), true);
-        cache.setFloating(QStringLiteral("app2|1"), true);
+        // Distinct instanceIds — real instanceIds are unique per window. Two ids
+        // sharing an instanceId would (correctly) collide on the instanceId key.
+        cache.setFloating(QStringLiteral("app1|uuid-1"), true);
+        cache.setFloating(QStringLiteral("app2|uuid-2"), true);
         QCOMPARE(cache.size(), 2);
         cache.clear();
+        QCOMPARE(cache.size(), 0);
+    }
+
+    // =================================================================
+    // FloatingCache: instance float survives appId (class) mutation
+    // =================================================================
+
+    void testFloatingCacheClassMutationRobustness()
+    {
+        PhosphorCompositor::FloatingCache cache;
+        // A specific window floated under its original appId.
+        cache.setFloating(QStringLiteral("slack|uuid-1"), true);
+        QVERIFY(cache.isFloating(QStringLiteral("slack|uuid-1")));
+
+        // The app renames its window class mid-session (Electron / CEF): the
+        // composite id's appId changes, the instanceId does not — the float must
+        // still resolve because instance floats key by instanceId.
+        QVERIFY(cache.isFloating(QStringLiteral("Slack|uuid-1")));
+
+        // A different INSTANCE of the same app is not floating (distinct instanceId,
+        // and no app-wide entry exists).
+        QVERIFY(!cache.isFloating(QStringLiteral("slack|uuid-2")));
+
+        // Unfloating via the mutated id clears it (same instanceId key).
+        cache.setFloating(QStringLiteral("Slack|uuid-1"), false);
+        QVERIFY(!cache.isFloating(QStringLiteral("slack|uuid-1")));
         QCOMPARE(cache.size(), 0);
     }
 

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -1035,6 +1035,64 @@ private Q_SLOTS:
     }
 
     // =========================================================================
+    // resolveWindowRestore — open-floating gate (FloatPredicate)
+    //
+    // The daemon injects a predicate that returns true when a "Float this app"
+    // rule matched the opening window. resolveWindowRestore must then mark the
+    // window floating and refuse the auto-snap chain, logging the distinctive
+    // "floated by rule" line so the test can assert it was THAT branch — not the
+    // no-match default-float terminal, which floats the window in this guiless
+    // fixture too.
+    // =========================================================================
+
+    void testResolveWindowRestore_floatPredicate_floatsMatchedWindow()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        engine.setFloatPredicate([](const QString&) {
+            return true;
+        });
+
+        const QString windowId = QStringLiteral("app|uuid-float-rule");
+        QSignalSpy floatSpy(&engine, &SnapEngine::windowFloatingChanged);
+
+        PhosphorEngine::SnapResult result;
+        const QStringList lines = captureResolveLogs(engine, windowId, QStringLiteral("DP-1"), &result);
+
+        QVERIFY2(!result.shouldSnap, "a rule-floated window must not auto-snap");
+        QVERIFY2(engine.snapState()->isFloating(windowId), "the matched window must be marked floating");
+        QVERIFY2(lines.join(QLatin1Char('\n')).contains(QStringLiteral("floated by rule")),
+                 "the open-floating gate must be the branch that floated the window");
+        QCOMPARE(floatSpy.count(), 1);
+        QCOMPARE(floatSpy.at(0).at(0).toString(), windowId);
+        QCOMPARE(floatSpy.at(0).at(1).toBool(), true);
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testResolveWindowRestore_floatPredicate_unsetOrFalse_gateInactive()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        // Predicate present but returns false — the gate must not fire. (No
+        // predicate at all is the same: m_floatPredicate is empty.)
+        engine.setFloatPredicate([](const QString&) {
+            return false;
+        });
+
+        PhosphorEngine::SnapResult result;
+        const QStringList lines =
+            captureResolveLogs(engine, QStringLiteral("app|uuid-no-float-rule"), QStringLiteral("DP-1"), &result);
+
+        QVERIFY2(!lines.join(QLatin1Char('\n')).contains(QStringLiteral("floated by rule")),
+                 "an unmatched window must not be floated by the open-floating gate");
+        m_wts->setSnapState(nullptr);
+    }
+
+    // =========================================================================
     // resolveWindowRestore — cross-screen ownership gate (multi-monitor login)
     //
     // A window snapped on a SNAP monitor can be reopened by KWin's session

--- a/tests/unit/dbus/test_wta_reactive_metadata.cpp
+++ b/tests/unit/dbus/test_wta_reactive_metadata.cpp
@@ -348,6 +348,58 @@ private Q_SLOTS:
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // Float rule resolves through the composite windowId. shouldFloatByRule is
+    // purely rule-driven (no global default): the verdict is the presence of a
+    // matched Float slot, resolved through the same bare-instance-id extraction
+    // as RestorePosition. An unmatched window — and the no-store case — is false.
+    // ────────────────────────────────────────────────────────────────────
+    void floatRule_floatsMatchedWindow_viaCompositeWindowId()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        PhosphorWindowRule::WindowRuleStore store(dir.filePath(QStringLiteral("windowrules.json")));
+
+        PhosphorWindowRule::WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.name = QStringLiteral("float-dolphin");
+        rule.enabled = true;
+        rule.priority = 100;
+        rule.match = PhosphorWindowRule::MatchExpression::makeLeaf(
+            PhosphorWindowRule::Field::AppId, PhosphorWindowRule::Operator::Equals, QStringLiteral("org.kde.dolphin"));
+        PhosphorWindowRule::RuleAction action;
+        action.type = QString(PhosphorWindowRule::ActionType::Float);
+        rule.actions.append(action);
+        QVERIFY(store.addRule(rule));
+
+        m_wta->setWindowRuleStore(&store);
+        const auto detach = qScopeGuard([this] {
+            m_wta->setWindowRuleStore(nullptr);
+        });
+
+        const QString dolphinInstance = QStringLiteral("dolphin-float-1");
+        m_registry->upsert(dolphinInstance, {QStringLiteral("org.kde.dolphin"), QString(), QString()});
+
+        QVERIFY2(m_wta->shouldFloatByRule(
+                     PhosphorIdentity::WindowId::buildCompositeId(QStringLiteral("org.kde.dolphin"), dolphinInstance)),
+                 "a matched Float rule must open the window floating (resolved via the composite windowId)");
+
+        // An unmatched window is never floated — Float has no global default.
+        const QString konsoleInstance = QStringLiteral("konsole-float-1");
+        m_registry->upsert(konsoleInstance, {QStringLiteral("org.kde.konsole"), QString(), QString()});
+        QVERIFY2(!m_wta->shouldFloatByRule(
+                     PhosphorIdentity::WindowId::buildCompositeId(QStringLiteral("org.kde.konsole"), konsoleInstance)),
+                 "an unmatched window must not be floated (no global float-on-open default)");
+    }
+
+    void floatRule_falsesWithoutStore()
+    {
+        m_wta->setWindowRuleStore(nullptr);
+        QVERIFY2(!m_wta->shouldFloatByRule(PhosphorIdentity::WindowId::buildCompositeId(
+                     QStringLiteral("org.kde.dolphin"), QStringLiteral("any-uuid"))),
+                 "with no rule store, no window is rule-floated");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // The no-rule fallback branches: with no store, or a store that has no
     // metadata for the window, the per-engine *RestoreFloatedWindowsOnLogin
     // setting is the whole policy. Guards the early-outs in

--- a/tests/unit/dbus/test_wta_reactive_metadata.cpp
+++ b/tests/unit/dbus/test_wta_reactive_metadata.cpp
@@ -481,6 +481,63 @@ private Q_SLOTS:
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // A caption-only metadata refresh (chatty title tick) sends an EMPTY extended
+    // a{sv}; the daemon must PRESERVE the window's prior extended snapshot rather
+    // than wipe it. Without the merge, the next title tick would clear IsModal /
+    // geometry and a property-based Float rule would silently stop matching.
+    // ────────────────────────────────────────────────────────────────────
+    void floatRule_captionOnlyPushPreservesExtendedSnapshot()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        PhosphorWindowRule::WindowRuleStore store(dir.filePath(QStringLiteral("windowrules.json")));
+
+        PhosphorWindowRule::WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.name = QStringLiteral("float-modal");
+        rule.enabled = true;
+        rule.priority = 100;
+        rule.match = PhosphorWindowRule::MatchExpression::makeLeaf(PhosphorWindowRule::Field::IsModal,
+                                                                   PhosphorWindowRule::Operator::Equals, true);
+        PhosphorWindowRule::RuleAction action;
+        action.type = QString(PhosphorWindowRule::ActionType::Float);
+        rule.actions.append(action);
+        QVERIFY(store.addRule(rule));
+
+        m_wta->setWindowRuleStore(&store);
+        const auto detach = qScopeGuard([this] {
+            m_wta->setWindowRuleStore(nullptr);
+        });
+
+        namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
+        const QString appId = QStringLiteral("org.kde.someapp");
+        const int normalType = static_cast<int>(PhosphorProtocol::WindowType::Normal);
+
+        // Window opens with the full extended snapshot (IsModal=true, title v1).
+        const QString instance = QStringLiteral("modal-merge-1");
+        QVariantMap modal;
+        modal.insert(Key::IsModal, true);
+        m_wta->setWindowMetadata(instance, appId, QString(), QStringLiteral("Title v1"), QString(), 0, 0, QString(),
+                                 normalType, modal);
+        // Caption-only refresh: title changes, extended map EMPTY. The daemon must
+        // preserve IsModal. Resolve only AFTER the merge (resolveCached memoises per
+        // windowId), so the verdict reflects the merged registry state.
+        m_wta->setWindowMetadata(instance, appId, QString(), QStringLiteral("Title v2 — chatty"), QString(), 0, 0,
+                                 QString(), normalType, QVariantMap());
+        QVERIFY2(
+            m_wta->shouldFloatByRule(PhosphorIdentity::WindowId::buildCompositeId(appId, instance)),
+            "a caption-only (empty a{sv}) push must preserve the prior IsModal snapshot, so the rule still matches");
+
+        // Control: a window whose ONLY push was an empty map has nothing to
+        // preserve → IsModal stays absent → the rule is inert.
+        const QString bare = QStringLiteral("modal-merge-bare-1");
+        m_wta->setWindowMetadata(bare, appId, QString(), QString(), QString(), 0, 0, QString(), normalType,
+                                 QVariantMap());
+        QVERIFY2(!m_wta->shouldFloatByRule(PhosphorIdentity::WindowId::buildCompositeId(appId, bare)),
+                 "with no prior snapshot, an empty-map push leaves IsModal absent → no float");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // The no-rule fallback branches: with no store, or a store that has no
     // metadata for the window, the per-engine *RestoreFloatedWindowsOnLogin
     // setting is the whole policy. Guards the early-outs in

--- a/tests/unit/dbus/test_wta_reactive_metadata.cpp
+++ b/tests/unit/dbus/test_wta_reactive_metadata.cpp
@@ -39,6 +39,8 @@
 #include <PhosphorWindowRule/WindowRule.h>
 #include <PhosphorIdentity/WindowId.h>
 #include <PhosphorWindowRule/WindowRuleStore.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorProtocol/WindowTypeEnum.h>
 #include <PhosphorZones/Zone.h>
 #include "dbus/windowtrackingadaptor.h"
 
@@ -397,6 +399,85 @@ private Q_SLOTS:
         QVERIFY2(!m_wta->shouldFloatByRule(PhosphorIdentity::WindowId::buildCompositeId(
                      QStringLiteral("org.kde.dolphin"), QStringLiteral("any-uuid"))),
                  "with no rule store, no window is rule-floated");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Extended window properties carried by setWindowMetadata's trailing a{sv}
+    // reach the Float resolver, so a rule keyed on a KWin-property / geometry
+    // field (not just appId) resolves daemon-side. Exercises the full path:
+    // setWindowMetadata QVariantMap unpack → WindowMetadata optionals →
+    // buildRuleQueryForWindow → rule evaluation. Also pins the engage-only-when-
+    // known contract: ABSENT keys leave the fields disengaged → predicate inert.
+    //
+    // Each scenario uses a DISTINCT instanceId: shouldFloatByRule resolves through
+    // resolveCached, keyed on (windowId, ruleSet revision), so the verdict for a
+    // given window is memoised — the production invariant (a window is resolved
+    // once at open). Reusing one windowId across differing metadata would read the
+    // first cached verdict, not the new metadata.
+    // ────────────────────────────────────────────────────────────────────
+    void floatRule_matchesExtendedProperty_isModalAndWidth()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        PhosphorWindowRule::WindowRuleStore store(dir.filePath(QStringLiteral("windowrules.json")));
+
+        // "Float any modal dialog narrower than 500px" — a bool field AND an int
+        // field, both carried only via the extended a{sv}, combined under All.
+        PhosphorWindowRule::WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.name = QStringLiteral("float-narrow-modal");
+        rule.enabled = true;
+        rule.priority = 100;
+        rule.match = PhosphorWindowRule::MatchExpression::makeAll(
+            {PhosphorWindowRule::MatchExpression::makeLeaf(PhosphorWindowRule::Field::IsModal,
+                                                           PhosphorWindowRule::Operator::Equals, true),
+             PhosphorWindowRule::MatchExpression::makeLeaf(PhosphorWindowRule::Field::Width,
+                                                           PhosphorWindowRule::Operator::LessThan, 500)});
+        PhosphorWindowRule::RuleAction action;
+        action.type = QString(PhosphorWindowRule::ActionType::Float);
+        rule.actions.append(action);
+        QVERIFY(store.addRule(rule));
+
+        m_wta->setWindowRuleStore(&store);
+        const auto detach = qScopeGuard([this] {
+            m_wta->setWindowRuleStore(nullptr);
+        });
+
+        namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
+        const QString appId = QStringLiteral("org.kde.someapp");
+        const int normalType = static_cast<int>(PhosphorProtocol::WindowType::Normal);
+        // Pushes the extended snapshot for a fresh window and returns its open-time
+        // float verdict. Distinct instanceId per call → distinct resolveCached key.
+        const auto floatVerdict = [&](const QString& instance, const QVariantMap& extended) {
+            m_wta->setWindowMetadata(instance, appId, QString(), QString(), QString(), 0, 0, QString(), normalType,
+                                     extended);
+            return m_wta->shouldFloatByRule(PhosphorIdentity::WindowId::buildCompositeId(appId, instance));
+        };
+
+        // Modal + width 400 → both leaves match → float.
+        QVariantMap modalNarrow;
+        modalNarrow.insert(Key::IsModal, true);
+        modalNarrow.insert(Key::Width, 400);
+        QVERIFY2(floatVerdict(QStringLiteral("modal-narrow-1"), modalNarrow),
+                 "modal dialog narrower than 500px must float (extended bool + int props matched)");
+
+        // Modal but wide (800) → Width leaf fails → no float.
+        QVariantMap modalWide;
+        modalWide.insert(Key::IsModal, true);
+        modalWide.insert(Key::Width, 800);
+        QVERIFY2(!floatVerdict(QStringLiteral("modal-wide-1"), modalWide),
+                 "a wide modal must not float (Width >= 500 fails the All)");
+
+        // Narrow but not modal → IsModal leaf fails → no float.
+        QVariantMap nonModalNarrow;
+        nonModalNarrow.insert(Key::IsModal, false);
+        nonModalNarrow.insert(Key::Width, 400);
+        QVERIFY2(!floatVerdict(QStringLiteral("nonmodal-narrow-1"), nonModalNarrow),
+                 "a non-modal narrow window must not float (IsModal == true fails)");
+
+        // Absent keys → both fields disengaged → predicate inert → no float.
+        QVERIFY2(!floatVerdict(QStringLiteral("no-props-1"), QVariantMap()),
+                 "with the extended props absent, an IsModal/Width rule stays inert (engage-only-when-known)");
     }
 
     // ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Improves the window-rule system in three connected pieces: a bug fix, a batch of new match fields, and the harder PlasmaZones-state match fields. Each is a separate commit on this branch.

## 1. Fix the inert `Float` action (`90fae40b6`)

`ActionType::Float` was registered, authorable, and shown in the rule editor, but **no runtime code consumed it** — a "Float this app" rule silently did nothing (only `RestorePosition` was read at placement). Wired through the same daemon-injected predicate pattern as `RestorePosition`, in both engines:

- `SnapEngine`/`AutotileEngine` gain a `FloatPredicate` hook, cleared on detach.
- Snap: `resolveWindowRestore` floats the matched window (after the exclusion/already-floating guards) and refuses the auto-snap chain.
- Autotile: `insertWindow` marks the matched window floating after insertion, so it stays managed and Meta+F can re-tile it (identical to a manual float).
- Daemon `shouldFloatByRule` resolves the `Float` slot (free-form params, so verdict = slot presence; no global default). Extracted the shared metadata→`WindowQuery` builder and renamed `m_restorePositionEvaluator` → `m_windowRuleEvaluator` (it now serves both resolvers).

## 2. KWin-property match fields (`86a210cc3`)

Eleven new WHEN fields, each from an accessor already reachable in the effect-side query builder:

- `KeepAbove`, `KeepBelow`, `SkipTaskbar`, `SkipPager`, `SkipSwitcher`, `IsModal`, `HasDecoration`, `IsResizable` (bool)
- `PositionX`, `PositionY` (numeric; from the `frameGeometry()` already read for Width/Height)
- `captionNormal` (string; raw `WM_NAME` without the WM-added app-name suffix that pollutes `Title`)

Wired through the full Field recipe (enum/`FieldCount`/string maps/classifiers, `WindowQuery` storage/`valueForField`, the builder, and the `fieldCategory`/`fieldDescription`/`fieldLabel` UI switches). The picker is data-driven off the classifiers, so each field surfaces with the correct input and operator set with no QML change.

## 3. PlasmaZones-state match fields (`734af9b2c` + `cff7acf51`)

Three fields the effect-side appearance/animation rules can evaluate (`WHEN isSnapped ⇒ SetBorderColor`):

- `IsFloating` (both snap- and autotile-floated), `IsSnapped`, `Zone` (snap-zone UUID).

The daemon already emits `windowStateChanged(WindowStateEntry)` on every snap/unsnap/float/screen-change. The effect now subscribes to it, keeps a `windowId→zoneId` cache, seeds it at daemon-ready via `getAllWindowStates`, and threads floating/snapped/zone into the builder via a new `windowRuleQuery(w)` member (the free builder gained **required** state params so the compiler forced every call site). Both `slotWindowStateChanged` and `slotWindowFloatingChanged` now drop the per-window rule match-cache and refresh the window's border/opacity (these are MATCH inputs now). Caches cleared on close and daemon reset.

**Design note:** autotile tiles carry no persistent zone UUID, so `IsSnapped`/`Zone` are snap-mode semantics by design; `IsFloating` covers both modes.

**Follow-up (`cff7acf51`):** the snap-zone cache is keyed by the stable `instanceId` (not the composite windowId) so a class-mutating snapped window (Electron/CEF rename) stays resolvable. Extracted into a shared, unit-tested `PhosphorCompositor::ZoneCache` (sibling of `FloatingCache`).

## Tests

- Library: `FieldCount` canary 19→33, `valueForField` coverage for all 14 new fields.
- Snap engine: open-floating gate (fires / inactive). Daemon: `shouldFloatByRule` resolver (matched / unmatched / no-store). `ZoneCache`: basic + class-mutation robustness + remove/clear.
- Full suite: **280/280 pass.**

## Caveat

Effect-side *runtime* behavior (live signal delivery, cache currency, rule re-evaluation on snap/unsnap) needs a live KWin session to verify — the library fields, daemon emit, metatype registration, and unit coverage are in place, but the integration isn't runtime-tested here.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)