### PR TITLE
feat(settings): categorized dropdown for the animation-event picker

### DIFF
--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -553,9 +553,21 @@ ColumnLayout {
     }
 
     _animationEventEditor: Component {
-        WideComboBox {
+        // Categorized event picker — the shared cascading category-menu button
+        // (PZCommon.CategoryMenuButton), grouping the events by their section
+        // (Window / Editor / Overlays / …) into submenus instead of the long
+        // flat "Section · Event" combo. The read-only rule row still renders the
+        // full "Section · Event" label (see ActionListView._resolveParamValue).
+        PZCommon.CategoryMenuButton {
             readonly property var _param: parent.modelData
-            readonly property var _events: {
+
+            // Map eventSections() into the picker's `{ id, name, category,
+            // categoryOrder }` shape: one item per leaf event, grouped under its
+            // section. `categoryOrder` preserves the section order (Window,
+            // Editor, Overlays, …); within a section the component sorts events
+            // by name. An unknown/custom stored path renders as "(missing: …)"
+            // rather than collapsing the picker, mirroring the prior fallback.
+            items: {
                 var controller = row.appSettings ? row.appSettings.animationsController : null;
                 if (!controller)
                     return [];
@@ -573,31 +585,20 @@ ColumnLayout {
                             continue;
 
                         out.push({
-                            "value": entry.path,
-                            "label": section.label + " · " + entry.label
+                            "id": entry.path,
+                            "name": entry.label,
+                            "category": section.label,
+                            "categoryOrder": s
                         });
                     }
                 }
                 return out;
             }
-
-            model: _events
-            textRole: "label"
-            valueRole: "value"
-            currentIndex: {
-                var target = row.action[_param.key];
-                for (var i = 0; i < _events.length; ++i) {
-                    if (_events[i].value === target)
-                        return i;
-                }
-                return -1;
-            }
-            // Fall back to the raw event path so a custom (non-built-in) path
-            // stays visible rather than collapsing the picker to a blank.
-            displayText: currentIndex >= 0 ? currentText : (row.action[_param.key] || i18n("Choose an event…"))
-            Accessible.name: _param.label
-            onActivated: function (index) {
-                row.actionEdited(row._withParam(_param.key, currentValue));
+            currentId: row.action[_param.key] || ""
+            placeholderText: i18n("Choose an event…")
+            Accessible.description: _param.label
+            onSelected: function (value) {
+                row.actionEdited(row._withParam(_param.key, value));
             }
         }
     }


### PR DESCRIPTION
## Summary

The animation-event action parameter used a single **flat** `WideComboBox` listing every event as `Section · Event` (Window · Open, Window · Close, … Editor · Snap In, Overlays · Show, …) — a long scroll with no grouping.

This swaps it for the shared **`PZCommon.CategoryMenuButton`** — the same cascading category menu the action-type and match-field pickers already use — so events group into **Window / Editor / Overlays / …** submenus.

## Implementation

Each leaf event is mapped to the picker's item shape:

```js
{ id: entry.path, name: entry.label, category: section.label, categoryOrder: s }
```

- `categoryOrder` preserves the **section** order (Window → Editor → Overlays).
- An unknown/custom stored path renders as `(missing: <path>)` instead of collapsing the picker — matching the prior raw-path fallback.
- The read-only rule row is unchanged (still shows the full `Section · Event` label via `ActionListView._resolveParamValue`).

## Behavior notes

- Within a section, events sort **alphabetically** (the component honors `categoryOrder` only at the top level), rather than the previous logical/lifecycle order.
- The closed button shows the **leaf name** (e.g. "Snap In"); the submenu and the read-only rule row disambiguate the section.

## Verification
- Settings app builds clean (qmlcachegen validated `ActionRow.qml`)
- 247/247 tests pass
- qmlformat clean
- `WideComboBox` still used by another editor — no dead reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)