### PR TITLE
fix(effect): animate window.open for transients per the animation setting

### DIFF
--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -77,19 +77,12 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
     setupWindowConnections(w);
     updateWindowStickyState(w);
 
-    // window.open shader transition: fires once for every newly-mapped
-    // normal top-level window we handle. Gate so the shader DOESN'T fire
-    // on the child surfaces an app spawns alongside its main window (popup
-    // menus, dropdowns, tooltips, dialogs, transient utility windows).
-    // Without this gate, a single app open like Discord triggers a
-    // fly-in on every sub-surface — main window sliding in slowly while
-    // sidebar / popup surfaces slide in moments behind it from t=0,
-    // producing the "main slow + copies fast" visual artifact users
-    // describe as "multiple ghosted copies of the animation". KWin's
-    // stock fade-in still handles the cosmetic motion for the filtered-
-    // out surfaces; we just skip the user's surface-extent shader leg.
-    // Same predicate gates both the user-assigned open shader and the
-    // first-frame suppression decision below. Compute once.
+    // Tileable-app predicate: a normal top-level window we both handle and can
+    // tile, that didn't open minimized. Drives the snap-restore candidacy and
+    // the first-frame suppression decision below. It does NOT gate the open
+    // shader — that gates on the animation filter (see the window.open block),
+    // so the user's "exclude transient windows" animation setting stays
+    // authoritative for which windows animate on open.
     const bool tileableAppWindow = shouldHandleWindow(w) && isTileableWindow(w) && !w->isMinimized();
 
     // Whether this window is a snap-restore candidate — it may be
@@ -97,13 +90,26 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
     // cache, or after an async daemon resolve). Stricter than
     // tileableAppWindow: also excludes multi-instance siblings.
     const bool canSnapRestore = tileableAppWindow && !hasOtherWindowOfClassWithDifferentPid(w);
-    if (tileableAppWindow) {
-        // holdAddedGrab=true: take KWin::WindowAddedGrabRole so KWin's
-        // stock window-open built-ins (fade / scale / slide / glide)
-        // skip this window. Without it, KWin's stock fade-in renders
-        // the window at its natural position concurrently with our
-        // shader's UV-shifted animation, producing the visible
-        // multi-copy ghost trail.
+    // window.open shader transition. Gate on the animation filter
+    // (shouldAnimateWindow, enforced inside tryBeginShaderForEvent) — NOT on
+    // tiling eligibility. isTileableWindow() rejects every transient / dialog /
+    // popup / menu, so gating the open shader on tileableAppWindow suppressed it
+    // for those windows regardless of the user's "exclude transient windows"
+    // animation setting, while slotWindowClosed (window.close) gates only on
+    // shouldAnimateWindow. That asymmetry made transients animate on close but
+    // never on open. Mirroring the close path makes the setting authoritative
+    // for both: with exclude-transients off (the default) a transient gets its
+    // open shader; with it on, shouldAnimateWindow drops the child surfaces,
+    // preserving the ghost-trail suppression the old tiling gate provided for
+    // apps that spawn popups/dropdowns alongside their main window.
+    //
+    // holdAddedGrab=true: take KWin::WindowAddedGrabRole so KWin's stock
+    // window-open built-ins (fade / scale / slide / glide) skip this window;
+    // without it KWin's stock fade-in renders concurrently with our shader,
+    // producing the visible multi-copy ghost trail. tryBeginShaderForEvent
+    // takes the grab only after shouldAnimateWindow passes, so it is never held
+    // for a window we don't animate.
+    if (!w->isMinimized()) {
         tryBeginShaderForEvent(w, PhosphorAnimation::ProfilePaths::WindowOpen, animationDurationMs(),
                                /*reverse=*/false, /*holdCloseGrab=*/false, /*holdAddedGrab=*/true);
     }


### PR DESCRIPTION
## Problem

With **Animations → "exclude transient windows" off** (which is also the default — `animationExcludeTransientWindows` defaults to `false`), transient windows (dialogs, popups, menus, tooltips) play the **window.close** animation but never the **window.open** one. Normal windows animate on open fine.

## Root cause

The open and close paths used different gates:

- **Close** (`slotWindowClosed`) calls `tryBeginShaderForEvent(...WindowClose...)` directly — gated only by the internal `shouldAnimateWindow`, which honors the `animationExcludeTransientWindows` setting. ✅
- **Open** (`slotWindowAdded`) wrapped the open shader in `if (tileableAppWindow)`, where `tileableAppWindow = shouldHandleWindow(w) && isTileableWindow(w) && …`. `isTileableWindow()` **unconditionally rejects** every transient/dialog/popup/menu/tooltip — it's a *tiling-eligibility* check. So transients never reached the open shader, **regardless of the animation setting**. ❌

That conflated "can this window be tiled" with "should this window's open animate."

## Fix

Gate the `window.open` shader on `shouldAnimateWindow` (enforced inside `tryBeginShaderForEvent`), mirroring the close path, so the setting is authoritative for **both** open and close.

- With **exclude-transients off** (your case / the default): transients now get their open shader — symmetric with close.
- With **exclude-transients on**: `shouldAnimateWindow` still drops the child surfaces, preserving the "ghost-trail" suppression (multiple sub-surfaces flying in at once) that the old tiling gate provided.

`tileableAppWindow` is retained for snap-restore candidacy and first-frame suppression (its real purpose); it just no longer gates the animation. Stale comment updated accordingly.

## Testing

Build green, 250/250 unit tests pass. The animation path is compositor integration, so verify by reinstalling the effect and restarting KWin: open a dialog/popup with "exclude transient windows" off and confirm the open animation now plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)