### PR TITLE
feat(settings): input hints for the window-rule editor

### DIFF
--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -63,6 +63,21 @@ ColumnLayout {
     readonly property var _typeEntry: row._entryForType(row.action.type)
     /// Parameter descriptors for the current type (empty when none / unknown).
     readonly property var _params: row._typeEntry !== undefined ? row._typeEntry.params : []
+    /// Combined input-format hint(s) for the current params — the optional
+    /// `param.hint` strings from the action metadata (windowruleauthoring's
+    /// paramHint), joined one per line. Empty when no param carries a hint.
+    /// Surfaces the accepted syntax (e.g. zone-number lists / ranges) that a
+    /// placeholder can't show once the field holds a value; there is no
+    /// per-type ladder here — a param gets a hint only if its descriptor does.
+    readonly property string _paramHint: {
+        var parts = [];
+        for (var i = 0; i < row._params.length; i++) {
+            var h = row._params[i].hint;
+            if (h !== undefined && h.length > 0)
+                parts.push(h);
+        }
+        return parts.join("\n");
+    }
     /// Shader-uniform schema for the action's currently-selected effect. Empty
     /// when the action is not a shader-override, no effect is set, or the
     /// effect declares no parameters. Drives the inline shader editor below
@@ -416,6 +431,23 @@ ColumnLayout {
             Accessible.name: i18n("Remove this action")
             onClicked: row.removeRequested()
         }
+    }
+
+    // ── Input-format hint for the current params ─────────────────────────────
+    // A muted helper line under the editor row, shown only when a param carries
+    // a `hint` (e.g. SnapToZone's zone-ordinal syntax). Indented to align under
+    // the editors, mirroring the shader-parameter editor's left margin. Plain
+    // text, word-wrapped; never interactive.
+    Label {
+        Layout.fillWidth: true
+        Layout.leftMargin: Kirigami.Units.iconSizes.small + Kirigami.Units.smallSpacing
+        visible: row._paramHint.length > 0
+        text: row._paramHint
+        font: Kirigami.Theme.smallFont
+        color: Kirigami.Theme.disabledTextColor
+        wrapMode: Text.WordWrap
+        textFormat: Text.PlainText
+        Accessible.ignored: true
     }
 
     // ── Bottom: shader-parameter editor for the shader-override actions ──────

