### PR TITLE
fix(settings): top breathing room so first card's hover border isn't clipped

### DIFF
--- a/src/settings/qml/SettingsFlickable.qml
+++ b/src/settings/qml/SettingsFlickable.qml
@@ -75,6 +75,12 @@ Flickable {
     /// produces visibly jittery wheel-during-decay frames.
     boundsBehavior: Flickable.StopAtBounds
 
+    /// Top breathing room so the first card's hover lift (-1px) and its
+    /// highlighted top border aren't clipped against the page's top edge
+    /// (every settings page sets `clip: true`). Without it the topmost card's
+    /// top border never fully shows on hover.
+    topMargin: Kirigami.Units.smallSpacing
+
     Kirigami.WheelHandler {
         // Leave `filterMouseEvents` at its default of `false` — that
         // flag is for nested-Flickable scenarios where you want the
@@ -97,5 +103,4 @@ Flickable {
         // but is fragile under any future Loader / Component wrapping.
         target: settingsFlickable
     }
-
 }


### PR DESCRIPTION
On every settings page, hovering the **topmost** card clipped its top border. The card hover effect lifts the card up 1px and highlights the border; since pages set `clip: true` on their `SettingsFlickable` root and the content starts flush at the top, the lifted top border fell above the clip boundary. Only the top is affected because the hover lift is vertical (the side borders, drawn inside the card bounds, don't move horizontally).

## Fix
Add `topMargin: Kirigami.Units.smallSpacing` to `SettingsFlickable` — the shared root of every settings page — so the first card has room above it for the hover lift + border. One change, applies to all pages.

Settings app builds clean (qmlcachegen validates the QML). Relaunch the settings app and hover the first card on any page to verify the full top border shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)