### PR TITLE
fix(per-screen): make per-monitor zone-selector & gap overrides actually apply

### DIFF
--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -686,7 +686,10 @@ private:
         int zonePadding;
         ::PhosphorLayout::EdgeGaps outerGaps;
     };
-    GapParams resolveGapParams() const;
+    // Resolve zone padding + outer gaps for @p screenId, honoring per-screen
+    // snapping overrides (with virtual->physical fallback) and falling back to
+    // the global values. An empty screenId yields the global values.
+    GapParams resolveGapParams(const QString& screenId) const;
 
     void commitSnapImpl(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
                         PhosphorEngine::SnapIntent intent);

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -25,6 +25,7 @@
 namespace PhosphorZones {
 class IZoneDetector;
 class LayoutRegistry;
+class Layout;
 }
 
 // PhosphorWindowRules::RuleEvaluator is included as a member type of
@@ -686,10 +687,12 @@ private:
         int zonePadding;
         ::PhosphorLayout::EdgeGaps outerGaps;
     };
-    // Resolve zone padding + outer gaps for @p screenId, honoring per-screen
-    // snapping overrides (with virtual->physical fallback) and falling back to
-    // the global values. An empty screenId yields the global values.
-    GapParams resolveGapParams(const QString& screenId) const;
+    // Resolve zone padding + outer gaps for @p screenId, honoring the same
+    // precedence the main geometry pipeline uses (minus the context-rule tier,
+    // which the engine has no registry for): per-screen snapping override (with
+    // virtual->physical fallback) -> @p layout override -> global. An empty
+    // screenId skips the per-screen tier; a null layout skips the layout tier.
+    GapParams resolveGapParams(const QString& screenId, PhosphorZones::Layout* layout) const;
 
     void commitSnapImpl(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
                         PhosphorEngine::SnapIntent intent);

--- a/libs/phosphor-snap-engine/src/SnapEngine.cpp
+++ b/libs/phosphor-snap-engine/src/SnapEngine.cpp
@@ -11,6 +11,7 @@
 #include <PhosphorIdentity/VirtualScreenId.h>
 #include <PhosphorLayoutApi/EdgeGaps.h>
 #include <PhosphorZones/LayoutRegistry.h>
+#include <PhosphorZones/Layout.h>
 #include <PhosphorZones/AssignmentEntry.h>
 #include "snapenginelogging.h"
 
@@ -41,15 +42,19 @@ PhosphorEngine::ISnapSettings* SnapEngine::snapSettings() const
 }
 
 namespace {
-// Resolve outer gaps from a per-screen snapping override map, falling back to
-// the global settings. Mirrors GeometryUtils::resolveOuterGapsFromMap + the
-// global branch of getEffectiveOuterGaps so the snap engine's empty-zone-fill
-// and rotation paths apply the same gaps as the main geometry pipeline.
-::PhosphorLayout::EdgeGaps resolveOuterGapsForScreen(const QVariantMap& perScreen,
+// Resolve outer gaps following the geometry pipeline's precedence (minus the
+// context-rule tier the engine can't reach): per-screen override map -> layout
+// override -> global. Mirrors GeometryUtils::resolveOuterGapsFromMap + the
+// layout/global branches of getEffectiveOuterGaps so the snap engine's
+// empty-zone-fill and rotation paths apply the same gaps as the main pipeline.
+::PhosphorLayout::EdgeGaps resolveOuterGapsForScreen(const QVariantMap& perScreen, PhosphorZones::Layout* layout,
                                                      PhosphorEngine::IGeometrySettings* gs)
 {
     namespace PSK = PhosphorEngine::PerScreenSnappingKey;
-    // Per-screen per-side block wins when engaged and any side is set.
+    namespace GD = PhosphorEngine::GeometryDefaults;
+    const int globalUniform = gs ? gs->outerGap() : GD::OuterGap;
+
+    // Tier 1: per-screen per-side block wins when engaged and any side is set.
     const auto usePerSideIt = perScreen.constFind(PSK::UsePerSideOuterGap);
     if (usePerSideIt != perScreen.constEnd() && usePerSideIt->toBool()) {
         const auto topIt = perScreen.constFind(PSK::OuterGapTop);
@@ -59,27 +64,49 @@ namespace {
         if (topIt != perScreen.constEnd() || bottomIt != perScreen.constEnd() || leftIt != perScreen.constEnd()
             || rightIt != perScreen.constEnd()) {
             const auto uniformIt = perScreen.constFind(PSK::OuterGap);
-            const int fallback = (uniformIt != perScreen.constEnd()) ? uniformIt->toInt() : gs->outerGap();
+            const int fallback = (uniformIt != perScreen.constEnd()) ? uniformIt->toInt() : globalUniform;
             return ::PhosphorLayout::EdgeGaps{(topIt != perScreen.constEnd()) ? topIt->toInt() : fallback,
                                               (bottomIt != perScreen.constEnd()) ? bottomIt->toInt() : fallback,
                                               (leftIt != perScreen.constEnd()) ? leftIt->toInt() : fallback,
                                               (rightIt != perScreen.constEnd()) ? rightIt->toInt() : fallback};
         }
     }
+    // Tier 1 (uniform): per-screen uniform override.
     const auto uniformIt = perScreen.constFind(PSK::OuterGap);
     if (uniformIt != perScreen.constEnd()) {
         return ::PhosphorLayout::EdgeGaps::uniform(uniformIt->toInt());
     }
-    // No per-screen override — global, honoring global per-side gaps.
-    if (gs->usePerSideOuterGap()) {
+
+    // Tier 2: layout per-side override, filling unset sides from the global
+    // per-side values (or the global uniform), mirroring getEffectiveOuterGaps.
+    if (layout && layout->usePerSideOuterGap() && layout->hasPerSideOuterGapOverride()) {
+        ::PhosphorLayout::EdgeGaps gaps = layout->rawOuterGaps();
+        const bool globalPerSide = gs && gs->usePerSideOuterGap();
+        if (gaps.top < 0)
+            gaps.top = globalPerSide ? gs->outerGapTop() : globalUniform;
+        if (gaps.bottom < 0)
+            gaps.bottom = globalPerSide ? gs->outerGapBottom() : globalUniform;
+        if (gaps.left < 0)
+            gaps.left = globalPerSide ? gs->outerGapLeft() : globalUniform;
+        if (gaps.right < 0)
+            gaps.right = globalPerSide ? gs->outerGapRight() : globalUniform;
+        return gaps;
+    }
+    // Tier 2 (uniform): layout uniform override.
+    if (layout && layout->hasOuterGapOverride()) {
+        return ::PhosphorLayout::EdgeGaps::uniform(layout->outerGap());
+    }
+
+    // Tier 3: global, honoring global per-side gaps.
+    if (gs && gs->usePerSideOuterGap()) {
         return ::PhosphorLayout::EdgeGaps{gs->outerGapTop(), gs->outerGapBottom(), gs->outerGapLeft(),
                                           gs->outerGapRight()};
     }
-    return ::PhosphorLayout::EdgeGaps::uniform(gs->outerGap());
+    return ::PhosphorLayout::EdgeGaps::uniform(globalUniform);
 }
 } // namespace
 
-SnapEngine::GapParams SnapEngine::resolveGapParams(const QString& screenId) const
+SnapEngine::GapParams SnapEngine::resolveGapParams(const QString& screenId, PhosphorZones::Layout* layout) const
 {
     namespace PSK = PhosphorEngine::PerScreenSnappingKey;
     auto* gs = dynamic_cast<PhosphorEngine::IGeometrySettings*>(engineSettings());
@@ -100,10 +127,18 @@ SnapEngine::GapParams SnapEngine::resolveGapParams(const QString& screenId) cons
         }
     }
 
+    // Zone padding precedence: per-screen -> layout override -> global.
+    int zonePadding;
     const auto zpIt = perScreen.constFind(PSK::ZonePadding);
-    const int zonePadding = (zpIt != perScreen.constEnd()) ? zpIt->toInt() : gs->zonePadding();
+    if (zpIt != perScreen.constEnd()) {
+        zonePadding = zpIt->toInt();
+    } else if (layout && layout->hasZonePaddingOverride()) {
+        zonePadding = layout->zonePadding();
+    } else {
+        zonePadding = gs->zonePadding();
+    }
 
-    return {zonePadding, resolveOuterGapsForScreen(perScreen, gs)};
+    return {zonePadding, resolveOuterGapsForScreen(perScreen, layout, gs)};
 }
 
 // Out-of-line so unique_ptr<SnapNavigationTargetResolver> can destroy the

--- a/libs/phosphor-snap-engine/src/SnapEngine.cpp
+++ b/libs/phosphor-snap-engine/src/SnapEngine.cpp
@@ -8,6 +8,7 @@
 #include <PhosphorSnapEngine/IZoneAdjacencyResolver.h>
 #include <PhosphorSnapEngine/ISnapSettings.h>
 #include <PhosphorEngine/IGeometrySettings.h>
+#include <PhosphorIdentity/VirtualScreenId.h>
 #include <PhosphorLayoutApi/EdgeGaps.h>
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorZones/AssignmentEntry.h>
@@ -39,13 +40,70 @@ PhosphorEngine::ISnapSettings* SnapEngine::snapSettings() const
     return dynamic_cast<PhosphorEngine::ISnapSettings*>(engineSettings());
 }
 
