### PR TITLE
feat(rules): route a window to a monitor / virtual desktop on open

### DIFF
--- a/libs/phosphor-engine/include/PhosphorEngine/EngineTypes.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/EngineTypes.h
@@ -87,6 +87,12 @@ struct SnapResult
     QString zoneId;
     QStringList zoneIds;
     QString screenId;
+    /// Target virtual desktop the snap should be committed in (1-based). 0 means
+    /// "the window's current desktop" — the historical behaviour. Set non-zero only
+    /// by a placement rule that also routes the window to a desktop (RouteToDesktop),
+    /// so the zone assignment is recorded on the desktop the window ends up on, not
+    /// the one it momentarily opened on.
+    int virtualDesktop = 0;
 
     bool isValid() const
     {

--- a/libs/phosphor-snap-engine/CMakeLists.txt
+++ b/libs/phosphor-snap-engine/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_AUTOMOC ON)
 
 add_library(PhosphorSnapEngine SHARED
     include/PhosphorSnapEngine/SnapEngine.h
+    include/PhosphorSnapEngine/PlacementDirective.h
     include/PhosphorSnapEngine/SnapState.h
     include/PhosphorSnapEngine/ISnapSettings.h
     include/PhosphorSnapEngine/INavigationStateProvider.h

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/PlacementDirective.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/PlacementDirective.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <QList>
+#include <QString>
+
+namespace PhosphorSnapEngine {
+
+/**
+ * @brief What a matched open-placement rule directs for an opening window.
+ *
+ * A small DTO crossing the daemon ↔ snap-engine boundary: the daemon resolves
+ * the window's matched rules and fills this in, the engine acts on it. It lives
+ * in its own lightweight header so both the engine's public API and the daemon's
+ * resolver declaration can reference it by value without pulling in the full
+ * SnapEngine definition.
+ *
+ *  - @c zoneOrdinals — the `SnapToZone` ordinal list (1-based). Empty means no
+ *    SnapToZone rule matched; the engine then has nothing to snap.
+ *  - @c targetScreenId — the `RouteToScreen` target monitor (canonical screen-id
+ *    form). When non-empty the zones resolve on THAT screen and the window is
+ *    moved there, restoring the per-monitor pinning the retired per-layout app
+ *    rules carried. Empty means resolve on the window's opening screen (a
+ *    `ScreenId` match leaf only SCOPES a rule; `RouteToScreen` is what ROUTES it).
+ */
+struct PlacementDirective
+{
+    QList<int> zoneOrdinals;
+    QString targetScreenId;
+    /// The `RouteToDesktop` target virtual desktop (1-based; 0 = no desktop
+    /// routing). When set, the zones resolve against THAT desktop's layout for the
+    /// placement screen and the snap is committed in that desktop's context, so a
+    /// combined "snap to zone N + open on desktop M" rule places the window into
+    /// zone N of desktop M's layout (not the desktop it momentarily opened on).
+    int targetDesktop = 0;
+};
+
+} // namespace PhosphorSnapEngine

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/PlacementDirective.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/PlacementDirective.h
@@ -24,16 +24,16 @@ namespace PhosphorSnapEngine {
  *    moved there, restoring the per-monitor pinning the retired per-layout app
  *    rules carried. Empty means resolve on the window's opening screen (a
  *    `ScreenId` match leaf only SCOPES a rule; `RouteToScreen` is what ROUTES it).
+ *  - @c targetDesktop — the `RouteToDesktop` target virtual desktop (1-based;
+ *    0 = no desktop routing). When set the zones resolve against THAT desktop's
+ *    layout for the placement screen and the snap commits in that desktop's
+ *    context, so a combined "snap to zone N + open on desktop M" rule places the
+ *    window into zone N of desktop M's layout (not the desktop it opened on).
  */
 struct PlacementDirective
 {
     QList<int> zoneOrdinals;
     QString targetScreenId;
-    /// The `RouteToDesktop` target virtual desktop (1-based; 0 = no desktop
-    /// routing). When set, the zones resolve against THAT desktop's layout for the
-    /// placement screen and the snap is committed in that desktop's context, so a
-    /// combined "snap to zone N + open on desktop M" rule places the window into
-    /// zone N of desktop M's layout (not the desktop it momentarily opened on).
     int targetDesktop = 0;
 };
 

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -10,6 +10,7 @@
 #include <PhosphorEngine/IWindowTrackingService.h>
 #include <PhosphorEngine/PlacementEngineBase.h>
 #include <PhosphorLayoutApi/EdgeGaps.h>
+#include <PhosphorSnapEngine/PlacementDirective.h>
 #include <PhosphorProtocol/NavigationTypes.h>
 #include <PhosphorProtocol/WindowTypes.h>
 #include <PhosphorWindowRules/RuleEvaluator.h>
@@ -262,7 +263,12 @@ public:
      *        Same lifetime contract as setFloatPredicate — clear with `{}` before
      *        destroying any captured state.
      */
-    using PlacementZonesResolver = std::function<QList<int>(const QString& windowId, const QString& screenId)>;
+    /// Resolver yielding the open-placement directive (SnapToZone ordinals plus an
+    /// optional RouteToScreen target) for an opening window. See
+    /// PhosphorSnapEngine::PlacementDirective. Empty ordinals ⇒ no SnapToZone rule
+    /// matched. When UNSET (default) no window is rule-snapped and the engine keeps
+    /// its historical open behaviour (path unit tests rely on this).
+    using PlacementZonesResolver = std::function<PlacementDirective(const QString& windowId, const QString& screenId)>;
 
     void setPlacementZonesResolver(PlacementZonesResolver resolver)
     {
@@ -521,11 +527,17 @@ public:
     // on WindowTrackingService.
     // ═══════════════════════════════════════════════════════════════════════════
 
+    /// @p virtualDesktop pins the assignment to a specific 1-based desktop; 0
+    /// (default) records it on the window's current desktop. Non-zero is used by
+    /// the RouteToDesktop placement path so the zone assignment is tracked on the
+    /// desktop the window is being moved to.
     void commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId,
-                    PhosphorEngine::SnapIntent intent = PhosphorEngine::SnapIntent::UserInitiated);
+                    PhosphorEngine::SnapIntent intent = PhosphorEngine::SnapIntent::UserInitiated,
+                    int virtualDesktop = 0);
 
     void commitMultiZoneSnap(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
-                             PhosphorEngine::SnapIntent intent = PhosphorEngine::SnapIntent::UserInitiated);
+                             PhosphorEngine::SnapIntent intent = PhosphorEngine::SnapIntent::UserInitiated,
+                             int virtualDesktop = 0);
 
     void uncommitSnap(const QString& windowId);
 
@@ -745,7 +757,7 @@ private:
     GapParams resolveGapParams(const QString& screenId, PhosphorZones::Layout* layout) const;
 
     void commitSnapImpl(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
-                        PhosphorEngine::SnapIntent intent);
+                        PhosphorEngine::SnapIntent intent, int virtualDesktop = 0);
 
     /// Resolve an unfloat target screen: take @p primaryScreen if it still exists
     /// (resolving virtual IDs), otherwise fall back to @p fallbackScreen. Returns an

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -249,25 +249,21 @@ public:
     }
 
     /**
-     * @brief Resolver yielding the 1-based zone ordinals an opening window should
-     *        snap into because a `SnapToZone` window rule matched it. Daemon-
-     *        injected, keyed by the live windowId plus the screen the window is
-     *        opening on (so a rule carrying a `ScreenId` constraint resolves
-     *        against the window's current screen), evaluated on the window-open
-     *        path (`calculateSnapToPlacementRule`, the highest-priority restore
-     *        chain level). Returns an empty list when no rule matches. Multiple
-     *        ordinals request a zone span (their unioned bounding rect). The
-     *        engine stays settings/rule-store-agnostic (LGPL boundary) — it only
-     *        asks. When UNSET (default) no window is rule-snapped and the engine
-     *        keeps its historical open behaviour (path unit tests rely on this).
-     *        Same lifetime contract as setFloatPredicate — clear with `{}` before
-     *        destroying any captured state.
+     * @brief Resolver yielding the open-placement directive — SnapToZone ordinals
+     *        plus an optional RouteToScreen target and an optional RouteToDesktop
+     *        target — for an opening window because a placement window rule matched
+     *        it. Daemon-injected, keyed by the live windowId plus the screen the
+     *        window is opening on (so a rule carrying a `ScreenId` constraint
+     *        resolves against the window's current screen), evaluated on the
+     *        window-open path (`calculateSnapToPlacementRule`, the highest-priority
+     *        restore chain level). See PhosphorSnapEngine::PlacementDirective. Empty
+     *        ordinals ⇒ no SnapToZone rule matched; multiple ordinals request a zone
+     *        span (their unioned bounding rect). The engine stays settings/rule-
+     *        store-agnostic (LGPL boundary) — it only asks. When UNSET (default) no
+     *        window is rule-snapped and the engine keeps its historical open
+     *        behaviour (path unit tests rely on this). Same lifetime contract as
+     *        setFloatPredicate — clear with `{}` before destroying any captured state.
      */
