### PR TITLE
refactor(layouts): persist per-layout settings in a sidecar, not the layout files

### DIFF
--- a/libs/phosphor-zones/CMakeLists.txt
+++ b/libs/phosphor-zones/CMakeLists.txt
@@ -72,6 +72,7 @@ set(phosphorzones_public_HDRS
     include/PhosphorZones/ZoneDefaults.h
     include/PhosphorZones/ZoneJsonKeys.h
     include/PhosphorZones/Layout.h
+    include/PhosphorZones/LayoutSettingsStore.h
     include/PhosphorZones/ZoneDetector.h
     include/PhosphorZones/ZoneHighlighter.h
     include/PhosphorZones/LayoutUtils.h
@@ -90,6 +91,7 @@ set(phosphorzones_public_HDRS
 set(phosphorzones_SRCS
     src/zone.cpp
     src/layout.cpp
+    src/layoutsettingsstore.cpp
     src/layout/factories.cpp
     src/layout/serialization.cpp
     src/zonedetector.cpp

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -6,6 +6,7 @@
 #include <PhosphorZones/AssignmentEntry.h>
 #include <PhosphorZones/IZoneLayoutRegistry.h>
 #include <PhosphorZones/Layout.h>
+#include <PhosphorZones/LayoutSettingsStore.h>
 
 #include <PhosphorWindowRules/RuleEvaluator.h>
 #include <PhosphorWindowRules/WindowRuleStore.h>
@@ -523,6 +524,7 @@ private:
     Layout* restoreSystemLayout(const QUuid& id, const QString& systemPath);
     QString layoutFilePath(const QUuid& id) const;
     QString quickLayoutsFilePath() const;
+    QString layoutSettingsFilePath() const;
     void readQuickLayouts();
     void writeQuickLayouts();
     Layout* cycleLayoutImpl(const QString& screenId, int direction);
@@ -773,6 +775,10 @@ private:
     Layout* m_activeLayout = nullptr;
     Layout* m_previousLayout = nullptr; ///< Active layout before last setActiveLayout (for resnap)
     QHash<int, QString> m_quickLayoutShortcuts; ///< slot number (1..9) → layout ID
+    /// Per-layout settings sidecar (layout-settings.json), keyed by layout UUID.
+    /// Settings are split out of the structural layout file on save and merged
+    /// back in on load — see layoutregistry_persistence.cpp.
+    LayoutSettingsStore m_layoutSettings;
     int m_currentVirtualDesktop = 1;
     /// Per-screen current virtual desktop (screenId → 1-based) under Plasma 6.7
     /// per-output virtual desktops (#648). Empty unless the daemon pushes

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutSettingsStore.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutSettingsStore.h
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <phosphorzones_export.h>
+
+#include <QHash>
+#include <QJsonObject>
+#include <QString>
+
+namespace PhosphorZones {
+
+/**
+ * @brief Persists per-layout SETTINGS in a sidecar, keyed by layout UUID,
+ *        separately from the structural layout files.
+ *
+ * A layout file should describe the layout — its zones and geometry, identity,
+ * and matching rules. The user-preference SETTINGS that can be tuned per layout
+ * (per-zone appearance, gap/padding overrides, showZoneNumbers, overlay display
+ * mode, auto-assign, shader binding) are NOT part of that structural definition
+ * and no longer live inside the layout `.json`. They live here, in a single
+ * `layout-settings.json` sidecar keyed by layout UUID — the same sibling-store
+ * pattern used by windowrules.json / quicklayouts.json.
+ *
+ * The split happens only at the file boundary. The in-memory Layout/Zone model
+ * still carries every setting (so the editor, D-Bus wire format, and runtime
+ * consumers are unchanged): @ref stripSettings is applied to Layout::toJson on
+ * write, and @ref mergeSettings re-applies the stored values before
+ * Layout::fromJson on read.
+ */
+class PHOSPHORZONES_EXPORT LayoutSettingsStore
+{
+public:
+    /// On-disk schema version for layout-settings.json. Independent of the
+    /// application config schema version.
+    static constexpr int SchemaVersion = 1;
+
+    // ── Pure split/merge helpers (no I/O) ──────────────────────────────────
+    // These operate on the FULL layout JSON as produced by Layout::toJson and
+    // consumed by Layout::fromJson. They are the single definition of "which
+    // keys are settings vs structural".
+
+    /// Pull the settings out of a full layout JSON. Returns a settings object
+    /// (the per-layout setting keys plus a per-zone appearance map keyed by zone
+    /// UUID). Returns an empty object when the layout carries no settings.
+    static QJsonObject extractSettings(const QJsonObject& fullLayout);
+
+    /// Return the structural-only layout JSON: the full layout minus every
+    /// settings key (and minus each zone's appearance block). This is what gets
+    /// written to the layout `.json`.
+    static QJsonObject stripSettings(const QJsonObject& fullLayout);
+
+    /// Overlay a settings object (as produced by @ref extractSettings) back onto
+    /// a structural layout JSON, yielding a full layout JSON for Layout::fromJson.
+    /// Keys already present in @p structural are preserved when @p settings does
+    /// not override them — so a not-yet-split (full-format) layout file still
+    /// round-trips correctly even with an empty store entry.
+    static QJsonObject mergeSettings(QJsonObject structural, const QJsonObject& settings);
+
+    // ── Sidecar persistence ────────────────────────────────────────────────
+
+    /// Replace the in-memory map with the contents of @p path. A missing file
+    /// is treated as an empty store (returns true). Returns false only on a
+    /// parse error.
+    bool loadFromFile(const QString& path);
+
+    /// Atomically write the in-memory map to @p path (stamped with
+    /// SchemaVersion). Layouts with empty settings are omitted.
+    bool saveToFile(const QString& path) const;
+
+    /// Settings for a layout (empty object if none stored).
+    QJsonObject settingsFor(const QString& layoutId) const;
+
+    /// Store (or, when @p settings is empty, clear) the settings for a layout.
+    void setSettingsFor(const QString& layoutId, const QJsonObject& settings);
+
+    /// Drop a layout's settings entry (e.g. when the layout is deleted).
+    void removeLayout(const QString& layoutId);
+
+    bool isEmpty() const
+    {
+        return m_byLayout.isEmpty();
+    }
+
+private:
+    QHash<QString, QJsonObject> m_byLayout;
+};
+
+} // namespace PhosphorZones

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutSettingsStore.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutSettingsStore.h
@@ -18,10 +18,11 @@ namespace PhosphorZones {
  * A layout file should describe the layout — its zones and geometry, identity,
  * and matching rules. The user-preference SETTINGS that can be tuned per layout
  * (per-zone appearance, gap/padding overrides, showZoneNumbers, overlay display
- * mode, auto-assign, shader binding) are NOT part of that structural definition
- * and no longer live inside the layout `.json`. They live here, in a single
- * `layout-settings.json` sidecar keyed by layout UUID — the same sibling-store
- * pattern used by windowrules.json / quicklayouts.json.
+ * mode, auto-assign, full-screen geometry mode, shader binding — the canonical
+ * set is `layoutSettingKeys` in the .cpp) are NOT part of that structural
+ * definition and no longer live inside the layout `.json`. They live here, in a
+ * single `layout-settings.json` sidecar keyed by layout UUID — the same
+ * sibling-store pattern used by windowrules.json / quicklayouts.json.
  *
  * The split happens only at the file boundary. The in-memory Layout/Zone model
  * still carries every setting (so the editor, D-Bus wire format, and runtime

--- a/libs/phosphor-zones/src/layoutregistry.cpp
+++ b/libs/phosphor-zones/src/layoutregistry.cpp
@@ -382,7 +382,9 @@ void LayoutRegistry::removeLayout(PhosphorZones::Layout* layout)
     // deleted to restore the system original, this is also what we want — the
     // restored system layout should not inherit the user's custom settings.
     m_layoutSettings.removeLayout(layoutIdStr);
-    m_layoutSettings.saveToFile(layoutSettingsFilePath());
+    if (!m_layoutSettings.saveToFile(layoutSettingsFilePath())) {
+        qCWarning(lcZonesLib) << "Failed to persist layout settings sidecar after removing" << layoutIdStr;
+    }
 
     // Clear every pointer that could capture the about-to-deleteLater
     // layout. m_previousLayout is obvious. m_activeLayout is the subtle

--- a/libs/phosphor-zones/src/layoutregistry.cpp
+++ b/libs/phosphor-zones/src/layoutregistry.cpp
@@ -378,6 +378,12 @@ void LayoutRegistry::removeLayout(PhosphorZones::Layout* layout)
     // Delete layout file (using stored path)
     QFile::remove(filePath);
 
+    // Drop the layout's settings sidecar entry. For a user override being
+    // deleted to restore the system original, this is also what we want — the
+    // restored system layout should not inherit the user's custom settings.
+    m_layoutSettings.removeLayout(layoutIdStr);
+    m_layoutSettings.saveToFile(layoutSettingsFilePath());
+
     // Clear every pointer that could capture the about-to-deleteLater
     // layout. m_previousLayout is obvious. m_activeLayout is the subtle
     // one: the wasActive branches below call setActiveLayout(newLayout),

--- a/libs/phosphor-zones/src/layoutregistry_persistence.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_persistence.cpp
@@ -5,6 +5,8 @@
 // Part of LayoutRegistry — split from layoutregistry.cpp for SRP.
 
 #include <PhosphorZones/LayoutRegistry.h>
+#include <PhosphorZones/LayoutSettingsStore.h>
+#include <PhosphorZones/ZoneJsonKeys.h>
 
 #include "zoneslogging.h"
 
@@ -22,6 +24,10 @@ namespace PhosphorZones {
 void LayoutRegistry::loadLayouts()
 {
     ensureLayoutDirectory();
+
+    // Load the per-layout settings sidecar once up front so each layout's
+    // settings can be merged back onto its structural JSON as it loads.
+    m_layoutSettings.loadFromFile(layoutSettingsFilePath());
 
     // Load from ALL data locations (system directories first, then user)
     // locateAll() returns paths in priority order: user first, system last
@@ -107,7 +113,16 @@ void LayoutRegistry::loadLayoutsFromDirectory(const QString& directory)
             continue;
         }
 
-        auto layout = PhosphorZones::Layout::fromJson(doc.object(), this);
+        // Merge the layout's settings (from the sidecar, keyed by layout UUID)
+        // back onto the structural JSON before constructing the Layout. A
+        // not-yet-split (full-format) file with no sidecar entry round-trips
+        // unchanged — mergeSettings preserves keys the file already carries.
+        const QJsonObject structural = doc.object();
+        const QString layoutId = structural.value(::PhosphorZones::ZoneJsonKeys::Id).toString();
+        const QJsonObject merged =
+            LayoutSettingsStore::mergeSettings(structural, m_layoutSettings.settingsFor(layoutId));
+
+        auto layout = PhosphorZones::Layout::fromJson(merged, this);
         if (!layout) {
             qCWarning(lcZonesLib) << "Failed to create layout from JSON:" << filePath;
             continue;
@@ -200,8 +215,17 @@ void LayoutRegistry::saveLayout(PhosphorZones::Layout* layout)
         return;
     }
 
-    // toJson() includes systemSourcePath so it persists across daemon restarts
-    QJsonDocument doc(layout->toJson());
+    // Split the full layout JSON: the per-layout SETTINGS go to the sidecar
+    // (keyed by layout UUID), and only the structural definition is written to
+    // the layout file. toJson() includes systemSourcePath so it persists across
+    // daemon restarts.
+    const QJsonObject full = layout->toJson();
+    m_layoutSettings.setSettingsFor(layout->id().toString(), LayoutSettingsStore::extractSettings(full));
+    if (!m_layoutSettings.saveToFile(layoutSettingsFilePath())) {
+        qCWarning(lcZonesLib) << "Failed to persist layout settings sidecar for" << layout->id().toString();
+    }
+
+    QJsonDocument doc(LayoutSettingsStore::stripSettings(full));
     const QByteArray data = doc.toJson(QJsonDocument::Indented);
 
     if (file.write(data) != data.size()) {
@@ -236,6 +260,14 @@ QString LayoutRegistry::quickLayoutsFilePath() const
     // JSON file next to the WindowRuleStore file (so the location is stable
     // and independent of any later setLayoutDirectory() call).
     return QFileInfo(m_ruleStore->filePath()).absolutePath() + QStringLiteral("/quicklayouts.json");
+}
+
+QString LayoutRegistry::layoutSettingsFilePath() const
+{
+    // Per-layout settings persist to a sibling JSON file next to the
+    // WindowRuleStore file — same stable, layout-dir-independent location as
+    // the quick-layout sidecar.
+    return QFileInfo(m_ruleStore->filePath()).absolutePath() + QStringLiteral("/layout-settings.json");
 }
 
 void LayoutRegistry::readQuickLayouts()

--- a/libs/phosphor-zones/src/layoutsettingsstore.cpp
+++ b/libs/phosphor-zones/src/layoutsettingsstore.cpp
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Per-layout settings sidecar (layout-settings.json) — split/merge + I/O.
+
+#include <PhosphorZones/LayoutSettingsStore.h>
+#include <PhosphorZones/ZoneJsonKeys.h>
+
+#include "zoneslogging.h"
+
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QSaveFile>
+
+#include <array>
+
+namespace PhosphorZones {
+
+namespace {
+
+// Root key holding the schema-version stamp in layout-settings.json.
+constexpr QLatin1String kVersionKey{"_version"};
+
+// Key under a layout's settings object that holds the per-zone appearance map
+// (zone UUID → appearance object). Distinct from the structural "zones" array
+// so the two never collide in the merged document.
+constexpr QLatin1String kZoneAppearanceMapKey{"zoneAppearance"};
+
+// The per-LAYOUT setting keys that move out of the layout file. The per-ZONE
+// appearance block is handled separately (see extract/strip/merge below).
+const std::array<QLatin1String, 13> layoutSettingKeys{{
+    ZoneJsonKeys::ZonePadding,
+    ZoneJsonKeys::OuterGap,
+    ZoneJsonKeys::UsePerSideOuterGap,
+    ZoneJsonKeys::OuterGapTop,
+    ZoneJsonKeys::OuterGapBottom,
+    ZoneJsonKeys::OuterGapLeft,
+    ZoneJsonKeys::OuterGapRight,
+    ZoneJsonKeys::ShowZoneNumbers,
+    ZoneJsonKeys::OverlayDisplayMode,
+    ZoneJsonKeys::AutoAssign,
+    ZoneJsonKeys::UseFullScreenGeometry,
+    ZoneJsonKeys::ShaderId,
+    ZoneJsonKeys::ShaderParams,
+}};
+
+} // namespace
+
+QJsonObject LayoutSettingsStore::extractSettings(const QJsonObject& fullLayout)
+{
+    QJsonObject settings;
+    for (const QLatin1String key : layoutSettingKeys) {
+        if (fullLayout.contains(key)) {
+            settings.insert(key, fullLayout.value(key));
+        }
+    }
+
+    QJsonObject zoneAppearance;
+    const QJsonArray zones = fullLayout.value(ZoneJsonKeys::Zones).toArray();
+    for (const QJsonValue& zoneVal : zones) {
+        const QJsonObject zone = zoneVal.toObject();
+        const QString zoneId = zone.value(ZoneJsonKeys::Id).toString();
+        if (!zoneId.isEmpty() && zone.contains(ZoneJsonKeys::Appearance)) {
+            zoneAppearance.insert(zoneId, zone.value(ZoneJsonKeys::Appearance));
+        }
+    }
+    if (!zoneAppearance.isEmpty()) {
+        settings.insert(kZoneAppearanceMapKey, zoneAppearance);
+    }
+    return settings;
+}
+
+QJsonObject LayoutSettingsStore::stripSettings(const QJsonObject& fullLayout)
+{
+    QJsonObject structural = fullLayout;
+    for (const QLatin1String key : layoutSettingKeys) {
+        structural.remove(key);
+    }
+
+    QJsonArray zones = structural.value(ZoneJsonKeys::Zones).toArray();
+    for (int i = 0; i < zones.size(); ++i) {
+        QJsonObject zone = zones.at(i).toObject();
+        zone.remove(ZoneJsonKeys::Appearance);
+        zones.replace(i, zone);
+    }
+    structural.insert(QString(ZoneJsonKeys::Zones), zones);
+    return structural;
+}
+
+QJsonObject LayoutSettingsStore::mergeSettings(QJsonObject structural, const QJsonObject& settings)
+{
+    QJsonObject zoneAppearance;
+    for (auto it = settings.constBegin(); it != settings.constEnd(); ++it) {
+        if (it.key() == kZoneAppearanceMapKey) {
+            zoneAppearance = it.value().toObject();
+            continue;
+        }
+        structural.insert(it.key(), it.value());
+    }
+
+    if (!zoneAppearance.isEmpty()) {
+        QJsonArray zones = structural.value(ZoneJsonKeys::Zones).toArray();
+        for (int i = 0; i < zones.size(); ++i) {
+            QJsonObject zone = zones.at(i).toObject();
+            const QString zoneId = zone.value(ZoneJsonKeys::Id).toString();
+            if (zoneAppearance.contains(zoneId)) {
+                zone.insert(QString(ZoneJsonKeys::Appearance), zoneAppearance.value(zoneId));
+                zones.replace(i, zone);
+            }
+        }
+        structural.insert(QString(ZoneJsonKeys::Zones), zones);
+    }
+    return structural;
+}
+
+bool LayoutSettingsStore::loadFromFile(const QString& path)
+{
+    m_byLayout.clear();
+
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly)) {
+        return true; // a missing sidecar is an empty store, not an error
+    }
+
+    QJsonParseError err;
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+        qCWarning(lcZonesLib) << "LayoutSettingsStore: failed to parse" << path << err.errorString();
+        return false;
+    }
+
+    const QJsonObject root = doc.object();
+    for (auto it = root.constBegin(); it != root.constEnd(); ++it) {
+        if (it.key() == kVersionKey || !it.value().isObject()) {
+            continue;
+        }
+        m_byLayout.insert(it.key(), it.value().toObject());
+    }
+    return true;
+}
+
+bool LayoutSettingsStore::saveToFile(const QString& path) const
+{
+    QJsonObject root;
+    root.insert(QString(kVersionKey), SchemaVersion);
+    for (auto it = m_byLayout.constBegin(); it != m_byLayout.constEnd(); ++it) {
+        if (!it.value().isEmpty()) {
+            root.insert(it.key(), it.value());
+        }
+    }
+
+    // QSaveFile gives atomic temp-write + rename — a crash mid-write never
+    // leaves a truncated sidecar behind.
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly)) {
+        qCWarning(lcZonesLib) << "LayoutSettingsStore: failed to open for writing" << path << file.errorString();
+        return false;
+    }
+    const QByteArray payload = QJsonDocument(root).toJson(QJsonDocument::Indented);
+    if (file.write(payload) != payload.size()) {
+        qCWarning(lcZonesLib) << "LayoutSettingsStore: failed to write" << path << file.errorString();
+        file.cancelWriting();
+        return false;
+    }
+    if (!file.commit()) {
+        qCWarning(lcZonesLib) << "LayoutSettingsStore: failed to commit" << path << file.errorString();
+        return false;
+    }
+    return true;
+}
+
+QJsonObject LayoutSettingsStore::settingsFor(const QString& layoutId) const
+{
+    return m_byLayout.value(layoutId);
+}
+
+void LayoutSettingsStore::setSettingsFor(const QString& layoutId, const QJsonObject& settings)
+{
+    if (settings.isEmpty()) {
+        m_byLayout.remove(layoutId);
+    } else {
+        m_byLayout.insert(layoutId, settings);
+    }
+}
+
+void LayoutSettingsStore::removeLayout(const QString& layoutId)
+{
+    m_byLayout.remove(layoutId);
+}
+
+} // namespace PhosphorZones

