### PR TITLE
fix(effect): drop superseded geometry ticks during fast rotation

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1049,8 +1049,9 @@ private:
     /// first one's ticks are still queued; the older batch's later-firing
     /// timers would then clobber the newer batch's positions, leaving windows
     /// in stale zones. Each batch bumps and captures the epoch for every screen
-    /// it targets; a staggered apply (and the z-order restore) drops itself when
-    /// its screen's epoch has advanced. Per-screen, not global, so a batch on
+    /// it targets. A staggered apply drops itself when its screen's epoch has
+    /// advanced, and the z-order restore drops only when every screen it
+    /// targeted has advanced. Per-screen, not global, so a batch on
     /// one output never strands an in-flight cascade on another — mirrors the
     /// autotile cascade guard (m_autotileStaggerGenByScreen).
     QHash<QString, uint64_t> m_daemonBatchGenByScreen;

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1042,6 +1042,18 @@ private:
     /// authoritative source of the window's intended VS during these applies, so the crossing check
     /// is unsafe and must be skipped.
     bool m_inDaemonGeometryApply = false;
+    /// Per-screen supersession epoch for slotApplyGeometriesBatch cascades.
+    /// When cascade stagger is enabled, a daemon geometry batch spreads its
+    /// per-window moves across QTimer::singleShot ticks. A rapid second batch
+    /// (e.g. holding the rotate shortcut) starts its own cascade while the
+    /// first one's ticks are still queued; the older batch's later-firing
+    /// timers would then clobber the newer batch's positions, leaving windows
+    /// in stale zones. Each batch bumps and captures the epoch for every screen
+    /// it targets; a staggered apply (and the z-order restore) drops itself when
+    /// its screen's epoch has advanced. Per-screen, not global, so a batch on
+    /// one output never strands an in-flight cascade on another — mirrors the
+    /// autotile cascade guard (m_autotileStaggerGenByScreen).
+    QHash<QString, uint64_t> m_daemonBatchGenByScreen;
     int m_pendingVsConfigReplies = 0; ///< countdown for fetchAllVirtualScreenConfigs async replies
     uint64_t m_vsConfigGeneration = 0; ///< generation counter for fetchAllVirtualScreenConfigs
     /// Per-physId fetchVirtualScreenConfig sequence. Every fetch bumps its

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -313,10 +313,31 @@ void PlasmaZonesEffect::slotApplyGeometriesBatch(const PhosphorProtocol::WindowG
         ? PhosphorAnimation::ProfilePaths::WindowLayoutSwitch
         : PhosphorAnimation::ProfilePaths::WindowSnapIn;
 
+    // Per-screen supersession epoch (see m_daemonBatchGenByScreen): bump and
+    // snapshot each target screen's counter so this cascade's still-queued
+    // ticks self-cancel if a newer batch lands on the same screen. Float/
+    // restore entries (empty screenId) are independent and never guarded.
+    QHash<QString, uint64_t> genByScreen;
+    for (const auto& p : pending) {
+        if (p.screenId.isEmpty() || genByScreen.contains(p.screenId)) {
+            continue;
+        }
+        genByScreen.insert(p.screenId, ++m_daemonBatchGenByScreen[p.screenId]);
+    }
+
     applyStaggeredOrImmediate(
         pending.size(),
-        [this, pending, batchProfilePath](int i) {
+        [this, pending, batchProfilePath, genByScreen](int i) {
             const auto& p = pending[i];
+            // Drop this apply if a newer daemon batch has superseded this
+            // window's screen: a later-firing tick of this (older) cascade would
+            // otherwise clobber the newer batch's position and strand the window
+            // in a stale zone. Only observable with cascade stagger enabled,
+            // where the per-window moves spread across timer ticks. Empty
+            // screenId (float/restore) is independent and always applies.
+            if (!p.screenId.isEmpty() && m_daemonBatchGenByScreen.value(p.screenId) != genByScreen.value(p.screenId)) {
+                return;
+            }
             // isDeleted too, not just destruction: close-shader grabs (which
             // this effect takes) keep deleted windows alive in the stacking
             // order for the close-animation duration, and the stagger delay
@@ -373,9 +394,22 @@ void PlasmaZonesEffect::slotApplyGeometriesBatch(const PhosphorProtocol::WindowG
                 m_snapHandler->markWindowSnapped(batchWid, p.screenId);
             }
         },
-        [this, savedStack, action]() {
-            // Restore z-order after all geometries applied
-            auto* ws = KWin::Workspace::self();
+        [this, savedStack, action, genByScreen]() {
+            // Restore z-order after all geometries applied — but skip it when a
+            // newer batch has superseded every screen this one targeted. The
+            // superseding cascade captured and re-asserts the current stacking
+            // order itself; replaying this batch's stale savedStack would
+            // shuffle windows into a pre-supersession order. drainPendingRestores
+            // and snap-assist below stay unconditional (no-ops for the
+            // non-mode-toggle batches this guard can affect).
+            bool fullySuperseded = !genByScreen.isEmpty();
+            for (auto it = genByScreen.constBegin(); it != genByScreen.constEnd(); ++it) {
+                if (m_daemonBatchGenByScreen.value(it.key()) == it.value()) {
+                    fullySuperseded = false;
+                    break;
+                }
+            }
+            auto* ws = fullySuperseded ? nullptr : KWin::Workspace::self();
             if (ws) {
                 for (const auto& wPtr : savedStack) {
                     if (wPtr && !wPtr->isDeleted()) {

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -400,8 +400,10 @@ void PlasmaZonesEffect::slotApplyGeometriesBatch(const PhosphorProtocol::WindowG
             // superseding cascade captured and re-asserts the current stacking
             // order itself; replaying this batch's stale savedStack would
             // shuffle windows into a pre-supersession order. drainPendingRestores
-            // and snap-assist below stay unconditional (no-ops for the
-            // non-mode-toggle batches this guard can affect).
+            // and snap-assist below stay unconditional: for the non-resnap
+            // batches (rotate, vs_reconfigure, snap_all) both are no-ops, and a
+            // superseded resnap is still safe because the superseding resnap
+            // re-drains its own queued restores and re-evaluates snap assist.
             bool fullySuperseded = !genByScreen.isEmpty();
             for (auto it = genByScreen.constBegin(); it != genByScreen.constEnd(); ++it) {
                 if (m_daemonBatchGenByScreen.value(it.key()) == it.value()) {


### PR DESCRIPTION
## Problem

Rotating windows fast enough (e.g. holding the rotate shortcut) leaves windows in the wrong zones, even though the daemon's internal window→zone model stays correct.

## Diagnosis

From the daemon journal, every `SnapEngine::rotateWindowsInLayout` produces a clean permutation — 4 windows, 4 distinct zones, no collisions or drops. So the assignment logic is sound; the desync is on the compositor side.

When cascade stagger animation is enabled, the KWin effect's `slotApplyGeometriesBatch` spreads a batch's per-window moves across `QTimer::singleShot` ticks (window 0 immediately, windows 1..N at increasing delays). Rotating faster than the stagger completes starts a new batch while the previous one's ticks are still queued. The older batch's later-firing timers then clobber the newer batch's positions, stranding windows in stale zones. It only reproduces with stagger on, which is why speed matters.

The autotile path already guards against this exact race with a per-screen generation epoch; the snap/rotate path never got one.

## Fix

- Add `m_daemonBatchGenByScreen`, a per-screen supersession epoch.
- Each batch bumps and snapshots the epoch for every screen it targets; a queued staggered apply drops itself once its screen's epoch advances.
- The z-order restore in the completion callback is skipped when the batch was fully superseded, so it can't reassert a pre-supersession stacking order.

Per-screen rather than global, so rapidly rotating one output never strands an in-flight cascade on another. Mirrors the existing autotile cascade guard (`m_autotileStaggerGenByScreen`). Float/restore entries (empty `screenId`) are independent and never guarded.

## Testing

- `kwin_effect_plasmazones` and full build green.
- 240/240 ctest pass.
- No automated regression test: the race lives in the KWin effect, which needs a live compositor and has no unit-test harness here. Verified by build, existing suite, and parity with the proven autotile pattern. To confirm in-session: reload the effect and hold the rotate shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)