### PR TITLE
feat: suppress default layout assignment (per-context override)

### DIFF
--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
@@ -288,6 +288,19 @@ inline constexpr QLatin1StringView DisableEngine{"disableEngine"};
 /// engines). The daemon resolves it LIVE on the context-lock path and never
 /// persists it, so rule locks and manual toggles never overwrite each other.
 inline constexpr QLatin1StringView LockContext{"lockContext"};
+/// Per-context override of the global "suppress default layout assignment"
+/// setting for the matched screen/desktop/activity context. Context domain
+/// (matches only context fields); mode-agnostic (the override governs the
+/// synthesized default for BOTH the snapping and tiling engines, since the
+/// level-1 default is a single mode-carrying `AssignmentEntry`). Boolean
+/// `value`: `false` SUPPRESSES the synthesized default for this context (no
+/// engine activates until the user explicitly assigns one), `true` ALLOWS it
+/// (forces the global default through even when the global suppress setting is
+/// on). With no such rule, the context follows the global setting. Carries no
+/// `SetEngineMode` action, so it is NOT a cascade-winning assignment rule — the
+/// daemon reads it as a per-slot overlay at cascade-miss via
+/// `LayoutRegistry::resolveContextDefaultAssignment`, mirroring `LockContext`.
+inline constexpr QLatin1StringView DefaultLayoutAssignment{"defaultLayoutAssignment"};
 inline constexpr QLatin1StringView Exclude{"exclude"};
 inline constexpr QLatin1StringView Float{"float"};
 /// Snap a matched window into one or more zones on open. Carries a non-empty
@@ -451,6 +464,12 @@ inline constexpr QLatin1StringView EngineEnable{"engine-enable"};
 /// Context-domain layout-lock slot — filled by `ActionType::LockContext`.
 /// A single boolean: a winning rule with `value == true` locks the context.
 inline constexpr QLatin1StringView Locked{"locked"};
+/// Context-domain default-assignment override slot — filled by
+/// `ActionType::DefaultLayoutAssignment`. A single boolean (first-matching-rule-
+/// wins): `false` suppresses the synthesized level-1 default for the context,
+/// `true` forces it through. Read at cascade-miss by
+/// `LayoutRegistry::resolveContextDefaultAssignment`.
+inline constexpr QLatin1StringView DefaultAssignment{"default-assignment"};
 inline constexpr QLatin1StringView Manage{"manage"};
 inline constexpr QLatin1StringView Float{"float"};
 /// Window-scoped open-placement slot — filled by `ActionType::SnapToZone`. A

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
@@ -404,7 +404,7 @@ inline bool isEffectRuleAction(const QString& type)
 inline bool isLayoutEngineContextAction(const QString& type)
 {
     return type == SetEngineMode || type == SetSnappingLayout || type == SetTilingAlgorithm || type == DisableEngine
-        || type == LockContext;
+        || type == LockContext || type == DefaultLayoutAssignment;
 }
 } // namespace ActionType
 

--- a/libs/phosphor-window-rules/src/ruleaction.cpp
+++ b/libs/phosphor-window-rules/src/ruleaction.cpp
@@ -424,6 +424,35 @@ void ActionRegistry::registerBuiltins()
         .tags = {QString(Tag::LayoutEngine)},
     });
 
+    // ── default-assignment slot — context-domain override of the global
+    //    "suppress default layout assignment" setting. A matched context rule
+    //    flips the synthesized level-1 default for its screen/desktop/activity:
+    //    value == false suppresses it (no engine activates until the user
+    //    explicitly assigns one), value == true forces it through even when the
+    //    global suppress setting is on. Mode-agnostic (the level-1 default is a
+    //    single mode-carrying AssignmentEntry) and live-resolved per-slot at
+    //    cascade-miss by LayoutRegistry::resolveContextDefaultAssignment —
+    //    carries no SetEngineMode action, so it never wins the single-rule
+    //    assignment cascade. Seeds FALSE: the global setting defaults OFF (every
+    //    context gets a default), so the only meaningful per-context rule a user
+    //    adds is "suppress on this monitor" — defaultDisplay 0.0 lands the fresh
+    //    action on that value.
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::DefaultLayoutAssignment),
+        .slotFor = constantSlot(ActionSlot::DefaultAssignment),
+        .validate =
+            [](const QJsonObject& p) {
+                return hasBool(p, ActionParam::Value);
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value), .kind = QStringLiteral("bool"), .defaultDisplay = 0.0}},
+        .category = QStringLiteral("layoutEngine"),
+        .displayOrder = 5,
+        .tags = {QString(Tag::LayoutEngine)},
+    });
+
     // ── manage slot — terminal. Exclude is intentionally free-form: an empty
     //    `allowedKeys` opts out of the strict-key check so a future Exclude
     //    reason/scope param can be added without a schema bump. ──

--- a/libs/phosphor-window-rules/tests/test_actionregistry.cpp
+++ b/libs/phosphor-window-rules/tests/test_actionregistry.cpp
@@ -114,6 +114,7 @@ private Q_SLOTS:
         QVERIFY(!reg.isTerminal(makeAction(ActionType::SetOpacity)));
         QVERIFY(!reg.isTerminal(makeAction(ActionType::RestorePosition)));
         QVERIFY(!reg.isTerminal(makeAction(ActionType::LockContext)));
+        QVERIFY(!reg.isTerminal(makeAction(ActionType::DefaultLayoutAssignment)));
     }
 
     void testValidateAcceptsWellFormedRegisteredAction()

--- a/libs/phosphor-window-rules/tests/test_actionregistry.cpp
+++ b/libs/phosphor-window-rules/tests/test_actionregistry.cpp
@@ -51,6 +51,7 @@ private Q_SLOTS:
         QVERIFY(reg.isRegistered(QString(ActionType::SetOpacity)));
         QVERIFY(reg.isRegistered(QString(ActionType::RestorePosition)));
         QVERIFY(reg.isRegistered(QString(ActionType::LockContext)));
+        QVERIFY(reg.isRegistered(QString(ActionType::DefaultLayoutAssignment)));
     }
 
     void testSlots()
@@ -192,6 +193,34 @@ private Q_SLOTS:
         QJsonObject notBool;
         notBool.insert(QStringLiteral("value"), 1);
         QVERIFY2(!reg.validate(makeAction(ActionType::LockContext, notBool)), "non-bool value must fail");
+    }
+
+    void testDefaultLayoutAssignmentAction()
+    {
+        const ActionRegistry& reg = ActionRegistry::instance();
+        QVERIFY(reg.isRegistered(QString(ActionType::DefaultLayoutAssignment)));
+
+        QJsonObject allow;
+        allow.insert(QStringLiteral("value"), true);
+        QJsonObject suppress;
+        suppress.insert(QStringLiteral("value"), false);
+
+        // Context-domain boolean action filling its dedicated slot. Non-terminal:
+        // a default-assignment-only context rule composes with other context
+        // slots rather than short-circuiting (mirrors LockContext).
+        QCOMPARE(reg.slotFor(makeAction(ActionType::DefaultLayoutAssignment, allow)),
+                 QString(ActionSlot::DefaultAssignment));
+        QCOMPARE(reg.domainFor(makeAction(ActionType::DefaultLayoutAssignment, allow)), ActionDomain::Context);
+        QVERIFY(!reg.isTerminal(makeAction(ActionType::DefaultLayoutAssignment, allow)));
+
+        // Requires a boolean `value`; both true (allow) and false (suppress) are
+        // well-formed.
+        QVERIFY(reg.validate(makeAction(ActionType::DefaultLayoutAssignment, allow)));
+        QVERIFY(reg.validate(makeAction(ActionType::DefaultLayoutAssignment, suppress)));
+        QVERIFY2(!reg.validate(makeAction(ActionType::DefaultLayoutAssignment)), "missing value must fail validation");
+        QJsonObject notBool;
+        notBool.insert(QStringLiteral("value"), 1);
+        QVERIFY2(!reg.validate(makeAction(ActionType::DefaultLayoutAssignment, notBool)), "non-bool value must fail");
     }
 
     void testRegisterCustomAction()

--- a/libs/phosphor-window-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-window-rules/tests/test_ruleaction.cpp
@@ -34,6 +34,10 @@ const QList<QLatin1StringView> kContextDomainTypes = {
     // Layout lock — context-domain, resolved during the screen/desktop/
     // activity pass (mode-agnostic) like the other context actions.
     ActionType::LockContext,
+    // Default-assignment override — context-domain, resolved during the
+    // screen/desktop/activity pass (LayoutRegistry::resolveContextDefaultAssignment),
+    // mode-agnostic like LockContext.
+    ActionType::DefaultLayoutAssignment,
     // Gap overrides are context-domain — resolved during the
     // screen/desktop/activity pass, never per-window.
     ActionType::SetZonePadding,

--- a/libs/phosphor-window-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-window-rules/tests/test_ruleaction.cpp
@@ -430,6 +430,7 @@ private Q_SLOTS:
         rejectsStray(ActionType::SetOuterGapTop, QJsonValue(8));
         rejectsStray(ActionType::SetUsePerSideOuterGap, QJsonValue(true));
         rejectsStray(ActionType::LockContext, QJsonValue(true));
+        rejectsStray(ActionType::DefaultLayoutAssignment, QJsonValue(true));
         // OverrideOverlayStyle also declares allowedKeys = {Value}.
         rejectsStray(ActionType::OverrideOverlayStyle, QJsonValue(QString(OverlayStyleToken::Preview)));
     }
@@ -540,6 +541,31 @@ private Q_SLOTS:
         for (const bool v : {true, false}) {
             QJsonObject o;
             o.insert(QStringLiteral("type"), QString(ActionType::LockContext));
+            o.insert(QStringLiteral("value"), v);
+            const auto action = RuleAction::fromJson(o);
+            QVERIFY(action.has_value());
+            QCOMPARE(action->params.value(QStringLiteral("value")), QJsonValue(v));
+            const auto roundTripped = RuleAction::fromJson(action->toJson());
+            QVERIFY(roundTripped.has_value());
+            QCOMPARE(roundTripped->params.value(QStringLiteral("value")), QJsonValue(v));
+        }
+    }
+
+    void testDefaultLayoutAssignment_fromJsonRoundTrip()
+    {
+        // DefaultLayoutAssignment is a context-domain boolean (per-context override
+        // of the global suppress setting): it must validate through the public
+        // fromJson boundary (not just the registry), require a bool `value`, and
+        // round-trip both true (allow / force the default through) and false
+        // (suppress this context) losslessly. Mirrors testLockContext_fromJsonRoundTrip.
+        QJsonObject bad;
+        bad.insert(QStringLiteral("type"), QString(ActionType::DefaultLayoutAssignment));
+        bad.insert(QStringLiteral("value"), 1); // a number is not a bool
+        QVERIFY(!RuleAction::fromJson(bad).has_value());
+
+        for (const bool v : {true, false}) {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString(ActionType::DefaultLayoutAssignment));
             o.insert(QStringLiteral("value"), v);
             const auto action = RuleAction::fromJson(o);
             QVERIFY(action.has_value());

--- a/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/IZoneLayoutRegistry.h
@@ -193,6 +193,22 @@ public:
         return false;
     }
 
