### PR TITLE
fix(settings): keep the global settings search centered while typing

### DIFF
--- a/src/settings/qml/GlobalSearchField.qml
+++ b/src/settings/qml/GlobalSearchField.qml
@@ -49,9 +49,9 @@ Item {
         anchors.fill: parent
         placeholderText: i18nc("@info:placeholder global settings search", "Search settings…")
         Accessible.name: i18n("Search settings")
-        // Centre the placeholder hint, but left-align once the user starts
-        // typing so the caret and query read normally.
-        horizontalAlignment: field.text.length === 0 ? Text.AlignHCenter : Text.AlignLeft
+        // Keep the field centered in both the placeholder and typing states so
+        // the caret/query stay centered instead of jumping left on first input.
+        horizontalAlignment: Text.AlignHCenter
         // Kirigami.SearchField auto-fires accepted() shortly after the text
         // changes by default — which would navigate to the top result as the
         // user types. Disable it so accepted() means "the user pressed Enter".


### PR DESCRIPTION
## Summary

The global header search field (`GlobalSearchField`) centered its placeholder but explicitly switched to left-alignment as soon as text was present:

```qml
horizontalAlignment: field.text.length === 0 ? Text.AlignHCenter : Text.AlignLeft
```

So the caret/query jumped from centered to left on the first keystroke. This pins it to a constant `Text.AlignHCenter`, keeping the field centered in both the placeholder and typing states.

## Change

- `src/settings/qml/GlobalSearchField.qml`: `horizontalAlignment` → constant `Text.AlignHCenter` (one line + comment).

## Testing

Verified in the running settings app: the top search now stays centered while typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)