-SnapEngine::GapParams SnapEngine::resolveGapParams() const
+namespace {
+// Resolve outer gaps from a per-screen snapping override map, falling back to
+// the global settings. Mirrors GeometryUtils::resolveOuterGapsFromMap + the
+// global branch of getEffectiveOuterGaps so the snap engine's empty-zone-fill
+// and rotation paths apply the same gaps as the main geometry pipeline.
+::PhosphorLayout::EdgeGaps resolveOuterGapsForScreen(const QVariantMap& perScreen,
+                                                     PhosphorEngine::IGeometrySettings* gs)
 {
+    namespace PSK = PhosphorEngine::PerScreenSnappingKey;
+    // Per-screen per-side block wins when engaged and any side is set.
+    const auto usePerSideIt = perScreen.constFind(PSK::UsePerSideOuterGap);
+    if (usePerSideIt != perScreen.constEnd() && usePerSideIt->toBool()) {
+        const auto topIt = perScreen.constFind(PSK::OuterGapTop);
+        const auto bottomIt = perScreen.constFind(PSK::OuterGapBottom);
+        const auto leftIt = perScreen.constFind(PSK::OuterGapLeft);
+        const auto rightIt = perScreen.constFind(PSK::OuterGapRight);
+        if (topIt != perScreen.constEnd() || bottomIt != perScreen.constEnd() || leftIt != perScreen.constEnd()
+            || rightIt != perScreen.constEnd()) {
+            const auto uniformIt = perScreen.constFind(PSK::OuterGap);
+            const int fallback = (uniformIt != perScreen.constEnd()) ? uniformIt->toInt() : gs->outerGap();
+            return ::PhosphorLayout::EdgeGaps{(topIt != perScreen.constEnd()) ? topIt->toInt() : fallback,
+                                              (bottomIt != perScreen.constEnd()) ? bottomIt->toInt() : fallback,
+                                              (leftIt != perScreen.constEnd()) ? leftIt->toInt() : fallback,
+                                              (rightIt != perScreen.constEnd()) ? rightIt->toInt() : fallback};
+        }
+    }
+    const auto uniformIt = perScreen.constFind(PSK::OuterGap);
+    if (uniformIt != perScreen.constEnd()) {
+        return ::PhosphorLayout::EdgeGaps::uniform(uniformIt->toInt());
+    }
+    // No per-screen override — global, honoring global per-side gaps.
+    if (gs->usePerSideOuterGap()) {
+        return ::PhosphorLayout::EdgeGaps{gs->outerGapTop(), gs->outerGapBottom(), gs->outerGapLeft(),
+                                          gs->outerGapRight()};
+    }
+    return ::PhosphorLayout::EdgeGaps::uniform(gs->outerGap());
+}
+} // namespace
+
+SnapEngine::GapParams SnapEngine::resolveGapParams(const QString& screenId) const
+{
+    namespace PSK = PhosphorEngine::PerScreenSnappingKey;
     auto* gs = dynamic_cast<PhosphorEngine::IGeometrySettings*>(engineSettings());
-    int zonePadding = gs ? gs->zonePadding() : PhosphorEngine::GeometryDefaults::ZonePadding;
-    auto outerGaps = gs ? ::PhosphorLayout::EdgeGaps::uniform(gs->outerGap())
-                        : ::PhosphorLayout::EdgeGaps::uniform(PhosphorEngine::GeometryDefaults::OuterGap);
-    return {zonePadding, outerGaps};
+    if (!gs) {
+        return {PhosphorEngine::GeometryDefaults::ZonePadding,
+                ::PhosphorLayout::EdgeGaps::uniform(PhosphorEngine::GeometryDefaults::OuterGap)};
+    }
+
+    // Per-screen snapping override with virtual->physical fallback, mirroring
+    // GeometryUtils::getPerScreenSnappingWithFallback so a per-monitor gap set on
+    // a physical screen still applies on its virtual sub-screens.
+    QVariantMap perScreen;
+    if (!screenId.isEmpty()) {
+        perScreen = gs->getPerScreenSnappingSettings(screenId);
+        if (perScreen.isEmpty() && PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
+            perScreen =
+                gs->getPerScreenSnappingSettings(PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId));
+        }
+    }
+
+    const auto zpIt = perScreen.constFind(PSK::ZonePadding);
+    const int zonePadding = (zpIt != perScreen.constEnd()) ? zpIt->toInt() : gs->zonePadding();
+
+    return {zonePadding, resolveOuterGapsForScreen(perScreen, gs)};
 }
 
 // Out-of-line so unique_ptr<SnapNavigationTargetResolver> can destroy the