+    /// True iff the (@p screenId, @p virtualDesktop, @p activity) context has no
+    /// active layout specifically because the default assignment is suppressed —
+    /// globally or by a per-context @c DefaultLayoutAssignment rule. Daemon
+    /// overlay / display paths that otherwise fall back to @ref defaultLayout on a
+    /// missing assignment use this to treat a suppressed context as "no layout,
+    /// engine inactive" without regressing other empty-assignment states. The
+    /// default returns false (a stub registry never suppresses).
+    virtual bool isContextActiveLayoutSuppressed(const QString& screenId, int virtualDesktop,
+                                                 const QString& activity) const
+    {
+        Q_UNUSED(screenId);
+        Q_UNUSED(virtualDesktop);
+        Q_UNUSED(activity);
+        return false;
+    }
+
     /// Resolve the per-context overlay-property override for the
     /// (@p screenId, @p virtualDesktop, @p activity) context — a per-slot read
     /// across all matching context rules (mirrors @ref resolveContextGaps), so

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -784,9 +784,10 @@ private:
         return h;
     }
 
-    /// Shared revision-invalidated memoization for the three context resolvers
+    /// Shared revision-invalidated memoization for the five context resolvers
     /// (@ref resolveAssignmentEntry, @ref resolveContextGaps,
-    /// @ref resolveContextLocked). Drops @p cache wholesale whenever the rule
+    /// @ref resolveContextLocked, @ref resolveContextDefaultAssignment,
+    /// @ref resolveContextOverlay). Drops @p cache wholesale whenever the rule
     /// set's monotonic revision moves past @p cacheRevision, returns a cached
     /// hit, else runs @p compute, then soft-caps the cache at 256 entries —
     /// dropping the whole cache on overflow rather than evicting one key, which

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -17,6 +17,7 @@
 #include <QUuid>
 #include <functional>
 #include <memory>
