### PR TITLE
fix(snap): never move a floated window across monitors on restore

### DIFF
--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -229,11 +229,9 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
                 // on the wrong monitor, unsnapped. The RECORDED screen must still be
                 // in snapping mode, though: a snapped record whose own screen is now
                 // autotile-owned must not snap-restore there (the early gate leaves it
-                // for autotile). A floated position is screen-local UNLESS the
-                // user opted into unsnapped-position restore (global setting / rule),
-                // in which case the record is eligible cross-screen so the window
-                // returns to its recorded monitor; otherwise it stays gated on the
-                // opening screen.
+                // for autotile). A floated position is ALWAYS screen-local: it is
+                // eligible only when the window opens on its recorded monitor (the
+                // gate below). Float restore never MOVES a window across monitors.
                 if (p.slotFor(engineId()).state == WindowPlacement::stateSnapped()) {
                     return recordedSnapScreenIsSnapping(p);
                 }
@@ -251,9 +249,17 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
                 if (!p.hasRestorableContent()) {
                     return false;
                 }
-                if (restoreFloatedPosition) {
-                    return true;
-                }
+                // A floated record is SCREEN-LOCAL: eligible only when the window
+                // opens on the monitor it was recorded on (or an unscreened record).
+                // Float restore must NEVER move a window to a different monitor —
+                // a stale float record left by an earlier instance on another output
+                // (matched via the appId FIFO, not an exact-windowId match) would
+                // otherwise teleport a freshly-launched window onto a monitor it never
+                // occupied, and the wrong-monitor capture that follows re-cements the
+                // bad record into a self-perpetuating cross-monitor jump. The opening
+                // monitor is owned by KWin's placement / session restore; PlasmaZones
+                // only restores the floated POSITION within that monitor (gated on the
+                // restore-floated opt-in at the geometry-move step below).
                 return p.screenId.isEmpty() || p.screenId == screenId;
             },
             [&](const WindowPlacement& p) {

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -95,11 +95,14 @@ void SnapEngine::windowOpened(const QString& windowId, const QString& screenId, 
 // geometry application.
 //
 // Screen mode semantics:
-//   - The placement-store restore and app rules (chain level 1) may
-//     cross-screen migrate: a stored record's own screenId or an app rule can
+//   - SNAPPED placement-store restore and app rules (chain level 1) may
+//     cross-screen migrate: a snapped record's own screenId or an app rule can
 //     route a window to a different screen, and the store's take() accept
 //     predicate / snapped-branch screen check keep an autotile-mode screen from
-//     being snapped onto (autotile on that screen will own it).
+//     being snapped onto (autotile on that screen will own it). FLOATED records
+//     are screen-local — a float-back is restored only when the window reopens
+//     on its recorded screen, never moved across monitors (the accept predicate
+//     gates floated records on the opening screen).
 //   - The empty-zone (level 2) and last-zone (level 3) fallbacks inherently use
 //     the caller screen as the target, so they are ONLY valid when the caller's
 //     screen is in snap mode. On autotile screens they're short-circuited —

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -1187,18 +1187,20 @@ private Q_SLOTS:
     // resolveWindowRestore — unsnapped-position restore gate
     // (RestorePositionPredicate)
     //
-    // A FREE (never-snapped) or snap-FLOATED window persists its global
-    // position keyed by its recorded screen. KWin's session restore can reopen
-    // it on a DIFFERENT monitor at login. When the daemon's restore-position
-    // predicate opts the window in, the record becomes eligible cross-screen and
-    // the engine emits geometryRestoreRequested with the RECORDED screen's
-    // geometry — which, being in global compositor coordinates, returns the
-    // window to its original monitor. With the predicate unset/false the
-    // historical behaviour stands: free positions are inert and a cross-screen
-    // record is not consumed.
+    // A FREE (never-snapped) or snap-FLOATED window persists its global position
+    // keyed by its recorded screen. Float/free position restore is SAME-MONITOR
+    // ONLY: a record is eligible only when the window reopens on its recorded
+    // screen, and even then the geometry MOVE is gated on the restore-position
+    // predicate (the snappingRestoreFloatedWindowsOnLogin setting / RestorePosition
+    // rule). A record whose recorded screen differs from the opening screen is
+    // NEVER consumed and NEVER moves the window — float restore must not drag a
+    // window across monitors: a stale sibling record on another output would
+    // otherwise teleport a freshly-launched window, and the wrong-monitor capture
+    // that follows would re-cement it into a self-perpetuating jump. KWin's own
+    // placement / session restore owns which monitor the window opens on.
     // =========================================================================
 
-    void testResolveWindowRestore_freeCrossScreen_restoresWhenPredicateOptsIn()
+    void testResolveWindowRestore_freeCrossScreen_inertEvenWithOptIn()
     {
         SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
         engine.setEngineSettings(m_settings);
@@ -1221,15 +1223,19 @@ private Q_SLOTS:
 
         QSignalSpy geoSpy(&engine, &PhosphorEngine::PlacementEngineBase::geometryRestoreRequested);
 
-        // KWin reopens the window (new uuid) on DP-2.
+        // KWin reopens the window (new uuid) on DP-2. Float/free restore is
+        // same-monitor only: even with the opt-in predicate, a record recorded on
+        // DP-1 must NOT move the window to its old monitor, and must NOT be
+        // consumed — it stays available for a later open on DP-1.
         const PhosphorEngine::SnapResult result =
             engine.resolveWindowRestore(QStringLiteral("app|new"), QStringLiteral("DP-2"), /*sticky*/ false);
 
-        QVERIFY2(!result.shouldSnap, "a free window is repositioned, never snapped into a zone");
-        QCOMPARE(geoSpy.count(), 1);
-        const QList<QVariant> args = geoSpy.takeFirst();
-        QCOMPARE(args.at(1).toRect(), dp1Geo);
-        QCOMPARE(args.at(2).toString(), QStringLiteral("DP-1"));
+        QVERIFY2(!result.shouldSnap, "a free window is never snapped into a zone");
+        QCOMPARE(geoSpy.count(), 0);
+        QVERIFY2(m_wts->placementStore().contains(QStringLiteral("app|orig"), QStringLiteral("app")),
+                 "a cross-monitor free record is not consumed — float restore never moves across monitors");
+        QVERIFY2(!m_wts->placementStore().contains(QStringLiteral("app|new")),
+                 "nothing is re-recorded under the live id when the cross-monitor record is left untouched");
         m_wts->setSnapState(nullptr);
     }
 
@@ -1262,7 +1268,7 @@ private Q_SLOTS:
         m_wts->setSnapState(nullptr);
     }
 
-    void testResolveWindowRestore_floatingCrossScreen_restoresToRecordedMonitor()
+    void testResolveWindowRestore_floatingCrossScreen_doesNotMoveAcrossMonitors()
     {
         SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
         engine.setEngineSettings(m_settings);
@@ -1285,32 +1291,21 @@ private Q_SLOTS:
         rec.freeGeometryByScreen.insert(QStringLiteral("DP-1"), dp1Geo);
         m_wts->placementStore().record(rec);
 
-        QSignalSpy floatSpy(&engine, &PhosphorEngine::PlacementEngineBase::windowFloatingChanged);
         QSignalSpy geoSpy(&engine, &PhosphorEngine::PlacementEngineBase::geometryRestoreRequested);
 
+        // Reopen on DP-2. Same-monitor-only: a floated record recorded on DP-1
+        // must not teleport the window to DP-1, and must not be consumed — it stays
+        // for a later DP-1 open. (This is the konsole/ghastty wrong-monitor bug:
+        // a stale cross-monitor floated record must never drag a fresh window.)
         const PhosphorEngine::SnapResult result =
             engine.resolveWindowRestore(QStringLiteral("app|new"), QStringLiteral("DP-2"), /*sticky*/ false);
 
-        QVERIFY2(!result.shouldSnap, "a floated window restores its float position, not a snap");
-        QCOMPARE(geoSpy.count(), 1);
-        QCOMPARE(geoSpy.takeFirst().at(1).toRect(), dp1Geo);
-        QCOMPARE(floatSpy.count(), 1);
-        const QList<QVariant> floatArgs = floatSpy.takeFirst();
-        QCOMPARE(floatArgs.at(1).toBool(), true);
-        QCOMPARE(floatArgs.at(2).toString(), QStringLiteral("DP-1"));
-        // A FIFO-reopened record (live id != recorded id) is RE-RECORDED under the
-        // LIVE windowId so the window's float-back survives logout/login (KWin assigns
-        // a new uuid at login). The stale recorded-uuid entry is rebound, not left as
-        // a duplicate.
-        QVERIFY2(m_wts->placementStore().contains(QStringLiteral("app|new")),
-                 "a cross-screen floating restore re-records under the live window id");
-        QVERIFY2(!m_wts->placementStore().contains(QStringLiteral("app|orig")),
-                 "the stale recorded-uuid entry is rebound to the live id, not left behind");
-        // The float-back geometry is preserved on the re-recorded placement, so a
-        // later float after login restores the pre-logout position.
-        const auto reRec = m_wts->placementStore().peek(QStringLiteral("app|new"), QStringLiteral("app"));
-        QVERIFY(reRec.has_value());
-        QCOMPARE(reRec->freeGeometryFor(QStringLiteral("DP-1")), dp1Geo);
+        QVERIFY2(!result.shouldSnap, "a floated record never snaps into a zone");
+        QVERIFY2(geoSpy.count() == 0, "float restore never moves a window across monitors");
+        QVERIFY2(m_wts->placementStore().contains(QStringLiteral("app|orig"), QStringLiteral("app")),
+                 "the cross-monitor floating record is left intact for a later DP-1 open");
+        QVERIFY2(!m_wts->placementStore().contains(QStringLiteral("app|new")),
+                 "nothing is re-recorded under the live id for a rejected cross-monitor record");
         m_wts->setSnapState(nullptr);
     }
 
@@ -1442,14 +1437,12 @@ private Q_SLOTS:
         m_wts->setSnapState(nullptr);
     }
 
