### PR TITLE
fix(snap): re-identify snap state across an effect-restart class mutation (#628)

### DIFF
--- a/libs/phosphor-engine/include/PhosphorEngine/IWindowTrackingService.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IWindowTrackingService.h
@@ -69,6 +69,12 @@ public:
     virtual const QHash<QString, QString>& screenAssignments() const = 0;
     virtual QString zoneForWindow(const QString& windowId) const = 0;
     virtual QStringList zonesForWindow(const QString& windowId) const = 0;
+    /// The screen a window is assigned to (empty when none), canonicalizing the
+    /// id — the point accessor callers use instead of screenAssignments().value()
+    /// so a window resolves across the effect-restart re-identification skew (#628).
+    virtual QString screenForWindow(const QString& windowId) const = 0;
+    /// Same, returning @p defaultScreen when the window has no assignment.
+    virtual QString screenForWindow(const QString& windowId, const QString& defaultScreen) const = 0;
     virtual QStringList windowsInZone(const QString& zoneId) const = 0;
     virtual bool isWindowSnapped(const QString& windowId) const = 0;
     virtual QString findEmptyZone(const QString& screenId = QString()) const = 0;

--- a/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
+++ b/libs/phosphor-placement/include/PhosphorPlacement/WindowTrackingService.h
@@ -310,6 +310,18 @@ public:
      */
     QStringList zonesForWindow(const QString& windowId) const override;
 
+    /// The screen a window is assigned to, or empty when it has none. Point
+    /// accessor over the screen-assignment map that canonicalizes @p windowId to
+    /// the first-seen composite (via SnapState), so external callers resolve a
+    /// window even after the effect-restart-after-class-mutation skew rather than
+    /// reading the raw whole-map getter with a stale composite (issue #628).
+    QString screenForWindow(const QString& windowId) const override;
+
+    /// Same, but returns @p defaultScreen when the window has no screen
+    /// assignment — the canonicalizing replacement for
+    /// `screenAssignments().value(windowId, defaultScreen)`.
+    QString screenForWindow(const QString& windowId, const QString& defaultScreen) const override;
+
     /**
      * @brief Get all windows in a specific zone
      * @param zoneId PhosphorZones::Zone UUID string

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -194,6 +194,24 @@ QStringList WindowTrackingService::zonesForWindow(const QString& windowId) const
     return m_snapState->zonesForWindow(windowId);
 }
 
+QString WindowTrackingService::screenForWindow(const QString& windowId) const
+{
+    // Delegates to SnapState, which canonicalizes the id — the canonicalizing
+    // point accessor external callers use instead of screenAssignments().value().
+    return m_snapState ? m_snapState->screenForWindow(windowId) : QString();
+}
+
+QString WindowTrackingService::screenForWindow(const QString& windowId, const QString& defaultScreen) const
+{
+    if (!m_snapState) {
+        return defaultScreen;
+    }
+    // A screen assignment is never the empty string, so "empty" means "no
+    // assignment" — equivalent to the absent-key branch of value(key, default).
+    const QString screen = m_snapState->screenForWindow(windowId);
+    return screen.isEmpty() ? defaultScreen : screen;
+}
+
 QStringList WindowTrackingService::windowsInZone(const QString& zoneId) const
 {
     Q_ASSERT(m_snapState);
@@ -210,11 +228,22 @@ QStringList WindowTrackingService::snappedWindows() const
     return m_snapState->snappedWindows();
 }
 
-int WindowTrackingService::pruneStaleAssignments(const QSet<QString>& aliveWindowIds)
+int WindowTrackingService::pruneStaleAssignments(const QSet<QString>& rawAliveWindowIds)
 {
     Q_ASSERT(m_snapState);
     if (!m_snapState)
         return 0;
+    // Canonicalize the alive set so it compares like-for-like against the
+    // canonical-keyed stores (the WTS-owned sticky / legacy-float sets below, and
+    // SnapState's maps). Otherwise a window still alive under a mutated-class
+    // composite would be pruned because its stored key is the first-seen one
+    // (issue #628). SnapState::pruneStaleAssignments re-canonicalizes defensively,
+    // so passing the canonical set there is correct too.
+    QSet<QString> aliveWindowIds;
+    aliveWindowIds.reserve(rawAliveWindowIds.size());
+    for (const QString& id : rawAliveWindowIds) {
+        aliveWindowIds.insert(canonicalizeForLookup(id));
+    }
     int pruned = m_snapState->pruneStaleAssignments(aliveWindowIds);
 
     int wtsCleaned = 0;
@@ -672,14 +701,18 @@ bool WindowTrackingService::clearFloatingForSnap(const QString& windowId)
 // Sticky Window Handling
 // ═══════════════════════════════════════════════════════════════════════════════
 
-void WindowTrackingService::setWindowSticky(const QString& windowId, bool sticky)
+void WindowTrackingService::setWindowSticky(const QString& rawWindowId, bool sticky)
 {
-    m_windowStickyStates[windowId] = sticky;
+    // Canonicalize so sticky state survives the effect-restart-after-class-mutation
+    // re-identification skew (issue #628). The daemon seeds the canonical mapping
+    // in setWindowMetadata, so canonicalizeForLookup resolves to the first-seen
+    // composite without seeding here.
+    m_windowStickyStates[canonicalizeForLookup(rawWindowId)] = sticky;
 }
 
-bool WindowTrackingService::isWindowSticky(const QString& windowId) const
+bool WindowTrackingService::isWindowSticky(const QString& rawWindowId) const
 {
-    return m_windowStickyStates.value(windowId, false);
+    return m_windowStickyStates.value(canonicalizeForLookup(rawWindowId), false);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -206,8 +206,10 @@ QString WindowTrackingService::screenForWindow(const QString& windowId, const QS
     if (!m_snapState) {
         return defaultScreen;
     }
-    // A screen assignment is never the empty string, so "empty" means "no
-    // assignment" — equivalent to the absent-key branch of value(key, default).
+    // Return defaultScreen when the window has no usable (non-empty) screen
+    // assignment. Callers (snap commit / unfloat) always record a real screen, so
+    // in practice this matches the old screenAssignments().value(windowId,
+    // defaultScreen) idiom while also canonicalizing the id (issue #628).
     const QString screen = m_snapState->screenForWindow(windowId);
     return screen.isEmpty() ? defaultScreen : screen;
 }
@@ -705,8 +707,8 @@ void WindowTrackingService::setWindowSticky(const QString& rawWindowId, bool sti
 {
     // Canonicalize so sticky state survives the effect-restart-after-class-mutation
     // re-identification skew (issue #628). The daemon seeds the canonical mapping
-    // in setWindowMetadata, so canonicalizeForLookup resolves to the first-seen
-    // composite without seeding here.
+    // in WindowTrackingAdaptor::setWindowMetadata, so canonicalizeForLookup
+    // resolves to the first-seen composite without seeding here.
     m_windowStickyStates[canonicalizeForLookup(rawWindowId)] = sticky;
 }
 
@@ -735,8 +737,10 @@ const QHash<QString, QStringList>& WindowTrackingService::zoneAssignments() cons
 QStringList WindowTrackingService::recordedSnapZones(const QString& windowId) const
 {
     // Prefer the live, runtime assignment — it reflects this session's snaps.
+    // Go through the canonicalizing point accessor (not the raw whole-map getter)
+    // so a class-mutated window still resolves its live zones (issue #628).
     if (m_snapState) {
-        const QStringList live = m_snapState->zoneAssignments().value(windowId);
+        const QStringList live = m_snapState->zonesForWindow(windowId);
         if (!live.isEmpty()) {
             return live;
         }

--- a/libs/phosphor-placement/src/lifecycle.cpp
+++ b/libs/phosphor-placement/src/lifecycle.cpp
@@ -675,8 +675,10 @@ void WindowTrackingService::windowClosed(const QString& windowId, PhosphorEngine
     if (appId != windowId) {
         m_snapState->clearPreFloatZone(appId);
     }
-    // Remove sticky-window tracking outright — do NOT migrate to appId.
-    m_windowStickyStates.remove(windowId);
+    // Remove sticky-window tracking outright — do NOT migrate to appId. The
+    // sticky map is keyed on the canonical (first-seen) composite, so remove
+    // under it (issue #628).
+    m_windowStickyStates.remove(canonicalizeForLookup(windowId));
 
     scheduleSaveState();
 }

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
@@ -5,6 +5,7 @@
 
 #include <phosphorsnapengine_export.h>
 #include <PhosphorEngine/IPlacementState.h>
+#include <PhosphorEngine/IWindowRegistry.h>
 
 #include <QHash>
 #include <QJsonObject>
@@ -38,6 +39,19 @@ public:
 
     SnapState(const SnapState&) = delete;
     SnapState& operator=(const SnapState&) = delete;
+
+    /// Attach the daemon's shared window registry so every windowId-keyed
+    /// accessor can canonicalize the incoming id to the stable first-seen
+    /// composite (instanceId → first observed `appId|instanceId`). This makes
+    /// the snap stores immune to the cross-process re-identification skew where
+    /// the KWin effect restarts after a window's WM_CLASS mutated and re-derives
+    /// a different composite for the same window (issue #628). Borrowed pointer,
+    /// not owned (the daemon owns the registry); null in unit tests, in which
+    /// case the accessors key on the raw id verbatim (today's behaviour).
+    void setWindowRegistry(PhosphorEngine::IWindowRegistry* registry)
+    {
+        m_windowRegistry = registry;
+    }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // IPlacementState
@@ -289,6 +303,14 @@ Q_SIGNALS:
     void stateChanged();
 
 private:
+    /// Resolve a raw windowId to its canonical (first-seen) composite for the
+    /// stable instance id, WITHOUT seeding — the daemon seeds once per window in
+    /// setWindowMetadata, so every snap accessor here only looks up. Returns the
+    /// input verbatim when the instance has no canonical entry (or no registry is
+    /// attached, e.g. unit tests), which also makes the bare-appId alias writes
+    /// (addPreFloat*/clearPreFloatZone) safe. See the .cpp header comment.
+    QString canonicalizeForLookup(const QString& rawWindowId) const;
+
     bool removeWindowData(const QString& windowId);
 
     /// Shared body of unassignWindow / unsnapForFloat. Removes the window's