+#include <optional>
 
 namespace PhosphorZones {
 

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -263,6 +263,28 @@ public:
      */
     void setSnappingPreferredProvider(std::function<bool()> provider);
 
+    /**
+     * @brief Inject a callback that returns true when the user has opted to
+     * suppress the synthesized level-1 default layout assignment globally.
+     *
+     * When the callback returns true, @ref resolveDefaultAssignmentEntry yields
+     * a default-constructed (invalid) entry on cascade-miss instead of
+     * synthesizing one from the snap / autotile / snapping-preferred providers —
+     * i.e. a context with no explicit assignment gets NO active layout and no
+     * engine activates until the user assigns one. This is the same effective
+     * state as a system with every provider returning empty, so the daemon's
+     * existing "empty entry ⇒ no default" handling covers it unchanged.
+     *
+     * The global baseline is overridable PER CONTEXT by a
+     * `DefaultLayoutAssignment` rule (see @ref resolveContextDefaultAssignment):
+     * a `false` rule suppresses a single context even when this provider is off,
+     * a `true` rule forces the default through even when this provider is on.
+     *
+     * Optional. When unset, the resolver behaves as before (never suppresses).
+     * Same threading rules as the other providers.
+     */
+    void setDefaultAssignmentSuppressedProvider(std::function<bool()> provider);
+
     /// True when the snapping-preferred provider is wired AND reports true — i.e.
     /// snapping is globally enabled (the daemon wires the provider to
     /// `ISettings::snappingEnabled`). Mirrors the internal default-assignment
@@ -327,6 +349,18 @@ public:
     /// `value` is true. Same owner-thread affinity as the rest of the registry.
     bool resolveContextLocked(const QString& screenId, int virtualDesktop, const QString& activity) const override;
 
+    /// Resolve a per-context override of the global default-layout-assignment
+    /// baseline for the (screen, desktop, activity) context by evaluating a
+    /// windowless WindowQuery and reading the `ActionSlot::DefaultAssignment`
+    /// slot. Per-slot read (mirrors @ref resolveContextLocked): returns the
+    /// winning `DefaultLayoutAssignment` action's boolean `value`
+    /// (true = allow / force the default through, false = suppress), or
+    /// @c std::nullopt when no matching rule fills the slot (the context then
+    /// follows the global setting). Same owner-thread affinity as the rest of
+    /// the registry.
+    std::optional<bool> resolveContextDefaultAssignment(const QString& screenId, int virtualDesktop,
+                                                        const QString& activity) const;
+
     /// Resolve the per-context overlay-property override (shader / style)
     /// for (screen, desktop, activity) by evaluating a windowless WindowQuery and
     /// reading the OverlayShader / OverlayStyle slots. Per-slot
@@ -385,6 +419,35 @@ public:
 
     AssignmentEntry::Mode modeForScreen(const QString& screenId, int virtualDesktop = 0,
                                         const QString& activity = QString()) const;
+
+    /// True iff the context has NO active layout specifically because the default
+    /// assignment is suppressed — globally (see
+    /// @ref setDefaultAssignmentSuppressedProvider) or by a per-context
+    /// @c DefaultLayoutAssignment rule. Returns false when an active layout exists
+    /// (an explicit assignment, or a default forced through by an "allow" rule),
+    /// AND false for OTHER empty-assignment states (e.g. snapping enabled with no
+    /// global default layout id, where callers still fall back to
+    /// @ref defaultLayout). This lets daemon overlay / display paths — which
+    /// otherwise fall back to @ref defaultLayout on a missing assignment — treat a
+    /// suppressed context as "no layout, engine inactive" without regressing the
+    /// no-global-default case. Mode-agnostic: a suppressed context has no layout
+    /// for either engine.
+    bool isContextActiveLayoutSuppressed(const QString& screenId, int virtualDesktop = 0,
+                                         const QString& activity = QString()) const override;
+
+    /// True iff the SYNTHESIZED default (the level-1 provider layout / autotile
+    /// algorithm) is suppressed for this context — a per-context
+    /// @c DefaultLayoutAssignment override decides locally (suppress → true,
+    /// allow → false), otherwise the global suppress setting. Unlike
+    /// @ref isContextActiveLayoutSuppressed this does NOT consider whether a
+    /// mode-only assignment rule covers the context: such a rule sets the mode
+    /// but still draws its layout / algorithm from the default. The autotile
+    /// activation path uses this to refuse to tile a bare @c "autotile:" context
+    /// (mode set, no concrete algorithm) with the global default algorithm when
+    /// the default is suppressed — a concrete assigned algorithm is explicit and
+    /// always tiles.
+    bool isDefaultAssignmentSuppressedForContext(const QString& screenId, int virtualDesktop = 0,
+                                                 const QString& activity = QString()) const;
 
     /// Per-field cascade readers — return the named field from the first
     /// entry in the cascade where it is non-empty. Crucially, these do
@@ -650,8 +713,8 @@ private:
     /// engine-mode is dropped entirely. Returns true if the rule set changed.
     bool purgeSnappingLayoutFromAssignments(const QString& layoutId);
 
-    /// Resolve the level-1 global default into an AssignmentEntry on
-    /// cascade-miss. Three-tier precedence:
+    /// Synthesize the level-1 global default into an AssignmentEntry,
+    /// IGNORING the global suppress setting. Three-tier precedence:
     ///   1. snapping-preferred provider (true → return Snapping with
     ///      possibly-empty layout, suppressing the autotile fallthrough
     ///      so users in snapping mode don't see autotile OSD content);
@@ -659,8 +722,38 @@ private:
     ///   3. autotile provider (non-empty → return AutoTile with that
     ///      algorithm).
     /// Returns a default-constructed (invalid) entry when no provider
-    /// has a value.
+    /// has a value. The "raw" sibling of @ref resolveDefaultAssignmentEntry —
+    /// used directly only by the per-context "allow" override, which must
+    /// force the default through even when the global suppress gate is on.
+    AssignmentEntry resolveDefaultAssignmentEntryRaw() const;
+
+    /// Resolve the level-1 global default into an AssignmentEntry on
+    /// cascade-miss, HONORING the global suppress setting. When the
+    /// default-assignment-suppressed provider (see
+    /// @ref setDefaultAssignmentSuppressedProvider) returns true, yields a
+    /// default-constructed (invalid) entry — no synthesized default. Otherwise
+    /// delegates to @ref resolveDefaultAssignmentEntryRaw.
     AssignmentEntry resolveDefaultAssignmentEntry() const;
+
+    /// Resolve the level-1 default for a specific context, applying the
+    /// per-context @c DefaultLayoutAssignment override (if any) over the global
+    /// suppress baseline. A `false` override returns an invalid entry (suppress
+    /// this context), a `true` override returns @ref resolveDefaultAssignmentEntryRaw
+    /// (force the default through), and no override defers to
+    /// @ref resolveDefaultAssignmentEntry (follow the global setting). This is
+    /// the single cascade-miss tail every per-context resolver routes through so
+    /// the override and the global gate can never drift between call sites.
+    AssignmentEntry resolveDefaultAssignmentEntryForContext(const QString& screenId, int virtualDesktop,
+                                                            const QString& activity) const;
+
+    /// True iff an enabled, PINNED (non-catch-all) engine-mode assignment rule
+    /// matches the (screen, desktop, activity) context — i.e. the user authored
+    /// an explicit per-context assignment, even one that sets only the mode with
+    /// no layout. Such a window rule overrides the global suppress setting (the
+    /// context is managed, never suppressed). Mirrors the connector /
+    /// virtual-screen fallback chain of @ref assignmentIdForScreen so a rule
+    /// keyed by the physical/connector id still matches a virtual-screen query.
+    bool hasMatchingAssignmentRule(const QString& screenId, int virtualDesktop, const QString& activity) const;
 
     /// Lookup key for @c m_contextResolveCache. Mirrors the parameters of
     /// @ref resolveAssignmentEntry — three independent context dimensions
@@ -752,6 +845,15 @@ private:
     mutable QHash<ContextResolveKey, bool> m_contextLockCache;
     mutable quint64 m_contextLockCacheRevision = 0;
 
+    /// Hot-path cache for @ref resolveContextDefaultAssignment, keyed and
+    /// revision-invalidated exactly like @c m_contextLockCache. The override is
+    /// read on every cascade-miss in @ref assignmentEntryForScreen /
+    /// @ref assignmentIdForScreen (and their connector / virtual-screen retries),
+    /// so memoizing the per-slot walk collapses repeats to one walk per rule-set
+    /// revision. A @c std::nullopt value (no override rule) is cached too.
+    mutable QHash<ContextResolveKey, std::optional<bool>> m_contextDefaultAssignmentCache;
+    mutable quint64 m_contextDefaultAssignmentCacheRevision = 0;
+
     /// Hot-path cache for @ref resolveContextOverlay, keyed and
     /// revision-invalidated exactly like @c m_contextGapCache. The overlay
     /// build path resolves the same (screen, desktop, activity) tuple on every
@@ -772,6 +874,11 @@ private:
     /// whether a global default snap layout id is configured. See
     /// @ref setSnappingPreferredProvider for the rationale.
     std::function<bool()> m_snappingPreferredProvider;
+    /// Empty = provider unset (never suppresses). Returns true when the user has
+    /// globally opted to suppress the synthesized level-1 default assignment, so
+    /// a context with no explicit assignment gets no active layout until the
+    /// user assigns one. See @ref setDefaultAssignmentSuppressedProvider.
+    std::function<bool()> m_defaultAssignmentSuppressedProvider;
     /// Borrowed unified rule store — the single assignment authority. The
     /// caller owns the store and must outlive the registry; always non-null
     /// (the ctor asserts it).

--- a/libs/phosphor-zones/src/layoutregistry.cpp
+++ b/libs/phosphor-zones/src/layoutregistry.cpp
@@ -81,12 +81,33 @@ void LayoutRegistry::setSnappingPreferredProvider(std::function<bool()> provider
     m_snappingPreferredProvider = std::move(provider);
 }
 
+void LayoutRegistry::setDefaultAssignmentSuppressedProvider(std::function<bool()> provider)
+{
+    m_defaultAssignmentSuppressedProvider = std::move(provider);
+}
+
 bool LayoutRegistry::snappingPreferred() const
 {
     return m_snappingPreferredProvider && m_snappingPreferredProvider();
 }
 
 AssignmentEntry LayoutRegistry::resolveDefaultAssignmentEntry() const
+{
+    // Global suppress gate. When the user has opted to suppress the synthesized
+    // default assignment, no unassigned context gets a level-1 default — the
+    // result is a default-constructed (invalid) entry whose activeLayoutId() is
+    // empty, the SAME effective state as a system with no default providers
+    // configured. The daemon's existing "empty entry ⇒ no default, no active
+    // engine" handling therefore covers it with no further change. The
+    // per-context "allow" override bypasses this by calling the raw sibling
+    // directly (see resolveDefaultAssignmentEntryForContext).
+    if (m_defaultAssignmentSuppressedProvider && m_defaultAssignmentSuppressedProvider()) {
+        return AssignmentEntry{};
+    }
+    return resolveDefaultAssignmentEntryRaw();
+}
+
+AssignmentEntry LayoutRegistry::resolveDefaultAssignmentEntryRaw() const
 {
     // Level-1 global default. Resolution order:
     //

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -222,8 +222,8 @@ AssignmentEntry LayoutRegistry::resolveDefaultAssignmentEntryForContext(const QS
     //   - true  (allow)    → raw synth: force the default through even when the
     //                        global suppress setting is on.
     //   - no override      → the global-gated resolveDefaultAssignmentEntry.
-    if (const auto override = resolveContextDefaultAssignment(screenId, virtualDesktop, activity)) {
-        return *override ? resolveDefaultAssignmentEntryRaw() : AssignmentEntry{};
+    if (const auto contextOverride = resolveContextDefaultAssignment(screenId, virtualDesktop, activity)) {
+        return *contextOverride ? resolveDefaultAssignmentEntryRaw() : AssignmentEntry{};
     }
     return resolveDefaultAssignmentEntry();
 }
@@ -710,8 +710,8 @@ bool LayoutRegistry::isDefaultAssignmentSuppressedForContext(const QString& scre
 {
     // The "is the synthesized default suppressed" primitive: a per-context
     // DefaultLayoutAssignment override decides locally, otherwise the global gate.
-    if (const auto override = resolveContextDefaultAssignment(screenId, virtualDesktop, activity)) {
-        return !*override;
+    if (const auto contextOverride = resolveContextDefaultAssignment(screenId, virtualDesktop, activity)) {
+        return !*contextOverride;
     }
     return m_defaultAssignmentSuppressedProvider && m_defaultAssignmentSuppressedProvider();
 }

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -44,6 +44,40 @@ namespace PWR = PhosphorWindowRules;
 // one place separate from the registry's member-bound resolution logic here.
 using namespace RuleHelpers;
 
+namespace {
+
+/// Run @p tryOne against the query-side screen-id fallback chain — the original
+/// id, then its connector-name → stable-id rewrite, then a virtual screen's
+/// physical id — and return the first engaged optional, or an empty optional if
+/// every variant misses. @p tryOne must return a @c std::optional; an engaged
+/// optional holding a "settled" value (e.g. a non-null-but-empty Layout*) stops
+/// the chain, exactly as the inline retries did. Centralizes the rewrite shared
+/// by layoutForScreen / assignmentIdForScreen / assignmentEntryForScreen /
+/// hasMatchingAssignmentRule so the four cannot drift.
+template<typename TryFn>
+auto resolveWithScreenFallback(const QString& screenId, TryFn&& tryOne) -> decltype(tryOne(screenId))
+{
+    if (auto result = tryOne(screenId)) {
+        return result;
+    }
+    if (PhosphorScreens::ScreenIdentity::isConnectorName(screenId)) {
+        const QString resolved = PhosphorScreens::ScreenIdentity::idForName(screenId);
+        if (resolved != screenId) {
+            if (auto result = tryOne(resolved)) {
+                return result;
+            }
+        }
+    }
+    if (PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
+        if (auto result = tryOne(PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId))) {
+            return result;
+        }
+    }
+    return {};
+}
+
+} // namespace
+
 // ── Rule-backed cascade resolution ──────────────────────────────────────────
 
 std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QString& screenId, int virtualDesktop,
@@ -564,30 +598,13 @@ PhosphorZones::Layout* LayoutRegistry::layoutForScreen(const QString& screenId, 
         return std::optional<PhosphorZones::Layout*>(layoutById(QUuid::fromString(entry->snappingLayout)));
     };
 
-    if (const auto result = tryResolve(screenId)) {
-        return *result ? *result : defaultLayout();
-    }
-    // Connector-name fallback.
-    if (PhosphorScreens::ScreenIdentity::isConnectorName(screenId)) {
-        const QString resolved = PhosphorScreens::ScreenIdentity::idForName(screenId);
-        if (resolved != screenId) {
-            if (const auto result = tryResolve(resolved)) {
-                return *result ? *result : defaultLayout();
-            }
-        }
-    }
-    // Virtual-screen fallback — inherit the physical screen's assignment.
-    if (PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
-        const QString physId = PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId);
-        if (const auto result = tryResolve(physId)) {
-            return *result ? *result : defaultLayout();
-        }
-    }
-
-    // No explicit assignment in the cascade — defer to the registry-wide
-    // default. layoutForScreen returns a snap Layout* and has no autotile
-    // counterpart; autotile-mode resolution is the autotile engine's job.
-    return defaultLayout();
+    // Connector-name then virtual-screen fallback (the physical screen's
+    // assignment is inherited). A settled {nullptr} stops the chain; a genuine
+    // miss (nullopt) and a {nullptr} both defer to the registry-wide default.
+    // layoutForScreen returns a snap Layout* and has no autotile counterpart;
+    // autotile-mode resolution is the autotile engine's job.
+    const auto result = resolveWithScreenFallback(screenId, tryResolve);
+    return (result && *result) ? *result : defaultLayout();
 }
 
 void LayoutRegistry::clearAssignment(const QString& screenId, int virtualDesktop, const QString& activity)
@@ -626,22 +643,8 @@ QString LayoutRegistry::assignmentIdForScreen(const QString& screenId, int virtu
         return id.isEmpty() ? std::nullopt : std::optional<QString>(id);
     };
 
-    if (const auto result = tryResolve(screenId)) {
+    if (const auto result = resolveWithScreenFallback(screenId, tryResolve)) {
         return *result;
-    }
-    if (PhosphorScreens::ScreenIdentity::isConnectorName(screenId)) {
-        const QString resolved = PhosphorScreens::ScreenIdentity::idForName(screenId);
-        if (resolved != screenId) {
-            if (const auto result = tryResolve(resolved)) {
-                return *result;
-            }
-        }
-    }
-    if (PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
-        const QString physId = PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId);
-        if (const auto result = tryResolve(physId)) {
-            return *result;
-        }
     }
 
     // No stored entry in the cascade — fall through to the level-1 global
@@ -665,22 +668,8 @@ AssignmentEntry LayoutRegistry::assignmentEntryForScreen(const QString& screenId
         return entry;
     };
 
-    if (const auto result = tryResolve(screenId)) {
+    if (const auto result = resolveWithScreenFallback(screenId, tryResolve)) {
         return *result;
-    }
-    if (PhosphorScreens::ScreenIdentity::isConnectorName(screenId)) {
-        const QString resolved = PhosphorScreens::ScreenIdentity::idForName(screenId);
-        if (resolved != screenId) {
-            if (const auto result = tryResolve(resolved)) {
-                return *result;
-            }
-        }
-    }
-    if (PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
-        const QString physId = PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId);
-        if (const auto result = tryResolve(physId)) {
-            return *result;
-        }
     }
 
     // Cascade miss — synthesize from the level-1 global default, honoring the
@@ -709,24 +698,11 @@ QString LayoutRegistry::tilingAlgorithmForScreen(const QString& screenId, int vi
 bool LayoutRegistry::hasMatchingAssignmentRule(const QString& screenId, int virtualDesktop,
                                                const QString& activity) const
 {
-    auto tryOne = [this, virtualDesktop, &activity](const QString& sid) {
-        return resolveAssignmentEntry(sid, virtualDesktop, activity).has_value();
-    };
-    if (tryOne(screenId)) {
-        return true;
-    }
-    if (PhosphorScreens::ScreenIdentity::isConnectorName(screenId)) {
-        const QString resolved = PhosphorScreens::ScreenIdentity::idForName(screenId);
-        if (resolved != screenId && tryOne(resolved)) {
-            return true;
-        }
-    }
-    if (PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
-        if (tryOne(PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId))) {
-            return true;
-        }
-    }
-    return false;
+    return resolveWithScreenFallback(screenId,
+                                     [this, virtualDesktop, &activity](const QString& sid) {
+                                         return resolveAssignmentEntry(sid, virtualDesktop, activity);
+                                     })
+        .has_value();
 }
 
 bool LayoutRegistry::isDefaultAssignmentSuppressedForContext(const QString& screenId, int virtualDesktop,

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -151,6 +151,49 @@ bool LayoutRegistry::resolveContextLocked(const QString& screenId, int virtualDe
                                 });
 }
 
+std::optional<bool> LayoutRegistry::resolveContextDefaultAssignment(const QString& screenId, int virtualDesktop,
+                                                                    const QString& activity) const
+{
+    // Mirror resolveContextLocked: a per-slot read off the evaluator's
+    // ResolvedActions, not the single-winner assignment walk. The
+    // DefaultAssignment slot is filled by the highest-priority matching context
+    // rule carrying a DefaultLayoutAssignment action; we report its boolean
+    // value (true = allow / force the default through, false = suppress). No
+    // engine-mode gate — a default-assignment-only context rule is a first-class
+    // overlay. std::nullopt means "no override rule" — the caller follows the
+    // global setting.
+    if (!m_evaluator) {
+        return std::nullopt;
+    }
+
+    return resolveCachedContext(m_contextDefaultAssignmentCache, m_contextDefaultAssignmentCacheRevision, screenId,
+                                virtualDesktop, activity, [&]() -> std::optional<bool> {
+                                    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+                                    const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
+                                    if (const auto action =
+                                            resolved.slot(QString(PWR::ActionSlot::DefaultAssignment))) {
+                                        return action->params.value(PWR::ActionParam::Value).toBool();
+                                    }
+                                    return std::nullopt;
+                                });
+}
+
+AssignmentEntry LayoutRegistry::resolveDefaultAssignmentEntryForContext(const QString& screenId, int virtualDesktop,
+                                                                        const QString& activity) const
+{
+    // Single cascade-miss tail for every per-context resolver. The per-context
+    // DefaultLayoutAssignment override (if present) wins over the global
+    // suppress baseline:
+    //   - false (suppress) → invalid entry: this context gets no default.
+    //   - true  (allow)    → raw synth: force the default through even when the
+    //                        global suppress setting is on.
+    //   - no override      → the global-gated resolveDefaultAssignmentEntry.
+    if (const auto override = resolveContextDefaultAssignment(screenId, virtualDesktop, activity)) {
+        return *override ? resolveDefaultAssignmentEntryRaw() : AssignmentEntry{};
+    }
+    return resolveDefaultAssignmentEntry();
+}
+
 ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& screenId, int virtualDesktop,
                                                              const QString& activity) const
 {
@@ -602,8 +645,9 @@ QString LayoutRegistry::assignmentIdForScreen(const QString& screenId, int virtu
     }
 
     // No stored entry in the cascade — fall through to the level-1 global
-    // default via the injected providers.
-    const AssignmentEntry def = resolveDefaultAssignmentEntry();
+    // default via the injected providers, honoring the global suppress setting
+    // and any per-context DefaultLayoutAssignment override.
+    const AssignmentEntry def = resolveDefaultAssignmentEntryForContext(screenId, virtualDesktop, activity);
     return def.activeLayoutId();
 }
 
