### PR TITLE
feat: window-rule actions to override overlay shader + style

### DIFF
--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
@@ -85,7 +85,7 @@ struct PHOSPHORWINDOWRULES_EXPORT RuleAction
  * switch. `kind` is a UI-side hint string (the canonical kinds are
  * `string`, `number`, `percent`, `enum`, `bool`, `color`, plus the
  * picker-aware kinds `snappingLayout`, `tilingAlgorithm`, `animationEvent`,
- * `shaderEffect`, `curveEditor`); QML loaders dispatch on it. Labels stay in
+ * `shaderEffect`, `overlayShader`, `curveEditor`); QML loaders dispatch on it. Labels stay in
  * the GPL settings layer because they need translation through PhosphorI18n::tr —
  * the lib only owns the structural part of the schema.
  *
@@ -135,7 +135,7 @@ inline constexpr QLatin1StringView Border{"border"};
 inline constexpr QLatin1StringView Animation{"animation"};
 inline constexpr QLatin1StringView LayoutEngine{"layoutEngine"};
 inline constexpr QLatin1StringView Gap{"gap"};
-/// Context-domain overlay-property overrides (overlay shader / style / layer).
+/// Context-domain overlay-property overrides (overlay shader / style).
 /// Consumed daemon-side by the overlay service via
 /// `LayoutRegistry::resolveContextOverlay` — NOT by the KWin effect, so these
 /// actions deliberately omit `Tag::Effect`.
@@ -412,6 +412,17 @@ inline constexpr QLatin1StringView LayoutId{"layoutId"};
 // SetTilingAlgorithm algorithm-token key — wire is the algorithm registry id.
 inline constexpr QLatin1StringView Algorithm{"algorithm"};
 } // namespace ActionParam