-    // Opt-in cross-screen eligibility (re-record) and the geometry move are
-    // SEPARATELY gated. A free record reopening cross-screen is eligible purely on
-    // the predicate opt-in, but the move only fires when restoreScreen has a
-    // recorded position. With geometry captured on a THIRD screen (not the
-    // record's own restoreScreen), freeGeometryFor(restoreScreen) is invalid, so
-    // the record is re-recorded (under the live id) without a move — the removed
-    // anyFreeGeometry() cross-screen fallback must NOT resurrect some other screen's rect.
-    void testResolveWindowRestore_freeCrossScreen_optInNoGeometryForRestoreScreen_reRecordsWithoutMove()
+    // Same-monitor-only restore rejects a cross-monitor record outright —
+    // regardless of which screen its recorded geometry lives on. Even with the
+    // opt-in predicate and geometry captured on a THIRD screen, the record is
+    // neither moved nor consumed: no anyFreeGeometry() resurrection, no
+    // cross-monitor teleport, and the record is left for a same-monitor open.
+    void testResolveWindowRestore_freeCrossScreen_inertRegardlessOfGeometryScreen()
     {
         SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
         engine.setEngineSettings(m_settings);
@@ -1471,17 +1464,16 @@ private Q_SLOTS:
 
         QSignalSpy geoSpy(&engine, &PhosphorEngine::PlacementEngineBase::geometryRestoreRequested);
 
-        // KWin reopens on DP-2; opt-in makes the cross-screen record eligible.
+        // KWin reopens on DP-2 (neither the record's screen nor its geometry's screen).
         const PhosphorEngine::SnapResult result =
             engine.resolveWindowRestore(QStringLiteral("app|new"), QStringLiteral("DP-2"), /*sticky*/ false);
 
         QVERIFY(!result.shouldSnap);
-        QVERIFY2(geoSpy.count() == 0,
-                 "no recorded position for restoreScreen → move skipped (no anyFreeGeometry fallback)");
-        QVERIFY2(m_wts->placementStore().contains(QStringLiteral("app|new")),
-                 "opt-in re-records the cross-screen free record under the live id even when the move is skipped");
-        QVERIFY2(!m_wts->placementStore().contains(QStringLiteral("app|orig")),
-                 "the stale recorded-uuid entry is rebound, not left behind");
+        QVERIFY2(geoSpy.count() == 0, "a cross-monitor record never moves the window");
+        QVERIFY2(m_wts->placementStore().contains(QStringLiteral("app|orig"), QStringLiteral("app")),
+                 "a cross-monitor record is not consumed regardless of where its geometry was captured");
+        QVERIFY2(!m_wts->placementStore().contains(QStringLiteral("app|new")),
+                 "nothing is re-recorded under the live id");
         m_wts->setSnapState(nullptr);
     }
 


