### PR TITLE
fix: snapping/autotile parity bugs from the settings audit

### DIFF
--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/ISnapSettings.h
@@ -27,6 +27,15 @@ public:
     // SnapEngine via `setExcludeRuleSet`; consumers that previously called
     // these accessors evaluate against the rule set instead.
 
+    // Global minimum-window-size exclusion (the shared Exclusions surface, not a
+    // snapping-only knob): a window whose frame is smaller than these thresholds
+    // is excluded from auto-snap, matching the autotile engine which already
+    // honours them. 0 disables the respective dimension. The engine only applies
+    // these when a full WindowQuery (carrying the frame size) is available via
+    // the injected exclusion query provider; the appId-only fast path skips them.
+    virtual int minimumWindowWidth() const = 0;
+    virtual int minimumWindowHeight() const = 0;
+
     virtual StickyWindowHandling snappingStickyWindowHandling() const = 0;
     virtual bool moveNewWindowsToLastZone() const = 0;
     virtual bool restoreWindowsToZonesOnLogin() const = 0;

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -679,35 +679,24 @@ public:
     }
 
     /// True if @p appId matches an enabled `Exclude`-action WindowRule
-    /// whose match leaf targets the `AppId` field. Public so the unit-
-    /// test layer can directly verify the wiring (nullptr borrow,
-    /// empty-set short-circuit, evaluator rebind on pointer change,
-    /// revision-bump invalidation on in-place setRules edits) without
-    /// staging the heavy navigation fixture every public navigation
-    /// method needs. Pure const observer — no side effects beyond the
-    /// `mutable` evaluator cache.
-    ///
-    /// **Limitation:** the engine builds a `WindowQuery` with only
-    /// `query.appId` populated and feeds it to the bound `RuleEvaluator`.
-    /// A user-authored Exclude rule whose match leaf targets a non-
-    /// `AppId` field (`WindowClass Contains "steam"`, `Title Regex …`,
-    /// a composite match) silently evaluates to false here because
-    /// those leaves never resolve against a query that only knows the
-    /// appId. Migration-produced rules are all `AppId AppIdMatches
-    /// <pattern>` so legacy v3 behaviour is preserved exactly; the gap
-    /// only opens for hand-authored rules with broader match leaves.
-    /// A more thorough check would require the caller to pass the full
-    /// `WindowQuery` it can build from the WTS registry's per-window
-    /// attributes, instead of just the appId.
+    /// resolved against an appId-ONLY `WindowQuery`. This is a narrow seam:
+    /// the runtime exclusion path is @ref isWindowExcluded, which evaluates the
+    /// FULL window attributes; this method survives as (a) the early-init /
+    /// no-metadata fallback inside isWindowExcluded and (b) a directly testable
+    /// hook for the rule-set wiring (nullptr borrow, empty-set short-circuit,
+    /// evaluator rebind on pointer change, revision-bump invalidation). An
+    /// Exclude rule keyed on a non-`AppId` field (`WindowClass Contains …`,
+    /// `Title Regex …`) does NOT match here — use isWindowExcluded for that.
+    /// Pure const observer — no side effects beyond the `mutable` evaluator cache.
     bool isAppIdExcluded(const QString& appId) const;
 
     /// Resolve exclusion for a live windowId using the FULL window attributes
     /// when the exclusion query provider is wired (matching the autotile
     /// engine): evaluates the Exclude rule set against the complete WindowQuery
     /// and applies the minimum-window-size thresholds to the query's frame
-    /// size. Falls back to the appId-only path when no provider is set or window
-    /// metadata is not yet known. Public so the unit-test layer can drive the
-    /// wiring directly, mirroring @ref isAppIdExcluded.
+    /// size. Falls back to the appId-only path (@ref isAppIdExcluded's query
+    /// shape) when no provider is set or window metadata is not yet known.
+    /// Public so the unit-test layer can drive the wiring directly.
     bool isWindowExcluded(const QString& windowId) const;
 
 Q_SIGNALS:
@@ -848,13 +837,18 @@ private:
     // section above (so the unit tests can drive the wiring directly); full
     // docstrings live with those declarations.
 
+    /// Shared tail of both exclusion entry points: bind the lazy evaluator to
+    /// the current Exclude rule set (empty/null set short-circuits) and resolve
+    /// @p query. Keeps the rule-set/evaluator invariant in one place.
+    bool evaluateExcludeRules(const PhosphorWindowRules::WindowQuery& query) const;
+
     /// Borrowed pointer to the daemon's filtered Exclude rule set. nullptr
     /// in early-init paths (before the daemon wires the store) — the
-    /// `isAppIdExcluded` fast path short-circuits to false in that case.
+    /// `evaluateExcludeRules` fast path short-circuits to false in that case.
     ///
     /// @note Daemon-main-thread-only. Every access path runs on the
     /// daemon's main thread (rulesChanged signal delivery, navigation
