### PR TITLE
feat: tiling-on-by-default + curated layout/algorithm picker

### DIFF
--- a/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
@@ -144,6 +144,21 @@ public:
         return {};
     }
 
+    /// Raw id of the tiling algorithm active for the (@p screenId,
+    /// @p virtualDesktop, @p activity) context, or empty when none resolves.
+    /// Used by the unified-list builder to keep the active algorithm visible in
+    /// the picker even when it's been hidden (mirrors the active-layout
+    /// exemption for manual layouts). Default empty for non-resolving
+    /// implementers.
+    virtual QString tilingAlgorithmForScreen(const QString& screenId, int virtualDesktop = 0,
+                                             const QString& activity = QString()) const
+    {
+        Q_UNUSED(screenId)
+        Q_UNUSED(virtualDesktop)
+        Q_UNUSED(activity)
+        return {};
+    }
+
     /// Resolve the per-context gap override (zone padding + outer gaps) that
     /// window rules pin for the (@p screenId, @p virtualDesktop, @p activity)
     /// context — the same resolution the daemon's geometry resolver uses on the

--- a/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
@@ -27,6 +27,7 @@
 #include <PhosphorZones/AssignmentEntry.h>
 #include <PhosphorZones/Layout.h>
 
+#include <QJsonObject>
 #include <QString>
 #include <QUuid>
 #include <QVector>
@@ -131,6 +132,17 @@ public:
         return currentVirtualDesktop();
     }
     virtual QString currentActivity() const = 0;
+
+    /// Per-algorithm autotile settings (gaps, shader, hiddenFromSelector, …)
+    /// stored in the unified layout-settings.json sidecar, keyed by raw
+    /// algorithm id. Default returns empty so non-persisting implementers and
+    /// the unified-list builder degrade to "no overrides". Concrete registries
+    /// (LayoutRegistry) read the sidecar.
+    virtual QJsonObject loadAutotileOverrides(const QString& algorithmId) const
+    {
+        Q_UNUSED(algorithmId)
+        return {};
+    }
 
     /// Resolve the per-context gap override (zone padding + outer gaps) that
     /// window rules pin for the (@p screenId, @p virtualDesktop, @p activity)

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -553,9 +553,8 @@ private:
      * extraction.
      */
     void applyLayoutToScreen(const QString& screenId, Layout* layout);
-    /// One-time fold of the retired standalone autotile-overrides.json into the
-    /// unified layout-settings.json sidecar (keyed by "autotile:<id>"). Runs on
-    /// load; deletes the legacy file afterwards so it executes exactly once.
+    /// One-time idempotent fold of the retired autotile-overrides.json into the
+    /// unified layout-settings.json sidecar; deletes the legacy file when done.
     void migrateLegacyAutotileOverrides();
     Layout* resolveConfiguredDefault() const;
 

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -489,7 +489,15 @@ public:
     // ─── Autotile layout overrides (per-algorithm user overrides) ─────────
 
     void saveAutotileOverrides(const QString& algorithmId, const QJsonObject& overrides);
-    QJsonObject loadAutotileOverrides(const QString& algorithmId) const;
+    QJsonObject loadAutotileOverrides(const QString& algorithmId) const override;
+
+    /// Seed curated default picker visibility into the sidecar, but ONLY on a
+    /// fresh install — when neither layout-settings.json nor the legacy
+    /// autotile-overrides.json exists. @p defaults is keyed exactly as the
+    /// sidecar (manual layouts by UUID, algorithms by "autotile:<id>"). Existing
+    /// installs are never reseeded. Call before @ref loadLayouts so the merge
+    /// picks up the seeded entries.
+    void seedDefaultLayoutSettingsIfFresh(const QJsonObject& defaults);
 
     /// Current entry count in the @ref resolveAssignmentEntry hot-path cache.
     /// Used by tests to verify the cache populates and invalidates against
@@ -545,8 +553,10 @@ private:
      * extraction.
      */
     void applyLayoutToScreen(const QString& screenId, Layout* layout);
-    QJsonObject loadAllAutotileOverrides() const;
-    void saveAllAutotileOverrides(const QJsonObject& all);
+    /// One-time fold of the retired standalone autotile-overrides.json into the
+    /// unified layout-settings.json sidecar (keyed by "autotile:<id>"). Runs on
+    /// load; deletes the legacy file afterwards so it executes exactly once.
+    void migrateLegacyAutotileOverrides();
     Layout* resolveConfiguredDefault() const;
 
     // ─── Rule-backed assignment resolution ────────────────────────────────

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -399,7 +399,7 @@ public:
     QString snappingLayoutForScreen(const QString& screenId, int virtualDesktop = 0,
                                     const QString& activity = QString()) const;
     QString tilingAlgorithmForScreen(const QString& screenId, int virtualDesktop = 0,
-                                     const QString& activity = QString()) const;
+                                     const QString& activity = QString()) const override;
 
     /// Flip mode to @c Snapping for every entry currently in @c Autotile
     /// (preserves @c snappingLayout + @c tilingAlgorithm). Emits

--- a/libs/phosphor-zones/src/layoutregistry_overrides.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_overrides.cpp
@@ -64,6 +64,10 @@ void LayoutRegistry::seedDefaultLayoutSettingsIfFresh(const QJsonObject& default
     }
     // Seeding runs at daemon init, before anything else has created the config
     // directory — ensure it exists so the QSaveFile write doesn't silently fail.
+    // Persistence is disk-mediated: the caller's loadLayouts() reloads the
+    // sidecar from disk immediately after (clearing the in-memory map), so the
+    // on-disk copy written here is authoritative. A failed write degrades
+    // benignly to "everything visible" (logged below), not a crash.
     QDir().mkpath(QFileInfo(settingsPath).absolutePath());
     if (!m_layoutSettings.saveToFile(settingsPath)) {
         qCWarning(lcZonesLib) << "Failed to seed default layout-settings.json";
@@ -81,26 +85,40 @@ void LayoutRegistry::migrateLegacyAutotileOverrides()
         qCWarning(lcZonesLib) << "Autotile-overrides migration: cannot read" << legacyPath;
         return;
     }
