### PR TITLE
fix(settings): resolve tiling-algorithm display name in read-only rule rows

### DIFF
--- a/src/settings/qml/ActionListView.qml
+++ b/src/settings/qml/ActionListView.qml
@@ -104,10 +104,23 @@ ColumnLayout {
             // layout, etc.) so the user can SEE what the rule contains
             // rather than an empty pill.
             var layouts = root.appSettings && root.appSettings.layouts ? root.appSettings.layouts : [];
-            for (var j = 0; j < layouts.length; ++j) {
-                if (layouts[j].id === raw) {
-                    var name = layouts[j].displayName;
-                    return name ? name : rawStr;
+            // Snapping layouts are stored by UUID, which keys the layouts list
+            // directly. Tiling-algorithm actions store the BARE registry token
+            // ("bsp"), while the layouts list keys autotile entries as
+            // "autotile:<token>" — so prefix before matching, mirroring the C++
+            // summary resolver (SettingsController::resolveTilingAlgorithmLookup)
+            // and the editor's `_tilingAlgorithmEditor`. Try the prefixed form
+            // first, then the bare token (covering already-prefixed / bare-keyed
+            // data) before falling back to the raw id.
+            var candidates = [raw];
+            if (kind === "tilingAlgorithm" && rawStr.indexOf("autotile:") !== 0)
+                candidates = ["autotile:" + rawStr, rawStr];
+            for (var c = 0; c < candidates.length; ++c) {
+                for (var j = 0; j < layouts.length; ++j) {
+                    if (layouts[j].id === candidates[c]) {
+                        var name = layouts[j].displayName;
+                        return name ? name : rawStr;
+                    }
                 }
             }
             return rawStr;


### PR DESCRIPTION
## Problem

In the expanded read-only rule view, the **Set tiling algorithm** action chip showed the raw registry token (`bsp`) instead of its friendly name (**Binary Split**) — even though the one-line rule summary and the rule editor both resolved it correctly.


## Root cause

`ActionListView.qml`'s `_resolveParamValue` resolved the `tilingAlgorithm` kind by matching the **bare** token (`bsp`) directly against `appSettings.layouts`. But that list keys autotile entries as `autotile:<token>` (e.g. `autotile:bsp`), so the bare token never matched and the resolver fell through to the raw id. Snapping layouts (UUID-keyed) matched directly, which is why only tiling algorithm was affected.

## Fix

For the `tilingAlgorithm` kind, prefix `autotile:` before matching — trying the prefixed form first, then the bare token, then the raw-id fallback — mirroring the two existing sources of truth:
- `SettingsController::resolveTilingAlgorithmLookup` (the C++ summary resolver)
- `ActionRow`'s `_tilingAlgorithmEditor` (the editor picker)

Snapping-layout resolution is unchanged.

## Verification
- Settings app builds clean (qmlcachegen validated `ActionListView.qml`)
- 247/247 tests pass
- qmlformat clean
- Confirmed `ActionListView.qml` was the only read-only renderer with the bare-token path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
