### PR TITLE
feat(window-rules): SnapToZone action with zone spanning

### DIFF
--- a/dbus/org.plasmazones.Snap.xml
+++ b/dbus/org.plasmazones.Snap.xml
@@ -37,7 +37,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
             </arg>
         </method>
         <method name="recordSnapIntent">
-            <annotation name="org.gtk.GDBus.DocString" value="Record that a window class was USER-snapped (not auto-snapped) — feeds the app-rule learning."/>
+            <annotation name="org.gtk.GDBus.DocString" value="Record that a window class was USER-snapped (not auto-snapped) — feeds the snap-intent (user-snapped-class) learning."/>
             <arg name="windowId" type="s" direction="in"/>
             <arg name="wasUserInitiated" type="b" direction="in"/>
         </method>
@@ -58,7 +58,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
             <arg name="shouldSnap" type="b" direction="out"/>
         </method>
         <method name="snapToAppRule">
-            <annotation name="org.gtk.GDBus.DocString" value="Resolve a snap into the window's app-rule-defined zone."/>
+            <annotation name="org.gtk.GDBus.DocString" value="Resolve a snap into the window's SnapToZone-rule-defined zone(s)."/>
             <arg name="windowId" type="s" direction="in"/>
             <arg name="windowScreenName" type="s" direction="in"/>
             <arg name="sticky" type="b" direction="in"/>
@@ -80,7 +80,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
             <arg name="shouldSnap" type="b" direction="out"/>
         </method>
         <method name="resolveWindowRestore">
-            <annotation name="org.gtk.GDBus.DocString" value="Run the full snap-restore resolution (placement-store restore + app-rule / empty-zone / last-zone fallback chain) in one call."/>
+            <annotation name="org.gtk.GDBus.DocString" value="Run the full snap-restore resolution (placement-store restore + placement-rule / empty-zone / last-zone fallback chain) in one call."/>
             <arg name="windowId" type="s" direction="in"/>
             <arg name="screenId" type="s" direction="in"/>
             <arg name="sticky" type="b" direction="in"/>

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -767,7 +767,20 @@ bool PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
         // nullptr when compilation or linking fails, so a null check is the
         // validity test.
         if (!shader) {
-            qCWarning(lcEffect) << "Failed to compile shader transition" << effectId;
+            qCWarning(lcEffect) << "Failed to compile shader transition" << effectId
+                                << "— caching the failure so subsequent transitions skip the recompile "
+                                   "until the next shader hot-reload.";
+            // Cache a null-shader sentinel. A failed compile must NOT be
+            // retried on every transition: without this the cache miss recurs
+            // each time and the full read+assemble+expand+compile re-runs on
+            // the compositor thread — a per-command stall (the same failure
+            // mode the GLSL #extension fix addressed for the morph shader).
+            // The sentinel is distinguishable from a live entry because a
+            // successful compile always emplaces a non-null shader. It is
+            // cleared by the effectsChanged handler's m_shaderCache.clear()
+            // (shader hot-reload / settings change), so a corrected shader
+            // recompiles on the next reload.
+            m_shaderManager.m_shaderCache.emplace(effectId, CachedShader{});
             return false;
         }
 
@@ -841,6 +854,16 @@ bool PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
         }
         cached.shader = std::move(shader);
         cacheIt = m_shaderManager.m_shaderCache.emplace(effectId, std::move(cached)).first;
+    }
+
+    // A cached null-shader sentinel marks a prior compile failure (see the
+    // "Failed to compile" branch above). Skip the transition without
+    // re-attempting the expensive compile on every trigger; the effectsChanged
+    // handler clears m_shaderCache on hot-reload, so a corrected shader
+    // recompiles then. A successfully compiled entry always holds a non-null
+    // shader, so this never false-positives on a live transition.
+    if (!cacheIt->second.shader) {
+        return false;
     }
 
     // Detect supersession before the teardown so we can skip the

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -123,8 +123,26 @@ inline QByteArray injectKwinDefineAfterVersion(const QString& source)
     // produces visually inconsistent diffs and trips lints. If any
     // CRLF appears in the source, emit "\r\n"; otherwise plain "\n".
     const bool useCrlf = working.contains(QStringLiteral("\r\n"));
-    const QString defineLine =
-        useCrlf ? QStringLiteral("#define PLASMAZONES_KWIN\r\n") : QStringLiteral("#define PLASMAZONES_KWIN\n");
+    const QString eol = useCrlf ? QStringLiteral("\r\n") : QStringLiteral("\n");
+    // KWin 6.7's generateCustomShader compiles custom effect shaders at GLSL
+    // #version 140 (it rewrites our #version 450 down to the GL context's core
+    // version). At 140 the `layout(location = N)` qualifiers our vertex stages
+    // declare on in/out attributes are illegal without these ARB extensions, so
+    // the vertex shader fails to compile (NVIDIA error C7548). Failed compiles
+    // are NOT cached (the compile path returns false without inserting into
+    // m_shaderCache), so every transition then re-runs the whole
+    // assemble+compile on the compositor thread — the cause of the severe
+    // per-command window-movement / mode-change lag. The daemon's Qt-RHI/SPIR-V
+    // path (no PLASMAZONES_KWIN) needs the explicit locations for SPIR-V, so we
+    // enable the extensions on the KWin path rather than stripping the
+    // qualifiers. `: enable` is a harmless no-op on the fragment stage and on
+    // drivers that already expose explicit locations in core 140. The
+    // directives precede every declaration (only KWin's #defines and the
+    // source's leading comments come before them), which is all NVIDIA's
+    // compiler requires.
+    const QString defineLine = QStringLiteral("#extension GL_ARB_explicit_attrib_location : enable") + eol
+        + QStringLiteral("#extension GL_ARB_separate_shader_objects : enable") + eol
+        + QStringLiteral("#define PLASMAZONES_KWIN") + eol;
 
     // Walk the source line-by-line and find the FIRST line whose
     // non-whitespace prefix is `#version`. A naive
@@ -204,8 +222,7 @@ inline QByteArray injectKwinDefineAfterVersion(const QString& source)
         qCWarning(lcEffect) << "Animation shader source has no #version directive — synthesizing `#version 450`. "
                                "Animation shaders MUST declare `#version 450` (the canonical contract); the bake "
                                "test on the daemon side enforces this.";