--- a/libs/phosphor-snap-engine/src/resnap_calc.cpp
+++ b/libs/phosphor-snap-engine/src/resnap_calc.cpp
@@ -380,7 +380,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateSnapAllWindowEntries(const QSt
     // Track zones we're assigning in this batch (to avoid double-assigning)
     QSet<QUuid> batchOccupied = occupiedZoneIds;
 
-    auto [gapZonePadding, gapOuterGaps] = resolveGapParams();
+    auto [gapZonePadding, gapOuterGaps] = resolveGapParams(screenId);
 
     for (const QString& windowId : windowIds) {
         // Find the first unoccupied zone
@@ -502,7 +502,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateRotation(bool clockwise, const
             continue;
         }
 
-        auto [rotGapPadding, rotGapOuter] = resolveGapParams();
+        auto [rotGapPadding, rotGapOuter] = resolveGapParams(screenId);
 
         // Calculate rotated positions within this screen's zones
         for (const auto& pair : windowZoneIndices) {

--- a/libs/phosphor-snap-engine/src/resnap_calc.cpp
+++ b/libs/phosphor-snap-engine/src/resnap_calc.cpp
@@ -380,7 +380,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateSnapAllWindowEntries(const QSt
     // Track zones we're assigning in this batch (to avoid double-assigning)
     QSet<QUuid> batchOccupied = occupiedZoneIds;
 
-    auto [gapZonePadding, gapOuterGaps] = resolveGapParams(screenId);
+    auto [gapZonePadding, gapOuterGaps] = resolveGapParams(screenId, layout);
 
     for (const QString& windowId : windowIds) {
         // Find the first unoccupied zone
@@ -502,7 +502,7 @@ QVector<ZoneAssignmentEntry> SnapEngine::calculateRotation(bool clockwise, const
             continue;
         }
 
-        auto [rotGapPadding, rotGapOuter] = resolveGapParams(screenId);
+        auto [rotGapPadding, rotGapOuter] = resolveGapParams(screenId, layout);
 
         // Calculate rotated positions within this screen's zones
         for (const auto& pair : windowZoneIndices) {

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -220,8 +220,23 @@ void Settings::load()
     // Rendering, Performance, ZoneGeometry, Shortcuts, Editor, Exclusions,
     // Display, ZoneSelector, Activation, Behavior, Autotiling) don't need
     // explicit load calls — their getters read through m_store on demand.
+    // Per-screen override maps are not Q_PROPERTYs, so the snapshot loop above
+    // doesn't cover them. Capture them around the reload so settingsChanged()
+    // can fire when a reload (e.g. the daemon's reloadSettings after a Save)
+    // brings in new per-screen gap / selector overrides. Without this the
+    // daemon reloads the maps but its settingsChanged-driven retile never runs,
+    // so per-monitor gaps never take effect on save (discussion #661).
+    const QHash<QString, QVariantMap> perScreenZoneSelectorBefore = m_perScreenZoneSelectorSettings;
+    const QHash<QString, QVariantMap> perScreenAutotileBefore = m_perScreenAutotileSettings;
+    const QHash<QString, QVariantMap> perScreenSnappingBefore = m_perScreenSnappingSettings;
+
     loadPerScreenOverrides(m_configBackend);
     loadVirtualScreenConfigs(m_configBackend);
+
+    const bool perScreenZoneSelectorChanged = perScreenZoneSelectorBefore != m_perScreenZoneSelectorSettings;
+    const bool perScreenAutotileChanged = perScreenAutotileBefore != m_perScreenAutotileSettings;
+    const bool perScreenSnappingChanged = perScreenSnappingBefore != m_perScreenSnappingSettings;
+    const bool perScreenChanged = perScreenZoneSelectorChanged || perScreenAutotileChanged || perScreenSnappingChanged;
 
     if (useSystemColors()) {
         applySystemColorScheme();
@@ -278,7 +293,19 @@ void Settings::load()
     // signals but NOT the aggregate — inconsistent with the direct
     // setter path (`writeDisableEntries` emits `settingsChanged()`
     // whenever persistence succeeds).
-    if (anyChanged || anyDisableChanged)
+    // Per-screen override maps are not Q_PROPERTYs, so the NOTIFY loop above
+    // doesn't cover them. Emit their change signals here, gated on the
+    // before/after comparison, so QML per-screen helpers refresh on Discard /
+    // Reset and the daemon resnaps on a per-screen gap change — without firing
+    // on reloads that left the maps untouched.
+    if (perScreenZoneSelectorChanged)
+        Q_EMIT perScreenZoneSelectorSettingsChanged();
+    if (perScreenAutotileChanged)
+        Q_EMIT perScreenAutotileSettingsChanged();
+    if (perScreenSnappingChanged)
+        Q_EMIT perScreenSnappingSettingsChanged();
+
+    if (anyChanged || anyDisableChanged || perScreenChanged)
         Q_EMIT settingsChanged();
 }
 

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -776,13 +776,6 @@ public:
     Q_INVOKABLE void clearPerScreenSnappingSettings(const QString& screenIdOrName) override;
     Q_INVOKABLE bool hasPerScreenSnappingSettings(const QString& screenIdOrName) const override;
 
-    // Gaps sub-domain of the per-screen snapping map (the Snapping → Window →
-    // Appearance "Gaps" card). Report/clear only the gap keys so the card's
-    // reset never wipes the map's other (SnapAssist / ZoneSelector) overrides
-    // — mirrors the autotile Gaps/Algorithm split above.
-    bool hasPerScreenSnappingGapsSettings(const QString& screenIdOrName) const;
-    void clearPerScreenSnappingGapsSettings(const QString& screenIdOrName);
-
     // ═══════════════════════════════════════════════════════════════════════════
     // Autotiling Settings (ISettings interface)
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/config/settings/perscreen.cpp
+++ b/src/config/settings/perscreen.cpp
@@ -260,15 +260,13 @@ QVariant readPerScreenAutotileEntry(PhosphorConfig::IGroup& group, const QString
 }
 
 const QLatin1String kPerScreenSnappingKeys[] = {
-    PerScreenSnappingKey::SnapAssistEnabled,
-    // Snapping gaps (per-screen) — without these the Gaps card's overrides would
-    // not be re-loaded on next launch even after the validator accepts the write.
-    PerScreenSnappingKey::ZonePadding,
-    PerScreenSnappingKey::OuterGap,
-    PerScreenSnappingKey::UsePerSideOuterGap,
-    PerScreenSnappingKey::OuterGapTop,
-    PerScreenSnappingKey::OuterGapBottom,
-    PerScreenSnappingKey::OuterGapLeft,
+    // Snapping gaps (per-screen) — the Snapping → Window → Appearance "Gaps"
+    // card. These are the ONLY per-screen snapping keys: snap-assist is global
+    // and the zone-selector keys live in their own per-screen map. Without these
+    // the Gaps card's overrides would not be re-loaded on next launch even after
+    // the validator accepts the write.
+    PerScreenSnappingKey::ZonePadding,   PerScreenSnappingKey::OuterGap,       PerScreenSnappingKey::UsePerSideOuterGap,
+    PerScreenSnappingKey::OuterGapTop,   PerScreenSnappingKey::OuterGapBottom, PerScreenSnappingKey::OuterGapLeft,
     PerScreenSnappingKey::OuterGapRight,
 };
 
@@ -300,8 +298,6 @@ bool isPerScreenSnappingGapsKey(const QString& key)
 QVariant validatePerScreenSnappingValue(const QString& key, const QVariant& value)
 {
     namespace K = PerScreenSnappingKey;
-    if (key == K::SnapAssistEnabled)
-        return QVariant(value.toBool());
     // Per-screen snapping gaps (the Gaps card on Snapping → Window → Appearance).
     // Each key clamps against its own ConfigDefaults bounds — mirroring the
     // per-side handling in the autotile validator above; a uniform startsWith
@@ -327,8 +323,6 @@ QVariant validatePerScreenSnappingValue(const QString& key, const QVariant& valu
 QVariant readPerScreenSnappingEntry(PhosphorConfig::IGroup& group, const QString& key)
 {
     namespace K = PerScreenSnappingKey;
-    if (key == K::SnapAssistEnabled)
-        return QVariant(group.readBool(key, ConfigDefaults::snapAssistEnabled()));
     // UsePerSideOuterGap is a bool; the int gap keys (ZonePadding/OuterGap/per-side)
     // fall through to readInt below, which is the correct type for them.
     if (key == K::UsePerSideOuterGap)

--- a/src/config/settings/perscreen.cpp
+++ b/src/config/settings/perscreen.cpp
@@ -261,14 +261,6 @@ QVariant readPerScreenAutotileEntry(PhosphorConfig::IGroup& group, const QString
 
 const QLatin1String kPerScreenSnappingKeys[] = {
     PerScreenSnappingKey::SnapAssistEnabled,
-    PerScreenSnappingKey::ZoneSelectorEnabled,
-    PerScreenSnappingKey::ZoneSelectorTriggerDistance,
-    PerScreenSnappingKey::ZoneSelectorPosition,
-    PerScreenSnappingKey::ZoneSelectorLayoutMode,
-    PerScreenSnappingKey::ZoneSelectorSizeMode,
-    PerScreenSnappingKey::ZoneSelectorMaxRows,
-    PerScreenSnappingKey::ZoneSelectorPreviewWidth,
-    PerScreenSnappingKey::ZoneSelectorPreviewHeight,
     // Snapping gaps (per-screen) — without these the Gaps card's overrides would
     // not be re-loaded on next launch even after the validator accepts the write.
     PerScreenSnappingKey::ZonePadding,
@@ -308,25 +300,8 @@ bool isPerScreenSnappingGapsKey(const QString& key)
 QVariant validatePerScreenSnappingValue(const QString& key, const QVariant& value)
 {
     namespace K = PerScreenSnappingKey;
-    if (key == K::SnapAssistEnabled || key == K::ZoneSelectorEnabled)
+    if (key == K::SnapAssistEnabled)
         return QVariant(value.toBool());
-    if (key == K::ZoneSelectorTriggerDistance)
-        return boundedInt(value, ConfigDefaults::triggerDistanceMin(), ConfigDefaults::triggerDistanceMax());
-    if (key == K::ZoneSelectorPosition) {
-        return enumInRange(value, static_cast<int>(ZoneSelectorPosition::BottomRight));
-    }
-    if (key == K::ZoneSelectorLayoutMode) {
-        return enumInRange(value, static_cast<int>(ZoneSelectorLayoutMode::Vertical));
-    }
-    if (key == K::ZoneSelectorSizeMode) {
-        return enumInRange(value, static_cast<int>(ZoneSelectorSizeMode::Manual));
-    }
-    if (key == K::ZoneSelectorMaxRows)
-        return boundedInt(value, ConfigDefaults::maxRowsMin(), ConfigDefaults::maxRowsMax());
-    if (key == K::ZoneSelectorPreviewWidth)
-        return boundedInt(value, ConfigDefaults::previewWidthMin(), ConfigDefaults::previewWidthMax());
-    if (key == K::ZoneSelectorPreviewHeight)
-        return boundedInt(value, ConfigDefaults::previewHeightMin(), ConfigDefaults::previewHeightMax());
     // Per-screen snapping gaps (the Gaps card on Snapping → Window → Appearance).
     // Each key clamps against its own ConfigDefaults bounds — mirroring the
     // per-side handling in the autotile validator above; a uniform startsWith
@@ -354,8 +329,6 @@ QVariant readPerScreenSnappingEntry(PhosphorConfig::IGroup& group, const QString
     namespace K = PerScreenSnappingKey;
     if (key == K::SnapAssistEnabled)
         return QVariant(group.readBool(key, ConfigDefaults::snapAssistEnabled()));
-    if (key == K::ZoneSelectorEnabled)
-        return QVariant(group.readBool(key, ConfigDefaults::zoneSelectorEnabled()));
     // UsePerSideOuterGap is a bool; the int gap keys (ZonePadding/OuterGap/per-side)
     // fall through to readInt below, which is the correct type for them.
     if (key == K::UsePerSideOuterGap)
@@ -513,6 +486,10 @@ void Settings::loadPerScreenOverrides(PhosphorConfig::IBackend* backend)
     loadPerScreenGroup(backend, allGroups, ConfigDefaults::snappingScreenGroupPrefix(), kPerScreenSnappingKeys,
                        std::size(kPerScreenSnappingKeys), readPerScreenSnappingEntry, validatePerScreenSnappingValue,
                        m_perScreenSnappingSettings);
+    // Per-screen change signals are emitted by the caller (Settings::load()),
+    // gated on a before/after comparison of each map — so they fire only when a
+    // reload actually changed something, which the daemon relies on to avoid
+    // resnapping on unrelated saves.
 }
 
 /**
@@ -720,6 +697,15 @@ ZoneSelectorConfig Settings::resolvedZoneSelectorConfig(const QString& screenIdO
                                  zoneSelectorTriggerDistance()};
 
     auto it = findPerScreenEntry(m_perScreenZoneSelectorSettings, screenIdOrName);
+    // Virtual-screen fallback: an override stored on the physical monitor must
+    // still apply when the selector runs on one of its virtual sub-screens.
+    // Mirrors getPerScreenSnappingWithFallback() in geometryutils.cpp so the
+    // selector resolver and the snapping geometry path resolve ids alike.
+    if (it == m_perScreenZoneSelectorSettings.constEnd()
+        && PhosphorIdentity::VirtualScreenId::isVirtual(screenIdOrName)) {
+        it = findPerScreenEntry(m_perScreenZoneSelectorSettings,
+                                PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenIdOrName));
+    }
     if (it == m_perScreenZoneSelectorSettings.constEnd()) {
         return config;
     }

--- a/src/config/settings/perscreen.cpp
+++ b/src/config/settings/perscreen.cpp
@@ -270,31 +270,6 @@ const QLatin1String kPerScreenSnappingKeys[] = {
     PerScreenSnappingKey::OuterGapRight,
 };
 
-// Gaps sub-domain of the per-screen snapping keys — the keys the Snapping →
-// Window → Appearance "Gaps" card writes. The rest of kPerScreenSnappingKeys
-// (SnapAssist / ZoneSelector) is a different concern; the card reports its
-// override dot and clears its reset against ONLY these gap keys so a shared
-// whole-domain clear can't wipe the map's other overrides (data loss on reset).
-const QLatin1String kPerScreenSnappingGapsKeys[] = {
-    PerScreenSnappingKey::ZonePadding,   PerScreenSnappingKey::OuterGap,       PerScreenSnappingKey::UsePerSideOuterGap,
-    PerScreenSnappingKey::OuterGapTop,   PerScreenSnappingKey::OuterGapBottom, PerScreenSnappingKey::OuterGapLeft,
-    PerScreenSnappingKey::OuterGapRight,
-};
-
-bool isPerScreenSnappingGapsKey(const QString& key)
-{
-    // Snapping per-screen keys are stored unprefixed, so this is a direct
-    // membership test against the gaps-key set (derived once into a static set,
-    // mirroring isPerScreenAutotileGapsKey).
-    static const QSet<QString> gapsKeys = []() {
-        QSet<QString> keys;
-        for (const QLatin1String& k : kPerScreenSnappingGapsKeys)
-            keys.insert(QString(k));
-        return keys;
-    }();
-    return gapsKeys.contains(key);
-}
-
 QVariant validatePerScreenSnappingValue(const QString& key, const QVariant& value)
 {
     namespace K = PerScreenSnappingKey;
@@ -860,25 +835,6 @@ void Settings::clearPerScreenSnappingSettings(const QString& screenIdOrName)
 bool Settings::hasPerScreenSnappingSettings(const QString& screenIdOrName) const
 {
     return findPerScreenEntry(m_perScreenSnappingSettings, screenIdOrName) != m_perScreenSnappingSettings.constEnd();
-}
-
-// Gaps sub-domain accessors: the Gaps card reports/clears only the snapping
-// gap keys, leaving the map's other (SnapAssist / ZoneSelector) overrides
-// untouched — mirrors the autotile Gaps/Algorithm split.
-
-bool Settings::hasPerScreenSnappingGapsSettings(const QString& screenIdOrName) const
-{
-    return hasPerScreenKeySubset(m_perScreenSnappingSettings, screenIdOrName, isPerScreenSnappingGapsKey,
-                                 /*wantGaps=*/true);
-}
-
-void Settings::clearPerScreenSnappingGapsSettings(const QString& screenIdOrName)
-{
-    if (clearPerScreenKeySubset(m_perScreenSnappingSettings, screenIdOrName, isPerScreenSnappingGapsKey,
-                                /*clearGaps=*/true)) {
-        Q_EMIT perScreenSnappingSettingsChanged();
-        Q_EMIT settingsChanged();
-    }
 }
 
 } // namespace PlasmaZones

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -105,11 +105,10 @@ using PhosphorEngine::PerScreenSnappingKey::OuterGapTop;
 using PhosphorEngine::PerScreenSnappingKey::UsePerSideOuterGap;
 using PhosphorEngine::PerScreenSnappingKey::ZonePadding;
 
-inline constexpr QLatin1String SnapAssistEnabled{"SnapAssistEnabled"};
-// Zone-selector per-screen overrides live in their own map/group keyed by
-// ZoneSelectorConfigKey (see kPerScreenKeys in perscreen.cpp); they are NOT
-// part of the snapping per-screen domain. The zone-selector enable switch is
-// global-only (ISettings::setZoneSelectorEnabled).
+// Only the gap keys above are per-screen. Snap-assist and the zone-selector
+// enable switch are global-only (ISettings::setSnapAssistEnabled /
+// setZoneSelectorEnabled); the per-screen zone-selector config lives in its own
+// map/group keyed by ZoneSelectorConfigKey (see kPerScreenKeys in perscreen.cpp).
 } // namespace PerScreenSnappingKey
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -106,14 +106,10 @@ using PhosphorEngine::PerScreenSnappingKey::UsePerSideOuterGap;
 using PhosphorEngine::PerScreenSnappingKey::ZonePadding;
 
 inline constexpr QLatin1String SnapAssistEnabled{"SnapAssistEnabled"};
-inline constexpr QLatin1String ZoneSelectorEnabled{"ZoneSelectorEnabled"};
-inline constexpr QLatin1String ZoneSelectorTriggerDistance{"ZoneSelectorTriggerDistance"};
-inline constexpr QLatin1String ZoneSelectorPosition{"ZoneSelectorPosition"};
-inline constexpr QLatin1String ZoneSelectorLayoutMode{"ZoneSelectorLayoutMode"};
-inline constexpr QLatin1String ZoneSelectorSizeMode{"ZoneSelectorSizeMode"};
-inline constexpr QLatin1String ZoneSelectorMaxRows{"ZoneSelectorMaxRows"};
-inline constexpr QLatin1String ZoneSelectorPreviewWidth{"ZoneSelectorPreviewWidth"};
-inline constexpr QLatin1String ZoneSelectorPreviewHeight{"ZoneSelectorPreviewHeight"};
+// Zone-selector per-screen overrides live in their own map/group keyed by
+// ZoneSelectorConfigKey (see kPerScreenKeys in perscreen.cpp); they are NOT
+// part of the snapping per-screen domain. The zone-selector enable switch is
+// global-only (ISettings::setZoneSelectorEnabled).
 } // namespace PerScreenSnappingKey
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1848,6 +1848,10 @@ void Daemon::stop()
 {
     m_shuttingDown = true;
 
+    // Cancel any pending debounced gap-resnap so it can't fire mid-teardown
+    // (the engine is cleared below; a late fire would be a wasted no-op).
+    m_gapResnapTimer.stop();
+
     // Drop the layout-manager provider lambdas FIRST, before the m_running
     // gate. They capture `this` and dereference m_settings; m_settings is
     // declared after m_layoutManager, so reverse-order member destruction

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -951,6 +951,35 @@ bool Daemon::init()
         syncModeFromAssignments();
     });
 
+    // Resnap currently-snapped windows when a snapping gap/padding setting
+    // changes (global or per-screen) so the new spacing is visible immediately
+    // instead of requiring a manual re-snap of each window (discussion #661).
+    // The signals below are re-emitted by Settings::load() only when the value
+    // actually changed, so this never fires on unrelated saves (colours,
+    // shortcuts). Autotile windows are already retiled by the settingsChanged
+    // handler above; this covers manually-snapped windows. Debounced so a batch
+    // of per-side gap edits in one save collapses into a single resnap pass.
+    m_gapResnapTimer.setSingleShot(true);
+    m_gapResnapTimer.setInterval(100);
+    connect(&m_gapResnapTimer, &QTimer::timeout, this, [this]() {
+        if (!m_snapAdaptor) {
+            return;
+        }
+        m_suppressResnapOsd = 1; // settings-driven reflow, not user navigation
+        m_snapAdaptor->resnapCurrentAssignments();
+    });
+    const auto scheduleGapResnap = [this]() {
+        m_gapResnapTimer.start();
+    };
+    connect(m_settings.get(), &Settings::zonePaddingChanged, this, scheduleGapResnap);
+    connect(m_settings.get(), &Settings::outerGapChanged, this, scheduleGapResnap);
+    connect(m_settings.get(), &Settings::usePerSideOuterGapChanged, this, scheduleGapResnap);
+    connect(m_settings.get(), &Settings::outerGapTopChanged, this, scheduleGapResnap);
+    connect(m_settings.get(), &Settings::outerGapBottomChanged, this, scheduleGapResnap);
+    connect(m_settings.get(), &Settings::outerGapLeftChanged, this, scheduleGapResnap);
+    connect(m_settings.get(), &Settings::outerGapRightChanged, this, scheduleGapResnap);
+    connect(m_settings.get(), &Settings::perScreenSnappingSettingsChanged, this, scheduleGapResnap);
+
     // Initialize domain-specific D-Bus adaptors
     // Each adaptor has its own D-Bus interface
     // D-Bus adaptors use raw new; Qt parent-child manages their lifetime.

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -930,6 +930,12 @@ private:
     // After geometry updates settle, request KWin effect to re-apply window positions (panel editor fix)
     QTimer m_reapplyGeometriesTimer;
 
+    // Debounced resnap of currently-snapped windows after a gap/padding change
+    // (global or per-screen snapping). Lets users see the new spacing applied to
+    // already-snapped windows on save instead of having to re-snap each one
+    // (discussion #661). Coalesces a batch of per-side edits into one pass.
+    QTimer m_gapResnapTimer;
+
     // Watchdog: if the KWin effect has not registered as a compositor bridge
     // within a grace period after startup, window control is dead (drags and
     // shortcuts do nothing). On timeout the daemon logs a diagnostic warning

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <QScreen>
 #include <PhosphorScreens/ScreenIdentity.h>
+#include <PhosphorIdentity/VirtualScreenId.h>
 
 namespace PlasmaZones {
 
@@ -108,7 +109,14 @@ void Daemon::updateAutotileScreens()
         for (const QString& screenId : effectiveIds) {
             if (!autotileScreens.contains(screenId))
                 continue;
+            // Virtual->physical fallback (mirrors getPerScreenSnappingWithFallback):
+            // a per-screen autotile override stored on a physical monitor must
+            // still apply when this screenId is one of its virtual sub-screens.
             QVariantMap overrides = m_settings->getPerScreenAutotileSettings(screenId);
+            if (overrides.isEmpty() && PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
+                overrides = m_settings->getPerScreenAutotileSettings(
+                    PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId));
+            }
             // Inject algorithm from layout assignment (authoritative source)
             if (screenAlgorithms.contains(screenId)) {
                 const QString screenAlgo = screenAlgorithms.value(screenId);

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -474,7 +474,10 @@ void OverlayService::createZoneSelectorWindow(const QString& screenId, QScreen* 
     writeQmlProperty(slot, QStringLiteral("screenAspectRatio"), aspectRatio);
     writeQmlProperty(slot, QStringLiteral("screenWidth"), screenGeom.width());
     if (m_settings) {
-        writeQmlProperty(slot, QStringLiteral("zonePadding"), m_settings->zonePadding());
+        // Zone padding honors per-screen overrides (per-screen → global →
+        // default); border width/radius are global-only (no per-screen key).
+        writeQmlProperty(slot, QStringLiteral("zonePadding"),
+                         GeometryUtils::getEffectiveZonePadding(nullptr, m_settings, screenId));
         writeQmlProperty(slot, QStringLiteral("zoneBorderWidth"), m_settings->borderWidth());
         writeQmlProperty(slot, QStringLiteral("zoneBorderRadius"), m_settings->borderRadius());
     }

--- a/src/daemon/overlayservice/selector_update.cpp
+++ b/src/daemon/overlayservice/selector_update.cpp
@@ -44,9 +44,11 @@ void updateZoneSelectorComputedProperties(PhosphorScreens::ScreenManager* mgr, Q
     writeQmlProperty(window, QStringLiteral("positionIsVertical"),
                      (pos == ZoneSelectorPosition::Left || pos == ZoneSelectorPosition::Right));
 
-    // Compute scaled zone appearance values (from global settings - not per-screen)
+    // Compute scaled zone appearance values. Zone padding honors per-screen
+    // overrides (resolution cascade: per-screen → global → default); border
+    // width/radius are global-only settings (no per-screen key exists).
     if (settings) {
-        const int zonePadding = settings->zonePadding();
+        const int zonePadding = GeometryUtils::getEffectiveZonePadding(nullptr, settings, virtualScreenId);
         const int zoneBorderWidth = settings->borderWidth();
         const int zoneBorderRadius = settings->borderRadius();
 
@@ -142,8 +144,11 @@ void OverlayService::updateZoneSelectorWindow(const QString& screenId)
     // Update settings-based properties
     if (m_settings) {
         writeColorSettings(window, m_settings);
-        // PhosphorZones::Zone appearance settings for scaled preview (global)
-        writeQmlProperty(window, QStringLiteral("zonePadding"), m_settings->zonePadding());
+        // PhosphorZones::Zone appearance for the scaled preview. Zone padding
+        // honors per-screen overrides (per-screen → global → default); border
+        // width/radius are global-only (no per-screen key exists).
+        writeQmlProperty(window, QStringLiteral("zonePadding"),
+                         GeometryUtils::getEffectiveZonePadding(nullptr, m_settings, screenId));
         writeQmlProperty(window, QStringLiteral("zoneBorderWidth"), m_settings->borderWidth());
         writeQmlProperty(window, QStringLiteral("zoneBorderRadius"), m_settings->borderRadius());
         // Font settings for zone number labels

--- a/src/settings/qml/MonitorScopeChip.qml
+++ b/src/settings/qml/MonitorScopeChip.qml
@@ -55,7 +55,14 @@ Item {
     }
 
     function _refresh() {
-        _hasOverride = isPerScreen && hasOverridesMethod !== "" && appSettings[hasOverridesMethod](scope) === true;
+        // Gate on `scope` directly, NOT the derived isPerScreen property:
+        // _refresh() runs from onScopeChanged, and on the ""→monitor transition
+        // the isPerScreen binding has not necessarily recomputed yet when this
+        // handler fires. Reading a stale isPerScreen (false) would leave
+        // _hasOverride false — hiding the override dot and the "Reset this
+        // monitor" action when switching from "All Monitors" to a scoped monitor
+        // that has overrides (discussion #661).
+        _hasOverride = scope !== "" && hasOverridesMethod !== "" && appSettings[hasOverridesMethod](scope) === true;
     }
     onScopeChanged: _refresh()
     onHasOverridesMethodChanged: _refresh()

--- a/src/settings/qml/PerScreenOverrideHelper.qml
+++ b/src/settings/qml/PerScreenOverrideHelper.qml
@@ -38,7 +38,14 @@ QtObject {
     property var perScreenOverrides: ({})
 
     function reload() {
-        if (isPerScreen && selectedScreenName !== "")
+        // Gate on selectedScreenName directly, NOT the derived isPerScreen
+        // property. reload() runs from onSelectedScreenNameChanged, and on the
+        // ""→screen transition the isPerScreen binding has not necessarily
+        // recomputed yet when this handler fires. Reading a stale isPerScreen
+        // (false) would take the else branch and wipe the freshly-scoped
+        // overrides to {}, leaving the control stuck on the global value when
+        // switching from "All Monitors" to a specific monitor (discussion #661).
+        if (selectedScreenName !== "")
             perScreenOverrides = appSettings[getterMethod](selectedScreenName);
         else
             perScreenOverrides = {};

--- a/src/settings/qml/SnappingWindowAppearancePage.qml
+++ b/src/settings/qml/SnappingWindowAppearancePage.qml
@@ -200,8 +200,8 @@ SettingsFlickable {
             searchAnchor: "gaps"
             scopeEnabled: true
             scopeAppSettings: settingsController
-            scopeHasOverridesMethod: "hasPerScreenSnappingGapsSettings"
-            scopeClearerMethod: "clearPerScreenSnappingGapsSettings"
+            scopeHasOverridesMethod: "hasPerScreenSnappingSettings"
+            scopeClearerMethod: "clearPerScreenSnappingSettings"
             // Snapping shares the "Inner gap" / "Outer gap" labels with tiling
             // (consistent cross-mode wording) but has no Smart gaps. Inner-gap
             // bounds come from zonePaddingMin/Max; the outer / per-side gaps from

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -480,8 +480,6 @@ public:
     Q_INVOKABLE void setPerScreenSnappingSetting(const QString& screenName, const QString& key, const QVariant& value);
     Q_INVOKABLE void clearPerScreenSnappingSettings(const QString& screenName);
     Q_INVOKABLE bool hasPerScreenSnappingSettings(const QString& screenName) const;
-    Q_INVOKABLE bool hasPerScreenSnappingGapsSettings(const QString& screenName) const;
-    Q_INVOKABLE void clearPerScreenSnappingGapsSettings(const QString& screenName);
 
     // ── Virtual screen configuration ──────────────────────────────────────────
     Q_INVOKABLE QStringList getPhysicalScreens() const;

--- a/src/settings/settingscontroller_perscreen.cpp
+++ b/src/settings/settingscontroller_perscreen.cpp
@@ -102,16 +102,6 @@ bool SettingsController::hasPerScreenSnappingSettings(const QString& screenName)
     return m_settings.hasPerScreenSnappingSettings(screenName);
 }
 
-bool SettingsController::hasPerScreenSnappingGapsSettings(const QString& screenName) const
-{
-    return m_settings.hasPerScreenSnappingGapsSettings(screenName);
-}
-
-void SettingsController::clearPerScreenSnappingGapsSettings(const QString& screenName)
-{
-    m_settings.clearPerScreenSnappingGapsSettings(screenName);
-}
-
 // ── Per-screen zone selector overrides ───────────────────────────────────
 
 QVariantMap SettingsController::getPerScreenZoneSelectorSettings(const QString& screenName) const

--- a/tests/unit/config/test_settings_perscreen.cpp
+++ b/tests/unit/config/test_settings_perscreen.cpp
@@ -359,11 +359,13 @@ private Q_SLOTS:
     }
 
     /**
-     * The per-screen snapping Gaps card shares one map with the snapping
-     * SnapAssist/ZoneSelector keys but must report and clear only its gap keys,
-     * so resetting the Gaps card never wipes the map's other overrides.
+     * The per-screen snapping map currently holds only gap keys (snap-assist is
+     * global; the zone-selector keys live in their own map), so the Gaps card's
+     * gaps-subdomain clear drops the whole entry. Verifies the clear reports the
+     * gap overrides, emits exactly once, and removes the entry — and that a
+     * redundant clear is a silent no-op.
      */
-    void testPerScreenSnapping_gapsSubdomainIsolatesNonGapsKeys()
+    void testPerScreenSnapping_gapsClearDropsEntry()
     {
         IsolatedConfigGuard guard;
 
@@ -371,30 +373,25 @@ private Q_SLOTS:
 
         const QString screen = QStringLiteral("test-screen-1");
 
-        // A gaps override (ZonePadding) and a non-gaps override
-        // (SnapAssistEnabled) coexist in the one shared per-screen snapping map.
         settings.setPerScreenSnappingSetting(screen, QStringLiteral("ZonePadding"), 8);
-        settings.setPerScreenSnappingSetting(screen, QStringLiteral("SnapAssistEnabled"), false);
+        settings.setPerScreenSnappingSetting(screen, QStringLiteral("OuterGap"), 12);
 
         QVERIFY(settings.hasPerScreenSnappingGapsSettings(screen));
         QVERIFY(settings.hasPerScreenSnappingSettings(screen));
 
         QSignalSpy spy(&settings, &Settings::perScreenSnappingSettingsChanged);
 
-        // Clearing the gaps sub-domain emits once and leaves the SnapAssist
-        // override intact (the entry survives because a non-gaps key remains).
+        // Clearing the gaps sub-domain emits once and, since gaps are the only
+        // per-screen snapping keys, removes the entry entirely.
         settings.clearPerScreenSnappingGapsSettings(screen);
         QCOMPARE(spy.count(), 1);
         QVERIFY(!settings.hasPerScreenSnappingGapsSettings(screen));
-        QVERIFY(settings.hasPerScreenSnappingSettings(screen));
-        QVariantMap afterGapsClear = settings.getPerScreenSnappingSettings(screen);
-        QVERIFY2(!afterGapsClear.contains(QStringLiteral("ZonePadding")), "gaps key must be cleared");
-        QCOMPARE(afterGapsClear.value(QStringLiteral("SnapAssistEnabled")).toBool(), false);
+        QVERIFY(!settings.hasPerScreenSnappingSettings(screen));
+        QVERIFY(settings.getPerScreenSnappingSettings(screen).isEmpty());
 
-        // A no-op gaps clear (no gaps remain) changes nothing and does not emit.
+        // A no-op clear (nothing left) changes nothing and does not emit.
         settings.clearPerScreenSnappingGapsSettings(screen);
         QCOMPARE(spy.count(), 1);
-        QVERIFY(settings.hasPerScreenSnappingSettings(screen));
     }
 
     // =========================================================================

--- a/tests/unit/config/test_settings_perscreen.cpp
+++ b/tests/unit/config/test_settings_perscreen.cpp
@@ -359,13 +359,12 @@ private Q_SLOTS:
     }
 
     /**
-     * The per-screen snapping map currently holds only gap keys (snap-assist is
-     * global; the zone-selector keys live in their own map), so the Gaps card's
-     * gaps-subdomain clear drops the whole entry. Verifies the clear reports the
-     * gap overrides, emits exactly once, and removes the entry — and that a
-     * redundant clear is a silent no-op.
+     * The per-screen snapping map holds only gap keys (snap-assist is global;
+     * the zone-selector keys live in their own map), so clearing it removes the
+     * whole entry. Verifies the clear reports the overrides, emits exactly once,
+     * and removes the entry — and that a redundant clear is a silent no-op.
      */
-    void testPerScreenSnapping_gapsClearDropsEntry()
+    void testPerScreenSnapping_clearDropsEntry()
     {
         IsolatedConfigGuard guard;
 
@@ -376,21 +375,17 @@ private Q_SLOTS:
         settings.setPerScreenSnappingSetting(screen, QStringLiteral("ZonePadding"), 8);
         settings.setPerScreenSnappingSetting(screen, QStringLiteral("OuterGap"), 12);
 
-        QVERIFY(settings.hasPerScreenSnappingGapsSettings(screen));
         QVERIFY(settings.hasPerScreenSnappingSettings(screen));
 
         QSignalSpy spy(&settings, &Settings::perScreenSnappingSettingsChanged);
 
-        // Clearing the gaps sub-domain emits once and, since gaps are the only
-        // per-screen snapping keys, removes the entry entirely.
-        settings.clearPerScreenSnappingGapsSettings(screen);
+        settings.clearPerScreenSnappingSettings(screen);
         QCOMPARE(spy.count(), 1);
-        QVERIFY(!settings.hasPerScreenSnappingGapsSettings(screen));
         QVERIFY(!settings.hasPerScreenSnappingSettings(screen));
         QVERIFY(settings.getPerScreenSnappingSettings(screen).isEmpty());
 
         // A no-op clear (nothing left) changes nothing and does not emit.
-        settings.clearPerScreenSnappingGapsSettings(screen);
+        settings.clearPerScreenSnappingSettings(screen);
         QCOMPARE(spy.count(), 1);
     }
 

--- a/tests/unit/config/test_settings_perscreen.cpp
+++ b/tests/unit/config/test_settings_perscreen.cpp
@@ -10,7 +10,7 @@
  * 2. Per-screen zone selector no-op-write emit/husk suppression
  * 3. Per-screen autotile validation
  * 4. Per-screen autotile gaps/algorithm sub-domain independence
- * 5. Per-screen snapping gaps sub-domain isolation
+ * 5. Per-screen snapping clear drops the (gaps-only) entry
  * 6. Fresh config defaults
  */
 
@@ -376,6 +376,10 @@ private Q_SLOTS:
         settings.setPerScreenSnappingSetting(screen, QStringLiteral("OuterGap"), 12);
 
         QVERIFY(settings.hasPerScreenSnappingSettings(screen));
+        // Pin the accept path: both gap keys round-trip through the validator.
+        const QVariantMap stored = settings.getPerScreenSnappingSettings(screen);
+        QCOMPARE(stored.value(QStringLiteral("ZonePadding")).toInt(), 8);
+        QCOMPARE(stored.value(QStringLiteral("OuterGap")).toInt(), 12);
 
         QSignalSpy spy(&settings, &Settings::perScreenSnappingSettingsChanged);
 

--- a/tests/unit/config/test_settings_perscreen.cpp
+++ b/tests/unit/config/test_settings_perscreen.cpp
@@ -23,6 +23,7 @@
 #include "../../../src/core/constants.h"
 #include "../../../src/core/settings_interfaces.h"
 #include "../helpers/IsolatedConfigGuard.h"
+#include <PhosphorIdentity/VirtualScreenId.h>
 
 using namespace PlasmaZones;
 using PlasmaZones::TestHelpers::IsolatedConfigGuard;
@@ -59,6 +60,38 @@ private Q_SLOTS:
         // Clear and verify
         settings.clearPerScreenZoneSelectorSettings(screen);
         QVERIFY(!settings.hasPerScreenZoneSelectorSettings(screen));
+    }
+
+    /**
+     * Per-screen zone selector resolver: an override stored on the physical
+     * monitor must still resolve when queried with one of its virtual
+     * sub-screen ids ("<physical>/vs:N"). Mirrors the snapping geometry path's
+     * getPerScreenSnappingWithFallback() so the selector honors per-monitor
+     * overrides on virtual screens (regression for discussion #661).
+     */
+    void testPerScreenZoneSelector_virtualScreenFallsBackToPhysical()
+    {
+        IsolatedConfigGuard guard;
+
+        Settings settings;
+
+        const QString physical = QStringLiteral("test-screen-1");
+        const QString virtualId = PhosphorIdentity::VirtualScreenId::make(physical, 0);
+
+        // Baseline: with no override, the virtual screen resolves to the global
+        // default position (and that default is not the value we will set).
+        const int defaultPosition = settings.resolvedZoneSelectorConfig(virtualId).position;
+        QVERIFY(defaultPosition != 3);
+
+        // Store the override on the PHYSICAL id (as the settings UI does).
+        settings.setPerScreenZoneSelectorSetting(physical, QStringLiteral("Position"), 3);
+
+        // Querying the VIRTUAL sub-screen must fall back to the physical entry.
+        QCOMPARE(settings.resolvedZoneSelectorConfig(virtualId).position, 3);
+
+        // An unrelated screen still resolves to the default (no spurious match).
+        const QString otherVirtual = PhosphorIdentity::VirtualScreenId::make(QStringLiteral("other-screen"), 0);
+        QCOMPARE(settings.resolvedZoneSelectorConfig(otherVirtual).position, defaultPosition);
     }
 
     /**


### PR DESCRIPTION
Fixes the per-monitor override issues reported in discussion #661, then audits and fixes the same bug classes across every other per-screen settings domain.

## Discussion #661 (commit 1)
Per-monitor overrides were stored correctly but didn't take effect, and the UI mis-displayed them:

- **Zone-selector preview ignored per-screen padding** — `selector_update.cpp` / `selector.cpp` pushed the global `zonePadding`; now resolves per-screen via `getEffectiveZonePadding`.
- **Zone-selector resolver lacked the virtual→physical screen-id fallback** that snapping has — added to `resolvedZoneSelectorConfig`, so an override set on a physical monitor applies on its virtual sub-screens.
- **Per-screen-only saves never reached the daemon** — `Settings::load()` only emitted `settingsChanged()` on a Q_PROPERTY change; per-screen maps aren't Q_PROPERTYs. It now diffs the maps and emits both `settingsChanged()` and the per-screen change signals (gated on actual change).
- **Snapped windows didn't reflow on a gap change** — the daemon now debounce-resnaps currently-snapped windows when a global or per-screen snapping gap changes.
- **Two QML reactivity bugs** — `PerScreenOverrideHelper.reload()` and `MonitorScopeChip._refresh()` read the derived `isPerScreen` at scope-change-handler time, before it recomputed, so switching from "All Monitors" to a specific monitor showed the global value and hid the override dot / "Reset this monitor". Both now read the raw scope.
- Removed dead duplicate `ZoneSelector*` keys from the snapping per-screen domain.

## Audit follow-up (commit 2)
Swept the remaining per-screen domains for the same classes:

- **Autotile** missed the virtual→physical fallback (`daemon/autotile.cpp`) — per-monitor algorithm/gap overrides were lost on virtual sub-screens. Fixed.
- **Snap engine** `resolveGapParams()` read global gaps, so empty-zone fill and window rotation ignored per-monitor gaps — now screen-aware with the fallback and per-side support.
- **Per-screen `SnapAssistEnabled`** was unreachable dead plumbing (no UI writes it per-screen; runtime reads global). Removed; snap-assist stays global.

## Refactor (commit 3)
With snap-assist and the zone-selector keys gone, the snapping per-screen map is gaps-only, so the gaps-subdomain split (`hasPerScreenSnappingGapsSettings` etc.) was redundant — removed and pointed the Gaps card at the whole-domain accessors. The generic `*KeySubset` helpers stay (autotile still has a real Gaps/Algorithm split).

## Testing
- Added a regression test for the zone-selector virtual→physical fallback.
- All 252 unit tests pass; build clean.
- Manually verified in the running app: per-monitor gaps apply + reflow on save, All→monitor value display, and the override dot / Reset action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)