-    /// slot dispatch, in-thread isAppIdExcluded calls). `setExcludeRuleSet`
+    /// slot dispatch, in-thread exclusion-resolve calls). `setExcludeRuleSet`
     /// writes the raw pointer non-atomically and the paired
     /// `m_excludeEvaluator` mutates a lazy priority-order index that
     /// must be externally serialised (see RuleEvaluator.h's thread-

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -202,6 +202,36 @@ public:
     }
 
     /**
+     * @brief Predicate consulted in `resolveWindowRestore` to decide whether a
+     *        window that was SNAPPED at logout should be restored to its recorded
+     *        zone on reopen/login (the "managed restore").
+     *
+     * This is the snapped-to-zone analogue of @ref RestorePositionPredicate
+     * (which governs FLOATED records). Keyed by the live windowId so the daemon
+     * closure stays settings-agnostic (LGPL boundary) — the engine only asks.
+     * The daemon wires it to the `restoreWindowsToZonesOnLogin` setting.
+     *
+     * When the predicate returns false the stored snap is not re-applied; the
+     * window falls through to the normal auto-snap policy chain, exactly as a
+     * disabled-context rejection does. When UNSET (default) the engine restores
+     * snapped records unconditionally — the historical behaviour unit tests rely
+     * on. This gate is independent of @ref ShouldRestorePredicate (the
+     * disabled-context gate); both must opt in for a managed restore to proceed.
+     */
+    using ManagedRestorePredicate = std::function<bool(const QString& windowId)>;
+
+    /**
+     * @brief Inject the managed (snapped-to-zone) restore gate. See
+     *        ManagedRestorePredicate. Same lifetime contract as
+     *        setRestorePositionPredicate — clear with `{}` before destroying any
+     *        captured state.
+     */
+    void setManagedRestorePredicate(ManagedRestorePredicate predicate)
+    {
+        m_managedRestorePredicate = std::move(predicate);
+    }
+
+    /**
      * @brief Predicate deciding whether an opening window should start FLOATING
      *        because a "Float this app" window rule matched it. Daemon-injected,
      *        keyed by the live windowId, evaluated on the window-open path. When
@@ -832,6 +862,11 @@ private:
     // only on the reopening screen — the historical behaviour unit tests rely on.
     // See RestorePositionPredicate doc above.
     RestorePositionPredicate m_restorePositionPredicate{};
+
+    // Managed (snapped-to-zone) restore gate. Empty until the daemon wires it;
+    // while empty the engine restores snapped records unconditionally — the
+    // historical behaviour unit tests rely on. See ManagedRestorePredicate.
+    ManagedRestorePredicate m_managedRestorePredicate{};
 
     // Rule-driven open-floating gate. Empty until the daemon wires it; while
     // empty no window is rule-floated. See FloatPredicate doc above.

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -641,8 +641,9 @@ public:
     /// navigation_actions.cpp for the lifetime contract — the pointer is
     /// borrowed and the cached evaluator drops on a pointer change.
     ///
-    /// The borrowed rule set MUST outlive every subsequent
-    /// `isAppIdExcluded` call. The Daemon currently guarantees this
+    /// The borrowed rule set MUST outlive every subsequent exclusion
+    /// resolve (`isWindowExcluded` / `evaluateExcludeRules`, and the
+    /// legacy `isAppIdExcluded` seam). The Daemon currently guarantees this
     /// through member-declaration order (`m_excludeRuleSet` is declared
     /// before `m_snapEngine` so reverse-order destruction tears the
     /// engine down first), AND additionally clears the borrow

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -657,6 +657,27 @@ public:
     /// translation unit redefine the function and the link fails.
     void setExcludeRuleSet(const PhosphorWindowRules::WindowRuleSet* ruleSet);
 
+    /// Provider that builds the full WindowQuery (window class / title / role /
+    /// frame size / flags) for a live windowId. Daemon-injected, keyed by the
+    /// live windowId — the daemon resolves it from its WindowRegistry (the same
+    /// `buildRuleQueryForWindow` the float / restore predicates use). When set,
+    /// exclusion evaluates a window's FULL attributes (matching the autotile
+    /// engine) instead of appId alone, and the frame size carried in the query
+    /// is checked against the minimum-window-size thresholds. When UNSET
+    /// (default) the engine falls back to the appId-only query — the historical
+    /// behaviour unit tests rely on. A null/empty optional from the provider
+    /// (metadata not yet known) also falls back to appId-only.
+    using ExclusionQueryProvider =
+        std::function<std::optional<PhosphorWindowRules::WindowQuery>(const QString& windowId)>;
+
+    /// Inject the exclusion query provider. See ExclusionQueryProvider. Same
+    /// lifetime contract as setExcludeRuleSet — the caller keeps captured state
+    /// valid for the engine's lifetime; clear with `{}` before destroying it.
+    void setExclusionQueryProvider(ExclusionQueryProvider provider)
+    {
+        m_exclusionQueryProvider = std::move(provider);
+    }
+
     /// True if @p appId matches an enabled `Exclude`-action WindowRule
     /// whose match leaf targets the `AppId` field. Public so the unit-
     /// test layer can directly verify the wiring (nullptr borrow,
@@ -679,6 +700,15 @@ public:
     /// `WindowQuery` it can build from the WTS registry's per-window
     /// attributes, instead of just the appId.
     bool isAppIdExcluded(const QString& appId) const;
+
+    /// Resolve exclusion for a live windowId using the FULL window attributes
+    /// when the exclusion query provider is wired (matching the autotile
+    /// engine): evaluates the Exclude rule set against the complete WindowQuery
+    /// and applies the minimum-window-size thresholds to the query's frame
+    /// size. Falls back to the appId-only path when no provider is set or window
+    /// metadata is not yet known. Public so the unit-test layer can drive the
+    /// wiring directly, mirroring @ref isAppIdExcluded.
+    bool isWindowExcluded(const QString& windowId) const;
 
 Q_SIGNALS:
     // ═══════════════════════════════════════════════════════════════════════════
@@ -814,9 +844,9 @@ private:
     /// otherwise.
     bool isWindowExcludedForAction(const QString& windowId, const QString& action, const QString& screenId);
 
-    // `isAppIdExcluded` is declared in the public section above (so the
-    // unit tests can drive the wiring directly); full docstring + the
-    // AppId-only matching limitation live with that declaration.
+    // `isAppIdExcluded` and `isWindowExcluded` are declared in the public
+    // section above (so the unit tests can drive the wiring directly); full
+    // docstrings live with those declarations.
 
     /// Borrowed pointer to the daemon's filtered Exclude rule set. nullptr
     /// in early-init paths (before the daemon wires the store) — the
@@ -840,6 +870,11 @@ private:
     ///
     /// @note Same daemon-main-thread-only contract as @ref m_excludeRuleSet.
     mutable std::optional<PhosphorWindowRules::RuleEvaluator> m_excludeEvaluator;
+
+    /// Daemon-injected full-query provider for exclusion. Empty until the
+    /// daemon wires it; while empty exclusion uses the appId-only query and the
+    /// minimum-window-size thresholds are not applied. See ExclusionQueryProvider.
+    ExclusionQueryProvider m_exclusionQueryProvider{};
 
     // Persistence delegates (KConfig stays in adaptor layer)
     std::function<void()> m_saveFn;

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -466,8 +466,8 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     // tracker. isAppIdExcluded resolves through the unified RuleEvaluator
     // (daemon-flavour AppIdMatches Exclude rules) — the same match model the
     // effect uses, replacing the hand-rolled appIdMatches loops.
-    if (m_windowTracker && isAppIdExcluded(m_windowTracker->currentAppIdFor(windowId))) {
-        qCInfo(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore:" << windowId << "excluded by rule";
+    if (m_windowTracker && isWindowExcluded(windowId)) {
+        qCInfo(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore:" << windowId << "excluded by rule or size";
         return SnapResult::noSnap();
     }
 

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -333,8 +333,20 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
             }
 
             if (slot.state == WindowPlacement::stateSnapped()) {
-                // A stored snap is still subject to the disabled-context gate.
-                if (!m_shouldRestorePredicate || m_shouldRestorePredicate(restoreScreen)) {
+                // A stored snap is subject to BOTH the disabled-context gate and
+                // the managed-restore gate (restoreWindowsToZonesOnLogin). Either
+                // veto falls the window through to the normal auto-snap chain
+                // rather than re-applying the recorded zone.
+                const bool contextAllows = !m_shouldRestorePredicate || m_shouldRestorePredicate(restoreScreen);
+                const bool managedAllows = !m_managedRestorePredicate || m_managedRestorePredicate(windowId);
+                if (contextAllows && !managedAllows) {
+                    // Distinct log so the managed gate (restoreWindowsToZonesOnLogin
+                    // off) is identifiable separately from a disabled-context veto.
+                    qCDebug(PhosphorSnapEngine::lcSnapEngine)
+                        << "resolveWindowRestore:" << windowId
+                        << "— managed-restore gate skipped snapped record (restoreWindowsToZonesOnLogin off)";
+                }
+                if (contextAllows && managedAllows) {
                     const QStringList zoneIds = slot.zoneIds;
                     const QRect geo =
                         zoneIds.isEmpty() ? QRect() : m_windowTracker->resolveZoneGeometry(zoneIds, restoreScreen);
@@ -359,8 +371,9 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
                         return SnapResult{true, geo, zoneIds.first(), zoneIds, restoreScreen};
                     }
                 }
-                // Disabled context or zone gone (layout edit) → fall through to
-                // the legacy chain below.
+                // Disabled context, managed-restore opt-out
+                // (restoreWindowsToZonesOnLogin off), or zone gone (layout edit)
+                // → fall through to the legacy chain below.
             } else {
                 // FLOATED restore. Snapping has only two states — snapped (above) or
                 // floated — so any non-snapped record is floated. This also absorbs

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -463,9 +463,10 @@ SnapResult SnapEngine::resolveWindowRestore(const QString& windowId, const QStri
     // has already updated (Electron/CEF apps renaming themselves) matches
     // against its CURRENT class, not a stale first-seen one. m_windowTracker
     // is non-null at runtime; production code never reaches this with a null
-    // tracker. isAppIdExcluded resolves through the unified RuleEvaluator
-    // (daemon-flavour AppIdMatches Exclude rules) — the same match model the
-    // effect uses, replacing the hand-rolled appIdMatches loops.
+    // tracker. isWindowExcluded resolves the full WindowQuery (class/title/
+    // frame size) through the unified RuleEvaluator and applies the
+    // minimum-window-size thresholds — the same match model the autotile
+    // engine uses, replacing the hand-rolled appIdMatches loops.
     if (m_windowTracker && isWindowExcluded(windowId)) {
         qCInfo(PhosphorSnapEngine::lcSnapEngine) << "resolveWindowRestore:" << windowId << "excluded by rule or size";
         return SnapResult::noSnap();

--- a/libs/phosphor-snap-engine/src/navigation_actions.cpp
+++ b/libs/phosphor-snap-engine/src/navigation_actions.cpp
@@ -166,13 +166,50 @@ bool SnapEngine::isAppIdExcluded(const QString& appId) const
     return m_excludeEvaluator->resolve(query).isExcluded();
 }
 
+bool SnapEngine::isWindowExcluded(const QString& windowId) const
+{
+    // Build the richest query available: the daemon-supplied full attributes
+    // (window class / title / frame size / flags) when the provider is wired,
+    // else the appId-only query — the historical fallback unit tests rely on.
+    std::optional<PhosphorWindowRules::WindowQuery> query;
+    if (m_exclusionQueryProvider) {
+        query = m_exclusionQueryProvider(windowId);
+    }
+    if (!query) {
+        PhosphorWindowRules::WindowQuery q;
+        q.appId = m_windowTracker ? m_windowTracker->currentAppIdFor(windowId) : QString();
+        query = std::move(q);
+    }
+
+    // Minimum-window-size exclusion — only meaningful when the query carries the
+    // frame size (full-query path). Mirrors the autotile eligibility filter, so
+    // a sub-threshold utility window is excluded from auto-snap in both modes.
+    if (auto* s = snapSettings()) {
+        const int minW = s->minimumWindowWidth();
+        const int minH = s->minimumWindowHeight();
+        if ((minW > 0 && query->width && *query->width < minW)
+            || (minH > 0 && query->height && *query->height < minH)) {
+            return true;
+        }
+    }
+
+    // Rule-based exclusion against the full query (no rules → nothing to match).
+    if (!m_excludeRuleSet || m_excludeRuleSet->isEmpty()) {
+        return false;
+    }
+    if (!m_excludeEvaluator) {
+        m_excludeEvaluator.emplace(*m_excludeRuleSet);
+    }
+    return m_excludeEvaluator->resolve(*query).isExcluded();
+}
+
 bool SnapEngine::isWindowExcludedForAction(const QString& windowId, const QString& action, const QString& screenId)
 {
     if (!m_windowTracker) {
         return false;
     }
-    const QString appId = m_windowTracker->currentAppIdFor(windowId);
-    if (isAppIdExcluded(appId)) {
+    if (isWindowExcluded(windowId)) {
+        const QString appId = m_windowTracker->currentAppIdFor(windowId);
         qCInfo(PhosphorSnapEngine::lcSnapEngine) << action << ":" << windowId << "excluded by rule, appId:" << appId;
         Q_EMIT navigationFeedback(false, action, QStringLiteral("excluded"), appId, QString(), screenId);
         return true;

--- a/libs/phosphor-snap-engine/src/navigation_actions.cpp
+++ b/libs/phosphor-snap-engine/src/navigation_actions.cpp
@@ -148,22 +148,24 @@ void SnapEngine::setExcludeRuleSet(const PhosphorWindowRules::WindowRuleSet* rul
     m_excludeEvaluator.reset();
 }
 
-bool SnapEngine::isAppIdExcluded(const QString& appId) const
+bool SnapEngine::evaluateExcludeRules(const PhosphorWindowRules::WindowQuery& query) const
 {
-    // No-wiring fast path: early-init can call isAppIdExcluded before the
-    // daemon hands the rule store over.
-    if (!m_excludeRuleSet) {
+    // No-wiring fast path: early-init can run before the daemon hands the rule
+    // store over; an empty set short-circuits with no evaluator allocation.
+    if (!m_excludeRuleSet || m_excludeRuleSet->isEmpty()) {
         return false;
-    }
-    if (m_excludeRuleSet->isEmpty()) {
-        return false; // no-exclusions fast path
     }
     if (!m_excludeEvaluator) {
         m_excludeEvaluator.emplace(*m_excludeRuleSet);
     }
+    return m_excludeEvaluator->resolve(query).isExcluded();
+}
+
+bool SnapEngine::isAppIdExcluded(const QString& appId) const
+{
     PhosphorWindowRules::WindowQuery query;
     query.appId = appId;
-    return m_excludeEvaluator->resolve(query).isExcluded();
+    return evaluateExcludeRules(query);
 }
 
 bool SnapEngine::isWindowExcluded(const QString& windowId) const
@@ -194,13 +196,7 @@ bool SnapEngine::isWindowExcluded(const QString& windowId) const
     }
 
     // Rule-based exclusion against the full query (no rules → nothing to match).
-    if (!m_excludeRuleSet || m_excludeRuleSet->isEmpty()) {
-        return false;
-    }
-    if (!m_excludeEvaluator) {
-        m_excludeEvaluator.emplace(*m_excludeRuleSet);
-    }
-    return m_excludeEvaluator->resolve(*query).isExcluded();
+    return evaluateExcludeRules(*query);
 }
 
 bool SnapEngine::isWindowExcludedForAction(const QString& windowId, const QString& action, const QString& screenId)

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -535,6 +535,11 @@ public:
     bool hasPerScreenOverride(const QString& screenId, const QString& key) const;
     void updatePerScreenOverride(const QString& screenId, const QString& key, const QVariant& value);
 
+    // Inject the per-context (window-rule) gap-override provider — forwarded to
+    // PerScreenConfigResolver. The daemon supplies the screen's current-context
+    // gap overrides so tiled windows honour context gap rules like snapping does.
+    void setContextGapProvider(std::function<QVariantMap(const QString& screenId)> provider);
+
     // Mark the active (screen, desktop, activity) state's split ratio / master
     // count as user-tuned so propagateGlobalSplitRatio/MasterCount leaves it
     // alone — the adjustment stays local to that desktop instead of bleeding into

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
@@ -126,6 +126,15 @@ public:
 private:
     std::optional<QVariant> perScreenOverride(const QString& screenId, const QString& key) const;
 
+    /// Clamped per-context override for a single gap key (InnerGap / OuterGap),
+    /// or nullopt when no provider is wired or the context map lacks the key.
+    std::optional<int> contextGap(const QString& screenId, QLatin1String key) const;
+
+    /// Per-context outer-gap override resolved as one atomic layer (per-side
+    /// honoured only when UsePerSideOuterGap is set), mirroring the snapping
+    /// pipeline. nullopt when the context layer carries no outer-gap info.
+    std::optional<::PhosphorLayout::EdgeGaps> contextOuterGaps(const QString& screenId) const;
+
     AutotileEngine* m_engine = nullptr;
     QHash<QString, QVariantMap> m_perScreenOverrides;
     ContextGapProvider m_contextGapProvider{};

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
@@ -9,6 +9,7 @@
 #include <QHash>
 #include <QString>
 #include <QVariantMap>
+#include <functional>
 #include <optional>
 
 namespace PhosphorTiles {
@@ -89,6 +90,25 @@ public:
      */
     void removeOverridesForScreen(const QString& screenId);
 