-    /// Resolver yielding the open-placement directive (SnapToZone ordinals plus an
-    /// optional RouteToScreen target) for an opening window. See
-    /// PhosphorSnapEngine::PlacementDirective. Empty ordinals ⇒ no SnapToZone rule
-    /// matched. When UNSET (default) no window is rule-snapped and the engine keeps
-    /// its historical open behaviour (path unit tests rely on this).
     using PlacementZonesResolver = std::function<PlacementDirective(const QString& windowId, const QString& screenId)>;
 
     void setPlacementZonesResolver(PlacementZonesResolver resolver)

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -87,10 +87,9 @@ SnapResult SnapEngine::calculateSnapToPlacementRule(const QString& windowId, con
     // through to the normal restore chain rather than being stranded. Gate whenever
     // the target differs from the opening (screen, desktop), so a cross-desktop or
     // cross-screen route is validated against where the window will actually land.
-    // (No layout manager ⇒ unit-test path: skip the gate; the layout miss below
-    // already yields noSnap.)
+    // (m_layoutManager is non-null here — the early guard above already returned.)
     const bool routed = placementScreen != windowScreenName || directive.targetDesktop >= 1;
-    if (routed && m_layoutManager
+    if (routed
         && m_layoutManager->modeForScreen(placementScreen, placementDesktop, currentActivity())
             != PhosphorZones::AssignmentEntry::Mode::Snapping) {
         qCDebug(PhosphorSnapEngine::lcSnapEngine)

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -58,20 +58,56 @@ SnapResult SnapEngine::calculateSnapToPlacementRule(const QString& windowId, con
     if (!m_placementZonesResolver) {
         return SnapResult::noSnap();
     }
-    const QList<int> ordinals = m_placementZonesResolver(windowId, windowScreenName);
-    if (ordinals.isEmpty()) {
+    const PlacementDirective directive = m_placementZonesResolver(windowId, windowScreenName);
+    if (directive.zoneOrdinals.isEmpty()) {
+        return SnapResult::noSnap();
+    }
+    const QList<int>& ordinals = directive.zoneOrdinals;
+
+    // A RouteToScreen action pins the placement to a specific monitor: resolve the
+    // zones on THAT screen and move the window there (the apply path honours
+    // result.screenId — commitSnap, the disabled-context gate, and the returned
+    // geometry all key off it, so cross-screen migration reuses the same machinery
+    // a cross-screen snapped-record restore uses). Empty target ⇒ the window's
+    // opening screen, the historical behaviour (a ScreenId match leaf only SCOPES
+    // such a rule; RouteToScreen is what ROUTES it).
+    const QString placementScreen = directive.targetScreenId.isEmpty() ? windowScreenName : directive.targetScreenId;
+
+    // A RouteToDesktop action snaps the window into its zone on the DESTINATION
+    // desktop's layout, not the one it momentarily opened on: resolve the layout and
+    // gate the mode in that desktop's context, and stamp the result so the commit
+    // records the assignment there too. 0 ⇒ no desktop routing ⇒ the placement
+    // screen's current desktop (the historical behaviour).
+    const int placementDesktop =
+        directive.targetDesktop >= 1 ? directive.targetDesktop : currentVirtualDesktopForScreen(placementScreen);
+
+    // The placement only applies when the (screen, desktop) target is in snapping
+    // mode. An autotile-mode target is owned by the autotile routing hook, and a
+    // disabled / unresolvable target has no layout — decline so the window falls
+    // through to the normal restore chain rather than being stranded. Gate whenever
+    // the target differs from the opening (screen, desktop), so a cross-desktop or
+    // cross-screen route is validated against where the window will actually land.
+    // (No layout manager ⇒ unit-test path: skip the gate; the layout miss below
+    // already yields noSnap.)
+    const bool routed = placementScreen != windowScreenName || directive.targetDesktop >= 1;
+    if (routed && m_layoutManager
+        && m_layoutManager->modeForScreen(placementScreen, placementDesktop, currentActivity())
+            != PhosphorZones::AssignmentEntry::Mode::Snapping) {
+        qCDebug(PhosphorSnapEngine::lcSnapEngine)
+            << "calculateSnapToPlacementRule: route target" << placementScreen << "desktop" << placementDesktop
+            << "is not in snapping mode — declining snap route for" << windowId;
         return SnapResult::noSnap();
     }
 
-    // Ordinals are layout-agnostic: resolve them against whatever layout is active
-    // on the window's CURRENT screen. Legacy per-layout app rules could target a
-    // different screen; that cross-screen routing is retired — a SnapToZone rule
-    // resolves on the window's current screen, and a user can scope it to a screen
-    // with a ScreenId match leaf, so there is no cross-screen scan here.
-    PhosphorZones::Layout* layout = m_layoutManager->resolveLayoutForScreen(windowScreenName);
+    // Ordinals are layout-agnostic: resolve them against the layout active on the
+    // placement (screen, desktop). For a desktop route that is the DESTINATION
+    // desktop's layout; otherwise it is the screen's current-desktop layout.
+    PhosphorZones::Layout* layout = directive.targetDesktop >= 1
+        ? m_layoutManager->layoutForScreen(placementScreen, placementDesktop, currentActivity())
+        : m_layoutManager->resolveLayoutForScreen(placementScreen);
     if (!layout) {
         qCDebug(PhosphorSnapEngine::lcSnapEngine)
-            << "calculateSnapToPlacementRule: no layout for screen" << windowScreenName;
+            << "calculateSnapToPlacementRule: no layout for screen" << placementScreen << "desktop" << placementDesktop;
         return SnapResult::noSnap();
     }
 
@@ -97,20 +133,22 @@ SnapResult SnapEngine::calculateSnapToPlacementRule(const QString& windowId, con
     // → resolveZoneGeometry). A per-QRect union here would diverge by a pixel at
     // fractional scaling, so a window floated off the span without moving would
     // leak the snap rect into its float-back geometry.
-    const QRect unionGeo = m_windowTracker->resolveZoneGeometry(zoneIds, windowScreenName);
+    const QRect unionGeo = m_windowTracker->resolveZoneGeometry(zoneIds, placementScreen);
     if (!unionGeo.isValid()) {
         return SnapResult::noSnap();
     }
 
-    qCInfo(PhosphorSnapEngine::lcSnapEngine) << "calculateSnapToPlacementRule: snapping" << windowId << "to zones"
-                                             << ordinals << "on screen" << windowScreenName;
+    qCInfo(PhosphorSnapEngine::lcSnapEngine)
+        << "calculateSnapToPlacementRule: snapping" << windowId << "to zones" << ordinals << "on screen"
+        << placementScreen << (directive.targetScreenId.isEmpty() ? "(opening screen)" : "(routed)");
 
     SnapResult result;
     result.shouldSnap = true;
     result.geometry = unionGeo;
     result.zoneId = zoneIds.first();
     result.zoneIds = zoneIds;
-    result.screenId = windowScreenName;
+    result.screenId = placementScreen;
+    result.virtualDesktop = directive.targetDesktop; // 0 ⇒ commit on the current desktop
     return result;
 }
 

--- a/libs/phosphor-snap-engine/src/calculate.cpp
+++ b/libs/phosphor-snap-engine/src/calculate.cpp
@@ -139,7 +139,7 @@ SnapResult SnapEngine::calculateSnapToPlacementRule(const QString& windowId, con
 
     qCInfo(PhosphorSnapEngine::lcSnapEngine)
         << "calculateSnapToPlacementRule: snapping" << windowId << "to zones" << ordinals << "on screen"
-        << placementScreen << (directive.targetScreenId.isEmpty() ? "(opening screen)" : "(routed)");
+        << placementScreen << (placementScreen != windowScreenName ? "(routed)" : "(opening screen)");
 
     SnapResult result;
     result.shouldSnap = true;

--- a/libs/phosphor-snap-engine/src/commit.cpp
+++ b/libs/phosphor-snap-engine/src/commit.cpp
@@ -16,7 +16,7 @@ using PhosphorEngine::SnapIntent;
 using PhosphorEngine::ZoneAssignmentEntry;
 
 void SnapEngine::commitSnapImpl(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
-                                SnapIntent intent)
+                                SnapIntent intent, int virtualDesktop)
 {
     Q_ASSERT(m_snapState);
     if (!m_snapState) {
@@ -41,7 +41,11 @@ void SnapEngine::commitSnapImpl(const QString& windowId, const QStringList& zone
         }
     }
 
-    const int currentDesktop = currentVirtualDesktopForScreen(screenId);
+    // A RouteToDesktop placement pins the assignment to its destination desktop
+    // (virtualDesktop >= 1); every other commit path records on the window's
+    // current desktop. Tracking the right desktop keeps zone occupancy, snap-assist,
+    // and empty-zone detection correct on both the source and destination desktops.
+    const int currentDesktop = virtualDesktop >= 1 ? virtualDesktop : currentVirtualDesktopForScreen(screenId);
     if (zoneIds.size() > 1) {
         m_windowTracker->assignWindowToZones(windowId, zoneIds, screenId, currentDesktop);
     } else {
@@ -80,23 +84,24 @@ void SnapEngine::commitSnapImpl(const QString& windowId, const QStringList& zone
     }
 }
 
-void SnapEngine::commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId, SnapIntent intent)
+void SnapEngine::commitSnap(const QString& windowId, const QString& zoneId, const QString& screenId, SnapIntent intent,
+                            int virtualDesktop)
 {
     if (windowId.isEmpty() || zoneId.isEmpty()) {
         qCWarning(PhosphorSnapEngine::lcSnapEngine) << "commitSnap: empty windowId or zoneId";
         return;
     }
-    commitSnapImpl(windowId, QStringList{zoneId}, screenId, intent);
+    commitSnapImpl(windowId, QStringList{zoneId}, screenId, intent, virtualDesktop);
 }
 
 void SnapEngine::commitMultiZoneSnap(const QString& windowId, const QStringList& zoneIds, const QString& screenId,
-                                     SnapIntent intent)
+                                     SnapIntent intent, int virtualDesktop)
 {
     if (windowId.isEmpty() || zoneIds.isEmpty() || zoneIds.first().isEmpty()) {
         qCWarning(PhosphorSnapEngine::lcSnapEngine) << "commitMultiZoneSnap: empty windowId or zoneIds";
         return;
     }
-    commitSnapImpl(windowId, zoneIds, screenId, intent);
+    commitSnapImpl(windowId, zoneIds, screenId, intent, virtualDesktop);
 }
 
 void SnapEngine::uncommitSnap(const QString& windowId)

--- a/libs/phosphor-snap-engine/src/commit.cpp
+++ b/libs/phosphor-snap-engine/src/commit.cpp
@@ -45,17 +45,17 @@ void SnapEngine::commitSnapImpl(const QString& windowId, const QStringList& zone
     // (virtualDesktop >= 1); every other commit path records on the window's
     // current desktop. Tracking the right desktop keeps zone occupancy, snap-assist,
     // and empty-zone detection correct on both the source and destination desktops.
-    const int currentDesktop = virtualDesktop >= 1 ? virtualDesktop : currentVirtualDesktopForScreen(screenId);
+    const int assignmentDesktop = virtualDesktop >= 1 ? virtualDesktop : currentVirtualDesktopForScreen(screenId);
     if (zoneIds.size() > 1) {
-        m_windowTracker->assignWindowToZones(windowId, zoneIds, screenId, currentDesktop);
+        m_windowTracker->assignWindowToZones(windowId, zoneIds, screenId, assignmentDesktop);
     } else {
-        m_windowTracker->assignWindowToZone(windowId, primaryZoneId, screenId, currentDesktop);
+        m_windowTracker->assignWindowToZone(windowId, primaryZoneId, screenId, assignmentDesktop);
     }
 
     if (intent == SnapIntent::UserInitiated && !wasAutoSnapped
         && !primaryZoneId.startsWith(QStringLiteral("zoneselector-"))) {
         const QString windowClass = m_windowTracker->currentAppIdFor(windowId);
-        m_windowTracker->updateLastUsedZone(primaryZoneId, screenId, windowClass, currentDesktop);
+        m_windowTracker->updateLastUsedZone(primaryZoneId, screenId, windowClass, assignmentDesktop);
     }
 
     qCInfo(PhosphorSnapEngine::lcSnapEngine)

--- a/libs/phosphor-snap-engine/src/float.cpp
+++ b/libs/phosphor-snap-engine/src/float.cpp
@@ -92,10 +92,18 @@ bool SnapEngine::unfloatToZone(const QString& windowId, const QString& screenId)
         const PhosphorEngine::SnapResult ruleSnap =
             calculateSnapToPlacementRule(windowId, screenId, /*isSticky=*/false);
         if (ruleSnap.shouldSnap && !ruleSnap.zoneIds.isEmpty()) {
+            // Forward the routed desktop (RouteToDesktop): calculateSnapToPlacementRule
+            // resolved the zones against ruleSnap.virtualDesktop's layout, so the commit
+            // must record the assignment on that same desktop — otherwise a
+            // SnapToZone + RouteToDesktop rule lands zones from the routed desktop's
+            // layout under the current desktop. Mirrors the open path (lifecycle.cpp);
+            // 0 ⇒ current desktop, the historical behaviour for unrouted rules.
             if (ruleSnap.zoneIds.size() > 1) {
-                commitMultiZoneSnap(windowId, ruleSnap.zoneIds, ruleSnap.screenId, SnapIntent::UserInitiated);
+                commitMultiZoneSnap(windowId, ruleSnap.zoneIds, ruleSnap.screenId, SnapIntent::UserInitiated,
+                                    ruleSnap.virtualDesktop);
             } else {
-                commitSnap(windowId, ruleSnap.zoneIds.first(), ruleSnap.screenId, SnapIntent::UserInitiated);
+                commitSnap(windowId, ruleSnap.zoneIds.first(), ruleSnap.screenId, SnapIntent::UserInitiated,
+                           ruleSnap.virtualDesktop);
             }
             // Non-empty zoneId so the effect treats this as a snap commit (re-applies
             // snap chrome), mirroring the pre-float-zone path below.

--- a/libs/phosphor-snap-engine/src/lifecycle.cpp
+++ b/libs/phosphor-snap-engine/src/lifecycle.cpp
@@ -65,9 +65,9 @@ void SnapEngine::windowOpened(const QString& windowId, const QString& screenId, 
     m_snapState->markAsAutoSnapped(windowId);
     const QStringList zoneIds = result.zoneIds.isEmpty() ? QStringList{result.zoneId} : result.zoneIds;
     if (zoneIds.size() > 1) {
-        commitMultiZoneSnap(windowId, zoneIds, result.screenId, SnapIntent::AutoRestored);
+        commitMultiZoneSnap(windowId, zoneIds, result.screenId, SnapIntent::AutoRestored, result.virtualDesktop);
     } else {
-        commitSnap(windowId, zoneIds.first(), result.screenId, SnapIntent::AutoRestored);
+        commitSnap(windowId, zoneIds.first(), result.screenId, SnapIntent::AutoRestored, result.virtualDesktop);
     }
 
     // Emit geometry for KWin effect to apply

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/MatchTypes.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/MatchTypes.h
@@ -67,10 +67,10 @@ inline constexpr int FieldCount = static_cast<int>(Field::Zone) + 1;
 
 /// Value-kind of a field's payload in a WindowQuery.
 enum class FieldType : int {
-    String, ///< QString-valued (operators: Equals/Contains/StartsWith/EndsWith/Regex/In)
+    String, ///< QString-valued (operators: Equals/Contains/StartsWith/EndsWith/Regex)
     Bool, ///< bool-valued (operator: Equals)
     Int, ///< int-valued (operators: Equals/GreaterThan/LessThan)
-    Enum, ///< enum-as-int (WindowType) — Equals/In only
+    Enum, ///< enum-as-int (WindowType) — Equals only
 };
 
 /// Whether a field is a window property or a context attribute.

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/MatchTypes.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/MatchTypes.h
@@ -205,9 +205,8 @@ enum class Operator : int {
     EndsWith = 3, ///< suffix, case-insensitive (strings)
     Regex = 4, ///< QRegularExpression, precompiled & cached per predicate
     AppIdMatches = 5, ///< segment-aware reverse-DNS match (AppId only)
-    In = 6, ///< value is a set; membership test
-    GreaterThan = 7, ///< numeric compare (Pid / VirtualDesktop / Width / Height / PositionX / PositionY)
-    LessThan = 8, ///< numeric compare (Pid / VirtualDesktop / Width / Height / PositionX / PositionY)
+    GreaterThan = 6, ///< numeric compare (Pid / VirtualDesktop / Width / Height / PositionX / PositionY)
+    LessThan = 7, ///< numeric compare (Pid / VirtualDesktop / Width / Height / PositionX / PositionY)
 };
 
 /// The number of distinct `Operator` enumerators. `Operator` is a contiguous
@@ -230,8 +229,6 @@ inline QString operatorToString(Operator op)
         return QStringLiteral("regex");
     case Operator::AppIdMatches:
         return QStringLiteral("appIdMatches");
-    case Operator::In:
-        return QStringLiteral("in");
     case Operator::GreaterThan:
         return QStringLiteral("greaterThan");
     case Operator::LessThan:
@@ -250,7 +247,6 @@ inline std::optional<Operator> operatorFromString(QStringView s)
         {QLatin1StringView("endsWith"), Operator::EndsWith},
         {QLatin1StringView("regex"), Operator::Regex},
         {QLatin1StringView("appIdMatches"), Operator::AppIdMatches},
-        {QLatin1StringView("in"), Operator::In},
         {QLatin1StringView("greaterThan"), Operator::GreaterThan},
         {QLatin1StringView("lessThan"), Operator::LessThan},
     };

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
@@ -85,7 +85,8 @@ struct PHOSPHORWINDOWRULES_EXPORT RuleAction
  * switch. `kind` is a UI-side hint string (the canonical kinds are
  * `string`, `number`, `percent`, `enum`, `bool`, `color`, plus the
  * picker-aware kinds `snappingLayout`, `tilingAlgorithm`, `animationEvent`,
- * `shaderEffect`, `overlayShader`, `zoneOrdinals`, `curveEditor`); QML loaders dispatch on it. Labels stay in
+ * `shaderEffect`, `overlayShader`, `zoneOrdinals`, `curveEditor`, `screenId`,
+ * `virtualDesktop`); QML loaders dispatch on it. Labels stay in
  * the GPL settings layer because they need translation through PhosphorI18n::tr —
  * the lib only owns the structural part of the schema.
  *

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
@@ -311,6 +311,20 @@ inline constexpr QLatin1StringView Float{"float"};
 /// shortcuts. Daemon-consumed (placement) on the SnapEngine open path; supersedes
 /// the retired per-layout `Layout::appRules`. Domain Window.
 inline constexpr QLatin1StringView SnapToZone{"snapToZone"};
+/// Route a matched window to a specific monitor on open. Carries the canonical
+/// target screen id (`ActionParam::TargetScreenId`, the EDID `Manuf:Model:Serial`
+/// form the settings screen-picker and the runtime both use — physical OR virtual
+/// screen id). Composes with `SnapToZone` (snap into a zone ON the target screen)
+/// and with autotile (insert the window into the target screen's tiling state); on
+/// its own it just moves the window to that monitor. Restores the per-monitor
+/// pinning the retired per-layout `Layout::appRules` `targetScreen` field carried.
+/// Daemon-consumed on the open path. Domain Window.
+inline constexpr QLatin1StringView RouteToScreen{"routeToScreen"};
+/// Route a matched window to a specific virtual desktop on open. Carries the
+/// 1-based desktop number (`ActionParam::TargetDesktop`). Composes with the other
+/// open-path placement actions. Sticky (on-all-desktops) windows are left alone.
+/// Daemon-consumed on the open path. Domain Window.
+inline constexpr QLatin1StringView RouteToDesktop{"routeToDesktop"};
 inline constexpr QLatin1StringView OverrideAnimationShader{"overrideAnimationShader"};
 inline constexpr QLatin1StringView OverrideAnimationTiming{"overrideAnimationTiming"};
 /// Curve-only animation override — separate slot from timing so a user can
@@ -435,6 +449,13 @@ inline constexpr QLatin1StringView Algorithm{"algorithm"};
 // SnapToZone target-zone key — wire is a non-empty JSON array of 1-based zone
 // ordinals (e.g. `[1]` or `[1, 2]`); multiple entries snap to their union.
 inline constexpr QLatin1StringView Zones{"zones"};
+// RouteToScreen target-monitor key — wire is the canonical EDID screen id
+// (`Manuf:Model:Serial`, optionally `/CONNECTOR`-disambiguated, or a virtual
+// screen id), the same form the ScreenId match field and the settings
+// screen-picker store.
+inline constexpr QLatin1StringView TargetScreenId{"targetScreenId"};
+// RouteToDesktop target-desktop key — wire is a 1-based virtual desktop number.
+inline constexpr QLatin1StringView TargetDesktop{"targetDesktop"};
 } // namespace ActionParam
 
 /// Upper bound for a `SnapToZone` zone ordinal (each `ActionParam::Zones` entry).
@@ -444,6 +465,13 @@ inline constexpr QLatin1StringView Zones{"zones"};
 /// an out-of-range double to int (which is UB). Shared by the descriptor validator
 /// (ruleaction.cpp) and the v3→v4 migration so the two stay in lockstep.
 inline constexpr int MaxZoneOrdinal = 64;
+
+/// Upper bound for a `RouteToDesktop` 1-based virtual-desktop number. KWin tops
+/// out far below this in practice; the cap exists only to reject a grossly
+/// malformed hand-edited payload and to keep the validator's integrality check
+/// from narrowing an out-of-range double to int (UB). Shared by the descriptor
+/// validator and any consumer that re-validates the ordinal.
+inline constexpr int MaxVirtualDesktopOrdinal = 1024;
 
 /// Wire tokens for OverrideOverlayStyle's `value` param — the closed vocabulary
 /// the descriptor's validator + `enumWireValues`, the daemon consumer
@@ -477,6 +505,13 @@ inline constexpr QLatin1StringView Float{"float"};
 /// (`ActionParam::Zones`) the daemon snaps the opening window into. Mutually
 /// resolved against `Float` on the open path (a float rule opts out of snapping).
 inline constexpr QLatin1StringView Placement{"placement"};
+/// Window-scoped open-routing slots — filled by `ActionType::RouteToScreen` /
+/// `RouteToDesktop`. Each is a single slot (first-matching-rule-wins) carrying the
+/// target monitor / desktop the daemon routes the opening window to. Independent
+/// of `Placement`: a window can be routed to a screen AND snapped to a zone there,
+/// or routed with no zone (just moved to the monitor / desktop).
+inline constexpr QLatin1StringView RouteScreen{"route-screen"};
+inline constexpr QLatin1StringView RouteDesktop{"route-desktop"};
 inline constexpr QLatin1StringView Opacity{"opacity"};
 inline constexpr QLatin1StringView RestorePosition{"restore-position"};
 // Per-window border / title-bar appearance slots (one per property so

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/RuleAction.h
@@ -470,8 +470,9 @@ inline constexpr int MaxZoneOrdinal = 64;
 /// Upper bound for a `RouteToDesktop` 1-based virtual-desktop number. KWin tops
 /// out far below this in practice; the cap exists only to reject a grossly
 /// malformed hand-edited payload and to keep the validator's integrality check
-/// from narrowing an out-of-range double to int (UB). Shared by the descriptor
-/// validator and any consumer that re-validates the ordinal.
+/// from narrowing an out-of-range double to int (UB). The descriptor validator
+/// (ruleaction.cpp) enforces the bound once, at load; downstream consumers only
+/// re-check the 1-based lower bound, trusting the load-time upper-bound clamp.
 inline constexpr int MaxVirtualDesktopOrdinal = 1024;
 
 /// Wire tokens for OverrideOverlayStyle's `value` param — the closed vocabulary

--- a/libs/phosphor-window-rules/include/PhosphorWindowRules/WindowQuery.h
+++ b/libs/phosphor-window-rules/include/PhosphorWindowRules/WindowQuery.h
@@ -85,7 +85,7 @@ struct WindowQuery
      * treats as a non-match). Context fields always resolve.
      *
      * Bool flags resolve to `bool`, numeric fields to `int`, the window
-     * type to its underlying `int` (so `Equals`/`In` compare uniformly),
+     * type to its underlying `int` (so `Equals` comparisons are uniform),
      * everything else to `QString`.
      */
     std::optional<QVariant> valueForField(Field field) const

--- a/libs/phosphor-window-rules/src/matchexpression.cpp
+++ b/libs/phosphor-window-rules/src/matchexpression.cpp
@@ -34,7 +34,6 @@ bool operatorIsStringOnly(Operator op)
         return true;
     case Operator::Equals:
     case Operator::AppIdMatches:
-    case Operator::In:
     case Operator::GreaterThan:
     case Operator::LessThan:
         return false;
@@ -206,21 +205,6 @@ bool MatchExpression::isValid() const
     if (operatorIsNumeric(op) && !fieldIsNumeric(field)) {
         return false;
     }
-    if (op == Operator::In) {
-        // In does not apply to a boolean flag — a bool has only two states,
-        // so a set-membership test is degenerate and almost certainly an
-        // authoring mistake. Reject it explicitly.
-        if (fieldIsBool(field)) {
-            return false;
-        }
-        // In requires a list value. A QVariantList is the canonical wire
-        // shape, but a programmatically built leaf may carry a QStringList —
-        // accept either.
-        const int valueTypeId = m_predicate.value.metaType().id();
-        if (valueTypeId != QMetaType::QVariantList && valueTypeId != QMetaType::QStringList) {
-            return false;
-        }
-    }
     // A Regex pattern must compile. The program was compiled eagerly by
     // ensureRegex() at construction — reuse it rather than recompiling.
     // Also reject an empty pattern: QRegularExpression("") is a valid
@@ -240,11 +224,8 @@ bool MatchExpression::isValid() const
     // double, so an authored `"value": 12.7` would otherwise be silently
     // truncated by `subject.toInt()` to 12 — a Pid 12.7 leaf would match pid
     // 12. Reject the leaf rather than accepting a value the user almost
-    // certainly did not intend. Skips Operator::In (the list-of-values
-    // shape is dimensional — element-wise enforcement would belong here as
-    // a future tightening but is out of scope for the current numeric
-    // tolerance fix).
-    if (fieldIsNumeric(field) && op != Operator::In) {
+    // certainly did not intend.
+    if (fieldIsNumeric(field)) {
         const int valueTypeId = m_predicate.value.metaType().id();
         if (valueTypeId == QMetaType::Double) {
             const double d = m_predicate.value.toDouble();
@@ -306,57 +287,6 @@ bool MatchExpression::evaluateLeaf(const WindowQuery& query) const
     const QVariant& subject = *resolved;
     const Operator op = m_predicate.op;
     const QVariant& value = m_predicate.value;
-
-    // ── Set membership ──
-    if (op == Operator::In) {
-        // isValid() accepts either a QVariantList (the canonical wire shape)
-        // or a QStringList (a programmatically built leaf). QVariant::toList()
-        // does NOT convert a QStringList-typed QVariant — it returns an empty
-        // list — so a QStringList leaf must be iterated through toStringList()
-        // to evaluate correctly. Keep both branches so isValid()/evaluate()
-        // agree on what an `In` leaf can carry.
-        const bool stringField = fieldIsString(m_predicate.field);
-        // For a numeric field, `subject` must itself parse as a number — a
-        // non-numeric subject would coerce to 0 via toInt() and spuriously
-        // match a `0` candidate.
-        bool subjectOk = false;
-        const int subjectInt = stringField ? 0 : subject.toInt(&subjectOk);
-        if (value.metaType().id() == QMetaType::QStringList) {
-            const QString subjectStr = subject.toString();
-            for (const QString& candidate : value.toStringList()) {
-                if (stringField) {
-                    if (subjectStr.compare(candidate, Qt::CaseInsensitive) == 0) {
-                        return true;
-                    }
-                } else if (subjectOk) {
-                    // Skip any candidate that does not parse as a number —
-                    // toInt() would otherwise coerce it to 0 and match a
-                    // zero-valued numeric subject.
-                    bool candidateOk = false;
-                    const int candidateInt = candidate.toInt(&candidateOk);
-                    if (candidateOk && subjectInt == candidateInt) {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-        const QVariantList set = value.toList();
-        for (const QVariant& candidate : set) {
-            if (stringField) {
-                if (subject.toString().compare(candidate.toString(), Qt::CaseInsensitive) == 0) {
-                    return true;
-                }
-            } else if (subjectOk) {
-                bool candidateOk = false;
-                const int candidateInt = candidate.toInt(&candidateOk);
-                if (candidateOk && subjectInt == candidateInt) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
 
     // ── Boolean fields ──
     if (fieldIsBool(m_predicate.field)) {

--- a/libs/phosphor-window-rules/src/matchexpression.cpp
+++ b/libs/phosphor-window-rules/src/matchexpression.cpp
@@ -313,8 +313,7 @@ bool MatchExpression::evaluateLeaf(const WindowQuery& query) const
         }
     }
 
-    // ── WindowType — compared by its underlying int (Equals only here;
-    //    In is handled above) ──
+    // ── WindowType — compared by its underlying int (Equals only) ──
     if (m_predicate.field == Field::WindowType) {
         if (op != Operator::Equals) {
             return false;

--- a/libs/phosphor-window-rules/src/ruleaction.cpp
+++ b/libs/phosphor-window-rules/src/ruleaction.cpp
@@ -522,6 +522,58 @@ void ActionRegistry::registerBuiltins()
         .displayOrder = 0,
     });
 
+    // ── open-routing: send a matched window to a target monitor / desktop ──
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::RouteToScreen),
+        .slotFor = constantSlot(ActionSlot::RouteScreen),
+        .validate =
+            [](const QJsonObject& p) {
+                // A non-empty canonical screen id (physical or virtual). The id
+                // form is not validated against live screen state here — this lib
+                // has no view of connected outputs, and a rule targeting a
+                // currently-absent monitor is legitimate (it fires when that
+                // monitor returns). The daemon's placement path no-ops a route
+                // whose target screen is not currently resolvable.
+                return hasNonEmptyString(p, ActionParam::TargetScreenId);
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::TargetScreenId)},
+        .domain = ActionDomain::Window,
+        .params = {P{.key = QString(ActionParam::TargetScreenId), .kind = QStringLiteral("screenId")}},
+        // No tags: RouteToScreen is daemon open-path routing only, not an
+        // Effect / Border / Animation / Overlay / Gap action.
+        .category = QStringLiteral("windowManagement"),
+        .displayOrder = 1,
+    });
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::RouteToDesktop),
+        .slotFor = constantSlot(ActionSlot::RouteDesktop),
+        .validate =
+            [](const QJsonObject& p) {
+                // A single 1-based virtual-desktop number. Bound the DOUBLE before
+                // narrowing (a float-to-int cast out of int's range is UB), then
+                // require integrality — mirrors the SnapToZone ordinal check.
+                const QJsonValue v = p.value(ActionParam::TargetDesktop);
+                if (!v.isDouble()) {
+                    return false;
+                }
+                const double d = v.toDouble();
+                if (d < 1.0 || d > MaxVirtualDesktopOrdinal) {
+                    return false;
+                }
+                return static_cast<double>(static_cast<int>(d)) == d;
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::TargetDesktop)},
+        .domain = ActionDomain::Window,
+        .params = {P{.key = QString(ActionParam::TargetDesktop),
+                     .kind = QStringLiteral("virtualDesktop"),
+                     .min = 1.0,
+                     .max = static_cast<double>(MaxVirtualDesktopOrdinal)}},
+        .category = QStringLiteral("windowManagement"),
+        .displayOrder = 2,
+    });
+
     // ── animation slots — event-scoped: "anim-shader:<event>" ──
     registerAction(ActionDescriptor{
         .type = QString(ActionType::OverrideAnimationShader),

--- a/libs/phosphor-window-rules/tests/test_matchexpression.cpp
+++ b/libs/phosphor-window-rules/tests/test_matchexpression.cpp
@@ -239,20 +239,6 @@ private Q_SLOTS:
         QVERIFY(!dialog.evaluate(firefoxQuery()));
     }
 
-    void testInOperator_strings()
-    {
-        const QVariantList screens{QStringLiteral("DP-1"), QStringLiteral("DP-2")};
-        const auto expr = MatchExpression::makeLeaf(Field::ScreenId, Operator::In, screens);
-        QVERIFY(expr.evaluate(firefoxQuery()));
-    }
-
-    void testInOperator_numeric()
-    {
-        const QVariantList desktops{1, 2, 3};
-        const auto expr = MatchExpression::makeLeaf(Field::VirtualDesktop, Operator::In, desktops);
-        QVERIFY(expr.evaluate(firefoxQuery()));
-    }
-
     // ── Composites ──
 
     void testAll_andSemantics()

--- a/libs/phosphor-window-rules/tests/test_matchtypes.cpp
+++ b/libs/phosphor-window-rules/tests/test_matchtypes.cpp
@@ -39,7 +39,7 @@ private Q_SLOTS:
     {
         // Canary: the loop bound is derived from OperatorCount — see
         // testFieldRoundTrip_data.
-        QCOMPARE(OperatorCount, 9);
+        QCOMPARE(OperatorCount, 8);
         QTest::addColumn<int>("opValue");
         for (int v = 0; v < OperatorCount; ++v) {
             QTest::addRow("op-%d", v) << v;

--- a/libs/phosphor-window-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-window-rules/tests/test_ruleaction.cpp
@@ -57,6 +57,10 @@ const QList<QLatin1StringView> kWindowDomainTypes = {
     ActionType::Exclude,
     ActionType::Float,
     ActionType::SnapToZone,
+    // Open-routing actions are window-domain — resolved per window on the
+    // daemon open path, applicable to any matched window.
+    ActionType::RouteToScreen,
+    ActionType::RouteToDesktop,
     ActionType::OverrideAnimationShader,
     ActionType::OverrideAnimationTiming,
     ActionType::OverrideAnimationCurve,
@@ -164,6 +168,49 @@ private Q_SLOTS:
     {
         QVERIFY(engineModeAction(QStringLiteral("autotile")) == engineModeAction(QStringLiteral("autotile")));
         QVERIFY(engineModeAction(QStringLiteral("autotile")) != engineModeAction(QStringLiteral("snapping")));
+    }
+
+    void testJson_routeToScreen()
+    {
+        QJsonObject o;
+        o.insert(QStringLiteral("type"), QString(ActionType::RouteToScreen));
+        // Missing / empty target screen id is rejected.
+        QVERIFY(!RuleAction::fromJson(o).has_value());
+        o.insert(QString(ActionParam::TargetScreenId), QString());
+        QVERIFY(!RuleAction::fromJson(o).has_value());
+        // A non-empty canonical screen id is accepted (not validated against
+        // live screen state — a route to a currently-absent monitor is legal).
+        o.insert(QString(ActionParam::TargetScreenId), QStringLiteral("LG Electronics:38GN950:688325"));
+        const auto loaded = RuleAction::fromJson(o);
+        QVERIFY(loaded.has_value());
+        QCOMPARE(ActionRegistry::instance().slotFor(*loaded), QString(ActionSlot::RouteScreen));
+        // Unknown param key is rejected by the strict loader.
+        o.insert(QStringLiteral("bogus"), 1);
+        QVERIFY(!RuleAction::fromJson(o).has_value());
+    }
+
+    void testJson_routeToDesktop()
+    {
+        QJsonObject o;
+        o.insert(QStringLiteral("type"), QString(ActionType::RouteToDesktop));
+        // Missing desktop is rejected.
+        QVERIFY(!RuleAction::fromJson(o).has_value());
+        // Desktops are 1-based: 0 and negatives are rejected.
+        o.insert(QString(ActionParam::TargetDesktop), 0);
+        QVERIFY(!RuleAction::fromJson(o).has_value());
+        o.insert(QString(ActionParam::TargetDesktop), -1);
+        QVERIFY(!RuleAction::fromJson(o).has_value());
+        // Non-integral is rejected.
+        o.insert(QString(ActionParam::TargetDesktop), 2.5);
+        QVERIFY(!RuleAction::fromJson(o).has_value());
+        // Out-of-range (above the cap) is rejected.
+        o.insert(QString(ActionParam::TargetDesktop), MaxVirtualDesktopOrdinal + 1);
+        QVERIFY(!RuleAction::fromJson(o).has_value());
+        // A valid 1-based desktop loads and resolves to the route-desktop slot.
+        o.insert(QString(ActionParam::TargetDesktop), 3);
+        const auto loaded = RuleAction::fromJson(o);
+        QVERIFY(loaded.has_value());
+        QCOMPARE(ActionRegistry::instance().slotFor(*loaded), QString(ActionSlot::RouteDesktop));
     }
 
     void testActionDomain_contextActions()

--- a/src/config/configmigration.cpp
+++ b/src/config/configmigration.cpp
@@ -15,6 +15,7 @@
 #include <PhosphorWindowRules/IdentityKey.h>
 #include <PhosphorWindowRules/MatchExpression.h>
 #include <PhosphorWindowRules/MatchTypes.h>
+#include <PhosphorIdentity/WindowId.h>
 #include <PhosphorWindowRules/RuleAction.h>
 #include <PhosphorWindowRules/WindowRule.h>
 #include <PhosphorWindowRules/WindowRuleSet.h>
@@ -2323,6 +2324,7 @@ inline const QUuid& snapToZoneMigrationNamespace()
 constexpr QLatin1String kLayoutAppRulesKey{"appRules"};
 constexpr QLatin1String kLayoutAppRulePattern{"pattern"};
 constexpr QLatin1String kLayoutAppRuleZoneNumber{"zoneNumber"};
+constexpr QLatin1String kLayoutAppRuleTargetScreen{"targetScreen"};
 
 // Frozen on-disk keys for the v4 per-layout settings relocation. Local literals
 // (NOT the live `ZoneJsonKeys::` / LayoutSettingsStore accessors) so a future
@@ -2361,25 +2363,35 @@ constexpr std::array<QLatin1String, 14> kLayoutSettingKeys{{
 }};
 
 /// Convert each layout file's legacy per-layout `appRules` into first-class
-/// SnapToZone WindowRules. v3 stored app→zone assignments on the Layout
-/// (`Layout::appRules`: a `{pattern, zoneNumber, targetScreen}` triple, single
-/// zone); v4 unifies them into the window-rule store. Each becomes
-/// `AppId AppIdMatches <pattern> → SnapToZone [zoneNumber]`. AppId / AppIdMatches
-/// mirrors the retired `Layout::matchAppRule` (which matched the pattern against
-/// the window's appId via segment-aware `appIdMatches`) and the daemon placement
-/// path, which resolves the query on appId — WindowClass is not tracked daemon-
-/// side, so a WindowClass leaf would never match.
+/// WindowRules. v3 stored app→zone assignments on the Layout (`Layout::appRules`:
+/// a `{pattern, zoneNumber, targetScreen}` triple, single zone); v4 unifies them
+/// into the window-rule store. Each becomes `AppId AppIdMatches <pattern> →
+/// SnapToZone [zoneNumber]`, plus a `RouteToScreen <targetScreen>` action when the
+/// legacy rule pinned a monitor. AppId / AppIdMatches mirrors the retired
+/// `Layout::matchAppRule` (which matched the pattern against the window's appId via
+/// segment-aware `appIdMatches`) and the daemon placement path, which resolves the
+/// query on appId — WindowClass is not tracked daemon-side, so a WindowClass leaf
+/// would never match.
 ///
-/// The legacy `targetScreen` (a connector name like "DP-1") is intentionally NOT
-/// carried over as a `ScreenId` constraint. v4 resolves a SnapToZone rule on the
-/// window's CURRENT screen, and a `ScreenId Equals` leaf would have to match the
-/// canonical screen-id form the daemon reports at runtime (EDID-form
-/// "Manuf:Model:Serial", what the settings screen-picker also stores), not a
-/// connector name. Translating connector→canonical here would couple this pure
-/// JSON transform to live screen state and make the deterministic rule id depend
-/// on which monitors are connected. So a migrated app snaps to its zone on
-/// whatever screen it opens on (per-monitor pinning is dropped; v3's cross-screen
-/// routing was already retired by this PR).
+/// The pattern is normalized through `WindowId::normalizeAppId` before becoming the
+/// AppId leaf. v3 stored the raw matcher, which for X11 windows was often the
+/// two-token "resourceName resourceClass" form ("chromium chromium"). The v4 daemon
+/// keys rule queries on the SINGLE normalized appId ("chromium"), and
+/// `appIdMatches` treats the embedded space as a literal — so a two-token pattern
+/// matched nothing. Normalizing here (last whitespace token, lowercased — the exact
+/// derivation the runtime applies) makes the migrated rule match the appId the
+/// daemon actually reports.
+///
+/// The legacy `targetScreen` is carried over as a `RouteToScreen` action, which
+/// pins the placement to that monitor on open — restoring the per-monitor
+/// assignment v3 had. The value is copied verbatim: real v3 data already stores the
+/// canonical EDID screen-id form ("Manuf:Model:Serial", what the runtime and the
+/// settings screen-picker use), so this stays a pure JSON transform with no
+/// coupling to live screen state. A legacy connector-name value ("DP-1") simply
+/// won't resolve at runtime and the route is skipped (the snap falls back to the
+/// opening screen) — no worse than the old behaviour, which dropped the pin
+/// entirely. The deterministic rule id folds in the target screen alongside the
+/// pattern and zone so a crash-and-retry conversion stays byte-identical.
 ///
 /// Patterns are deduped across layouts — a SnapToZone ordinal rule fires
 /// regardless of which layout is active, so one pattern can map to only one
@@ -2412,11 +2424,23 @@ void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& ru
                 continue;
             }
             const QJsonObject ar = entry.toObject();
-            const QString pattern = ar.value(kLayoutAppRulePattern).toString().trimmed();
+            const QString rawPattern = ar.value(kLayoutAppRulePattern).toString().trimmed();
             const int zoneNumber = ar.value(kLayoutAppRuleZoneNumber).toInt(0);
-            if (pattern.isEmpty() || zoneNumber < 1) {
+            if (rawPattern.isEmpty() || zoneNumber < 1) {
                 continue;
             }
+            // Normalize the legacy matcher to the single appId token the v4 daemon
+            // keys rule queries on. v3 stored the raw class string, often the X11
+            // "resourceName resourceClass" two-token form ("chromium chromium");
+            // `appIdMatches` treats the embedded space literally, so that pattern
+            // matched nothing once the daemon switched to the normalized appId. Use
+            // the SAME derivation the runtime applies (last whitespace token,
+            // lowercased) so the migrated leaf matches.
+            const QString pattern = PhosphorIdentity::WindowId::normalizeAppId(QString(), rawPattern);
+            if (pattern.isEmpty()) {
+                continue;
+            }
+            const QString targetScreen = ar.value(kLayoutAppRuleTargetScreen).toString().trimmed();
             // The SnapToZone action validator caps ordinals at MaxZoneOrdinal, so a
             // legacy zoneNumber beyond it would be silently dropped by the loader's
             // validator. Skip it here with a visible warning instead of emitting a
@@ -2425,26 +2449,31 @@ void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& ru
                 qWarning(
                     "ConfigMigration: app->zone pattern '%s' targets zone %d beyond the max ordinal (%d) — "
                     "dropping the assignment.",
-                    qPrintable(pattern), zoneNumber, MaxZoneOrdinal);
+                    qPrintable(rawPattern), zoneNumber, MaxZoneOrdinal);
                 continue;
             }
-            const QString patternKey = pattern.toLower();
+            // Dedup on the NORMALIZED appId: two raw patterns that normalize to the
+            // same app ("chromium chromium" and "chromium") are one placement. A
+            // SnapToZone rule fires regardless of the active layout, so a normalized
+            // pattern can map to only one placement — first wins.
+            const QString patternKey = pattern;
             if (seenPatterns.contains(patternKey)) {
                 qWarning(
-                    "ConfigMigration: duplicate app->zone pattern '%s' across layouts — keeping the first, "
-                    "dropping zone %d (a SnapToZone ordinal rule fires regardless of the active layout, so a "
-                    "pattern can map to only one placement).",
-                    qPrintable(pattern), zoneNumber);
+                    "ConfigMigration: duplicate app->zone pattern '%s' (normalized '%s') across layouts — keeping "
+                    "the first, dropping zone %d (a SnapToZone ordinal rule fires regardless of the active layout, "
+                    "so a pattern can map to only one placement).",
+                    qPrintable(rawPattern), qPrintable(pattern), zoneNumber);
                 continue;
             }
             seenPatterns.insert(patternKey);
 
             WindowRule rule;
-            // Deterministic id from (pattern, zone) so a crash-and-retry
-            // conversion yields byte-identical rules.
-            rule.id = QUuid::createUuidV5(snapToZoneMigrationNamespace(),
-                                          Detail::encodeSegment(pattern)
-                                              + Detail::encodeSegment(QString::number(zoneNumber)));
+            // Deterministic id from (normalized pattern, zone, target screen) so a
+            // crash-and-retry conversion yields byte-identical rules.
+            rule.id =
+                QUuid::createUuidV5(snapToZoneMigrationNamespace(),
+                                    Detail::encodeSegment(pattern) + Detail::encodeSegment(QString::number(zoneNumber))
+                                        + Detail::encodeSegment(targetScreen));
             rule.enabled = true;
             // priority 0 mirrors the other migrated rules; the controller
             // renormalizes display order on load and the user can reorder.
@@ -2456,6 +2485,19 @@ void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& ru
             params.insert(QString(ActionParam::Zones), QJsonArray{zoneNumber});
             action.params = params;
             rule.actions.append(action);
+            // Carry the legacy per-monitor pin as a RouteToScreen action so the app
+            // still opens into its zone on the target monitor. Verbatim copy — real
+            // v3 data stores the canonical EDID screen id the runtime matches; a
+            // legacy connector-name value just won't resolve and the route is
+            // skipped (the snap falls back to the opening screen).
+            if (!targetScreen.isEmpty()) {
+                RuleAction route;
+                route.type = QString(ActionType::RouteToScreen);
+                QJsonObject routeParams;
+                routeParams.insert(QString(ActionParam::TargetScreenId), targetScreen);
+                route.params = routeParams;
+                rule.actions.append(route);
+            }
             rules.append(rule);
         }
     }

--- a/src/config/configmigration.cpp
+++ b/src/config/configmigration.cpp
@@ -11,11 +11,11 @@
 #include <PhosphorAnimation/Profile.h>
 #include <PhosphorConfig/MigrationRunner.h>
 #include <PhosphorConfig/Schema.h>
+#include <PhosphorIdentity/WindowId.h>
 #include <PhosphorWindowRules/ContextRuleBridge.h>
 #include <PhosphorWindowRules/IdentityKey.h>
 #include <PhosphorWindowRules/MatchExpression.h>
 #include <PhosphorWindowRules/MatchTypes.h>
-#include <PhosphorIdentity/WindowId.h>
 #include <PhosphorWindowRules/RuleAction.h>
 #include <PhosphorWindowRules/WindowRule.h>
 #include <PhosphorWindowRules/WindowRuleSet.h>
@@ -2434,7 +2434,7 @@ void appendLayoutAppRulesAsSnapToZone(QList<PhosphorWindowRules::WindowRule>& ru
             // "resourceName resourceClass" two-token form ("chromium chromium");
             // `appIdMatches` treats the embedded space literally, so that pattern
             // matched nothing once the daemon switched to the normalized appId. Use
-            // the SAME derivation the runtime applies (last whitespace token,
+            // the SAME derivation the runtime applies (last space-delimited token,
             // lowercased) so the migrated leaf matches.
             const QString pattern = PhosphorIdentity::WindowId::normalizeAppId(QString(), rawPattern);
             if (pattern.isEmpty()) {

--- a/src/config/configmigration.h
+++ b/src/config/configmigration.h
@@ -46,9 +46,10 @@ namespace PlasmaZones {
 ///     Each layout's retired per-layout `appRules` triple
 ///     (`{pattern, zoneNumber, targetScreen}`) also folds into windowrules.json
 ///     as an `AppId AppIdMatches <pattern> → SnapToZone [zoneNumber]` rule,
-///     deduped by pattern across layouts (the legacy `targetScreen` is dropped —
-///     a migrated app snaps on whatever screen it opens on) — see
-///     appendLayoutAppRulesAsSnapToZone in configmigration.cpp.
+///     deduped by normalized pattern across layouts. A legacy `targetScreen` is
+///     carried over as a companion `RouteToScreen` action so the app reopens on
+///     its pinned monitor. See appendLayoutAppRulesAsSnapToZone in
+///     configmigration.cpp.
 ///     Additionally renames the drag-time zone-overlay groups
 ///     Snapping.Appearance.{Colors,Opacity,Border,Labels} → Snapping.Zones.*,
 ///     freeing the Snapping.Appearance.* namespace for the new per-window

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2135,7 +2135,7 @@ void Daemon::stop()
     }
     if (m_autotileAdaptor) {
         // Sever the autotile adaptor's post-construction borrow of the WTA (wired
-        // in start() so the autotile open path can resolve RouteToScreen /
+        // in init() so the autotile open path can resolve RouteToScreen /
         // RouteToDesktop rules). The autotile open path no-ops on a null WTA, so
         // a D-Bus open landing in the teardown gap can't drive routing against
         // half-torn-down state. Symmetric with the resolver / router clears above

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -2133,6 +2133,15 @@ void Daemon::stop()
         // the symmetric clear (snapadaptor.cpp).
         m_windowTrackingAdaptor->setScreenModeRouter(nullptr);
     }
+    if (m_autotileAdaptor) {
+        // Sever the autotile adaptor's post-construction borrow of the WTA (wired
+        // in start() so the autotile open path can resolve RouteToScreen /
+        // RouteToDesktop rules). The autotile open path no-ops on a null WTA, so
+        // a D-Bus open landing in the teardown gap can't drive routing against
+        // half-torn-down state. Symmetric with the resolver / router clears above
+        // and honours the shutdown-nullptr contract documented in autotileadaptor.h.
+        m_autotileAdaptor->setWindowTrackingAdaptor(nullptr);
+    }
     m_contextResolver.reset();
     m_settingsGateAdapter.reset();
     m_screenModeAdapter.reset();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1533,6 +1533,9 @@ bool Daemon::init()
     m_snapAdaptor = new SnapAdaptor(snapEngine, m_windowTrackingAdaptor, m_settings.get(), this);
     m_snapAdaptor->setContextResolver(m_contextResolver.get());
     m_autotileAdaptor = new AutotileAdaptor(autotileEngine, m_screenManager.get(), m_algorithmRegistry.get(), this);
+    // Wire the WTA so the autotile open path can resolve RouteToScreen /
+    // RouteToDesktop window rules (the rule store + evaluator live on the WTA).
+    m_autotileAdaptor->setWindowTrackingAdaptor(m_windowTrackingAdaptor);
 
     // Control adaptor - high-level convenience API for third-party integrations.
     // Held as a member so stop() can detach() it before the unique_ptr members

--- a/src/dbus/autotileadaptor.cpp
+++ b/src/dbus/autotileadaptor.cpp
@@ -4,6 +4,7 @@
 #include "autotileadaptor.h"
 
 #include "core/logging.h"
+#include "windowtrackingadaptor.h"
 
 #include <PhosphorProtocol/AutotileMarshalling.h>
 #include <PhosphorProtocol/WindowMarshalling.h>
@@ -208,7 +209,20 @@ void AutotileAdaptor::dispatchWindowOpened(const PhosphorProtocol::WindowOpenedE
     if (entry.windowId.isEmpty() || entry.screenId.isEmpty()) {
         return;
     }
-    m_engine->windowOpened(entry.windowId, entry.screenId, qMax(0, entry.minWidth), qMax(0, entry.minHeight));
+    // Window-rule open routing (RouteToScreen / RouteToDesktop). The WTA owns the
+    // rule store + evaluator and the desktop/output-move relay signals. It emits a
+    // RouteToDesktop move and, for a RouteToScreen pin onto a DIFFERENT autotile
+    // monitor, returns that screen so we insert the window into its tiling state
+    // instead of the spawn screen's (snap-mode targets are handled by the snap
+    // placement path, so the returned screen is always empty or an autotile screen).
+    QString screenId = entry.screenId;
+    if (m_windowTrackingAdaptor) {
+        const QString routed = m_windowTrackingAdaptor->applyOpenRoutingForAutotile(entry.windowId, entry.screenId);
+        if (!routed.isEmpty()) {
+            screenId = routed;
+        }
+    }
+    m_engine->windowOpened(entry.windowId, screenId, qMax(0, entry.minWidth), qMax(0, entry.minHeight));
 }
 
 bool AutotileAdaptor::deferUntilPanelReady()

--- a/src/dbus/autotileadaptor.h
+++ b/src/dbus/autotileadaptor.h
@@ -28,6 +28,8 @@ class AutotileEngine;
 
 namespace PlasmaZones {
 
+class WindowTrackingAdaptor;
+
 /**
  * @brief D-Bus adaptor for autotiling control
  *
@@ -82,6 +84,14 @@ public:
     explicit AutotileAdaptor(PhosphorTileEngine::AutotileEngine* engine, PhosphorScreens::ScreenManager* screenManager,
                              PhosphorTiles::ITileAlgorithmRegistry* algorithmRegistry, QObject* parent = nullptr);
     ~AutotileAdaptor() override = default;
+
+    /// Wire the WindowTrackingAdaptor (post-construction, to break the
+    /// construction-order cycle) so the autotile open path can resolve
+    /// RouteToScreen / RouteToDesktop window rules. Pass nullptr on shutdown.
+    void setWindowTrackingAdaptor(WindowTrackingAdaptor* wta)
+    {
+        m_windowTrackingAdaptor = wta;
+    }
 
     /**
      * @brief Number of windowOpened entries waiting for panel geometry
@@ -422,6 +432,11 @@ private:
 
     PhosphorTileEngine::AutotileEngine* m_engine = nullptr;
     PhosphorScreens::ScreenManager* m_screenManager = nullptr;
+    /// Borrowed; outlives adaptor. Wired post-construction by the daemon so the
+    /// autotile open path can resolve RouteToScreen / RouteToDesktop window rules
+    /// (the rule store + evaluator live on the WTA). Null in tests / when unset —
+    /// routing is then skipped and windows open on their spawn screen.
+    WindowTrackingAdaptor* m_windowTrackingAdaptor = nullptr;
     PhosphorTiles::ITileAlgorithmRegistry* m_algorithmRegistry = nullptr; ///< Borrowed; outlives adaptor
 
     // Window-opened events received before the first panel D-Bus query completed.

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -232,24 +232,26 @@ bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
         // whose mode differs from the caller's, so the disable list to consult
         // is the one for result.screenId's mode — not a hard-coded Snapping.
         //
-        // currentVirtualDesktop()/currentActivity() are the precise destination
-        // context here, not an approximation: a restore only ever targets the
-        // current desktop. Every calculator feeding this path either snaps a
-        // window opening now on the current desktop (calculateSnapToPlacementRule /
-        // calculateSnapToEmptyZone) or refuses outright when the saved desktop
-        // is not the current one — the WindowPlacementStore restore block gates
-        // on screen and disabled-context (restoring onto the current desktop),
-        // and calculateSnapToLastZone returns noSnap on a desktop mismatch. A
-        // restored window therefore lands on the current desktop/activity.
-        // Resolver's handleFor pulls (currentVirtualDesktop, currentActivity)
-        // from the daemon's VDM/AM — same values the snap engine sees on
-        // its own state surface — and routes the screen through the mode
-        // provider, collapsing the 3-step `(modeFor + currentVirtualDesktop
-        // + currentActivity)` cascade rebuild to one snapshot call.
-        if (m_contextResolver && m_contextResolver->isDisabled(m_contextResolver->handleFor(result.screenId))) {
-            qCInfo(lcDbusWindow) << "applySnapResult: refusing auto-snap of" << windowId
-                                 << "— PlasmaZones is disabled for screen" << result.screenId;
-            return false;
+        // The destination DESKTOP is result.virtualDesktop when the result was
+        // routed there (a RouteToDesktop placement, calculateSnapToPlacementRule),
+        // otherwise the current desktop (every other calculator opens the window on
+        // the current desktop, or refuses outright on a saved-desktop mismatch).
+        // For a routed result handleForPersisted composes the explicit destination
+        // desktop, so the disable check keys on the desktop the window will actually
+        // land on rather than the live current desktop; for a non-routed result
+        // (virtualDesktop == 0) handleFor is exact, pulling (currentVirtualDesktop,
+        // currentActivity) from the daemon's VDM/AM — the same values the snap engine
+        // sees — and routing the screen through the mode provider in one snapshot.
+        if (m_contextResolver) {
+            const auto handle = result.virtualDesktop >= 1
+                ? m_contextResolver->handleForPersisted(result.screenId, result.virtualDesktop,
+                                                        m_contextResolver->currentActivity())
+                : m_contextResolver->handleFor(result.screenId);
+            if (m_contextResolver->isDisabled(handle)) {
+                qCInfo(lcDbusWindow) << "applySnapResult: refusing auto-snap of" << windowId
+                                     << "— PlasmaZones is disabled for screen" << result.screenId;
+                return false;
+            }
         }
     }
 

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -180,6 +180,12 @@ void SnapAdaptor::resolveWindowRestore(const QString& windowId, const QString& s
         return;
     }
 
+    // Engine-neutral RouteToDesktop runs first and unconditionally — a window can
+    // be routed to a desktop whether or not it snaps (and even when it doesn't
+    // match a SnapToZone rule at all), so it must not sit behind the shouldSnap
+    // early-return below.
+    m_adaptor->applyOpenDesktopRouting(windowId, screenId);
+
     const PhosphorEngine::WindowKind kind = PhosphorEngine::clampWindowKindFromWire(windowKind);
     SnapResult result = m_engine->resolveWindowRestore(windowId, screenId, sticky, kind);
     if (!result.shouldSnap) {
@@ -261,9 +267,11 @@ bool SnapAdaptor::applySnapResult(const SnapResult& result, const QString& windo
     m_adaptor->service()->markAsAutoSnapped(windowId);
     const QStringList zoneIds = result.zoneIds.isEmpty() ? QStringList{result.zoneId} : result.zoneIds;
     if (zoneIds.size() > 1) {
-        m_engine->commitMultiZoneSnap(windowId, zoneIds, result.screenId, SnapIntent::AutoRestored);
+        m_engine->commitMultiZoneSnap(windowId, zoneIds, result.screenId, SnapIntent::AutoRestored,
+                                      result.virtualDesktop);
     } else {
-        m_engine->commitSnap(windowId, zoneIds.first(), result.screenId, SnapIntent::AutoRestored);
+        m_engine->commitSnap(windowId, zoneIds.first(), result.screenId, SnapIntent::AutoRestored,
+                             result.virtualDesktop);
     }
     // Focus-new-windows is handled inside SnapEngine::commitSnapImpl on the
     // AutoRestored path (mirrors AutotileEngine), so it covers every auto-snap-on-open

--- a/src/dbus/snapadaptor/snaprestore.cpp
+++ b/src/dbus/snapadaptor/snaprestore.cpp
@@ -189,6 +189,14 @@ void SnapAdaptor::resolveWindowRestore(const QString& windowId, const QString& s
     const PhosphorEngine::WindowKind kind = PhosphorEngine::clampWindowKindFromWire(windowKind);
     SnapResult result = m_engine->resolveWindowRestore(windowId, screenId, sticky, kind);
     if (!result.shouldSnap) {
+        // Nothing snapped this window. A bare RouteToScreen rule (move-to-monitor
+        // with no SnapToZone) takes effect here, deliberately AFTER the snap/float
+        // restore has had its chance: a SnapToZone restore or a remembered snap
+        // already returned shouldSnap=true above (so the route never fights a snap),
+        // and the explicit route wins over a remembered float position (it applies
+        // the final geometry). A route WITH SnapToZone moved+snapped on the target
+        // via the placement directive and never reaches here.
+        m_adaptor->applyOpenScreenRouting(windowId, screenId);
         return;
     }
 

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -9,6 +9,7 @@
 #include <PhosphorEngine/PlacementEngineBase.h>
 #include <PhosphorZones/AssignmentEntry.h>
 #include <PhosphorSnapEngine/INavigationStateProvider.h>
+#include <PhosphorSnapEngine/PlacementDirective.h>
 #include <PhosphorProtocol/AutotileMarshalling.h>
 #include <PhosphorProtocol/WindowMarshalling.h>
 #include <PhosphorProtocol/ZoneMarshalling.h>
@@ -56,6 +57,7 @@ class ActivityManager;
 namespace PhosphorWindowRules {
 class WindowRuleStore;
 class RuleEvaluator;
+class ResolvedActions;
 }
 
 namespace PlasmaZones {
@@ -680,15 +682,37 @@ public:
     /// params are free-form, so the verdict is the presence of the filled slot.
     bool shouldFloatByRule(const QString& windowId);
 
-    /// Resolve the 1-based zone ordinals an opening window should snap into
-    /// because a `SnapToZone` window rule matched it. Consulted by the placement
-    /// resolver the daemon injects into the SnapEngine (in-process, not via
-    /// D-Bus). Returns an empty list when no SnapToZone rule matches; multiple
-    /// ordinals request a zone span. Builds a WindowQuery from the window
-    /// registry metadata, pins it to @p screenId (the screen the window is
-    /// opening on) so a `ScreenId`-constrained rule resolves, and reads the
-    /// `Placement` slot — mirrors shouldFloatByRule.
-    QList<int> placementZonesByRule(const QString& windowId, const QString& screenId);
+    /// Resolve the open-placement directive for a window from its matched window
+    /// rules: the 1-based `SnapToZone` ordinals to snap into (empty when no
+    /// SnapToZone rule matches; multiple ordinals request a zone span) plus the
+    /// `RouteToScreen` target monitor (empty when unrouted). Consulted by the
+    /// placement resolver the daemon injects into the SnapEngine (in-process, not
+    /// via D-Bus). Builds a WindowQuery from the window registry metadata, pins it
+    /// to @p screenId (the screen the window is opening on) so a
+    /// `ScreenId`-constrained rule resolves, and reads the `Placement` /
+    /// `RouteScreen` slots — mirrors shouldFloatByRule.
+    PhosphorSnapEngine::PlacementDirective placementZonesByRule(const QString& windowId, const QString& screenId);
+
+    /// Engine-neutral RouteToDesktop: if a matched window rule pins @p windowId to
+    /// a virtual desktop, emit windowDesktopMoveRequested so the compositor moves
+    /// it there on open. Independent of snapping/tiling — composes with the
+    /// window's placement. Called from the snap open-path facade. Pins @p screenId
+    /// so a ScreenId-scoped rule resolves; reuses the per-window evaluator cache
+    /// placementZonesByRule seeds.
+    void applyOpenDesktopRouting(const QString& windowId, const QString& screenId);
+
+    /// Autotile open-path routing. Emits RouteToDesktop (as applyOpenDesktopRouting)
+    /// AND resolves a RouteToScreen pin: when the matched rule routes the window to a
+    /// DIFFERENT monitor that is itself in autotile mode, emits windowOutputMoveExpected
+    /// and returns that screen id so the caller inserts the window into that screen's
+    /// tiling state. Returns an empty string when there is no autotile redirect (no
+    /// rule, snap/disabled target, or same screen) — the caller then uses the spawn
+    /// screen. Snap-mode targets are handled by the snap placement directive, not here.
+    QString applyOpenRoutingForAutotile(const QString& windowId, const QString& screenId);
+
+    /// Shared by the two open-routing entry points: if @p resolved carries a
+    /// RouteToDesktop action, emit windowDesktopMoveRequested for @p windowId.
+    void emitRouteToDesktopIfMatched(const PhosphorWindowRules::ResolvedActions& resolved, const QString& windowId);
     /**
      * @brief Drop unified WindowPlacement records for excluded appIds.
      *

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -710,6 +710,22 @@ public:
     /// screen. Snap-mode targets are handled by the snap placement directive, not here.
     QString applyOpenRoutingForAutotile(const QString& windowId, const QString& screenId);
 
+    /// Engine-neutral RouteToScreen for a BARE route (no SnapToZone): if a matched
+    /// rule pins @p windowId to a different monitor and the rule carries no
+    /// SnapToZone (a route + snap is placed by the snap placement directive, which
+    /// resolves the zones ON the target screen), move the window there free.
+    /// Translates the window's current frame geometry onto the target screen's
+    /// available area (preserving its relative position, clamped to fit) and emits
+    /// applyGeometryRequested with an empty zone id (a free placement, no snap
+    /// chrome) plus the windowOutputMoveExpected marker. Called from the snap
+    /// open-path facade only when nothing snapped the window, so a SnapToZone
+    /// restore or a remembered snap takes precedence and the explicit route wins
+    /// over a remembered float position. No-ops when the target is unset, the spawn
+    /// screen, or not currently connected, or when the window has pushed no geometry
+    /// yet. A target in autotile mode is moved (not tiled) — cross-engine tiling
+    /// insertion stays with the autotile spawn path (applyOpenRoutingForAutotile).
+    void applyOpenScreenRouting(const QString& windowId, const QString& screenId);
+
     /// Shared by the two open-routing entry points: if @p resolved carries a
     /// RouteToDesktop action, emit windowDesktopMoveRequested for @p windowId.
     void emitRouteToDesktopIfMatched(const PhosphorWindowRules::ResolvedActions& resolved, const QString& windowId);

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -666,7 +666,19 @@ QString WindowTrackingAdaptor::applyOpenRoutingForAutotile(const QString& window
     if (target.isEmpty() || target == screenId || !m_layoutManager) {
         return QString();
     }
-    if (m_layoutManager->modeForScreen(target, currentDesktopForScreen(target), m_layoutManager->currentActivity())
+    // When the same rule also pins a target desktop (RouteToDesktop), the window
+    // lands on THAT desktop of the target screen, so gate the autotile-mode check
+    // against the destination desktop — not the target's current desktop. Mirrors
+    // the snap path (calculateSnapToPlacementRule), which gates modeForScreen on the
+    // routed desktop. Absent / 0 ⇒ the target screen's current desktop.
+    int destDesktop = currentDesktopForScreen(target);
+    if (const auto desktopRoute = resolved.slot(QString(PhosphorWindowRules::ActionSlot::RouteDesktop))) {
+        const int d = desktopRoute->params.value(QString(PhosphorWindowRules::ActionParam::TargetDesktop)).toInt(0);
+        if (d >= 1) {
+            destDesktop = d;
+        }
+    }
+    if (m_layoutManager->modeForScreen(target, destDesktop, m_layoutManager->currentActivity())
         != PhosphorZones::AssignmentEntry::Mode::Autotile) {
         qCDebug(lcDbusWindow) << "applyOpenRoutingForAutotile: RouteToScreen target" << target
                               << "is not in autotile mode — not redirecting" << windowId;

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -665,7 +665,9 @@ void WindowTrackingAdaptor::applyOpenScreenRouting(const QString& windowId, cons
     if (target.isEmpty() || target == screenId) {
         return;
     }
-    PhosphorScreens::ScreenManager* screens = m_service ? m_service->screenManager() : nullptr;
+    // m_service is non-null post-construction (class invariant); screenManager()
+    // itself may still be null (e.g. an unconfigured test fixture), so guard that.
+    PhosphorScreens::ScreenManager* screens = m_service->screenManager();
     if (!screens) {
         return;
     }

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -13,6 +13,7 @@
 
 #include "../zonedetectionadaptor.h"
 #include "core/isettings.h"
+#include "core/logging.h"
 #include <PhosphorEngine/IPlacementEngine.h>
 #include <PhosphorIdentity/WindowId.h>
 #include <PhosphorSnapEngine/SnapEngine.h>
@@ -203,9 +204,10 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
         // highest-priority restore-chain level), superseding the retired
         // per-layout Layout::appRules. Snap-only — autotile owns placement on
         // its screens, so no resolver is wired into the autotile engine.
-        snap->setPlacementZonesResolver([this](const QString& windowId, const QString& screenId) -> QList<int> {
-            return placementZonesByRule(windowId, screenId);
-        });
+        snap->setPlacementZonesResolver(
+            [this](const QString& windowId, const QString& screenId) -> PhosphorSnapEngine::PlacementDirective {
+                return placementZonesByRule(windowId, screenId);
+            });
 
         // Snap-specific signal: carries PhosphorProtocol::WindowStateEntry which is snap-mode-only.
         // Connected via qobject_cast since the member type is PlacementEngineBase.
@@ -502,10 +504,11 @@ bool WindowTrackingAdaptor::shouldFloatByRule(const QString& windowId)
     return resolved.slot(QString(PhosphorWindowRules::ActionSlot::Float)).has_value();
 }
 
-QList<int> WindowTrackingAdaptor::placementZonesByRule(const QString& windowId, const QString& screenId)
+PhosphorSnapEngine::PlacementDirective WindowTrackingAdaptor::placementZonesByRule(const QString& windowId,
+                                                                                   const QString& screenId)
 {
-    // Placement is purely rule-driven: absent a matching SnapToZone rule there is
-    // nothing to snap, so the answer is an empty list.
+    // Placement is purely rule-driven: absent a matching SnapToZone / RouteToScreen
+    // rule there is nothing to snap or route, so the answer is empty.
     if (!m_windowRuleStore) {
         return {};
     }
@@ -536,25 +539,143 @@ QList<int> WindowTrackingAdaptor::placementZonesByRule(const QString& windowId, 
     // slot, so reading the Placement slot off the same verdict is free. Same open-path
     // lifetime guarantee (resolved once per window lifetime) as the sibling predicates.
     const PhosphorWindowRules::ResolvedActions resolved = m_windowRuleEvaluator->resolveCached(windowId, *query);
+
+    PhosphorSnapEngine::PlacementDirective directive;
+
+    // RouteToScreen target (optional, independent of SnapToZone): pin the placement
+    // to a specific monitor. A non-empty target moves the window there and resolves
+    // its zone on that screen. The id is the canonical screen-id form the picker and
+    // the runtime both use; the snap engine declines the route if the target is not
+    // currently a snapping-mode screen, so an absent / autotile / disabled target is
+    // safe here.
+    if (const auto route = resolved.slot(QString(PhosphorWindowRules::ActionSlot::RouteScreen))) {
+        directive.targetScreenId =
+            route->params.value(QString(PhosphorWindowRules::ActionParam::TargetScreenId)).toString();
+    }
+
+    // RouteToDesktop target (optional): when set, the zones resolve on this
+    // desktop's layout and the snap commits in this desktop's context, so a
+    // combined SnapToZone + RouteToDesktop rule lands the window in the right zone
+    // of the destination desktop. The desktop MOVE itself is emitted separately by
+    // applyOpenDesktopRouting (engine-neutral); this only steers the snap placement.
+    if (const auto route = resolved.slot(QString(PhosphorWindowRules::ActionSlot::RouteDesktop))) {
+        const int desktop = route->params.value(QString(PhosphorWindowRules::ActionParam::TargetDesktop)).toInt(0);
+        if (desktop >= 1) {
+            directive.targetDesktop = desktop;
+        }
+    }
+
     const std::optional<PhosphorWindowRules::RuleAction> action =
         resolved.slot(QString(PhosphorWindowRules::ActionSlot::Placement));
     if (!action) {
-        return {};
+        // No SnapToZone: return the (possibly route-only) directive. With no ordinals
+        // the snap engine treats it as "nothing to snap", so a RouteToScreen WITHOUT
+        // an accompanying SnapToZone is a no-op on this snap path — bare "move to
+        // monitor X" routing is handled by the engine-neutral open-path mover
+        // (alongside RouteToDesktop), not here.
+        return directive;
     }
     // The descriptor validator already guaranteed a non-empty array of in-range
     // 1-based ordinals at load; re-validate defensively against the SAME bound
     // (1..MaxZoneOrdinal) so a future loader change can never feed a bad ordinal
     // into zone resolution.
     const QJsonArray arr = action->params.value(QString(PhosphorWindowRules::ActionParam::Zones)).toArray();
-    QList<int> ordinals;
-    ordinals.reserve(arr.size());
+    directive.zoneOrdinals.reserve(arr.size());
     for (const QJsonValue& v : arr) {
         const int n = v.toInt(0);
         if (n >= 1 && n <= PhosphorWindowRules::MaxZoneOrdinal) {
-            ordinals.append(n);
+            directive.zoneOrdinals.append(n);
         }
     }
-    return ordinals;
+    return directive;
+}
+
+void WindowTrackingAdaptor::emitRouteToDesktopIfMatched(const PhosphorWindowRules::ResolvedActions& resolved,
+                                                        const QString& windowId)
+{
+    const std::optional<PhosphorWindowRules::RuleAction> route =
+        resolved.slot(QString(PhosphorWindowRules::ActionSlot::RouteDesktop));
+    if (!route) {
+        return;
+    }
+    // The descriptor validator already guaranteed a 1-based desktop in range; the
+    // effect-side slot re-guards (rejects < 1, out-of-range, and sticky windows),
+    // so moving to the desktop the window already occupies is a harmless no-op.
+    const int desktop = route->params.value(QString(PhosphorWindowRules::ActionParam::TargetDesktop)).toInt(0);
+    if (desktop >= 1) {
+        qCInfo(lcDbusWindow) << "open-routing: routing" << windowId << "to virtual desktop" << desktop;
+        Q_EMIT windowDesktopMoveRequested(windowId, desktop);
+    }
+}
+
+void WindowTrackingAdaptor::applyOpenDesktopRouting(const QString& windowId, const QString& screenId)
+{
+    // Engine-neutral RouteToDesktop: when a matched rule pins the opening window
+    // to a virtual desktop, ask the compositor to move it there. Independent of
+    // snapping/tiling — the desktop move composes with the window's placement.
+    // Called from the snap open-path facade (the autotile path uses
+    // applyOpenRoutingForAutotile, which also handles the screen redirect).
+    if (!m_windowRuleStore) {
+        return;
+    }
+    std::optional<PhosphorWindowRules::WindowQuery> query = buildRuleQueryForWindow(m_windowRegistry, windowId);
+    if (!query) {
+        return;
+    }
+    // Pin the screen so a ScreenId-scoped rule resolves, mirroring placementZonesByRule.
+    // resolveCached is keyed on windowId (+ rule-set revision), so on the snap open path
+    // this reuses the verdict placementZonesByRule already seeded — no second evaluation.
+    query->screenId = screenId;
+    if (!m_windowRuleEvaluator) {
+        m_windowRuleEvaluator = std::make_unique<PhosphorWindowRules::RuleEvaluator>(m_windowRuleStore->ruleSet());
+    }
+    emitRouteToDesktopIfMatched(m_windowRuleEvaluator->resolveCached(windowId, *query), windowId);
+}
+
+QString WindowTrackingAdaptor::applyOpenRoutingForAutotile(const QString& windowId, const QString& screenId)
+{
+    if (!m_windowRuleStore) {
+        return QString();
+    }
+    std::optional<PhosphorWindowRules::WindowQuery> query = buildRuleQueryForWindow(m_windowRegistry, windowId);
+    if (!query) {
+        return QString();
+    }
+    query->screenId = screenId;
+    if (!m_windowRuleEvaluator) {
+        m_windowRuleEvaluator = std::make_unique<PhosphorWindowRules::RuleEvaluator>(m_windowRuleStore->ruleSet());
+    }
+    const PhosphorWindowRules::ResolvedActions resolved = m_windowRuleEvaluator->resolveCached(windowId, *query);
+
+    // RouteToDesktop is engine-neutral — emit it for autotile windows too.
+    emitRouteToDesktopIfMatched(resolved, windowId);
+
+    // RouteToScreen: redirect the window onto a different AUTOTILE monitor. The
+    // snap open path handles snap-mode targets itself (the placement directive),
+    // so here we only honour a target that is currently in autotile mode — a snap
+    // or disabled target is left to the window's spawn screen (cross-engine
+    // routing is out of scope). Returning the target tells the caller to insert
+    // the window into that screen's tiling state; the output-move marker stops the
+    // effect from re-processing the resulting outputChanged as a fresh open.
+    const std::optional<PhosphorWindowRules::RuleAction> route =
+        resolved.slot(QString(PhosphorWindowRules::ActionSlot::RouteScreen));
+    if (!route) {
+        return QString();
+    }
+    const QString target = route->params.value(QString(PhosphorWindowRules::ActionParam::TargetScreenId)).toString();
+    if (target.isEmpty() || target == screenId || !m_layoutManager) {
+        return QString();
+    }
+    if (m_layoutManager->modeForScreen(target, m_layoutManager->currentVirtualDesktopForScreen(target),
+                                       m_layoutManager->currentActivity())
+        != PhosphorZones::AssignmentEntry::Mode::Autotile) {
+        qCDebug(lcDbusWindow) << "applyOpenRoutingForAutotile: RouteToScreen target" << target
+                              << "is not in autotile mode — not redirecting" << windowId;
+        return QString();
+    }
+    qCInfo(lcDbusWindow) << "applyOpenRoutingForAutotile: routing" << windowId << "to autotile screen" << target;
+    Q_EMIT windowOutputMoveExpected(windowId, target);
+    return target;
 }
 
 void WindowTrackingAdaptor::handleCrossModeMove(const QString& windowId, const QString& targetScreenId,

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -666,8 +666,7 @@ QString WindowTrackingAdaptor::applyOpenRoutingForAutotile(const QString& window
     if (target.isEmpty() || target == screenId || !m_layoutManager) {
         return QString();
     }
-    if (m_layoutManager->modeForScreen(target, m_layoutManager->currentVirtualDesktopForScreen(target),
-                                       m_layoutManager->currentActivity())
+    if (m_layoutManager->modeForScreen(target, currentDesktopForScreen(target), m_layoutManager->currentActivity())
         != PhosphorZones::AssignmentEntry::Mode::Autotile) {
         qCDebug(lcDbusWindow) << "applyOpenRoutingForAutotile: RouteToScreen target" << target
                               << "is not in autotile mode — not redirecting" << windowId;

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -16,6 +16,7 @@
 #include "core/logging.h"
 #include <PhosphorEngine/IPlacementEngine.h>
 #include <PhosphorIdentity/WindowId.h>
+#include <PhosphorScreens/Manager.h>
 #include <PhosphorSnapEngine/SnapEngine.h>
 #include <PhosphorSnapEngine/SnapState.h>
 #include <PhosphorTileEngine/AutotileEngine.h>
@@ -570,9 +571,9 @@ PhosphorSnapEngine::PlacementDirective WindowTrackingAdaptor::placementZonesByRu
     if (!action) {
         // No SnapToZone: return the (possibly route-only) directive. With no ordinals
         // the snap engine treats it as "nothing to snap", so a RouteToScreen WITHOUT
-        // an accompanying SnapToZone is a no-op on this snap path — bare "move to
-        // monitor X" routing is handled by the engine-neutral open-path mover
-        // (alongside RouteToDesktop), not here.
+        // an accompanying SnapToZone produces no snap here. The bare "move to monitor
+        // X" is performed by applyOpenScreenRouting on the snap open-path facade (it
+        // runs only when nothing snapped the window), not in this directive builder.
         return directive;
     }
     // The descriptor validator already guaranteed a non-empty array of in-range
@@ -630,6 +631,84 @@ void WindowTrackingAdaptor::applyOpenDesktopRouting(const QString& windowId, con
         m_windowRuleEvaluator = std::make_unique<PhosphorWindowRules::RuleEvaluator>(m_windowRuleStore->ruleSet());
     }
     emitRouteToDesktopIfMatched(m_windowRuleEvaluator->resolveCached(windowId, *query), windowId);
+}
+
+void WindowTrackingAdaptor::applyOpenScreenRouting(const QString& windowId, const QString& screenId)
+{
+    if (!m_windowRuleStore) {
+        return;
+    }
+    std::optional<PhosphorWindowRules::WindowQuery> query = buildRuleQueryForWindow(m_windowRegistry, windowId);
+    if (!query) {
+        return;
+    }
+    // Pin the screen so a ScreenId-scoped rule resolves, mirroring placementZonesByRule.
+    query->screenId = screenId;
+    if (!m_windowRuleEvaluator) {
+        m_windowRuleEvaluator = std::make_unique<PhosphorWindowRules::RuleEvaluator>(m_windowRuleStore->ruleSet());
+    }
+    const PhosphorWindowRules::ResolvedActions resolved = m_windowRuleEvaluator->resolveCached(windowId, *query);
+
+    // Bare RouteToScreen only. A rule that ALSO carries SnapToZone routes AND snaps
+    // via the placement directive (calculateSnapToPlacementRule resolves the zones
+    // ON the target screen and returns shouldSnap, so the facade never reaches the
+    // no-snap branch that calls this); moving here too would double-place the window.
+    if (resolved.slot(QString(PhosphorWindowRules::ActionSlot::Placement))) {
+        return;
+    }
+    const std::optional<PhosphorWindowRules::RuleAction> route =
+        resolved.slot(QString(PhosphorWindowRules::ActionSlot::RouteScreen));
+    if (!route) {
+        return;
+    }
+    const QString target = route->params.value(QString(PhosphorWindowRules::ActionParam::TargetScreenId)).toString();
+    if (target.isEmpty() || target == screenId) {
+        return;
+    }
+    PhosphorScreens::ScreenManager* screens = m_service ? m_service->screenManager() : nullptr;
+    if (!screens) {
+        return;
+    }
+    const QRect dstAvail = screens->screenAvailableGeometry(target);
+    if (!dstAvail.isValid()) {
+        // Target monitor is not currently connected — leave the window on its spawn
+        // screen (the rule fires again when that monitor returns).
+        qCDebug(lcDbusWindow) << "applyOpenScreenRouting: route target" << target
+                              << "is not currently connected — not moving" << windowId;
+        return;
+    }
+    const QRect cur = frameGeometry(windowId);
+    if (!cur.isValid()) {
+        // No geometry pushed yet — nothing to translate onto the target screen.
+        return;
+    }
+
+    // Map the window's position relative to its current screen's available area onto
+    // the target screen's, preserving size, then clamp so the whole frame fits.
+    // Preserves "the same spot on the other monitor" across differing resolutions; an
+    // unknown / degenerate source area falls back to the target's top-left.
+    const QRect srcAvail = screens->screenAvailableGeometry(screenId);
+    const int w = qMin(cur.width(), dstAvail.width());
+    const int h = qMin(cur.height(), dstAvail.height());
+    int x = dstAvail.x();
+    int y = dstAvail.y();
+    if (srcAvail.isValid() && srcAvail.width() > 0 && srcAvail.height() > 0) {
+        const double relX = static_cast<double>(cur.x() - srcAvail.x()) / srcAvail.width();
+        const double relY = static_cast<double>(cur.y() - srcAvail.y()) / srcAvail.height();
+        x = dstAvail.x() + qRound(relX * dstAvail.width());
+        y = dstAvail.y() + qRound(relY * dstAvail.height());
+    }
+    // Clamp the frame fully inside the target available area.
+    x = qBound(dstAvail.left(), x, dstAvail.right() - w + 1);
+    y = qBound(dstAvail.top(), y, dstAvail.bottom() - h + 1);
+
+    qCInfo(lcDbusWindow) << "applyOpenScreenRouting: routing" << windowId << "to monitor" << target << "at"
+                         << QRect(x, y, w, h);
+    // Emit the marker first so the effect treats the resulting outputChanged as an
+    // expected daemon-driven move (bookkeeping + decoration only, no reopen), then
+    // the free placement (empty zone id ⇒ no snap chrome).
+    Q_EMIT windowOutputMoveExpected(windowId, target);
+    Q_EMIT applyGeometryRequested(windowId, x, y, w, h, QString(), target, false);
 }
 
 QString WindowTrackingAdaptor::applyOpenRoutingForAutotile(const QString& windowId, const QString& screenId)

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -374,6 +374,7 @@ qt_add_resources(plasmazones-settings "shared_common_qml"
     BASE "${CMAKE_SOURCE_DIR}/src/shared"
     FILES
         ${CMAKE_SOURCE_DIR}/src/shared/AspectRatioBadge.qml
+        ${CMAKE_SOURCE_DIR}/src/shared/CapabilityBadgeRow.qml
         ${CMAKE_SOURCE_DIR}/src/shared/ZonePreview.qml
         ${CMAKE_SOURCE_DIR}/src/shared/CategoryBadge.qml
         ${CMAKE_SOURCE_DIR}/src/shared/CategoryMenuButton.qml

--- a/src/settings/org_plasmazones_common/qmldir
+++ b/src/settings/org_plasmazones_common/qmldir
@@ -1,5 +1,6 @@
 module org.plasmazones.common
 AspectRatioBadge 1.0 AspectRatioBadge.qml
+CapabilityBadgeRow 1.0 CapabilityBadgeRow.qml
 ZonePreview 1.0 ZonePreview.qml
 CategoryBadge 1.0 CategoryBadge.qml
 CategoryMenuButton 1.0 CategoryMenuButton.qml

--- a/src/settings/qml/ActionListView.qml
+++ b/src/settings/qml/ActionListView.qml
@@ -187,6 +187,26 @@ ColumnLayout {
                 return raw.join(", ");
             return rawStr;
         }
+        if (kind === "screenId") {
+            // Show the friendly monitor label for the stored canonical id; fall
+            // back to the raw id when the monitor isn't currently connected so the
+            // user still sees what the rule pins to.
+            var screens = root.appSettings && root.appSettings.screens ? root.appSettings.screens : [];
+            for (var s = 0; s < screens.length; ++s) {
+                if (screens[s].name === raw)
+                    return screens[s].displayLabel || screens[s].name || rawStr;
+            }
+            return rawStr;
+        }
+        if (kind === "virtualDesktop") {
+            // Render "N: <name>" when KWin reports a name for the 1-based desktop,
+            // else just the number.
+            var names = root.appSettings && root.appSettings.virtualDesktopNames ? root.appSettings.virtualDesktopNames : [];
+            var num = parseInt(raw, 10);
+            if (num >= 1 && names.length >= num && names[num - 1])
+                return num + ": " + names[num - 1];
+            return num > 0 ? String(num) : rawStr;
+        }
         return rawStr;
     }
 

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -746,7 +746,7 @@ ColumnLayout {
             textRole: "label"
             valueRole: "value"
             currentIndex: {
-                var target = row.action[_param.key];
+                var target = Number(row.action[_param.key]);
                 for (var i = 0; i < desktopCombo.model.length; ++i) {
                     if (desktopCombo.model[i].value === target)
                         return i;

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -199,6 +199,12 @@ ColumnLayout {
     // (SnapToZone). Stores a JSON array of 1-based ordinals; multiple ordinals
     // span their combined area. Accepts "1, 2", "1;2", "1 2", and ranges "1-3".
     property Component _zoneOrdinalsEditor
+    // Monitor picker for `kind == "screenId"` (RouteToScreen). Drives off
+    // `appSettings.screens`; the wire value is the canonical screen id.
+    property Component _screenIdEditor
+    // Virtual-desktop picker for `kind == "virtualDesktop"` (RouteToDesktop).
+    // Lists 1..virtualDesktopCount; the wire value is the 1-based desktop number.
+    property Component _virtualDesktopEditor
 
     /// Encode a QML color to a `#AARRGGBB` wire string (alpha-first) — the form
     /// the SetBorderColor validator accepts and the consumer parses back via
@@ -417,6 +423,12 @@ ColumnLayout {
 
                     if (modelData.kind === "zoneOrdinals")
                         return row._zoneOrdinalsEditor;
+
+                    if (modelData.kind === "screenId")
+                        return row._screenIdEditor;
+
+                    if (modelData.kind === "virtualDesktop")
+                        return row._virtualDesktopEditor;
 
                     return row._stringParamEditor;
                 }
@@ -666,6 +678,83 @@ ColumnLayout {
             layoutFilter: 0
             showNoneOption: false
             showPreview: true
+            onActivated: function (index) {
+                row.actionEdited(row._withParam(_param.key, currentValue));
+            }
+        }
+    }
+
+    // Monitor picker for RouteToScreen. Mirrors the ScreenId match-condition
+    // editor (MatchLeafEditor's screenValueEditor): the user picks a friendly
+    // label while the wire value stays the canonical screen id. A stored id whose
+    // monitor is offline still surfaces (so the user sees what the rule pins to).
+    _screenIdEditor: Component {
+        WideComboBox {
+            id: screenCombo
+
+            readonly property var _param: parent.modelData
+            readonly property var _screens: row.appSettings ? row.appSettings.screens : []
+            model: _screens.map(function (s) {
+                var label = s.displayLabel || s.name || "";
+                if (s.isPrimary)
+                    label += " · " + i18n("Primary");
+                return {
+                    "label": label,
+                    "name": s.name
+                };
+            })
+            textRole: "label"
+            valueRole: "name"
+            currentIndex: {
+                var target = row.action[_param.key] || "";
+                for (var i = 0; i < screenCombo._screens.length; ++i) {
+                    if (screenCombo._screens[i].name === target)
+                        return i;
+                }
+                return -1;
+            }
+            displayText: currentIndex >= 0 ? currentText : (row.action[_param.key] || i18n("Choose a monitor…"))
+            Accessible.name: _param.label
+            onActivated: function (index) {
+                row.actionEdited(row._withParam(_param.key, currentValue));
+            }
+        }
+    }
+
+    // Virtual-desktop picker for RouteToDesktop. Lists 1..virtualDesktopCount,
+    // labelled with the desktop name when KWin reports one. The wire value is the
+    // 1-based desktop number. A stored desktop beyond the current count still
+    // surfaces its number so the rule's target stays legible.
+    _virtualDesktopEditor: Component {
+        WideComboBox {
+            id: desktopCombo
+
+            readonly property var _param: parent.modelData
+            readonly property int _count: row.appSettings && row.appSettings.virtualDesktopCount > 0 ? row.appSettings.virtualDesktopCount : 1
+            readonly property var _names: row.appSettings ? row.appSettings.virtualDesktopNames : []
+            model: {
+                var items = [];
+                for (var i = 1; i <= desktopCombo._count; ++i) {
+                    var name = desktopCombo._names.length >= i ? desktopCombo._names[i - 1] : "";
+                    items.push({
+                        "label": name && name.length > 0 ? (i + ": " + name) : ("" + i),
+                        "value": i
+                    });
+                }
+                return items;
+            }
+            textRole: "label"
+            valueRole: "value"
+            currentIndex: {
+                var target = row.action[_param.key];
+                for (var i = 0; i < desktopCombo.model.length; ++i) {
+                    if (desktopCombo.model[i].value === target)
+                        return i;
+                }
+                return -1;
+            }
+            displayText: currentIndex >= 0 ? currentText : (row.action[_param.key] ? ("" + row.action[_param.key]) : i18n("Choose a desktop…"))
+            Accessible.name: _param.label
             onActivated: function (index) {
                 row.actionEdited(row._withParam(_param.key, currentValue));
             }

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -716,7 +716,8 @@ ColumnLayout {
             displayText: currentIndex >= 0 ? currentText : (row.action[_param.key] || i18n("Choose a monitor…"))
             Accessible.name: _param.label
             onActivated: function (index) {
-                row.actionEdited(row._withParam(_param.key, currentValue));
+                if (currentValue !== row.action[_param.key])
+                    row.actionEdited(row._withParam(_param.key, currentValue));
             }
         }
     }
@@ -756,7 +757,8 @@ ColumnLayout {
             displayText: currentIndex >= 0 ? currentText : (row.action[_param.key] ? ("" + row.action[_param.key]) : i18n("Choose a desktop…"))
             Accessible.name: _param.label
             onActivated: function (index) {
-                row.actionEdited(row._withParam(_param.key, currentValue));
+                if (currentValue !== row.action[_param.key])
+                    row.actionEdited(row._withParam(_param.key, currentValue));
             }
         }
     }

--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -433,7 +433,7 @@ RowLayout {
             // A rule may reference a desktop beyond the current count (the desktop
             // was removed). Surface the stored number so the rule stays legible.
             displayText: currentIndex >= 0 ? currentText : (leaf.node.value ? ("" + leaf.node.value) : i18n("Choose a desktop…"))
-            Accessible.name: i18n("Virtual desktop")
+            Accessible.name: i18n("Desktop")
             onActivated: function (index) {
                 if (currentValue !== leaf.node.value)
                     leaf._emit(leaf.node.field, leaf.node.op, currentValue);

--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -171,7 +171,14 @@ RowLayout {
         source: "dialog-information"
         Layout.preferredWidth: Kirigami.Units.iconSizes.small
         Layout.preferredHeight: Kirigami.Units.iconSizes.small
-        Layout.alignment: Qt.AlignVCenter
+        // Top-align every control in the row so they line up with the value
+        // field's top. The value editor can grow tall (a wrapped operator hint
+        // sits beneath the field); vertically centring the siblings against that
+        // taller column would drop the combos and trash below the field. The icon
+        // is shorter than the field controls, so nudge it down to sit centred on
+        // the first control line rather than at its very top.
+        Layout.alignment: Qt.AlignTop
+        Layout.topMargin: Math.max(0, (fieldCombo.height - height) / 2)
         color: Kirigami.Theme.highlightColor
         // Hover help describing the selected field. An unknown / legacy field
         // (_fieldEntry undefined) yields no text, so the tooltip just doesn't
@@ -194,6 +201,7 @@ RowLayout {
     PZCommon.CategoryMenuButton {
         id: fieldCombo
 
+        Layout.alignment: Qt.AlignTop
         Layout.preferredWidth: Kirigami.Units.gridUnit * 9
         // Map the field metadata to the picker's { id, name, category,
         // categoryOrder } item shape.
@@ -246,6 +254,7 @@ RowLayout {
     WideComboBox {
         id: opCombo
 
+        Layout.alignment: Qt.AlignTop
         // Fixed to the widest operator label across ALL fields' operator sets
         // (plus chrome for the dropdown indicator + padding) instead of the
         // WideComboBox auto-width, which keys off the CURRENT field's operator
@@ -266,13 +275,16 @@ RowLayout {
 
     Loader {
         Layout.fillWidth: true
-        Layout.alignment: Qt.AlignVCenter
+        Layout.alignment: Qt.AlignTop
         sourceComponent: {
             if (leaf._valueKind === "bool")
                 return boolValueEditor;
 
             if (leaf._valueKind === "number")
                 return numberValueEditor;
+
+            if (leaf._valueKind === "virtualDesktop")
+                return virtualDesktopValueEditor;
 
             if (leaf._valueKind === "screen")
                 return screenValueEditor;
@@ -289,7 +301,7 @@ RowLayout {
 
     ToolButton {
         icon.name: "edit-delete"
-        Layout.alignment: Qt.AlignVCenter
+        Layout.alignment: Qt.AlignTop
         ToolTip.text: i18n("Remove condition")
         ToolTip.visible: hovered
         Accessible.name: i18n("Remove this condition")
@@ -379,6 +391,50 @@ RowLayout {
             text: checked ? i18n("True") : i18n("False")
             Accessible.name: i18n("Match value")
             onToggled: leaf._emit(leaf.node.field, leaf.node.op, checked)
+        }
+    }
+
+    // Virtual-desktop picker for the VirtualDesktop condition. The wire value stays
+    // the 1-based desktop NUMBER (so the operator semantics — equals / greater /
+    // less — are unchanged); the user just picks "2: Work" instead of typing a
+    // number. Mirrors the screen picker, and the RouteToDesktop action editor.
+    Component {
+        id: virtualDesktopValueEditor
+
+        WideComboBox {
+            id: desktopCombo
+
+            readonly property int _count: leaf.appSettings && leaf.appSettings.virtualDesktopCount > 0 ? leaf.appSettings.virtualDesktopCount : 1
+            readonly property var _names: leaf.appSettings ? leaf.appSettings.virtualDesktopNames : []
+            model: {
+                var items = [];
+                for (var i = 1; i <= desktopCombo._count; ++i) {
+                    var name = desktopCombo._names.length >= i ? desktopCombo._names[i - 1] : "";
+                    items.push({
+                        "label": name && name.length > 0 ? (i + ": " + name) : ("" + i),
+                        "value": i
+                    });
+                }
+                return items;
+            }
+            textRole: "label"
+            valueRole: "value"
+            currentIndex: {
+                var target = Number(leaf.node.value);
+                for (var i = 0; i < desktopCombo.model.length; ++i) {
+                    if (desktopCombo.model[i].value === target)
+                        return i;
+                }
+                return -1;
+            }
+            // A rule may reference a desktop beyond the current count (the desktop
+            // was removed). Surface the stored number so the rule stays legible.
+            displayText: currentIndex >= 0 ? currentText : (leaf.node.value ? ("" + leaf.node.value) : i18n("Choose a desktop…"))
+            Accessible.name: i18n("Virtual desktop")
+            onActivated: function (index) {
+                if (currentValue !== leaf.node.value)
+                    leaf._emit(leaf.node.field, leaf.node.op, currentValue);
+            }
         }
     }
 

--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -244,7 +244,10 @@ RowLayout {
             // Seed a value of the new field's kind so the leaf is immediately
             // well-typed rather than carrying an empty string a bool/number
             // field would coerce: bool -> false, number -> 0, everything else
-            // (string / screen / activity / windowType picker) -> "".
+            // (string / screen / activity / windowType / virtualDesktop picker)
+            // -> "". The picker kinds (including virtualDesktop) treat "" as the
+            // "no value yet" state and surface their placeholder until the user
+            // picks, mirroring the screen / activity editors.
             var newKind = newFieldEntry !== undefined ? newFieldEntry.valueKind : "string";
             var seedValue = newKind === "bool" ? false : (newKind === "number" ? 0 : "");
             leaf._emit(value, carryOp, seedValue);

--- a/src/settings/qml/WindowRulesPage.qml
+++ b/src/settings/qml/WindowRulesPage.qml
@@ -76,6 +76,9 @@ SettingsFlickable {
         readonly property var layouts: settingsController.layouts
         readonly property var screens: settingsController.screens
         readonly property var activities: settingsController.activities
+        // Backs the RouteToDesktop action's virtual-desktop picker.
+        readonly property int virtualDesktopCount: settingsController.virtualDesktopCount
+        readonly property var virtualDesktopNames: settingsController.virtualDesktopNames
         // `AnimationsPageController` — exposes `eventSections()` and
         // `availableShaderEffects()` for the animationEvent / shaderEffect
         // picker editors in ActionRow.

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -305,7 +305,7 @@ QString paramLabel(const QString& type, const QString& key)
         return PhosphorI18n::tr("Monitor");
     }
     if (type == ActionType::RouteToDesktop && key == ActionParam::TargetDesktop) {
-        return PhosphorI18n::tr("Virtual desktop");
+        return PhosphorI18n::tr("Desktop");
     }
     if (key == ActionParam::Event) {
         return PhosphorI18n::tr("Event");
@@ -519,7 +519,7 @@ QString actionTypeLabelImpl(const QString& type)
         return PhosphorI18n::tr("Open on monitor");
     }
     if (type == ActionType::RouteToDesktop) {
-        return PhosphorI18n::tr("Open on virtual desktop");
+        return PhosphorI18n::tr("Open on desktop");
     }
     return WindowRuleModel::actionTypeFallbackLabel(type);
 }

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -539,8 +539,6 @@ QString operatorLabelImpl(Operator op)
         return PhosphorI18n::tr("matches regex");
     case Operator::AppIdMatches:
         return PhosphorI18n::tr("matches app-id");
-    case Operator::In:
-        return PhosphorI18n::tr("is one of");
     case Operator::GreaterThan:
         return PhosphorI18n::tr("greater than");
     case Operator::LessThan:
@@ -676,19 +674,10 @@ QVariantList operatorsForField(int fieldValue)
         if (field == Field::AppId) {
             ops.append(Operator::AppIdMatches);
         }
-        if (field == Field::ScreenId || field == Field::Activity) {
-            ops.append(Operator::In);
-        }
     } else if (PhosphorWindowRules::fieldIsNumeric(field)) {
         ops = {Operator::Equals, Operator::GreaterThan, Operator::LessThan};
-        if (field == Field::VirtualDesktop) {
-            ops.append(Operator::In);
-        }
     } else if (PhosphorWindowRules::fieldIsBool(field) || field == Field::WindowType) {
         ops = {Operator::Equals};
-        if (field == Field::WindowType) {
-            ops.append(Operator::In);
-        }
     }
     QVariantList out;
     for (Operator op : ops) {

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -301,6 +301,12 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::OverrideOverlayStyle && key == ActionParam::Value) {
         return PhosphorI18n::tr("Overlay style");
     }
+    if (type == ActionType::RouteToScreen && key == ActionParam::TargetScreenId) {
+        return PhosphorI18n::tr("Monitor");
+    }
+    if (type == ActionType::RouteToDesktop && key == ActionParam::TargetDesktop) {
+        return PhosphorI18n::tr("Virtual desktop");
+    }
     if (key == ActionParam::Event) {
         return PhosphorI18n::tr("Event");
     }
@@ -509,6 +515,12 @@ QString actionTypeLabelImpl(const QString& type)
     if (type == ActionType::SetOuterGapRight) {
         return PhosphorI18n::tr("Set right gap");
     }
+    if (type == ActionType::RouteToScreen) {
+        return PhosphorI18n::tr("Open on monitor");
+    }
+    if (type == ActionType::RouteToDesktop) {
+        return PhosphorI18n::tr("Open on virtual desktop");
+    }
     return WindowRuleModel::actionTypeFallbackLabel(type);
 }
 
@@ -623,6 +635,12 @@ QVariantList matchFields()
                 options.append(option);
             }
             entry[QStringLiteral("options")] = options;
+        } else if (f == Field::VirtualDesktop) {
+            // Numeric on the wire (a 1-based desktop number), but the QML editor
+            // swaps the bare SpinBox for a desktop-picker ComboBox driven by
+            // `settingsController.virtualDesktopNames`, so the user picks "2: Work"
+            // rather than typing a number. Must precede the generic numeric branch.
+            kind = QStringLiteral("virtualDesktop");
         } else if (PhosphorWindowRules::fieldIsNumeric(f)) {
             kind = QStringLiteral("number");
         } else if (PhosphorWindowRules::fieldIsBool(f)) {
@@ -849,9 +867,14 @@ QVariantMap defaultPayloadFor(const QString& typeWire)
             // passes the validator (non-empty array of positive ordinals) before
             // the user edits the zone list.
             payload[key] = QVariantList{1};
+        } else if (kind == QLatin1String("virtualDesktop")) {
+            // Seed desktop 1 so a fresh RouteToDesktop rule passes the validator
+            // (a 1-based ordinal) before the user picks a desktop.
+            payload[key] = 1;
         } else {
             // Picker kinds (snappingLayout, tilingAlgorithm, animationEvent,
-            // shaderEffect, curveEditor) and plain strings all start empty —
+            // shaderEffect, curveEditor, screenId) and plain strings all start
+            // empty —
             // the user has to choose a value before the rule is savable, and
             // `canSave` surfaces the gap explicitly. Seeding a placeholder
             // here would mask the "user has to pick" state.

--- a/src/settings/windowruleauthoring.cpp
+++ b/src/settings/windowruleauthoring.cpp
@@ -863,10 +863,10 @@ QVariantMap defaultPayloadFor(const QString& typeWire)
         } else {
             // Picker kinds (snappingLayout, tilingAlgorithm, animationEvent,
             // shaderEffect, curveEditor, screenId) and plain strings all start
-            // empty —
-            // the user has to choose a value before the rule is savable, and
-            // `canSave` surfaces the gap explicitly. Seeding a placeholder
-            // here would mask the "user has to pick" state.
+            // empty (zoneOrdinals and virtualDesktop are seeded above because their
+            // validators reject an empty value). The user has to choose a value
+            // before the rule is savable, and `canSave` surfaces the gap explicitly.
+            // Seeding a placeholder here would mask the "user has to pick" state.
             payload[key] = QString();
         }
     }

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -66,41 +66,18 @@ void collectFields(const MatchExpression& match, QList<Field>& out)
 }
 
 /// Append every non-empty ScreenId leaf value in @p match to @p out.
-/// Handles both the scalar shape (Equals/Contains/…: value is a QString) and
-/// the set-membership shape (Operator::In: value is a QVariantList or
-/// QStringList — `toString()` returns empty for a list, so the entries must be
-/// iterated explicitly). Mirrors the dual-shape handling in
-/// `MatchExpression::evaluate` for the In case.
+/// Only the scalar Equals shape pins a literal monitor (the value is a
+/// connector / screen id string).
 void collectScreenIds(const MatchExpression& match, QStringList& out)
 {
     if (match.isLeaf()) {
         const auto& predicate = match.predicate();
-        if (predicate.field == Field::ScreenId) {
-            if (predicate.op == Operator::In) {
-                // The wire form is a QVariantList; a programmatically built
-                // leaf may carry a QStringList. Accept either — same contract
-                // as the validator/evaluator.
-                if (predicate.value.metaType().id() == QMetaType::QStringList) {
-                    for (const QString& member : predicate.value.toStringList()) {
-                        if (!member.isEmpty()) {
-                            out.append(member);
-                        }
-                    }
-                } else {
-                    for (const QVariant& member : predicate.value.toList()) {
-                        const QString value = member.toString();
-                        if (!value.isEmpty()) {
-                            out.append(value);
-                        }
-                    }
-                }
-            } else if (predicate.op == Operator::Equals) {
-                const QString value = predicate.value.toString();
-                if (!value.isEmpty()) {
-                    out.append(value);
-                }
+        if (predicate.field == Field::ScreenId && predicate.op == Operator::Equals) {
+            const QString value = predicate.value.toString();
+            if (!value.isEmpty()) {
+                out.append(value);
             }
-            // Any operator other than Equals/In (substring, regex, app-id, or
+            // Any operator other than Equals (substring, regex, app-id, or
             // numeric comparison) is not a literal monitor pin — its token never
             // equals a real connector id, so collecting it would silently
             // under-count the rule against every tile. Such a rule doesn't pin a
@@ -158,33 +135,6 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const WindowRuleM
         const QString label = (*lookup)(raw);
         return label.isEmpty() ? raw : label;
     };
-
-    // An `In` operator stores the candidate set as a QVariantList or
-    // QStringList. `toString()` on either of those returns the empty string,
-    // so without this fan-out a rule like "ScreenId In [DP-2, DP-3]" would
-    // render as "Monitor: " with nothing after the colon. Mirror the dual-
-    // shape handling pattern the collectScreenIds helper uses.
-    if (predicate.op == Operator::In) {
-        QStringList resolved;
-        const QVariant& v = predicate.value;
-        if (v.metaType().id() == QMetaType::QStringList) {
-            const QStringList list = v.toStringList();
-            resolved.reserve(list.size());
-            for (const QString& raw : list) {
-                resolved.append(resolveOne(raw));
-            }
-        } else {
-            const QVariantList list = v.toList();
-            resolved.reserve(list.size());
-            for (const QVariant& item : list) {
-                resolved.append(resolveOne(item.toString()));
-            }
-        }
-        // QStringList::join keeps the rendered list short; falling back to
-        // a single space-joined line matches how the daemon logs the same set.
-        return PhosphorI18n::tr("%1: %2").arg(WindowRuleModel::fieldLabel(predicate.field),
-                                              resolved.join(QStringLiteral(", ")));
-    }
 
     return PhosphorI18n::tr("%1: %2").arg(WindowRuleModel::fieldLabel(predicate.field),
                                           resolveOne(predicate.value.toString()));

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -249,8 +249,7 @@ QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup
     }
     if (action.type == ActionType::RouteToDesktop) {
         const int desktop = action.params.value(PhosphorWindowRules::ActionParam::TargetDesktop).toInt();
-        return desktop >= 1 ? PhosphorI18n::tr("Open on virtual desktop %1").arg(desktop)
-                            : PhosphorI18n::tr("Open on virtual desktop");
+        return desktop >= 1 ? PhosphorI18n::tr("Open on desktop %1").arg(desktop) : PhosphorI18n::tr("Open on desktop");
     }
     if (action.type == ActionType::SetOpacity) {
         // Mirror EVERY resolver reject path (shader_resolve.cpp's

--- a/src/settings/windowrulemodel.cpp
+++ b/src/settings/windowrulemodel.cpp
@@ -176,7 +176,7 @@ QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup
                     const WindowRuleModel::LabelLookup& tilingAlgorithmLookup,
                     const WindowRuleModel::LabelLookup& shaderEffectLookup,
                     const WindowRuleModel::LabelLookup& overlayShaderLookup,
-                    const WindowRuleModel::LabelLookup& curveLookup)
+                    const WindowRuleModel::LabelLookup& curveLookup, const WindowRuleModel::LabelLookup& screenLookup)
 {
     auto resolveWith = [](const QString& wire, const WindowRuleModel::LabelLookup& lookup) {
         if (wire.isEmpty() || !lookup) {
@@ -237,6 +237,20 @@ QString actionLabel(const RuleAction& action, const WindowRuleModel::LabelLookup
             return PhosphorI18n::tr("Snap to zone %1").arg(nums.first());
         }
         return PhosphorI18n::tr("Snap to zones %1").arg(nums.join(QStringLiteral(", ")));
+    }
+    if (action.type == ActionType::RouteToScreen) {
+        // Resolve the canonical target screen id to the same friendly monitor
+        // label the ScreenId match-leaf surfaces (e.g. "LG Ultra HD · DP-2");
+        // fall back to the raw id when no live monitor matches so a rule pinned
+        // to an absent display stays legible.
+        const QString screenId = action.params.value(PhosphorWindowRules::ActionParam::TargetScreenId).toString();
+        return screenId.isEmpty() ? PhosphorI18n::tr("Open on monitor")
+                                  : PhosphorI18n::tr("Open on monitor: %1").arg(resolveWith(screenId, screenLookup));
+    }
+    if (action.type == ActionType::RouteToDesktop) {
+        const int desktop = action.params.value(PhosphorWindowRules::ActionParam::TargetDesktop).toInt();
+        return desktop >= 1 ? PhosphorI18n::tr("Open on virtual desktop %1").arg(desktop)
+                            : PhosphorI18n::tr("Open on virtual desktop");
     }
     if (action.type == ActionType::SetOpacity) {
         // Mirror EVERY resolver reject path (shader_resolve.cpp's
@@ -718,7 +732,7 @@ QString WindowRuleModel::actionSummary(const QList<RuleAction>& actions) const
     QStringList parts;
     for (const RuleAction& a : actions) {
         parts.append(actionLabel(a, m_snappingLayoutLookup, m_tilingAlgorithmLookup, m_shaderEffectLookup,
-                                 m_overlayShaderLookup, m_curveLookup));
+                                 m_overlayShaderLookup, m_curveLookup, m_screenLookup));
     }
     return parts.join(QStringLiteral(" · "));
 }

--- a/tests/unit/config/test_migration_v3_to_v4.cpp
+++ b/tests/unit/config/test_migration_v3_to_v4.cpp
@@ -327,8 +327,8 @@ private Q_SLOTS:
 
         // A v3 layout file carrying two legacy app→zone rules: firefox → zone 2
         // (no screen), and konsole → zone 3 with a legacy targetScreen "DP-1"
-        // (which v4 intentionally drops — see below). They live in the user data
-        // dir the migration scans.
+        // (which v4 carries over as a RouteToScreen action — see below). They live
+        // in the user data dir the migration scans.
         const QString layoutsDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
             + QLatin1Char('/') + ConfigDefaults::layoutsSubdir();
         QJsonArray appRules;
@@ -372,18 +372,88 @@ private Q_SLOTS:
             }
         }
 
+        // The targetScreenId carried by a rule's RouteToScreen action (empty when
+        // the rule has none).
+        const auto routeScreen = [](const QJsonObject& rule) -> QString {
+            for (const QJsonValue& v : rule.value(QStringLiteral("actions")).toArray()) {
+                const QJsonObject a = v.toObject();
+                if (a.value(QStringLiteral("type")).toString() == QLatin1String("routeToScreen")) {
+                    return a.value(QStringLiteral("targetScreenId")).toString();
+                }
+            }
+            return QString();
+        };
+
         // firefox → SnapToZone [2]; a single AppId-appIdMatches leaf (no screen).
+        // No targetScreen in the source, so no RouteToScreen action is emitted.
         QVERIFY(!firefoxRule.isEmpty());
         QCOMPARE(snapZones(firefoxRule), (QList<int>{2}));
         QCOMPARE(matchLeaves(firefoxRule).size(), 1);
+        QVERIFY(routeScreen(firefoxRule).isEmpty());
+        QVERIFY(!actionTypes(firefoxRule).contains(QLatin1String("routeToScreen")));
 
-        // konsole → SnapToZone [3]; the legacy targetScreen "DP-1" is dropped, so
-        // it is a single AppId-appIdMatches leaf with NO ScreenId constraint (a
-        // migrated app snaps on whatever screen it opens on).
+        // konsole → SnapToZone [3] PLUS a RouteToScreen action carrying the legacy
+        // targetScreen "DP-1". The MATCH stays a single AppId-appIdMatches leaf with
+        // NO ScreenId constraint — RouteToScreen is an ACTION (it routes), not a
+        // ScreenId match (which would only scope).
         QVERIFY(!konsoleRule.isEmpty());
         QCOMPARE(snapZones(konsoleRule), (QList<int>{3}));
         QCOMPARE(matchLeaves(konsoleRule).size(), 1);
         QVERIFY(matchLeafValueByOp(konsoleRule, QStringLiteral("screenId"), QStringLiteral("equals")).isEmpty());
+        QCOMPARE(routeScreen(konsoleRule), QStringLiteral("DP-1"));
+    }
+
+    // The reporter's exact shape (discussion #686): a v3 appRule whose pattern is
+    // the X11 two-token "resourceName resourceClass" form, pinned to a monitor.
+    // v4 must (a) normalize the pattern to the single appId token the daemon keys
+    // on — without this the AppIdMatches leaf would never fire — and (b) carry the
+    // targetScreen as a RouteToScreen action so the app still opens on that monitor.
+    void testLayoutAppRules_normalizesTwoTokenPatternAndRoutesScreen()
+    {
+        IsolatedConfigGuard guard;
+        writeJson(ConfigDefaults::configFilePath(), makeV3Config());
+        writeJson(assignmentsPath(), makeAssignments());
+
+        const QString layoutsDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+            + QLatin1Char('/') + ConfigDefaults::layoutsSubdir();
+        const QString kGigabyte = QStringLiteral("GIGA-BYTE TECHNOLOGY CO., LTD.:MO34WQC:16843009");
+        QJsonObject appRule;
+        appRule.insert(QStringLiteral("pattern"), QStringLiteral("chromium chromium"));
+        appRule.insert(QStringLiteral("zoneNumber"), 2);
+        appRule.insert(QStringLiteral("targetScreen"), kGigabyte);
+        QJsonObject layout;
+        layout.insert(QStringLiteral("appRules"), QJsonArray{appRule});
+        writeJson(layoutsDir + QStringLiteral("/columns.json"), layout);
+
+        QVERIFY(ConfigMigration::ensureJsonConfig());
+
+        // Exactly one rule whose AppId leaf is the NORMALIZED single token.
+        QJsonObject chromiumRule;
+        for (const QJsonValue& v : rulesFromWindowRules()) {
+            const QJsonObject r = v.toObject();
+            if (matchLeafValueByOp(r, QStringLiteral("appId"), QStringLiteral("appIdMatches"))
+                == QLatin1String("chromium")) {
+                chromiumRule = r;
+            }
+        }
+        QVERIFY2(!chromiumRule.isEmpty(), "two-token 'chromium chromium' must normalize to the appId leaf 'chromium'");
+
+        // The RouteToScreen action carries the legacy monitor verbatim.
+        QString routedScreen;
+        QList<int> zones;
+        for (const QJsonValue& v : chromiumRule.value(QStringLiteral("actions")).toArray()) {
+            const QJsonObject a = v.toObject();
+            const QString type = a.value(QStringLiteral("type")).toString();
+            if (type == QLatin1String("routeToScreen")) {
+                routedScreen = a.value(QStringLiteral("targetScreenId")).toString();
+            } else if (type == QLatin1String("snapToZone")) {
+                for (const QJsonValue& z : a.value(QStringLiteral("zones")).toArray()) {
+                    zones.append(z.toInt());
+                }
+            }
+        }
+        QCOMPARE(zones, (QList<int>{2}));
+        QCOMPARE(routedScreen, kGigabyte);
     }
 
     void testLayoutAppRules_dedupePatternAcrossLayouts()
@@ -469,12 +539,14 @@ private Q_SLOTS:
 
         // Golden assertion against the SPEC: namespace UUID + length-prefixed
         // segment encoding ("<size>:<bytes>" per segment, no separator). The id is
-        // derived from (pattern, zoneNumber) only — targetScreen is not carried
-        // into the rule, so it is not part of the identity.
-        //   segment 1 → pattern    "firefox" → "7:firefox"
-        //   segment 2 → zoneNumber "2"       → "1:2"
+        // derived from (normalized pattern, zoneNumber, targetScreen). This fixture
+        // pins firefox with no targetScreen, so the third segment is the empty
+        // string ("0:").
+        //   segment 1 → pattern      "firefox" → "7:firefox"
+        //   segment 2 → zoneNumber   "2"       → "1:2"
+        //   segment 3 → targetScreen ""        → "0:"
         const QUuid kExpectedNamespace(QStringLiteral("{6f1c8e44-2a7b-5d93-8e10-4b2c9a7f1d35}"));
-        const QString kExpectedKey = QStringLiteral("7:firefox") + QStringLiteral("1:2");
+        const QString kExpectedKey = QStringLiteral("7:firefox") + QStringLiteral("1:2") + QStringLiteral("0:");
         QCOMPARE(firstId, QUuid::createUuidV5(kExpectedNamespace, kExpectedKey).toString());
 
         // Force the rebuild path again and re-stage the same v3 inputs.

--- a/tests/unit/config/test_migration_v3_to_v4.cpp
+++ b/tests/unit/config/test_migration_v3_to_v4.cpp
@@ -503,8 +503,9 @@ private Q_SLOTS:
     void testLayoutAppRules_idempotentRuleIds()
     {
         // The SnapToZone migration's rule id is derived from
-        // (pattern, zoneNumber) via a fixed v5-UUID namespace, so a
-        // crash-and-retry conversion yields byte-identical rules. This mirrors the
+        // (normalized pattern, zoneNumber, targetScreen) via a fixed v5-UUID
+        // namespace, so a crash-and-retry conversion yields byte-identical rules.
+        // This mirrors the
         // sibling exclusion / animation folds' idempotency tests and pins the
         // namespace UUID + segment encoding so a future drift in either forces a
         // deliberate update here (the migration owns both ends of the derivation,

--- a/tests/unit/core/test_snap_unfloat_fallback.cpp
+++ b/tests/unit/core/test_snap_unfloat_fallback.cpp
@@ -352,6 +352,38 @@ private Q_SLOTS:
         m_wts->setSnapState(nullptr);
     }
 
+    // Un-floating a window into a matched SnapToZone + RouteToDesktop rule must
+    // COMMIT the zone assignment on the routed desktop, not the current one. The
+    // rule resolves the zones against the destination desktop's layout, so a
+    // commit that dropped the routed desktop would record those zones under the
+    // current desktop — a cross-desktop assignment mismatch. Mirrors the open
+    // path (resolveWindowRestore → commitSnap forwards result.virtualDesktop).
+    void testUnfloatToZone_routeToDesktop_commitsAssignmentOnRoutedDesktop()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        installLayout(3);
+        // Snap zone 1, and route to virtual desktop 2.
+        engine.setPlacementZonesResolver([](const QString&, const QString&) {
+            PlacementDirective d;
+            d.zoneOrdinals = {1};
+            d.targetDesktop = 2;
+            return d;
+        });
+
+        // Mark the window floating so the public toggle takes the un-float path,
+        // which routes through the private unfloatToZone (the code under test).
+        engine.snapState()->setFloating(QStringLiteral("fresh|win"), true);
+        engine.toggleWindowFloat(QStringLiteral("fresh|win"), QStringLiteral("DP-1"));
+
+        QVERIFY2(!engine.snapState()->zoneForWindow(QStringLiteral("fresh|win")).isEmpty(),
+                 "un-floating into a SnapToZone + RouteToDesktop rule must assign the window to its rule zone");
+        QCOMPARE(engine.snapState()->desktopForWindow(QStringLiteral("fresh|win")), 2);
+        m_wts->setSnapState(nullptr);
+    }
+
     // An empty resolver result (no matching rule) must NOT snap — the window
     // falls through to the normal restore/float path.
     void testResolveWindowRestore_placementRule_emptyResolver_doesNotSnap()

--- a/tests/unit/core/test_snap_unfloat_fallback.cpp
+++ b/tests/unit/core/test_snap_unfloat_fallback.cpp
@@ -245,7 +245,7 @@ private Q_SLOTS:
 
         installLayout(3);
         engine.setPlacementZonesResolver([](const QString&, const QString&) {
-            return QList<int>{2, 3};
+            return PlacementDirective{{2, 3}};
         });
 
         // A remembered FLOATED record on DP-1 carrying the window's free position.
@@ -289,7 +289,7 @@ private Q_SLOTS:
 
         installLayout(3);
         engine.setPlacementZonesResolver([](const QString&, const QString&) {
-            return QList<int>{1};
+            return PlacementDirective{{1}};
         });
 
         const PhosphorEngine::SnapResult result =
@@ -297,6 +297,58 @@ private Q_SLOTS:
 
         QVERIFY2(result.shouldSnap, "a SnapToZone rule must snap a fresh window with no stored record");
         QCOMPARE(result.zoneIds.size(), 1);
+        m_wts->setSnapState(nullptr);
+    }
+
+    // A RouteToScreen directive pins the placement to a different monitor than the
+    // one the window opened on: the snap must resolve on the ROUTED screen, so
+    // result.screenId is the target (the apply path then moves the window there).
+    void testResolveWindowRestore_routeToScreen_resolvesOnTargetScreen()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        installLayout(3);
+        // Window opens on DP-1 but the rule routes it to DP-2 and snaps zone 1.
+        engine.setPlacementZonesResolver([](const QString&, const QString&) {
+            return PlacementDirective{{1}, QStringLiteral("DP-2")};
+        });
+
+        const PhosphorEngine::SnapResult result =
+            engine.resolveWindowRestore(QStringLiteral("fresh|win"), QStringLiteral("DP-1"), /*sticky*/ false);
+
+        QVERIFY2(result.shouldSnap, "RouteToScreen + SnapToZone must snap the window");
+        QCOMPARE(result.zoneIds.size(), 1);
+        QCOMPARE(result.screenId, QStringLiteral("DP-2"));
+        m_wts->setSnapState(nullptr);
+    }
+
+    // A RouteToDesktop directive snaps the window into its zone on the DESTINATION
+    // desktop's layout and stamps that desktop on the result, so the commit records
+    // the assignment on the desktop the window is being moved to (not the one it
+    // momentarily opened on).
+    void testResolveWindowRestore_routeToDesktop_stampsResultDesktop()
+    {
+        SnapEngine engine(m_layoutManager, m_wts, nullptr, nullptr, nullptr);
+        engine.setEngineSettings(m_settings);
+        m_wts->setSnapState(engine.snapState());
+
+        installLayout(3);
+        // Snap zone 1, and route to virtual desktop 2.
+        engine.setPlacementZonesResolver([](const QString&, const QString&) {
+            PlacementDirective d;
+            d.zoneOrdinals = {1};
+            d.targetDesktop = 2;
+            return d;
+        });
+
+        const PhosphorEngine::SnapResult result =
+            engine.resolveWindowRestore(QStringLiteral("fresh|win"), QStringLiteral("DP-1"), /*sticky*/ false);
+
+        QVERIFY2(result.shouldSnap, "SnapToZone + RouteToDesktop must still snap the window");
+        QCOMPARE(result.zoneIds.size(), 1);
+        QCOMPARE(result.virtualDesktop, 2);
         m_wts->setSnapState(nullptr);
     }
 
@@ -310,7 +362,7 @@ private Q_SLOTS:
 
         installLayout(3);
         engine.setPlacementZonesResolver([](const QString&, const QString&) {
-            return QList<int>{};
+            return PlacementDirective{};
         });
 
         const PhosphorEngine::SnapResult result =

--- a/tests/unit/dbus/test_wta_convenience.cpp
+++ b/tests/unit/dbus/test_wta_convenience.cpp
@@ -290,6 +290,46 @@ private Q_SLOTS:
         m_wta->setWindowRegistry(nullptr);
     }
 
+    // The snap open path's RouteToDesktop emit (applyOpenDesktopRouting, called from
+    // SnapAdaptor::resolveWindowRestore) emits windowDesktopMoveRequested when a
+    // matched rule pins a desktop, and stays silent otherwise.
+    void testApplyOpenDesktopRouting_emitsDesktopMoveForMatch()
+    {
+        auto* registry = new PhosphorEngine::WindowRegistry(m_parent);
+        m_wta->setWindowRegistry(registry);
+        m_wta->setWindowMetadata(QStringLiteral("inst3"), QStringLiteral("deskapp"), QString(), QString(), QString(), 0,
+                                 0, QString(), 0, QVariantMap());
+
+        using namespace PhosphorWindowRules;
+        WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.enabled = true;
+        rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::AppIdMatches, QStringLiteral("deskapp"));
+        RuleAction desk;
+        desk.type = QString(ActionType::RouteToDesktop);
+        desk.params.insert(QString(ActionParam::TargetDesktop), 4);
+        rule.actions = {desk};
+
+        WindowRuleStore store(ConfigDefaults::windowRulesFilePath(), m_parent);
+        QVERIFY(store.addRule(rule));
+        m_wta->setWindowRuleStore(&store);
+
+        QSignalSpy desktopSpy(m_wta, &WindowTrackingAdaptor::windowDesktopMoveRequested);
+        m_wta->applyOpenDesktopRouting(QStringLiteral("deskapp|inst3"), QStringLiteral("DP-1"));
+        QCOMPARE(desktopSpy.count(), 1);
+        QCOMPARE(desktopSpy.at(0).at(1).toInt(), 4);
+
+        // A window with no matching rule emits nothing.
+        m_wta->setWindowMetadata(QStringLiteral("inst4"), QStringLiteral("nomatch"), QString(), QString(), QString(), 0,
+                                 0, QString(), 0, QVariantMap());
+        QSignalSpy quietSpy(m_wta, &WindowTrackingAdaptor::windowDesktopMoveRequested);
+        m_wta->applyOpenDesktopRouting(QStringLiteral("nomatch|inst4"), QStringLiteral("DP-1"));
+        QCOMPARE(quietSpy.count(), 0);
+
+        m_wta->setWindowRuleStore(nullptr);
+        m_wta->setWindowRegistry(nullptr);
+    }
+
     void testMoveWindowToZone_validZone_emitsApplyGeometry()
     {
         QString windowId = QStringLiteral("firefox|12345");

--- a/tests/unit/dbus/test_wta_convenience.cpp
+++ b/tests/unit/dbus/test_wta_convenience.cpp
@@ -330,6 +330,135 @@ private Q_SLOTS:
         m_wta->setWindowRegistry(nullptr);
     }
 
+    // A BARE RouteToScreen rule (no SnapToZone) must move the opening window to the
+    // target monitor on the snap open path: applyOpenScreenRouting translates the
+    // window's frame onto the target screen's available area and emits the
+    // output-move marker plus a FREE applyGeometryRequested (empty zone id). A local
+    // WTA wired to a deterministic two-screen ScreenManager is used because the
+    // shared fixture has a null ScreenManager.
+    void testApplyOpenScreenRouting_movesBareRouteToTargetMonitor()
+    {
+        PhosphorScreens::FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 1920, 1080), QStringLiteral("DP-1"));
+        fake.addScreen(QStringLiteral("DP-2"), QRect(1920, 0, 1920, 1080), QStringLiteral("DP-2"));
+        PhosphorScreens::ScreenManager screenMgr(
+            PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        screenMgr.start();
+
+        QObject parent;
+        auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
+                                              &parent);
+        auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        wta->service()->setSnapState(snap->snapState());
+        wta->service()->setSnapEngine(snap);
+        wta->setEngines(snap, nullptr);
+
+        auto* registry = new PhosphorEngine::WindowRegistry(&parent);
+        wta->setWindowRegistry(registry);
+        wta->setWindowMetadata(QStringLiteral("inst1"), QStringLiteral("routeapp"), QString(), QString(), QString(), 0,
+                               0, QString(), 0, QVariantMap());
+
+        using namespace PhosphorWindowRules;
+        WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.enabled = true;
+        rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::AppIdMatches, QStringLiteral("routeapp"));
+        RuleAction route;
+        route.type = QString(ActionType::RouteToScreen);
+        route.params.insert(QString(ActionParam::TargetScreenId), QStringLiteral("DP-2"));
+        rule.actions = {route}; // bare RouteToScreen, NO SnapToZone
+        WindowRuleStore store(ConfigDefaults::windowRulesFilePath(), &parent);
+        QVERIFY(store.addRule(rule));
+        wta->setWindowRuleStore(&store);
+
+        // Window opened on DP-1 at a known frame.
+        const QString w = QStringLiteral("routeapp|inst1");
+        wta->setFrameGeometry(w, 100, 100, 800, 600);
+
+        QSignalSpy outputSpy(wta, &WindowTrackingAdaptor::windowOutputMoveExpected);
+        QSignalSpy geomSpy(wta, &WindowTrackingAdaptor::applyGeometryRequested);
+
+        wta->applyOpenScreenRouting(w, QStringLiteral("DP-1"));
+
+        // Output-move marker for DP-2.
+        QCOMPARE(outputSpy.count(), 1);
+        QCOMPARE(outputSpy.at(0).at(1).toString(), QStringLiteral("DP-2"));
+        // Free placement on DP-2: applyGeometryRequested(windowId, x, y, w, h, zoneId, screenId, sizeOnly).
+        QCOMPARE(geomSpy.count(), 1);
+        const auto args = geomSpy.at(0);
+        QCOMPARE(args.at(0).toString(), w);
+        QVERIFY2(args.at(5).toString().isEmpty(), "a bare route must be a free placement (empty zone id)");
+        QCOMPARE(args.at(6).toString(), QStringLiteral("DP-2"));
+        const int x = args.at(1).toInt();
+        QVERIFY2(x >= 1920 && x < 3840, "the window must land within DP-2's geometry");
+
+        wta->setWindowRuleStore(nullptr);
+        wta->setWindowRegistry(nullptr);
+        wta->service()->setSnapEngine(nullptr);
+        wta->service()->setSnapState(nullptr);
+        delete snap;
+    }
+
+    // A rule carrying BOTH SnapToZone and RouteToScreen must NOT be moved by
+    // applyOpenScreenRouting: the snap placement directive routes AND snaps it on the
+    // target screen, so a free move here would double-place the window. The Placement
+    // slot guard suppresses it even with everything else set up to move.
+    void testApplyOpenScreenRouting_snapToZonePresent_doesNotDoubleMove()
+    {
+        PhosphorScreens::FakeScreenProvider fake;
+        fake.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 1920, 1080), QStringLiteral("DP-1"));
+        fake.addScreen(QStringLiteral("DP-2"), QRect(1920, 0, 1920, 1080), QStringLiteral("DP-2"));
+        PhosphorScreens::ScreenManager screenMgr(
+            PhosphorScreens::ScreenManagerConfig{.screenProvider = &fake, .useGeometrySensors = false});
+        screenMgr.start();
+
+        QObject parent;
+        auto* wta = new WindowTrackingAdaptor(m_layoutManager, m_zoneDetector, &screenMgr, m_settings, nullptr, nullptr,
+                                              &parent);
+        auto* snap = new SnapEngine(m_layoutManager, wta->service(), m_zoneDetector, nullptr, nullptr);
+        wta->service()->setSnapState(snap->snapState());
+        wta->service()->setSnapEngine(snap);
+        wta->setEngines(snap, nullptr);
+
+        auto* registry = new PhosphorEngine::WindowRegistry(&parent);
+        wta->setWindowRegistry(registry);
+        wta->setWindowMetadata(QStringLiteral("inst2"), QStringLiteral("snaproute"), QString(), QString(), QString(), 0,
+                               0, QString(), 0, QVariantMap());
+
+        using namespace PhosphorWindowRules;
+        WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.enabled = true;
+        rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::AppIdMatches, QStringLiteral("snaproute"));
+        RuleAction route;
+        route.type = QString(ActionType::RouteToScreen);
+        route.params.insert(QString(ActionParam::TargetScreenId), QStringLiteral("DP-2"));
+        RuleAction snapTo;
+        snapTo.type = QString(ActionType::SnapToZone);
+        snapTo.params.insert(QString(ActionParam::Zones), QJsonArray{1});
+        rule.actions = {route, snapTo};
+        WindowRuleStore store(ConfigDefaults::windowRulesFilePath(), &parent);
+        QVERIFY(store.addRule(rule));
+        wta->setWindowRuleStore(&store);
+
+        const QString w = QStringLiteral("snaproute|inst2");
+        wta->setFrameGeometry(w, 100, 100, 800, 600);
+
+        QSignalSpy outputSpy(wta, &WindowTrackingAdaptor::windowOutputMoveExpected);
+        QSignalSpy geomSpy(wta, &WindowTrackingAdaptor::applyGeometryRequested);
+
+        wta->applyOpenScreenRouting(w, QStringLiteral("DP-1"));
+
+        QVERIFY2(outputSpy.isEmpty(), "a route+snap rule must not free-move via applyOpenScreenRouting");
+        QVERIFY2(geomSpy.isEmpty(), "a route+snap rule must not free-move via applyOpenScreenRouting");
+
+        wta->setWindowRuleStore(nullptr);
+        wta->setWindowRegistry(nullptr);
+        wta->service()->setSnapEngine(nullptr);
+        wta->service()->setSnapState(nullptr);
+        delete snap;
+    }
+
     void testMoveWindowToZone_validZone_emitsApplyGeometry()
     {
         QString windowId = QStringLiteral("firefox|12345");

--- a/tests/unit/dbus/test_wta_convenience.cpp
+++ b/tests/unit/dbus/test_wta_convenience.cpp
@@ -30,6 +30,14 @@
 #include "dbus/snapadaptor.h"
 #include "dbus/windowtrackingadaptor.h"
 #include <PhosphorSnapEngine/SnapEngine.h>
+#include <PhosphorEngine/WindowRegistry.h>
+#include <PhosphorWindowRules/WindowRuleStore.h>
+#include <PhosphorWindowRules/RuleAction.h>
+#include <PhosphorWindowRules/MatchExpression.h>
+#include <PhosphorWindowRules/MatchTypes.h>
+#include <PhosphorZones/AssignmentEntry.h>
+#include "config/configdefaults.h"
+#include <QUuid>
 #include "../helpers/IsolatedConfigGuard.h"
 #include "../helpers/LayoutRegistryTestHelpers.h"
 
@@ -187,6 +195,100 @@ private Q_SLOTS:
     // =====================================================================
     // moveWindowToZone
     // =====================================================================
+
+    // ── Open routing: RouteToScreen / RouteToDesktop window rules ──
+    void testApplyOpenRoutingForAutotile_routesToAutotileScreenAndDesktop()
+    {
+        // DP-2 is an AUTOTILE screen; DP-1 (the spawn screen) stays snapping (the
+        // registry default).
+        PhosphorZones::AssignmentEntry autotile;
+        autotile.mode = PhosphorZones::AssignmentEntry::Autotile;
+        autotile.tilingAlgorithm = QStringLiteral("dwindle");
+        m_layoutManager->setAssignmentEntryDirect(QStringLiteral("DP-2"), 0, QString(), autotile);
+
+        // Register the opening window's metadata so the rule query resolves its appId.
+        auto* registry = new PhosphorEngine::WindowRegistry(m_parent);
+        m_wta->setWindowRegistry(registry);
+        m_wta->setWindowMetadata(QStringLiteral("inst1"), QStringLiteral("routeapp"), QString(), QString(), QString(),
+                                 0, 0, QString(), 0, QVariantMap());
+
+        // Rule: route "routeapp" onto DP-2 and onto virtual desktop 2.
+        using namespace PhosphorWindowRules;
+        WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.enabled = true;
+        rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::AppIdMatches, QStringLiteral("routeapp"));
+        RuleAction route;
+        route.type = QString(ActionType::RouteToScreen);
+        route.params.insert(QString(ActionParam::TargetScreenId), QStringLiteral("DP-2"));
+        RuleAction desk;
+        desk.type = QString(ActionType::RouteToDesktop);
+        desk.params.insert(QString(ActionParam::TargetDesktop), 2);
+        rule.actions = {route, desk};
+
+        WindowRuleStore store(ConfigDefaults::windowRulesFilePath(), m_parent);
+        QVERIFY(store.addRule(rule));
+        m_wta->setWindowRuleStore(&store);
+
+        QSignalSpy outputSpy(m_wta, &WindowTrackingAdaptor::windowOutputMoveExpected);
+        QSignalSpy desktopSpy(m_wta, &WindowTrackingAdaptor::windowDesktopMoveRequested);
+
+        const QString routed =
+            m_wta->applyOpenRoutingForAutotile(QStringLiteral("routeapp|inst1"), QStringLiteral("DP-1"));
+
+        // Redirected to the autotile target, with both the output- and desktop-move
+        // signals emitted for the compositor to act on.
+        QCOMPARE(routed, QStringLiteral("DP-2"));
+        QCOMPARE(outputSpy.count(), 1);
+        QCOMPARE(outputSpy.at(0).at(1).toString(), QStringLiteral("DP-2"));
+        QCOMPARE(desktopSpy.count(), 1);
+        QCOMPARE(desktopSpy.at(0).at(1).toInt(), 2);
+
+        m_wta->setWindowRuleStore(nullptr);
+        m_wta->setWindowRegistry(nullptr);
+    }
+
+    void testApplyOpenRoutingForAutotile_declinesSnapModeTarget()
+    {
+        // DP-2 stays SNAPPING (registry default): autotile must NOT redirect onto a
+        // snap-mode monitor (the snap placement path owns those), but RouteToDesktop
+        // is engine-neutral and still fires.
+        auto* registry = new PhosphorEngine::WindowRegistry(m_parent);
+        m_wta->setWindowRegistry(registry);
+        m_wta->setWindowMetadata(QStringLiteral("inst2"), QStringLiteral("snaproute"), QString(), QString(), QString(),
+                                 0, 0, QString(), 0, QVariantMap());
+
+        using namespace PhosphorWindowRules;
+        WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.enabled = true;
+        rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::AppIdMatches, QStringLiteral("snaproute"));
+        RuleAction route;
+        route.type = QString(ActionType::RouteToScreen);
+        route.params.insert(QString(ActionParam::TargetScreenId), QStringLiteral("DP-2"));
+        RuleAction desk;
+        desk.type = QString(ActionType::RouteToDesktop);
+        desk.params.insert(QString(ActionParam::TargetDesktop), 3);
+        rule.actions = {route, desk};
+
+        WindowRuleStore store(ConfigDefaults::windowRulesFilePath(), m_parent);
+        QVERIFY(store.addRule(rule));
+        m_wta->setWindowRuleStore(&store);
+
+        QSignalSpy outputSpy(m_wta, &WindowTrackingAdaptor::windowOutputMoveExpected);
+        QSignalSpy desktopSpy(m_wta, &WindowTrackingAdaptor::windowDesktopMoveRequested);
+
+        const QString routed =
+            m_wta->applyOpenRoutingForAutotile(QStringLiteral("snaproute|inst2"), QStringLiteral("DP-1"));
+
+        QVERIFY2(routed.isEmpty(), "a snap-mode RouteToScreen target must not be an autotile redirect");
+        QCOMPARE(outputSpy.count(), 0);
+        QCOMPARE(desktopSpy.count(), 1); // desktop routing is engine-neutral
+        QCOMPARE(desktopSpy.at(0).at(1).toInt(), 3);
+
+        m_wta->setWindowRuleStore(nullptr);
+        m_wta->setWindowRegistry(nullptr);
+    }
 
     void testMoveWindowToZone_validZone_emitsApplyGeometry()
     {

--- a/tests/unit/settings/test_window_rule_controller.cpp
+++ b/tests/unit/settings/test_window_rule_controller.cpp
@@ -760,7 +760,7 @@ void TestWindowRuleController::authoringMetadata()
         const QString kind = f.value(QStringLiteral("valueKind")).toString();
         QVERIFY(kind == QLatin1String("string") || kind == QLatin1String("number") || kind == QLatin1String("bool")
                 || kind == QLatin1String("screen") || kind == QLatin1String("activity")
-                || kind == QLatin1String("windowType"));
+                || kind == QLatin1String("windowType") || kind == QLatin1String("virtualDesktop"));
         if (kind == QLatin1String("screen")) {
             sawScreenKind = true;
         }