+
+/// Wire tokens for OverrideOverlayStyle's `value` param — the closed vocabulary
+/// the descriptor's validator + `enumWireValues`, the daemon consumer
+/// (`LayoutRegistry::resolveContextOverlay`), and the settings authoring layer
+/// (`enumOptionLabel`) all read from this single source, so a future rename can
+/// never desync the four sites. Mirrors how `engineModeOptions()` centralizes
+/// the engine-mode vocabulary.
+namespace OverlayStyleToken {
+inline constexpr QLatin1StringView Rectangles{"rectangles"}; ///< OverlayDisplayMode::ZoneRectangles (0)
+inline constexpr QLatin1StringView Preview{"preview"}; ///< OverlayDisplayMode::LayoutPreview (1)
+} // namespace OverlayStyleToken
 
 // ── Built-in slot ids ──
 namespace ActionSlot {

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
@@ -135,6 +135,11 @@ inline constexpr QLatin1StringView Border{"border"};
 inline constexpr QLatin1StringView Animation{"animation"};
 inline constexpr QLatin1StringView LayoutEngine{"layoutEngine"};
 inline constexpr QLatin1StringView Gap{"gap"};
+/// Context-domain overlay-property overrides (overlay shader / style / layer).
+/// Consumed daemon-side by the overlay service via
+/// `LayoutRegistry::resolveContextOverlay` — NOT by the KWin effect, so these
+/// actions deliberately omit `Tag::Effect`.
+inline constexpr QLatin1StringView Overlay{"overlay"};
 } // namespace Tag
 
 /**
@@ -294,6 +299,12 @@ inline constexpr QLatin1StringView OverrideAnimationTiming{"overrideAnimationTim
 /// checks the curve slot first.
 inline constexpr QLatin1StringView OverrideAnimationCurve{"overrideAnimationCurve"};
 inline constexpr QLatin1StringView SetOpacity{"setOpacity"};
+/// Context-domain overlay-property overrides. A matched context rule
+/// (screen / desktop / activity) overrides the active layout's overlay shader
+/// or style (display mode: zone rectangles vs layout preview) for that context's
+/// zone overlay. Resolved daemon-side via `LayoutRegistry::resolveContextOverlay`.
+inline constexpr QLatin1StringView OverrideOverlayShader{"overrideOverlayShader"};
+inline constexpr QLatin1StringView OverrideOverlayStyle{"overrideOverlayStyle"};
 /// Disable every animation override on a matched window. The opposite of
 /// the OverrideAnimation* family — the effect's shouldAnimateWindow gate
 /// surfaces this as "no animation for this window, regardless of other
@@ -429,6 +440,13 @@ inline constexpr QLatin1StringView OuterGapTop{"outer-gap-top"};
 inline constexpr QLatin1StringView OuterGapBottom{"outer-gap-bottom"};
 inline constexpr QLatin1StringView OuterGapLeft{"outer-gap-left"};
 inline constexpr QLatin1StringView OuterGapRight{"outer-gap-right"};
+// Per-context overlay-property slots (one per property so independent rules
+// cascade per-property). Filled by the OverrideOverlay* context actions, read
+// by `LayoutRegistry::resolveContextOverlay`. OverlayShader carries the shader
+// effect id (ActionParam::EffectId); OverlayStyle carries a wire token
+// (ActionParam::Value).
+inline constexpr QLatin1StringView OverlayShader{"overlay-shader"};
+inline constexpr QLatin1StringView OverlayStyle{"overlay-style"};
 // Animation slots are event-scoped: "anim-shader:<event>" / "anim-timing:<event>"
 // / "anim-curve:<event>". Curve and timing are split so they can be overridden
 // independently per event — `resolveAnimationMotionProfile` reads the curve

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
@@ -415,10 +415,10 @@ inline constexpr QLatin1StringView Algorithm{"algorithm"};
 
 /// Wire tokens for OverrideOverlayStyle's `value` param — the closed vocabulary
 /// the descriptor's validator + `enumWireValues`, the daemon consumer
-/// (`LayoutRegistry::resolveContextOverlay`), and the settings authoring layer
-/// (`enumOptionLabel`) all read from this single source, so a future rename can
-/// never desync the four sites. Mirrors how `engineModeOptions()` centralizes
-/// the engine-mode vocabulary.
+/// (`LayoutRegistry::resolveContextOverlay`), and the settings label layers
+/// (`enumOptionLabel` + the rule-list summary) all read from this single source,
+/// so a future rename can never desync the consumers. Mirrors how
+/// `engineModeOptions()` centralizes the engine-mode vocabulary.
 namespace OverlayStyleToken {
 inline constexpr QLatin1StringView Rectangles{"rectangles"}; ///< OverlayDisplayMode::ZoneRectangles (0)
 inline constexpr QLatin1StringView Preview{"preview"}; ///< OverlayDisplayMode::LayoutPreview (1)

--- a/libs/phosphor-window-rules/src/ruleaction.cpp
+++ b/libs/phosphor-window-rules/src/ruleaction.cpp
@@ -582,7 +582,9 @@ void ActionRegistry::registerBuiltins()
                 return hasNonEmptyString(p, ActionParam::EffectId);
             },
         .terminal = false,
-        .allowedKeys = {QString(ActionParam::EffectId)},
+        // Params carries the optional shader-uniform overrides, mirroring
+        // OverrideAnimationShader; the inline ShaderParameterEditor writes it.
+        .allowedKeys = {QString(ActionParam::EffectId), QString(ActionParam::Params)},
         .domain = ActionDomain::Context,
         .params = {P{.key = QString(ActionParam::EffectId), .kind = QStringLiteral("overlayShader")}},
         .category = QStringLiteral("overlay"),

--- a/libs/phosphor-window-rules/src/ruleaction.cpp
+++ b/libs/phosphor-window-rules/src/ruleaction.cpp
@@ -569,7 +569,7 @@ void ActionRegistry::registerBuiltins()
     });
 
     // ── overlay-property slots — context-domain overrides of the active
-    //    layout's zone-overlay shader / style / layer. Daemon-side only
+    //    layout's zone-overlay shader / style. Daemon-side only
     //    (LayoutRegistry::resolveContextOverlay → OverlayService); no Tag::Effect.
     //    Shader-id vocabulary validation lives at the consumer (the overlay
     //    service falls back to the layout default for an unknown id), mirroring
@@ -597,14 +597,14 @@ void ActionRegistry::registerBuiltins()
         .validate =
             [](const QJsonObject& p) {
                 const QString v = p.value(ActionParam::Value).toString();
-                return v == QLatin1String("rectangles") || v == QLatin1String("preview");
+                return v == OverlayStyleToken::Rectangles || v == OverlayStyleToken::Preview;
             },
         .terminal = false,
         .allowedKeys = {QString(ActionParam::Value)},
         .domain = ActionDomain::Context,
         .params = {P{.key = QString(ActionParam::Value),
                      .kind = QStringLiteral("enum"),
-                     .enumWireValues = {QStringLiteral("rectangles"), QStringLiteral("preview")}}},
+                     .enumWireValues = {QString(OverlayStyleToken::Rectangles), QString(OverlayStyleToken::Preview)}}},
         .category = QStringLiteral("overlay"),
         .displayOrder = 1,
         .tags = {QString(Tag::Overlay)},

--- a/libs/phosphor-window-rules/src/ruleaction.cpp
+++ b/libs/phosphor-window-rules/src/ruleaction.cpp
@@ -568,6 +568,46 @@ void ActionRegistry::registerBuiltins()
         .tags = {QString(Tag::Effect)},
     });
 
+    // ── overlay-property slots — context-domain overrides of the active
+    //    layout's zone-overlay shader / style / layer. Daemon-side only
+    //    (LayoutRegistry::resolveContextOverlay → OverlayService); no Tag::Effect.
+    //    Shader-id vocabulary validation lives at the consumer (the overlay
+    //    service falls back to the layout default for an unknown id), mirroring
+    //    SetEngineMode's open-vocabulary rationale above.
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::OverrideOverlayShader),
+        .slotFor = constantSlot(ActionSlot::OverlayShader),
+        .validate =
+            [](const QJsonObject& p) {
+                return hasNonEmptyString(p, ActionParam::EffectId);
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::EffectId)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::EffectId), .kind = QStringLiteral("overlayShader")}},
+        .category = QStringLiteral("overlay"),
+        .displayOrder = 0,
+        .tags = {QString(Tag::Overlay)},
+    });
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::OverrideOverlayStyle),
+        .slotFor = constantSlot(ActionSlot::OverlayStyle),
+        .validate =
+            [](const QJsonObject& p) {
+                const QString v = p.value(ActionParam::Value).toString();
+                return v == QLatin1String("rectangles") || v == QLatin1String("preview");
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value),
+                     .kind = QStringLiteral("enum"),
+                     .enumWireValues = {QStringLiteral("rectangles"), QStringLiteral("preview")}}},
+        .category = QStringLiteral("overlay"),
+        .displayOrder = 1,
+        .tags = {QString(Tag::Overlay)},
+    });
+
     // RestorePosition is window-domain but NOT a border/appearance slot — it is
     // consumed daemon-side (both engines' restore-position predicate), not by the
     // effect. Unlike the border bools below it seeds FALSE: the per-engine

--- a/libs/phosphor-window-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-window-rules/tests/test_ruleaction.cpp
@@ -42,6 +42,11 @@ const QList<QLatin1StringView> kContextDomainTypes = {
     ActionType::SetOuterGapBottom,
     ActionType::SetOuterGapLeft,
     ActionType::SetOuterGapRight,
+    // Overlay-property overrides are context-domain — resolved during the
+    // screen/desktop/activity pass (LayoutRegistry::resolveContextOverlay),
+    // never per-window.
+    ActionType::OverrideOverlayShader,
+    ActionType::OverrideOverlayStyle,
 };
 const QList<QLatin1StringView> kWindowDomainTypes = {
     ActionType::Exclude,

--- a/libs/phosphor-window-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-window-rules/tests/test_ruleaction.cpp
@@ -424,6 +424,60 @@ private Q_SLOTS:
         rejectsStray(ActionType::SetOuterGapTop, QJsonValue(8));
         rejectsStray(ActionType::SetUsePerSideOuterGap, QJsonValue(true));
         rejectsStray(ActionType::LockContext, QJsonValue(true));
+        // OverrideOverlayStyle also declares allowedKeys = {Value}.
+        rejectsStray(ActionType::OverrideOverlayStyle, QJsonValue(QString(OverlayStyleToken::Preview)));
+    }
+
+    void testOverrideOverlay_fromJson()
+    {
+        // The two context-domain overlay actions validate through the public
+        // fromJson boundary. OverrideOverlayShader requires a non-empty effectId
+        // (open shader-id vocabulary, like OverrideAnimationShader);
+        // OverrideOverlayStyle is a CLOSED enum — only the OverlayStyleToken
+        // vocabulary survives load, so a hand-edited windowrules.json naming an
+        // unknown style is dropped. Pins both validators against a widening
+        // regression in registerBuiltins (which the resolution-layer tests in
+        // test_windowrule_cascade_fidelity.cpp would not catch).
+
+        // ── OverrideOverlayShader ──
+        QJsonObject missingId;
+        missingId.insert(QStringLiteral("type"), QString(ActionType::OverrideOverlayShader));
+        QVERIFY(!RuleAction::fromJson(missingId).has_value()); // no effectId
+
+        QJsonObject emptyId;
+        emptyId.insert(QStringLiteral("type"), QString(ActionType::OverrideOverlayShader));
+        emptyId.insert(QStringLiteral("effectId"), QString());
+        QVERIFY(!RuleAction::fromJson(emptyId).has_value()); // empty effectId rejected
+
+        QJsonObject shader;
+        shader.insert(QStringLiteral("type"), QString(ActionType::OverrideOverlayShader));
+        shader.insert(QStringLiteral("effectId"), QStringLiteral("plasma-glow"));
+        QVERIFY(RuleAction::fromJson(shader).has_value());
+
+        // The optional params object is in allowedKeys; a populated one validates.
+        QJsonObject shaderParams = shader;
+        QJsonObject params;
+        params.insert(QStringLiteral("intensity"), 0.5);
+        shaderParams.insert(QString(ActionParam::Params), params);
+        QVERIFY(RuleAction::fromJson(shaderParams).has_value());
+
+        // A key outside allowedKeys ({effectId, params}) is rejected.
+        QJsonObject shaderStray = shader;
+        shaderStray.insert(QStringLiteral("mode"), QStringLiteral("snapping"));
+        QVERIFY(!RuleAction::fromJson(shaderStray).has_value());
+
+        // ── OverrideOverlayStyle ──
+        QJsonObject unknownStyle;
+        unknownStyle.insert(QStringLiteral("type"), QString(ActionType::OverrideOverlayStyle));
+        unknownStyle.insert(QStringLiteral("value"), QLatin1String("grid"));
+        QVERIFY(!RuleAction::fromJson(unknownStyle).has_value()); // not in vocabulary
+
+        for (const QLatin1StringView token : {OverlayStyleToken::Rectangles, OverlayStyleToken::Preview}) {
+            QJsonObject ok;
+            ok.insert(QStringLiteral("type"), QString(ActionType::OverrideOverlayStyle));
+            ok.insert(QStringLiteral("value"), QString(token));
+            QVERIFY2(RuleAction::fromJson(ok).has_value(), token.data());
+        }
     }
 
     void testLockContext_fromJsonRoundTrip()

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -205,7 +205,7 @@ struct ContextGapOverride
  * @brief Per-context overlay-property overrides resolved from window-rule actions.
  *
  * Each field is set only when a matching context rule fills the corresponding
- * overlay slot (OverrideOverlay{Shader,Style}); an unset field falls through to
+ * overlay slot (OverrideOverlayShader / OverrideOverlayStyle); an unset field falls through to
  * the active layout's own value. Consumed daemon-side by the overlay service —
  * see @c LayoutRegistry::resolveContextOverlay.
  *

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -8,6 +8,7 @@
 #include <QHash>
 #include <QList>
 #include <QString>
+#include <QVariantMap>
 #include <QtGlobal>
 
 #include <optional>
@@ -211,10 +212,14 @@ struct ContextGapOverride
  * @c style is the @c OverlayDisplayMode int (0 = ZoneRectangles, 1 =
  * LayoutPreview); the resolver maps the wire token ("rectangles" / "preview")
  * to the int so consumers compare against the same enum the layout exposes.
+ * @c shaderParams holds the overridden shader's uniform values (translated by
+ * the overlay service); it is only meaningful when @c shaderId is set and is
+ * empty when the rule overrides only the shader id (shader defaults apply).
  */
 struct ContextOverlayOverride
 {
     std::optional<QString> shaderId;
+    QVariantMap shaderParams;
     std::optional<int> style;
 
     bool isEmpty() const

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -201,6 +201,29 @@ struct ContextGapOverride
 };
 
 /**
+ * @brief Per-context overlay-property overrides resolved from window-rule actions.
+ *
+ * Each field is set only when a matching context rule fills the corresponding
+ * overlay slot (OverrideOverlay{Shader,Style}); an unset field falls through to
+ * the active layout's own value. Consumed daemon-side by the overlay service —
+ * see @c LayoutRegistry::resolveContextOverlay.
+ *
+ * @c style is the @c OverlayDisplayMode int (0 = ZoneRectangles, 1 =
+ * LayoutPreview); the resolver maps the wire token ("rectangles" / "preview")
+ * to the int so consumers compare against the same enum the layout exposes.
+ */
+struct ContextOverlayOverride
+{
+    std::optional<QString> shaderId;
+    std::optional<int> style;
+
+    bool isEmpty() const
+    {
+        return !shaderId && !style;
+    }
+};
+
+/**
  * @brief Canonical wire-string for an @ref AssignmentEntry::Mode.
  *
  * The wire vocabulary lives next to the enum so every persister/consumer

--- a/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
@@ -161,7 +161,7 @@ public:
     /// Resolve the per-context overlay-property override for the
     /// (@p screenId, @p virtualDesktop, @p activity) context — a per-slot read
     /// across all matching context rules (mirrors @ref resolveContextGaps), so
-    /// independent shader / style / layer rules compose. The overlay service
+    /// independent shader / style rules compose. The overlay service
     /// applies a populated field over the active layout's own value. The default
     /// returns an empty override (no rule overlay overrides); a registry that
     /// does not model context rules — e.g. a fixture stub — keeps the layout's

--- a/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
@@ -158,6 +158,23 @@ public:
         return false;
     }
 
+    /// Resolve the per-context overlay-property override for the
+    /// (@p screenId, @p virtualDesktop, @p activity) context — a per-slot read
+    /// across all matching context rules (mirrors @ref resolveContextGaps), so
+    /// independent shader / style / layer rules compose. The overlay service
+    /// applies a populated field over the active layout's own value. The default
+    /// returns an empty override (no rule overlay overrides); a registry that
+    /// does not model context rules — e.g. a fixture stub — keeps the layout's
+    /// own overlay properties.
+    virtual ContextOverlayOverride resolveContextOverlay(const QString& screenId, int virtualDesktop,
+                                                         const QString& activity) const
+    {
+        Q_UNUSED(screenId);
+        Q_UNUSED(virtualDesktop);
+        Q_UNUSED(activity);
+        return {};
+    }
+
 Q_SIGNALS:
     // Catalog mutation. @c addLayout / @c duplicateLayout fire `layoutAdded`;
     // @c removeLayout / @c removeLayoutById fire `layoutRemoved`.

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -322,9 +322,9 @@ public:
     /// `value` is true. Same owner-thread affinity as the rest of the registry.
     bool resolveContextLocked(const QString& screenId, int virtualDesktop, const QString& activity) const override;
 
-    /// Resolve the per-context overlay-property override (shader / style / layer)
+    /// Resolve the per-context overlay-property override (shader / style)
     /// for (screen, desktop, activity) by evaluating a windowless WindowQuery and
-    /// reading the OverlayShader / OverlayStyle / OverlayLayer slots. Per-slot
+    /// reading the OverlayShader / OverlayStyle slots. Per-slot
     /// read (mirrors @ref resolveContextGaps), so independent overlay rules
     /// compose; returns an all-unset @ref ContextOverlayOverride when no matching
     /// rule fills an overlay slot. Same owner-thread affinity as the rest of the

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -322,6 +322,16 @@ public:
     /// `value` is true. Same owner-thread affinity as the rest of the registry.
     bool resolveContextLocked(const QString& screenId, int virtualDesktop, const QString& activity) const override;
 
+    /// Resolve the per-context overlay-property override (shader / style / layer)
+    /// for (screen, desktop, activity) by evaluating a windowless WindowQuery and
+    /// reading the OverlayShader / OverlayStyle / OverlayLayer slots. Per-slot
+    /// read (mirrors @ref resolveContextGaps), so independent overlay rules
+    /// compose; returns an all-unset @ref ContextOverlayOverride when no matching
+    /// rule fills an overlay slot. Same owner-thread affinity as the rest of the
+    /// registry.
+    ContextOverlayOverride resolveContextOverlay(const QString& screenId, int virtualDesktop,
+                                                 const QString& activity) const override;
+
     Q_INVOKABLE void clearAssignment(const QString& screenId, int virtualDesktop = 0,
                                      const QString& activity = QString());
     /// True iff a context-assignment rule whose match is exactly this
@@ -706,6 +716,14 @@ private:
     /// walk collapses repeats to one walk per rule-set revision.
     mutable QHash<ContextResolveKey, bool> m_contextLockCache;
     mutable quint64 m_contextLockCacheRevision = 0;
+
+    /// Hot-path cache for @ref resolveContextOverlay, keyed and
+    /// revision-invalidated exactly like @c m_contextGapCache. The overlay
+    /// build path resolves the same (screen, desktop, activity) tuple on every
+    /// overlay show / screen-change, so memoizing the per-slot walk collapses
+    /// repeats to one walk per rule-set revision.
+    mutable QHash<ContextResolveKey, ContextOverlayOverride> m_contextOverlayCache;
+    mutable quint64 m_contextOverlayCacheRevision = 0;
 
     std::function<QString()> m_defaultLayoutIdProvider; ///< Empty = provider disabled; falls back to first layout
     /// Empty = provider disabled. Returns the user's default autotile

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -183,9 +183,9 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
                 // the same enum Layout::overlayDisplayMode() exposes (0 =
                 // ZoneRectangles, 1 = LayoutPreview).
                 const QString token = action->params.value(PWR::ActionParam::Value).toString();
-                if (token == QLatin1String("rectangles")) {
+                if (token == PWR::OverlayStyleToken::Rectangles) {
                     overlay.style = 0;
-                } else if (token == QLatin1String("preview")) {
+                } else if (token == PWR::OverlayStyleToken::Preview) {
                     overlay.style = 1;
                 }
             }

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -155,7 +155,7 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
                                                              const QString& activity) const
 {
     // Per-slot read across all matching context rules (mirrors resolveContextGaps):
-    // independent overlay-shader / overlay-style / overlay-layer rules compose, and
+    // independent overlay-shader / overlay-style rules compose, and
     // each populated field overrides the active layout's own value at the overlay
     // build site. No engine-mode gate — an overlay-only context rule is first-class.
     if (!m_evaluator) {

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -162,31 +162,35 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
         return ContextOverlayOverride{};
     }
 
-    return resolveCachedContext(m_contextOverlayCache, m_contextOverlayCacheRevision, screenId, virtualDesktop,
-                                activity, [&]() -> ContextOverlayOverride {
-                                    ContextOverlayOverride overlay;
-                                    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
-                                    const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
+    return resolveCachedContext(
+        m_contextOverlayCache, m_contextOverlayCacheRevision, screenId, virtualDesktop, activity,
+        [&]() -> ContextOverlayOverride {
+            ContextOverlayOverride overlay;
+            const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+            const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
 
-                                    if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayShader))) {
-                                        const QString id = action->params.value(PWR::ActionParam::EffectId).toString();
-                                        if (!id.isEmpty()) {
-                                            overlay.shaderId = id;
-                                        }
-                                    }
-                                    if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayStyle))) {
-                                        // Wire token → OverlayDisplayMode int so consumers compare against
-                                        // the same enum Layout::overlayDisplayMode() exposes (0 =
-                                        // ZoneRectangles, 1 = LayoutPreview).
-                                        const QString token = action->params.value(PWR::ActionParam::Value).toString();
-                                        if (token == QLatin1String("rectangles")) {
-                                            overlay.style = 0;
-                                        } else if (token == QLatin1String("preview")) {
-                                            overlay.style = 1;
-                                        }
-                                    }
-                                    return overlay;
-                                });
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayShader))) {
+                const QString id = action->params.value(PWR::ActionParam::EffectId).toString();
+                if (!id.isEmpty()) {
+                    overlay.shaderId = id;
+                    // Optional shader uniform overrides — empty when the rule
+                    // overrides only the shader id (shader defaults apply).
+                    overlay.shaderParams = action->params.value(PWR::ActionParam::Params).toObject().toVariantMap();
+                }
+            }
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayStyle))) {
+                // Wire token → OverlayDisplayMode int so consumers compare against
+                // the same enum Layout::overlayDisplayMode() exposes (0 =
+                // ZoneRectangles, 1 = LayoutPreview).
+                const QString token = action->params.value(PWR::ActionParam::Value).toString();
+                if (token == QLatin1String("rectangles")) {
+                    overlay.style = 0;
+                } else if (token == QLatin1String("preview")) {
+                    overlay.style = 1;
+                }
+            }
+            return overlay;
+        });
 }
 
 bool LayoutRegistry::hasExactContextRule(const QString& screenId, int virtualDesktop, const QString& activity) const

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -151,6 +151,44 @@ bool LayoutRegistry::resolveContextLocked(const QString& screenId, int virtualDe
                                 });
 }
 
+ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& screenId, int virtualDesktop,
+                                                             const QString& activity) const
+{
+    // Per-slot read across all matching context rules (mirrors resolveContextGaps):
+    // independent overlay-shader / overlay-style / overlay-layer rules compose, and
+    // each populated field overrides the active layout's own value at the overlay
+    // build site. No engine-mode gate — an overlay-only context rule is first-class.
+    if (!m_evaluator) {
+        return ContextOverlayOverride{};
+    }
+
+    return resolveCachedContext(m_contextOverlayCache, m_contextOverlayCacheRevision, screenId, virtualDesktop,
+                                activity, [&]() -> ContextOverlayOverride {
+                                    ContextOverlayOverride overlay;
+                                    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+                                    const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
+
+                                    if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayShader))) {
+                                        const QString id = action->params.value(PWR::ActionParam::EffectId).toString();
+                                        if (!id.isEmpty()) {
+                                            overlay.shaderId = id;
+                                        }
+                                    }
+                                    if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayStyle))) {
+                                        // Wire token → OverlayDisplayMode int so consumers compare against
+                                        // the same enum Layout::overlayDisplayMode() exposes (0 =
+                                        // ZoneRectangles, 1 = LayoutPreview).
+                                        const QString token = action->params.value(PWR::ActionParam::Value).toString();
+                                        if (token == QLatin1String("rectangles")) {
+                                            overlay.style = 0;
+                                        } else if (token == QLatin1String("preview")) {
+                                            overlay.style = 1;
+                                        }
+                                    }
+                                    return overlay;
+                                });
+}
+
 bool LayoutRegistry::hasExactContextRule(const QString& screenId, int virtualDesktop, const QString& activity) const
 {
     return findExactContextRule(screenId, virtualDesktop, activity) != nullptr;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1230,6 +1230,10 @@ bool Daemon::init()
             [overlay = QPointer(m_overlayService.get())](bool /*persisted*/) {
                 if (overlay) {
                     overlay->refreshContextLockState();
+                    // A rule change can also alter the resolved overlay shader /
+                    // style for the active context; re-apply it live if the
+                    // overlay is currently shown (no-op otherwise).
+                    overlay->refreshOverlayPropertiesIfShown();
                 }
             });
 

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -402,9 +402,10 @@ public:
     void refreshContextLockState();
 
     /// Re-apply the (possibly rule-overridden) overlay shader / style to a