### PR DESCRIPTION
## Problem

Windows reopened **on the wrong monitor** (reported with konsole and ghastty). A window launched on monitor A would jump to monitor B at a stale geometry, and every subsequent reopen jumped again.

## Root cause (confirmed from logs + session store)

`SnapEngine::resolveWindowRestore`'s float/free restore accepted a floated record on **any** monitor when the restore-position opt-in was set (`snappingRestoreFloatedWindowsOnLogin` / per-window `RestorePosition` rule):

```cpp
if (restoreFloatedPosition) return true;   // eligible cross-screen
```

So a fresh window opening on monitor A matched — via the **appId FIFO** (a *different* instance's record, `exactMatch=false`) — a stale floated record left by an earlier instance on monitor B, and was teleported to B with that record's geometry. The wrong-monitor capture that followed re-recorded the window on B, so the next reopen jumped again — a **self-perpetuating** cross-monitor loop.

Live trace (konsole opened on DP-2/115107, dragged to DP-3/45071):
```
take() chose konsole|<old-uuid>  openScreen=115107  recScreen=45071
   snapState=floating  exactMatch=false  restoreFloatedPosition=true  freeGeoOnOpenScreen=(0,0 0x0)
resolveWindowRestore: placement(floated) … -> QRect(3200,0 3200x1800) move=true
Window moved between monitors: konsole … 115107 -> 45071
```
The session store held a bogus `screen=45071` full-monitor floated record for a window that never legitimately lived on DP-3.

## Fix

Float/free restore is now **same-monitor only**: a floated record is eligible only when the window reopens on its recorded screen (the screen-local gate), matching the autotile engine's `insertWindow`, which was already same-screen. A cross-monitor record is **neither consumed nor moves the window** — KWin's own placement / session restore owns the opening monitor; PlasmaZones only restores the floated *position* within that monitor (still gated on the restore opt-in at the geometry-move step). This also breaks the self-perpetuation: no teleport → no wrong-monitor capture → no re-cemented record.

This was a product decision — cross-monitor float restore is intentionally dropped (chosen over "own-window-only" and "login grace period" alternatives).

## Testing
- `ctest`: **282/282 pass**
- The three `resolveWindowRestore` tests that pinned the old cross-monitor restore are rewritten to assert the new contract (cross-monitor record → no move, not consumed, left for a same-monitor open); the section doc comment is updated.
- Manually confirmed konsole/ghastty now open on the monitor KWin places them on.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)