### PR TITLE
fix(settings): virtual-screen preview label overflow + preset % labels

### DIFF
--- a/src/settings/qml/VirtualScreenPreview.qml
+++ b/src/settings/qml/VirtualScreenPreview.qml
@@ -68,23 +68,32 @@ Rectangle {
             border.color: Kirigami.Theme.highlightColor
             border.width: Math.max(1, Math.round(Screen.devicePixelRatio * 2))
             radius: Kirigami.Units.smallSpacing / 2
+            // Keep labels from painting outside the region in narrow (portrait /
+            // thin-split) zones \u2014 belt-and-braces alongside the width cap below.
+            clip: true
 
             ColumnLayout {
                 anchors.centerIn: parent
+                // Cap to the region width so the labels elide instead of
+                // overflowing past narrow zone edges.
+                width: Math.min(implicitWidth, regionRect.width - Kirigami.Units.smallSpacing)
                 spacing: Math.round(Kirigami.Units.smallSpacing / 2)
 
                 Label {
-                    Layout.alignment: Qt.AlignHCenter
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
                     text: modelData.displayName || i18n("Screen %1", index + 1)
                     font.weight: Font.DemiBold
                     font.pixelSize: Math.max(Kirigami.Theme.defaultFont.pixelSize * 0.7, Math.min(Kirigami.Theme.defaultFont.pixelSize * 1, regionRect.width * previewRoot.titleFontScaleFraction))
                     color: Kirigami.Theme.textColor
-                    elide: Text.ElideRight
-                    maximumLineCount: 1
+                    // Wrap rather than elide: portrait/thin zones are narrow but
+                    // tall, so wrapping keeps the full label readable.
+                    wrapMode: Text.Wrap
                 }
 
                 Label {
-                    Layout.alignment: Qt.AlignHCenter
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignHCenter
                     text: {
                         var wpx = Math.round(modelData.width * previewRoot.screenWidth);
                         var hpx = Math.round(modelData.height * previewRoot.screenHeight);
@@ -96,6 +105,7 @@ Rectangle {
                     }
                     font.pixelSize: Math.max(Kirigami.Theme.defaultFont.pixelSize * 0.65, Math.min(Kirigami.Theme.defaultFont.pixelSize * 0.85, regionRect.width * previewRoot.detailFontScaleFraction))
                     color: Kirigami.Theme.disabledTextColor
+                    wrapMode: Text.Wrap
                 }
             }
         }

--- a/src/settings/qml/VirtualScreensPage.qml
+++ b/src/settings/qml/VirtualScreensPage.qml
@@ -574,42 +574,42 @@ SettingsFlickable {
                     Repeater {
                         model: [
                             {
-                                "label": i18n("50 / 50"),
+                                "label": i18n("50% / 50%"),
                                 "detail": i18n("Horizontal"),
                                 "regions": root._horizontalRegions([50, 50], [i18n("Left"), i18n("Right")])
                             },
                             {
-                                "label": i18n("60 / 40"),
+                                "label": i18n("60% / 40%"),
                                 "detail": i18n("Horizontal"),
                                 "regions": root._horizontalRegions([60, 40], [i18n("Main"), i18n("Side")])
                             },
                             {
-                                "label": i18n("33 / 33 / 33"),
+                                "label": i18n("33% / 33% / 33%"),
                                 "detail": i18n("Horizontal"),
                                 "regions": root._horizontalRegions([33.3, 33.4, 33.3], [i18n("Left"), i18n("Center"), i18n("Right")])
                             },
                             {
-                                "label": i18n("40 / 20 / 40"),
+                                "label": i18n("40% / 20% / 40%"),
                                 "detail": i18n("Horizontal"),
                                 "regions": root._horizontalRegions([40, 20, 40], [i18n("Left"), i18n("Center"), i18n("Right")])
                             },
                             {
-                                "label": i18n("50 / 50"),
+                                "label": i18n("50% / 50%"),
                                 "detail": i18n("Vertical"),
                                 "regions": root._gridRegions(1, 2, [i18n("Top"), i18n("Bottom")])
                             },
                             {
-                                "label": i18n("50 / 50"),
+                                "label": i18n("50% / 50%"),
                                 "detail": i18n("Grid"),
                                 "regions": root._gridRegions(2, 2, [i18n("Top-Left"), i18n("Top-Right"), i18n("Bottom-Left"), i18n("Bottom-Right")])
                             },
                             {
-                                "label": i18n("33 / 33 / 33"),
+                                "label": i18n("33% / 33% / 33%"),
                                 "detail": i18n("Grid"),
                                 "regions": root._gridRegions(3, 2, [i18n("Top-Left"), i18n("Top-Center"), i18n("Top-Right"), i18n("Bottom-Left"), i18n("Bottom-Center"), i18n("Bottom-Right")])
                             },
                             {
-                                "label": i18n("60 / 40"),
+                                "label": i18n("60% / 40%"),
                                 "detail": i18n("Grid"),
                                 "regions": [
                                     {


### PR DESCRIPTION
## Summary

Two Virtual Screens page fixes:

- **Preview label overflow** — in the subdivision preview, portrait / thin-split zones are narrow but tall, so the centered region labels (name + dimensions) spilled outside their boxes. Each region is now clipped, the label column is capped to the zone width, and the labels wrap (instead of overflowing) so the full text stays readable.
- **Preset labels missing units** — the split preset cards showed bare ratios (`50 / 50`, `33 / 33 / 33`, `40 / 20 / 40`). Added `%` to every preset label so it's clear the numbers are percentages.

## Changes
- `src/settings/qml/VirtualScreenPreview.qml`: clip regions, cap label column width, wrap labels.
- `src/settings/qml/VirtualScreensPage.qml`: `%` on all 8 split preset labels.

## Testing
Verified in the running settings app: labels stay inside their zones (incl. portrait), and presets read `50% / 50%`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)