-    /// currently-displaying overlay after a window-rule change. A rule edit
-    /// invalidates `LayoutRegistry::resolveContextOverlay`'s cache but does not
-    /// itself re-query it for the live main overlay; this flips any
+    /// currently-displaying overlay after a window-rule change. A rule edit bumps
+    /// the rule-set revision (so the next `LayoutRegistry::resolveContextOverlay`
+    /// read drops its now-stale cache) but does not itself re-query it for the
+    /// live main overlay; this flips any
     /// shader↔non-shader slot whose type the new style override changed, then
     /// re-pushes each window's shader id/params. A no-op when the overlay is
     /// hidden — the next `show()` re-resolves via `initializeOverlay`. Mirrors

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -401,6 +401,17 @@ public:
     /// this only keeps the visual in sync.
     void refreshContextLockState();
 
+    /// Re-apply the (possibly rule-overridden) overlay shader / style to a
+    /// currently-displaying overlay after a window-rule change. A rule edit
+    /// invalidates `LayoutRegistry::resolveContextOverlay`'s cache but does not
+    /// itself re-query it for the live main overlay; this flips any
+    /// shader↔non-shader slot whose type the new style override changed, then
+    /// re-pushes each window's shader id/params. A no-op when the overlay is
+    /// hidden — the next `show()` re-resolves via `initializeOverlay`. Mirrors
+    /// the `overlayDisplayModeChanged` / `enableShaderEffectsChanged` wiring for
+    /// the equivalent global settings.
+    void refreshOverlayPropertiesIfShown();
+
 public Q_SLOTS:
     // hideLayoutOsd / hideNavigationOsd intentionally absent. Phase-5
     // dismiss path: QML auto-dismiss timer → loaded content's