+    /**
+     * @brief Inject a per-context (window-rule) gap-override provider.
+     *
+     * Returns a QVariantMap keyed by the same PerScreenKeys gap keys this
+     * resolver already understands (InnerGap, OuterGap, OuterGap{Top,Bottom,
+     * Left,Right}, UsePerSideOuterGap) for the screen's CURRENT context
+     * (desktop / activity, resolved by the daemon closure). These take
+     * precedence over the static per-screen overrides, matching the snapping
+     * gap pipeline where a context-rule gap override is the highest-priority
+     * layer. Engine library stays settings-agnostic (LGPL boundary): the daemon
+     * adapts its LayoutRegistry::resolveContextGaps result into the map. Empty /
+     * unset → no context override (the historical behaviour).
+     */
+    using ContextGapProvider = std::function<QVariantMap(const QString& screenId)>;
+    void setContextGapProvider(ContextGapProvider provider)
+    {
+        m_contextGapProvider = std::move(provider);
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Effective per-screen values (per-screen override → global fallback)
     // ═══════════════════════════════════════════════════════════════════════════
@@ -108,6 +128,7 @@ private:
 
     AutotileEngine* m_engine = nullptr;
     QHash<QString, QVariantMap> m_perScreenOverrides;
+    ContextGapProvider m_contextGapProvider{};
 };
 
 } // namespace PhosphorTileEngine

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -1501,6 +1501,11 @@ void AutotileEngine::clearPerScreenConfig(const QString& screenId)
     m_configResolver->clearPerScreenConfig(screenId);
 }
 
+void AutotileEngine::setContextGapProvider(std::function<QVariantMap(const QString& screenId)> provider)
+{
+    m_configResolver->setContextGapProvider(std::move(provider));
+}
+
 QVariantMap AutotileEngine::perScreenOverrides(const QString& screenId) const
 {
     return m_configResolver->perScreenOverrides(screenId);

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -143,18 +143,6 @@ void PerScreenConfigResolver::removeOverridesForScreen(const QString& screenId)
 
 std::optional<QVariant> PerScreenConfigResolver::perScreenOverride(const QString& screenId, const QString& key) const
 {
-    // Highest precedence: a per-context (window-rule) gap override for this
-    // screen's current context, matching the snapping gap pipeline where the
-    // context override is the top layer. Only gap keys appear in the provider's
-    // map, so non-gap lookups (algorithm, split ratio, …) fall straight
-    // through to the static per-screen overrides below.
-    if (m_contextGapProvider) {
-        const QVariantMap ctx = m_contextGapProvider(screenId);
-        auto cit = ctx.constFind(key);
-        if (cit != ctx.constEnd()) {
-            return *cit;
-        }
-    }
     auto it = m_perScreenOverrides.constFind(screenId);
     if (it != m_perScreenOverrides.constEnd()) {
         auto git = it->constFind(key);
@@ -165,51 +153,109 @@ std::optional<QVariant> PerScreenConfigResolver::perScreenOverride(const QString
     return std::nullopt;
 }
 
+namespace {
+// Clamp a raw gap value to the shared [MinGap, MaxGap] range — the same range
+// the snapping side clamps to (tied by a static_assert in the daemon).
+int clampGap(int v)
+{
+    return qBound(PhosphorTiles::AutotileDefaults::MinGap, v, PhosphorTiles::AutotileDefaults::MaxGap);
+}
+} // namespace
+
+std::optional<int> PerScreenConfigResolver::contextGap(const QString& screenId, QLatin1String key) const
+{
+    if (!m_contextGapProvider) {
+        return std::nullopt;
+    }
+    const QVariantMap ctx = m_contextGapProvider(screenId);
+    const auto it = ctx.constFind(key);
+    if (it == ctx.constEnd()) {
+        return std::nullopt;
+    }
+    return clampGap(it->toInt());
+}
+
+std::optional<::PhosphorLayout::EdgeGaps> PerScreenConfigResolver::contextOuterGaps(const QString& screenId) const
+{
+    // Resolve the per-context (window-rule) outer-gap override as ONE atomic
+    // layer, mirroring the snapping pipeline (GeometryUtils::
+    // resolveOuterGapsFromMap): per-side values are honoured only when the rule
+    // set UsePerSideOuterGap, and if the layer yields any outer gap it wins
+    // wholesale — no per-key blending with the static per-screen layer below.
+    if (!m_contextGapProvider) {
+        return std::nullopt;
+    }
+    const QVariantMap ctx = m_contextGapProvider(screenId);
+    if (ctx.isEmpty()) {
+        return std::nullopt;
+    }
+    const auto uniformIt = ctx.constFind(QString(PerScreenKeys::OuterGap));
+    const bool usePerSide = ctx.value(QString(PerScreenKeys::UsePerSideOuterGap), false).toBool();
+    if (usePerSide) {
+        const auto topIt = ctx.constFind(QString(PerScreenKeys::OuterGapTop));
+        const auto bottomIt = ctx.constFind(QString(PerScreenKeys::OuterGapBottom));
+        const auto leftIt = ctx.constFind(QString(PerScreenKeys::OuterGapLeft));
+        const auto rightIt = ctx.constFind(QString(PerScreenKeys::OuterGapRight));
+        if (topIt != ctx.constEnd() || bottomIt != ctx.constEnd() || leftIt != ctx.constEnd()
+            || rightIt != ctx.constEnd()) {
+            // Missing sides fall back to the layer's own uniform OuterGap, else
+            // the global config — matching resolveOuterGapsFromMap's base.
+            const int base =
+                (uniformIt != ctx.constEnd()) ? clampGap(uniformIt->toInt()) : m_engine->config()->outerGap;
+            return ::PhosphorLayout::EdgeGaps{(topIt != ctx.constEnd()) ? clampGap(topIt->toInt()) : base,
+                                              (bottomIt != ctx.constEnd()) ? clampGap(bottomIt->toInt()) : base,
+                                              (leftIt != ctx.constEnd()) ? clampGap(leftIt->toInt()) : base,
+                                              (rightIt != ctx.constEnd()) ? clampGap(rightIt->toInt()) : base};
+        }
+    }
+    if (uniformIt != ctx.constEnd()) {
+        return ::PhosphorLayout::EdgeGaps::uniform(clampGap(uniformIt->toInt()));
+    }
+    return std::nullopt;
+}
+
 int PerScreenConfigResolver::effectiveInnerGap(const QString& screenId) const
 {
-    if (auto v = perScreenOverride(screenId, QStringLiteral("InnerGap")))
-        return qBound(PhosphorTiles::AutotileDefaults::MinGap, v->toInt(), PhosphorTiles::AutotileDefaults::MaxGap);
+    if (auto ctx = contextGap(screenId, PerScreenKeys::InnerGap))
+        return *ctx;
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::InnerGap)))
+        return clampGap(v->toInt());
     return m_engine->config()->innerGap;
 }
 
 int PerScreenConfigResolver::effectiveOuterGap(const QString& screenId) const
 {
-    if (auto v = perScreenOverride(screenId, QStringLiteral("OuterGap")))
-        return qBound(PhosphorTiles::AutotileDefaults::MinGap, v->toInt(), PhosphorTiles::AutotileDefaults::MaxGap);
+    if (auto ctx = contextGap(screenId, PerScreenKeys::OuterGap))
+        return *ctx;
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::OuterGap)))
+        return clampGap(v->toInt());
     return m_engine->config()->outerGap;
 }
 
 ::PhosphorLayout::EdgeGaps PerScreenConfigResolver::effectiveOuterGaps(const QString& screenId) const
 {
-    // Check per-screen per-side overrides first
-    auto topOv = perScreenOverride(screenId, QStringLiteral("OuterGapTop"));
-    auto bottomOv = perScreenOverride(screenId, QStringLiteral("OuterGapBottom"));
-    auto leftOv = perScreenOverride(screenId, QStringLiteral("OuterGapLeft"));
-    auto rightOv = perScreenOverride(screenId, QStringLiteral("OuterGapRight"));
+    // Highest precedence: the per-context override, resolved as one atomic layer.
+    if (auto ctx = contextOuterGaps(screenId))
+        return *ctx;
+
+    // Per-screen per-side overrides next.
+    auto topOv = perScreenOverride(screenId, QString(PerScreenKeys::OuterGapTop));
+    auto bottomOv = perScreenOverride(screenId, QString(PerScreenKeys::OuterGapBottom));
+    auto leftOv = perScreenOverride(screenId, QString(PerScreenKeys::OuterGapLeft));
+    auto rightOv = perScreenOverride(screenId, QString(PerScreenKeys::OuterGapRight));
 
     // If any per-screen per-side override exists, build from those
     if (topOv || bottomOv || leftOv || rightOv) {
         // Use per-screen uniform gap as base, then per-side overrides on top
         const int base = effectiveOuterGap(screenId);
-        return ::PhosphorLayout::EdgeGaps{topOv ? qBound(PhosphorTiles::AutotileDefaults::MinGap, topOv->toInt(),
-                                                         PhosphorTiles::AutotileDefaults::MaxGap)
-                                                : base,
-                                          bottomOv ? qBound(PhosphorTiles::AutotileDefaults::MinGap, bottomOv->toInt(),
-                                                            PhosphorTiles::AutotileDefaults::MaxGap)
-                                                   : base,
-                                          leftOv ? qBound(PhosphorTiles::AutotileDefaults::MinGap, leftOv->toInt(),
-                                                          PhosphorTiles::AutotileDefaults::MaxGap)
-                                                 : base,
-                                          rightOv ? qBound(PhosphorTiles::AutotileDefaults::MinGap, rightOv->toInt(),
-                                                           PhosphorTiles::AutotileDefaults::MaxGap)
-                                                  : base};
+        return ::PhosphorLayout::EdgeGaps{
+            topOv ? clampGap(topOv->toInt()) : base, bottomOv ? clampGap(bottomOv->toInt()) : base,
+            leftOv ? clampGap(leftOv->toInt()) : base, rightOv ? clampGap(rightOv->toInt()) : base};
     }
 
     // Check per-screen uniform outer gap
-    if (auto v = perScreenOverride(screenId, QStringLiteral("OuterGap"))) {
-        const int gap =
-            qBound(PhosphorTiles::AutotileDefaults::MinGap, v->toInt(), PhosphorTiles::AutotileDefaults::MaxGap);
-        return ::PhosphorLayout::EdgeGaps::uniform(gap);
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::OuterGap))) {
+        return ::PhosphorLayout::EdgeGaps::uniform(clampGap(v->toInt()));
     }
 
     // Fall back to global config

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -46,13 +46,13 @@ void PerScreenConfigResolver::applyPerScreenConfig(const QString& screenId, cons
     }
 
     // Apply PhosphorTiles::TilingState-level overrides (splitRatio, masterCount)