--- a/tests/unit/settings/test_window_rule_model.cpp
+++ b/tests/unit/settings/test_window_rule_model.cpp
@@ -570,8 +570,8 @@ void TestWindowRuleModel::routeActionsRenderFriendlyLabels()
     // summary rather than leaking their raw wire tokens. Both actions are
     // user-authorable (they appear in the action picker), so a missing
     // actionLabel branch would surface "routeToScreen" / "routeToDesktop" in the
-    // rules list while the editor shows "Open on monitor" / "Open on virtual
-    // desktop" — an inconsistency this test guards against. RouteToScreen also
+    // rules list while the editor shows "Open on monitor" / "Open on desktop" — an
+    // inconsistency this test guards against. RouteToScreen also
     // resolves its target through the injected screen lookup, mirroring the
     // ScreenId match-leaf path, and falls back to the raw id when unresolved.
     const auto screenRuleWith = [](const QString& screenId) {

--- a/tests/unit/settings/test_window_rule_model.cpp
+++ b/tests/unit/settings/test_window_rule_model.cpp
@@ -616,8 +616,8 @@ void TestWindowRuleModel::routeActionsRenderFriendlyLabels()
     // No screen lookup wired → the raw canonical id round-trips behind the label.
     QCOMPARE(summaryAt(0), QStringLiteral("Open on monitor: DP-2"));
     QCOMPARE(summaryAt(1), QStringLiteral("Open on monitor"));
-    QCOMPARE(summaryAt(2), QStringLiteral("Open on virtual desktop 2"));
-    QCOMPARE(summaryAt(3), QStringLiteral("Open on virtual desktop"));
+    QCOMPARE(summaryAt(2), QStringLiteral("Open on desktop 2"));
+    QCOMPARE(summaryAt(3), QStringLiteral("Open on desktop"));
 
     // No summary may leak the lowercase wire token — that signals the
     // actionLabel branch fell through to the raw-type fallback.

--- a/tests/unit/settings/test_window_rule_model.cpp
+++ b/tests/unit/settings/test_window_rule_model.cpp
@@ -107,7 +107,6 @@ private Q_SLOTS:
     void reorder();
     void addRuleAtInsertsAtIndexWithSingleSignal();
     void validationIssueCountRole();
-    void screenIdsRoleHandlesInOperator();
     void screenIdsOfCollectsOnlyLiteralPinOperators();
     void actionSummaryRendersAllEngineModes();
     void disableEngineNamesTheModeBeingDisabled();
@@ -313,57 +312,9 @@ void TestWindowRuleModel::validationIssueCountRole()
     QVERIFY(model.roleNames().values().contains(QByteArrayLiteral("validationIssueCount")));
 }
 