@@ -639,8 +683,9 @@ AssignmentEntry LayoutRegistry::assignmentEntryForScreen(const QString& screenId
         }
     }
 
-    // Cascade miss — synthesize from the level-1 global default.
-    return resolveDefaultAssignmentEntry();
+    // Cascade miss — synthesize from the level-1 global default, honoring the
+    // global suppress setting and any per-context DefaultLayoutAssignment override.
+    return resolveDefaultAssignmentEntryForContext(screenId, virtualDesktop, activity);
 }
 
 AssignmentEntry::Mode LayoutRegistry::modeForScreen(const QString& screenId, int virtualDesktop,
@@ -659,6 +704,64 @@ QString LayoutRegistry::tilingAlgorithmForScreen(const QString& screenId, int vi
                                                  const QString& activity) const
 {
     return assignmentEntryForScreen(screenId, virtualDesktop, activity).tilingAlgorithm;
+}
+
+bool LayoutRegistry::hasMatchingAssignmentRule(const QString& screenId, int virtualDesktop,
+                                               const QString& activity) const
+{
+    auto tryOne = [this, virtualDesktop, &activity](const QString& sid) {
+        return resolveAssignmentEntry(sid, virtualDesktop, activity).has_value();
+    };
+    if (tryOne(screenId)) {
+        return true;
+    }
+    if (PhosphorScreens::ScreenIdentity::isConnectorName(screenId)) {
+        const QString resolved = PhosphorScreens::ScreenIdentity::idForName(screenId);
+        if (resolved != screenId && tryOne(resolved)) {
+            return true;
+        }
+    }
+    if (PhosphorIdentity::VirtualScreenId::isVirtual(screenId)) {
+        if (tryOne(PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool LayoutRegistry::isDefaultAssignmentSuppressedForContext(const QString& screenId, int virtualDesktop,
+                                                             const QString& activity) const
+{
+    // The "is the synthesized default suppressed" primitive: a per-context
+    // DefaultLayoutAssignment override decides locally, otherwise the global gate.
+    if (const auto override = resolveContextDefaultAssignment(screenId, virtualDesktop, activity)) {
+        return !*override;
+    }
+    return m_defaultAssignmentSuppressedProvider && m_defaultAssignmentSuppressedProvider();
+}
+
+bool LayoutRegistry::isContextActiveLayoutSuppressed(const QString& screenId, int virtualDesktop,
+                                                     const QString& activity) const
+{
+    // An active layout exists (explicit assignment at any cascade level, or a
+    // default forced through by an "allow" override) — never suppressed.
+    if (!assignmentIdForScreen(screenId, virtualDesktop, activity).isEmpty()) {
+        return false;
+    }
+    // An enabled PINNED engine-mode assignment rule covers this context — a
+    // window rule that overrides the global suppress setting. The context stays
+    // active even when the rule sets only the mode (no layout): the layout
+    // falls back to the default exactly as it did before suppression existed,
+    // and the overlay / zone selector show because the mode is on.
+    if (hasMatchingAssignmentRule(screenId, virtualDesktop, activity)) {
+        return false;
+    }
+    // No active layout and no covering assignment rule. Report suppressed ONLY
+    // when the cause is the suppress feature (per-context override or the global
+    // gate). Any OTHER empty-assignment state (e.g. snapping enabled with no
+    // global default layout id) returns false, so callers keep their existing
+    // defaultLayout() fallback there.
+    return isDefaultAssignmentSuppressedForContext(screenId, virtualDesktop, activity);
 }
 
 } // namespace PhosphorZones

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -429,8 +429,8 @@ bool LayoutRegistry::purgeSnappingLayoutFromAssignments(const QString& layoutId)
         // Gate on isPureAssignmentRule (not isContextAssignmentRule) — the
         // Shape-1 rebuild path emits ONLY the three assignment slot actions
         // via makeAssignmentActions, so a mixed context rule carrying
-        // SetOpacity / OverrideAnimation* / Float / Exclude / LockContext
-        // alongside its assignment actions would silently lose those
+        // SetOpacity / OverrideAnimation* / Float / Exclude / LockContext /
+        // DefaultLayoutAssignment alongside its assignment actions would silently lose those
         // non-assignment actions on rebuild. Mixed rules fall through to Shape 2's
         // surgical SetSnappingLayout removal, which preserves every
         // other action verbatim.

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -455,6 +455,14 @@ public:
     {
         return false;
     }
+    // Off by default: every context still gets the synthesized level-1 default
+    // layout (today's behavior). When on, no context is assigned an active
+    // snapping or autotiling layout until the user explicitly assigns one —
+    // overridable per context by a DefaultLayoutAssignment window rule.
+    static bool suppressDefaultLayoutAssignment()
+    {
+        return false;
+    }
     static bool filterLayoutsByAspectRatio()
     {
         return true;

--- a/src/config/configkeys.h
+++ b/src/config/configkeys.h
@@ -233,6 +233,11 @@ public:
     P_CONFIG_KEY(autoAssignAllLayoutsKey, "AutoAssignAllLayouts")
     P_CONFIG_KEY(stickyWindowHandlingKey, "StickyWindowHandling")
     P_CONFIG_KEY(defaultLayoutIdKey, "DefaultLayoutId")
+    // Mode-neutral: suppresses the synthesized level-1 default for BOTH the
+    // snapping and tiling engines (the default is a single mode-carrying
+    // AssignmentEntry). Stored in this group alongside the other
+    // default-assignment keys; surfaced mode-neutrally in the General UI page.
+    P_CONFIG_KEY(suppressDefaultLayoutAssignmentKey, "SuppressDefaultLayoutAssignment")
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Config Keys — Snapping.Zones.Colors

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -2114,6 +2114,10 @@ P_STORE_SET_BOOL(setSnapUnfloatFallbackToZone, snappingBehaviorWindowHandlingGro
 P_STORE_GET(bool, autoAssignAllLayouts, snappingBehaviorWindowHandlingGroup, autoAssignAllLayoutsKey, bool)
 P_STORE_SET_BOOL(setAutoAssignAllLayouts, snappingBehaviorWindowHandlingGroup, autoAssignAllLayoutsKey,
                  autoAssignAllLayoutsChanged)
+P_STORE_GET(bool, suppressDefaultLayoutAssignment, snappingBehaviorWindowHandlingGroup,
+            suppressDefaultLayoutAssignmentKey, bool)
+P_STORE_SET_BOOL(setSuppressDefaultLayoutAssignment, snappingBehaviorWindowHandlingGroup,
+                 suppressDefaultLayoutAssignmentKey, suppressDefaultLayoutAssignmentChanged)
 
 QString Settings::defaultLayoutId() const
 {

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -188,6 +188,8 @@ public:
 
     // Default layout (used when no explicit assignment exists)
     Q_PROPERTY(QString defaultLayoutId READ defaultLayoutId WRITE setDefaultLayoutId NOTIFY defaultLayoutIdChanged)
+    Q_PROPERTY(bool suppressDefaultLayoutAssignment READ suppressDefaultLayoutAssignment WRITE
+                   setSuppressDefaultLayoutAssignment NOTIFY suppressDefaultLayoutAssignmentChanged)
 
     // PhosphorZones::Layout filtering
     Q_PROPERTY(bool filterLayoutsByAspectRatio READ filterLayoutsByAspectRatio WRITE setFilterLayoutsByAspectRatio
@@ -683,6 +685,8 @@ public:
     void setSnapAssistTriggers(const QVariantList& triggers) override;
     QString defaultLayoutId() const override;
     void setDefaultLayoutId(const QString& layoutId) override;
+    bool suppressDefaultLayoutAssignment() const override;
+    void setSuppressDefaultLayoutAssignment(bool suppress) override;
 
     bool filterLayoutsByAspectRatio() const override;
     void setFilterLayoutsByAspectRatio(bool filter) override;

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -731,6 +731,7 @@ void appendBehaviorSchema(PhosphorConfig::Schema& schema)
         {CD::restoreFloatedOnLoginKey(), CD::snappingRestoreFloatedWindowsOnLogin(), QMetaType::Bool},
         {CD::unfloatFallbackToZoneKey(), CD::snapUnfloatFallbackToZone(), QMetaType::Bool},
         {CD::autoAssignAllLayoutsKey(), CD::autoAssignAllLayouts(), QMetaType::Bool},
+        {CD::suppressDefaultLayoutAssignmentKey(), CD::suppressDefaultLayoutAssignment(), QMetaType::Bool},
         {CD::defaultLayoutIdKey(), QString(), QMetaType::QString},
     };
     schema.groups[CD::snappingBehaviorSnapAssistGroup()] = {

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -391,6 +391,7 @@ Q_SIGNALS:
     void snapAssistEnabledChanged();
     void snapAssistTriggersChanged();
     void defaultLayoutIdChanged();
+    void suppressDefaultLayoutAssignmentChanged();
     void filterLayoutsByAspectRatioChanged();
     // excludedApplications / excludedWindowClasses signals retired in v4
     // — see settings_interfaces.h for the rationale (lists folded into

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -418,6 +418,15 @@ public:
 
     virtual QString defaultLayoutId() const = 0;
     virtual void setDefaultLayoutId(const QString& layoutId) = 0;
+
+    /// When true, no context is assigned an active snapping or autotiling layout
+    /// by default — the synthesized level-1 default is suppressed and a mode only
+    /// activates for a context the user has explicitly assigned (or a
+    /// DefaultLayoutAssignment window rule has re-enabled). Mode-neutral: governs
+    /// both engines, since the level-1 default is a single mode-carrying entry.
+    /// Off by default (every context gets the default, today's behavior).
+    virtual bool suppressDefaultLayoutAssignment() const = 0;
+    virtual void setSuppressDefaultLayoutAssignment(bool suppress) = 0;
 };
 
 /**

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -764,6 +764,14 @@ bool Daemon::init()
     m_layoutManager->setSnappingPreferredProvider([this]() {
         return m_settings && m_settings->snappingEnabled();
     });
+    // Global "suppress default layout assignment" gate. When on, the level-1
+    // default synthesis above is short-circuited so an unassigned context gets
+    // no active layout (no engine activates) until the user assigns one — the
+    // same effective state as having no default providers configured. The
+    // per-context DefaultLayoutAssignment window rule overrides this either way.
+    m_layoutManager->setDefaultAssignmentSuppressedProvider([this]() {
+        return m_settings && m_settings->suppressDefaultLayoutAssignment();
+    });
     // Wire the compute service to the layout manager so tracked layouts
     // are evicted on removal (bounds m_trackedLayouts over time).
     m_layoutComputeService->setLayoutManager(m_layoutManager.get());
@@ -1528,6 +1536,13 @@ bool Daemon::init()
             // pattern used for the mode-toggle locked feedback in connectShortcutSignals().
             const bool osdEnabled = m_settings && m_settings->showOsdOnLayoutSwitch();
             for (const auto& osd : std::as_const(osdEntries)) {
+                // Suppressed context → no active layout; skip its OSD, mirroring
+                // the per-screen desktop-switch OSD gate in showOsdForScreens.
+                if (m_layoutManager
+                    && m_layoutManager->isContextActiveLayoutSuppressed(
+                        osd.screenId, currentDesktopForScreen(osd.screenId), activity)) {
+                    continue;
+                }
                 const PhosphorZones::AssignmentEntry::Mode mode = osd.isAutotile
                     ? PhosphorZones::AssignmentEntry::Autotile
                     : PhosphorZones::AssignmentEntry::Snapping;
@@ -1875,6 +1890,7 @@ void Daemon::stop()
         m_layoutManager->setDefaultLayoutIdProvider({});
         m_layoutManager->setDefaultAutotileAlgorithmProvider({});
         m_layoutManager->setSnappingPreferredProvider({});
+        m_layoutManager->setDefaultAssignmentSuppressedProvider({});
     }
 
     // Null the QML static registry / manager pointers BEFORE the m_running

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -229,6 +229,12 @@ public:
     void showLockedOsd(const QString& screenId);
     void showLockedPreviewOsd(const QString& screenId);
     void showContextDisabledOsd(const QString& screenId, int desktop, const QString& activity, DisabledReason reason);
+    /// OSD shown when a context has no active layout because its default
+    /// assignment is suppressed (global setting or per-context rule) — the
+    /// "not assigned" counterpart to @ref showContextDisabledOsd. Tells the user
+    /// the mode is selected but nothing is assigned, instead of silently showing
+    /// no OSD.
+    void showNotAssignedOsd(const QString& screenId);
 
 private:
     /**

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -71,8 +71,19 @@ void Daemon::updateAutotileScreens()
         }
         QString assignmentId = m_layoutManager->assignmentIdForScreen(screenId, desktop, activity);
         if (PhosphorLayout::LayoutId::isAutotile(assignmentId)) {
+            const QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(assignmentId);
+            // Bare autotile (mode set, no concrete algorithm — e.g. a mode-only
+            // rule or a plain mode swap) draws its algorithm from the global
+            // default, which the suppress setting disables. Don't tile such a
+            // context when its default is suppressed (globally or by a
+            // per-context rule): tiling is active and would rearrange windows
+            // with a default the user opted out of. A concrete assigned
+            // algorithm is explicit and always tiles.
+            if (algoId.isEmpty()
+                && m_layoutManager->isDefaultAssignmentSuppressedForContext(screenId, desktop, activity)) {
+                continue;
+            }
             autotileScreens.insert(screenId);
-            QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(assignmentId);
             if (!algoId.isEmpty()) {
                 screenAlgorithms[screenId] = algoId;
             }

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -239,6 +239,25 @@ void Daemon::showContextDisabledOsd(const QString& screenId, int desktop, const 
     qCInfo(lcDaemon) << "Showing disabled text OSD:" << reasonText << "screen=" << screenId;
 }
 
+void Daemon::showNotAssignedOsd(const QString& screenId)
+{
+    if (shouldSuppressOsd()) {
+        return;
+    }
+    const OsdStyle style = m_settings ? m_settings->osdStyle() : OsdStyle::Preview;
+    if (style == OsdStyle::None) {
+        return;
+    }
+    const QString text = PhosphorI18n::tr("No layout assigned");
+    if (style == OsdStyle::Preview && m_overlayService) {
+        m_overlayService->showDisabledOsd(text, screenId);
+        qCInfo(lcDaemon) << "Showing not-assigned preview OSD: screen=" << screenId;
+        return;
+    }
+    showKdeTextOsd(QStringLiteral("dialog-information"), text);
+    qCInfo(lcDaemon) << "Showing not-assigned text OSD: screen=" << screenId;
+}
+
 void Daemon::showLayoutOsdForAlgorithm(const QString& algorithmId, const QString& displayName, const QString& screenId)
 {
     if (shouldSuppressOsd()) {
@@ -573,9 +592,27 @@ void Daemon::showOsdForScreens(const QStringList& screenIds, const QString& acti
                 showContextDisabledOsd(screenId, desktop, activity, why);
                 continue;
             }
+            // No active layout for this context because the default assignment is
+            // suppressed (global setting or per-context rule) — show a "not
+            // assigned" OSD instead of the global default layout / algorithm the
+            // fallback would otherwise surface for an unassigned screen.
+            if (m_layoutManager->isContextActiveLayoutSuppressed(screenId, desktop, activity)) {
+                showNotAssignedOsd(screenId);
+                continue;
+            }
             const QString assignmentId = m_layoutManager->assignmentIdForScreen(screenId, desktop, activity);
             if (PhosphorLayout::LayoutId::isAutotile(assignmentId)) {
                 const QString algoId = PhosphorLayout::LayoutId::extractAlgorithmId(assignmentId);
+                // Bare autotile (mode set, no concrete algorithm) draws its
+                // algorithm from the suppressed global default, so it won't tile
+                // (see updateAutotileScreens) — show "not assigned" rather than
+                // announcing the default algorithm. A concrete assigned algorithm
+                // always shows.
+                if (algoId.isEmpty()
+                    && m_layoutManager->isDefaultAssignmentSuppressedForContext(screenId, desktop, activity)) {
+                    showNotAssignedOsd(screenId);
+                    continue;
+                }
                 auto* algo = m_algorithmRegistry->algorithm(algoId);
                 const QString displayName = algo ? algo->name() : algoId;
                 showLayoutOsdForAlgorithm(algoId, displayName, screenId);

--- a/src/daemon/daemon/osd.cpp
+++ b/src/daemon/daemon/osd.cpp
@@ -263,7 +263,7 @@ void Daemon::showLayoutOsdForAlgorithm(const QString& algorithmId, const QString
     if (shouldSuppressOsd()) {
         return;
     }
-    auto* algo = m_algorithmRegistry.get()->algorithm(algorithmId);
+    auto* algo = m_algorithmRegistry ? m_algorithmRegistry->algorithm(algorithmId) : nullptr;
     if (!algo) {
         qCWarning(lcDaemon) << "OSD: algorithm not found, algorithmId=" << algorithmId;
         return;
@@ -613,7 +613,7 @@ void Daemon::showOsdForScreens(const QStringList& screenIds, const QString& acti
                     showNotAssignedOsd(screenId);
                     continue;
                 }
-                auto* algo = m_algorithmRegistry->algorithm(algoId);
+                auto* algo = m_algorithmRegistry ? m_algorithmRegistry->algorithm(algoId) : nullptr;
                 const QString displayName = algo ? algo->name() : algoId;
                 showLayoutOsdForAlgorithm(algoId, displayName, screenId);
             } else {

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -64,7 +64,7 @@ void Daemon::initializeAutotile()
                     // change is irrelevant in that case.
                     if (m_running && m_modeTracker && m_modeTracker->isAnyScreenAutotile() && m_settings
                         && m_settings->showOsdOnLayoutSwitch() && m_overlayService) {
-                        auto* algo = m_algorithmRegistry->algorithm(algorithmId);
+                        auto* algo = m_algorithmRegistry ? m_algorithmRegistry->algorithm(algorithmId) : nullptr;
                         QString displayName = algo ? algo->name() : algorithmId;
                         QString screenId;
                         if (m_autotileEngine) {
@@ -361,13 +361,13 @@ void Daemon::initializeAutotile()
                     // mode but does not tile. applyLayoutById can't apply a bare
                     // "autotile:" (it has no matching layout preview and returns
                     // false), so write the entry directly. The emitted layoutAssigned
-                    // drives the daemon's updateAutotileScreens, which skips this bare
-                    // suppressed context (no tiling); we refresh the mode filter here
-                    // since no layoutApplied/autotileApplied signal fires.
+                    // drives the daemon's updateAutotileScreens (which skips this bare
+                    // suppressed context, so it does not tile) AND updateLayoutFilter,
+                    // so the mode filter refreshes off that signal — no explicit call
+                    // needed here.
                     PhosphorZones::AssignmentEntry entry;
                     entry.mode = PhosphorZones::AssignmentEntry::Autotile;
                     m_layoutManager->setAssignmentEntryDirect(screenId, desktop, activity, entry);
-                    updateLayoutFilter();
                     // No layoutApplied/autotileApplied signal fires for a direct
                     // entry write, so surface the feedback OSD here: the mode
                     // switched to autotile but nothing is assigned to tile with.

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -331,20 +331,48 @@ void Daemon::initializeAutotile()
 
                 // Resolve algorithm from the AssignmentEntry's tilingAlgorithm
                 // (preserved even when mode is Snapping), then fall back to broader
-                // scopes, then to the user's configured default (settings).
+                // scopes. This is the EXPLICITLY-assigned algorithm for the context.
                 QString algoId = m_layoutManager->tilingAlgorithmForScreen(screenId, desktop, activity);
                 if (algoId.isEmpty() && !activity.isEmpty()) {
                     algoId = m_layoutManager->tilingAlgorithmForScreen(screenId, desktop, QString());
                 }
-                if (algoId.isEmpty() && m_settings) {
-                    algoId = m_settings->defaultAutotileAlgorithm();
-                }
-                if (algoId.isEmpty()) {
-                    algoId = PhosphorTiles::AlgorithmRegistry::staticDefaultAlgorithmId();
+                // No explicitly-assigned algorithm: fall back to the user's
+                // configured default — UNLESS the default is suppressed for this
+                // context. Under suppress, switching to autotile applies a bare
+                // "autotile:" assignment (mode set, no algorithm) so the context
+                // selects autotile mode but does NOT tile with the global default;
+                // updateAutotileScreens skips a suppressed bare context until the
+                // user assigns a concrete algorithm.
+                if (algoId.isEmpty()
+                    && !m_layoutManager->isDefaultAssignmentSuppressedForContext(screenId, desktop, activity)) {
+                    if (m_settings) {
+                        algoId = m_settings->defaultAutotileAlgorithm();
+                    }
+                    if (algoId.isEmpty()) {
+                        algoId = PhosphorTiles::AlgorithmRegistry::staticDefaultAlgorithmId();
+                    }
                 }
                 if (!algoId.isEmpty()) {
                     applied =
                         m_unifiedLayoutController->applyLayoutById(PhosphorLayout::LayoutId::makeAutotileId(algoId));
+                } else {
+                    // Suppressed with no explicitly-assigned algorithm: switch the
+                    // context to autotile mode WITHOUT an algorithm so it selects the
+                    // mode but does not tile. applyLayoutById can't apply a bare
+                    // "autotile:" (it has no matching layout preview and returns
+                    // false), so write the entry directly. The emitted layoutAssigned
+                    // drives the daemon's updateAutotileScreens, which skips this bare
+                    // suppressed context (no tiling); we refresh the mode filter here
+                    // since no layoutApplied/autotileApplied signal fires.
+                    PhosphorZones::AssignmentEntry entry;
+                    entry.mode = PhosphorZones::AssignmentEntry::Autotile;
+                    m_layoutManager->setAssignmentEntryDirect(screenId, desktop, activity, entry);
+                    updateLayoutFilter();
+                    // No layoutApplied/autotileApplied signal fires for a direct
+                    // entry write, so surface the feedback OSD here: the mode
+                    // switched to autotile but nothing is assigned to tile with.
+                    showNotAssignedOsd(screenId);
+                    applied = true;
                 }
             }
 

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -562,6 +562,31 @@ PhosphorZones::Layout* OverlayService::resolveScreenLayout(QScreen* screen) cons
     return resolveScreenLayout(PhosphorScreens::ScreenIdentity::identifierFor(screen));
 }
 
+bool OverlayService::isSnappingContextInactive(const QString& screenId) const
+{
+    const int virtualDesktop = currentVirtualDesktopForScreen(screenId);
+    if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId, virtualDesktop,
+                          m_currentActivity)) {
+        return true;
+    }
+    if (!m_layoutManager) {
+        return false;
+    }
+    if (m_layoutManager->isContextActiveLayoutSuppressed(screenId, virtualDesktop, m_currentActivity)) {
+        return true;
+    }
+    // The context is in autotile mode — the snapping overlay/selector never
+    // applies there. Active autotile screens are already kept out via
+    // setExcludedScreens(autotileScreens), but a bare/suppressed autotile
+    // context (mode set, no concrete algorithm) is deliberately NOT in that
+    // active set, so without this check the snap overlay would surface on it and
+    // make a screen the user just switched to autotile look like it's still
+    // snapping. Derive the mode from the resolved assignment id (an "autotile:"
+    // id — bare or concrete — means autotile mode).
+    return PhosphorLayout::LayoutId::isAutotile(
+        m_layoutManager->assignmentIdForScreen(screenId, virtualDesktop, m_currentActivity));
+}
+
 PhosphorZones::Layout* OverlayService::resolveScreenLayout(const QString& screenId) const
 {
     PhosphorZones::Layout* screenLayout = nullptr;
@@ -589,8 +614,7 @@ void OverlayService::hideDisabledAndRefresh()
     if (m_settings) {
         const QStringList screenIds = m_screenStates.keys();
         for (const QString& screenId : screenIds) {
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
+            if (isSnappingContextInactive(screenId)) {
                 destroyZoneSelectorWindow(screenId);
                 if (m_visible) {
                     dismissOverlayWindow(screenId);
@@ -602,8 +626,7 @@ void OverlayService::hideDisabledAndRefresh()
     // Update remaining (non-disabled) zone selector and overlay windows
     for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
         const QString& screenId = it.key();
-        if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                              currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
+        if (isSnappingContextInactive(screenId)) {
             continue;
         }
         if (it.value().zoneSelectorSlot()) {

--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -611,28 +611,33 @@ void OverlayService::hideDisabledAndRefresh()
     // context-toggle); each per-content slot fades out via its
     // configured hide leg. dismissOverlayWindow / hideZoneSelectorSlotOnScreen
     // both clear the per-screen sentinel on completion.
+    // The zone selector / layout picker is gated ONLY by the disabled list (it
+    // is how a layout gets assigned, so suppress must not hide it); the snap
+    // overlay is additionally gated by suppress / autotile mode via
+    // isSnappingContextInactive.
     if (m_settings) {
         const QStringList screenIds = m_screenStates.keys();
         for (const QString& screenId : screenIds) {
-            if (isSnappingContextInactive(screenId)) {
+            const bool disabled = isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
+                                                    currentVirtualDesktopForScreen(screenId), m_currentActivity);
+            if (disabled) {
                 destroyZoneSelectorWindow(screenId);
-                if (m_visible) {
-                    dismissOverlayWindow(screenId);
-                }
+            }
+            if (m_visible && isSnappingContextInactive(screenId)) {
+                dismissOverlayWindow(screenId);
             }
         }
     }
 
-    // Update remaining (non-disabled) zone selector and overlay windows
+    // Update remaining zone selector (disabled-gated) and overlay (suppress-gated) windows.
     for (auto it = m_screenStates.constBegin(); it != m_screenStates.constEnd(); ++it) {
         const QString& screenId = it.key();
-        if (isSnappingContextInactive(screenId)) {
-            continue;
-        }
-        if (it.value().zoneSelectorSlot()) {
+        const bool disabled = isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
+                                                currentVirtualDesktopForScreen(screenId), m_currentActivity);
+        if (!disabled && it.value().zoneSelectorSlot()) {
             updateZoneSelectorWindow(screenId);
         }
-        if (m_visible && it.value().overlayPhysScreen) {
+        if (!isSnappingContextInactive(screenId) && m_visible && it.value().overlayPhysScreen) {
             updateOverlayWindow(screenId, it.value().overlayPhysScreen);
         }
     }

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -580,6 +580,14 @@ private:
     PhosphorZones::Layout* resolveScreenLayout(QScreen* screen) const;
     PhosphorZones::Layout* resolveScreenLayout(const QString& screenId) const;
 
+    /// True when the snapping overlay must NOT show on @p screenId for the current
+    /// desktop/activity: either the context is on a disable list, OR its default
+    /// layout assignment is suppressed (the global "don't assign by default"
+    /// setting, or a per-context rule) and nothing is explicitly assigned. Folds
+    /// the two gates so every overlay / selector activation site treats a
+    /// suppressed context exactly like a disabled one.
+    bool isSnappingContextInactive(const QString& screenId) const;
+
     // PhosphorLayer infrastructure - owns the wlr-layer-shell binding, screen
     // enumeration, and Surface factory for all overlay-style windows. Members
     // ordered so factory is destroyed before provider/transport (factory keeps

--- a/src/daemon/overlayservice/lifecycle.cpp
+++ b/src/daemon/overlayservice/lifecycle.cpp
@@ -48,12 +48,13 @@ void OverlayService::show()
             // Fallback to primary screen if cursor position detection fails
             cursorScreen = Utils::primaryScreen();
         }
-        // If the cursor's screen has PlasmaZones disabled, don't show overlay at all
-        // Check both physical and effective (virtual) screen IDs
+        // If the cursor's screen has no active snapping overlay — disabled, or its
+        // default layout is suppressed, or it's in autotile mode — don't show the
+        // overlay at all. Mirrors the per-target gate in initializeOverlay.
+        // Check both physical and effective (virtual) screen IDs.
         if (cursorScreen && m_settings) {
             QString effectiveId = Utils::effectiveScreenIdAt(m_screenManager, QCursor::pos(), cursorScreen);
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, effectiveId,
-                                  currentVirtualDesktopForScreen(effectiveId), m_currentActivity)) {
+            if (isSnappingContextInactive(effectiveId)) {
                 return;
             }
         }
@@ -77,12 +78,13 @@ void OverlayService::showAtPosition(int cursorX, int cursorY)
             cursorScreen = Utils::primaryScreen();
         }
 
-        // If the cursor's screen has PlasmaZones disabled, don't show overlay at all
-        // Check both physical and effective (virtual) screen IDs
+        // If the cursor's screen has no active snapping overlay — disabled, or its
+        // default layout is suppressed, or it's in autotile mode — don't show the
+        // overlay at all. Mirrors the per-target gate in initializeOverlay.
+        // Check both physical and effective (virtual) screen IDs.
         if (cursorScreen && m_settings) {
             QString effectiveId = Utils::effectiveScreenIdAt(m_screenManager, QPoint(cursorX, cursorY), cursorScreen);
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, effectiveId,
-                                  currentVirtualDesktopForScreen(effectiveId), m_currentActivity)) {
+            if (isSnappingContextInactive(effectiveId)) {
                 return;
             }
         }

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -132,8 +132,7 @@ void OverlayService::initializeOverlay(QScreen* cursorScreen, const QPoint& curs
             if (!physScreen) {
                 continue;
             }
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
+            if (isSnappingContextInactive(screenId)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {
@@ -146,8 +145,7 @@ void OverlayService::initializeOverlay(QScreen* cursorScreen, const QPoint& curs
     } else {
         for (auto* screen : Utils::allScreens()) {
             const QString screenId = PhosphorScreens::ScreenIdentity::identifierFor(screen);
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
+            if (isSnappingContextInactive(screenId)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {
@@ -575,8 +573,7 @@ void OverlayService::recreateOverlayWindowsOnTypeMismatch()
         stopShaderAnimation();
 
     for (const QString& screenId : screensToFlip) {
-        if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                              currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
+        if (isSnappingContextInactive(screenId)) {
             continue;
         }
         QScreen* physScreen = m_screenStates.value(screenId).overlayPhysScreen;

--- a/src/daemon/overlayservice/screens.cpp
+++ b/src/daemon/overlayservice/screens.cpp
@@ -96,8 +96,10 @@ void OverlayService::handleScreenAdded(QScreen* screen)
     if (mgr && mgr->hasVirtualScreens(physScreenId)) {
         // Create overlays for each virtual screen on this physical screen
         for (const QString& vsId : mgr->virtualScreenIdsFor(physScreenId)) {
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, vsId,
-                                  currentVirtualDesktopForScreen(vsId), m_currentActivity)) {
+            // Recreate the snap overlay only on virtual screens that have one —
+            // skip disabled, suppressed-default, and autotile-mode contexts,
+            // matching the overlay activation gate in overlay.cpp.
+            if (isSnappingContextInactive(vsId)) {
                 continue;
             }
             QRect vsGeom = mgr->screenGeometry(vsId);

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -95,7 +95,8 @@ void OverlayService::showZoneSelector(const QString& targetScreenId)
             if (!targetScreenId.isEmpty() && screenId != targetScreenId) {
                 continue;
             }
-            if (isSnappingContextInactive(screenId)) {
+            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
+                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {
@@ -111,7 +112,8 @@ void OverlayService::showZoneSelector(const QString& targetScreenId)
                 continue;
             }
             QString screenId = PhosphorScreens::ScreenIdentity::identifierFor(screen);
-            if (isSnappingContextInactive(screenId)) {
+            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
+                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -95,8 +95,7 @@ void OverlayService::showZoneSelector(const QString& targetScreenId)
             if (!targetScreenId.isEmpty() && screenId != targetScreenId) {
                 continue;
             }
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
+            if (isSnappingContextInactive(screenId)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {
@@ -112,8 +111,7 @@ void OverlayService::showZoneSelector(const QString& targetScreenId)
                 continue;
             }
             QString screenId = PhosphorScreens::ScreenIdentity::identifierFor(screen);
-            if (isContextDisabled(m_settings, PhosphorZones::AssignmentEntry::Snapping, screenId,
-                                  currentVirtualDesktopForScreen(screenId), m_currentActivity)) {
+            if (isSnappingContextInactive(screenId)) {
                 continue;
             }
             if (m_excludedScreens.contains(screenId)) {

--- a/src/dbus/layoutadaptor/assignment.cpp
+++ b/src/dbus/layoutadaptor/assignment.cpp
@@ -310,8 +310,14 @@ QString LayoutAdaptor::getScreenStates()
         obj[QLatin1String("activity")] = activity;
         obj[QLatin1String("mode")] = static_cast<int>(entry.mode);
 
-        // Snapping layout — use resolved layout (includes default fallback)
-        PhosphorZones::Layout* resolvedLayout = m_layoutManager->layoutForScreen(screenId, desktop, activity);
+        // Snapping layout — use the resolved layout (includes the default
+        // fallback), EXCEPT when the default is suppressed for this context: then
+        // report no layout so the settings/KCM monitor view shows the screen as
+        // unassigned instead of the default-layout fallback.
+        PhosphorZones::Layout* resolvedLayout =
+            m_layoutManager->isContextActiveLayoutSuppressed(screenId, desktop, activity)
+            ? nullptr
+            : m_layoutManager->layoutForScreen(screenId, desktop, activity);
         if (resolvedLayout) {
             obj[QLatin1String("layoutId")] = resolvedLayout->id().toString();
             obj[QLatin1String("layoutName")] = resolvedLayout->name();

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -464,6 +464,8 @@ void SettingsAdaptor::initializeRegistry()
                           setAutotileRestoreFloatedWindowsOnLogin)
     REGISTER_BOOL_SETTING("snapUnfloatFallbackToZone", snapUnfloatFallbackToZone, setSnapUnfloatFallbackToZone)
     REGISTER_BOOL_SETTING("autoAssignAllLayouts", autoAssignAllLayouts, setAutoAssignAllLayouts)
+    REGISTER_BOOL_SETTING("suppressDefaultLayoutAssignment", suppressDefaultLayoutAssignment,
+                          setSuppressDefaultLayoutAssignment)
     REGISTER_BOOL_SETTING("snapAssistFeatureEnabled", snapAssistFeatureEnabled, setSnapAssistFeatureEnabled)
     REGISTER_BOOL_SETTING("snapAssistEnabled", snapAssistEnabled, setSnapAssistEnabled)
     REGISTER_BOOL_SETTING("snappingFocusNewWindows", snappingFocusNewWindows, setSnappingFocusNewWindows)

--- a/src/settings/qml/GeneralPage.qml
+++ b/src/settings/qml/GeneralPage.qml
@@ -116,7 +116,7 @@ SettingsFlickable {
 
                     SettingsSwitch {
                         checked: appSettings.suppressDefaultLayoutAssignment
-                        accessibleName: i18n("Don't assign a layout to contexts by default")
+                        accessibleName: i18n("Don't assign a layout by default")
                         onToggled: function (newValue) {
                             appSettings.suppressDefaultLayoutAssignment = newValue;
                         }

--- a/src/settings/qml/GeneralPage.qml
+++ b/src/settings/qml/GeneralPage.qml
@@ -96,6 +96,36 @@ SettingsFlickable {
         }
 
         // =====================================================================
+        // LAYOUT ASSIGNMENT CARD
+        // =====================================================================
+        // Mode-neutral: the toggle governs the synthesized default for BOTH the
+        // snapping and tiling engines, so it lives on the General page rather
+        // than either mode's behavior page.
+        SettingsCard {
+            headerText: i18n("Layout assignment")
+            collapsible: true
+            searchAnchor: "layoutAssignment"
+
+            contentItem: ColumnLayout {
+                spacing: Kirigami.Units.smallSpacing
+
+                SettingsRow {
+                    title: i18n("Don't assign a layout by default")
+                    searchAnchor: "suppressDefaultLayoutAssignment"
+                    description: i18n("Snapping and tiling stay off until you assign a layout. A window rule can re-enable the default per monitor.")
+
+                    SettingsSwitch {
+                        checked: appSettings.suppressDefaultLayoutAssignment
+                        accessibleName: i18n("Don't assign a layout to contexts by default")
+                        onToggled: function (newValue) {
+                            appSettings.suppressDefaultLayoutAssignment = newValue;
+                        }
+                    }
+                }
+            }
+        }
+
+        // =====================================================================
         // WINDOW FILTERING CARD
         // =====================================================================
         // The three global filters previously hosted on the standalone

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -274,6 +274,13 @@ QString paramLabel(const QString& type, const QString& key)
         // by priority, so a higher-priority off rule cancels a lower-priority on.
         return PhosphorI18n::tr("Lock the layout (off = don't lock)");
     }
+    if (type == ActionType::DefaultLayoutAssignment && key == ActionParam::Value) {
+        // on = this context gets the global default layout even when the global
+        // "don't assign by default" setting is on; off = suppress the default for
+        // this context (no layout until one is explicitly assigned), overriding
+        // the global setting the other way. Single-winner by priority.
+        return PhosphorI18n::tr("Assign a default layout (off = leave unassigned)");
+    }
     if (type == ActionType::SetOuterGapTop && key == ActionParam::Value) {
         return PhosphorI18n::tr("Top gap (px)");
     }
@@ -425,6 +432,9 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::LockContext) {
         return PhosphorI18n::tr("Lock layout");
+    }
+    if (type == ActionType::DefaultLayoutAssignment) {
+        return PhosphorI18n::tr("Default layout assignment");
     }
     if (type == ActionType::Exclude) {
         return PhosphorI18n::tr("Exclude window");

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -351,6 +351,10 @@ QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup
         if (action.type == ActionType::LockContext) {
             return raw.toBool() ? PhosphorI18n::tr("Lock layout") : PhosphorI18n::tr("Don't lock layout");
         }
+        if (action.type == ActionType::DefaultLayoutAssignment) {
+            return raw.toBool() ? PhosphorI18n::tr("Assign default layout")
+                                : PhosphorI18n::tr("Don't assign default layout");
+        }
         if (action.type == ActionType::SetBorderVisible) {
             return raw.toBool() ? PhosphorI18n::tr("Show border") : PhosphorI18n::tr("Hide border");
         }

--- a/tests/unit/core/test_layoutmanager_assignment.cpp
+++ b/tests/unit/core/test_layoutmanager_assignment.cpp
@@ -22,6 +22,10 @@
 #include <PhosphorZones/LayoutRegistry.h>
 #include <PhosphorZones/Layout.h>
 #include <PhosphorZones/Zone.h>
+#include <PhosphorWindowRules/ContextRuleBridge.h>
+#include <PhosphorWindowRules/RuleAction.h>
+#include <PhosphorWindowRules/WindowRule.h>
+#include <PhosphorWindowRules/WindowRuleStore.h>
 #include "core/constants.h"
 #include "../helpers/StubSettings.h"
 #include "../helpers/IsolatedConfigGuard.h"
@@ -52,6 +56,46 @@ private:
         QDir().mkpath(layoutDir);
         mgr->setLayoutDirectory(layoutDir);
         return mgr;
+    }
+
+    /// Author a per-context DefaultLayoutAssignment override rule into the
+    /// registry's owned rule store. @p allow true forces the synthesized default
+    /// through for the context; false suppresses it. Mirrors the shape
+    /// ContextRuleBridge::makeDisableRule produces for the per-mode disable case.
+    void addDefaultAssignmentRule(PhosphorZones::LayoutRegistry* mgr, const QString& screenId, int virtualDesktop,
+                                  const QString& activity, bool allow)
+    {
+        namespace PWR = PhosphorWindowRules;
+        auto* store = mgr->findChild<PWR::WindowRuleStore*>();
+        QVERIFY(store != nullptr);
+
+        PWR::WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.name = QStringLiteral("test-default-assignment");
+        rule.enabled = true;
+        rule.priority =
+            PWR::ContextRuleBridge::contextPriority(!screenId.isEmpty(), virtualDesktop > 0, !activity.isEmpty());
+        rule.match = PWR::ContextRuleBridge::makeContextMatch(screenId, virtualDesktop, activity);
+
+        PWR::RuleAction action;
+        action.type = QString(PWR::ActionType::DefaultLayoutAssignment);
+        action.params.insert(PWR::ActionParam::Value, allow);
+        rule.actions.append(action);
+
+        QVERIFY(store->addRule(rule));
+    }
+
+    /// Author a PINNED engine-mode assignment rule (no layout) — the shape a user
+    /// gets from "set this monitor to snapping/autotile" without picking a layout.
+    void addEngineModeRule(PhosphorZones::LayoutRegistry* mgr, const QString& screenId, int virtualDesktop,
+                           const QString& activity, const QString& modeToken)
+    {
+        namespace PWR = PhosphorWindowRules;
+        auto* store = mgr->findChild<PWR::WindowRuleStore*>();
+        QVERIFY(store != nullptr);
+        const PWR::WindowRule rule = PWR::ContextRuleBridge::makeAssignmentRule(
+            QStringLiteral("test-mode"), screenId, virtualDesktop, activity, modeToken, QString(), QString());
+        QVERIFY(store->addRule(rule));
     }
 
     std::vector<std::unique_ptr<IsolatedConfigGuard>> m_guards;
@@ -767,6 +811,224 @@ private Q_SLOTS:
         QCOMPARE(entry.mode, PhosphorZones::AssignmentEntry::Snapping);
         QCOMPARE(entry.snappingLayout, layoutId);
         QCOMPARE(mgr->assignmentIdForScreen(QStringLiteral("DP-1"), 4), layoutId);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Suppress default layout assignment — the global gate + per-context override.
+    //
+    // The global setDefaultAssignmentSuppressedProvider gate makes an unassigned
+    // context resolve to NO active layout (the same empty-entry state as having no
+    // providers). A per-context DefaultLayoutAssignment rule overrides the global
+    // baseline either way: false suppresses one context even when global allows,
+    // true forces the default through even when global suppresses. Explicit
+    // assignments are never affected — suppression only gates the synthesized
+    // default.
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testSuppressDefault_globalOn_suppressesSynthesizedDefault()
+    {
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        auto* layout = createTestLayout(QStringLiteral("Snap"));
+        mgr->addLayout(layout);
+
+        const QString layoutId = layout->id().toString();
+        mgr->setDefaultLayoutIdProvider([layoutId]() {
+            return layoutId;
+        });
+        // Global suppress on — the snap default must NOT be synthesized.
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return true;
+        });
+
+        const auto entry = mgr->assignmentEntryForScreen(QStringLiteral("DP-1"), 4);
+        QVERIFY(!entry.isValid());
+        QVERIFY(mgr->assignmentIdForScreen(QStringLiteral("DP-1"), 4).isEmpty());
+    }
+
+    void testSuppressDefault_globalOff_synthesizesAsBefore()
+    {
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        auto* layout = createTestLayout(QStringLiteral("Snap"));
+        mgr->addLayout(layout);
+
+        const QString layoutId = layout->id().toString();
+        mgr->setDefaultLayoutIdProvider([layoutId]() {
+            return layoutId;
+        });
+        // Provider wired but reports off — behaviour is unchanged from today.
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return false;
+        });
+
+        const auto entry = mgr->assignmentEntryForScreen(QStringLiteral("DP-1"), 4);
+        QCOMPARE(entry.snappingLayout, layoutId);
+        QCOMPARE(mgr->assignmentIdForScreen(QStringLiteral("DP-1"), 4), layoutId);
+    }
+
+    void testSuppressDefault_perContextSuppress_overridesGlobalAllow()
+    {
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        auto* layout = createTestLayout(QStringLiteral("Snap"));
+        mgr->addLayout(layout);
+
+        const QString layoutId = layout->id().toString();
+        mgr->setDefaultLayoutIdProvider([layoutId]() {
+            return layoutId;
+        });
+        // Global allows the default (off). A per-context rule suppresses DP-1.
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return false;
+        });
+        addDefaultAssignmentRule(mgr.data(), QStringLiteral("DP-1"), 0, QString(), /*allow=*/false);
+
+        // DP-1 is suppressed by its rule.
+        QVERIFY(!mgr->assignmentEntryForScreen(QStringLiteral("DP-1"), 4).isValid());
+        QVERIFY(mgr->assignmentIdForScreen(QStringLiteral("DP-1"), 4).isEmpty());
+        // DP-2 (no rule) still gets the global default.
+        QCOMPARE(mgr->assignmentIdForScreen(QStringLiteral("DP-2"), 4), layoutId);
+    }
+
+    void testSuppressDefault_perContextAllow_overridesGlobalSuppress()
+    {
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        auto* layout = createTestLayout(QStringLiteral("Snap"));
+        mgr->addLayout(layout);
+
+        const QString layoutId = layout->id().toString();
+        mgr->setDefaultLayoutIdProvider([layoutId]() {
+            return layoutId;
+        });
+        // Global suppresses everywhere. A per-context rule re-enables DP-1.
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return true;
+        });
+        addDefaultAssignmentRule(mgr.data(), QStringLiteral("DP-1"), 0, QString(), /*allow=*/true);
+
+        // DP-1 forces the default through.
+        QCOMPARE(mgr->assignmentIdForScreen(QStringLiteral("DP-1"), 4), layoutId);
+        // DP-2 (no rule) stays suppressed by the global setting.
+        QVERIFY(mgr->assignmentIdForScreen(QStringLiteral("DP-2"), 4).isEmpty());
+    }
+
+    void testSuppressDefault_explicitAssignmentUnaffected()
+    {
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        auto* layout = createTestLayout(QStringLiteral("Manual"));
+        mgr->addLayout(layout);
+
+        // Global suppress on, but the user has an explicit assignment on DP-1.
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return true;
+        });
+        mgr->assignLayout(QStringLiteral("DP-1"), 0, QString(), layout);
+
+        // The explicit assignment wins — suppression only gates the synthesized
+        // default, never a stored assignment.
+        const auto entry = mgr->assignmentEntryForScreen(QStringLiteral("DP-1"), 0);
+        QCOMPARE(entry.snappingLayout, layout->id().toString());
+        QCOMPARE(entry.activeLayoutId(), layout->id().toString());
+    }
+
+    // isContextActiveLayoutSuppressed — the daemon's "no active layout because of
+    // suppression" gate. Must fire ONLY when suppression is the cause, never for
+    // other empty-assignment states (e.g. snapping enabled with no default id),
+    // so the daemon's defaultLayout() fallbacks are preserved there.
+
+    void testIsContextSuppressed_globalOn_unassigned_true()
+    {
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        auto* layout = createTestLayout(QStringLiteral("Snap"));
+        mgr->addLayout(layout);
+        const QString layoutId = layout->id().toString();
+        mgr->setDefaultLayoutIdProvider([layoutId]() {
+            return layoutId;
+        });
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return true;
+        });
+        QVERIFY(mgr->isContextActiveLayoutSuppressed(QStringLiteral("DP-1"), 4));
+    }
+
+    void testIsContextSuppressed_globalOff_noDefault_false()
+    {
+        // Regression guard: no providers wired (no default configured) is NOT
+        // suppression — the daemon must keep its defaultLayout() fallback here.
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return false;
+        });
+        QVERIFY(mgr->assignmentIdForScreen(QStringLiteral("DP-1"), 4).isEmpty());
+        QVERIFY(!mgr->isContextActiveLayoutSuppressed(QStringLiteral("DP-1"), 4));
+    }
+
+    void testIsContextSuppressed_explicitAssignment_false()
+    {
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        auto* layout = createTestLayout(QStringLiteral("Manual"));
+        mgr->addLayout(layout);
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return true;
+        });
+        mgr->assignLayout(QStringLiteral("DP-1"), 0, QString(), layout);
+        QVERIFY(!mgr->isContextActiveLayoutSuppressed(QStringLiteral("DP-1"), 0));
+    }
+
+    void testIsContextSuppressed_perContextOverrides()
+    {
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        auto* layout = createTestLayout(QStringLiteral("Snap"));
+        mgr->addLayout(layout);
+        const QString layoutId = layout->id().toString();
+        mgr->setDefaultLayoutIdProvider([layoutId]() {
+            return layoutId;
+        });
+        // Global off, but a per-context suppress rule on DP-1.
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return false;
+        });
+        addDefaultAssignmentRule(mgr.data(), QStringLiteral("DP-1"), 0, QString(), /*allow=*/false);
+        QVERIFY(mgr->isContextActiveLayoutSuppressed(QStringLiteral("DP-1"), 4));
+        // DP-2 (no rule) follows the global off → not suppressed.
+        QVERIFY(!mgr->isContextActiveLayoutSuppressed(QStringLiteral("DP-2"), 4));
+    }
+
+    void testIsContextSuppressed_pinnedModeOnlyRule_overridesGlobalSuppress()
+    {
+        // A window rule that sets only the engine mode (no layout) on a monitor
+        // must override the global suppress setting — the context stays active so
+        // the overlay / zone selector show and the layout falls back to default.
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        auto* layout = createTestLayout(QStringLiteral("Snap"));
+        mgr->addLayout(layout);
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return true;
+        });
+        addEngineModeRule(mgr.data(), QStringLiteral("DP-1"), 2, QString(), QStringLiteral("snapping"));
+        // DP-1 has a pinned mode rule → not suppressed despite global suppress.
+        QVERIFY(!mgr->isContextActiveLayoutSuppressed(QStringLiteral("DP-1"), 2));
+        // DP-2 (no rule) → still suppressed by the global setting.
+        QVERIFY(mgr->isContextActiveLayoutSuppressed(QStringLiteral("DP-2"), 2));
+    }
+
+    void testDefaultSuppressedForContext_bareAutotileModeRule_stillSuppressed()
+    {
+        // The autotile gate's primitive. A mode-only autotile rule sets the mode
+        // but draws its algorithm from the suppressed global default. So the
+        // context is NOT "active-layout-suppressed" (the mode rule covers it),
+        // yet its DEFAULT *is* suppressed — which is what the autotile activation
+        // gate checks to refuse tiling a bare "autotile:" context.
+        QScopedPointer<PhosphorZones::LayoutRegistry> mgr(createManager());
+        mgr->setDefaultAssignmentSuppressedProvider([]() {
+            return true;
+        });
+        addEngineModeRule(mgr.data(), QStringLiteral("DP-1"), 2, QString(), QStringLiteral("autotile"));
+        // The mode rule covers the context → not active-layout-suppressed.
+        QVERIFY(!mgr->isContextActiveLayoutSuppressed(QStringLiteral("DP-1"), 2));
+        // But the synthesized default IS suppressed → bare autotile must not tile.
+        QVERIFY(mgr->isDefaultAssignmentSuppressedForContext(QStringLiteral("DP-1"), 2));
+        // A per-context allow override flips it back on.
+        addDefaultAssignmentRule(mgr.data(), QStringLiteral("DP-1"), 2, QString(), /*allow=*/true);
+        QVERIFY(!mgr->isDefaultAssignmentSuppressedForContext(QStringLiteral("DP-1"), 2));
     }
 
     void testLevel1Default_storedEntryTakesPrecedence()

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -59,6 +59,18 @@ public:
         Q_EMIT defaultLayoutIdChanged();
         Q_EMIT settingsChanged();
     }
