### PR TITLE
fix(settings): hide sidebar search divider when search is hidden

### DIFF
--- a/libs/phosphor-control/qml/Sidebar.qml
+++ b/libs/phosphor-control/qml/Sidebar.qml
@@ -516,8 +516,12 @@ ColumnLayout {
         }
     }
 
+    // Divides the search field from the list — only meaningful when the
+    // search field is shown. Hidden (e.g. a consumer that disabled the
+    // in-sidebar search, or compact mode) it would leave an orphaned top border.
     Kirigami.Separator {
         Layout.fillWidth: true
+        visible: searchField.visible
     }
 
     // ── Scrollable list area ────────────────────────────────────────


### PR DESCRIPTION
## What
Hides the sidebar separator between the sticky search field and the nav list when the search field isn't shown.

## Why
With the in-sidebar search hidden (a consumer disabled it — e.g. global search moved to the header — or compact mode), the divider stayed visible, leaving an orphaned horizontal border across the top of the sidebar above the first nav item.

## How
`phosphor-control` Sidebar: gate the separator's `visible` on `searchField.visible`. When there's no search field, there's nothing to divide, so no border.

## Notes
- Build green, qmlformat clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)