-    const QJsonDocument doc = QJsonDocument::fromJson(legacy.readAll());
+    QJsonParseError parseError;
+    const QJsonDocument doc = QJsonDocument::fromJson(legacy.readAll(), &parseError);
     legacy.close();
 
-    if (doc.isObject()) {
-        const QJsonObject all = doc.object();
-        for (auto it = all.constBegin(); it != all.constEnd(); ++it) {
-            if (!it.value().isObject()) {
-                continue;
-            }
-            const QString key = PhosphorLayout::LayoutId::makeAutotileId(it.key());
-            // A store entry that already exists (a seeded default or a
-            // post-migration user toggle) wins over the legacy value.
-            if (m_layoutSettings.settingsFor(key).isEmpty()) {
-                m_layoutSettings.setSettingsFor(key, it.value().toObject());
-            }
-        }
-        m_layoutSettings.saveToFile(layoutSettingsFilePath());
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject()) {
+        // Don't delete an unreadable/corrupt legacy file — leave it in place so
+        // the user's overrides survive for inspection and the fold can retry on
+        // a future launch, rather than silently dropping data.
+        qCWarning(lcZonesLib) << "Autotile-overrides migration: skipping unparseable" << legacyPath << ":"
+                              << parseError.errorString();
+        return;
     }
 
-    // Remove the legacy file so the fold runs exactly once.
+    const QJsonObject all = doc.object();
+    for (auto it = all.constBegin(); it != all.constEnd(); ++it) {
+        if (!it.value().isObject()) {
+            continue;
+        }
+        const QString key = PhosphorLayout::LayoutId::makeAutotileId(it.key());
+        // A store entry that already exists (a seeded default or a
+        // post-migration user toggle) wins over the legacy value.
+        if (m_layoutSettings.settingsFor(key).isEmpty()) {
+            m_layoutSettings.setSettingsFor(key, it.value().toObject());
+        }
+    }
+
+    // Retire the legacy file only after its contents are safely folded in. A
+    // failed write keeps it in place so the fold retries next launch instead of
+    // permanently losing the user's autotile overrides.
+    if (!m_layoutSettings.saveToFile(layoutSettingsFilePath())) {
+        qCWarning(lcZonesLib) << "Autotile-overrides migration: failed to write unified sidecar — "
+                                 "keeping legacy file for retry";
+        return;
+    }
     QFile::remove(legacyPath);
 }
 

--- a/libs/phosphor-zones/src/layoutregistry_overrides.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_overrides.cpp
@@ -113,13 +113,19 @@ void LayoutRegistry::migrateLegacyAutotileOverrides()
 
     // Retire the legacy file only after its contents are safely folded in. A
     // failed write keeps it in place so the fold retries next launch instead of
-    // permanently losing the user's autotile overrides.
+    // permanently losing the user's autotile overrides. The fold is idempotent
+    // (the settingsFor-empty guard above lets an already-migrated entry win), so
+    // a failed remove harmlessly re-folds next launch rather than duplicating.
     if (!m_layoutSettings.saveToFile(layoutSettingsFilePath())) {
         qCWarning(lcZonesLib) << "Autotile-overrides migration: failed to write unified sidecar — "
                                  "keeping legacy file for retry";
         return;
     }
-    QFile::remove(legacyPath);
+    if (!QFile::remove(legacyPath)) {
+        qCWarning(lcZonesLib) << "Autotile-overrides migration: folded into the unified sidecar but could not remove "
+                                 "the legacy file (will harmlessly re-fold next launch):"
+                              << legacyPath;
+    }
 }
 
 } // namespace PhosphorZones

--- a/libs/phosphor-zones/src/layoutregistry_overrides.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_overrides.cpp
@@ -1,73 +1,107 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: LGPL-2.1-or-later
 //
-// Per-algorithm autotile layout overrides — JSON sidecar I/O.
-// Part of LayoutRegistry — split from layoutregistry_assignments.cpp to keep
-// each translation unit under the 800-line limit and to isolate the
-// autotile-overrides persistence concern (a single autotile-overrides.json
-// keyed by algorithm id) from the per-context assignment cascade.
+// Per-algorithm autotile layout overrides.
+// Autotile entries are NOT separate from manual layouts: they live in the same
+// layout-settings.json sidecar (LayoutSettingsStore), keyed by the canonical
+// "autotile:<id>" form so manual and autotile per-id settings share one store.
+// This file owns the autotile-facing accessors plus the one-time fold of the
+// legacy standalone autotile-overrides.json into that unified store.
 
 #include <PhosphorZones/LayoutRegistry.h>
+#include <PhosphorZones/LayoutSettingsStore.h>
+
+#include <PhosphorLayoutApi/LayoutId.h>
 
 #include "zoneslogging.h"
 