@@ -313,6 +335,9 @@ private:
     }
 
     QString m_screenId;
+
+    /// Borrowed; not owned. See setWindowRegistry. Null in unit tests.
+    PhosphorEngine::IWindowRegistry* m_windowRegistry = nullptr;
 
     QHash<QString, QStringList> m_windowZoneAssignments;
     QHash<QString, QString> m_windowScreenAssignments;

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
@@ -305,10 +305,11 @@ Q_SIGNALS:
 private:
     /// Resolve a raw windowId to its canonical (first-seen) composite for the
     /// stable instance id, WITHOUT seeding — the daemon seeds once per window in
-    /// setWindowMetadata, so every snap accessor here only looks up. Returns the
-    /// input verbatim when the instance has no canonical entry (or no registry is
-    /// attached, e.g. unit tests), which also makes the bare-appId alias writes
-    /// (addPreFloat*/clearPreFloatZone) safe. See the .cpp header comment.
+    /// WindowTrackingAdaptor::setWindowMetadata, so every snap accessor here only
+    /// looks up. Returns the input verbatim when the instance has no canonical
+    /// entry (or no registry is attached, e.g. unit tests), which also makes the
+    /// bare-appId alias writes (addPreFloat*/clearPreFloatZone) safe. See the
+    /// .cpp header comment.
     QString canonicalizeForLookup(const QString& rawWindowId) const;
 
     bool removeWindowData(const QString& windowId);

--- a/libs/phosphor-snap-engine/src/SnapEngine.cpp
+++ b/libs/phosphor-snap-engine/src/SnapEngine.cpp
@@ -270,7 +270,7 @@ void SnapEngine::reapplyManagedWindowAppearance()
         if (zoneIds.isEmpty()) {
             continue;
         }
-        const QString screenId = m_snapState->screenAssignments().value(windowId);
+        const QString screenId = m_snapState->screenForWindow(windowId);
         if (screenId.isEmpty()) {
             continue;
         }

--- a/libs/phosphor-snap-engine/src/SnapState.cpp
+++ b/libs/phosphor-snap-engine/src/SnapState.cpp
@@ -15,6 +15,36 @@ SnapState::SnapState(const QString& screenId, QObject* parent)
 
 SnapState::~SnapState() = default;
 
+// ── Window-id canonicalization ──────────────────────────────────────────────
+//
+// The KWin effect freezes a window's composite id `appId|instanceId` at first
+// observation, but that freeze is per effect process. If the effect restarts
+// while a window's WM_CLASS mutated during downtime (Electron/CEF apps rename
+// their class after mapping), the restarted effect re-derives a DIFFERENT
+// composite (`appId'|instanceId`) for the same window, while the daemon's snap
+// stores still hold the old `appId|instanceId`. Canonicalizing every store key
+// through the shared registry (instanceId → first-seen composite) re-unifies the
+// two: the stable instanceId never changes, so both composites resolve to the
+// first-seen one. Mirrors AutotileEngine, which already does this for tiling
+// state (issue #628).
+//
+// SnapState only ever LOOKS UP (never seeds): the daemon seeds the canonical
+// mapping once per window in WindowTrackingAdaptor::setWindowMetadata (the
+// universal window-open choke point), so by the time any snap accessor runs the
+// window already has a canonical entry. Looking up (rather than seeding) here is
+// also what keeps the appId-alias writes safe — the pre-float session-restore
+// fallback passes a BARE appId (no instance id) to addPreFloat*/clearPreFloatZone,
+// and a no-seed lookup returns it verbatim instead of polluting the registry's
+// instance map with an appId-keyed entry that would never be released.
+
+QString SnapState::canonicalizeForLookup(const QString& rawWindowId) const
+{
+    if (m_windowRegistry) {
+        return m_windowRegistry->canonicalizeForLookup(rawWindowId);
+    }
+    return rawWindowId;
+}
+
 // ── IPlacementState ─────────────────────────────────────────────────────────
 
 QString SnapState::screenId() const
