### PR TITLE
fix(overlay): highlight the active autotile algorithm in the layout picker

### DIFF
--- a/src/daemon/overlayservice.cpp
+++ b/src/daemon/overlayservice.cpp
@@ -603,6 +603,24 @@ PhosphorZones::Layout* OverlayService::resolveScreenLayout(const QString& screen
     return screenLayout;
 }
 
+QString OverlayService::activeLayoutIdForScreen(const QString& screenId) const
+{
+    // Autotile contexts have no backing Layout object — their active id is the
+    // resolved "autotile:<algorithm>" assignment id, which matches the autotile
+    // cards in the picker / selector. Manual contexts keep the existing
+    // Layout-based resolution (its fallback chain to default/global is what makes
+    // snapping highlight correctly).
+    if (m_layoutManager && !screenId.isEmpty()) {
+        const QString assignmentId = m_layoutManager->assignmentIdForScreen(
+            screenId, currentVirtualDesktopForScreen(screenId), m_currentActivity);
+        if (PhosphorLayout::LayoutId::isAutotile(assignmentId)) {
+            return assignmentId;
+        }
+    }
+    PhosphorZones::Layout* screenLayout = resolveScreenLayout(screenId);
+    return screenLayout ? screenLayout->id().toString() : QString();
+}
+
 void OverlayService::hideDisabledAndRefresh()
 {
     // Hide overlay + zone-selector slots on screens where the current

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -580,6 +580,15 @@ private:
     PhosphorZones::Layout* resolveScreenLayout(QScreen* screen) const;
     PhosphorZones::Layout* resolveScreenLayout(const QString& screenId) const;
 
+    /// The id the layout picker / zone selector highlights as active on @p
+    /// screenId. In autotile mode this is the resolved "autotile:<algorithm>"
+    /// assignment id (matching the autotile cards); in snapping mode it is the
+    /// resolved Layout's UUID (matching the manual cards). Snapping resolves
+    /// through resolveScreenLayout() so its fallback chain is preserved, while
+    /// autotile uses the assignment id directly because no Layout object backs
+    /// an algorithm.
+    QString activeLayoutIdForScreen(const QString& screenId) const;
+
     /// True when the snapping overlay must NOT show on @p screenId for the current
     /// desktop/activity: either the context is on a disable list, OR its default
     /// layout assignment is suppressed (the global "don't assign by default"

--- a/src/daemon/overlayservice/selector_update.cpp
+++ b/src/daemon/overlayservice/selector_update.cpp
@@ -179,13 +179,9 @@ void OverlayService::updateZoneSelectorWindow(const QString& screenId)
     writeQmlProperty(window, QStringLiteral("globalAutoAssign"), m_settings && m_settings->autoAssignAllLayouts());
 
     // Set active layout ID for this screen
-    // Per-screen assignment takes priority so each monitor highlights its own layout
-    QString activeLayoutId;
-    PhosphorZones::Layout* screenLayout = resolveScreenLayout(screenId);
-    if (screenLayout) {
-        activeLayoutId = screenLayout->id().toString();
-    }
-    writeQmlProperty(window, QStringLiteral("activeLayoutId"), activeLayoutId);
+    // Per-screen assignment takes priority so each monitor highlights its own
+    // layout (or its autotile algorithm, via the "autotile:<algorithm>" id).
+    writeQmlProperty(window, QStringLiteral("activeLayoutId"), activeLayoutIdForScreen(screenId));
 
     // Push lock state so QML disables non-active layout interaction.
     // isAnyModeLocked checks a LockContext rule first, then both manual modes -

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -547,13 +547,7 @@ void OverlayService::showLayoutPicker(const QString& screenId)
         return;
     }
 
-    QString activeId;
-    if (m_layoutManager) {
-        PhosphorZones::Layout* activeLayout = resolveScreenLayout(resolvedId);
-        if (activeLayout) {
-            activeId = activeLayout->id().toString();
-        }
-    }
+    const QString activeId = activeLayoutIdForScreen(resolvedId);
 
     qreal aspectRatio =
         (screenGeom.height() > 0) ? static_cast<qreal>(screenGeom.width()) / screenGeom.height() : (16.0 / 9.0);


### PR DESCRIPTION
## Problem

In autotile mode, the "Choose Layout" picker (and the drag-time zone selector) did not highlight the currently active algorithm. Snapping mode highlights correctly.

## Root cause

The picker highlights the card whose `id` equals `activeLayoutId` (`isActive: layoutData.id === root.activeLayoutId`). Both `snapassist.cpp` (picker) and `selector_update.cpp` (zone selector) computed `activeLayoutId` from `resolveScreenLayout()->id()`, which only ever resolves a snapping `Layout` (or the default snapping layout as fallback). In autotile mode there is no backing `Layout`, so `activeLayoutId` became a snapping UUID that matched no autotile card.

Snapping worked because its cards are keyed by that same UUID; autotile cards are keyed `autotile:<algorithm>` and never matched. The selection ring on the first card was just the default keyboard `selectedIndex = 0` fallback, not the active highlight.

## Fix

Add `OverlayService::activeLayoutIdForScreen(screenId)`:

- **Autotile** → returns `assignmentIdForScreen()` directly (the resolved `autotile:<algorithm>` id, already used by the service for mode detection in `isSnappingContextInactive`), which matches the autotile cards.
- **Snapping** → unchanged: resolves through `resolveScreenLayout()->id()`, preserving its fallback chain.

Both call sites now use the helper, so the active autotile algorithm highlights in the picker and the zone selector, matching snapping behavior.

## Known edge (unchanged from before)

A screen set to autotile with "use default algorithm" (a bare `autotile:` assignment with no concrete algorithm) still highlights nothing, because the effective default algorithm lives in the tile engine rather than the daemon's settings. This is rare; a concrete algorithm now highlights correctly.

## Testing

Build green; full suite 244/244. The routing the helper performs (autotile `assignment:<algo>` vs snapping UUID) is covered at the registry level by `test_layoutmanager_assignment` (`activeLayoutId() == "autotile:wide"`). `OverlayService` is not instantiated in the unit-test infra (it owns the layer-shell/screen stack), so the helper is verified by build + manual in-app check rather than a bespoke unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)