### PR TITLE
fix(zones): resolve per-context layout rules per-slot, honoring catch-alls

### DIFF
--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -837,13 +837,32 @@ private:
         return value;
     }
 
-    /// Cache of @ref resolveAssignmentEntry results keyed by context tuple.
-    /// A @c nullopt value caches a genuine cascade miss (no pinned context
-    /// rule wins) — so a missed lookup pays the linear walk exactly once per
-    /// rule-set revision, not three times per cursor-move (the
+    /// The rule-derived slot resolution cached by @ref resolveAssignmentEntry.
+    /// Holds ONLY what the rule set produced for each of the three independent
+    /// slots, so the cache stays a pure function of the rule set (the cache's
+    /// revision-invalidation contract). The global default — an external
+    /// provider, not part of the rule set and not revision-tracked — is folded
+    /// in AFTER the cache returns, so a default-setting change is reflected
+    /// immediately without a rule-set revision bump (a settings edit produces
+    /// none). @c modeEntry is engaged when an engine-mode rule won (it carries
+    /// that rule's mode plus its own layout tokens); when disengaged the caller
+    /// bases the entry on the live global default for the context.
+    /// @c snappingLayout / @c tilingAlgorithm are engaged when a layout rule
+    /// filled that slot, and override the base's field.
+    struct RuleSlotResolution
+    {
+        std::optional<AssignmentEntry> modeEntry;
+        std::optional<QString> snappingLayout;
+        std::optional<QString> tilingAlgorithm;
+    };
+
+    /// Cache of @ref resolveAssignmentEntry's rule-derived resolution keyed by
+    /// context tuple. A @c nullopt value caches a genuine cascade miss (no rule
+    /// filled any slot) — so a missed lookup pays the linear walk exactly once
+    /// per rule-set revision, not three times per cursor-move (the
     /// connector / virtual-screen fallback chain in
     /// @ref assignmentEntryForScreen drives the same miss into three lookups).
-    mutable QHash<ContextResolveKey, std::optional<AssignmentEntry>> m_contextResolveCache;
+    mutable QHash<ContextResolveKey, std::optional<RuleSlotResolution>> m_contextResolveCache;
     /// The rule-set revision the cache contents are valid for. The cache is
     /// dropped wholesale whenever this no longer matches
     /// @c m_ruleStore->ruleSet().revision() — see @ref resolveAssignmentEntry.

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -123,9 +123,20 @@ std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QStr
     // per cursor-move, and the connector + virtual-screen fallback chain in the
     // public resolvers triples that on a miss. A @c nullopt is cached too — a
     // genuine miss must not re-walk three times per cursor frame.
