### PR TITLE
fix(settings): UI padding/layout polish, close-time crash fixes, daemon-stop confirm

### DIFF
--- a/libs/phosphor-control/qml/PageHost.qml
+++ b/libs/phosphor-control/qml/PageHost.qml
@@ -96,6 +96,15 @@ Item {
             required property string modelData
             readonly property string pageId: pageLoader.modelData
             readonly property bool isCurrent: root.controller.currentPageId === pageLoader.pageId
+            // Lazy-build latch: a page incubates the first time it becomes
+            // current and stays built (cached) thereafter. Without it, `active:
+            // true` built ALL pages at once on startup — an async-incubation
+            // storm that overlapped the daemon's initial D-Bus broadcasts
+            // (model resets / layout reloads re-entering mid-incubation), an
+            // observed source of incubation-time crashes. Building one page at
+            // a time, on navigation, keeps the async no-hitch behaviour while
+            // removing the storm.
+            property bool _everCurrent: false
 
             // Deep-link reveal latch: when this page is built + current,
             // consume any pending anchor targeting it and invoke the page's
@@ -116,7 +125,11 @@ Item {
             // unit is already warm, so construction is the only cost. Async
             // so even a heavy first build never hitches the UI thread.
             asynchronous: true
-            active: true
+            active: pageLoader.isCurrent || pageLoader._everCurrent
+            // Latch the initial current page so navigating away from it doesn't
+            // unload it (onIsCurrentChanged never fires for the initial value).
+            Component.onCompleted: if (pageLoader.isCurrent)
+                pageLoader._everCurrent = true
             source: {
                 const data = root.controller.registry.pageData(pageLoader.pageId);
                 return (data && data.id) ? data.qmlSource : "";
@@ -140,6 +153,8 @@ Item {
             opacity: 0
             onIsCurrentChanged: {
                 if (pageLoader.isCurrent) {
+                    // Latch so this page stays built/cached once visited.
+                    pageLoader._everCurrent = true;
                     if (pageLoader.status === Loader.Ready) {
                         pageFadeIn.restart();
                         pageLoader._maybeReveal();

--- a/libs/phosphor-control/qml/SettingsAppWindow.qml
+++ b/libs/phosphor-control/qml/SettingsAppWindow.qml
@@ -257,155 +257,166 @@ Kirigami.ApplicationWindow {
         padding: 0
         title: root.title
 
-        RowLayout {
+        ColumnLayout {
             anchors.fill: parent
             spacing: 0
 
-            Sidebar {
-                // `sidebarItem` (not `sidebar`) — the root has a
-                // `readonly property QtObject sidebar` façade above,
-                // and JS scope chain would resolve a bare `sidebar`
-                // identifier inside the façade's methods to the root
-                // property (returning the façade itself) before
-                // resolving it as a QML id. Naming the underlying
-                // Sidebar item `sidebarItem` removes the collision so
-                // the façade's `sidebarItem.drillInto(...)` etc. land
-                // on the actual Sidebar.
-                id: sidebarItem
+            // Full-width header bar spanning the ENTIRE window, ABOVE both the
+            // sidebar and the content panel: the headerExtras slot (e.g. global
+            // search) centered across the whole window, with the optional
+            // headerTrailing slot (e.g. a status toggle) pinned right. The row
+            // collapses when neither slot is filled. A left phantom the width of
+            // the trailing keeps the centered slot window-centered (not biased
+            // left by the trailing's width).
+            RowLayout {
+                id: headerExtrasRow
 
-                // Single intermediate property drives all three Layout
-                // width hints — one Behavior+animation runs per
-                // compact/non-compact transition instead of three
-                // concurrent ones doing identical work. Pattern
-                // mirrors UnsavedChangesFooter.qml's expansion driver.
-                //
-                // NOTE: not `readonly` — Qt 6.11 hardened the readonly
-                // contract and blocks Behavior attachments on
-                // readonly-marked properties. The value still flows
-                // from the binding below; the Behavior intercepts the
-                // transition between binding-driven values.
-                property real targetWidth: root.sidebarCompact ? Kirigami.Units.gridUnit * 3 : Kirigami.Units.gridUnit * 12
+                Layout.fillWidth: true
+                Layout.leftMargin: Kirigami.Units.largeSpacing
+                Layout.rightMargin: Kirigami.Units.largeSpacing
+                Layout.topMargin: Kirigami.Units.largeSpacing
+                Layout.bottomMargin: Kirigami.Units.largeSpacing
+                spacing: 0
+                visible: headerExtrasLoader.item !== null || headerTrailingLoader.item !== null
 
-                Layout.fillHeight: true
-                // Sidebar width tracks sidebarCompact: 12 gridUnits at
-                // normal width (matches legacy), collapses to 3
-                // gridUnits in compact mode (icon-only rail). All
-                // three Layout width hints stay in lockstep via
-                // targetWidth so the animation lands at a clean width
-                // and inner-child implicitWidth can't push the rail
-                // wider during the transition.
-                Layout.preferredWidth: targetWidth
-                Layout.minimumWidth: targetWidth
-                Layout.maximumWidth: targetWidth
-                controller: root.controller
-                compact: root.sidebarCompact
+                Item {
+                    Layout.preferredWidth: headerTrailingLoader.width
+                }
 
-                // Slide animation when the rail collapses / expands.
-                // Direction is read from `root.sidebarCompact` (the
-                // same flag that drove the width assignment above) so
-                // the easing leg is decided synchronously — reading
-                // `targetWidth` inside the Behavior would re-evaluate
-                // during the animation and converge to the wrong leg
-                // as the value approached its target.
-                Behavior on targetWidth {
-                    PhosphorMotionAnimation {
-                        profile: !root.sidebarCompact ? "panel.slideIn" : "panel.slideOut"
-                    }
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                // The Loaders adopt their loaded item's implicit size (slot
+                // contract: the consumer Component declares implicitWidth/Height).
+                Loader {
+                    id: headerExtrasLoader
+
+                    Layout.alignment: Qt.AlignVCenter
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                Loader {
+                    id: headerTrailingLoader
+
+                    Layout.alignment: Qt.AlignVCenter
                 }
             }
 
             Kirigami.Separator {
-                Layout.fillHeight: true
+                Layout.fillWidth: true
+                visible: headerExtrasRow.visible
             }
 
-            ColumnLayout {
-                Layout.fillHeight: true
+            // Sidebar + content panel sit BELOW the full-width header bar.
+            RowLayout {
                 Layout.fillWidth: true
+                Layout.fillHeight: true
                 spacing: 0
 
-                // Header-extras row ABOVE the breadcrumb trail: the headerExtras
-                // slot (e.g. global search) centered, with the optional
-                // headerTrailing slot (e.g. a status toggle) pinned right. The
-                // row collapses when neither slot is filled. Side margins match
-                // the breadcrumb gutter so the trailing slot aligns to the
-                // content's right edge. A left phantom the width of the trailing
-                // keeps the centered slot window-centered (not biased left by
-                // the trailing's width).
-                RowLayout {
-                    id: headerExtrasRow
+                Sidebar {
+                    // `sidebarItem` (not `sidebar`) — the root has a
+                    // `readonly property QtObject sidebar` façade above,
+                    // and JS scope chain would resolve a bare `sidebar`
+                    // identifier inside the façade's methods to the root
+                    // property (returning the façade itself) before
+                    // resolving it as a QML id. Naming the underlying
+                    // Sidebar item `sidebarItem` removes the collision so
+                    // the façade's `sidebarItem.drillInto(...)` etc. land
+                    // on the actual Sidebar.
+                    id: sidebarItem
 
-                    Layout.fillWidth: true
-                    Layout.leftMargin: Kirigami.Units.largeSpacing
-                    Layout.rightMargin: Kirigami.Units.largeSpacing
-                    Layout.topMargin: Kirigami.Units.smallSpacing
-                    Layout.bottomMargin: Kirigami.Units.smallSpacing
-                    spacing: 0
-                    visible: headerExtrasLoader.item !== null || headerTrailingLoader.item !== null
+                    // Single intermediate property drives all three Layout
+                    // width hints — one Behavior+animation runs per
+                    // compact/non-compact transition instead of three
+                    // concurrent ones doing identical work. Pattern
+                    // mirrors UnsavedChangesFooter.qml's expansion driver.
+                    //
+                    // NOTE: not `readonly` — Qt 6.11 hardened the readonly
+                    // contract and blocks Behavior attachments on
+                    // readonly-marked properties. The value still flows
+                    // from the binding below; the Behavior intercepts the
+                    // transition between binding-driven values.
+                    property real targetWidth: root.sidebarCompact ? Kirigami.Units.gridUnit * 3 : Kirigami.Units.gridUnit * 12
 
-                    Item {
-                        Layout.preferredWidth: headerTrailingLoader.width
-                    }
+                    Layout.fillHeight: true
+                    // Sidebar width tracks sidebarCompact: 12 gridUnits at
+                    // normal width (matches legacy), collapses to 3
+                    // gridUnits in compact mode (icon-only rail). All
+                    // three Layout width hints stay in lockstep via
+                    // targetWidth so the animation lands at a clean width
+                    // and inner-child implicitWidth can't push the rail
+                    // wider during the transition.
+                    Layout.preferredWidth: targetWidth
+                    Layout.minimumWidth: targetWidth
+                    Layout.maximumWidth: targetWidth
+                    controller: root.controller
+                    compact: root.sidebarCompact
 
-                    Item {
-                        Layout.fillWidth: true
-                    }
-
-                    // The Loaders adopt their loaded item's implicit size (slot
-                    // contract: the consumer Component declares implicitWidth/Height).
-                    Loader {
-                        id: headerExtrasLoader
-
-                        Layout.alignment: Qt.AlignVCenter
-                    }
-
-                    Item {
-                        Layout.fillWidth: true
-                    }
-
-                    Loader {
-                        id: headerTrailingLoader
-
-                        Layout.alignment: Qt.AlignVCenter
+                    // Slide animation when the rail collapses / expands.
+                    // Direction is read from `root.sidebarCompact` (the
+                    // same flag that drove the width assignment above) so
+                    // the easing leg is decided synchronously — reading
+                    // `targetWidth` inside the Behavior would re-evaluate
+                    // during the animation and converge to the wrong leg
+                    // as the value approached its target.
+                    Behavior on targetWidth {
+                        PhosphorMotionAnimation {
+                            profile: !root.sidebarCompact ? "panel.slideIn" : "panel.slideOut"
+                        }
                     }
                 }
 
-                RowLayout {
-                    id: breadcrumbBar
+                Kirigami.Separator {
+                    Layout.fillHeight: true
+                }
 
+                ColumnLayout {
+                    Layout.fillHeight: true
                     Layout.fillWidth: true
-                    // Horizontal gutter matches the PageHost content margin + the
-                    // UnsavedChangesFooter inset (both largeSpacing) so breadcrumb,
-                    // page body, and footer share one left/right edge.
-                    Layout.leftMargin: Kirigami.Units.largeSpacing
-                    Layout.rightMargin: Kirigami.Units.largeSpacing
-                    Layout.topMargin: Kirigami.Units.smallSpacing
-                    Layout.bottomMargin: Kirigami.Units.smallSpacing
-                    spacing: Kirigami.Units.smallSpacing
+                    spacing: 0
 
-                    Breadcrumbs {
+                    RowLayout {
+                        id: breadcrumbBar
+
                         Layout.fillWidth: true
-                        Layout.alignment: Qt.AlignVCenter
+                        // Horizontal gutter matches the PageHost content margin + the
+                        // UnsavedChangesFooter inset (both largeSpacing) so breadcrumb,
+                        // page body, and footer share one left/right edge.
+                        Layout.leftMargin: Kirigami.Units.largeSpacing
+                        Layout.rightMargin: Kirigami.Units.largeSpacing
+                        Layout.topMargin: Kirigami.Units.smallSpacing
+                        Layout.bottomMargin: Kirigami.Units.smallSpacing
+                        spacing: Kirigami.Units.smallSpacing
+
+                        Breadcrumbs {
+                            Layout.fillWidth: true
+                            Layout.alignment: Qt.AlignVCenter
+                            controller: root.controller
+                        }
+                    }
+
+                    Kirigami.Separator {
+                        Layout.fillWidth: true
+                    }
+
+                    PageHost {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
                         controller: root.controller
                     }
-                }
 
-                Kirigami.Separator {
-                    Layout.fillWidth: true
-                }
+                    Kirigami.Separator {
+                        Layout.fillWidth: true
+                    }
 
-                PageHost {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    controller: root.controller
-                }
-
-                Kirigami.Separator {
-                    Layout.fillWidth: true
-                }
-
-                UnsavedChangesFooter {
-                    Layout.fillWidth: true
-                    controller: root.controller
+                    UnsavedChangesFooter {
+                        Layout.fillWidth: true
+                        controller: root.controller
+                    }
                 }
             }
         }

--- a/libs/phosphor-control/qml/Sidebar.qml
+++ b/libs/phosphor-control/qml/Sidebar.qml
@@ -563,19 +563,25 @@ ColumnLayout {
                 model: visibleModel
                 interactive: false
                 spacing: 0
+                // Contain the accordion add/displaced transitions: without it
+                // the in-flight rows (animating `y` as a category expands)
+                // paint outside the list's bounds and are seen sliding down
+                // behind the rows / footer below it.
+                clip: true
 
                 add: Transition {
                     enabled: !root._suppressAccordion
 
+                    // Fade newly-revealed rows in AT their final position — no
+                    // `y` animation. Translating added rows made the category's
+                    // children visibly fly in from above the header; the
+                    // `displaced` transition below already slides the rows after
+                    // the insertion point down to open the gap, which is the
+                    // accordion motion we actually want.
                     PhosphorMotionAnimation {
                         properties: "opacity"
                         from: 0
                         to: 1
-                        profile: "widget.accordionExpand"
-                    }
-
-                    PhosphorMotionAnimation {
-                        properties: "y"
                         profile: "widget.accordionExpand"
                     }
                 }

--- a/src/settings/qml/AboutPage.qml
+++ b/src/settings/qml/AboutPage.qml
@@ -104,18 +104,24 @@ PhosphorUi.AboutPageShell {
 
                 Label {
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     text: i18n("Created by fuddlesworth")
                     font.weight: Font.DemiBold
                 }
 
                 Label {
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     text: i18n("Inspired by FancyZones, extended with automatic tiling")
                     opacity: 0.7
                 }
 
                 Label {
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     text: i18n("Built with Qt, KDE Frameworks, and Kirigami")
                     opacity: 0.7
                 }

--- a/src/settings/qml/AnimationEventCardList.qml
+++ b/src/settings/qml/AnimationEventCardList.qml
@@ -120,6 +120,12 @@ SettingsFlickable {
                 function _checkInView() {
                     if (cardLoader._everInView)
                         return;
+                    // Fast page-switching can destroy this delegate while a
+                    // queued Qt.callLater / onYChanged is still pending; the
+                    // dying context resolves `page` to undefined. Bail instead
+                    // of throwing a TypeError reading page.placeholderHeight.
+                    if (!page)
+                        return;
                     const top = cardLoader.y;
                     if ((top + page.placeholderHeight) >= (page.contentY - page.buildBuffer) && top <= (page.contentY + page.height + page.buildBuffer))
                         cardLoader._everInView = true;

--- a/src/settings/qml/AnimationsMotionSetsPage.qml
+++ b/src/settings/qml/AnimationsMotionSetsPage.qml
@@ -74,6 +74,8 @@ SettingsFlickable {
 
                 Label {
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     text: i18n("Capture every per-event override file as a named motion set.")
                     color: Kirigami.Theme.disabledTextColor
                     wrapMode: Text.WordWrap
@@ -87,6 +89,8 @@ SettingsFlickable {
                 // matches typeflow (name → description → save).
                 ColumnLayout {
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     spacing: Kirigami.Units.smallSpacing
 
                     TextField {
@@ -109,8 +113,6 @@ SettingsFlickable {
                         id: saveStatus
 
                         Layout.fillWidth: true
-                        Layout.leftMargin: Kirigami.Units.largeSpacing
-                        Layout.rightMargin: Kirigami.Units.largeSpacing
                         type: Kirigami.MessageType.Error
                         showCloseButton: true
                     }
@@ -156,6 +158,8 @@ SettingsFlickable {
                     color: Kirigami.Theme.disabledTextColor
                     font.italic: true
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                 }
 
                 Repeater {
@@ -165,6 +169,8 @@ SettingsFlickable {
                         required property var modelData
 
                         Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.largeSpacing
+                        Layout.rightMargin: Kirigami.Units.largeSpacing
                         spacing: Kirigami.Units.smallSpacing
 
                         ColumnLayout {

--- a/src/settings/qml/AnimationsPresetsPage.qml
+++ b/src/settings/qml/AnimationsPresetsPage.qml
@@ -123,6 +123,9 @@ SettingsFlickable {
                     delegate: RowLayout {
                         required property var modelData
 
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.largeSpacing
+                        Layout.rightMargin: Kirigami.Units.largeSpacing
                         spacing: Kirigami.Units.smallSpacing
 
                         CurveThumbnail {
@@ -164,6 +167,9 @@ SettingsFlickable {
                     delegate: RowLayout {
                         required property var modelData
 
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.largeSpacing
+                        Layout.rightMargin: Kirigami.Units.largeSpacing
                         spacing: Kirigami.Units.smallSpacing
 
                         CurveThumbnail {
@@ -231,6 +237,8 @@ SettingsFlickable {
                     color: Kirigami.Theme.disabledTextColor
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     font.italic: true
                 }
             }
@@ -253,6 +261,9 @@ SettingsFlickable {
                     delegate: RowLayout {
                         required property var modelData
 
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.largeSpacing
+                        Layout.rightMargin: Kirigami.Units.largeSpacing
                         spacing: Kirigami.Units.smallSpacing
 
                         CurveThumbnail {
@@ -299,6 +310,9 @@ SettingsFlickable {
                         required property var modelData
                         readonly property var _spring: root.parseSpring(modelData.curve)
 
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Kirigami.Units.largeSpacing
+                        Layout.rightMargin: Kirigami.Units.largeSpacing
                         spacing: Kirigami.Units.smallSpacing
 
                         CurveThumbnail {
@@ -364,6 +378,8 @@ SettingsFlickable {
                     color: Kirigami.Theme.disabledTextColor
                     wrapMode: Text.WordWrap
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     font.italic: true
                 }
             }

--- a/src/settings/qml/GapsSettingsCard.qml
+++ b/src/settings/qml/GapsSettingsCard.qml
@@ -76,8 +76,6 @@ SettingsCard {
             }
         }
 
-        SettingsSeparator {}
-
         SettingsRow {
             visible: !tilePerSideSwitch.checked
             title: root.outerGapLabel
@@ -99,6 +97,8 @@ SettingsCard {
                 }
             }
         }
+
+        SettingsSeparator {}
 
         SettingsRow {
             title: i18n("Per-side outer gaps")

--- a/src/settings/qml/GlobalSearchField.qml
+++ b/src/settings/qml/GlobalSearchField.qml
@@ -49,6 +49,9 @@ Item {
         anchors.fill: parent
         placeholderText: i18nc("@info:placeholder global settings search", "Search settings…")
         Accessible.name: i18n("Search settings")
+        // Centre the placeholder hint, but left-align once the user starts
+        // typing so the caret and query read normally.
+        horizontalAlignment: field.text.length === 0 ? Text.AlignHCenter : Text.AlignLeft
         // Kirigami.SearchField auto-fires accepted() shortly after the text
         // changes by default — which would navigate to the top result as the
         // user types. Disable it so accepted() means "the user pressed Enter".

--- a/src/settings/qml/LayoutComboBox.qml
+++ b/src/settings/qml/LayoutComboBox.qml
@@ -215,6 +215,12 @@ ComboBox {
     }
 
     function updateSelection() {
+        // Same teardown guard as _doRebuild: a coalesced Qt.callLater(updateSelection)
+        // (the onLayoutFilterChanged path) can fire after this ComboBox is
+        // destroyed by fast page-switching; the dying context resolves the
+        // component's own members to undefined. Bail before touching them.
+        if (typeof _buildItems !== "function")
+            return;
         // Unmatched id → -1 (no selection), not 0. Coercing to row 0
         // silently rewrites a stale / deleted layout id to whatever
         // happens to be first in the list — when `showNoneOption: false`

--- a/src/settings/qml/LayoutComboBox.qml
+++ b/src/settings/qml/LayoutComboBox.qml
@@ -192,6 +192,12 @@ ComboBox {
     }
 
     function _doRebuild() {
+        // A coalesced rebuild can fire via Qt.callLater after this ComboBox
+        // has been destroyed (fast page-switching); the dying context resolves
+        // the component's own methods to undefined. Bail before invoking them
+        // rather than throwing "_buildItems is not a function".
+        if (typeof _buildItems !== "function")
+            return;
         _rebuildScheduled = false;
         let items = _buildItems();
         if (_modelMatchesItems(items)) {

--- a/src/settings/qml/LayoutGridDelegate.qml
+++ b/src/settings/qml/LayoutGridDelegate.qml
@@ -32,6 +32,11 @@ Item {
     // Selection state (bound from parent GridView)
     property bool isSelected: false
     property bool isHovered: false
+    // Inner padding of the card body (border → content). Single-sourced so the
+    // corner status/toggle icons — which offset back out past this inset with a
+    // negative anchor margin to sit near the card corner — can't drift off-corner
+    // if the body inset changes.
+    readonly property real _bodyInset: Kirigami.Units.largeSpacing
     // When false, the delegate's right-click context-menu affordance is
     // suppressed entirely (the underlying MouseArea drops RightButton
     // from `acceptedButtons`). Hosts that have no `layoutContextMenu`
@@ -114,7 +119,7 @@ Item {
             anchors.fill: parent
             // Standard inner padding so the content (status icons, thumbnail,
             // footer) doesn't hug the card border. smallSpacing was too tight.
-            anchors.margins: Kirigami.Units.largeSpacing
+            anchors.margins: root._bodyInset
             spacing: Kirigami.Units.smallSpacing
 
             // Thumbnail area
@@ -155,12 +160,12 @@ Item {
 
                     anchors.top: parent.top
                     anchors.left: parent.left
-                    // The content column is inset by largeSpacing, but these
-                    // corner status icons read better tucked near the card edge.
-                    // Offset back out past the column inset so they sit a small
-                    // padding from the card corner, not the thumbnail's.
-                    anchors.topMargin: Kirigami.Units.smallSpacing - Kirigami.Units.largeSpacing
-                    anchors.leftMargin: Kirigami.Units.smallSpacing - Kirigami.Units.largeSpacing
+                    // The content column is inset by _bodyInset, but these corner
+                    // status icons read better tucked near the card edge. Offset
+                    // back out past the column inset so they sit a small padding
+                    // from the card corner, not the thumbnail's.
+                    anchors.topMargin: Kirigami.Units.smallSpacing - root._bodyInset
+                    anchors.leftMargin: Kirigami.Units.smallSpacing - root._bodyInset
                     spacing: Kirigami.Units.smallSpacing / 2
 
                     Kirigami.Icon {
@@ -244,10 +249,10 @@ Item {
                     anchors.top: parent.top
                     anchors.right: parent.right
                     // See the top-left row: offset back out past the column's
-                    // largeSpacing inset so the toggle buttons sit near the card
-                    // corner with a small padding.
-                    anchors.topMargin: Kirigami.Units.smallSpacing / 2 - Kirigami.Units.largeSpacing
-                    anchors.rightMargin: Kirigami.Units.smallSpacing / 2 - Kirigami.Units.largeSpacing
+                    // _bodyInset so the toggle buttons sit near the card corner
+                    // with a small padding.
+                    anchors.topMargin: Kirigami.Units.smallSpacing / 2 - root._bodyInset
+                    anchors.rightMargin: Kirigami.Units.smallSpacing / 2 - root._bodyInset
                     spacing: 0
 
                     // Auto-assign toggle (hidden for autotile — the tiling engine manages those).

--- a/src/settings/qml/LayoutGridDelegate.qml
+++ b/src/settings/qml/LayoutGridDelegate.qml
@@ -112,7 +112,9 @@ Item {
 
         ColumnLayout {
             anchors.fill: parent
-            anchors.margins: Kirigami.Units.smallSpacing
+            // Standard inner padding so the content (status icons, thumbnail,
+            // footer) doesn't hug the card border. smallSpacing was too tight.
+            anchors.margins: Kirigami.Units.largeSpacing
             spacing: Kirigami.Units.smallSpacing
 
             // Thumbnail area
@@ -153,7 +155,12 @@ Item {
 
                     anchors.top: parent.top
                     anchors.left: parent.left
-                    anchors.margins: Kirigami.Units.smallSpacing
+                    // The content column is inset by largeSpacing, but these
+                    // corner status icons read better tucked near the card edge.
+                    // Offset back out past the column inset so they sit a small
+                    // padding from the card corner, not the thumbnail's.
+                    anchors.topMargin: Kirigami.Units.smallSpacing - Kirigami.Units.largeSpacing
+                    anchors.leftMargin: Kirigami.Units.smallSpacing - Kirigami.Units.largeSpacing
                     spacing: Kirigami.Units.smallSpacing / 2
 
                     Kirigami.Icon {
@@ -236,7 +243,11 @@ Item {
                 Row {
                     anchors.top: parent.top
                     anchors.right: parent.right
-                    anchors.margins: Kirigami.Units.smallSpacing / 2
+                    // See the top-left row: offset back out past the column's
+                    // largeSpacing inset so the toggle buttons sit near the card
+                    // corner with a small padding.
+                    anchors.topMargin: Kirigami.Units.smallSpacing / 2 - Kirigami.Units.largeSpacing
+                    anchors.rightMargin: Kirigami.Units.smallSpacing / 2 - Kirigami.Units.largeSpacing
                     spacing: 0
 
                     // Auto-assign toggle (hidden for autotile — the tiling engine manages those).
@@ -333,7 +344,7 @@ Item {
                 Label {
                     elide: Text.ElideRight
                     font: Kirigami.Theme.smallFont
-                    color: root.isSelected ? Kirigami.Theme.highlightedTextColor : Kirigami.Theme.disabledTextColor
+                    color: Kirigami.Theme.disabledTextColor
                     text: i18n("%1 zones", root.modelData.zoneCount || 0)
                 }
             }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -166,9 +166,35 @@ PhosphorUi.SettingsAppWindow {
                 checked: settingsController.daemonRunning
                 enabled: !settingsController.daemonController.busy
                 accessibleName: i18n("Toggle daemon")
+                // The switch is fully controlled (checked is bound to
+                // daemonRunning and never self-toggles), so it stays visually
+                // "on" until the daemon actually stops. Turning OFF kills tiling
+                // + snapping for the whole session, so confirm first; turning ON
+                // applies immediately.
                 onToggled: function (newValue) {
-                    settingsController.daemonController.setEnabled(newValue);
+                    if (newValue)
+                        settingsController.daemonController.setEnabled(true);
+                    else
+                        daemonStopConfirm.open();
                 }
+            }
+
+            Kirigami.PromptDialog {
+                id: daemonStopConfirm
+
+                title: i18n("Stop daemon?")
+                subtitle: i18n("Stopping the PlasmaZones daemon disables window tiling and snapping until you start it again.")
+                standardButtons: Kirigami.Dialog.Cancel
+                customFooterActions: [
+                    Kirigami.Action {
+                        text: i18n("Stop daemon")
+                        icon.name: "system-shutdown"
+                        onTriggered: {
+                            settingsController.daemonController.setEnabled(false);
+                            daemonStopConfirm.close();
+                        }
+                    }
+                ]
             }
         }
     }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -171,30 +171,15 @@ PhosphorUi.SettingsAppWindow {
                 // "on" until the daemon actually stops. Turning OFF kills tiling
                 // + snapping for the whole session, so confirm first; turning ON
                 // applies immediately.
+                // Routes through the root-level daemonStopConfirm (declared
+                // beside the other inline confirm dialogs) so the page-nav
+                // shortcut guard can see its `visible` state.
                 onToggled: function (newValue) {
                     if (newValue)
                         settingsController.daemonController.setEnabled(true);
                     else
                         daemonStopConfirm.open();
                 }
-            }
-
-            Kirigami.PromptDialog {
-                id: daemonStopConfirm
-
-                title: i18n("Stop daemon?")
-                subtitle: i18n("Stopping the PlasmaZones daemon disables window tiling and snapping until you start it again.")
-                standardButtons: Kirigami.Dialog.Cancel
-                customFooterActions: [
-                    Kirigami.Action {
-                        text: i18n("Stop daemon")
-                        icon.name: "system-shutdown"
-                        onTriggered: {
-                            settingsController.daemonController.setEnabled(false);
-                            daemonStopConfirm.close();
-                        }
-                    }
-                ]
             }
         }
     }
@@ -351,7 +336,8 @@ PhosphorUi.SettingsAppWindow {
     // ── Ctrl+PgUp / Ctrl+PgDown — step through navigable pages ──────
     // Guarded: page navigation must not fire while any of the inline
     // confirm dialogs (whatsNewDialog, resetConfirmDialog,
-    // defaultsConfirmDialog, sectionToggleDiscardConfirm), the shortcut
+    // defaultsConfirmDialog, sectionToggleDiscardConfirm, daemonStopConfirm),
+    // the shortcut
     // overlay, the active page's own modal stack (WindowRulesPage's
     // forceSaveConfirm / addRuleWizard / ruleEditorSheet /
     // windowPickerDialog), OR a native child window (QtQuick FileDialog,
@@ -384,7 +370,7 @@ PhosphorUi.SettingsAppWindow {
     // Shared enable-guard for page-navigation shortcuts. Hoisted from
     // the two identical inline expressions so a future dialog addition
     // doesn't drift between Ctrl+PgUp / Ctrl+PgDown.
-    readonly property bool _navShortcutsEnabled: window.active && !whatsNewDialog.visible && !resetConfirmDialog.visible && !defaultsConfirmDialog.visible && !sectionToggleDiscardConfirm.visible && !window._showShortcuts && !window._pageOwnedModalOpen && !window._searchOpen
+    readonly property bool _navShortcutsEnabled: window.active && !whatsNewDialog.visible && !resetConfirmDialog.visible && !defaultsConfirmDialog.visible && !sectionToggleDiscardConfirm.visible && !daemonStopConfirm.visible && !window._showShortcuts && !window._pageOwnedModalOpen && !window._searchOpen
 
     Shortcut {
         sequence: "Ctrl+PgUp"
@@ -877,6 +863,28 @@ PhosphorUi.SettingsAppWindow {
                 text: i18n("Cancel")
                 icon.name: "dialog-cancel"
                 onTriggered: sectionToggleDiscardConfirm.close()
+            }
+        ]
+    }
+
+    // Confirm before stopping the daemon from the header toggle. Declared at the
+    // window root (not in the headerTrailing Component) so the page-nav shortcut
+    // guard `_navShortcutsEnabled` can read its `visible` state; the header
+    // SettingsSwitch opens it via outer-scope reference.
+    Kirigami.PromptDialog {
+        id: daemonStopConfirm
+
+        title: i18n("Stop daemon?")
+        subtitle: i18n("Stopping the PlasmaZones daemon disables window tiling and snapping until you start it again.")
+        standardButtons: Kirigami.Dialog.Cancel
+        customFooterActions: [
+            Kirigami.Action {
+                text: i18n("Stop daemon")
+                icon.name: "system-shutdown"
+                onTriggered: {
+                    settingsController.daemonController.setEnabled(false);
+                    daemonStopConfirm.close();
+                }
             }
         ]
     }

--- a/src/settings/qml/OrderingPage.qml
+++ b/src/settings/qml/OrderingPage.qml
@@ -101,6 +101,8 @@ SettingsFlickable {
                     property bool isDragging: false
 
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     Layout.preferredHeight: Math.max(orderModel.count * rowHeight, Kirigami.Units.gridUnit * 10)
                     clip: true
 
@@ -419,6 +421,8 @@ SettingsFlickable {
 
                 RowLayout {
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     spacing: Kirigami.Units.smallSpacing
 
                     Item {

--- a/src/settings/qml/OrderingPage.qml
+++ b/src/settings/qml/OrderingPage.qml
@@ -101,8 +101,11 @@ SettingsFlickable {
                     property bool isDragging: false
 
                     Layout.fillWidth: true
-                    Layout.leftMargin: Kirigami.Units.largeSpacing
-                    Layout.rightMargin: Kirigami.Units.largeSpacing
+                    // No horizontal Layout margin here: each drag row already
+                    // insets its content by largeSpacing (the inner RowLayout's
+                    // anchors), so adding it here too double-inset the rows
+                    // relative to the reset row below. Row cards stay full-width;
+                    // their content lines up with the reset row at largeSpacing.
                     Layout.preferredHeight: Math.max(orderModel.count * rowHeight, Kirigami.Units.gridUnit * 10)
                     clip: true
 

--- a/src/settings/qml/SettingsCard.qml
+++ b/src/settings/qml/SettingsCard.qml
@@ -57,6 +57,11 @@ Item {
     /// Stable type marker so a contained SettingsRow can identify its hosting
     /// card by walking up the parent chain (used to expand the card on reveal).
     readonly property bool isSettingsCard: true
+    /// Opacity applied to the card body when the master toggle is off. Kept
+    /// high enough that the muted content stays legible — the disabled palette
+    /// already greys the text, so a low opacity on top compounds into an
+    /// unreadable wash. This dims for "off" without hiding what's inside.
+    readonly property real disabledContentOpacity: 0.85
 
     // Per-monitor scope chip (optional). When scopeEnabled, the header shows a
     // monitor scope chip right after the title, collapsed to "All Monitors",
@@ -297,7 +302,7 @@ Item {
             width: parent.width
             height: contentColumn.implicitHeight
             clip: true
-            opacity: root.showToggle && !root.toggleChecked ? 0.5 : 1
+            opacity: root.showToggle && !root.toggleChecked ? root.disabledContentOpacity : 1
             enabled: root.showToggle ? root.toggleChecked : true
 
             Item {
@@ -341,7 +346,7 @@ Item {
                 PhosphorMotionAnimation {
                     target: contentClip
                     properties: "opacity"
-                    to: root.showToggle && !root.toggleChecked ? 0.5 : 1
+                    to: root.showToggle && !root.toggleChecked ? root.disabledContentOpacity : 1
                     profile: "widget.fadeIn"
                 }
 
@@ -351,7 +356,7 @@ Item {
                             return contentColumn.implicitHeight;
                         });
                         contentClip.opacity = Qt.binding(function () {
-                            return root.showToggle && !root.toggleChecked ? 0.5 : 1;
+                            return root.showToggle && !root.toggleChecked ? root.disabledContentOpacity : 1;
                         });
                     }
                 }

--- a/src/settings/qml/SettingsCard.qml
+++ b/src/settings/qml/SettingsCard.qml
@@ -60,10 +60,10 @@ Item {
     /// Opacity applied to the card body when the master toggle is off. Kept
     /// high enough that muted content stays legible — the disabled palette
     /// already greys the text, so a low opacity on top compounds into an
-    /// unreadable wash. Note SettingsRows hide themselves when disabled (see
-    /// SettingsRow's `visible: enabled`), so a row-only body collapses to its
-    /// separators; cards with non-row content (editors, custom items) keep that
-    /// content visibly muted by this opacity.
+    /// unreadable wash. Note SettingsRows and SettingsSeparators hide themselves
+    /// when disabled (their `visible: enabled`), so a row-only body collapses
+    /// away entirely; cards with non-row content (editors, custom items) keep
+    /// that content visibly muted by this opacity.
     readonly property real disabledContentOpacity: 0.85
 
     // Per-monitor scope chip (optional). When scopeEnabled, the header shows a

--- a/src/settings/qml/SettingsCard.qml
+++ b/src/settings/qml/SettingsCard.qml
@@ -58,9 +58,12 @@ Item {
     /// card by walking up the parent chain (used to expand the card on reveal).
     readonly property bool isSettingsCard: true
     /// Opacity applied to the card body when the master toggle is off. Kept
-    /// high enough that the muted content stays legible — the disabled palette
+    /// high enough that muted content stays legible — the disabled palette
     /// already greys the text, so a low opacity on top compounds into an
-    /// unreadable wash. This dims for "off" without hiding what's inside.
+    /// unreadable wash. Note SettingsRows hide themselves when disabled (see
+    /// SettingsRow's `visible: enabled`), so a row-only body collapses to its
+    /// separators; cards with non-row content (editors, custom items) keep that
+    /// content visibly muted by this opacity.
     readonly property real disabledContentOpacity: 0.85
 
     // Per-monitor scope chip (optional). When scopeEnabled, the header shows a

--- a/src/settings/qml/SettingsRow.qml
+++ b/src/settings/qml/SettingsRow.qml
@@ -30,6 +30,15 @@ Item {
     property string searchAnchor: ""
     default property alias content: controlContainer.data
 
+    // A disabled row is hidden rather than shown super-dimmed: when a setting
+    // can't apply in the current state there's nothing actionable in it, so it
+    // collapses out of the layout instead of leaving dead, greyed space. This
+    // tracks `enabled` directly, so a row disabled by an ancestor (e.g. a
+    // card-level master toggle) hides too. Consumers that set their own
+    // `visible` binding override this default (those rows manage their own
+    // show/hide).
+    visible: enabled
+
     Layout.fillWidth: true
     implicitWidth: rowLayout.implicitWidth
     implicitHeight: rowLayout.implicitHeight

--- a/src/settings/qml/SettingsSeparator.qml
+++ b/src/settings/qml/SettingsSeparator.qml
@@ -9,6 +9,12 @@ import org.kde.kirigami as Kirigami
  * @brief Inset separator for use between SettingsRow items inside a card.
  */
 Kirigami.Separator {
+    // Hide when disabled, mirroring SettingsRow's `visible: enabled`. In a
+    // master-toggle card that is switched off, the rows collapse out; without
+    // this the interleaved separators would remain as stray lines floating over
+    // the dimmed body. Consumers that set their own `visible` override this.
+    visible: enabled
+
     Layout.fillWidth: true
     Layout.leftMargin: Kirigami.Units.largeSpacing
     Layout.rightMargin: Kirigami.Units.largeSpacing

--- a/src/settings/qml/ShaderBrowserCard.qml
+++ b/src/settings/qml/ShaderBrowserCard.qml
@@ -6,6 +6,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Window
 import org.kde.kirigami as Kirigami
+import org.phosphor.animation
 
 /**
  * @brief Compact shader card for a shader-browser grid.
@@ -44,7 +45,7 @@ ItemDelegate {
     required property var effect
     required property var bridge
     property int usagesRev: 0
-    property var usageChipTextFn: function(count) {
+    property var usageChipTextFn: function (count) {
         return i18ncp("@info shader usage count", "%n use", "%n uses", count);
     }
 
@@ -52,140 +53,167 @@ ItemDelegate {
 
     width: Kirigami.Units.gridUnit * 14
     implicitWidth: width
-    implicitHeight: cardLayout.implicitHeight + topPadding + bottomPadding
+    implicitHeight: contentItem.implicitHeight
+    // The inner padding (card border -> text) is applied as a MARGIN inside our
+    // own contentItem (anchors.margins on the inner ColumnLayout below), NOT via
+    // the Control's padding. The org.kde.desktop ItemDelegate style overrides
+    // per-side padding, so `padding:`/`leftPadding:` set here are ignored and the
+    // text hugged the border. Control padding is zeroed so contentItem fills the
+    // card and the margin is the sole, style-proof inset.
+    padding: 0
+    readonly property real _cardPad: Math.round(Kirigami.Units.largeSpacing * 1.5)
     hoverEnabled: true
     Accessible.name: effect ? (effect.name || effect.id || "") : ""
     Accessible.description: effect && effect.description ? effect.description : i18nc("@info:tooltip generic shader card", "Shader effect details")
     onClicked: {
         if (effect)
             root.showDetails(effect);
-
     }
 
     background: Rectangle {
         radius: Kirigami.Units.smallSpacing
-        color: root.hovered ? Kirigami.Theme.hoverColor : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.04)
+        // Match the SettingsCard standard: keep the fill subtle and signal
+        // hover through an accent-tinted border, rather than flooding the
+        // whole card with hoverColor.
+        color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, root.hovered ? 0.06 : 0.04)
         border.width: Math.max(1, Math.round(Screen.devicePixelRatio))
-        border.color: root.activeFocus ? Kirigami.Theme.focusColor : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.12)
-    }
+        border.color: {
+            if (root.activeFocus)
+                return Kirigami.Theme.focusColor;
 
-    contentItem: ColumnLayout {
-        id: cardLayout
+            if (root.hovered)
+                return Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.4);
 
-        spacing: Kirigami.Units.smallSpacing
-
-        Rectangle {
-            readonly property bool _hasPreview: root.effect && root.effect.previewPath && root.effect.previewPath.length > 0
-
-            Layout.fillWidth: true
-            Layout.preferredHeight: width * 9 / 16
-            visible: _hasPreview
-            radius: Kirigami.Units.smallSpacing
-            color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.08)
-            border.width: Math.max(1, Math.round(Screen.devicePixelRatio))
-            border.color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.12)
-            clip: true
-
-            Image {
-                anchors.fill: parent
-                anchors.margins: Math.max(1, Math.round(Screen.devicePixelRatio))
-                // `encodeURI` percent-encodes spaces and unicode while
-                // preserving path separators, which a raw `"file://" + path`
-                // concat would silently break on (e.g. user-installed packs
-                // under `~/My Shaders/`).
-                source: parent._hasPreview ? "file://" + encodeURI(root.effect.previewPath) : ""
-                fillMode: Image.PreserveAspectCrop
-                sourceSize.width: width * 2
-                sourceSize.height: height * 2
-                asynchronous: true
-                cache: true
-                visible: status === Image.Ready
-            }
-
+            return Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.12);
         }
 
-        RowLayout {
-            Layout.fillWidth: true
+        Behavior on border.color {
+            PhosphorMotionAnimation {
+                profile: "widget.hover"
+                durationOverride: Kirigami.Units.shortDuration
+            }
+        }
+    }
+
+    contentItem: Item {
+        implicitWidth: cardLayout.implicitWidth + root._cardPad * 2
+        implicitHeight: cardLayout.implicitHeight + root._cardPad * 2
+
+        ColumnLayout {
+            id: cardLayout
+
+            anchors.fill: parent
+            anchors.margins: root._cardPad
             spacing: Kirigami.Units.smallSpacing
 
-            Label {
+            Rectangle {
+                readonly property bool _hasPreview: root.effect && root.effect.previewPath && root.effect.previewPath.length > 0
+
                 Layout.fillWidth: true
-                text: root.effect ? (root.effect.name || root.effect.id || "") : ""
-                font.weight: Font.DemiBold
+                Layout.preferredHeight: width * 9 / 16
+                visible: _hasPreview
+                radius: Kirigami.Units.smallSpacing
+                color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.08)
+                border.width: Math.max(1, Math.round(Screen.devicePixelRatio))
+                border.color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.12)
+                clip: true
+
+                Image {
+                    anchors.fill: parent
+                    anchors.margins: Math.max(1, Math.round(Screen.devicePixelRatio))
+                    // `encodeURI` percent-encodes spaces and unicode while
+                    // preserving path separators, which a raw `"file://" + path`
+                    // concat would silently break on (e.g. user-installed packs
+                    // under `~/My Shaders/`).
+                    source: parent._hasPreview ? "file://" + encodeURI(root.effect.previewPath) : ""
+                    fillMode: Image.PreserveAspectCrop
+                    sourceSize.width: width * 2
+                    sourceSize.height: height * 2
+                    asynchronous: true
+                    cache: true
+                    visible: status === Image.Ready
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Kirigami.Units.smallSpacing
+
+                Label {
+                    Layout.fillWidth: true
+                    text: root.effect ? (root.effect.name || root.effect.id || "") : ""
+                    font.weight: Font.DemiBold
+                    elide: Text.ElideRight
+                }
+
+                Label {
+                    visible: root.effect && root.effect.isUserEffect
+                    text: i18nc("@info shader source badge", "User")
+                    font: Kirigami.Theme.smallFont
+                    color: Kirigami.Theme.positiveTextColor
+                }
+            }
+
+            Label {
+                readonly property string _description: root.effect && typeof root.effect.description === "string" ? root.effect.description : ""
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: visible ? Kirigami.Units.gridUnit * 2 : 0
+                visible: _description.length > 0
+                text: _description
+                color: Kirigami.Theme.disabledTextColor
+                font: Kirigami.Theme.smallFont
+                wrapMode: Text.Wrap
+                maximumLineCount: 2
                 elide: Text.ElideRight
+                verticalAlignment: Text.AlignTop
             }
 
-            Label {
-                visible: root.effect && root.effect.isUserEffect
-                text: i18nc("@info shader source badge", "User")
-                font: Kirigami.Theme.smallFont
-                color: Kirigami.Theme.positiveTextColor
-            }
-
-        }
-
-        Label {
-            readonly property string _description: root.effect && typeof root.effect.description === "string" ? root.effect.description : ""
-
-            Layout.fillWidth: true
-            Layout.preferredHeight: visible ? Kirigami.Units.gridUnit * 2 : 0
-            visible: _description.length > 0
-            text: _description
-            color: Kirigami.Theme.disabledTextColor
-            font: Kirigami.Theme.smallFont
-            wrapMode: Text.Wrap
-            maximumLineCount: 2
-            elide: Text.ElideRight
-            verticalAlignment: Text.AlignTop
-        }
-
-        RowLayout {
-            Layout.fillWidth: true
-            spacing: Kirigami.Units.smallSpacing
-
-            Label {
-                text: i18np("%n parameter", "%n parameters", (root.effect && root.effect.parameters) ? root.effect.parameters.length : 0)
-                font: Kirigami.Theme.smallFont
-                color: Kirigami.Theme.disabledTextColor
-            }
-
-            Item {
+            RowLayout {
                 Layout.fillWidth: true
+                spacing: Kirigami.Units.smallSpacing
+
+                Label {
+                    text: i18np("%n parameter", "%n parameters", (root.effect && root.effect.parameters) ? root.effect.parameters.length : 0)
+                    font: Kirigami.Theme.smallFont
+                    color: Kirigami.Theme.disabledTextColor
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                // Usage chip — visible only when this shader is assigned
+                // somewhere. Tooltip carries the full list; the detail dialog
+                // renders them inline.
+                Label {
+                    readonly property var _usages: {
+                        root.usagesRev; // reactive dep
+                        var id = root.effect ? root.effect.id : "";
+                        if (!id || id.length === 0 || !root.bridge)
+                            return [];
+
+                        return root.bridge.shaderEffectUsages(id);
+                    }
+
+                    visible: _usages.length > 0
+                    text: root.usageChipTextFn(_usages.length)
+                    font: Kirigami.Theme.smallFont
+                    color: Kirigami.Theme.disabledTextColor
+                    ToolTip.visible: hovered.hovered && _usages.length > 0
+                    ToolTip.text: {
+                        var names = [];
+                        for (var i = 0; i < _usages.length; i++)
+                            names.push(_usages[i].label || _usages[i].path);
+                        return names.join(", ");
+                    }
+                    ToolTip.delay: Kirigami.Units.toolTipDelay
+
+                    HoverHandler {
+                        id: hovered
+                    }
+                }
             }
-
-            // Usage chip — visible only when this shader is assigned
-            // somewhere. Tooltip carries the full list; the detail dialog
-            // renders them inline.
-            Label {
-                readonly property var _usages: {
-                    root.usagesRev; // reactive dep
-                    var id = root.effect ? root.effect.id : "";
-                    if (!id || id.length === 0 || !root.bridge)
-                        return [];
-
-                    return root.bridge.shaderEffectUsages(id);
-                }
-
-                visible: _usages.length > 0
-                text: root.usageChipTextFn(_usages.length)
-                font: Kirigami.Theme.smallFont
-                color: Kirigami.Theme.disabledTextColor
-                ToolTip.visible: hovered.hovered && _usages.length > 0
-                ToolTip.text: {
-                    var names = [];
-                    for (var i = 0; i < _usages.length; i++) names.push(_usages[i].label || _usages[i].path)
-                    return names.join(", ");
-                }
-                ToolTip.delay: Kirigami.Units.toolTipDelay
-
-                HoverHandler {
-                    id: hovered
-                }
-
-            }
-
         }
-
     }
-
 }

--- a/src/settings/qml/ShaderBrowserPage.qml
+++ b/src/settings/qml/ShaderBrowserPage.qml
@@ -224,6 +224,8 @@ SettingsFlickable {
 
                 Label {
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     text: root.userShadersDescription
                     wrapMode: Text.WordWrap
                     color: Kirigami.Theme.disabledTextColor
@@ -235,6 +237,8 @@ SettingsFlickable {
                     readonly property bool _highlight: dropArea.containsDrag
 
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
                     Layout.preferredHeight: Kirigami.Units.gridUnit * 5
                     radius: Kirigami.Units.smallSpacing
                     color: _highlight ? Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.12) : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.04)
@@ -312,6 +316,8 @@ SettingsFlickable {
 
                 RowLayout {
                     Layout.fillWidth: true
+                    Layout.leftMargin: Kirigami.Units.largeSpacing
+                    Layout.rightMargin: Kirigami.Units.largeSpacing
 
                     Item {
                         Layout.fillWidth: true
@@ -475,10 +481,22 @@ SettingsFlickable {
                     // delegate's identically-named `modelData` doesn't shadow
                     // the Repeater's auto-injection.
                     Flow {
+                        id: shaderFlow
+
                         Layout.fillWidth: true
-                        Layout.leftMargin: Kirigami.Units.smallSpacing
-                        Layout.rightMargin: Kirigami.Units.smallSpacing
+                        // Standard card-content inset (matches SettingsRow / the
+                        // section header), so the cards line up with everything
+                        // else rather than hugging the category card edge.
+                        Layout.leftMargin: Kirigami.Units.largeSpacing
+                        Layout.rightMargin: Kirigami.Units.largeSpacing
                         spacing: Kirigami.Units.smallSpacing
+
+                        // Responsive columns: fit as many cards as the minimum
+                        // card width allows, then stretch each card to fill the
+                        // row evenly so there's no dead gap on the right edge.
+                        readonly property real _minCardWidth: Kirigami.Units.gridUnit * 13
+                        readonly property int _columns: Math.max(1, Math.floor((width + spacing) / (_minCardWidth + spacing)))
+                        readonly property real _cardWidth: (width - spacing * (_columns - 1)) / _columns
 
                         Repeater {
                             model: modelData.effects
@@ -486,6 +504,7 @@ SettingsFlickable {
                             delegate: ShaderBrowserCard {
                                 required property var modelData
 
+                                width: shaderFlow._cardWidth
                                 effect: modelData
                                 bridge: root.bridge
                                 usagesRev: root._usagesRev

--- a/src/settings/qml/SnappingWindowBehaviorPage.qml
+++ b/src/settings/qml/SnappingWindowBehaviorPage.qml
@@ -71,7 +71,6 @@ SettingsFlickable {
                         searchAnchor: "holdToEnable"
                         description: i18n("Hold this modifier when releasing a window to show the picker for that snap only")
                         enabled: !snapAssistAlwaysSwitch.checked
-                        opacity: enabled ? 1 : 0.4
 
                         ModifierAndMouseCheckBoxes {
                             width: root.sliderPreferredWidth

--- a/src/settings/qml/TilingBehaviorPage.qml
+++ b/src/settings/qml/TilingBehaviorPage.qml
@@ -58,7 +58,6 @@ SettingsFlickable {
                     searchAnchor: "holdToReinsert"
                     description: i18n("Hold a modifier or mouse button while dragging a window to dynamically insert it into the autotile stack at the cursor position")
                     enabled: !alwaysReinsertSwitch.checked
-                    opacity: enabled ? 1 : 0.4
 
                     ModifierAndMouseCheckBoxes {
                         width: root.triggerPreferredWidth
@@ -80,7 +79,6 @@ SettingsFlickable {
                     searchAnchor: "triggersToggleMode"
                     description: i18n("Tap the re-insert trigger once to activate the stack preview, tap again to deactivate it")
                     enabled: !alwaysReinsertSwitch.checked
-                    opacity: enabled ? 1 : 0.4
 
                     SettingsSwitch {
                         checked: appSettings.autotileDragInsertToggle

--- a/src/settings/qml/VirtualScreensPage.qml
+++ b/src/settings/qml/VirtualScreensPage.qml
@@ -36,6 +36,10 @@ SettingsFlickable {
     // Grid dimensions inferred from pending screens
     property int _columns: 1
     property int _rows: 1
+    // Flips true one tick after the first geometry resolution so the preview
+    // box doesn't animate the initial fallback(16:9)→real-aspect jump on page
+    // open; monitor switches afterwards still animate.
+    property bool _geometrySettled: false
 
     function _refreshConfig() {
         if (_selectedScreen === "")
@@ -150,6 +154,15 @@ SettingsFlickable {
     }
 
     function _updateScreenGeometry() {
+        // Mark geometry settled on the next tick the first time we resolve, so
+        // the initial fallback→real transition lands without animating (the
+        // Behaviors below gate on _geometrySettled). Scheduled here, before the
+        // assignments, so it survives the function's several early returns.
+        if (!root._geometrySettled)
+            Qt.callLater(function () {
+                root._geometrySettled = true;
+            });
+
         var screens = settingsController.screens;
         // First pass: exact name match (physical screen entry)
         for (var i = 0; i < screens.length; i++) {
@@ -516,6 +529,7 @@ SettingsFlickable {
                     // the split — width and height animate independently so a
                     // landscape→portrait change eases into the new shape.
                     Behavior on Layout.preferredWidth {
+                        enabled: root._geometrySettled
                         PhosphorMotionAnimation {
                             profile: "widget.hover"
                             durationOverride: Kirigami.Units.longDuration
@@ -523,6 +537,7 @@ SettingsFlickable {
                     }
 
                     Behavior on Layout.preferredHeight {
+                        enabled: root._geometrySettled
                         PhosphorMotionAnimation {
                             profile: "widget.hover"
                             durationOverride: Kirigami.Units.longDuration

--- a/src/settings/qml/VirtualScreensPage.qml
+++ b/src/settings/qml/VirtualScreensPage.qml
@@ -7,6 +7,7 @@ import QtQuick.Layouts
 import QtQuick.Window
 import org.kde.kirigami as Kirigami
 import org.plasmazones.common as QFZCommon
+import org.phosphor.animation
 
 /**
  * @brief Settings page for virtual screen configuration.
@@ -462,7 +463,8 @@ SettingsFlickable {
                 Label {
                     Layout.leftMargin: Kirigami.Units.largeSpacing
                     text: {
-                        let res = root._screenWidth + " \u00d7 " + root._screenHeight;
+                        let orient = root._screenHeight > root._screenWidth ? i18nc("@label screen orientation", "Portrait") : i18nc("@label screen orientation", "Landscape");
+                        let res = root._screenWidth + " \u00d7 " + root._screenHeight + " \u00b7 " + orient;
                         let count = root._pendingScreens.length;
                         if (count > 1) {
                             if (root._rows > 1)
@@ -481,13 +483,20 @@ SettingsFlickable {
                 VirtualScreenPreview {
                     id: previewRect
 
-                    Layout.fillWidth: true
-                    Layout.maximumWidth: Kirigami.Units.gridUnit * 30
+                    // Fit the screen's real pixel dimensions inside the available
+                    // box so the preview is portrait for portrait monitors and
+                    // landscape for landscape ones — not a fixed horizontal
+                    // rectangle. A single uniform scale drives both width and
+                    // height off the true monitor size (bounded by the card's
+                    // content width and a max height, smaller bound wins), so the
+                    // whole screen always fits; the box is then centred.
+                    readonly property real _availWidth: Math.min(parent.width - Kirigami.Units.largeSpacing * 2, Kirigami.Units.gridUnit * 30)
+                    readonly property real _maxHeight: Kirigami.Units.gridUnit * 16
+                    readonly property real _fitScale: (root._screenWidth > 0 && root._screenHeight > 0) ? Math.min(_availWidth / root._screenWidth, _maxHeight / root._screenHeight) : 0
+
                     Layout.alignment: Qt.AlignHCenter
-                    Layout.preferredHeight: {
-                        var ratio = root._screenHeight / root._screenWidth;
-                        return Math.min(width * ratio, Kirigami.Units.gridUnit * 10);
-                    }
+                    Layout.preferredWidth: _fitScale > 0 ? root._screenWidth * _fitScale : _availWidth
+                    Layout.preferredHeight: _fitScale > 0 ? root._screenHeight * _fitScale : _availWidth * 9 / 16
                     Layout.leftMargin: Kirigami.Units.largeSpacing
                     Layout.rightMargin: Kirigami.Units.largeSpacing
                     Layout.bottomMargin: Kirigami.Units.largeSpacing
@@ -501,6 +510,23 @@ SettingsFlickable {
                     }
                     onRowDividerMoved: function (rowIndex, newFraction) {
                         root._moveRowDivider(rowIndex, newFraction);
+                    }
+
+                    // Smoothly morph the box when switching monitors or changing
+                    // the split — width and height animate independently so a
+                    // landscape→portrait change eases into the new shape.
+                    Behavior on Layout.preferredWidth {
+                        PhosphorMotionAnimation {
+                            profile: "widget.hover"
+                            durationOverride: Kirigami.Units.longDuration
+                        }
+                    }
+
+                    Behavior on Layout.preferredHeight {
+                        PhosphorMotionAnimation {
+                            profile: "widget.hover"
+                            durationOverride: Kirigami.Units.longDuration
+                        }
                     }
                 }
             }
@@ -611,10 +637,17 @@ SettingsFlickable {
 
                             readonly property bool active: root._matchesPreset(presetCard.modelData.regions)
 
+                            // Inner padding (card border -> content) applied as a
+                            // margin inside contentItem below, not via the Control's
+                            // padding: the org.kde.desktop ItemDelegate style overrides
+                            // per-side padding, so it would be ignored and the content
+                            // hugged the border. Control padding zeroed.
+                            readonly property real _cardPad: Kirigami.Units.largeSpacing
+
                             Layout.fillWidth: true
                             enabled: root._selectedScreen !== ""
                             hoverEnabled: true
-                            padding: Kirigami.Units.smallSpacing
+                            padding: 0
                             Accessible.name: i18n("Preset: %1 %2", presetCard.modelData.label, presetCard.modelData.detail)
                             // Deep-copy the preset's regions so divider drags mutate
                             // _pendingScreens, not the shared model entry.
@@ -638,53 +671,62 @@ SettingsFlickable {
                                 border.color: presetCard.active ? Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.5) : (presetCard.hovered ? Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.3) : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.08))
                             }
 
-                            contentItem: RowLayout {
-                                spacing: Kirigami.Units.largeSpacing
+                            contentItem: Item {
+                                implicitWidth: presetRow.implicitWidth + presetCard._cardPad * 2
+                                implicitHeight: presetRow.implicitHeight + presetCard._cardPad * 2
 
-                                // Preview thumbnail (left): fixed 16:9 box using the
-                                // shared ZonePreview + the same box treatment as
-                                // LayoutThumbnail (0.08 fill, accent border that
-                                // thickens when active). Zone numbers off — the split
-                                // shape is what matters here.
-                                Rectangle {
-                                    Layout.preferredHeight: Kirigami.Units.gridUnit * 3
-                                    Layout.preferredWidth: Kirigami.Units.gridUnit * 3 * 16 / 9
-                                    Layout.alignment: Qt.AlignVCenter
-                                    radius: Kirigami.Units.smallSpacing
-                                    color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.08)
-                                    border.width: presetCard.active ? Math.round(Screen.devicePixelRatio * 2.5) : Math.round(Screen.devicePixelRatio)
-                                    border.color: presetCard.active ? Kirigami.Theme.highlightColor : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.12)
+                                RowLayout {
+                                    id: presetRow
 
-                                    QFZCommon.ZonePreview {
-                                        anchors.fill: parent
-                                        anchors.margins: Kirigami.Units.smallSpacing
-                                        zones: presetCard.modelData.regions
-                                        isActive: presetCard.active
-                                        zonePadding: Math.round(Kirigami.Units.smallSpacing / 2)
-                                        edgeGap: Math.round(Kirigami.Units.smallSpacing / 2)
-                                        minZoneSize: 6
-                                        showZoneNumbers: false
-                                    }
-                                }
+                                    anchors.fill: parent
+                                    anchors.margins: presetCard._cardPad
+                                    spacing: Kirigami.Units.largeSpacing
 
-                                ColumnLayout {
-                                    Layout.fillWidth: true
-                                    Layout.alignment: Qt.AlignVCenter
-                                    spacing: 0
+                                    // Preview thumbnail (left): fixed 16:9 box using the
+                                    // shared ZonePreview + the same box treatment as
+                                    // LayoutThumbnail (0.08 fill, accent border that
+                                    // thickens when active). Zone numbers off — the split
+                                    // shape is what matters here.
+                                    Rectangle {
+                                        Layout.preferredHeight: Kirigami.Units.gridUnit * 3
+                                        Layout.preferredWidth: Kirigami.Units.gridUnit * 3 * 16 / 9
+                                        Layout.alignment: Qt.AlignVCenter
+                                        radius: Kirigami.Units.smallSpacing
+                                        color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.08)
+                                        border.width: presetCard.active ? Math.round(Screen.devicePixelRatio * 2.5) : Math.round(Screen.devicePixelRatio)
+                                        border.color: presetCard.active ? Kirigami.Theme.highlightColor : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.12)
 
-                                    Label {
-                                        Layout.fillWidth: true
-                                        text: presetCard.modelData.label
-                                        font.weight: Font.Medium
-                                        elide: Text.ElideRight
+                                        QFZCommon.ZonePreview {
+                                            anchors.fill: parent
+                                            anchors.margins: Kirigami.Units.smallSpacing
+                                            zones: presetCard.modelData.regions
+                                            isActive: presetCard.active
+                                            zonePadding: Math.round(Kirigami.Units.smallSpacing / 2)
+                                            edgeGap: Math.round(Kirigami.Units.smallSpacing / 2)
+                                            minZoneSize: 6
+                                            showZoneNumbers: false
+                                        }
                                     }
 
-                                    Label {
+                                    ColumnLayout {
                                         Layout.fillWidth: true
-                                        text: presetCard.modelData.detail
-                                        font: Kirigami.Theme.smallFont
-                                        color: Kirigami.Theme.disabledTextColor
-                                        elide: Text.ElideRight
+                                        Layout.alignment: Qt.AlignVCenter
+                                        spacing: 0
+
+                                        Label {
+                                            Layout.fillWidth: true
+                                            text: presetCard.modelData.label
+                                            font.weight: Font.Medium
+                                            elide: Text.ElideRight
+                                        }
+
+                                        Label {
+                                            Layout.fillWidth: true
+                                            text: presetCard.modelData.detail
+                                            font: Kirigami.Theme.smallFont
+                                            color: Kirigami.Theme.disabledTextColor
+                                            elide: Text.ElideRight
+                                        }
                                     }
                                 }
                             }

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -389,12 +389,17 @@ SettingsController::SettingsController(QObject* parent)
     // Tiling→Algorithm page sub-controller. Owns 7 slider bounds + the
     // custom-parameter CRUD surface. Borrows the algorithm registry this
     // controller already owns; declared as a unique_ptr AFTER
-    // m_localAlgorithmRegistry so reverse-order member destruction tears
-    // the sub-controller down BEFORE the registry resets. Parenting to
-    // `this` would defer destruction to ~QObject, which runs AFTER the
-    // registry unique_ptr — leaving the controller's raw m_registry pointer
-    // briefly dangling.
-    m_tilingAlgorithmPage = std::make_unique<TilingAlgorithmController>(m_settings, *m_localAlgorithmRegistry, nullptr);
+    // m_localAlgorithmRegistry so reverse-order member destruction tears the
+    // sub-controller down BEFORE the registry resets.
+    //
+    // Parented to `this` so ApplicationController::registerPage does NOT adopt
+    // it: registerPage reparents parent-LESS pages to m_app, and m_app —
+    // declared last, destroyed first — would then delete this page, leaving the
+    // unique_ptr to double-free it (SIGSEGV on close). The parent is purely an
+    // ownership marker; the unique_ptr still resets in member order (before the
+    // borrowed registry, so raw m_registry never dangles), and ~QObject(this)
+    // finds nothing left to delete.
+    m_tilingAlgorithmPage = std::make_unique<TilingAlgorithmController>(m_settings, *m_localAlgorithmRegistry, this);
     connect(m_tilingAlgorithmPage.get(), &TilingAlgorithmController::changed, this,
             &SettingsController::onSettingsPropertyChanged);
 
@@ -671,8 +676,12 @@ SettingsController::SettingsController(QObject* parent)
     m_shaderPreviewBackend = std::make_unique<RegistryShaderPreviewBackend>(m_overlayShaderRegistry, &m_settings);
     m_shaderPreviewController = std::make_unique<ShaderPreviewController>(m_shaderPreviewBackend.get());
 
+    // Parented to `this` for the same reason as m_tilingAlgorithmPage above:
+    // without a parent, registerPage would adopt it to m_app (destroyed first)
+    // and the unique_ptr would then double-free it on close. The unique_ptr
+    // still drives destruction in member order, before the borrowed registries.
     m_snappingShadersPage = std::make_unique<SnappingShadersPageController>(
-        m_overlayShaderRegistry, m_localLayoutManager.get(), m_shaderPreviewController.get());
+        m_overlayShaderRegistry, m_localLayoutManager.get(), m_shaderPreviewController.get(), this);
 
     // Screen helper signals — wire BEFORE the initial refreshScreens()
     // so a synchronous screensChanged emit from the refresh reaches our

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -749,25 +749,25 @@ private:
     /// and m_localAlgorithmRegistry reset.
     std::unique_ptr<AlgorithmService> m_algorithmService;
 
-    /// Tiling→Algorithm page sub-controller. Declared as unique_ptr (not
-    /// parented to `this`) and placed AFTER m_localAlgorithmRegistry so
-    /// reverse-order destruction runs ~TilingAlgorithmController BEFORE
-    /// the registry unique_ptr resets — the controller holds a raw pointer
-    /// to the registry. Parenting to `this` would defer destruction to
-    /// ~QObject, which runs AFTER these member unique_ptrs have already
-    /// released their borrowed targets.
+    /// Tiling→Algorithm page sub-controller. Held by unique_ptr and placed
+    /// AFTER m_localAlgorithmRegistry so reverse-order member destruction runs
+    /// ~TilingAlgorithmController (which holds a raw pointer to the registry)
+    /// BEFORE the registry unique_ptr resets. The unique_ptr — NOT ~QObject —
+    /// is what destroys it, so that ordering holds regardless of parent.
+    /// It is nonetheless constructed with parent `this` (see the ctor site):
+    /// registerPage adopts parent-LESS pages to m_app, which is destroyed
+    /// first and would double-free this object on close.
     std::unique_ptr<TilingAlgorithmController> m_tilingAlgorithmPage;
 
-    /// Snapping→Shaders page sub-controller. Same declaration-order
-    /// rationale as `m_tilingAlgorithmPage`: borrows
-    /// `m_localLayoutManager` (the registry walked by `shaderEffectUsages`
-    /// for the "Used in:" reverse-lookup), so it MUST be a `unique_ptr<>`
-    /// declared AFTER that registry. A QObject-child raw pointer would
-    /// defer destruction to ~QObject, which runs AFTER the registry's
-    /// unique_ptr has already reset, leaving the controller holding a
-    /// dangling layout-registry pointer if any teardown signal fires.
-    /// Borrows `m_overlayShaderRegistry` too, but that registry is a
-    /// QObject child of `this` and survives until ~QObject — fine.
+    /// Snapping→Shaders page sub-controller. Same rationale as
+    /// `m_tilingAlgorithmPage`: borrows `m_localLayoutManager` (the registry
+    /// walked by `shaderEffectUsages` for the "Used in:" reverse-lookup), so it
+    /// MUST be a `unique_ptr<>` declared AFTER that registry — the unique_ptr
+    /// reset (member order), not ~QObject, drives its destruction before the
+    /// borrowed registry resets. Constructed with parent `this` so registerPage
+    /// does not adopt it to the first-destroyed m_app (double-free on close).
+    /// Borrows `m_overlayShaderRegistry` too, but that registry is a QObject
+    /// child of `this` and survives until ~QObject — fine.
     std::unique_ptr<SnappingShadersPageController> m_snappingShadersPage;
 
     /// Recompute zone geometry for every manual layout in

--- a/src/shared/ShaderParameterSection.qml
+++ b/src/shared/ShaderParameterSection.qml
@@ -73,6 +73,7 @@ ColumnLayout {
         onClicked: root.toggled()
 
         contentItem: Item {
+            implicitWidth: paramHeaderRow.implicitWidth + Kirigami.Units.largeSpacing * 2
             implicitHeight: paramHeaderRow.implicitHeight
 
             // Inset via a margin inside contentItem (not the Control's padding,

--- a/src/shared/ShaderParameterSection.qml
+++ b/src/shared/ShaderParameterSection.qml
@@ -72,76 +72,88 @@ ColumnLayout {
         Accessible.description: root.expanded ? i18ncp("@info:tooltip expanded section", "%1 parameter. Click to collapse.", "%1 parameters. Click to collapse.", root.paramCount) : i18ncp("@info:tooltip collapsed section", "%1 parameter. Click to expand.", "%1 parameters. Click to expand.", root.paramCount)
         onClicked: root.toggled()
 
-        contentItem: RowLayout {
-            spacing: Kirigami.Units.smallSpacing
+        contentItem: Item {
+            implicitHeight: paramHeaderRow.implicitHeight
 
-            Kirigami.Icon {
-                source: "arrow-right"
-                implicitWidth: Kirigami.Units.iconSizes.small
-                implicitHeight: Kirigami.Units.iconSizes.small
-                color: Kirigami.Theme.textColor
-                rotation: root.expanded ? 90 : 0
+            // Inset via a margin inside contentItem (not the Control's padding,
+            // which the org.kde.desktop ItemDelegate style overrides) so the
+            // header content doesn't hug the edge.
+            RowLayout {
+                id: paramHeaderRow
 
-                Behavior on rotation {
-                    PhosphorMotionAnimation {
-                        // Direction-bound: profile reads root.expanded after the
-                        // flip — true is the expand direction, false is collapse.
-                        profile: root.expanded ? "widget.accordionExpand" : "widget.accordionCollapse"
-                        durationOverride: Kirigami.Units.longDuration
+                anchors.fill: parent
+                anchors.leftMargin: Kirigami.Units.largeSpacing
+                anchors.rightMargin: Kirigami.Units.largeSpacing
+                spacing: Kirigami.Units.smallSpacing
+
+                Kirigami.Icon {
+                    source: "arrow-right"
+                    implicitWidth: Kirigami.Units.iconSizes.small
+                    implicitHeight: Kirigami.Units.iconSizes.small
+                    color: Kirigami.Theme.textColor
+                    rotation: root.expanded ? 90 : 0
+
+                    Behavior on rotation {
+                        PhosphorMotionAnimation {
+                            // Direction-bound: profile reads root.expanded after the
+                            // flip — true is the expand direction, false is collapse.
+                            profile: root.expanded ? "widget.accordionExpand" : "widget.accordionCollapse"
+                            durationOverride: Kirigami.Units.longDuration
+                        }
                     }
                 }
-            }
-
-            QQC.Label {
-                text: root.title
-                font.weight: Font.Medium
-                Layout.fillWidth: true
-            }
-
-            QQC.ToolButton {
-                // Reads `root.lockedParams[p.id]` inside the loop register
-                // the parent map as a binding dependency directly — no
-                // separate proxy property is needed for reactivity.
-                readonly property bool allLocked: {
-                    if (!root.groupParams || root.groupParams.length === 0 || !root.lockedParams)
-                        return false;
-
-                    for (var i = 0; i < root.groupParams.length; i++) {
-                        var p = root.groupParams[i];
-                        if (p && p.id !== undefined && root.lockedParams[p.id] !== true)
-                            return false;
-                    }
-                    return true;
-                }
-
-                // Hide the lock button on empty groups too — there's
-                // nothing to lock there, and rendering the unlocked-icon
-                // button on an empty section is just visual noise.
-                visible: root.enableLocking && root.paramCount > 0
-                icon.name: allLocked ? "object-locked" : "object-unlocked"
-                icon.width: Kirigami.Units.iconSizes.small
-                icon.height: Kirigami.Units.iconSizes.small
-                opacity: allLocked ? 1 : 0.4
-                display: QQC.ToolButton.IconOnly
-                QQC.ToolTip.text: allLocked ? i18nc("@info:tooltip", "Unlock all in %1", root.title) : i18nc("@info:tooltip", "Lock all in %1", root.title)
-                QQC.ToolTip.visible: hovered
-                QQC.ToolTip.delay: Kirigami.Units.toolTipDelay
-                onClicked: root.groupLockToggled(!allLocked)
-            }
-
-            Rectangle {
-                implicitWidth: countLabel.implicitWidth + Kirigami.Units.smallSpacing * 2
-                implicitHeight: Kirigami.Units.gridUnit
-                radius: height / 2
-                color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.2)
 
                 QQC.Label {
-                    id: countLabel
+                    text: root.title
+                    font.weight: Font.Medium
+                    Layout.fillWidth: true
+                }
 
-                    anchors.centerIn: parent
-                    text: root.paramCount
-                    font: Kirigami.Theme.smallFont
-                    color: Kirigami.Theme.textColor
+                QQC.ToolButton {
+                    // Reads `root.lockedParams[p.id]` inside the loop register
+                    // the parent map as a binding dependency directly — no
+                    // separate proxy property is needed for reactivity.
+                    readonly property bool allLocked: {
+                        if (!root.groupParams || root.groupParams.length === 0 || !root.lockedParams)
+                            return false;
+
+                        for (var i = 0; i < root.groupParams.length; i++) {
+                            var p = root.groupParams[i];
+                            if (p && p.id !== undefined && root.lockedParams[p.id] !== true)
+                                return false;
+                        }
+                        return true;
+                    }
+
+                    // Hide the lock button on empty groups too — there's
+                    // nothing to lock there, and rendering the unlocked-icon
+                    // button on an empty section is just visual noise.
+                    visible: root.enableLocking && root.paramCount > 0
+                    icon.name: allLocked ? "object-locked" : "object-unlocked"
+                    icon.width: Kirigami.Units.iconSizes.small
+                    icon.height: Kirigami.Units.iconSizes.small
+                    opacity: allLocked ? 1 : 0.4
+                    display: QQC.ToolButton.IconOnly
+                    QQC.ToolTip.text: allLocked ? i18nc("@info:tooltip", "Unlock all in %1", root.title) : i18nc("@info:tooltip", "Lock all in %1", root.title)
+                    QQC.ToolTip.visible: hovered
+                    QQC.ToolTip.delay: Kirigami.Units.toolTipDelay
+                    onClicked: root.groupLockToggled(!allLocked)
+                }
+
+                Rectangle {
+                    implicitWidth: countLabel.implicitWidth + Kirigami.Units.smallSpacing * 2
+                    implicitHeight: Kirigami.Units.gridUnit
+                    radius: height / 2
+                    color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.2)
+
+                    QQC.Label {
+                        id: countLabel
+
+                        anchors.centerIn: parent
+                        text: root.paramCount
+                        font: Kirigami.Theme.smallFont
+                        color: Kirigami.Theme.textColor
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

A batch of settings-app UI polish plus two stability fixes uncovered along the way.

### UI padding & layout
- **Consistent card/content padding** across the settings UI: standard `largeSpacing` insets on the Presets / Animations / About / shader-category containers; per-card **inner** padding applied via `contentItem` margins (style-proof) instead of the `org.kde.desktop`-overridden Control padding (shader cards, preset cards, shader-parameter headers); standard inset for layout cards with **tighter corner status/toggle icons**.
- **Full-width header bar** (global search + daemon status) now spans the whole window above the sidebar and content panel; centred search hint; standard header vertical padding.
- **Responsive shader-card grid** that stretches cards to fill each row (no dead right-edge gap).
- **Virtual-screen preview** honours the real monitor aspect ratio (portrait/landscape), with an orientation label and an animated reshape when switching monitors.
- Hide fully-disabled `SettingsRow`s instead of dimming; readable `0.85` dim for toggled-off card bodies; shader-card hover matches the `SettingsCard` accent-border standard; drop the selection-driven colour on the layout "N zones" label; move the Gaps separator between Outer / Per-side; sidebar accordion no longer shows rows flying in behind content.

### Stability (SIGSEGV on close + QML races)
- **Double-delete crash on close**: `SnappingShadersPageController` / `TilingAlgorithmController` were double-owned (`unique_ptr` **and** an `ApplicationController` QObject parent assigned by `registerPage`). They're now parented to `this`, so `registerPage` doesn't adopt them — confirmed via coredump triage and a clean-teardown repro.
- **Lazy page incubation**: `PageHost` now builds a page on first visit and caches it, instead of incubating all ~40 pages at once on startup — removing the incubation storm that raced the daemon's initial D-Bus broadcasts (an observed source of `QQmlConnections` incubation crashes).
- Guard delayed callbacks against post-destruction (`AnimationEventCardList`, `LayoutComboBox`).

### UX
- Confirmation dialog before stopping the daemon via the header toggle.

## Testing
- `cmake --build` green (Qt `qmlcachegen` validates all touched QML).
- No unit-test target is configured in this build (`ctest` finds none); QML/visual changes verified by building + launching the settings app headless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)