--- a/libs/phosphor-zones/src/layoutsettingsstore.cpp
+++ b/libs/phosphor-zones/src/layoutsettingsstore.cpp
@@ -78,13 +78,24 @@ QJsonObject LayoutSettingsStore::stripSettings(const QJsonObject& fullLayout)
         structural.remove(key);
     }
 
-    QJsonArray zones = structural.value(ZoneJsonKeys::Zones).toArray();
-    for (int i = 0; i < zones.size(); ++i) {
-        QJsonObject zone = zones.at(i).toObject();
-        zone.remove(ZoneJsonKeys::Appearance);
-        zones.replace(i, zone);
+    // Only touch the zones array if it actually exists, so stripSettings is the
+    // identity on a settings-free object rather than synthesising an empty
+    // "zones": [].
+    if (structural.contains(ZoneJsonKeys::Zones)) {
+        QJsonArray zones = structural.value(ZoneJsonKeys::Zones).toArray();
+        for (int i = 0; i < zones.size(); ++i) {
+            QJsonObject zone = zones.at(i).toObject();
+            // Mirror extractSettings: only an id-bearing zone's appearance is
+            // moved to the sidecar (the map is keyed by zone id), so only those
+            // are stripped here. An id-less zone keeps its inline appearance —
+            // it has no sidecar key to be restored from.
+            if (!zone.value(ZoneJsonKeys::Id).toString().isEmpty()) {
+                zone.remove(ZoneJsonKeys::Appearance);
+                zones.replace(i, zone);
+            }
+        }
+        structural.insert(QString(ZoneJsonKeys::Zones), zones);
     }
-    structural.insert(QString(ZoneJsonKeys::Zones), zones);
     return structural;
 }
 