-    return resolveCachedContext(
+    //
+    // Only the RULE-derived resolution is cached, keeping the cache a pure
+    // function of the rule set (its revision-invalidation contract). The global
+    // default — an external provider, not part of the rule set and not
+    // revision-tracked — is folded in AFTER the cache so a default-setting
+    // change (snapping toggled, a different default layout/algorithm) is
+    // reflected immediately, with no rule-set revision bump (a settings edit
+    // produces none). Caching the default-derived entry would otherwise pin a
+    // stale mode/layout on the layout-only path until the next rule edit. The
+    // fold-in is a handful of O(1) provider / per-context-slot reads, so the
+    // expensive priority walk stays memoized.
+    const std::optional<RuleSlotResolution> rules = resolveCachedContext(
         m_contextResolveCache, m_contextResolveCacheRevision, screenId, virtualDesktop, activity,
-        [&]() -> std::optional<AssignmentEntry> {
+        [&]() -> std::optional<RuleSlotResolution> {
             const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
 
             // Specificity-tiered slot match: a pinned rule wins over a user
@@ -152,24 +163,43 @@ std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QStr
                 return std::nullopt; // genuine miss — the caller routes to the default
             }
 
-            // Base: the engine-mode rule decides the mode (and carries its own
-            // layout tokens). With no engine-mode rule, the default for this
-            // context supplies the mode — a layout-only rule must not force one.
-            AssignmentEntry entry = modeRule != nullptr
-                ? entryFromRuleMatchActions(*modeRule)
-                : resolveDefaultAssignmentEntryForContext(screenId, virtualDesktop, activity);
-
-            // Per-slot layout winners override their field. tieredMatch already
-            // ranks pinned over catch-all, so a more-specific layout rule beats
-            // a catch-all layout rule regardless of the raw priority numbers.
+            // The engine-mode rule decides the mode (and carries its own layout
+            // tokens, preserving mode-toggle losslessness); the per-slot layout
+            // winners fill their own field. tieredMatch already ranks pinned over
+            // catch-all, so a more-specific layout rule beats a catch-all layout
+            // rule regardless of the raw priority numbers.
+            RuleSlotResolution resolved;
+            if (modeRule != nullptr) {
+                resolved.modeEntry = entryFromRuleMatchActions(*modeRule);
+            }
             if (snapRule != nullptr) {
-                entry.snappingLayout = entryFromRuleMatchActions(*snapRule).snappingLayout;
+                resolved.snappingLayout = entryFromRuleMatchActions(*snapRule).snappingLayout;
             }
             if (algoRule != nullptr) {
-                entry.tilingAlgorithm = entryFromRuleMatchActions(*algoRule).tilingAlgorithm;
+                resolved.tilingAlgorithm = entryFromRuleMatchActions(*algoRule).tilingAlgorithm;
             }
-            return entry;
+            return resolved;
         });
+
+    if (!rules) {
+        return std::nullopt; // genuine miss — the caller routes to the default
+    }
+
+    // Base: the engine-mode rule's decoded entry. With no engine-mode rule, the
+    // live default for this context supplies the mode — a layout-only rule must
+    // not force one. Resolved here, OUTSIDE the cache, so it tracks settings.
+    AssignmentEntry entry = rules->modeEntry
+        ? *rules->modeEntry
+        : resolveDefaultAssignmentEntryForContext(screenId, virtualDesktop, activity);
+
+    // Per-slot layout winners override their field.
+    if (rules->snappingLayout) {
+        entry.snappingLayout = *rules->snappingLayout;
+    }
+    if (rules->tilingAlgorithm) {
+        entry.tilingAlgorithm = *rules->tilingAlgorithm;
+    }
+    return entry;
 }
 
 ContextGapOverride LayoutRegistry::resolveContextGaps(const QString& screenId, int virtualDesktop,

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -83,38 +83,93 @@ auto resolveWithScreenFallback(const QString& screenId, TryFn&& tryOne) -> declt
 std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QString& screenId, int virtualDesktop,
                                                                       const QString& activity) const
 {
-    // The cascade is reproduced by the rule set's descending-priority order.
-    // The legacy walkCascade treated the provider default as a MISS
-    // (resolveDefaultAssignmentEntry handled it via injected lambdas), so the
-    // catch-all rule is excluded here — only PINNED context rules count as a
-    // cascade hit.
+    // Resolution is per-slot AND specificity-tiered. There are three
+    // independent slots — engine mode, snapping layout, tiling algorithm — each
+    // resolved separately, so a layout-only rule (a SetSnappingLayout or
+    // SetTilingAlgorithm with NO SetEngineMode) sets the layout for its engine
+    // in this context WITHOUT forcing the engine mode. The engine mode is the
+    // global default's (or another rule's); the layout slot is just filled.
     //
-    // The descending-priority, tie-break-by-list-order walk is the shared
-    // RuleEvaluator::highestPriorityMatch — the one place that walk lives, so
-    // this resolver can never drift from the evaluator's own ordering. The
-    // candidate filter keeps only pinned context-assignment rules.
-    // SetSnappingLayout and SetTilingAlgorithm share the `layout` action slot,
-    // so the winning rule's full action list is read, preserving the
-    // mode-toggle losslessness invariant (an entry keeps BOTH snappingLayout
-    // and tilingAlgorithm regardless of active mode).
+    // Within each slot the match is specificity-tiered, not a flat priority
+    // walk: the most specific *kind* of rule wins, and only within a kind does
+    // descending priority (then list order) break the tie. This keeps the
+    // answer correct even though pinned-rule priorities (ContextRuleBridge's
+    // cascade weights) and user-authored catch-all priorities (the Settings UI
+    // bands) live in one numeric space that can overlap — a screen-only pin at
+    // 310 must still beat a catch-all authored at 399.
+    //
+    //   Tier 1 — a PINNED (non-catch-all) rule carrying the slot's action.
+    //   Tier 2 — a USER-authored catch-all rule carrying it: the explicit
+    //            floor. The synthesized provider-default carries
+    //            kProviderDefaultPriority and is excluded so the settings-gated
+    //            resolveDefaultAssignmentEntry stays the single source of truth
+    //            for the true global default.
+    //
+    // Each tier is the shared RuleEvaluator::highestPriorityMatch — the one
+    // place the descending-priority, tie-break-by-list-order walk lives, so this
+    // resolver can never drift from the evaluator's own ordering.
+    //
+    // If no slot matched at all it's a genuine miss (nullopt) and the caller
+    // routes to the global default. If at least one slot matched, the entry's
+    // base is the engine-mode rule (mode + the layout tokens that rule itself
+    // carries, preserving mode-toggle losslessness); the per-slot layout
+    // winners then override the snapping-layout / tiling-algorithm fields. When
+    // only a layout rule matched (no engine-mode rule), the base is the global
+    // default for this context, so the resolved mode is the default's and the
+    // layout rule merely fills its slot.
     //
     // Hot-path cache via the shared revision-invalidated memoizer. The linear
     // walk is O(N rules × M predicates per match); overlay/OSD callers issue it
     // per cursor-move, and the connector + virtual-screen fallback chain in the
     // public resolvers triples that on a miss. A @c nullopt is cached too — a
     // genuine miss must not re-walk three times per cursor frame.
-    return resolveCachedContext(m_contextResolveCache, m_contextResolveCacheRevision, screenId, virtualDesktop,
-                                activity, [&]() -> std::optional<AssignmentEntry> {
-                                    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
-                                    const PWR::WindowRule* winner =
-                                        m_evaluator->highestPriorityMatch(query, [](const PWR::WindowRule& rule) {
-                                            return hasEngineModeAction(rule) && !rule.match.isCatchAll();
-                                        });
-                                    if (winner != nullptr) {
-                                        return entryFromRuleMatchActions(*winner);
-                                    }
-                                    return std::nullopt;
-                                });
+    return resolveCachedContext(
+        m_contextResolveCache, m_contextResolveCacheRevision, screenId, virtualDesktop, activity,
+        [&]() -> std::optional<AssignmentEntry> {
+            const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+
+            // Specificity-tiered slot match: a pinned rule wins over a user
+            // catch-all, and the synthesized provider-default (priority 0) is
+            // excluded so the gated default resolver remains authoritative.
+            const auto tieredMatch = [&](bool (*carriesSlot)(const PWR::WindowRule&)) -> const PWR::WindowRule* {
+                if (const PWR::WindowRule* pinned =
+                        m_evaluator->highestPriorityMatch(query, [carriesSlot](const PWR::WindowRule& rule) {
+                            return carriesSlot(rule) && !rule.match.isCatchAll();
+                        })) {
+                    return pinned;
+                }
+                return m_evaluator->highestPriorityMatch(query, [carriesSlot](const PWR::WindowRule& rule) {
+                    return carriesSlot(rule) && rule.match.isCatchAll()
+                        && rule.priority > PWR::ContextRuleBridge::kProviderDefaultPriority;
+                });
+            };
+
+            const PWR::WindowRule* modeRule = tieredMatch(hasEngineModeAction);
+            const PWR::WindowRule* snapRule = tieredMatch(hasSnappingLayoutAction);
+            const PWR::WindowRule* algoRule = tieredMatch(hasTilingAlgorithmAction);
+
+            if (modeRule == nullptr && snapRule == nullptr && algoRule == nullptr) {
+                return std::nullopt; // genuine miss — the caller routes to the default
+            }
+
+            // Base: the engine-mode rule decides the mode (and carries its own
+            // layout tokens). With no engine-mode rule, the default for this
+            // context supplies the mode — a layout-only rule must not force one.
+            AssignmentEntry entry = modeRule != nullptr
+                ? entryFromRuleMatchActions(*modeRule)
+                : resolveDefaultAssignmentEntryForContext(screenId, virtualDesktop, activity);
+
+            // Per-slot layout winners override their field. tieredMatch already
+            // ranks pinned over catch-all, so a more-specific layout rule beats
+            // a catch-all layout rule regardless of the raw priority numbers.
+            if (snapRule != nullptr) {
+                entry.snappingLayout = entryFromRuleMatchActions(*snapRule).snappingLayout;
+            }
+            if (algoRule != nullptr) {
+                entry.tilingAlgorithm = entryFromRuleMatchActions(*algoRule).tilingAlgorithm;
+            }
+            return entry;
+        });
 }
 
 ContextGapOverride LayoutRegistry::resolveContextGaps(const QString& screenId, int virtualDesktop,

--- a/libs/phosphor-zones/src/layoutregistry_rulehelpers.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_rulehelpers.cpp
@@ -58,6 +58,26 @@ bool hasEngineModeAction(const PWR::WindowRule& rule)
     return false;
 }
 
