### PR TITLE
fix(tests): isolate unit-test config into a throwaway XDG dir

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -849,15 +849,29 @@ target_link_libraries(test_decoration_manager_timers PRIVATE Qt6::Test PhosphorC
 add_test(NAME test_decoration_manager_timers COMMAND test_decoration_manager_timers)
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Headless environment support
-# Apply QT_QPA_PLATFORM=offscreen to every test in this directory so new tests
-# added above automatically inherit it - a hand-maintained list rotted and left
-# tests aborting in CI when the author forgot to append.
+# Headless environment + config isolation
+# Apply a shared environment to every test in this directory so new tests added
+# above automatically inherit it - a hand-maintained list rotted and left tests
+# aborting in CI when the author forgot to append.
+#
+#   QT_QPA_PLATFORM=offscreen — headless rendering.
+#   XDG_{CONFIG,DATA,STATE,CACHE}_HOME — redirect QStandardPaths into a throwaway
+#     build-tree directory so tests that exercise config-writing paths
+#     (LayoutManager assignments, mode toggles, the WindowRule store) never
+#     mutate the developer's real ~/.config/plasmazones. Without this, running
+#     ctest wrote sample-screen rules (e.g. "eDP-1") into the live config.
 #
 # IMPORTANT: get_property(... PROPERTY TESTS) reads the test list at CMake
 # configure time, which means tests added BELOW this line are NOT covered.
 # Always add new test targets ABOVE this block — never after it.
 # ═══════════════════════════════════════════════════════════════════════════════
+set(_pz_test_home "${CMAKE_BINARY_DIR}/test-xdg")
+file(MAKE_DIRECTORY
+    "${_pz_test_home}/config"
+    "${_pz_test_home}/data"
+    "${_pz_test_home}/state"
+    "${_pz_test_home}/cache")
 get_property(_all_tests DIRECTORY . PROPERTY TESTS)
-set_tests_properties(${_all_tests} PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+set_tests_properties(${_all_tests} PROPERTIES ENVIRONMENT
+    "QT_QPA_PLATFORM=offscreen;XDG_CONFIG_HOME=${_pz_test_home}/config;XDG_DATA_HOME=${_pz_test_home}/data;XDG_STATE_HOME=${_pz_test_home}/state;XDG_CACHE_HOME=${_pz_test_home}/cache")
 # ─── ABOVE THIS LINE: ADD NEW TESTS — BELOW THIS LINE: env wiring only ───


### PR DESCRIPTION
## Problem

Running `ctest` mutates the developer's **real** `~/.config/plasmazones/`.

Unit tests that exercise config-writing paths (LayoutManager `assignLayout`, mode toggles, the WindowRule store) go through `ConfigDefaults`, which resolves to `QStandardPaths::writableLocation(GenericConfigLocation)` = `~/.config`. The suite did not sandbox `QStandardPaths` (only `test_shellloader` called `setTestModeEnabled`), so tests using sample screen names wrote rules straight into the live config.

This was found in the wild: a stray **`Monitor: eDP-1 · Desktop: 2 · Engine: Snapping`** rule appeared in a user's Window Rules. `eDP-1` exists only in test fixtures (`test_autotile_engine_core.cpp`, `test_matchexpression.cpp`, …) — the user has no such monitor. It was a bare `setEngineMode` rule keyed by a connector name (real rules use the full ScreenIdentity), written by a test during a `ctest` run.

## Fix

Extend the existing per-directory `ENVIRONMENT` finalizer in `tests/unit/CMakeLists.txt` (already used to apply `QT_QPA_PLATFORM=offscreen` to every test via the directory's `TESTS` property) to also set `XDG_CONFIG_HOME` / `XDG_DATA_HOME` / `XDG_STATE_HOME` / `XDG_CACHE_HOME` to `${CMAKE_BINARY_DIR}/test-xdg`.

Single point, no per-test wiring: every current and future unit test inherits it automatically (new tests are added above the finalizer block, same as the existing QPA rule).

## Verification

- Full suite **254/254** still passes.
- `~/.config/plasmazones/windowrules.json` is **byte-identical** before and after a `ctest` run (was being rewritten before).
- The test writes (including the `eDP-1` rule) now land in `build/test-xdg/config/plasmazones/` instead.

## Note

This only stops *future* pollution. An existing stray rule in a developer's live config should be removed via the Settings → Window Rules trash icon (the daemon owns the in-memory rule set, so hand-editing the JSON while it runs gets overwritten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)