--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -299,31 +299,57 @@ RowLayout {
     Component {
         id: stringValueEditor
 
-        // RowLayout root so the Loader sizes the editor to the available
-        // width and the "pick from running windows" button can sit next to
-        // the freeform field. The button only appears for fields where a
-        // live-window lookup makes sense — typing an AppId / windowClass
-        // from memory is the friction the picker existed to solve.
-        RowLayout {
-            spacing: Kirigami.Units.smallSpacing
+        // ColumnLayout root so an operator-specific input hint (regex syntax /
+        // app-id-match semantics) can sit beneath the freeform field. The inner
+        // RowLayout keeps the "pick from running windows" button next to the
+        // field — that button only appears for fields where a live-window lookup
+        // makes sense (typing an AppId / windowClass from memory is the friction
+        // the picker existed to solve).
+        ColumnLayout {
+            id: stringEditorRoot
 
-            TextField {
-                Accessible.name: i18n("Match value")
+            spacing: Kirigami.Units.smallSpacing / 2
+
+            // Operator-keyed input hint (regex / app-id match); empty for
+            // operators that need none. Re-reads when the operator changes.
+            readonly property string _valueHint: leaf.controller ? leaf.controller.matchValueHint(leaf.node.op) : ""
+
+            RowLayout {
                 Layout.fillWidth: true
-                placeholderText: i18n("Value")
-                text: leaf.node.value !== undefined ? String(leaf.node.value) : ""
-                onEditingFinished: leaf._emit(leaf.node.field, leaf.node.op, text)
+                spacing: Kirigami.Units.smallSpacing
+
+                TextField {
+                    Accessible.name: i18n("Match value")
+                    Layout.fillWidth: true
+                    placeholderText: i18n("Value")
+                    text: leaf.node.value !== undefined ? String(leaf.node.value) : ""
+                    onEditingFinished: leaf._emit(leaf.node.field, leaf.node.op, text)
+                }
+
+                ToolButton {
+                    Accessible.name: leaf._pickTooltip(leaf.node.field)
+                    Layout.alignment: Qt.AlignVCenter
+                    ToolTip.delay: 500
+                    ToolTip.text: leaf._pickTooltip(leaf.node.field)
+                    ToolTip.visible: hovered
+                    icon.name: "window-duplicate"
+                    visible: leaf._fieldIsPickable(leaf.node.field)
+                    onClicked: leaf._openWindowPicker()
+                }
             }
 
-            ToolButton {
-                Accessible.name: leaf._pickTooltip(leaf.node.field)
-                Layout.alignment: Qt.AlignVCenter
-                ToolTip.delay: 500
-                ToolTip.text: leaf._pickTooltip(leaf.node.field)
-                ToolTip.visible: hovered
-                icon.name: "window-duplicate"
-                visible: leaf._fieldIsPickable(leaf.node.field)
-                onClicked: leaf._openWindowPicker()
+            // Muted helper line under the value field; only present when the
+            // current operator carries a hint. Plain text, word-wrapped, never
+            // interactive. Mirrors the action-param hint in ActionRow.
+            Label {
+                Layout.fillWidth: true
+                visible: stringEditorRoot._valueHint.length > 0
+                text: stringEditorRoot._valueHint
+                font: Kirigami.Theme.smallFont
+                color: Kirigami.Theme.disabledTextColor
+                wrapMode: Text.WordWrap
+                textFormat: Text.PlainText
+                Accessible.ignored: true
             }
         }
     }

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -309,6 +309,23 @@ QString paramLabel(const QString& type, const QString& key)
     return key;
 }
 
+/// Optional translated input hint for action @p type, param @p key — a short line
+/// of guidance shown beneath the editor for params whose accepted input format is
+/// not obvious from the control itself (e.g. the free-text zone-ordinal list).
+/// Returns an empty string for params that need no hint (pickers, spin boxes,
+/// toggles, colour swatches are self-explanatory). Mirrors paramLabel — keyed on
+/// `(type, key)` so the hint stays next to the label it explains.
+QString paramHint(const QString& type, const QString& key)
+{
+    namespace ActionParam = PhosphorWindowRules::ActionParam;
+    if (type == ActionType::SnapToZone && key == ActionParam::Zones) {
+        return PhosphorI18n::tr(
+            "Zone numbers like “1, 2”, or a range like “1-3”. "
+            "Multiple zones snap the window to their combined area.");
+    }
+    return {};
+}
+
 /// Translated label for one enum wire value on action @p type, param @p key.
 /// Mirrors paramLabel — structural enum membership lives on the descriptor;
 /// the human-facing label is per `(type, key, wireValue)`.
@@ -361,6 +378,9 @@ QVariantList paramsForActionTypeImpl(const QString& type)
         p[QStringLiteral("key")] = schema.key;
         p[QStringLiteral("kind")] = schema.kind;
         p[QStringLiteral("label")] = paramLabel(type, schema.key);
+        if (const QString hint = paramHint(type, schema.key); !hint.isEmpty()) {
+            p[QStringLiteral("hint")] = hint;
+        }
         if (schema.min.has_value()) {
             p[QStringLiteral("min")] = *schema.min;
         }
@@ -669,6 +689,22 @@ QVariantList allOperators()
         out.append(entry);
     }
     return out;
+}
+
+QString matchValueHint(const QString& op)
+{
+    // Keyed on the operator wire token: only the operators whose value editor is
+    // a plain text box AND whose accepted syntax / matching semantics aren't
+    // obvious get a hint. equals / contains / starts-with / ends-with are
+    // self-explanatory; the picker / spin-box operators have no free-text field
+    // to annotate. The match-side counterpart to the action-side paramHint.
+    if (op == PhosphorWindowRules::operatorToString(Operator::Regex)) {
+        return PhosphorI18n::tr("Regular expression, e.g. ^(firefox|chromium)$");
+    }
+    if (op == PhosphorWindowRules::operatorToString(Operator::AppIdMatches)) {
+        return PhosphorI18n::tr("Matches by reverse-DNS segments — “firefox” also matches “org.mozilla.firefox”.");
+    }
+    return {};
 }
 
 QVariantList actionTypes()

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -702,7 +702,7 @@ QString matchValueHint(const QString& op)
         return PhosphorI18n::tr("Regular expression, e.g. ^(firefox|chromium)$");
     }
     if (op == PhosphorWindowRules::operatorToString(Operator::AppIdMatches)) {
-        return PhosphorI18n::tr("Matches by reverse-DNS segments — “firefox” also matches “org.mozilla.firefox”.");
+        return PhosphorI18n::tr("Matches by reverse-DNS segments, so “firefox” also matches “org.mozilla.firefox”.");
     }
     return {};
 }