+bool hasSnappingLayoutAction(const PWR::WindowRule& rule)
+{
+    for (const PWR::RuleAction& action : rule.actions) {
+        if (action.type == QLatin1String(PWR::ActionType::SetSnappingLayout)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool hasTilingAlgorithmAction(const PWR::WindowRule& rule)
+{
+    for (const PWR::RuleAction& action : rule.actions) {
+        if (action.type == QLatin1String(PWR::ActionType::SetTilingAlgorithm)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool isPureAssignmentRule(const PWR::WindowRule& rule)
 {
     // True when every action belongs to the three assignment slots

--- a/libs/phosphor-zones/src/layoutregistry_rulehelpers_p.h
+++ b/libs/phosphor-zones/src/layoutregistry_rulehelpers_p.h
@@ -80,6 +80,13 @@ bool matchIsExactContext(const PWR::MatchExpression& match, const QString& scree
 // the matchIsExactContext* shape filters reject a catch-all anyway.
 bool hasEngineModeAction(const PWR::WindowRule& rule);
 
+// True if @p rule carries a SetSnappingLayout / SetTilingAlgorithm action. The
+// per-slot assignment resolver reads each layout slot independently of the
+// engine-mode slot, so a layout-only rule (no SetEngineMode) sets the layout
+// for its engine in a context without forcing the engine mode.
+bool hasSnappingLayoutAction(const PWR::WindowRule& rule);
+bool hasTilingAlgorithmAction(const PWR::WindowRule& rule);
+
 // True when every action on @p rule is one of the three assignment slots
 // (SetEngineMode / SetSnappingLayout / SetTilingAlgorithm). False on an
 // empty action list. Used by the shape-based fallback in

--- a/tests/unit/core/test_windowrule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_windowrule_cascade_fidelity.cpp
@@ -811,6 +811,57 @@ private Q_SLOTS:
         }
     }
 
+    // ─── Default change is reflected without a rule-set mutation ──────────
+    //
+    // A layout-only rule bases its entry on the GLOBAL default for every slot
+    // it does not fill. The resolver memoizes only the rule-derived portion, so
+    // a default-setting change must surface immediately — with NO rule-set
+    // revision bump (a settings edit produces none). This guards against baking
+    // the live default into the revision-invalidated context cache, which would
+    // pin a stale mode/algorithm on the layout-only path until the next rule
+    // edit or daemon restart.
+
+    void testDefaultChangeReflectedWithoutRuleMutation()
+    {
+        RegistryFixture f = makeRegistryFixture();
+        bool snappingPreferred = false;
+        f.registry->setSnappingPreferredProvider([&snappingPreferred]() {
+            return snappingPreferred;
+        });
+        f.registry->setDefaultAutotileAlgorithmProvider([]() {
+            return QStringLiteral("bsp");
+        });
+
+        // Layout-only catch-all: snapping layout, NO engine-mode action.
+        PWR::WindowRule layoutOnly =
+            makeUserCatchAllRule(/*autotileMode=*/false, QStringLiteral("{columns-3}"), QString(), 398);
+        layoutOnly.actions.removeIf([](const PWR::RuleAction& a) {
+            return a.type == QString(PWR::ActionType::SetEngineMode);
+        });
+        QVERIFY(f.store->addRule(layoutOnly));
+
+        // Default engine is autotile (snapping not preferred). The rule fills
+        // the snapping slot; the mode is the default's autotile.
+        {
+            const PhosphorZones::AssignmentEntry entry =
+                f.registry->assignmentEntryForScreen(QStringLiteral("DP-2"), 2, QString());
+            QCOMPARE(entry.mode, PhosphorZones::AssignmentEntry::Autotile);
+            QCOMPARE(entry.tilingAlgorithm, QStringLiteral("bsp"));
+            QCOMPARE(entry.snappingLayout, QStringLiteral("{columns-3}"));
+        }
+
+        // Flip the global default to snapping-preferred WITHOUT mutating any
+        // rule. The same cached context must now report the NEW default mode,
+        // not the stale autotile one.
+        snappingPreferred = true;
+        {
+            const PhosphorZones::AssignmentEntry entry =
+                f.registry->assignmentEntryForScreen(QStringLiteral("DP-2"), 2, QString());
+            QCOMPARE(entry.mode, PhosphorZones::AssignmentEntry::Snapping);
+            QCOMPARE(entry.snappingLayout, QStringLiteral("{columns-3}"));
+        }
+    }
+
     // ─── Context-rule gap overrides ──────────────────────────────────────
     // Gaps are context-domain but, unlike engine-mode assignments, resolve
     // PER SLOT — so a zone-padding rule and a separate outer-gap rule on the

--- a/tests/unit/core/test_windowrule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_windowrule_cascade_fidelity.cpp
@@ -157,6 +157,25 @@ private:
         return mixed;
     }
 
+    /// A USER-authored catch-all engine rule — an empty-All{} match (so
+    /// isCatchAll() is true) at a non-zero, UI-band priority. This is the shape
+    /// the Settings UI persists for a "Default / Any window" engine+layout rule,
+    /// distinct from CRB::makeProviderDefaultRule (which forces priority 0 and a
+    /// fixed identity). It must act as the default floor, not be discarded.
+    PWR::WindowRule makeUserCatchAllRule(bool autotileMode, const QString& snappingLayout,
+                                         const QString& tilingAlgorithm, int priority)
+    {
+        PWR::WindowRule r;
+        r.id = QUuid::createUuid();
+        r.name = QStringLiteral("Default");
+        r.enabled = true;
+        r.priority = priority;
+        r.match = PWR::MatchExpression(); // default-constructed → empty All{} catch-all
+        r.actions = CRB::makeAssignmentActions(autotileMode ? QStringLiteral("autotile") : QStringLiteral("snapping"),
+                                               snappingLayout, tilingAlgorithm);
+        return r;
+    }
+
 private Q_SLOTS:
 
     // ─── Priority formula — exact values ─────────────────────────────────
@@ -629,6 +648,166 @@ private Q_SLOTS:
             QCOMPARE(entry.mode, PhosphorZones::AssignmentEntry::Autotile);
             QVERIFY(entry.snappingLayout.isEmpty());
             QCOMPARE(entry.tilingAlgorithm, QStringLiteral("bsp"));
+        }
+    }
+
+    // ─── User catch-all engine rule is the default floor ──────────────────
+    //
+    // The reported bug: a "Default / Any window" rule (catch-all match,
+    // engine=snapping, layout=Grid 2x2) was discarded by the resolver's old
+    // `!isCatchAll()` candidate filter, so every context with no more-specific
+    // pin — including a freshly-switched virtual desktop — fell through to the
+    // global default (BSP). resolveAssignmentEntry is specificity-tiered: a
+    // pinned rule wins first, else a USER catch-all engine rule (priority > 0)
+    // is the floor, and only the synthesized provider-default (priority 0)
+    // stays a miss so the settings-gated default resolver remains authoritative.
+
+    void testUserCatchAllEngineRuleDrivesFloor()
+    {
+        // ── A: the catch-all drives a context with no pin (the bug repro) ──
+        {
+            RegistryFixture f = makeRegistryFixture();
+            // A global default DISTINCT from the rule's output, so a wrong
+            // fallthrough would surface as Autotile/bsp instead of the rule.
+            f.registry->setDefaultAutotileAlgorithmProvider([]() {
+                return QStringLiteral("bsp");
+            });
+            QVERIFY(f.store->addRule(
+                makeUserCatchAllRule(/*autotileMode=*/false, QStringLiteral("{grid-2x2}"), QString(), 398)));
+
+            // Desktop 2, any screen — no pinned rule. The catch-all floor wins,
+            // not the BSP global default.
+            const PhosphorZones::AssignmentEntry entry =
+                f.registry->assignmentEntryForScreen(QStringLiteral("DP-2"), 2, QString());
+            QCOMPARE(entry.mode, PhosphorZones::AssignmentEntry::Snapping);
+            QCOMPARE(entry.snappingLayout, QStringLiteral("{grid-2x2}"));
+        }
+
+        // ── B: a pinned rule beats the catch-all even at LOWER numeric
+        //       priority — specificity tier, not the raw number, decides ──
+        {
+            RegistryFixture f = makeRegistryFixture();
+            // Screen-only pin at the cascade's screen band (310) ...
+            const PWR::WindowRule pinned =
+                CRB::makeAssignmentRule(QStringLiteral("DP-5"), QStringLiteral("DP-5"), 0, QString(),
+                                        QStringLiteral("snapping"), QStringLiteral("{screen-pin}"), QString());
+            // ... versus a user catch-all at 398, numerically ABOVE 310.
+            const PWR::WindowRule catchAll =
+                makeUserCatchAllRule(/*autotileMode=*/false, QStringLiteral("{grid-2x2}"), QString(), 398);
+            // Insert the catch-all FIRST so neither list order nor numeric
+            // priority would pick the pin unless the specificity tier holds.
+            QVERIFY(f.store->setAllRules({catchAll, pinned}));
+
+            // On DP-5 the pin wins despite its lower number.
+            QCOMPARE(f.registry->assignmentEntryForScreen(QStringLiteral("DP-5"), 1, QString()).snappingLayout,
+                     QStringLiteral("{screen-pin}"));
+            // On any other screen the catch-all floor still applies.
+            QCOMPARE(f.registry->assignmentEntryForScreen(QStringLiteral("DP-6"), 1, QString()).snappingLayout,
+                     QStringLiteral("{grid-2x2}"));
+        }
+
+        // ── C: the synthesized provider-default (priority 0) is NOT a tier-2
+        //       floor — it defers to the settings-gated default resolver ──
+        {
+            RegistryFixture f = makeRegistryFixture();
+            f.registry->setDefaultLayoutIdProvider([]() {
+                return QStringLiteral("{gated-default}");
+            });
+            // A provider-default catch-all carrying a DIFFERENT layout. If the
+            // resolver wrongly treated it as a user floor, the entry would carry
+            // {provider-rule-layout}; the gated lambda default must win instead.
+            QVERIFY(
+                f.store->addRule(CRB::makeProviderDefaultRule(QStringLiteral("Default"), QStringLiteral("snapping"),
+                                                              QStringLiteral("{provider-rule-layout}"), QString())));
+
+            const PhosphorZones::AssignmentEntry entry =
+                f.registry->assignmentEntryForScreen(QStringLiteral("HDMI-3"), 1, QString());
+            QCOMPARE(entry.mode, PhosphorZones::AssignmentEntry::Snapping);
+            QCOMPARE(entry.snappingLayout, QStringLiteral("{gated-default}"));
+        }
+    }
+
+    // ─── Layout-only rule fills its slot without forcing the engine ───────
+    //
+    // A rule carrying ONLY a SetSnappingLayout (or SetTilingAlgorithm) action,
+    // no SetEngineMode, sets the layout for that engine in the context but does
+    // NOT force the engine mode. The mode comes from the default (or another
+    // rule); the layout slot is filled independently. This is the per-slot
+    // composition model — distinct from a rule that pins the engine.
+
+    void testLayoutOnlyRuleFillsSlotWithoutForcingMode()
+    {
+        // ── A: the reported scenario — global default is snapping, a catch-all
+        //       SetSnappingLayout rule supplies the snapping layout ──
+        {
+            RegistryFixture f = makeRegistryFixture();
+            f.registry->setSnappingPreferredProvider([]() {
+                return true; // default engine is snapping, but with no default layout id
+            });
+            // A layout-only catch-all: Columns(3), NO engine-mode action.
+            PWR::WindowRule layoutOnly =
+                makeUserCatchAllRule(/*autotileMode=*/false, QStringLiteral("{columns-3}"), QString(), 398);
+            // Drop the engine-mode action makeUserCatchAllRule's helper does not
+            // add (it builds via makeAssignmentActions with a snapping mode, so
+            // strip the SetEngineMode to model the UI's layout-only rule).
+            layoutOnly.actions.removeIf([](const PWR::RuleAction& a) {
+                return a.type == QString(PWR::ActionType::SetEngineMode);
+            });
+            QVERIFY(f.store->addRule(layoutOnly));
+
+            const PhosphorZones::AssignmentEntry entry =
+                f.registry->assignmentEntryForScreen(QStringLiteral("DP-2"), 2, QString());
+            // Mode is the default's snapping (not forced by the rule), and the
+            // rule supplies the layout the default left empty.
+            QCOMPARE(entry.mode, PhosphorZones::AssignmentEntry::Snapping);
+            QCOMPARE(entry.snappingLayout, QStringLiteral("{columns-3}"));
+        }
+
+        // ── B: a layout-only rule does NOT flip the engine — default autotile
+        //       stays autotile, the snapping layout is merely stored (lossless) ──
+        {
+            RegistryFixture f = makeRegistryFixture();
+            f.registry->setDefaultAutotileAlgorithmProvider([]() {
+                return QStringLiteral("bsp"); // default engine resolves to autotile
+            });
+            PWR::WindowRule layoutOnly =
+                makeUserCatchAllRule(/*autotileMode=*/false, QStringLiteral("{columns-3}"), QString(), 398);
+            layoutOnly.actions.removeIf([](const PWR::RuleAction& a) {
+                return a.type == QString(PWR::ActionType::SetEngineMode);
+            });
+            QVERIFY(f.store->addRule(layoutOnly));
+
+            const PhosphorZones::AssignmentEntry entry =
+                f.registry->assignmentEntryForScreen(QStringLiteral("HDMI-1"), 1, QString());
+            // The rule did not force snapping — the engine stays the default's
+            // autotile — but the snapping layout slot is filled for a later toggle.
+            QCOMPARE(entry.mode, PhosphorZones::AssignmentEntry::Autotile);
+            QCOMPARE(entry.tilingAlgorithm, QStringLiteral("bsp"));
+            QCOMPARE(entry.snappingLayout, QStringLiteral("{columns-3}"));
+        }
+
+        // ── C: a pinned engine rule sets the mode; a separate catch-all
+        //       layout-only rule fills the layout slot — they compose ──
+        {
+            RegistryFixture f = makeRegistryFixture();
+            // Pinned engine-only rule (autotile, default algorithm) on DP-4.
+            const PWR::WindowRule pinnedMode =
+                CRB::makeAssignmentRule(QStringLiteral("DP-4 autotile"), QStringLiteral("DP-4"), 0, QString(),
+                                        QStringLiteral("autotile"), QString(), QStringLiteral("dwindle"));
+            // Catch-all layout-only snapping rule.
+            PWR::WindowRule layoutOnly =
+                makeUserCatchAllRule(/*autotileMode=*/false, QStringLiteral("{columns-3}"), QString(), 398);
+            layoutOnly.actions.removeIf([](const PWR::RuleAction& a) {
+                return a.type == QString(PWR::ActionType::SetEngineMode);
+            });
+            QVERIFY(f.store->setAllRules({layoutOnly, pinnedMode}));
+
+            const PhosphorZones::AssignmentEntry entry =
+                f.registry->assignmentEntryForScreen(QStringLiteral("DP-4"), 1, QString());
+            // Engine from the pinned rule; snapping layout from the catch-all.
+            QCOMPARE(entry.mode, PhosphorZones::AssignmentEntry::Autotile);
+            QCOMPARE(entry.tilingAlgorithm, QStringLiteral("dwindle"));
+            QCOMPARE(entry.snappingLayout, QStringLiteral("{columns-3}"));
         }
     }
 


### PR DESCRIPTION
## Problem

A "Default / Any window" context rule (e.g. *Engine: Snapping · Snapping: Grid (2x2)*) was silently ignored. Switching to a virtual desktop with no explicit pin fell through to the global default (BSP) instead of the configured layout. A layout-only rule (e.g. *Snapping: Columns (3)* with no explicit engine) also did nothing.

## Root cause

`resolveAssignmentEntry` filtered candidates with `hasEngineModeAction(rule) && !rule.match.isCatchAll()`, which dropped two legitimate rule shapes:

- a **user-authored catch-all** rule — its "Any window" match is a catch-all, so it was excluded wholesale alongside the synthesized provider-default; and
- a **layout-only** rule (`SetSnappingLayout` / `SetTilingAlgorithm` with no `SetEngineMode`) — it never carried an engine-mode action, so the gate dropped it.

## Fix

Resolve the three assignment slots independently and specificity-tiered:

- **Per-slot.** Engine mode, snapping layout, and tiling algorithm each resolve on their own. A layout-only rule sets the layout for its engine in a context **without forcing the engine mode** (the mode comes from the default or a separate rule); the layout slot is simply filled.
- **Specificity-tiered.** Within each slot a pinned rule beats a user catch-all, which beats nothing, independent of the raw priority numbers. The pinned-rule cascade weights (310/410/510/610) and the Settings UI bands (300–399) share one numeric space that can overlap (a screen-only pin at 310 vs. a catch-all authored at 399); tiering keeps most-specific-wins correct regardless.
- **Provider-default unchanged.** The synthesized provider-default (priority 0) stays excluded so the settings-gated `resolveDefaultAssignmentEntry` remains the single source of truth for the global default.

## Tests

Added regression coverage in `test_windowrule_cascade_fidelity.cpp`:

- a user catch-all engine rule drives the default floor;
- a pinned rule beats a catch-all at a **lower** numeric priority (specificity, not the number, decides);
- the priority-0 provider-default still defers to the gated resolver;
- a layout-only rule fills its slot without forcing the mode (snapping default, autotile default, and composing with a pinned engine rule).

## Verification

- Full build succeeds; **240/240 tests pass**, including the assignment oracle (`test_layoutmanager_assignment`).
- Audited all other action types for the same inert-rule gap pattern; none found (the layout slots were the only ones gated this way).

## Notes / out of scope

- The per-monitor tile summary in Settings (`windowrulecontroller_views.cpp`) still reads layout only from rules carrying `SetEngineMode`. That's display-only and doesn't affect what the daemon applies; can be aligned in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)