### PR TITLE
fix(settings): add trailing periods to About credit sentences

### DIFF
--- a/src/settings/qml/AboutPage.qml
+++ b/src/settings/qml/AboutPage.qml
@@ -114,7 +114,7 @@ PhosphorUi.AboutPageShell {
                     Layout.fillWidth: true
                     Layout.leftMargin: Kirigami.Units.largeSpacing
                     Layout.rightMargin: Kirigami.Units.largeSpacing
-                    text: i18n("Inspired by FancyZones, extended with automatic tiling")
+                    text: i18n("Inspired by FancyZones, extended with automatic tiling.")
                     opacity: 0.7
                 }
 
@@ -122,7 +122,7 @@ PhosphorUi.AboutPageShell {
                     Layout.fillWidth: true
                     Layout.leftMargin: Kirigami.Units.largeSpacing
                     Layout.rightMargin: Kirigami.Units.largeSpacing
-                    text: i18n("Built with Qt, KDE Frameworks, and Kirigami")
+                    text: i18n("Built with Qt, KDE Frameworks, and Kirigami.")
                     opacity: 0.7
                 }
             }


### PR DESCRIPTION
## Summary

The About page's two descriptive credit lines were missing end punctuation:

- "Inspired by FancyZones, extended with automatic tiling" → "…tiling."
- "Built with Qt, KDE Frameworks, and Kirigami" → "…Kirigami."

Added trailing periods. (The bold "Created by fuddlesworth" attribution line is a heading, left without a period.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)