--- a/src/settings/windowruleauthoring.h
+++ b/src/settings/windowruleauthoring.h
@@ -27,6 +27,13 @@ QVariantList operatorsForField(int fieldValue);
 /// operator subset — changes.
 QVariantList allOperators();
 
+/// Optional translated input hint for a match condition's value editor, keyed on
+/// the operator wire token @p op (the leaf's `node.op`). Non-empty only for
+/// operators whose value editor is a free-text box and whose syntax / matching
+/// semantics aren't obvious (regex, app-id match); empty otherwise. The
+/// match-side counterpart to the action-param hints.
+QString matchValueHint(const QString& op);
+
 /// Registered action types for the action-editor dropdown. Each entry:
 /// `{ value: QString (action type id), label, params: [ ... ],
 ///    domain: "context"|"window" }`. See `WindowRuleController::actionTypes`

--- a/src/settings/windowrulecontroller.h
+++ b/src/settings/windowrulecontroller.h
@@ -284,6 +284,13 @@ public:
     /// Same entry shape as operatorsForField.
     Q_INVOKABLE QVariantList allOperators() const;
 
+    /// Optional input hint for a match condition's value editor, keyed on the
+    /// operator wire token @p op (the leaf's `node.op`) — empty when the operator
+    /// needs none. Shown beneath the value field for operators whose syntax or
+    /// matching semantics aren't obvious from a plain text box (regex, app-id
+    /// match). The match-side counterpart to the per-param action hints.
+    Q_INVOKABLE QString matchValueHint(const QString& op) const;
+
     /// Registered action types for the action-editor dropdown. Each entry:
     /// `{ value: QString (action type id), label, params: [ ... ],
     ///   domain: "context"|"window" }` where each param descriptor is

--- a/src/settings/windowrulecontroller_views.cpp
+++ b/src/settings/windowrulecontroller_views.cpp
@@ -318,6 +318,11 @@ QVariantList WindowRuleController::allOperators() const
     return WindowRuleAuthoring::allOperators();
 }
 
+QString WindowRuleController::matchValueHint(const QString& op) const
+{
+    return WindowRuleAuthoring::matchValueHint(op);
+}
+
 QVariantList WindowRuleController::actionTypes() const
 {
     return WindowRuleAuthoring::actionTypes();

--- a/tests/unit/settings/test_window_rule_controller.cpp
+++ b/tests/unit/settings/test_window_rule_controller.cpp
@@ -57,6 +57,7 @@ private Q_SLOTS:
     void userAuthorableFilterHidesInternalActions();
     void moveRuleReorders();
     void authoringMetadata();
+    void inputHints();
     void templatesProduceSeededRules();
     void actionTypesCarryDomain();
     void matchIsContextOnlyClassifies();
@@ -897,6 +898,49 @@ void TestWindowRuleController::authoringMetadata()
     QCOMPARE(actionCategoryOrder.value(QStringLiteral("exclude")), 2); // Window
     QCOMPARE(actionCategoryOrder.value(QStringLiteral("setOpacity")), 3); // Appearance
     QCOMPARE(actionCategoryOrder.value(QStringLiteral("excludeAnimations")), 4); // Animation
+}
+
+void TestWindowRuleController::inputHints()
+{
+    WindowRuleController controller;
+
+    // Match-condition value hints are keyed on the operator wire token: the
+    // operators whose value editor is a plain text box AND whose syntax /
+    // matching semantics aren't obvious carry a hint; the self-explanatory ones
+    // (and the picker / spin-box operators) carry none. Pins the QML contract —
+    // MatchLeafEditor calls matchValueHint(node.op) and shows the result beneath
+    // the value field — so a regression that drops or widens it is caught.
+    QVERIFY2(!controller.matchValueHint(QStringLiteral("regex")).isEmpty(),
+             "the regex operator must carry an input hint");
+    QVERIFY2(!controller.matchValueHint(QStringLiteral("appIdMatches")).isEmpty(),
+             "the app-id-match operator must carry an input hint");
+    QVERIFY2(controller.matchValueHint(QStringLiteral("equals")).isEmpty(),
+             "equals is self-explanatory and must carry no hint");
+    QVERIFY2(controller.matchValueHint(QStringLiteral("contains")).isEmpty(),
+             "contains is self-explanatory and must carry no hint");
+    QVERIFY2(controller.matchValueHint(QString()).isEmpty(), "an empty operator token yields no hint");
+
+    // The SnapToZone action's `zones` param carries an input hint (its free-text
+    // ordinal-list syntax isn't discoverable from the field). The hint rides on
+    // the param descriptor in actionTypes() — ActionRow reads `param.hint`.
+    const QVariantList actions = controller.actionTypes();
+    bool sawSnapToZoneZones = false;
+    for (const QVariant& a : actions) {
+        const QVariantMap action = a.toMap();
+        if (action.value(QStringLiteral("value")).toString() != QLatin1String("snapToZone")) {
+            continue;
+        }
+        for (const QVariant& p : action.value(QStringLiteral("params")).toList()) {
+            const QVariantMap param = p.toMap();
+            if (param.value(QStringLiteral("key")).toString() != QLatin1String("zones")) {
+                continue;
+            }
+            sawSnapToZoneZones = true;
+            QVERIFY2(!param.value(QStringLiteral("hint")).toString().isEmpty(),
+                     "SnapToZone's zones param must carry an input hint");
+        }
+    }
+    QVERIFY2(sawSnapToZoneZones, "actionTypes() must expose the SnapToZone zones param");
 }
 
 void TestWindowRuleController::templatesProduceSeededRules()