-    auto it = overrides.constFind(QStringLiteral("SplitRatio"));
+    auto it = overrides.constFind(QString(PerScreenKeys::SplitRatio));
     if (it != overrides.constEnd()) {
         state->setSplitRatio(qBound(PhosphorTiles::AutotileDefaults::MinSplitRatio, it->toDouble(),
                                     PhosphorTiles::AutotileDefaults::MaxSplitRatio));
     }
 
-    it = overrides.constFind(QStringLiteral("MasterCount"));
+    it = overrides.constFind(QString(PerScreenKeys::MasterCount));
     if (it != overrides.constEnd()) {
         state->setMasterCount(qBound(PhosphorTiles::AutotileDefaults::MinMasterCount, it->toInt(),
                                      PhosphorTiles::AutotileDefaults::MaxMasterCount));
@@ -60,13 +60,13 @@ void PerScreenConfigResolver::applyPerScreenConfig(const QString& screenId, cons
 
     // If algorithm changed and split ratio wasn't explicitly overridden,
     // reset to the new algorithm's default (matching setAlgorithm() logic).
-    it = overrides.constFind(QStringLiteral("Algorithm"));
+    it = overrides.constFind(QString(PerScreenKeys::Algorithm));
     if (it != overrides.constEnd()) {
         QString algoId = it->toString();
         auto* registry = m_engine->algorithmRegistry();
         PhosphorTiles::TilingAlgorithm* newAlgo = registry->algorithm(algoId);
         if (newAlgo) {
-            if (!overrides.contains(QStringLiteral("SplitRatio"))) {
+            if (!overrides.contains(QString(PerScreenKeys::SplitRatio))) {
                 state->setSplitRatio(newAlgo->defaultSplitRatio());
             }
         }
@@ -268,14 +268,14 @@ int PerScreenConfigResolver::effectiveOuterGap(const QString& screenId) const
 
 bool PerScreenConfigResolver::effectiveSmartGaps(const QString& screenId) const
 {
-    if (auto v = perScreenOverride(screenId, QStringLiteral("SmartGaps")))
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::SmartGaps)))
         return v->toBool();
     return m_engine->config()->smartGaps;
 }
 
 bool PerScreenConfigResolver::effectiveRespectMinimumSize(const QString& screenId) const
 {
-    if (auto v = perScreenOverride(screenId, QStringLiteral("RespectMinimumSize")))
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::RespectMinimumSize)))
         return v->toBool();
     return m_engine->config()->respectMinimumSize;
 }

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -143,6 +143,18 @@ void PerScreenConfigResolver::removeOverridesForScreen(const QString& screenId)
 
 std::optional<QVariant> PerScreenConfigResolver::perScreenOverride(const QString& screenId, const QString& key) const
 {
+    // Highest precedence: a per-context (window-rule) gap override for this
+    // screen's current context, matching the snapping gap pipeline where the
+    // context override is the top layer. Only gap keys appear in the provider's
+    // map, so non-gap lookups (algorithm, split ratio, …) fall straight
+    // through to the static per-screen overrides below.
+    if (m_contextGapProvider) {
+        const QVariantMap ctx = m_contextGapProvider(screenId);
+        auto cit = ctx.constFind(key);
+        if (cit != ctx.constEnd()) {
+            return *cit;
+        }
+    }
     auto it = m_perScreenOverrides.constFind(screenId);
     if (it != m_perScreenOverrides.constEnd()) {
         auto git = it->constFind(key);

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -154,8 +154,9 @@ std::optional<QVariant> PerScreenConfigResolver::perScreenOverride(const QString
 }
 
 namespace {
-// Clamp a raw gap value to the shared [MinGap, MaxGap] range — the same range
-// the snapping side clamps to (tied by a static_assert in the daemon).
+// Clamp a raw gap value to [MinGap, MaxGap]. The ceiling is tied to the
+// snapping side by a static_assert in the daemon; the floor is a fixed 0 on
+// both sides (snapping has no MinGap constant to tie against).
 int clampGap(int v)
 {
     return qBound(PhosphorTiles::AutotileDefaults::MinGap, v, PhosphorTiles::AutotileDefaults::MaxGap);

--- a/libs/phosphor-zones/include/PhosphorZones/Zone.h
+++ b/libs/phosphor-zones/include/PhosphorZones/Zone.h
@@ -214,7 +214,6 @@ public:
     Q_INVOKABLE bool containsPoint(const QPointF& point) const;
     Q_INVOKABLE qreal distanceToPoint(const QPointF& point) const;
     Q_INVOKABLE QRectF calculateAbsoluteGeometry(const QRectF& screenGeometry) const;
-    Q_INVOKABLE QRectF applyPadding(int padding) const;
 
     /**
      * @brief Pure helper shared between Zone::calculateAbsoluteGeometry and

--- a/libs/phosphor-zones/src/zone.cpp
+++ b/libs/phosphor-zones/src/zone.cpp
@@ -204,11 +204,6 @@ QRectF Zone::normalizedGeometry(const QRectF& referenceGeometry) const
     return m_relativeGeometry;
 }
 
-QRectF Zone::applyPadding(int padding) const
-{
-    return m_geometry.adjusted(padding, padding, -padding, -padding);
-}
-
 QJsonObject Zone::toJson(const QRectF& referenceGeometry) const
 {
     using namespace ::PhosphorZones::ZoneJsonKeys;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -102,6 +102,18 @@
 
 namespace PlasmaZones {
 
+// Snapping and autotile gaps are the SAME two quantities under different names:
+// snapping's per-zone "zonePadding" is the full inter-region gap (each zone's
+// interior edge insets by zonePadding/2, so two neighbours leave a zonePadding
+// gap — see GeometryUtils::applyGapsToZoneGeometry), exactly like autotile's
+// "innerGap" (the single gap between two tiles). Snapping "outerGap" and
+// autotile "outerGap" both inset the content area from the screen edge per side.
+// A context gap-override rule must therefore clamp to the same range in both
+// modes; these assertions fail the build if the two ranges ever drift apart.
+// (The defaults may legitimately differ per mode, so only the range is tied.)
+static_assert(Defaults::MaxGap == PhosphorTiles::AutotileDefaults::MaxGap,
+              "Snapping and autotile gap clamp ceilings must match — they are the same gap quantity");
+
 namespace {
 // Debounce interval (ms): coalesce rapid geometry changes (multi-screen, panel editor) into one update.
 // Conceptually distinct from DELAYED_PANEL_REQUERY_MS in autotile.cpp (which schedules a

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1154,10 +1154,11 @@ bool Daemon::init()
     // The closure resolves the screen's CURRENT context here (the engine library
     // stays settings-agnostic) and adapts ContextGapOverride into the
     // PerScreenKeys-shaped map the resolver already consumes.
-    // setContextGapProvider is derived-only (AutotileEngine), while
-    // m_autotileEngine is held as the base PlacementEngineBase — narrow with a
-    // qobject_cast (same pattern as the snap-engine wiring).
-    if (auto* autotileEngine = qobject_cast<PhosphorTileEngine::AutotileEngine*>(m_autotileEngine.get())) {
+    // setContextGapProvider is derived-only (AutotileEngine); m_autotileEngine is
+    // held as the base PlacementEngineBase. Use the derived `autotileEngine`
+    // pointer captured above — the std::move into m_autotileEngine transferred
+    // ownership but not the pointee, so it still points at the live engine.
+    if (autotileEngine) {
         autotileEngine->setContextGapProvider([this](const QString& screenId) -> QVariantMap {
             if (!m_layoutManager) {
                 return {};

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1164,25 +1164,33 @@ bool Daemon::init()
             if (gaps.isEmpty()) {
                 return {};
             }
+            namespace PSK = PhosphorEngine::PerScreenKeys;
             QVariantMap map;
             // zonePadding is snapping's inner spacing — the autotile inner gap.
             if (gaps.zonePadding) {
-                map.insert(QStringLiteral("InnerGap"), *gaps.zonePadding);
+                map.insert(QString(PSK::InnerGap), *gaps.zonePadding);
             }
             if (gaps.outerGap) {
-                map.insert(QStringLiteral("OuterGap"), *gaps.outerGap);
+                map.insert(QString(PSK::OuterGap), *gaps.outerGap);
+            }
+            // The per-side toggle gates whether the resolver honours the per-side
+            // values below — without it, stale per-side entries (left from when
+            // the rule had per-side enabled) would apply on autotile but not on
+            // snapping, which checks this flag (resolveOuterGapsFromMap).
+            if (gaps.usePerSideOuterGap) {
+                map.insert(QString(PSK::UsePerSideOuterGap), *gaps.usePerSideOuterGap);
             }
             if (gaps.outerGapTop) {
-                map.insert(QStringLiteral("OuterGapTop"), *gaps.outerGapTop);
+                map.insert(QString(PSK::OuterGapTop), *gaps.outerGapTop);
             }
             if (gaps.outerGapBottom) {
-                map.insert(QStringLiteral("OuterGapBottom"), *gaps.outerGapBottom);
+                map.insert(QString(PSK::OuterGapBottom), *gaps.outerGapBottom);
             }
             if (gaps.outerGapLeft) {
-                map.insert(QStringLiteral("OuterGapLeft"), *gaps.outerGapLeft);
+                map.insert(QString(PSK::OuterGapLeft), *gaps.outerGapLeft);
             }
             if (gaps.outerGapRight) {
-                map.insert(QStringLiteral("OuterGapRight"), *gaps.outerGapRight);
+                map.insert(QString(PSK::OuterGapRight), *gaps.outerGapRight);
             }
             return map;
         });

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1154,8 +1154,11 @@ bool Daemon::init()
     // The closure resolves the screen's CURRENT context here (the engine library
     // stays settings-agnostic) and adapts ContextGapOverride into the
     // PerScreenKeys-shaped map the resolver already consumes.
-    if (m_autotileEngine) {
-        m_autotileEngine->setContextGapProvider([this](const QString& screenId) -> QVariantMap {
+    // setContextGapProvider is derived-only (AutotileEngine), while
+    // m_autotileEngine is held as the base PlacementEngineBase — narrow with a
+    // qobject_cast (same pattern as the snap-engine wiring).
+    if (auto* autotileEngine = qobject_cast<PhosphorTileEngine::AutotileEngine*>(m_autotileEngine.get())) {
+        autotileEngine->setContextGapProvider([this](const QString& screenId) -> QVariantMap {
             if (!m_layoutManager) {
                 return {};
             }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2160,6 +2160,17 @@ void Daemon::stop()
         m_windowTrackingAdaptor->setWindowRuleStore(nullptr);
     }
 
+    // Clear the autotile context-gap provider, which captures `this` (Daemon, via
+    // m_layoutManager / currentDesktopForScreen / currentActivity). No live deref
+    // can occur today — m_autotileEngine is destroyed below while `this` is still
+    // alive — but clearing it keeps the "every `this`-capturing closure is cleared
+    // before teardown" contract complete and grep-discoverable, exactly like the
+    // SnapEngine exclude-rule borrow above. `m_autotileEngine` is base-typed
+    // `PlacementEngineBase*`; setContextGapProvider lives on the concrete engine.
+    if (auto* concreteAutotile = qobject_cast<PhosphorTileEngine::AutotileEngine*>(m_autotileEngine.get())) {
+        concreteAutotile->setContextGapProvider({});
+    }
+
     // Destroy engines now (during stop(), before Qt child destruction order).
     m_snapEngine.reset();
     m_autotileEngine.reset();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1136,6 +1136,46 @@ bool Daemon::init()
     m_snapEngine = std::move(engines.snap);
     m_screenModeRouter = std::move(engines.router);
 
+    // Per-context (window-rule) gap overrides for autotile. Snapping resolves
+    // these as the highest-priority gap layer (GeometryUtils::getEffective*);
+    // without this, a context gap rule was silently ignored on tiled windows.
+    // The closure resolves the screen's CURRENT context here (the engine library
+    // stays settings-agnostic) and adapts ContextGapOverride into the
+    // PerScreenKeys-shaped map the resolver already consumes.
+    if (m_autotileEngine) {
+        m_autotileEngine->setContextGapProvider([this](const QString& screenId) -> QVariantMap {
+            if (!m_layoutManager) {
+                return {};
+            }
+            const PhosphorZones::ContextGapOverride gaps =
+                m_layoutManager->resolveContextGaps(screenId, currentDesktopForScreen(screenId), currentActivity());
+            if (gaps.isEmpty()) {
+                return {};
+            }
+            QVariantMap map;
+            // zonePadding is snapping's inner spacing — the autotile inner gap.
+            if (gaps.zonePadding) {
+                map.insert(QStringLiteral("InnerGap"), *gaps.zonePadding);
+            }
+            if (gaps.outerGap) {
+                map.insert(QStringLiteral("OuterGap"), *gaps.outerGap);
+            }
+            if (gaps.outerGapTop) {
+                map.insert(QStringLiteral("OuterGapTop"), *gaps.outerGapTop);
+            }
+            if (gaps.outerGapBottom) {
+                map.insert(QStringLiteral("OuterGapBottom"), *gaps.outerGapBottom);
+            }
+            if (gaps.outerGapLeft) {
+                map.insert(QStringLiteral("OuterGapLeft"), *gaps.outerGapLeft);
+            }
+            if (gaps.outerGapRight) {
+                map.insert(QStringLiteral("OuterGapRight"), *gaps.outerGapRight);
+            }
+            return map;
+        });
+    }
+
     // Build the PhosphorContext::ContextResolver wiring NOW — after the
     // workspace managers, settings, and router exist; before any D-Bus
     // adaptor or OverlayService method that consumes it runs. Three

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -158,6 +158,17 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
             return shouldRestoreFloatedPosition(windowId, PhosphorZones::AssignmentEntry::Mode::Snapping);
         });
 
+        // Managed (snapped-to-zone) restore gate. The snapped-to-zone analogue of
+        // the floated-position predicate above: when the user disables
+        // `restoreWindowsToZonesOnLogin`, a window that was snapped at logout is
+        // not auto-restored to its recorded zone on reopen. Settings-gated, so the
+        // engine stays settings-agnostic. windowId is unused today (the policy is a
+        // single global toggle) but keeps the signature aligned with the floated
+        // predicate for a future per-window override.
+        snap->setManagedRestorePredicate([this](const QString& /*windowId*/) -> bool {
+            return m_settings->restoreWindowsToZonesOnLogin();
+        });
+
         // Open-floating gate (snap). A matched "Float this app" rule opens the
         // window floating instead of auto-snapping it. Purely rule-driven (no
         // global default), so the same resolver serves both engines.

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -101,6 +101,8 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
     if (m_cachedSnapEngine) {
         m_cachedSnapEngine->setShouldRestorePredicate({});
         m_cachedSnapEngine->setRestorePositionPredicate({});
+        m_cachedSnapEngine->setManagedRestorePredicate({});
+        m_cachedSnapEngine->setExclusionQueryProvider({});
         m_cachedSnapEngine->setFloatPredicate({});
         m_cachedSnapEngine->setPlacementZonesResolver({});
     }

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -29,6 +29,14 @@
 
 namespace PlasmaZones {
 
+namespace {
+// Defined further down in this TU's anonymous namespace; forward-declared here
+// so setEngines() (above that definition) can reference it from the snap
+// engine's exclusion-query-provider closure.
+std::optional<PhosphorWindowRules::WindowQuery>
+buildRuleQueryForWindow(const QPointer<PhosphorEngine::WindowRegistry>& registry, const QString& windowId);
+} // namespace
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Engine wiring — cross-references and shared navigation feedback
 //
@@ -168,6 +176,18 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
         snap->setManagedRestorePredicate([this](const QString& /*windowId*/) -> bool {
             return m_settings->restoreWindowsToZonesOnLogin();
         });
+
+        // Full-query exclusion provider. The snap engine owns the Exclude rule
+        // set + evaluator but, without this, could only build an appId-only
+        // query — so Exclude rules keyed on window class / title / size, and the
+        // minimum-window-size thresholds, were silently ignored on snap (the
+        // autotile engine, which sees the live window in the effect, honoured
+        // them). Supplying the same full WindowQuery the float / restore
+        // predicates use brings snapping to parity.
+        snap->setExclusionQueryProvider(
+            [this](const QString& windowId) -> std::optional<PhosphorWindowRules::WindowQuery> {
+                return buildRuleQueryForWindow(m_windowRegistry, windowId);
+            });
 
         // Open-floating gate (snap). A matched "Float this app" rule opens the
         // window floating instead of auto-snapping it. Purely rule-driven (no

--- a/tests/unit/autotile/test_per_screen_config.cpp
+++ b/tests/unit/autotile/test_per_screen_config.cpp
@@ -300,6 +300,61 @@ private Q_SLOTS:
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // Context gap provider (per-context window-rule gap overrides) — highest
+    // precedence, matching the snapping gap pipeline.
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    void testPerScreen_contextGapProvider_beatsPerScreenAndGlobal()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("DP-1");
+        engine.setAutotileScreens({screen});
+
+        // Global + per-screen gaps (the lower-precedence layers).
+        engine.config()->innerGap = 4;
+        engine.config()->outerGap = 6;
+        QVariantMap overrides;
+        overrides[QStringLiteral("InnerGap")] = 8;
+        overrides[QStringLiteral("OuterGap")] = 10;
+        engine.applyPerScreenConfig(screen, overrides);
+        QCOMPARE(engine.effectiveInnerGap(screen), 8); // per-screen beats global
+        QCOMPARE(engine.effectiveOuterGap(screen), 10);
+
+        // A context gap override for this screen must win over both.
+        engine.setContextGapProvider([screen](const QString& s) -> QVariantMap {
+            if (s != screen) {
+                return {};
+            }
+            QVariantMap m;
+            m.insert(QStringLiteral("InnerGap"), 14);
+            m.insert(QStringLiteral("OuterGap"), 18);
+            return m;
+        });
+        QCOMPARE(engine.effectiveInnerGap(screen), 14);
+        QCOMPARE(engine.effectiveOuterGap(screen), 18);
+
+        // A different screen with no context override still resolves normally.
+        const QString other = QStringLiteral("DP-2");
+        engine.setAutotileScreens({screen, other});
+        QCOMPARE(engine.effectiveInnerGap(other), 4); // global (no per-screen, no context)
+        QCOMPARE(engine.effectiveOuterGap(other), 6);
+    }
+
+    void testPerScreen_contextGapProvider_emptyMapFallsThrough()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("DP-1");
+        engine.setAutotileScreens({screen});
+        engine.config()->innerGap = 5;
+
+        // Provider returns an empty map → no context override → global value.
+        engine.setContextGapProvider([](const QString&) -> QVariantMap {
+            return {};
+        });
+        QCOMPARE(engine.effectiveInnerGap(screen), 5);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // Edge cases
     // ═══════════════════════════════════════════════════════════════════════════
 

--- a/tests/unit/autotile/test_per_screen_config.cpp
+++ b/tests/unit/autotile/test_per_screen_config.cpp
@@ -354,6 +354,96 @@ private Q_SLOTS:
         QCOMPARE(engine.effectiveInnerGap(screen), 5);
     }
 
+    // Context per-side outer gaps are honoured (and beat a per-screen per-side
+    // override) only when the rule set UsePerSideOuterGap — mirroring snapping.
+    void testPerScreen_contextGapProvider_perSideHonoredWhenUsePerSideSet()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("DP-1");
+        engine.setAutotileScreens({screen});
+        engine.config()->outerGap = 6;
+
+        // A per-screen per-side override sits below the context layer.
+        QVariantMap overrides;
+        overrides[QStringLiteral("OuterGapTop")] = 10;
+        engine.applyPerScreenConfig(screen, overrides);
+
+        engine.setContextGapProvider([screen](const QString& s) -> QVariantMap {
+            if (s != screen) {
+                return {};
+            }
+            QVariantMap m;
+            m.insert(QStringLiteral("UsePerSideOuterGap"), true);
+            m.insert(QStringLiteral("OuterGapTop"), 20);
+            m.insert(QStringLiteral("OuterGapBottom"), 22);
+            return m;
+        });
+
+        const ::PhosphorLayout::EdgeGaps gaps = engine.effectiveOuterGaps(screen);
+        QCOMPARE(gaps.top, 20); // context per-side beats per-screen per-side (10)
+        QCOMPARE(gaps.bottom, 22);
+        // Unset sides fall back to the global outer gap (no context uniform).
+        QCOMPARE(gaps.left, 6);
+        QCOMPARE(gaps.right, 6);
+    }
+
+    // Context per-side outer gaps WITHOUT UsePerSideOuterGap are ignored — a
+    // stale per-side entry must not apply (it would diverge from snapping).
+    void testPerScreen_contextGapProvider_perSideIgnoredWhenUsePerSideUnset()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("DP-1");
+        engine.setAutotileScreens({screen});
+        engine.config()->outerGap = 6;
+
+        engine.setContextGapProvider([screen](const QString& s) -> QVariantMap {
+            if (s != screen) {
+                return {};
+            }
+            QVariantMap m;
+            m.insert(QStringLiteral("OuterGapTop"), 30); // no UsePerSideOuterGap flag
+            return m;
+        });
+
+        const ::PhosphorLayout::EdgeGaps gaps = engine.effectiveOuterGaps(screen);
+        // The context layer yields nothing (per-side gated off, no uniform), so
+        // resolution falls through to the global uniform outer gap.
+        QCOMPARE(gaps.top, 6);
+        QCOMPARE(gaps.bottom, 6);
+        QCOMPARE(gaps.left, 6);
+        QCOMPARE(gaps.right, 6);
+    }
+
+    // A context uniform OuterGap wins as one atomic layer: it is NOT blended
+    // per-key with a static per-screen per-side override below it.
+    void testPerScreen_contextGapProvider_uniformWinsAtomicallyOverPerScreenPerSide()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("DP-1");
+        engine.setAutotileScreens({screen});
+        engine.config()->outerGap = 6;
+
+        QVariantMap overrides;
+        overrides[QStringLiteral("OuterGapTop")] = 40; // per-screen per-side
+        engine.applyPerScreenConfig(screen, overrides);
+
+        engine.setContextGapProvider([screen](const QString& s) -> QVariantMap {
+            if (s != screen) {
+                return {};
+            }
+            QVariantMap m;
+            m.insert(QStringLiteral("OuterGap"), 12); // context uniform, no per-side
+            return m;
+        });
+
+        const ::PhosphorLayout::EdgeGaps gaps = engine.effectiveOuterGaps(screen);
+        // All sides take the context uniform; the per-screen top=40 does NOT bleed in.
+        QCOMPARE(gaps.top, 12);
+        QCOMPARE(gaps.bottom, 12);
+        QCOMPARE(gaps.left, 12);
+        QCOMPARE(gaps.right, 12);
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Edge cases
     // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -1793,6 +1793,81 @@ private Q_SLOTS:
         QVERIFY(!engine.isAppIdExcluded(QStringLiteral("konsole")));
     }
 
