### PR TITLE
ci(release): add --fallback to Verify Nix Build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -587,7 +587,10 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build via flake
-        run: nix build -L .#default
+        # --fallback: build from source if a binary substitute fails, so
+        # transient cache.nixos.org corruption (e.g. a hash mismatch on a
+        # transitive dep's NAR) can't red a release. Mirrors ci.yml.
+        run: nix build -L --fallback .#default
 
       - name: Verify package version
         run: |


### PR DESCRIPTION
Mirrors the ci.yml hardening from #638. Adds \`--fallback\` to the release pipeline's \`nix build -L .#default\` step so transient cache.nixos.org NAR corruption (the openapv aarch64 hash mismatch hit during #638) can't red a release.

The release Nix verify is x86_64-only, so this is preventive consistency, not a current breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)