-void TestWindowRuleModel::screenIdsRoleHandlesInOperator()
-{
-    // A rule authored as `ScreenId IN [DP-2, DP-3]` must surface both ids
-    // in ScreenIdsRole — earlier code did `value.toString()` on the leaf's
-    // value and dropped them silently (toString() returns empty for a list).
-    // The role drives the monitor-overview filter chip and the ruleCount
-    // tally per monitor, so a regression here makes In-rules invisible to
-    // the page.
-    WindowRule rule;
-    rule.id = QUuid::createUuid();
-    rule.name = QStringLiteral("DP-2/DP-3 layout");
-    rule.priority = 300;
-    rule.match = MatchExpression::makeLeaf(Field::ScreenId, Operator::In,
-                                           QVariantList{QStringLiteral("DP-2"), QStringLiteral("DP-3")});
-    RuleAction engine;
-    engine.type = QString(ActionType::SetEngineMode);
-    engine.params.insert(ActionParam::Mode, QStringLiteral("autotile"));
-    rule.actions = {engine};
-
-    WindowRuleModel model;
-    model.setRules({rule});
-
-    const QStringList ids = model.data(model.index(0, 0), WindowRuleModel::ScreenIdsRole).toStringList();
-    QCOMPARE(ids.size(), 2);
-    QVERIFY(ids.contains(QStringLiteral("DP-2")));
-    QVERIFY(ids.contains(QStringLiteral("DP-3")));
-
-    // Static helper exposed to the controller (used by monitorOverview)
-    // must walk the same path.
-    const QStringList collected = WindowRuleModel::screenIdsOf(rule.match);
-    QCOMPARE(collected.size(), 2);
-    QVERIFY(collected.contains(QStringLiteral("DP-2")));
-    QVERIFY(collected.contains(QStringLiteral("DP-3")));
-
-    // QStringList-typed predicate values must also be iterated correctly —
-    // a programmatically built leaf can carry that shape (see the
-    // matchexpression.cpp evaluator's dual-shape handling).
-    WindowRule rule2 = rule;
-    rule2.id = QUuid::createUuid();
-    rule2.match = MatchExpression::makeLeaf(
-        Field::ScreenId, Operator::In,
-        QVariant::fromValue(QStringList{QStringLiteral("HDMI-A-1"), QStringLiteral("eDP-1")}));
-    const QStringList ids2 = WindowRuleModel::screenIdsOf(rule2.match);
-    QCOMPARE(ids2.size(), 2);
-    QVERIFY(ids2.contains(QStringLiteral("HDMI-A-1")));
-    QVERIFY(ids2.contains(QStringLiteral("eDP-1")));
-}
-
 void TestWindowRuleModel::screenIdsOfCollectsOnlyLiteralPinOperators()
 {
-    // Only Equals and In are literal monitor pins. A substring / regex operator
+    // Only Equals is a literal monitor pin. A substring / regex operator
     // (StartsWith, Contains, …) never equals a real connector id, so collecting
     // its token would silently under-count the rule against every monitor tile.
     // Such rules must contribute NO screen id.

--- a/tests/unit/settings/test_window_rule_model.cpp
+++ b/tests/unit/settings/test_window_rule_model.cpp
@@ -113,6 +113,7 @@ private Q_SLOTS:
     void setOpacityRendersValidValuesAndGuardsRejectPaths();
     void restorePositionRendersValueAwareLabel();
     void shaderAndCurveLabelsResolveThroughLookups();
+    void routeActionsRenderFriendlyLabels();
 };
 
 void TestWindowRuleModel::rolesExposed()
