### PR TITLE
feat: per-screen virtual desktops (Plasma 6.7) — fix Desktop-Switch OSD on cursor move (#648)

### DIFF
--- a/dbus/org.plasmazones.WindowTracking.xml
+++ b/dbus/org.plasmazones.WindowTracking.xml
@@ -345,6 +345,15 @@ SPDX-License-Identifier: GPL-3.0-or-later
                 <annotation name="org.gtk.GDBus.DocString" value="Screen identifier the cursor is now on (e.g. Dell:U2722D:115107 or Dell:U2722D:115107/vs:0)."/>
             </arg>
         </method>
+        <method name="screenDesktopChanged">
+            <annotation name="org.gtk.GDBus.DocString" value="Report a screen's current virtual desktop (Plasma 6.7 per-output virtual desktops). Called by the KWin effect on KWin::EffectsHandler::desktopChanged with the per-output desktop. KWin's own D-Bus interface only exposes the global current desktop, so per-screen data arrives this way."/>
+            <arg name="screenId" type="s" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="Physical screen identifier whose desktop changed (NOT virtual-screen-suffixed; per-output desktops belong to the physical output)."/>
+            </arg>
+            <arg name="desktop" type="i" direction="in">
+                <annotation name="org.gtk.GDBus.DocString" value="The screen's current virtual desktop, 1-based (x11DesktopNumber)."/>
+            </arg>
+        </method>
         <method name="setWindowMetadata">
             <annotation name="org.gtk.GDBus.DocString" value="Register or update metadata for a live window. Called by the compositor bridge on window-added and on every mutation of the window's app class, desktop file, caption, virtual desktop, activity, or role. Idempotent — safe to call on every observation; a no-op if metadata is unchanged."/>
             <arg name="instanceId" type="s" direction="in">

--- a/docs/per-screen-virtual-desktops-plan.md
+++ b/docs/per-screen-virtual-desktops-plan.md
@@ -1,0 +1,498 @@
+<!-- SPDX-FileCopyrightText: 2026 fuddlesworth -->
+<!-- SPDX-License-Identifier: GPL-3.0-or-later -->
+
+# Per-Screen Virtual Desktops — Implementation Plan
+
+Tracking: GitHub discussion **#648** — "Desktop Switch OSD fires on cursor movement between displays (Plasma 6.7 per-display virtual desktops)."
+
+Branch: `feat/per-screen-virtual-desktops` (off `v3.1`).
+
+> This plan was produced from a 5-agent codebase + KWin-API investigation. Every
+> claim below is grounded in a `file:line` reference or a cited KWin source.
+
+---
+
+## 1. Problem & confirmed root cause
+
+Plasma 6.7 added **"switch desktops independently for each screen"** (per-output
+virtual desktops; `kwinrc` `[Windows]/PerOutputVirtualDesktops`, `Bool`, default
+`false`). When ON, each monitor has its own current virtual desktop, and KWin
+reports the **active monitor's** desktop as the **global**
+`org.kde.KWin.VirtualDesktopManager.current`.
+
+PlasmaZones assumes a single global current desktop. Its daemon `VirtualDesktopManager`
+subscribes only to KWin's **global** `currentChanged` D-Bus signal
+(`libs/phosphor-workspaces/src/VirtualDesktopManager.cpp:44-47`, `:196-207`). So as
+the cursor crosses monitors on different desktops, the global value flips and the
+daemon's handler (`src/daemon/daemon/start.cpp:197-240`) treats every flip as a real
+switch — re-applying layouts, **switching the autotile context**, and firing the
+desktop-switch OSD on every screen.
+
+**Confirmed by the reporter's support report** (`journal.log`): a 3-monitor setup with
+monitors pinned to desktops 1 / 4 / 7 produced **55 "Virtual desktop changed" events**
+in one short session, bouncing `1↔4↔7` with repeating `"Switching autotile context"`
++ layout-OSD churn — purely from cursor movement. The OSD is the visible symptom; the
+**per-desktop context thrash is the deeper defect**.
+
+---
+
+## 2. The KWin 6.7 mechanism (verified) — why Path A is deterministic
+
+KWin's **effects API** (the API available to our in-process KWin effect) exposes
+per-output desktops in 6.7 (verified against KWin source — see §11 citations):
+
+- `EffectsHandler::currentDesktop(KWin::LogicalOutput* output = nullptr)` — that
+  output's current `VirtualDesktop*`; `->x11DesktopNumber()` is the 1-based number
+  the daemon already speaks.
+- `EffectsHandler::desktopChanged(VirtualDesktop* old, VirtualDesktop* new, EffectWindow* with, KWin::LogicalOutput* output)`
+  — the **`output` param was added in 6.7**; it identifies the screen whose desktop
+  changed. **It fires only on an actual desktop change for an output — moving the
+  cursor between monitors does NOT fire it** (no output's desktop changed).
+- `kwinrc [Windows]/PerOutputVirtualDesktops` is readable if explicit mode detection
+  is ever needed, but is **not required**: querying `currentDesktop(output)` per
+  output is correct under both modes (global mode → all outputs return the same).
+
+KWin's **D-Bus** `org.kde.KWin.VirtualDesktopManager` interface remains **global-only**
+(`current` + `currentChanged`) — confirmed. Therefore **per-output desktop data must
+come from the effect, not the daemon's VDM D-Bus client.**
+
+**Consequence:** drive all OSD/context off the effect's per-output `desktopChanged`.
+Because that signal never fires on cursor movement, the entire cursor-follow detection
+problem **dissolves** — no timing/correlation heuristics needed. (The inference
+approach, §9 Path B, is retained only as a pre-6.7 fallback.)
+
+---
+
+## 3. Architecture — target data flow
+
+```
+                         ┌──────────────────────── KWin (compositor) ───────────────────────┐
+                         │  EffectsHandler::desktopChanged(old,new,with, OUTPUT)             │
+                         │  EffectsHandler::currentDesktop(output)                           │
+                         └───────────────┬───────────────────────────────────────────────────┘
+                                         │  (in-process, effect)
+        kwin-effect/plasmazoneseffect ── │  on desktopChanged: if output → report ONE screen
+                                         │                      if output==null → fan out all
+                                         ▼
+        D-Bus: org.plasmazones.WindowTracking.screenDesktopChanged(s screenId, i desktop)   [NEW]
+                                         │
+                                         ▼
+        WindowTrackingAdaptor::screenDesktopChanged(screenId, desktop)   [NEW slot]
+                                         │  forwards to the desktop authority
+                                         ▼
+        VirtualDesktopManager::updateScreenDesktop(screenId, desktop)   [NEW]
+                                         │  updates per-screen map, emits …
+                                         ▼
+        VirtualDesktopManager::screenDesktopChanged(screenId, desktop)   [NEW signal]
+                                         │
+                                         ▼
+        Daemon per-screen handler  →  per-screen: autotile ctx + layout + overlay + OSD(screen)
+```
+
+The daemon's VDM **keeps** its existing global KWin `currentChanged` subscription, but
+**only** to maintain `m_currentDesktop` as the *active/global fallback* for the handful
+of genuinely-global callers (§6 bucket C). The global signal **no longer drives OSD or
+context** — that moves entirely to the per-screen `screenDesktopChanged` path. This
+removes the double-trigger and the cursor-follow thrash at the root.
+
+**One downstream code path.** When per-output mode is OFF, KWin fires
+`desktopChanged` with `output == nullptr`; the effect fans that out to one
+`screenDesktopChanged` per screen (same desktop). So the daemon only ever wires the
+per-screen signal, and mode-off behavior is byte-identical to today (OSD on all
+screens, context applied to all).
+
+---
+
+## 4. KWin effect (compositor side)
+
+Files: `kwin-effect/plasmazoneseffect/lifecycle.cpp`, `.../daemon_bringup.cpp`,
+`.../screens.cpp`, `.../mouse_drag.cpp`; D-Bus XML `dbus/org.plasmazones.WindowTracking.xml`.
+
+The effect already bridges screen-scoped events to the daemon via
+`PhosphorProtocol::ClientHelpers::fireAndForget`. `cursorScreenChanged` is the exact
+template (`mouse_drag.cpp:99-115`; XML `:342-347`; screen-id via
+`outputScreenId(output)` at `screens.cpp:38-85`).
+
+1. **New D-Bus method** in `dbus/org.plasmazones.WindowTracking.xml` (next to
+   `cursorScreenChanged`):
+   ```xml
+   <method name="screenDesktopChanged">
+     <arg name="screenId" type="s" direction="in"/>
+     <arg name="desktop"  type="i" direction="in"/>   <!-- 1-based x11DesktopNumber -->
+   </method>
+   ```
+2. **Full-signature `desktopChanged` slot.** Today the effect connects zero-arg lambdas
+   to `desktopChanged` (`lifecycle.cpp:487-488`, `:495-497`) which discard `output`.
+   Add a slot taking the full 6.7 signature:
+   ```cpp
+   connect(KWin::effects, &KWin::EffectsHandler::desktopChanged, this,
+       [this](KWin::VirtualDesktop*, KWin::VirtualDesktop* nd,
+              KWin::EffectWindow*, KWin::LogicalOutput* output) {
+           if (!nd || !m_daemonServiceRegistered) return;
+           if (output) {
+               reportScreenDesktop(outputScreenId(output), nd->x11DesktopNumber());
+           } else {                                   // global all-output switch (mode off)
+               for (auto* out : KWin::effects->screens())
+                   reportScreenDesktop(outputScreenId(out),
+                                       KWin::effects->currentDesktop(out)->x11DesktopNumber());
+           }
+       });
+   ```
+   `reportScreenDesktop` dedups against a `QHash<QString,int> m_lastScreenDesktop`
+   (mirrors `m_lastEffectiveScreenId`) and `fireAndForget`s `screenDesktopChanged`.
+   **Use `outputScreenId(output)` (physical), NOT the `vs:`-suffixed effective id** —
+   per-output desktops belong to the physical output; virtual-screen subdivisions
+   share their parent's desktop.
+3. **Bringup re-sync** (`daemon_bringup.cpp:186-213`, next to the cursor re-send):
+   iterate `KWin::effects->screens()` and `reportScreenDesktop(...)` for each, so the
+   daemon's per-screen map is seeded on every (re)registration and survives daemon
+   restarts.
+
+---
+
+## 5. Daemon VirtualDesktopManager — per-screen model
+
+Files: `libs/phosphor-workspaces/{include/PhosphorWorkspaces,src}/VirtualDesktopManager.{h,cpp}`,
+`libs/phosphor-engine/include/PhosphorEngine/IVirtualDesktopManager.h`.
+
+### Members
+```cpp
+int                 m_currentDesktop = 1;   // RETAINED: global/active fallback (legacy)
+QHash<QString,int>  m_screenDesktops;       // screenId -> 1-based desktop (per-output, effect-fed)
+QStringList         m_knownScreenIds;       // for the mode-off fan-out (daemon-maintained)
+```
+`m_screenDesktops` is fed by the **effect** (via `updateScreenDesktop`), **not** by the
+VDM's KWin D-Bus client (which is global-only).
+
+### API
+```cpp
+int  currentDesktopForScreen(const QString& screenId) const;  // map else m_currentDesktop
+void updateScreenDesktop(const QString& screenId, int desktop); // effect-fed; emits on change
+bool perScreenModeActive() const;                              // derived: distinct(map values) > 1
+void setKnownScreens(const QStringList& ids);                  // daemon keeps current (screen add/remove)
+// RETAINED unchanged: currentDesktop(), setCurrentDesktop(int), desktopCount(), …
+```
+```cpp
+int VirtualDesktopManager::currentDesktopForScreen(const QString& s) const {
+    auto it = m_screenDesktops.constFind(s);
+    return it != m_screenDesktops.constEnd() ? *it : m_currentDesktop;
+}
+void VirtualDesktopManager::updateScreenDesktop(const QString& s, int d) {
+    if (m_screenDesktops.value(s, -1) == d) return;   // emit-on-change
+    m_screenDesktops.insert(s, d);
+    Q_EMIT screenDesktopChanged(s, d);
+}
+```
+
+### Signals
+```cpp
+void screenDesktopChanged(const QString& screenId, int desktop);  // NEW — primary trigger
+void currentDesktopChanged(int desktop);                          // RETAINED (global fallback only)
+void desktopCountChanged(int count);                              // RETAINED unchanged
+```
+
+### Mode-off fan-out
+On a global switch in mode-off, the **effect** already fans out one
+`screenDesktopChanged` per screen (output==null path, §4.2). The VDM's global
+`onKWinCurrentChanged` (`VirtualDesktopManager.cpp:196-207`) therefore only updates
+`m_currentDesktop` + emits the legacy `currentDesktopChanged`; it does **not** fan out
+(the effect did). If, for resilience, we ever need the VDM to fan out independently of
+the effect, it can loop `m_knownScreenIds` calling `updateScreenDesktop(id, newDesktop)`
+— but the effect path is authoritative.
+
+### Interface ripple
+Add `currentDesktopForScreen(const QString&)` and `perScreenModeActive()` to
+`IVirtualDesktopManager` **as non-pure (defaulted)** methods
+(`return currentDesktop();` / `return false;`). Rationale: the **only** interface
+consumer is `SnapEngine` (holds `IVirtualDesktopManager*`, calls `currentDesktop()` at 7
+sites); **no test subclasses the interface** (tests use the concrete class). Non-pure
+defaults keep SnapEngine and every test source-compatible. The `screenDesktopChanged`
+**signal lives on the concrete QObject**, not the interface.
+
+### Count-changed (`desktopCountChanged`) — stays global
+Desktop add/remove is workspace-wide (`start.cpp:243-282`). One addition: after a
+removal, prune/clamp any `m_screenDesktops` entry whose desktop number now exceeds the
+count (fold into `onKWinDesktopRemoved`, `VirtualDesktopManager.cpp:215-219`), emitting
+`screenDesktopChanged` for any screen whose number shifted.
+
+---
+
+## 6. WindowTrackingAdaptor (receives the effect report)
+
+File: `src/dbus/windowtrackingadaptor.cpp`.
+
+Add the D-Bus slot mirroring `cursorScreenChanged` (`:873`):
+```cpp
+void WindowTrackingAdaptor::screenDesktopChanged(const QString& screenId, int desktop) {
+    if (screenId.isEmpty() || desktop < 1) return;
+    if (m_virtualDesktopManager) m_virtualDesktopManager->updateScreenDesktop(screenId, desktop);
+}
+```
+The adaptor already holds the VDM (used for `currentDesktop()` mirror at `:251-253`).
+
+---
+
+## 7. Daemon handler rewrite (the core behavior change)
+
+File: `src/daemon/daemon/start.cpp:197-291`, `src/daemon/daemon/osd.cpp`.
+
+**Move the context/OSD handler off `currentDesktopChanged` and onto
+`screenDesktopChanged(screenId, desktop)`.** The handler now operates on **one screen**.
+
+What the current lambda (`start.cpp:197-240`) does, and the new scope:
+
+| # | Action (line) | New scope |
+|---|---|---|
+| 1 | `overlayService->setCurrentVirtualDesktop` (202) | **per-screen** → `setCurrentVirtualDesktopForScreen(screenId, desktop)` (§8) |
+| 2 | `layoutManager->setCurrentVirtualDesktop` (203) | **per-screen** → `setCurrentVirtualDesktopForScreen(screenId, desktop)` (§8) |
+| 3 | `unifiedLayoutController->setCurrentVirtualDesktop` (204-206) | global (active/focused screen's desktop) |
+| 4 | `cancelDragInsertPreview()` (210-212) | cancel iff `screenId == previewScreen` (else harmless eager cancel) |
+| 5 | `updateStickyScreenPins(...)` (217-222) | global, **runs BEFORE any desktop ctx change** [SEQ B] |
+| 6 | `autotileEngine->setCurrentDesktop` (226-228) | **per-screen** → `setCurrentDesktopForScreen(screenId, desktop)` (§8), **BEFORE #7/#8** [SEQ C] |
+| 7 | `updateAutotileScreens()` (230) | recompute (global; cheap, idempotent) |
+| 8 | `syncModeFromAssignments()` (234) | now reads `currentDesktopForScreen(focusedScreen)` |
+| 9 | `overlayService->updateGeometries()` (235-237) | global, idempotent |
+| 10 | `showDesktopSwitchOsd(desktop, activity)` (239) | **per-screen** → OSD only on `screenId` |
+
+**Sequencing invariants (preserved, see comments at `start.cpp:207-230`):**
+[SEQ A] cancel drag-insert preview → [SEQ B] sticky-pin screens → [SEQ C]
+`setCurrentDesktopForScreen` → [SEQ D] push layout/overlay/controller → [SEQ E]
+`updateAutotileScreens()` then `syncModeFromAssignments()` → OSD. SEQ C must precede
+both SEQ E steps (engine resolves `TilingState` by the new per-screen key).
+
+**Per-screen OSD.** Factor the single-screen body out of `showOsdForAllScreens`
+(`osd.cpp:490-561`, the loop interior at `:508-559`) into
+`showDesktopSwitchOsdForScreen(screenId, desktop, activity)`. Keep `showOsdForAllScreens`
+for the genuinely-global callers (startup welcome / activity OSD,
+`signals.cpp:839/870/891`). In mode-off the effect fan-out calls the per-screen OSD once
+per screen → visually identical to today.
+
+**Initial-desktop wiring** (`start.cpp:284-291`): loop `effectiveScreenIds()`, seeding
+each component with `currentDesktopForScreen(screenId)` and the engine via
+`setCurrentDesktopForScreen` per screen. Mode-off collapses to today.
+
+---
+
+## 8. Engine + Layout + Overlay per-screen plumbing
+
+### 8a. AutotileEngine — generalize the existing per-screen mechanism
+Files: `libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h`,
+`libs/phosphor-tile-engine/src/AutotileEngine.cpp`, `.../NavigationController.cpp`.
+
+The engine **already** resolves a per-screen desktop:
+`currentKeyForScreen(screenId)` (`AutotileEngine.h:1156-1161`) returns
+`m_screenDesktopOverride[screenId]` else `m_currentDesktop`. `m_screenDesktopOverride`
+(`:1410`) exists today, written **only** by the `virtualdesktopsonlyonprimary`
+sticky-pin lifecycle.
+
+**Two-map design (chosen).** The sticky pin and a per-output-VD value both want a
+screen's entry — two writers, one map would clobber. Keep them separate:
+- `m_screenDesktopOverride` — **sticky-pin** map (unchanged; 5 existing sites at
+  `AutotileEngine.cpp:329-335, 547-557, 774, 1078`).
+- `m_screenCurrentDesktop` (**NEW** `QHash<QString,int>`) — per-output-VD map.
+- Precedence in `currentKeyForScreen`: **sticky-pin override WINS**, else
+  per-output-VD, else `m_currentDesktop`. Rationale: the sticky pin is a *correctness*
+  constraint (sticky on-all-desktops windows must keep their state on the desktop where
+  they live, `AutotileEngine.h:1150-1155`); per-output-VD is the *normal* input. The
+  pin must win or a sticky screen's state orphans — the exact bug the pin prevents.
+
+New API (add to `ITileEngine` next to `setCurrentDesktop`, `AutotileEngine.h:281`):
+```cpp
+void setCurrentDesktopForScreen(const QString& screenId, int desktop) override; // writes m_screenCurrentDesktop
+void clearCurrentDesktopForScreen(const QString& screenId) override;            // revert to fallback
+```
+
+**`setCurrentDesktopForScreen` is a PURE context swap — NO state migration.** This is
+the central correctness point: per-desktop `TilingState`s must stay put (the old
+desktop's state reappears when that screen returns). Only the **sticky-unpin** path
+migrates (`AutotileEngine.cpp:561-591`), and only because the pin forced two logical
+desktops to share one state. Do not migrate on a per-output-VD change.
+
+**Read sites to convert** to `key.desktop == currentKeyForScreen(key.screenId).desktop`
+(reference impl already at `NavigationController.cpp:405, 813`):
+`AutotileEngine.cpp:194, 733, 1770, 1832, 3694, 3708, 3751`. The setter
+(`:457-485`) and unpin-migration (`:562-589`) keep raw `m_currentDesktop`.
+
+**Switch-arming flag** `m_isDesktopContextSwitch` (`:482`, consumed globally at `:605,
+:792`): keep global initially — arming the whole effect pass on any per-screen change
+is over-broad but idempotent (catch-scan re-adds, `:607-609`). Promote to a
+`QSet<QString>` only if the over-broad pass proves costly.
+
+**Prune:** extend `pruneStatesForDesktop` (`:1055-1089`) to sweep `m_screenCurrentDesktop`
+by value exactly as it already sweeps `m_screenDesktopOverride` at `:1078`.
+
+### 8b. LayoutRegistry — one change point
+Files: `libs/phosphor-zones/{include/PhosphorZones,src}/LayoutRegistry.*`,
+`IZoneLayoutRegistry.h`.
+
+The layout layer is already per-screen at lookup (`layoutForScreen(screenId, vd, act)`,
+`modeForScreen`, …). Only `resolveLayoutForScreen` (`LayoutRegistry.h:300-303`) injects
+the desktop from the single member `m_currentVirtualDesktop` (`:752`). Change:
+- Add `QHash<QString,int> m_screenVirtualDesktop` + `setCurrentVirtualDesktopForScreen`
+  + `currentVirtualDesktopForScreen(screenId)` (override else `m_currentVirtualDesktop`).
+- `resolveLayoutForScreen(screenId)` → `layoutForScreen(screenId, currentVirtualDesktopForScreen(screenId), m_currentActivity)`.
+  **Every caller already passes a `screenId`** (~15 sites), so this single change
+  propagates per-screen resolution everywhere with zero caller edits.
+- `currentVirtualDesktop()` (`:447`) stays as the global accessor.
+
+### 8c. OverlayService + controllers — per-screen members
+Files: `src/daemon/overlayservice.{h,cpp}`, `unifiedlayoutcontroller.cpp`,
+`zoneselectorcontroller.cpp`.
+
+`OverlayService::m_currentVirtualDesktop` (`overlayservice.h:639`) is used at 5 sites
+that **already have a `screenId` in scope** (`overlayservice.cpp:569, 592, 604, 659,
+674, 710`). Make it a `QHash<QString,int>` with `setCurrentVirtualDesktopForScreen`;
+each usage resolves per its local `screenId`. This single sink change **auto-fixes ~16
+of the bucket-A reads** in §9. `ZoneSelectorController` is already screen-targeted
+(`m_screenId`); track that screen's desktop. `UnifiedLayoutController` is focused-screen
+context (`m_currentScreenName`); store per-screen or derive at use.
+
+---
+
+## 9. Call-site audit — `currentDesktop()` → `currentDesktopForScreen(screenId)`
+
+Full per-site table lives in the agent report; summary (grep-verified, repo-wide):
+
+- **(A) screenId in scope** (must become per-screen, else reads the wrong screen's
+  desktop): ~41 direct sites + ~16 cached-member reads fixed via the §8c sink change
+  ≈ **57**. Canonical seam: `ContextResolver::handleFor(screenId)` pulling the global
+  desktop (`libs/phosphor-context-resolver/src/contextresolver.cpp:47, 79`). Notable:
+  `daemon.cpp:1283`, `autotile.cpp:447`, snap `commit.cpp:44`/`calculate.cpp:168,231`,
+  `geometryutils.cpp:105`, `screenmoderouter.cpp:41`, `layoutregistry.cpp:241,261,300,302`.
+  `daemongeometryresolver.cpp:19` requires a callback signature change
+  (`std::function<int()>` → `std::function<int(QString)>`).
+- **(B) fan-out per-screen** (loop, each screen its own desktop): **14**, incl.
+  `autotile.cpp:56,229,293,345,476`, `daemon.cpp:1449`, `osd.cpp:416`,
+  `start.cpp:129,812,895`. **API change:** `populateResnapBufferForAllScreens(excl,
+  incl, desktopFilter)` (`resnap.cpp:28`) applies one filter to all screens
+  (`navigation.cpp:422`) — must become per-screen.
+- **(C) genuinely global** (keep global / active-screen fallback): **~14** — startup
+  wiring, global welcome/activity OSD (`signals.cpp:509,839,870,891`,
+  `start.cpp:286,368`), boot-time state restore, the `globalHandle`, and the helper
+  *definitions* themselves. `crosssurfaceresolver.cpp:52,58` takes desktop as a param
+  (its bucket-A callers pass the per-screen value).
+- **(D) ambiguous — design decisions resolved in §10:** 3 sites.
+
+**Sinks made per-screen:** OverlayService, LayoutRegistry, ContextResolver/IWorkspaceState,
+UnifiedLayoutController, ZoneSelectorController. **AutotileEngine's `m_currentDesktop`
+stays the global fallback** (per-screen via the override maps).
+
+---
+
+## 10. The 3 ambiguous (D) decisions — resolved
+
+1. **`snap/lifecycle.cpp:597` `capturePlacement` — `p.virtualDesktop = currentVirtualDesktop()`.**
+   `effScreen` is in scope (`:586`). The persisted float-back record must stamp the
+   **window's screen's** desktop, else float-back restores to the wrong desktop.
+   → **Bucket A:** `currentDesktopForScreen(effScreen)`.
+2. **`snap/float.cpp:393` `handoffReceive` — `setFloatingOnScreen(win, ctx.toScreenId, currentDesktop)`.**
+   The stored desktop must be the **destination** screen's desktop. → use
+   `ctx.toDesktop` if `HandoffContext` carries it; else `currentDesktopForScreen(ctx.toScreenId)`.
+3. **`placement/resnap.cpp:248` `pendingRestoreGeometries` — global desktop filter.**
+   Each record is filtered (`:284`) by "is this the current desktop?" — must be answered
+   against the **record's own screen** (`p.screenId`, in scope ~`:270`). → filter each
+   record against `currentDesktopForScreen(p.screenId)`.
+
+Plus a confirmation flag: `navigation_crosssurface.cpp:73` (cross-mode output to a
+neighbour) uses the **neighbour** screen's desktop — confirm intended (the neighbour
+may be on a different desktop than the source).
+
+---
+
+## 11. Detection paths
+
+- **Path A (primary, Plasma 6.7+): effect-sourced, deterministic.** §2–§7. The effect
+  reports each output's real desktop; cursor moves fire nothing; the daemon ignores the
+  global `currentChanged` for OSD/context. **No correlation heuristics.** This is the
+  recommended implementation.
+- **Path B (fallback, pre-6.7 only): inference.** If `desktopChanged`'s `output`
+  param / `currentDesktop(output)` are unavailable, correlate the global `currentChanged`
+  with the effect's existing `cursorScreenChanged`: a global flip *with* a recent
+  cursor-screen change (within an ε window, order-independent) = a follow (record the
+  cursor screen's desktop, suppress OSD/context); *without* = a real switch of the
+  cursor's screen. Mode is derived from divergence (two screens, different desktops).
+  Path B is **strictly inferior** (unresolvable cross-bus ordering race; can't enumerate
+  all screens at startup) and is **out of scope unless pre-6.7 support is required.**
+
+KWin source citations (verified):
+`https://invent.kde.org/plasma/kwin/-/raw/Plasma/6.7/src/effect/effecthandler.h`
+(`currentDesktop(output)`, `desktopChanged(...,output)`);
+`https://invent.kde.org/plasma/kwin/-/raw/master/src/kwin.kcfg`
+(`[Windows]/PerOutputVirtualDesktops`);
+per-output commit `fa6c4a424a5c8bcefddcb163852aefae8313a9a1`.
+
+---
+
+## 12. Backward compatibility
+
+- **Plasma < 6.7 / setting OFF:** KWin fires `desktopChanged(output=null)`; the effect
+  fans out one `screenDesktopChanged` per screen (same desktop). The daemon applies
+  context + OSD to every screen — **byte-identical to today**. `m_screenDesktops` never
+  diverges; `perScreenModeActive()` stays false; all `currentDesktopForScreen` calls
+  fall through to `m_currentDesktop`.
+- **Single monitor:** divergence impossible → legacy path exactly.
+- **Interface additions are non-pure defaulted** → SnapEngine + all existing tests
+  compile unchanged.
+
+---
+
+## 13. Test plan
+
+Harness gaps today: **no `IVirtualDesktopManager` mock**, **no OSD spy**, and the
+daemon desktop-switch lambda is **untested**. So most coverage is **new**.
+
+- **(a) Effect report → VDM map (unit).** `VirtualDesktopManager::updateScreenDesktop`
+  + `currentDesktopForScreen` + `perScreenModeActive` + emit-on-change + count-removal
+  pruning. Concrete `VirtualDesktopManager` (no D-Bus needed; `m_useKWinDBus=false`).
+- **(b) #648 regression (the key test).** Simulate: screen2 on desktop 2, cursor crosses
+  to screen2 → **no `screenDesktopChanged`** (cursor moves don't change an output's
+  desktop) → assert **no desktop-switch OSD** and **no autotile context switch**. Then a
+  *real* switch of screen2 → `screenDesktopChanged(screen2, 2)` → OSD on screen2 only +
+  engine `setCurrentDesktopForScreen(screen2, 2)`.
+- **(c) Per-screen OSD scoping.** A real switch of one screen fires OSD only on that
+  screen's surface. Requires the `showDesktopSwitchOsdForScreen` factor-out (§7).
+- **(d) Engine two-map precedence.** Sticky-pin override wins over per-output-VD;
+  `setCurrentDesktopForScreen` does not migrate state; desktop-removal prunes both maps.
+- **(e) Mode-off fan-out.** `desktopChanged(output=null)` → all screens updated, OSD on
+  all → matches legacy.
+
+Recommended seam: extract the daemon classification/scoping into a small testable unit
+(`PerScreenDesktopTracker`, LGPL, `libs/phosphor-workspaces`) so the core logic tests
+with zero D-Bus/KWin/QML. New tests under `tests/unit/` via `p_add_test`; a lib-resident
+tracker's test goes under `libs/phosphor-workspaces/tests/` (LGPL header).
+
+---
+
+## 14. Risks
+
+1. **Call-site completeness (highest).** A missed bucket-A site reads the wrong screen's
+   desktop in production. Mitigation: the §9 table is the checklist; the §8b/§8c sink
+   changes collapse ~16 of them; grep `currentDesktop()` / `m_currentVirtualDesktop` to
+   verify zero stragglers post-refactor.
+2. **Sticky-pin vs per-output-VD clobber.** Mitigated by the two-map design (§8a) with
+   sticky precedence.
+3. **State migration.** `setCurrentDesktopForScreen` must be a pure context swap (no
+   migration) — only sticky-unpin migrates.
+4. **`m_isDesktopContextSwitch` over-broad arming** — accepted (idempotent); revisit if
+   costly.
+5. **KWin effect API drift.** `desktopChanged`'s `output` param is 6.7-only; older KWin
+   uses Path B or shows today's behavior. Guard the effect connection accordingly.
+
+---
+
+## 15. Phasing (each phase builds + tests green)
+
+1. **VDM model** — per-screen map, `currentDesktopForScreen`, `updateScreenDesktop`,
+   `screenDesktopChanged` signal, non-pure interface additions, count-removal pruning.
+   Tests (a). *No behavior change yet.*
+2. **Effect + D-Bus + WTA** — `screenDesktopChanged` XML method, effect full-signature
+   `desktopChanged` slot + bringup re-sync, WTA forwarder. *Wires the data source.*
+3. **Engine** — two-map design, `setCurrentDesktopForScreen`, read-site conversions,
+   prune. Tests (d).
+4. **Layout + Overlay sinks** — `resolveLayoutForScreen` per-screen, OverlayService /
+   controllers per-screen members. Collapses bucket-A reads.
+5. **Daemon handler** — move to `screenDesktopChanged`, per-screen OSD factor-out,
+   initial-desktop loop, sequencing. Tests (b), (c), (e).
+6. **Call-site sweep** — remaining bucket-A/B sites + the 3 (D) decisions + the
+   `populateResnapBufferForAllScreens` API change. Final grep sweep.
+7. **Audit + regression on a real Plasma 6.7 session.**

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -513,6 +513,10 @@ private:
      * when EDID fields are empty.
      */
     QString outputScreenId(const KWin::LogicalOutput* output) const;
+    /// Report a screen's current virtual desktop to the daemon (Plasma 6.7
+    /// per-output virtual desktops). Deduplicates against m_lastScreenDesktop and
+    /// only fires when the daemon service is registered.
+    void reportScreenDesktop(const QString& screenId, int desktop);
     QString getWindowScreenId(KWin::EffectWindow* w) const;
     AutotileHandler* autotileHandler() const
     {
@@ -1071,6 +1075,9 @@ private:
     // Stores the connector name of the last output the cursor was on.
     // Used for deduplication only — the actual D-Bus call sends the EDID screen ID.
     QString m_lastCursorOutput;
+    // Per-screen current virtual desktop last reported to the daemon (physical
+    // screenId → 1-based desktop), for dedup of KWin's per-output desktopChanged.
+    QHash<QString, int> m_lastScreenDesktop;
 
     // Last effective screen ID reported to daemon (physical or virtual).
     // Used for deduplication of cursorScreenChanged D-Bus calls when virtual

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -21,6 +21,7 @@
 
 #include <effect/effecthandler.h>
 #include <core/output.h>
+#include <virtualdesktops.h>
 #include <window.h>
 #include <workspace.h>
 
@@ -210,6 +211,23 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
                                                        QStringLiteral("cursorScreenChanged"), {cursorScreenId},
                                                        QStringLiteral("cursorScreenChanged"));
         qCDebug(lcEffect) << "Re-sent cursor screen (physical fallback):" << cursorScreenId;
+    }
+
+    // Re-sync each output's current virtual desktop (Plasma 6.7 per-output virtual
+    // desktops, #648). The daemon may have just (re)registered with an empty
+    // per-screen map, so push the authoritative value for every screen — bypassing
+    // reportScreenDesktop's dedup — and refresh the dedup cache to match.
+    for (auto* output : KWin::effects->screens()) {
+        auto* vd = KWin::effects->currentDesktop(output);
+        if (!vd) {
+            continue;
+        }
+        const QString screenId = outputScreenId(output);
+        const int desktop = static_cast<int>(vd->x11DesktopNumber());
+        m_lastScreenDesktop.insert(screenId, desktop);
+        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("screenDesktopChanged"), {screenId, desktop});
+        qCDebug(lcEffect) << "Re-sent screen desktop:" << screenId << "->" << desktop;
     }
 
     // Re-notify active window (gives daemon lastActiveScreenName).

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -10,6 +10,7 @@
 
 #include <effect/effecthandler.h>
 #include <core/output.h>
+#include <virtualdesktops.h>
 #include <workspace.h>
 
 #include <QCoreApplication>
@@ -495,6 +496,31 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     connect(KWin::effects, &KWin::EffectsHandler::desktopChanged, this, [this]() {
         updateAllBorders();
     });
+
+    // Per-output virtual desktops (Plasma 6.7 "switch desktops independently for
+    // each screen"): report each output's current desktop so the daemon keys its
+    // per-screen desktop map off real per-output switches instead of KWin's global
+    // current — which flips merely on cursor movement between monitors on
+    // different desktops (#648). This signal does NOT fire on cursor movement,
+    // only on an actual desktop change for an output, so it is the deterministic
+    // source. `output == nullptr` is a global all-output switch (per-output mode
+    // off); fan out to every screen so the daemon has one code path.
+    connect(KWin::effects, &KWin::EffectsHandler::desktopChanged, this,
+            [this](KWin::VirtualDesktop*, KWin::VirtualDesktop* newDesktop, KWin::EffectWindow*,
+                   KWin::LogicalOutput* output) {
+                if (!newDesktop) {
+                    return;
+                }
+                if (output) {
+                    reportScreenDesktop(outputScreenId(output), static_cast<int>(newDesktop->x11DesktopNumber()));
+                    return;
+                }
+                for (auto* out : KWin::effects->screens()) {
+                    if (auto* vd = KWin::effects->currentDesktop(out)) {
+                        reportScreenDesktop(outputScreenId(out), static_cast<int>(vd->x11DesktopNumber()));
+                    }
+                }
+            });
 
     // Belt-and-suspenders: windowClosed removes animations, but if a deferred
     // timer re-adds one between windowClosed and windowDeleted, the Item tree

--- a/kwin-effect/plasmazoneseffect/screens.cpp
+++ b/kwin-effect/plasmazoneseffect/screens.cpp
@@ -84,6 +84,26 @@ QString PlasmaZonesEffect::outputScreenId(const KWin::LogicalOutput* output) con
     return result;
 }
 
+void PlasmaZonesEffect::reportScreenDesktop(const QString& screenId, int desktop)
+{
+    if (screenId.isEmpty() || desktop < 1) {
+        return;
+    }
+    // Dedup KWin's per-output desktopChanged — only forward a genuine change.
+    // m_lastScreenDesktop is updated even when the daemon service isn't
+    // registered yet; the bringup re-sync (daemon_bringup.cpp) re-pushes every
+    // screen's authoritative desktop after (re)registration, so a missed live
+    // report here is recovered there.
+    if (m_lastScreenDesktop.value(screenId, -1) == desktop) {
+        return;
+    }
+    m_lastScreenDesktop.insert(screenId, desktop);
+    if (m_daemonServiceRegistered) {
+        PhosphorProtocol::ClientHelpers::fireAndForget(this, PhosphorProtocol::Service::Interface::WindowTracking,
+                                                       QStringLiteral("screenDesktopChanged"), {screenId, desktop});
+    }
+}
+
 QString PlasmaZonesEffect::getWindowScreenId(KWin::EffectWindow* w) const
 {
     if (!w) {

--- a/kwin-effect/plasmazoneseffect/screens.cpp
+++ b/kwin-effect/plasmazoneseffect/screens.cpp
@@ -433,6 +433,14 @@ void PlasmaZonesEffect::onScreenRemoved(KWin::LogicalOutput* output)
     if (!output) {
         return;
     }
+
+    // Drop this output's per-screen desktop dedup entry, symmetric with the
+    // daemon's VirtualDesktopManager::removeScreenDesktop (#648): otherwise
+    // reportScreenDesktop's m_lastScreenDesktop cache retains a stale value for
+    // a disconnected connector. Runs before the motion-clock early-return below
+    // so it fires even for an output that never had an animation clock.
+    m_lastScreenDesktop.remove(outputScreenId(output));
+
     // Any in-flight AnimatedValue whose MotionSpec captured this clock's
     // pointer would UAF on its next advance() if we just dropped the
     // unique_ptr. Reap only the animations bound to THIS output's clock

--- a/libs/phosphor-context-resolver/include/PhosphorContext/IContextInputs.h
+++ b/libs/phosphor-context-resolver/include/PhosphorContext/IContextInputs.h
@@ -53,6 +53,16 @@ public:
     /// when no VirtualDesktopManager is wired.
     virtual int currentVirtualDesktop() const = 0;
 
+    /// 1-based desktop index for a specific screen (Plasma 6.7 "switch desktops
+    /// independently for each screen", #648). The default ignores the screen and
+    /// returns the global currentVirtualDesktop(), so single-desktop setups and
+    /// non-per-output implementers are unaffected.
+    virtual int currentVirtualDesktopForScreen(const QString& screenId) const
+    {
+        Q_UNUSED(screenId)
+        return currentVirtualDesktop();
+    }
+
     /// Current activity uuid. Empty when no ActivityManager is wired or
     /// no activity is currently active.
     virtual QString currentActivity() const = 0;

--- a/libs/phosphor-context-resolver/src/contextresolver.cpp
+++ b/libs/phosphor-context-resolver/src/contextresolver.cpp
@@ -44,7 +44,7 @@ ContextHandle ContextResolver::handleFor(const QString& screenId) const
     // GUI thread can only process between event-loop ticks).
     ContextHandle handle;
     handle.screenId = screenId;
-    handle.virtualDesktop = m_workspaceState->currentVirtualDesktop();
+    handle.virtualDesktop = m_workspaceState->currentVirtualDesktopForScreen(screenId);
     handle.activity = m_workspaceState->currentActivity();
     handle.mode = m_modeProvider->modeFor(screenId);
     return handle;
@@ -76,7 +76,7 @@ ContextHandle ContextResolver::handleForMode(const QString& screenId, PhosphorZo
     // overload) but otherwise mirrors handleFor's snapshot semantics.
     ContextHandle handle;
     handle.screenId = screenId;
-    handle.virtualDesktop = m_workspaceState->currentVirtualDesktop();
+    handle.virtualDesktop = m_workspaceState->currentVirtualDesktopForScreen(screenId);
     handle.activity = m_workspaceState->currentActivity();
     handle.mode = mode;
     return handle;

--- a/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IPlacementEngine.h
@@ -476,6 +476,22 @@ public:
     {
         Q_UNUSED(desktop)
     }
+    /// Set a single screen's current virtual desktop (Plasma 6.7 "switch desktops
+    /// independently for each screen"). A PURE context swap — it selects which
+    /// per-(screen, desktop) tiling state is current for this screen; it does NOT
+    /// migrate windows between desktop states (the other desktop's state must stay
+    /// put so it reappears when that screen returns). Default no-op for engines
+    /// that are not per-screen-desktop-aware.
+    virtual void setCurrentDesktopForScreen(const QString& screenId, int desktop)
+    {
+        Q_UNUSED(screenId)
+        Q_UNUSED(desktop)
+    }
+    /// Drop a screen's per-output desktop, reverting it to the global current.
+    virtual void clearCurrentDesktopForScreen(const QString& screenId)
+    {
+        Q_UNUSED(screenId)
+    }
     virtual void setCurrentActivity(const QString& activity)
     {
         Q_UNUSED(activity)

--- a/libs/phosphor-engine/include/PhosphorEngine/IVirtualDesktopManager.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IVirtualDesktopManager.h
@@ -24,7 +24,7 @@ public:
     /// setups and for screens with no per-output desktop on record.
     virtual int currentDesktopForScreen(const QString& screenId) const
     {
-        Q_UNUSED(screenId);
+        Q_UNUSED(screenId)
         return currentDesktop();
     }
 

--- a/libs/phosphor-engine/include/PhosphorEngine/IVirtualDesktopManager.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/IVirtualDesktopManager.h
@@ -5,6 +5,8 @@
 
 #include <phosphorengine_export.h>
 
+#include <QString>
+
 namespace PhosphorEngine {
 
 class PHOSPHORENGINE_EXPORT IVirtualDesktopManager
@@ -12,7 +14,26 @@ class PHOSPHORENGINE_EXPORT IVirtualDesktopManager
 public:
     virtual ~IVirtualDesktopManager() = default;
 
+    /// The global (active-screen) current virtual desktop, 1-based.
     virtual int currentDesktop() const = 0;
+
+    /// The current virtual desktop for a specific screen, 1-based. Under Plasma
+    /// 6.7 "switch desktops independently for each screen" (per-output virtual
+    /// desktops) each screen can be on its own desktop. The default returns the
+    /// global currentDesktop(), which is correct for single-desktop / pre-6.7
+    /// setups and for screens with no per-output desktop on record.
+    virtual int currentDesktopForScreen(const QString& screenId) const
+    {
+        Q_UNUSED(screenId);
+        return currentDesktop();
+    }
+
+    /// True when at least two screens are on different virtual desktops, i.e.
+    /// per-output virtual desktops are in effect. Default: false.
+    virtual bool perScreenModeActive() const
+    {
+        return false;
+    }
 };
 
 } // namespace PhosphorEngine

--- a/libs/phosphor-placement/src/lifecycle.cpp
+++ b/libs/phosphor-placement/src/lifecycle.cpp
@@ -897,7 +897,6 @@ void WindowTrackingService::onLayoutChanged()
     // autotile period so resnapCurrentAssignments() can restore them when tiling is toggled off.
     // Skip windows on OTHER virtual desktops — their zone assignments belong to that
     // desktop's layout and must not be purged when the current desktop's layout changes.
-    const int currentDesktop = m_layoutManager->currentVirtualDesktop();
     const QString currentActivity = m_layoutManager->currentActivity();
 
     // Cache autotile status per screen to avoid redundant lookups (O(screens) instead of O(windows))
@@ -931,12 +930,15 @@ void WindowTrackingService::onLayoutChanged()
         // is a separate axis that only matters for windows whose desktop is
         // current." Don't reorder these without checking that the new ordering
         // still preserves the union {other-desktop OR autotile-screen}.
+        const QString windowScreen = lcScreens.value(it.key());
+        // Per-output virtual desktops (#648): "other desktop" is relative to the
+        // window's OWN screen's current desktop, not the global current.
+        const int currentDesktop = m_layoutManager->currentVirtualDesktopForScreen(windowScreen);
+
         const int windowDesktop = lcDesktops.value(it.key(), 0);
         if (windowDesktop != 0 && windowDesktop != currentDesktop) {
             continue;
         }
-
-        QString windowScreen = lcScreens.value(it.key());
 
         // If this screen's assignment is autotile, preserve zone assignments for resnap
         auto cached = screenIsAutotile.constFind(windowScreen);

--- a/libs/phosphor-placement/src/navigation.cpp
+++ b/libs/phosphor-placement/src/navigation.cpp
@@ -96,7 +96,7 @@ QString WindowTrackingService::findEmptyZoneInLayout(PhosphorZones::Layout* layo
 QString WindowTrackingService::findEmptyZone(const QString& screenId) const
 {
     PhosphorZones::Layout* layout = m_layoutManager->resolveLayoutForScreen(screenId);
-    const int desktopFilter = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    const int desktopFilter = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : 0;
     return findEmptyZoneInLayout(layout, screenId, desktopFilter);
 }
 
@@ -155,7 +155,7 @@ PhosphorProtocol::EmptyZoneList WindowTrackingService::getEmptyZones(const QStri
     // same layout (same zone IDs). Without the desktop filter, windows parked on
     // other virtual desktops keep their zone occupied on the current desktop,
     // blocking snap assist (discussion #323).
-    const int desktopFilter = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    const int desktopFilter = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : 0;
     QSet<QUuid> occupied = buildOccupiedZoneSet(screenId, desktopFilter);
     int zp = m_geometryResolver ? m_geometryResolver->resolveZonePadding(layout, screenId)
                                 : PhosphorEngine::GeometryDefaults::ZonePadding;

--- a/libs/phosphor-placement/src/resnap.cpp
+++ b/libs/phosphor-placement/src/resnap.cpp
@@ -158,7 +158,7 @@ QStringList WindowTrackingService::buildZoneOrderedWindowList(const QString& scr
     // desktop's window positions). Scope to the current desktop; desktop==0
     // (sticky / unknown) stays desktop-agnostic and is kept. Mirrors the
     // desktopFilter guard in populateResnapBufferForAllScreens (addCandidate).
-    const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : 0;
 
     int insertionIdx = 0;
     QVector<std::tuple<int, int, QString>> windowsByZone; // (zoneNum, insertionIdx, windowId)
@@ -245,7 +245,6 @@ QHash<QString, QRect> WindowTrackingService::updatedWindowGeometries() const
 QHash<QString, WindowTrackingService::PendingRestoreTarget> WindowTrackingService::pendingRestoreGeometries() const
 {
     QHash<QString, PendingRestoreTarget> result;
-    int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
 
     // Source the effect's instant-restore cache from the unified placement store:
     // one snapped WindowPlacement per appId-keyed window, resolved to its zone
@@ -268,6 +267,10 @@ QHash<QString, WindowTrackingService::PendingRestoreTarget> WindowTrackingServic
         }
 
         const QString screenId = resolveEffectiveScreenId(p.screenId);
+        // Per-output virtual desktops (#648): validate the record against ITS
+        // screen's current desktop, not the global current.
+        const int currentDesktop =
+            m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : 0;
 
         // Skip screens currently in autotile mode — autotile owns placement there
         // and would otherwise fight a stale snap teleport. Both context

--- a/libs/phosphor-placement/src/resnap.cpp
+++ b/libs/phosphor-placement/src/resnap.cpp
@@ -73,7 +73,13 @@ void WindowTrackingService::populateResnapBufferForAllScreens(const QSet<QString
         // Desktop filter: a per-desktop layout change should resnap only the
         // windows on that desktop. virtualDesktop==0 means sticky / unknown
         // (visible on every desktop) so include those regardless of the filter.
-        if (desktopFilter > 0 && virtualDesktop != 0 && virtualDesktop != desktopFilter)
+        // Under Plasma 6.7 per-output virtual desktops (#648) the "current desktop"
+        // is per-screen, so when filtering (desktopFilter > 0) compare each window
+        // against ITS screen's current desktop rather than the single global value
+        // the caller passed (falling back to that value when no VDM is wired).
+        const int screenDesktop =
+            m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : desktopFilter;
+        if (desktopFilter > 0 && virtualDesktop != 0 && virtualDesktop != screenDesktop)
             return;
 
         if (addedIds.contains(windowId))

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -77,6 +77,9 @@ public:
     /// wants the engine's own view (e.g. for a per-engine OSD) doesn't
     /// have to wire its own VDM.
     int currentVirtualDesktop() const;
+    /// This screen's current virtual desktop (Plasma 6.7 per-output virtual
+    /// desktops, #648), falling back to the global currentVirtualDesktop().
+    int currentVirtualDesktopForScreen(const QString& screenId) const;
     QString currentActivity() const;
 
     /// Resolve the zone on @p screenId's @p targetDesktop layout that is

--- a/libs/phosphor-snap-engine/src/SnapEngine.cpp
+++ b/libs/phosphor-snap-engine/src/SnapEngine.cpp
@@ -159,7 +159,7 @@ SnapNavigationTargetResolver* SnapEngine::ensureTargetResolver(const QString& ac
     // autotile neighbour to the cross-mode handoff instead of snapping onto it.
     m_targetResolver->setNeighbourAutotileProvider([this](const QString& screenId) {
         return m_layoutManager
-            && m_layoutManager->modeForScreen(screenId, currentVirtualDesktop(), currentActivity())
+            && m_layoutManager->modeForScreen(screenId, currentVirtualDesktopForScreen(screenId), currentActivity())
             == PhosphorZones::AssignmentEntry::Autotile;
     });
     return m_targetResolver.get();

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -165,7 +165,7 @@ SnapResult SnapEngine::calculateSnapToLastZone(const QString& windowId, const QS
     // Check virtual desktop match (unless sticky or desktop 0 = all)
     const int lastUsedDesktop = m_snapState->lastUsedDesktop();
     if (!isSticky && m_virtualDesktopManager && lastUsedDesktop > 0) {
-        int currentDesktop = m_virtualDesktopManager->currentDesktop();
+        int currentDesktop = currentVirtualDesktopForScreen(windowScreenId);
         if (currentDesktop != lastUsedDesktop) {
             return SnapResult::noSnap();
         }
@@ -228,7 +228,7 @@ SnapResult SnapEngine::calculateSnapToEmptyZone(const QString& windowId, const Q
     // Reuse findEmptyZoneInLayout() with already-resolved layout to avoid double resolution.
     // Filter occupancy by the current virtual desktop so windows parked on other desktops
     // don't prevent auto-snap placement on the current desktop.
-    const int desktopFilter = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    const int desktopFilter = currentVirtualDesktopForScreen(windowScreenId);
     QString emptyZoneId = m_windowTracker->findEmptyZoneInLayout(layout, windowScreenId, desktopFilter);
     if (emptyZoneId.isEmpty()) {
         qCDebug(PhosphorSnapEngine::lcSnapEngine) << "snapToEmptyZone: no empty zone on" << windowScreenId;

--- a/libs/phosphor-snap-engine/src/commit.cpp
+++ b/libs/phosphor-snap-engine/src/commit.cpp
@@ -41,7 +41,7 @@ void SnapEngine::commitSnapImpl(const QString& windowId, const QStringList& zone
         }
     }
 
-    const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    const int currentDesktop = currentVirtualDesktopForScreen(screenId);
     if (zoneIds.size() > 1) {
         m_windowTracker->assignWindowToZones(windowId, zoneIds, screenId, currentDesktop);
     } else {

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -302,7 +302,7 @@ UnfloatResult SnapEngine::resolveFallbackUnfloatGeometry(const QString& windowId
         }
     }
     if (zoneId.isEmpty()) {
-        const int desktopFilter = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+        const int desktopFilter = currentVirtualDesktopForScreen(fallbackScreen);
         zoneId = m_windowTracker->findEmptyZoneInLayout(layout, screen, desktopFilter);
     }
     if (zoneId.isEmpty()) {
@@ -346,7 +346,7 @@ void SnapEngine::handoffReceive(const HandoffContext& ctx)
     if (!ctx.sourceZoneIds.isEmpty()) {
         QRect zoneGeo = m_windowTracker->resolveZoneGeometry(ctx.sourceZoneIds, ctx.toScreenId);
         if (zoneGeo.isValid()) {
-            const int curDesktop = currentVirtualDesktop();
+            const int curDesktop = currentVirtualDesktopForScreen(ctx.toScreenId);
             if (ctx.toDesktop > 0 && ctx.toDesktop != curDesktop) {
                 // Cross-DESKTOP handoff: the target desktop isn't the visible one,
                 // so assign the snap slot directly on SnapState for that desktop
@@ -390,7 +390,7 @@ void SnapEngine::handoffReceive(const HandoffContext& ctx)
         }
     }
 
-    const int currentDesktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    const int currentDesktop = ctx.toDesktop > 0 ? ctx.toDesktop : currentVirtualDesktopForScreen(ctx.toScreenId);
     m_snapState->setFloatingOnScreen(ctx.windowId, ctx.toScreenId, currentDesktop);
     m_windowTracker->setWindowFloating(ctx.windowId, true);
     Q_EMIT windowFloatingChanged(ctx.windowId, true, ctx.toScreenId);

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -302,7 +302,7 @@ UnfloatResult SnapEngine::resolveFallbackUnfloatGeometry(const QString& windowId
         }
     }
     if (zoneId.isEmpty()) {
-        const int desktopFilter = currentVirtualDesktopForScreen(fallbackScreen);
+        const int desktopFilter = currentVirtualDesktopForScreen(screen);
         zoneId = m_windowTracker->findEmptyZoneInLayout(layout, screen, desktopFilter);
     }
     if (zoneId.isEmpty()) {

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -171,7 +171,7 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     // record (recorded screen == this autotile screen) is NOT snapping, so the peek
     // misses and we correctly defer, leaving the record for autotile.
     if (m_layoutManager
-        && m_layoutManager->modeForScreen(screenId, currentVirtualDesktop(), currentActivity())
+        && m_layoutManager->modeForScreen(screenId, currentVirtualDesktopForScreen(screenId), currentActivity())
             != PhosphorZones::AssignmentEntry::Mode::Snapping) {
         bool crossScreenSnapRestorePending = false;
         if (m_windowTracker) {
@@ -372,7 +372,8 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
                 // That gate refuses to auto-SNAP a window onto a context the user
                 // disabled snapping for; a floated window is not being snapped into a
                 // zone, so restoring its floating state is correct regardless.
-                m_snapState->setFloatingOnScreen(windowId, restoreScreen, currentVirtualDesktop());
+                m_snapState->setFloatingOnScreen(windowId, restoreScreen,
+                                                 currentVirtualDesktopForScreen(restoreScreen));
                 if (!slot.zoneIds.isEmpty()) {
                     // A window floated FROM a snapped state carries its pre-float zones
                     // for the resnap path; a never-snapped floated window has none.
@@ -477,7 +478,7 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     // so a rule-floated window never auto-snaps to a zone.
     // Mirrors the no-match default-float terminal at the end of this function.
     if (m_floatPredicate && m_floatPredicate(windowId)) {
-        m_snapState->setFloatingOnScreen(windowId, screenId, currentVirtualDesktop());
+        m_snapState->setFloatingOnScreen(windowId, screenId, currentVirtualDesktopForScreen(screenId));
         Q_EMIT windowFloatingChanged(windowId, true, screenId);
         qCInfo(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore:" << windowId << "floated by rule";
         return SnapResult::noSnap();
@@ -498,7 +499,7 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     // on an autotile screen must not be auto-assigned, autotile owns
     // placement there.
     if (m_layoutManager) {
-        const int dt = currentVirtualDesktop();
+        const int dt = currentVirtualDesktopForScreen(screenId);
         if (m_layoutManager->modeForScreen(screenId, dt, currentActivity())
             != PhosphorZones::AssignmentEntry::Mode::Snapping) {
             qCDebug(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore:" << windowId << "caller screen"
@@ -535,7 +536,7 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     // already-snapped guards above all return earlier, and the autotile-caller
     // short-circuit returns before the empty/last-zone chain — so this is always a
     // genuine snap-mode window with no zone match.
-    m_snapState->setFloatingOnScreen(windowId, screenId, currentVirtualDesktop());
+    m_snapState->setFloatingOnScreen(windowId, screenId, currentVirtualDesktopForScreen(screenId));
     Q_EMIT windowFloatingChanged(windowId, true, screenId);
     qCInfo(PhosphorSnapEngine::lcSnapEngine)
         << "resolveWindowRestore:" << windowId << "no snap match — defaulting to floated on" << screenId;
@@ -545,6 +546,13 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
 int SnapEngine::currentVirtualDesktop() const
 {
     return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+}
+
+int SnapEngine::currentVirtualDesktopForScreen(const QString& screenId) const
+{
+    // Per-output virtual desktops (#648): a snapped window's context binds to the
+    // desktop of the screen it lives on, not the global current desktop.
+    return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : 0;
 }
 
 QString SnapEngine::currentActivity() const
@@ -585,7 +593,7 @@ std::optional<PhosphorEngine::WindowPlacement> SnapEngine::capturePlacement(cons
     if (m_layoutManager) {
         const QString effScreen = screenForTrackedWindow(windowId);
         if (!effScreen.isEmpty()
-            && m_layoutManager->modeForScreen(effScreen, currentVirtualDesktop(), currentActivity())
+            && m_layoutManager->modeForScreen(effScreen, currentVirtualDesktopForScreen(effScreen), currentActivity())
                 != PhosphorZones::AssignmentEntry::Mode::Snapping) {
             return std::nullopt;
         }
@@ -594,7 +602,10 @@ std::optional<PhosphorEngine::WindowPlacement> SnapEngine::capturePlacement(cons
     WindowPlacement p;
     p.windowId = windowId;
     p.appId = m_windowTracker ? m_windowTracker->currentAppIdFor(windowId) : QString();
-    p.virtualDesktop = currentVirtualDesktop();
+    // Bind the captured desktop to the window's OWN screen, not the global current
+    // (Plasma 6.7 per-output virtual desktops, #648), so a float-back restores to
+    // the right desktop on a screen that isn't the active one.
+    p.virtualDesktop = currentVirtualDesktopForScreen(screenForTrackedWindow(windowId));
     p.activity = currentActivity();
 
     // The slot carries only the snap engine's STATE + slot reference (zone IDs) —

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -590,8 +590,10 @@ std::optional<PhosphorEngine::WindowPlacement> SnapEngine::capturePlacement(cons
     // engine remembers
     // the window's state in its OWN mode; returning nullopt leaves the snap record
     // untouched.
+    // Resolve the window's own screen once: the mode gate below and the
+    // captured per-output desktop (#648) both key on it.
+    const QString effScreen = screenForTrackedWindow(windowId);
     if (m_layoutManager) {
-        const QString effScreen = screenForTrackedWindow(windowId);
         if (!effScreen.isEmpty()
             && m_layoutManager->modeForScreen(effScreen, currentVirtualDesktopForScreen(effScreen), currentActivity())
                 != PhosphorZones::AssignmentEntry::Mode::Snapping) {
@@ -605,7 +607,7 @@ std::optional<PhosphorEngine::WindowPlacement> SnapEngine::capturePlacement(cons
     // Bind the captured desktop to the window's OWN screen, not the global current
     // (Plasma 6.7 per-output virtual desktops, #648), so a float-back restores to
     // the right desktop on a screen that isn't the active one.
-    p.virtualDesktop = currentVirtualDesktopForScreen(screenForTrackedWindow(windowId));
+    p.virtualDesktop = currentVirtualDesktopForScreen(effScreen);
     p.activity = currentActivity();
 
     // The slot carries only the snap engine's STATE + slot reference (zone IDs) —

--- a/libs/phosphor-snap-engine/src/navigation_actions.cpp
+++ b/libs/phosphor-snap-engine/src/navigation_actions.cpp
@@ -231,7 +231,8 @@ bool SnapEngine::tryCrossDesktopFocus(const QString& focusedWindowId, const QStr
     if (!m_crossSurfaceResolver || !m_snapState) {
         return false;
     }
-    const int targetDesktop = m_crossSurfaceResolver->neighborDesktopInDirection(currentVirtualDesktop(), direction);
+    const int targetDesktop =
+        m_crossSurfaceResolver->neighborDesktopInDirection(currentVirtualDesktopForScreen(screenId), direction);
     if (targetDesktop <= 0) {
         return false;
     }
@@ -317,7 +318,8 @@ bool SnapEngine::tryCrossDesktopMove(const QString& windowId, const QString& dir
     if (!m_crossSurfaceResolver || !m_snapState) {
         return false;
     }
-    const int targetDesktop = m_crossSurfaceResolver->neighborDesktopInDirection(currentVirtualDesktop(), direction);
+    const int targetDesktop =
+        m_crossSurfaceResolver->neighborDesktopInDirection(currentVirtualDesktopForScreen(screenId), direction);
     if (targetDesktop <= 0) {
         return false;
     }

--- a/libs/phosphor-snap-engine/src/navigation_crosssurface.cpp
+++ b/libs/phosphor-snap-engine/src/navigation_crosssurface.cpp
@@ -70,7 +70,7 @@ bool SnapEngine::tryCrossModeOutput(const QString& windowId, const QString& dire
     // cross-mode handoff; a snap neighbour with no entry zone is a genuine
     // boundary — leave it. A move inserts the window into the neighbour's stack;
     // a swap trades it with the neighbour's entry-edge tile.
-    if (m_layoutManager->modeForScreen(neighbour, currentVirtualDesktop(), currentActivity())
+    if (m_layoutManager->modeForScreen(neighbour, currentVirtualDesktopForScreen(neighbour), currentActivity())
         != PhosphorZones::AssignmentEntry::Autotile) {
         return false;
     }

--- a/libs/phosphor-snap-engine/src/resnap_calc.cpp
+++ b/libs/phosphor-snap-engine/src/resnap_calc.cpp
@@ -366,7 +366,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateSnapAllWindowEntries(const QSt
 
     // Filter occupancy by the current virtual desktop so windows parked on other
     // desktops don't make zones appear occupied on the current-desktop batch snap.
-    const int desktopFilter = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+    const int desktopFilter = currentVirtualDesktopForScreen(screenId);
     QSet<QUuid> occupiedZoneIds = m_windowTracker->buildOccupiedZoneSet(screenId, desktopFilter);
 
     // Resolve physical screen for zone geometry calculation

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -280,6 +280,21 @@ public:
      */
     void setCurrentDesktop(int desktop) override;
 
+    /**
+     * @brief Set a single screen's current virtual desktop (Plasma 6.7 per-output
+     *        virtual desktops, #648)
+     *
+     * Pure context swap: records the screen's desktop in m_screenCurrentDesktop so
+     * currentKeyForScreen() resolves that screen's per-(screen, desktop) state. Does
+     * NOT migrate windows between states — the other desktop's state stays put so it
+     * reappears when the screen returns. Like setCurrentDesktop(), call BEFORE
+     * updateAutotileScreens() so the new key resolves.
+     */
+    void setCurrentDesktopForScreen(const QString& screenId, int desktop) override;
+
+    /// Drop a screen's per-output desktop, reverting it to the global m_currentDesktop.
+    void clearCurrentDesktopForScreen(const QString& screenId) override;
+
     /// Inject the cross-surface resolver (neighbouring output / desktop lookup)
     /// used by directional navigation when it reaches a layout boundary.
     void setCrossSurfaceResolver(PhosphorEngine::ICrossSurfaceResolver* resolver) override
@@ -1155,8 +1170,20 @@ private:
      */
     PhosphorEngine::TilingStateKey currentKeyForScreen(const QString& screenId) const
     {
-        auto it = m_screenDesktopOverride.constFind(screenId);
-        int desktop = (it != m_screenDesktopOverride.constEnd()) ? it.value() : m_currentDesktop;
+        // Precedence (highest first):
+        //   1. sticky-pin override (m_screenDesktopOverride) — a CORRECTNESS
+        //      constraint: sticky on-all-desktops windows must keep their state on
+        //      the desktop where they live, so the pin must win;
+        //   2. per-output virtual desktop (m_screenCurrentDesktop, Plasma 6.7) —
+        //      the normal per-screen input;
+        //   3. the global current desktop (m_currentDesktop) — fallback.
+        int desktop = m_currentDesktop;
+        if (auto perOut = m_screenCurrentDesktop.constFind(screenId); perOut != m_screenCurrentDesktop.constEnd()) {
+            desktop = perOut.value();
+        }
+        if (auto pin = m_screenDesktopOverride.constFind(screenId); pin != m_screenDesktopOverride.constEnd()) {
+            desktop = pin.value();
+        }
         return PhosphorEngine::TilingStateKey{screenId, desktop, m_currentActivity};
     }
 
@@ -1408,6 +1435,15 @@ private:
     // currentKeyForScreen() returns the key of the existing PhosphorTiles::TilingState rather
     // than a new (empty) key after a desktop switch.
     QHash<QString, int> m_screenDesktopOverride;
+
+    // Per-screen current virtual desktop under Plasma 6.7 "switch desktops
+    // independently for each screen" (#648). Fed by setCurrentDesktopForScreen
+    // from the daemon's per-output desktop reports. Distinct from
+    // m_screenDesktopOverride (the sticky-pin map): the sticky pin is a
+    // correctness constraint and wins in currentKeyForScreen; this is the normal
+    // per-screen input. Empty when per-output desktops aren't in use, so every
+    // screen falls back to m_currentDesktop.
+    QHash<QString, int> m_screenCurrentDesktop;
 
     // Pre-seeded window order for snapping → autotile transitions.
     // Keyed by stable EDID-based screen ID (PhosphorScreens::ScreenIdentity::identifierFor).

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -324,18 +324,29 @@ void AutotileEngine::connectSignals()
                         Q_EMIT settingsPersistRequested();
                     }
 
-                    // Clean up desktop overrides for removed virtual screens on this physical screen.
-                    // Use newVsSet (freshly-computed from PhosphorScreens::ScreenManager) rather than
-                    // m_autotileScreens which reflects mode assignments and may not yet be updated for the new config.
+                    // Clean up per-screen desktop maps for removed virtual screens on this
+                    // physical screen — BOTH the sticky-pin override and the per-output-VD
+                    // map (#648). Use newVsSet (freshly-computed from
+                    // PhosphorScreens::ScreenManager) rather than m_autotileScreens which
+                    // reflects mode assignments and may not yet be updated for the new config.
+                    const auto isOrphanedVsOfThisPhysical = [&](const QString& key) {
+                        return PhosphorIdentity::VirtualScreenId::isVirtual(key)
+                            && PhosphorIdentity::VirtualScreenId::extractPhysicalId(key) == physicalScreenId
+                            && !newVsSet.contains(key);
+                    };
                     auto overrideIt = m_screenDesktopOverride.begin();
                     while (overrideIt != m_screenDesktopOverride.end()) {
-                        if (PhosphorIdentity::VirtualScreenId::isVirtual(overrideIt.key())
-                            && PhosphorIdentity::VirtualScreenId::extractPhysicalId(overrideIt.key())
-                                == physicalScreenId
-                            && !newVsSet.contains(overrideIt.key()))
+                        if (isOrphanedVsOfThisPhysical(overrideIt.key()))
                             overrideIt = m_screenDesktopOverride.erase(overrideIt);
                         else
                             ++overrideIt;
+                    }
+                    auto perOutputIt = m_screenCurrentDesktop.begin();
+                    while (perOutputIt != m_screenCurrentDesktop.end()) {
+                        if (isOrphanedVsOfThisPhysical(perOutputIt.key()))
+                            perOutputIt = m_screenCurrentDesktop.erase(perOutputIt);
+                        else
+                            ++perOutputIt;
                     }
 
                     // Retile the new virtual screens
@@ -806,9 +817,11 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
     // toggle-off while another context holds overflow on the same screen.
     m_overflow.clearForRemovedScreens(m_autotileScreens);
 
-    // Clear desktop overrides for removed screens
+    // Clear per-screen desktop maps for removed screens — both the sticky-pin
+    // override and the per-output-VD map (#648).
     for (const QString& screenId : removed) {
         m_screenDesktopOverride.remove(screenId);
+        m_screenCurrentDesktop.remove(screenId);
     }
 
     // Clear any pending deferred retiles and retry state for removed screens

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -191,7 +191,8 @@ void AutotileEngine::onWindowZoneChanged(const QString& windowId, const QString&
         return;
     if (zoneId.isEmpty()) {
         for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-            if (it.key().desktop != m_currentDesktop || it.key().activity != m_currentActivity) {
+            if (it.key().desktop != currentKeyForScreen(it.key().screenId).desktop
+                || it.key().activity != m_currentActivity) {
                 continue;
             }
             if (it.value() && it.value()->isFloating(windowId)) {
@@ -484,6 +485,36 @@ void AutotileEngine::setCurrentDesktop(int desktop)
     m_currentDesktop = desktop;
 }
 
+void AutotileEngine::setCurrentDesktopForScreen(const QString& screenId, int desktop)
+{
+    if (screenId.isEmpty() || desktop < 1) {
+        return;
+    }
+    const int previous = m_screenCurrentDesktop.value(screenId, m_currentDesktop);
+    if (previous == desktop) {
+        // Same per-screen desktop still establishes the context (mirrors the
+        // same-desktop branch of setCurrentDesktop for the startup push).
+        m_desktopContextEverSet = true;
+        return;
+    }
+    qCInfo(PhosphorTileEngine::lcTileEngine)
+        << "Switching autotile context for screen" << screenId << "desktop" << previous << "->" << desktop;
+    // PURE context swap — no state migration. The other desktop's TilingState for
+    // this screen stays put and reappears when the screen returns to it; migrating
+    // would destroy the per-desktop isolation that the (screen, desktop) keying
+    // exists to provide. Arm the (global) desktop-switch flag exactly like
+    // setCurrentDesktop so the effect's desktop-switch pass runs — over-broad
+    // across screens but idempotent (the catch-scan re-adds).
+    m_isDesktopContextSwitch |= m_desktopContextEverSet;
+    m_desktopContextEverSet = true;
+    m_screenCurrentDesktop.insert(screenId, desktop);
+}
+
+void AutotileEngine::clearCurrentDesktopForScreen(const QString& screenId)
+{
+    m_screenCurrentDesktop.remove(screenId);
+}
+
 void AutotileEngine::setCurrentActivity(const QString& activity)
 {
     if (activity == m_currentActivity) {
@@ -558,10 +589,16 @@ void AutotileEngine::updateStickyScreenPins(const std::function<bool(const QStri
                 qCInfo(PhosphorTileEngine::lcTileEngine)
                     << "Unpinning screen" << screenId << "from desktop" << pinnedDesktop;
 
-                // Migrate PhosphorTiles::TilingState from pinned key to current desktop key
-                if (pinnedDesktop != m_currentDesktop) {
+                // Migrate PhosphorTiles::TilingState from the pinned key to this
+                // screen's CURRENT desktop key. The sticky-pin override was just
+                // removed above, so currentKeyForScreen now resolves the screen's
+                // effective desktop — its per-output virtual desktop under Plasma
+                // 6.7 (#648), else the global m_currentDesktop. Identical to
+                // m_currentDesktop when per-output desktops aren't in use.
+                const int targetDesktop = currentKeyForScreen(screenId).desktop;
+                if (pinnedDesktop != targetDesktop) {
                     TilingStateKey oldKey{screenId, pinnedDesktop, m_currentActivity};
-                    TilingStateKey newKey{screenId, m_currentDesktop, m_currentActivity};
+                    TilingStateKey newKey{screenId, targetDesktop, m_currentActivity};
 
                     auto oldIt = m_screenStates.find(oldKey);
                     if (oldIt != m_screenStates.end()) {
@@ -586,7 +623,7 @@ void AutotileEngine::updateStickyScreenPins(const std::function<bool(const QStri
 
                         qCInfo(PhosphorTileEngine::lcTileEngine)
                             << "Migrated screen" << screenId << "state from desktop" << pinnedDesktop << "to"
-                            << m_currentDesktop;
+                            << targetDesktop;
                     }
                 }
             }
@@ -730,7 +767,7 @@ void AutotileEngine::setAutotileScreens(const QSet<QString>& screens)
         // windowOpened migration) and reaped wholesale by
         // pruneStatesForDesktop / pruneStatesForActivities when their
         // desktop or activity is destroyed.
-        if (key.desktop != m_currentDesktop || key.activity != m_currentActivity) {
+        if (key.desktop != currentKeyForScreen(key.screenId).desktop || key.activity != m_currentActivity) {
             continue;
         }
         if (!removed.contains(key.screenId)) {
@@ -1080,6 +1117,16 @@ void AutotileEngine::pruneStatesForDesktop(int removedDesktop)
         oit.next();
         if (oit.value() == removedDesktop) {
             oit.remove();
+        }
+    }
+    // Same for the per-output virtual-desktop map (#648) — a screen pinned to a
+    // now-deleted desktop number must drop the entry; the effect re-reports the
+    // screen's true (renumbered) desktop shortly after.
+    QMutableHashIterator<QString, int> sit(m_screenCurrentDesktop);
+    while (sit.hasNext()) {
+        sit.next();
+        if (sit.value() == removedDesktop) {
+            sit.remove();
         }
     }
     if (pruned > 0) {
@@ -1767,7 +1814,8 @@ void AutotileEngine::toggleFocusedWindowFloat()
     }
     if (!state) {
         for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-            if (it.value() && !it.value()->focusedWindow().isEmpty() && it.key().desktop == m_currentDesktop
+            if (it.value() && !it.value()->focusedWindow().isEmpty()
+                && it.key().desktop == currentKeyForScreen(it.key().screenId).desktop
                 && it.key().activity == m_currentActivity) {
                 screenId = it.key().screenId;
                 state = it.value();
@@ -1829,7 +1877,8 @@ void AutotileEngine::toggleWindowFloat(const QString& rawWindowId, const QString
     // states only — states for other desktops should not be considered.
     if (!state) {
         for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-            if (it.key().desktop != m_currentDesktop || it.key().activity != m_currentActivity) {
+            if (it.key().desktop != currentKeyForScreen(it.key().screenId).desktop
+                || it.key().activity != m_currentActivity) {
                 continue;
             }
             if (it.value() && it.value()->containsWindow(windowId)) {
@@ -3691,7 +3740,8 @@ void AutotileEngine::propagateGlobalSplitRatio()
     // Only propagate to current desktop/activity states — per-desktop split
     // ratio adjustments (via increaseMasterRatio) are preserved on other desktops.
     for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-        if (it.key().desktop != m_currentDesktop || it.key().activity != m_currentActivity) {
+        if (it.key().desktop != currentKeyForScreen(it.key().screenId).desktop
+            || it.key().activity != m_currentActivity) {
             continue;
         }
         if (it.value() && !hasPerScreenOverride(it.key().screenId, PerScreenKeys::SplitRatio)) {
@@ -3705,7 +3755,8 @@ void AutotileEngine::propagateGlobalMasterCount()
     // Only propagate to current desktop/activity states — per-desktop master
     // count adjustments are preserved on other desktops.
     for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
-        if (it.key().desktop != m_currentDesktop || it.key().activity != m_currentActivity) {
+        if (it.key().desktop != currentKeyForScreen(it.key().screenId).desktop
+            || it.key().activity != m_currentActivity) {
             continue;
         }
         if (it.value() && !hasPerScreenOverride(it.key().screenId, PerScreenKeys::MasterCount)) {
@@ -3748,7 +3799,8 @@ void AutotileEngine::backfillWindows()
         // (insertWindow calls m_windowToStateKey.insert which is unsafe during const iteration)
         QStringList candidates;
         for (auto it = m_windowToStateKey.constBegin(); it != m_windowToStateKey.constEnd(); ++it) {
-            if (it.value().screenId == screenId && it.value().desktop == m_currentDesktop
+            if (it.value().screenId == screenId
+                && it.value().desktop == currentKeyForScreen(it.value().screenId).desktop
                 && it.value().activity == m_currentActivity && !state->containsWindow(it.key())
                 && shouldTileWindow(it.key())) {
                 candidates.append(it.key());

--- a/libs/phosphor-tile-engine/src/NavigationController.cpp
+++ b/libs/phosphor-tile-engine/src/NavigationController.cpp
@@ -878,10 +878,12 @@ void NavigationController::applyToAllStates(const std::function<void(PhosphorTil
         return; // No states to modify
     }
 
-    // Only apply to states for the current desktop/activity
+    // Only apply to states for each screen's current desktop/activity. Under
+    // per-output virtual desktops (#648) the desktop is resolved per-screen,
+    // matching propagateGlobalSplitRatio/propagateGlobalMasterCount.
     for (auto it = m_engine->m_screenStates.begin(); it != m_engine->m_screenStates.end(); ++it) {
-        if (it.key().desktop == m_engine->m_currentDesktop && it.key().activity == m_engine->m_currentActivity
-            && it.value()) {
+        if (it.key().desktop == m_engine->currentKeyForScreen(it.key().screenId).desktop
+            && it.key().activity == m_engine->m_currentActivity && it.value()) {
             operation(it.value());
         }
     }

--- a/libs/phosphor-workspaces/include/PhosphorWorkspaces/VirtualDesktopManager.h
+++ b/libs/phosphor-workspaces/include/PhosphorWorkspaces/VirtualDesktopManager.h
@@ -5,7 +5,9 @@
 
 #include <PhosphorEngine/IVirtualDesktopManager.h>
 #include <phosphorworkspaces_export.h>
+#include <QHash>
 #include <QObject>
+#include <QString>
 #include <QStringList>
 
 class QDBusInterface;
@@ -26,6 +28,16 @@ public:
     void stop();
 
     int currentDesktop() const override;
+    int currentDesktopForScreen(const QString& screenId) const override;
+    bool perScreenModeActive() const override;
+
+    /// Record a screen's current virtual desktop (1-based). This is fed by the
+    /// KWin effect's per-output desktopChanged report (Plasma 6.7 per-output
+    /// virtual desktops) — KWin's own D-Bus VirtualDesktopManager interface only
+    /// exposes the GLOBAL current desktop, so per-screen data arrives this way.
+    /// Emits screenDesktopChanged only when the value actually changes.
+    void updateScreenDesktop(const QString& screenId, int desktop);
+
     void setCurrentDesktop(int desktop);
     int desktopCount() const;
     /// Number of rows in KWin's virtual-desktop grid (>= 1). With the count,
@@ -37,6 +49,11 @@ public:
 Q_SIGNALS:
     void currentDesktopChanged(int desktop);
     void desktopCountChanged(int count);
+    /// A single screen's current virtual desktop changed (per-output virtual
+    /// desktops). The primary trigger the daemon's per-screen desktop handler
+    /// subscribes to; in single-desktop mode it is driven the same for every
+    /// screen so downstream has one code path.
+    void screenDesktopChanged(const QString& screenId, int desktop);
 
 private Q_SLOTS:
     void onNumberOfDesktopsChanged(int count);
@@ -49,11 +66,19 @@ private Q_SLOTS:
 private:
     void initKWinDBus();
     void applyDesktopListReply(const QDBusMessage& reply, const QString& currentId);
+    /// Clamp any per-screen desktop entry above the live desktop count back down
+    /// to the count (KWin renumbers on removal; the effect re-reports the true
+    /// value shortly after, this just keeps the map valid in the interim).
+    void clampScreenDesktopsToCount();
 
     QDBusInterface* m_kwinVDInterface = nullptr;
     bool m_running = false;
     bool m_useKWinDBus = false;
     int m_currentDesktop = 1;
+    /// Per-screen current virtual desktop (screenId → 1-based), populated only
+    /// in per-output mode via updateScreenDesktop. Empty otherwise, so every
+    /// currentDesktopForScreen() falls back to the global m_currentDesktop.
+    QHash<QString, int> m_screenDesktops;
     int m_desktopCount = 1;
     int m_desktopRows = 1;
     QStringList m_desktopNames;

--- a/libs/phosphor-workspaces/include/PhosphorWorkspaces/VirtualDesktopManager.h
+++ b/libs/phosphor-workspaces/include/PhosphorWorkspaces/VirtualDesktopManager.h
@@ -38,6 +38,12 @@ public:
     /// Emits screenDesktopChanged only when the value actually changes.
     void updateScreenDesktop(const QString& screenId, int desktop);
 
+    /// Drop a screen's recorded per-output desktop when the output is removed,
+    /// so the map doesn't retain stale entries (and perScreenModeActive() doesn't
+    /// keep counting a gone screen) across monitor hot-plug. Driven by the
+    /// daemon's screenRemoved handler.
+    void removeScreenDesktop(const QString& screenId);
+
     void setCurrentDesktop(int desktop);
     int desktopCount() const;
     /// Number of rows in KWin's virtual-desktop grid (>= 1). With the count,

--- a/libs/phosphor-workspaces/src/VirtualDesktopManager.cpp
+++ b/libs/phosphor-workspaces/src/VirtualDesktopManager.cpp
@@ -12,6 +12,8 @@
 #include <QDBusPendingCall>
 #include <QDBusPendingCallWatcher>
 
+#include <utility>
+
 namespace PhosphorWorkspaces {
 
 VirtualDesktopManager::VirtualDesktopManager(QObject* parent)
@@ -282,19 +284,31 @@ void VirtualDesktopManager::updateScreenDesktop(const QString& screenId, int des
     Q_EMIT screenDesktopChanged(screenId, desktop);
 }
 
+void VirtualDesktopManager::removeScreenDesktop(const QString& screenId)
+{
+    m_screenDesktops.remove(screenId);
+}
+
 void VirtualDesktopManager::clampScreenDesktopsToCount()
 {
-    // Mutate first, then emit — emitting mid-iteration could re-enter
-    // updateScreenDesktop and invalidate the hash iterator.
-    QStringList clamped;
+    // Clamp only entries above the live count: KWin renumbers on desktop
+    // removal, so a screen pinned past the new count is pulled down to it here.
+    // This does NOT re-identify a surviving entry whose desktop was renumbered
+    // by a mid-list removal — the effect re-reports each output's true desktop
+    // shortly after via updateScreenDesktop, which is authoritative for that.
+    //
+    // Mutate first, then emit the captured value — emitting mid-iteration could
+    // re-enter updateScreenDesktop and invalidate the hash iterator, and a
+    // re-entrant write must not change the value we report for this clamp.
+    QList<std::pair<QString, int>> clamped;
     for (auto it = m_screenDesktops.begin(); it != m_screenDesktops.end(); ++it) {
         if (it.value() > m_desktopCount) {
             it.value() = m_desktopCount;
-            clamped.append(it.key());
+            clamped.append({it.key(), m_desktopCount});
         }
     }
-    for (const QString& screenId : clamped) {
-        Q_EMIT screenDesktopChanged(screenId, m_screenDesktops.value(screenId));
+    for (const auto& [screenId, desktop] : clamped) {
+        Q_EMIT screenDesktopChanged(screenId, desktop);
     }
 }
 

--- a/libs/phosphor-workspaces/src/VirtualDesktopManager.cpp
+++ b/libs/phosphor-workspaces/src/VirtualDesktopManager.cpp
@@ -215,6 +215,7 @@ void VirtualDesktopManager::onKWinDesktopCreated()
 void VirtualDesktopManager::onKWinDesktopRemoved()
 {
     refreshFromKWin();
+    clampScreenDesktopsToCount();
     Q_EMIT desktopCountChanged(m_desktopCount);
 }
 
@@ -246,6 +247,55 @@ void VirtualDesktopManager::stop()
 int VirtualDesktopManager::currentDesktop() const
 {
     return m_useKWinDBus ? m_currentDesktop : 1;
+}
+
+int VirtualDesktopManager::currentDesktopForScreen(const QString& screenId) const
+{
+    const auto it = m_screenDesktops.constFind(screenId);
+    return it != m_screenDesktops.constEnd() ? it.value() : currentDesktop();
+}
+
+bool VirtualDesktopManager::perScreenModeActive() const
+{
+    if (m_screenDesktops.size() < 2) {
+        return false;
+    }
+    auto it = m_screenDesktops.constBegin();
+    const int first = it.value();
+    for (++it; it != m_screenDesktops.constEnd(); ++it) {
+        if (it.value() != first) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void VirtualDesktopManager::updateScreenDesktop(const QString& screenId, int desktop)
+{
+    if (screenId.isEmpty() || desktop < 1) {
+        return;
+    }
+    if (m_screenDesktops.value(screenId, -1) == desktop) {
+        return;
+    }
+    m_screenDesktops.insert(screenId, desktop);
+    Q_EMIT screenDesktopChanged(screenId, desktop);
+}
+
+void VirtualDesktopManager::clampScreenDesktopsToCount()
+{
+    // Mutate first, then emit — emitting mid-iteration could re-enter
+    // updateScreenDesktop and invalidate the hash iterator.
+    QStringList clamped;
+    for (auto it = m_screenDesktops.begin(); it != m_screenDesktops.end(); ++it) {
+        if (it.value() > m_desktopCount) {
+            it.value() = m_desktopCount;
+            clamped.append(it.key());
+        }
+    }
+    for (const QString& screenId : clamped) {
+        Q_EMIT screenDesktopChanged(screenId, m_screenDesktops.value(screenId));
+    }
 }
 
 void VirtualDesktopManager::setCurrentDesktop(int desktop)
@@ -281,6 +331,8 @@ void VirtualDesktopManager::onNumberOfDesktopsChanged(int count)
         m_currentDesktop = m_desktopCount;
         Q_EMIT currentDesktopChanged(m_currentDesktop);
     }
+
+    clampScreenDesktopsToCount();
 
     Q_EMIT desktopCountChanged(count);
 }

--- a/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
@@ -122,6 +122,14 @@ public:
     // activity change) read it through the interface.
 
     virtual int currentVirtualDesktop() const = 0;
+    /// This screen's current virtual desktop (Plasma 6.7 per-output virtual
+    /// desktops, #648). Default ignores the screen and returns the global
+    /// currentVirtualDesktop(), so non-per-output implementers are unaffected.
+    virtual int currentVirtualDesktopForScreen(const QString& screenId) const
+    {
+        Q_UNUSED(screenId)
+        return currentVirtualDesktop();
+    }
     virtual QString currentActivity() const = 0;
 
     /// Resolve the per-context gap override (zone padding + outer gaps) that

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -299,7 +299,11 @@ public:
     /// so this helper is a thin context-filling forwarder.
     Q_INVOKABLE Layout* resolveLayoutForScreen(const QString& screenId) const override
     {
-        return layoutForScreen(screenId, m_currentVirtualDesktop, m_currentActivity);
+        // Resolve against THIS screen's current virtual desktop (Plasma 6.7
+        // per-output virtual desktops, #648). Falls back to the global desktop
+        // when the screen has no per-output value, so every caller (all of which
+        // already pass a screenId) gets per-screen resolution with no edits.
+        return layoutForScreen(screenId, currentVirtualDesktopForScreen(screenId), m_currentActivity);
     }
 
     /// Resolve the per-context gap override for (screen, desktop, activity) by
@@ -455,6 +459,26 @@ public:
     void setCurrentVirtualDesktop(int desktop)
     {
         m_currentVirtualDesktop = desktop;
+    }
+    /// This screen's current virtual desktop, falling back to the global
+    /// m_currentVirtualDesktop when no per-output value is set (#648).
+    int currentVirtualDesktopForScreen(const QString& screenId) const
+    {
+        const auto it = m_screenVirtualDesktop.constFind(screenId);
+        return it != m_screenVirtualDesktop.constEnd() ? it.value() : m_currentVirtualDesktop;
+    }
+    /// Record a single screen's current virtual desktop (per-output virtual
+    /// desktops). Pushed by the daemon's per-screen desktop handler.
+    void setCurrentVirtualDesktopForScreen(const QString& screenId, int desktop)
+    {
+        if (!screenId.isEmpty() && desktop >= 1) {
+            m_screenVirtualDesktop.insert(screenId, desktop);
+        }
+    }
+    /// Drop a screen's per-output desktop, reverting it to the global value.
+    void clearCurrentVirtualDesktopForScreen(const QString& screenId)
+    {
+        m_screenVirtualDesktop.remove(screenId);
     }
     void setCurrentActivity(const QString& activity)
     {
@@ -750,6 +774,10 @@ private:
     Layout* m_previousLayout = nullptr; ///< Active layout before last setActiveLayout (for resnap)
     QHash<int, QString> m_quickLayoutShortcuts; ///< slot number (1..9) → layout ID
     int m_currentVirtualDesktop = 1;
+    /// Per-screen current virtual desktop (screenId → 1-based) under Plasma 6.7
+    /// per-output virtual desktops (#648). Empty unless the daemon pushes
+    /// per-screen values, so resolveLayoutForScreen falls back to the global.
+    QHash<QString, int> m_screenVirtualDesktop;
     QString m_currentActivity;
 };
 

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -462,7 +462,7 @@ public:
     }
     /// This screen's current virtual desktop, falling back to the global
     /// m_currentVirtualDesktop when no per-output value is set (#648).
-    int currentVirtualDesktopForScreen(const QString& screenId) const
+    int currentVirtualDesktopForScreen(const QString& screenId) const override
     {
         const auto it = m_screenVirtualDesktop.constFind(screenId);
         return it != m_screenVirtualDesktop.constEnd() ? it.value() : m_currentVirtualDesktop;

--- a/libs/phosphor-zones/src/layoutregistry.cpp
+++ b/libs/phosphor-zones/src/layoutregistry.cpp
@@ -227,6 +227,14 @@ PhosphorZones::Layout* LayoutRegistry::cycleLayoutImpl(const QString& screenId, 
             : screenId;
     }
 
+    // Per-output virtual desktops (#648): cycle relative to the target screen's
+    // OWN desktop, not the global active one, so the visibility filter and the
+    // reference-layout lookup below resolve against the same desktop the screen
+    // is actually showing. Falls back to the global desktop when no screen is
+    // known (empty screenId) or no per-output value is on record.
+    const int desktop =
+        resolvedScreenId.isEmpty() ? m_currentVirtualDesktop : currentVirtualDesktopForScreen(resolvedScreenId);
+
     // Build filtered list of visible layouts for current context
     QVector<PhosphorZones::Layout*> visible;
     for (PhosphorZones::Layout* l : m_layouts) {
@@ -238,8 +246,8 @@ PhosphorZones::Layout* LayoutRegistry::cycleLayoutImpl(const QString& screenId, 
                 continue;
             }
         }
-        if (m_currentVirtualDesktop > 0 && !l->allowedDesktops().isEmpty()) {
-            if (!l->allowedDesktops().contains(m_currentVirtualDesktop)) {
+        if (desktop > 0 && !l->allowedDesktops().isEmpty()) {
+            if (!l->allowedDesktops().contains(desktop)) {
                 continue;
             }
         }
@@ -258,7 +266,7 @@ PhosphorZones::Layout* LayoutRegistry::cycleLayoutImpl(const QString& screenId, 
     // Use per-screen layout as reference for cycling so each screen cycles independently
     PhosphorZones::Layout* currentLayout = nullptr;
     if (!resolvedScreenId.isEmpty()) {
-        currentLayout = layoutForScreen(resolvedScreenId, m_currentVirtualDesktop, m_currentActivity);
+        currentLayout = layoutForScreen(resolvedScreenId, desktop, m_currentActivity);
     }
     if (!currentLayout) {
         currentLayout = defaultLayout();
@@ -292,14 +300,19 @@ void LayoutRegistry::applyLayoutToScreen(const QString& screenId, PhosphorZones:
     // Per-screen assignment: write per-desktop assignment first so the
     // layoutAssigned handler recalculates zone geometry for this screen.
     if (!screenId.isEmpty()) {
+        // Per-output virtual desktops (#648): write to the screen's OWN desktop,
+        // not the global active one. Both callers (cycleLayoutImpl and the D-Bus
+        // applyQuickLayout via LayoutAdaptor) pass an already idForName-resolved
+        // screenId, matching the per-output map's key.
+        const int desktop = currentVirtualDesktopForScreen(screenId);
         // Write per-desktop assignment with empty activity so it applies
         // regardless of which activity is active. Activity-specific
         // overrides are a separate KCM-only feature. Clear any stale
         // activity-keyed entry that would shadow this one in the cascade.
         if (!m_currentActivity.isEmpty()) {
-            clearAssignment(screenId, m_currentVirtualDesktop, m_currentActivity);
+            clearAssignment(screenId, desktop, m_currentActivity);
         }
-        assignLayout(screenId, m_currentVirtualDesktop, QString(), layout);
+        assignLayout(screenId, desktop, QString(), layout);
     }
     // Update the global active layout pointer (for overlay/zone detector
     // queries) but suppress activeLayoutChanged to prevent resnap buffer

--- a/libs/phosphor-zones/src/layoutregistry_batch.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_batch.cpp
@@ -101,7 +101,9 @@ struct BatchContext
 // entry a non-empty activity, else a wrong-family base rule is built);
 // @p familyMatches selects which existing rules to drop; @p emitDesktop /
 // @p emitActivity are the context the closing layoutAssigned is computed
-// under; @p label names the family in log output.
+// under (@p emitDesktop < 0 is the per-output-virtual-desktops sentinel, #648:
+// each screen's own current desktop is resolved at emit time; 0 = base/any);
+// @p label names the family in log output.
 template<typename KeyT, typename DecodeFn, typename ValidFn, typename FamilyFn>
 void LayoutRegistry::applyBatchAssignments(const QHash<KeyT, QString>& assignments, DecodeFn decode, ValidFn valid,
                                            FamilyFn familyMatches, int emitDesktop, const QString& emitActivity,
@@ -172,7 +174,12 @@ void LayoutRegistry::applyBatchAssignments(const QHash<KeyT, QString>& assignmen
     // Step 4 — one commit, then signal per stored screen.
     m_ruleStore->setAllRules(kept);
     for (const QString& screenId : storedScreens) {
-        emitLayoutAssigned(screenId, emitDesktop, assignmentIdForScreen(screenId, emitDesktop, emitActivity));
+        // Per-output virtual desktops (#648): a desktop-family batch passes
+        // emitDesktop < 0 so each screen refreshes against the desktop it is
+        // actually showing, not a single global one. A concrete emitDesktop
+        // (including 0 = base/any) is used verbatim.
+        const int ed = emitDesktop < 0 ? currentVirtualDesktopForScreen(screenId) : emitDesktop;
+        emitLayoutAssigned(screenId, ed, assignmentIdForScreen(screenId, ed, emitActivity));
     }
     qCInfo(lcZonesLib) << "Batch set" << count << label << "assignments";
 }
@@ -201,7 +208,7 @@ void LayoutRegistry::setAllDesktopAssignments(const QHash<QPair<QString, int>, Q
         [](const BatchContext& ctx) {
             return !ctx.screenId.isEmpty() && ctx.virtualDesktop >= 1;
         },
-        matchIsExactContextDesktop, m_currentVirtualDesktop, m_currentActivity, "desktop");
+        matchIsExactContextDesktop, /*emitDesktop=*/-1, m_currentActivity, "desktop");
 }
 
 void LayoutRegistry::setAllActivityAssignments(const QHash<QPair<QString, QString>, QString>& assignments)

--- a/src/core/daemongeometryresolver.cpp
+++ b/src/core/daemongeometryresolver.cpp
@@ -16,7 +16,7 @@ QVariantMap DaemonGeometryResolver::contextGapOverrideFor(const QString& screenI
     if (!m_layoutRegistry || screenId.isEmpty()) {
         return {};
     }
-    const int virtualDesktop = m_currentVirtualDesktop ? m_currentVirtualDesktop() : 0;
+    const int virtualDesktop = m_currentVirtualDesktop ? m_currentVirtualDesktop(screenId) : 0;
     const QString activity = m_currentActivity ? m_currentActivity() : QString();
     // Translation to the PerScreenSnappingKey-shaped map is shared with the
     // preview/query geometry helpers via GeometryUtils::contextGapOverrideMap.

--- a/src/core/daemongeometryresolver.h
+++ b/src/core/daemongeometryresolver.h
@@ -29,7 +29,7 @@ class DaemonGeometryResolver : public PhosphorPlacement::IGeometryResolver
 {
 public:
     explicit DaemonGeometryResolver(ISettings* settings, PhosphorZones::LayoutRegistry* layoutRegistry = nullptr,
-                                    std::function<int()> currentVirtualDesktop = {},
+                                    std::function<int(const QString&)> currentVirtualDesktop = {},
                                     std::function<QString()> currentActivity = {})
         : m_settings(settings)
         , m_layoutRegistry(layoutRegistry)
@@ -51,7 +51,7 @@ private:
 
     ISettings* m_settings;
     PhosphorZones::LayoutRegistry* m_layoutRegistry;
-    std::function<int()> m_currentVirtualDesktop;
+    std::function<int(const QString&)> m_currentVirtualDesktop;
     std::function<QString()> m_currentActivity;
 };
 

--- a/src/core/geometryutils.cpp
+++ b/src/core/geometryutils.cpp
@@ -102,7 +102,7 @@ QVariantMap currentContextGapOverride(PhosphorZones::IZoneLayoutRegistry* reg, c
         return {};
     }
     return contextGapOverrideMap(
-        reg->resolveContextGaps(screenId, reg->currentVirtualDesktop(), reg->currentActivity()));
+        reg->resolveContextGaps(screenId, reg->currentVirtualDesktopForScreen(screenId), reg->currentActivity()));
 }
 } // anonymous namespace
 

--- a/src/core/screenmoderouter.cpp
+++ b/src/core/screenmoderouter.cpp
@@ -38,7 +38,7 @@ PhosphorZones::AssignmentEntry::Mode ScreenModeRouter::modeFor(const QString& sc
     if (m_autotileEngine->isActiveOnScreen(screenId)) {
         return PhosphorZones::AssignmentEntry::Autotile;
     }
-    const int desktop = m_layoutManager->currentVirtualDesktop();
+    const int desktop = m_layoutManager->currentVirtualDesktopForScreen(screenId);
     const QString activity = m_layoutManager->currentActivity();
     const auto mode = m_layoutManager->modeForScreen(screenId, desktop, activity);
     // Engine already confirmed "not autotile" at the top of this function,

--- a/src/daemon/contextresolverwiring.cpp
+++ b/src/daemon/contextresolverwiring.cpp
@@ -34,6 +34,14 @@ int DaemonWorkspaceStateAdapter::currentVirtualDesktop() const
     return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
 }
 
+int DaemonWorkspaceStateAdapter::currentVirtualDesktopForScreen(const QString& screenId) const
+{
+    // Per-output virtual desktops (#648): the disabled-context cascade must
+    // resolve against the desktop of the screen being checked, not the global
+    // current. Falls back to the global when no per-output value is on record.
+    return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : 0;
+}
+
 QString DaemonWorkspaceStateAdapter::currentActivity() const
 {
     // Guard on both the manager pointer AND `ActivityManager::isAvailable()`

--- a/src/daemon/contextresolverwiring.h
+++ b/src/daemon/contextresolverwiring.h
@@ -57,6 +57,7 @@ public:
     ~DaemonWorkspaceStateAdapter() override = default;
 
     int currentVirtualDesktop() const override;
+    int currentVirtualDesktopForScreen(const QString& screenId) const override;
     QString currentActivity() const override;
 
 private:

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1446,7 +1446,6 @@ bool Daemon::init()
             if (!m_snapEngine || !m_windowTrackingAdaptor || !m_screenManager || !m_layoutManager)
                 return;
 
-            const int desktop = currentDesktop();
             const QString activity = currentActivity();
 
             // Collect autotile screens and per-screen OSD data in one pass
@@ -1460,6 +1459,8 @@ bool Daemon::init()
             QVector<ScreenOsd> osdEntries;
             const QStringList effectiveIds = m_screenManager->effectiveScreenIds();
             for (const QString& screenId : effectiveIds) {
+                // Per-output virtual desktops (#648): each screen resolves its own desktop.
+                const int desktop = currentDesktopForScreen(screenId);
                 const QString assignmentId = m_layoutManager->assignmentIdForScreen(screenId, desktop, activity);
                 if (PhosphorLayout::LayoutId::isAutotile(assignmentId)) {
                     autotileScreens.insert(screenId);
@@ -1511,6 +1512,8 @@ bool Daemon::init()
                         showLayoutOsdForAlgorithm(osd.algoId, displayName, osd.screenId);
                     }
                 } else {
+                    // Per-output virtual desktops (#648): each screen resolves its own desktop.
+                    const int desktop = currentDesktopForScreen(osd.screenId);
                     PhosphorZones::Layout* layout = m_layoutManager->layoutForScreen(osd.screenId, desktop, activity);
                     if (layout)
                         showLayoutOsd(layout, osd.screenId);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1506,7 +1506,8 @@ bool Daemon::init()
                         // Resolve the algorithm's human-readable display
                         // name via the registry instead of surfacing the
                         // wire-format id (e.g. "bsp" → "Binary Split").
-                        // Mirrors osd.cpp:548-551.
+                        // Mirrors the algorithm display-name resolution in the
+                        // per-screen OSD path (showOsdForScreens, osd.cpp).
                         const auto* algo = m_algorithmRegistry ? m_algorithmRegistry->algorithm(osd.algoId) : nullptr;
                         const QString displayName = algo ? algo->name() : osd.algoId;
                         showLayoutOsdForAlgorithm(osd.algoId, displayName, osd.screenId);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1280,7 +1280,7 @@ bool Daemon::init()
                 screenId = m_windowTrackingAdaptor->service()->screenForWindow(windowId);
             }
             if (!screenId.isEmpty() && m_layoutManager) {
-                return m_layoutManager->modeForScreen(screenId, currentDesktop(), currentActivity());
+                return m_layoutManager->modeForScreen(screenId, currentDesktopForScreen(screenId), currentActivity());
             }
             // No tracked screen in WTS (e.g. a window snap never saw): if the
             // autotile engine tracks it, its current mode is Autotile. Otherwise

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -452,7 +452,16 @@ private:
      * @param desktop Current virtual desktop number
      * @param activity Current activity ID
      */
-    void showDesktopSwitchOsd(int desktop, const QString& activity);
+    void showDesktopSwitchOsd(const QString& activity);
+
+    /**
+     * @brief Per-screen desktop-switch OSD (Plasma 6.7 per-output virtual desktops)
+     *
+     * Shows the desktop-switch OSD only on @p screenId, using that screen's own
+     * current virtual desktop. Driven by the per-screen screenDesktopChanged
+     * handler so a single screen's switch doesn't flash every monitor (#648).
+     */
+    void showDesktopSwitchOsdForScreen(const QString& screenId, const QString& activity);
 
     /**
      * @brief Show per-screen OSD for all effective screens
@@ -462,7 +471,16 @@ private:
      * a single deferred event-loop pass so all surfaces show simultaneously.
      * DRY helper shared by showDesktopSwitchOsd and settingsChanged handler.
      */
-    void showOsdForAllScreens(int desktop, const QString& activity);
+    void showOsdForAllScreens(const QString& activity);
+
+    /**
+     * @brief Per-screen OSD for an explicit screen set
+     *
+     * Like showOsdForAllScreens but for the given @p screenIds; each screen uses
+     * its OWN current virtual desktop (per-output virtual desktops). Backs both
+     * showOsdForAllScreens and showDesktopSwitchOsdForScreen.
+     */
+    void showOsdForScreens(const QStringList& screenIds, const QString& activity);
 
     /**
      * @brief Recompute which screens use autotile from layout assignments

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -794,6 +794,9 @@ private:
 
     // Desktop/activity resolution helpers (DRY — used by multiple handlers)
     int currentDesktop() const;
+    /// This screen's current virtual desktop (Plasma 6.7 per-output virtual
+    /// desktops, #648), falling back to the global currentDesktop().
+    int currentDesktopForScreen(const QString& screenId) const;
     QString currentActivity() const;
     bool isCurrentContextLockedForMode(const QString& screenId, PhosphorZones::AssignmentEntry::Mode mode) const;
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -468,7 +468,8 @@ private:
      * Iterates effectiveScreenIds, resolves assignment (autotile vs snapping),
      * and calls showLayoutOsdForAlgorithm or showLayoutOsd per screen inside
      * a single deferred event-loop pass so all surfaces show simultaneously.
-     * DRY helper shared by showDesktopSwitchOsd and settingsChanged handler.
+     * DRY helper shared by showDesktopSwitchOsd and the startup OSD path
+     * (finalizeStartup).
      */
     void showOsdForAllScreens(const QString& activity);
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -449,7 +449,6 @@ private:
      * the appropriate OSD (layout or algorithm). DRY helper for both
      * currentDesktopChanged and currentActivityChanged handlers.
      *
-     * @param desktop Current virtual desktop number
      * @param activity Current activity ID
      */
     void showDesktopSwitchOsd(const QString& activity);

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -444,7 +444,7 @@ void Daemon::seedAutotileOrderForScreen(const QString& screenId)
     // Prefer saved autotile order from last mode toggle (deterministic re-entry).
     // Falls back to zone-ordered window list when no saved order exists (first
     // activation, or windows changed between toggles).
-    TilingStateKey orderKey{screenId, currentDesktop(), currentActivity()};
+    TilingStateKey orderKey{screenId, currentDesktopForScreen(screenId), currentActivity()};
     QStringList order = m_lastAutotileOrders.value(orderKey);
     if (order.isEmpty()) {
         PhosphorPlacement::WindowTrackingService* wts = m_windowTrackingAdaptor->service();

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -53,13 +53,14 @@ void Daemon::updateAutotileScreens()
         return;
     }
 
-    const int desktop = currentDesktop();
     const QString activity = currentActivity();
 
     QSet<QString> autotileScreens;
     QHash<QString, QString> screenAlgorithms;
     const QStringList effectiveIds = m_screenManager->effectiveScreenIds();
     for (const QString& screenId : effectiveIds) {
+        // Per-output virtual desktops (#648): each screen resolves its own desktop.
+        const int desktop = currentDesktopForScreen(screenId);
         // Skip screens/desktops/activities where PlasmaZones is disabled.
         // Single cascade path through the resolver — see
         // libs/phosphor-context-resolver/README.md.
@@ -84,6 +85,8 @@ void Daemon::updateAutotileScreens()
     const QSet<QString> currentAutotileScreens = m_autotileEngine->activeScreens();
     const QSet<QString> removedScreens = currentAutotileScreens - autotileScreens;
     for (const QString& screenId : removedScreens) {
+        // Per-output virtual desktops (#648): each screen resolves its own desktop.
+        const int desktop = currentDesktopForScreen(screenId);
         QStringList order = m_autotileEngine->managedWindowOrder(screenId);
         if (!order.isEmpty()) {
             m_lastAutotileOrders[TilingStateKey{screenId, desktop, activity}] = order;
@@ -226,7 +229,6 @@ void Daemon::handleAutotileDisabled()
     // an explicit per-screen assignment. Fill those in individually without
     // clobbering screens that already have a valid snap layout.
     if (m_layoutManager && m_screenManager) {
-        const int desktop = currentDesktop();
         const QString activity = currentActivity();
         const QStringList effectiveIds = m_screenManager->effectiveScreenIds();
 
@@ -238,6 +240,8 @@ void Daemon::handleAutotileDisabled()
         {
             QSignalBlocker blocker(m_layoutManager.get());
             for (const QString& screenId : effectiveIds) {
+                // Per-output virtual desktops (#648): each screen resolves its own desktop.
+                const int desktop = currentDesktopForScreen(screenId);
                 const QString existingSnapId = m_layoutManager->snappingLayoutForScreen(screenId, desktop, activity);
                 const auto existingSnapUuid = Utils::parseUuid(existingSnapId);
                 PhosphorZones::Layout* existing =
@@ -290,11 +294,12 @@ void Daemon::handleSnappingToAutotile()
     // that already have an autotile assignment so we preserve their per-screen
     // algorithm customization (mixed-mode: screen A snap → autotile, screen B
     // already autotile stays on its configured algorithm).
-    const int desktop = currentDesktop();
     const QString activity = currentActivity();
     QStringList screensToConvert;
     const QStringList effectiveIds = m_screenManager->effectiveScreenIds();
     for (const QString& screenId : effectiveIds) {
+        // Per-output virtual desktops (#648): each screen resolves its own desktop.
+        const int desktop = currentDesktopForScreen(screenId);
         const QString existing = m_layoutManager->assignmentIdForScreen(screenId, desktop, activity);
         if (!PhosphorLayout::LayoutId::isAutotile(existing)) {
             screensToConvert.append(screenId);
@@ -328,6 +333,8 @@ void Daemon::handleSnappingToAutotile()
     {
         QSignalBlocker blocker(m_layoutManager.get());
         for (const QString& screenId : screensToConvert) {
+            // Per-output virtual desktops (#648): each screen resolves its own desktop.
+            const int desktop = currentDesktopForScreen(screenId);
             if (!activity.isEmpty()) {
                 m_layoutManager->clearAssignment(screenId, desktop, activity);
             }
@@ -342,9 +349,10 @@ QHash<TilingStateKey, QStringList> Daemon::captureAutotileOrders() const
     if (!m_autotileEngine) {
         return orders;
     }
-    const int desktop = currentDesktop();
     const QString activity = currentActivity();
     for (const QString& screenId : m_autotileEngine->activeScreens()) {
+        // Per-output virtual desktops (#648): each screen resolves its own desktop.
+        const int desktop = currentDesktopForScreen(screenId);
         QStringList order = m_autotileEngine->managedWindowOrder(screenId);
         if (!order.isEmpty()) {
             orders[TilingStateKey{screenId, desktop, activity}] = order;
@@ -473,7 +481,6 @@ void Daemon::processPendingGeometryUpdates()
     // tracks pending (screenId, layoutId) pairs explicitly so unrelated
     // geometriesComputed emissions (e.g. from an async layoutAssigned firing
     // mid-barrier) cannot drain it prematurely.
-    const int desktop = currentDesktop();
     const QString activity = currentActivity();
     const QStringList screenIds = m_screenManager->effectiveScreenIds();
 
@@ -491,6 +498,8 @@ void Daemon::processPendingGeometryUpdates()
     };
 
     for (const QString& screenId : screenIds) {
+        // Per-output virtual desktops (#648): each screen resolves its own desktop.
+        const int desktop = currentDesktopForScreen(screenId);
         PhosphorZones::Layout* layout = m_layoutManager->layoutForScreen(screenId, desktop, activity);
         if (layout) {
             requestFor(layout, screenId,

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -413,7 +413,6 @@ void Daemon::syncModeFromAssignments()
         return;
     }
 
-    const int desktop = currentDesktop();
     const QString activity = currentActivity();
 
     // Sync UnifiedLayoutController's current layout ID to match this desktop.
@@ -433,6 +432,8 @@ void Daemon::syncModeFromAssignments()
                 }
             }
         }
+        // Per-output virtual desktops (#648): each screen resolves its own desktop.
+        const int desktop = currentDesktopForScreen(focusedScreenId);
         if (!focusedScreenId.isEmpty()) {
             const QString focusedAssignmentId =
                 m_layoutManager->assignmentIdForScreen(focusedScreenId, desktop, activity);

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -470,7 +470,7 @@ void Daemon::syncModeFromAssignments()
     updateLayoutFilter();
 }
 
-void Daemon::showDesktopSwitchOsd(int desktop, const QString& activity)
+void Daemon::showDesktopSwitchOsd(const QString& activity)
 {
     // Skip during startup — the initial activity/desktop detection fires
     // before start() completes and should not produce an OSD flash.
@@ -484,10 +484,35 @@ void Daemon::showDesktopSwitchOsd(int desktop, const QString& activity)
         || !m_screenManager) {
         return;
     }
-    showOsdForAllScreens(desktop, activity);
+    showOsdForAllScreens(activity);
 }
 
-void Daemon::showOsdForAllScreens(int desktop, const QString& activity)
+void Daemon::showDesktopSwitchOsdForScreen(const QString& screenId, const QString& activity)
+{
+    // Per-output virtual desktops (#648): only the screen that actually switched
+    // shows the OSD, not every monitor. Same gating as the all-screens variant.
+    if (!m_running) {
+        return;
+    }
+    if (shouldSuppressOsd()) {
+        return;
+    }
+    if (!m_settings || !m_settings->showOsdOnDesktopSwitch() || !m_overlayService || !m_layoutManager
+        || !m_screenManager) {
+        return;
+    }
+    showOsdForScreens({screenId}, activity);
+}
+
+void Daemon::showOsdForAllScreens(const QString& activity)
+{
+    if (!m_screenManager) {
+        return;
+    }
+    showOsdForScreens(m_screenManager->effectiveScreenIds(), activity);
+}
+
+void Daemon::showOsdForScreens(const QStringList& screenIds, const QString& activity)
 {
     if (!m_layoutManager || !m_screenManager) {
         return;
@@ -498,15 +523,18 @@ void Daemon::showOsdForAllScreens(int desktop, const QString& activity)
     // Batch all per-screen OSD shows into one deferred call so every
     // screen's surface->show() fires in the same event loop pass and the
     // compositor renders them simultaneously.
-    QTimer::singleShot(0, this, [this, desktop, activity]() {
+    QTimer::singleShot(0, this, [this, screenIds, activity]() {
         if (!m_layoutManager || !m_screenManager) {
             return;
         }
         if (shouldSuppressOsd()) {
             return;
         }
-        const QStringList effectiveIds = m_screenManager->effectiveScreenIds();
-        for (const QString& screenId : effectiveIds) {
+        for (const QString& screenId : screenIds) {
+            // Each screen reports against its OWN current virtual desktop
+            // (Plasma 6.7 per-output virtual desktops, #648).
+            const int desktop =
+                m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : currentDesktop();
             // Route the disabled-context probe through the resolver so this
             // OSD pass uses the same single snapshot façade as every other
             // call site — the prior hand-stitched (modeFor → settings →

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -367,7 +367,7 @@ void Daemon::updateLayoutFilterForScreen(const QString& focusedScreenId)
     bool manualActive = false;
 
     if (m_settings->autotileEnabled() && m_layoutManager && m_screenManager) {
-        const int desktop = currentDesktop();
+        const int desktop = currentDesktopForScreen(focusedScreenId);
         const QString activity = currentActivity();
 
         if (!focusedScreenId.isEmpty()) {
@@ -591,6 +591,13 @@ void Daemon::showOsdForScreens(const QStringList& screenIds, const QString& acti
 int Daemon::currentDesktop() const
 {
     return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
+}
+
+int Daemon::currentDesktopForScreen(const QString& screenId) const
+{
+    // Per-output virtual desktops (#648): resolve THIS screen's current desktop,
+    // falling back to the global current when no per-output value is on record.
+    return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : 0;
 }
 
 QString Daemon::currentActivity() const

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -836,7 +836,7 @@ void Daemon::finalizeStartup()
         // KActivities is unavailable on this system (no point waiting).
         const bool activityReady = !activity.isEmpty() || !PhosphorWorkspaces::ActivityManager::isAvailable();
         if (activityReady) {
-            showOsdForAllScreens(currentDesktop(), activity);
+            showOsdForAllScreens(activity);
         } else if (m_activityManager) {
             // Defer the welcome OSD until the activity arrives from
             // KActivities, otherwise the cascade walks with empty
@@ -867,7 +867,7 @@ void Daemon::finalizeStartup()
                                 }
                                 *fired = true;
                                 QObject::disconnect(*conn);
-                                showOsdForAllScreens(currentDesktop(), a);
+                                showOsdForAllScreens(a);
                             });
             QTimer::singleShot(5000, this, [this, conn, fired]() {
                 if (*fired) {
@@ -888,7 +888,7 @@ void Daemon::finalizeStartup()
                 if (activity.isEmpty() && PhosphorWorkspaces::ActivityManager::isAvailable()) {
                     return;
                 }
-                showOsdForAllScreens(currentDesktop(), activity);
+                showOsdForAllScreens(activity);
             });
         }
     }

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -224,7 +224,7 @@ void Daemon::initializeAutotile()
                 qCWarning(lcDaemon) << "Mode toggle: empty screenId from resolveCursorScreenId";
                 return;
             }
-            int desktop = currentDesktop();
+            int desktop = currentDesktopForScreen(screenId);
             QString activity = currentActivity();
             qCInfo(lcDaemon) << "Mode toggle: screenId=" << screenId << "desktop=" << desktop
                              << "activity=" << activity;
@@ -572,7 +572,7 @@ void Daemon::connectLayoutSignals()
                 updateLayoutFilter();
 
                 // Sync unified controller cycling index when assignment affects current desktop.
-                const int curDesktop = currentDesktop();
+                const int curDesktop = currentDesktopForScreen(screenId);
                 if (virtualDesktop != 0 && virtualDesktop != curDesktop) {
                     return;
                 }

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -126,9 +126,10 @@ void Daemon::connectScreenSignals()
                 // refreshVirtualConfigs() in response to its own change signal.
                 const QString physId = screen.identifier;
                 const QStringList vsIds = m_screenManager->virtualScreenIdsFor(physId);
-                const int desktop = currentDesktop();
                 const QString activity = currentActivity();
                 for (const QString& sid : vsIds) {
+                    // Per-output virtual desktops (#648): each screen its own desktop.
+                    const int desktop = currentDesktopForScreen(sid);
                     PhosphorZones::Layout* screenLayout = m_layoutManager->layoutForScreen(sid, desktop, activity);
                     if (screenLayout) {
                         PhosphorZones::LayoutComputeService::recalculateSync(
@@ -823,12 +824,13 @@ void Daemon::onVirtualScreensReconfigured(const QString& physicalScreenId)
     // that any PhosphorTiles::TilingState created by the upcoming updateAutotileScreens
     // call (and the resnap below) reads fresh zone bounds. The screenAdded
     // handler does the same inline recalc for newly-added physical screens.
-    const int desktop = currentDesktop();
     const QString activity = currentActivity();
     const QStringList affectedScreenIds = config.hasSubdivisions()
         ? m_screenManager->virtualScreenIdsFor(physicalScreenId)
         : QStringList{physicalScreenId};
     for (const QString& sid : affectedScreenIds) {
+        // Per-output virtual desktops (#648): each screen its own desktop.
+        const int desktop = currentDesktopForScreen(sid);
         PhosphorZones::Layout* screenLayout = m_layoutManager->layoutForScreen(sid, desktop, activity);
         if (screenLayout) {
             PhosphorZones::LayoutComputeService::recalculateSync(
@@ -906,10 +908,11 @@ void Daemon::onVirtualScreenRegionsChanged(const QString& physicalScreenId)
     // pass on top of the engine's own, producing the visible "move then
     // retile" double-movement reported on VS swap/rotate.
 
-    const int desktop = currentDesktop();
     const QString activity = currentActivity();
     const QStringList affectedScreenIds = m_screenManager->virtualScreenIdsFor(physicalScreenId);
     for (const QString& sid : affectedScreenIds) {
+        // Per-output virtual desktops (#648): each screen its own desktop.
+        const int desktop = currentDesktopForScreen(sid);
         PhosphorZones::Layout* screenLayout = m_layoutManager->layoutForScreen(sid, desktop, activity);
         if (screenLayout) {
             PhosphorZones::LayoutComputeService::recalculateSync(

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -152,16 +152,16 @@ void Daemon::connectScreenSignals()
 
                 // Drop the removed output's per-output virtual-desktop entries (#648)
                 // so the maps don't retain stale desktops across monitor hot-plug.
-                // The autotile engine self-prunes via updateAutotileScreens; the VDM,
-                // layout registry and overlay service are physical-id keyed (the
-                // effect reports physical output ids), matching removedScreenId.
+                // The autotile engine self-prunes via updateAutotileScreens; the VDM
+                // and layout registry are physical-id keyed (the effect reports
+                // physical output ids), matching removedScreenId. The overlay service
+                // delegates to the layout registry, so clearing it there suffices.
                 if (m_virtualDesktopManager) {
                     m_virtualDesktopManager->removeScreenDesktop(removedScreenId);
                 }
                 if (m_layoutManager) {
                     m_layoutManager->clearCurrentVirtualDesktopForScreen(removedScreenId);
                 }
-                m_overlayService->clearCurrentVirtualDesktopForScreen(removedScreenId);
 
                 // Invalidate cached EDID serial so a different monitor on this connector is detected
                 PhosphorScreens::ScreenIdentity::invalidateEdidCache(removedName);
@@ -253,9 +253,10 @@ void Daemon::connectDesktopActivity()
                 if (m_autotileEngine) {
                     m_autotileEngine->setCurrentDesktopForScreen(screenId, desktop);
                 }
-                // [SEQ D] Per-screen layout/overlay resolution context.
+                // [SEQ D] Per-screen layout/overlay resolution context. The
+                // overlay service delegates to the layout registry for per-output
+                // desktop resolution, so this one push drives both (#648).
                 m_layoutManager->setCurrentVirtualDesktopForScreen(screenId, desktop);
-                m_overlayService->setCurrentVirtualDesktopForScreen(screenId, desktop);
                 // [SEQ E] Per-desktop assignments may differ — recompute autotile
                 // screens, re-sync mode/filter, then refresh overlay geometry.
                 updateAutotileScreens();

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -150,6 +150,19 @@ void Daemon::connectScreenSignals()
                 const QString removedName = screen.name;
                 const QString removedScreenId = screen.identifier;
 
+                // Drop the removed output's per-output virtual-desktop entries (#648)
+                // so the maps don't retain stale desktops across monitor hot-plug.
+                // The autotile engine self-prunes via updateAutotileScreens; the VDM,
+                // layout registry and overlay service are physical-id keyed (the
+                // effect reports physical output ids), matching removedScreenId.
+                if (m_virtualDesktopManager) {
+                    m_virtualDesktopManager->removeScreenDesktop(removedScreenId);
+                }
+                if (m_layoutManager) {
+                    m_layoutManager->clearCurrentVirtualDesktopForScreen(removedScreenId);
+                }
+                m_overlayService->clearCurrentVirtualDesktopForScreen(removedScreenId);
+
                 // Invalidate cached EDID serial so a different monitor on this connector is detected
                 PhosphorScreens::ScreenIdentity::invalidateEdidCache(removedName);
 

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -193,50 +193,64 @@ void Daemon::connectDesktopActivity()
     m_virtualDesktopManager->init();
     m_virtualDesktopManager->start();
 
-    // Connect virtual desktop changes to layout switching
+    // Virtual desktop changes are handled on TWO distinct paths (#648):
+    //
+    // 1) currentDesktopChanged — KWin's GLOBAL current desktop. Under Plasma 6.7
+    //    "switch desktops independently for each screen", this flips merely on
+    //    cursor movement between monitors on different desktops, so reacting to it
+    //    with OSD / autotile recompute is the bug. Here it ONLY keeps the global
+    //    desktop caches coherent with the active screen's desktop, for the
+    //    currentVirtualDesktop() consumers (and the per-screen-map fallback). These
+    //    are cheap value-sets that already fired on cursor-follow before the fix,
+    //    so this is not a regression. NO OSD, NO autotile recompute here.
     connect(m_virtualDesktopManager.get(), &PhosphorWorkspaces::VirtualDesktopManager::currentDesktopChanged, this,
             [this](int desktop) {
-                // Update all components with current desktop for per-desktop layout lookup
-                // NOTE: PhosphorZones::LayoutRegistry is the single source of truth for desktop/activity.
-                // WindowDragAdaptor reads from PhosphorZones::LayoutRegistry directly via resolveLayoutForScreen().
-                m_overlayService->setCurrentVirtualDesktop(desktop);
                 m_layoutManager->setCurrentVirtualDesktop(desktop);
                 if (m_unifiedLayoutController) {
                     m_unifiedLayoutController->setCurrentVirtualDesktop(desktop);
                 }
-                // Desktop switch invalidates the TilingStateKey context — cancel any
-                // active drag-insert preview before the engine's desktop changes,
-                // otherwise cancel/commit would operate on the wrong PhosphorTiles::TilingState.
+            });
+
+    // 2) screenDesktopChanged — the KWin effect's PER-OUTPUT desktopChanged report
+    //    (via VirtualDesktopManager). The authoritative per-screen switch; drives
+    //    all context + OSD work scoped to the ONE screen that switched. The effect
+    //    does NOT report this on cursor movement, so the per-desktop context thrash
+    //    and the spurious all-screens OSD of #648 are gone. In single-desktop mode
+    //    the effect fans this out to every screen, so behaviour is unchanged.
+    connect(m_virtualDesktopManager.get(), &PhosphorWorkspaces::VirtualDesktopManager::screenDesktopChanged, this,
+            [this](const QString& screenId, int desktop) {
+                // [SEQ A] Cancel any active drag-insert preview before the engine's
+                // desktop changes, else cancel/commit would hit the wrong TilingState.
                 if (m_autotileEngine && m_autotileEngine->hasDragInsertPreview()) {
                     m_autotileEngine->cancelDragInsertPreview();
                 }
-                // Pin screens where all autotiled windows are sticky (on all desktops)
-                // BEFORE changing the desktop context. This ensures currentKeyForScreen()
-                // continues to resolve existing TilingStates for screens managed by the
-                // KWin "virtualdesktopsonlyonprimary" script.
+                // [SEQ B] Pin screens where all autotiled windows are sticky BEFORE
+                // changing the desktop context, so currentKeyForScreen() still
+                // resolves existing TilingStates ("virtualdesktopsonlyonprimary").
                 if (m_autotileEngine && m_windowTrackingAdaptor) {
                     auto* service = m_windowTrackingAdaptor->service();
                     m_autotileEngine->updateStickyScreenPins([service](const QString& windowId) {
                         return service->isWindowSticky(windowId);
                     });
                 }
-                // Set engine's desktop context BEFORE updateAutotileScreens() so it
-                // resolves TilingStates for the correct desktop. Without this, the
-                // engine would look up/create states under the OLD desktop's key.
+                // [SEQ C] Set THIS screen's engine desktop context (pure per-screen
+                // swap, no state migration) BEFORE updateAutotileScreens() so the
+                // engine resolves TilingStates under the new (screen, desktop) key.
                 if (m_autotileEngine) {
-                    m_autotileEngine->setCurrentDesktop(desktop);
+                    m_autotileEngine->setCurrentDesktopForScreen(screenId, desktop);
                 }
-                // Per-desktop assignments may differ — recompute autotile screens
+                // [SEQ D] Per-screen layout/overlay resolution context.
+                m_layoutManager->setCurrentVirtualDesktopForScreen(screenId, desktop);
+                m_overlayService->setCurrentVirtualDesktopForScreen(screenId, desktop);
+                // [SEQ E] Per-desktop assignments may differ — recompute autotile
+                // screens, re-sync mode/filter, then refresh overlay geometry.
                 updateAutotileScreens();
-                // Sync mode, layout filter, and controller state from per-desktop assignments.
-                // This ensures ModeTracker, layout filter, and cycling index reflect the
-                // new desktop — not the old one's global state.
                 syncModeFromAssignments();
                 if (m_overlayService->isVisible()) {
                     m_overlayService->updateGeometries();
                 }
-
-                showDesktopSwitchOsd(desktop, currentActivity());
+                // OSD on the ONE screen that switched (#648).
+                showDesktopSwitchOsdForScreen(screenId, currentActivity());
             });
 
     // Prune stale PhosphorTiles::TilingState entries and disabled-desktop numbers when desktops are removed
@@ -365,7 +379,7 @@ void Daemon::connectDesktopActivity()
                         m_overlayService->updateGeometries();
                     }
 
-                    showDesktopSwitchOsd(currentDesktop(), activityId);
+                    showDesktopSwitchOsd(activityId);
                 });
     }
 }

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -566,7 +566,8 @@ PhosphorZones::Layout* OverlayService::resolveScreenLayout(const QString& screen
 {
     PhosphorZones::Layout* screenLayout = nullptr;
     if (m_layoutManager && !screenId.isEmpty()) {
-        screenLayout = m_layoutManager->layoutForScreen(screenId, m_currentVirtualDesktop, m_currentActivity);
+        screenLayout =
+            m_layoutManager->layoutForScreen(screenId, currentVirtualDesktopForScreen(screenId), m_currentActivity);
         if (!screenLayout) {
             screenLayout = m_layoutManager->defaultLayout();
         }
@@ -589,7 +590,7 @@ void OverlayService::hideDisabledAndRefresh()
         const QStringList screenIds = m_screenStates.keys();
         for (const QString& screenId : screenIds) {
             if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  m_currentVirtualDesktop, m_currentActivity)) {
+                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
                 destroyZoneSelectorWindow(screenId);
                 if (m_visible) {
                     dismissOverlayWindow(screenId);
@@ -601,8 +602,8 @@ void OverlayService::hideDisabledAndRefresh()
     // Update remaining (non-disabled) zone selector and overlay windows
     for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
         const QString& screenId = it.key();
-        if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId, m_currentVirtualDesktop,
-                              m_currentActivity)) {
+        if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
+                              currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
             continue;
         }
         if (it.value().zoneSelectorSlot()) {
@@ -621,6 +622,27 @@ void OverlayService::setCurrentVirtualDesktop(int desktop)
         qCInfo(lcOverlay) << "Virtual desktop changed to" << desktop;
         hideDisabledAndRefresh();
     }
+}
+
+int OverlayService::currentVirtualDesktopForScreen(const QString& screenId) const
+{
+    const auto it = m_screenVirtualDesktop.constFind(screenId);
+    return it != m_screenVirtualDesktop.constEnd() ? it.value() : m_currentVirtualDesktop;
+}
+
+void OverlayService::setCurrentVirtualDesktopForScreen(const QString& screenId, int desktop)
+{
+    if (screenId.isEmpty() || desktop < 1 || m_screenVirtualDesktop.value(screenId, -1) == desktop) {
+        return;
+    }
+    m_screenVirtualDesktop.insert(screenId, desktop);
+    // The daemon's per-screen handler drives the geometry/visibility refresh
+    // after pushing all sinks, so this setter only records the value.
+}
+
+void OverlayService::clearCurrentVirtualDesktopForScreen(const QString& screenId)
+{
+    m_screenVirtualDesktop.remove(screenId);
 }
 
 void OverlayService::setCurrentActivity(const QString& activityId)
@@ -655,8 +677,8 @@ OverlayService::LayoutIncludeFlags OverlayService::resolvePerScreenLayoutInclude
     if (resolvedId.isEmpty()) {
         return flags;
     }
-    const QString assignmentId =
-        m_layoutManager->assignmentIdForScreen(resolvedId, m_currentVirtualDesktop, m_currentActivity);
+    const QString assignmentId = m_layoutManager->assignmentIdForScreen(
+        resolvedId, currentVirtualDesktopForScreen(resolvedId), m_currentActivity);
     if (PhosphorLayout::LayoutId::isAutotile(assignmentId)) {
         flags.manual = false;
         flags.autotile = true;
@@ -671,8 +693,8 @@ QVariantList OverlayService::buildLayoutsList(const QString& screenId, QSize aut
 {
     const auto inc = resolvePerScreenLayoutInclude(screenId);
     const auto entries = PhosphorZones::LayoutUtils::buildUnifiedLayoutList(
-        m_layoutManager, m_algorithmRegistry, screenId, m_currentVirtualDesktop, m_currentActivity, inc.manual,
-        inc.autotile, Utils::screenAspectRatio(m_screenManager, screenId),
+        m_layoutManager, m_algorithmRegistry, screenId, currentVirtualDesktopForScreen(screenId), m_currentActivity,
+        inc.manual, inc.autotile, Utils::screenAspectRatio(m_screenManager, screenId),
         m_settings && m_settings->filterLayoutsByAspectRatio(),
         PhosphorZones::LayoutUtils::buildCustomOrder(m_settings, inc.manual, inc.autotile), m_autotileLayoutSource,
         autotilePreviewCanvas);
@@ -707,8 +729,8 @@ int OverlayService::visibleLayoutCount(const QString& screenId) const
     const auto inc = resolvePerScreenLayoutInclude(screenId);
     // Ordering doesn't affect count - skip custom order for performance.
     const auto entries = PhosphorZones::LayoutUtils::buildUnifiedLayoutList(
-        m_layoutManager, m_algorithmRegistry, screenId, m_currentVirtualDesktop, m_currentActivity, inc.manual,
-        inc.autotile, Utils::screenAspectRatio(m_screenManager, screenId),
+        m_layoutManager, m_algorithmRegistry, screenId, currentVirtualDesktopForScreen(screenId), m_currentActivity,
+        inc.manual, inc.autotile, Utils::screenAspectRatio(m_screenManager, screenId),
         m_settings && m_settings->filterLayoutsByAspectRatio(),
         /*customOrder=*/{}, m_autotileLayoutSource);
     return entries.size();

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -626,23 +626,11 @@ void OverlayService::setCurrentVirtualDesktop(int desktop)
 
 int OverlayService::currentVirtualDesktopForScreen(const QString& screenId) const
 {
-    const auto it = m_screenVirtualDesktop.constFind(screenId);
-    return it != m_screenVirtualDesktop.constEnd() ? it.value() : m_currentVirtualDesktop;
-}
-
-void OverlayService::setCurrentVirtualDesktopForScreen(const QString& screenId, int desktop)
-{
-    if (screenId.isEmpty() || desktop < 1 || m_screenVirtualDesktop.value(screenId, -1) == desktop) {
-        return;
-    }
-    m_screenVirtualDesktop.insert(screenId, desktop);
-    // The daemon's per-screen handler drives the geometry/visibility refresh
-    // after pushing all sinks, so this setter only records the value.
-}
-
-void OverlayService::clearCurrentVirtualDesktopForScreen(const QString& screenId)
-{
-    m_screenVirtualDesktop.remove(screenId);
+    // Single source of truth: the layout registry owns the per-output desktop
+    // map (#648); OverlayService delegates rather than mirroring it, so overlay
+    // resolution can never drift from layout resolution. Falls back to the
+    // global desktop when no registry is wired.
+    return m_layoutManager ? m_layoutManager->currentVirtualDesktopForScreen(screenId) : m_currentVirtualDesktop;
 }
 
 void OverlayService::setCurrentActivity(const QString& activityId)

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -222,6 +222,15 @@ public:
         return m_screenManager;
     }
     void setCurrentVirtualDesktop(int desktop);
+    /// Record a single screen's current virtual desktop (Plasma 6.7 per-output
+    /// virtual desktops, #648). Pushed by the daemon's per-screen desktop handler
+    /// alongside the LayoutRegistry, so overlay resolution matches layout resolution.
+    void setCurrentVirtualDesktopForScreen(const QString& screenId, int desktop);
+    /// Drop a screen's per-output desktop, reverting it to the global value.
+    void clearCurrentVirtualDesktopForScreen(const QString& screenId);
+    /// This screen's current virtual desktop, falling back to the global
+    /// m_currentVirtualDesktop when no per-output value is set.
+    int currentVirtualDesktopForScreen(const QString& screenId) const;
     void setCurrentActivity(const QString& activityId);
 
     /**
@@ -637,6 +646,10 @@ private:
     // nothing; the timer callback runs refreshVisibleWindows once.
     bool m_refreshCoalescePending = false;
     int m_currentVirtualDesktop = 1; // Current virtual desktop (1-based)
+    // Per-screen current virtual desktop (screenId → 1-based) under Plasma 6.7
+    // per-output virtual desktops (#648). Empty unless the daemon pushes
+    // per-screen values, so every read falls back to m_currentVirtualDesktop.
+    QHash<QString, int> m_screenVirtualDesktop;
     QString m_currentActivity; // Current KDE activity (empty = all activities)
     bool m_visible = false;
     bool m_zoneSelectorVisible = false;

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -222,14 +222,11 @@ public:
         return m_screenManager;
     }
     void setCurrentVirtualDesktop(int desktop);
-    /// Record a single screen's current virtual desktop (Plasma 6.7 per-output
-    /// virtual desktops, #648). Pushed by the daemon's per-screen desktop handler
-    /// alongside the LayoutRegistry, so overlay resolution matches layout resolution.
-    void setCurrentVirtualDesktopForScreen(const QString& screenId, int desktop);
-    /// Drop a screen's per-output desktop, reverting it to the global value.
-    void clearCurrentVirtualDesktopForScreen(const QString& screenId);
-    /// This screen's current virtual desktop, falling back to the global
-    /// m_currentVirtualDesktop when no per-output value is set.
+    /// This screen's current virtual desktop under Plasma 6.7 per-output virtual
+    /// desktops (#648). Delegates to the layout registry — the single source of
+    /// truth for the per-output desktop map — so overlay resolution matches
+    /// layout resolution; falls back to the global desktop when no registry is
+    /// wired.
     int currentVirtualDesktopForScreen(const QString& screenId) const;
     void setCurrentActivity(const QString& activityId);
 
@@ -645,11 +642,9 @@ private:
     // fire starts a timer; subsequent fires before the timer elapses do
     // nothing; the timer callback runs refreshVisibleWindows once.
     bool m_refreshCoalescePending = false;
-    int m_currentVirtualDesktop = 1; // Current virtual desktop (1-based)
-    // Per-screen current virtual desktop (screenId → 1-based) under Plasma 6.7
-    // per-output virtual desktops (#648). Empty unless the daemon pushes
-    // per-screen values, so every read falls back to m_currentVirtualDesktop.
-    QHash<QString, int> m_screenVirtualDesktop;
+    int m_currentVirtualDesktop = 1; // Current virtual desktop (1-based); global
+                                     // fallback for currentVirtualDesktopForScreen
+                                     // when no layout registry is wired (#648).
     QString m_currentActivity; // Current KDE activity (empty = all activities)
     bool m_visible = false;
     bool m_zoneSelectorVisible = false;

--- a/src/daemon/overlayservice/internal.h
+++ b/src/daemon/overlayservice/internal.h
@@ -283,18 +283,21 @@ inline bool isAnyModeLocked(ISettings* settings, PhosphorZones::IZoneLayoutRegis
 }
 
 /// Resolve the per-context overlay-property override (shader / style)
-/// for @p screenId at the current virtual desktop + activity. A thin wrapper
-/// over IZoneLayoutRegistry::resolveContextOverlay that supplies the live
-/// context, mirroring how @ref isAnyModeLocked routes the lock check. Returns an
-/// empty override when there is no registry or no matching overlay rule, so the
-/// overlay falls through to the active layout's own shader / display-mode.
+/// for @p screenId at that screen's current virtual desktop + activity. A thin
+/// wrapper over IZoneLayoutRegistry::resolveContextOverlay that supplies the live
+/// context, mirroring how @ref isAnyModeLocked routes the lock check. Under
+/// per-output virtual desktops (#648) the desktop is resolved per-screen so the
+/// override matches the desktop actually shown on @p screenId, not the active
+/// monitor's. Returns an empty override when there is no registry or no matching
+/// overlay rule, so the overlay falls through to the active layout's own
+/// shader / display-mode.
 inline PhosphorZones::ContextOverlayOverride
 overlayOverrideForScreen(PhosphorZones::IZoneLayoutRegistry* layoutRegistry, const QString& screenId)
 {
     if (!layoutRegistry) {
         return {};
     }
-    return layoutRegistry->resolveContextOverlay(screenId, layoutRegistry->currentVirtualDesktop(),
+    return layoutRegistry->resolveContextOverlay(screenId, layoutRegistry->currentVirtualDesktopForScreen(screenId),
                                                  layoutRegistry->currentActivity());
 }
 

--- a/src/daemon/overlayservice/lifecycle.cpp
+++ b/src/daemon/overlayservice/lifecycle.cpp
@@ -53,7 +53,7 @@ void OverlayService::show()
         if (cursorScreen && m_settings) {
             QString effectiveId = Utils::effectiveScreenIdAt(m_screenManager, QCursor::pos(), cursorScreen);
             if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, effectiveId,
-                                  m_currentVirtualDesktop, m_currentActivity)) {
+                                  currentVirtualDesktopForScreen(effectiveId), m_currentActivity)) {
                 return;
             }
         }
@@ -82,7 +82,7 @@ void OverlayService::showAtPosition(int cursorX, int cursorY)
         if (cursorScreen && m_settings) {
             QString effectiveId = Utils::effectiveScreenIdAt(m_screenManager, QPoint(cursorX, cursorY), cursorScreen);
             if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, effectiveId,
-                                  m_currentVirtualDesktop, m_currentActivity)) {
+                                  currentVirtualDesktopForScreen(effectiveId), m_currentActivity)) {
                 return;
             }
         }

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -133,7 +133,7 @@ void OverlayService::initializeOverlay(QScreen* cursorScreen, const QPoint& curs
                 continue;
             }
             if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  m_currentVirtualDesktop, m_currentActivity)) {
+                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {
@@ -147,7 +147,7 @@ void OverlayService::initializeOverlay(QScreen* cursorScreen, const QPoint& curs
         for (auto* screen : Utils::allScreens()) {
             const QString screenId = PhosphorScreens::ScreenIdentity::identifierFor(screen);
             if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  m_currentVirtualDesktop, m_currentActivity)) {
+                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {
@@ -575,8 +575,8 @@ void OverlayService::recreateOverlayWindowsOnTypeMismatch()
         stopShaderAnimation();
 
     for (const QString& screenId : screensToFlip) {
-        if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId, m_currentVirtualDesktop,
-                              m_currentActivity)) {
+        if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
+                              currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
             continue;
         }
         QScreen* physScreen = m_screenStates.value(screenId).overlayPhysScreen;

--- a/src/daemon/overlayservice/screens.cpp
+++ b/src/daemon/overlayservice/screens.cpp
@@ -96,8 +96,8 @@ void OverlayService::handleScreenAdded(QScreen* screen)
     if (mgr && mgr->hasVirtualScreens(physScreenId)) {
         // Create overlays for each virtual screen on this physical screen
         for (const QString& vsId : mgr->virtualScreenIdsFor(physScreenId)) {
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, vsId, m_currentVirtualDesktop,
-                                  m_currentActivity)) {
+            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, vsId,
+                                  currentVirtualDesktopForScreen(vsId), m_currentActivity)) {
                 continue;
             }
             QRect vsGeom = mgr->screenGeometry(vsId);

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -364,7 +364,7 @@ void OverlayService::updateSelectorPosition(int cursorX, int cursorY)
                 // Skip non-active layouts when screen is locked — a LockContext
                 // rule (checked first) or a manual lock on either mode.
                 if (m_settings && m_layoutManager) {
-                    int curDesktop = m_layoutManager->currentVirtualDesktop();
+                    int curDesktop = currentVirtualDesktopForScreen(cursorScreenId);
                     QString curActivity = m_layoutManager->currentActivity();
                     bool locked = isAnyModeLocked(m_settings, m_layoutManager, cursorScreenId, curDesktop, curActivity);
                     if (locked) {

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -96,7 +96,7 @@ void OverlayService::showZoneSelector(const QString& targetScreenId)
                 continue;
             }
             if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  m_currentVirtualDesktop, m_currentActivity)) {
+                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {
@@ -113,7 +113,7 @@ void OverlayService::showZoneSelector(const QString& targetScreenId)
             }
             QString screenId = PhosphorScreens::ScreenIdentity::identifierFor(screen);
             if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  m_currentVirtualDesktop, m_currentActivity)) {
+                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {

--- a/src/daemon/overlayservice/selector_update.cpp
+++ b/src/daemon/overlayservice/selector_update.cpp
@@ -180,7 +180,7 @@ void OverlayService::updateZoneSelectorWindow(const QString& screenId)
     // the zone selector appears during drag for the current mode.
     bool locked = false;
     if (m_settings && m_layoutManager) {
-        int curDesktop = m_layoutManager->currentVirtualDesktop();
+        int curDesktop = currentVirtualDesktopForScreen(screenId);
         QString curActivity = m_layoutManager->currentActivity();
         locked = isAnyModeLocked(m_settings, m_layoutManager, screenId, curDesktop, curActivity);
     }
@@ -240,7 +240,6 @@ void OverlayService::refreshContextLockState()
     if (!m_settings || !m_layoutManager) {
         return;
     }
-    const int curDesktop = m_layoutManager->currentVirtualDesktop();
     const QString curActivity = m_layoutManager->currentActivity();
 
     // Open zone selectors: one entry per screen with a live slot.
@@ -249,6 +248,8 @@ void OverlayService::refreshContextLockState()
         if (!window) {
             continue;
         }
+        // Per-output virtual desktops (#648): each screen resolves its own desktop.
+        const int curDesktop = currentVirtualDesktopForScreen(it.key());
         const bool locked = isAnyModeLocked(m_settings, m_layoutManager, it.key(), curDesktop, curActivity);
         writeQmlProperty(window, QStringLiteral("locked"), locked);
     }
@@ -257,6 +258,8 @@ void OverlayService::refreshContextLockState()
     // it, so push just the lock state to the live slot).
     if (m_layoutPickerVisible && !m_layoutPickerScreenId.isEmpty()) {
         if (auto* slot = m_screenStates.value(m_layoutPickerScreenId).layoutPickerSlot()) {
+            // Per-output virtual desktops (#648): each screen resolves its own desktop.
+            const int curDesktop = currentVirtualDesktopForScreen(m_layoutPickerScreenId);
             const bool locked =
                 isAnyModeLocked(m_settings, m_layoutManager, m_layoutPickerScreenId, curDesktop, curActivity);
             writeQmlProperty(slot, QStringLiteral("locked"), locked);

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -571,7 +571,7 @@ void OverlayService::showLayoutPicker(const QString& screenId)
 
     bool locked = false;
     if (m_settings && m_layoutManager) {
-        int curDesktop = m_layoutManager->currentVirtualDesktop();
+        int curDesktop = currentVirtualDesktopForScreen(resolvedId);
         QString curActivity = m_layoutManager->currentActivity();
         locked = isAnyModeLocked(m_settings, m_layoutManager, resolvedId, curDesktop, curActivity);
     }

--- a/src/daemon/unifiedlayoutcontroller.cpp
+++ b/src/daemon/unifiedlayoutcontroller.cpp
@@ -115,8 +115,12 @@ QVector<PhosphorLayout::LayoutPreview> UnifiedLayoutController::layouts() const
         // and mode-based filtering (manual-only vs autotile-only).
         // Registry comes directly from our injected pointer rather than the
         // Law-of-Demeter reach-through engine->algorithmRegistry().
+        // Per-output virtual desktops (#648): resolve the current screen's own
+        // desktop, not the global active one.
+        const int desktop = m_layoutManager ? m_layoutManager->currentVirtualDesktopForScreen(m_currentScreenName)
+                                            : m_currentVirtualDesktop;
         m_cachedLayouts = PhosphorZones::LayoutUtils::buildUnifiedLayoutList(
-            m_layoutManager, m_algorithmRegistry, m_currentScreenName, m_currentVirtualDesktop, m_currentActivity,
+            m_layoutManager, m_algorithmRegistry, m_currentScreenName, desktop, m_currentActivity,
             m_includeManualLayouts, m_includeAutotileLayouts,
             Utils::screenAspectRatio(m_screenManager, m_currentScreenName),
             m_settings && m_settings->filterLayoutsByAspectRatio(),
@@ -219,8 +223,10 @@ void UnifiedLayoutController::setCurrentScreenName(const QString& screenId)
         // Sync current layout ID to what's actually assigned to this screen
         // (not the global active layout, which may belong to a different screen)
         if (m_layoutManager && !screenId.isEmpty()) {
+            // Per-output virtual desktops (#648): this screen's own desktop.
+            const int desktop = m_layoutManager->currentVirtualDesktopForScreen(screenId);
             PhosphorZones::Layout* screenLayout =
-                m_layoutManager->layoutForScreen(screenId, m_currentVirtualDesktop, m_currentActivity);
+                m_layoutManager->layoutForScreen(screenId, desktop, m_currentActivity);
             if (screenLayout) {
                 m_currentLayoutId = screenLayout->id().toString();
             }
@@ -271,8 +277,9 @@ bool UnifiedLayoutController::applyEntry(const PhosphorLayout::LayoutPreview& pr
                 // Most specific context wins — an activity-keyed entry takes
                 // priority over a desktop-only entry in the cascade, and a
                 // different activity falls through to the broader entry.
-                m_layoutManager->assignLayoutById(m_currentScreenName, m_currentVirtualDesktop, m_currentActivity,
-                                                  preview.id);
+                m_layoutManager->assignLayoutById(m_currentScreenName,
+                                                  m_layoutManager->currentVirtualDesktopForScreen(m_currentScreenName),
+                                                  m_currentActivity, preview.id);
             }
             m_autotileEngine->setAlgorithm(algoId);
             setCurrentLayoutId(preview.id);
@@ -296,7 +303,9 @@ bool UnifiedLayoutController::applyEntry(const PhosphorLayout::LayoutPreview& pr
                 // Only the per-context assignment is stored — the global
                 // activeLayout pointer is NOT updated so that other screens
                 // and contexts keep their existing fallback layout.
-                m_layoutManager->assignLayout(m_currentScreenName, m_currentVirtualDesktop, m_currentActivity, layout);
+                m_layoutManager->assignLayout(m_currentScreenName,
+                                              m_layoutManager->currentVirtualDesktopForScreen(m_currentScreenName),
+                                              m_currentActivity, layout);
             }
             setCurrentLayoutId(preview.id);
             qCInfo(lcDaemon) << "Applied unified layout=" << preview.displayName << "screen=" << m_currentScreenName;

--- a/src/daemon/zoneselectorcontroller.cpp
+++ b/src/daemon/zoneselectorcontroller.cpp
@@ -98,10 +98,11 @@ QVariantList ZoneSelectorController::layouts() const
         screenId = m_screenId;
         aspectRatio = Utils::screenAspectRatio(m_screen);
     }
+    const int desktop =
+        m_layoutManager ? m_layoutManager->currentVirtualDesktopForScreen(screenId) : m_currentVirtualDesktop;
     const auto entries = PhosphorZones::LayoutUtils::buildUnifiedLayoutList(
-        m_layoutManager, m_algorithmRegistry, screenId, m_currentVirtualDesktop, m_currentActivity,
-        m_includeManualLayouts, m_includeAutotileLayouts, aspectRatio,
-        m_settings && m_settings->filterLayoutsByAspectRatio(),
+        m_layoutManager, m_algorithmRegistry, screenId, desktop, m_currentActivity, m_includeManualLayouts,
+        m_includeAutotileLayouts, aspectRatio, m_settings && m_settings->filterLayoutsByAspectRatio(),
         PhosphorZones::LayoutUtils::buildCustomOrder(m_settings, m_includeManualLayouts, m_includeAutotileLayouts),
         m_autotileLayoutSource);
     return PlasmaZones::toVariantList(entries);
@@ -201,8 +202,8 @@ void ZoneSelectorController::setLayoutManager(PhosphorZones::LayoutRegistry* lay
                     // Pass current virtual desktop for per-desktop layout lookup
                     PhosphorZones::Layout* effectiveLayout = nullptr;
                     if (m_screen) {
-                        effectiveLayout =
-                            m_layoutManager->layoutForScreen(m_screenId, m_currentVirtualDesktop, m_currentActivity);
+                        effectiveLayout = m_layoutManager->layoutForScreen(
+                            m_screenId, m_layoutManager->currentVirtualDesktopForScreen(m_screenId), m_currentActivity);
                     }
                     if (!effectiveLayout) {
                         effectiveLayout = layout;
@@ -245,8 +246,8 @@ void ZoneSelectorController::setScreen(QScreen* screen)
 
     // Update active layout ID for this screen and current desktop
     if (m_screen && m_layoutManager) {
-        PhosphorZones::Layout* screenLayout =
-            m_layoutManager->layoutForScreen(m_screenId, m_currentVirtualDesktop, m_currentActivity);
+        PhosphorZones::Layout* screenLayout = m_layoutManager->layoutForScreen(
+            m_screenId, m_layoutManager->currentVirtualDesktopForScreen(m_screenId), m_currentActivity);
         if (screenLayout) {
             setActiveLayoutId(screenLayout->id().toString());
         } else if (auto* def = m_layoutManager->defaultLayout()) {
@@ -262,8 +263,8 @@ void ZoneSelectorController::setCurrentVirtualDesktop(int desktop)
         m_currentVirtualDesktop = desktop;
         // Update active layout ID when desktop changes
         if (m_screen && m_layoutManager) {
-            PhosphorZones::Layout* screenLayout =
-                m_layoutManager->layoutForScreen(m_screenId, m_currentVirtualDesktop, m_currentActivity);
+            PhosphorZones::Layout* screenLayout = m_layoutManager->layoutForScreen(
+                m_screenId, m_layoutManager->currentVirtualDesktopForScreen(m_screenId), m_currentActivity);
             if (screenLayout) {
                 setActiveLayoutId(screenLayout->id().toString());
             }

--- a/src/daemon/zoneselectorcontroller.cpp
+++ b/src/daemon/zoneselectorcontroller.cpp
@@ -403,7 +403,7 @@ void ZoneSelectorController::selectLayout(const QString& layoutId)
 bool ZoneSelectorController::isScreenLocked() const
 {
     if (m_layoutManager && m_settings && m_screen) {
-        const int desktop = m_layoutManager->currentVirtualDesktop();
+        const int desktop = m_layoutManager->currentVirtualDesktopForScreen(m_screenId);
         const QString activity = m_layoutManager->currentActivity();
         // Match OverlayService behavior: a rule-driven LockContext lock is checked first,
         // then both manual modes (0 = manual, 1 = autotile). A lock from any of these

--- a/src/dbus/layoutadaptor/assignment.cpp
+++ b/src/dbus/layoutadaptor/assignment.cpp
@@ -290,7 +290,6 @@ QString LayoutAdaptor::getScreenStates()
 
     QJsonArray result;
 
-    const int desktop = m_layoutManager->currentVirtualDesktop();
     const QString activity = m_layoutManager->currentActivity();
 
     // Use effective screen IDs (includes virtual screens when configured)
@@ -298,6 +297,8 @@ QString LayoutAdaptor::getScreenStates()
     const QStringList screenIds = (m_screenManager ? m_screenManager->effectiveScreenIds() : QStringList());
 
     for (const QString& screenId : std::as_const(screenIds)) {
+        // Per-output virtual desktops (#648): each screen resolves its own desktop.
+        const int desktop = m_layoutManager->currentVirtualDesktopForScreen(screenId);
         const auto entry = m_layoutManager->assignmentEntryForScreen(screenId, desktop, activity);
 
         QJsonObject obj;

--- a/src/dbus/layoutadaptor/assignment.cpp
+++ b/src/dbus/layoutadaptor/assignment.cpp
@@ -44,9 +44,12 @@ int LayoutAdaptor::getCurrentVirtualDesktop()
 // clearAssignment(), setAssignmentEntryDirect(), and the batch setAll*() methods.
 QString LayoutAdaptor::getLayoutForScreen(const QString& screenId)
 {
-    int desktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
-    QString activity = m_activityManager ? m_activityManager->currentActivity() : QString();
     QString resolvedId = PhosphorScreens::ScreenIdentity::idForName(screenId);
+    // Per-output virtual desktops (#648): resolve the queried screen's own
+    // desktop, not the active monitor's, so getLayoutForScreen(screenA) issued
+    // while screenB is focused still returns screenA's layout.
+    int desktop = m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(resolvedId) : 0;
+    QString activity = m_activityManager ? m_activityManager->currentActivity() : QString();
 
     // Check for autotile assignment first (layoutForScreen returns nullptr for autotile)
     QString assignmentId = m_layoutManager->assignmentIdForScreen(resolvedId, desktop, activity);

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -459,7 +459,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
         // desktops between here and the timer firing, a live currentDesktop()
         // read would describe the new desktop's occupancy instead of the
         // desktop the user actually dropped on.
-        m_snapAssistPendingDesktop = m_layoutManager->currentVirtualDesktop();
+        m_snapAssistPendingDesktop = m_layoutManager->currentVirtualDesktopForScreen(releaseScreenId);
     }
 
     // Reset drag state for next operation.
@@ -510,7 +510,8 @@ void WindowDragAdaptor::computeAndEmitSnapAssist()
     // pre-snapshot codepath or invalid pending state).
     // m_layoutManager non-null is guaranteed by the early-return above; the
     // earlier ternary was dead-defensive.
-    const int desktopFilter = desktopAtDrop > 0 ? desktopAtDrop : m_layoutManager->currentVirtualDesktop();
+    const int desktopFilter =
+        desktopAtDrop > 0 ? desktopAtDrop : m_layoutManager->currentVirtualDesktopForScreen(screenId);
     QSet<QUuid> occupied = m_windowTracking->service()->buildOccupiedZoneSet(screenId, desktopFilter);
     PhosphorProtocol::EmptyZoneList emptyZones = GeometryUtils::buildEmptyZoneList(
         m_screenManager, layout, screenId, releaseScreen, m_settings,

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -253,6 +253,13 @@ int WindowTrackingAdaptor::currentDesktop() const
     return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktop() : 0;
 }
 
+int WindowTrackingAdaptor::currentDesktopForScreen(const QString& screenId) const
+{
+    // Per-output virtual desktops (#648): this screen's current desktop, falling
+    // back to the global current when no per-output value is on record.
+    return m_virtualDesktopManager ? m_virtualDesktopManager->currentDesktopForScreen(screenId) : 0;
+}
+
 void WindowTrackingAdaptor::setScreenModeRouter(ScreenModeRouter* router)
 {
     m_screenModeRouter = router;
@@ -998,7 +1005,7 @@ void WindowTrackingAdaptor::windowActivated(const QString& windowId, const QStri
     if (!zoneId.isEmpty() && m_settings && m_settings->moveNewWindowsToLastZone()
         && !m_service->isAutoSnapped(windowId)) {
         QString windowClass = m_service->currentAppIdFor(windowId);
-        m_service->updateLastUsedZone(zoneId, resolvedScreen, windowClass, currentDesktop());
+        m_service->updateLastUsedZone(zoneId, resolvedScreen, windowClass, currentDesktopForScreen(resolvedScreen));
     }
 }
 

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -74,8 +74,8 @@ WindowTrackingAdaptor::WindowTrackingAdaptor(PhosphorZones::LayoutRegistry* layo
     // current-desktop occupancy filter used in buildEmptyZoneList.
     m_geometryResolver = std::make_unique<PlasmaZones::DaemonGeometryResolver>(
         settings, layoutManager,
-        [vdm = m_virtualDesktopManager]() -> int {
-            return vdm ? vdm->currentDesktop() : 0;
+        [vdm = m_virtualDesktopManager](const QString& screenId) -> int {
+            return vdm ? vdm->currentDesktopForScreen(screenId) : 0;
         },
         [am = m_activityManager]() -> QString {
             return PhosphorWorkspaces::ActivityManager::currentActivityOrEmpty(am);

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -905,6 +905,17 @@ void WindowTrackingAdaptor::cursorScreenChanged(const QString& screenId)
     qCDebug(lcDbusWindow) << "Cursor screen changed to" << resolvedId;
 }
 
+void WindowTrackingAdaptor::screenDesktopChanged(const QString& screenId, int desktop)
+{
+    if (screenId.isEmpty() || desktop < 1 || !m_virtualDesktopManager) {
+        return;
+    }
+    // The effect reports the PHYSICAL screen id; VirtualDesktopManager keys its
+    // per-screen map on the same id the daemon uses everywhere. updateScreenDesktop
+    // emits screenDesktopChanged only on a real change (emit-on-change).
+    m_virtualDesktopManager->updateScreenDesktop(screenId, desktop);
+}
+
 void WindowTrackingAdaptor::setFrameGeometry(const QString& windowId, int x, int y, int width, int height)
 {
     if (windowId.isEmpty() || width <= 0 || height <= 0) {

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -390,6 +390,16 @@ public Q_SLOTS:
     void cursorScreenChanged(const QString& screenId);
 
     /**
+     * Record a screen's current virtual desktop (Plasma 6.7 per-output virtual
+     * desktops). Called by the KWin effect on KWin::EffectsHandler::desktopChanged.
+     * Forwarded to VirtualDesktopManager::updateScreenDesktop — KWin's own D-Bus
+     * VirtualDesktopManager interface only exposes the global current desktop.
+     * @param screenId Physical screen whose desktop changed
+     * @param desktop  The screen's current virtual desktop, 1-based
+     */
+    void screenDesktopChanged(const QString& screenId, int desktop);
+
+    /**
      * Report navigation feedback from KWin effect (D-Bus method)
      * @param success Whether the navigation succeeded
      * @param action Action attempted (e.g., "move", "focus", "swap")

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -1005,6 +1005,9 @@ private:
      *        disabled-context gates and last-used-zone tracking.
      */
     int currentDesktop() const;
+    /// This screen's current virtual desktop (Plasma 6.7 per-output virtual
+    /// desktops, #648), falling back to the global currentDesktop().
+    int currentDesktopForScreen(const QString& screenId) const;
 
     // clearFloatingStateForSnap was removed — PhosphorSnapEngine::SnapEngine::commitSnap
     // now handles floating-state clearing internally (and emits

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -144,7 +144,7 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
         // restore onto a desktop other than the current one is therefore gated
         // by the current desktop's disable state rather than the target's.
         snap->setShouldRestorePredicate([this](const QString& screenId) -> bool {
-            return !isPersistedContextDisabled(screenId, currentDesktop());
+            return !isPersistedContextDisabled(screenId, currentDesktopForScreen(screenId));
         });
 
         // Floated-position restore gate (snap-floated windows). On open the engine
@@ -536,7 +536,7 @@ void WindowTrackingAdaptor::handleCrossModeMove(const QString& windowId, const Q
     // (possibly different) mode on the same screen's target desktop; a monitor
     // crossing targets the neighbour screen on the current desktop (targetDesktop
     // == 0).
-    const int effectiveDesktop = targetDesktop > 0 ? targetDesktop : currentDesktop();
+    const int effectiveDesktop = targetDesktop > 0 ? targetDesktop : currentDesktopForScreen(targetScreenId);
     const QString activity = m_layoutManager->currentActivity();
     const bool targetIsAutotile = m_layoutManager->modeForScreen(targetScreenId, effectiveDesktop, activity)
         == PhosphorZones::AssignmentEntry::Autotile;
@@ -641,7 +641,8 @@ void WindowTrackingAdaptor::handleCrossModeSwap(const QString& windowId, const Q
     }
 
     const QString activity = m_layoutManager->currentActivity();
-    const bool targetIsAutotile = m_layoutManager->modeForScreen(targetScreenId, currentDesktop(), activity)
+    const bool targetIsAutotile =
+        m_layoutManager->modeForScreen(targetScreenId, currentDesktopForScreen(targetScreenId), activity)
         == PhosphorZones::AssignmentEntry::Autotile;
     PhosphorEngine::PlacementEngineBase* targetEngine =
         targetIsAutotile ? m_autotileEngine.data() : m_snapEngine.data();

--- a/src/dbus/windowtrackingadaptor/persistence.cpp
+++ b/src/dbus/windowtrackingadaptor/persistence.cpp
@@ -160,11 +160,11 @@ QString WindowTrackingAdaptor::getPendingRestoreGeometries()
     // virtual desktop is used — consistent with the snap-side
     // setShouldRestorePredicate gate. Activity is left unset: snap-mode storage
     // carries no per-window activity tag (see isPersistedContextDisabled).
-    const int desktop = currentDesktop();
-
     QJsonObject result;
     for (auto it = targets.constBegin(); it != targets.constEnd(); ++it) {
         const auto& target = it.value();
+        // Per-output virtual desktops (#648): gate each record on ITS screen's desktop.
+        const int desktop = currentDesktopForScreen(target.screenId);
         if (isPersistedContextDisabled(target.screenId, desktop)) {
             qCDebug(lcDbusWindow) << "getPendingRestoreGeometries: skipping" << it.key()
                                   << "— disabled context on screen" << target.screenId;
@@ -247,14 +247,14 @@ QString WindowTrackingAdaptor::detectScreenForZone(const QString& zoneId) const
         return QString();
     }
 
-    const int desktop = currentDesktop();
-
     // Search per-screen layouts to find which screen's layout contains this zone.
     // This correctly handles multi-monitor setups where each screen has a different layout.
     // Use effective screen IDs (virtual + physical) so virtual screen layouts are searched too.
     const QStringList effectiveIds =
         (m_service->screenManager() ? m_service->screenManager()->effectiveScreenIds() : QStringList());
     for (const QString& sid : effectiveIds) {
+        // Per-output virtual desktops (#648): each screen resolves its own desktop.
+        const int desktop = currentDesktopForScreen(sid);
         PhosphorZones::Layout* layout =
             m_layoutManager->layoutForScreen(sid, desktop, m_layoutManager->currentActivity());
         if (layout && layout->zoneById(*zoneUuid)) {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -25,6 +25,7 @@ endmacro()
 # ═══════════════════════════════════════════════════════════════════════════════
 p_add_test(test_window_identity core/test_window_identity.cpp)
 p_add_test(test_window_registry core/test_window_registry.cpp)
+p_add_test(test_virtual_desktop_per_screen core/test_virtual_desktop_per_screen.cpp)
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # core/ - Window Tracking Tests (snap/unsnap, floating)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -193,6 +193,7 @@ target_link_libraries(test_autotile_tile_request_validation PRIVATE PhosphorComp
 # autotile/ - Autotile + Virtual Screen Integration Tests
 # ═══════════════════════════════════════════════════════════════════════════════
 p_add_test(test_autotile_virtual autotile/test_autotile_virtual.cpp)
+p_add_test(test_autotile_per_screen_desktop autotile/test_autotile_per_screen_desktop.cpp)
 target_compile_definitions(test_autotile_virtual PRIVATE "P_SOURCE_DIR=\"${PROJECT_SOURCE_DIR}\"")
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/unit/autotile/test_autotile_per_screen_desktop.cpp
+++ b/tests/unit/autotile/test_autotile_per_screen_desktop.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_autotile_per_screen_desktop.cpp
+ * @brief Phase 3 of per-screen virtual desktops (#648): AutotileEngine's
+ *        per-output desktop input (setCurrentDesktopForScreen).
+ *
+ * Plasma 6.7 "switch desktops independently for each screen" lets each output sit
+ * on its own virtual desktop. The engine already keyed TilingState by
+ * (screen, desktop, activity); setCurrentDesktopForScreen feeds a per-screen
+ * desktop into currentKeyForScreen() via m_screenCurrentDesktop (distinct from the
+ * sticky-pin override map). It is a PURE context swap — switching a screen's
+ * desktop must NOT migrate windows between per-desktop states.
+ *
+ * State keying is exercised through the public tilingStateForScreen() (the
+ * underlying map / currentKeyForScreen are private), mirroring the existing
+ * perDesktopState_* tests which drive the global setCurrentDesktop the same way.
+ */
+
+#include <QTest>
+
+#include <PhosphorTileEngine/AutotileEngine.h>
+#include <PhosphorTiles/TilingState.h>
+
+#include "../helpers/AutotileTestHelpers.h"
+
+using namespace PlasmaZones;
+using namespace PhosphorTileEngine;
+
+namespace {
+const QString kS1 = QStringLiteral("DP-1");
+const QString kS2 = QStringLiteral("DP-2");
+} // namespace
+
+class TestAutotilePerScreenDesktop : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    // A single screen on two different per-output desktops yields two distinct
+    // TilingState instances (the desktop dimension of the key differs).
+    void distinctStatesPerScreenDesktop()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+
+        engine.setCurrentDesktopForScreen(kS1, 3);
+        engine.setAutotileScreens({kS1});
+        PhosphorTiles::TilingState* d3 = engine.tilingStateForScreen(kS1);
+
+        engine.setCurrentDesktopForScreen(kS1, 5);
+        engine.setAutotileScreens({kS1});
+        PhosphorTiles::TilingState* d5 = engine.tilingStateForScreen(kS1);
+
+        QVERIFY(d3 != nullptr);
+        QVERIFY(d5 != nullptr);
+        QVERIFY(d3 != d5);
+    }
+
+    // Switching a screen's desktop and back returns the ORIGINAL state instance —
+    // proving setCurrentDesktopForScreen is a pure context swap with no migration:
+    // the first desktop's state was preserved untouched while the screen was away.
+    void pureContextSwapPreservesState()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+
+        engine.setCurrentDesktopForScreen(kS1, 3);
+        engine.setAutotileScreens({kS1});
+        PhosphorTiles::TilingState* d3 = engine.tilingStateForScreen(kS1);
+
+        engine.setCurrentDesktopForScreen(kS1, 5);
+        engine.setAutotileScreens({kS1});
+        (void)engine.tilingStateForScreen(kS1); // materialise the desktop-5 state
+
+        engine.setCurrentDesktopForScreen(kS1, 3); // swap back
+        engine.setAutotileScreens({kS1});
+        QCOMPARE(engine.tilingStateForScreen(kS1), d3);
+    }
+
+    // A per-screen desktop change touches neither the global current desktop nor
+    // any other screen's resolved state.
+    void isolatedFromGlobalAndOtherScreens()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+
+        engine.setAutotileScreens({kS1, kS2});
+        PhosphorTiles::TilingState* s2before = engine.tilingStateForScreen(kS2);
+        const int globalBefore = engine.currentDesktop();
+
+        engine.setCurrentDesktopForScreen(kS1, 7); // change only kS1
+        engine.setAutotileScreens({kS1, kS2});
+
+        QCOMPARE(engine.currentDesktop(), globalBefore); // global untouched
+        QCOMPARE(engine.tilingStateForScreen(kS2), s2before); // kS2 untouched
+    }
+
+    // clearCurrentDesktopForScreen reverts a screen to the global current desktop.
+    void clearRevertsToGlobal()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+
+        // Global default desktop is 1; capture the screen's global-desktop state.
+        engine.setAutotileScreens({kS1});
+        PhosphorTiles::TilingState* globalState = engine.tilingStateForScreen(kS1);
+
+        engine.setCurrentDesktopForScreen(kS1, 4);
+        engine.setAutotileScreens({kS1});
+        PhosphorTiles::TilingState* d4 = engine.tilingStateForScreen(kS1);
+        QVERIFY(d4 != globalState);
+
+        engine.clearCurrentDesktopForScreen(kS1); // back to the global desktop
+        engine.setAutotileScreens({kS1});
+        QCOMPARE(engine.tilingStateForScreen(kS1), globalState);
+    }
+};
+
+QTEST_MAIN(TestAutotilePerScreenDesktop)
+#include "test_autotile_per_screen_desktop.moc"

--- a/tests/unit/core/test_virtual_desktop_per_screen.cpp
+++ b/tests/unit/core/test_virtual_desktop_per_screen.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_virtual_desktop_per_screen.cpp
+ * @brief Phase 1 of the per-screen virtual desktops work (discussion #648):
+ *        the VirtualDesktopManager per-screen current-desktop model.
+ *
+ * Plasma 6.7's "switch desktops independently for each screen" lets each output
+ * sit on its own virtual desktop. The daemon's VirtualDesktopManager gains a
+ * screenId -> desktop map (fed by the KWin effect's per-output report) plus
+ * currentDesktopForScreen()/perScreenModeActive(). KWin's own D-Bus interface is
+ * global-only, so these tests construct the manager WITHOUT a live KWin D-Bus
+ * connection (m_useKWinDBus stays false, currentDesktop() == 1) and exercise the
+ * per-screen model directly through its public API.
+ *
+ * This phase is behaviour-preserving: nothing consumes screenDesktopChanged yet.
+ */
+
+#include <QSignalSpy>
+#include <QTest>
+
+#include <PhosphorWorkspaces/VirtualDesktopManager.h>
+
+using PhosphorWorkspaces::VirtualDesktopManager;
+
+class TestVirtualDesktopPerScreen : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    // A screen with no per-output desktop on record resolves to the global value.
+    void unknownScreen_fallsBackToGlobal()
+    {
+        VirtualDesktopManager vdm;
+        QCOMPARE(vdm.currentDesktopForScreen(QStringLiteral("DP-1")), vdm.currentDesktop());
+        QVERIFY(!vdm.perScreenModeActive());
+    }
+
+    // Recorded per-screen desktops resolve independently; unknown screens still
+    // fall back to the global desktop.
+    void updateScreenDesktop_recordsAndResolves()
+    {
+        VirtualDesktopManager vdm;
+        vdm.updateScreenDesktop(QStringLiteral("DP-1"), 3);
+        vdm.updateScreenDesktop(QStringLiteral("DP-2"), 5);
+
+        QCOMPARE(vdm.currentDesktopForScreen(QStringLiteral("DP-1")), 3);
+        QCOMPARE(vdm.currentDesktopForScreen(QStringLiteral("DP-2")), 5);
+        QCOMPARE(vdm.currentDesktopForScreen(QStringLiteral("DP-9")), vdm.currentDesktop());
+    }
+
+    // screenDesktopChanged fires only when a screen's desktop actually changes.
+    void updateScreenDesktop_emitsOnlyOnChange()
+    {
+        VirtualDesktopManager vdm;
+        QSignalSpy spy(&vdm, &VirtualDesktopManager::screenDesktopChanged);
+
+        vdm.updateScreenDesktop(QStringLiteral("DP-1"), 3);
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.last().at(0).toString(), QStringLiteral("DP-1"));
+        QCOMPARE(spy.last().at(1).toInt(), 3);
+
+        vdm.updateScreenDesktop(QStringLiteral("DP-1"), 3); // same value — no emit
+        QCOMPARE(spy.count(), 1);
+
+        vdm.updateScreenDesktop(QStringLiteral("DP-1"), 4); // changed — emit
+        QCOMPARE(spy.count(), 2);
+        QCOMPARE(spy.last().at(1).toInt(), 4);
+    }
+
+    // Empty screen id or a non-positive desktop are rejected silently.
+    void updateScreenDesktop_rejectsInvalid()
+    {
+        VirtualDesktopManager vdm;
+        QSignalSpy spy(&vdm, &VirtualDesktopManager::screenDesktopChanged);
+
+        vdm.updateScreenDesktop(QString(), 3);
+        vdm.updateScreenDesktop(QStringLiteral("DP-1"), 0);
+        vdm.updateScreenDesktop(QStringLiteral("DP-1"), -2);
+
+        QCOMPARE(spy.count(), 0);
+        QCOMPARE(vdm.currentDesktopForScreen(QStringLiteral("DP-1")), vdm.currentDesktop());
+    }
+
+    // Per-screen mode is active iff two screens are on different desktops, and
+    // deactivates when they reconverge.
+    void perScreenModeActive_tracksDivergence()
+    {
+        VirtualDesktopManager vdm;
+        QVERIFY(!vdm.perScreenModeActive()); // empty
+
+        vdm.updateScreenDesktop(QStringLiteral("DP-1"), 2);
+        QVERIFY(!vdm.perScreenModeActive()); // single screen
+
+        vdm.updateScreenDesktop(QStringLiteral("DP-2"), 2);
+        QVERIFY(!vdm.perScreenModeActive()); // two screens, same desktop
+
+        vdm.updateScreenDesktop(QStringLiteral("DP-2"), 5);
+        QVERIFY(vdm.perScreenModeActive()); // diverged
+
+        vdm.updateScreenDesktop(QStringLiteral("DP-2"), 2);
+        QVERIFY(!vdm.perScreenModeActive()); // reconverged
+    }
+
+    // When the desktop count shrinks, per-screen entries above the new count are
+    // clamped back to the count (KWin renumbers on removal; the effect re-reports
+    // the true value shortly after). Only the affected screen re-emits.
+    void desktopCountShrink_clampsPerScreenEntries()
+    {
+        VirtualDesktopManager vdm;
+        // Drive the private count-changed slot directly (no KWin D-Bus in tests).
+        QVERIFY(QMetaObject::invokeMethod(&vdm, "onNumberOfDesktopsChanged", Q_ARG(int, 7)));
+
+        vdm.updateScreenDesktop(QStringLiteral("DP-1"), 3);
+        vdm.updateScreenDesktop(QStringLiteral("DP-2"), 7);
+
+        QSignalSpy spy(&vdm, &VirtualDesktopManager::screenDesktopChanged);
+        // Desktops 5..7 removed -> count 4. The entry on 7 must clamp to 4; the
+        // entry on 3 is unaffected.
+        QVERIFY(QMetaObject::invokeMethod(&vdm, "onNumberOfDesktopsChanged", Q_ARG(int, 4)));
+
+        QCOMPARE(vdm.currentDesktopForScreen(QStringLiteral("DP-1")), 3);
+        QCOMPARE(vdm.currentDesktopForScreen(QStringLiteral("DP-2")), 4);
+
+        QCOMPARE(spy.count(), 1);
+        QCOMPARE(spy.last().at(0).toString(), QStringLiteral("DP-2"));
+        QCOMPARE(spy.last().at(1).toInt(), 4);
+    }
+};
+
+QTEST_GUILESS_MAIN(TestVirtualDesktopPerScreen)
+#include "test_virtual_desktop_per_screen.moc"

--- a/tests/unit/core/test_virtual_desktop_per_screen.cpp
+++ b/tests/unit/core/test_virtual_desktop_per_screen.cpp
@@ -14,7 +14,9 @@
  * connection (m_useKWinDBus stays false, currentDesktop() == 1) and exercise the
  * per-screen model directly through its public API.
  *
- * This phase is behaviour-preserving: nothing consumes screenDesktopChanged yet.
+ * These tests exercise the VirtualDesktopManager model in isolation; the daemon
+ * wires screenDesktopChanged into its per-screen context and OSD handling
+ * downstream (see Daemon::screenDesktopChanged).
  */
 
 #include <QSignalSpy>


### PR DESCRIPTION
## Problem

Discussion #648. Plasma 6.7 added **"switch desktops independently for each screen"** (per-output virtual desktops). When on, each monitor has its own current desktop, and KWin reports the *active* monitor's desktop as the **global** `current`. So moving the cursor between monitors on different desktops flips the global value, and PlasmaZones — which assumed a single global current desktop — fired the Desktop-Switch OSD on every screen and **thrashed its whole per-desktop autotile/layout context** on each cursor crossing. The reporter's logs showed 55 spurious "Virtual desktop changed" events (1↔4↔7) from cursor movement alone.

## Approach (verified against KWin 6.7)

KWin 6.7's **effects API** exposes per-output desktops directly (`currentDesktop(output)`, `desktopChanged(old,new,with,output)`), and — crucially — `desktopChanged` does **not** fire on cursor movement. So the fix is deterministic: drive OSD/context off the effect's per-output report and stop trusting the global `currentChanged` for OSD/context.

Built and tested against **KWin 6.7.0**. Each phase is **behaviour-preserving for single-desktop setups** (every per-screen read falls back to the global). Build green and **250/250 tests pass at every phase**.

## Phases

1. **VDM model** — `VirtualDesktopManager` gains a per-screen `screenId → desktop` map, `currentDesktopForScreen`, `perScreenModeActive`, and a `screenDesktopChanged` signal (+ unit test).
2. **Effect → daemon** — the KWin effect reports each output's desktop via a new `screenDesktopChanged` D-Bus method (full 6.7 `desktopChanged` signature; `output==null` fans out; bringup re-sync); WTA forwards to the VDM.
3. **AutotileEngine** — two-map design: per-output desktop input (`setCurrentDesktopForScreen`) distinct from the sticky-pin map, with sticky-pin precedence; pure context swap (no state migration) (+ unit test).
4. **Layout/Overlay sinks** — `LayoutRegistry::resolveLayoutForScreen` + `OverlayService` resolve per-screen.
5. **The fix** — the daemon drives OSD + context off the effect's per-output `screenDesktopChanged`, scoped to the one screen that switched; the global `currentChanged` only keeps the global caches coherent. Cursor-follow no longer OSDs or thrashes; per-output OSD is per-screen.
6. **Call-site sweep (6a–6d)** — every `currentDesktop()`/`currentVirtualDesktop()` read with a screenId in scope now resolves per-output (daemon, snap-engine, layout consumers, the ContextResolver disabled-context seam, the per-context gap resolver, the resnap filters, and the `(B)` fan-out loops). Non-pure interface additions keep all implementers/mocks source-compatible. Only the genuinely-global sites remain (the no-screen `getCurrentVirtualDesktop` D-Bus query and the resolver's `globalHandle`).

Implementation plan: `docs/per-screen-virtual-desktops-plan.md`.

## Remaining

**Phase 7 — end-to-end verification on real Plasma 6.7 multi-monitor hardware** (cannot be done here): enable per-screen desktops, confirm cursor movement between monitors no longer pops the OSD or thrashes context, while an actual per-screen switch still updates that one screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)