+    // isWindowExcluded — full-query exclusion (parity with autotile)
+    //
+    // With the daemon's exclusion query provider wired, a window's FULL
+    // attributes are evaluated, so an Exclude rule keyed on a non-appId field
+    // (here Title) matches — where the appId-only path silently would not.
+    void testWindowExcluded_fullQueryMatchesNonAppIdRule()
+    {
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+
+        PhosphorWindowRules::WindowRuleSet set;
+        PhosphorWindowRules::WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.enabled = true;
+        rule.match = PhosphorWindowRules::MatchExpression::makeLeaf(
+            PhosphorWindowRules::Field::Title, PhosphorWindowRules::Operator::Contains, QStringLiteral("scratch"));
+        PhosphorWindowRules::RuleAction action;
+        action.type = QString(PhosphorWindowRules::ActionType::Exclude);
+        rule.actions.append(action);
+        QVERIFY(set.addRule(rule));
+        engine.setExcludeRuleSet(&set);
+
+        // Without the provider, the appId-only query can't see the title — the
+        // Title rule stays inert (the historical gap).
+        QVERIFY(!engine.isWindowExcluded(QStringLiteral("app|win")));
+
+        // With the provider supplying a full query, the Title rule matches.
+        engine.setExclusionQueryProvider([](const QString&) {
+            PhosphorWindowRules::WindowQuery q;
+            q.appId = QStringLiteral("editor");
+            q.title = QStringLiteral("scratchpad - notes");
+            return std::optional<PhosphorWindowRules::WindowQuery>(q);
+        });
+        QVERIFY(engine.isWindowExcluded(QStringLiteral("app|win")));
+
+        // A non-matching title is not excluded.
+        engine.setExclusionQueryProvider([](const QString&) {
+            PhosphorWindowRules::WindowQuery q;
+            q.title = QStringLiteral("main window");
+            return std::optional<PhosphorWindowRules::WindowQuery>(q);
+        });
+        QVERIFY(!engine.isWindowExcluded(QStringLiteral("app|win")));
+    }
+
+    // isWindowExcluded — minimum-window-size exclusion (parity with autotile)
+    void testWindowExcluded_minimumWindowSize()
+    {
+        SnapEngine engine(nullptr, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_settings->setMinimumWindowWidth(200);
+        m_settings->setMinimumWindowHeight(150);
+
+        // Sub-threshold frame → excluded (when the full query carries the size).
+        engine.setExclusionQueryProvider([](const QString&) {
+            PhosphorWindowRules::WindowQuery q;
+            q.width = 120;
+            q.height = 90;
+            return std::optional<PhosphorWindowRules::WindowQuery>(q);
+        });
+        QVERIFY(engine.isWindowExcluded(QStringLiteral("app|tiny")));
+
+        // At/above threshold → not excluded.
+        engine.setExclusionQueryProvider([](const QString&) {
+            PhosphorWindowRules::WindowQuery q;
+            q.width = 800;
+            q.height = 600;
+            return std::optional<PhosphorWindowRules::WindowQuery>(q);
+        });
+        QVERIFY(!engine.isWindowExcluded(QStringLiteral("app|big")));
+
+        // No provider → no frame size is known, so the size threshold is not
+        // applied (the appId-only fallback, preserving historical behaviour).
+        engine.setExclusionQueryProvider({});
+        QVERIFY(!engine.isWindowExcluded(QStringLiteral("app|unknown")));
+    }
+
     // Honest scope of this test (renamed from the earlier
     // `…InvalidatesEvalCache` name): exercises that across in-place
     // `WindowRuleSet::setRules` edits at the SAME bound pointer, the

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -1036,6 +1036,110 @@ private Q_SLOTS:
     }
 
     // =========================================================================