--- a/src/config/configdefaults.cpp
+++ b/src/config/configdefaults.cpp
@@ -44,6 +44,11 @@ QString ConfigDefaults::quickLayoutsFilePath()
     return configDir() + QStringLiteral("/plasmazones/quicklayouts.json");
 }
 
+QString ConfigDefaults::layoutSettingsFilePath()
+{
+    return configDir() + QStringLiteral("/plasmazones/layout-settings.json");
+}
+
 QString ConfigDefaults::legacyConfigFilePath()
 {
     return configDir() + QStringLiteral("/plasmazonesrc");

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -678,6 +678,12 @@ public:
     // rule store. LayoutRegistry reads/writes this file directly.
     PLASMAZONES_EXPORT static QString quickLayoutsFilePath();
 
+    // Returns the absolute path to layout-settings.json — the per-layout
+    // settings sidecar (keyed by layout UUID). Per-layout settings are NOT part
+    // of the structural layout definition, so they live in a sibling sidecar
+    // next to windowrules.json rather than inside each layout file.
+    PLASMAZONES_EXPORT static QString layoutSettingsFilePath();
+
     // Returns the absolute path to the legacy plasmazonesrc file (INI format).
     // Used only by the one-time migration module.
     PLASMAZONES_EXPORT static QString legacyConfigFilePath();

--- a/src/config/configmigration.cpp
+++ b/src/config/configmigration.cpp
@@ -2489,13 +2489,21 @@ QJsonObject stripLayoutSettings(const QJsonObject& full)
     for (const QLatin1String key : kLayoutSettingKeys) {
         structural.remove(key);
     }
-    QJsonArray zones = structural.value(kLayoutZonesKey).toArray();
-    for (int i = 0; i < zones.size(); ++i) {
-        QJsonObject zone = zones.at(i).toObject();
-        zone.remove(kLayoutAppearanceKey);
-        zones.replace(i, zone);
+    // Kept in lockstep with PhosphorZones::LayoutSettingsStore::stripSettings:
+    // only touch zones when present, and only strip the appearance of an
+    // id-bearing zone (its appearance is what extractLayoutSettings moved to the
+    // sidecar map, keyed by zone id). An id-less zone keeps its inline appearance.
+    if (structural.contains(kLayoutZonesKey)) {
+        QJsonArray zones = structural.value(kLayoutZonesKey).toArray();
+        for (int i = 0; i < zones.size(); ++i) {
+            QJsonObject zone = zones.at(i).toObject();
+            if (!zone.value(kLayoutIdKey).toString().isEmpty()) {
+                zone.remove(kLayoutAppearanceKey);
+                zones.replace(i, zone);
+            }
+        }
+        structural.insert(QString(kLayoutZonesKey), zones);
     }
-    structural.insert(QString(kLayoutZonesKey), zones);
     return structural;
 }
 

--- a/src/config/configmigration.cpp
+++ b/src/config/configmigration.cpp
@@ -2521,9 +2521,21 @@ bool relocateLayoutSettingsImpl(const QString& layoutsDir, const QString& sideca
         }
     }
 
+    // Pass 1: scan every layout file, accumulate its settings into the in-memory
+    // sidecar, and stage the slimmed structural body — but DON'T touch any layout
+    // file on disk yet. The sidecar is the authoritative copy; it must be durably
+    // written BEFORE any source file is slimmed, so a crash (or a sidecar write
+    // failure) can never leave settings stripped from the layout file but absent
+    // from the sidecar. Mirrors finalizeV4Conversion's "write windowrules.json
+    // before retiring assignments.json" ordering.
+    struct PendingStrip
+    {
+        QString path;
+        QJsonObject structural;
+    };
     const QStringList files = dir.entryList({QStringLiteral("*.json")}, QDir::Files, QDir::Name);
+    QList<PendingStrip> pending;
     bool sidecarDirty = false;