@@ -35,13 +65,15 @@ QStringList SnapState::managedWindows() const
     return list;
 }
 
-bool SnapState::containsWindow(const QString& windowId) const
+bool SnapState::containsWindow(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     return m_windowZoneAssignments.contains(windowId) || m_floatingWindows.contains(windowId);
 }
 
-bool SnapState::isFloating(const QString& windowId) const
+bool SnapState::isFloating(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     return m_floatingWindows.contains(windowId);
 }
 
@@ -52,8 +84,9 @@ QStringList SnapState::floatingWindows() const
     return list;
 }
 
-QString SnapState::placementIdForWindow(const QString& windowId) const
+QString SnapState::placementIdForWindow(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     if (m_floatingWindows.contains(windowId)) {
         return {};
     }
@@ -133,9 +166,10 @@ QJsonObject SnapState::toJson() const
 
 // ── Zone Assignment CRUD ────────────────────────────────────────────────────
 
-void SnapState::assignWindowToZone(const QString& windowId, const QString& zoneId, const QString& screenId,
+void SnapState::assignWindowToZone(const QString& rawWindowId, const QString& zoneId, const QString& screenId,
                                    int virtualDesktop)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     if (zoneId.isEmpty()) {
         unassignWindow(windowId);
         return;
@@ -143,9 +177,10 @@ void SnapState::assignWindowToZone(const QString& windowId, const QString& zoneI
     assignWindowToZones(windowId, {zoneId}, screenId, virtualDesktop);
 }
 
-void SnapState::assignWindowToZones(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
+void SnapState::assignWindowToZones(const QString& rawWindowId, const QStringList& zoneIds, const QString& screenId,
                                     int virtualDesktop)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     if (windowId.isEmpty()) {
         return;
     }
@@ -182,13 +217,14 @@ void SnapState::assignWindowToZones(const QString& windowId, const QStringList& 
     }
 }
 
-SnapState::UnassignResult SnapState::unassignWindow(const QString& windowId)
+SnapState::UnassignResult SnapState::unassignWindow(const QString& rawWindowId)
 {
-    return clearZoneAssignment(windowId, /*preserveScreenAndDesktop=*/false);
+    return clearZoneAssignment(canonicalizeForLookup(rawWindowId), /*preserveScreenAndDesktop=*/false);
 }
 
-SnapState::UnassignResult SnapState::clearZoneAssignment(const QString& windowId, bool preserveScreenAndDesktop)
+SnapState::UnassignResult SnapState::clearZoneAssignment(const QString& rawWindowId, bool preserveScreenAndDesktop)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     UnassignResult result;
     QStringList previousZones = m_windowZoneAssignments.value(windowId);
     if (!m_windowZoneAssignments.remove(windowId)) {
@@ -211,18 +247,21 @@ SnapState::UnassignResult SnapState::clearZoneAssignment(const QString& windowId
     return result;
 }
 
-QString SnapState::screenForWindow(const QString& windowId) const
+QString SnapState::screenForWindow(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     return m_windowScreenAssignments.value(windowId);
 }
 
-int SnapState::desktopForWindow(const QString& windowId) const
+int SnapState::desktopForWindow(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     return m_windowDesktopAssignments.value(windowId, 0);
 }
 
-bool SnapState::reassignDesktop(const QString& windowId, int virtualDesktop)
+bool SnapState::reassignDesktop(const QString& rawWindowId, int virtualDesktop)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     // Only re-stamp a window that is actually assigned (has a zone); the
     // desktop attribute alone is meaningless without a snap slot.
     if (!m_windowZoneAssignments.contains(windowId)) {
@@ -252,8 +291,9 @@ QStringList SnapState::windowsOnScreenAndDesktop(const QString& screenId, int vi
     return result;
 }
 
-QString SnapState::zoneForWindow(const QString& windowId) const
+QString SnapState::zoneForWindow(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     const auto it = m_windowZoneAssignments.constFind(windowId);
     if (it == m_windowZoneAssignments.constEnd() || it->isEmpty()) {
         return {};
@@ -261,8 +301,9 @@ QString SnapState::zoneForWindow(const QString& windowId) const
     return it->first();
 }
 
-QStringList SnapState::zonesForWindow(const QString& windowId) const
+QStringList SnapState::zonesForWindow(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     return m_windowZoneAssignments.value(windowId);
 }
 
@@ -287,15 +328,17 @@ QStringList SnapState::snappedWindows() const
     return result;
 }
 
-bool SnapState::isWindowSnapped(const QString& windowId) const
+bool SnapState::isWindowSnapped(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     return m_windowZoneAssignments.contains(windowId);
 }
 
 // ── Floating State ──────────────────────────────────────────────────────────
 
-void SnapState::setFloating(const QString& windowId, bool floating)
+void SnapState::setFloating(const QString& rawWindowId, bool floating)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     bool changed = false;
     if (floating) {
         if (!m_floatingWindows.contains(windowId)) {
@@ -311,8 +354,9 @@ void SnapState::setFloating(const QString& windowId, bool floating)
     }
 }
 
-void SnapState::setFloatingOnScreen(const QString& windowId, const QString& screenId, int virtualDesktop)
+void SnapState::setFloatingOnScreen(const QString& rawWindowId, const QString& screenId, int virtualDesktop)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     if (windowId.isEmpty() || screenId.isEmpty()) {
         return;
     }
@@ -335,8 +379,9 @@ void SnapState::setFloatingOnScreen(const QString& windowId, const QString& scre
     }
 }
 
-SnapState::UnassignResult SnapState::unsnapForFloat(const QString& windowId)
+SnapState::UnassignResult SnapState::unsnapForFloat(const QString& rawWindowId)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     const auto zones = zonesForWindow(windowId);
     if (!zones.isEmpty()) {
         m_preFloatZoneAssignments[windowId] = zones;
@@ -358,30 +403,35 @@ SnapState::UnassignResult SnapState::unsnapForFloat(const QString& windowId)
     return clearZoneAssignment(windowId, /*preserveScreenAndDesktop=*/true);
 }
 
-QString SnapState::preFloatScreen(const QString& windowId) const
+QString SnapState::preFloatScreen(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     return m_preFloatScreenAssignments.value(windowId);
 }
 
-QString SnapState::preFloatZone(const QString& windowId) const
+QString SnapState::preFloatZone(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     const auto zones = m_preFloatZoneAssignments.value(windowId);
     return zones.isEmpty() ? QString() : zones.first();
 }
 
-QStringList SnapState::preFloatZones(const QString& windowId) const
+QStringList SnapState::preFloatZones(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     return m_preFloatZoneAssignments.value(windowId);
 }
 
-void SnapState::clearPreFloatZone(const QString& windowId)
+void SnapState::clearPreFloatZone(const QString& rawWindowId)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     m_preFloatZoneAssignments.remove(windowId);
     m_preFloatScreenAssignments.remove(windowId);
 }
 
-void SnapState::addPreFloatZone(const QString& windowId, const QStringList& zoneIds)
+void SnapState::addPreFloatZone(const QString& rawWindowId, const QStringList& zoneIds)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     if (m_preFloatZoneAssignments.value(windowId) == zoneIds) {
         return;
     }
@@ -389,8 +439,9 @@ void SnapState::addPreFloatZone(const QString& windowId, const QStringList& zone
     Q_EMIT stateChanged();
 }
 
-void SnapState::addPreFloatScreen(const QString& windowId, const QString& screenId)
+void SnapState::addPreFloatScreen(const QString& rawWindowId, const QString& screenId)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     if (m_preFloatScreenAssignments.value(windowId) == screenId) {
         return;
     }
@@ -400,8 +451,9 @@ void SnapState::addPreFloatScreen(const QString& windowId, const QString& screen
 
 // ── Window Lifecycle ────────────────────────────────────────────────────────
 
-bool SnapState::removeWindowData(const QString& windowId)
+bool SnapState::removeWindowData(const QString& rawWindowId)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     bool removed = false;
     removed |= m_windowZoneAssignments.remove(windowId);
     removed |= m_windowScreenAssignments.remove(windowId);
@@ -413,9 +465,9 @@ bool SnapState::removeWindowData(const QString& windowId)
     return removed;
 }
 
-void SnapState::windowClosed(const QString& windowId)
+void SnapState::windowClosed(const QString& rawWindowId)
 {
-    if (removeWindowData(windowId)) {
+    if (removeWindowData(canonicalizeForLookup(rawWindowId))) {
         Q_EMIT stateChanged();
     }
 }
@@ -549,8 +601,9 @@ void SnapState::recordSnapIntent(const QString& windowClass, bool wasUserInitiat
     }
 }
 
-void SnapState::markAsAutoSnapped(const QString& windowId)
+void SnapState::markAsAutoSnapped(const QString& rawWindowId)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     if (m_autoSnappedWindows.contains(windowId)) {
         return;
     }
@@ -558,13 +611,15 @@ void SnapState::markAsAutoSnapped(const QString& windowId)
     Q_EMIT stateChanged();
 }
 
-bool SnapState::isAutoSnapped(const QString& windowId) const
+bool SnapState::isAutoSnapped(const QString& rawWindowId) const
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     return m_autoSnappedWindows.contains(windowId);
 }
 
-bool SnapState::clearAutoSnapped(const QString& windowId)
+bool SnapState::clearAutoSnapped(const QString& rawWindowId)
 {
+    const QString windowId = canonicalizeForLookup(rawWindowId);
     if (m_autoSnappedWindows.remove(windowId)) {
         Q_EMIT stateChanged();
         return true;
@@ -597,8 +652,19 @@ QSet<QString> SnapState::buildOccupiedZoneSet(const QString& screenFilter, int d
     return occupied;
 }
 
-int SnapState::pruneStaleAssignments(const QSet<QString>& aliveWindowIds)
+int SnapState::pruneStaleAssignments(const QSet<QString>& rawAliveWindowIds)
 {
+    // The stores are keyed by the canonical (first-seen) composite, so the alive
+    // set must be canonicalized to compare like-for-like — otherwise a window
+    // still alive under a mutated-class composite would be pruned just because
+    // its stored key is the first-seen one. canonicalizeForLookup (const, no
+    // seed) is correct: a stale window must not gain a fresh canonical entry.
+    QSet<QString> aliveWindowIds;
+    aliveWindowIds.reserve(rawAliveWindowIds.size());
+    for (const QString& id : rawAliveWindowIds) {
+        aliveWindowIds.insert(canonicalizeForLookup(id));
+    }
+
     QSet<QString> allTracked;
     for (auto it = m_windowZoneAssignments.constBegin(); it != m_windowZoneAssignments.constEnd(); ++it) {
         allTracked.insert(it.key());

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -418,8 +418,13 @@ QString SnapEngine::screenForTrackedWindow(const QString& windowId) const
 
 bool SnapEngine::isWindowTracked(const QString& windowId) const
 {
+    // All three arms must resolve a class-mutated window (issue #628).
+    // isWindowSnapped/isFloating canonicalize the id internally; the screen arm
+    // goes through screenForWindow (which canonicalizes) instead of a raw
+    // screenAssignments().contains() on the canonical-keyed map. A screen
+    // assignment is never empty, so a non-empty result means "present".
     return m_snapState->isWindowSnapped(windowId) || m_snapState->isFloating(windowId)
-        || m_snapState->screenAssignments().contains(windowId);
+        || !m_snapState->screenForWindow(windowId).isEmpty();
 }
 
 } // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -53,7 +53,7 @@ void SnapEngine::setWindowFloat(const QString& windowId, bool shouldFloat)
     // 1. Try the window's tracked screen from WTS (most accurate)
     // 2. Fall back to m_lastActiveScreenId (from last windowFocused)
     // 3. Fall back to empty (unfloatToZone/applyGeometryForFloat handle gracefully)
-    QString screenId = m_snapState->screenAssignments().value(windowId);
+    QString screenId = m_snapState->screenForWindow(windowId);
     if (screenId.isEmpty()) {
         screenId = m_lastActiveScreenId;
     }
@@ -275,7 +275,7 @@ UnfloatResult SnapEngine::resolveFallbackUnfloatGeometry(const QString& windowId
     // caller's fallback. A tracked screen that no longer exists (output unplugged)
     // is discarded in favour of the caller's fallback. Zone geometry is resolved on
     // the resulting screen so the fallback lands where the window currently is.
-    const QString screen = resolveUnfloatScreen(m_snapState->screenAssignments().value(windowId), fallbackScreen);
+    const QString screen = resolveUnfloatScreen(m_snapState->screenForWindow(windowId), fallbackScreen);
     if (screen.isEmpty() || !m_layoutManager) {
         return result;
     }
@@ -413,7 +413,7 @@ void SnapEngine::handoffRelease(const QString& windowId)
 
 QString SnapEngine::screenForTrackedWindow(const QString& windowId) const
 {
-    return m_snapState->screenAssignments().value(windowId);
+    return m_snapState->screenForWindow(windowId);
 }
 
 bool SnapEngine::isWindowTracked(const QString& windowId) const

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -613,7 +613,7 @@ std::optional<PhosphorEngine::WindowPlacement> SnapEngine::capturePlacement(cons
     } else if (m_snapState->isWindowSnapped(windowId)) {
         slot.state = WindowPlacement::stateSnapped();
         slot.zoneIds = m_snapState->zonesForWindow(windowId);
-        p.screenId = m_snapState->screenAssignments().value(windowId);
+        p.screenId = m_snapState->screenForWindow(windowId);
     } else {
         // Snapping has only two states — snapped (above) or floated. An unmanaged
         // window on a snap-mode screen is FLOATED (the retired `free` state). The

--- a/libs/phosphor-snap-engine/src/navigation_actions.cpp
+++ b/libs/phosphor-snap-engine/src/navigation_actions.cpp
@@ -75,7 +75,7 @@ QString resolveNavScreen(INavigationStateProvider* navState, const QString& wind
     if (service && !windowId.isEmpty()) {
         const QString zoneId = service->zoneForWindow(windowId);
         if (!zoneId.isEmpty()) {
-            const QString storedScreen = service->screenAssignments().value(windowId);
+            const QString storedScreen = service->screenForWindow(windowId);
             if (!storedScreen.isEmpty()) {
                 if (PhosphorIdentity::VirtualScreenId::isVirtual(storedScreen)) {
                     const QString physId = PhosphorIdentity::VirtualScreenId::extractPhysicalId(storedScreen);
@@ -461,7 +461,7 @@ void SnapEngine::swapFocusedInDirection(const QString& direction, const Navigati
         // to its current assignment (then window1's screen) as before.
         QString screen2 = result.screenName2;
         if (screen2.isEmpty()) {
-            screen2 = m_snapState->screenAssignments().value(result.windowId2);
+            screen2 = m_snapState->screenForWindow(result.windowId2);
         }
         if (screen2.isEmpty()) {
             screen2 = result.screenName;

--- a/libs/phosphor-snap-engine/src/snapnavigationtargets.cpp
+++ b/libs/phosphor-snap-engine/src/snapnavigationtargets.cpp
@@ -291,7 +291,7 @@ PhosphorProtocol::MoveTargetResult SnapNavigationTargetResolver::getMoveTargetFo
     // at the dead output.
     QString effectiveScreenId = screenId;
     if (!currentZoneId.isEmpty()) {
-        QString storedScreen = m_service->screenAssignments().value(windowId);
+        QString storedScreen = m_service->screenForWindow(windowId);
         if (isStoredScreenValid(m_service->screenManager(), storedScreen)) {
             effectiveScreenId = storedScreen;
         }
@@ -371,7 +371,7 @@ PhosphorProtocol::FocusTargetResult SnapNavigationTargetResolver::getFocusTarget
     // Trust stored screen for snapped windows — see getMoveTargetForWindow comment
     QString effectiveScreenId = screenId;
     {
-        QString storedScreen = m_service->screenAssignments().value(windowId);
+        QString storedScreen = m_service->screenForWindow(windowId);
         if (isStoredScreenValid(m_service->screenManager(), storedScreen)) {
             effectiveScreenId = storedScreen;
         }
@@ -486,7 +486,7 @@ SnapNavigationTargetResolver::getCycleTargetForWindow(const QString& windowId, b
     // multi-monitor setups), then pin the ring to it.
     QString effectiveScreenId = screenId;
     {
-        const QString storedScreen = m_service->screenAssignments().value(windowId);
+        const QString storedScreen = m_service->screenForWindow(windowId);
         if (isStoredScreenValid(m_service->screenManager(), storedScreen)) {
             effectiveScreenId = storedScreen;
         }
@@ -566,7 +566,7 @@ PhosphorProtocol::SwapTargetResult SnapNavigationTargetResolver::getSwapTargetFo
     // Trust stored screen for snapped windows — see getMoveTargetForWindow comment
     QString effectiveScreenId = screenId;
     {
-        QString storedScreen = m_service->screenAssignments().value(windowId);
+        QString storedScreen = m_service->screenForWindow(windowId);
         if (isStoredScreenValid(m_service->screenManager(), storedScreen)) {
             effectiveScreenId = storedScreen;
         }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1139,6 +1139,12 @@ bool Daemon::init()
     // AutotileEngine/TilingState). WTS references it for zone queries.
     m_windowTrackingAdaptor->service()->setSnapState(snapEngine->snapState());
     m_windowTrackingAdaptor->service()->setSnapEngine(snapEngine);
+    // Inject the shared window registry so SnapState canonicalizes its
+    // windowId-keyed stores to the stable first-seen composite (instanceId →
+    // first observed appId|instanceId). This makes snap float/zone/screen state
+    // immune to the effect-restart-after-WM_CLASS-mutation re-identification
+    // skew, mirroring how AutotileEngine canonicalizes tiling state (issue #628).
+    snapEngine->snapState()->setWindowRegistry(m_windowRegistry.get());
 
     // Filter the unified rule store down to its Exclude-shaped slice and
     // hand the address to SnapEngine for its isAppIdExcluded probe. The
@@ -1271,7 +1277,7 @@ bool Daemon::init()
                                        const QString& windowId) -> PhosphorZones::AssignmentEntry::Mode {
             QString screenId;
             if (m_windowTrackingAdaptor && m_windowTrackingAdaptor->service()) {
-                screenId = m_windowTrackingAdaptor->service()->screenAssignments().value(windowId);
+                screenId = m_windowTrackingAdaptor->service()->screenForWindow(windowId);
             }
             if (!screenId.isEmpty() && m_layoutManager) {
                 return m_layoutManager->modeForScreen(screenId, currentDesktop(), currentActivity());

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -425,7 +425,7 @@ void Daemon::presaveSnapFloats(const QString& screenId)
         // When scoped to a screen, only snapshot windows on that screen.
         // Windows floating on other screens are not entering autotile.
         if (!screenId.isEmpty()) {
-            const QString windowScreen = wts->screenAssignments().value(fid);
+            const QString windowScreen = wts->screenForWindow(fid);
             if (!windowScreen.isEmpty() && windowScreen != screenId) {
                 continue;
             }

--- a/src/daemon/daemon/helpers.h
+++ b/src/daemon/daemon/helpers.h
@@ -43,7 +43,7 @@ inline QString resolveVirtualScreenId(PhosphorScreens::ScreenManager* mgr, const
     if (trackingAdaptor && trackingAdaptor->service()) {
         const QString activeWindowId = trackingAdaptor->lastActiveWindowId();
         if (!activeWindowId.isEmpty()) {
-            const QString trackedScreen = trackingAdaptor->service()->screenAssignments().value(activeWindowId);
+            const QString trackedScreen = trackingAdaptor->service()->screenForWindow(activeWindowId);
             if (PhosphorIdentity::VirtualScreenId::isVirtual(trackedScreen)
                 && PhosphorIdentity::VirtualScreenId::extractPhysicalId(trackedScreen) == physicalId) {
                 return trackedScreen;

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -118,7 +118,7 @@ void Daemon::initializeAutotile()
                             // screen (e.g., dragged from autotile VS to snap VS and resnapped)
                             // is no longer on the releasing screen — its state on the current
                             // screen must not be disturbed.
-                            const QString windowScreen = wts->screenAssignments().value(windowId);
+                            const QString windowScreen = wts->screenForWindow(windowId);
                             if (!windowScreen.isEmpty() && !releasedScreenIds.contains(windowScreen)) {
                                 // Window is on a different screen — do NOT touch its state.
                                 // It may be on another autotile screen (flag still valid) or
@@ -159,7 +159,7 @@ void Daemon::initializeAutotile()
                             if (snapFloat) {
                                 qCInfo(lcDaemon) << "windowsReleased: restoring snap-float for" << windowId;
                                 m_windowTrackingAdaptor->setWindowFloating(windowId, true);
-                                const QString screen = wts->screenAssignments().value(windowId);
+                                const QString screen = wts->screenForWindow(windowId);
                                 QRect g = rec->freeGeometryFor(screen.isEmpty() ? rec->screenId : screen);
                                 if (!g.isValid()) {
                                     g = rec->anyFreeGeometry();
@@ -172,7 +172,7 @@ void Daemon::initializeAutotile()
                                     m_pendingSnapFloatRestores.append(entry);
                                 }
                             } else if (snapSnapped) {
-                                const QString screen = wts->screenAssignments().value(windowId);
+                                const QString screen = wts->screenForWindow(windowId);
                                 const QString restoreScreen = screen.isEmpty() ? rec->screenId : screen;
                                 const QRect geo = wts->resolveZoneGeometry(snapSlot.zoneIds, restoreScreen);
                                 if (geo.isValid()) {
@@ -703,7 +703,7 @@ void Daemon::connectOverlaySignals()
             // autotile, notify the engine so it removes the window from the source
             // screen's tiling tree and retiles the remaining windows.
             if (m_autotileEngine && m_windowTrackingAdaptor && m_windowTrackingAdaptor->service()) {
-                const QString sourceScreen = m_windowTrackingAdaptor->service()->screenAssignments().value(windowId);
+                const QString sourceScreen = m_windowTrackingAdaptor->service()->screenForWindow(windowId);
                 if (!sourceScreen.isEmpty() && sourceScreen != effectiveScreenId && isAutotileScreen(sourceScreen)) {
                     m_autotileEngine->windowClosed(windowId);
                     // Clear autotile-floated marker immediately — windowClosed removes

--- a/src/dbus/snapadaptor/commit.cpp
+++ b/src/dbus/snapadaptor/commit.cpp
@@ -170,8 +170,8 @@ void SnapAdaptor::swapWindowsById(const QString& windowId1, const QString& windo
     }
 
     // Get screens for each window
-    QString screen1 = svc->screenAssignments().value(windowId1);
-    QString screen2 = svc->screenAssignments().value(windowId2);
+    QString screen1 = svc->screenForWindow(windowId1);
+    QString screen2 = svc->screenForWindow(windowId2);
 
     // Get the OTHER window's zone geometry (for the swap)
     QRect geo1 = svc->zoneGeometry(zoneId2, screen2); // window1 moves to zone2

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -574,7 +574,7 @@ void WindowTrackingAdaptor::windowScreenChanged(const QString& windowId, const Q
     // If they match (format-agnostic), the window was moved programmatically
     // to its assigned zone's screen (restore, resnap, snap assist) — keep snapped.
     // If they differ, the user moved the window away — unsnap it.
-    QString storedScreen = m_service->screenAssignments().value(windowId);
+    QString storedScreen = m_service->screenForWindow(windowId);
 
     // KWin reports physical screen names in outputChanged. When the stored screen
     // is a virtual screen (e.g. "HDMI-1/vs:0"), comparing against the physical name
@@ -856,6 +856,17 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
         meta.captionNormal = optString(Key::CaptionNormal);
     }
 
+    // Universal canonical seed. setWindowMetadata is the per-window choke point —
+    // the effect pushes it (unconditionally, before any other notification) for
+    // every window it observes, snap-mode included. Freezing the first-seen
+    // composite (appId|instanceId) here gives EVERY window a canonical entry from
+    // first contact, so the snap stores (which canonicalize their keys) resolve a
+    // window even after the effect restarts and re-derives a mutated-class
+    // composite for it. Idempotent: the instance id is stable, so a later push
+    // carrying a mutated appId returns the original composite rather than
+    // re-seeding (issue #628). Cleaned up by releaseCanonical on windowClosed.
+    m_windowRegistry->canonicalizeWindowId(PhosphorIdentity::WindowId::buildCompositeId(appId, instanceId));
+
     m_windowRegistry->upsert(instanceId, meta);
 }
 
@@ -874,7 +885,7 @@ void WindowTrackingAdaptor::cursorScreenChanged(const QString& screenId)
         if (mgr && mgr->hasVirtualScreens(screenId)) {
             // Use focused window's tracked screen as hint
             if (m_service && !m_lastActiveWindowId.isEmpty()) {
-                const QString trackedScreen = m_service->screenAssignments().value(m_lastActiveWindowId);
+                const QString trackedScreen = m_service->screenForWindow(m_lastActiveWindowId);
                 if (PhosphorIdentity::VirtualScreenId::isVirtual(trackedScreen)
                     && PhosphorIdentity::VirtualScreenId::extractPhysicalId(trackedScreen) == screenId) {
                     resolvedId = trackedScreen;
@@ -958,7 +969,7 @@ void WindowTrackingAdaptor::windowActivated(const QString& windowId, const QStri
     QString resolvedScreen = screenId;
     if (!screenId.isEmpty()) {
         if (!PhosphorIdentity::VirtualScreenId::isVirtual(screenId) && m_service) {
-            const QString trackedScreen = m_service->screenAssignments().value(windowId);
+            const QString trackedScreen = m_service->screenForWindow(windowId);
             if (PhosphorIdentity::VirtualScreenId::isVirtual(trackedScreen)
                 && PhosphorIdentity::VirtualScreenId::extractPhysicalId(trackedScreen)
                     == PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId)) {

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -857,8 +857,8 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
     }
 
     // Universal canonical seed. setWindowMetadata is the per-window choke point —
-    // the effect pushes it (unconditionally, before any other notification) for
-    // every window it observes, snap-mode included. Freezing the first-seen
+    // the effect pushes it for every window it tracks, ahead of the other
+    // per-window notifications, snap-mode included. Freezing the first-seen
     // composite (appId|instanceId) here gives EVERY window a canonical entry from
     // first contact, so the snap stores (which canonicalize their keys) resolve a
     // window even after the effect restarts and re-derives a mutated-class

--- a/src/dbus/windowtrackingadaptor/convenience.cpp
+++ b/src/dbus/windowtrackingadaptor/convenience.cpp
@@ -23,7 +23,7 @@ PhosphorProtocol::WindowStateEntry WindowTrackingAdaptor::getWindowState(const Q
     return PhosphorProtocol::WindowStateEntry{
         windowId,
         m_service->zoneForWindow(windowId),
-        m_service->screenAssignments().value(windowId),
+        m_service->screenForWindow(windowId),
         m_service->isWindowFloating(windowId),
         QString(), // changeType: empty for query (not a state change event)
         m_service->zonesForWindow(windowId),
@@ -55,7 +55,7 @@ PhosphorProtocol::WindowStateList WindowTrackingAdaptor::getAllWindowStates()
         result.append(PhosphorProtocol::WindowStateEntry{
             windowId,
             m_service->zoneForWindow(windowId),
-            m_service->screenAssignments().value(windowId),
+            m_service->screenForWindow(windowId),
             m_service->isWindowFloating(windowId),
             QString(), // changeType: empty for query
             m_service->zonesForWindow(windowId),

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -30,7 +30,7 @@ void WindowTrackingAdaptor::notifyDragOutUnsnap(const QString& windowId)
         return;
     }
 
-    QString screenId = m_service->screenAssignments().value(windowId, m_lastActiveScreenId);
+    QString screenId = m_service->screenForWindow(windowId, m_lastActiveScreenId);
     qCInfo(lcDbusWindow) << "Drag-out unsnap (no activation trigger) for" << windowId << "screen:" << screenId;
 
     // Delegate unsnap-for-float to the service directly (the SnapAdaptor
@@ -118,7 +118,7 @@ void WindowTrackingAdaptor::setWindowFloating(const QString& windowId, bool floa
     qCInfo(lcDbusWindow) << "Window" << windowId << "is now" << (floating ? "floating" : "not floating");
     // Notify effect so it can update its local cache (use full windowId for per-instance tracking).
     // Use the window's tracked screen if available, otherwise fall back to last active screen.
-    QString screen = m_service->screenAssignments().value(windowId, m_lastActiveScreenId);
+    QString screen = m_service->screenForWindow(windowId, m_lastActiveScreenId);
     Q_EMIT windowFloatingChanged(windowId, floating, screen);
 
     // Emit unified state change

--- a/src/dbus/windowtrackingadaptor/persistence.cpp
+++ b/src/dbus/windowtrackingadaptor/persistence.cpp
@@ -47,7 +47,7 @@ bool WindowTrackingAdaptor::hasPreTileGeometry(const QString& windowId)
     if (windowId.isEmpty() || !m_service) {
         return false;
     }
-    const QString screenId = m_service->screenAssignments().value(windowId);
+    const QString screenId = m_service->screenForWindow(windowId);
     return m_service->validatedUnmanagedGeometry(windowId, screenId).has_value();
 }
 
@@ -112,7 +112,7 @@ bool WindowTrackingAdaptor::getValidatedPreTileGeometry(const QString& windowId,
     // m_service is non-null by constructor invariant (the ctor qFatals on
     // null), so no guard is needed; the half-guard this replaced checked
     // one deref and missed the next.
-    const QString screenId = m_service->screenAssignments().value(windowId);
+    const QString screenId = m_service->screenForWindow(windowId);
 
     auto geo = m_service->validatedUnmanagedGeometry(windowId, screenId);
     if (!geo) {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -437,6 +437,7 @@ target_compile_definitions(test_per_screen_config PRIVATE "P_SOURCE_DIR=\"${PROJ
 # ═══════════════════════════════════════════════════════════════════════════════
 p_add_test(test_navigation_controller autotile/test_navigation_controller.cpp)
 p_add_test(test_snap_cross_surface snap/test_snap_cross_surface.cpp)
+p_add_test(test_snap_state_class_mutation snap/test_snap_state_class_mutation.cpp)
 
 # Cross-surface navigation exercises cross-output handoff, which needs real
 # output geometry — compile in the FakeScreenProvider (like the WTA tests).

--- a/tests/unit/snap/test_snap_cross_surface.cpp
+++ b/tests/unit/snap/test_snap_cross_surface.cpp
@@ -47,6 +47,15 @@ public:
     {
         return zoneOfWindow.value(w);
     }
+    QString screenForWindow(const QString& w) const override
+    {
+        return screenOfWindow.value(w);
+    }
+    QString screenForWindow(const QString& w, const QString& def) const override
+    {
+        const QString s = screenOfWindow.value(w);
+        return s.isEmpty() ? def : s;
+    }
     QStringList windowsInZone(const QString& z) const override
     {
         return windowsByZone.value(z);

--- a/tests/unit/snap/test_snap_state_class_mutation.cpp
+++ b/tests/unit/snap/test_snap_state_class_mutation.cpp
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_snap_state_class_mutation.cpp
+ * @brief Regression tests for issue #628: the daemon's snap stores must not
+ *        orphan a window's state when the KWin effect restarts after the
+ *        window's WM_CLASS mutated during downtime (Electron/CEF apps rename
+ *        their class after mapping), so the restarted effect re-derives a
+ *        DIFFERENT `appId|instanceId` composite for the same window.
+ *
+ * The fix canonicalizes every windowId-keyed SnapState accessor through the
+ * shared WindowRegistry (instanceId → first-seen composite), mirroring what the
+ * AutotileEngine already does for tiling state (test_autotile_engine_class_mutation).
+ * Seeding is centralized in the daemon's setWindowMetadata; here we seed the
+ * registry directly to stand in for that one call.
+ *
+ * These tests exercise SnapState directly — no KWin effect, no D-Bus — with a
+ * real WindowRegistry wired in, which is exactly the production configuration.
+ */
+
+#include <QTest>
+
+#include <PhosphorEngine/WindowRegistry.h>
+#include <PhosphorSnapEngine/SnapState.h>
+
+using PhosphorEngine::WindowRegistry;
+using PhosphorSnapEngine::SnapState;
+
+namespace {
+
+QString makeComposite(const QString& appId, const QString& instanceId)
+{
+    return appId + QLatin1Char('|') + instanceId;
+}
+
+// A stable instance id (KWin internalId) — the part that never changes when the
+// app mutates its class.
+const QString kInstanceId = QStringLiteral("cef1ba31-3316-4f05-84f5-ef627674b504");
+const QString kFirstSeen = QStringLiteral("google-chrome|") + kInstanceId;
+const QString kAfterRename = QStringLiteral("google-chrome-beta|") + kInstanceId;
+const QString kScreen = QStringLiteral("DP-1");
+const QString kZone = QStringLiteral("zone-uuid-1");
+
+} // namespace
+
+class TestSnapStateClassMutation : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    // ────────────────────────────────────────────────────────────────────
+    // The bug case: state written under the first-seen composite must resolve
+    // when queried/mutated under the post-restart, mutated-class composite.
+    // ────────────────────────────────────────────────────────────────────
+    void snapStateResolvesAcrossClassMutation()
+    {
+        WindowRegistry registry;
+        SnapState state{QString()};
+        state.setWindowRegistry(&registry);
+
+        // The daemon seeds the canonical mapping once per window at open
+        // (setWindowMetadata). First composite wins.
+        registry.canonicalizeWindowId(kFirstSeen);
+
+        // Snap the window under the first-seen composite.
+        state.assignWindowToZones(kFirstSeen, {kZone}, kScreen, /*virtualDesktop=*/1);
+        QVERIFY(state.isWindowSnapped(kFirstSeen));
+
+        // Effect restarts → it re-derives a mutated-class composite for the SAME
+        // window (same instance id). Every windowId-keyed read must resolve it
+        // back to the first-seen entry — no orphaning.
+        QVERIFY2(state.isWindowSnapped(kAfterRename), "snapped state must resolve across the class mutation");
+        QCOMPARE(state.zoneForWindow(kAfterRename), kZone);
+        QCOMPARE(state.zonesForWindow(kAfterRename), QStringList{kZone});
+        QCOMPARE(state.screenForWindow(kAfterRename), kScreen);
+        QCOMPARE(state.desktopForWindow(kAfterRename), 1);
+        QVERIFY(!state.isFloating(kAfterRename));
+
+        // A WRITE under the mutated composite must land on the SAME entry, not a
+        // phantom second window.
+        state.setFloating(kAfterRename, true);
+        QVERIFY2(state.isFloating(kFirstSeen),
+                 "float written under the mutated composite must flip the first-seen entry");
+        QVERIFY(state.isFloating(kAfterRename));
+
+        state.markAsAutoSnapped(kAfterRename);
+        QVERIFY(state.isAutoSnapped(kFirstSeen));
+
+        // Still exactly one managed window — no duplicate under the new composite.
+        QCOMPARE(state.windowCount(), 1);
+
+        // Closing under the mutated composite removes the first-seen entry.
+        state.windowClosed(kAfterRename);
+        QVERIFY(!state.isWindowSnapped(kFirstSeen));
+        QVERIFY(!state.isFloating(kFirstSeen));
+        QCOMPARE(state.windowCount(), 0);
+    }
+
+    // Pre-float (unfloat memory) must also resolve cross-composite.
+    void preFloatResolvesAcrossClassMutation()
+    {
+        WindowRegistry registry;
+        SnapState state{QString()};
+        state.setWindowRegistry(&registry);
+        registry.canonicalizeWindowId(kFirstSeen);
+
+        state.assignWindowToZones(kFirstSeen, {kZone}, kScreen, /*virtualDesktop=*/1);
+        // Float-from-snap records the pre-float zone+screen, keyed canonically.
+        state.unsnapForFloat(kAfterRename);
+
+        QCOMPARE(state.preFloatZone(kAfterRename), kZone);
+        QCOMPARE(state.preFloatZone(kFirstSeen), kZone);
+        QCOMPARE(state.preFloatZones(kAfterRename), QStringList{kZone});
+        QCOMPARE(state.preFloatScreen(kAfterRename), kScreen);
+    }
+
+    // pruneStaleAssignments must NOT prune a window that is still alive under a
+    // mutated-class composite (the alive set arrives in raw form).
+    void pruneKeepsWindowAliveUnderMutatedComposite()
+    {
+        WindowRegistry registry;
+        SnapState state{QString()};
+        state.setWindowRegistry(&registry);
+        registry.canonicalizeWindowId(kFirstSeen);
+
+        state.assignWindowToZones(kFirstSeen, {kZone}, kScreen, /*virtualDesktop=*/1);
+
+        // The window is reported alive under the MUTATED composite. It must
+        // canonicalize to the first-seen key and survive the prune.
+        const int pruned = state.pruneStaleAssignments({kAfterRename});
+        QCOMPARE(pruned, 0);
+        QVERIFY(state.isWindowSnapped(kFirstSeen));
+
+        // A genuinely-gone window (different instance) IS pruned.
+        const int pruned2 =
+            state.pruneStaleAssignments({makeComposite(QStringLiteral("x"), QStringLiteral("other-uuid"))});
+        QCOMPARE(pruned2, 1);
+        QVERIFY(!state.isWindowSnapped(kFirstSeen));
+    }
+
+    // Without a registry (unit-test / pre-engine-wiring path) the state keys on
+    // the raw id verbatim — preserving the pre-#628 behaviour so existing tests
+    // and the unwired fallback are unaffected.
+    void withoutRegistry_keysVerbatim()
+    {
+        SnapState state{QString()};
+        state.assignWindowToZones(kFirstSeen, {kZone}, kScreen, /*virtualDesktop=*/1);
+
+        QVERIFY(state.isWindowSnapped(kFirstSeen));
+        // No canonicalization without a registry, so a different composite is a
+        // different (unknown) window.
+        QVERIFY(!state.isWindowSnapped(kAfterRename));
+        QVERIFY(state.zoneForWindow(kAfterRename).isEmpty());
+    }
+};
+
+QTEST_GUILESS_MAIN(TestSnapStateClassMutation)
+#include "test_snap_state_class_mutation.moc"

--- a/tests/unit/snap/test_snap_state_class_mutation.cpp
+++ b/tests/unit/snap/test_snap_state_class_mutation.cpp
@@ -12,8 +12,8 @@
  * The fix canonicalizes every windowId-keyed SnapState accessor through the
  * shared WindowRegistry (instanceId → first-seen composite), mirroring what the
  * AutotileEngine already does for tiling state (test_autotile_engine_class_mutation).
- * Seeding is centralized in the daemon's setWindowMetadata; here we seed the
- * registry directly to stand in for that one call.
+ * Seeding is centralized in the daemon's WindowTrackingAdaptor::setWindowMetadata;
+ * here we seed the registry directly to stand in for that one call.
  *
  * These tests exercise SnapState directly — no KWin effect, no D-Bus — with a
  * real WindowRegistry wired in, which is exactly the production configuration.
@@ -72,8 +72,10 @@ private Q_SLOTS:
         // window (same instance id). Every windowId-keyed read must resolve it
         // back to the first-seen entry — no orphaning.
         QVERIFY2(state.isWindowSnapped(kAfterRename), "snapped state must resolve across the class mutation");
+        QVERIFY(state.containsWindow(kAfterRename));
         QCOMPARE(state.zoneForWindow(kAfterRename), kZone);
         QCOMPARE(state.zonesForWindow(kAfterRename), QStringList{kZone});
+        QCOMPARE(state.placementIdForWindow(kAfterRename), kZone);
         QCOMPARE(state.screenForWindow(kAfterRename), kScreen);
         QCOMPARE(state.desktopForWindow(kAfterRename), 1);
         QVERIFY(!state.isFloating(kAfterRename));


### PR DESCRIPTION
## Issue

Closes #628.

When the KWin effect restarts while a window's `WM_CLASS` mutated during downtime (Electron/CEF apps rename their class after mapping), the restarted effect re-derives a **different** `appId|instanceId` composite for the same window. The daemon's snap-side windowId-keyed stores still hold the **old** composite, so the window orphans — its float/zone/sticky state silently vanishes until a mode toggle rebuilds it. Only the `appId` portion changes; the `instanceId` (KWin internalId) is stable.

`AutotileEngine` already canonicalizes tiling state through the shared `WindowRegistry` (instanceId → first-seen composite). The snap side did not. This closes the gap symmetrically.

## Approach

- **SnapState** takes a borrowed `IWindowRegistry` and routes every windowId-keyed accessor through `canonicalizeForLookup` (no-seed). Seeding is centralized in the daemon's `setWindowMetadata` — the per-window choke point the effect pushes unconditionally for every window — so by the time any snap accessor runs the window already has a canonical entry. No-seed lookup also keeps the pre-float **appId-alias** writes safe (a bare appId must not pollute the registry's instance map with an entry that is never released).
- **`pruneStaleAssignments`** canonicalizes its alive set so a window still alive under a mutated composite is not pruned against the now canonical-keyed stores.
- **WindowTrackingService** canonicalizes its own stores (the legacy float set and the sticky map) and exposes a canonicalizing `screenForWindow` accessor (added to `IWindowTrackingService`). The ~28 external `screenAssignments().value(windowId)` point-lookups across daemon/dbus/snap-engine now route through it instead of keying the canonical map with a raw composite.

The daemon owns the registry and does **not** restart when the effect does, so the canonical map survives the effect restart that triggers the bug. (Full daemon restart is a separate axis, already handled by the appId-keyed placement store — out of scope here.)

## Tests

New `test_snap_state_class_mutation` pins the cross-composite resolution (zone / screen / desktop / float / auto-snap / pre-float / prune) and the no-registry verbatim-keying fallback. Full suite: **248/248 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)