### PR TITLE
fix(settings): spring presets now move the sliders, and tighten spring slider ranges

### DIFF
--- a/src/settings/animationspagecontroller.h
+++ b/src/settings/animationspagecontroller.h
@@ -84,21 +84,30 @@ public:
     void apply() override;
     void discard() override;
 
+    // Slider bounds for the spring editor. These are a deliberately narrower,
+    // usable subset of the engine's accepted clamp range (PhosphorAnimation::
+    // Spring clamps omega to [0.1, 200] and zeta to [0, 10]). The slider only
+    // needs to cover values a user can perceive: above omega ~40 the spring
+    // settles in well under ~75 ms (visually instant), and zeta > ~4 is a
+    // barely-moving overdamped crawl. zeta is floored at 0.1 (not 0) so the
+    // edited spring always settles rather than oscillating forever. A
+    // hand-edited config outside this band still parses — the engine clamp,
+    // not the slider, is the validity boundary.
     qreal springOmegaMin() const
     {
-        return 0.1;
+        return 1.0;
     }
     qreal springOmegaMax() const
     {
-        return 200.0;
+        return 40.0;
     }
     qreal springZetaMin() const
     {
-        return 0.0;
+        return 0.1;
     }
     qreal springZetaMax() const
     {
-        return 10.0;
+        return 4.0;
     }
 
     /// Built-in event paths, grouped by section. Each entry:

--- a/src/settings/qml/SettingsSlider.qml
+++ b/src/settings/qml/SettingsSlider.qml
@@ -47,15 +47,18 @@ RowLayout {
         from: root.from
         to: root.to
         stepSize: root.stepSize
-        onMoved: {
-            root.value = value;
-            root.moved(value);
-        }
+        // Emit `moved` only — do NOT write `root.value` here. Callers bind
+        // `value:` to their source and update it from `onMoved`; the new value
+        // flows back through that binding and the Binding above re-syncs the
+        // handle on release. Writing `root.value` imperatively would sever the
+        // caller's `value:` binding, so a later EXTERNAL update to the source
+        // (e.g. picking a spring preset that sets ω/ζ) would no longer move the
+        // handle.
+        onMoved: root.moved(value)
     }
 
     Label {
         text: root.formatValue ? root.formatValue(slider.value) : Math.round(slider.value) + root.valueSuffix
         Layout.preferredWidth: root.labelWidth
     }
-
 }

--- a/tests/unit/settings/test_animations_page_controller.cpp
+++ b/tests/unit/settings/test_animations_page_controller.cpp
@@ -54,17 +54,24 @@ private Q_SLOTS:
 
     // ─── Slider bounds ────────────────────────────────────────────────────
 
-    void springBounds_matchPhosphorAnimationSpringDoc()
+    void springBounds_areUsableSubsetOfEngineClamp()
     {
         AnimationsPageController c;
-        // Bounds are documented in PhosphorAnimation/Spring.h:
-        //   omega ∈ [0.1, 200], zeta ∈ [0.0, 10.0]
-        // The controller exposes them as CONSTANT properties so QML
-        // sliders can bind once.
-        QCOMPARE(c.springOmegaMin(), 0.1);
-        QCOMPARE(c.springOmegaMax(), 200.0);
-        QCOMPARE(c.springZetaMin(), 0.0);
-        QCOMPARE(c.springZetaMax(), 10.0);
+        // The engine clamps to omega ∈ [0.1, 200], zeta ∈ [0, 10]
+        // (PhosphorAnimation/Spring.h). The slider exposes a deliberately
+        // narrower, usable band within that clamp: above omega ~40 the spring
+        // settles visually instantly, and zeta > ~4 is a barely-moving crawl;
+        // zeta is floored at 0.1 so the edited spring always settles.
+        QCOMPARE(c.springOmegaMin(), 1.0);
+        QCOMPARE(c.springOmegaMax(), 40.0);
+        QCOMPARE(c.springZetaMin(), 0.1);
+        QCOMPARE(c.springZetaMax(), 4.0);
+
+        // The slider band stays inside the engine's accepted clamp range.
+        QVERIFY(c.springOmegaMin() >= 0.1);
+        QVERIFY(c.springOmegaMax() <= 200.0);
+        QVERIFY(c.springZetaMin() >= 0.0);
+        QVERIFY(c.springZetaMax() <= 10.0);
     }
 
     // ─── Path discovery ───────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

In the spring animation editor (Customize… → Spring mode):
1. **Picking a preset didn't move the ω/ζ sliders.** The preset updated the working values (and the preview), but the slider handles/labels stayed frozen.
2. The slider **maximum values were too generous to be usable** — most of each slider's travel covered springs that are visually instant or barely moving.

## Fix 1 — severed binding in `SettingsSlider`

The dialog binds `value: root._workingOmega` on the slider and updates `_workingOmega` from `onMoved`. But `SettingsSlider`'s inner `Slider.onMoved` also did `root.value = value` — an imperative write that **destroys the caller's `value:` binding** the first time the handle moves. After that, an *external* update to the bound source (the preset combo setting ω/ζ) no longer reached the handle.

`onMoved` now emits `moved(value)` only. The new value flows back through the preserved `value:` binding, and the existing internal `Binding { when: !slider.pressed }` re-syncs the handle on release. This also fixes the same latent freeze for every other `SettingsSlider` (any slider whose source can change externally).

All 7 `SettingsSlider` call sites use the `value:` + `onMoved` pattern, so dropping the imperative writeback is safe.

## Fix 2 — usable spring slider ranges

The slider bounds mirrored the engine's full clamp (`PhosphorAnimation::Spring`: ω `[0.1,200]`, ζ `[0,10]`). But above ω≈40 a spring settles in well under ~75 ms (visually instant), and ζ>~4 is a barely-moving overdamped crawl, so the useful band (presets sit at ω 8–12, ζ 0.5–1) was cramped into a sliver of the slider.

Narrowed the **slider** bounds to a usable subset: **ω `[1, 40]`, ζ `[0.1, 4]`** (ζ floored above 0 so the edited spring always settles instead of oscillating forever). The **engine clamp is unchanged** at `[0.1,200]`/`[0,10]`, so a hand-edited config outside the slider band still parses — the engine, not the slider, remains the validity boundary.

## Testing

- `test_animations_page_controller` updated for the new slider bounds, with an added assertion that the band stays inside the engine clamp.
- Full suite: 244/244 pass; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)