### PR TITLE
fix(settings): use the standard subtle tint for layout dropdown highlight

### DIFF
--- a/src/settings/qml/LayoutComboBox.qml
+++ b/src/settings/qml/LayoutComboBox.qml
@@ -429,8 +429,12 @@ ComboBox {
 
         // Opaque background prevents the ComboBox's closed-state display text
         // from bleeding through the popup delegate (especially the first item).
+        // Highlight matches the standard subtle tint used everywhere else (e.g.
+        // LayoutGridDelegate): a 0.15-alpha highlightColor wash rather than a
+        // full opaque band, so badges and labels stay legible without having to
+        // recolor to highlightedTextColor.
         background: Rectangle {
-            color: highlighted ? Kirigami.Theme.highlightColor : isCurrentSelection ? Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.15) : Kirigami.Theme.backgroundColor
+            color: highlighted ? Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.15) : Kirigami.Theme.backgroundColor
         }
 
         contentItem: RowLayout {
@@ -443,7 +447,7 @@ ComboBox {
                 Layout.alignment: Qt.AlignVCenter
                 source: "checkmark"
                 visible: isCurrentSelection
-                color: highlighted ? Kirigami.Theme.highlightedTextColor : Kirigami.Theme.textColor
+                color: Kirigami.Theme.textColor
             }
 
             // Spacer when no checkmark — keeps text aligned
@@ -505,7 +509,7 @@ ComboBox {
                     Label {
                         text: modelData.text
                         font.weight: (highlighted || isCurrentSelection) ? Font.DemiBold : Font.Normal
-                        color: highlighted ? Kirigami.Theme.highlightedTextColor : Kirigami.Theme.textColor
+                        color: Kirigami.Theme.textColor
                         elide: Text.ElideRight
                         Layout.fillWidth: true
                     }
@@ -545,7 +549,7 @@ ComboBox {
                         }
                     }
                     font: Kirigami.Theme.smallFont
-                    color: highlighted ? Kirigami.Theme.highlightedTextColor : Kirigami.Theme.textColor
+                    color: Kirigami.Theme.textColor
                     opacity: 0.7
                     elide: Text.ElideRight
                     Layout.fillWidth: true


### PR DESCRIPTION
## Summary

The layout combo box (`LayoutComboBox`) popup highlighted its hovered/keyboard-navigated row with a **full opaque `highlightColor` band**, then flipped the label, subtitle, and checkmark to `highlightedTextColor` to keep them readable. The category, capability, and aspect-ratio badges have no highlight flag, so they kept their normal theme colors and washed out against the bright band.

This brings the dropdown in line with how highlighting is handled everywhere else (e.g. `LayoutGridDelegate`): a **0.15-alpha `highlightColor` wash** over the normal background, with text kept in the normal `textColor`. The badges now sit on a light tint and stay legible without any per-badge highlight handling.

## Changes
- Delegate background uses the standard `Qt.rgba(highlightColor, 0.15)` tint for the hovered row instead of a full opaque band.
- Removed the now-unneeded `highlightedTextColor` swaps on the checkmark, title label, and subtitle.
- Current selection remains indicated by the checkmark only, per the delegate's existing comment.

## Testing
Visual change only (pure QML). Verified the highlighted row now shows the subtle tint with legible badges, matching the layouts grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)