-    bool allOk = true;
     for (const QString& fileName : files) {
         const QString path = dir.filePath(fileName);
         QFile f(path);
@@ -2547,19 +2559,32 @@ bool relocateLayoutSettingsImpl(const QString& layoutsDir, const QString& sideca
 
         sidecar.insert(layoutId, settings);
         sidecarDirty = true;
-
-        // Rewrite the layout file stripped of its settings.
-        if (!PhosphorConfig::JsonBackend::writeJsonAtomically(path, stripLayoutSettings(full))) {
-            qWarning("ConfigMigration: layout-settings relocation failed to rewrite %s", qPrintable(path));
-            allOk = false;
-        }
+        pending.append({path, stripLayoutSettings(full)});
     }
 
-    if (sidecarDirty) {
-        sidecar.insert(QString(kSettingsVersionKey), kLayoutSettingsSchemaVersion);
-        QDir().mkpath(QFileInfo(sidecarPath).absolutePath());
-        if (!PhosphorConfig::JsonBackend::writeJsonAtomically(sidecarPath, sidecar)) {
-            qWarning("ConfigMigration: layout-settings relocation failed to write %s", qPrintable(sidecarPath));
+    if (!sidecarDirty) {
+        return true; // every layout already slim — no writes, fully idempotent
+    }
+
+    // Commit the authoritative sidecar FIRST. If it can't be persisted, leave the
+    // layout files untouched (their embedded settings are still read by the
+    // runtime store) and report failure — the next run retries.
+    sidecar.insert(QString(kSettingsVersionKey), kLayoutSettingsSchemaVersion);
+    QDir().mkpath(QFileInfo(sidecarPath).absolutePath());
+    if (!PhosphorConfig::JsonBackend::writeJsonAtomically(sidecarPath, sidecar)) {
+        qWarning("ConfigMigration: layout-settings relocation failed to write %s — leaving layout files intact",
+                 qPrintable(sidecarPath));
+        return false;
+    }
+
+    // Pass 2: slim the source files now that their settings are durably stored.
+    // A failure here is recoverable — the still-fat file keeps its embedded
+    // settings (harmlessly re-applied by mergeSettings) and is re-slimmed on the
+    // next run.
+    bool allOk = true;
+    for (const PendingStrip& p : pending) {
+        if (!PhosphorConfig::JsonBackend::writeJsonAtomically(p.path, p.structural)) {
+            qWarning("ConfigMigration: layout-settings relocation failed to rewrite %s", qPrintable(p.path));
             allOk = false;
         }
     }
@@ -2585,6 +2610,15 @@ bool ConfigMigration::finalizeV4Conversion(const QString& jsonPath)
     // — a relocation failure leaves the settings embedded (still read by the
     // runtime store) and must not abort the v4 conversion, so its result does
     // not gate the return value.
+    //
+    // Deliberately runs BEFORE — and independent of — the config-version stall
+    // gate further down (the `configVersion < ConfigSchemaVersion` guard that
+    // refuses to commit windowrules.json on a stalled chain). The layout file
+    // format is NOT tied to config.json's `_version`: layouts live in the data
+    // dir, the version stamp lives in config.json. Relocating them is correct
+    // and safe regardless of whether the config chain advanced, and the step is
+    // crash-safe and idempotent, so running it on a stalled-chain retry is a
+    // no-op-or-progress, never a regression.
     {
         const QString layoutsDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
             + QLatin1Char('/') + ConfigDefaults::layoutsSubdir();

--- a/src/config/configmigration.cpp
+++ b/src/config/configmigration.cpp
@@ -2323,6 +2323,37 @@ constexpr QLatin1String kLayoutAppRulesKey{"appRules"};
 constexpr QLatin1String kLayoutAppRulePattern{"pattern"};
 constexpr QLatin1String kLayoutAppRuleZoneNumber{"zoneNumber"};
 
+// Frozen on-disk keys for the v4 per-layout settings relocation. Local literals
+// (NOT the live `ZoneJsonKeys::` / LayoutSettingsStore accessors) so a future
+// rename of those live keys can never retarget this migration away from what v4
+// layout files had on disk. The layout-settings.json format produced here MUST
+// match what PhosphorZones::LayoutSettingsStore reads — a round-trip test locks
+// the two together.
+constexpr QLatin1String kLayoutIdKey{"id"};
+constexpr QLatin1String kLayoutZonesKey{"zones"};
+constexpr QLatin1String kLayoutAppearanceKey{"appearance"};
+constexpr QLatin1String kSettingsVersionKey{"_version"};
+constexpr QLatin1String kSettingsZoneAppearanceMapKey{"zoneAppearance"};
+constexpr int kLayoutSettingsSchemaVersion = 1; // mirrors LayoutSettingsStore::SchemaVersion
+
+// The per-LAYOUT setting keys that move out of the layout file into the sidecar.
+// The per-ZONE appearance block is handled separately. Order is irrelevant.
+constexpr std::array<QLatin1String, 13> kLayoutSettingKeys{{
+    QLatin1String{"zonePadding"},
+    QLatin1String{"outerGap"},
+    QLatin1String{"usePerSideOuterGap"},
+    QLatin1String{"outerGapTop"},
+    QLatin1String{"outerGapBottom"},
+    QLatin1String{"outerGapLeft"},
+    QLatin1String{"outerGapRight"},
+    QLatin1String{"showZoneNumbers"},
+    QLatin1String{"overlayDisplayMode"},
+    QLatin1String{"autoAssign"},
+    QLatin1String{"useFullScreenGeometry"},
+    QLatin1String{"shaderId"},
+    QLatin1String{"shaderParams"},
+}};
+
 /// Convert each layout file's legacy per-layout `appRules` into first-class
 /// SnapToZone WindowRules. v3 stored app→zone assignments on the Layout
 /// (`Layout::appRules`: a `{pattern, zoneNumber, targetScreen}` triple, single
@@ -2424,12 +2455,145 @@ void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& ru
     }
 }
 
+/// Extract the settings object (per-layout setting keys + per-zone appearance
+/// map) from a full layout JSON, in the LayoutSettingsStore on-disk shape.
+/// Returns an empty object when the layout carries no settings.
+QJsonObject extractLayoutSettings(const QJsonObject& full)
+{
+    QJsonObject settings;
+    for (const QLatin1String key : kLayoutSettingKeys) {
+        if (full.contains(key)) {
+            settings.insert(key, full.value(key));
+        }
+    }
+    QJsonObject zoneAppearance;
+    const QJsonArray zones = full.value(kLayoutZonesKey).toArray();
+    for (const QJsonValue& zoneVal : zones) {
+        const QJsonObject zone = zoneVal.toObject();
+        const QString zoneId = zone.value(kLayoutIdKey).toString();
+        if (!zoneId.isEmpty() && zone.contains(kLayoutAppearanceKey)) {
+            zoneAppearance.insert(zoneId, zone.value(kLayoutAppearanceKey));
+        }
+    }
+    if (!zoneAppearance.isEmpty()) {
+        settings.insert(QString(kSettingsZoneAppearanceMapKey), zoneAppearance);
+    }
+    return settings;
+}
+
+/// Return the structural-only layout JSON: the full layout minus every settings
+/// key and minus each zone's appearance block.
+QJsonObject stripLayoutSettings(const QJsonObject& full)
+{
+    QJsonObject structural = full;
+    for (const QLatin1String key : kLayoutSettingKeys) {
+        structural.remove(key);
+    }
+    QJsonArray zones = structural.value(kLayoutZonesKey).toArray();
+    for (int i = 0; i < zones.size(); ++i) {
+        QJsonObject zone = zones.at(i).toObject();
+        zone.remove(kLayoutAppearanceKey);
+        zones.replace(i, zone);
+    }
+    structural.insert(QString(kLayoutZonesKey), zones);
+    return structural;
+}
+
+/// Worker for ConfigMigration::relocateLayoutSettings — kept in this anonymous
+/// namespace so it can reach the frozen `kLayout*` literals above.
+bool relocateLayoutSettingsImpl(const QString& layoutsDir, const QString& sidecarPath)
+{
+    QDir dir(layoutsDir);
+    if (!dir.exists()) {
+        return true; // nothing to relocate — not an error
+    }
+
+    // Merge into any existing sidecar rather than clobbering it, so a re-run
+    // (or a sidecar already partly written by the runtime store) is preserved.
+    QJsonObject sidecar;
+    {
+        QFile sf(sidecarPath);
+        if (sf.open(QIODevice::ReadOnly)) {
+            const QJsonDocument doc = QJsonDocument::fromJson(sf.readAll());
+            if (doc.isObject()) {
+                sidecar = doc.object();
+            }
+        }
+    }
+
+    const QStringList files = dir.entryList({QStringLiteral("*.json")}, QDir::Files, QDir::Name);
+    bool sidecarDirty = false;
+    bool allOk = true;
+    for (const QString& fileName : files) {
+        const QString path = dir.filePath(fileName);
+        QFile f(path);
+        if (!f.open(QIODevice::ReadOnly)) {
+            qWarning("ConfigMigration: layout-settings relocation could not read %s — skipping", qPrintable(path));
+            continue;
+        }
+        QJsonParseError err;
+        const QJsonDocument doc = QJsonDocument::fromJson(f.readAll(), &err);
+        f.close();
+        if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+            qWarning("ConfigMigration: layout-settings relocation skipping unparseable %s", qPrintable(path));
+            continue;
+        }
+        const QJsonObject full = doc.object();
+        const QString layoutId = full.value(kLayoutIdKey).toString();
+        const QJsonObject settings = extractLayoutSettings(full);
+        if (layoutId.isEmpty() || settings.isEmpty()) {
+            continue; // already slimmed, or no settings / unidentifiable — leave as-is
+        }
+
+        sidecar.insert(layoutId, settings);
+        sidecarDirty = true;
+
+        // Rewrite the layout file stripped of its settings.
+        if (!PhosphorConfig::JsonBackend::writeJsonAtomically(path, stripLayoutSettings(full))) {
+            qWarning("ConfigMigration: layout-settings relocation failed to rewrite %s", qPrintable(path));
+            allOk = false;
+        }
+    }
+
+    if (sidecarDirty) {
+        sidecar.insert(QString(kSettingsVersionKey), kLayoutSettingsSchemaVersion);
+        QDir().mkpath(QFileInfo(sidecarPath).absolutePath());
+        if (!PhosphorConfig::JsonBackend::writeJsonAtomically(sidecarPath, sidecar)) {
+            qWarning("ConfigMigration: layout-settings relocation failed to write %s", qPrintable(sidecarPath));
+            allOk = false;
+        }
+    }
+    return allOk;
+}
+
 } // namespace
+
+bool ConfigMigration::relocateLayoutSettings(const QString& layoutsDir, const QString& sidecarPath)
+{
+    return relocateLayoutSettingsImpl(layoutsDir, sidecarPath);
+}
 
 bool ConfigMigration::finalizeV4Conversion(const QString& jsonPath)
 {
     const QString windowRulesPath = ConfigDefaults::windowRulesFilePath();
     const QString assignmentsPath = legacyAssignmentsFilePath();
+
+    // ── Relocate per-layout settings out of the layout files (v4) ──────────
+    // Independent of the windowrules/assignments machinery below: split each
+    // layout file's embedded settings into the layout-settings.json sidecar and
+    // slim the file. Idempotent (already-slim files are skipped) and best-effort
+    // — a relocation failure leaves the settings embedded (still read by the
+    // runtime store) and must not abort the v4 conversion, so its result does
+    // not gate the return value.
+    {
+        const QString layoutsDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+            + QLatin1Char('/') + ConfigDefaults::layoutsSubdir();
+        if (!relocateLayoutSettings(layoutsDir, ConfigDefaults::layoutSettingsFilePath())) {
+            qWarning(
+                "ConfigMigration: per-layout settings relocation reported a write failure — "
+                "affected layouts keep their embedded settings until next save");
+        }
+    }
 
     // ── Conversion-done vs cleanup-done — two SEPARATE concerns ─────────────
     // The conversion is multi-step: write windowrules.json (the irreversible

--- a/src/config/configmigration.h
+++ b/src/config/configmigration.h
@@ -54,6 +54,17 @@ namespace PlasmaZones {
 ///     freeing the Snapping.Appearance.* namespace for the new per-window
 ///     snapped-window decoration settings (snapping*). See moveGroupAtPath
 ///     in configmigration.cpp.
+///     v4 also relocates per-layout SETTINGS out of the layout files. The
+///     settings that used to be embedded in each layout JSON (per-zone
+///     appearance, gap/padding overrides, showZoneNumbers, overlay display mode,
+///     auto-assign, shader binding) move into a single layout-settings.json
+///     sidecar keyed by layout UUID — the same sibling-store pattern as
+///     windowrules.json / quicklayouts.json. Layout files keep only their
+///     structural definition (zones, geometry, identity, matching rules). The
+///     relocation runs from finalizeV4Conversion (see relocateLayoutSettings),
+///     and the runtime LayoutSettingsStore (in phosphor-zones) merges the
+///     sidecar back onto each layout on load, so the in-memory model is
+///     unchanged.
 inline constexpr int ConfigSchemaVersion = 4;
 
 class PLASMAZONES_EXPORT ConfigMigration
@@ -181,6 +192,16 @@ public:
     ///                 are derived as siblings via ConfigDefaults).
     /// @return true on success or a clean no-op; false on an I/O failure.
     static bool finalizeV4Conversion(const QString& jsonPath);
+
+    /// Part of the v4 conversion: read every `*.json` layout in @p layoutsDir,
+    /// split its embedded per-layout settings into the @p sidecarPath store
+    /// (keyed by layout UUID, in the LayoutSettingsStore format), and rewrite the
+    /// layout file stripped of those settings. Merges into an existing sidecar
+    /// rather than clobbering it, and skips already-slimmed files, so it is
+    /// idempotent and crash-safe — finalizeV4Conversion calls it on every run.
+    /// A missing layouts dir is a no-op success. Returns false only on a write
+    /// failure. Public for direct testing.
+    static bool relocateLayoutSettings(const QString& layoutsDir, const QString& sidecarPath);
 
 private:
     ConfigMigration() = default;

--- a/tests/unit/config/test_configmigration.cpp
+++ b/tests/unit/config/test_configmigration.cpp
@@ -17,6 +17,8 @@
 #include "../../../src/config/settingsschema.h"
 #include "../helpers/IsolatedConfigGuard.h"
 
+#include <PhosphorZones/LayoutSettingsStore.h>
+
 #include <PhosphorConfig/Schema.h>
 
 #include <QSet>
@@ -45,6 +47,14 @@ private:
             return {};
         }
         return QJsonDocument::fromJson(f.readAll()).object();
+    }
+
+    void writeJsonRaw(const QString& path, const QJsonObject& obj)
+    {
+        QDir().mkpath(QFileInfo(path).absolutePath());
+        QFile f(path);
+        QVERIFY(f.open(QIODevice::WriteOnly));
+        f.write(QJsonDocument(obj).toJson());
     }
 
 private Q_SLOTS:
@@ -1554,32 +1564,48 @@ private Q_SLOTS:
             + ConfigDefaults::layoutsSubdir();
     }
 
-    void writeLayoutFileWithSettings(const QString& fileName, const QString& layoutId)
+    QJsonObject zoneWithAppearance(const QString& zoneId, int zoneNumber) const
     {
-        QDir().mkpath(layoutsDirPath());
         const QJsonObject relGeo{{QStringLiteral("x"), 0.0},
                                  {QStringLiteral("y"), 0.0},
                                  {QStringLiteral("width"), 1.0},
                                  {QStringLiteral("height"), 1.0}};
         const QJsonObject appearance{{QStringLiteral("useCustomColors"), true},
                                      {QStringLiteral("highlightColor"), QStringLiteral("#ff112233")}};
-        const QJsonObject zone{{QStringLiteral("id"), QStringLiteral("{11111111-0000-0000-0000-000000000001}")},
-                               {QStringLiteral("name"), QStringLiteral("Z1")},
-                               {QStringLiteral("zoneNumber"), 1},
-                               {QStringLiteral("relativeGeometry"), relGeo},
-                               {QStringLiteral("appearance"), appearance}};
-        const QJsonObject layout{
+        return QJsonObject{{QStringLiteral("id"), zoneId},
+                           {QStringLiteral("name"), QStringLiteral("Z%1").arg(zoneNumber)},
+                           {QStringLiteral("zoneNumber"), zoneNumber},
+                           {QStringLiteral("relativeGeometry"), relGeo},
+                           {QStringLiteral("appearance"), appearance}};
+    }
+
+    QJsonObject fullLayoutWithSettings(const QString& layoutId) const
+    {
+        return QJsonObject{
             {QStringLiteral("id"), layoutId},
             {QStringLiteral("name"), QStringLiteral("Settings Layout")},
             {QStringLiteral("showZoneNumbers"), false},
             {QStringLiteral("zonePadding"), 8},
             {QStringLiteral("autoAssign"), true},
             {QStringLiteral("useFullScreenGeometry"), true},
-            {QStringLiteral("zones"), QJsonArray{zone}},
+            {QStringLiteral("shaderId"), QStringLiteral("dissolve")},
+            {QStringLiteral("shaderParams"), QJsonObject{{QStringLiteral("intensity"), 0.5}}},
+            {QStringLiteral("zones"),
+             QJsonArray{zoneWithAppearance(QStringLiteral("{11111111-0000-0000-0000-000000000001}"), 1)}},
         };
+    }
+
+    void writeLayoutFile(const QString& fileName, const QJsonObject& layout)
+    {
+        QDir().mkpath(layoutsDirPath());
         QFile f(layoutsDirPath() + QLatin1Char('/') + fileName);
         QVERIFY(f.open(QIODevice::WriteOnly));
         f.write(QJsonDocument(layout).toJson());
+    }
+
+    void writeLayoutFileWithSettings(const QString& fileName, const QString& layoutId)
+    {
+        writeLayoutFile(fileName, fullLayoutWithSettings(layoutId));
     }
 
     QByteArray readBytes(const QString& path)
@@ -1639,6 +1665,81 @@ private Q_SLOTS:
         IsolatedConfigGuard guard;
         QVERIFY(ConfigMigration::relocateLayoutSettings(layoutsDirPath(), ConfigDefaults::layoutSettingsFilePath()));
         QVERIFY(!QFile::exists(ConfigDefaults::layoutSettingsFilePath()));
+    }
+
+    // Format lock: the sidecar the migration writes MUST be consumable by
+    // PhosphorZones::LayoutSettingsStore (the two split implementations are
+    // duplicated by the migration-freeze policy). Load the migration's output
+    // through the real store and reconstruct the original layout — proves the
+    // formats agree end to end, not just by hand-asserted key shape.
+    void testLayoutSettingsRelocation_outputRoundTripsThroughStore()
+    {
+        IsolatedConfigGuard guard;
+        const QString layoutId = QStringLiteral("{abcd0000-0000-0000-0000-000000000000}");
+        const QJsonObject original = fullLayoutWithSettings(layoutId);
+        writeLayoutFile(QStringLiteral("layout.json"), original);
+
+        QVERIFY(ConfigMigration::relocateLayoutSettings(layoutsDirPath(), ConfigDefaults::layoutSettingsFilePath()));
+
+        PhosphorZones::LayoutSettingsStore store;
+        QVERIFY(store.loadFromFile(ConfigDefaults::layoutSettingsFilePath()));
+        const QJsonObject slim =
+            QJsonDocument::fromJson(readBytes(layoutsDirPath() + QStringLiteral("/layout.json"))).object();
+
+        const QJsonObject reconstructed =
+            PhosphorZones::LayoutSettingsStore::mergeSettings(slim, store.settingsFor(layoutId));
+        QCOMPARE(reconstructed, original);
+    }
+
+    void testLayoutSettingsRelocation_mergesIntoExistingSidecar()
+    {
+        IsolatedConfigGuard guard;
+        // A sidecar already holding a different layout's entry (e.g. written by
+        // the runtime store, or a prior partial run) must be preserved.
+        const QString existingId = QStringLiteral("{eeee0000-0000-0000-0000-000000000000}");
+        QDir().mkpath(QFileInfo(ConfigDefaults::layoutSettingsFilePath()).absolutePath());
+        writeJsonRaw(ConfigDefaults::layoutSettingsFilePath(),
+                     QJsonObject{{QStringLiteral("_version"), 1},
+                                 {existingId, QJsonObject{{QStringLiteral("zonePadding"), 99}}}});
+
+        const QString newId = QStringLiteral("{abcd0000-0000-0000-0000-000000000000}");
+        writeLayoutFileWithSettings(QStringLiteral("layout.json"), newId);
+
+        QVERIFY(ConfigMigration::relocateLayoutSettings(layoutsDirPath(), ConfigDefaults::layoutSettingsFilePath()));
+
+        const QJsonObject sidecar = readJsonConfig(ConfigDefaults::layoutSettingsFilePath());
+        QCOMPARE(sidecar.value(existingId).toObject().value(QStringLiteral("zonePadding")).toInt(), 99);
+        QCOMPARE(sidecar.value(newId).toObject().value(QStringLiteral("zonePadding")).toInt(), 8);
+    }
+
+    void testLayoutSettingsRelocation_multipleLayoutsSelectiveZoneAppearance()
+    {
+        IsolatedConfigGuard guard;
+        const QString idA = QStringLiteral("{aaaa0000-0000-0000-0000-000000000000}");
+        const QString idB = QStringLiteral("{bbbb0000-0000-0000-0000-000000000000}");
+        writeLayoutFileWithSettings(QStringLiteral("a.json"), idA);
+
+        // Layout B: two zones, only the first has a custom appearance.
+        const QJsonObject zone1 = zoneWithAppearance(QStringLiteral("{22222222-0000-0000-0000-000000000001}"), 1);
+        QJsonObject zone2 = zoneWithAppearance(QStringLiteral("{22222222-0000-0000-0000-000000000002}"), 2);
+        zone2.remove(QStringLiteral("appearance"));
+        writeLayoutFile(QStringLiteral("b.json"),
+                        QJsonObject{{QStringLiteral("id"), idB},
+                                    {QStringLiteral("name"), QStringLiteral("B")},
+                                    {QStringLiteral("zonePadding"), 3},
+                                    {QStringLiteral("zones"), QJsonArray{zone1, zone2}}});
+
+        QVERIFY(ConfigMigration::relocateLayoutSettings(layoutsDirPath(), ConfigDefaults::layoutSettingsFilePath()));
+
+        const QJsonObject sidecar = readJsonConfig(ConfigDefaults::layoutSettingsFilePath());
+        // Both layouts relocated; each keyed independently.
+        QCOMPARE(sidecar.value(idA).toObject().value(QStringLiteral("zonePadding")).toInt(), 8);
+        QCOMPARE(sidecar.value(idB).toObject().value(QStringLiteral("zonePadding")).toInt(), 3);
+        // Only the zone that HAD an appearance is in B's zoneAppearance map.
+        const QJsonObject bZoneAppearance =
+            sidecar.value(idB).toObject().value(QStringLiteral("zoneAppearance")).toObject();
+        QVERIFY(bZoneAppearance.contains(QStringLiteral("{22222222-0000-0000-0000-000000000001}")));
+        QVERIFY(!bZoneAppearance.contains(QStringLiteral("{22222222-0000-0000-0000-000000000002}")));
     }
 };
 

--- a/tests/unit/config/test_configmigration.cpp
+++ b/tests/unit/config/test_configmigration.cpp
@@ -7,6 +7,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QStandardPaths>
+#include <QStringList>
 #include <QTextStream>
 
 #include "../../../src/config/configmigration.h"
@@ -1540,6 +1542,103 @@ private Q_SLOTS:
             }
         }
         QCOMPARE(disableMonitorRules, 4);