+    // resolveWindowRestore — managed (snapped-to-zone) restore gate
+    // (ManagedRestorePredicate, restoreWindowsToZonesOnLogin)
+    //
+    // The daemon injects a predicate wired to restoreWindowsToZonesOnLogin. When
+    // it returns false a window that was SNAPPED last session must NOT be
+    // restored to its recorded zone on reopen — the snapped record is skipped and
+    // the window falls through to the normal chain. The distinctive log isolates
+    // this gate from a disabled-context veto. With no predicate (or one returning
+    // true) the snapped path is taken (it still resolves to noSnap in this guiless
+    // fixture because zone geometry can't resolve, asserted via log absence).
+    // =========================================================================
+
+    void testResolveWindowRestore_managedRestoreGate_rejectsWhenOff()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        // restoreWindowsToZonesOnLogin is OFF.
+        engine.setManagedRestorePredicate([](const QString&) {
+            return false;
+        });
+
+        // A window snapped on DP-1 (its recorded screen, snapping mode).
+        PhosphorEngine::WindowPlacement rec;
+        rec.windowId = QStringLiteral("app|orig");
+        rec.appId = QStringLiteral("app");
+        rec.screenId = QStringLiteral("DP-1");
+        PhosphorEngine::EngineSlot slot;
+        slot.state = PhosphorEngine::WindowPlacement::stateSnapped();
+        slot.zoneIds = QStringList{QStringLiteral("z1")};
+        rec.engines.insert(PhosphorEngine::WindowPlacement::snapEngineId(), slot);
+        m_wts->placementStore().record(rec);
+
+        PhosphorEngine::SnapResult result;
+        const QStringList lines =
+            captureResolveLogs(engine, QStringLiteral("app|new"), QStringLiteral("DP-1"), &result);
+
+        QVERIFY2(!result.shouldSnap, "with managed restore off, a snapped record must not be re-applied");
+        QVERIFY2(lines.join(QLatin1Char('\n')).contains(QStringLiteral("managed-restore gate skipped snapped record")),
+                 "the managed-restore gate must be the branch that skipped the snapped record");
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testResolveWindowRestore_managedRestoreGate_allowsWhenOn()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        engine.setManagedRestorePredicate([](const QString&) {
+            return true;
+        });
+
+        PhosphorEngine::WindowPlacement rec;
+        rec.windowId = QStringLiteral("app|orig");
+        rec.appId = QStringLiteral("app");
+        rec.screenId = QStringLiteral("DP-1");
+        PhosphorEngine::EngineSlot slot;
+        slot.state = PhosphorEngine::WindowPlacement::stateSnapped();
+        slot.zoneIds = QStringList{QStringLiteral("z1")};
+        rec.engines.insert(PhosphorEngine::WindowPlacement::snapEngineId(), slot);
+        m_wts->placementStore().record(rec);
+
+        PhosphorEngine::SnapResult result;
+        const QStringList lines =
+            captureResolveLogs(engine, QStringLiteral("app|new"), QStringLiteral("DP-1"), &result);
+
+        // Geometry can't resolve in the guiless fixture, so the snapped restore
+        // still terminates at noSnap — but the managed gate must NOT be what
+        // skipped it.
+        QVERIFY2(!lines.join(QLatin1Char('\n')).contains(QStringLiteral("managed-restore gate skipped snapped record")),
+                 "with managed restore on, the managed-restore gate must not fire");
+        m_wts->setSnapState(nullptr);
+    }
+
+    void testResolveWindowRestore_managedRestoreGate_noPredicateRestores()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        // No predicate injected — the engine must restore snapped records
+        // unconditionally (the historical default).
+        PhosphorEngine::WindowPlacement rec;
+        rec.windowId = QStringLiteral("app|orig");
+        rec.appId = QStringLiteral("app");
+        rec.screenId = QStringLiteral("DP-1");
+        PhosphorEngine::EngineSlot slot;
+        slot.state = PhosphorEngine::WindowPlacement::stateSnapped();
+        slot.zoneIds = QStringList{QStringLiteral("z1")};
+        rec.engines.insert(PhosphorEngine::WindowPlacement::snapEngineId(), slot);
+        m_wts->placementStore().record(rec);
+
+        PhosphorEngine::SnapResult result;
+        const QStringList lines =
+            captureResolveLogs(engine, QStringLiteral("app|new"), QStringLiteral("DP-1"), &result);
+
+        QVERIFY2(!lines.join(QLatin1Char('\n')).contains(QStringLiteral("managed-restore gate skipped snapped record")),
+                 "with no predicate the managed-restore gate must never fire");
+        m_wts->setSnapState(nullptr);
+    }
+
+    // =========================================================================
     // resolveWindowRestore — open-floating gate (FloatPredicate)
     //
     // The daemon injects a predicate that returns true when a "Float this app"

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -1869,6 +1869,15 @@ private Q_SLOTS:
         });
         QVERIFY(!engine.isWindowExcluded(QStringLiteral("app|big")));
 