@@ -561,6 +562,77 @@ void TestWindowRuleModel::shaderAndCurveLabelsResolveThroughLookups()
     QCOMPARE(summaryAt(2), QStringLiteral("Block animation shader"));
     QCOMPARE(summaryAt(3), QStringLiteral("Animation curve"));
     QCOMPARE(summaryAt(4), QStringLiteral("Shader: mystery"));
+}
+
+void TestWindowRuleModel::routeActionsRenderFriendlyLabels()
+{
+    // Pin that RouteToScreen / RouteToDesktop render human labels in the action
+    // summary rather than leaking their raw wire tokens. Both actions are
+    // user-authorable (they appear in the action picker), so a missing
+    // actionLabel branch would surface "routeToScreen" / "routeToDesktop" in the
+    // rules list while the editor shows "Open on monitor" / "Open on virtual
+    // desktop" — an inconsistency this test guards against. RouteToScreen also
+    // resolves its target through the injected screen lookup, mirroring the
+    // ScreenId match-leaf path, and falls back to the raw id when unresolved.
+    const auto screenRuleWith = [](const QString& screenId) {
+        WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.priority = 200;
+        rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::Equals, QStringLiteral("firefox"));
+        RuleAction route;
+        route.type = QString(ActionType::RouteToScreen);
+        if (!screenId.isNull()) {
+            route.params.insert(ActionParam::TargetScreenId, screenId);
+        }
+        rule.actions = {route};
+        return rule;
+    };
+    const auto desktopRuleWith = [](int desktop) {
+        WindowRule rule;
+        rule.id = QUuid::createUuid();
+        rule.priority = 199;
+        rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::Equals, QStringLiteral("konsole"));
+        RuleAction route;
+        route.type = QString(ActionType::RouteToDesktop);
+        if (desktop >= 1) {
+            route.params.insert(ActionParam::TargetDesktop, desktop);
+        }
+        rule.actions = {route};
+        return rule;
+    };
+
+    WindowRuleModel model;
+    model.setRules({
+        screenRuleWith(QStringLiteral("DP-2")), // resolved through the lookup once installed
+        screenRuleWith(QString()), // no target → placeholder, lookup not consulted
+        desktopRuleWith(2),
+        desktopRuleWith(0), // absent/invalid desktop → placeholder
+    });
+
+    const auto summaryAt = [&](int row) {
+        return model.data(model.index(row, 0), WindowRuleModel::ActionSummaryRole).toString();
+    };
+
+    // No screen lookup wired → the raw canonical id round-trips behind the label.
+    QCOMPARE(summaryAt(0), QStringLiteral("Open on monitor: DP-2"));
+    QCOMPARE(summaryAt(1), QStringLiteral("Open on monitor"));
+    QCOMPARE(summaryAt(2), QStringLiteral("Open on virtual desktop 2"));
+    QCOMPARE(summaryAt(3), QStringLiteral("Open on virtual desktop"));
+
+    // No summary may leak the lowercase wire token — that signals the
+    // actionLabel branch fell through to the raw-type fallback.
+    for (int row = 0; row < model.rowCount(); ++row) {
+        QVERIFY2(!summaryAt(row).contains(QStringLiteral("routeToScreen")), qPrintable(summaryAt(row)));
+        QVERIFY2(!summaryAt(row).contains(QStringLiteral("routeToDesktop")), qPrintable(summaryAt(row)));
+    }
+
+    // Installing the screen lookup resolves the target to its friendly monitor
+    // label; refreshLabels coalesces the update into one dataChanged.
+    model.setScreenLabelLookup([](const QString& id) {
+        return id == QLatin1String("DP-2") ? QStringLiteral("LG Ultra HD · DP-2") : id;
+    });
+    model.refreshLabels();
+    QCOMPARE(summaryAt(0), QStringLiteral("Open on monitor: LG Ultra HD · DP-2"));
 }
 
 QTEST_MAIN(TestWindowRuleModel)


