### PR TITLE
fix(settings): per-algorithm tiling tuning, live preview, and two settings cleanups

### DIFF
--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileConfig.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileConfig.h
@@ -13,19 +13,21 @@
 namespace PhosphorTileEngine {
 
 /**
- * @brief Per-algorithm saved settings (split ratio + master count)
+ * @brief Per-algorithm saved settings (split ratio, master count, max windows)
  *
- * Replaces AlgorithmSettings for clarity. Saved when switching away
- * from an algorithm, restored when switching back.
+ * Saved when switching away from an algorithm, restored when switching back,
+ * so each algorithm keeps its own tuning.
  */
 struct AlgorithmSettings
 {
     qreal splitRatio = PhosphorTiles::AutotileDefaults::DefaultSplitRatio;
     int masterCount = PhosphorTiles::AutotileDefaults::DefaultMasterCount;
+    int maxWindows = PhosphorTiles::AutotileDefaults::DefaultMaxWindows;
     QVariantMap customParams; ///< Algorithm-declared custom parameter values
     bool operator==(const AlgorithmSettings& other) const
     {
-        if (masterCount != other.masterCount || !qFuzzyCompare(1.0 + splitRatio, 1.0 + other.splitRatio)) {
+        if (masterCount != other.masterCount || maxWindows != other.maxWindows
+            || !qFuzzyCompare(1.0 + splitRatio, 1.0 + other.splitRatio)) {
             return false;
         }
         if (customParams.size() != other.customParams.size()) {
@@ -111,7 +113,7 @@ struct PHOSPHORTILEENGINE_EXPORT AutotileConfig
      */
     int masterCount = PhosphorTiles::AutotileDefaults::DefaultMasterCount;
 
-    /// Per-algorithm saved settings (split ratio + master count).
+    /// Per-algorithm saved settings (split ratio, master count, max windows).
     /// Saved when switching away from an algorithm, restored when switching back.
     /// Key: algorithm ID (e.g. "master-stack", "centered-master", "script:deck")
     QHash<QString, AlgorithmSettings> savedAlgorithmSettings;

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1243,16 +1243,6 @@ private:
     PhosphorTiles::TilingState* stateForKey(const PhosphorEngine::TilingStateKey& key);
 
     /**
-     * @brief Reset maxWindows when switching algorithms (DRY helper)
-     *
-     * If the current maxWindows matches the old algorithm's default, reset
-     * it to the new algorithm's default. Shared by setAlgorithm() and
-     * syncFromSettings().
-     */
-    void resetMaxWindowsForAlgorithmSwitch(PhosphorTiles::TilingAlgorithm* oldAlgo,
-                                           PhosphorTiles::TilingAlgorithm* newAlgo);
-
-    /**
      * @brief Propagate global split ratio to screens without per-screen overrides
      */
     void propagateGlobalSplitRatio();

--- a/libs/phosphor-tile-engine/src/AutotileConfig.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileConfig.cpp
@@ -87,7 +87,8 @@ QHash<QString, AlgorithmSettings> AutotileConfig::perAlgoFromVariantMap(const QV
                        MinMasterCount, MaxMasterCount);
         const QVariant mwVar = entry.value(PhosphorTiles::AutotileJsonKeys::MaxWindows);
         const int maxWindows =
-            std::clamp(mwVar.isValid() ? mwVar.toInt() : DefaultMaxWindows, MinMaxWindows, MaxMaxWindows);
+            std::clamp(mwVar.isValid() ? mwVar.toInt() : PhosphorTiles::AutotileDefaults::DefaultMaxWindows,
+                       MinMaxWindows, MaxMaxWindows);
         AlgorithmSettings settings;
         settings.splitRatio = ratio;
         settings.masterCount = masterCount;

--- a/libs/phosphor-tile-engine/src/AutotileConfig.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileConfig.cpp
@@ -85,7 +85,13 @@ QHash<QString, AlgorithmSettings> AutotileConfig::perAlgoFromVariantMap(const QV
         const int masterCount =
             std::clamp(mcVar.isValid() ? mcVar.toInt() : PhosphorTiles::AutotileDefaults::DefaultMasterCount,
                        MinMasterCount, MaxMasterCount);
-        AlgorithmSettings settings{ratio, masterCount, {}};
+        const QVariant mwVar = entry.value(PhosphorTiles::AutotileJsonKeys::MaxWindows);
+        const int maxWindows =
+            std::clamp(mwVar.isValid() ? mwVar.toInt() : DefaultMaxWindows, MinMaxWindows, MaxMaxWindows);
+        AlgorithmSettings settings;
+        settings.splitRatio = ratio;
+        settings.masterCount = masterCount;
+        settings.maxWindows = maxWindows;
         // Load custom params if present
         const QVariant customVar = entry.value(PhosphorTiles::AutotileJsonKeys::CustomParams);
         if (customVar.isValid() && customVar.typeId() == QMetaType::QVariantMap) {
@@ -103,6 +109,7 @@ QVariantMap AutotileConfig::perAlgoToVariantMap(const QHash<QString, AlgorithmSe
         QVariantMap entry;
         entry[PhosphorTiles::AutotileJsonKeys::SplitRatio] = it.value().splitRatio;
         entry[PhosphorTiles::AutotileJsonKeys::MasterCount] = it.value().masterCount;
+        entry[PhosphorTiles::AutotileJsonKeys::MaxWindows] = it.value().maxWindows;
         if (!it.value().customParams.isEmpty()) {
             entry[PhosphorTiles::AutotileJsonKeys::CustomParams] = it.value().customParams;
         }

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -963,23 +963,27 @@ void AutotileEngine::setAlgorithm(const QString& algorithmId)
         auto& entry = m_config->savedAlgorithmSettings[m_algorithmId];
         entry.splitRatio = m_config->splitRatio;
         entry.masterCount = m_config->masterCount;
-        // customParams are not touched here — only splitRatio/masterCount are engine-managed
+        entry.maxWindows = m_config->maxWindows;
+        // customParams are not touched here — only splitRatio/masterCount/maxWindows are engine-managed
     }
 
     // Look up saved settings AFTER the save above — insertion may rehash the
     // QHash, invalidating any iterator obtained before the insert.
     auto savedIt = m_config->savedAlgorithmSettings.constFind(newId);
 
-    // Restore per-algorithm split ratio and master count from saved settings,
-    // falling back to the algorithm's defaults when no saved entry exists.
+    // Restore per-algorithm split ratio, master count, and max windows from
+    // saved settings, falling back to the algorithm's defaults when no saved
+    // entry exists. Each algorithm keeps its own tuning across switches.
     auto restorePerAlgoSettings = [this](PhosphorTiles::TilingAlgorithm* algo,
                                          QHash<QString, AlgorithmSettings>::const_iterator it) {
         if (it != m_config->savedAlgorithmSettings.constEnd()) {
             m_config->splitRatio = it->splitRatio;
             m_config->masterCount = it->masterCount;
+            m_config->maxWindows = it->maxWindows;
         } else {
             m_config->splitRatio = algo->defaultSplitRatio();
             m_config->masterCount = PhosphorTiles::AutotileDefaults::DefaultMasterCount;
+            m_config->maxWindows = algo->defaultMaxWindows();
         }
     };
 
@@ -987,16 +991,10 @@ void AutotileEngine::setAlgorithm(const QString& algorithmId)
         restorePerAlgoSettings(newAlgo, savedIt);
         propagateGlobalSplitRatio();
         propagateGlobalMasterCount();
-
-        // Same pattern for maxWindows: if the user hasn't customized it away
-        // from the old algorithm's default, reset to the new algorithm's default.
-        // Without this, switching from MasterStack (4) to BSP (5) keeps maxWindows=4.
-        resetMaxWindowsForAlgorithmSwitch(oldAlgo, newAlgo);
     } else if (newAlgo) {
         // oldAlgo is nullptr (first-ever call or corrupted m_algorithmId).
         // Initialize config from the new algorithm's defaults or saved settings.
         restorePerAlgoSettings(newAlgo, savedIt);
-        m_config->maxWindows = newAlgo->defaultMaxWindows();
         propagateGlobalSplitRatio();
         propagateGlobalMasterCount();
     }
@@ -1445,6 +1443,7 @@ void AutotileEngine::refreshConfigFromSettings()
         if (savedIt != m_config->savedAlgorithmSettings.constEnd()) {
             m_config->splitRatio = savedIt->splitRatio;
             m_config->masterCount = savedIt->masterCount;
+            m_config->maxWindows = savedIt->maxWindows;
         }
     }
 
@@ -4089,16 +4088,6 @@ bool AutotileEngine::isKnownScreen(const QString& screenId) const
         return true;
     }
     return PhosphorScreens::ScreenIdentity::findByIdOrName(screenId) != nullptr;
-}
-
-void AutotileEngine::resetMaxWindowsForAlgorithmSwitch(PhosphorTiles::TilingAlgorithm* oldAlgo,
-                                                       PhosphorTiles::TilingAlgorithm* newAlgo)
-{
-    if (!oldAlgo || !newAlgo)
-        return;
-    if (m_config->maxWindows == oldAlgo->defaultMaxWindows()) {
-        m_config->maxWindows = newAlgo->defaultMaxWindows();
-    }
 }
 
 void AutotileEngine::propagateGlobalSplitRatio()

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -987,13 +987,11 @@ void AutotileEngine::setAlgorithm(const QString& algorithmId)
         }
     };
 
-    if (oldAlgo && newAlgo) {
-        restorePerAlgoSettings(newAlgo, savedIt);
-        propagateGlobalSplitRatio();
-        propagateGlobalMasterCount();
-    } else if (newAlgo) {
-        // oldAlgo is nullptr (first-ever call or corrupted m_algorithmId).
-        // Initialize config from the new algorithm's defaults or saved settings.
+    if (newAlgo) {
+        // Restore the new algorithm's saved tuning, or its defaults when it has
+        // no saved entry. Identical whether switching from another algorithm or
+        // initializing on the first-ever call (oldAlgo null): the save block
+        // above already persisted the outgoing algorithm's values when present.
         restorePerAlgoSettings(newAlgo, savedIt);
         propagateGlobalSplitRatio();
         propagateGlobalMasterCount();
@@ -1387,7 +1385,14 @@ void AutotileEngine::refreshConfigFromSettings()
     SYNC_FIELD(smartGaps, autotileSmartGaps);
     SYNC_FIELD(focusFollowsMouse, autotileFocusFollowsMouse);
     SYNC_FIELD(respectMinimumSize, autotileRespectMinimumSize);
-    SYNC_FIELD(maxWindows, autotileMaxWindows);
+
+    // maxWindows is engine-managed: the global is written back on algorithm
+    // switch (under the write-back guard) and the per-algorithm restore below
+    // is its authoritative source. Skip the global re-read while our own
+    // write-back is in flight, matching the splitRatio/masterCount guards.
+    if (!m_writeBackGuardTimer.isActive()) {
+        SYNC_FIELD(maxWindows, autotileMaxWindows);
+    }
 
     if (!m_writeBackGuardTimer.isActive()) {
         const qreal newRatio = s->autotileSplitRatio();

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -1472,17 +1472,12 @@ void AutotileEngine::refreshConfigFromSettings()
     previewParams.maxWindows = m_config->maxWindows;
     previewParams.masterCount = m_config->masterCount;
     previewParams.splitRatio = m_config->splitRatio;
-    for (auto it = m_config->savedAlgorithmSettings.constBegin(); it != m_config->savedAlgorithmSettings.constEnd();
-         ++it) {
-        QVariantMap entry{
-            {PhosphorTiles::AutotileJsonKeys::MasterCount, it.value().masterCount},
-            {PhosphorTiles::AutotileJsonKeys::SplitRatio, it.value().splitRatio},
-            {PhosphorTiles::AutotileJsonKeys::MaxWindows, it.value().maxWindows},
-        };
-        if (!it.value().customParams.isEmpty()) {
-            entry[PhosphorTiles::AutotileJsonKeys::CustomParams] = it.value().customParams;
-        }
-        previewParams.savedAlgorithmSettings[it.key()] = entry;
+    // Reuse the canonical serializer so the per-algorithm preview entries can't
+    // drift from the on-disk form (every saved field, incl. maxWindows, in one
+    // place).
+    const QVariantMap serialized = AutotileConfig::perAlgoToVariantMap(m_config->savedAlgorithmSettings);
+    for (auto it = serialized.constBegin(); it != serialized.constEnd(); ++it) {
+        previewParams.savedAlgorithmSettings.insert(it.key(), it.value().toMap());
     }
     if (auto* reg = algorithmRegistry()) {
         reg->setPreviewParams(previewParams);

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -1477,6 +1477,7 @@ void AutotileEngine::refreshConfigFromSettings()
         QVariantMap entry{
             {PhosphorTiles::AutotileJsonKeys::MasterCount, it.value().masterCount},
             {PhosphorTiles::AutotileJsonKeys::SplitRatio, it.value().splitRatio},
+            {PhosphorTiles::AutotileJsonKeys::MaxWindows, it.value().maxWindows},
         };
         if (!it.value().customParams.isEmpty()) {
             entry[PhosphorTiles::AutotileJsonKeys::CustomParams] = it.value().customParams;

--- a/src/daemon/plasmazonesd.desktop
+++ b/src/daemon/plasmazonesd.desktop
@@ -9,3 +9,9 @@
 Type=Application
 Name=PlasmaZones
 Icon=plasmazones
+# The daemon is a background service, not a launchable app. NoDisplay keeps it
+# out of application launchers and files it under "System Services" (not
+# "Applications") in System Settings > Shortcuts. KGlobalAccel still reads the
+# Name/Icon above for the shortcuts list.
+NoDisplay=true
+X-KDE-StartupNotify=false

--- a/src/settings/algorithmservice.cpp
+++ b/src/settings/algorithmservice.cpp
@@ -231,7 +231,7 @@ QVariantList AlgorithmService::availableAlgorithms() const
 }
 
 QVariantList AlgorithmService::generateAlgorithmPreview(const QString& algorithmId, int windowCount, double splitRatio,
-                                                        int masterCount) const
+                                                        int masterCount, const QVariantMap& customParams) const
 {
     auto* registry = m_registry;
     PhosphorTiles::TilingAlgorithm* algo = registry->algorithm(algorithmId);
@@ -239,10 +239,10 @@ QVariantList AlgorithmService::generateAlgorithmPreview(const QString& algorithm
         return {};
     }
 
-    // Custom-param-aware preview: the settings KCM's preview slider passes
-    // live master/split values without persisting them, and bundles saved
-    // custom params for the algorithm. That path diverges from
-    // previewFromAlgorithm (which reads the registry's configured params),
+    // Custom-param-aware preview: the settings KCM's preview passes the live
+    // master/split values and the live custom-param map as explicit inputs, so
+    // the diagram is a pure function of what the UI shows. That path diverges
+    // from previewFromAlgorithm (which reads the registry's configured params),
     // so we build the TilingParams explicitly here. The relative-space
     // projection mirrors LayoutPreview's contract (0..1 against the shared
     // preview canvas size).
@@ -255,16 +255,7 @@ QVariantList AlgorithmService::generateAlgorithmPreview(const QString& algorithm
 
     const int count = qMax(1, windowCount);
     PhosphorTiles::TilingParams params = PhosphorTiles::TilingParams::forPreview(count, previewRect, &state);
-    // Inline the saved-custom-params lookup (previously a private helper; full
-    // surface now lives on TilingAlgorithmController).
-    const QVariantMap perAlgo = m_settings->autotilePerAlgorithmSettings();
-    const QVariant algoEntry = perAlgo.value(algorithmId);
-    if (algoEntry.isValid()) {
-        const QVariant customVar = algoEntry.toMap().value(PhosphorTiles::AutotileJsonKeys::CustomParams);
-        if (customVar.isValid()) {
-            params.customParams = customVar.toMap();
-        }
-    }
+    params.customParams = customParams;
 
     const QVector<QRect> zones = algo->calculateZones(params);
 
@@ -292,8 +283,16 @@ QVariantList AlgorithmService::generateAlgorithmDefaultPreview(const QString& al
     if (!algo) {
         return {};
     }
+    // Default thumbnails reflect any custom params the user has saved for the
+    // algorithm (the live KCM preview supplies its own map; this caller reads
+    // the persisted one).
+    QVariantMap savedCustom;
+    const QVariant algoEntry = m_settings->autotilePerAlgorithmSettings().value(algorithmId);
+    if (algoEntry.isValid()) {
+        savedCustom = algoEntry.toMap().value(PhosphorTiles::AutotileJsonKeys::CustomParams).toMap();
+    }
     return generateAlgorithmPreview(algorithmId, algo->defaultMaxWindows(), algo->defaultSplitRatio(),
-                                    PhosphorTiles::AutotileDefaults::DefaultMasterCount);
+                                    PhosphorTiles::AutotileDefaults::DefaultMasterCount, savedCustom);
 }
 
 void AlgorithmService::openAlgorithmsFolder()

--- a/src/settings/algorithmservice.h
+++ b/src/settings/algorithmservice.h
@@ -52,7 +52,7 @@ public:
     // ── Catalog queries ─────────────────────────────────────────────────
     QVariantList availableAlgorithms() const;
     QVariantList generateAlgorithmPreview(const QString& algorithmId, int windowCount, double splitRatio,
-                                          int masterCount) const;
+                                          int masterCount, const QVariantMap& customParams) const;
     QVariantList generateAlgorithmDefaultPreview(const QString& algorithmId) const;
 
     // ── Filesystem CRUD ─────────────────────────────────────────────────

--- a/src/settings/qml/AboutPage.qml
+++ b/src/settings/qml/AboutPage.qml
@@ -129,36 +129,6 @@ PhosphorUi.AboutPageShell {
         }
     ]
 
-    // ── Daemon enable/disable toggle, anchored above the header ──
-    topContent: Component {
-        RowLayout {
-            spacing: Kirigami.Units.smallSpacing
-
-            Label {
-                text: i18n("Enable PlasmaZones")
-                font.weight: Font.DemiBold
-            }
-
-            Item {
-                Layout.fillWidth: true
-            }
-
-            Label {
-                text: settingsController.daemonRunning ? i18n("Running") : i18n("Stopped")
-                opacity: 0.7
-            }
-
-            SettingsSwitch {
-                checked: settingsController.daemonRunning
-                enabled: !settingsController.daemonController.busy
-                onToggled: function (newValue) {
-                    settingsController.daemonController.setEnabled(newValue);
-                }
-                accessibleName: i18n("Enable PlasmaZones")
-            }
-        }
-    }
-
     component LinkButton: Button {
         id: linkButton
 

--- a/src/settings/qml/AboutPage.qml
+++ b/src/settings/qml/AboutPage.qml
@@ -8,9 +8,8 @@ import org.kde.kirigami as Kirigami
 import org.phosphor.control as PhosphorUi
 
 // PhosphorUi.AboutPageShell hosts the standard chrome (icon + name +
-// version + description + license + homepage); PlasmaZones-specific
-// content (daemon toggle on top, link / license / credits cards in
-// extras) is injected through the shell's slots.
+// version + description + license + homepage). PlasmaZones-specific content
+// (the Links and Credits cards) is injected through the shell's extras slot.
 PhosphorUi.AboutPageShell {
     id: root
 

--- a/src/settings/qml/AlgorithmPreview.qml
+++ b/src/settings/qml/AlgorithmPreview.qml
@@ -25,6 +25,10 @@ Item {
     property int windowCount: 4
     property real splitRatio: 0.6
     property int masterCount: 1
+    // Per-algorithm custom param values (name → value). Just another layout
+    // input, on equal footing with windowCount / splitRatio / masterCount: a
+    // change re-runs the C++ preview through the same recalc path.
+    property var customParams: ({})
     // Color customization (passed through to ZonePreview)
     property color windowColor: Kirigami.Theme.highlightColor
     property color windowBorder: Kirigami.Theme.textColor
@@ -63,11 +67,11 @@ Item {
 
     function recalcZones() {
         if (root.algorithmId !== "") {
-            root.zones = root.appSettings.generateAlgorithmPreview(root.algorithmId, root.windowCount, root.splitRatio, root.masterCount);
+            root.zones = root.appSettings.generateAlgorithmPreview(root.algorithmId, root.windowCount, root.splitRatio, root.masterCount, root.customParams);
             // Retry once if a stale watchdog interrupt caused empty results —
             // the first call clears the interrupt flag, so the second succeeds.
             if (root.zones.length === 0 && root.windowCount > 0)
-                root.zones = root.appSettings.generateAlgorithmPreview(root.algorithmId, root.windowCount, root.splitRatio, root.masterCount);
+                root.zones = root.appSettings.generateAlgorithmPreview(root.algorithmId, root.windowCount, root.splitRatio, root.masterCount, root.customParams);
         } else {
             root.zones = [];
         }
@@ -77,6 +81,7 @@ Item {
     onWindowCountChanged: recalcTimer.restart()
     onSplitRatioChanged: recalcTimer.restart()
     onMasterCountChanged: recalcTimer.restart()
+    onCustomParamsChanged: recalcTimer.restart()
     Component.onCompleted: recalcTimer.start()
 
     Connections {

--- a/src/settings/qml/AlgorithmPreview.qml
+++ b/src/settings/qml/AlgorithmPreview.qml
@@ -32,8 +32,9 @@ Item {
     // Color customization (passed through to ZonePreview)
     property color windowColor: Kirigami.Theme.highlightColor
     property color windowBorder: Kirigami.Theme.textColor
-    // Throttled zone calculation (~60fps cap) to avoid redundant recalcs
-    // when multiple properties change in the same frame
+    // Computed zones, rendered by ZonePreview. Recomputed by recalcTimer, which
+    // throttles to ~60fps so several input changes in one frame coalesce into a
+    // single C++ call.
     property var zones: []
     property string zoneNumberDisplay: "all"
     // Read the availableAlgorithms PROPERTY (not a call): it is exposed as both a

--- a/src/settings/qml/TilingAlgorithmPage.qml
+++ b/src/settings/qml/TilingAlgorithmPage.qml
@@ -393,6 +393,10 @@ SettingsFlickable {
                 // =============================================================
                 // Custom Algorithm Parameters
                 // =============================================================
+                // Unlike the built-in sliders above, custom params are stored
+                // per-algorithm only — there is no per-screen override for them,
+                // so the controls write the global per-algorithm value via
+                // setCustomParam() regardless of the active monitor scope.
                 Repeater {
                     model: root.customParamDefs
 

--- a/src/settings/qml/TilingAlgorithmPage.qml
+++ b/src/settings/qml/TilingAlgorithmPage.qml
@@ -57,6 +57,64 @@ SettingsFlickable {
 
         return root.settingsBridge.customParamsForAlgorithm(root.selectedAlgorithm);
     }
+    // Live custom-param values (name → value) for the selected algorithm. This
+    // is the single source of truth the param controls read and write, and the
+    // value the live preview consumes — exactly the role appSettings holds for
+    // split ratio / master count. customParamDefs (the Repeater model) is
+    // intentionally not refreshed on edit, so the current values live here
+    // instead. Re-seeded from the saved/default values whenever the algorithm
+    // changes (i.e. customParamDefs re-evaluates).
+    property var liveCustomParams: ({})
+
+    function _seedLiveCustomParams() {
+        const defs = root.customParamDefs;
+        let m = {};
+        for (let i = 0; i < defs.length; ++i) {
+            const d = defs[i];
+            m[d.name] = (d.value !== undefined ? d.value : d.defaultValue);
+        }
+        root.liveCustomParams = m;
+    }
+
+    function setLiveCustomParam(name, value) {
+        // Reassign a fresh object so the `var` property emits changed —
+        // mutating in place would not re-trigger the preview binding or the
+        // delegates' paramValue.
+        let m = Object.assign({}, root.liveCustomParams);
+        m[name] = value;
+        root.liveCustomParams = m;
+    }
+
+    onCustomParamDefsChanged: _seedLiveCustomParams()
+
+    // Live per-algorithm built-in tuning (split ratio, master count, max
+    // windows) for the selected algorithm. Like liveCustomParams, this is the
+    // reactive source the sliders read in global scope so they don't snap back
+    // to the non-reactive algorithmSettingsFor() value, and it re-seeds on
+    // algorithm change so each algorithm shows its own saved tuning. Per-screen
+    // overrides bypass this (they flow through settingValue/writeSetting's
+    // per-screen path, which is reactive on its own).
+    property var liveAlgoSettings: ({})
+
+    function _seedLiveAlgoSettings() {
+        root.liveAlgoSettings = root.settingsBridge.algorithmSettingsFor(root.selectedAlgorithm);
+    }
+
+    function setLiveAlgoSetting(key, value) {
+        if (psHelper.isPerScreen)
+            return;
+        let m = Object.assign({}, root.liveAlgoSettings);
+        m[key] = value;
+        root.liveAlgoSettings = m;
+    }
+
+    onSelectedAlgorithmChanged: _seedLiveAlgoSettings()
+
+    Component.onCompleted: {
+        _seedLiveCustomParams();
+        _seedLiveAlgoSettings();
+    }
+
     // Whether the algorithm uses a center layout (ratio/count labels say "Center" instead of "Master").
     // Check capabilities map first (for future extensibility via scripted algorithm metadata),
     // falling back to hardcoded IDs for built-in algorithms. See PR #256 / M13.
@@ -68,18 +126,6 @@ SettingsFlickable {
 
     function writeSetting(key, value, globalSetter) {
         psHelper.writeSetting(key, value, globalSetter);
-    }
-
-    // Default max-windows for an algorithm id, looked up from the cached
-    // capabilities list. Returns -1 when the id is unknown so the caller can
-    // preserve the current value rather than guess.
-    function _defaultMaxWindowsFor(algoId) {
-        var algos = root._cachedAlgos;
-        for (var i = 0; i < algos.length; i++) {
-            if (algos[i].id === algoId)
-                return algos[i].defaultMaxWindows;
-        }
-        return -1;
     }
 
     contentHeight: content.implicitHeight
@@ -154,11 +200,15 @@ SettingsFlickable {
                                 showLabel: false
                                 algorithmId: root.selectedAlgorithm
                                 algorithmName: root.algoCapabilities ? (root.algoCapabilities.name || "") : ""
-                                // Track the live Max-windows slider so the diagram and the
-                                // "Max N windows" caption below always show the same count.
+                                // Every layout input the user can edit feeds the preview
+                                // from the live slider handle, so the diagram updates as the
+                                // user drags any of them (master ratio and master count
+                                // included, not just max windows). The "Max N windows"
+                                // caption below also tracks the windows slider.
                                 windowCount: previewWindowSlider.slider.value
-                                splitRatio: root.algoCapabilities ? root.algoCapabilities.defaultSplitRatio : 0.6
-                                masterCount: (root.algoCapabilities && root.algoCapabilities.supportsMasterCount) ? 1 : 0
+                                splitRatio: root.algoSupportsSplitRatio ? masterRatioSlider.slider.value : (root.algoCapabilities ? root.algoCapabilities.defaultSplitRatio : 0.6)
+                                masterCount: root.algoSupportsMasterCount ? masterCountSlider.slider.value : 0
+                                customParams: root.liveCustomParams
                                 zoneNumberDisplay: root.algoCapabilities ? (root.algoCapabilities.zoneNumberDisplay || "all") : "all"
                             }
                         }
@@ -215,38 +265,14 @@ SettingsFlickable {
                                 selectedId = appSettings.defaultAutotileAlgorithm;
                             else if (selectedId.startsWith("autotile:"))
                                 selectedId = selectedId.substring(9);
-                            // Decide BEFORE the switch whether max-windows should
-                            // follow the new algorithm's default. Mirror the
-                            // daemon (AutotileEngine::resetMaxWindowsForAlgorithmSwitch):
-                            // only reset when the user never customized it, i.e. the
-                            // current value still equals the OLD algorithm's default.
-                            // effectiveAlgorithm/settingValue still read the old
-                            // state here (the write below hasn't landed yet).
-                            // Without this guard, switching algorithm would clobber a
-                            // customized value and — when scoped to a monitor — force a
-                            // per-screen MaxWindows override the user never set.
-                            var oldDefaultMax = root._defaultMaxWindowsFor(root.effectiveAlgorithm);
-                            var currentMax = root.settingValue("MaxWindows", appSettings.autotileMaxWindows);
-                            var resetMax = oldDefaultMax >= 0 && currentMax === oldDefaultMax;
+                            // Just change the algorithm. Max windows / split ratio /
+                            // master count are per-algorithm now: selectedAlgorithm
+                            // updates from the combo, re-seeding liveAlgoSettings from
+                            // the new algorithm's saved tuning, and the daemon performs
+                            // the same save/restore on its side. Resetting global
+                            // values here would clobber a sibling algorithm's slot.
                             root.writeSetting("Algorithm", selectedId, function (v) {
                                 appSettings.defaultAutotileAlgorithm = v;
-                            });
-                            if (!resetMax)
-                                return;
-                            // Reset maxWindows to the new algorithm's default.
-                            // Use Qt.callLater so algoCapabilities binding has
-                            // re-evaluated with the newly selected algorithm.
-                            Qt.callLater(function () {
-                                if (!root.algoCapabilities)
-                                    return;
-                                var newDefault = root.algoCapabilities.defaultMaxWindows || 6;
-                                // Writing the setting moves the slider via its
-                                // value binding (settingValue → SettingsSlider);
-                                // an imperative slider write here would just be
-                                // reasserted by that binding, so don't.
-                                root.writeSetting("MaxWindows", newDefault, function (v) {
-                                    appSettings.autotileMaxWindows = v;
-                                });
                             });
                         }
                     }
@@ -267,13 +293,14 @@ SettingsFlickable {
                         from: root.settingsBridge.autotileMaxWindowsMin
                         to: root.settingsBridge.autotileMaxWindowsMax
                         stepSize: 1
-                        value: root.settingValue("MaxWindows", appSettings.autotileMaxWindows)
+                        value: root.settingValue("MaxWindows", root.liveAlgoSettings.maxWindows !== undefined ? root.liveAlgoSettings.maxWindows : appSettings.autotileMaxWindows)
                         formatValue: function (v) {
                             return Math.round(v).toString();
                         }
                         onMoved: value => {
-                            return root.writeSetting("MaxWindows", Math.round(value), function (v) {
-                                appSettings.autotileMaxWindows = v;
+                            root.setLiveAlgoSetting("maxWindows", Math.round(value));
+                            root.writeSetting("MaxWindows", Math.round(value), function (v) {
+                                root.settingsBridge.setAlgorithmMaxWindows(root.selectedAlgorithm, v);
                             });
                         }
                     }
@@ -291,17 +318,20 @@ SettingsFlickable {
                     description: root.algoCenterLayout ? i18n("Width proportion allocated to the center column") : i18n("Width proportion allocated to the master area")
 
                     SettingsSlider {
+                        id: masterRatioSlider
+
                         Accessible.name: root.algoCenterLayout ? i18n("Center ratio") : i18n("Master ratio")
                         from: root.settingsBridge.autotileSplitRatioMin
                         to: root.settingsBridge.autotileSplitRatioMax
                         stepSize: 0.05
-                        value: root.settingValue("SplitRatio", appSettings.autotileSplitRatio)
+                        value: root.settingValue("SplitRatio", root.liveAlgoSettings.splitRatio !== undefined ? root.liveAlgoSettings.splitRatio : appSettings.autotileSplitRatio)
                         formatValue: function (v) {
                             return Math.round(v * 100) + "%";
                         }
                         onMoved: value => {
+                            root.setLiveAlgoSetting("splitRatio", value);
                             root.writeSetting("SplitRatio", value, function (v) {
-                                appSettings.autotileSplitRatio = v;
+                                root.settingsBridge.setAlgorithmSplitRatio(root.selectedAlgorithm, v);
                             });
                         }
                     }
@@ -341,17 +371,20 @@ SettingsFlickable {
                     description: root.algoCenterLayout ? i18n("Number of windows in the center column") : i18n("Number of windows in the master area")
 
                     SettingsSlider {
+                        id: masterCountSlider
+
                         Accessible.name: root.algoCenterLayout ? i18n("Center count") : i18n("Master count")
                         from: root.settingsBridge.autotileMasterCountMin
                         to: root.settingsBridge.autotileMasterCountMax
                         stepSize: 1
-                        value: root.settingValue("MasterCount", appSettings.autotileMasterCount)
+                        value: root.settingValue("MasterCount", root.liveAlgoSettings.masterCount !== undefined ? root.liveAlgoSettings.masterCount : appSettings.autotileMasterCount)
                         formatValue: function (v) {
                             return Math.round(v).toString();
                         }
                         onMoved: value => {
+                            root.setLiveAlgoSetting("masterCount", Math.round(value));
                             root.writeSetting("MasterCount", Math.round(value), function (v) {
-                                appSettings.autotileMasterCount = v;
+                                root.settingsBridge.setAlgorithmMasterCount(root.selectedAlgorithm, v);
                             });
                         }
                     }
@@ -364,12 +397,26 @@ SettingsFlickable {
                     model: root.customParamDefs
 
                     delegate: ColumnLayout {
+                        id: paramDelegate
+
                         required property var modelData
                         required property int index
                         readonly property string paramLabel: modelData.description || modelData.name
                         // Show the raw param name as subtitle when description was used as title
                         readonly property string paramDescription: modelData.description ? modelData.name : ""
-                        readonly property var paramValue: modelData.value !== undefined ? modelData.value : modelData.defaultValue
+                        // Current value, read from the page's live map (the single
+                        // source of truth). Falls back to the model's saved/default
+                        // value before the map is seeded. Because this tracks
+                        // liveCustomParams, the slider's on-release re-sync
+                        // (Binding when: !pressed) and the switch / combo all settle
+                        // on the value the user just set instead of snapping back to
+                        // the never-refreshed model value.
+                        readonly property var paramValue: {
+                            const v = root.liveCustomParams[modelData.name];
+                            if (v !== undefined)
+                                return v;
+                            return modelData.value !== undefined ? modelData.value : modelData.defaultValue;
+                        }
                         readonly property real paramMin: modelData.minValue !== undefined ? modelData.minValue : 0
                         readonly property real paramMax: {
                             let mx = modelData.maxValue !== undefined ? modelData.maxValue : 1;
@@ -414,6 +461,7 @@ SettingsFlickable {
                                     return Math.round(v).toString();
                                 }
                                 onMoved: value => {
+                                    root.setLiveCustomParam(modelData.name, value);
                                     root.settingsBridge.setCustomParam(root.selectedAlgorithm, modelData.name, value);
                                 }
                             }
@@ -424,6 +472,7 @@ SettingsFlickable {
                                 Accessible.name: paramLabel
                                 checked: paramValue === true
                                 onToggled: {
+                                    root.setLiveCustomParam(modelData.name, checked);
                                     root.settingsBridge.setCustomParam(root.selectedAlgorithm, modelData.name, checked);
                                 }
                             }
@@ -441,10 +490,7 @@ SettingsFlickable {
                                     return idx >= 0 ? idx : 0;
                                 }
                                 onActivated: {
-                                    // Imperative assignment breaks the declarative currentIndex
-                                    // binding above, preventing it from snapping back to the
-                                    // old value after the user makes a selection.
-                                    currentIndex = enumCombo.currentIndex;
+                                    root.setLiveCustomParam(modelData.name, currentText);
                                     root.settingsBridge.setCustomParam(root.selectedAlgorithm, modelData.name, currentText);
                                 }
                             }

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -445,7 +445,7 @@ public:
     Q_PROPERTY(QVariantList availableAlgorithms READ availableAlgorithms NOTIFY availableAlgorithmsChanged)
     Q_INVOKABLE QVariantList availableAlgorithms() const;
     Q_INVOKABLE QVariantList generateAlgorithmPreview(const QString& algorithmId, int windowCount, double splitRatio,
-                                                      int masterCount) const;
+                                                      int masterCount, const QVariantMap& customParams) const;
     Q_INVOKABLE QVariantList generateAlgorithmDefaultPreview(const QString& algorithmId) const;
     Q_INVOKABLE void openAlgorithmsFolder();
     Q_INVOKABLE bool importAlgorithm(const QString& filePath);

--- a/src/settings/settingscontroller_layouts.cpp
+++ b/src/settings/settingscontroller_layouts.cpp
@@ -478,9 +478,11 @@ QVariantList SettingsController::availableAlgorithms() const
 }
 
 QVariantList SettingsController::generateAlgorithmPreview(const QString& algorithmId, int windowCount,
-                                                          double splitRatio, int masterCount) const
+                                                          double splitRatio, int masterCount,
+                                                          const QVariantMap& customParams) const
 {
-    return m_algorithmService->generateAlgorithmPreview(algorithmId, windowCount, splitRatio, masterCount);
+    return m_algorithmService->generateAlgorithmPreview(algorithmId, windowCount, splitRatio, masterCount,
+                                                        customParams);
 }
 
 QVariantList SettingsController::generateAlgorithmDefaultPreview(const QString& algorithmId) const

--- a/src/settings/tilingalgorithmcontroller.cpp
+++ b/src/settings/tilingalgorithmcontroller.cpp
@@ -277,16 +277,22 @@ QVariantMap TilingAlgorithmController::algorithmSettingsFor(const QString& algor
         maxWindows = algo->defaultMaxWindows();
     }
 
+    // Override with saved values. Read each via toDouble(&ok): it yields
+    // ok=true for both int- and double-typed QVariants (the JSON backend may
+    // return either) and ok=false for missing or non-numeric entries, in which
+    // case the seeded default is kept rather than collapsing to 0 (mirrors
+    // customParamsForAlgorithm's `ok` guard). Integer fields round back.
     const QVariantMap entry = m_settings->autotilePerAlgorithmSettings().value(algorithmId).toMap();
-    const QVariant srVar = entry.value(PhosphorTiles::AutotileJsonKeys::SplitRatio);
-    if (srVar.isValid())
-        splitRatio = srVar.toDouble();
-    const QVariant mcVar = entry.value(PhosphorTiles::AutotileJsonKeys::MasterCount);
-    if (mcVar.isValid())
-        masterCount = mcVar.toInt();
-    const QVariant mwVar = entry.value(PhosphorTiles::AutotileJsonKeys::MaxWindows);
-    if (mwVar.isValid())
-        maxWindows = mwVar.toInt();
+    bool ok = false;
+    const qreal srSaved = entry.value(PhosphorTiles::AutotileJsonKeys::SplitRatio).toDouble(&ok);
+    if (ok)
+        splitRatio = srSaved;
+    const qreal mcSaved = entry.value(PhosphorTiles::AutotileJsonKeys::MasterCount).toDouble(&ok);
+    if (ok)
+        masterCount = qRound(mcSaved);
+    const qreal mwSaved = entry.value(PhosphorTiles::AutotileJsonKeys::MaxWindows).toDouble(&ok);
+    if (ok)
+        maxWindows = qRound(mwSaved);
 
     // Clamp the read-back values, mirroring customParamsForAlgorithm: a stale
     // or hand-edited on-disk value outside the current bounds must not reach

--- a/src/settings/tilingalgorithmcontroller.cpp
+++ b/src/settings/tilingalgorithmcontroller.cpp
@@ -264,4 +264,80 @@ void TilingAlgorithmController::setCustomParam(const QString& algorithmId, const
     Q_EMIT changed();
 }
 
+QVariantMap TilingAlgorithmController::algorithmSettingsFor(const QString& algorithmId) const
+{
+    // Seed with the algorithm's declared defaults so an algorithm with no
+    // saved entry still shows its own sensible values (e.g. BSP's default
+    // max windows, not a global constant).
+    qreal splitRatio = PhosphorTiles::AutotileDefaults::DefaultSplitRatio;
+    int masterCount = PhosphorTiles::AutotileDefaults::DefaultMasterCount;
+    int maxWindows = PhosphorTiles::AutotileDefaults::DefaultMaxWindows;
+    if (PhosphorTiles::TilingAlgorithm* algo = m_registry->algorithm(algorithmId)) {
+        splitRatio = algo->defaultSplitRatio();
+        maxWindows = algo->defaultMaxWindows();
+    }
+
+    const QVariantMap entry = m_settings->autotilePerAlgorithmSettings().value(algorithmId).toMap();
+    const QVariant srVar = entry.value(PhosphorTiles::AutotileJsonKeys::SplitRatio);
+    if (srVar.isValid())
+        splitRatio = srVar.toDouble();
+    const QVariant mcVar = entry.value(PhosphorTiles::AutotileJsonKeys::MasterCount);
+    if (mcVar.isValid())
+        masterCount = mcVar.toInt();
+    const QVariant mwVar = entry.value(PhosphorTiles::AutotileJsonKeys::MaxWindows);
+    if (mwVar.isValid())
+        maxWindows = mwVar.toInt();
+
+    QVariantMap result;
+    result[PhosphorTiles::AutotileJsonKeys::SplitRatio] = splitRatio;
+    result[PhosphorTiles::AutotileJsonKeys::MasterCount] = masterCount;
+    result[PhosphorTiles::AutotileJsonKeys::MaxWindows] = maxWindows;
+    return result;
+}
+
+bool TilingAlgorithmController::writeAlgorithmField(const QString& algorithmId, QLatin1String key,
+                                                    const QVariant& value)
+{
+    if (algorithmId.isEmpty())
+        return false;
+    QVariantMap perAlgo = m_settings->autotilePerAlgorithmSettings();
+    QVariantMap entry = perAlgo.value(algorithmId).toMap();
+    if (entry.contains(key) && entry.value(key) == value)
+        return false;
+    entry[key] = value;
+    perAlgo[algorithmId] = entry;
+    m_settings->setAutotilePerAlgorithmSettings(perAlgo);
+    return true;
+}
+
+void TilingAlgorithmController::setAlgorithmSplitRatio(const QString& algorithmId, qreal value)
+{
+    const qreal clamped =
+        std::clamp(value, ConfigDefaults::autotileSplitRatioMin(), ConfigDefaults::autotileSplitRatioMax());
+    if (writeAlgorithmField(algorithmId, PhosphorTiles::AutotileJsonKeys::SplitRatio, clamped)) {
+        Q_EMIT algorithmSettingsChanged(algorithmId);
+        Q_EMIT changed();
+    }
+}
+
+void TilingAlgorithmController::setAlgorithmMasterCount(const QString& algorithmId, int value)
+{
+    const int clamped =
+        std::clamp(value, ConfigDefaults::autotileMasterCountMin(), ConfigDefaults::autotileMasterCountMax());
+    if (writeAlgorithmField(algorithmId, PhosphorTiles::AutotileJsonKeys::MasterCount, clamped)) {
+        Q_EMIT algorithmSettingsChanged(algorithmId);
+        Q_EMIT changed();
+    }
+}
+
+void TilingAlgorithmController::setAlgorithmMaxWindows(const QString& algorithmId, int value)
+{
+    const int clamped =
+        std::clamp(value, ConfigDefaults::autotileMaxWindowsMin(), ConfigDefaults::autotileMaxWindowsMax());
+    if (writeAlgorithmField(algorithmId, PhosphorTiles::AutotileJsonKeys::MaxWindows, clamped)) {
+        Q_EMIT algorithmSettingsChanged(algorithmId);
+        Q_EMIT changed();
+    }
+}
+
 } // namespace PlasmaZones

--- a/src/settings/tilingalgorithmcontroller.cpp
+++ b/src/settings/tilingalgorithmcontroller.cpp
@@ -288,10 +288,16 @@ QVariantMap TilingAlgorithmController::algorithmSettingsFor(const QString& algor
     if (mwVar.isValid())
         maxWindows = mwVar.toInt();
 
+    // Clamp the read-back values, mirroring customParamsForAlgorithm: a stale
+    // or hand-edited on-disk value outside the current bounds must not reach
+    // the QML slider or the live preview.
     QVariantMap result;
-    result[PhosphorTiles::AutotileJsonKeys::SplitRatio] = splitRatio;
-    result[PhosphorTiles::AutotileJsonKeys::MasterCount] = masterCount;
-    result[PhosphorTiles::AutotileJsonKeys::MaxWindows] = maxWindows;
+    result[PhosphorTiles::AutotileJsonKeys::SplitRatio] =
+        std::clamp(splitRatio, ConfigDefaults::autotileSplitRatioMin(), ConfigDefaults::autotileSplitRatioMax());
+    result[PhosphorTiles::AutotileJsonKeys::MasterCount] =
+        std::clamp(masterCount, ConfigDefaults::autotileMasterCountMin(), ConfigDefaults::autotileMasterCountMax());
+    result[PhosphorTiles::AutotileJsonKeys::MaxWindows] =
+        std::clamp(maxWindows, ConfigDefaults::autotileMaxWindowsMin(), ConfigDefaults::autotileMaxWindowsMax());
     return result;
 }
 
@@ -315,7 +321,6 @@ void TilingAlgorithmController::setAlgorithmSplitRatio(const QString& algorithmI
     const qreal clamped =
         std::clamp(value, ConfigDefaults::autotileSplitRatioMin(), ConfigDefaults::autotileSplitRatioMax());
     if (writeAlgorithmField(algorithmId, PhosphorTiles::AutotileJsonKeys::SplitRatio, clamped)) {
-        Q_EMIT algorithmSettingsChanged(algorithmId);
         Q_EMIT changed();
     }
 }
@@ -325,7 +330,6 @@ void TilingAlgorithmController::setAlgorithmMasterCount(const QString& algorithm
     const int clamped =
         std::clamp(value, ConfigDefaults::autotileMasterCountMin(), ConfigDefaults::autotileMasterCountMax());
     if (writeAlgorithmField(algorithmId, PhosphorTiles::AutotileJsonKeys::MasterCount, clamped)) {
-        Q_EMIT algorithmSettingsChanged(algorithmId);
         Q_EMIT changed();
     }
 }
@@ -335,7 +339,6 @@ void TilingAlgorithmController::setAlgorithmMaxWindows(const QString& algorithmI
     const int clamped =
         std::clamp(value, ConfigDefaults::autotileMaxWindowsMin(), ConfigDefaults::autotileMaxWindowsMax());
     if (writeAlgorithmField(algorithmId, PhosphorTiles::AutotileJsonKeys::MaxWindows, clamped)) {
-        Q_EMIT algorithmSettingsChanged(algorithmId);
         Q_EMIT changed();
     }
 }

--- a/src/settings/tilingalgorithmcontroller.cpp
+++ b/src/settings/tilingalgorithmcontroller.cpp
@@ -281,29 +281,30 @@ QVariantMap TilingAlgorithmController::algorithmSettingsFor(const QString& algor
     // ok=true for both int- and double-typed QVariants (the JSON backend may
     // return either) and ok=false for missing or non-numeric entries, in which
     // case the seeded default is kept rather than collapsing to 0 (mirrors
-    // customParamsForAlgorithm's `ok` guard). Integer fields round back.
+    // customParamsForAlgorithm's `ok` guard). Clamp each saved value in the
+    // double domain BEFORE narrowing to int — a hand-edited out-of-int-range
+    // value would otherwise hit undefined behaviour in the double→int cast. The
+    // seeded defaults are already in range, so clamping only the saved value is
+    // sufficient.
     const QVariantMap entry = m_settings->autotilePerAlgorithmSettings().value(algorithmId).toMap();
     bool ok = false;
     const qreal srSaved = entry.value(PhosphorTiles::AutotileJsonKeys::SplitRatio).toDouble(&ok);
     if (ok)
-        splitRatio = srSaved;
+        splitRatio =
+            std::clamp(srSaved, ConfigDefaults::autotileSplitRatioMin(), ConfigDefaults::autotileSplitRatioMax());
     const qreal mcSaved = entry.value(PhosphorTiles::AutotileJsonKeys::MasterCount).toDouble(&ok);
     if (ok)
-        masterCount = qRound(mcSaved);
+        masterCount = qRound(std::clamp(mcSaved, qreal(ConfigDefaults::autotileMasterCountMin()),
+                                        qreal(ConfigDefaults::autotileMasterCountMax())));
     const qreal mwSaved = entry.value(PhosphorTiles::AutotileJsonKeys::MaxWindows).toDouble(&ok);
     if (ok)
-        maxWindows = qRound(mwSaved);
+        maxWindows = qRound(std::clamp(mwSaved, qreal(ConfigDefaults::autotileMaxWindowsMin()),
+                                       qreal(ConfigDefaults::autotileMaxWindowsMax())));
 
-    // Clamp the read-back values, mirroring customParamsForAlgorithm: a stale
-    // or hand-edited on-disk value outside the current bounds must not reach
-    // the QML slider or the live preview.
     QVariantMap result;
-    result[PhosphorTiles::AutotileJsonKeys::SplitRatio] =
-        std::clamp(splitRatio, ConfigDefaults::autotileSplitRatioMin(), ConfigDefaults::autotileSplitRatioMax());
-    result[PhosphorTiles::AutotileJsonKeys::MasterCount] =
-        std::clamp(masterCount, ConfigDefaults::autotileMasterCountMin(), ConfigDefaults::autotileMasterCountMax());
-    result[PhosphorTiles::AutotileJsonKeys::MaxWindows] =
-        std::clamp(maxWindows, ConfigDefaults::autotileMaxWindowsMin(), ConfigDefaults::autotileMaxWindowsMax());
+    result[PhosphorTiles::AutotileJsonKeys::SplitRatio] = splitRatio;
+    result[PhosphorTiles::AutotileJsonKeys::MasterCount] = masterCount;
+    result[PhosphorTiles::AutotileJsonKeys::MaxWindows] = maxWindows;
     return result;
 }
 

--- a/src/settings/tilingalgorithmcontroller.cpp
+++ b/src/settings/tilingalgorithmcontroller.cpp
@@ -268,13 +268,17 @@ QVariantMap TilingAlgorithmController::algorithmSettingsFor(const QString& algor
 {
     // Seed with the algorithm's declared defaults so an algorithm with no
     // saved entry still shows its own sensible values (e.g. BSP's default
-    // max windows, not a global constant).
+    // max windows, not a global constant). Clamp the algorithm-derived
+    // defaults: a scripted (Luau) algorithm's metadata is user-authored and may
+    // declare an out-of-range value.
     qreal splitRatio = PhosphorTiles::AutotileDefaults::DefaultSplitRatio;
     int masterCount = PhosphorTiles::AutotileDefaults::DefaultMasterCount;
     int maxWindows = PhosphorTiles::AutotileDefaults::DefaultMaxWindows;
     if (PhosphorTiles::TilingAlgorithm* algo = m_registry->algorithm(algorithmId)) {
-        splitRatio = algo->defaultSplitRatio();
-        maxWindows = algo->defaultMaxWindows();
+        splitRatio = std::clamp(algo->defaultSplitRatio(), ConfigDefaults::autotileSplitRatioMin(),
+                                ConfigDefaults::autotileSplitRatioMax());
+        maxWindows = std::clamp(algo->defaultMaxWindows(), ConfigDefaults::autotileMaxWindowsMin(),
+                                ConfigDefaults::autotileMaxWindowsMax());
     }
 
     // Override with saved values. Read each via toDouble(&ok): it yields

--- a/src/settings/tilingalgorithmcontroller.h
+++ b/src/settings/tilingalgorithmcontroller.h
@@ -84,25 +84,27 @@ public:
     /// Per-algorithm built-in tuning (split ratio, master count, max windows).
     /// Each algorithm keeps its own values, mirroring the daemon's
     /// per-algorithm save/restore (AutotileConfig::AlgorithmSettings). Returns
-    /// a map with keys "splitRatio", "masterCount", "maxWindows", falling back
-    /// to the algorithm's declared defaults for any key not yet saved.
+    /// a map with keys "splitRatio", "masterCount", "maxWindows". Split ratio
+    /// and max windows fall back to the algorithm's declared defaults; master
+    /// count falls back to the global default (algorithms don't declare one).
+    /// All values are clamped to their configured ranges.
     Q_INVOKABLE QVariantMap algorithmSettingsFor(const QString& algorithmId) const;
 
     /// Persist a per-algorithm built-in value (clamped to its allowed range),
     /// writing ONLY the per-algorithm entry — never the global current value.
     /// The daemon restores the per-algorithm entry into the active config, so
     /// writing the global here would let the daemon's switch-time save clobber
-    /// a sibling algorithm's slot. Emits `algorithmSettingsChanged` + `changed`.
+    /// a sibling algorithm's slot. Emits `changed` for dirty tracking.
     Q_INVOKABLE void setAlgorithmSplitRatio(const QString& algorithmId, qreal value);
     Q_INVOKABLE void setAlgorithmMasterCount(const QString& algorithmId, int value);
     Q_INVOKABLE void setAlgorithmMaxWindows(const QString& algorithmId, int value);
 
 Q_SIGNALS:
     void customParamChanged(const QString& algorithmId, const QString& paramName);
-    void algorithmSettingsChanged(const QString& algorithmId);
 
     /// Generic "something changed" — SettingsController hooks this to its
-    /// dirty-tracking slot so custom-param writes flip needsSave.
+    /// dirty-tracking slot so custom-param and per-algorithm writes flip
+    /// needsSave.
     void changed();
 
 private:

--- a/src/settings/tilingalgorithmcontroller.h
+++ b/src/settings/tilingalgorithmcontroller.h
@@ -81,8 +81,25 @@ public:
     /// `changed()` drives page dirty tracking via SettingsController.
     Q_INVOKABLE void setCustomParam(const QString& algorithmId, const QString& paramName, const QVariant& value);
 
+    /// Per-algorithm built-in tuning (split ratio, master count, max windows).
+    /// Each algorithm keeps its own values, mirroring the daemon's
+    /// per-algorithm save/restore (AutotileConfig::AlgorithmSettings). Returns
+    /// a map with keys "splitRatio", "masterCount", "maxWindows", falling back
+    /// to the algorithm's declared defaults for any key not yet saved.
+    Q_INVOKABLE QVariantMap algorithmSettingsFor(const QString& algorithmId) const;
+
+    /// Persist a per-algorithm built-in value (clamped to its allowed range),
+    /// writing ONLY the per-algorithm entry — never the global current value.
+    /// The daemon restores the per-algorithm entry into the active config, so
+    /// writing the global here would let the daemon's switch-time save clobber
+    /// a sibling algorithm's slot. Emits `algorithmSettingsChanged` + `changed`.
+    Q_INVOKABLE void setAlgorithmSplitRatio(const QString& algorithmId, qreal value);
+    Q_INVOKABLE void setAlgorithmMasterCount(const QString& algorithmId, int value);
+    Q_INVOKABLE void setAlgorithmMaxWindows(const QString& algorithmId, int value);
+
 Q_SIGNALS:
     void customParamChanged(const QString& algorithmId, const QString& paramName);
+    void algorithmSettingsChanged(const QString& algorithmId);
 
     /// Generic "something changed" — SettingsController hooks this to its
     /// dirty-tracking slot so custom-param writes flip needsSave.
@@ -90,6 +107,10 @@ Q_SIGNALS:
 
 private:
     QVariantMap savedCustomParams(const QString& algorithmId) const;
+    /// Read-modify-write a single key in the per-algorithm settings entry,
+    /// preserving the other keys (incl. customParams). Returns false (no-op)
+    /// when the coerced value already matches what's stored.
+    bool writeAlgorithmField(const QString& algorithmId, QLatin1String key, const QVariant& value);
 
     ISettings* m_settings = nullptr;
     PhosphorTiles::AlgorithmRegistry* m_registry = nullptr;

--- a/tests/unit/autotile/test_autotile_ext_algoswitch.cpp
+++ b/tests/unit/autotile/test_autotile_ext_algoswitch.cpp
@@ -67,19 +67,26 @@ private Q_SLOTS:
         QCOMPARE(engine.config()->maxWindows, bspAlgo->defaultMaxWindows());
     }
 
-    void testAlgorithmSwitch_maxWindowsPreservedWhenCustomized()
+    void testAlgorithmSwitch_maxWindowsPerAlgorithm()
     {
         AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
         engine.setAlgorithm(QLatin1String("master-stack"));
 
         auto* msAlgo = m_scriptSetup.registry()->algorithm(QLatin1String("master-stack"));
-        QVERIFY(msAlgo);
+        auto* bspAlgo = m_scriptSetup.registry()->algorithm(QLatin1String("bsp"));
+        QVERIFY(msAlgo && bspAlgo);
 
+        // Customize master-stack's max windows.
         const int customMax = msAlgo->defaultMaxWindows() + 3;
         engine.config()->maxWindows = customMax;
 
+        // Switching to BSP loads BSP's own value (its default — no saved entry
+        // yet), not master-stack's customization.
         engine.setAlgorithm(QLatin1String("bsp"));
+        QCOMPARE(engine.config()->maxWindows, bspAlgo->defaultMaxWindows());
 
+        // Switching back restores master-stack's customized value.
+        engine.setAlgorithm(QLatin1String("master-stack"));
         QCOMPARE(engine.config()->maxWindows, customMax);
     }
 


### PR DESCRIPTION
A batch of fixes for the standalone settings app, the tiling Algorithm page, and the daemon's KGlobalAccel component.

## About page
- Remove the "Enable PlasmaZones" daemon toggle (and the separator beneath it) from the About page. The shell hides its separator automatically when `topContent` is unset.

## Tiling → Algorithm page
- **Custom params no longer snap back.** Edits flow through a reactive live map so the slider's on-release re-sync settles on the edited value instead of the never-refreshed model value.
- **Live preview for every input.** `AlgorithmPreview` is now a pure function of its inputs: it gains a `customParams` property and `generateAlgorithmPreview()` takes the custom-param map explicitly. Max windows, split ratio, master count, and custom params all drive the diagram through the same recalc path (previously only max windows updated it).
- **Per-algorithm tuning.** Split ratio, master count, and **window count** are now per-algorithm: switching algorithms loads that algorithm's saved values instead of carrying the previous one's.
  - Engine: `AlgorithmSettings` gains a `maxWindows` field (serialized in `perAlgoFrom/ToVariantMap`); `setAlgorithm`/`syncFromSettings` save and restore it per-algorithm, replacing the old reset-when-uncustomized helper.
  - Controller: `algorithmSettingsFor()` + per-field setters that write **only** the per-algorithm entry. The daemon owns the switch-time save of the global current into the old algorithm's slot, so writing the global from the settings app would clobber a sibling slot.
  - UI: the ratio / count / windows sliders read and write the per-algorithm values and re-seed on algorithm change.

## Daemon
- Mark the KGlobalAccel component `plasmazonesd.desktop` as `NoDisplay=true` so the daemon stops appearing as a launchable "PlasmaZones" application (and files under System Services, not Applications, in the Shortcuts KCM).

## Testing
- Full suite green (245/245). Rewrote `test_autotile_ext_algoswitch` to assert per-algorithm max-windows save/restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)