### PR TITLE
fix(scripting): pin LC_NUMERIC to "C" while compiling Luau

### DIFF
--- a/libs/phosphor-scripting/src/luauengine.cpp
+++ b/libs/phosphor-scripting/src/luauengine.cpp
@@ -19,17 +19,26 @@ namespace {
 // Compile/run budget for prelude + module chunks (well-behaved host code).
 constexpr int ChunkTimeoutMs = 1000;
 
-// RAII guard that pins the calling thread's LC_NUMERIC to "C" for its
-// lifetime. luau_compile() lexes number literals through Luau's parser, which
-// converts them with strtod() — and strtod() honours LC_NUMERIC. Under a locale
-// whose decimal separator is not '.' (e.g. de_DE, fr_FR, most non-English
-// European locales use ','), strtod("0.1") parses only "0" and stops at the
-// '.', so Luau rejects the literal as a "Malformed number" and the entire chunk
-// fails to compile. The bundled tiling algorithms and the pluau prelude are all
-// written with '.'-decimal literals, so on a comma-decimal locale every one of
-// them would fail to load and the user would see no algorithms at all. Scoping
-// the override to the compiling thread via uselocale() keeps it off the global
-// process locale, so user-facing number formatting elsewhere is untouched.
+// RAII guard that pins the calling thread's LC_NUMERIC to "C" for its lifetime.
+// The Luau VM assumes a C numeric locale end to end, and both halves of that
+// assumption route through locale-sensitive C library calls:
+//   • Compile: luau_compile() lexes number literals through Luau's parser, which
+//     converts them with strtod(). strtod() honours LC_NUMERIC, so under a
+//     locale whose decimal separator is not '.' (e.g. de_DE, fr_FR, most
+//     non-English European locales use ','), strtod("0.1") parses only "0" and
+//     stops at the '.'. Luau then rejects the literal as a "Malformed number"
+//     and the whole chunk fails to compile. The bundled tiling algorithms and
+//     the pluau prelude are all written with '.'-decimal literals, so on a
+//     comma-decimal locale every one of them would fail to load and the user
+//     would see no algorithms at all.
+//   • Execute: at runtime, tonumber()/string.format("%f", …)/tostring(number)
+//     go through strtod()/snprintf(), which are locale-sensitive too. A script
+//     that round-trips a decimal through a string would silently misparse or
+//     misformat under the same locales.
+// Both luau_compile() and the lua_pcall() that runs script bodies are wrapped in
+// this guard. Scoping the override to the executing thread via uselocale() keeps
+// it off the global process locale, so user-facing number formatting elsewhere
+// is untouched.
 class ScopedCNumericLocale
 {
 public:
@@ -383,7 +392,15 @@ LuauEngine::CallStatus LuauEngine::guardedPcall(int nargs, int nresults, int tim
     // runs outside any pcall. Trusted preludes run before sandbox() and stay
     // unenforced. Not re-entrant — the VM is single-threaded.
     m_memory.enforce = m_sandboxed;
-    const int rc = lua_pcall(m_L, nargs, nresults, 0);
+    int rc = 0;
+    {
+        // Script bodies run number↔string conversions (tonumber, string.format,
+        // tostring) through locale-sensitive C library calls — pin LC_NUMERIC to
+        // "C" for the duration of execution (see ScopedCNumericLocale). Result
+        // marshalling afterward uses binary lua_tonumber, so it needs no guard.
+        const ScopedCNumericLocale cNumeric;
+        rc = lua_pcall(m_L, nargs, nresults, 0);
+    }
     m_memory.enforce = false;
     if (m_watchdog) {
         m_watchdog->disarm(this);

--- a/libs/phosphor-scripting/src/luauengine.cpp
+++ b/libs/phosphor-scripting/src/luauengine.cpp
@@ -11,12 +11,50 @@
 #include <luacode.h>
 
 #include <cstdlib>
+#include <locale.h>
 
 namespace PhosphorScripting {
 
 namespace {
 // Compile/run budget for prelude + module chunks (well-behaved host code).
 constexpr int ChunkTimeoutMs = 1000;
+
+// RAII guard that pins the calling thread's LC_NUMERIC to "C" for its
+// lifetime. luau_compile() lexes number literals through Luau's parser, which
+// converts them with strtod() — and strtod() honours LC_NUMERIC. Under a locale
+// whose decimal separator is not '.' (e.g. de_DE, fr_FR, most non-English
+// European locales use ','), strtod("0.1") parses only "0" and stops at the
+// '.', so Luau rejects the literal as a "Malformed number" and the entire chunk
+// fails to compile. The bundled tiling algorithms and the pluau prelude are all
+// written with '.'-decimal literals, so on a comma-decimal locale every one of
+// them would fail to load and the user would see no algorithms at all. Scoping
+// the override to the compiling thread via uselocale() keeps it off the global
+// process locale, so user-facing number formatting elsewhere is untouched.
+class ScopedCNumericLocale
+{
+public:
+    ScopedCNumericLocale()
+    {
+        // Created once and intentionally never freed (process-lifetime). The
+        // locale object is immutable after creation, so sharing the same
+        // handle across threads via uselocale() is safe.
+        static const locale_t s_cLocale = newlocale(LC_NUMERIC_MASK, "C", static_cast<locale_t>(nullptr));
+        if (s_cLocale != static_cast<locale_t>(nullptr)) {
+            m_previous = uselocale(s_cLocale);
+        }
+    }
+    ~ScopedCNumericLocale()
+    {
+        if (m_previous != static_cast<locale_t>(nullptr)) {
+            uselocale(m_previous);
+        }
+    }
+    ScopedCNumericLocale(const ScopedCNumericLocale&) = delete;
+    ScopedCNumericLocale& operator=(const ScopedCNumericLocale&) = delete;
+
+private:
+    locale_t m_previous = static_cast<locale_t>(nullptr);
+};
 
 // Read the error object on the top of the stack as text. Luau leaves a
 // non-string error object (e.g. `error({})`) un-coercible, in which case
@@ -125,7 +163,13 @@ bool LuauEngine::runPrelude(const QString& chunkName, const QByteArray& source, 
     }
 
     size_t bcSize = 0;
-    char* bc = luau_compile(source.constData(), static_cast<size_t>(source.size()), nullptr, &bcSize);
+    char* bc = nullptr;
+    {
+        // Pin LC_NUMERIC to "C" so '.'-decimal literals lex correctly
+        // regardless of the user's locale (see ScopedCNumericLocale).
+        const ScopedCNumericLocale cNumeric;
+        bc = luau_compile(source.constData(), static_cast<size_t>(source.size()), nullptr, &bcSize);
+    }
     // luau_compile allocates the result with its own allocator (outside the VM
     // heap cap) and encodes syntax errors into a non-null blob — a null return
     // means allocation failure, not a syntax error.
@@ -178,7 +222,13 @@ int LuauEngine::loadModule(const QString& chunkName, const QByteArray& source, Q
     }
 
     size_t bcSize = 0;
-    char* bc = luau_compile(source.constData(), static_cast<size_t>(source.size()), nullptr, &bcSize);
+    char* bc = nullptr;
+    {
+        // Pin LC_NUMERIC to "C" so '.'-decimal literals lex correctly
+        // regardless of the user's locale (see ScopedCNumericLocale).
+        const ScopedCNumericLocale cNumeric;
+        bc = luau_compile(source.constData(), static_cast<size_t>(source.size()), nullptr, &bcSize);
+    }
     // See runPrelude: a null blob is an allocation failure, not a syntax error.
     if (!bc) {
         if (error) {

--- a/tests/unit/scripting/test_luau_engine.cpp
+++ b/tests/unit/scripting/test_luau_engine.cpp
@@ -10,6 +10,7 @@
 #include <PhosphorScripting/LuauEngine.h>
 #include <PhosphorScripting/LuauWatchdog.h>
 
+#include <cstdio>
 #include <cstdlib>
 #include <locale.h>
 #include <memory>
@@ -37,7 +38,25 @@ private Q_SLOTS:
     void memoryCapEnforcedAndRecovers();
     void memoryCapAllowsNormalWork();
     void compilesFloatLiteralsUnderCommaDecimalLocale();
+    void executesNumberFormattingUnderCommaDecimalLocale();
 };
+
+namespace {
+// Open the first installed comma-decimal locale from a candidate list, or
+// nullptr if none is available. Callers QSKIP on nullptr.
+locale_t openCommaDecimalLocale()
+{
+    static const char* const kCandidates[] = {"de_DE.UTF-8", "fr_FR.UTF-8", "nl_NL.UTF-8", "es_ES.UTF-8",
+                                              "it_IT.UTF-8", "de_DE",       "fr_FR"};
+    for (const char* name : kCandidates) {
+        const locale_t loc = newlocale(LC_NUMERIC_MASK, name, static_cast<locale_t>(nullptr));
+        if (loc != static_cast<locale_t>(nullptr)) {
+            return loc;
+        }
+    }
+    return static_cast<locale_t>(nullptr);
+}
+} // namespace
 
 void TestLuauEngine::happyPathAndMarshalling()
 {
@@ -394,15 +413,7 @@ void TestLuauEngine::compilesFloatLiteralsUnderCommaDecimalLocale()
     // the pluau prelude + every bundled algorithm fail to load. The engine must
     // pin LC_NUMERIC to "C" across the compile so '.'-decimal literals parse
     // regardless of the ambient locale.
-    static const char* const kCandidates[] = {"de_DE.UTF-8", "fr_FR.UTF-8", "nl_NL.UTF-8", "es_ES.UTF-8",
-                                              "it_IT.UTF-8", "de_DE",       "fr_FR"};
-    locale_t commaLocale = static_cast<locale_t>(nullptr);
-    for (const char* name : kCandidates) {
-        commaLocale = newlocale(LC_NUMERIC_MASK, name, static_cast<locale_t>(nullptr));
-        if (commaLocale != static_cast<locale_t>(nullptr)) {
-            break;
-        }
-    }
+    const locale_t commaLocale = openCommaDecimalLocale();
     if (commaLocale == static_cast<locale_t>(nullptr)) {
         QSKIP("No comma-decimal locale installed; cannot exercise the LC_NUMERIC regression");
     }
@@ -435,6 +446,49 @@ void TestLuauEngine::compilesFloatLiteralsUnderCommaDecimalLocale()
     const QVariantMap z = out.result.toList().value(0).toMap();
     QCOMPARE(z.value(QStringLiteral("width")).toDouble(), 0.25);
     QCOMPARE(z.value(QStringLiteral("height")).toDouble(), 0.5);
+    engine.releaseModule(handle);
+}
+
+void TestLuauEngine::executesNumberFormattingUnderCommaDecimalLocale()
+{
+    // Companion to compilesFloatLiteralsUnderCommaDecimalLocale: even after a
+    // chunk compiles, Luau's runtime number→string conversions (string.format,
+    // tostring) go through locale-sensitive snprintf. The engine pins LC_NUMERIC
+    // to "C" across script execution too, so a script that formats a decimal
+    // emits '.'-decimal output regardless of the ambient locale.
+    const locale_t commaLocale = openCommaDecimalLocale();
+    if (commaLocale == static_cast<locale_t>(nullptr)) {
+        QSKIP("No comma-decimal locale installed; cannot exercise the LC_NUMERIC regression");
+    }
+
+    // Compile under the default locale (the compile path has its own test); this
+    // case isolates the runtime-execution path, so the locale only needs to be
+    // comma-decimal while the script body runs below.
+    LuauEngine engine;
+    QVERIFY(engine.init());
+    engine.sandbox();
+    QString err;
+    const int handle = engine.loadModule(QStringLiteral("fmt"),
+                                         "return { fmt = function() return string.format('%.3f', 0.25) end }", &err);
+    QVERIFY2(handle >= 0, qPrintable(err));
+
+    const locale_t previous = uselocale(commaLocale);
+    // Sanity: confirm the C library really formats decimals with ',' under this
+    // locale, so a pass proves the engine's runtime guard rather than a no-op
+    // environment.
+    char buf[16];
+    std::snprintf(buf, sizeof(buf), "%.1f", 0.5);
+    const bool ambientFormatsWithComma = (QByteArray(buf) == "0,5");
+
+    const auto out = engine.callModule(handle, QStringLiteral("fmt"), {}, 200);
+
+    // Restore the thread locale before any QVERIFY can early-return.
+    uselocale(previous);
+    freelocale(commaLocale);
+
+    QVERIFY2(ambientFormatsWithComma, "selected locale is not actually comma-decimal; the test would be a no-op");
+    QCOMPARE(out.status, LuauEngine::CallStatus::Ok);
+    QCOMPARE(out.result.toString(), QStringLiteral("0.250"));
     engine.releaseModule(handle);
 }
 

--- a/tests/unit/scripting/test_luau_engine.cpp
+++ b/tests/unit/scripting/test_luau_engine.cpp
@@ -10,6 +10,8 @@
 #include <PhosphorScripting/LuauEngine.h>
 #include <PhosphorScripting/LuauWatchdog.h>
 
+#include <cstdlib>
+#include <locale.h>
 #include <memory>
 
 using namespace PhosphorScripting;
@@ -34,6 +36,7 @@ private Q_SLOTS:
     void callMissingFunctionFails();
     void memoryCapEnforcedAndRecovers();
     void memoryCapAllowsNormalWork();
+    void compilesFloatLiteralsUnderCommaDecimalLocale();
 };
 
 void TestLuauEngine::happyPathAndMarshalling()
@@ -380,6 +383,59 @@ void TestLuauEngine::memoryCapAllowsNormalWork()
     QVERIFY(engine.peakMemoryBytes() > 0);
     QVERIFY(engine.peakMemoryBytes() < engine.memoryCapBytes());
     QVERIFY(engine.peakMemoryBytes() < 16ull * 1024 * 1024);
+}
+
+void TestLuauEngine::compilesFloatLiteralsUnderCommaDecimalLocale()
+{
+    // Regression for discussion #690: luau_compile() lexes number literals with
+    // strtod(), which honours LC_NUMERIC. Under a locale whose decimal separator
+    // is ',', an unguarded compile parses "0.25" as just "0" with a trailing
+    // ".25", so Luau rejects every '.'-decimal literal as "Malformed number" and
+    // the pluau prelude + every bundled algorithm fail to load. The engine must
+    // pin LC_NUMERIC to "C" across the compile so '.'-decimal literals parse
+    // regardless of the ambient locale.
+    static const char* const kCandidates[] = {"de_DE.UTF-8", "fr_FR.UTF-8", "nl_NL.UTF-8", "es_ES.UTF-8",
+                                              "it_IT.UTF-8", "de_DE",       "fr_FR"};
+    locale_t commaLocale = static_cast<locale_t>(nullptr);
+    for (const char* name : kCandidates) {
+        commaLocale = newlocale(LC_NUMERIC_MASK, name, static_cast<locale_t>(nullptr));
+        if (commaLocale != static_cast<locale_t>(nullptr)) {
+            break;
+        }
+    }
+    if (commaLocale == static_cast<locale_t>(nullptr)) {
+        QSKIP("No comma-decimal locale installed; cannot exercise the LC_NUMERIC regression");
+    }
+
+    const locale_t previous = uselocale(commaLocale);
+    // Guard against a no-op test: confirm the ambient locale really does
+    // mis-parse '.' decimals, so a pass proves the engine's fix rather than an
+    // environment where the bug could never reproduce.
+    const bool ambientMisparsesDot = (std::strtod("0.5", nullptr) != 0.5);
+
+    LuauEngine engine;
+    const bool inited = engine.init();
+    QString err;
+    const int handle = engine.loadModule(
+        QStringLiteral("ratios"),
+        "return { tile = function(ctx) return { { x = 0, y = 0, width = 0.25, height = 0.5 } } end }", &err);
+
+    // Restore the thread locale before any QVERIFY can early-return, then free
+    // the now-unused handle.
+    uselocale(previous);
+    freelocale(commaLocale);
+
+    QVERIFY(inited);
+    QVERIFY2(ambientMisparsesDot, "selected locale is not actually comma-decimal; the test would be a no-op");
+    QVERIFY2(handle >= 0, qPrintable(err));
+
+    engine.sandbox();
+    const auto out = engine.callModule(handle, QStringLiteral("tile"), {}, 200);
+    QCOMPARE(out.status, LuauEngine::CallStatus::Ok);
+    const QVariantMap z = out.result.toList().value(0).toMap();
+    QCOMPARE(z.value(QStringLiteral("width")).toDouble(), 0.25);
+    QCOMPARE(z.value(QStringLiteral("height")).toDouble(), 0.5);
+    engine.releaseModule(handle);
 }
 
 QTEST_MAIN(TestLuauEngine)


### PR DESCRIPTION
## Problem

Fixes [discussion #690](https://github.com/fuddlesworth/PlasmaZones/discussions/690): autotiling stopped working after an update. The user's config had `Tiling.Enabled = true` and `Tiling.Algorithm.Default = bsp`, yet the UI showed "No autotile algorithms available" and downloaded/generated algorithms were not recognized either.

The attached support report's journal was conclusive: **every** algorithm failed to compile, including the shared prelude:

```
LuauTileAlgorithm: pluau prelude failed: "[string \"pluau\"]:17: Malformed number"
LuauTileAlgorithm: engine setup failed file= ".../bsp.luau" : "[string \"pluau\"]:17: Malformed number"
Invalid scripted algorithm, skipping: ".../bsp.luau"
```

## Root cause

A locale bug. Luau compiles number literals via `parseDouble()` → `strtod()` (`luau-0.723/Ast/src/Parser.cpp:3881`), and `strtod()` honors `LC_NUMERIC`. Under a locale whose decimal separator is `,` (most non-English European locales; the reporter's timestamps are `+02:00`), `strtod("0.1")` parses only `0` and stops at the `.`, so Luau rejects the literal as "Malformed number".

`pluau.luau:17` is the first float literal in the shared prelude (`local MIN_SPLIT = 0.1`), so the prelude and every bundled tiling algorithm fail to compile, and the user is left with zero registered algorithms. This regressed when the tiling engine moved from the old JS engine to embedded Luau.

## Fix

Wrap both `luau_compile()` call sites (`runPrelude()` and `loadModule()`) in a thread-scoped RAII guard that pins `LC_NUMERIC` to `"C"` via `uselocale()` for the duration of compilation. Scoping it to the compiling thread keeps the global process locale and user-facing number formatting untouched. The fix covers the daemon, settings app, and editor since they share the engine.

## Verification

- Builds clean; clang-format / conventional-commit hooks pass.
- New regression test `compilesFloatLiteralsUnderCommaDecimalLocale` compiles a `.`-decimal script under a comma-decimal locale (`QSKIP` when no such locale is installed).
- Proven end-to-end by generating a `de_DE.UTF-8` locale into a temp dir (`LOCPATH`, no sudo):
  - **Without the guard:** test fails with the exact `[string "ratios"]:1: Malformed number`.
  - **With the guard:** test passes.
- Full scripting suite under a comma-decimal locale: **91 passed, 0 failed** (`test_luau_engine`, `test_luau_tile_algorithm`, `test_luau_parity` — which loads the real bundled `.luau` files — `test_luau_aligned_grid`, `test_luau_ratio_reflow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)