+    }
+
+    // =========================================================================
+    // v4: per-layout settings relocation into the layout-settings.json sidecar
+    // =========================================================================
+
+    QString layoutsDirPath() const
+    {
+        return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + QLatin1Char('/')
+            + ConfigDefaults::layoutsSubdir();
+    }
+
+    void writeLayoutFileWithSettings(const QString& fileName, const QString& layoutId)
+    {
+        QDir().mkpath(layoutsDirPath());
+        const QJsonObject relGeo{{QStringLiteral("x"), 0.0},
+                                 {QStringLiteral("y"), 0.0},
+                                 {QStringLiteral("width"), 1.0},
+                                 {QStringLiteral("height"), 1.0}};
+        const QJsonObject appearance{{QStringLiteral("useCustomColors"), true},
+                                     {QStringLiteral("highlightColor"), QStringLiteral("#ff112233")}};
+        const QJsonObject zone{{QStringLiteral("id"), QStringLiteral("{11111111-0000-0000-0000-000000000001}")},
+                               {QStringLiteral("name"), QStringLiteral("Z1")},
+                               {QStringLiteral("zoneNumber"), 1},
+                               {QStringLiteral("relativeGeometry"), relGeo},
+                               {QStringLiteral("appearance"), appearance}};
+        const QJsonObject layout{
+            {QStringLiteral("id"), layoutId},
+            {QStringLiteral("name"), QStringLiteral("Settings Layout")},
+            {QStringLiteral("showZoneNumbers"), false},
+            {QStringLiteral("zonePadding"), 8},
+            {QStringLiteral("autoAssign"), true},
+            {QStringLiteral("useFullScreenGeometry"), true},
+            {QStringLiteral("zones"), QJsonArray{zone}},
+        };
+        QFile f(layoutsDirPath() + QLatin1Char('/') + fileName);
+        QVERIFY(f.open(QIODevice::WriteOnly));
+        f.write(QJsonDocument(layout).toJson());
+    }
+
+    QByteArray readBytes(const QString& path)
+    {
+        QFile f(path);
+        return f.open(QIODevice::ReadOnly) ? f.readAll() : QByteArray();
+    }
+
+    void testLayoutSettingsRelocation_splitsLayoutFileIntoSidecar()
+    {
+        IsolatedConfigGuard guard;
+        const QString layoutId = QStringLiteral("{abcd0000-0000-0000-0000-000000000000}");
+        writeLayoutFileWithSettings(QStringLiteral("layout.json"), layoutId);
+
+        QVERIFY(ConfigMigration::relocateLayoutSettings(layoutsDirPath(), ConfigDefaults::layoutSettingsFilePath()));
+
+        // Layout file is slimmed: structural keys remain, settings gone.
+        const QJsonObject slim =
+            QJsonDocument::fromJson(readBytes(layoutsDirPath() + QStringLiteral("/layout.json"))).object();
+        QVERIFY(slim.contains(QStringLiteral("id")));
+        QVERIFY(slim.contains(QStringLiteral("zones")));
+        QVERIFY(!slim.contains(QStringLiteral("zonePadding")));
+        QVERIFY(!slim.contains(QStringLiteral("autoAssign")));
+        QVERIFY(!slim.contains(QStringLiteral("useFullScreenGeometry")));
+        QVERIFY(!slim.contains(QStringLiteral("showZoneNumbers")));
+        QVERIFY(!slim.value(QStringLiteral("zones")).toArray().at(0).toObject().contains(QStringLiteral("appearance")));
+
+        // Sidecar carries the settings keyed by layout UUID, in store format.
+        const QJsonObject sidecar = readJsonConfig(ConfigDefaults::layoutSettingsFilePath());
+        QCOMPARE(sidecar.value(QStringLiteral("_version")).toInt(), 1);
+        const QJsonObject settings = sidecar.value(layoutId).toObject();
+        QCOMPARE(settings.value(QStringLiteral("zonePadding")).toInt(), 8);
+        QCOMPARE(settings.value(QStringLiteral("autoAssign")).toBool(), true);
+        QCOMPARE(settings.value(QStringLiteral("useFullScreenGeometry")).toBool(), true);
+        const QJsonObject zoneAppearance = settings.value(QStringLiteral("zoneAppearance")).toObject();
+        QVERIFY(zoneAppearance.contains(QStringLiteral("{11111111-0000-0000-0000-000000000001}")));
+    }
+
+    void testLayoutSettingsRelocation_isIdempotent()
+    {
+        IsolatedConfigGuard guard;
+        writeLayoutFileWithSettings(QStringLiteral("layout.json"),
+                                    QStringLiteral("{abcd0000-0000-0000-0000-000000000000}"));
+
+        QVERIFY(ConfigMigration::relocateLayoutSettings(layoutsDirPath(), ConfigDefaults::layoutSettingsFilePath()));
+        const QByteArray layoutAfter1 = readBytes(layoutsDirPath() + QStringLiteral("/layout.json"));
+        const QByteArray sidecarAfter1 = readBytes(ConfigDefaults::layoutSettingsFilePath());
+
+        // Second pass over the already-slim file must not rewrite either file.
+        QVERIFY(ConfigMigration::relocateLayoutSettings(layoutsDirPath(), ConfigDefaults::layoutSettingsFilePath()));
+        QCOMPARE(readBytes(layoutsDirPath() + QStringLiteral("/layout.json")), layoutAfter1);
+        QCOMPARE(readBytes(ConfigDefaults::layoutSettingsFilePath()), sidecarAfter1);
+    }
+
+    void testLayoutSettingsRelocation_missingDirIsNoOpSuccess()
+    {
+        IsolatedConfigGuard guard;
+        QVERIFY(ConfigMigration::relocateLayoutSettings(layoutsDirPath(), ConfigDefaults::layoutSettingsFilePath()));
+        QVERIFY(!QFile::exists(ConfigDefaults::layoutSettingsFilePath()));
     }
 };
 

--- a/tests/unit/config/test_configmigration.cpp
+++ b/tests/unit/config/test_configmigration.cpp
@@ -1581,11 +1581,20 @@ private Q_SLOTS:
 
     QJsonObject fullLayoutWithSettings(const QString& layoutId) const
     {
+        // Carries all 13 relocated per-layout setting keys so the relocation and
+        // format-lock round-trip tests exercise the complete split, not a subset.
         return QJsonObject{
             {QStringLiteral("id"), layoutId},
             {QStringLiteral("name"), QStringLiteral("Settings Layout")},
             {QStringLiteral("showZoneNumbers"), false},
             {QStringLiteral("zonePadding"), 8},
+            {QStringLiteral("outerGap"), 12},
+            {QStringLiteral("usePerSideOuterGap"), true},
+            {QStringLiteral("outerGapTop"), 1},
+            {QStringLiteral("outerGapBottom"), 2},
+            {QStringLiteral("outerGapLeft"), 3},
+            {QStringLiteral("outerGapRight"), 4},
+            {QStringLiteral("overlayDisplayMode"), 1},
             {QStringLiteral("autoAssign"), true},
             {QStringLiteral("useFullScreenGeometry"), true},
             {QStringLiteral("shaderId"), QStringLiteral("dissolve")},

--- a/tests/unit/core/test_layout_core.cpp
+++ b/tests/unit/core/test_layout_core.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <QTest>
+#include <QFile>
 #include <QSignalSpy>
 #include <QJsonObject>
 #include <QJsonArray>
@@ -489,14 +490,26 @@ private Q_SLOTS:
                          {QStringLiteral("zoneNumber"), 1},
                          {QStringLiteral("relativeGeometry"), relGeo},
                          {QStringLiteral("appearance"), appearance}};
+        // shaderParams is the only object-valued setting — the highest-risk one
+        // for a strip/merge bug — so it's covered here alongside the sentinel
+        // (overlayDisplayMode) and per-side gap keys.
+        const QJsonObject shaderParams{{QStringLiteral("intensity"), 0.75}, {QStringLiteral("seed"), 42}};
         return QJsonObject{
             {QStringLiteral("id"), QStringLiteral("{abcd0000-0000-0000-0000-000000000000}")},
             {QStringLiteral("name"), QStringLiteral("Settings Layout")},
             {QStringLiteral("showZoneNumbers"), false},
             {QStringLiteral("zonePadding"), 8},
+            {QStringLiteral("outerGap"), 12},
+            {QStringLiteral("usePerSideOuterGap"), true},
+            {QStringLiteral("outerGapTop"), 1},
+            {QStringLiteral("outerGapBottom"), 2},
+            {QStringLiteral("outerGapLeft"), 3},
+            {QStringLiteral("outerGapRight"), 4},
+            {QStringLiteral("overlayDisplayMode"), 1},
             {QStringLiteral("autoAssign"), true},
             {QStringLiteral("useFullScreenGeometry"), true},
             {QStringLiteral("shaderId"), QStringLiteral("dissolve")},
+            {QStringLiteral("shaderParams"), shaderParams},
             {QStringLiteral("zones"), QJsonArray{zone}},
         };
     }
@@ -515,6 +528,10 @@ private Q_SLOTS:
         QVERIFY(!structural.contains(QStringLiteral("autoAssign")));
         QVERIFY(!structural.contains(QStringLiteral("useFullScreenGeometry")));
         QVERIFY(!structural.contains(QStringLiteral("shaderId")));
+        QVERIFY(!structural.contains(QStringLiteral("shaderParams")));
+        QVERIFY(!structural.contains(QStringLiteral("overlayDisplayMode")));
+        QVERIFY(!structural.contains(QStringLiteral("usePerSideOuterGap")));
+        QVERIFY(!structural.contains(QStringLiteral("outerGapTop")));
         const QJsonObject sZone = structural.value(QStringLiteral("zones")).toArray().at(0).toObject();
         QVERIFY(sZone.contains(QStringLiteral("relativeGeometry")));
         QVERIFY(!sZone.contains(QStringLiteral("appearance")));
@@ -523,7 +540,13 @@ private Q_SLOTS:
         QCOMPARE(settings.value(QStringLiteral("zonePadding")).toInt(), 8);
         QCOMPARE(settings.value(QStringLiteral("autoAssign")).toBool(), true);
         QCOMPARE(settings.value(QStringLiteral("useFullScreenGeometry")).toBool(), true);
+        QCOMPARE(settings.value(QStringLiteral("overlayDisplayMode")).toInt(), 1);
+        QCOMPARE(settings.value(QStringLiteral("outerGapLeft")).toInt(), 3);
         QCOMPARE(settings.value(QStringLiteral("shaderId")).toString(), QStringLiteral("dissolve"));