### PR DESCRIPTION
## Input hints for the window-rule editor

Several rule-editor inputs are free-text fields whose accepted syntax isn't discoverable from the control. The most acute is the **SnapToZone** zone list — its placeholder never shows because the field is pre-seeded with a default — but the **regex** and **app-id-match** operators on a match condition are just as opaque (a blank text box with no indication of the expected format). This adds a small, metadata-driven hint mechanism and populates the inputs that need it.

### What changed

**Action params** — a new `paramHint(type, key)` accessor (mirroring the existing `paramLabel`) attaches an optional `hint` to each param's metadata. `ActionRow` renders the current params' hints as a muted helper line under the editor row. There is no per-type ladder in QML — a param shows a hint only if its descriptor carries one.
- **SnapToZone · zones**: *Zone numbers like "1, 2", or a range like "1-3". Multiple zones snap the window to their combined area.*

**Match conditions** — a new `matchValueHint(op)` accessor (`Q_INVOKABLE` on the controller), keyed on the operator wire token. `MatchLeafEditor`'s string value editor renders it beneath the field, re-reading when the operator changes.
- **Matches (regex)**: *Regular expression, e.g. `^(firefox|chromium)$`*
- **Matches app id** (`AppIdMatches`): *Matches by reverse-DNS segments — "firefox" also matches "org.mozilla.firefox"*

The self-explanatory operators (equals / contains / starts-with / ends-with) and the picker / spin-box value editors get nothing.

### Notes

- This is complementary to the existing per-field info-icon tooltip (`fieldDescription`): that explains *what a field is* ("AppId = the application's ID"); these hints explain *the operator/param's input format*.
- `In` was deliberately left out: the value editor is chosen by the field's kind, not the operator, so `In` renders a picker (Screen/Activity) or a single-value spin box (Virtual desktop) — none accept a list, so a "comma-separated list" hint would point at a control that can't take one. Making `In` accept multiple values is a separate editor change.
- Both sides share one shape (a C++ `*Hint` accessor → muted, word-wrapped, non-interactive helper `Label`), so adding more hints later is a one-line change. New strings are translatable via `PhosphorI18n::tr`.

Build clean, 247/247 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Known limitations
- File-size guideline (CLAUDE.md "<800 lines"): `ActionRow.qml` (920) and `windowruleauthoring.cpp` (854) were already over 800 before this PR; the hint additions (+32 / +36) nudge them further. The hint accessors belong next to `paramLabel` in that file, and a split is a separate refactor, deferred rather than churned into this UX PR.
