### PR TITLE
fix(settings/osd): uniform card headers, banner alignment, OSD name overflow

### DIFF
--- a/src/settings/qml/AnimationEventCard.qml
+++ b/src/settings/qml/AnimationEventCard.qml
@@ -426,6 +426,8 @@ Item {
             // ── Inheritance info ──────────────────────────────────────
             Kirigami.InlineMessage {
                 Layout.fillWidth: true
+                Layout.leftMargin: Kirigami.Units.largeSpacing
+                Layout.rightMargin: Kirigami.Units.largeSpacing
                 type: Kirigami.MessageType.Information
                 visible: !root.alwaysEnabled && (root.isParentNode ? root.overrideEnabled : !root.overrideEnabled)
                 text: {
@@ -453,6 +455,8 @@ Item {
             // each shadowing leaf manually and clear its override.
             Kirigami.InlineMessage {
                 Layout.fillWidth: true
+                Layout.leftMargin: Kirigami.Units.largeSpacing
+                Layout.rightMargin: Kirigami.Units.largeSpacing
                 type: Kirigami.MessageType.Warning
                 visible: root.isParentNode && root._shadowingChildrenCount > 0
                 text: i18np("%n descendant event has a shader override that shadows this parent.", "%n descendant events have shader overrides that shadow this parent.", root._shadowingChildrenCount)

--- a/src/settings/qml/AnimationsMotionSetsPage.qml
+++ b/src/settings/qml/AnimationsMotionSetsPage.qml
@@ -108,6 +108,8 @@ SettingsFlickable {
                         id: saveStatus
 
                         Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.largeSpacing
+                        Layout.rightMargin: Kirigami.Units.largeSpacing
                         type: Kirigami.MessageType.Error
                         showCloseButton: true
                     }

--- a/src/settings/qml/GeneralPage.qml
+++ b/src/settings/qml/GeneralPage.qml
@@ -81,6 +81,11 @@ SettingsFlickable {
 
                 Kirigami.InlineMessage {
                     Layout.fillWidth: true
+                    // Match SettingsRow's horizontal inset so the banner lines
+                    // up with the rows above it instead of running edge-to-edge
+                    // to the card border.
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     type: Kirigami.MessageType.Information
                     text: settingsController.daemonRunning ? i18n("Stop the daemon to change the rendering backend.") : i18n("Rendering backend changes take effect after restarting the daemon.")
                     visible: settingsController.daemonRunning || appSettings.renderingBackend !== settingsController.generalPage.startupRenderingBackend

--- a/src/settings/qml/SettingsCard.qml
+++ b/src/settings/qml/SettingsCard.qml
@@ -132,21 +132,25 @@ Item {
         }
 
         // ── Header ─────────────────────────────────────────────────────
-        Rectangle {
+        Kirigami.ShadowedRectangle {
             id: headerArea
 
             width: parent.width
             height: headerLoader.height
             visible: root.headerText.length > 0 || root.header !== null
+            // Single uniform header fill: the whole header row is one proper
+            // header color, distinct from the content rows below. Only the TOP
+            // corners are rounded (to match the card); the bottom stays square so
+            // the header sits flush against the content. Using per-corner radius
+            // on one fill — instead of a rounded rect plus a semi-transparent
+            // corner overlay — avoids doubling the alpha into a darker band along
+            // the bottom of the header. Tune the alpha to taste.
             color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.03)
-            radius: cardBg.radius
-
-            // Square off the bottom corners since content is below
-            Rectangle {
-                anchors.bottom: parent.bottom
-                width: parent.width
-                height: parent.radius
-                color: parent.color
+            corners {
+                topLeftRadius: cardBg.radius
+                topRightRadius: cardBg.radius
+                bottomLeftRadius: 0
+                bottomRightRadius: 0
             }
 
             // Click to collapse/expand
@@ -177,7 +181,12 @@ Item {
                         text: root.headerText
                         level: 3
                         padding: Kirigami.Units.smallSpacing
-                        leftPadding: Kirigami.Units.smallSpacing
+                        // Align the title's left edge with the card's content
+                        // rows (SettingsRow insets by largeSpacing) and the
+                        // trailing chevron (also largeSpacing), so the header is
+                        // uniformly inset rather than hugging the left while the
+                        // right controls sit further in.
+                        leftPadding: Kirigami.Units.largeSpacing
                     }
 
                     // Per-monitor scope chip, title-adjacent. Kept clear of the
@@ -217,12 +226,16 @@ Item {
                         Layout.alignment: Qt.AlignVCenter
                     }
 
-                    // Header enable toggle
+                    // Header enable toggle. When a collapse chevron follows, the
+                    // margin is just the inter-control gap (smallSpacing); when
+                    // the toggle is the trailing control, it takes the full
+                    // largeSpacing edge inset so it lines up with the content
+                    // rows and chevron-terminated cards.
                     SettingsSwitch {
                         visible: root.showToggle
                         checked: root.toggleChecked
                         accessibleName: root.headerText
-                        Layout.rightMargin: Kirigami.Units.smallSpacing
+                        Layout.rightMargin: root.collapsible ? Kirigami.Units.smallSpacing : Kirigami.Units.largeSpacing
                         onToggled: function (newValue) {
                             root.toggleClicked(newValue);
                         }
@@ -249,25 +262,11 @@ Item {
             }
         }
 
-        // ── Separator ──────────────────────────────────────────────────
-        Rectangle {
-            id: headerSep
-
-            anchors.top: headerArea.bottom
-            width: parent.width
-            // HiDPI: scale the 1px hairline by devicePixelRatio so it
-            // remains a single physical pixel on high-DPI displays
-            // instead of collapsing to ~0.5px (browser-style anti-alias
-            // blur) or disappearing on integer fractional scales.
-            height: headerArea.visible ? Math.round(Screen.devicePixelRatio) : 0
-            color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.08)
-        }
-
         // ── Content (clipped for collapse animation) ───────────────────
         Item {
             id: contentClip
 
-            anchors.top: headerSep.bottom
+            anchors.top: headerArea.bottom
             width: parent.width
             height: contentColumn.implicitHeight
             clip: true

--- a/src/settings/qml/ShaderBrowserPage.qml
+++ b/src/settings/qml/ShaderBrowserPage.qml
@@ -299,6 +299,8 @@ SettingsFlickable {
                     }
 
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     visible: false
                     showCloseButton: true
 

--- a/src/settings/qml/SnappingOverlayAppearancePage.qml
+++ b/src/settings/qml/SnappingOverlayAppearancePage.qml
@@ -142,6 +142,8 @@ SettingsFlickable {
                         id: colorImportMessage
 
                         Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.largeSpacing
+                        Layout.rightMargin: Kirigami.Units.largeSpacing
                         visible: false
                         type: Kirigami.MessageType.Positive
                         Accessible.name: text
@@ -472,6 +474,8 @@ SettingsFlickable {
 
                     Kirigami.InlineMessage {
                         Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.largeSpacing
+                        Layout.rightMargin: Kirigami.Units.largeSpacing
                         type: Kirigami.MessageType.Warning
                         text: i18n("CAVA is not installed. Install the <b>cava</b> package to enable audio-reactive shader effects.")
                         visible: !root.effectsBridge.cavaAvailable && shaderCard.toggleChecked

--- a/src/ui/LayoutOsdContent.qml
+++ b/src/ui/LayoutOsdContent.qml
@@ -95,7 +95,7 @@ Item {
     /// The unified NotificationOverlay host re-emits this as its own
     /// `dismissRequested` so OverlayService::createWarmedOsdSurface's
     /// connect to Surface::hide() drives the library animator's beginHide.
-    signal dismissRequested()
+    signal dismissRequested
 
     /// Restart the auto-dismiss timer from C++ on every show. Forwards to
     /// the shared OsdDismissable helper so the latch reset is driven off
@@ -125,7 +125,11 @@ Item {
         id: container
 
         anchors.centerIn: parent
-        width: previewContainer.width + Kirigami.Units.gridUnit * 3
+        // Grow to fit whichever is wider — the preview or the name row — so a
+        // long layout name (e.g. "Portrait Master + Stack") doesn't overflow the
+        // frame. The name label is capped + elided below, so the OSD widens only
+        // up to that cap rather than without bound.
+        width: Math.max(previewContainer.width, nameLabelRow.width) + Kirigami.Units.gridUnit * 3
         height: previewContainer.height + nameLabelRow.height + Kirigami.Units.gridUnit * 3
         backgroundColor: root.backgroundColor
         textColor: root.textColor
@@ -175,7 +179,6 @@ Item {
                 fontStrikeout: root.fontStrikeout
                 animationDuration: Kirigami.Units.shortDuration
             }
-
         }
 
         // Lock overlay (shown on top of preview when locked — mutually exclusive with disabled)
@@ -192,7 +195,6 @@ Item {
                 height: Kirigami.Units.iconSizes.large
                 color: Kirigami.Theme.highlightedTextColor
             }
-
         }
 
         // Disabled overlay (shown when context is disabled for this desktop/screen)
@@ -209,7 +211,6 @@ Item {
                 height: Kirigami.Units.iconSizes.large
                 color: Kirigami.Theme.neutralTextColor
             }
-
         }
 
         // Layout name with category badge
@@ -236,16 +237,21 @@ Item {
             Label {
                 id: nameLabel
 
+                // Cap the name width so a long layout name widens the OSD only up
+                // to this bound, then elides with "…" instead of spilling past the
+                // frame. Short names use their natural width (full text shown).
+                readonly property int maxWidth: Kirigami.Units.gridUnit * 16
+
                 anchors.verticalCenter: parent.verticalCenter
                 text: root.disabled ? root.disabledReason : (root.locked ? i18n("%1 (Locked)", root.layoutName) : root.layoutName)
                 font.pixelSize: Kirigami.Theme.defaultFont.pixelSize * 1.2
                 font.weight: Font.Medium
                 color: root.textColor
                 horizontalAlignment: Text.AlignHCenter
+                elide: Text.ElideRight
+                width: Math.min(implicitWidth, maxWidth)
             }
-
         }
-
     }
 
     // Click to dismiss. dismiss.fire() collapses timer-fire + click into
@@ -255,5 +261,4 @@ Item {
         onClicked: dismiss.fire()
         Accessible.name: i18n("Dismiss notification")
     }
-
 }


### PR DESCRIPTION
Settings-UI polish reported by Korta, plus an OSD overflow fix.

## Settings cards (`SettingsCard.qml` + pages)
- **Uniform header**: the section header was a fill *plus* a separate hairline separator, which read as two stacked bars — and the corner-rounding overlay doubled the semi-transparent fill into a darker band along the bottom. Replaced with a single `Kirigami.ShadowedRectangle` (top corners rounded, bottom square), removing the separator and the overlay. The header is now one clean color.
- **Title alignment**: the header title's left edge now lines up with the content rows and the trailing chevron (`largeSpacing`) instead of hugging the left at `smallSpacing`.
- **Toggle inset**: a header toggle that's the trailing control now takes the full `largeSpacing` edge inset, so toggle-terminated cards line up with chevron-terminated ones.
- **Banner insets**: `Kirigami.InlineMessage` banners *inside* card content were running edge-to-edge while the rows are inset by `largeSpacing`. Added matching margins to the card-internal banners (rendering backend, animation-event inheritance/override, motion-set save status, color import + CAVA-missing, shader-pack install). Page-level banners stay full-width.

## OSD (`LayoutOsdContent.qml`)
- The layout OSD frame width was bound only to the preview, so a long layout name (e.g. "Portrait Master + Stack") overflowed the rounded frame. The frame now sizes to the wider of the preview or the name row, and the name label is capped + `ElideRight` so short names show in full while very long ones elide instead of growing the OSD without bound.

## Testing
Settings app + daemon build clean (qmlcachegen validates all QML). The OSD change is daemon-side — reinstall + restart the daemon to see it; the settings changes need a settings-app relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)