+    bool suppressDefaultLayoutAssignment() const override
+    {
+        return m_suppressDefaultLayoutAssignment;
+    }
+    void setSuppressDefaultLayoutAssignment(bool suppress) override
+    {
+        if (m_suppressDefaultLayoutAssignment == suppress)
+            return;
+        m_suppressDefaultLayoutAssignment = suppress;
+        Q_EMIT suppressDefaultLayoutAssignmentChanged();
+        Q_EMIT settingsChanged();
+    }
 
     // IZoneActivationSettings
     bool snappingEnabled() const override
@@ -1165,6 +1177,7 @@ public:
 
 private:
     QString m_defaultLayoutId;
+    bool m_suppressDefaultLayoutAssignment = false;
     QString m_renderingBackend = ConfigDefaults::renderingBackend();
     bool m_snapAssistFeatureEnabled = false;
     bool m_snapAssistEnabled = false;


### PR DESCRIPTION
## Summary

Adds a mode-neutral global option, **"Don't assign a layout by default"**, so a context (monitor / virtual desktop / activity) gets **no** active snapping or autotiling layout until one is explicitly assigned. Per-context window rules override the global setting either way, implementing the "monitor 1 off, monitor 2 on" model.

Default is **off** — zero behavior change until you enable it.

## Behavior

