### PR TITLE
fix(overlay): layout names + autotile capability badges in previews

### DIFF
--- a/src/settings/qml/LayoutComboBox.qml
+++ b/src/settings/qml/LayoutComboBox.qml
@@ -518,6 +518,11 @@ ComboBox {
                         globalAutoAssign: root.appSettings && root.appSettings.autoAssignAllLayouts === true
                     }
 
+                    // Autotile capability badges (memory / reflow / script-state)
+                    PZCommon.CapabilityBadgeRow {
+                        layoutData: modelData.layout || ({})
+                    }
+
                     // Aspect ratio badge
                     PZCommon.AspectRatioBadge {
                         aspectRatioClass: (modelData.layout && modelData.layout.aspectRatioClass) || "any"

--- a/src/settings/qml/LayoutGridDelegate.qml
+++ b/src/settings/qml/LayoutGridDelegate.qml
@@ -56,31 +56,6 @@ Item {
     width: cellWidth
     height: cellHeight
 
-    // Small capability indicator (the memory / reflow / script-state card badges).
-    // One definition keeps the icon sizing, opacity, and hover-tooltip wiring in a
-    // single place; each instance sets only visible/source/color/text.
-    component CapabilityBadge: Kirigami.Icon {
-        id: badge
-
-        property string tooltipText
-
-        implicitWidth: Kirigami.Units.iconSizes.small
-        implicitHeight: Kirigami.Units.iconSizes.small
-        // Render as a mask tinted with `color` so every badge recolors uniformly:
-        // some symbolic icons (transform-scale, code-context) are not auto-recolored
-        // by the icon theme and would otherwise show a default grey, reading as
-        // "disabled" next to the recolored memory badge.
-        isMask: true
-        opacity: 0.7
-        ToolTip.delay: Kirigami.Units.toolTipDelay
-        ToolTip.visible: badgeHover.hovered && badge.visible
-        ToolTip.text: badge.tooltipText
-
-        HoverHandler {
-            id: badgeHover
-        }
-    }
-
     // Register a per-layout deep-link anchor ("layout:<id>") with the host
     // page's reveal registry so a layouts search result scrolls to and pulses
     // this exact card (expanding its group card if collapsed). Deferred via
@@ -379,34 +354,10 @@ Item {
                     globalAutoAssign: root.globalAutoAssign
                 }
 
-                // Memory indicator for algorithms that persist split state
-                CapabilityBadge {
-                    visible: root.modelData.supportsMemory === true
-                    source: "document-save-symbolic"
-                    color: Kirigami.Theme.positiveTextColor
-                    Accessible.name: i18n("Persistent algorithm")
-                    tooltipText: i18n("Remembers split positions across window changes")
-                }
-
-                // Reflow indicator for algorithms that adjust the layout when a
-                // tiled window is interactively resized.
-                CapabilityBadge {
-                    visible: root.modelData.reflowsOnResize === true
-                    source: "transform-scale-symbolic"
-                    color: Kirigami.Theme.highlightColor
-                    Accessible.name: i18n("Reflows")
-                    tooltipText: i18n("Reflows neighbouring windows when you resize a tiled window")
-                }
-
-                // Script-state indicator for scripted algorithms that persist an
-                // opaque per-screen state bag across retiles. Distinct colour from
-                // the reflow badge so the two are tellable apart when both show.
-                CapabilityBadge {
-                    visible: root.modelData.supportsScriptState === true
-                    source: "code-context-symbolic"
-                    color: Kirigami.Theme.neutralTextColor
-                    Accessible.name: i18n("Persistent script state")
-                    tooltipText: i18n("Remembers script-managed layout state across window changes")
+                // Autotile capability badges (memory / reflow / script-state).
+                // Shared with the overlay layout card so the set stays identical.
+                QFZCommon.CapabilityBadgeRow {
+                    layoutData: root.modelData
                 }
 
                 QFZCommon.AspectRatioBadge {

--- a/src/settings/qml/LayoutGridDelegate.qml
+++ b/src/settings/qml/LayoutGridDelegate.qml
@@ -73,7 +73,7 @@ Item {
             pg.unregisterSearchAnchor("layout:" + root.modelData.id);
     }
 
-    Accessible.name: modelData.name || i18n("Unnamed Layout")
+    Accessible.name: modelData.displayName || i18n("Unnamed Layout")
     Accessible.description: i18n("Layout with %1 zones", modelData.zoneCount || 0)
     Accessible.role: Accessible.ListItem
     Keys.onReturnPressed: root.activated(root.modelData.id)

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -37,6 +37,7 @@ qt_add_qml_module(plasmazones_shared_qml
         shared_qml_plugin.cpp
     QML_FILES
         AspectRatioBadge.qml
+        CapabilityBadgeRow.qml
         CategoryBadge.qml
         LayoutCard.qml
         PopupFrame.qml

--- a/src/shared/CapabilityBadgeRow.qml
+++ b/src/shared/CapabilityBadgeRow.qml
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import org.kde.kirigami as Kirigami
+
+/**
+ * Autotile capability badges for layout cards.
+ *
+ * Shows a compact icon per capability an autotile algorithm advertises
+ * (persistent split memory, resize reflow, persistent script state). Manual
+ * layouts leave every flag false, so the whole row hides and reserves no space.
+ *
+ * Driven by the serialized LayoutPreview shape (flattened autotile metadata):
+ * supportsMemory, reflowsOnResize, supportsScriptState. Shared by the settings
+ * layout grid and the overlay layout card so the badge set stays identical.
+ */
+Row {
+    id: root
+
+    property var layoutData: ({})
+
+    spacing: Kirigami.Units.smallSpacing
+    // Hidden (and space-free in the enclosing positioner) when the layout
+    // advertises no capabilities — i.e. every manual layout.
+    visible: layoutData.supportsMemory === true || layoutData.reflowsOnResize === true || layoutData.supportsScriptState === true
+
+    // Shared icon-badge primitive: a small masked symbolic icon with a hover
+    // tooltip. Each instance sets only visible/source/color/text.
+    component CapabilityBadge: Kirigami.Icon {
+        id: badge
+
+        property string tooltipText
+
+        implicitWidth: Kirigami.Units.iconSizes.small
+        implicitHeight: Kirigami.Units.iconSizes.small
+        // Render as a mask tinted with `color` so every badge recolors
+        // uniformly — some symbolic icons (transform-scale, code-context) are
+        // not auto-recolored by the icon theme and would otherwise show a
+        // default grey, reading as "disabled" next to the recolored memory badge.
+        isMask: true
+        opacity: 0.7
+        ToolTip.delay: Kirigami.Units.toolTipDelay
+        ToolTip.visible: badgeHover.hovered && badge.visible
+        ToolTip.text: badge.tooltipText
+
+        HoverHandler {
+            id: badgeHover
+        }
+    }
+
+    // Memory indicator for algorithms that persist split state.
+    CapabilityBadge {
+        visible: root.layoutData.supportsMemory === true
+        source: "document-save-symbolic"
+        color: Kirigami.Theme.positiveTextColor
+        Accessible.name: i18n("Persistent algorithm")
+        tooltipText: i18n("Remembers split positions across window changes")
+    }
+
+    // Reflow indicator for algorithms that adjust the layout when a tiled
+    // window is interactively resized.
+    CapabilityBadge {
+        visible: root.layoutData.reflowsOnResize === true
+        source: "transform-scale-symbolic"
+        color: Kirigami.Theme.highlightColor
+        Accessible.name: i18n("Reflows")
+        tooltipText: i18n("Reflows neighbouring windows when you resize a tiled window")
+    }
+
+    // Script-state indicator for scripted algorithms that persist an opaque
+    // per-screen state bag across retiles. Distinct colour from the reflow
+    // badge so the two are tellable apart when both show.
+    CapabilityBadge {
+        visible: root.layoutData.supportsScriptState === true
+        source: "code-context-symbolic"
+        color: Kirigami.Theme.neutralTextColor
+        Accessible.name: i18n("Persistent script state")
+        tooltipText: i18n("Remembers script-managed layout state across window changes")
+    }
+}

--- a/src/shared/LayoutCard.qml
+++ b/src/shared/LayoutCard.qml
@@ -327,6 +327,11 @@ Item {
             globalAutoAssign: root.globalAutoAssign
         }
 
+        CapabilityBadgeRow {
+            anchors.verticalCenter: parent.verticalCenter
+            layoutData: root.layoutData
+        }
+
         AspectRatioBadge {
             anchors.verticalCenter: parent.verticalCenter
             aspectRatioClass: root.layoutData.aspectRatioClass || "any"

--- a/src/shared/LayoutCard.qml
+++ b/src/shared/LayoutCard.qml
@@ -19,8 +19,7 @@ Item {
     id: root
 
     // Data
-    property var layoutData: ({
-    })
+    property var layoutData: ({})
     property bool isActive: false
     property bool isSelected: false
     property bool isHovered: false
@@ -102,7 +101,7 @@ Item {
     opacity: root.isRecommended ? 1 : 0.65
     // Accessibility
     Accessible.role: Accessible.Pane
-    Accessible.name: root.layoutData.name || ""
+    Accessible.name: root.layoutData.displayName || ""
 
     // Visual constants
     QtObject {
@@ -145,7 +144,6 @@ Item {
                 profile: "widget.hover"
                 durationOverride: root.animationDuration
             }
-
         }
 
         Behavior on border.color {
@@ -153,9 +151,7 @@ Item {
                 profile: "widget.hover"
                 durationOverride: root.animationDuration
             }
-
         }
-
     }
 
     // Preview area — bounding box for the layout preview.
@@ -210,7 +206,6 @@ Item {
                     profile: "widget.hover"
                     durationOverride: root.animationDuration
                 }
-
             }
 
             Behavior on border.color {
@@ -218,7 +213,6 @@ Item {
                     profile: "widget.hover"
                     durationOverride: root.animationDuration
                 }
-
             }
 
             Behavior on border.width {
@@ -226,9 +220,7 @@ Item {
                     profile: "widget.hover"
                     durationOverride: root.shortAnimationDuration
                 }
-
             }
-
         }
 
         // Active checkmark badge (top-right)
@@ -262,7 +254,6 @@ Item {
                     profile: root.isActive ? "widget.badgeShow" : "widget.badgeHide"
                     durationOverride: root.animationDuration
                 }
-
             }
 
             Behavior on height {
@@ -270,7 +261,6 @@ Item {
                     profile: root.isActive ? "widget.badgeShow" : "widget.badgeHide"
                     durationOverride: root.animationDuration
                 }
-
             }
 
             // Opacity must not overshoot — badgeShow's curve has overshoot
@@ -280,9 +270,7 @@ Item {
                     profile: root.isActive ? "widget.fadeIn" : "widget.fadeOut"
                     durationOverride: root.shortAnimationDuration
                 }
-
             }
-
         }
 
         // Zone rectangles — fill the fitted preview background, not the bounding box
@@ -317,11 +305,10 @@ Item {
             fontStrikeout: root.fontStrikeout
             showMasterDot: root.showMasterDot
             animationDuration: root.animationDuration
-            onZoneHovered: function(index) {
+            onZoneHovered: function (index) {
                 root.zoneHovered(index);
             }
         }
-
     }
 
     // Name label row
@@ -349,7 +336,7 @@ Item {
             id: nameLabel
 
             anchors.verticalCenter: parent.verticalCenter
-            text: root.layoutData.name || ""
+            text: root.layoutData.displayName || ""
             font.pixelSize: Kirigami.Theme.smallFont.pixelSize + 1
             font.weight: root.isActive ? Font.Bold : Font.Normal
             color: {
@@ -371,7 +358,6 @@ Item {
                     profile: "widget.tint"
                     durationOverride: root.animationDuration
                 }
-
             }
 
             Behavior on opacity {
@@ -383,11 +369,7 @@ Item {
                     profile: (root.isSelected || root.isHovered || root.isActive) ? "widget.fadeIn" : "widget.fadeOut"
                     durationOverride: root.animationDuration
                 }
-
             }
-
         }
-
     }
-
 }

