### PR TITLE
fix(placement): restore floating windows to the monitor they were last closed on

### DIFF
--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -386,6 +386,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
             <arg name="windowKind" type="i" direction="in">
                 <annotation name="org.gtk.GDBus.DocString" value="Structural kind of the closing window (0=Unknown, 1=Normal, 2=Transient). Recorded on the PendingRestore entry if one is enqueued. Pass 0 to opt out of the gate (legacy callers)."/>
             </arg>
+            <arg name="screenId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="The window's authoritative current screen at close (KWin's getWindowScreenId). Used by the final placement capture to record the float-back on the screen the window actually closed on, even when a cross-screen move has torn down both engines' tracking. Empty opts out (legacy callers)."/>
+            </arg>
         </method>
         <method name="windowActivated">
             <annotation name="org.gtk.GDBus.DocString" value="Notify daemon that a window was activated/focused."/>

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -841,9 +841,15 @@ void PlasmaZonesEffect::notifyWindowClosed(KWin::EffectWindow* w)
     }
 
     const int kindInt = static_cast<int>(classifyWindowKind(w));
-    qCInfo(lcEffect) << "Notifying daemon: windowClosed" << windowId << "kind=" << kindInt;
+    // Pass KWin's authoritative current screen for the window. The daemon uses it
+    // as the final-placement screen when a cross-screen move has left the window
+    // untracked by both engines at close — otherwise its float-back records the
+    // stale source screen and it reopens on the wrong monitor.
+    const QString closeScreenId = getWindowScreenId(w);
+    qCInfo(lcEffect) << "Notifying daemon: windowClosed" << windowId << "kind=" << kindInt
+                     << "screen=" << closeScreenId;
     PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
-                                                   QStringLiteral("windowClosed"), {windowId, kindInt});
+                                                   QStringLiteral("windowClosed"), {windowId, kindInt, closeScreenId});
 }
 
 void PlasmaZonesEffect::notifyWindowActivated(KWin::EffectWindow* w)

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
@@ -88,7 +88,12 @@ public:
     /// siblings (left by rapid open/close or overlapping short-lived instances)
     /// are stale. Without this the oldest-first take() rotates a reopening window
     /// between the duplicates — it "opens in a different spot each time."
-    void collapsePureFloatSiblings(const QString& appId, const QString& keepWindowId);
+    ///
+    /// Returns true if at least one sibling was removed, so the caller can mark
+    /// its persistence dirty: the preceding record() may have been a
+    /// content-identical no-op, in which case this prune is the only mutation and
+    /// would otherwise not reach disk until an incidental save.
+    bool collapsePureFloatSiblings(const QString& appId, const QString& keepWindowId);
 
     /// Drop any record for the exact windowId (and prune the empty bucket).
     /// Returns true if a record was actually removed.

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowPlacementStore.h
@@ -74,6 +74,22 @@ public:
     /// any record in that appId bucket.
     bool contains(const QString& windowId, const QString& appId = QString()) const;
 
+    /// Collapse stale pure-float duplicates for an app, keeping @p keepWindowId.
+    /// A "pure-float" record carries float-back geometry but NO managed
+    /// (snapped/tiled) engine slot. When @p keepWindowId names a pure-float
+    /// record, every OTHER pure-float record in the same @p appId bucket that
+    /// remembers a float position on a screen @p keepWindowId also covers is
+    /// removed. Records carrying a snapped/tiled slot are never touched (managed
+    /// placements whose multi-instance distribution must survive). No-op when the
+    /// kept record is absent or itself managed.
+    ///
+    /// Called ONLY from close-capture paths: a window closing floating is the
+    /// freshest authority for its app's float-back on that screen, so duplicate
+    /// siblings (left by rapid open/close or overlapping short-lived instances)
+    /// are stale. Without this the oldest-first take() rotates a reopening window
+    /// between the duplicates — it "opens in a different spot each time."
+    void collapsePureFloatSiblings(const QString& appId, const QString& keepWindowId);
+
     /// Drop any record for the exact windowId (and prune the empty bucket).
     /// Returns true if a record was actually removed.
     bool clear(const QString& windowId);

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -125,65 +125,71 @@ bool WindowPlacementStore::collapsePureFloatSiblings(const QString& appId, const
     }
     QList<WindowPlacement>& bucket = bit.value();
 