- **Global off (default):** unchanged — every context gets the synthesized default.
- **Global on:** a context with no explicit assignment has no active layout. Snapping shows no overlay/selector; autotile doesn't tile; the OSD shows **"No layout assigned."**
- **Window rules override the global setting:**
  - A pinned engine-mode assignment rule keeps a context active even if it only sets the mode (layout falls back to the default), so snapping/selector still work there.
  - A new **`DefaultLayoutAssignment`** rule action (allow/suppress) flips the baseline per context.
- **Autotile is gated on an explicit algorithm:** swapping to autotile under suppress sets the mode but applies a *bare* `autotile:` (no algorithm) instead of baking in the global default, so it doesn't tile until you assign a concrete algorithm.

## Implementation

- **phosphor-window-rules:** `DefaultLayoutAssignment` context action (boolean, `DefaultAssignment` slot), read as a per-slot overlay like `LockContext`.
- **phosphor-zones:** provider-driven suppress gate at the single level-1 cascade-miss tail; `isContextActiveLayoutSuppressed` (snapping/display) and `isDefaultAssignmentSuppressedForContext` (autotile primitive).
- **settings:** `SuppressDefaultLayoutAssignment` (default off) through `ConfigDefaults` / schema / `ISettings`.
- **daemon:** suppress wired into the overlay, zone selector, `getScreenStates`, OSD (new "No layout assigned" graphic), `updateAutotileScreens`, and the mode-swap handler.
- **settings UI:** General-page toggle + window-rule editor labels/summary for the new action.

## Tests

New `phosphor-zones` tests cover the global gate, both per-context override directions, explicit-assignment precedence, the pinned-mode-only override, and the bare-autotile primitive; plus a `phosphor-window-rules` descriptor test. **Full suite: 252/252 passing.**

## Note

Engine/settings logic is unit-tested; the daemon runtime paths (overlay/OSD/mode-swap) were verified manually during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)