### PR DESCRIPTION
## Summary

Adds composable **RouteToScreen** and **RouteToDesktop** window-rule actions so a rule can open a matched window on a specific monitor and/or virtual desktop, and snap it into a zone there. This restores the per-monitor app→zone assignment that v3 had and generalizes it to "open app X on context Y" for both snapping and tiling.

Fixes the regression in discussion [#686](https://github.com/fuddlesworth/PlasmaZones/discussions/686): the v3→v4 migration dropped the legacy per-monitor `targetScreen` pin and left X11 two-token patterns (`chromium chromium`) that never matched the normalized appId, so per-monitor assignments silently stopped working.

## What's in it

- **New actions** `RouteToScreen` / `RouteToDesktop` — Window-domain, each its own slot, with params, validators, and unit tests. They compose with `SnapToZone` and with each other.
- **Snap placement** honors `RouteToScreen` (resolves the zone on the routed monitor and moves the window there) and `RouteToDesktop` (resolves against the **destination desktop's** layout and commits the zone assignment in that desktop's context, so zone occupancy / snap-assist / empty-zone detection stay correct on both desktops).
- **Autotile open path** redirects a window onto a target autotile monitor and emits the desktop move, via a WTA routing resolver wired into the autotile adaptor.
- **Migration fix** — normalizes the legacy app-rule pattern (kills the dead two-token matcher) and carries the legacy `targetScreen` over as a `RouteToScreen` action. Fix-forward only (already-migrated users re-create or re-trigger).
- **Rule editor** — monitor and named virtual-desktop pickers for the new actions; the WHEN `VirtualDesktop` condition now uses the named desktop picker too; fixed condition-row alignment when an operator hint wraps to two lines.

## Cleanup: removed the unusable `In` ("is one of") match operator

`In` needed a list value, but every condition value editor only ever produced a single scalar — so a UI-built `In` leaf could never carry a real set and never matched. It was offered for Monitor / Virtual desktop / Activity / Window type conditions but was effectively dead (the same intent is expressible with an OR group of `Equals` leaves). Removed entirely rather than leaving hidden vestigial code: the `Operator` enum value + wire strings, the evaluator/validator set-membership branches, the rule-model set fan-out, the `"is one of"` label, the `operatorsForField` appends, and the `In`-specific tests. `OperatorCount` drops to 8; operators after `In` renumber, but serialization is by wire string so persisted rules are unaffected.

## Also included

A separate first commit fixes a pre-existing bug: `CapabilityBadgeRow` (added in `5e7d3842f`) was never registered in the standalone settings app's hand-rolled `org.plasmazones.common` module, so the whole rule editor and MonitorStatePage failed to load with `PZCommon.CapabilityBadgeRow is not a type`.

## Scope limits (deliberate)

- Cross-*engine* routing (snap screen → autotile screen, or vice-versa) is not handled; each engine routes within its own kind. Same-engine and desktop routing work for both.

## Testing

All 240 test suites pass. New tests cover the action validation/slots, snap routing to a target screen, snap-on-target-desktop result stamping, the autotile routing decision (redirect + snap-target decline), and the migration (reporter scenario + golden id + pattern normalization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)