-    int keepIdx = -1;
-    for (int i = 0; i < bucket.size(); ++i) {
-        if (bucket.at(i).windowId == keepWindowId) {
-            keepIdx = i;
-            break;
+    const auto findKeep = [&]() -> int {
+        for (int i = 0; i < bucket.size(); ++i) {
+            if (bucket.at(i).windowId == keepWindowId) {
+                return i;
+            }
         }
-    }
+        return -1;
+    };
+    int keepIdx = findKeep();
     // Only collapse when the kept record is itself a pure float — a managed
-    // (snapped/tiled) close has no business pruning float siblings.
-    if (keepIdx < 0 || !isPureFloatRecord(bucket.at(keepIdx))) {
-        return false;
-    }
-    // Snapshot the kept record's remembered float screens; a sibling sharing any
-    // of them is a stale duplicate of the same per-app/per-screen float memory.
-    const QList<QString> keptScreens = bucket.at(keepIdx).freeGeometryByScreen.keys();
-    if (keptScreens.isEmpty()) {
+    // (snapped/tiled) close has no business pruning float siblings — and only when
+    // it actually remembers a float position.
+    if (keepIdx < 0 || !isPureFloatRecord(bucket.at(keepIdx)) || bucket.at(keepIdx).freeGeometryByScreen.isEmpty()) {
         return false;
     }
 
+    // Fixpoint prune: remove every pure-float sibling that shares a screen the kept
+    // record currently covers, absorbing the sibling's OTHER-screen geometry first
+    // (so a different-monitor position the sibling alone held is never dropped). The
+    // kept record's coverage grows as it absorbs, so re-scanning until stable
+    // collapses the WHOLE set of float records transitively connected by a shared
+    // screen — regardless of FIFO order — into the single kept record, leaving no
+    // residual same-screen duplicate to rotate to. bucket <= MaxPerApp, so the
+    // repeat is cheap. Wholly different-monitor records (no shared screen) are never
+    // pruned: distinct-monitor float memory is preserved as its own record.
     bool removedAny = false;
-    for (int i = bucket.size() - 1; i >= 0; --i) {
-        if (i == keepIdx) {
-            continue;
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        keepIdx = findKeep();
+        if (keepIdx < 0) {
+            break; // defensive — the kept record itself is never removed
         }
-        const WindowPlacement& other = bucket.at(i);
-        if (!isPureFloatRecord(other)) {
-            continue; // never prune a managed placement
-        }
-        bool sharesScreen = false;
-        for (const QString& screen : keptScreens) {
-            if (other.freeGeometryByScreen.contains(screen)) {
-                sharesScreen = true;
-                break;
+        for (int i = bucket.size() - 1; i >= 0; --i) {
+            if (i == keepIdx) {
+                continue;
             }
-        }
-        if (sharesScreen) {
-            // Absorb the sibling's float memory for any screen the kept record
-            // does NOT already cover, so collapsing a same-screen duplicate never
-            // silently drops a DIFFERENT-monitor position the sibling alone held.
-            // The kept record is newest, so its own per-screen geometry wins; the
-            // sibling only fills gaps. (keptScreens is the kept record's ORIGINAL
-            // coverage snapshot, so a gap-filled screen does not retroactively make
-            // an older sibling a "share" — its geometry for that screen is the same
-            // memory and is correctly left untouched.)
-            //
-            // Copy the sibling's geometry out first: mutating bucket[keepIdx] below
-            // could detach/reallocate the list and dangle the `other` reference.
+            const WindowPlacement& other = bucket.at(i);
+            if (!isPureFloatRecord(other)) {
+                continue; // never prune a managed placement
+            }
+            bool sharesScreen = false;
+            for (auto git = other.freeGeometryByScreen.constBegin(); git != other.freeGeometryByScreen.constEnd();
+                 ++git) {
+                if (bucket.at(keepIdx).freeGeometryByScreen.contains(git.key())) {
+                    sharesScreen = true;
+                    break;
+                }
+            }
+            if (!sharesScreen) {
+                continue; // wholly different-monitor record — distinct memory, kept
+            }
+            // Copy the sibling's geometry out before mutating bucket[keepIdx]:
+            // operator[] may detach/reallocate the list and dangle `other`.
             const QHash<QString, QRect> otherFree = other.freeGeometryByScreen;
             WindowPlacement& keep = bucket[keepIdx];
             for (auto git = otherFree.constBegin(); git != otherFree.constEnd(); ++git) {
                 if (!keep.freeGeometryByScreen.contains(git.key())) {
-                    keep.freeGeometryByScreen.insert(git.key(), git.value());
+                    keep.freeGeometryByScreen.insert(git.key(), git.value()); // kept (newest) wins; fill gaps only
                 }
             }
             bucket.removeAt(i);
             removedAny = true;
-            if (i < keepIdx) {
-                --keepIdx; // the kept record shifted down by the removal
-            }
+            changed = true;
+            break; // indices + keepIdx shifted; restart the scan
         }
     }
     return removedAny;

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -114,14 +114,14 @@ bool isPureFloatRecord(const WindowPlacement& p)
 }
 } // namespace
 
-void WindowPlacementStore::collapsePureFloatSiblings(const QString& appId, const QString& keepWindowId)
+bool WindowPlacementStore::collapsePureFloatSiblings(const QString& appId, const QString& keepWindowId)
 {
     if (appId.isEmpty() || keepWindowId.isEmpty()) {
-        return;
+        return false;
     }
     auto bit = m_byApp.find(appId);
     if (bit == m_byApp.end()) {
-        return;
+        return false;
     }
     QList<WindowPlacement>& bucket = bit.value();
 
@@ -135,15 +135,16 @@ void WindowPlacementStore::collapsePureFloatSiblings(const QString& appId, const
     // Only collapse when the kept record is itself a pure float — a managed
     // (snapped/tiled) close has no business pruning float siblings.
     if (keepIdx < 0 || !isPureFloatRecord(bucket.at(keepIdx))) {
-        return;
+        return false;
     }
     // Snapshot the kept record's remembered float screens; a sibling sharing any
     // of them is a stale duplicate of the same per-app/per-screen float memory.
     const QList<QString> keptScreens = bucket.at(keepIdx).freeGeometryByScreen.keys();
     if (keptScreens.isEmpty()) {
-        return;
+        return false;
     }
 
+    bool removedAny = false;
     for (int i = bucket.size() - 1; i >= 0; --i) {
         if (i == keepIdx) {
             continue;
@@ -161,11 +162,13 @@ void WindowPlacementStore::collapsePureFloatSiblings(const QString& appId, const
         }
         if (sharesScreen) {
             bucket.removeAt(i);
+            removedAny = true;
             if (i < keepIdx) {
                 --keepIdx; // the kept record shifted down by the removal
             }
         }
     }
+    return removedAny;
 }
 
 std::optional<WindowPlacement> WindowPlacementStore::take(const QString& windowId, const QString& appId,

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -95,6 +95,79 @@ bool WindowPlacementStore::record(WindowPlacement incoming)
     return true;
 }
 
+namespace {
+/// True when @p p carries float-back geometry but NO managed (snapped/tiled)
+/// engine slot — i.e. a pure floating placement whose only value is its
+/// remembered free position. A record with a snapped/tiled slot is a managed
+/// placement and is never a collapse candidate.
+bool isPureFloatRecord(const WindowPlacement& p)
+{
+    if (p.engines.isEmpty()) {
+        return false;
+    }
+    for (auto it = p.engines.constBegin(); it != p.engines.constEnd(); ++it) {
+        if (it.value().state == WindowPlacement::stateSnapped() || it.value().state == WindowPlacement::stateTiled()) {
+            return false;
+        }
+    }
+    return true;
+}
+} // namespace
+
+void WindowPlacementStore::collapsePureFloatSiblings(const QString& appId, const QString& keepWindowId)
+{
+    if (appId.isEmpty() || keepWindowId.isEmpty()) {
+        return;
+    }
+    auto bit = m_byApp.find(appId);
+    if (bit == m_byApp.end()) {
+        return;
+    }
+    QList<WindowPlacement>& bucket = bit.value();
+
+    int keepIdx = -1;
+    for (int i = 0; i < bucket.size(); ++i) {
+        if (bucket.at(i).windowId == keepWindowId) {
+            keepIdx = i;
+            break;
+        }
+    }
+    // Only collapse when the kept record is itself a pure float — a managed
+    // (snapped/tiled) close has no business pruning float siblings.
+    if (keepIdx < 0 || !isPureFloatRecord(bucket.at(keepIdx))) {
+        return;
+    }
+    // Snapshot the kept record's remembered float screens; a sibling sharing any
+    // of them is a stale duplicate of the same per-app/per-screen float memory.
+    const QList<QString> keptScreens = bucket.at(keepIdx).freeGeometryByScreen.keys();
+    if (keptScreens.isEmpty()) {
+        return;
+    }
+
+    for (int i = bucket.size() - 1; i >= 0; --i) {
+        if (i == keepIdx) {
+            continue;
+        }
+        const WindowPlacement& other = bucket.at(i);
+        if (!isPureFloatRecord(other)) {
+            continue; // never prune a managed placement
+        }
+        bool sharesScreen = false;
+        for (const QString& screen : keptScreens) {
+            if (other.freeGeometryByScreen.contains(screen)) {
+                sharesScreen = true;
+                break;
+            }
+        }
+        if (sharesScreen) {
+            bucket.removeAt(i);
+            if (i < keepIdx) {
+                --keepIdx; // the kept record shifted down by the removal
+            }
+        }
+    }
+}
+
 std::optional<WindowPlacement> WindowPlacementStore::take(const QString& windowId, const QString& appId,
                                                           const std::function<bool(const WindowPlacement&)>& accept,
                                                           const std::function<bool(const WindowPlacement&)>& preferred)

--- a/libs/phosphor-engine/src/WindowPlacementStore.cpp
+++ b/libs/phosphor-engine/src/WindowPlacementStore.cpp
@@ -161,6 +161,24 @@ bool WindowPlacementStore::collapsePureFloatSiblings(const QString& appId, const
             }
         }
         if (sharesScreen) {
+            // Absorb the sibling's float memory for any screen the kept record
+            // does NOT already cover, so collapsing a same-screen duplicate never
+            // silently drops a DIFFERENT-monitor position the sibling alone held.
+            // The kept record is newest, so its own per-screen geometry wins; the
+            // sibling only fills gaps. (keptScreens is the kept record's ORIGINAL
+            // coverage snapshot, so a gap-filled screen does not retroactively make
+            // an older sibling a "share" — its geometry for that screen is the same
+            // memory and is correctly left untouched.)
+            //
+            // Copy the sibling's geometry out first: mutating bucket[keepIdx] below
+            // could detach/reallocate the list and dangle the `other` reference.
+            const QHash<QString, QRect> otherFree = other.freeGeometryByScreen;
+            WindowPlacement& keep = bucket[keepIdx];
+            for (auto git = otherFree.constBegin(); git != otherFree.constEnd(); ++git) {
+                if (!keep.freeGeometryByScreen.contains(git.key())) {
+                    keep.freeGeometryByScreen.insert(git.key(), git.value());
+                }
+            }
             bucket.removeAt(i);
             removedAny = true;
             if (i < keepIdx) {

--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -372,6 +372,17 @@ public:
     void recordFreeGeometry(const QString& windowId, const QString& screenId, const QRect& geometry,
                             bool overwrite) override;
 
+    /// Authoritative float-back capture for a window closing on @p screenId.
+    /// Unlike recordFreeGeometry (a geometry-only partial that deliberately leaves
+    /// the managed-context screen untouched), this records the float geometry AND
+    /// updates the record's managed `screenId` to @p screenId — carrying an engine
+    /// slot so the store merge adopts the new screen. Used by the close-capture
+    /// fallback when a cross-screen move has orphaned the window from both engines,
+    /// so the only authoritative source of its final screen is KWin (passed down
+    /// from the effect). The existing record's per-engine slots and desktop/activity
+    /// are preserved; only the screen and this screen's free geometry change.
+    void recordFloatingClose(const QString& windowId, const QString& screenId, const QRect& geometry);
+
     /// Clear a window's shared free/float geometry from the record. See
     /// IWindowTrackingService::clearFreeGeometry.
     void clearFreeGeometry(const QString& windowId) override;

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -450,8 +450,12 @@ void WindowTrackingService::recordFloatingClose(const QString& windowId, const Q
     }
     // Close-capture convergence: this orphaned cross-screen close is the freshest
     // authority for the app's float-back, so drop stale pure-float duplicates on
-    // the same screen (see WindowPlacementStore::collapsePureFloatSiblings).
-    m_placementStore.collapsePureFloatSiblings(appId, windowId);
+    // the same screen (see WindowPlacementStore::collapsePureFloatSiblings). Mark
+    // dirty when it pruned — the record() above may have been a no-op, leaving this
+    // as the only mutation to persist.
+    if (m_placementStore.collapsePureFloatSiblings(appId, windowId)) {
+        markDirty(DirtyWindowPlacements);
+    }
 }
 
 void WindowTrackingService::clearFreeGeometry(const QString& windowId)

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -406,6 +406,54 @@ void WindowTrackingService::recordFreeGeometry(const QString& windowId, const QS
     }
 }
 
+void WindowTrackingService::recordFloatingClose(const QString& windowId, const QString& screenId, const QRect& geometry)
+{
+    if (windowId.isEmpty() || screenId.isEmpty() || !geometry.isValid()) {
+        return;
+    }
+    // Never let a tile rect become the float-back — same invariant recordFreeGeometry
+    // enforces. (An orphaned cross-screen-dragged window is floating, not tiled, so
+    // this is belt-and-braces.)
+    if (isWindowAutotileTiled(windowId)) {
+        return;
+    }
+    const QString appId = currentAppIdFor(windowId);
+    if (appId.isEmpty()) {
+        return;
+    }
+    PhosphorEngine::WindowPlacement p;
+    p.windowId = windowId;
+    p.appId = appId;
+    p.screenId = screenId;
+    p.freeGeometryByScreen.insert(screenId, geometry);
+    // Preserve the existing record's per-engine slots and context. Carrying a
+    // non-empty engine map is what makes the store merge adopt the new screenId
+    // (a geometry-only partial, like recordFreeGeometry, would leave the stale
+    // managed screen in place — exactly the bug this fixes).
+    if (const auto existing = m_placementStore.peek(windowId, appId)) {
+        p.virtualDesktop = existing->virtualDesktop;
+        p.activity = existing->activity;
+        p.kind = existing->kind;
+        p.engines = existing->engines;
+    }
+    if (p.engines.isEmpty()) {
+        // No prior record (first close after a cross-screen drag): synthesize a
+        // floating slot so the merge still adopts the screen. A floated restore
+        // keys off screenId + freeGeometryByScreen, not the slot's engine id, so
+        // the slot id is not load-bearing here.
+        PhosphorEngine::EngineSlot slot;
+        slot.state = PhosphorEngine::WindowPlacement::stateFloating();
+        p.engines.insert(QString(PhosphorEngine::WindowPlacement::snapEngineId()), slot);
+    }
+    if (m_placementStore.record(p)) {
+        markDirty(DirtyWindowPlacements);
+    }
+    // Close-capture convergence: this orphaned cross-screen close is the freshest
+    // authority for the app's float-back, so drop stale pure-float duplicates on
+    // the same screen (see WindowPlacementStore::collapsePureFloatSiblings).
+    m_placementStore.collapsePureFloatSiblings(appId, windowId);
+}
+
 void WindowTrackingService::clearFreeGeometry(const QString& windowId)
 {
     if (windowId.isEmpty()) {

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -267,7 +267,7 @@ void WindowTrackingAdaptor::setZoneDetectionAdaptor(ZoneDetectionAdaptor* adapto
     // except record the pointer for any WTA-side consumers.
 }
 
-void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId)
+void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, const QString& authoritativeScreen)
 {
     if (windowId.isEmpty() || !m_service) {
         return;
@@ -376,6 +376,15 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId)
             if (m_service->placementStore().record(*p)) {
                 m_service->markDirty(PhosphorPlacement::WindowTrackingService::DirtyWindowPlacements);
             }
+            // Close-capture convergence (see WindowPlacementStore::collapsePureFloatSiblings).
+            // Only on the close path (authoritativeScreen supplied): a window closing
+            // floating supersedes stale pure-float duplicates of the same app on the
+            // same screen, so a reopen restores to one consistent spot instead of
+            // rotating between leftover records. Live captures (refresh / float-change)
+            // pass no screen and never prune live siblings.
+            if (!authoritativeScreen.isEmpty()) {
+                m_service->placementStore().collapsePureFloatSiblings(p->appId, p->windowId);
+            }
             return;
         }
     }
@@ -387,6 +396,24 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId)
     // state (record()), consumed on restore (take), or removed by an explicit
     // exclude-rule prune (removeIf) — never by a capture miss. (Stale records are
     // bounded by MaxPerApp and consumed on reopen.)
+    //
+    // Authoritative close-screen fallback. A window dragged cross-screen and then
+    // closed reaches here with NEITHER engine tracking it: the source engine was
+    // cleared when the window left its screen (onWindowRemoved) and the destination
+    // engine never adopted it (a same-engine-type cross-screen move skips the
+    // handoff, and a floated window is not inserted into the destination tile
+    // layout). With both capturePlacement calls declined, the record's screen would
+    // keep the stale source value and a reopen would restore to the wrong monitor.
+    // The caller (windowClosed) supplies the window's true current screen from KWin;
+    // record the float-back there so the next open restores to the right monitor.
+    // Scoped to the engine-miss path so a normally-tracked close (an engine captured
+    // above and returned) is never second-guessed.
+    if (!authoritativeScreen.isEmpty() && m_service && !m_service->isWindowAutotileTiled(windowId)) {
+        const QRect frame = m_frameGeometry.value(windowId);
+        if (frame.isValid()) {
+            m_service->recordFloatingClose(windowId, authoritativeScreen, frame);
+        }
+    }
 }
 
 void WindowTrackingAdaptor::refreshOpenWindowPlacements()
@@ -599,7 +626,7 @@ void WindowTrackingAdaptor::setWindowSticky(const QString& windowId, bool sticky
 // Window Lifecycle - Delegate to Service
 // ═══════════════════════════════════════════════════════════════════════════════
 
-void WindowTrackingAdaptor::windowClosed(const QString& windowId, int windowKind)
+void WindowTrackingAdaptor::windowClosed(const QString& windowId, int windowKind, const QString& screenId)
 {
     if (!validateWindowId(windowId, QStringLiteral("clean up closed window"))) {
         return;
@@ -621,7 +648,12 @@ void WindowTrackingAdaptor::windowClosed(const QString& windowId, int windowKind
     // corresponding state. Runs while the window is still floating
     // (m_service->windowClosed below tears that down) and before m_frameGeometry
     // is dropped, so the live floated geometry is captured.
-    captureWindowPlacement(windowId);
+    //
+    // Pass the effect's authoritative close screen: when a cross-screen move has
+    // orphaned the window from both engines' tracking by close time, both engine
+    // capturePlacement calls miss/decline and the real screen would be lost —
+    // captureWindowPlacement falls back to this screen to record the float-back.
+    captureWindowPlacement(windowId, screenId);
 
     // Drop frame-geometry shadow entry for this window.
     m_frameGeometry.remove(windowId);

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -382,8 +382,11 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
             // same screen, so a reopen restores to one consistent spot instead of
             // rotating between leftover records. Live captures (refresh / float-change)
             // pass no screen and never prune live siblings.
-            if (!authoritativeScreen.isEmpty()) {
-                m_service->placementStore().collapsePureFloatSiblings(p->appId, p->windowId);
+            if (!authoritativeScreen.isEmpty()
+                && m_service->placementStore().collapsePureFloatSiblings(p->appId, p->windowId)) {
+                // The prune mutated the store; flag dirty in case the record()
+                // above was a content-identical no-op (then this is the only change).
+                m_service->markDirty(PhosphorPlacement::WindowTrackingService::DirtyWindowPlacements);
             }
             return;
         }

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -352,9 +352,15 @@ public Q_SLOTS:
      * @param windowId Window ID that was closed
      * @param windowKind PhosphorEngine::WindowKind wire value (Unknown/Normal/
      *        Transient) — gates the snap-restore consume on reopen
+     * @param screenId The window's authoritative current screen at close (KWin's
+     *        getWindowScreenId). Threaded into the final placement capture so a
+     *        window dragged cross-screen and closed records its float-back on the
+     *        screen it actually closed on — by close time a cross-screen move has
+     *        torn down both engines' tracking, so neither capturePlacement can
+     *        report the real screen. Empty = legacy/opt-out.
      * @note Call this when KWin reports a window has been closed to prevent memory leaks
      */
-    void windowClosed(const QString& windowId, int windowKind);
+    void windowClosed(const QString& windowId, int windowKind, const QString& screenId = QString());
 
     /**
      * Notify daemon that a window was activated/focused
@@ -600,7 +606,16 @@ public:
     /// the WindowPlacementStore (or clear the record if no engine manages it).
     /// Shadow-written in P1; the single funnel every state-change + close hook
     /// calls so the persisted record always reflects the window's live state.
-    void captureWindowPlacement(const QString& windowId);
+    ///
+    /// @p authoritativeScreen, when non-empty (the close path passes KWin's
+    /// getWindowScreenId), is the window's true current screen. It is used ONLY
+    /// as a fallback when NEITHER engine produces a placement — the case where a
+    /// cross-screen move has removed the window from the source engine's tracking
+    /// and the destination engine has not adopted it, so both capturePlacement
+    /// calls return nullopt and the live screen would otherwise be lost. In that
+    /// case the float-back is recorded on @p authoritativeScreen via
+    /// WindowTrackingService::recordFloatingClose.
+    void captureWindowPlacement(const QString& windowId, const QString& authoritativeScreen = QString());
 
     /// Re-capture every open floating window's live geometry into the unified
     /// store at save time (no per-move hook fires for drags). Called before the

--- a/tests/unit/core/test_window_placement_store.cpp
+++ b/tests/unit/core/test_window_placement_store.cpp
@@ -652,6 +652,35 @@ private Q_SLOTS:
         QVERIFY(kept->freeGeometryFor(QStringLiteral("S1")).isValid());
         QVERIFY(kept->freeGeometryFor(QStringLiteral("S2")).isValid()); // absorbed from the pruned sibling
     }
+
+    void testCollapse_transitiveCollapseIsOrderIndependent()
+    {
+        // bridge(S1+S2) connects keep(S1) to leaf(S2). The leaf shares NO screen
+        // with the kept record directly — only through the screen the bridge
+        // contributes. A naive single backward pass would process the leaf (newer,
+        // higher index) before the bridge and miss it; the fixpoint re-scans after
+        // absorbing the bridge's S2 and prunes the leaf too. Whole connected set
+        // collapses into keep regardless of FIFO order.
+        WindowPlacementStore store;
+        store.record(make(QStringLiteral("dolphin|bridge"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(make(QStringLiteral("dolphin|bridge"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S2"))); // bridge now S1+S2
+        store.record(make(QStringLiteral("dolphin|leaf"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S2"))); // newer than bridge
+        store.record(make(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1"))); // newest
+
+        QVERIFY(store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep")));
+
+        QVERIFY(store.contains(QStringLiteral("dolphin|keep")));
+        QVERIFY(!store.contains(QStringLiteral("dolphin|bridge"))); // shares S1 → pruned (S2 absorbed)
+        QVERIFY(!store.contains(QStringLiteral("dolphin|leaf"))); // connected via absorbed S2 → pruned
+        const auto kept = store.peek(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"));
+        QVERIFY(kept.has_value());
+        QVERIFY(kept->freeGeometryFor(QStringLiteral("S1")).isValid());
+        QVERIFY(kept->freeGeometryFor(QStringLiteral("S2")).isValid());
+    }
 };
 
 QTEST_MAIN(TestWindowPlacementStore)

--- a/tests/unit/core/test_window_placement_store.cpp
+++ b/tests/unit/core/test_window_placement_store.cpp
@@ -628,6 +628,30 @@ private Q_SLOTS:
         QVERIFY(store.contains(QStringLiteral("dolphin|float")));
         QVERIFY(store.contains(QStringLiteral("dolphin|snapped")));
     }
+
+    void testCollapse_absorbsPrunedSiblingOtherScreenGeometry()
+    {
+        // A pruned same-screen duplicate may also hold a float position on a
+        // DIFFERENT monitor the kept record lacks. That position must not be lost
+        // — the kept record absorbs it before the duplicate is removed.
+        WindowPlacementStore store;
+        // Sibling floated on S1 then S2 — its single record accumulates both.
+        store.record(make(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(make(QStringLiteral("dolphin|sib"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S2")));
+        // Kept record floated only on S1.
+        store.record(make(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+
+        QVERIFY(store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep")));
+
+        QVERIFY(!store.contains(QStringLiteral("dolphin|sib"))); // S1-sharing duplicate pruned
+        const auto kept = store.peek(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"));
+        QVERIFY(kept.has_value());
+        QVERIFY(kept->freeGeometryFor(QStringLiteral("S1")).isValid());
+        QVERIFY(kept->freeGeometryFor(QStringLiteral("S2")).isValid()); // absorbed from the pruned sibling
+    }
 };
 
 QTEST_MAIN(TestWindowPlacementStore)

--- a/tests/unit/core/test_window_placement_store.cpp
+++ b/tests/unit/core/test_window_placement_store.cpp
@@ -585,7 +585,9 @@ private Q_SLOTS:
 
         store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|new"));
 
-        QVERIFY(store.contains(QStringLiteral("dolphin|new"), QStringLiteral("dolphin")));
+        // Exact-windowId checks (no appId): contains(id, appId) would pass on any
+        // surviving bucket record, so it can't prove the RIGHT record was kept.
+        QVERIFY(store.contains(QStringLiteral("dolphin|new")));
         QVERIFY(!store.contains(QStringLiteral("dolphin|old")));
     }
 
@@ -606,7 +608,7 @@ private Q_SLOTS:
 
         store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep"));
 
-        QVERIFY(store.contains(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin")));
+        QVERIFY(store.contains(QStringLiteral("dolphin|keep"))); // exact survival
         QVERIFY(store.contains(QStringLiteral("dolphin|snapped"))); // managed — kept
         QVERIFY(store.contains(QStringLiteral("dolphin|other"))); // different screen — kept
         QVERIFY(!store.contains(QStringLiteral("dolphin|dup"))); // same-screen float dup — pruned

--- a/tests/unit/core/test_window_placement_store.cpp
+++ b/tests/unit/core/test_window_placement_store.cpp
@@ -569,6 +569,63 @@ private Q_SLOTS:
         QCOMPARE(gotSlot.state, QString(WindowPlacement::stateTiled()));
         QCOMPARE(gotSlot.order, 3);
     }
+
+    // ── collapsePureFloatSiblings (close-capture convergence) ──
+
+    void testCollapse_dropsSameScreenFloatDuplicate()
+    {
+        // Two pure-float records for one app on the same screen — the duplicate
+        // state that makes a reopen "open in a different spot each time" under the
+        // oldest-first take(). Collapsing keeps the named (closing) record only.
+        WindowPlacementStore store;
+        store.record(make(QStringLiteral("dolphin|old"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(make(QStringLiteral("dolphin|new"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+
+        store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|new"));
+
+        QVERIFY(store.contains(QStringLiteral("dolphin|new"), QStringLiteral("dolphin")));
+        QVERIFY(!store.contains(QStringLiteral("dolphin|old")));
+    }
+
+    void testCollapse_keepsManagedAndOtherScreenSiblings()
+    {
+        WindowPlacementStore store;
+        // Snapped (managed) sibling — never pruned.
+        store.record(make(QStringLiteral("dolphin|snapped"), QStringLiteral("dolphin"), WindowPlacement::stateSnapped(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        // Pure-float on a DIFFERENT screen — distinct memory, kept.
+        store.record(make(QStringLiteral("dolphin|other"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S2")));
+        // Pure-float on the SAME screen as the kept record — pruned.
+        store.record(make(QStringLiteral("dolphin|dup"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(make(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+
+        store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|keep"));
+
+        QVERIFY(store.contains(QStringLiteral("dolphin|keep"), QStringLiteral("dolphin")));
+        QVERIFY(store.contains(QStringLiteral("dolphin|snapped"))); // managed — kept
+        QVERIFY(store.contains(QStringLiteral("dolphin|other"))); // different screen — kept
+        QVERIFY(!store.contains(QStringLiteral("dolphin|dup"))); // same-screen float dup — pruned
+    }
+
+    void testCollapse_noopWhenKeptRecordIsManaged()
+    {
+        // A managed (snapped) close must not prune float siblings.
+        WindowPlacementStore store;
+        store.record(make(QStringLiteral("dolphin|float"), QStringLiteral("dolphin"), WindowPlacement::stateFloating(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+        store.record(make(QStringLiteral("dolphin|snapped"), QStringLiteral("dolphin"), WindowPlacement::stateSnapped(),
+                          WindowPlacement::snapEngineId(), QStringLiteral("S1")));
+
+        store.collapsePureFloatSiblings(QStringLiteral("dolphin"), QStringLiteral("dolphin|snapped"));
+
+        QVERIFY(store.contains(QStringLiteral("dolphin|float")));
+        QVERIFY(store.contains(QStringLiteral("dolphin|snapped")));
+    }
 };
 
 QTEST_MAIN(TestWindowPlacementStore)


### PR DESCRIPTION
## Summary

Fixes a window dragged across monitors and then closed reopening on the **wrong monitor** — and, once two divergent records existed, "opening in a different spot each time." Two distinct defects, found by instrumenting the placement capture/restore path and confirming against the live `session.json`.

### 1. The placement record's screen went stale on a cross-screen close
The record's `screenId` was sourced from the owning engine's per-mode tracking at capture time. After a cross-screen drag, the source engine has already dropped the window (`onWindowRemoved` as it left the source screen) and the destination engine never adopted it (a same-engine-type cross-screen move skips the handoff; a floated window isn't inserted into the destination tile layout). So at **close, both `capturePlacement` calls decline**, the window's real screen is lost, the stale source screen survives in the record, and restore sends the window back to the wrong monitor — which the next (wrong-monitor) open re-records, perpetuating the loop.

**Fix:** thread the window's authoritative current screen (KWin's `getWindowScreenId`) through `windowClosed`. When neither engine produces a placement, the close-capture records the float-back on that screen via the new `WindowTrackingService::recordFloatingClose`, which carries an engine slot so the store merge **adopts the new `screenId`** (`recordFreeGeometry` is geometry-only and would leave the stale managed screen in place). No pixel/`frame.center()` derivation — the screen comes straight from KWin's authoritative report.

### 2. Divergent float records made a reopen rotate between monitors/positions
Once an app had two pure-float records (e.g. one per monitor), the oldest-first FIFO `take()` + rebind-to-newest rotated a reopening window between them.

**Fix:** `WindowPlacementStore::collapsePureFloatSiblings`, invoked on **close-capture only** (a window closing floating is the freshest authority for its app's float-back on that screen). It drops other pure-float records of the same app that share a screen, keeping the newest. **Snapped/tiled (managed) records and different-screen float records are never touched**, so multi-instance distribution is preserved; only the stale same-screen float duplicates collapse.

## Test plan
- `cmake --build build` — clean.
- `ctest` — **282/282 pass**, including 3 new `WindowPlacementStore` tests: same-screen float duplicate pruned; managed + different-screen siblings kept; managed-close is a no-op.
- Manually verified on a 2-monitor setup (one snap-mode, one autotile-mode): Dolphin dragged across monitors and closed now reopens consistently on the monitor it was last closed on, instead of bouncing between two locations.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