+#include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QJsonDocument>
-#include <QSaveFile>
 
 namespace PhosphorZones {
 
 namespace {
-// Filename of the per-algorithm autotile-overrides JSON sidecar, relative to
-// the layout directory. Hoisted so the load and save paths share one literal.
-const QString kAutotileOverridesFile = QStringLiteral("/autotile-overrides.json");
+// Legacy standalone sidecar, retired in favour of layout-settings.json. Read
+// once by migrateLegacyAutotileOverrides() and then deleted.
+const QString kLegacyAutotileOverridesFile = QStringLiteral("/autotile-overrides.json");
 } // namespace
-
-QJsonObject LayoutRegistry::loadAllAutotileOverrides() const
-{
-    QFile file(m_layoutDirectory + kAutotileOverridesFile);
-    if (!file.open(QIODevice::ReadOnly)) {
-        return {};
-    }
-    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
-    return doc.isObject() ? doc.object() : QJsonObject();
-}
-
-void LayoutRegistry::saveAllAutotileOverrides(const QJsonObject& all)
-{
-    ensureLayoutDirectory();
-    // QSaveFile gives atomic temp-write + rename — a crash mid-write never
-    // leaves a truncated autotile-overrides.json behind.
-    QSaveFile file(m_layoutDirectory + kAutotileOverridesFile);
-    if (!file.open(QIODevice::WriteOnly)) {
-        qCWarning(lcZonesLib) << "Failed to save autotile overrides:" << file.errorString();
-        return;
-    }
-    const QByteArray payload = QJsonDocument(all).toJson();
-    if (file.write(payload) != payload.size()) {
-        qCWarning(lcZonesLib) << "Failed to write autotile overrides:" << file.errorString();
-        file.cancelWriting();
-        return;
-    }
-    if (!file.commit()) {
-        qCWarning(lcZonesLib) << "Failed to commit autotile overrides:" << file.errorString();
-    }
-}
 
 QJsonObject LayoutRegistry::loadAutotileOverrides(const QString& algorithmId) const
 {
-    return loadAllAutotileOverrides().value(algorithmId).toObject();
+    return m_layoutSettings.settingsFor(PhosphorLayout::LayoutId::makeAutotileId(algorithmId));
 }
 
 void LayoutRegistry::saveAutotileOverrides(const QString& algorithmId, const QJsonObject& overrides)
 {
-    QJsonObject all = loadAllAutotileOverrides();
-    if (overrides.isEmpty()) {
-        all.remove(algorithmId);
-    } else {
-        all[algorithmId] = overrides;
+    // setSettingsFor clears the entry when overrides is empty, so a fully-reset
+    // algorithm collapses back to its defaults rather than persisting an empty
+    // object.
+    m_layoutSettings.setSettingsFor(PhosphorLayout::LayoutId::makeAutotileId(algorithmId), overrides);
+    if (!m_layoutSettings.saveToFile(layoutSettingsFilePath())) {
+        qCWarning(lcZonesLib) << "Failed to persist autotile overrides for" << algorithmId;
     }
-    saveAllAutotileOverrides(all);
+}
+
+void LayoutRegistry::seedDefaultLayoutSettingsIfFresh(const QJsonObject& defaults)
+{
+    if (defaults.isEmpty()) {
+        return;
+    }
+    // "Fresh" = neither the unified sidecar nor the legacy autotile sidecar
+    // exists yet. A user with either is an existing install and keeps every
+    // layout/algorithm visible — the curated default seeds new configs only,
+    // and never clobbers migrated legacy overrides.
+    const QString settingsPath = layoutSettingsFilePath();
+    if (QFile::exists(settingsPath) || QFile::exists(m_layoutDirectory + kLegacyAutotileOverridesFile)) {
+        return;
+    }
+    for (auto it = defaults.constBegin(); it != defaults.constEnd(); ++it) {
+        if (it.value().isObject()) {
+            m_layoutSettings.setSettingsFor(it.key(), it.value().toObject());
+        }
+    }
+    // Seeding runs at daemon init, before anything else has created the config
+    // directory — ensure it exists so the QSaveFile write doesn't silently fail.
+    QDir().mkpath(QFileInfo(settingsPath).absolutePath());
+    if (!m_layoutSettings.saveToFile(settingsPath)) {
+        qCWarning(lcZonesLib) << "Failed to seed default layout-settings.json";
+    }
+}
+
+void LayoutRegistry::migrateLegacyAutotileOverrides()
+{
+    const QString legacyPath = m_layoutDirectory + kLegacyAutotileOverridesFile;
+    QFile legacy(legacyPath);
+    if (!legacy.exists()) {
+        return;
+    }
+    if (!legacy.open(QIODevice::ReadOnly)) {
+        qCWarning(lcZonesLib) << "Autotile-overrides migration: cannot read" << legacyPath;
+        return;
+    }
+    const QJsonDocument doc = QJsonDocument::fromJson(legacy.readAll());
+    legacy.close();
+
+    if (doc.isObject()) {
+        const QJsonObject all = doc.object();
+        for (auto it = all.constBegin(); it != all.constEnd(); ++it) {
+            if (!it.value().isObject()) {
+                continue;
+            }
+            const QString key = PhosphorLayout::LayoutId::makeAutotileId(it.key());
+            // A store entry that already exists (a seeded default or a
+            // post-migration user toggle) wins over the legacy value.
+            if (m_layoutSettings.settingsFor(key).isEmpty()) {
+                m_layoutSettings.setSettingsFor(key, it.value().toObject());
+            }
+        }
+        m_layoutSettings.saveToFile(layoutSettingsFilePath());
+    }
+
+    // Remove the legacy file so the fold runs exactly once.
+    QFile::remove(legacyPath);
 }
 
 } // namespace PhosphorZones

--- a/libs/phosphor-zones/src/layoutregistry_persistence.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_persistence.cpp
@@ -87,9 +87,14 @@ void LayoutRegistry::loadLayoutsFromDirectory(const QString& directory)
     const auto entries = dir.entryList({QStringLiteral("*.json")}, QDir::Files);
 
     for (const auto& entry : entries) {
+        // Skip sibling sidecar files that share this directory but aren't
+        // layouts. "autotile-overrides.json" is a retired format (folded into
+        // layout-settings.json by migrateLegacyAutotileOverrides); it's kept in
+        // the skip-list as a one-release safety net in case a stale copy lingers
+        // in a system data dir the migration didn't delete.
         if (entry == QStringLiteral("assignments.json") || entry == QStringLiteral("autotile-overrides.json")
             || entry == QStringLiteral("windowrules.json") || entry == QStringLiteral("quicklayouts.json")) {
-            continue; // Skip non-layout files
+            continue;
         }
 
         const QString filePath = dir.absoluteFilePath(entry);

--- a/libs/phosphor-zones/src/layoutregistry_persistence.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_persistence.cpp
@@ -29,6 +29,12 @@ void LayoutRegistry::loadLayouts()
     // settings can be merged back onto its structural JSON as it loads.
     m_layoutSettings.loadFromFile(layoutSettingsFilePath());
 
+    // Fold the retired standalone autotile-overrides.json into the unified
+    // sidecar (one-time; self-deletes the legacy file). Done after the sidecar
+    // load so the store is populated, and before layouts merge so autotile
+    // entries are queryable for the rest of this load.
+    migrateLegacyAutotileOverrides();
+
     // Load from ALL data locations (system directories first, then user)
     // locateAll() returns paths in priority order: user first, system last
     // We reverse to load system first, so user layouts can override

--- a/libs/phosphor-zones/src/layoutsettingsstore.cpp
+++ b/libs/phosphor-zones/src/layoutsettingsstore.cpp
@@ -149,7 +149,10 @@ bool LayoutSettingsStore::loadFromFile(const QString& path)
 
     const QJsonObject root = doc.object();
     for (auto it = root.constBegin(); it != root.constEnd(); ++it) {
-        if (it.key() == kVersionKey || !it.value().isObject()) {
+        // Skip the version stamp, non-object values, and an empty key (which a
+        // hand-edited/corrupt file could carry) — settingsFor("") must never
+        // resolve to a stored object.
+        if (it.key().isEmpty() || it.key() == kVersionKey || !it.value().isObject()) {
             continue;
         }
         m_byLayout.insert(it.key(), it.value().toObject());

--- a/libs/phosphor-zones/src/layoutsettingsstore.cpp
+++ b/libs/phosphor-zones/src/layoutsettingsstore.cpp
@@ -29,7 +29,12 @@ constexpr QLatin1String kZoneAppearanceMapKey{"zoneAppearance"};
 
 // The per-LAYOUT setting keys that move out of the layout file. The per-ZONE
 // appearance block is handled separately (see extract/strip/merge below).
-const std::array<QLatin1String, 13> layoutSettingKeys{{
+//
+// hiddenFromSelector is a user preference (which layouts the curated picker
+// shows), not part of the structural layout definition — so it lives here in
+// the sidecar, keyed by id, the same way the curated defaults are seeded. The
+// same store also holds autotile entries keyed by "autotile:<id>".
+const std::array<QLatin1String, 14> layoutSettingKeys{{
     ZoneJsonKeys::ZonePadding,
     ZoneJsonKeys::OuterGap,
     ZoneJsonKeys::UsePerSideOuterGap,
@@ -40,6 +45,7 @@ const std::array<QLatin1String, 13> layoutSettingKeys{{
     ZoneJsonKeys::ShowZoneNumbers,
     ZoneJsonKeys::OverlayDisplayMode,
     ZoneJsonKeys::AutoAssign,
+    ZoneJsonKeys::HiddenFromSelector,
     ZoneJsonKeys::UseFullScreenGeometry,
     ZoneJsonKeys::ShaderId,
     ZoneJsonKeys::ShaderParams,

--- a/src/config/configdefaults.cpp
+++ b/src/config/configdefaults.cpp
@@ -49,6 +49,57 @@ QString ConfigDefaults::layoutSettingsFilePath()
     return configDir() + QStringLiteral("/plasmazones/layout-settings.json");
 }
 
+QJsonObject ConfigDefaults::defaultLayoutVisibilitySettings()
+{
+    // Out-of-the-box the picker shows a curated subset; the rest start hidden
+    // (users re-show any via the eye toggle). Keys mirror layout-settings.json
+    // exactly. The "hiddenFromSelector" key and "autotile:" prefix match
+    // PhosphorZones::ZoneJsonKeys::HiddenFromSelector and
+    // PhosphorLayout::LayoutId::AutotilePrefix — kept as literals here so the
+    // config layer takes no phosphor-zones / phosphor-layout-api dependency.
+    const QJsonObject hidden{{QStringLiteral("hiddenFromSelector"), true}};
+
+    // Non-curated standard snapping layouts, by bundled layout UUID.
+    static const QStringList layoutIds{
+        QStringLiteral("{b8669c74-947a-4551-ba8b-79b6444439e8}"), // Fibonacci
+        QStringLiteral("{a40ad8ca-2d60-4418-92cc-01b83420918e}"), // Grid (3x2)
+        QStringLiteral("{0c9585bc-ecae-4e87-a6b8-9d34e9b791f2}"), // Priority Grid
+        QStringLiteral("{a11899b1-f0e3-4425-9363-acb71726c566}"), // Split Focus
+        QStringLiteral("{a83addbc-1907-45a8-a3d5-59dedf079030}"), // Wide
+    };
+
+    // Non-curated tiling algorithms (visible set: bsp, master-stack, monocle,
+    // columns, spiral, three-column, grid, deck).
+    static const QStringList algorithmIds{
+        QStringLiteral("cascade"),
+        QStringLiteral("centered-master"),
+        QStringLiteral("cluster"),
+        QStringLiteral("corner-master"),
+        QStringLiteral("dwindle"),
+        QStringLiteral("dwindle-memory"),
+        QStringLiteral("floating-center"),
+        QStringLiteral("focus-sidebar"),
+        QStringLiteral("horizontal-deck"),
+        QStringLiteral("paper"),
+        QStringLiteral("quadrant-priority"),
+        QStringLiteral("rows"),
+        QStringLiteral("spread"),
+        QStringLiteral("stair"),
+        QStringLiteral("tatami"),
+        QStringLiteral("wide"),
+        QStringLiteral("zen"),
+    };
+
+    QJsonObject out;
+    for (const QString& id : layoutIds) {
+        out.insert(id, hidden);
+    }
+    for (const QString& id : algorithmIds) {
+        out.insert(QStringLiteral("autotile:") + id, hidden);
+    }
+    return out;
+}
+
 QString ConfigDefaults::legacyConfigFilePath()
 {
     return configDir() + QStringLiteral("/plasmazonesrc");

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -6,6 +6,7 @@
 #include <QColor>
 #include <QHash>
 #include <QRectF>
+#include <QJsonObject>
 #include <QString>
 #include <QStringList>
 #include <QVariantList>
@@ -683,6 +684,15 @@ public:
     // of the structural layout definition, so they live in a sibling sidecar
     // next to windowrules.json rather than inside each layout file.
     PLASMAZONES_EXPORT static QString layoutSettingsFilePath();
+
+    // Curated default picker visibility, seeded into layout-settings.json on a
+    // fresh install only (LayoutRegistry::seedDefaultLayoutSettingsIfFresh).
+    // Returns an object keyed exactly as layout-settings.json — manual layouts
+    // by bundled UUID (with braces), algorithms by the "autotile:<id>" form —
+    // mapping each non-curated id to `{ "hiddenFromSelector": true }`. Listed
+    // ids start hidden; everything else stays visible. Users re-show any item
+    // via the eye toggle, and existing installs are never reseeded.
+    PLASMAZONES_EXPORT static QJsonObject defaultLayoutVisibilitySettings();
 
     // Returns the absolute path to the legacy plasmazonesrc file (INI format).
     // Used only by the one-time migration module.

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -810,9 +810,16 @@ public:
     // Autotile Settings
     // ═══════════════════════════════════════════════════════════════════════════
 
+    // Autotiling is on out of the box so PlasmaZones tiles like a dynamic
+    // tiler (krohnkite, dwm, xmonad) without setup. The companion
+    // krohnkite-parity behaviors are already on by default elsewhere here:
+    // autotileFocusNewWindows, autotileSmartGaps (sole window fills the
+    // screen), autotileRespectMinimumSize, and excludeTransientWindows
+    // (dialogs / utility windows float), with new windows inserted at the
+    // stack end rather than as master.
     static bool autotileEnabled()
     {
-        return false;
+        return true;
     }
     static QString defaultAutotileAlgorithm()
     {

--- a/src/core/unifiedlayoutlist.cpp
+++ b/src/core/unifiedlayoutlist.cpp
@@ -10,6 +10,7 @@
 
 #include <PhosphorLayoutApi/AspectRatioClass.h>
 #include <PhosphorLayoutApi/ILayoutSource.h>
+#include <PhosphorLayoutApi/LayoutId.h>
 #include <PhosphorScreens/ScreenIdentity.h>
 #include <PhosphorTiles/AutotileLayoutSource.h>
 #include <PhosphorTiles/AutotilePreviewRender.h>
@@ -18,6 +19,7 @@
 #include <PhosphorZones/IZoneLayoutRegistry.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/LayoutUtils.h>
+#include <PhosphorZones/ZoneJsonKeys.h>
 #include <PhosphorZones/ZonesLayoutSource.h>
 
 #include <algorithm>
@@ -296,6 +298,21 @@ QVector<LayoutPreview> buildUnifiedLayoutList(PhosphorZones::IZoneLayoutRegistry
 
     if (includeAutotile) {
         appendAutotilePreviews(list, algorithmRegistry, autotileSource, autotilePreviewCanvas);
+
+        // Drop autotile previews the user has hidden from the curated picker.
+        // Manual layouts are filtered inline above (hiddenFromSelector on the
+        // Layout); autotile entries have no Layout, so their hidden state lives
+        // in the unified layout-settings.json sidecar keyed by "autotile:<id>".
+        list.erase(std::remove_if(list.begin(), list.end(),
+                                  [layoutManager](const LayoutPreview& preview) {
+                                      if (!preview.isAutotile()) {
+                                          return false;
+                                      }
+                                      const QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(preview.id);
+                                      const QJsonObject overrides = layoutManager->loadAutotileOverrides(algoId);
+                                      return overrides.value(ZoneJsonKeys::HiddenFromSelector).toBool(false);
+                                  }),
+                   list.end());
     }
 
     sortPreviews(list, customOrder);

--- a/src/core/unifiedlayoutlist.cpp
+++ b/src/core/unifiedlayoutlist.cpp
@@ -303,12 +303,21 @@ QVector<LayoutPreview> buildUnifiedLayoutList(PhosphorZones::IZoneLayoutRegistry
         // Manual layouts are filtered inline above (hiddenFromSelector on the
         // Layout); autotile entries have no Layout, so their hidden state lives
         // in the unified layout-settings.json sidecar keyed by "autotile:<id>".
+        // The algorithm active for this context is kept visible even when hidden
+        // — mirrors the manual active-layout exemption above so the picker/OSD
+        // can't lose the currently-tiling algorithm (broken cycling / empty
+        // selector).
+        const QString activeAlgoId =
+            layoutManager->tilingAlgorithmForScreen(resolvedScreenId, virtualDesktop, activity);
         list.erase(std::remove_if(list.begin(), list.end(),
-                                  [layoutManager](const LayoutPreview& preview) {
+                                  [layoutManager, &activeAlgoId](const LayoutPreview& preview) {
                                       if (!preview.isAutotile()) {
                                           return false;
                                       }
                                       const QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(preview.id);
+                                      if (!activeAlgoId.isEmpty() && algoId == activeAlgoId) {
+                                          return false;
+                                      }
                                       const QJsonObject overrides = layoutManager->loadAutotileOverrides(algoId);
                                       return overrides.value(ZoneJsonKeys::HiddenFromSelector).toBool(false);
                                   }),

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -768,6 +768,11 @@ bool Daemon::init()
     // are evicted on removal (bounds m_trackedLayouts over time).
     m_layoutComputeService->setLayoutManager(m_layoutManager.get());
 
+    // Seed the curated default picker visibility on a fresh install (no-op when
+    // a layout-settings.json / autotile-overrides.json already exists), before
+    // loadLayouts() so the seeded hidden state merges onto each layout.
+    m_layoutManager->seedDefaultLayoutSettingsIfFresh(ConfigDefaults::defaultLayoutVisibilitySettings());
+
     // Load layouts (defaultLayout() reads settings internally)
     m_layoutManager->loadLayouts();
     m_layoutManager->loadAssignments();

--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -303,8 +303,7 @@ QStringList LayoutAdaptor::getLayoutList()
 
         // Enrich manual-layout entries with Layout-specific fields that
         // LayoutPreview doesn't carry (hasSystemOrigin, hiddenFromSelector,
-        // defaultOrder, allow-lists). Autotile entries have no Layout to
-        // look up so they skip this block.
+        // defaultOrder, allow-lists).
         auto uuidOpt = Utils::parseUuid(entry.id);
         if (uuidOpt) {
             PhosphorZones::Layout* layout = m_layoutManager->layoutById(*uuidOpt);
@@ -319,6 +318,15 @@ QStringList LayoutAdaptor::getLayoutList()
                 PhosphorZones::LayoutUtils::serializeAllowLists(json, layout->allowedScreens(),
                                                                 layout->allowedDesktops(), layout->allowedActivities());
             }
+        } else if (PhosphorLayout::LayoutId::isAutotile(entry.id)) {
+            // Autotile entries have no Layout object; their hiddenFromSelector
+            // (curated-picker state) lives in the unified sidecar keyed by
+            // "autotile:<id>". Surface it so the settings list shows the eye
+            // toggle's true state.
+            const QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(entry.id);
+            const QJsonObject overrides = m_layoutManager->loadAutotileOverrides(algoId);
+            json[QStringLiteral("hiddenFromSelector")] =
+                overrides.value(PhosphorZones::ZoneJsonKeys::HiddenFromSelector).toBool(false);
         }
 
         result.append(QString::fromUtf8(QJsonDocument(json).toJson(QJsonDocument::Compact)));
@@ -400,6 +408,29 @@ const QString kPropAspectRatioClass = QStringLiteral("aspectRatioClass");
 
 void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
 {
+    // Autotile algorithms have no backing Layout object — their per-id settings
+    // (here, hiddenFromSelector for the curated picker) live in the unified
+    // layout-settings.json sidecar keyed by "autotile:<id>".
+    if (PhosphorLayout::LayoutId::isAutotile(layoutId)) {
+        const QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(layoutId);
+        const QString hiddenKey = PhosphorZones::ZoneJsonKeys::HiddenFromSelector;
+        QJsonObject overrides = m_layoutManager->loadAutotileOverrides(algoId);
+        if (overrides.value(hiddenKey).toBool(false) == hidden) {
+            return;
+        }
+        // Persist only the hiding state; drop the key on re-show so the entry
+        // collapses back to the algorithm default instead of storing "false".
+        if (hidden) {
+            overrides.insert(hiddenKey, true);
+        } else {
+            overrides.remove(hiddenKey);
+        }
+        m_layoutManager->saveAutotileOverrides(algoId, overrides);
+        qCInfo(lcDbusLayout) << "Set autotile" << layoutId << "hidden:" << hidden;
+        Q_EMIT layoutPropertyChanged(layoutId, kPropHidden, QDBusVariant(hidden));
+        return;
+    }
+
     auto* layout = getValidatedLayout(layoutId, QStringLiteral("set layout hidden"));
     if (!layout) {
         return;

--- a/src/dbus/layoutadaptor.cpp
+++ b/src/dbus/layoutadaptor.cpp
@@ -324,9 +324,11 @@ QStringList LayoutAdaptor::getLayoutList()
             // "autotile:<id>". Surface it so the settings list shows the eye
             // toggle's true state.
             const QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(entry.id);
-            const QJsonObject overrides = m_layoutManager->loadAutotileOverrides(algoId);
-            json[QStringLiteral("hiddenFromSelector")] =
-                overrides.value(PhosphorZones::ZoneJsonKeys::HiddenFromSelector).toBool(false);
+            if (!algoId.isEmpty()) {
+                const QJsonObject overrides = m_layoutManager->loadAutotileOverrides(algoId);
+                json[QStringLiteral("hiddenFromSelector")] =
+                    overrides.value(PhosphorZones::ZoneJsonKeys::HiddenFromSelector).toBool(false);
+            }
         }
 
         result.append(QString::fromUtf8(QJsonDocument(json).toJson(QJsonDocument::Compact)));
@@ -413,6 +415,13 @@ void LayoutAdaptor::setLayoutHidden(const QString& layoutId, bool hidden)
     // layout-settings.json sidecar keyed by "autotile:<id>".
     if (PhosphorLayout::LayoutId::isAutotile(layoutId)) {
         const QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(layoutId);
+        // A bare "autotile:" id yields an empty algorithm key; writing under it
+        // would create an orphan sidecar entry no algorithm maps to. Mirror
+        // updateLayout's guard and reject it.
+        if (algoId.isEmpty()) {
+            qCWarning(lcDbusLayout) << "setLayoutHidden: autotile id with empty algorithm id rejected:" << layoutId;
+            return;
+        }
         const QString hiddenKey = PhosphorZones::ZoneJsonKeys::HiddenFromSelector;
         QJsonObject overrides = m_layoutManager->loadAutotileOverrides(algoId);
         if (overrides.value(hiddenKey).toBool(false) == hidden) {

--- a/src/dbus/layoutadaptor/editor.cpp
+++ b/src/dbus/layoutadaptor/editor.cpp
@@ -125,16 +125,15 @@ bool LayoutAdaptor::updateLayout(const QString& layoutJson)
         // layout-settings.json sidecar. Editor-managed keys are set when present
         // in the incoming object and cleared when absent (reset-to-default).
         QJsonObject overrides = m_layoutManager->loadAutotileOverrides(algoId);
-        const std::array<QLatin1String, 8> editorKeys{{
-            ::PhosphorZones::ZoneJsonKeys::ZonePadding,
-            ::PhosphorZones::ZoneJsonKeys::OuterGap,
-            ::PhosphorZones::ZoneJsonKeys::AllowedScreens,
-            ::PhosphorZones::ZoneJsonKeys::AllowedDesktops,
-            ::PhosphorZones::ZoneJsonKeys::AllowedActivities,
-            ::PhosphorZones::ZoneJsonKeys::ShaderId,
-            ::PhosphorZones::ZoneJsonKeys::ShaderParams,
-            ::PhosphorZones::ZoneJsonKeys::OverlayDisplayMode,
-        }};
+        // CTAD deduces the array size from the initializer so the element count
+        // stays in sync automatically (no hand-maintained size). hiddenFromSelector
+        // is intentionally absent — it's owned by setLayoutHidden, not the editor.
+        const std::array editorKeys{
+            ::PhosphorZones::ZoneJsonKeys::ZonePadding,       ::PhosphorZones::ZoneJsonKeys::OuterGap,
+            ::PhosphorZones::ZoneJsonKeys::AllowedScreens,    ::PhosphorZones::ZoneJsonKeys::AllowedDesktops,
+            ::PhosphorZones::ZoneJsonKeys::AllowedActivities, ::PhosphorZones::ZoneJsonKeys::ShaderId,
+            ::PhosphorZones::ZoneJsonKeys::ShaderParams,      ::PhosphorZones::ZoneJsonKeys::OverlayDisplayMode,
+        };
         for (const QLatin1String key : editorKeys) {
             if (obj.contains(key)) {
                 overrides[key] = obj.value(key);

--- a/src/dbus/layoutadaptor/editor.cpp
+++ b/src/dbus/layoutadaptor/editor.cpp
@@ -18,6 +18,7 @@
 #include <QProcess>
 #include <QStandardPaths>
 #include <QCoreApplication>
+#include <array>
 #include <QFile>
 #include <QScopeGuard>
 
@@ -118,27 +119,29 @@ bool LayoutAdaptor::updateLayout(const QString& layoutJson)
             qCWarning(lcDbusLayout) << "updateLayout: autotile id with empty algorithm id rejected:" << idStr;
             return false;
         }
-        QJsonObject overrides;
-        if (obj.contains(::PhosphorZones::ZoneJsonKeys::ZonePadding))
-            overrides[::PhosphorZones::ZoneJsonKeys::ZonePadding] = obj[::PhosphorZones::ZoneJsonKeys::ZonePadding];
-        if (obj.contains(::PhosphorZones::ZoneJsonKeys::OuterGap))
-            overrides[::PhosphorZones::ZoneJsonKeys::OuterGap] = obj[::PhosphorZones::ZoneJsonKeys::OuterGap];
-        if (obj.contains(::PhosphorZones::ZoneJsonKeys::AllowedScreens))
-            overrides[::PhosphorZones::ZoneJsonKeys::AllowedScreens] =
-                obj[::PhosphorZones::ZoneJsonKeys::AllowedScreens];
-        if (obj.contains(::PhosphorZones::ZoneJsonKeys::AllowedDesktops))
-            overrides[::PhosphorZones::ZoneJsonKeys::AllowedDesktops] =
-                obj[::PhosphorZones::ZoneJsonKeys::AllowedDesktops];
-        if (obj.contains(::PhosphorZones::ZoneJsonKeys::AllowedActivities))
-            overrides[::PhosphorZones::ZoneJsonKeys::AllowedActivities] =
-                obj[::PhosphorZones::ZoneJsonKeys::AllowedActivities];
-        if (obj.contains(::PhosphorZones::ZoneJsonKeys::ShaderId))
-            overrides[::PhosphorZones::ZoneJsonKeys::ShaderId] = obj[::PhosphorZones::ZoneJsonKeys::ShaderId];
-        if (obj.contains(::PhosphorZones::ZoneJsonKeys::ShaderParams))
-            overrides[::PhosphorZones::ZoneJsonKeys::ShaderParams] = obj[::PhosphorZones::ZoneJsonKeys::ShaderParams];
-        if (obj.contains(::PhosphorZones::ZoneJsonKeys::OverlayDisplayMode))
-            overrides[::PhosphorZones::ZoneJsonKeys::OverlayDisplayMode] =
-                obj[::PhosphorZones::ZoneJsonKeys::OverlayDisplayMode];
+        // Start from the stored entry so keys this editor doesn't manage
+        // (notably hiddenFromSelector, written via setLayoutHidden) survive a
+        // gaps/shader/allow-list save — autotile entries now share the unified
+        // layout-settings.json sidecar. Editor-managed keys are set when present
+        // in the incoming object and cleared when absent (reset-to-default).
+        QJsonObject overrides = m_layoutManager->loadAutotileOverrides(algoId);
+        const std::array<QLatin1String, 8> editorKeys{{
+            ::PhosphorZones::ZoneJsonKeys::ZonePadding,
+            ::PhosphorZones::ZoneJsonKeys::OuterGap,
+            ::PhosphorZones::ZoneJsonKeys::AllowedScreens,
+            ::PhosphorZones::ZoneJsonKeys::AllowedDesktops,
+            ::PhosphorZones::ZoneJsonKeys::AllowedActivities,
+            ::PhosphorZones::ZoneJsonKeys::ShaderId,
+            ::PhosphorZones::ZoneJsonKeys::ShaderParams,
+            ::PhosphorZones::ZoneJsonKeys::OverlayDisplayMode,
+        }};
+        for (const QLatin1String key : editorKeys) {
+            if (obj.contains(key)) {
+                overrides[key] = obj.value(key);
+            } else {
+                overrides.remove(key);
+            }
+        }
         m_layoutManager->saveAutotileOverrides(algoId, overrides);
         qCInfo(lcDbusLayout) << "Saved autotile overrides for algorithm:" << algoId;
         // Autotile override save mutates a single autotile preview entry, not

--- a/src/settings/qml/LayoutFilterBar.qml
+++ b/src/settings/qml/LayoutFilterBar.qml
@@ -22,7 +22,9 @@ RowLayout {
     property bool sortAscending: true
     property string filterText: ""
     // ── Exposed state: shared filters ───────────────────────────────────────
-    property bool showHidden: false
+    // Default ON: the layouts page shows hidden (curated-out) items by default
+    // so users can see and re-enable them; unchecking hides them.
+    property bool showHidden: true
     // ── Exposed state: snapping filters (all ON = show everything) ──────────
     property bool showAspectAny: true
     property bool showAspectStandard: true
@@ -47,9 +49,9 @@ RowLayout {
             return true;
 
         if (root.viewMode === 0)
-            return !showAspectAny || !showAspectStandard || !showAspectUltrawide || !showAspectSuperUltrawide || !showAspectPortrait || showHidden || !showAutoLayouts || !showManualLayouts || !showBuiltInLayouts || !showUserLayouts;
+            return !showAspectAny || !showAspectStandard || !showAspectUltrawide || !showAspectSuperUltrawide || !showAspectPortrait || !showHidden || !showAutoLayouts || !showManualLayouts || !showBuiltInLayouts || !showUserLayouts;
         else
-            return !showBuiltInAlgorithms || !showUserAlgorithms || showHidden || !showMasterCount || !showSplitRatio || !showOverlapping || !showPersistent || !showCustomParams;
+            return !showBuiltInAlgorithms || !showUserAlgorithms || !showHidden || !showMasterCount || !showSplitRatio || !showOverlapping || !showPersistent || !showCustomParams;
     }
     // ── Group-by index constants (must match model order below) ───────────
     // Snapping
@@ -81,7 +83,7 @@ RowLayout {
     // Adding a filter requires updating: property declaration, _defaultValues,
     // the relevant state map, persistedState, hasActiveFilters, menu item, and JS logic.
     readonly property var _defaultValues: {
-        "showHidden": false,
+        "showHidden": true,
         "showAspectAny": true,
         "showAspectStandard": true,
         "showAspectUltrawide": true,
@@ -416,7 +418,7 @@ RowLayout {
         property int snappingGroupByIndex: 0
         property int snappingSortByIndex: 0
         property bool snappingSortAscending: true
-        property bool snappingShowHidden: false
+        property bool snappingShowHidden: true
         property bool snappingShowAspectAny: true
         property bool snappingShowAspectStandard: true
         property bool snappingShowAspectUltrawide: true
@@ -430,7 +432,7 @@ RowLayout {
         property int tilingGroupByIndex: 0
         property int tilingSortByIndex: 0
         property bool tilingSortAscending: true
-        property bool tilingShowHidden: false
+        property bool tilingShowHidden: true
         property bool tilingShowBuiltInAlgorithms: true
         property bool tilingShowUserAlgorithms: true
         property bool tilingShowMasterCount: true


### PR DESCRIPTION
## Summary

Defaults fix-ups so PlasmaZones is useful out of the box without an overwhelming catalogue:

- **Autotiling on by default** — behaves like a dynamic tiler (krohnkite / dwm / xmonad) without setup. The companion krohnkite-parity behaviors were already on (focus new windows, smart gaps, respect minimum size, exclude transient windows, insert-at-stack-end); default algorithm (`bsp`) and gaps unchanged.
- **Curated default picker visibility** — out of the box the picker shows a curated subset of layouts and tiling algorithms; the rest start hidden (users re-show any via the eye toggle). All per-id visibility state lives in `layout-settings.json`, keyed by id — never on the bundled layout JSON or luau metadata.
- **Show-hidden by default in the layouts page** — so the curated-out items are visible (dimmed, with the toggle) in settings and easy to re-enable.

## How visibility works

- `hiddenFromSelector` moves into the `LayoutSettingsStore` sidecar key set (alongside `autoAssign`), so it splits out of the structural layout file.
- Autotile overrides fold into the same `layout-settings.json` keyed by `autotile:<id>`; the standalone `autotile-overrides.json` is **retired** via a one-time, self-deleting migration on load.
- Fixed `setLayoutHidden` for autotile ids (was a silent no-op: rejected as a non-UUID), and surfaced autotile `hiddenFromSelector` in `getLayoutList` + the editor save path (merge, don't clobber).
- The zone selector now honors algorithm hidden state (`loadAutotileOverrides` added to `IZoneLayoutRegistry`; filtered in `buildUnifiedLayoutList`).
- Curated defaults (`ConfigDefaults::defaultLayoutVisibilitySettings`) are seeded on a **fresh install only** — when neither sidecar exists — so existing installs are untouched.

Hidden set: 5 layouts (fibonacci, grid-3x2, priority-grid, split-focus, wide) + 17 algorithms (everything except bsp, master-stack, monocle, columns, spiral, three-column, grid, deck).

## Testing

- Full suite: **252/252 passing**; builds clean.
- Not yet validated live (fresh-install seed + picker filtering) — verified by build + unit tests + logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)