+        // The object-valued setting must survive as a nested object, not be flattened.
+        const QJsonObject sp = settings.value(QStringLiteral("shaderParams")).toObject();
+        QCOMPARE(sp.value(QStringLiteral("intensity")).toDouble(), 0.75);
+        QCOMPARE(sp.value(QStringLiteral("seed")).toInt(), 42);
         const QJsonObject zoneAppearance = settings.value(QStringLiteral("zoneAppearance")).toObject();
         QVERIFY(zoneAppearance.contains(QStringLiteral("{11111111-0000-0000-0000-000000000001}")));
     }
@@ -567,6 +590,49 @@ private Q_SLOTS:
 
         // Empty settings are dropped, not persisted as an empty object.
         store.setSettingsFor(layoutId, QJsonObject{});
+        QVERIFY(store.isEmpty());
+    }
+
+    void testLayoutSettings_removeLayoutDropsOnlyThatEntry()
+    {
+        using PhosphorZones::LayoutSettingsStore;
+        const QString idA = QStringLiteral("{aaaa0000-0000-0000-0000-000000000000}");
+        const QString idB = QStringLiteral("{bbbb0000-0000-0000-0000-000000000000}");
+
+        LayoutSettingsStore store;
+        store.setSettingsFor(idA, QJsonObject{{QStringLiteral("zonePadding"), 4}});
+        store.setSettingsFor(idB, QJsonObject{{QStringLiteral("zonePadding"), 9}});
+
+        store.removeLayout(idA);
+        QVERIFY(store.settingsFor(idA).isEmpty());
+        QCOMPARE(store.settingsFor(idB).value(QStringLiteral("zonePadding")).toInt(), 9);
+        QVERIFY(!store.isEmpty());
+    }
+
+    void testLayoutSettings_loadMissingFileIsEmptySuccess()
+    {
+        using PhosphorZones::LayoutSettingsStore;
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        LayoutSettingsStore store;
+        // A missing sidecar is an empty store, not an error.
+        QVERIFY(store.loadFromFile(tmp.filePath(QStringLiteral("does-not-exist.json"))));
+        QVERIFY(store.isEmpty());
+    }
+
+    void testLayoutSettings_loadCorruptFileFails()
+    {
+        using PhosphorZones::LayoutSettingsStore;
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString path = tmp.filePath(QStringLiteral("corrupt.json"));
+        QFile f(path);
+        QVERIFY(f.open(QIODevice::WriteOnly));
+        f.write(QByteArrayLiteral("{ not valid json"));
+        f.close();
+
+        LayoutSettingsStore store;
+        QVERIFY(!store.loadFromFile(path));
         QVERIFY(store.isEmpty());
     }
 };

--- a/tests/unit/core/test_layout_core.cpp
+++ b/tests/unit/core/test_layout_core.cpp
@@ -627,9 +627,49 @@ private Q_SLOTS:
         QVERIFY(reloaded.loadFromFile(path));
         QCOMPARE(reloaded.settingsFor(layoutId).value(QStringLiteral("zonePadding")).toInt(), 8);
 
-        // Empty settings are dropped, not persisted as an empty object.
+        // Empty settings are dropped, not persisted as an empty object — and the
+        // save-time filter keeps an emptied layout out of the file entirely, so a
+        // reload sees no entry for it.
         store.setSettingsFor(layoutId, QJsonObject{});
         QVERIFY(store.isEmpty());
+        QVERIFY(store.saveToFile(path));
+        LayoutSettingsStore reloadedEmpty;
+        QVERIFY(reloadedEmpty.loadFromFile(path));
+        QVERIFY(reloadedEmpty.settingsFor(layoutId).isEmpty());
+        QVERIFY(reloadedEmpty.isEmpty());
+    }
+
+    void testLayoutSettings_stripIsIdentityOnSettingsFreeInput()
+    {
+        using PhosphorZones::LayoutSettingsStore;
+        // No settings keys and no zones → stripSettings must not synthesise an
+        // empty "zones" array; it is the identity.
+        const QJsonObject bare{{QStringLiteral("id"), QStringLiteral("{x}")},
+                               {QStringLiteral("name"), QStringLiteral("Bare")}};
+        QCOMPARE(LayoutSettingsStore::stripSettings(bare), bare);
+    }
+
+    void testLayoutSettings_idlessZoneKeepsInlineAppearance()
+    {
+        using PhosphorZones::LayoutSettingsStore;
+        // An id-less zone has no sidecar key, so extractSettings skips its
+        // appearance and stripSettings must leave it inline (otherwise it would
+        // be lost). Strip→merge round-trips the id-less zone unchanged.
+        QJsonObject idlessZone{{QStringLiteral("id"), QString()},
+                               {QStringLiteral("zoneNumber"), 1},
+                               {QStringLiteral("appearance"), QJsonObject{{QStringLiteral("borderWidth"), 3}}}};
+        const QJsonObject full{{QStringLiteral("id"), QStringLiteral("{abcd0000-0000-0000-0000-000000000000}")},
+                               {QStringLiteral("zonePadding"), 8},
+                               {QStringLiteral("zones"), QJsonArray{idlessZone}}};
+
+        const QJsonObject settings = LayoutSettingsStore::extractSettings(full);
+        QVERIFY(!settings.contains(QStringLiteral("zoneAppearance"))); // id-less zone not mapped
+
+        const QJsonObject structural = LayoutSettingsStore::stripSettings(full);
+        const QJsonObject sZone = structural.value(QStringLiteral("zones")).toArray().at(0).toObject();
+        QVERIFY(sZone.contains(QStringLiteral("appearance"))); // kept inline, not lost
+
+        QCOMPARE(LayoutSettingsStore::mergeSettings(structural, settings), full);
     }
 
     void testLayoutSettings_removeLayoutDropsOnlyThatEntry()

--- a/tests/unit/core/test_layout_core.cpp
+++ b/tests/unit/core/test_layout_core.cpp
@@ -12,9 +12,12 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 
+#include <QTemporaryDir>
+
 #include "core/constants.h"
 #include <PhosphorLayoutApi/AspectRatioClass.h>
 #include <PhosphorZones/Layout.h>
+#include <PhosphorZones/LayoutSettingsStore.h>
 #include <PhosphorZones/Zone.h>
 
 using namespace PlasmaZones;
@@ -464,6 +467,107 @@ private Q_SLOTS:
         QVERIFY(layout.fixedZoneBoundingBox().isEmpty());
         layout.recalculateZoneGeometries(QRectF(0, 0, 3840, 2160));
         QVERIFY(layout.fixedZoneReferenceGeometry().isEmpty());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // LayoutSettingsStore: per-layout settings split out of the layout file
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    // Build a full layout JSON (as Layout::toJson would) carrying both structural
+    // data and per-layout settings, including one zone with a custom appearance.
+    QJsonObject makeFullLayoutWithSettings() const
+    {
+        QJsonObject relGeo{{QStringLiteral("x"), 0.0},
+                           {QStringLiteral("y"), 0.0},
+                           {QStringLiteral("width"), 1.0},
+                           {QStringLiteral("height"), 1.0}};
+        QJsonObject appearance{{QStringLiteral("useCustomColors"), true},
+                               {QStringLiteral("highlightColor"), QStringLiteral("#ff112233")},
+                               {QStringLiteral("borderWidth"), 5}};
+        QJsonObject zone{{QStringLiteral("id"), QStringLiteral("{11111111-0000-0000-0000-000000000001}")},
+                         {QStringLiteral("name"), QStringLiteral("Z1")},
+                         {QStringLiteral("zoneNumber"), 1},
+                         {QStringLiteral("relativeGeometry"), relGeo},
+                         {QStringLiteral("appearance"), appearance}};
+        return QJsonObject{
+            {QStringLiteral("id"), QStringLiteral("{abcd0000-0000-0000-0000-000000000000}")},
+            {QStringLiteral("name"), QStringLiteral("Settings Layout")},
+            {QStringLiteral("showZoneNumbers"), false},
+            {QStringLiteral("zonePadding"), 8},
+            {QStringLiteral("autoAssign"), true},
+            {QStringLiteral("useFullScreenGeometry"), true},
+            {QStringLiteral("shaderId"), QStringLiteral("dissolve")},
+            {QStringLiteral("zones"), QJsonArray{zone}},
+        };
+    }
+
+    void testLayoutSettings_splitProducesStructuralAndSettings()
+    {
+        using PhosphorZones::LayoutSettingsStore;
+        const QJsonObject full = makeFullLayoutWithSettings();
+
+        const QJsonObject structural = LayoutSettingsStore::stripSettings(full);
+        // Structural keeps identity + zone geometry, drops every setting.
+        QVERIFY(structural.contains(QStringLiteral("id")));
+        QVERIFY(structural.contains(QStringLiteral("zones")));
+        QVERIFY(!structural.contains(QStringLiteral("showZoneNumbers")));
+        QVERIFY(!structural.contains(QStringLiteral("zonePadding")));
+        QVERIFY(!structural.contains(QStringLiteral("autoAssign")));
+        QVERIFY(!structural.contains(QStringLiteral("useFullScreenGeometry")));
+        QVERIFY(!structural.contains(QStringLiteral("shaderId")));
+        const QJsonObject sZone = structural.value(QStringLiteral("zones")).toArray().at(0).toObject();
+        QVERIFY(sZone.contains(QStringLiteral("relativeGeometry")));
+        QVERIFY(!sZone.contains(QStringLiteral("appearance")));
+
+        const QJsonObject settings = LayoutSettingsStore::extractSettings(full);
+        QCOMPARE(settings.value(QStringLiteral("zonePadding")).toInt(), 8);
+        QCOMPARE(settings.value(QStringLiteral("autoAssign")).toBool(), true);
+        QCOMPARE(settings.value(QStringLiteral("useFullScreenGeometry")).toBool(), true);
+        QCOMPARE(settings.value(QStringLiteral("shaderId")).toString(), QStringLiteral("dissolve"));
+        const QJsonObject zoneAppearance = settings.value(QStringLiteral("zoneAppearance")).toObject();
+        QVERIFY(zoneAppearance.contains(QStringLiteral("{11111111-0000-0000-0000-000000000001}")));
+    }
+
+    void testLayoutSettings_mergeRestoresFullLayout()
+    {
+        using PhosphorZones::LayoutSettingsStore;
+        const QJsonObject full = makeFullLayoutWithSettings();
+        const QJsonObject structural = LayoutSettingsStore::stripSettings(full);
+        const QJsonObject settings = LayoutSettingsStore::extractSettings(full);
+
+        const QJsonObject merged = LayoutSettingsStore::mergeSettings(structural, settings);
+        QCOMPARE(merged, full);
+    }
+
+    void testLayoutSettings_mergeEmptyKeepsStructuralAsIs()
+    {
+        using PhosphorZones::LayoutSettingsStore;
+        // A not-yet-split (full-format) layout with no sidecar entry must round-
+        // trip unchanged through merge — settings already embedded survive.
+        const QJsonObject full = makeFullLayoutWithSettings();
+        const QJsonObject merged = LayoutSettingsStore::mergeSettings(full, QJsonObject{});
+        QCOMPARE(merged, full);
+    }
+
+    void testLayoutSettings_storeSaveLoadRoundTrip()
+    {
+        using PhosphorZones::LayoutSettingsStore;
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        const QString path = tmp.filePath(QStringLiteral("layout-settings.json"));
+        const QString layoutId = QStringLiteral("{abcd0000-0000-0000-0000-000000000000}");
+
+        LayoutSettingsStore store;
+        store.setSettingsFor(layoutId, LayoutSettingsStore::extractSettings(makeFullLayoutWithSettings()));
+        QVERIFY(store.saveToFile(path));
+
+        LayoutSettingsStore reloaded;
+        QVERIFY(reloaded.loadFromFile(path));
+        QCOMPARE(reloaded.settingsFor(layoutId).value(QStringLiteral("zonePadding")).toInt(), 8);
+
+        // Empty settings are dropped, not persisted as an empty object.
+        store.setSettingsFor(layoutId, QJsonObject{});
+        QVERIFY(store.isEmpty());
     }
 };
 