+        // Exactly AT the threshold → not excluded (the comparison is strict `<`).
+        engine.setExclusionQueryProvider([](const QString&) {
+            PhosphorWindowRules::WindowQuery q;
+            q.width = 200; // == minW
+            q.height = 150; // == minH
+            return std::optional<PhosphorWindowRules::WindowQuery>(q);
+        });
+        QVERIFY(!engine.isWindowExcluded(QStringLiteral("app|exact")));
+
         // OR semantics: width under but height over → excluded (pins that the
         // check is OR, not AND, and that each dimension is evaluated).
         engine.setExclusionQueryProvider([](const QString&) {

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -1917,6 +1917,42 @@ private Q_SLOTS:
         QVERIFY(!engine.isWindowExcluded(QStringLiteral("app|unknown")));
     }
 
+    // resolveWindowRestore — full-query/size exclusion path (parity consumer)
+    //
+    // isWindowExcluded is exercised in isolation above; this pins the production
+    // wiring in resolveWindowRestore (lifecycle.cpp), which switched from the
+    // appId-only isAppIdExcluded to the full-query isWindowExcluded. A window
+    // with no stored record falls through to the legacy chain and must be
+    // refused (noSnap) when its full query is sub-threshold, with the distinct
+    // "excluded by rule or size" log identifying the branch that produced it.
+    void testResolveWindowRestore_excludedBySize_returnsNoSnap()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        m_settings->setMinimumWindowWidth(200);
+        m_settings->setMinimumWindowHeight(150);
+        // Full query carries a sub-threshold frame → isWindowExcluded is true.
+        engine.setExclusionQueryProvider([](const QString&) {
+            PhosphorWindowRules::WindowQuery q;
+            q.width = 80;
+            q.height = 60;
+            return std::optional<PhosphorWindowRules::WindowQuery>(q);
+        });
+
+        // No stored record for this windowId → resolveWindowRestore falls through
+        // to the legacy chain and hits the exclusion check.
+        PhosphorEngine::SnapResult result;
+        const QStringList lines =
+            captureResolveLogs(engine, QStringLiteral("app|tiny-restore"), QStringLiteral("DP-1"), &result);
+
+        QVERIFY2(!result.shouldSnap, "a size-excluded window must not be auto-restored");
+        QVERIFY2(lines.join(QLatin1Char('\n')).contains(QStringLiteral("excluded by rule or size")),
+                 "the exclusion branch (rule or size) must be the one that refused the restore");
+        m_wts->setSnapState(nullptr);
+    }
+
     // Honest scope of this test (renamed from the earlier
     // `…InvalidatesEvalCache` name): exercises that across in-place
     // `WindowRuleSet::setRules` edits at the SAME bound pointer, the

