### PR TITLE
fix(settings): sidebar polish — back row, alignment, spacing, active pill

### DIFF
--- a/libs/phosphor-control/qml/Sidebar.qml
+++ b/libs/phosphor-control/qml/Sidebar.qml
@@ -525,8 +525,8 @@ ColumnLayout {
 
         Layout.fillWidth: true
         Layout.fillHeight: true
-        // Inset the row list horizontally so the active-row accent
-        // stripe and hover backgrounds don't run flush against the
+        // Inset the row list horizontally so the active-row highlight
+        // and hover backgrounds don't run flush against the
         // window's left edge. Matches the SearchField's smallSpacing
         // inset above so rows align with the search field's left edge,
         // and balances the right-hand scrollbar gutter the ScrollView

--- a/libs/phosphor-control/qml/Sidebar.qml
+++ b/libs/phosphor-control/qml/Sidebar.qml
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick
-import QtQuick.Window
 import QtQuick.Controls as QQC2
 import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
@@ -92,11 +91,7 @@ ColumnLayout {
     // Legacy row-height multipliers — extracted from inline magic numbers
     // to a single source so a future row-density tweak touches one place.
     readonly property real backButtonHeight: Kirigami.Units.gridUnit * 2.6
-    readonly property real navRowHeight: Kirigami.Units.gridUnit * 2.2
-    // Active-row left-accent stripe width — Math.round so fractional DPRs
-    // (1.5×, 1.25×) don't yield sub-pixel widths that anti-alias to a
-    // washed-out half-pixel line.
-    readonly property int accentBarWidth: Math.round(Screen.devicePixelRatio * 2.5)
+    readonly property real navRowHeight: Kirigami.Units.gridUnit * 2.5
 
     function drillInto(parentId) {
         // Short-circuit on either the already-displayed scope OR a
@@ -552,7 +547,21 @@ ColumnLayout {
 
                 visible: root.currentParentId !== "" && root.searchText.length === 0
                 backButtonHeight: root.backButtonHeight
+                compact: root.compact
+                // Show the parent category name (e.g. "‹ Snapping"); pageData()
+                // returns an empty map for an unknown/empty id, so guard to "".
+                title: root.currentParentId !== "" ? (root.controller.registry.pageData(root.currentParentId).title || "") : ""
                 onBackClicked: root.drillOut()
+            }
+
+            // Drill-out rule — a first-class sibling (not buried in the back
+            // row's background) so it shares the section dividers' largeSpacing
+            // inset and lines up with the rows below.
+            Kirigami.Separator {
+                Layout.fillWidth: true
+                Layout.leftMargin: root.compact ? Kirigami.Units.smallSpacing : Kirigami.Units.largeSpacing
+                Layout.rightMargin: root.compact ? Kirigami.Units.smallSpacing : Kirigami.Units.largeSpacing
+                visible: backButton.visible
             }
 
             ListView {
@@ -621,7 +630,6 @@ ColumnLayout {
                     isCurrent: !rowItem._isCollapsibleHeader && rowItem.hasQmlSource && root.controller.currentPageId === rowItem.pageId
                     compact: root.compact
                     navRowHeight: root.navRowHeight
-                    accentBarWidth: root.accentBarWidth
                     trailingDelegate: root.trailingDelegate
                     onNavigationRequested: pid => {
                         // Synthetic divider rows have pageIds like

--- a/libs/phosphor-control/qml/SidebarBackButton.qml
+++ b/libs/phosphor-control/qml/SidebarBackButton.qml
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 import QtQuick
-import QtQuick.Window
 import QtQuick.Controls as QQC2
 import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
@@ -10,63 +9,65 @@ import org.phosphor.animation
 import "ThemeHelpers.js" as ThemeHelpers
 
 /**
- * Drill-out "Back" row shown at the top of the sidebar list when the user
- * has drilled into a parent page.
+ * Drill-out header row shown at the top of the sidebar list when the user has
+ * drilled into a parent page. Reads as a section header: a leading chevron plus
+ * the parent category's name (e.g. "‹ Snapping"); clicking anywhere drills out.
  *
- * Extracted from Sidebar.qml's inline `ItemDelegate { id: backButton }` to
- * keep Sidebar.qml under the 800-line cap (CLAUDE.md). The visual + a11y
- * behaviour is unchanged — same hover tint, same demi-bold "Back" label,
- * same 1-dp bottom separator.
+ * The chevron is a text-run glyph inside the same Label as the title (not a
+ * Kirigami.Icon): its ink sits flush on the content-left edge exactly like the
+ * section-header text below, whereas an icon box centres the glyph and pushes it
+ * off the grid. It also mirrors under RTL (‹ → ›) for free. The bottom rule is
+ * NOT drawn here — the hosting Sidebar places a Kirigami.Separator below this
+ * row so it shares the section dividers' inset. Extracted from Sidebar.qml to
+ * keep that file under the 800-line cap (CLAUDE.md).
  */
 QQC2.ItemDelegate {
     id: backButton
 
-    // Match legacy row height for the back button (slightly taller than
-    // nav rows so it reads as a header).
+    /// Parent category name shown after the chevron (e.g. "Snapping").
+    property string title: ""
+    /// Icon-only rail: collapse to a centered chevron with a tooltip.
+    property bool compact: false
+    // Match legacy row height for the back button (slightly taller than nav
+    // rows so it reads as a header).
     property real backButtonHeight: Kirigami.Units.gridUnit * 2.6
+
+    /// Accessible / tooltip label — announces where "back" goes.
+    readonly property string _backLabel: backButton.title.length > 0 ? qsTr("Back to %1").arg(backButton.title) : qsTr("Back")
 
     //* Fired when the user clicks the back row. Sidebar wires this to drillOut().
     signal backClicked
 
     Layout.fillWidth: true
     implicitHeight: backButton.backButtonHeight
-    leftPadding: Kirigami.Units.smallSpacing
-    rightPadding: Kirigami.Units.smallSpacing
-    Accessible.name: qsTr("Back")
+    // Compact rail centers the chevron (leftPadding 0); otherwise content starts
+    // at the same largeSpacing inset as the nav rows / section headers.
+    leftPadding: backButton.compact ? 0 : Kirigami.Units.largeSpacing
+    rightPadding: backButton.compact ? 0 : Kirigami.Units.largeSpacing
+    // Symmetric vertical padding so the content is centered in the row (the
+    // ItemDelegate style's default top/bottom padding is asymmetric).
+    topPadding: 0
+    bottomPadding: 0
+    Accessible.name: backButton._backLabel
     Accessible.role: Accessible.Button
+    // Tooltip surfaces the destination when compact mode has hidden the label.
+    QQC2.ToolTip.visible: backButton.compact && backButton.hovered
+    QQC2.ToolTip.text: backButton._backLabel
+    QQC2.ToolTip.delay: Kirigami.Units.toolTipDelay
     onClicked: backButton.backClicked()
 
     background: Rectangle {
         id: backButtonBackground
 
-        // Default Rectangle color is white — without an initial
-        // assignment the Behavior would tint from white to
-        // "transparent" on the very first paint (binding eval).
-        // Gate the Behavior on completion so the first eval
-        // lands without animation.
-        //
-        // Shared pattern with SidebarRow.qml — Qt's `Behavior on X`
-        // block must be a sibling of the animated property, so we
-        // can't extract this into a reusable Component. If you
-        // change the gate/profile here, mirror the edit there.
+        // Default Rectangle color is white — without an initial assignment the
+        // Behavior would tint from white to "transparent" on the very first
+        // paint. Gate the Behavior on completion so the first eval lands without
+        // animation. Shared pattern with SidebarRow.qml.
         property bool _behaviorReady: false
 
         Component.onCompleted: _behaviorReady = true
         color: backButton.hovered ? ThemeHelpers.hoverTint(Kirigami.Theme.textColor) : Qt.rgba(0, 0, 0, 0)
         radius: Kirigami.Units.smallSpacing
-
-        // Legacy back-button bottom separator — a 1-dp line tucked
-        // inside the row's bottom edge so the rail reads as "you're
-        // inside a sub-section".
-        Rectangle {
-            anchors.bottom: parent.bottom
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.leftMargin: Kirigami.Units.smallSpacing
-            anchors.rightMargin: Kirigami.Units.smallSpacing
-            height: Math.round(Screen.devicePixelRatio)
-            color: ThemeHelpers.withAlpha(Kirigami.Theme.textColor, 0.1)
-        }
 
         Behavior on color {
             enabled: backButtonBackground._behaviorReady
@@ -77,23 +78,17 @@ QQC2.ItemDelegate {
         }
     }
 
-    contentItem: RowLayout {
-        spacing: Kirigami.Units.smallSpacing
+    // Single Label so the chevron lives in the text run — its ink lands flush on
+    // the content-left edge like the section-header text, and it mirrors under
+    // RTL. Demi-bold @ 0.8 opacity reads as a header rather than a nav row.
+    contentItem: QQC2.Label {
+        readonly property string _chevron: LayoutMirroring.enabled ? "›" : "‹"
 
-        Kirigami.Icon {
-            source: "go-previous-symbolic"
-            Layout.preferredWidth: Kirigami.Units.iconSizes.small
-            Layout.preferredHeight: Kirigami.Units.iconSizes.small
-            opacity: 0.7
-        }
-
-        QQC2.Label {
-            Layout.fillWidth: true
-            text: qsTr("Back")
-            // Legacy back-button label uses demi-bold @ 0.8 opacity
-            // — reads as a section header rather than another nav row.
-            font.weight: Font.DemiBold
-            opacity: 0.8
-        }
+        text: backButton.compact ? _chevron : _chevron + " " + backButton.title
+        font.weight: Font.DemiBold
+        opacity: 0.8
+        elide: Text.ElideRight
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: backButton.compact ? Text.AlignHCenter : Text.AlignLeft
     }
 }

--- a/libs/phosphor-control/qml/SidebarBackButton.qml
+++ b/libs/phosphor-control/qml/SidebarBackButton.qml
@@ -84,7 +84,10 @@ QQC2.ItemDelegate {
     contentItem: QQC2.Label {
         readonly property string _chevron: LayoutMirroring.enabled ? "›" : "‹"
 
-        text: backButton.compact ? _chevron : _chevron + " " + backButton.title
+        // Title is normally the parent category name; fall back to "Back" if a
+        // malformed registry yields no title (so the row never reads as a lone
+        // chevron with a dangling space).
+        text: backButton.compact ? _chevron : _chevron + " " + (backButton.title.length > 0 ? backButton.title : qsTr("Back"))
         font.weight: Font.DemiBold
         opacity: 0.8
         elide: Text.ElideRight

--- a/libs/phosphor-control/qml/SidebarRow.qml
+++ b/libs/phosphor-control/qml/SidebarRow.qml
@@ -62,7 +62,7 @@ QQC2.ItemDelegate {
     Accessible.name: rowItem._isDivider ? "" : rowItem.title
     Accessible.role: rowItem._isDivider ? Accessible.Separator : Accessible.Button
     // Active row reads as "checked" to AT tools (matches the visual
-    // accent + bold label affordance). Dividers stay
+    // highlight + bold label affordance). Dividers stay
     // un-checkable — they're ornament with role Separator.
     Accessible.checkable: !rowItem._isDivider
     Accessible.checked: !rowItem._isDivider && rowItem.isCurrent
@@ -114,11 +114,10 @@ QQC2.ItemDelegate {
         property bool _behaviorReady: false
 
         Component.onCompleted: _behaviorReady = true
-        // Active row: highlight tinted at 12% — same tint legacy used
-        // so the visual weight matches KCM modules. Hover: 6%
-        // textColor for a subtle "interactive" cue. Both transitions
-        // run through `widget.tint.fast` so they feel snappy without
-        // flicker.
+        // Active row: highlightColor background at ACTIVE_TINT_ALPHA (see
+        // ThemeHelpers). Hover: textColor at HOVER_TINT_ALPHA for a subtle
+        // "interactive" cue. Both transitions run through `widget.tint.fast`
+        // so they feel snappy without flicker.
         color: {
             // Dividers paint nothing — the Separator child below
             // provides their only visual.

--- a/libs/phosphor-control/qml/SidebarRow.qml
+++ b/libs/phosphor-control/qml/SidebarRow.qml
@@ -14,7 +14,7 @@ import "ThemeHelpers.js" as ThemeHelpers
  * Extracted from Sidebar.qml so the (originally ~270-line) ItemDelegate
  * body can be reviewed and tested independently. The parent Sidebar
  * threads the model role values in as required properties + a small set
- * of visual settings (compact, navRowHeight, accentBarWidth); navigation
+ * of visual settings (compact, navRowHeight); navigation
  * intent flows back out through the three Q_SIGNALS below.
  *
  * Naming: the model role is called `pageId` (not `id`) because `id`
@@ -39,7 +39,6 @@ QQC2.ItemDelegate {
     required property bool isCurrent
     required property bool compact
     required property real navRowHeight
-    required property real accentBarWidth
     property Component trailingDelegate: null
 
     /// Navigation intents. Parent Sidebar wires these to
@@ -76,8 +75,8 @@ QQC2.ItemDelegate {
     // there's no room to express hierarchy when only the icon is
     // visible, and the user has the tooltip + active accent to orient
     // by.
-    leftPadding: rowItem.compact ? 0 : (Kirigami.Units.smallSpacing + (rowItem._depth * Kirigami.Units.gridUnit))
-    rightPadding: rowItem.compact ? 0 : Kirigami.Units.smallSpacing
+    leftPadding: rowItem.compact ? 0 : (Kirigami.Units.largeSpacing + (rowItem._depth * Kirigami.Units.gridUnit))
+    rightPadding: rowItem.compact ? 0 : Kirigami.Units.largeSpacing
     // Tooltip surfaces the row label when compact mode has hidden it.
     // Delay uses the Kirigami platform unit so theming / accessibility
     // overrides (slow-motion mode, high-feedback profiles) flow
@@ -135,20 +134,6 @@ QQC2.ItemDelegate {
             return Qt.rgba(0, 0, 0, 0);
         }
         radius: Kirigami.Units.smallSpacing
-
-        // Left accent bar — 2.5dp wide, half the row's height, rounded
-        // ends, highlightColor. Only visible on the active leaf so the
-        // user's location reads at a glance even when the background
-        // tint is subtle.
-        Rectangle {
-            anchors.left: parent.left
-            anchors.verticalCenter: parent.verticalCenter
-            width: rowItem.accentBarWidth
-            height: parent.height * 0.5
-            radius: width / 2
-            color: Kirigami.Theme.highlightColor
-            visible: rowItem.isCurrent
-        }
 
         // Section divider line — only present on divider rows.
         // Centered vertically with largeSpacing horizontal margins so

--- a/libs/phosphor-control/qml/ThemeHelpers.js
+++ b/libs/phosphor-control/qml/ThemeHelpers.js
@@ -19,11 +19,10 @@ function withAlpha(baseColor, alpha) {
 }
 
 // Conventional alpha presets — pre-named so the call sites read as
-// "highlightTintActive(color)" instead of "withAlpha(color, 0.12)"
-// where the 0.12 carries semantic meaning the literal doesn't.
+// "activeTint(color)" instead of "withAlpha(color, 0.18)" where the
+// literal carries semantic meaning it otherwise wouldn't.
 //
-// Values match the tints the legacy Phosphor chrome shipped — a
-// future visual-tweak pass can adjust them in one place.
+// Centralised so a future visual-tweak pass can adjust them in one place.
 var ACTIVE_TINT_ALPHA = 0.18;   // Active-row highlight background
 var HOVER_TINT_ALPHA = 0.06;    // Hover background
 var SUBTLE_BACKGROUND_ALPHA = 0.15; // Less-busy "I'm a placeholder" tint

--- a/libs/phosphor-control/qml/ThemeHelpers.js
+++ b/libs/phosphor-control/qml/ThemeHelpers.js
@@ -24,7 +24,7 @@ function withAlpha(baseColor, alpha) {
 //
 // Values match the tints the legacy Phosphor chrome shipped — a
 // future visual-tweak pass can adjust them in one place.
-var ACTIVE_TINT_ALPHA = 0.12;   // Active-row highlight background
+var ACTIVE_TINT_ALPHA = 0.18;   // Active-row highlight background
 var HOVER_TINT_ALPHA = 0.06;    // Hover background
 var SUBTLE_BACKGROUND_ALPHA = 0.15; // Less-busy "I'm a placeholder" tint
 var SUBTLE_OUTLINE_ALPHA = 0.2; // Outline / divider tint


### PR DESCRIPTION
## Summary

A pass of visual fixes to the settings sidebar rail.

### Drill-out "Back" row (redesigned)
- Now shows the parent category with a **text-run chevron** — e.g. `‹ Snapping` instead of a generic "Back". Because the chevron is a glyph in the same Label as the title, its ink sits flush on the content-left edge and lines up with the section headers below — the old `Kirigami.Icon` centred its glyph inside the icon box, so it always drifted ~8px off the grid no matter how the padding was nudged.
- The drill-out **rule moved out of the back row** into a sibling `Kirigami.Separator` at the `largeSpacing` inset, so it shares the exact line of the section dividers below it.
- "Back" label is now vertically centered (the `org.kde.desktop` ItemDelegate's default top/bottom padding is asymmetric — 10/4).
- Mirrors under RTL (`‹`→`›`); compact rail collapses to a centered chevron + tooltip; native hover/focus/keyboard preserved.

### Spacing
- Nav row height `2.2` → `2.5` gridUnit, and horizontal padding `smallSpacing` → `largeSpacing` — more breathing room.

### Active-row indicator
- Removed the left **accent stripe** (a one-off "pill" indicator used nowhere else in the design) and its `accentBarWidth` plumbing. Selection now reads via the highlighted row background (tint `12%` → `18%`) plus the demi-bold label — the standard KDE list-selection look.

## Files
- `libs/phosphor-control/qml/SidebarBackButton.qml`
- `libs/phosphor-control/qml/Sidebar.qml`
- `libs/phosphor-control/qml/SidebarRow.qml`
- `libs/phosphor-control/qml/ThemeHelpers.js`

## Testing
Built (`phosphor-control` + `plasmazones-settings`), qmllint clean, verified in the running settings app: `‹ <Category>` aligned under the headers, rule lined up, active row a clean highlighted pill with no stripe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)