--- a/src/ui/LayoutPickerContent.qml
+++ b/src/ui/LayoutPickerContent.qml
@@ -295,7 +295,7 @@ Item {
                     width: root.cardWidth
                     height: root.cardHeight
                     Accessible.role: Accessible.Button
-                    Accessible.name: layoutData.name || ""
+                    Accessible.name: layoutData.displayName || ""
                     Accessible.focusable: true
 
                     QFZCommon.LayoutCard {

--- a/src/ui/ZoneSelector.qml
+++ b/src/ui/ZoneSelector.qml
@@ -274,7 +274,7 @@ Rectangle {
                     isActive: layoutId === root.activeLayoutId
                     isHovered: layoutId === root.hoveredLayoutId
                     layoutId: modelData.id || ""
-                    layoutName: modelData.name || i18n("Layout %1", index + 1)
+                    layoutName: modelData.displayName || i18n("Layout %1", index + 1)
                     // Show lock overlay on non-active layouts when screen is locked
                     locked: root.locked && !isActive
                     previewHeight: root.previewHeight


### PR DESCRIPTION
Two related fixes/improvements to the shared layout-preview cards used by the overlay picker, the zone selector, and the settings layout surfaces.

## 1. Layout names were blank in the overlay previews (fix)

The `LayoutPreview` wire shape was canonicalised to `displayName` (commit `8609e32d`) and the settings-app QML was updated, but the shared/overlay components kept reading the old `.name` key — undefined in the serialized shape — so the name label rendered empty while the category and aspect-ratio badges (other fields) still showed.

Pointed them at the canonical field:
- `shared/LayoutCard.qml` — the visible name label and `Accessible.name`.
- `ui/LayoutPickerContent.qml` — the card `Accessible.name`.
- `ui/ZoneSelector.qml` — the per-layout `layoutName` fed to the mini preview.

The layout-change OSD is unaffected (it gets its name from `LayoutOsdContentParams.name` via `layout->name()`, not the preview model).

## 2. Autotile capability badges in the previews (improvement)

Previews showed the aspect-ratio tag for snapping layouts but no capability indicators for autotile algorithms. The settings grid card already rendered memory / reflow / script-state badges; extracted that set into a shared `CapabilityBadgeRow` (`org.plasmazones.common`) and used it everywhere a preview shows the aspect-ratio tag:
- `shared/LayoutCard.qml` — overlay picker and zone selector.
- `settings/LayoutComboBox.qml` — the layout dropdown.
- `settings/LayoutGridDelegate.qml` — now consumes the shared component instead of its own inline copy, so the badge set stays identical across surfaces.

Badges are driven by the serialized `LayoutPreview` flags (`supportsMemory`, `reflowsOnResize`, `supportsScriptState`) and the row hides (reserving no space) for manual layouts.

## Testing

- `cmake --build build` — green (QML AOT-compiled).
- `ctest` — 240/240 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)