--- a/src/daemon/overlayservice/internal.h
+++ b/src/daemon/overlayservice/internal.h
@@ -282,6 +282,22 @@ inline bool isAnyModeLocked(ISettings* settings, PhosphorZones::IZoneLayoutRegis
         || settings->isContextLocked(Utils::contextLockKey(1, screenId), desktop, activity);
 }
 
+/// Resolve the per-context overlay-property override (shader / style / layer)
+/// for @p screenId at the current virtual desktop + activity. A thin wrapper
+/// over IZoneLayoutRegistry::resolveContextOverlay that supplies the live
+/// context, mirroring how @ref isAnyModeLocked routes the lock check. Returns an
+/// empty override when there is no registry or no matching overlay rule, so the
+/// overlay falls through to the active layout's own shader / display-mode / layer.
+inline PhosphorZones::ContextOverlayOverride
+overlayOverrideForScreen(PhosphorZones::IZoneLayoutRegistry* layoutRegistry, const QString& screenId)
+{
+    if (!layoutRegistry) {
+        return {};
+    }
+    return layoutRegistry->resolveContextOverlay(screenId, layoutRegistry->currentVirtualDesktop(),
+                                                 layoutRegistry->currentActivity());
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // PhosphorZones::Zone selector helpers shared across overlayservice_selector*.cpp TUs
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/daemon/overlayservice/internal.h
+++ b/src/daemon/overlayservice/internal.h
@@ -282,12 +282,12 @@ inline bool isAnyModeLocked(ISettings* settings, PhosphorZones::IZoneLayoutRegis
         || settings->isContextLocked(Utils::contextLockKey(1, screenId), desktop, activity);
 }
 
-/// Resolve the per-context overlay-property override (shader / style / layer)
+/// Resolve the per-context overlay-property override (shader / style)
 /// for @p screenId at the current virtual desktop + activity. A thin wrapper
 /// over IZoneLayoutRegistry::resolveContextOverlay that supplies the live
 /// context, mirroring how @ref isAnyModeLocked routes the lock check. Returns an
 /// empty override when there is no registry or no matching overlay rule, so the
-/// overlay falls through to the active layout's own shader / display-mode / layer.
+/// overlay falls through to the active layout's own shader / display-mode.
 inline PhosphorZones::ContextOverlayOverride
 overlayOverrideForScreen(PhosphorZones::IZoneLayoutRegistry* layoutRegistry, const QString& screenId)
 {

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -509,11 +509,17 @@ void OverlayService::createOverlayWindow(const QString& screenId, QScreen* physS
     if (usingShader && screenLayout) {
         auto* registry = m_shaderRegistry;
         if (registry) {
-            const QString shaderId = screenLayout->shaderId();
+            // A context overlay rule may override the layout's shader. The
+            // override carries only the shader id, so an overridden shader
+            // renders with its default uniforms; otherwise use the layout params.
+            const PhosphorZones::ContextOverlayOverride overlayOverride =
+                overlayOverrideForScreen(m_layoutManager, screenId);
+            const QString shaderId = overlayOverride.shaderId.value_or(screenLayout->shaderId());
+            const QVariantMap rawParams = overlayOverride.shaderId ? QVariantMap{} : screenLayout->shaderParams();
             const ShaderRegistry::ShaderInfo info = registry->shader(shaderId);
             qCDebug(lcOverlay) << "Overlay shader=" << shaderId << "multipass=" << info.isMultipass
                                << "bufferPaths=" << info.bufferShaderPaths.size();
-            QVariantMap translatedParams = registry->translateParamsToUniforms(shaderId, screenLayout->shaderParams());
+            QVariantMap translatedParams = registry->translateParamsToUniforms(shaderId, rawParams);
             applyShaderInfoToWindow(slot, info, translatedParams, geometry, physScreenGeom);
         }
     }
@@ -731,9 +737,12 @@ void OverlayService::updateOverlayWindow(const QString& screenId, QScreen* physS
     if (windowIsShader && screenUsesShader && screenLayout) {
         auto* registry = m_shaderRegistry;
         if (registry) {
-            const QString shaderId = screenLayout->shaderId();
+            const PhosphorZones::ContextOverlayOverride overlayOverride =
+                overlayOverrideForScreen(m_layoutManager, screenId);
+            const QString shaderId = overlayOverride.shaderId.value_or(screenLayout->shaderId());
+            const QVariantMap rawParams = overlayOverride.shaderId ? QVariantMap{} : screenLayout->shaderParams();
             const ShaderRegistry::ShaderInfo info = registry->shader(shaderId);
-            QVariantMap translatedParams = registry->translateParamsToUniforms(shaderId, screenLayout->shaderParams());
+            QVariantMap translatedParams = registry->translateParamsToUniforms(shaderId, rawParams);
             const QRect vsGeom = resolveScreenGeometry(m_screenManager, screenId);
             const QRect physGeom = physScreen ? physScreen->geometry() : vsGeom;
             applyShaderInfoToWindow(slot, info, translatedParams, vsGeom, physGeom);

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -509,9 +509,10 @@ void OverlayService::createOverlayWindow(const QString& screenId, QScreen* physS
     if (usingShader && screenLayout) {
         auto* registry = m_shaderRegistry;
         if (registry) {
-            // A context overlay rule may override the layout's shader. The
-            // override carries only the shader id, so an overridden shader
-            // renders with its default uniforms; otherwise use the layout params.
+            // A context overlay rule may override the layout's shader (with
+            // optional uniform params). When the rule sets the shader, use its
+            // params — an override with no params falls back to the shader's
+            // defaults; otherwise use the layout's params.
             const PhosphorZones::ContextOverlayOverride overlayOverride =
                 overlayOverrideForScreen(m_layoutManager, screenId);
             const QString shaderId = overlayOverride.shaderId.value_or(screenLayout->shaderId());
@@ -530,6 +531,22 @@ void OverlayService::createOverlayWindow(const QString& screenId, QScreen* physS
         writeQmlProperty(slot, QStringLiteral("zoneDataVersion"), m_zoneDataVersion);
     }
     state->overlayGeomConnection = geomConn;
+}
+
+void OverlayService::refreshOverlayPropertiesIfShown()
+{
+    // Only the live overlay needs this: when hidden, the next show() re-resolves
+    // the override through initializeOverlay (destroyIfTypeMismatch +
+    // updateOverlayWindow), so a hidden overlay already picks up the rule change.
+    if (!isOverlayDisplaying()) {
+        return;
+    }
+    // A style override can flip whether a screen uses the shader overlay (the
+    // Loader's `useShader`); recreate the mismatched slots first (no-op when no
+    // type changed), then re-push each window's effective shader id/params via
+    // updateGeometries() → updateOverlayWindow().
+    recreateOverlayWindowsOnTypeMismatch();
+    updateGeometries();
 }
 
 void OverlayService::recreateOverlayWindowsOnTypeMismatch()

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -515,7 +515,8 @@ void OverlayService::createOverlayWindow(const QString& screenId, QScreen* physS
             const PhosphorZones::ContextOverlayOverride overlayOverride =
                 overlayOverrideForScreen(m_layoutManager, screenId);
             const QString shaderId = overlayOverride.shaderId.value_or(screenLayout->shaderId());
-            const QVariantMap rawParams = overlayOverride.shaderId ? QVariantMap{} : screenLayout->shaderParams();
+            const QVariantMap rawParams =
+                overlayOverride.shaderId ? overlayOverride.shaderParams : screenLayout->shaderParams();
             const ShaderRegistry::ShaderInfo info = registry->shader(shaderId);
             qCDebug(lcOverlay) << "Overlay shader=" << shaderId << "multipass=" << info.isMultipass
                                << "bufferPaths=" << info.bufferShaderPaths.size();
@@ -740,7 +741,8 @@ void OverlayService::updateOverlayWindow(const QString& screenId, QScreen* physS
             const PhosphorZones::ContextOverlayOverride overlayOverride =
                 overlayOverrideForScreen(m_layoutManager, screenId);
             const QString shaderId = overlayOverride.shaderId.value_or(screenLayout->shaderId());
-            const QVariantMap rawParams = overlayOverride.shaderId ? QVariantMap{} : screenLayout->shaderParams();
+            const QVariantMap rawParams =
+                overlayOverride.shaderId ? overlayOverride.shaderParams : screenLayout->shaderParams();
             const ShaderRegistry::ShaderInfo info = registry->shader(shaderId);
             QVariantMap translatedParams = registry->translateParamsToUniforms(shaderId, rawParams);
             const QRect vsGeom = resolveScreenGeometry(m_screenManager, screenId);

--- a/src/daemon/overlayservice/overlay_data.cpp
+++ b/src/daemon/overlayservice/overlay_data.cpp
@@ -272,11 +272,16 @@ QVariantMap OverlayService::zoneToVariantMap(PhosphorZones::Zone* zone, const QS
     map[::PhosphorZones::ZoneJsonKeys::BorderRadius] = zone->borderRadius();
 
     // ═══════════════════════════════════════════════════════════════════════════════
-    // Overlay display mode cascade: zone → layout → global
+    // Overlay display mode cascade: zone → context rule → layout → global
     // ═══════════════════════════════════════════════════════════════════════════════
+    // A context overlay-style rule slots between the per-zone override and the
+    // layout value, mirroring the precedence useShaderForScreen applies.
+    const PhosphorZones::ContextOverlayOverride overlayOverride = overlayOverrideForScreen(m_layoutManager, screenId);
     int resolvedDisplayMode = 0; // default: ZoneRectangles
     if (zone->overlayDisplayMode() >= 0) {
         resolvedDisplayMode = zone->overlayDisplayMode();
+    } else if (overlayOverride.style) {
+        resolvedDisplayMode = *overlayOverride.style;
     } else if (layout && layout->overlayDisplayMode() >= 0) {
         resolvedDisplayMode = layout->overlayDisplayMode();
     } else if (m_settings) {

--- a/src/daemon/overlayservice/shader.cpp
+++ b/src/daemon/overlayservice/shader.cpp
@@ -144,23 +144,30 @@ bool OverlayService::useShaderForScreen(const QString& screenId) const
     if (!screenLayout) {
         return false;
     }
-    if (ShaderRegistry::isNoneShader(screenLayout->shaderId())) {
+    // A context overlay rule may override the layout's own shader / style for
+    // this (screen, desktop, activity). Resolve once and apply over the layout.
+    const PhosphorZones::ContextOverlayOverride overlayOverride = overlayOverrideForScreen(m_layoutManager, screenId);
+    const QString effectiveShaderId = overlayOverride.shaderId.value_or(screenLayout->shaderId());
+    if (ShaderRegistry::isNoneShader(effectiveShaderId)) {
         return false;
     }
 
     // LayoutPreview mode requires standard QML overlay (ZonePreview can't be rendered in GLSL).
     // If any zone resolves to LayoutPreview mode, fall back to standard overlay for this screen.
+    // A context rule's style override slots between the per-zone override and the
+    // layout value: zone > rule > layout > global.
     int globalMode = m_settings ? static_cast<int>(m_settings->overlayDisplayMode()) : 0;
     int layoutMode = screenLayout->overlayDisplayMode();
     for (const auto* zone : screenLayout->zones()) {
-        int resolved =
-            zone->overlayDisplayMode() >= 0 ? zone->overlayDisplayMode() : (layoutMode >= 0 ? layoutMode : globalMode);
+        int resolved = zone->overlayDisplayMode() >= 0 ? zone->overlayDisplayMode()
+            : overlayOverride.style                    ? *overlayOverride.style
+                                                       : (layoutMode >= 0 ? layoutMode : globalMode);
         if (resolved == 1) { // OverlayDisplayMode::LayoutPreview
             return false;
         }
     }
 
-    return m_shaderRegistry && m_shaderRegistry->shader(screenLayout->shaderId()).isValid();
+    return m_shaderRegistry && m_shaderRegistry->shader(effectiveShaderId).isValid();
 }
 
 void OverlayService::startShaderAnimation()

--- a/src/settings/qml/ActionListView.qml
+++ b/src/settings/qml/ActionListView.qml
@@ -152,6 +152,20 @@ ColumnLayout {
             }
             return rawStr;
         }
+        if (kind === "overlayShader") {
+            // Overlay shaders come from the snapping-shaders registry, not the
+            // animation one (mirrors ActionRow's _overlayShaderEditor source).
+            var ssCtl = root.appSettings ? root.appSettings.snappingShadersPage : null;
+            if (!ssCtl)
+                return rawStr;
+
+            var overlayEffects = ssCtl.availableShaderEffects() || [];
+            for (var oe = 0; oe < overlayEffects.length; ++oe) {
+                if (overlayEffects[oe].id === raw)
+                    return overlayEffects[oe].name;
+            }
+            return rawStr;
+        }
         if (kind === "curveEditor") {
             // CurvePresets.curveLabel is the single source of truth for the
             // spring (`spring:omega,zeta`) + easing display name, shared with

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -18,9 +18,11 @@ import org.plasmazones.common as PZCommon
  * there is no per-type `if (t === "...")` ladder here. Two-way: edits emit
  * `actionEdited(updatedAction)`; the parent owns the list.
  *
- * For `overrideAnimationShader`, a `ShaderParameterEditor` surfaces below the
- * row when an effect is selected so shader uniforms can be edited in place —
- * matching the animation-settings page's per-event editor.
+ * For `overrideAnimationShader` and `overrideOverlayShader`, a
+ * `ShaderParameterEditor` surfaces below the row when an effect is selected so
+ * shader uniforms can be edited in place — matching the animation-settings
+ * page's per-event editor. Each shader-override type sources its uniform schema
+ * from its own registry (animation vs overlay/snapping).
  */
 ColumnLayout {
     id: row
@@ -75,6 +77,38 @@ ColumnLayout {
 
         var controller = row.appSettings ? row.appSettings.animationsController : null;
         return controller ? controller.shaderParameters(effectId) : [];
+    }
+    /// Shader-uniform schema for OverrideOverlayShader — same shape as
+    /// `_shaderParamSchema` but sourced from the overlay/snapping shader
+    /// registry (the catalog entry's `parameters`), not the animation one.
+    readonly property var _overlayShaderParamSchema: {
+        if (row.action.type !== "overrideOverlayShader")
+            return [];
+
+        var effectId = row.action.effectId || "";
+        if (effectId.length === 0)
+            return [];
+
+        var controller = row.appSettings ? row.appSettings.snappingShadersPage : null;
+        if (!controller)
+            return [];
+
+        var effects = controller.availableShaderEffects() || [];
+        for (var i = 0; i < effects.length; ++i) {
+            if (effects[i].id === effectId)
+                return effects[i].parameters || [];
+        }
+        return [];
+    }
+    /// The active shader-uniform schema for whichever shader-override action is
+    /// being edited (animation or overlay) — drives the inline
+    /// ShaderParameterEditor below the row.
+    readonly property var _activeShaderParamSchema: {
+        if (row.action.type === "overrideAnimationShader")
+            return row._shaderParamSchema;
+        if (row.action.type === "overrideOverlayShader")
+            return row._overlayShaderParamSchema;
+        return [];
     }
     /// Working-state lock map for the shader-params editor — mirrors the
     /// per-event animation editor's behaviour. Locks influence randomize
@@ -222,7 +256,7 @@ ColumnLayout {
         function onActionEdited(updated) {
             // Compare against the action BEFORE the edit lands — `row.action`
             // is still the previous state until the parent re-feeds us.
-            if (row.action.type === "overrideAnimationShader" && updated && updated.effectId !== row.action.effectId)
+            if ((row.action.type === "overrideAnimationShader" || row.action.type === "overrideOverlayShader") && updated && updated.effectId !== row.action.effectId)
                 row._shaderParamLocks = ({});
         }
 
@@ -382,7 +416,7 @@ ColumnLayout {
     Loader {
         Layout.fillWidth: true
         Layout.leftMargin: Kirigami.Units.iconSizes.small + Kirigami.Units.smallSpacing
-        active: row.action.type === "overrideAnimationShader" && row._shaderParamSchema.length > 0
+        active: row._activeShaderParamSchema.length > 0
         visible: active
         sourceComponent: row._shaderParamsEditor
     }
@@ -732,7 +766,7 @@ ColumnLayout {
         PZCommon.ShaderParameterEditor {
             id: paramEditor
 
-            parameters: row._shaderParamSchema
+            parameters: row._activeShaderParamSchema
             currentValues: row.action.params || row._emptyShaderParams
             lockedParams: row._shaderParamLocks
             enableLocking: true

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -411,11 +411,12 @@ ColumnLayout {
         }
     }
 
-    // ── Bottom: shader-parameter editor for OverrideAnimationShader ──────
-    // Surfaces when the action type is `overrideAnimationShader`, the user
-    // has picked an effect, and that effect declares parameters. Matches the
-    // per-event editor on the animation settings page so users can tweak
-    // uniforms without leaving the rule editor.
+    // ── Bottom: shader-parameter editor for the shader-override actions ──────
+    // Surfaces when the action type is `overrideAnimationShader` or
+    // `overrideOverlayShader`, the user has picked an effect, and that effect
+    // declares parameters (`_activeShaderParamSchema` resolves the right
+    // registry's schema). Matches the per-event editor on the animation settings
+    // page so users can tweak uniforms without leaving the rule editor.
     Loader {
         Layout.fillWidth: true
         Layout.leftMargin: Kirigami.Units.iconSizes.small + Kirigami.Units.smallSpacing

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -121,6 +121,10 @@ ColumnLayout {
     // ones incompatible with the action's target event render dimmed. Wire
     // value is the effect id.
     property Component _shaderEffectEditor
+    // Overlay-shader picker for OverrideOverlayShader actions — the overlay/
+    // snapping shader registry (Snapping → Shaders page), distinct from the
+    // animation shaders above. Wire value is the shader id.
+    property Component _overlayShaderEditor
     // Inline shader-uniform editor for OverrideAnimationShader actions. The
     // action stores a nested `params` object (the shader uniform values);
     // changing any value rewrites the whole object. Locks live on the row
@@ -342,6 +346,9 @@ ColumnLayout {
 
                     if (modelData.kind === "shaderEffect")
                         return row._shaderEffectEditor;
+
+                    if (modelData.kind === "overlayShader")
+                        return row._overlayShaderEditor;
 
                     if (modelData.kind === "curveEditor")
                         return row._curveEditorEditor;
@@ -692,6 +699,28 @@ ColumnLayout {
             // stale / uninstalled shader id, so the placeholder is only seen
             // when nothing is selected.
             placeholderText: i18n("Choose a shader…")
+            Accessible.description: _param.label
+            onSelected: function (id) {
+                row.actionEdited(row._withParam(_param.key, id));
+            }
+        }
+    }
+
+    _overlayShaderEditor: Component {
+        // Cascading category menu of the overlay/snapping shaders — the same
+        // registry the "Snapping → Shaders" page edits and that Layout::shaderId
+        // stores — grouped by category. Distinct from _shaderEffectEditor, which
+        // lists the ANIMATION shaders. Wire value is the shader id; an
+        // unknown/uninstalled id renders as "(missing: <id>)".
+        PZCommon.CategoryMenuButton {
+            readonly property var _param: parent.modelData
+
+            items: {
+                var controller = row.appSettings ? row.appSettings.snappingShadersPage : null;
+                return controller ? controller.availableShaderEffects() : [];
+            }
+            currentId: row.action[_param.key] || ""
+            placeholderText: i18n("Choose an overlay shader…")
             Accessible.description: _param.label
             onSelected: function (id) {
                 row.actionEdited(row._withParam(_param.key, id));

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -159,8 +159,11 @@ ColumnLayout {
     // snapping shader registry (Snapping → Shaders page), distinct from the
     // animation shaders above. Wire value is the shader id.
     property Component _overlayShaderEditor
-    // Inline shader-uniform editor for OverrideAnimationShader actions. The
-    // action stores a nested `params` object (the shader uniform values);
+    // Inline shader-uniform editor shared by both shader-override actions
+    // (OverrideAnimationShader and OverrideOverlayShader) — bound to
+    // `_activeShaderParamSchema`, which selects the matching registry's schema
+    // per action type. The action stores a nested `params` object (the shader
+    // uniform values);
     // changing any value rewrites the whole object. Locks live on the row
     // as working state (not persisted) — exactly like the per-event card on
     // the animations page. Randomize rolls a new map respecting locks and
@@ -744,8 +747,10 @@ ColumnLayout {
         // Cascading category menu of the overlay/snapping shaders — the same
         // registry the "Snapping → Shaders" page edits and that Layout::shaderId
         // stores — grouped by category. Distinct from _shaderEffectEditor, which
-        // lists the ANIMATION shaders. Wire value is the shader id; an
-        // unknown/uninstalled id renders as "(missing: <id>)".
+        // lists the ANIMATION shaders. No path-aware dim/incompatible state here
+        // (overlay shaders are event-agnostic, unlike the per-event animation
+        // shaders). Wire value is the shader id; an unknown/uninstalled id
+        // renders as "(missing: <id>)".
         PZCommon.CategoryMenuButton {
             readonly property var _param: parent.modelData
 

--- a/src/settings/qml/WindowRulesPage.qml
+++ b/src/settings/qml/WindowRulesPage.qml
@@ -80,6 +80,10 @@ SettingsFlickable {
         // `availableShaderEffects()` for the animationEvent / shaderEffect
         // picker editors in ActionRow.
         readonly property var animationsController: settingsController.animationsPage
+        // `SnappingShadersPageController` — exposes `availableShaderEffects()`
+        // (the overlay/snapping shader catalog) for the overlayShader picker
+        // editor (OverrideOverlayShader) and its read-only name resolution.
+        readonly property var snappingShadersPage: settingsController.snappingShadersPage
         // Reference to the page-level WindowPickerDialog — exposed via the
         // bridge so MatchLeafEditor can open the picker without having to
         // own its own instance. Hosting the picker inside the OverlaySheet

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -124,6 +124,9 @@ SettingsController::~SettingsController()
         // The shader resolver captures `this` and reaches m_animationShaderRegistry;
         // clear it too so the cleared set stays symmetric with what's installed.
         m_windowRulesPage->setShaderEffectLookup({});
+        // The overlay-shader resolver reaches m_overlayShaderRegistry — clear it
+        // too for the same symmetry.
+        m_windowRulesPage->setOverlayShaderLookup({});
         // Drain any in-flight `dataChanged` emissions queued against
         // the cleared lookups before the model captures the now-
         // empty resolvers. refreshLabels walks every row once and
@@ -617,6 +620,19 @@ SettingsController::SettingsController(QObject* parent)
         return name.isEmpty() ? effectId : name;
     };
     m_windowRulesPage->setShaderEffectLookup(resolveShaderEffectLookup);
+    // OverrideOverlayShader stores an overlay/snapping shader id; resolve it to
+    // the friendly name via the overlay shader registry (the same source the
+    // rule editor's overlay-shader picker reads), so the list shows
+    // "Overlay shader: <name>" rather than the raw id. Unknown ids round-trip
+    // verbatim (registry miss → empty name → raw id).
+    auto resolveOverlayShaderLookup = [this](const QString& effectId) -> QString {
+        if (effectId.isEmpty() || !m_overlayShaderRegistry) {
+            return effectId;
+        }
+        const QString name = m_overlayShaderRegistry->shader(effectId).name;
+        return name.isEmpty() ? effectId : name;
+    };
+    m_windowRulesPage->setOverlayShaderLookup(resolveOverlayShaderLookup);
     auto refreshRuleLabels = [this]() {
         if (m_windowRulesPage && m_windowRulesPage->model()) {
             m_windowRulesPage->model()->refreshLabels();

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -624,7 +624,10 @@ SettingsController::SettingsController(QObject* parent)
     // the friendly name via the overlay shader registry (the same source the
     // rule editor's overlay-shader picker reads), so the list shows
     // "Overlay shader: <name>" rather than the raw id. Unknown ids round-trip
-    // verbatim (registry miss → empty name → raw id).
+    // verbatim (registry miss → empty name → raw id). m_overlayShaderRegistry is
+    // constructed later in this ctor; the `!m_overlayShaderRegistry` guard below
+    // covers that window — the lambda captures `this` and is invoked only lazily
+    // (on the model's first label render, after construction completes).
     auto resolveOverlayShaderLookup = [this](const QString& effectId) -> QString {
         if (effectId.isEmpty() || !m_overlayShaderRegistry) {
             return effectId;

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -324,10 +324,10 @@ QString enumOptionLabel(const QString& type, const QString& key, const QString& 
         }
     }
     if (type == ActionType::OverrideOverlayStyle && key == ActionParam::Value) {
-        if (wireValue == QLatin1String("rectangles")) {
+        if (wireValue == PhosphorWindowRules::OverlayStyleToken::Rectangles) {
             return PhosphorI18n::tr("Zone rectangles");
         }
-        if (wireValue == QLatin1String("preview")) {
+        if (wireValue == PhosphorWindowRules::OverlayStyleToken::Preview) {
             return PhosphorI18n::tr("Layout preview");
         }
     }

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -200,6 +200,9 @@ PickerCategory actionCategory(const QString& type)
     if (cat == QLatin1String("animation")) {
         return {PhosphorI18n::tr("Animation"), 4};
     }
+    if (cat == QLatin1String("overlay")) {
+        return {PhosphorI18n::tr("Overlay"), 5};
+    }
     return {PhosphorI18n::tr("Other"), 99};
 }
 
@@ -280,6 +283,14 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::SetOuterGapRight && key == ActionParam::Value) {
         return PhosphorI18n::tr("Right gap (px)");
     }
+    // Context overlay-property overrides. These come BEFORE the generic
+    // EffectId / Value fallbacks so they win for the overlay actions.
+    if (type == ActionType::OverrideOverlayShader && key == ActionParam::EffectId) {
+        return PhosphorI18n::tr("Overlay shader");
+    }
+    if (type == ActionType::OverrideOverlayStyle && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Overlay style");
+    }
     if (key == ActionParam::Event) {
         return PhosphorI18n::tr("Event");
     }
@@ -310,6 +321,14 @@ QString enumOptionLabel(const QString& type, const QString& key, const QString& 
         }
         if (wireValue == QLatin1String("scrolling")) {
             return PhosphorI18n::tr("Scrolling");
+        }
+    }
+    if (type == ActionType::OverrideOverlayStyle && key == ActionParam::Value) {
+        if (wireValue == QLatin1String("rectangles")) {
+            return PhosphorI18n::tr("Zone rectangles");
+        }
+        if (wireValue == QLatin1String("preview")) {
+            return PhosphorI18n::tr("Layout preview");
         }
     }
     return wireValue;
@@ -404,6 +423,12 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::SetOpacity) {
         return PhosphorI18n::tr("Set opacity");
+    }
+    if (type == ActionType::OverrideOverlayShader) {
+        return PhosphorI18n::tr("Set overlay shader");
+    }
+    if (type == ActionType::OverrideOverlayStyle) {
+        return PhosphorI18n::tr("Set overlay style");
     }
     if (type == ActionType::ExcludeAnimations) {
         return PhosphorI18n::tr("Exclude from animations");

--- a/src/settings/windowrulecontroller.h
+++ b/src/settings/windowrulecontroller.h
@@ -98,6 +98,11 @@ public:
     /// animation shader registry (the same source the rule editor's shader
     /// picker uses), so the list renders "Dissolve" rather than the raw id.
     void setShaderEffectLookup(WindowRuleModel::LabelLookup fn);
+    /// Overlay shader id → display name resolver for OverrideOverlayShader
+    /// actions. SettingsController wires this from the overlay/snapping shader
+    /// registry (the source the rule editor's overlay-shader picker uses), so
+    /// the list renders the friendly name rather than the raw id.
+    void setOverlayShaderLookup(WindowRuleModel::LabelLookup fn);
     /// Curve wire-string → display name resolver for OverrideAnimationCurve
     /// actions. Q_INVOKABLE and QJSValue-typed because the canonical curve
     /// naming (easing-preset matching + spring formatting + i18n labels) lives

--- a/src/settings/windowrulecontroller_lookups.cpp
+++ b/src/settings/windowrulecontroller_lookups.cpp
@@ -46,6 +46,13 @@ void WindowRuleController::setShaderEffectLookup(WindowRuleModel::LabelLookup fn
     m_model.setShaderEffectLabelLookup(std::move(fn));
 }
 
+void WindowRuleController::setOverlayShaderLookup(WindowRuleModel::LabelLookup fn)
+{
+    // Same separate-wiring rationale as setShaderEffectLookup above; the overlay
+    // shader registry is distinct from the animation one.
+    m_model.setOverlayShaderLabelLookup(std::move(fn));
+}
+
 void WindowRuleController::setCurveLabelResolver(const QJSValue& resolver)
 {
     m_curveResolver = resolver;

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -224,6 +224,7 @@ QString engineModeDisplayLabel(const QString& wire)
 QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup& snappingLayoutLookup,
                     const WindowRuleModel::LabelLookup& tilingAlgorithmLookup,
                     const WindowRuleModel::LabelLookup& shaderEffectLookup,
+                    const WindowRuleModel::LabelLookup& overlayShaderLookup,
                     const WindowRuleModel::LabelLookup& curveLookup)
 {
     auto resolveWith = [](const QString& wire, const WindowRuleModel::LabelLookup& lookup) {
@@ -306,11 +307,9 @@ QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup
                                : PhosphorI18n::tr("Curve: %1").arg(resolveWith(curve, curveLookup));
     }
     if (action.type == ActionType::OverrideOverlayShader) {
-        // One-line summary uses the raw shader id (a short readable token);
-        // the detailed THEN chip (ActionListView) resolves the friendly name
-        // via the snapping-shader registry.
         const QString id = action.params.value(PhosphorWindowRules::ActionParam::EffectId).toString();
-        return id.isEmpty() ? PhosphorI18n::tr("Overlay shader") : PhosphorI18n::tr("Overlay shader: %1").arg(id);
+        return id.isEmpty() ? PhosphorI18n::tr("Overlay shader")
+                            : PhosphorI18n::tr("Overlay shader: %1").arg(resolveWith(id, overlayShaderLookup));
     }
     if (action.type == ActionType::OverrideOverlayStyle) {
         const QString v = action.params.value(PhosphorWindowRules::ActionParam::Value).toString();
@@ -748,8 +747,8 @@ QString WindowRuleModel::actionSummary(const QList<RuleAction>& actions) const
     }
     QStringList parts;
     for (const RuleAction& a : actions) {
-        parts.append(
-            actionLabel(a, m_snappingLayoutLookup, m_tilingAlgorithmLookup, m_shaderEffectLookup, m_curveLookup));
+        parts.append(actionLabel(a, m_snappingLayoutLookup, m_tilingAlgorithmLookup, m_shaderEffectLookup,
+                                 m_overlayShaderLookup, m_curveLookup));
     }
     return parts.join(QStringLiteral(" · "));
 }
@@ -810,6 +809,11 @@ void WindowRuleModel::setTilingAlgorithmLabelLookup(LabelLookup fn)
 void WindowRuleModel::setShaderEffectLabelLookup(LabelLookup fn)
 {
     m_shaderEffectLookup = std::move(fn);
+}
+
+void WindowRuleModel::setOverlayShaderLabelLookup(LabelLookup fn)
+{
+    m_overlayShaderLookup = std::move(fn);
 }
 
 void WindowRuleModel::setCurveLabelLookup(LabelLookup fn)

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -305,6 +305,23 @@ QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup
         return curve.isEmpty() ? PhosphorI18n::tr("Animation curve")
                                : PhosphorI18n::tr("Curve: %1").arg(resolveWith(curve, curveLookup));
     }
+    if (action.type == ActionType::OverrideOverlayShader) {
+        // One-line summary uses the raw shader id (a short readable token);
+        // the detailed THEN chip (ActionListView) resolves the friendly name
+        // via the snapping-shader registry.
+        const QString id = action.params.value(PhosphorWindowRules::ActionParam::EffectId).toString();
+        return id.isEmpty() ? PhosphorI18n::tr("Overlay shader") : PhosphorI18n::tr("Overlay shader: %1").arg(id);
+    }
+    if (action.type == ActionType::OverrideOverlayStyle) {
+        const QString v = action.params.value(PhosphorWindowRules::ActionParam::Value).toString();
+        if (v == QLatin1String("rectangles")) {
+            return PhosphorI18n::tr("Overlay style: Zone rectangles");
+        }
+        if (v == QLatin1String("preview")) {
+            return PhosphorI18n::tr("Overlay style: Layout preview");
+        }
+        return PhosphorI18n::tr("Overlay style");
+    }
     // ── single-value actions keyed on ActionParam::Value (restore-position,
     //    border / title-bar overrides, per-context gap overrides) ──
     {

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -313,10 +313,10 @@ QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup
     }
     if (action.type == ActionType::OverrideOverlayStyle) {
         const QString v = action.params.value(PhosphorWindowRules::ActionParam::Value).toString();
-        if (v == QLatin1String("rectangles")) {
+        if (v == PhosphorWindowRules::OverlayStyleToken::Rectangles) {
             return PhosphorI18n::tr("Overlay style: Zone rectangles");
         }
-        if (v == QLatin1String("preview")) {
+        if (v == PhosphorWindowRules::OverlayStyleToken::Preview) {
             return PhosphorI18n::tr("Overlay style: Layout preview");
         }
         return PhosphorI18n::tr("Overlay style");

--- a/src/settings/windowrulemodel.h
+++ b/src/settings/windowrulemodel.h
@@ -231,6 +231,10 @@ public:
     /// Resolver for `OverrideAnimationShader` action params (effect ids like
     /// "dissolve") so the summary renders "Dissolve" rather than the raw id.
     void setShaderEffectLabelLookup(LabelLookup fn);
+    /// Resolver for `OverrideOverlayShader` action params (overlay shader ids)
+    /// so the summary renders the friendly name rather than the raw id. Sourced
+    /// from the overlay/snapping shader registry, NOT the animation one.
+    void setOverlayShaderLabelLookup(LabelLookup fn);
     /// Resolver for `OverrideAnimationCurve` action params (curve wire strings
     /// like "0.33,1.00,0.68,1.00" / "spring:12,1") so the summary renders the
     /// friendly preset name ("Standard (Cubic)", "Spring (12, 1)", "Custom")
@@ -283,6 +287,7 @@ private:
     LabelLookup m_snappingLayoutLookup;
     LabelLookup m_tilingAlgorithmLookup;
     LabelLookup m_shaderEffectLookup;
+    LabelLookup m_overlayShaderLookup;
     LabelLookup m_curveLookup;
 };
 

--- a/tests/unit/core/test_windowrule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_windowrule_cascade_fidelity.cpp
@@ -679,6 +679,67 @@ private Q_SLOTS:
         QVERIFY(f.registry->resolveContextGaps(QStringLiteral("DP-2"), 0, QString()).isEmpty());
     }
 
+    // ─── Context overlay-property resolution (OverlayShader / OverlayStyle) ──
+    // resolveContextOverlay is a per-slot read across all matching context
+    // rules (mirrors resolveContextGaps): independent shader / style rules
+    // compose, and the style wire token maps to the OverlayDisplayMode int.
+
+    void testContextOverlay_perSlotComposition()
+    {
+        const auto overlayRule = [](const QString& name, int priority, const QString& screenId,
+                                    const QList<PWR::RuleAction>& actions) {
+            PWR::WindowRule r;
+            r.id = QUuid::createUuid();
+            r.name = name;
+            r.enabled = true;
+            r.priority = priority;
+            r.match = PWR::MatchExpression::makeLeaf(PWR::Field::ScreenId, PWR::Operator::Equals, screenId);
+            r.actions = actions;
+            return r;
+        };
+        const auto shaderAction = [](const QString& id) {
+            PWR::RuleAction a;
+            a.type = QString(PWR::ActionType::OverrideOverlayShader);
+            a.params.insert(QString(PWR::ActionParam::EffectId), id);
+            return a;
+        };
+        const auto styleAction = [](const QString& token) {
+            PWR::RuleAction a;
+            a.type = QString(PWR::ActionType::OverrideOverlayStyle);
+            a.params.insert(QString(PWR::ActionParam::Value), token);
+            return a;
+        };
+
+        RegistryFixture f = makeRegistryFixture();
+        // One rule sets ONLY the overlay shader; a separate rule sets ONLY the
+        // overlay style. Different slots → both compose (no shadowing).
+        const PWR::WindowRule sh = overlayRule(QStringLiteral("sh"), 400, QStringLiteral("DP-1"),
+                                               {shaderAction(QStringLiteral("plasma-glow"))});
+        const PWR::WindowRule st =
+            overlayRule(QStringLiteral("st"), 300, QStringLiteral("DP-1"), {styleAction(QStringLiteral("preview"))});
+        QVERIFY(f.store->setAllRules({sh, st}));
+
+        const PhosphorZones::ContextOverlayOverride resolved =
+            f.registry->resolveContextOverlay(QStringLiteral("DP-1"), 0, QString());
+        QVERIFY(resolved.shaderId.has_value());
+        QCOMPARE(*resolved.shaderId, QStringLiteral("plasma-glow"));
+        QVERIFY(resolved.style.has_value());
+        QCOMPARE(*resolved.style, 1); // "preview" → OverlayDisplayMode::LayoutPreview
+
+        // A context the rules do not pin → no override (falls through to layout).
+        QVERIFY(f.registry->resolveContextOverlay(QStringLiteral("DP-2"), 0, QString()).isEmpty());
+
+        // The "rectangles" token maps to OverlayDisplayMode::ZoneRectangles (0).
+        const PWR::WindowRule rect = overlayRule(QStringLiteral("rect"), 500, QStringLiteral("HDMI-1"),
+                                                 {styleAction(QStringLiteral("rectangles"))});
+        QVERIFY(f.store->setAllRules({rect}));
+        const PhosphorZones::ContextOverlayOverride r2 =
+            f.registry->resolveContextOverlay(QStringLiteral("HDMI-1"), 0, QString());
+        QVERIFY(r2.style.has_value());
+        QCOMPARE(*r2.style, 0);
+        QVERIFY(!r2.shaderId.has_value());
+    }
+
     // ─── Context lock resolution (ActionSlot::Locked) ─────────────────────
     // resolveContextLocked reads the boolean Locked slot off a matching
     // context rule. Mode-agnostic, never persisted — the daemon's

--- a/tests/unit/core/test_windowrule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_windowrule_cascade_fidelity.cpp
@@ -715,8 +715,8 @@ private Q_SLOTS:
         // overlay style. Different slots → both compose (no shadowing).
         const PWR::WindowRule sh = overlayRule(QStringLiteral("sh"), 400, QStringLiteral("DP-1"),
                                                {shaderAction(QStringLiteral("plasma-glow"))});
-        const PWR::WindowRule st =
-            overlayRule(QStringLiteral("st"), 300, QStringLiteral("DP-1"), {styleAction(QStringLiteral("preview"))});
+        const PWR::WindowRule st = overlayRule(QStringLiteral("st"), 300, QStringLiteral("DP-1"),
+                                               {styleAction(QString(PWR::OverlayStyleToken::Preview))});
         QVERIFY(f.store->setAllRules({sh, st}));
 
         const PhosphorZones::ContextOverlayOverride resolved =
@@ -731,7 +731,7 @@ private Q_SLOTS:
 
         // The "rectangles" token maps to OverlayDisplayMode::ZoneRectangles (0).
         const PWR::WindowRule rect = overlayRule(QStringLiteral("rect"), 500, QStringLiteral("HDMI-1"),
-                                                 {styleAction(QStringLiteral("rectangles"))});
+                                                 {styleAction(QString(PWR::OverlayStyleToken::Rectangles))});
         QVERIFY(f.store->setAllRules({rect}));
         const PhosphorZones::ContextOverlayOverride r2 =
             f.registry->resolveContextOverlay(QStringLiteral("HDMI-1"), 0, QString());

--- a/tests/unit/core/test_windowrule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_windowrule_cascade_fidelity.cpp
@@ -738,6 +738,28 @@ private Q_SLOTS:
         QVERIFY(r2.style.has_value());
         QCOMPARE(*r2.style, 0);
         QVERIFY(!r2.shaderId.has_value());
+
+        // shaderParams round-trip: a shader override carrying a params object
+        // resolves it into ContextOverlayOverride::shaderParams (the headline
+        // shader-uniform-override feature). The nested object is stored as JSON
+        // and decoded via toObject().toVariantMap().
+        const auto shaderWithParams = [](const QString& id, const QJsonObject& params) {
+            PWR::RuleAction a;
+            a.type = QString(PWR::ActionType::OverrideOverlayShader);
+            a.params.insert(QString(PWR::ActionParam::EffectId), id);
+            a.params.insert(QString(PWR::ActionParam::Params), params);
+            return a;
+        };
+        QJsonObject uniforms;
+        uniforms.insert(QStringLiteral("intensity"), 0.5);
+        const PWR::WindowRule shp = overlayRule(QStringLiteral("shp"), 600, QStringLiteral("DVI-1"),
+                                                {shaderWithParams(QStringLiteral("plasma-glow"), uniforms)});
+        QVERIFY(f.store->setAllRules({shp}));
+        const PhosphorZones::ContextOverlayOverride r3 =
+            f.registry->resolveContextOverlay(QStringLiteral("DVI-1"), 0, QString());
+        QVERIFY(r3.shaderId.has_value());
+        QCOMPARE(*r3.shaderId, QStringLiteral("plasma-glow"));
+        QCOMPARE(r3.shaderParams.value(QStringLiteral("intensity")).toDouble(), 0.5);
     }
 
     // ─── Context lock resolution (ActionSlot::Locked) ─────────────────────


### PR DESCRIPTION
## Summary

Adds window-rule **actions** to override two overlay properties that were previously only configurable per-layout, so a rule matching a monitor / desktop / activity can set them:

- **Set overlay shader** (`OverrideOverlayShader`) — overrides the active layout's `shaderId`
- **Set overlay style** (`OverrideOverlayStyle`) — overrides the display mode (zone rectangles vs layout preview)

Both are **context-domain** actions (resolved per screen/desktop/activity, like the existing engine-mode / snapping-layout / gap actions).

> **Scope note:** the originally-discussed third property — overlay geometry / "behind panels" (layer) — is **not** in this PR. The zone overlay is a single persistent per-screen `PassiveShell` surface shared by all overlay content, and a wlr-layer-shell surface's layer is immutable after `show()` — so a per-context layer override would require recreating that shared surface on every context switch (disruptive to OSD/snap-assist/selector, and at odds with the deliberate #516 Top-layer choice). It's deferred to a focused follow-up.

## How it works

1. **LGPL rules lib** (`phosphor-window-rules`): new `ActionType` / `ActionSlot` constants, `Tag::Overlay`, and the two `ActionDescriptor` registrations (Context domain, `overlay` category). Shader carries the shader id; style carries a `rectangles` / `preview` wire token.
2. **`phosphor-zones`**: `ContextOverlayOverride` struct + `LayoutRegistry::resolveContextOverlay` — a per-slot read across matching context rules (mirrors `resolveContextGaps`), mapping the style token to the `OverlayDisplayMode` int, memoized via the shared revision-invalidated cache. Declared on `IZoneLayoutRegistry` with an empty default so stubs are unaffected.
3. **Daemon overlay service**: `overlayOverrideForScreen()` resolves the override for the current context; `useShaderForScreen` + both shader-apply sites use the effective shader id, and the display-mode cascade slots the rule between the per-zone override and the layout (`zone > rule > layout > global`).
4. **Settings editor**: new "Overlay" picker category, action/param/enum labels, a new `overlayShader` editor kind (a `CategoryMenuButton` backed by the overlay/snapping shader registry — distinct from the animation-shader picker), and read-only resolution in `ActionListView`.

## Tests

- Domain canary in `test_ruleaction` now covers the two new actions.
- New `resolveContextOverlay` per-slot composition test (shader + style compose; `rectangles`→0 / `preview`→1; unpinned context falls through).
- Full suite green: **247/247**.

## Verification
- Full build clean (libs + daemon + settings)
- 247/247 tests pass
- clang-format + qmlformat clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)