### PR TITLE
feat(settings): collapsible (animated) filter bar on shader + window-rule pages

### DIFF
--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -321,6 +321,7 @@ qt_add_qml_module(plasmazones-settings
         # are thin wrappers that pass the right controller bridge.
         qml/ShaderBrowserPage.qml
         qml/ShaderBrowserCard.qml
+        qml/FilterDisclosureHeader.qml
         qml/ShaderBrowserDetailDialog.qml
         qml/CurveEditorDialog.qml
         qml/CurvePresets.qml

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -322,6 +322,7 @@ qt_add_qml_module(plasmazones-settings
         qml/ShaderBrowserPage.qml
         qml/ShaderBrowserCard.qml
         qml/FilterDisclosureHeader.qml
+        qml/CollapsibleChipFlow.qml
         qml/ShaderBrowserDetailDialog.qml
         qml/CurveEditorDialog.qml
         qml/CurvePresets.qml

--- a/src/settings/qml/CollapsibleChipFlow.qml
+++ b/src/settings/qml/CollapsibleChipFlow.qml
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+/**
+ * @brief A wrapping chip row that slides + fades open/closed.
+ *
+ * The root IS the Flow, so chips are declared as its direct children (no
+ * content-slot needed). `open` drives a `revealFraction` (0…1) that animates
+ * `Layout.preferredHeight` and opacity, clipping the chips during the reveal so
+ * it reads like a drop-down. Pair with FilterDisclosureHeader:
+ *
+ *   FilterDisclosureHeader { id: h; hasActiveFilters: ... }
+ *   CollapsibleChipFlow { open: h.expanded; <chips> }
+ */
+Flow {
+    id: root
+
+    /// Show (true) or hide (false) the chips.
+    property bool open: false
+    // Animated 0…1 reveal. A plain property (Behavior on attached Layout
+    // properties is unreliable) that scales the clipped height + opacity.
+    property real revealFraction: open ? 1 : 0
+
+    Layout.fillWidth: true
+    spacing: Kirigami.Units.smallSpacing
+    clip: true
+    // implicitHeight is the Flow's natural wrapped content height; reveal scales
+    // it. preferredHeight (not implicitHeight) drives the layout so the row
+    // animates without feeding back into the content measurement.
+    Layout.preferredHeight: implicitHeight * revealFraction
+    opacity: revealFraction
+    // Drop out of the layout once fully closed (no leftover spacing gap); the
+    // `|| open` keeps it laid out the instant it starts opening so the Flow
+    // measures its real width before the reveal animates.
+    visible: open || revealFraction > 0
+
+    Behavior on revealFraction {
+        NumberAnimation {
+            duration: Kirigami.Units.shortDuration
+            easing.type: Easing.InOutCubic
+        }
+    }
+}

--- a/src/settings/qml/CollapsibleChipFlow.qml
+++ b/src/settings/qml/CollapsibleChipFlow.qml
@@ -4,6 +4,7 @@
 import QtQuick
 import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
+import org.phosphor.animation
 
 /**
  * @brief A wrapping chip row that slides + fades open/closed.
@@ -22,7 +23,8 @@ Flow {
     /// Show (true) or hide (false) the chips.
     property bool open: false
     // Animated 0…1 reveal. A plain property (Behavior on attached Layout
-    // properties is unreliable) that scales the clipped height + opacity.
+    // properties is unreliable) that scales the clipped height + opacity, driven
+    // through the shared motion system rather than a hand-rolled easing.
     property real revealFraction: open ? 1 : 0
 
     Layout.fillWidth: true
@@ -39,9 +41,11 @@ Flow {
     visible: open || revealFraction > 0
 
     Behavior on revealFraction {
-        NumberAnimation {
-            duration: Kirigami.Units.shortDuration
-            easing.type: Easing.InOutCubic
+        // Directional accordion profiles, mirroring SettingsCard's collapse.
+        // `open` is already settled when revealFraction re-binds, so it picks
+        // the correct leg (same idiom as the sidebar's slideIn/slideOut).
+        PhosphorMotionAnimation {
+            profile: root.open ? "widget.accordionExpand" : "widget.accordionCollapse"
         }
     }
 }

--- a/src/settings/qml/FilterDisclosureHeader.qml
+++ b/src/settings/qml/FilterDisclosureHeader.qml
@@ -14,14 +14,15 @@ import org.kde.kirigami as Kirigami
  * the chip content and gates its visibility on `expanded`:
  *
  *   FilterDisclosureHeader { id: filterHeader; hasActiveFilters: ... }
- *   Flow { visible: filterHeader.expanded; <chips> }
+ *   CollapsibleChipFlow { open: filterHeader.expanded; <chips> }
  */
 RowLayout {
     id: root
 
-    /// Whether the consumer's filter chips should be shown. Collapsed by
-    /// default to keep the page uncluttered.
-    property bool expanded: false
+    /// Whether the consumer's filter chips should be shown. Driven by the
+    /// toggle button (the single source of truth) so the state can't desync;
+    /// collapsed by default to keep the page uncluttered.
+    readonly property alias expanded: toggleButton.checked
     /// When collapsed, show an accent dot if a filter is currently applied.
     property bool hasActiveFilters: false
 
@@ -29,12 +30,12 @@ RowLayout {
     spacing: Kirigami.Units.smallSpacing
 
     ToolButton {
+        id: toggleButton
+
         text: i18nc("@action:button toggle the filter chips", "Filter")
-        icon.name: root.expanded ? "arrow-down" : "arrow-right"
+        icon.name: toggleButton.checked ? "arrow-down" : "arrow-right"
         checkable: true
-        checked: root.expanded
-        onClicked: root.expanded = !root.expanded
-        Accessible.name: root.expanded ? i18nc("@action:button", "Hide filters") : i18nc("@action:button", "Show filters")
+        Accessible.name: toggleButton.checked ? i18nc("@action:button", "Hide filters") : i18nc("@action:button", "Show filters")
     }
 
     Rectangle {

--- a/src/settings/qml/FilterDisclosureHeader.qml
+++ b/src/settings/qml/FilterDisclosureHeader.qml
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+/**
+ * @brief Disclosure header for a collapsible filter row.
+ *
+ * A chevron "Filter" toggle plus an accent dot shown while collapsed when a
+ * filter is active (so a hidden filter stays discoverable). The consumer owns
+ * the chip content and gates its visibility on `expanded`:
+ *
+ *   FilterDisclosureHeader { id: filterHeader; hasActiveFilters: ... }
+ *   Flow { visible: filterHeader.expanded; <chips> }
+ */
+RowLayout {
+    id: root
+
+    /// Whether the consumer's filter chips should be shown. Collapsed by
+    /// default to keep the page uncluttered.
+    property bool expanded: false
+    /// When collapsed, show an accent dot if a filter is currently applied.
+    property bool hasActiveFilters: false
+
+    Layout.fillWidth: true
+    spacing: Kirigami.Units.smallSpacing
+
+    ToolButton {
+        text: i18nc("@action:button toggle the filter chips", "Filter")
+        icon.name: root.expanded ? "arrow-down" : "arrow-right"
+        checkable: true
+        checked: root.expanded
+        onClicked: root.expanded = !root.expanded
+        Accessible.name: root.expanded ? i18nc("@action:button", "Hide filters") : i18nc("@action:button", "Show filters")
+    }
+
+    Rectangle {
+        Layout.alignment: Qt.AlignVCenter
+        implicitWidth: Kirigami.Units.smallSpacing * 1.5
+        implicitHeight: implicitWidth
+        radius: width / 2
+        color: Kirigami.Theme.highlightColor
+        visible: !root.expanded && root.hasActiveFilters
+    }
+
+    Item {
+        Layout.fillWidth: true
+    }
+}

--- a/src/settings/qml/ShaderBrowserPage.qml
+++ b/src/settings/qml/ShaderBrowserPage.qml
@@ -396,42 +396,40 @@ SettingsFlickable {
             }
         }
 
-        // ── Filter chips ────────────────────────────────────────────────
-        // "Filter:" label + single-select category chips ("All" first),
-        // matching the Window Rules filter row.
-        RowLayout {
+        // ── Filter chips (collapsible) ────────────────────────────────────
+        // Disclosure toggle + single-select category chips ("All" first),
+        // matching the Window Rules filter row. Collapsed by default; the dot
+        // shows when a category filter is active while collapsed.
+        FilterDisclosureHeader {
+            id: shaderFilterHeader
+
+            hasActiveFilters: root.selectedCategory.length > 0
+        }
+
+        Flow {
             Layout.fillWidth: true
             spacing: Kirigami.Units.smallSpacing
+            visible: shaderFilterHeader.expanded
 
-            Label {
-                text: i18n("Filter:")
-                opacity: 0.7
+            Button {
+                text: i18nc("@action:button show every shader category", "All")
+                checkable: true
+                checked: root.selectedCategory === ""
+                Accessible.name: i18n("Show all shader categories")
+                onClicked: root.selectedCategory = ""
             }
 
-            Flow {
-                Layout.fillWidth: true
-                spacing: Kirigami.Units.smallSpacing
+            Repeater {
+                model: root._allCategories
 
-                Button {
-                    text: i18nc("@action:button show every shader category", "All")
+                delegate: Button {
+                    required property var modelData
+
+                    text: i18nc("@action:button category filter chip", "%1 (%2)", modelData.name, modelData.count)
                     checkable: true
-                    checked: root.selectedCategory === ""
-                    Accessible.name: i18n("Show all shader categories")
-                    onClicked: root.selectedCategory = ""
-                }
-
-                Repeater {
-                    model: root._allCategories
-
-                    delegate: Button {
-                        required property var modelData
-
-                        text: i18nc("@action:button category filter chip", "%1 (%2)", modelData.name, modelData.count)
-                        checkable: true
-                        checked: root.selectedCategory === modelData.name
-                        Accessible.name: i18n("Filter shaders by category: %1", modelData.name)
-                        onClicked: root.selectedCategory = modelData.name
-                    }
+                    checked: root.selectedCategory === modelData.name
+                    Accessible.name: i18n("Filter shaders by category: %1", modelData.name)
+                    onClicked: root.selectedCategory = modelData.name
                 }
             }
         }

--- a/src/settings/qml/ShaderBrowserPage.qml
+++ b/src/settings/qml/ShaderBrowserPage.qml
@@ -406,10 +406,8 @@ SettingsFlickable {
             hasActiveFilters: root.selectedCategory.length > 0
         }
 
-        Flow {
-            Layout.fillWidth: true
-            spacing: Kirigami.Units.smallSpacing
-            visible: shaderFilterHeader.expanded
+        CollapsibleChipFlow {
+            open: shaderFilterHeader.expanded
 
             Button {
                 text: i18nc("@action:button show every shader category", "All")

--- a/src/settings/qml/WindowRulesPage.qml
+++ b/src/settings/qml/WindowRulesPage.qml
@@ -431,15 +431,19 @@ SettingsFlickable {
             }
         }
 
-        // ── Filter chips ──
-        RowLayout {
+        // ── Filter chips (collapsible) ──
+        // Disclosure toggle + single-select section chips. Collapsed by default;
+        // the dot shows when a section filter is active while collapsed.
+        FilterDisclosureHeader {
+            id: rulesFilterHeader
+
+            hasActiveFilters: page.chipFilter !== -1
+        }
+
+        Flow {
             Layout.fillWidth: true
             spacing: Kirigami.Units.smallSpacing
-
-            Label {
-                text: i18n("Filter:")
-                opacity: 0.7
-            }
+            visible: rulesFilterHeader.expanded
 
             Repeater {
                 // "All" chip prepended to the controller's section list — the
@@ -460,10 +464,6 @@ SettingsFlickable {
                     Accessible.name: i18n("Filter rules: %1", modelData.label)
                     onClicked: page.chipFilter = modelData.value
                 }
-            }
-
-            Item {
-                Layout.fillWidth: true
             }
         }
 

--- a/src/settings/qml/WindowRulesPage.qml
+++ b/src/settings/qml/WindowRulesPage.qml
@@ -440,10 +440,8 @@ SettingsFlickable {
             hasActiveFilters: page.chipFilter !== -1
         }
 
-        Flow {
-            Layout.fillWidth: true
-            spacing: Kirigami.Units.smallSpacing
-            visible: rulesFilterHeader.expanded
+        CollapsibleChipFlow {
+            open: rulesFilterHeader.expanded
 
             Repeater {
                 // "All" chip prepended to the controller's section list — the


### PR DESCRIPTION
## What
Makes the filter-chip rows on the shader listing pages and the Window Rules page a collapsible disclosure that slides + fades open/closed.

## Why
Per request — the chip rows take vertical space; a toggle declutters the page.

## How
- **`FilterDisclosureHeader.qml`** (new, shared): a chevron **"Filter"** toggle plus an accent dot shown while collapsed when a filter is active (so a hidden filter stays discoverable). Exposes `expanded` / `hasActiveFilters`.
- **`CollapsibleChipFlow.qml`** (new, shared): a `Flow` whose `revealFraction` (0…1) animates `Layout.preferredHeight` + opacity, clipped for a drop-down wipe (`shortDuration`, `InOutCubic`). Chips are its direct children (no content-slot pitfall); it drops out of the layout when fully closed and re-enters the instant it starts opening so the Flow measures its real width first.
- **ShaderBrowserPage / WindowRulesPage:** category / section chips now live behind the toggle. Collapsed by default. The search + source/reset (shaders) and search + Add-rule (rules) rows are unchanged.

## Notes
- Default collapsed to declutter; trivial to flip to default-open.
- Build green, qmlformat/clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)