--- a/tests/unit/core/test_layout_core.cpp
+++ b/tests/unit/core/test_layout_core.cpp
@@ -77,6 +77,45 @@ private Q_SLOTS:
         layout.clearDirty();
         layout.setHiddenFromSelector(true);
         QVERIFY(layout.isDirty());
+
+        // The remaining per-layout settings (now relocated to the sidecar on
+        // save) must each mark the layout dirty, so an edit reaches saveLayout
+        // and triggers the structural/settings split.
+        layout.clearDirty();
+        layout.setUsePerSideOuterGap(true);
+        QVERIFY(layout.isDirty());
+
+        layout.clearDirty();
+        layout.setOuterGapTop(10);
+        QVERIFY(layout.isDirty());
+
+        layout.clearDirty();
+        layout.setOuterGapBottom(11);
+        QVERIFY(layout.isDirty());
+
+        layout.clearDirty();
+        layout.setOuterGapLeft(12);
+        QVERIFY(layout.isDirty());
+
+        layout.clearDirty();
+        layout.setOuterGapRight(13);
+        QVERIFY(layout.isDirty());
+
+        layout.clearDirty();
+        layout.setShowZoneNumbers(false);
+        QVERIFY(layout.isDirty());
+
+        layout.clearDirty();
+        layout.setOverlayDisplayMode(1);
+        QVERIFY(layout.isDirty());
+
+        layout.clearDirty();
+        layout.setAutoAssign(true);
+        QVERIFY(layout.isDirty());
+
+        layout.clearDirty();
+        layout.setUseFullScreenGeometry(true);
+        QVERIFY(layout.isDirty());
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/core/test_layoutmanager_persistence.cpp
+++ b/tests/unit/core/test_layoutmanager_persistence.cpp
@@ -214,6 +214,9 @@ private Q_SLOTS:
 
         PhosphorZones::Layout* reloaded = mgr2->layoutById(id);
         QVERIFY(reloaded != nullptr);
+        // A genuinely fresh load from disk, not the in-memory object mgr still
+        // holds — proves the merge ran against the on-disk sidecar.
+        QVERIFY(reloaded != layout);
         QCOMPARE(reloaded->zonePadding(), 8);
         QVERIFY(reloaded->useFullScreenGeometry());
         QVERIFY(reloaded->autoAssign());

--- a/tests/unit/core/test_layoutmanager_persistence.cpp
+++ b/tests/unit/core/test_layoutmanager_persistence.cpp
@@ -13,6 +13,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QScopedPointer>
+#include <QColor>
 #include <QUuid>
 #include <memory>
 #include <vector>
@@ -170,6 +171,55 @@ private Q_SLOTS:
         QVERIFY(duplicate->id() != original->id());
         QCOMPARE(duplicate->name(), QStringLiteral("Original (Copy)"));
         QCOMPARE(duplicate->zoneCount(), original->zoneCount());
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Per-layout settings split to sidecar on save, merged back on load
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testLayoutManager_settings_splitOnSaveMergedOnLoad()
+    {
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        const QString layoutDir = mgr->layoutDirectory();
+
+        auto* layout = new PhosphorZones::Layout(QStringLiteral("WithSettings"));
+        layout->setZonePadding(8);
+        layout->setUseFullScreenGeometry(true);
+        layout->setAutoAssign(true);
+        auto* zone = new PhosphorZones::Zone();
+        zone->setRelativeGeometry(QRectF(0, 0, 1, 1));
+        zone->setUseCustomColors(true);
+        zone->setHighlightColor(QColor(QStringLiteral("#ff112233")));
+        layout->addZone(zone);
+        const QUuid id = layout->id();
+        mgr->addLayout(layout); // triggers save → split
+
+        // The structural layout file is slim: no settings keys, no zone appearance.
+        const QString filePath =
+            layoutDir + QStringLiteral("/") + id.toString(QUuid::WithoutBraces) + QStringLiteral(".json");
+        QFile lf(filePath);
+        QVERIFY(lf.open(QIODevice::ReadOnly));
+        const QJsonObject onDisk = QJsonDocument::fromJson(lf.readAll()).object();
+        QVERIFY(!onDisk.contains(QStringLiteral("zonePadding")));
+        QVERIFY(!onDisk.contains(QStringLiteral("useFullScreenGeometry")));
+        QVERIFY(
+            !onDisk.value(QStringLiteral("zones")).toArray().at(0).toObject().contains(QStringLiteral("appearance")));
+
+        // A fresh registry on the SAME dirs (guard still alive) reloads the layout
+        // and merges its settings back from the sidecar.
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr2(
+            PlasmaZones::TestHelpers::makeLayoutRegistry(QStringLiteral("plasmazones/layouts")));
+        mgr2->setLayoutDirectory(layoutDir);
+        mgr2->loadLayouts();
+
+        PhosphorZones::Layout* reloaded = mgr2->layoutById(id);
+        QVERIFY(reloaded != nullptr);
+        QCOMPARE(reloaded->zonePadding(), 8);
+        QVERIFY(reloaded->useFullScreenGeometry());
+        QVERIFY(reloaded->autoAssign());
+        QCOMPARE(reloaded->zones().size(), 1);
+        QVERIFY(reloaded->zones().at(0)->useCustomColors());
+        QCOMPARE(reloaded->zones().at(0)->highlightColor(), QColor(QStringLiteral("#ff112233")));
     }
 
     void testLayoutManager_duplicateLayout_resetsVisibility()


### PR DESCRIPTION
## What

Layout files mixed two unrelated things: the **structural** definition of a layout (zones, geometry, identity, matching rules) and user-preference **settings** that happen to be tunable per layout. This moves the settings out into a dedicated store so layout files describe only the layout.

Per-layout settings now persist in a single `layout-settings.json` sidecar keyed by layout UUID — the same sibling-store pattern as `windowrules.json` / `quicklayouts.json`.

### Settings evicted from layout files
- Per-zone appearance (`highlightColor`, `inactiveColor`, `borderColor`, opacities, `borderWidth`, `borderRadius`, `useCustomColors`)
- Gap/padding overrides (`zonePadding`, `outerGap`, `usePerSideOuterGap`, per-side gaps)
- `showZoneNumbers`, `overlayDisplayMode` (layout- and zone-level)
- `autoAssign`, `useFullScreenGeometry`
- `shaderId` / `shaderParams`

Layout files keep only structure: id/name/description, zones (id/name/zoneNumber/geometry/geometryMode/fixedGeometry), matching rules (aspect-ratio, allowed screens/desktops/activities, hidden-from-selector), defaultOrder, systemSourcePath.

## How

The in-memory `Layout`/`Zone` model is **unchanged** — every setting still lives on the objects, so the editor, the D-Bus wire format, and all runtime consumers/cascades are untouched. The split happens only at the file boundary:

- **`LayoutSettingsStore`** (new, phosphor-zones) — `extractSettings` / `stripSettings` / `mergeSettings` are the single definition of settings-vs-structural, plus atomic load/save of the sidecar.
- **`LayoutRegistry`** — on save, splits `Layout::toJson` (structure → layout file, settings → sidecar); on load, merges the sidecar back before `Layout::fromJson`; on delete, drops the sidecar entry. `mergeSettings` preserves keys a file already carries, so a not-yet-split (full-format) file still round-trips.

## Migration

Folded into the existing **(unreleased) v4** migration — **no new config schema version**. `finalizeV4Conversion` calls `relocateLayoutSettings`, which reads each existing layout file, splits its embedded settings into the sidecar, and rewrites the slimmed file. Idempotent and crash-safe (merges into an existing sidecar, skips already-slim files), best-effort so it never aborts the v4 conversion. Uses frozen on-disk key literals per the migration freeze policy, with a round-trip test locking the migration's output format to what `LayoutSettingsStore` reads.

## Tests

- `LayoutSettingsStore` split/merge round-trip, structural-only assertions, empty-merge passthrough, sidecar save/load (`test_layout_core.cpp`).
- Migration relocation: splits a layout file into the sidecar, idempotency (no rewrite when already slim), missing-dir no-op (`test_configmigration.cpp`).
- Full suite: **252/252 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
