### PR TITLE
feat(settings): split the window-rule field picker's "State" group into focused categories

### DIFF
--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -38,10 +38,16 @@ struct PickerCategory
 
 /// Group a match Field into a picker category. The `Field` enum interleaves
 /// state and context (e.g. IsMaximized sits after Activity), so the picker
-/// groups by THIS classification, never by enum / emit order.
+/// groups by THIS classification, never by enum / emit order. The categories
+/// are deliberately fine-grained: a single flat "State" bucket of ~19 entries
+/// is hard to scan, so the window-kind, taskbar/switcher-hint, and
+/// PlasmaZones-tiling concepts each get their own top-level fly-out. Items
+/// within a category are sorted alphabetically by CategoryMenuButton; only the
+/// returned order int controls the relative position of the categories.
 PickerCategory fieldCategory(Field f)
 {
     switch (f) {
+    // Who the window is — identifiers a rule matches against.
     case Field::AppId:
     case Field::WindowClass:
     case Field::DesktopFile:
@@ -50,35 +56,43 @@ PickerCategory fieldCategory(Field f)
     case Field::Title:
     case Field::CaptionNormal:
         return {PhosphorI18n::tr("Identity"), 0};
+    // What kind of window it is (its role/type), not a toggled runtime state.
     case Field::WindowType:
-    case Field::IsSticky:
-    case Field::IsFullscreen:
-    case Field::IsMinimized:
-    case Field::IsMaximized:
-    case Field::IsFocused:
     case Field::IsTransient:
+    case Field::IsModal:
     case Field::IsNotification:
+        return {PhosphorI18n::tr("Type"), 1};
+    // Live window-manager state and chrome flags.
+    case Field::IsMaximized:
+    case Field::IsMinimized:
+    case Field::IsFullscreen:
+    case Field::IsFocused:
     case Field::KeepAbove:
     case Field::KeepBelow:
+    case Field::IsSticky:
+    case Field::HasDecoration:
+    case Field::IsResizable:
+        return {PhosphorI18n::tr("State"), 2};
+    // NETWM "skip" hints — whether the window opts out of the taskbar, pager,
+    // or Alt+Tab switcher.
     case Field::SkipTaskbar:
     case Field::SkipPager:
     case Field::SkipSwitcher:
-    case Field::IsModal:
-    case Field::HasDecoration:
-    case Field::IsResizable:
+        return {PhosphorI18n::tr("Taskbar & switcher"), 3};
+    // PlasmaZones-owned placement state.
     case Field::IsFloating:
     case Field::IsSnapped:
     case Field::Zone:
-        return {PhosphorI18n::tr("State"), 1};
+        return {PhosphorI18n::tr("Tiling"), 4};
     case Field::Width:
     case Field::Height:
     case Field::PositionX:
     case Field::PositionY:
-        return {PhosphorI18n::tr("Size"), 2};
+        return {PhosphorI18n::tr("Size"), 5};
     case Field::ScreenId:
     case Field::VirtualDesktop:
     case Field::Activity:
-        return {PhosphorI18n::tr("Context"), 3};
+        return {PhosphorI18n::tr("Context"), 6};
     }
     return {PhosphorI18n::tr("Other"), 99};
 }

--- a/tests/unit/settings/test_window_rule_controller.cpp
+++ b/tests/unit/settings/test_window_rule_controller.cpp
@@ -787,8 +787,10 @@ void TestWindowRuleController::authoringMetadata()
     // Picker categories drive the fly-out submenu grouping. Every field carries
     // a non-empty category label + a categoryOrder int. The Field enum
     // interleaves state/context, so assert grouping is by CATEGORY (via the
-    // language-independent order), not by enum position: Identity=0, State=1,
-    // Size=2, Context=3.
+    // language-independent order), not by enum position. The (formerly single,
+    // 19-entry) State bucket is split into fine-grained categories:
+    // Identity=0, Type=1, State=2, Taskbar & switcher=3, Tiling=4, Size=5,
+    // Context=6.
     QHash<QString, int> fieldCategoryOrder;
     for (const QVariant& v : fields) {
         const QVariantMap f = v.toMap();
@@ -803,11 +805,17 @@ void TestWindowRuleController::authoringMetadata()
                                   f.value(QStringLiteral("categoryOrder")).toInt());
     }
     QCOMPARE(fieldCategoryOrder.value(QStringLiteral("appId")), 0); // Identity
-    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("isFullscreen")), 1); // State
-    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("isMaximized")), 1); // State (after Context in enum order)
-    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("width")), 2); // Size
-    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("height")), 2); // Size
-    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("screenId")), 3); // Context
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("windowType")), 1); // Type
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("isTransient")), 1); // Type
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("isFullscreen")), 2); // State
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("isMaximized")), 2); // State (after Context in enum order)
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("skipTaskbar")), 3); // Taskbar & switcher
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("skipSwitcher")), 3); // Taskbar & switcher
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("isFloating")), 4); // Tiling
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("zone")), 4); // Tiling
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("width")), 5); // Size
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("height")), 5); // Size
+    QCOMPARE(fieldCategoryOrder.value(QStringLiteral("screenId")), 6); // Context
 
     // The four match conditions (IsTransient/IsNotification/Width/Height) must be
     // authorable: present in the picker with the correct value kind, and with


### PR DESCRIPTION
## Problem

The **WHEN** field picker in the window-rule editor lumped **19** match fields into a single flat "State" fly-out — window kind, live WM-state flags, NETWM skip hints, and PlasmaZones tiling state all jumbled together and only alphabetised. It was hard to scan, and the three "Skip …" entries had no obvious home.

## Change

Split `fieldCategory()` (`src/settings/windowruleauthoring.cpp`) into fine-grained top-level categories so each fly-out is short and self-explanatory:

| Order | Category | Fields |
|---|---|---|
| 0 | **Identity** | App ID, Window class, Desktop file, Window role, PID, Title, Caption |
| 1 | **Type** | Window type, Transient, Modal, Notification |
| 2 | **State** | Maximized, Minimized, Fullscreen, Focused, Keep above, Keep below, Sticky, Decorated, Resizable |
| 3 | **Taskbar & switcher** | Skip taskbar, Skip pager, Skip switcher |
| 4 | **Tiling** | Floating, Snapped, Zone |
| 5 | **Size** | Width, Height, Position X/Y |
| 6 | **Context** | Monitor, Virtual desktop, Activity |

Notes:
- The window-kind category is named **Type** (not "Window type") so it doesn't collide with the field of the same name inside it.
- The three NETWM **skip** hints now sit under one obvious **Taskbar & switcher** heading; their info-icon tooltips already explain each one.
- `CategoryMenuButton` already groups by `categoryOrder` and splits the category string on `/`, so this is a **single-function change** — no QML or shared-component edits.

## Testing
- `ctest`: **282/282 pass**
- The category-order unit test (`test_window_rule_controller.cpp`) is updated to lock in the new grouping (Identity=0 … Context=6) and now also asserts the new Type / Taskbar & switcher / Tiling categories.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)