-        const QString header = useCrlf ? QStringLiteral("#version 450\r\n#define PLASMAZONES_KWIN\r\n")
-                                       : QStringLiteral("#version 450\n#define PLASMAZONES_KWIN\n");
+        const QString header = QStringLiteral("#version 450") + eol + defineLine;
         return (header + working).toUtf8();
     }
     if (realVersionEnd < 0) {
@@ -714,7 +731,11 @@ bool PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
         // the source.
         const QByteArray fragWithKwinDefine = injectKwinDefineAfterVersion(expanded);
 
-        QByteArray vertWithKwinDefine = kKwinDefaultVertexSource;
+        // Route the built-in default vertex source through the same injection
+        // as custom vertex stages so it gets the layout(location) extension
+        // enables (it uses explicit locations too, and KWin compiles it at
+        // #version 140 — see injectKwinDefineAfterVersion).
+        QByteArray vertWithKwinDefine = injectKwinDefineAfterVersion(QString::fromUtf8(kKwinDefaultVertexSource));
         if (!eff.vertexShaderPath.isEmpty()) {
             QFile vertFile(eff.vertexShaderPath);
             if (!vertFile.open(QIODevice::ReadOnly)) {

--- a/libs/phosphor-identity/CMakeLists.txt
+++ b/libs/phosphor-identity/CMakeLists.txt
@@ -11,7 +11,7 @@
 #   • The KWin effect (separate process) constructs ids from
 #     KWin::Window::internalId() + desktopFileName() / windowClass().
 #   • The daemon parses them in WindowTrackingService.
-#   • PhosphorZones uses them in app-rule matching (Layout::matchAppRule).
+#   • PhosphorZones uses VirtualScreenId for virtual-screen id parsing.
 #   • Future PhosphorTiles runtime engine will hold them per-tiled-window.
 #
 # This library carries no Qt-Widgets / Wayland / KWin / Gui dependencies —

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
@@ -32,7 +32,7 @@ public:
     virtual bool restoreWindowsToZonesOnLogin() const = 0;
 
     // When true, a window that is auto-placed into a zone on open (session
-    // restore, app rule, empty-zone auto-assign, last-used-zone) is given focus.
+    // restore, placement rule, empty-zone auto-assign, last-used-zone) is given focus.
     // Read only on the AutoRestored commit path in SnapEngine::commitSnapImpl, so
     // it never affects manual drag or keyboard snaps (those use UserInitiated).
     // Mirrors AutotileConfig::focusNewWindows. Default false.

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -216,7 +216,9 @@ public:
     /**
      * @brief Resolver yielding the 1-based zone ordinals an opening window should
      *        snap into because a `SnapToZone` window rule matched it. Daemon-
-     *        injected, keyed by the live windowId, evaluated on the window-open
+     *        injected, keyed by the live windowId plus the screen the window is
+     *        opening on (so a rule carrying a `ScreenId` constraint resolves
+     *        against the window's current screen), evaluated on the window-open
      *        path (`calculateSnapToPlacementRule`, the highest-priority restore
      *        chain level). Returns an empty list when no rule matches. Multiple
      *        ordinals request a zone span (their unioned bounding rect). The
@@ -226,7 +228,7 @@ public:
      *        Same lifetime contract as setFloatPredicate — clear with `{}` before
      *        destroying any captured state.
      */
-    using PlacementZonesResolver = std::function<QList<int>(const QString& windowId)>;
+    using PlacementZonesResolver = std::function<QList<int>(const QString& windowId, const QString& screenId)>;
 
     void setPlacementZonesResolver(PlacementZonesResolver resolver)
     {

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -328,12 +328,14 @@ public:
     /**
      * @brief Resolve auto-snap for a newly opened window
      *
-     * First consults the unified WindowPlacementStore: a snapped or floated
-     * record reopens the window from its stored placement (cross-screen where the
-     * predicates allow). If no stored record applies, runs the fallback chain:
-     *   1. App rules (highest priority)
-     *   2. Auto-assign to empty zone
-     *   3. Snap to last zone (final fallback)
+     * A matched SnapToZone placement rule has highest priority and overrides any
+     * stored placement (the store still re-binds the record first, so the window's
+     * float-back geometry survives the override). Otherwise the unified
+     * WindowPlacementStore reopens the window from its snapped or floated record
+     * (cross-screen where the predicates allow). With neither, the fallback chain
+     * runs:
+     *   1. Auto-assign to empty zone
+     *   2. Snap to last zone (final fallback)
      *
      * Returns a PhosphorEngine::SnapResult so the D-Bus adaptor can unpack geometry for the
      * KWin effect. Also handles floating windows (skips snap, emits feedback).

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -213,6 +213,26 @@ public:
         m_floatPredicate = std::move(predicate);
     }
 
+    /**
+     * @brief Resolver yielding the 1-based zone ordinals an opening window should
+     *        snap into because a `SnapToZone` window rule matched it. Daemon-
+     *        injected, keyed by the live windowId, evaluated on the window-open
+     *        path (`calculateSnapToPlacementRule`, the highest-priority restore
+     *        chain level). Returns an empty list when no rule matches. Multiple
+     *        ordinals request a zone span (their unioned bounding rect). The
+     *        engine stays settings/rule-store-agnostic (LGPL boundary) — it only
+     *        asks. When UNSET (default) no window is rule-snapped and the engine
+     *        keeps its historical open behaviour (path unit tests rely on this).
+     *        Same lifetime contract as setFloatPredicate — clear with `{}` before
+     *        destroying any captured state.
+     */
+    using PlacementZonesResolver = std::function<QList<int>(const QString& windowId)>;
+
+    void setPlacementZonesResolver(PlacementZonesResolver resolver)
+    {
+        m_placementZonesResolver = std::move(resolver);
+    }
+
     void windowClosed(const QString& windowId) override;
     void windowFocused(const QString& windowId, const QString& screenId) override;
     void toggleWindowFloat(const QString& windowId, const QString& screenId) override;
@@ -491,8 +511,8 @@ public:
     // Auto-snap calculations (moved from WTS)
     // ═══════════════════════════════════════════════════════════════════════════
 
-    PhosphorEngine::SnapResult calculateSnapToAppRule(const QString& windowId, const QString& windowScreenName,
-                                                      bool isSticky) const;
+    PhosphorEngine::SnapResult calculateSnapToPlacementRule(const QString& windowId, const QString& windowScreenName,
+                                                            bool isSticky) const;
     PhosphorEngine::SnapResult calculateSnapToLastZone(const QString& windowId, const QString& windowScreenId,
                                                        bool isSticky) const;
     PhosphorEngine::SnapResult calculateSnapToEmptyZone(const QString& windowId, const QString& windowScreenId,
@@ -803,6 +823,11 @@ private:
     // Rule-driven open-floating gate. Empty until the daemon wires it; while
     // empty no window is rule-floated. See FloatPredicate doc above.
     FloatPredicate m_floatPredicate{};
+
+    // Rule-driven open-placement resolver (SnapToZone). Empty until the daemon
+    // wires it; while empty no window is rule-snapped. See PlacementZonesResolver
+    // doc above.
+    PlacementZonesResolver m_placementZonesResolver{};
 };
 
 } // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -58,7 +58,7 @@ SnapResult SnapEngine::calculateSnapToPlacementRule(const QString& windowId, con
     if (!m_placementZonesResolver) {
         return SnapResult::noSnap();
     }
-    const QList<int> ordinals = m_placementZonesResolver(windowId);
+    const QList<int> ordinals = m_placementZonesResolver(windowId, windowScreenName);
     if (ordinals.isEmpty()) {
         return SnapResult::noSnap();
     }

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -65,8 +65,9 @@ SnapResult SnapEngine::calculateSnapToPlacementRule(const QString& windowId, con
 
     // Ordinals are layout-agnostic: resolve them against whatever layout is active
     // on the window's CURRENT screen. Legacy per-layout app rules could target a
-    // different screen; that is now expressed as a ScreenId match on the rule
-    // itself (set during v3→v4 migration), so there is no cross-screen scan here.
+    // different screen; that cross-screen routing is retired — a SnapToZone rule
+    // resolves on the window's current screen, and a user can scope it to a screen
+    // with a ScreenId match leaf, so there is no cross-screen scan here.
     PhosphorZones::Layout* layout = m_layoutManager->resolveLayoutForScreen(windowScreenName);
     if (!layout) {
         qCDebug(PhosphorSnapEngine::lcSnapEngine)

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -29,8 +29,8 @@ using PhosphorEngine::StickyWindowHandling;
 // Auto-Snap Logic
 // ═══════════════════════════════════════════════════════════════════════════════
 
-SnapResult SnapEngine::calculateSnapToAppRule(const QString& windowId, const QString& windowScreenName,
-                                              bool isSticky) const
+SnapResult SnapEngine::calculateSnapToPlacementRule(const QString& windowId, const QString& windowScreenName,
+                                                    bool isSticky) const
 {
     // Check if window was floating - floating windows should NOT be auto-snapped
     if (m_windowTracker->isWindowFloating(windowId)) {
@@ -49,119 +49,65 @@ SnapResult SnapEngine::calculateSnapToAppRule(const QString& windowId, const QSt
         return SnapResult::noSnap();
     }
 
-    QString windowClass = m_windowTracker->currentAppIdFor(windowId);
-    if (windowClass.isEmpty()) {
+    // The placement resolver is the daemon's SnapToZone window-rule evaluation —
+    // the engine never reads the rule store directly (LGPL boundary). It returns
+    // the 1-based zone ordinals to snap into, or an empty list when no SnapToZone
+    // rule matched this window. Unset resolver (unit tests) ⇒ no rule snapping.
+    if (!m_placementZonesResolver) {
+        return SnapResult::noSnap();
+    }
+    const QList<int> ordinals = m_placementZonesResolver(windowId);
+    if (ordinals.isEmpty()) {
         return SnapResult::noSnap();
     }
 
-    auto* screenManager = m_windowTracker->screenManager();
+    // Ordinals are layout-agnostic: resolve them against whatever layout is active
+    // on the window's CURRENT screen. Legacy per-layout app rules could target a
+    // different screen; that is now expressed as a ScreenId match on the rule
+    // itself (set during v3→v4 migration), so there is no cross-screen scan here.
+    PhosphorZones::Layout* layout = m_layoutManager->resolveLayoutForScreen(windowScreenName);
+    if (!layout) {
+        qCDebug(PhosphorSnapEngine::lcSnapEngine)
+            << "calculateSnapToPlacementRule: no layout for screen" << windowScreenName;
+        return SnapResult::noSnap();
+    }
 
-    // Helper: given a match and a resolved screen name, build the SnapResult
-    auto buildResult = [&](const PhosphorZones::AppRuleMatch& match, const QString& resolvedScreen) -> SnapResult {
-        // Determine which screen to resolve the zone on
-        QString effectiveScreen = match.targetScreen.isEmpty() ? resolvedScreen : match.targetScreen;
-
-        if (!screenManager) {
-            qCWarning(PhosphorSnapEngine::lcSnapEngine)
-                << "App rule: no screen manager, falling back to primary screen for" << windowClass;
-        }
-        const bool screenFound = screenManager ? screenManager->physicalScreenFor(effectiveScreen).isValid()
-                                               : (QGuiApplication::primaryScreen() != nullptr);
-        if (!screenFound) {
-            qCInfo(PhosphorSnapEngine::lcSnapEngine)
-                << "App rule: screen" << effectiveScreen << "not found for" << windowClass
-                << (match.targetScreen.isEmpty() ? "(current screen)" : "(target screen)") << ", skipping";
-            return SnapResult::noSnap();
-        }
-
-        // Get the layout for the effective screen to find the zone
-        PhosphorZones::Layout* targetLayout = m_layoutManager->resolveLayoutForScreen(effectiveScreen);
-        if (!targetLayout) {
-            return SnapResult::noSnap();
-        }
-
-        PhosphorZones::Zone* zone = targetLayout->zoneByNumber(match.zoneNumber);
+    // Resolve each ordinal to its zone geometry and union them (zone span). An
+    // ordinal naming a zone the active layout lacks is skipped — a span rule is
+    // layout-agnostic and may reference a zone count this layout does not have.
+    QStringList zoneIds;
+    QRect unionGeo;
+    for (const int ordinal : ordinals) {
+        PhosphorZones::Zone* zone = layout->zoneByNumber(ordinal);
         if (!zone) {
-            return SnapResult::noSnap();
-        }
-
-        QString zoneId = zone->id().toString();
-        QRect geo = m_windowTracker->zoneGeometry(zoneId, effectiveScreen);
-        if (!geo.isValid()) {
-            return SnapResult::noSnap();
-        }
-
-        qCInfo(PhosphorSnapEngine::lcSnapEngine) << "App rule matched:" << windowClass << "-> zone" << match.zoneNumber
-                                                 << "on screen" << effectiveScreen << "(" << zoneId << ")";
-
-        SnapResult result;
-        result.shouldSnap = true;
-        result.geometry = geo;
-        result.zoneId = zoneId;
-        result.zoneIds = QStringList{zoneId};
-        result.screenId = effectiveScreen;
-        return result;
-    };
-
-    // Phase 1: Check the current screen's layout first (preserves existing behavior)
-    PhosphorZones::Layout* currentLayout = m_layoutManager->resolveLayoutForScreen(windowScreenName);
-    if (currentLayout) {
-        PhosphorZones::AppRuleMatch match = currentLayout->matchAppRule(windowClass);
-        if (match.matched()) {
-            SnapResult result = buildResult(match, windowScreenName);
-            if (result.isValid()) {
-                return result;
-            }
-        } else {
             qCDebug(PhosphorSnapEngine::lcSnapEngine)
-                << "calculateSnapToAppRule:" << windowClass << "no match in layout" << currentLayout->name() << "("
-                << currentLayout->appRules().size() << "rules)";
-        }
-    } else {
-        qCDebug(PhosphorSnapEngine::lcSnapEngine) << "calculateSnapToAppRule: no layout for screen" << windowScreenName;
-    }
-
-    // Phase 2: Scan other screens' layouts for cross-screen rules
-    // Only accept matches that have targetScreen set (rules without targetScreen
-    // are local to their layout's screen and shouldn't fire from other screens)
-    QSet<QUuid> checkedLayouts;
-    if (currentLayout) {
-        checkedLayouts.insert(currentLayout->id());
-    }
-
-    // Build a unified list of screen IDs from either effective screens (includes
-    // virtual screens) or physical screens as fallback, then use a single loop.
-    QStringList screenIds;
-    if (screenManager) {
-        screenIds = screenManager->effectiveScreenIds();
-    } else {
-        const auto screens = QGuiApplication::screens();
-        for (auto* s : screens) {
-            screenIds.append(PhosphorScreens::ScreenIdentity::identifierFor(s));
-        }
-    }
-
-    for (const QString& screenId : std::as_const(screenIds)) {
-        if (PhosphorScreens::ScreenIdentity::screensMatch(screenId, windowScreenName)) {
+                << "calculateSnapToPlacementRule: zone ordinal" << ordinal << "absent in layout" << layout->name();
             continue;
         }
-
-        PhosphorZones::Layout* layout = m_layoutManager->resolveLayoutForScreen(screenId);
-        if (!layout || checkedLayouts.contains(layout->id())) {
+        const QString zoneId = zone->id().toString();
+        const QRect geo = m_windowTracker->zoneGeometry(zoneId, windowScreenName);
+        if (!geo.isValid()) {
             continue;
         }
-        checkedLayouts.insert(layout->id());
-
-        PhosphorZones::AppRuleMatch match = layout->matchAppRule(windowClass);
-        if (match.matched() && !match.targetScreen.isEmpty()) {
-            SnapResult result = buildResult(match, screenId);
-            if (result.isValid()) {
-                return result;
-            }
-        }
+        zoneIds.append(zoneId);
+        // Default QRect is empty, so the first united() returns geo unchanged.
+        unionGeo = unionGeo.united(geo);
     }
 
-    return SnapResult::noSnap();
+    if (zoneIds.isEmpty() || !unionGeo.isValid()) {
+        return SnapResult::noSnap();
+    }
+
+    qCInfo(PhosphorSnapEngine::lcSnapEngine) << "calculateSnapToPlacementRule: snapping" << windowId << "to zones"
+                                             << ordinals << "on screen" << windowScreenName;
+
+    SnapResult result;
+    result.shouldSnap = true;
+    result.geometry = unionGeo;
+    result.zoneId = zoneIds.first();
+    result.zoneIds = zoneIds;
+    result.screenId = windowScreenName;
+    return result;
 }
 
 SnapResult SnapEngine::calculateSnapToLastZone(const QString& windowId, const QString& windowScreenId,

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -32,10 +32,12 @@ using PhosphorEngine::StickyWindowHandling;
 SnapResult SnapEngine::calculateSnapToPlacementRule(const QString& windowId, const QString& windowScreenName,
                                                     bool isSticky) const
 {
-    // Check if window was floating - floating windows should NOT be auto-snapped
-    if (m_windowTracker->isWindowFloating(windowId)) {
-        return SnapResult::noSnap();
-    }
+    // NOTE: deliberately NO isWindowFloating() guard here. A SnapToZone rule is an
+    // explicit "this app belongs in these zones" directive that outranks float
+    // state — both on open (it overrides a remembered floated position) and on a
+    // Meta+F un-float (the rule is the authoritative un-float target). The old
+    // per-layout app-rule path skipped floating windows; the rule-driven path
+    // intentionally does not.
 
     // Check sticky window handling
     if (auto* s = snapSettings(); isSticky && s) {

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -74,11 +74,10 @@ SnapResult SnapEngine::calculateSnapToPlacementRule(const QString& windowId, con
         return SnapResult::noSnap();
     }
 
-    // Resolve each ordinal to its zone geometry and union them (zone span). An
-    // ordinal naming a zone the active layout lacks is skipped — a span rule is
-    // layout-agnostic and may reference a zone count this layout does not have.
+    // Resolve each ordinal to its zone id (an ordinal naming a zone the active
+    // layout lacks is skipped — a span rule is layout-agnostic and may reference
+    // a zone count this layout does not have).
     QStringList zoneIds;
-    QRect unionGeo;
     for (const int ordinal : ordinals) {
         PhosphorZones::Zone* zone = layout->zoneByNumber(ordinal);
         if (!zone) {
@@ -86,17 +85,19 @@ SnapResult SnapEngine::calculateSnapToPlacementRule(const QString& windowId, con
                 << "calculateSnapToPlacementRule: zone ordinal" << ordinal << "absent in layout" << layout->name();
             continue;
         }
-        const QString zoneId = zone->id().toString();
-        const QRect geo = m_windowTracker->zoneGeometry(zoneId, windowScreenName);
-        if (!geo.isValid()) {
-            continue;
-        }
-        zoneIds.append(zoneId);
-        // Default QRect is empty, so the first united() returns geo unchanged.
-        unionGeo = unionGeo.united(geo);
+        zoneIds.append(zone->id().toString());
+    }
+    if (zoneIds.isEmpty()) {
+        return SnapResult::noSnap();
     }
 
-    if (zoneIds.isEmpty() || !unionGeo.isValid()) {
+    // Union via resolveZoneGeometry so the span uses the SAME QRectF-union-then-
+    // align rounding the float-back poison guard uses (WTA::captureWindowPlacement
+    // → resolveZoneGeometry). A per-QRect union here would diverge by a pixel at
+    // fractional scaling, so a window floated off the span without moving would
+    // leak the snap rect into its float-back geometry.
+    const QRect unionGeo = m_windowTracker->resolveZoneGeometry(zoneIds, windowScreenName);
+    if (!unionGeo.isValid()) {
         return SnapResult::noSnap();
     }
 

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -84,6 +84,28 @@ void SnapEngine::setWindowFloat(const QString& windowId, bool shouldFloat)
 
 bool SnapEngine::unfloatToZone(const QString& windowId, const QString& screenId)
 {
+    // Highest-priority un-float target: a matched SnapToZone rule. Toggling a
+    // window out of float lands it in the rule's zones, not a stale pre-float
+    // zone, so the rule stays authoritative for both open and Meta+F. Falls
+    // through to the pre-float / fallback zone when no rule matches.
+    {
+        const PhosphorEngine::SnapResult ruleSnap =
+            calculateSnapToPlacementRule(windowId, screenId, /*isSticky=*/false);
+        if (ruleSnap.shouldSnap && !ruleSnap.zoneIds.isEmpty()) {
+            if (ruleSnap.zoneIds.size() > 1) {
+                commitMultiZoneSnap(windowId, ruleSnap.zoneIds, ruleSnap.screenId, SnapIntent::UserInitiated);
+            } else {
+                commitSnap(windowId, ruleSnap.zoneIds.first(), ruleSnap.screenId, SnapIntent::UserInitiated);
+            }
+            // Non-empty zoneId so the effect treats this as a snap commit (re-applies
+            // snap chrome), mirroring the pre-float-zone path below.
+            Q_EMIT applyGeometryRequested(windowId, ruleSnap.geometry.x(), ruleSnap.geometry.y(),
+                                          ruleSnap.geometry.width(), ruleSnap.geometry.height(),
+                                          ruleSnap.zoneIds.first(), ruleSnap.screenId, false);
+            return true;
+        }
+    }
+
     UnfloatResult unfloat = resolveUnfloatGeometry(windowId, screenId);
     if (!unfloat.found) {
         // No pre-float zone (a never-snapped window that defaulted to floating).

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -81,12 +81,14 @@ void SnapEngine::windowOpened(const QString& windowId, const QString& screenId, 
 // ═══════════════════════════════════════════════════════════════════════════════
 // resolveWindowRestore — WindowPlacementStore restore + auto-snap fallback chain
 //
-// A matched SnapToZone placement rule wins first (highest priority — it overrides
-// any remembered placement). Otherwise consults the unified WindowPlacementStore
-// (snapped or floated record — snapping's two states); if neither applies, runs the
-// fallback chain (1. empty zone, 2. last zone), and a no-match window defaults to
-// floated. Persisted session restore is served by the store block, not a chain
-// level.
+// A matched SnapToZone placement rule has highest priority: it overrides any
+// remembered placement. It is APPLIED inside the WindowPlacementStore block, AFTER
+// the store re-binds the window's record to the live id, so the rule decides WHERE
+// the window snaps while the store still preserves its float-back geometry for a
+// later Meta+F. With no rule, the store restores the snapped or floated record
+// (snapping's two states); with neither, the fallback chain runs (1. empty zone,
+// 2. last zone), and a no-match window defaults to floated. Persisted session
+// restore is served by the store block, not a chain level.
 //
 // Mostly decision logic: returns a SnapResult for the caller to apply geometry.
 // Side effects: consumePendingAssignment; marks floated windows floating
@@ -188,30 +190,18 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
             << "but carries a cross-screen snap restore — not deferring";
     }
 
-    // Highest-priority restore: a matched SnapToZone placement rule. An explicit
-    // "this app snaps to these zones" directive outranks ANY remembered placement
-    // — a floated position or a prior snap to a different zone — so the rule wins
-    // on every open. Runs AFTER the autotile screen-mode gate (autotile screens
-    // still own their own windows) but BEFORE the placement store, so a stale
-    // record can never shadow the rule. The disabled-context gate is load-bearing
-    // here: the chain's own gate runs only after the store block, which this path
-    // skips. The rule's snap re-captures the window's placement record, replacing
-    // the now-stale floated/snapped one on the next save.
-    {
-        SnapResult ruleResult = calculateSnapToPlacementRule(windowId, screenId, sticky);
-        if (ruleResult.shouldSnap) {
-            if (m_shouldRestorePredicate && !m_shouldRestorePredicate(ruleResult.screenId)) {
-                qCDebug(PhosphorSnapEngine::lcSnapEngine)
-                    << "resolveWindowRestore:" << windowId << "placement-rule target" << ruleResult.screenId
-                    << "rejected by disabled-context gate";
-                return SnapResult::noSnap();
-            }
-            qCInfo(PhosphorSnapEngine::lcSnapEngine)
-                << "resolveWindowRestore: placement rule matched (highest priority) for" << windowId
-                << "zones=" << ruleResult.zoneIds;
-            return ruleResult;
-        }
-    }
+    // Highest-priority placement: a matched SnapToZone rule. An explicit "this app
+    // snaps to these zones" directive outranks ANY remembered placement — a floated
+    // position or a prior snap to a different zone. Resolved up front (after the
+    // autotile screen-mode gate, so autotile screens still own their windows) but
+    // APPLIED below, AFTER the placement store has re-bound the window's record: the
+    // rule overrides WHERE the window goes, while the store still preserves the
+    // window's float-back geometry so a later Meta+F returns it to its remembered
+    // free position rather than the zone rect. When the rule's own target context is
+    // disabled, it does NOT win and we fall through to the normal store restore.
+    const SnapResult placementRuleResult = calculateSnapToPlacementRule(windowId, screenId, sticky);
+    const bool placementRuleWins = placementRuleResult.shouldSnap
+        && (!m_shouldRestorePredicate || m_shouldRestorePredicate(placementRuleResult.screenId));
 
     // Unified placement store — the single authoritative restore record for this
     // window. Consulted before the legacy "already has assignment" skip and the
@@ -331,6 +321,17 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
             rec->windowId = windowId;
             m_windowTracker->placementStore().record(*rec);
 
+            // The record (and its float-back geometry) is now re-bound to the live
+            // window. A matched SnapToZone rule overrides the remembered placement
+            // here — the window snaps to the rule's zones while its freeGeo survives
+            // in the record for a later Meta+F float.
+            if (placementRuleWins) {
+                qCInfo(PhosphorSnapEngine::lcSnapEngine)
+                    << "resolveWindowRestore: placement rule overrides stored record for" << windowId
+                    << "zones=" << placementRuleResult.zoneIds << "(freeGeo preserved=" << freeGeo << ")";
+                return placementRuleResult;
+            }
+
             if (slot.state == WindowPlacement::stateSnapped()) {
                 // A stored snap is still subject to the disabled-context gate.
                 if (!m_shouldRestorePredicate || m_shouldRestorePredicate(restoreScreen)) {
@@ -405,6 +406,15 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
         qCDebug(PhosphorSnapEngine::lcSnapEngine)
             << "resolveWindowRestore:" << windowId << "already snapped, skipping auto-snap";
         return SnapResult::noSnap();
+    }
+
+    // No stored record matched above, so there is no float-back geometry to
+    // inherit — but a matched SnapToZone rule still wins for a fresh window.
+    if (placementRuleWins) {
+        qCInfo(PhosphorSnapEngine::lcSnapEngine)
+            << "resolveWindowRestore: placement rule matched (no stored record) for" << windowId
+            << "zones=" << placementRuleResult.zoneIds;
+        return placementRuleResult;
     }
 
     // Disabled-context gate: refuse auto-snap onto a (screen, virtualDesktop,

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -81,11 +81,12 @@ void SnapEngine::windowOpened(const QString& windowId, const QString& screenId, 
 // ═══════════════════════════════════════════════════════════════════════════════
 // resolveWindowRestore — WindowPlacementStore restore + auto-snap fallback chain
 //
-// Consults the unified WindowPlacementStore first (snapped or floated record —
-// snapping's two states); if none applies, runs the fallback chain (1. SnapToZone
-// placement rules, 2. empty zone, 3. last zone), and a no-match window defaults to
-// floated. Persisted session restore is now served by the store block above, not a
-// chain level.
+// A matched SnapToZone placement rule wins first (highest priority — it overrides
+// any remembered placement). Otherwise consults the unified WindowPlacementStore
+// (snapped or floated record — snapping's two states); if neither applies, runs the
+// fallback chain (1. empty zone, 2. last zone), and a no-match window defaults to
+// floated. Persisted session restore is served by the store block, not a chain
+// level.
 //
 // Mostly decision logic: returns a SnapResult for the caller to apply geometry.
 // Side effects: consumePendingAssignment; marks floated windows floating
@@ -187,9 +188,35 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
             << "but carries a cross-screen snap restore — not deferring";
     }
 
+    // Highest-priority restore: a matched SnapToZone placement rule. An explicit
+    // "this app snaps to these zones" directive outranks ANY remembered placement
+    // — a floated position or a prior snap to a different zone — so the rule wins
+    // on every open. Runs AFTER the autotile screen-mode gate (autotile screens
+    // still own their own windows) but BEFORE the placement store, so a stale
+    // record can never shadow the rule. The disabled-context gate is load-bearing
+    // here: the chain's own gate runs only after the store block, which this path
+    // skips. The rule's snap re-captures the window's placement record, replacing
+    // the now-stale floated/snapped one on the next save.
+    {
+        SnapResult ruleResult = calculateSnapToPlacementRule(windowId, screenId, sticky);
+        if (ruleResult.shouldSnap) {
+            if (m_shouldRestorePredicate && !m_shouldRestorePredicate(ruleResult.screenId)) {
+                qCDebug(PhosphorSnapEngine::lcSnapEngine)
+                    << "resolveWindowRestore:" << windowId << "placement-rule target" << ruleResult.screenId
+                    << "rejected by disabled-context gate";
+                return SnapResult::noSnap();
+            }
+            qCInfo(PhosphorSnapEngine::lcSnapEngine)
+                << "resolveWindowRestore: placement rule matched (highest priority) for" << windowId
+                << "zones=" << ruleResult.zoneIds;
+            return ruleResult;
+        }
+    }
+
     // Unified placement store — the single authoritative restore record for this
-    // window. Consulted FIRST, before the legacy "already has assignment" skip and
-    // the snap/float chains. This ordering is load-bearing: on a daemon-only
+    // window. Consulted before the legacy "already has assignment" skip and the
+    // snap/float chains (but after a matched SnapToZone rule, above). This
+    // ordering is load-bearing: on a daemon-only
     // restart the old WindowZoneAssignmentsFull is still loaded, so a window that
     // was FLOATED (floating keeps its zone assignment) comes back isWindowSnapped()
     // == true and would hit the legacy skip below — never floating. Consulting the
@@ -446,27 +473,9 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
         return SnapResult::noSnap();
     }
 
-    // 1. SnapToZone window rules (highest priority).
-    {
-        SnapResult result = calculateSnapToPlacementRule(windowId, screenId, sticky);
-        if (result.shouldSnap) {
-            // The result always targets the caller's own screen (SnapToZone
-            // ordinals resolve on the window's current screen). The disabled-
-            // context gate above already validated that screenId, so this
-            // re-check is a defensive no-op kept symmetric with the other
-            // chain levels — a placement rule must not route a window onto a
-            // context the user disabled.
-            if (m_shouldRestorePredicate && !m_shouldRestorePredicate(result.screenId)) {
-                qCDebug(PhosphorSnapEngine::lcSnapEngine)
-                    << "resolveWindowRestore:" << windowId << "placement-rule target" << result.screenId
-                    << "rejected by disabled-context gate";
-                return SnapResult::noSnap();
-            }
-            qCInfo(PhosphorSnapEngine::lcSnapEngine)
-                << "resolveWindowRestore: placement rule matched for" << windowId << "zone=" << result.zoneId;
-            return result;
-        }
-    }
+    // (SnapToZone placement rules are resolved BEFORE the placement store, near
+    // the top of this function — an explicit rule outranks any remembered
+    // placement. See the "highest-priority restore" block above.)
 
     // (Persisted session restore is now served entirely by the unified
     // WindowPlacementStore block at the top of this function — a snapped window

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -445,15 +445,16 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
         return SnapResult::noSnap();
     }
 
-    // 1. App rules (highest priority). May cross-screen migrate.
+    // 1. SnapToZone window rules (highest priority).
     {
-        SnapResult result = calculateSnapToAppRule(windowId, screenId, sticky);
+        SnapResult result = calculateSnapToPlacementRule(windowId, screenId, sticky);
         if (result.shouldSnap) {
-            // An app rule may target a screen other than the caller's. The
-            // disabled-context gate above validated only the caller's screenId,
-            // so re-check the predicate against the result's destination
-            // screen. An app rule must not route a window onto a context the
-            // user disabled.
+            // The result always targets the caller's own screen (SnapToZone
+            // ordinals resolve on the window's current screen). The disabled-
+            // context gate above already validated that screenId, so this
+            // re-check is a defensive no-op kept symmetric with the other
+            // chain levels — a placement rule must not route a window onto a
+            // context the user disabled.
             if (m_shouldRestorePredicate && !m_shouldRestorePredicate(result.screenId)) {
                 qCDebug(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore:" << windowId << "appRule target"
                                                           << result.screenId << "rejected by disabled-context gate";

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -82,10 +82,10 @@ void SnapEngine::windowOpened(const QString& windowId, const QString& screenId, 
 // resolveWindowRestore — WindowPlacementStore restore + auto-snap fallback chain
 //
 // Consults the unified WindowPlacementStore first (snapped or floated record —
-// snapping's two states); if none applies, runs the fallback chain (1. app rules,
-// 2. empty zone, 3. last zone), and a no-match window defaults to floated.
-// Persisted session restore is now served by the store block above, not a chain
-// level.
+// snapping's two states); if none applies, runs the fallback chain (1. SnapToZone
+// placement rules, 2. empty zone, 3. last zone), and a no-match window defaults to
+// floated. Persisted session restore is now served by the store block above, not a
+// chain level.
 //
 // Mostly decision logic: returns a SnapResult for the caller to apply geometry.
 // Side effects: consumePendingAssignment; marks floated windows floating
@@ -95,14 +95,15 @@ void SnapEngine::windowOpened(const QString& windowId, const QString& screenId, 
 // geometry application.
 //
 // Screen mode semantics:
-//   - SNAPPED placement-store restore and app rules (chain level 1) may
-//     cross-screen migrate: a snapped record's own screenId or an app rule can
-//     route a window to a different screen, and the store's take() accept
-//     predicate / snapped-branch screen check keep an autotile-mode screen from
-//     being snapped onto (autotile on that screen will own it). FLOATED records
-//     are screen-local — a float-back is restored only when the window reopens
-//     on its recorded screen, never moved across monitors (the accept predicate
-//     gates floated records on the opening screen).
+//   - SNAPPED placement-store restore may cross-screen migrate: a snapped record's
+//     own screenId can route a window to a different screen, and the store's take()
+//     accept predicate / snapped-branch screen check keep an autotile-mode screen
+//     from being snapped onto (autotile on that screen will own it). SnapToZone
+//     placement rules (chain level 1) resolve on the window's CURRENT screen — a
+//     screen constraint is expressed as a ScreenId match on the rule itself, not a
+//     cross-screen move. FLOATED records are screen-local — a float-back is restored
+//     only when the window reopens on its recorded screen, never moved across
+//     monitors (the accept predicate gates floated records on the opening screen).
 //   - The empty-zone (level 2) and last-zone (level 3) fallbacks inherently use
 //     the caller screen as the target, so they are ONLY valid when the caller's
 //     screen is in snap mode. On autotile screens they're short-circuited —
@@ -118,8 +119,8 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     }
 
     // Global snapping kill-switch. When the user turns snapping off entirely,
-    // no window may be auto-snapped on open — not via app rules, session
-    // restore, empty-zone auto-assign, or last-used-zone. The screen-mode gate
+    // no window may be auto-snapped on open — not via SnapToZone placement rules,
+    // session restore, empty-zone auto-assign, or last-used-zone. The screen-mode gate
     // below only covers autotile-mode screens; a screen still carrying a
     // Snapping-mode layout assignment would otherwise keep auto-snapping new
     // windows even with snapping globally disabled (discussion #461 item 2).
@@ -391,7 +392,7 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     //
     // Placed AFTER the isWindowSnapped/consume guard so windows that are
     // already snapped still consume their appId pending entry; placed
-    // BEFORE the exclusion lookup and the calculate* chain so app rules,
+    // BEFORE the exclusion lookup and the calculate* chain so placement rules,
     // session restore, empty-zone, and last-zone fallbacks are all gated
     // by the same predicate.
     //
@@ -405,7 +406,7 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
 
     // Exclusion check: skip auto-snap for excluded applications/window classes.
     // This must run before any calculate method so excluded apps are never snapped
-    // by app rules, session restore, empty zone, or last zone features.
+    // by placement rules, session restore, empty zone, or last zone features.
     //
     // Use the WTS's registry-aware lookup so a window whose class the effect
     // has already updated (Electron/CEF apps renaming themselves) matches
@@ -456,12 +457,13 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
             // chain levels — a placement rule must not route a window onto a
             // context the user disabled.
             if (m_shouldRestorePredicate && !m_shouldRestorePredicate(result.screenId)) {
-                qCDebug(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore:" << windowId << "appRule target"
-                                                          << result.screenId << "rejected by disabled-context gate";
+                qCDebug(PhosphorSnapEngine::lcSnapEngine)
+                    << "resolveWindowRestore:" << windowId << "placement-rule target" << result.screenId
+                    << "rejected by disabled-context gate";
                 return SnapResult::noSnap();
             }
             qCInfo(PhosphorSnapEngine::lcSnapEngine)
-                << "resolveWindowRestore: appRule matched for" << windowId << "zone=" << result.zoneId;
+                << "resolveWindowRestore: placement rule matched for" << windowId << "zone=" << result.zoneId;
             return result;
         }
     }

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
@@ -85,7 +85,7 @@ struct PHOSPHORWINDOWRULES_EXPORT RuleAction
  * switch. `kind` is a UI-side hint string (the canonical kinds are
  * `string`, `number`, `percent`, `enum`, `bool`, `color`, plus the
  * picker-aware kinds `snappingLayout`, `tilingAlgorithm`, `animationEvent`,
- * `shaderEffect`, `overlayShader`, `curveEditor`); QML loaders dispatch on it. Labels stay in
+ * `shaderEffect`, `overlayShader`, `zoneOrdinals`, `curveEditor`); QML loaders dispatch on it. Labels stay in
  * the GPL settings layer because they need translation through PhosphorI18n::tr —
  * the lib only owns the structural part of the schema.
  *
@@ -290,6 +290,14 @@ inline constexpr QLatin1StringView DisableEngine{"disableEngine"};
 inline constexpr QLatin1StringView LockContext{"lockContext"};
 inline constexpr QLatin1StringView Exclude{"exclude"};
 inline constexpr QLatin1StringView Float{"float"};
+/// Snap a matched window into one or more zones on open. Carries a non-empty
+/// list of 1-based zone ordinals (`ActionParam::Zones`); a single ordinal snaps
+/// to that zone, multiple ordinals snap to their unioned bounding rect (zone
+/// spanning). Ordinals are layout-agnostic — they address "zone N of whatever
+/// layout is active on the window's screen", matching the snapToZone1..9
+/// shortcuts. Daemon-consumed (placement) on the SnapEngine open path; supersedes
+/// the retired per-layout `Layout::appRules`. Domain Window.
+inline constexpr QLatin1StringView SnapToZone{"snapToZone"};
 inline constexpr QLatin1StringView OverrideAnimationShader{"overrideAnimationShader"};
 inline constexpr QLatin1StringView OverrideAnimationTiming{"overrideAnimationTiming"};
 /// Curve-only animation override — separate slot from timing so a user can
@@ -411,6 +419,9 @@ inline constexpr QLatin1StringView Mode{"mode"};
 inline constexpr QLatin1StringView LayoutId{"layoutId"};
 // SetTilingAlgorithm algorithm-token key — wire is the algorithm registry id.
 inline constexpr QLatin1StringView Algorithm{"algorithm"};
+// SnapToZone target-zone key — wire is a non-empty JSON array of 1-based zone
+// ordinals (e.g. `[1]` or `[1, 2]`); multiple entries snap to their union.
+inline constexpr QLatin1StringView Zones{"zones"};
 } // namespace ActionParam
 
 /// Wire tokens for OverrideOverlayStyle's `value` param — the closed vocabulary
@@ -434,6 +445,11 @@ inline constexpr QLatin1StringView EngineEnable{"engine-enable"};
 inline constexpr QLatin1StringView Locked{"locked"};
 inline constexpr QLatin1StringView Manage{"manage"};
 inline constexpr QLatin1StringView Float{"float"};
+/// Window-scoped open-placement slot — filled by `ActionType::SnapToZone`. A
+/// single slot (first-matching-rule-wins), carrying the zone-ordinal list
+/// (`ActionParam::Zones`) the daemon snaps the opening window into. Mutually
+/// resolved against `Float` on the open path (a float rule opts out of snapping).
+inline constexpr QLatin1StringView Placement{"placement"};
 inline constexpr QLatin1StringView Opacity{"opacity"};
 inline constexpr QLatin1StringView RestorePosition{"restore-position"};
 // Per-window border / title-bar appearance slots (one per property so

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
@@ -424,6 +424,14 @@ inline constexpr QLatin1StringView Algorithm{"algorithm"};
 inline constexpr QLatin1StringView Zones{"zones"};
 } // namespace ActionParam
 
+/// Upper bound for a `SnapToZone` zone ordinal (each `ActionParam::Zones` entry).
+/// No real layout has anywhere near this many zones (the snapToZone1..9 shortcuts
+/// only reach 9); the cap exists purely to reject a grossly malformed hand-edited
+/// payload AND to keep the load-time validator's integrality check from narrowing
+/// an out-of-range double to int (which is UB). Shared by the descriptor validator
+/// (ruleaction.cpp) and the v3→v4 migration so the two stay in lockstep.
+inline constexpr int MaxZoneOrdinal = 64;
+
 /// Wire tokens for OverrideOverlayStyle's `value` param — the closed vocabulary
 /// the descriptor's validator + `enumWireValues`, the daemon consumer
 /// (`LayoutRegistry::resolveContextOverlay`), and the settings label layers

--- a/libs/phosphor-window-rules/src/ruleaction.cpp
+++ b/libs/phosphor-window-rules/src/ruleaction.cpp
@@ -3,6 +3,7 @@
 
 #include <PhosphorWindowRules/RuleAction.h>
 
+#include <QJsonArray>
 #include <QJsonValue>
 
 #include "windowrulelogging.h"
@@ -448,6 +449,41 @@ void ActionRegistry::registerBuiltins()
         .domain = ActionDomain::Window,
         .category = QStringLiteral("windowManagement"),
         .displayOrder = 1,
+    });
+
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SnapToZone),
+        .slotFor = constantSlot(ActionSlot::Placement),
+        .validate =
+            [](const QJsonObject& p) {
+                // A non-empty array of positive integer (1-based) zone ordinals.
+                const QJsonValue v = p.value(ActionParam::Zones);
+                if (!v.isArray()) {
+                    return false;
+                }
+                const QJsonArray arr = v.toArray();
+                if (arr.isEmpty()) {
+                    return false;
+                }
+                for (const QJsonValue& e : arr) {
+                    if (!e.isDouble()) {
+                        return false;
+                    }
+                    const double d = e.toDouble();
+                    const int n = static_cast<int>(d);
+                    // Reject non-integral and < 1 (ordinals are 1-based).
+                    if (n < 1 || static_cast<double>(n) != d) {
+                        return false;
+                    }
+                }
+                return true;
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Zones)},
+        .domain = ActionDomain::Window,
+        .params = {P{.key = QString(ActionParam::Zones), .kind = QStringLiteral("zoneOrdinals")}},
+        .category = QStringLiteral("windowManagement"),
+        .displayOrder = 0,
     });
 
     // ── animation slots — event-scoped: "anim-shader:<event>" ──

--- a/libs/phosphor-window-rules/src/ruleaction.cpp
+++ b/libs/phosphor-window-rules/src/ruleaction.cpp
@@ -85,6 +85,11 @@ bool hasHexColor(const QJsonObject& params, QLatin1StringView key)
 constexpr double kMaxBorderWidth = 10.0;
 constexpr double kMaxBorderRadius = 20.0;
 constexpr double kMaxGap = 500.0;
+// Upper bound for a SnapToZone ordinal. No real layout has anywhere near this
+// many zones (the snapToZone1..9 shortcuts only reach 9); the cap exists purely
+// to reject a grossly malformed hand-edited payload AND to keep the integrality
+// check from narrowing an out-of-range double to int (which is UB).
+constexpr double kMaxZoneOrdinal = 64.0;
 
 } // namespace
 
@@ -470,10 +475,15 @@ void ActionRegistry::registerBuiltins()
                         return false;
                     }
                     const double d = e.toDouble();
-                    const int n = static_cast<int>(d);
-                    // Reject non-integral and < 1 (ordinals are 1-based).
-                    if (n < 1 || static_cast<double>(n) != d) {
+                    // Bound on the DOUBLE before narrowing — a float-to-int cast
+                    // out of int's range is undefined behaviour. Reject < 1
+                    // (ordinals are 1-based) and an absurd upper value first; only
+                    // then is the cast for the integrality check well-defined.
+                    if (d < 1.0 || d > kMaxZoneOrdinal) {
                         return false;
+                    }
+                    if (static_cast<double>(static_cast<int>(d)) != d) {
+                        return false; // non-integral
                     }
                 }
                 return true;
@@ -482,6 +492,8 @@ void ActionRegistry::registerBuiltins()
         .allowedKeys = {QString(ActionParam::Zones)},
         .domain = ActionDomain::Window,
         .params = {P{.key = QString(ActionParam::Zones), .kind = QStringLiteral("zoneOrdinals")}},
+        // No tags: SnapToZone is daemon-placement only (consumed by the SnapEngine
+        // open path), not an Effect / Border / Animation / Overlay action.
         .category = QStringLiteral("windowManagement"),
         .displayOrder = 0,
     });

--- a/libs/phosphor-window-rules/src/ruleaction.cpp
+++ b/libs/phosphor-window-rules/src/ruleaction.cpp
@@ -85,11 +85,6 @@ bool hasHexColor(const QJsonObject& params, QLatin1StringView key)
 constexpr double kMaxBorderWidth = 10.0;
 constexpr double kMaxBorderRadius = 20.0;
 constexpr double kMaxGap = 500.0;
-// Upper bound for a SnapToZone ordinal. No real layout has anywhere near this
-// many zones (the snapToZone1..9 shortcuts only reach 9); the cap exists purely
-// to reject a grossly malformed hand-edited payload AND to keep the integrality
-// check from narrowing an out-of-range double to int (which is UB).
-constexpr double kMaxZoneOrdinal = 64.0;
 
 } // namespace
 
@@ -479,7 +474,7 @@ void ActionRegistry::registerBuiltins()
                     // out of int's range is undefined behaviour. Reject < 1
                     // (ordinals are 1-based) and an absurd upper value first; only
                     // then is the cast for the integrality check well-defined.
-                    if (d < 1.0 || d > kMaxZoneOrdinal) {
+                    if (d < 1.0 || d > MaxZoneOrdinal) {
                         return false;
                     }
                     if (static_cast<double>(static_cast<int>(d)) != d) {

--- a/libs/phosphor-window-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-window-rules/tests/test_ruleaction.cpp
@@ -5,6 +5,7 @@
 
 #include <PhosphorWindowRules/RuleAction.h>
 
+#include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QSet>
@@ -51,6 +52,7 @@ const QList<QLatin1StringView> kContextDomainTypes = {
 const QList<QLatin1StringView> kWindowDomainTypes = {
     ActionType::Exclude,
     ActionType::Float,
+    ActionType::SnapToZone,
     ActionType::OverrideAnimationShader,
     ActionType::OverrideAnimationTiming,
     ActionType::OverrideAnimationCurve,
@@ -478,6 +480,41 @@ private Q_SLOTS:
             ok.insert(QStringLiteral("value"), QString(token));
             QVERIFY2(RuleAction::fromJson(ok).has_value(), token.data());
         }
+    }
+
+    void testSnapToZone_fromJson()
+    {
+        // SnapToZone is a window-domain placement action whose `zones` param is a
+        // non-empty JSON array of 1-based integer ordinals. Pin the validator at
+        // the public fromJson boundary: it is the single line of defence against
+        // a hand-edited windowrules.json carrying a malformed ordinal list, and a
+        // widening regression in registerBuiltins would otherwise slip past.
+        const auto withZones = [](const QJsonValue& zones) {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString(ActionType::SnapToZone));
+            o.insert(QString(ActionParam::Zones), zones);
+            return o;
+        };
+
+        // Missing / wrong-typed / empty → rejected.
+        QJsonObject missing;
+        missing.insert(QStringLiteral("type"), QString(ActionType::SnapToZone));
+        QVERIFY(!RuleAction::fromJson(missing).has_value());
+        QVERIFY(!RuleAction::fromJson(withZones(QJsonValue(2))).has_value()); // not an array
+        QVERIFY(!RuleAction::fromJson(withZones(QJsonArray{})).has_value()); // empty
+        QVERIFY(!RuleAction::fromJson(withZones(QJsonArray{0})).has_value()); // 0 not 1-based
+        QVERIFY(!RuleAction::fromJson(withZones(QJsonArray{-1})).has_value()); // negative
+        QVERIFY(!RuleAction::fromJson(withZones(QJsonArray{1.5})).has_value()); // non-integral
+        QVERIFY(!RuleAction::fromJson(withZones(QJsonArray{QStringLiteral("1")})).has_value()); // string
+
+        // Single zone + span both accepted.
+        QVERIFY(RuleAction::fromJson(withZones(QJsonArray{1})).has_value());
+        QVERIFY(RuleAction::fromJson(withZones(QJsonArray{1, 2})).has_value());
+
+        // A key outside allowedKeys ({zones}) is rejected.
+        QJsonObject stray = withZones(QJsonArray{1});
+        stray.insert(QStringLiteral("value"), 3);
+        QVERIFY(!RuleAction::fromJson(stray).has_value());
     }
 
     void testLockContext_fromJsonRoundTrip()

--- a/libs/phosphor-window-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-window-rules/tests/test_ruleaction.cpp
@@ -506,10 +506,15 @@ private Q_SLOTS:
         QVERIFY(!RuleAction::fromJson(withZones(QJsonArray{-1})).has_value()); // negative
         QVERIFY(!RuleAction::fromJson(withZones(QJsonArray{1.5})).has_value()); // non-integral
         QVERIFY(!RuleAction::fromJson(withZones(QJsonArray{QStringLiteral("1")})).has_value()); // string
+        QVERIFY(!RuleAction::fromJson(withZones(QJsonArray{65})).has_value()); // above the ordinal cap (64)
+        // A double far beyond int range must be rejected by the bound BEFORE any
+        // narrowing cast (an out-of-range float-to-int cast is UB) — must not crash.
+        QVERIFY(!RuleAction::fromJson(withZones(QJsonArray{1e18})).has_value());
 
-        // Single zone + span both accepted.
+        // Single zone, span, and the inclusive cap boundary are all accepted.
         QVERIFY(RuleAction::fromJson(withZones(QJsonArray{1})).has_value());
         QVERIFY(RuleAction::fromJson(withZones(QJsonArray{1, 2})).has_value());
+        QVERIFY(RuleAction::fromJson(withZones(QJsonArray{64})).has_value());
 
         // A key outside allowedKeys ({zones}) is rejected.
         QJsonObject stray = withZones(QJsonArray{1});

--- a/libs/phosphor-zones/CMakeLists.txt
+++ b/libs/phosphor-zones/CMakeLists.txt
@@ -13,9 +13,9 @@
 # autotile algorithms (phosphor-tile-algo, future work).
 #
 # Self-contained: depends only on Qt6 + PhosphorLayoutApi (PUBLIC) and
-# PhosphorIdentity (PRIVATE — used by Layout::matchAppRule for
-# composite window-id parsing; the dep doesn't leak through any public
-# PhosphorZones header).
+# PhosphorIdentity (PRIVATE — used for virtual-screen id parsing
+# (VirtualScreenId) in geometryutils / layoutregistry_assignments; the dep
+# doesn't leak through any public PhosphorZones header).
 
 cmake_minimum_required(VERSION 3.16)
 
@@ -164,9 +164,9 @@ target_link_libraries(PhosphorZones
         # the public LayoutRegistry.h ctor signature so the dep is PUBLIC.
         PhosphorWindowRules::PhosphorWindowRules
     PRIVATE
-        # Layout::matchAppRule uses PhosphorIdentity::WindowId for
-        # composite window-id parsing; PRIVATE because the dep doesn't
-        # leak through any public PhosphorZones header.
+        # Uses PhosphorIdentity::VirtualScreenId for virtual-screen id parsing
+        # (geometryutils / layoutregistry_assignments); PRIVATE because the dep
+        # doesn't leak through any public PhosphorZones header.
         PhosphorIdentity::PhosphorIdentity
         # GeometryUtils calls ScreenManager geometry queries, and LayoutRegistry
         # uses ScreenIdentity / VirtualScreen for assignment-cascade screen-id

--- a/libs/phosphor-zones/include/PhosphorZones/Layout.h
+++ b/libs/phosphor-zones/include/PhosphorZones/Layout.h
@@ -20,40 +20,6 @@
 namespace PhosphorZones {
 
 /**
- * @brief App-to-zone auto-snap rule
- *
- * Maps a window class pattern to a zone number within a layout.
- * Patterns are case-insensitive substring matches against the window class.
- */
-struct PHOSPHORZONES_EXPORT AppRule
-{
-    QString pattern; // Window class or app name pattern (case-insensitive substring match)
-    int zoneNumber = 0; // 1-based zone number to snap to
-    QString targetScreen; // Optional: snap to zone on this screen instead of current
-
-    // C++20 synthesises operator!= from operator==.
-    bool operator==(const AppRule& other) const = default;
-
-    // Serialization helpers (centralized to avoid DRY violations)
-    QJsonObject toJson() const;
-    static AppRule fromJson(const QJsonObject& obj);
-    static QVector<AppRule> fromJsonArray(const QJsonArray& array);
-};
-
-/**
- * @brief Result of matching a window class against app rules
- */
-struct PHOSPHORZONES_EXPORT AppRuleMatch
-{
-    int zoneNumber = 0;
-    QString targetScreen;
-    bool matched() const
-    {
-        return zoneNumber > 0;
-    }
-};
-
-/**
  * @brief Category for layout type
  *
  * QML Note: Passed as int to QML. Values: 0 = Manual, 1 = Autotile
@@ -96,9 +62,6 @@ class PHOSPHORZONES_EXPORT Layout : public QObject
     Q_PROPERTY(bool isSystemLayout READ isSystemLayout NOTIFY sourcePathChanged)
     Q_PROPERTY(QString shaderId READ shaderId WRITE setShaderId NOTIFY shaderIdChanged)
     Q_PROPERTY(QVariantMap shaderParams READ shaderParams WRITE setShaderParams NOTIFY shaderParamsChanged)
-
-    // App-to-zone rules
-    Q_PROPERTY(QVariantList appRules READ appRulesVariant WRITE setAppRulesVariant NOTIFY appRulesChanged)
 
     // Auto-assign: new windows fill first empty zone
     Q_PROPERTY(bool autoAssign READ autoAssign WRITE setAutoAssign NOTIFY autoAssignChanged)
@@ -316,16 +279,6 @@ public:
     }
     void setAllowedActivities(const QStringList& activities);
 
-    // App-to-zone rules
-    QVector<AppRule> appRules() const
-    {
-        return m_appRules;
-    }
-    void setAppRules(const QVector<AppRule>& rules);
-    QVariantList appRulesVariant() const;
-    void setAppRulesVariant(const QVariantList& rules);
-    AppRuleMatch matchAppRule(const QString& windowClass) const;
-
     // Auto-assign: new windows fill first empty zone
     bool autoAssign() const
     {
@@ -465,7 +418,6 @@ Q_SIGNALS:
     void allowedScreensChanged();
     void allowedDesktopsChanged();
     void allowedActivitiesChanged();
-    void appRulesChanged();
     void autoAssignChanged();
     void useFullScreenGeometryChanged();
     void zonesChanged();
@@ -511,9 +463,6 @@ private:
     QString m_systemSourcePath; // Original system path if this is a user override of a system layout
     int m_defaultOrder = 999; // Optional: lower values appear first when choosing default (999 = not set)
     QVector<Zone*> m_zones;
-
-    // App-to-zone rules
-    QVector<AppRule> m_appRules;
 
     // Auto-assign: new windows fill first empty zone
     bool m_autoAssign = false;

--- a/libs/phosphor-zones/include/PhosphorZones/ZoneJsonKeys.h
+++ b/libs/phosphor-zones/include/PhosphorZones/ZoneJsonKeys.h
@@ -86,11 +86,6 @@ inline constexpr QLatin1String AspectRatioClassKey{"aspectRatioClass"};
 inline constexpr QLatin1String MinAspectRatio{"minAspectRatio"};
 inline constexpr QLatin1String MaxAspectRatio{"maxAspectRatio"};
 
-// App-rule (auto-assign) keys.
-inline constexpr QLatin1String AppRules{"appRules"};
-inline constexpr QLatin1String Pattern{"pattern"};
-// `ZoneNumber` (above) is reused for the rule target.
-inline constexpr QLatin1String TargetScreen{"targetScreen"};
 inline constexpr QLatin1String AutoAssign{"autoAssign"};
 
 // Geometry-mode keys.

--- a/libs/phosphor-zones/src/layout.cpp
+++ b/libs/phosphor-zones/src/layout.cpp
@@ -4,7 +4,6 @@
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutUtils.h>
 #include "zoneslogging.h"
-#include <PhosphorIdentity/WindowId.h>
 #include <QJsonArray>
 #include <QStandardPaths>
 #include <algorithm>
@@ -127,7 +126,6 @@ Layout::Layout(const Layout& other)
     , m_sourcePath() // Copies have no source path (will be saved to user directory)
     , m_systemSourcePath() // Copies carry no system-origin tracking (see class comment)
     , m_defaultOrder(other.m_defaultOrder)
-    , m_appRules(other.m_appRules)
     , m_autoAssign(other.m_autoAssign)
     , m_useFullScreenGeometry(other.m_useFullScreenGeometry)
     , m_shaderId(other.m_shaderId)
@@ -188,8 +186,6 @@ Layout& Layout::operator=(const Layout& other)
         m_isSystemLayout = false; // Cache stays consistent with the cleared source path
         m_shaderId = other.m_shaderId;
         m_shaderParams = other.m_shaderParams;
-        bool rulesChanged = m_appRules != other.m_appRules;
-        m_appRules = other.m_appRules;
         bool autoAssignDiff = m_autoAssign != other.m_autoAssign;
         m_autoAssign = other.m_autoAssign;
         bool fullScreenGeomDiff = m_useFullScreenGeometry != other.m_useFullScreenGeometry;
@@ -224,8 +220,6 @@ Layout& Layout::operator=(const Layout& other)
             Q_EMIT allowedDesktopsChanged();
         if (activitiesChanged)
             Q_EMIT allowedActivitiesChanged();
-        if (rulesChanged)
-            Q_EMIT appRulesChanged();
         if (autoAssignDiff)
             Q_EMIT autoAssignChanged();
         if (fullScreenGeomDiff)
@@ -409,35 +403,6 @@ void Layout::setSourcePath(const QString& path)
         }
         Q_EMIT sourcePathChanged();
     }
-}
-
-// App-to-zone rules
-void Layout::setAppRules(const QVector<AppRule>& rules)
-{
-    if (m_appRules != rules) {
-        m_appRules = rules;
-        Q_EMIT appRulesChanged();
-        emitModifiedIfNotBatched();
-    }
-}
-
-AppRuleMatch Layout::matchAppRule(const QString& windowClass) const
-{
-    if (windowClass.isEmpty() || m_appRules.isEmpty()) {
-        return {};
-    }
-    for (const auto& rule : m_appRules) {
-        if (rule.pattern.isEmpty()) {
-            continue;
-        }
-        // Segment-aware match: "firefox" matches "org.mozilla.firefox" (dot-boundary),
-        // "org.mozilla.firefox" matches "firefox", exact match always works.
-        // Prevents "fire" from matching "firefox" (no dot boundary).
-        if (::PhosphorIdentity::WindowId::appIdMatches(windowClass, rule.pattern)) {
-            return {rule.zoneNumber, rule.targetScreen};
-        }
-    }
-    return {};
 }
 
 void Layout::clearZonePaddingOverride()

--- a/libs/phosphor-zones/src/layout/serialization.cpp
+++ b/libs/phosphor-zones/src/layout/serialization.cpp
@@ -16,63 +16,6 @@
 
 namespace PhosphorZones {
 
-// JSON is the canonical shape for AppRule (disk persistence, import/export,
-// wire format). The QVariantList accessors below exist only to satisfy the
-// Qt property / QML binding path — they route through the JSON form so there
-// is a single source of truth for keys, defaults, and validation rules.
-
-QJsonObject AppRule::toJson() const
-{
-    QJsonObject obj;
-    obj[::PhosphorZones::ZoneJsonKeys::Pattern] = pattern;
-    obj[::PhosphorZones::ZoneJsonKeys::ZoneNumber] = zoneNumber;
-    if (!targetScreen.isEmpty()) {
-        obj[::PhosphorZones::ZoneJsonKeys::TargetScreen] = targetScreen;
-    }
-    return obj;
-}
-
-AppRule AppRule::fromJson(const QJsonObject& obj)
-{
-    AppRule rule;
-    rule.pattern = obj[::PhosphorZones::ZoneJsonKeys::Pattern].toString();
-    rule.zoneNumber = obj[::PhosphorZones::ZoneJsonKeys::ZoneNumber].toInt();
-    rule.targetScreen = obj[::PhosphorZones::ZoneJsonKeys::TargetScreen].toString();
-    return rule;
-}
-
-QVector<AppRule> AppRule::fromJsonArray(const QJsonArray& array)
-{
-    QVector<AppRule> rules;
-    rules.reserve(array.size());
-    for (const auto& value : array) {
-        AppRule rule = AppRule::fromJson(value.toObject());
-        if (!rule.pattern.isEmpty() && rule.zoneNumber > 0) {
-            rules.append(rule);
-        }
-    }
-    return rules;
-}
-
-QVariantList Layout::appRulesVariant() const
-{
-    QVariantList result;
-    result.reserve(m_appRules.size());
-    for (const auto& rule : m_appRules) {
-        result.append(rule.toJson().toVariantMap());
-    }
-    return result;
-}
-
-void Layout::setAppRulesVariant(const QVariantList& rules)
-{
-    QJsonArray array;
-    for (const auto& item : rules) {
-        array.append(QJsonObject::fromVariantMap(item.toMap()));
-    }
-    setAppRules(AppRule::fromJsonArray(array));
-}
-
 QJsonObject Layout::toJson() const
 {
     QJsonObject json;
@@ -131,15 +74,6 @@ QJsonObject Layout::toJson() const
     // shaderId are meaningless to consumers and just bloat the file.
     if (!m_shaderId.isEmpty() && !m_shaderParams.isEmpty()) {
         json[::PhosphorZones::ZoneJsonKeys::ShaderParams] = QJsonObject::fromVariantMap(m_shaderParams);
-    }
-
-    // App-to-zone rules - only serialize if non-empty
-    if (!m_appRules.isEmpty()) {
-        QJsonArray rulesArray;
-        for (const auto& rule : m_appRules) {
-            rulesArray.append(rule.toJson());
-        }
-        json[::PhosphorZones::ZoneJsonKeys::AppRules] = rulesArray;
     }
 
     // Auto-assign - only serialize if true
@@ -283,11 +217,6 @@ void Layout::initFromJson(const QJsonObject& json)
     m_shaderId = json[::PhosphorZones::ZoneJsonKeys::ShaderId].toString();
     if (json.contains(::PhosphorZones::ZoneJsonKeys::ShaderParams)) {
         m_shaderParams = json[::PhosphorZones::ZoneJsonKeys::ShaderParams].toObject().toVariantMap();
-    }
-
-    // App-to-zone rules
-    if (json.contains(::PhosphorZones::ZoneJsonKeys::AppRules)) {
-        m_appRules = AppRule::fromJsonArray(json[::PhosphorZones::ZoneJsonKeys::AppRules].toArray());
     }
 
     // Auto-assign

--- a/src/config/configmigration.cpp
+++ b/src/config/configmigration.cpp
@@ -2363,7 +2363,7 @@ void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& ru
             const QJsonObject ar = entry.toObject();
             const QString pattern = ar.value(kLayoutAppRulePattern).toString().trimmed();
             const int zoneNumber = ar.value(kLayoutAppRuleZoneNumber).toInt(0);
-            const QString targetScreen = ar.value(kLayoutAppRuleTargetScreen).toString();
+            const QString targetScreen = ar.value(kLayoutAppRuleTargetScreen).toString().trimmed();
             if (pattern.isEmpty() || zoneNumber < 1) {
                 continue;
             }

--- a/src/config/configmigration.cpp
+++ b/src/config/configmigration.cpp
@@ -2322,23 +2322,33 @@ inline const QUuid& snapToZoneMigrationNamespace()
 constexpr QLatin1String kLayoutAppRulesKey{"appRules"};
 constexpr QLatin1String kLayoutAppRulePattern{"pattern"};
 constexpr QLatin1String kLayoutAppRuleZoneNumber{"zoneNumber"};
-constexpr QLatin1String kLayoutAppRuleTargetScreen{"targetScreen"};
 
 /// Convert each layout file's legacy per-layout `appRules` into first-class
 /// SnapToZone WindowRules. v3 stored app→zone assignments on the Layout
 /// (`Layout::appRules`: a `{pattern, zoneNumber, targetScreen}` triple, single
 /// zone); v4 unifies them into the window-rule store. Each becomes
-/// `AppId AppIdMatches <pattern> → SnapToZone [zoneNumber]`, plus a
-/// `ScreenId Equals <targetScreen>` leaf when the legacy rule pinned a screen
-/// (replacing v3's cross-screen targeting with a match constraint). AppId /
-/// AppIdMatches mirrors the retired `Layout::matchAppRule` (which matched the
-/// pattern against the window's appId via segment-aware `appIdMatches`) and the
-/// daemon placement path, which resolves the query on appId — WindowClass is not
-/// tracked daemon-side, so a WindowClass leaf would never match. Patterns are
-/// deduped across layouts — a SnapToZone ordinal rule fires regardless of which
-/// layout is active, so one pattern can map to only one placement; on a
-/// same-pattern / different-zone conflict the first wins and the rest are
-/// logged. Layout files are visited in name order for deterministic "first wins".
+/// `AppId AppIdMatches <pattern> → SnapToZone [zoneNumber]`. AppId / AppIdMatches
+/// mirrors the retired `Layout::matchAppRule` (which matched the pattern against
+/// the window's appId via segment-aware `appIdMatches`) and the daemon placement
+/// path, which resolves the query on appId — WindowClass is not tracked daemon-
+/// side, so a WindowClass leaf would never match.
+///
+/// The legacy `targetScreen` (a connector name like "DP-1") is intentionally NOT
+/// carried over as a `ScreenId` constraint. v4 resolves a SnapToZone rule on the
+/// window's CURRENT screen, and a `ScreenId Equals` leaf would have to match the
+/// canonical screen-id form the daemon reports at runtime (EDID-form
+/// "Manuf:Model:Serial", what the settings screen-picker also stores), not a
+/// connector name. Translating connector→canonical here would couple this pure
+/// JSON transform to live screen state and make the deterministic rule id depend
+/// on which monitors are connected. So a migrated app snaps to its zone on
+/// whatever screen it opens on (per-monitor pinning is dropped; v3's cross-screen
+/// routing was already retired by this PR).
+///
+/// Patterns are deduped across layouts — a SnapToZone ordinal rule fires
+/// regardless of which layout is active, so one pattern can map to only one
+/// placement; on a same-pattern / different-zone conflict the first wins and the
+/// rest are logged. Layout files are visited in name order for deterministic
+/// "first wins".
 void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& rules, const QString& layoutsDir)
 {
     using namespace PhosphorWindowRules;
@@ -2367,7 +2377,6 @@ void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& ru
             const QJsonObject ar = entry.toObject();
             const QString pattern = ar.value(kLayoutAppRulePattern).toString().trimmed();
             const int zoneNumber = ar.value(kLayoutAppRuleZoneNumber).toInt(0);
-            const QString targetScreen = ar.value(kLayoutAppRuleTargetScreen).toString().trimmed();
             if (pattern.isEmpty() || zoneNumber < 1) {
                 continue;
             }
@@ -2394,23 +2403,16 @@ void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& ru
             seenPatterns.insert(patternKey);
 
             WindowRule rule;
-            // Deterministic id from (pattern, zone, screen) so a crash-and-retry
+            // Deterministic id from (pattern, zone) so a crash-and-retry
             // conversion yields byte-identical rules.
-            rule.id =
-                QUuid::createUuidV5(snapToZoneMigrationNamespace(),
-                                    Detail::encodeSegment(pattern) + Detail::encodeSegment(QString::number(zoneNumber))
-                                        + Detail::encodeSegment(targetScreen));
+            rule.id = QUuid::createUuidV5(snapToZoneMigrationNamespace(),
+                                          Detail::encodeSegment(pattern)
+                                              + Detail::encodeSegment(QString::number(zoneNumber)));
             rule.enabled = true;
             // priority 0 mirrors the other migrated rules; the controller
             // renormalizes display order on load and the user can reorder.
             rule.priority = 0;
-            if (targetScreen.isEmpty()) {
-                rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::AppIdMatches, pattern);
-            } else {
-                rule.match = MatchExpression::makeAll(
-                    {MatchExpression::makeLeaf(Field::AppId, Operator::AppIdMatches, pattern),
-                     MatchExpression::makeLeaf(Field::ScreenId, Operator::Equals, targetScreen)});
-            }
+            rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::AppIdMatches, pattern);
             RuleAction action;
             action.type = QString(ActionType::SnapToZone);
             QJsonObject params;

--- a/src/config/configmigration.cpp
+++ b/src/config/configmigration.cpp
@@ -25,11 +25,11 @@
 #include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
-#include <QStandardPaths>
 #include <QJsonObject>
 #include <QLatin1String>
 #include <QLockFile>
 #include <QSet>
+#include <QStandardPaths>
 #include <QUuid>
 #include <array>
 #include <atomic>
@@ -2328,9 +2328,13 @@ constexpr QLatin1String kLayoutAppRuleTargetScreen{"targetScreen"};
 /// SnapToZone WindowRules. v3 stored app→zone assignments on the Layout
 /// (`Layout::appRules`: a `{pattern, zoneNumber, targetScreen}` triple, single
 /// zone); v4 unifies them into the window-rule store. Each becomes
-/// `WindowClass Contains <pattern> → SnapToZone [zoneNumber]`, plus a
+/// `AppId AppIdMatches <pattern> → SnapToZone [zoneNumber]`, plus a
 /// `ScreenId Equals <targetScreen>` leaf when the legacy rule pinned a screen
-/// (replacing v3's cross-screen targeting with a match constraint). Patterns are
+/// (replacing v3's cross-screen targeting with a match constraint). AppId /
+/// AppIdMatches mirrors the retired `Layout::matchAppRule` (which matched the
+/// pattern against the window's appId via segment-aware `appIdMatches`) and the
+/// daemon placement path, which resolves the query on appId — WindowClass is not
+/// tracked daemon-side, so a WindowClass leaf would never match. Patterns are
 /// deduped across layouts — a SnapToZone ordinal rule fires regardless of which
 /// layout is active, so one pattern can map to only one placement; on a
 /// same-pattern / different-zone conflict the first wins and the rest are
@@ -2367,6 +2371,17 @@ void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& ru
             if (pattern.isEmpty() || zoneNumber < 1) {
                 continue;
             }
+            // The SnapToZone action validator caps ordinals at MaxZoneOrdinal, so a
+            // legacy zoneNumber beyond it would be silently dropped by the loader's
+            // validator. Skip it here with a visible warning instead of emitting a
+            // rule that vanishes on the next load.
+            if (zoneNumber > MaxZoneOrdinal) {
+                qWarning(
+                    "ConfigMigration: app->zone pattern '%s' targets zone %d beyond the max ordinal (%d) — "
+                    "dropping the assignment.",
+                    qPrintable(pattern), zoneNumber, MaxZoneOrdinal);
+                continue;
+            }
             const QString patternKey = pattern.toLower();
             if (seenPatterns.contains(patternKey)) {
                 qWarning(
@@ -2390,10 +2405,10 @@ void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& ru
             // renormalizes display order on load and the user can reorder.
             rule.priority = 0;
             if (targetScreen.isEmpty()) {
-                rule.match = MatchExpression::makeLeaf(Field::WindowClass, Operator::Contains, pattern);
+                rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::AppIdMatches, pattern);
             } else {
                 rule.match = MatchExpression::makeAll(
-                    {MatchExpression::makeLeaf(Field::WindowClass, Operator::Contains, pattern),
+                    {MatchExpression::makeLeaf(Field::AppId, Operator::AppIdMatches, pattern),
                      MatchExpression::makeLeaf(Field::ScreenId, Operator::Equals, targetScreen)});
             }
             RuleAction action;

--- a/src/config/configmigration.cpp
+++ b/src/config/configmigration.cpp
@@ -25,6 +25,7 @@
 #include <QFileInfo>
 #include <QJsonArray>
 #include <QJsonDocument>
+#include <QStandardPaths>
 #include <QJsonObject>
 #include <QLatin1String>
 #include <QLockFile>
@@ -2306,6 +2307,106 @@ void appendAnimationExclusionRulesFromStash(QList<PhosphorWindowRules::WindowRul
     appendOne(stash.value(ConfigKeys::Legacy::v3ExcludedWindowClassesKey()).toString(), Field::WindowClass);
 }
 
+/// Fixed v5-UUID namespace for migrated SnapToZone-rule identities — distinct
+/// from the exclusion namespace so the two folds can never collide on id.
+inline const QUuid& snapToZoneMigrationNamespace()
+{
+    static const QUuid ns(QStringLiteral("{6f1c8e44-2a7b-5d93-8e10-4b2c9a7f1d35}"));
+    return ns;
+}
+
+// Frozen on-disk keys for the legacy per-layout `appRules` array — the dead v3
+// zone app-assignment format this fold is the last reader of. Local literals
+// (NOT the live `ZoneJsonKeys::` accessors) so a future rename of those live
+// keys can never retarget this migration away from what v3 wrote to disk.
+constexpr QLatin1String kLayoutAppRulesKey{"appRules"};
+constexpr QLatin1String kLayoutAppRulePattern{"pattern"};
+constexpr QLatin1String kLayoutAppRuleZoneNumber{"zoneNumber"};
+constexpr QLatin1String kLayoutAppRuleTargetScreen{"targetScreen"};
+
+/// Convert each layout file's legacy per-layout `appRules` into first-class
+/// SnapToZone WindowRules. v3 stored app→zone assignments on the Layout
+/// (`Layout::appRules`: a `{pattern, zoneNumber, targetScreen}` triple, single
+/// zone); v4 unifies them into the window-rule store. Each becomes
+/// `WindowClass Contains <pattern> → SnapToZone [zoneNumber]`, plus a
+/// `ScreenId Equals <targetScreen>` leaf when the legacy rule pinned a screen
+/// (replacing v3's cross-screen targeting with a match constraint). Patterns are
+/// deduped across layouts — a SnapToZone ordinal rule fires regardless of which
+/// layout is active, so one pattern can map to only one placement; on a
+/// same-pattern / different-zone conflict the first wins and the rest are
+/// logged. Layout files are visited in name order for deterministic "first wins".
+void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& rules, const QString& layoutsDir)
+{
+    using namespace PhosphorWindowRules;
+    QDir dir(layoutsDir);
+    if (!dir.exists()) {
+        return;
+    }
+    const QStringList files = dir.entryList({QStringLiteral("*.json")}, QDir::Files, QDir::Name);
+    QSet<QString> seenPatterns;
+    for (const QString& fileName : files) {
+        QFile f(dir.filePath(fileName));
+        if (!f.open(QIODevice::ReadOnly)) {
+            continue;
+        }
+        QJsonParseError err;
+        const QJsonDocument doc = QJsonDocument::fromJson(f.readAll(), &err);
+        f.close();
+        if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+            continue;
+        }
+        const QJsonArray appRules = doc.object().value(kLayoutAppRulesKey).toArray();
+        for (const QJsonValue& entry : appRules) {
+            if (!entry.isObject()) {
+                continue;
+            }
+            const QJsonObject ar = entry.toObject();
+            const QString pattern = ar.value(kLayoutAppRulePattern).toString().trimmed();
+            const int zoneNumber = ar.value(kLayoutAppRuleZoneNumber).toInt(0);
+            const QString targetScreen = ar.value(kLayoutAppRuleTargetScreen).toString();
+            if (pattern.isEmpty() || zoneNumber < 1) {
+                continue;
+            }
+            const QString patternKey = pattern.toLower();
+            if (seenPatterns.contains(patternKey)) {
+                qWarning(
+                    "ConfigMigration: duplicate app->zone pattern '%s' across layouts — keeping the first, "
+                    "dropping zone %d (a SnapToZone ordinal rule fires regardless of the active layout, so a "
+                    "pattern can map to only one placement).",
+                    qPrintable(pattern), zoneNumber);
+                continue;
+            }
+            seenPatterns.insert(patternKey);
+
+            WindowRule rule;
+            // Deterministic id from (pattern, zone, screen) so a crash-and-retry
+            // conversion yields byte-identical rules.
+            rule.id =
+                QUuid::createUuidV5(snapToZoneMigrationNamespace(),
+                                    Detail::encodeSegment(pattern) + Detail::encodeSegment(QString::number(zoneNumber))
+                                        + Detail::encodeSegment(targetScreen));
+            rule.enabled = true;
+            // priority 0 mirrors the other migrated rules; the controller
+            // renormalizes display order on load and the user can reorder.
+            rule.priority = 0;
+            if (targetScreen.isEmpty()) {
+                rule.match = MatchExpression::makeLeaf(Field::WindowClass, Operator::Contains, pattern);
+            } else {
+                rule.match = MatchExpression::makeAll(
+                    {MatchExpression::makeLeaf(Field::WindowClass, Operator::Contains, pattern),
+                     MatchExpression::makeLeaf(Field::ScreenId, Operator::Equals, targetScreen)});
+            }
+            RuleAction action;
+            action.type = QString(ActionType::SnapToZone);
+            QJsonObject params;
+            params.insert(QString(ActionParam::Zones), QJsonArray{zoneNumber});
+            action.params = params;
+            rule.actions.append(action);
+            rules.append(rule);
+        }
+    }
+}
+
 } // namespace
 
 bool ConfigMigration::finalizeV4Conversion(const QString& jsonPath)
@@ -2696,6 +2797,21 @@ bool ConfigMigration::finalizeV4Conversion(const QString& jsonPath)
     // it) on any later run. See `appendSteamDefaultRule` for the match/enforcement
     // rationale.
     appendSteamDefaultRule(rules);
+
+    // ── Per-layout app rules → SnapToZone WindowRules ──────────────────────
+    // v3 stored app→zone assignments on each Layout (`Layout::appRules`); v4
+    // unifies them into the window-rule store. Read every layout file's legacy
+    // `appRules` array and emit one SnapToZone rule per assignment, so an
+    // upgrading user's pinned apps keep snapping to their zone(s) through the
+    // new single system. Layouts live in the user-writable data dir (separate
+    // from config.json / windowrules.json), so resolve that path directly. This
+    // runs only on the first conversion (the `windowRulesAlreadyConverted` gate
+    // above), which every real v3→v4 upgrade hits exactly once.
+    {
+        const QString layoutsDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+            + QLatin1Char('/') + ConfigDefaults::layoutsSubdir();
+        appendLayoutAppRulesAsSnapToZone(rules, layoutsDir);
+    }
 
     // ── Relocate QuickLayouts to the quicklayouts.json sidecar (FIRST) ─────
     // Quick-layout slots are NOT window rules — they belong in the sibling

--- a/src/config/configmigration.h
+++ b/src/config/configmigration.h
@@ -43,6 +43,12 @@ namespace PlasmaZones {
 ///     knobs (excludeTransientWindows / minimumWindowWidth /
 ///     minimumWindowHeight) move to the General page. See
 ///     docs/window-rule-refactor-design.md §8.
+///     Each layout's retired per-layout `appRules` triple
+///     (`{pattern, zoneNumber, targetScreen}`) also folds into windowrules.json
+///     as an `AppId AppIdMatches <pattern> → SnapToZone [zoneNumber]` rule,
+///     deduped by pattern across layouts (the legacy `targetScreen` is dropped —
+///     a migrated app snaps on whatever screen it opens on) — see
+///     appendLayoutAppRulesAsSnapToZone in configmigration.cpp.
 ///     Additionally renames the drag-time zone-overlay groups
 ///     Snapping.Appearance.{Colors,Opacity,Border,Labels} → Snapping.Zones.*,
 ///     freeing the Snapping.Appearance.* namespace for the new per-window

--- a/src/dbus/layoutadaptor/editor.cpp
+++ b/src/dbus/layoutadaptor/editor.cpp
@@ -224,12 +224,6 @@ bool LayoutAdaptor::updateLayout(const QString& layoutJson)
         layout->setAllowedActivities(activities);
     }
 
-    // Update app-to-zone rules
-    if (obj.contains(::PhosphorZones::ZoneJsonKeys::AppRules)) {
-        layout->setAppRules(
-            PhosphorZones::AppRule::fromJsonArray(obj[::PhosphorZones::ZoneJsonKeys::AppRules].toArray()));
-    }
-
     // Clear existing zones and add new ones
     layout->clearZones();
 

--- a/src/dbus/snapadaptor.h
+++ b/src/dbus/snapadaptor.h
@@ -134,7 +134,7 @@ public Q_SLOTS:
                         int& snapWidth, int& snapHeight, bool& shouldSnap);
 
     /**
-     * @brief Snap a window to its app-rule-defined zone
+     * @brief Snap a window to its SnapToZone-rule-defined zone(s)
      */
     void snapToAppRule(const QString& windowId, const QString& windowScreenName, bool sticky, int& snapX, int& snapY,
                        int& snapWidth, int& snapHeight, bool& shouldSnap);
@@ -147,7 +147,7 @@ public Q_SLOTS:
 
     /**
      * @brief Run the full snap-restore resolution (WindowPlacementStore restore +
-     *        app-rule / empty-zone / last-zone fallback chain) in one call
+     *        placement-rule / empty-zone / last-zone fallback chain) in one call
      * @param windowKind Structural kind of the opening window (0=Unknown, 1=Normal, 2=Transient).
      *                   Forwarded to SnapEngine for protocol compatibility; the unified
      *                   placement record now carries the kind, so it no longer gates restore.

--- a/src/dbus/snapadaptor.h
+++ b/src/dbus/snapadaptor.h
@@ -32,7 +32,7 @@ class ISettings;
  * Provides D-Bus interface: org.plasmazones.Snap
  *
  * Owns the snap-specific D-Bus surface: commit/uncommit, snap-restore
- * (appRule / emptyZone / lastZone / resolveWindowRestore),
+ * (placement rule / emptyZone / lastZone / resolveWindowRestore),
  * resnap, calculateSnapAllWindows, windowsSnappedBatch, snap-mode navigation
  * (move/focus/swap/push/snap-by-number/rotate/cycle/restore),
  * snap-mode convenience (moveWindowToZone, swapWindowsById), and

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -115,7 +115,7 @@ void SnapAdaptor::snapToAppRule(const QString& windowId, const QString& windowSc
     if (!applySnapResult(result, windowId, snapX, snapY, snapWidth, snapHeight, shouldSnap)) {
         return;
     }
-    qCInfo(lcDbusWindow) << "App rule snapping window" << windowId << "to zone" << result.zoneId;
+    qCInfo(lcDbusWindow) << "Placement rule snapping window" << windowId << "to zone" << result.zoneId;
 }
 
 void SnapAdaptor::snapToEmptyZone(const QString& windowId, const QString& windowScreenId, bool sticky, int& snapX,
@@ -222,7 +222,7 @@ bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
     // entry points in one place.
     if (m_settings && !result.screenId.isEmpty()) {
         // Gate against the DESTINATION screen's actual mode. A restore result
-        // can cross-screen-migrate (app rule / session restore) onto a screen
+        // can cross-screen-migrate (placement rule / session restore) onto a screen
         // whose mode differs from the caller's, so the disable list to consult
         // is the one for result.screenId's mode — not a hard-coded Snapping.
         //

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -107,7 +107,7 @@ void SnapAdaptor::snapToAppRule(const QString& windowId, const QString& windowSc
         return;
     }
 
-    SnapResult result = m_engine->calculateSnapToAppRule(windowId, windowScreenName, sticky);
+    SnapResult result = m_engine->calculateSnapToPlacementRule(windowId, windowScreenName, sticky);
     if (!result.shouldSnap) {
         return;
     }
@@ -229,7 +229,7 @@ bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
         // currentVirtualDesktop()/currentActivity() are the precise destination
         // context here, not an approximation: a restore only ever targets the
         // current desktop. Every calculator feeding this path either snaps a
-        // window opening now on the current desktop (calculateSnapToAppRule /
+        // window opening now on the current desktop (calculateSnapToPlacementRule /
         // calculateSnapToEmptyZone) or refuses outright when the saved desktop
         // is not the current one — the WindowPlacementStore restore block gates
         // on screen and disabled-context (restoring onto the current desktop),

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -351,8 +351,21 @@ void WindowTrackingAdaptor::captureWindowPlacement(const QString& windowId, cons
                         screenKey = Utils::effectiveScreenIdAt(m_service->screenManager(), frame.center());
                     }
                     if (!screenKey.isEmpty()) {
-                        p->screenId = screenKey;
-                        p->freeGeometryByScreen.insert(screenKey, frame);
+                        // Float-back poison guard. A window floated FROM a snap (its slot
+                        // carries the pre-float zones) that has NOT yet moved is still
+                        // sitting on its snap rect — recording that as the free/float
+                        // geometry would make a later float return to the zone, not a
+                        // genuine free position. This bites windows that opened directly
+                        // snapped (e.g. a SnapToZone rule) and were then floated without
+                        // ever being moved: the live frame is still the zone rect. Skip
+                        // until the frame differs from the pre-float zones' geometry — the
+                        // user's next move while floating captures the real free spot.
+                        const bool stillOnSnapRect =
+                            !slot.zoneIds.isEmpty() && m_service->resolveZoneGeometry(slot.zoneIds, screenKey) == frame;
+                        if (!stillOnSnapRect) {
+                            p->screenId = screenKey;
+                            p->freeGeometryByScreen.insert(screenKey, frame);
+                        }
                     }
                 }
             }

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -651,6 +651,15 @@ public:
     /// so the answer is false unless a Float rule matches. The Float action's
     /// params are free-form, so the verdict is the presence of the filled slot.
     bool shouldFloatByRule(const QString& windowId);
+
+    /// Resolve the 1-based zone ordinals an opening window should snap into
+    /// because a `SnapToZone` window rule matched it. Consulted by the placement
+    /// resolver the daemon injects into the SnapEngine (in-process, not via
+    /// D-Bus). Returns an empty list when no SnapToZone rule matches; multiple
+    /// ordinals request a zone span. Builds a WindowQuery from the window
+    /// registry metadata and reads the `Placement` slot — mirrors
+    /// shouldFloatByRule.
+    QList<int> placementZonesByRule(const QString& windowId);
     /**
      * @brief Drop unified WindowPlacement records for excluded appIds.
      *

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -657,9 +657,10 @@ public:
     /// resolver the daemon injects into the SnapEngine (in-process, not via
     /// D-Bus). Returns an empty list when no SnapToZone rule matches; multiple
     /// ordinals request a zone span. Builds a WindowQuery from the window
-    /// registry metadata and reads the `Placement` slot — mirrors
-    /// shouldFloatByRule.
-    QList<int> placementZonesByRule(const QString& windowId);
+    /// registry metadata, pins it to @p screenId (the screen the window is
+    /// opening on) so a `ScreenId`-constrained rule resolves, and reads the
+    /// `Placement` slot — mirrors shouldFloatByRule.
+    QList<int> placementZonesByRule(const QString& windowId, const QString& screenId);
     /**
      * @brief Drop unified WindowPlacement records for excluded appIds.
      *

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -21,11 +21,11 @@
 #include <PhosphorZones/AssignmentEntry.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorWindowRules/RuleAction.h>
-
-#include <QJsonArray>
 #include <PhosphorWindowRules/RuleEvaluator.h>
 #include <PhosphorWindowRules/WindowQuery.h>
 #include <PhosphorWindowRules/WindowRuleStore.h>
+
+#include <QJsonArray>
 
 namespace PlasmaZones {
 
@@ -480,11 +480,19 @@ QList<int> WindowTrackingAdaptor::placementZonesByRule(const QString& windowId, 
     if (!query) {
         return {};
     }
-    // Pin the query to the window's opening screen so a SnapToZone rule carrying a
-    // ScreenId constraint (migrated from a v3 targetScreen) resolves against the
-    // screen the window is actually opening on. buildRuleQueryForWindow leaves
-    // screenId empty (a generic window-domain rule does not pin a screen) — the
-    // placement path is the one consumer that does.
+    // Pin the query to the window's opening screen so a user-authored SnapToZone
+    // rule carrying a `ScreenId` match (the settings screen-picker stores the
+    // canonical id form the runtime reports) resolves against the screen the
+    // window is actually opening on. buildRuleQueryForWindow leaves screenId empty
+    // (the sibling Float / RestorePosition resolvers do not have the screen), so
+    // the placement path is the one consumer that pins it.
+    //
+    // The shared evaluator cache is keyed on windowId only, so the FIRST resolver
+    // to touch a window seeds the verdict the others reuse. On the open path that
+    // is this placement resolve: SnapEngine::resolveWindowRestore calls
+    // calculateSnapToPlacementRule up front, before it consults the float /
+    // restore predicates — so the screen-pinned query populates the cache first
+    // and a screen-constrained rule resolves correctly.
     query->screenId = screenId;
 
     if (!m_windowRuleEvaluator) {

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -170,8 +170,8 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
         // highest-priority restore-chain level), superseding the retired
         // per-layout Layout::appRules. Snap-only — autotile owns placement on
         // its screens, so no resolver is wired into the autotile engine.
-        snap->setPlacementZonesResolver([this](const QString& windowId) -> QList<int> {
-            return placementZonesByRule(windowId);
+        snap->setPlacementZonesResolver([this](const QString& windowId, const QString& screenId) -> QList<int> {
+            return placementZonesByRule(windowId, screenId);
         });
 
         // Snap-specific signal: carries PhosphorProtocol::WindowStateEntry which is snap-mode-only.
@@ -469,17 +469,23 @@ bool WindowTrackingAdaptor::shouldFloatByRule(const QString& windowId)
     return resolved.slot(QString(PhosphorWindowRules::ActionSlot::Float)).has_value();
 }
 
-QList<int> WindowTrackingAdaptor::placementZonesByRule(const QString& windowId)
+QList<int> WindowTrackingAdaptor::placementZonesByRule(const QString& windowId, const QString& screenId)
 {
     // Placement is purely rule-driven: absent a matching SnapToZone rule there is
     // nothing to snap, so the answer is an empty list.
     if (!m_windowRuleStore) {
         return {};
     }
-    const std::optional<PhosphorWindowRules::WindowQuery> query = buildRuleQueryForWindow(m_windowRegistry, windowId);
+    std::optional<PhosphorWindowRules::WindowQuery> query = buildRuleQueryForWindow(m_windowRegistry, windowId);
     if (!query) {
         return {};
     }
+    // Pin the query to the window's opening screen so a SnapToZone rule carrying a
+    // ScreenId constraint (migrated from a v3 targetScreen) resolves against the
+    // screen the window is actually opening on. buildRuleQueryForWindow leaves
+    // screenId empty (a generic window-domain rule does not pin a screen) — the
+    // placement path is the one consumer that does.
+    query->screenId = screenId;
 
     if (!m_windowRuleEvaluator) {
         m_windowRuleEvaluator = std::make_unique<PhosphorWindowRules::RuleEvaluator>(m_windowRuleStore->ruleSet());
@@ -494,15 +500,16 @@ QList<int> WindowTrackingAdaptor::placementZonesByRule(const QString& windowId)
     if (!action) {
         return {};
     }
-    // The descriptor validator already guaranteed a non-empty array of positive
-    // integer ordinals at load; re-validate defensively (toInt, >= 1) so a future
-    // loader change can never feed a bad ordinal into zone resolution.
+    // The descriptor validator already guaranteed a non-empty array of in-range
+    // 1-based ordinals at load; re-validate defensively against the SAME bound
+    // (1..MaxZoneOrdinal) so a future loader change can never feed a bad ordinal
+    // into zone resolution.
     const QJsonArray arr = action->params.value(QString(PhosphorWindowRules::ActionParam::Zones)).toArray();
     QList<int> ordinals;
     ordinals.reserve(arr.size());
     for (const QJsonValue& v : arr) {
         const int n = v.toInt(0);
-        if (n >= 1) {
+        if (n >= 1 && n <= PhosphorWindowRules::MaxZoneOrdinal) {
             ordinals.append(n);
         }
     }

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -21,6 +21,8 @@
 #include <PhosphorZones/AssignmentEntry.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorWindowRules/RuleAction.h>
+
+#include <QJsonArray>
 #include <PhosphorWindowRules/RuleEvaluator.h>
 #include <PhosphorWindowRules/WindowQuery.h>
 #include <PhosphorWindowRules/WindowRuleStore.h>
@@ -92,6 +94,7 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
         m_cachedSnapEngine->setShouldRestorePredicate({});
         m_cachedSnapEngine->setRestorePositionPredicate({});
         m_cachedSnapEngine->setFloatPredicate({});
+        m_cachedSnapEngine->setPlacementZonesResolver({});
     }
     if (m_cachedAutotileEngine) {
         m_cachedAutotileEngine->setRestorePositionPredicate({});
@@ -160,6 +163,15 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
         // global default), so the same resolver serves both engines.
         snap->setFloatPredicate([this](const QString& windowId) -> bool {
             return shouldFloatByRule(windowId);
+        });
+
+        // Open-placement resolver (snap). A matched "Snap this app to zone(s)"
+        // rule snaps the opening window into the resolved zone ordinals (the
+        // highest-priority restore-chain level), superseding the retired
+        // per-layout Layout::appRules. Snap-only — autotile owns placement on
+        // its screens, so no resolver is wired into the autotile engine.
+        snap->setPlacementZonesResolver([this](const QString& windowId) -> QList<int> {
+            return placementZonesByRule(windowId);
         });
 
         // Snap-specific signal: carries PhosphorProtocol::WindowStateEntry which is snap-mode-only.
@@ -455,6 +467,46 @@ bool WindowTrackingAdaptor::shouldFloatByRule(const QString& windowId)
     // The Float action carries free-form params (no Value key), so the verdict is
     // the PRESENCE of the filled slot, not a bool payload.
     return resolved.slot(QString(PhosphorWindowRules::ActionSlot::Float)).has_value();
+}
+
+QList<int> WindowTrackingAdaptor::placementZonesByRule(const QString& windowId)
+{
+    // Placement is purely rule-driven: absent a matching SnapToZone rule there is
+    // nothing to snap, so the answer is an empty list.
+    if (!m_windowRuleStore) {
+        return {};
+    }
+    const std::optional<PhosphorWindowRules::WindowQuery> query = buildRuleQueryForWindow(m_windowRegistry, windowId);
+    if (!query) {
+        return {};
+    }
+
+    if (!m_windowRuleEvaluator) {
+        m_windowRuleEvaluator = std::make_unique<PhosphorWindowRules::RuleEvaluator>(m_windowRuleStore->ruleSet());
+    }
+    // Shares m_windowRuleEvaluator with shouldFloatByRule / shouldRestoreFloatedPosition;
+    // resolveCached is keyed on (windowId, ruleSet revision) and returns every matched
+    // slot, so reading the Placement slot off the same verdict is free. Same open-path
+    // lifetime guarantee (resolved once per window lifetime) as the sibling predicates.
+    const PhosphorWindowRules::ResolvedActions resolved = m_windowRuleEvaluator->resolveCached(windowId, *query);
+    const std::optional<PhosphorWindowRules::RuleAction> action =
+        resolved.slot(QString(PhosphorWindowRules::ActionSlot::Placement));
+    if (!action) {
+        return {};
+    }
+    // The descriptor validator already guaranteed a non-empty array of positive
+    // integer ordinals at load; re-validate defensively (toInt, >= 1) so a future
+    // loader change can never feed a bad ordinal into zone resolution.
+    const QJsonArray arr = action->params.value(QString(PhosphorWindowRules::ActionParam::Zones)).toArray();
+    QList<int> ordinals;
+    ordinals.reserve(arr.size());
+    for (const QJsonValue& v : arr) {
+        const int n = v.toInt(0);
+        if (n >= 1) {
+            ordinals.append(n);
+        }
+    }
+    return ordinals;
 }
 
 void WindowTrackingAdaptor::handleCrossModeMove(const QString& windowId, const QString& targetScreenId,

--- a/src/settings/kzonesimporter.cpp
+++ b/src/settings/kzonesimporter.cpp
@@ -6,11 +6,17 @@
 #include "dbusutils.h"
 #include "../phosphor_i18n.h"
 
+#include <PhosphorWindowRules/MatchExpression.h>
+#include <PhosphorWindowRules/MatchTypes.h>
+#include <PhosphorWindowRules/RuleAction.h>
+#include <PhosphorWindowRules/WindowRule.h>
 #include <PhosphorZones/ZoneJsonKeys.h>
 
 #include <QDBusMessage>
 #include <QFile>
+#include <QHash>
 #include <QIODevice>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonParseError>
@@ -146,7 +152,10 @@ ImportResult importLayouts(const QJsonArray& kzonesArray)
         }
 
         QJsonArray pZones;
-        QJsonArray appRules;
+        // app class → 1-based zone number. The per-layout appRules concept was
+        // retired; these become SnapToZone window rules after the layout is
+        // created. First zone wins per app within this layout.
+        QHash<QString, int> appToZone;
 
         for (int i = 0; i < kzZones.size(); ++i) {
             const QJsonObject kzZone = kzZones[i].toObject();
@@ -179,24 +188,17 @@ ImportResult importLayouts(const QJsonArray& kzonesArray)
 
             pZones.append(pZone);
 
-            // Collect per-zone applications into layout-level appRules.
+            // Collect per-zone applications as app→zone pairs.
             const QJsonArray apps = kzZone[QStringLiteral("applications")].toArray();
             for (const QJsonValue& appVal : apps) {
                 const QString appClass = appVal.toString().trimmed();
-                if (appClass.isEmpty()) {
-                    continue;
+                if (!appClass.isEmpty() && !appToZone.contains(appClass)) {
+                    appToZone.insert(appClass, zoneNum);
                 }
-                QJsonObject rule;
-                rule[QLatin1String(::PhosphorZones::ZoneJsonKeys::Pattern)] = appClass;
-                rule[QLatin1String(::PhosphorZones::ZoneJsonKeys::ZoneNumber)] = zoneNum;
-                appRules.append(rule);
             }
         }
 
         pLayout[QLatin1String(::PhosphorZones::ZoneJsonKeys::Zones)] = pZones;
-        if (!appRules.isEmpty()) {
-            pLayout[QLatin1String(::PhosphorZones::ZoneJsonKeys::AppRules)] = appRules;
-        }
 
         // Send to daemon via createLayoutFromJson D-Bus method.
         const QString layoutJson = QString::fromUtf8(QJsonDocument(pLayout).toJson(QJsonDocument::Compact));
@@ -209,6 +211,29 @@ ImportResult importLayouts(const QJsonArray& kzonesArray)
                 ++result.imported;
                 if (result.pendingSelectLayoutId.isEmpty()) {
                     result.pendingSelectLayoutId = newId;
+                }
+
+                // The KZones per-zone app assignments become SnapToZone window
+                // rules (the per-layout appRules concept was retired): one rule
+                // per app, `WindowClass contains <appClass> → SnapToZone [zone]`.
+                namespace PWR = PhosphorWindowRules;
+                for (auto it = appToZone.constBegin(); it != appToZone.constEnd(); ++it) {
+                    PWR::WindowRule rule;
+                    rule.id = QUuid::createUuid();
+                    rule.enabled = true;
+                    rule.priority = 0;
+                    rule.match =
+                        PWR::MatchExpression::makeLeaf(PWR::Field::WindowClass, PWR::Operator::Contains, it.key());
+                    PWR::RuleAction action;
+                    action.type = QString(PWR::ActionType::SnapToZone);
+                    QJsonObject params;
+                    params.insert(QString(PWR::ActionParam::Zones), QJsonArray{it.value()});
+                    action.params = params;
+                    rule.actions.append(action);
+                    const QString ruleJson =
+                        QString::fromUtf8(QJsonDocument(rule.toJson()).toJson(QJsonDocument::Compact));
+                    DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::WindowRules),
+                                           QStringLiteral("addRule"), {ruleJson});
                 }
             }
         }

--- a/src/settings/kzonesimporter.cpp
+++ b/src/settings/kzonesimporter.cpp
@@ -215,7 +215,11 @@ ImportResult importLayouts(const QJsonArray& kzonesArray)
 
                 // The KZones per-zone app assignments become SnapToZone window
                 // rules (the per-layout appRules concept was retired): one rule
-                // per app, `WindowClass contains <appClass> → SnapToZone [zone]`.
+                // per app, `AppId appIdMatches <appClass> → SnapToZone [zone]`.
+                // AppId / AppIdMatches matches the daemon placement path (which
+                // resolves on appId — windowClass is not tracked daemon-side, so a
+                // WindowClass leaf would never fire) and the retired matchAppRule's
+                // segment-aware semantics.
                 namespace PWR = PhosphorWindowRules;
                 for (auto it = appToZone.constBegin(); it != appToZone.constEnd(); ++it) {
                     PWR::WindowRule rule;
@@ -223,7 +227,7 @@ ImportResult importLayouts(const QJsonArray& kzonesArray)
                     rule.enabled = true;
                     rule.priority = 0;
                     rule.match =
-                        PWR::MatchExpression::makeLeaf(PWR::Field::WindowClass, PWR::Operator::Contains, it.key());
+                        PWR::MatchExpression::makeLeaf(PWR::Field::AppId, PWR::Operator::AppIdMatches, it.key());
                     PWR::RuleAction action;
                     action.type = QString(PWR::ActionType::SnapToZone);
                     QJsonObject params;

--- a/src/settings/kzonesimporter.cpp
+++ b/src/settings/kzonesimporter.cpp
@@ -232,8 +232,20 @@ ImportResult importLayouts(const QJsonArray& kzonesArray)
                     rule.actions.append(action);
                     const QString ruleJson =
                         QString::fromUtf8(QJsonDocument(rule.toJson()).toJson(QJsonDocument::Compact));
-                    DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::WindowRules),
-                                           QStringLiteral("addRule"), {ruleJson});
+                    const QDBusMessage ruleReply =
+                        DaemonDBus::callDaemon(QString(PhosphorProtocol::Service::Interface::WindowRules),
+                                               QStringLiteral("addRule"), {ruleJson});
+                    // addRule returns false on daemon-side validation/persistence
+                    // failure. Surface a dropped app→zone rule rather than reporting
+                    // the import as fully successful (the layout still imported).
+                    const bool ruleAdded = ruleReply.type() == QDBusMessage::ReplyMessage
+                        && !ruleReply.arguments().isEmpty() && ruleReply.arguments().first().toBool();
+                    if (!ruleAdded) {
+                        qWarning(
+                            "KZonesImporter: failed to add SnapToZone rule for app '%s' (zone %d) — the layout "
+                            "imported but this app-to-zone assignment was dropped.",
+                            qPrintable(it.key()), it.value());
+                    }
                 }
             }
         }

--- a/src/settings/qml/ActionListView.qml
+++ b/src/settings/qml/ActionListView.qml
@@ -181,6 +181,12 @@ ColumnLayout {
             }
             return rawStr;
         }
+        if (kind === "zoneOrdinals") {
+            // `raw` is a JS array of 1-based zone ordinals; render "1, 2".
+            if (Array.isArray(raw))
+                return raw.join(", ");
+            return rawStr;
+        }
         return rawStr;
     }
 

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -446,7 +446,7 @@ ColumnLayout {
     _zoneOrdinalsEditor: Component {
         TextField {
             readonly property var _param: parent.modelData
-            readonly property var _zones: row.action[_param.key] !== undefined ? row.action[_param.key] : []
+            readonly property var _zones: Array.isArray(row.action[_param.key]) ? row.action[_param.key] : []
 
             // Normalised display (sorted, deduped) re-binds after each edit.
             text: _zones.join(", ")

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -467,6 +467,13 @@ ColumnLayout {
                     if (range) {
                         var lo = parseInt(range[1], 10);
                         var hi = parseInt(range[2], 10);
+                        // Clamp the upper bound to the SnapToZone ordinal cap
+                        // (MaxZoneOrdinal = 64 in RuleAction.h). An unbounded
+                        // expansion (e.g. "1-100000") would build a huge array on
+                        // the UI thread and freeze it; ordinals past the cap are
+                        // rejected by the validator anyway.
+                        if (hi > 64)
+                            hi = 64;
                         if (lo >= 1 && hi >= lo) {
                             for (var z = lo; z <= hi; z++) {
                                 if (!seen[z]) {
@@ -488,6 +495,16 @@ ColumnLayout {
                 parsed.sort(function (a, b) {
                     return a - b;
                 });
+                // A SnapToZone action requires a non-empty ordinal list (the
+                // descriptor validator rejects []). If the user cleared the field
+                // or typed only invalid tokens, keep the last valid value rather
+                // than committing an empty list — that would produce an action the
+                // validator drops on save, silently losing the rule with the Save
+                // button still enabled.
+                if (parsed.length === 0) {
+                    text = _zones.join(", ");
+                    return;
+                }
                 row.actionEdited(row._withParam(_param.key, parsed));
             }
         }

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -500,9 +500,13 @@ ColumnLayout {
                 // or typed only invalid tokens, keep the last valid value rather
                 // than committing an empty list — that would produce an action the
                 // validator drops on save, silently losing the rule with the Save
-                // button still enabled.
+                // button still enabled. Restore via Qt.binding (not a bare
+                // `text = ...`) so the declarative `text: _zones.join(", ")`
+                // binding survives and keeps normalising on later edits.
                 if (parsed.length === 0) {
-                    text = _zones.join(", ");
+                    text = Qt.binding(function () {
+                        return _zones.join(", ");
+                    });
                     return;
                 }
                 row.actionEdited(row._withParam(_param.key, parsed));

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -180,6 +180,10 @@ ColumnLayout {
     // The validator accepts the `#AARRGGBB` shape and the effect-side consumer
     // parses it via `QColor(QString)` (which reads 9-digit hex alpha-first).
     property Component _colorParamEditor
+    // Comma/space/range-separated zone-number input for `kind == "zoneOrdinals"`
+    // (SnapToZone). Stores a JSON array of 1-based ordinals; multiple ordinals
+    // span their combined area. Accepts "1, 2", "1;2", "1 2", and ranges "1-3".
+    property Component _zoneOrdinalsEditor
 
     /// Encode a QML color to a `#AARRGGBB` wire string (alpha-first) — the form
     /// the SetBorderColor validator accepts and the consumer parses back via
@@ -396,6 +400,9 @@ ColumnLayout {
                     if (modelData.kind === "color")
                         return row._colorParamEditor;
 
+                    if (modelData.kind === "zoneOrdinals")
+                        return row._zoneOrdinalsEditor;
+
                     return row._stringParamEditor;
                 }
             }
@@ -433,6 +440,56 @@ ColumnLayout {
             placeholderText: _param.label
             Accessible.name: _param.label
             onEditingFinished: row.actionEdited(row._withParam(_param.key, text))
+        }
+    }
+
+    _zoneOrdinalsEditor: Component {
+        TextField {
+            readonly property var _param: parent.modelData
+            readonly property var _zones: row.action[_param.key] !== undefined ? row.action[_param.key] : []
+
+            // Normalised display (sorted, deduped) re-binds after each edit.
+            text: _zones.join(", ")
+            placeholderText: i18nc("@info:placeholder zone numbers for a snap-to-zone rule", "e.g. 1, 2 or 1-2")
+            Accessible.name: _param.label
+            Accessible.description: i18nc("@info:whatsthis", "One or more 1-based zone numbers to snap matched windows to. Multiple zones span their combined area.")
+            onEditingFinished: {
+                // Parse comma/semicolon/space-separated ordinals and "lo-hi"
+                // ranges into a deduped, ascending array of 1-based integers.
+                var seen = ({});
+                var parsed = [];
+                var tokens = text.split(/[,;\s]+/);
+                for (var i = 0; i < tokens.length; i++) {
+                    var t = tokens[i].trim();
+                    if (t.length === 0)
+                        continue;
+                    var range = t.match(/^(\d+)-(\d+)$/);
+                    if (range) {
+                        var lo = parseInt(range[1], 10);
+                        var hi = parseInt(range[2], 10);
+                        if (lo >= 1 && hi >= lo) {
+                            for (var z = lo; z <= hi; z++) {
+                                if (!seen[z]) {
+                                    seen[z] = true;
+                                    parsed.push(z);
+                                }
+                            }
+                        }
+                        continue;
+                    }
+                    if (/^\d+$/.test(t)) {
+                        var n = parseInt(t, 10);
+                        if (n >= 1 && !seen[n]) {
+                            seen[n] = true;
+                            parsed.push(n);
+                        }
+                    }
+                }
+                parsed.sort(function (a, b) {
+                    return a - b;
+                });
+                row.actionEdited(row._withParam(_param.key, parsed));
+            }
         }
     }
 

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -231,6 +231,9 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::SetOpacity && key == ActionParam::Value) {
         return PhosphorI18n::tr("Opacity (%)");
     }
+    if (type == ActionType::SnapToZone && key == ActionParam::Zones) {
+        return PhosphorI18n::tr("Zones");
+    }
     // Unsnapped-position restore override (window-domain, single bool value).
     if (type == ActionType::RestorePosition && key == ActionParam::Value) {
         return PhosphorI18n::tr("Restore position on login");
@@ -408,6 +411,9 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::Float) {
         return PhosphorI18n::tr("Float window");
+    }
+    if (type == ActionType::SnapToZone) {
+        return PhosphorI18n::tr("Snap to zone(s)");
     }
     if (type == ActionType::RestorePosition) {
         return PhosphorI18n::tr("Restore position on login");
@@ -792,6 +798,11 @@ QVariantMap defaultPayloadFor(const QString& typeWire)
             // SetBorderColor validator before the user opens the picker.
             // Neutral KDE accent blue, fully opaque.
             payload[key] = QStringLiteral("#FF3DAEE9");
+        } else if (kind == QLatin1String("zoneOrdinals")) {
+            // Seed a valid single-zone default ([1]) so a fresh SnapToZone rule
+            // passes the validator (non-empty array of positive ordinals) before
+            // the user edits the zone list.
+            payload[key] = QVariantList{1};
         } else {
             // Picker kinds (snappingLayout, tilingAlgorithm, animationEvent,
             // shaderEffect, curveEditor) and plain strings all start empty —

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -11,6 +11,7 @@
 
 #include <PhosphorZones/AssignmentEntry.h>
 
+#include <QJsonArray>
 #include <QStringList>
 
 #include <algorithm>
@@ -271,6 +272,21 @@ QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup
     }
     if (action.type == ActionType::Float) {
         return PhosphorI18n::tr("Float");
+    }
+    if (action.type == ActionType::SnapToZone) {
+        const QJsonArray zones = action.params.value(PhosphorWindowRules::ActionParam::Zones).toArray();
+        QStringList nums;
+        nums.reserve(zones.size());
+        for (const QJsonValue& z : zones) {
+            nums.append(QString::number(z.toInt()));
+        }
+        if (nums.isEmpty()) {
+            return PhosphorI18n::tr("Snap to zone");
+        }
+        if (nums.size() == 1) {
+            return PhosphorI18n::tr("Snap to zone %1").arg(nums.first());
+        }
+        return PhosphorI18n::tr("Snap to zones %1").arg(nums.join(QStringLiteral(", ")));
     }
     if (action.type == ActionType::SetOpacity) {
         // Mirror EVERY resolver reject path (shader_resolve.cpp's

--- a/tests/unit/config/test_migration_v3_to_v4.cpp
+++ b/tests/unit/config/test_migration_v3_to_v4.cpp
@@ -40,6 +40,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QStandardPaths>
 #include <QTest>
 
 #include <algorithm>
@@ -316,6 +317,115 @@ private Q_SLOTS:
         QVERIFY(!cfg.contains(QStringLiteral("_v4AnimationRulesStash")));
         QVERIFY(!cfg.contains(QStringLiteral("_v4ExclusionStash")));
         QVERIFY(!cfg.contains(QStringLiteral("_v4AnimationExclusionStash")));
+    }
+
+    void testLayoutAppRules_becomeSnapToZoneRules()
+    {
+        IsolatedConfigGuard guard;
+        writeJson(ConfigDefaults::configFilePath(), makeV3Config());
+        writeJson(assignmentsPath(), makeAssignments());
+
+        // A v3 layout file carrying two legacy app→zone rules: one current-
+        // screen (firefox → zone 2), one screen-pinned (konsole → zone 3 on
+        // DP-1). They live in the user data dir the migration scans.
+        const QString layoutsDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+            + QLatin1Char('/') + ConfigDefaults::layoutsSubdir();
+        QJsonArray appRules;
+        appRules.append(
+            QJsonObject{{QStringLiteral("pattern"), QStringLiteral("firefox")}, {QStringLiteral("zoneNumber"), 2}});
+        appRules.append(QJsonObject{{QStringLiteral("pattern"), QStringLiteral("konsole")},
+                                    {QStringLiteral("zoneNumber"), 3},
+                                    {QStringLiteral("targetScreen"), QStringLiteral("DP-1")}});
+        writeJson(layoutsDir + QStringLiteral("/layout1.json"), QJsonObject{{QStringLiteral("appRules"), appRules}});
+
+        QVERIFY(ConfigMigration::ensureJsonConfig());
+
+        const QJsonArray rules = rulesFromWindowRules();
+
+        // The 1-based zone ordinals carried by a rule's SnapToZone action.
+        const auto snapZones = [](const QJsonObject& rule) -> QList<int> {
+            QList<int> out;
+            for (const QJsonValue& v : rule.value(QStringLiteral("actions")).toArray()) {
+                const QJsonObject a = v.toObject();
+                if (a.value(QStringLiteral("type")).toString() == QLatin1String("snapToZone")) {
+                    for (const QJsonValue& z : a.value(QStringLiteral("zones")).toArray()) {
+                        out.append(z.toInt());
+                    }
+                }
+            }
+            return out;
+        };
+
+        QJsonObject firefoxRule;
+        QJsonObject konsoleRule;
+        for (const QJsonValue& v : rules) {
+            const QJsonObject r = v.toObject();
+            if (!actionTypes(r).contains(QLatin1String("snapToZone"))) {
+                continue;
+            }
+            const QString cls = matchLeafValueByOp(r, QStringLiteral("windowClass"), QStringLiteral("contains"));
+            if (cls == QLatin1String("firefox")) {
+                firefoxRule = r;
+            } else if (cls == QLatin1String("konsole")) {
+                konsoleRule = r;
+            }
+        }
+
+        // firefox → SnapToZone [2]; a single WindowClass-contains leaf (no screen).
+        QVERIFY(!firefoxRule.isEmpty());
+        QCOMPARE(snapZones(firefoxRule), (QList<int>{2}));
+        QCOMPARE(matchLeaves(firefoxRule).size(), 1);
+
+        // konsole → SnapToZone [3]; screen-pinned, so an All{} of WindowClass-
+        // contains AND ScreenId-equals DP-1 (v3 targetScreen → match constraint).
+        QVERIFY(!konsoleRule.isEmpty());
+        QCOMPARE(snapZones(konsoleRule), (QList<int>{3}));
+        QCOMPARE(matchLeafValueByOp(konsoleRule, QStringLiteral("screenId"), QStringLiteral("equals")),
+                 QStringLiteral("DP-1"));
+    }
+
+    void testLayoutAppRules_dedupePatternAcrossLayouts()
+    {
+        IsolatedConfigGuard guard;
+        writeJson(ConfigDefaults::configFilePath(), makeV3Config());
+        writeJson(assignmentsPath(), makeAssignments());
+
+        // Same pattern in two layout files mapping to DIFFERENT zones. A global
+        // ordinal SnapToZone rule fires regardless of the active layout, so only
+        // the first (name-order) wins; the second is dropped.
+        const QString layoutsDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+            + QLatin1Char('/') + ConfigDefaults::layoutsSubdir();
+        writeJson(layoutsDir + QStringLiteral("/a-layout.json"),
+                  QJsonObject{{QStringLiteral("appRules"),
+                               QJsonArray{QJsonObject{{QStringLiteral("pattern"), QStringLiteral("mpv")},
+                                                      {QStringLiteral("zoneNumber"), 1}}}}});
+        writeJson(layoutsDir + QStringLiteral("/b-layout.json"),
+                  QJsonObject{{QStringLiteral("appRules"),
+                               QJsonArray{QJsonObject{{QStringLiteral("pattern"), QStringLiteral("mpv")},
+                                                      {QStringLiteral("zoneNumber"), 4}}}}});
+
+        QVERIFY(ConfigMigration::ensureJsonConfig());
+
+        int mpvRuleCount = 0;
+        QList<int> winningZones;
+        for (const QJsonValue& v : rulesFromWindowRules()) {
+            const QJsonObject r = v.toObject();
+            if (matchLeafValueByOp(r, QStringLiteral("windowClass"), QStringLiteral("contains"))
+                != QLatin1String("mpv")) {
+                continue;
+            }
+            ++mpvRuleCount;
+            for (const QJsonValue& av : r.value(QStringLiteral("actions")).toArray()) {
+                const QJsonObject a = av.toObject();
+                if (a.value(QStringLiteral("type")).toString() == QLatin1String("snapToZone")) {
+                    for (const QJsonValue& z : a.value(QStringLiteral("zones")).toArray()) {
+                        winningZones.append(z.toInt());
+                    }
+                }
+            }
+        }
+        QCOMPARE(mpvRuleCount, 1);
+        QCOMPARE(winningZones, (QList<int>{1})); // a-layout.json wins on name order
     }
 
     // ─── Exact cascade priorities ─────────────────────────────────────────

--- a/tests/unit/config/test_migration_v3_to_v4.cpp
+++ b/tests/unit/config/test_migration_v3_to_v4.cpp
@@ -363,7 +363,7 @@ private Q_SLOTS:
             if (!actionTypes(r).contains(QLatin1String("snapToZone"))) {
                 continue;
             }
-            const QString cls = matchLeafValueByOp(r, QStringLiteral("windowClass"), QStringLiteral("contains"));
+            const QString cls = matchLeafValueByOp(r, QStringLiteral("appId"), QStringLiteral("appIdMatches"));
             if (cls == QLatin1String("firefox")) {
                 firefoxRule = r;
             } else if (cls == QLatin1String("konsole")) {
@@ -371,13 +371,13 @@ private Q_SLOTS:
             }
         }
 
-        // firefox → SnapToZone [2]; a single WindowClass-contains leaf (no screen).
+        // firefox → SnapToZone [2]; a single AppId-appIdMatches leaf (no screen).
         QVERIFY(!firefoxRule.isEmpty());
         QCOMPARE(snapZones(firefoxRule), (QList<int>{2}));
         QCOMPARE(matchLeaves(firefoxRule).size(), 1);
 
-        // konsole → SnapToZone [3]; screen-pinned, so an All{} of WindowClass-
-        // contains AND ScreenId-equals DP-1 (v3 targetScreen → match constraint).
+        // konsole → SnapToZone [3]; screen-pinned, so an All{} of AppId-
+        // appIdMatches AND ScreenId-equals DP-1 (v3 targetScreen → match constraint).
         QVERIFY(!konsoleRule.isEmpty());
         QCOMPARE(snapZones(konsoleRule), (QList<int>{3}));
         QCOMPARE(matchLeafValueByOp(konsoleRule, QStringLiteral("screenId"), QStringLiteral("equals")),
@@ -410,7 +410,7 @@ private Q_SLOTS:
         QList<int> winningZones;
         for (const QJsonValue& v : rulesFromWindowRules()) {
             const QJsonObject r = v.toObject();
-            if (matchLeafValueByOp(r, QStringLiteral("windowClass"), QStringLiteral("contains"))
+            if (matchLeafValueByOp(r, QStringLiteral("appId"), QStringLiteral("appIdMatches"))
                 != QLatin1String("mpv")) {
                 continue;
             }
@@ -426,6 +426,65 @@ private Q_SLOTS:
         }
         QCOMPARE(mpvRuleCount, 1);
         QCOMPARE(winningZones, (QList<int>{1})); // a-layout.json wins on name order
+    }
+
+    void testLayoutAppRules_idempotentRuleIds()
+    {
+        // The SnapToZone migration's rule id is derived from
+        // (pattern, zoneNumber, targetScreen) via a fixed v5-UUID namespace, so a
+        // crash-and-retry conversion yields byte-identical rules. This mirrors the
+        // sibling exclusion / animation folds' idempotency tests and pins the
+        // namespace UUID + segment encoding so a future drift in either forces a
+        // deliberate update here (the migration owns both ends of the derivation,
+        // so a same-inputs→same-id check alone cannot catch a namespace change).
+        IsolatedConfigGuard guard;
+        writeJson(ConfigDefaults::configFilePath(), makeV3Config());
+        writeJson(assignmentsPath(), makeAssignments());
+
+        const QString layoutsDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+            + QLatin1Char('/') + ConfigDefaults::layoutsSubdir();
+        writeJson(layoutsDir + QStringLiteral("/layout1.json"),
+                  QJsonObject{{QStringLiteral("appRules"),
+                               QJsonArray{QJsonObject{{QStringLiteral("pattern"), QStringLiteral("firefox")},
+                                                      {QStringLiteral("zoneNumber"), 2}}}}});
+
+        // Finds the id of the SnapToZone rule whose AppId-appIdMatches leaf is the
+        // given pattern.
+        const auto snapRuleIdFor = [this](const QString& pattern) -> QString {
+            for (const QJsonValue& v : rulesFromWindowRules()) {
+                const QJsonObject r = v.toObject();
+                if (actionTypes(r).contains(QLatin1String("snapToZone"))
+                    && matchLeafValueByOp(r, QStringLiteral("appId"), QStringLiteral("appIdMatches")) == pattern) {
+                    return r.value(QStringLiteral("id")).toString();
+                }
+            }
+            return {};
+        };
+
+        QVERIFY(ConfigMigration::ensureJsonConfig());
+        const QString firstId = snapRuleIdFor(QStringLiteral("firefox"));
+        QVERIFY(!firstId.isEmpty());
+
+        // Golden assertion against the SPEC: namespace UUID + length-prefixed
+        // segment encoding ("<size>:<bytes>" per segment, no separator).
+        //   segment 1 → pattern      "firefox" → "7:firefox"
+        //   segment 2 → zoneNumber   "2"       → "1:2"
+        //   segment 3 → targetScreen ""        → "0:"
+        const QUuid kExpectedNamespace(QStringLiteral("{6f1c8e44-2a7b-5d93-8e10-4b2c9a7f1d35}"));
+        const QString kExpectedKey = QStringLiteral("7:firefox") + QStringLiteral("1:2") + QStringLiteral("0:");
+        QCOMPARE(firstId, QUuid::createUuidV5(kExpectedNamespace, kExpectedKey).toString());
+
+        // Force the rebuild path again and re-stage the same v3 inputs.
+        QFile::remove(ConfigDefaults::windowRulesFilePath());
+        writeJson(ConfigDefaults::configFilePath(), makeV3Config());
+        writeJson(layoutsDir + QStringLiteral("/layout1.json"),
+                  QJsonObject{{QStringLiteral("appRules"),
+                               QJsonArray{QJsonObject{{QStringLiteral("pattern"), QStringLiteral("firefox")},
+                                                      {QStringLiteral("zoneNumber"), 2}}}}});
+        ConfigMigration::resetMigrationGuardForTesting();
+        QVERIFY(ConfigMigration::ensureJsonConfig());
+
+        QCOMPARE(snapRuleIdFor(QStringLiteral("firefox")), firstId);
     }
 
     // ─── Exact cascade priorities ─────────────────────────────────────────

--- a/tests/unit/config/test_migration_v3_to_v4.cpp
+++ b/tests/unit/config/test_migration_v3_to_v4.cpp
@@ -433,7 +433,7 @@ private Q_SLOTS:
     void testLayoutAppRules_idempotentRuleIds()
     {
         // The SnapToZone migration's rule id is derived from
-        // (pattern, zoneNumber, targetScreen) via a fixed v5-UUID namespace, so a
+        // (pattern, zoneNumber) via a fixed v5-UUID namespace, so a
         // crash-and-retry conversion yields byte-identical rules. This mirrors the
         // sibling exclusion / animation folds' idempotency tests and pins the
         // namespace UUID + segment encoding so a future drift in either forces a

--- a/tests/unit/config/test_migration_v3_to_v4.cpp
+++ b/tests/unit/config/test_migration_v3_to_v4.cpp
@@ -325,9 +325,10 @@ private Q_SLOTS:
         writeJson(ConfigDefaults::configFilePath(), makeV3Config());
         writeJson(assignmentsPath(), makeAssignments());
 
-        // A v3 layout file carrying two legacy app→zone rules: one current-
-        // screen (firefox → zone 2), one screen-pinned (konsole → zone 3 on
-        // DP-1). They live in the user data dir the migration scans.
+        // A v3 layout file carrying two legacy app→zone rules: firefox → zone 2
+        // (no screen), and konsole → zone 3 with a legacy targetScreen "DP-1"
+        // (which v4 intentionally drops — see below). They live in the user data
+        // dir the migration scans.
         const QString layoutsDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
             + QLatin1Char('/') + ConfigDefaults::layoutsSubdir();
         QJsonArray appRules;
@@ -376,12 +377,13 @@ private Q_SLOTS:
         QCOMPARE(snapZones(firefoxRule), (QList<int>{2}));
         QCOMPARE(matchLeaves(firefoxRule).size(), 1);
 
-        // konsole → SnapToZone [3]; screen-pinned, so an All{} of AppId-
-        // appIdMatches AND ScreenId-equals DP-1 (v3 targetScreen → match constraint).
+        // konsole → SnapToZone [3]; the legacy targetScreen "DP-1" is dropped, so
+        // it is a single AppId-appIdMatches leaf with NO ScreenId constraint (a
+        // migrated app snaps on whatever screen it opens on).
         QVERIFY(!konsoleRule.isEmpty());
         QCOMPARE(snapZones(konsoleRule), (QList<int>{3}));
-        QCOMPARE(matchLeafValueByOp(konsoleRule, QStringLiteral("screenId"), QStringLiteral("equals")),
-                 QStringLiteral("DP-1"));
+        QCOMPARE(matchLeaves(konsoleRule).size(), 1);
+        QVERIFY(matchLeafValueByOp(konsoleRule, QStringLiteral("screenId"), QStringLiteral("equals")).isEmpty());
     }
 
     void testLayoutAppRules_dedupePatternAcrossLayouts()
@@ -466,12 +468,13 @@ private Q_SLOTS:
         QVERIFY(!firstId.isEmpty());
 
         // Golden assertion against the SPEC: namespace UUID + length-prefixed
-        // segment encoding ("<size>:<bytes>" per segment, no separator).
-        //   segment 1 → pattern      "firefox" → "7:firefox"
-        //   segment 2 → zoneNumber   "2"       → "1:2"
-        //   segment 3 → targetScreen ""        → "0:"
+        // segment encoding ("<size>:<bytes>" per segment, no separator). The id is
+        // derived from (pattern, zoneNumber) only — targetScreen is not carried
+        // into the rule, so it is not part of the identity.
+        //   segment 1 → pattern    "firefox" → "7:firefox"
+        //   segment 2 → zoneNumber "2"       → "1:2"
         const QUuid kExpectedNamespace(QStringLiteral("{6f1c8e44-2a7b-5d93-8e10-4b2c9a7f1d35}"));
-        const QString kExpectedKey = QStringLiteral("7:firefox") + QStringLiteral("1:2") + QStringLiteral("0:");
+        const QString kExpectedKey = QStringLiteral("7:firefox") + QStringLiteral("1:2");
         QCOMPARE(firstId, QUuid::createUuidV5(kExpectedNamespace, kExpectedKey).toString());
 
         // Force the rebuild path again and re-stage the same v3 inputs.

--- a/tests/unit/core/test_snap_unfloat_fallback.cpp
+++ b/tests/unit/core/test_snap_unfloat_fallback.cpp
@@ -244,7 +244,7 @@ private Q_SLOTS:
         m_wts->setSnapState(engine.snapState());
 
         installLayout(3);
-        engine.setPlacementZonesResolver([](const QString&) {
+        engine.setPlacementZonesResolver([](const QString&, const QString&) {
             return QList<int>{2, 3};
         });
 
@@ -288,7 +288,7 @@ private Q_SLOTS:
         m_wts->setSnapState(engine.snapState());
 
         installLayout(3);
-        engine.setPlacementZonesResolver([](const QString&) {
+        engine.setPlacementZonesResolver([](const QString&, const QString&) {
             return QList<int>{1};
         });
 
@@ -309,7 +309,7 @@ private Q_SLOTS:
         m_wts->setSnapState(engine.snapState());
 
         installLayout(3);
-        engine.setPlacementZonesResolver([](const QString&) {
+        engine.setPlacementZonesResolver([](const QString&, const QString&) {
             return QList<int>{};
         });
 

--- a/tests/unit/core/test_snap_unfloat_fallback.cpp
+++ b/tests/unit/core/test_snap_unfloat_fallback.cpp
@@ -229,6 +229,96 @@ private Q_SLOTS:
                  "off → not-found even though zoneGeometry is valid in this GUI fixture");
         m_wts->setSnapState(nullptr);
     }
+
+    // ── SnapToZone placement-rule precedence ────────────────────────────────
+    // A matched SnapToZone rule (the daemon-injected placement-zones resolver) is
+    // the highest-priority restore: it overrides a remembered placement record on
+    // open. The store still re-binds the record FIRST, so the window's float-back
+    // geometry survives the override (a later Meta+F floats it to its remembered
+    // free position, not the zone rect). Lives in this GUI fixture because the
+    // rule's snap only resolves with valid zone geometry.
+    void testResolveWindowRestore_placementRule_beatsFloatedRecord_preservesFreeGeo()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        installLayout(3);
+        engine.setPlacementZonesResolver([](const QString&) {
+            return QList<int>{2, 3};
+        });
+
+        // A remembered FLOATED record on DP-1 carrying the window's free position.
+        const QRect floatGeo(120, 80, 800, 600);
+        PhosphorEngine::WindowPlacement rec;
+        rec.windowId = QStringLiteral("app|orig");
+        rec.appId = QStringLiteral("app");
+        rec.screenId = QStringLiteral("DP-1");
+        PhosphorEngine::EngineSlot slot;
+        slot.state = PhosphorEngine::WindowPlacement::stateFloating();
+        rec.engines.insert(PhosphorEngine::WindowPlacement::snapEngineId(), slot);
+        rec.freeGeometryByScreen.insert(QStringLiteral("DP-1"), floatGeo);
+        m_wts->placementStore().record(rec);
+
+        // KWin reopens the window with a new uuid on the same screen.
+        const PhosphorEngine::SnapResult result =
+            engine.resolveWindowRestore(QStringLiteral("app|new"), QStringLiteral("DP-1"), /*sticky*/ false);
+
+        // The rule wins over the stored floated record: snap to the two rule zones.
+        QVERIFY2(result.shouldSnap, "a SnapToZone rule must override a remembered floated record");
+        QCOMPARE(result.zoneIds.size(), 2);
+
+        // The record was re-bound to the live id with its float-back geometry
+        // intact, so a later float returns to the remembered free position — NOT
+        // the zone rect the rule just snapped to.
+        QVERIFY2(m_wts->placementStore().contains(QStringLiteral("app|new"), QStringLiteral("app")),
+                 "the placement record must be re-bound to the live window id");
+        const auto rebound = m_wts->placementStore().peek(QStringLiteral("app|new"), QStringLiteral("app"));
+        QVERIFY(rebound.has_value());
+        QCOMPARE(rebound->freeGeometryFor(QStringLiteral("DP-1")), floatGeo);
+        m_wts->setSnapState(nullptr);
+    }
+
+    // A SnapToZone rule snaps a fresh window that has no stored record at all
+    // (nothing to inherit, so no float-back to preserve).
+    void testResolveWindowRestore_placementRule_noRecord_snaps()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        installLayout(3);
+        engine.setPlacementZonesResolver([](const QString&) {
+            return QList<int>{1};
+        });
+
+        const PhosphorEngine::SnapResult result =
+            engine.resolveWindowRestore(QStringLiteral("fresh|win"), QStringLiteral("DP-1"), /*sticky*/ false);
+
+        QVERIFY2(result.shouldSnap, "a SnapToZone rule must snap a fresh window with no stored record");
+        QCOMPARE(result.zoneIds.size(), 1);
+        m_wts->setSnapState(nullptr);
+    }
+
+    // An empty resolver result (no matching rule) must NOT snap — the window
+    // falls through to the normal restore/float path.
+    void testResolveWindowRestore_placementRule_emptyResolver_doesNotSnap()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        installLayout(3);
+        engine.setPlacementZonesResolver([](const QString&) {
+            return QList<int>{};
+        });
+
+        const PhosphorEngine::SnapResult result =
+            engine.resolveWindowRestore(QStringLiteral("nomatch|win"), QStringLiteral("DP-1"), /*sticky*/ false);
+
+        QVERIFY2(!result.shouldSnap, "no matching rule → the placement rule must not snap the window");
+        m_wts->setSnapState(nullptr);
+    }
 };
 
 QTEST_MAIN(TestSnapUnfloatFallback)

--- a/tests/unit/core/test_window_identity.cpp
+++ b/tests/unit/core/test_window_identity.cpp
@@ -327,7 +327,7 @@ private Q_SLOTS:
     }
 
     // =====================================================================
-    // appIdMatches — segment-aware pattern matching used by Layout::matchAppRule
+    // appIdMatches — segment-aware pattern matching for app/window-class patterns
     //
     // The semantics here are subtle enough that the inline header comment
     // is the spec; these tests pin it so future refactors can't quietly


### PR DESCRIPTION
Adds a window-rule action that snaps matched windows into one or more zones on open, unifying app→zone placement into the window-rule system (discussion #646). Multiple zone ordinals snap to their combined area, which the old single-zone per-layout app rules never supported.

## What changed

**New `SnapToZone` rule action** (`phosphor-window-rules`)
- `ActionType::SnapToZone` (slot `Placement`, domain Window) carrying a non-empty JSON array of 1-based zone ordinals. Ordinals are layout-agnostic ("zone N of whatever layout is active on the window's screen"), matching the `snapToZone1..9` shortcuts. New `zoneOrdinals` param kind. Validator pinned at the `fromJson` boundary (rejects empty/non-integral/out-of-range; the ordinal cap `MaxZoneOrdinal = 64` is shared with the migration, the daemon re-validation, and the settings editor).

**Daemon placement**
- `SnapEngine` gains a `PlacementZonesResolver`; the WTA resolves the `Placement` slot to ordinals (`placementZonesByRule`, mirroring `shouldFloatByRule`) and `calculateSnapToPlacementRule` unions the zone geometries on the window's screen. Runtime placement now flows solely through the window-rule store.

**Precedence** (from live testing)
- A matched rule outranks any remembered placement on open. The store still re-binds the window's record first, so the float-back geometry survives the override.
- Meta+F un-float targets the rule's zones, then the pre-float zone, then the fallback zone.
- Capture never records a snap rect as float-back geometry (fixes a window that opened directly snapped, then floated without moving, cementing the zone rect as its free position).

**Migration** — `finalizeV4Conversion` reads each layout file's legacy `appRules` and emits one `SnapToZone` rule per assignment (`AppId appIdMatches <pattern> → SnapToZone [zone]`), deduping patterns case-insensitively across layouts. `AppId`/`AppIdMatches` mirrors the retired `Layout::matchAppRule` (which matched the pattern against the window's appId) and the daemon placement path, which resolves on appId — windowClass is not tracked daemon-side. The legacy `targetScreen` is intentionally **not** carried over as a screen constraint: the runtime resolves a SnapToZone rule on the window's current screen, and pinning would require matching the canonical screen-id form the daemon reports (which a deterministic JSON migration cannot derive without coupling to live screen state). A migrated app snaps to its zone on whatever screen it opens on; v3 cross-screen routing was already retired. (Users can still scope a hand-authored SnapToZone rule to a monitor with a `ScreenId` match leaf, which the settings screen-picker stores in the canonical form.)

**Retire** — removed the per-layout `Layout::appRules` / `matchAppRule` / `AppRuleMatch` model and its serialization. KZones import now produces `AppId appIdMatches <app> → SnapToZone [zone]` window rules instead of dead per-layout app rules. Clean single-system end-state.

**Settings UI** — zone-ordinal editor in `ActionRow` (accepts `1, 2`, `1;2`, ranges like `1-3`; ranges clamp to the ordinal cap; clearing the field keeps the last valid value rather than committing an empty list), action/param/summary labels, read-only list rendering.

## Tests
- `test_ruleaction`: `SnapToZone` validator at the load boundary (incl. the inclusive 64 / exclusive 65 cap boundary and the out-of-range-double UB guard).
- `test_migration_v3_to_v4`: layout `appRules` → `SnapToZone` rules, cross-layout dedup, and deterministic-id idempotency.
- `test_snap_unfloat_fallback`: rule beats a remembered floated record (with float-back geometry preserved), snaps a fresh window, and an empty resolver does not snap.

Build clean, 247/247 tests pass.

## Known limitations
- File-size guideline (CLAUDE.md "keep files under 800 lines"): `SnapEngine.h` grew to 837 lines (from 596) from the placement-resolver API and its documentation; `ActionRow.qml` (888) and `ruleaction.cpp` (867) were already over 800 before this PR. A header / QML-component split is deferred to a dedicated refactor rather than churned into this feature PR, consistent with the codebase's existing large files (e.g. `configmigration.cpp` ~2965, `shader_transitions.cpp` ~1829).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