--- a/tests/unit/core/test_snap_engine.cpp
+++ b/tests/unit/core/test_snap_engine.cpp
@@ -1086,7 +1086,14 @@ private Q_SLOTS:
         engine.setEngineSettings(m_settings);
         m_wts->setSnapState(engine.snapState());
 
-        engine.setManagedRestorePredicate([](const QString&) {
+        // Record that the gate actually CONSULTED the predicate. Geometry can't
+        // resolve in the guiless fixture, so we can't assert a positive snap —
+        // but this flag fails if the managed-restore gate were removed entirely
+        // (a full revert would never call the predicate), which a bare
+        // log-absence assertion would not catch.
+        bool consulted = false;
+        engine.setManagedRestorePredicate([&consulted](const QString&) {
+            consulted = true;
             return true;
         });
 
@@ -1104,11 +1111,9 @@ private Q_SLOTS:
         const QStringList lines =
             captureResolveLogs(engine, QStringLiteral("app|new"), QStringLiteral("DP-1"), &result);
 
-        // Geometry can't resolve in the guiless fixture, so the snapped restore
-        // still terminates at noSnap — but the managed gate must NOT be what
-        // skipped it.
+        QVERIFY2(consulted, "the snapped-record restore path must consult the managed-restore predicate");
         QVERIFY2(!lines.join(QLatin1Char('\n')).contains(QStringLiteral("managed-restore gate skipped snapped record")),
-                 "with managed restore on, the managed-restore gate must not fire");
+                 "with managed restore on, the managed-restore gate must not skip the record");
         m_wts->setSnapState(nullptr);
     }
 
@@ -1119,7 +1124,9 @@ private Q_SLOTS:
         m_wts->setSnapState(engine.snapState());
 
         // No predicate injected — the engine must restore snapped records
-        // unconditionally (the historical default).
+        // unconditionally (the historical default). This guards against a
+        // regression that treated a NULL predicate as "block" (skip): the gate
+        // must never fire when no predicate is wired.
         PhosphorEngine::WindowPlacement rec;
         rec.windowId = QStringLiteral("app|orig");
         rec.appId = QStringLiteral("app");
@@ -1862,8 +1869,41 @@ private Q_SLOTS:
         });
         QVERIFY(!engine.isWindowExcluded(QStringLiteral("app|big")));
 
+        // OR semantics: width under but height over → excluded (pins that the
+        // check is OR, not AND, and that each dimension is evaluated).
+        engine.setExclusionQueryProvider([](const QString&) {
+            PhosphorWindowRules::WindowQuery q;
+            q.width = 120; // under 200
+            q.height = 600; // over 150
+            return std::optional<PhosphorWindowRules::WindowQuery>(q);
+        });
+        QVERIFY(engine.isWindowExcluded(QStringLiteral("app|narrow")));
+
+        // Symmetric: height under but width over → excluded.
+        engine.setExclusionQueryProvider([](const QString&) {
+            PhosphorWindowRules::WindowQuery q;
+            q.width = 800; // over 200
+            q.height = 90; // under 150
+            return std::optional<PhosphorWindowRules::WindowQuery>(q);
+        });
+        QVERIFY(engine.isWindowExcluded(QStringLiteral("app|short")));
+
+        // A zero threshold disables that dimension: a 1x1 window is NOT excluded
+        // by size when both thresholds are 0 (guards the `> 0` enable check).
+        m_settings->setMinimumWindowWidth(0);
+        m_settings->setMinimumWindowHeight(0);
+        engine.setExclusionQueryProvider([](const QString&) {
+            PhosphorWindowRules::WindowQuery q;
+            q.width = 1;
+            q.height = 1;
+            return std::optional<PhosphorWindowRules::WindowQuery>(q);
+        });
+        QVERIFY(!engine.isWindowExcluded(QStringLiteral("app|zero-thresh")));
+
         // No provider → no frame size is known, so the size threshold is not
         // applied (the appId-only fallback, preserving historical behaviour).
+        m_settings->setMinimumWindowWidth(200);
+        m_settings->setMinimumWindowHeight(150);
         engine.setExclusionQueryProvider({});
         QVERIFY(!engine.isWindowExcluded(QStringLiteral("app|unknown")));
     }

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -446,17 +446,19 @@ public:
     }
     int minimumWindowWidth() const override
     {
-        return 0;
+        return m_minimumWindowWidth;
     }
-    void setMinimumWindowWidth(int) override
+    void setMinimumWindowWidth(int w) override
     {
+        m_minimumWindowWidth = w;
     }
     int minimumWindowHeight() const override
     {
-        return 0;
+        return m_minimumWindowHeight;
     }
-    void setMinimumWindowHeight(int) override
+    void setMinimumWindowHeight(int h) override
     {
+        m_minimumWindowHeight = h;
     }
 
     // Animation window filtering — pure-stub no-op accessors backed by
@@ -1193,6 +1195,8 @@ private:
     // Animation-filter defaults routed through ConfigDefaults so a future
     // tweak to the production defaults flows into tests automatically — keeps
     // the stub from drifting into "tests pass against a stale baseline".
+    int m_minimumWindowWidth = 0;
+    int m_minimumWindowHeight = 0;
     bool m_animationExcludeTransientWindows = ConfigDefaults::animationExcludeTransientWindows();
     bool m_animationExcludeNotificationsAndOsd = ConfigDefaults::animationExcludeNotificationsAndOsd();
     int m_animationMinimumWindowWidth = ConfigDefaults::animationMinimumWindowWidth();

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -1192,11 +1192,11 @@ private:
     QStringList m_snappingLayoutOrder;
     QStringList m_tilingAlgorithmOrder;
     QVariantList m_dragActivationTriggers;
+    int m_minimumWindowWidth = 0;
+    int m_minimumWindowHeight = 0;
     // Animation-filter defaults routed through ConfigDefaults so a future
     // tweak to the production defaults flows into tests automatically — keeps
     // the stub from drifting into "tests pass against a stale baseline".
-    int m_minimumWindowWidth = 0;
-    int m_minimumWindowHeight = 0;
     bool m_animationExcludeTransientWindows = ConfigDefaults::animationExcludeTransientWindows();
     bool m_animationExcludeNotificationsAndOsd = ConfigDefaults::animationExcludeNotificationsAndOsd();
     int m_animationMinimumWindowWidth = ConfigDefaults::animationMinimumWindowWidth();


### PR DESCRIPTION
Follow-up fixes from the snapping-vs-autotile parity audit (the same investigation that surfaced the Quick Shortcuts bug, #684). Each is an independent, tested commit.

## 1. `restoreWindowsToZonesOnLogin` was a dead setting
The toggle round-tripped through config, D-Bus, and the UI but its getter was **never called** — a window snapped at logout always restored to its zone regardless of the setting. The `ISnapSettings` doc already says this setting governs the managed (snapped-to-zone) restore.

Added a `ManagedRestorePredicate` to `SnapEngine` (the snapped-to-zone analogue of the existing floated `RestorePositionPredicate`), consulted in `resolveWindowRestore` before re-applying a stored snap. The daemon wires it to the setting; the engine stays settings-agnostic.

## 2 + 3. Snapping ignored window-class/title/size exclusions
The autotile engine honors the full exclusion model (window class, title, size, min-window-size) because it sees the live window in the effect. The snap engine evaluated exclusion with an **appId-only** `WindowQuery` and ignored the minimum-window-size thresholds entirely — so an exclusion rule keyed on class/title/size, or the min-size setting, excluded a window from tiling but let snapping snap it.

Added a daemon-injected `ExclusionQueryProvider` (the same `buildRuleQueryForWindow` the float/restore predicates use) so the snap engine evaluates the **full** query, plus `minimumWindowWidth/Height` on `ISnapSettings` for the size threshold. The appId-only path remains the fallback when metadata isn't yet known.

*(Note: the audit originally flagged a `Q_UNUSED(minWidth, minHeight)` in `windowOpened`, but those are the window's **declared** min-size for tile-sizing — legitimately unused by snapping. The real gap was the exclusion path, which is what this fixes.)*

## 4. Autotile ignored per-context gap overrides
A window-rule gap override scoped to a context (screen/desktop/activity) was the highest-priority layer in the snapping gap pipeline but silently ignored by autotile, whose `PerScreenConfigResolver` resolved gaps only from per-screen + global config.

Added a daemon-injected context-gap provider consulted at the single gap-lookup chokepoint, so it takes precedence over per-screen and global for every gap dimension — matching snapping. The daemon adapts `ContextGapOverride` into the resolver's `PerScreenKeys` map (`zonePadding → InnerGap`, `outerGap`/per-side → outer gaps).

## Behavior changes
- Snapping now refuses to snap windows matching an exclusion rule (any field) or under the min-window-size — previously it snapped them.
- `restoreWindowsToZonesOnLogin = off` now actually suppresses snapped-zone login restore.

## Testing
- Full build clean.
- `ctest`: **240/240 pass**, including new coverage for each fix (managed-restore gate, full-query + min-size exclusion, context-gap precedence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)