### PR TITLE
feat(settings): move daemon status to the header search row

### DIFF
--- a/libs/phosphor-control/qml/SettingsAppWindow.qml
+++ b/libs/phosphor-control/qml/SettingsAppWindow.qml
@@ -326,11 +326,12 @@ Kirigami.ApplicationWindow {
                 // Header-extras row ABOVE the breadcrumb trail: the headerExtras
                 // slot (e.g. global search) centered, with the optional
                 // headerTrailing slot (e.g. a status toggle) pinned right. The
-                // row collapses to zero height when neither slot is filled (a
-                // visible:false Layout child is excluded from the column).
-                // Side margins match the breadcrumb gutter so the trailing slot
-                // aligns to the content's right edge.
-                Item {
+                // row collapses when neither slot is filled. Side margins match
+                // the breadcrumb gutter so the trailing slot aligns to the
+                // content's right edge. A left phantom the width of the trailing
+                // keeps the centered slot window-centered (not biased left by
+                // the trailing's width).
+                RowLayout {
                     id: headerExtrasRow
 
                     Layout.fillWidth: true
@@ -338,25 +339,33 @@ Kirigami.ApplicationWindow {
                     Layout.rightMargin: Kirigami.Units.largeSpacing
                     Layout.topMargin: Kirigami.Units.smallSpacing
                     Layout.bottomMargin: Kirigami.Units.smallSpacing
-                    implicitHeight: Math.max(headerExtrasLoader.implicitHeight, headerTrailingLoader.implicitHeight)
-                    visible: headerExtrasLoader.visible || headerTrailingLoader.visible
+                    spacing: 0
+                    visible: headerExtrasLoader.item !== null || headerTrailingLoader.item !== null
 
-                    // Both Loaders adopt their loaded item's implicit size (slot
+                    Item {
+                        Layout.preferredWidth: headerTrailingLoader.width
+                    }
+
+                    Item {
+                        Layout.fillWidth: true
+                    }
+
+                    // The Loaders adopt their loaded item's implicit size (slot
                     // contract: the consumer Component declares implicitWidth/Height).
                     Loader {
                         id: headerExtrasLoader
 
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        anchors.verticalCenter: parent.verticalCenter
-                        visible: status === Loader.Ready && item !== null
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    Item {
+                        Layout.fillWidth: true
                     }
 
                     Loader {
                         id: headerTrailingLoader
 
-                        anchors.right: parent.right
-                        anchors.verticalCenter: parent.verticalCenter
-                        visible: status === Loader.Ready && item !== null
+                        Layout.alignment: Qt.AlignVCenter
                     }
                 }
 

--- a/libs/phosphor-control/qml/SettingsAppWindow.qml
+++ b/libs/phosphor-control/qml/SettingsAppWindow.qml
@@ -21,8 +21,11 @@ Kirigami.ApplicationWindow {
     id: root
 
     required property ApplicationController controller
-    //* Optional extra content shown in the header toolbar (e.g. global search).
+    //* Optional extra content shown centered in the header toolbar (e.g. global search).
     property alias headerExtras: headerExtrasLoader.sourceComponent
+    //* Optional content pinned to the RIGHT of the header-extras row (e.g. a
+    //  status toggle), sharing the row with the centered headerExtras.
+    property alias headerTrailing: headerTrailingLoader.sourceComponent
     /** Alias onto the chrome Sidebar item so consumers can configure
      *  the two delegate slots and drive navigation:
      *
@@ -320,22 +323,41 @@ Kirigami.ApplicationWindow {
                 Layout.fillWidth: true
                 spacing: 0
 
-                // Header extras (e.g. global search) on their own centered row
-                // ABOVE the breadcrumb trail. A Layout child with visible:false
-                // is excluded from the column, so consumers that don't provide a
-                // headerExtras Component get no empty row — no wrapper needed.
-                Loader {
-                    id: headerExtrasLoader
+                // Header-extras row ABOVE the breadcrumb trail: the headerExtras
+                // slot (e.g. global search) centered, with the optional
+                // headerTrailing slot (e.g. a status toggle) pinned right. The
+                // row collapses to zero height when neither slot is filled (a
+                // visible:false Layout child is excluded from the column).
+                // Side margins match the breadcrumb gutter so the trailing slot
+                // aligns to the content's right edge.
+                Item {
+                    id: headerExtrasRow
 
-                    // Centered horizontally; the Loader adopts the loaded item's
-                    // implicit size (slot contract: the consumer Component
-                    // declares implicitWidth/Height). visible gates on
-                    // Loader.Ready so a mid-instantiation skeleton can't take
-                    // layout space.
-                    Layout.alignment: Qt.AlignHCenter
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     Layout.topMargin: Kirigami.Units.smallSpacing
                     Layout.bottomMargin: Kirigami.Units.smallSpacing
-                    visible: status === Loader.Ready && item !== null
+                    implicitHeight: Math.max(headerExtrasLoader.implicitHeight, headerTrailingLoader.implicitHeight)
+                    visible: headerExtrasLoader.visible || headerTrailingLoader.visible
+
+                    // Both Loaders adopt their loaded item's implicit size (slot
+                    // contract: the consumer Component declares implicitWidth/Height).
+                    Loader {
+                        id: headerExtrasLoader
+
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.verticalCenter: parent.verticalCenter
+                        visible: status === Loader.Ready && item !== null
+                    }
+
+                    Loader {
+                        id: headerTrailingLoader
+
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        visible: status === Loader.Ready && item !== null
+                    }
                 }
 
                 RowLayout {

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -121,6 +121,58 @@ PhosphorUi.SettingsAppWindow {
         }
     }
 
+    // Daemon status, right-aligned on the search row: pulsing colored dot
+    // (positive when running, negative when stopped) + Running/Stopped label +
+    // enable/disable switch.
+    headerTrailing: Component {
+        RowLayout {
+            spacing: Kirigami.Units.smallSpacing
+
+            Rectangle {
+                id: daemonDot
+
+                Layout.alignment: Qt.AlignVCenter
+                width: Kirigami.Units.smallSpacing * 1.5
+                height: Kirigami.Units.smallSpacing * 1.5
+                radius: width / 2
+                color: settingsController.daemonRunning ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.negativeTextColor
+
+                SequentialAnimation on opacity {
+                    loops: Animation.Infinite
+                    running: settingsController.daemonRunning
+
+                    PhosphorMotionAnimation {
+                        from: 1
+                        to: 0.4
+                        profile: "widget.pulse.slow"
+                    }
+
+                    PhosphorMotionAnimation {
+                        from: 0.4
+                        to: 1
+                        profile: "widget.pulse.slow"
+                    }
+                }
+            }
+
+            Label {
+                text: settingsController.daemonRunning ? i18n("Running") : i18n("Stopped")
+                opacity: 0.7
+                Layout.alignment: Qt.AlignVCenter
+            }
+
+            SettingsSwitch {
+                Layout.alignment: Qt.AlignVCenter
+                checked: settingsController.daemonRunning
+                enabled: !settingsController.daemonController.busy
+                accessibleName: i18n("Toggle daemon")
+                onToggled: function (newValue) {
+                    settingsController.daemonController.setEnabled(newValue);
+                }
+            }
+        }
+    }
+
     Component.onCompleted: {
         // The header search supersedes the sidebar's page-tree search.
         window.sidebar.searchEnabled = false;
@@ -829,86 +881,6 @@ PhosphorUi.SettingsAppWindow {
         interval: Kirigami.Units.veryLongDuration
         running: settingsController.hasUnseenWhatsNew
         onTriggered: whatsNewDialog.open()
-    }
-
-    // Sticky daemon-status footer at the bottom of the sidebar, always
-    // visible regardless of which page is active. Mirrors the legacy
-    // chrome's persistent status Pane: pulsing colored dot (positive
-    // when running, negative when stopped) + Running/Stopped label +
-    // enable/disable SettingsSwitch.
-    sidebar.footerContent: Component {
-        Pane {
-            padding: Kirigami.Units.smallSpacing * 1.5
-            topPadding: Kirigami.Units.smallSpacing * 2
-            bottomPadding: Kirigami.Units.smallSpacing * 2
-
-            background: Rectangle {
-                color: "transparent"
-
-                Rectangle {
-                    anchors.top: parent.top
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    height: Math.round(Screen.devicePixelRatio)
-                    // Subtle theme-tinted hairline. Same shape as the
-                    // KeyboardShortcutOverlay subtleBorder + Toast
-                    // toastBg tints documented in E32; future tweaks
-                    // should go through PhosphorUi.ThemeHelpers when
-                    // it's exposed publicly. For now we accept the
-                    // copy here (3 sites, low churn).
-                    color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.1)
-                }
-            }
-
-            contentItem: RowLayout {
-                spacing: Kirigami.Units.smallSpacing
-
-                Rectangle {
-                    id: daemonDot
-
-                    width: Kirigami.Units.smallSpacing * 1.5
-                    height: Kirigami.Units.smallSpacing * 1.5
-                    radius: width / 2
-                    Layout.alignment: Qt.AlignVCenter
-                    color: settingsController.daemonRunning ? Kirigami.Theme.positiveTextColor : Kirigami.Theme.negativeTextColor
-
-                    SequentialAnimation on opacity {
-                        loops: Animation.Infinite
-                        running: settingsController.daemonRunning
-
-                        PhosphorMotionAnimation {
-                            from: 1
-                            to: 0.4
-                            profile: "widget.pulse.slow"
-                        }
-
-                        PhosphorMotionAnimation {
-                            from: 0.4
-                            to: 1
-                            profile: "widget.pulse.slow"
-                        }
-                    }
-                }
-
-                Label {
-                    text: settingsController.daemonRunning ? i18n("Running") : i18n("Stopped")
-                    opacity: 0.7
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignVCenter
-                    visible: !window.sidebarCompact
-                }
-
-                SettingsSwitch {
-                    Layout.alignment: Qt.AlignVCenter
-                    checked: settingsController.daemonRunning
-                    enabled: !settingsController.daemonController.busy
-                    accessibleName: i18n("Toggle daemon")
-                    onToggled: function (newValue) {
-                        settingsController.daemonController.setEnabled(newValue);
-                    }
-                }
-            }
-        }
     }
 
     // Per-row sidebar trailing content — a Row with two slots:


### PR DESCRIPTION
## What
Moves the daemon **Running/Stopped** status (pulsing dot + label + enable toggle) out of the bottom-left sidebar corner to the **right of the header search row**.

## Why
The status toggle was tucked in the sidebar footer corner; surfacing it on the header row puts it where it's seen and keeps the sidebar footer clean.

## How
- **phosphor-control:** added a generic `headerTrailing` slot to `SettingsAppWindow`, pinned to the right of the header-extras row. The centered `headerExtras` (global search) shares the row; a left phantom equal to the trailing width keeps the search **window-centered**, and side margins match the breadcrumb gutter so the trailing slot aligns to the content's right edge. The row collapses when neither slot is filled.
- **settings:** mounted the daemon-status group in `headerTrailing` and removed the sidebar `footerContent`.

## Notes
- Implemented with a `RowLayout` (an earlier anchored-`Item` attempt collapsed the whole header row).
- Build green, qmlformat/clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)