### PR TITLE
fix(settings): inset animation curve-summary row to match card rows

### DIFF
--- a/src/settings/qml/AnimationEventCard.qml
+++ b/src/settings/qml/AnimationEventCard.qml
@@ -472,6 +472,11 @@ Item {
             }
 
             Label {
+                Layout.fillWidth: true
+                // Inset to match the rows / banners in this card instead of
+                // hugging the left edge.
+                Layout.leftMargin: Kirigami.Units.largeSpacing
+                Layout.rightMargin: Kirigami.Units.largeSpacing
                 visible: !root.alwaysEnabled && !root.overrideEnabled
                 text: i18n("Current: %1", root.inheritSummaryText())
                 font.italic: true

--- a/src/settings/qml/AnimationProfileEditor.qml
+++ b/src/settings/qml/AnimationProfileEditor.qml
@@ -215,6 +215,10 @@ ColumnLayout {
         // override toggle gates the whole timing section).
         CheckBox {
             Layout.fillWidth: true
+            // Inset to match the SettingsRows below (which self-inset by
+            // largeSpacing); without it this custom row runs edge-to-edge.
+            Layout.leftMargin: Kirigami.Units.largeSpacing
+            Layout.rightMargin: Kirigami.Units.largeSpacing
             visible: root.showOverrideCheckboxes
             text: i18n("Override curve")
             checked: root.overrideCurve
@@ -232,6 +236,12 @@ ColumnLayout {
         // weight with the active controls.
         RowLayout {
             Layout.fillWidth: true
+            // Inset the curve-summary row (thumbnail + description + Customize…)
+            // to match the SettingsRows below, which self-inset by largeSpacing.
+            // Without it the thumbnail hugs the left edge and the Customize button
+            // the right edge of the card.
+            Layout.leftMargin: Kirigami.Units.largeSpacing
+            Layout.rightMargin: Kirigami.Units.largeSpacing
             spacing: Kirigami.Units.largeSpacing
             opacity: (!root.showOverrideCheckboxes || root.overrideCurve) ? 1 : 0.5
             enabled: !root.showOverrideCheckboxes || root.overrideCurve


### PR DESCRIPTION
The animation-event card's curve-summary row (easing thumbnail + description + **Customize…** button) ran edge-to-edge — the thumbnail hugged the left card border and the Customize button the right — while the `Timing mode` / `Duration` / `Shader effect` rows below it are `SettingsRow`s that self-inset by `largeSpacing`.

## Fix
- `AnimationProfileEditor.qml`: inset the curve-summary `RowLayout` and the Override-curve `CheckBox` by `largeSpacing` (left/right).
- `AnimationEventCard.qml`: inset the "Current: …" inheritance label (shown when the override is off), which was also flush.

Since the editor's `SettingsRow`s already self-inset, this makes every row in the editor uniformly inset wherever it's used (per-event cards and App Rules), so there's no double-inset.

Settings app builds clean (qmlcachegen validates the QML). Relaunch the settings app to verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)