### PR TITLE
feat(shell): Phase 3 — UI primitives (atoms, connected-corner bar, OSD, toasts)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,7 @@ if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(libs/phosphor-shell)   # shell infrastructure and QML types
     add_subdirectory(libs/phosphor-shell-widgets)  # Phosphor.Widgets M3 atom library (Phase 3.1); depends on phosphor-theme
     add_subdirectory(libs/phosphor-shell-osd)      # Phosphor.OSD on-screen-display framework (Phase 3.3); depends on theme + widgets
+    add_subdirectory(libs/phosphor-shell-notifications) # Phosphor.Notifications toast framework (Phase 3.4); depends on theme + widgets
 endif()
 add_subdirectory(libs/phosphor-engine)  # unified placement engine contracts + window registry (SHARED lib)
 add_subdirectory(libs/phosphor-workspaces)  # virtual desktop / workspace management
@@ -671,6 +672,8 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples")
 #                            the bar as one Shape, toggled via PopoutService.
 #   phosphor-osd-demo — OSDHost overlay; the four built-in OSDs via
 #                            Registry<IOSDFactory>, driven by phosphorctl.
+#   phosphor-toast-demo — ToastHost overlay fed by a real NotificationServer
+#                            (notify-send) + buttons; DND exercises the rules seam.
 if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(examples/phosphor-theme-demo)
     add_subdirectory(examples/phosphor-theme-cli)
@@ -680,6 +683,7 @@ if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(examples/phosphor-widgets-kitchen-sink)
     add_subdirectory(examples/phosphor-bar-canvas-demo)
     add_subdirectory(examples/phosphor-osd-demo)
+    add_subdirectory(examples/phosphor-toast-demo)
 endif()
 
 # phosphor-perscreen-demo. Acceptance harness for the Phosphor.Shell

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,6 +666,8 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples")
 #   phosphor-ipc-demo    — three IpcTargets driven via phosphorctl.
 #   phosphor-widgets-kitchen-sink — every Phosphor.Widgets atom in its
 #                            enabled/disabled states (widgets + theme).
+#   phosphor-bar-canvas-demo — connected-corner bar; a popout grows out of
+#                            the bar as one Shape, toggled via PopoutService.
 if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(examples/phosphor-theme-demo)
     add_subdirectory(examples/phosphor-theme-cli)
@@ -673,6 +675,7 @@ if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(examples/phosphor-registry-demo)
     add_subdirectory(examples/phosphor-ipc-demo)
     add_subdirectory(examples/phosphor-widgets-kitchen-sink)
+    add_subdirectory(examples/phosphor-bar-canvas-demo)
 endif()
 
 # phosphor-perscreen-demo. Acceptance harness for the Phosphor.Shell

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(libs/phosphor-ipc)     # JSON-over-Unix-socket IpcRouter + IpcTarget QML type
     add_subdirectory(cli/phosphorctl)       # phosphorctl call / list / schema / subscribe
     add_subdirectory(libs/phosphor-shell)   # shell infrastructure and QML types
+    add_subdirectory(libs/phosphor-shell-widgets)  # Phosphor.Widgets M3 atom library (Phase 3.1); depends on phosphor-theme
 endif()
 add_subdirectory(libs/phosphor-engine)  # unified placement engine contracts + window registry (SHARED lib)
 add_subdirectory(libs/phosphor-workspaces)  # virtual desktop / workspace management
@@ -663,12 +664,15 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples")
 #   phosphor-registry-demo — in-process IBarWidgetFactory registration
 #                            (registry + theme).
 #   phosphor-ipc-demo    — three IpcTargets driven via phosphorctl.
+#   phosphor-widgets-kitchen-sink — every Phosphor.Widgets atom in its
+#                            enabled/disabled states (widgets + theme).
 if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(examples/phosphor-theme-demo)
     add_subdirectory(examples/phosphor-theme-cli)
     add_subdirectory(examples/phosphor-popout-demo)
     add_subdirectory(examples/phosphor-registry-demo)
     add_subdirectory(examples/phosphor-ipc-demo)
+    add_subdirectory(examples/phosphor-widgets-kitchen-sink)
 endif()
 
 # phosphor-perscreen-demo. Acceptance harness for the Phosphor.Shell

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(cli/phosphorctl)       # phosphorctl call / list / schema / subscribe
     add_subdirectory(libs/phosphor-shell)   # shell infrastructure and QML types
     add_subdirectory(libs/phosphor-shell-widgets)  # Phosphor.Widgets M3 atom library (Phase 3.1); depends on phosphor-theme
+    add_subdirectory(libs/phosphor-shell-osd)      # Phosphor.OSD on-screen-display framework (Phase 3.3); depends on theme + widgets
 endif()
 add_subdirectory(libs/phosphor-engine)  # unified placement engine contracts + window registry (SHARED lib)
 add_subdirectory(libs/phosphor-workspaces)  # virtual desktop / workspace management
@@ -668,6 +669,8 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/examples")
 #                            enabled/disabled states (widgets + theme).
 #   phosphor-bar-canvas-demo — connected-corner bar; a popout grows out of
 #                            the bar as one Shape, toggled via PopoutService.
+#   phosphor-osd-demo — OSDHost overlay; the four built-in OSDs via
+#                            Registry<IOSDFactory>, driven by phosphorctl.
 if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(examples/phosphor-theme-demo)
     add_subdirectory(examples/phosphor-theme-cli)
@@ -676,6 +679,7 @@ if(BUILD_PHOSPHOR_SHELL)
     add_subdirectory(examples/phosphor-ipc-demo)
     add_subdirectory(examples/phosphor-widgets-kitchen-sink)
     add_subdirectory(examples/phosphor-bar-canvas-demo)
+    add_subdirectory(examples/phosphor-osd-demo)
 endif()
 
 # phosphor-perscreen-demo. Acceptance harness for the Phosphor.Shell

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -906,7 +906,7 @@ Lives in a dedicated `libs/phosphor-shell-widgets/` library shipping the `Phosph
 - [ ] Accent cycle retints every atom live
 - [x] All colours/timing/state opacities route through `Theme` / `Motion` / `StateLayer` (no literals)
 
-**Known limitation:** `PhosphorRipple`'s expanding circle is not rounded-clipped (`Item.clip` is rectangular); the resting state-layer tint honours `radius`. Adopts the shared rounded-clip primitive when 3.2 lands.
+**Known limitation:** `PhosphorRipple`'s expanding circle is not rounded-clipped (`Item.clip` is rectangular). The resting state-layer tint honours `radius`. Adopts the shared rounded-clip primitive when 3.2 lands.
 
 **Effort:** M (~2 weeks)
 

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -935,15 +935,24 @@ Lives in `phosphor-shell-widgets` alongside the 3.1 atoms (same `Phosphor.Widget
 
 **Effort:** L (~3 weeks, the geometry math is the bulk)
 
-### 3.3: OSD framework + first OSDs
+### 3.3: OSD framework + first OSDs *(scaffolded)*
 
-| Deliverable                                                  | Notes                                                                                       |
-|--------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `qml/Phosphor/OSD/OSDHost.qml`                               | Single layer-shell surface per screen. Owns timers / debounce / dedupe.                     |
-| Built-in OSDs (`VolumeOSD`, `BrightnessOSD`, `MicOSD`, `CapsLockOSD`) | Registered via `IOSDFactory`.                                                       |
-| `examples/phosphor-osd-demo/`                                | Standalone window that displays the OSD layer overlay; `phosphorctl call osd.show volume 62` triggers it. |
+Lives in a new `phosphor-shell-osd` library (module `Phosphor.OSD`), depending on theme + widgets. `OSDHost` is screen-agnostic and routed by name (compose one per monitor via `PerScreen`); the layer-shell surface is the shell's job in Phase 4, so the framework renders into whatever item it's parented to.
+
+| Deliverable                                                  | Status | Notes                                                                                       |
+|--------------------------------------------------------------|--------|---------------------------------------------------------------------------------------------|
+| `libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml`       | scaffolded | One-at-a-time OSD surface manager: hold timer, debounce/dedupe (repeat = update + restart, not recreate), state-driven opacity+scale fade (Motion tokens), and `screenName`/`targetScreen` routing. Delegates come from a `provider` (createOSD(kind, parent)). |
+| `OSDCard` + `VolumeOSD` / `BrightnessOSD` / `MicOSD` / `CapsLockOSD` | scaffolded | Shared elevated card chrome (glyph + label + optional progress) and the four built-ins (QtQuick.Shapes glyphs). Registered via `IOSDFactory` (the demo wraps each in a `QmlComponentOSDFactory` held in a `Registry<IOSDFactory>`). |
+| `libs/phosphor-shell-osd/tests/`                             | scaffolded | QtQuickTest (9 cases): creation, dedupe, kind-swap, per-screen routing, empty-target broadcast, the shown signal, and the full auto-hide lifecycle. |
+| `examples/phosphor-osd-demo/`                                | scaffolded | OSDHost overlay driven by in-window buttons and by `phosphorctl call osd.show --arg kind=volume --arg value=62` (an `osd` IpcTarget). The four OSDs come from OSDController's `Registry<IOSDFactory>`. |
 
 **Acceptance:** repeated triggers restart the timer; multi-screen routing works; theme-tinted; uses Motion tokens for fade.
+- [x] Repeat restarts the timer (dedupe path reuses the delegate; unit-tested).
+- [x] Multi-screen routing (by `screenName`/`targetScreen`; unit-tested) — one OSDHost per monitor via PerScreen in production.
+- [x] Theme-tinted + Motion-token fade (card uses theme tokens; show/hide transitions use Motion emphasized/standard).
+- [x] `phosphorctl call osd.show` triggers every OSD end-to-end (verified live against the running demo).
+
+**Note:** `OSDHost` defers delegate teardown via `Qt.callLater`. `show()` is dispatched synchronously from C++ by the IPC router (meta-object call); destroying a QML object inline inside such a call corrupts the invoked function's return-value marshalling (the caller saw `false`). Deferring the destroy fixes that and is the right place to tear down anyway. The drop shadow (ElevationShadow / MultiEffect) needs a GPU; it does not render under the headless software/offscreen path used for CI screenshots, but does on a real session.
 
 **Effort:** M (~2 weeks)
 

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -956,18 +956,28 @@ Lives in a new `phosphor-shell-osd` library (module `Phosphor.OSD`), depending o
 
 **Effort:** M (~2 weeks)
 
-### 3.4: Toast framework
+### 3.4: Toast framework *(scaffolded)*
 
-| Deliverable                                                  | Notes                                                                                            |
-|--------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| `qml/Phosphor/Notifications/ToastHost.qml` + `Toast.qml`     | Layer-shell surface per screen, stacks toasts top-right. Slide-in from edge, auto-dismiss, hover-to-pause. |
-| `examples/phosphor-toast-demo/`                              | Send a notification via `notify-send` and a toast appears. Uses `phosphor-service-notifications` from Phase 2.5. |
+Lives in a new `phosphor-shell-notifications` library (module `Phosphor.Notifications`), depending on theme + widgets. `ToastHost` renders into whatever it's parented to; the layer-shell surface per screen is the shell's job in Phase 4 (compose via `PerScreen`).
+
+| Deliverable                                                  | Status | Notes                                                                                            |
+|--------------------------------------------------------------|--------|--------------------------------------------------------------------------------------------------|
+| `libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml` | scaffolded | Top-right stack: shows up to `maxVisible`, queues the rest, dismiss + promote. Slide-in / slide-out / reflow via ListView add/remove/displaced transitions (Motion). Per-app-rules seam (`rules.evaluate(toast) -> {suppress, timeout}`). |
+| `Toast.qml`                                                  | scaffolded | A toast card: optional image, app name, summary, rich-text (`StyledText`) body, close, critical-urgency accent stripe, hover-to-pause auto-dismiss. |
+| `libs/phosphor-shell-notifications/tests/`                   | scaffolded | QtQuickTest (9 cases): show, queue beyond max, dismiss + promote, the dismissed signal, unknown-id safety, clear, and the rules seam (suppress + pass-through). |
+| `examples/phosphor-toast-demo/`                              | scaffolded | ToastHost overlay fed by a real `NotificationServer` (so `notify-send` raises a toast when this process owns the bus name) plus in-window buttons; a Do-Not-Disturb pill exercises the rules seam. |
 
 **Acceptance:** toasts queue, dismiss correctly; rich text + image support; the per-app-rules consumption seam exists and applies any rules supplied by the rules service. The rules editor and its persistence layer belong to Phase 4.3 (Notification center) and wire into this seam without changes to ToastHost.
+- [x] Queue + dismiss + promote (unit-tested).
+- [x] Rich text + image (verified in an offscreen render: bold body markup, image avatar, critical accent stripe).
+- [x] Per-app-rules seam applies (suppress unit-tested; DND pill in the demo).
+- [ ] `notify-send` → toast on a live session owning the bus name (offscreen can't own it; wired and ready for a real-session check).
+
+**Note:** toast/card backgrounds use `ElevationShadow` (MultiEffect), which needs a GPU and does not render under the headless offscreen path; content (text/image/stripe) renders regardless.
 
 **Effort:** M (~2 weeks)
 
-**Phase 3 gate:** All four examples runnable. The connected-corner bar demo is the headline, visually identical to the mockup. Tag `phosphor-ui-primitives-0.1`.
+**Phase 3 gate:** All four examples runnable (`phosphor-widgets-kitchen-sink`, `phosphor-bar-canvas-demo`, `phosphor-osd-demo`, `phosphor-toast-demo`). The connected-corner bar demo is the headline, visually identical to the mockup. Tag `phosphor-ui-primitives-0.1`.
 
 ---
 

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -912,14 +912,26 @@ Lives in a dedicated `libs/phosphor-shell-widgets/` library shipping the `Phosph
 
 ### 3.2: `ConnectedCorner` / `ConnectedShape` / `BarCanvas`
 
-The connected-corner geometry primitive, central to the visual identity.
+The connected-corner geometry primitive, central to the visual identity. *(scaffolded)*
 
-| Deliverable                                                                          | Notes                                                                                   |
-|--------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
-| `qml/Phosphor/Widgets/{ConnectedShape,ConnectedCorner,BarCanvas}.qml`               | QML `Shape` + JS geometry (`ConnectorGeometry.js`). Sockets are a binding; geometry recomputes on socket change with `Behavior on …` Motion easing. |
-| `examples/phosphor-bar-canvas-demo/`                                                 | A standalone bar with one button that opens a popout. The popout grows out of the bar with the inverted-corner join, exactly the animation from `mockups/control-center.svg`. |
+Lives in `phosphor-shell-widgets` alongside the 3.1 atoms (same `Phosphor.Widgets` module), so the bar surface and the widgets it hosts share one import.
+
+| Deliverable                                                                          | Status | Notes                                                                                   |
+|--------------------------------------------------------------------------------------|--------|-----------------------------------------------------------------------------------------|
+| `qml/Phosphor/Widgets/ConnectorGeometry.js`                                          | scaffolded | `.pragma library` path math: builds the SVG `d` string for the bar outline weaving sockets into its bottom edge (convex pocket-floor corners, concave/inverted top corners, sweep flags matching the mockups). Degrades to a flat edge at `depth <= 0.5`. |
+| `qml/Phosphor/Widgets/ConnectedShape.qml`                                            | scaffolded | Generic `Shape` + `ShapePath` + `PathSvg` painter for a path string; `CurveRenderer` antialiasing; theme fill retints live. The renderer behind `BarCanvas`. |
+| `qml/Phosphor/Widgets/ConnectedCorner.qml`                                           | scaffolded | Standalone concave / convex quarter-fillet primitive for hand-composing joins. |
+| `qml/Phosphor/Widgets/BarCanvas.qml`                                                 | scaffolded | Bar surface: `sockets` ([{x,width,depth}]) drives the path; default children land in the bar strip; `pathData` exposed for tests. The host animates a socket's `depth` to morph the shape. |
+| `examples/phosphor-bar-canvas-demo/`                                                 | scaffolded | Floating bar with a "Control Center" button. Toggling it grows a centred popout out of the bar with the inverted-corner join (the `control-center.svg` animation). Routes through a real `PopoutController` via a minimal `SocketPopoutTransport`; pocket content reuses the 3.1 atoms. |
+| `libs/phosphor-shell-widgets/tests/tst_connector.qml`                                | scaffolded | Geometry contract via `BarCanvas.pathData`: 4 arcs socketless, 8 with an open socket, exactly one sweep-0 (left inverted) corner, zero-depth collapses to flat, `implicitHeight` reserves pocket depth. |
 
 **Acceptance:** opening/closing the popout morphs the shared Shape; one popout per bar; uses `PopoutService` from Phase 1.2.
+- [x] Socket morph: `pathData` grows/collapses with `depth` (unit-tested); demo animates `depth` via `Behavior` + Motion `emphasized`.
+- [x] One popout per bar: enforced by the `PopoutController` (Cooperative, single scope).
+- [x] Uses `PopoutService`: the demo's button toggles through `PopoutController`; the socket binds the controller's open-state.
+- [x] Visual match to the mockup confirmed via an offscreen render (bar floats on the wallpaper, popout grows out of it, concave/inverted joins correct). A human eyeball pass on a live GPU session is still nice-to-have.
+
+**Note:** the demo backdrop is a darkened brand gradient (wallpaper-like) on purpose. An early flat-navy backdrop was near-identical to `surface_container`, which made the (correct) painted pocket read as an inverted notch. A real shell sits on a photo wallpaper, so this is a demo-presentation fix, not a geometry change.
 
 **Effort:** L (~3 weeks, the geometry math is the bulk)
 

--- a/docs/phosphor-shell-design/04-implementation-plan.md
+++ b/docs/phosphor-shell-design/04-implementation-plan.md
@@ -890,14 +890,23 @@ A bounded timeout guards step 3 (see Risks) so a missing or slow lock never wedg
 
 **Goal:** end-user-visible building blocks that we'll glue together in Phase 4. Each is a runnable demo, not a real shell surface yet.
 
-### 3.1: `Phosphor*` atom library
+### 3.1: `Phosphor*` atom library *(in progress)*
 
-| Deliverable                                                                  | Notes                                                                            |
-|------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| `qml/Phosphor/Widgets/` (or `libs/phosphor-shell-widgets/qml/`)              | `PhosphorButton`, `PhosphorSlider`, `PhosphorTextField`, `PhosphorCard`, `PhosphorRipple`, `PhosphorPill`, `ElevationShadow`, `StateLayer`, `Motion`-aware transitions |
-| `examples/phosphor-widgets-kitchen-sink/`                                    | One window listing every atom in every state (default / hover / pressed / focused / disabled). Theme-switch button at top. |
+Lives in a dedicated `libs/phosphor-shell-widgets/` library shipping the `Phosphor.Widgets` QML module (chosen over folding the atoms into `phosphor-shell` so the seam stays clean and the library-first philosophy holds). `StateLayer` and `Motion` are NOT re-created here: they already ship as singletons in `phosphor-theme`'s `Phosphor.Theme` module, and the atoms consume them directly. The new components are the seven below.
+
+| Deliverable                                                                  | Status | Notes                                                                            |
+|------------------------------------------------------------------------------|--------|----------------------------------------------------------------------------------|
+| `libs/phosphor-shell-widgets/qml/Phosphor/Widgets/`                          | scaffolded | `PhosphorButton` (4 variants), `PhosphorSlider`, `PhosphorTextField`, `PhosphorCard`, `PhosphorPill`, `PhosphorRipple` (shared hover/press state-layer + touch ripple), `ElevationShadow` (M3 levels 0-5, used as a `layer.effect`). Pure QML; all colours via `Theme.*`, all timing via `Motion.*`, all state opacities via `StateLayer.*`. |
+| `libs/phosphor-shell-widgets/{CMakeLists.txt, …Config.cmake.in, README.md}`  | scaffolded | Static QML module mirroring the `phosphor-theme` / `phosphor-popout` split (glue TU + `qt_add_qml_module`, `IMPORTS Phosphor.Theme QtQuick.Effects`, links the theme QML plugin). Canonical phosphor-* README. |
+| `libs/phosphor-shell-widgets/tests/`                                         | scaffolded | QtQuickTest harness (`tst_atoms.qml`) pinning each atom's default property surface + the pure logic (slider ratio clamp, `from == to` safety, elevation level clamp). Offscreen QPA, ctest-integrated. |
+| `examples/phosphor-widgets-kitchen-sink/`                                    | scaffolded | One scrollable window listing every atom in enabled/disabled states; hover/press/focus are live on the enabled specimens. Header cycles the accent token (`applyTokens`) and resets the palette to prove live retinting. |
 
 **Acceptance:** every atom respects the theme tokens; states use M3 state-layer opacities; ripple uses Motion timing.
+- [ ] Build + kitchen-sink demo runnable (pending a `-DBUILD_PHOSPHOR_SHELL=ON` build on a KDE/Qt host)
+- [ ] Accent cycle retints every atom live
+- [x] All colours/timing/state opacities route through `Theme` / `Motion` / `StateLayer` (no literals)
+
+**Known limitation:** `PhosphorRipple`'s expanding circle is not rounded-clipped (`Item.clip` is rectangular); the resting state-layer tint honours `radius`. Adopts the shared rounded-clip primitive when 3.2 lands.
 
 **Effort:** M (~2 weeks)
 

--- a/examples/phosphor-bar-canvas-demo/BarDemoController.h
+++ b/examples/phosphor-bar-canvas-demo/BarDemoController.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <QObject>
+
+#include <memory>
+
+namespace PhosphorPopout {
+class PopoutController;
+}
+
+namespace PhosphorBarCanvasDemo {
+
+class SocketPopoutTransport;
+
+// QML-exposed glue for the bar-canvas demo. Owns a real PopoutController
+// (the Phase-1.2 PopoutService) plus the demo's SocketPopoutTransport,
+// and mirrors the controller's open-state for the one demo popout into a
+// Q_PROPERTY the QML binds the socket animation to. The button calls
+// toggleControlCenter(); arbitration (one popout per scope, toggle) is
+// the controller's, exactly as the production shell will drive it.
+class BarDemoController : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool controlCenterOpen READ controlCenterOpen NOTIFY controlCenterOpenChanged)
+
+public:
+    explicit BarDemoController(QObject* parent = nullptr);
+    ~BarDemoController() override;
+
+    // Toggle the Control Center popout through the PopoutController.
+    Q_INVOKABLE void toggleControlCenter();
+
+    [[nodiscard]] bool controlCenterOpen() const;
+
+    // Close everything before the engine tears down QML bindings. Wired
+    // to QGuiApplication::aboutToQuit in main.cpp.
+    void shutdown();
+
+Q_SIGNALS:
+    void controlCenterOpenChanged();
+
+private:
+    // Declaration order is load-bearing: the controller's destructor
+    // detaches its dismissed-callback from the transport, so the
+    // transport must outlive the controller. C++ destroys members in
+    // reverse-declaration order, so the transport is declared first.
+    std::unique_ptr<SocketPopoutTransport> m_transport;
+    std::unique_ptr<PhosphorPopout::PopoutController> m_controller;
+    bool m_controlCenterOpen = false;
+};
+
+} // namespace PhosphorBarCanvasDemo

--- a/examples/phosphor-bar-canvas-demo/CMakeLists.txt
+++ b/examples/phosphor-bar-canvas-demo/CMakeLists.txt
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# phosphor-bar-canvas-demo, the Phase 3.2 acceptance demo for the
+# connected-corner geometry. A floating bar whose "Control Center" button
+# opens a popout that grows out of the bar as one painted Shape. The
+# toggle routes through a real PopoutController (PopoutService, Phase 1.2)
+# via a minimal SocketPopoutTransport.
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2 QuickShapes)
+
+if(COMMAND qt_policy)
+    qt_policy(SET QTP0001 NEW)
+endif()
+
+# Directory-scope suppression of -Wmissing-include-dirs for the targets
+# qt_add_qml_module generates here. Full rationale: src/shared/CMakeLists.txt.
+set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-Wno-missing-include-dirs")
+
+# Bundle the demo QML into its own static module so qmlcachegen compiles
+# it and the resources are reachable via qrc:/qt/qml/Phosphor/BarCanvasDemo/.
+qt_add_qml_module(phosphor_bar_canvas_demo_qml
+    URI Phosphor.BarCanvasDemo
+    VERSION 1.0
+    STATIC
+    RESOURCE_PREFIX /qt/qml
+    OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Phosphor/BarCanvasDemo
+    IMPORTS
+        Phosphor.Theme
+        Phosphor.Widgets
+    QML_FILES
+        Main.qml
+)
+
+target_link_libraries(phosphor_bar_canvas_demo_qml
+    PRIVATE
+        PhosphorShellWidgets::PhosphorShellWidgetsQml
+        Qt6::Quick
+)
+
+target_compile_features(phosphor_bar_canvas_demo_qml PRIVATE cxx_std_20)
+
+add_executable(phosphor-bar-canvas-demo
+    main.cpp
+    BarDemoController.h
+    bardemocontroller.cpp
+    SocketPopoutTransport.h
+    socketpopouttransport.cpp
+)
+
+target_compile_features(phosphor-bar-canvas-demo PRIVATE cxx_std_20)
+
+target_link_libraries(phosphor-bar-canvas-demo
+    PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        Qt6::QuickShapes
+        # The demo C++ drives the real PopoutController + PopoutRequest +
+        # IPopoutTransport from phosphor-popout's C++ core.
+        PhosphorPopout::PhosphorPopout
+        # Static QML modules ship a library and a plugin registrar; the
+        # registrar publishes the module to QQmlEngine at runtime. Link the
+        # demo module, the widgets module + plugin, and the theme module +
+        # plugin (the demo and BarCanvas import both).
+        phosphor_bar_canvas_demo_qmlplugin
+        PhosphorShellWidgets::PhosphorShellWidgetsQml
+        PhosphorShellWidgetsQmlplugin
+        PhosphorThemeQml
+        PhosphorThemeQmlplugin
+)

--- a/examples/phosphor-bar-canvas-demo/Main.qml
+++ b/examples/phosphor-bar-canvas-demo/Main.qml
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+// phosphor-bar-canvas-demo, the Phase 3.2 acceptance demo.
+//
+// A floating bar with a "Control Center" button. Toggling it opens a
+// popout that grows out of the bar as one continuous painted surface,
+// with the concave/inverted corner join from the mockups
+// (docs/phosphor-shell-design/mockups/control-center.svg). The toggle
+// routes through a real PopoutController (PopoutService, Phase 1.2): the
+// socket animation binds to the controller's open-state, and the popout
+// content reuses the Phase 3.1 atoms.
+
+import Phosphor.Theme
+import Phosphor.Widgets
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ApplicationWindow {
+    id: root
+
+    readonly property real margin: 16
+
+    width: 960
+    height: 640
+    visible: true
+    title: qsTr("Phosphor Bar Canvas, Connected Corner")
+
+    // A wallpaper-like backdrop (darkened brand gradient) so the
+    // surface_container bar clearly floats on it and the connected-corner
+    // shape reads. A real shell sits on a photo wallpaper; a flat navy
+    // backdrop here would be near-identical to surface_container and make
+    // the painted pocket invisible.
+    Rectangle {
+        anchors.fill: parent
+        gradient: Gradient {
+            GradientStop {
+                position: 0.0
+                color: Qt.darker(Theme.brand_stop_0, 1.6)
+            }
+            GradientStop {
+                position: 0.55
+                color: Qt.darker(Theme.brand_stop_1, 1.4)
+            }
+            GradientStop {
+                position: 1.0
+                color: Qt.darker(Theme.brand_stop_2, 1.25)
+            }
+        }
+    }
+
+    BarCanvas {
+        id: bar
+
+        // Socket placement: a centred pocket the Control Center fills.
+        readonly property real socketW: 360
+        readonly property real socketX: (width - socketW) / 2
+        // Animated pocket depth, driven by the PopoutService open-state.
+        property real ccDepth: barController.controlCenterOpen ? 380 : 0
+
+        x: root.margin
+        y: root.margin
+        width: parent.width - root.margin * 2
+        height: barHeight + Math.max(0, ccDepth)
+        barHeight: 48
+        cornerRadius: 16
+        connectorRadius: 18
+        color: Theme.surface_container
+        // Below ~0.5 the socket reads as closed (flat edge), so the
+        // animation grows the pocket out of nothing and removes it cleanly.
+        sockets: ccDepth > 0.5 ? [
+            {
+                "x": socketX,
+                "width": socketW,
+                "depth": ccDepth
+            }
+        ] : []
+
+        Behavior on ccDepth {
+            NumberAnimation {
+                duration: Motion.duration_long_2
+                easing: Motion.emphasized
+            }
+        }
+
+        // Bar strip widgets (default children land in the strip band).
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: 20
+            anchors.rightMargin: 12
+            spacing: 12
+
+            Label {
+                text: Qt.formatTime(new Date(), "HH:mm")
+                color: Theme.on_surface
+                font.pixelSize: 15
+                font.weight: Font.Medium
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
+
+            PhosphorPill {
+                text: qsTr("Control Center")
+                selected: barController.controlCenterOpen
+                onClicked: barController.toggleControlCenter()
+            }
+        }
+    }
+
+    // Control Center popout content, drawn over the bar's pocket so the
+    // painted socket and the content read as one surface. Clipped to the
+    // pocket and faded in as it opens.
+    Item {
+        x: bar.x + bar.socketX
+        y: bar.y + bar.barHeight
+        width: bar.socketW
+        height: Math.max(0, bar.ccDepth)
+        clip: true
+        opacity: barController.controlCenterOpen ? 1 : 0
+
+        Behavior on opacity {
+            NumberAnimation {
+                duration: Motion.duration_short_3
+                easing: Motion.standard
+            }
+        }
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 24
+            spacing: 16
+
+            Label {
+                text: qsTr("Control Center")
+                color: Theme.on_surface
+                font.pixelSize: 16
+                font.weight: Font.DemiBold
+            }
+
+            Flow {
+                Layout.fillWidth: true
+                spacing: 10
+
+                PhosphorPill {
+                    property bool checked: true
+
+                    text: qsTr("Wi-Fi")
+                    selected: checked
+                    onToggled: checked = !checked
+                }
+
+                PhosphorPill {
+                    property bool checked: false
+
+                    text: qsTr("Bluetooth")
+                    selected: checked
+                    onToggled: checked = !checked
+                }
+
+                PhosphorPill {
+                    property bool checked: false
+
+                    text: qsTr("Night light")
+                    selected: checked
+                    onToggled: checked = !checked
+                }
+            }
+
+            Label {
+                text: qsTr("Brightness")
+                color: Theme.on_surface_variant
+                font.pixelSize: 12
+            }
+
+            PhosphorSlider {
+                Layout.fillWidth: true
+                from: 0
+                to: 100
+                value: 65
+            }
+
+            Item {
+                Layout.fillHeight: true
+            }
+        }
+    }
+}

--- a/examples/phosphor-bar-canvas-demo/Main.qml
+++ b/examples/phosphor-bar-canvas-demo/Main.qml
@@ -119,6 +119,10 @@ ApplicationWindow {
         height: Math.max(0, bar.ccDepth)
         clip: true
         opacity: barController.controlCenterOpen ? 1 : 0
+        // Gate input off immediately on close: opacity-0 items stay
+        // hit-testable, and the height collapse outlasts the opacity fade,
+        // so without this the invisible controls remain clickable mid-close.
+        enabled: barController.controlCenterOpen
 
         Behavior on opacity {
             NumberAnimation {

--- a/examples/phosphor-bar-canvas-demo/Main.qml
+++ b/examples/phosphor-bar-canvas-demo/Main.qml
@@ -19,7 +19,7 @@ import QtQuick.Layouts
 ApplicationWindow {
     id: root
 
-    readonly property real margin: 16
+    readonly property real margin: Tokens.spacing_l
 
     width: 960
     height: 640
@@ -63,8 +63,8 @@ ApplicationWindow {
         width: parent.width - root.margin * 2
         height: barHeight + Math.max(0, ccDepth)
         barHeight: 48
-        cornerRadius: 16
-        connectorRadius: 18
+        cornerRadius: Tokens.radius_l
+        connectorRadius: Tokens.radius_l
         color: Theme.surface_container
         // Below ~0.5 the socket reads as closed (flat edge), so the
         // animation grows the pocket out of nothing and removes it cleanly.
@@ -86,15 +86,15 @@ ApplicationWindow {
         // Bar strip widgets (default children land in the strip band).
         RowLayout {
             anchors.fill: parent
-            anchors.leftMargin: 20
-            anchors.rightMargin: 12
-            spacing: 12
+            anchors.leftMargin: Tokens.spacing_l
+            anchors.rightMargin: Tokens.spacing_m
+            spacing: Tokens.spacing_m
 
             Label {
                 text: Qt.formatTime(new Date(), "HH:mm")
                 color: Theme.on_surface
-                font.pixelSize: 15
-                font.weight: Font.Medium
+                font.pixelSize: Tokens.font_size_title_s
+                font.weight: Tokens.font_weight_medium
             }
 
             Item {
@@ -129,19 +129,19 @@ ApplicationWindow {
 
         ColumnLayout {
             anchors.fill: parent
-            anchors.margins: 24
-            spacing: 16
+            anchors.margins: Tokens.spacing_xl
+            spacing: Tokens.spacing_l
 
             Label {
                 text: qsTr("Control Center")
                 color: Theme.on_surface
-                font.pixelSize: 16
-                font.weight: Font.DemiBold
+                font.pixelSize: Tokens.font_size_title_m
+                font.weight: Tokens.font_weight_demibold
             }
 
             Flow {
                 Layout.fillWidth: true
-                spacing: 10
+                spacing: Tokens.spacing_s
 
                 PhosphorPill {
                     property bool checked: true
@@ -171,7 +171,7 @@ ApplicationWindow {
             Label {
                 text: qsTr("Brightness")
                 color: Theme.on_surface_variant
-                font.pixelSize: 12
+                font.pixelSize: Tokens.font_size_body_s
             }
 
             PhosphorSlider {

--- a/examples/phosphor-bar-canvas-demo/SocketPopoutTransport.h
+++ b/examples/phosphor-bar-canvas-demo/SocketPopoutTransport.h
@@ -4,7 +4,6 @@
 
 #include <PhosphorPopout/IPopoutTransport.h>
 
-#include <QHash>
 #include <QString>
 
 #include <functional>
@@ -13,11 +12,11 @@ namespace PhosphorBarCanvasDemo {
 
 // Minimal IPopoutTransport for the connected-corner demo. In the
 // connected-corner design the popout body is drawn inside the bar's own
-// painted Shape (the socket), so there is no separate layer-shell
-// surface to create: this transport only hands back opaque handles so the
-// PopoutController's arbitration state machine has something to track.
-// The visible open/close is the BarCanvas socket growing, driven off the
-// controller's popoutOpened / popoutClosed signals.
+// painted Shape (the socket), so there is no separate layer-shell surface
+// to create: this transport only hands back unique non-empty handles so
+// the PopoutController accepts the open. The visible open/close is the
+// BarCanvas socket growing, driven off the controller's popoutOpened /
+// popoutClosed signals.
 //
 // This is the same seam the production shell fills with a real
 // layer-shell-backed transport; swapping is a dependency-injection flip.
@@ -30,7 +29,6 @@ public:
 
 private:
     int m_counter = 0;
-    QHash<QString, QString> m_open; // handle -> popoutId
     // Stored to honour the contract (the controller installs one and
     // detaches it on teardown). This transport never self-dismisses, so
     // it is never invoked.

--- a/examples/phosphor-bar-canvas-demo/SocketPopoutTransport.h
+++ b/examples/phosphor-bar-canvas-demo/SocketPopoutTransport.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <PhosphorPopout/IPopoutTransport.h>
+
+#include <QHash>
+#include <QString>
+
+#include <functional>
+
+namespace PhosphorBarCanvasDemo {
+
+// Minimal IPopoutTransport for the connected-corner demo. In the
+// connected-corner design the popout body is drawn inside the bar's own
+// painted Shape (the socket), so there is no separate layer-shell
+// surface to create: this transport only hands back opaque handles so the
+// PopoutController's arbitration state machine has something to track.
+// The visible open/close is the BarCanvas socket growing, driven off the
+// controller's popoutOpened / popoutClosed signals.
+//
+// This is the same seam the production shell fills with a real
+// layer-shell-backed transport; swapping is a dependency-injection flip.
+class SocketPopoutTransport : public PhosphorPopout::IPopoutTransport
+{
+public:
+    [[nodiscard]] QString openSurface(const PhosphorPopout::PopoutRequest& request) override;
+    void closeSurface(const QString& handle) override;
+    void setSurfaceDismissedCallback(std::function<void(const QString&)> callback) override;
+
+private:
+    int m_counter = 0;
+    QHash<QString, QString> m_open; // handle -> popoutId
+    // Stored to honour the contract (the controller installs one and
+    // detaches it on teardown). This transport never self-dismisses, so
+    // it is never invoked.
+    std::function<void(const QString&)> m_dismissed;
+};
+
+} // namespace PhosphorBarCanvasDemo

--- a/examples/phosphor-bar-canvas-demo/bardemocontroller.cpp
+++ b/examples/phosphor-bar-canvas-demo/bardemocontroller.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "BarDemoController.h"
+
+#include "SocketPopoutTransport.h"
+
+#include <PhosphorPopout/PopoutController.h>
+#include <PhosphorPopout/PopoutRequest.h>
+
+#include <QStringLiteral>
+
+namespace PhosphorBarCanvasDemo {
+
+namespace {
+const QString kControlCenterId = QStringLiteral("control-center");
+}
+
+BarDemoController::BarDemoController(QObject* parent)
+    : QObject(parent)
+    , m_transport(std::make_unique<SocketPopoutTransport>())
+    , m_controller(std::make_unique<PhosphorPopout::PopoutController>(m_transport.get()))
+{
+    // Mirror the controller's open-state for our one demo popout into the
+    // Q_PROPERTY. popoutClosed fires regardless of who closed it (button,
+    // toggle, or arbitration), so the bound socket always reflects truth.
+    connect(m_controller.get(), &PhosphorPopout::PopoutController::popoutOpened, this,
+            [this](const QString& popoutId, const QString&) {
+                if (popoutId == kControlCenterId && !m_controlCenterOpen) {
+                    m_controlCenterOpen = true;
+                    Q_EMIT controlCenterOpenChanged();
+                }
+            });
+    connect(m_controller.get(), &PhosphorPopout::PopoutController::popoutClosed, this,
+            [this](const QString& popoutId, const QString&) {
+                if (popoutId == kControlCenterId && m_controlCenterOpen) {
+                    m_controlCenterOpen = false;
+                    Q_EMIT controlCenterOpenChanged();
+                }
+            });
+}
+
+BarDemoController::~BarDemoController() = default;
+
+void BarDemoController::toggleControlCenter()
+{
+    PhosphorPopout::PopoutRequest request;
+    request.popoutId = kControlCenterId;
+    request.exclusive = PhosphorPopout::ExclusiveMode::Cooperative;
+    request.anchor = PhosphorPopout::Anchor::BarCenter;
+    // Content is painted by the BarCanvas socket, not a transport surface.
+    request.content = nullptr;
+    // The demo drives open/close from the button, not focus loss.
+    request.dismissOnFocusLoss = false;
+    (void)m_controller->toggle(request);
+}
+
+bool BarDemoController::controlCenterOpen() const
+{
+    return m_controlCenterOpen;
+}
+
+void BarDemoController::shutdown()
+{
+    if (m_controller)
+        m_controller->closeAll();
+}
+
+} // namespace PhosphorBarCanvasDemo

--- a/examples/phosphor-bar-canvas-demo/main.cpp
+++ b/examples/phosphor-bar-canvas-demo/main.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// phosphor-bar-canvas-demo entry point.
+//
+// QGuiApplication + QQmlApplicationEngine. Constructs a BarDemoController
+// (which owns the PopoutController + the demo's SocketPopoutTransport),
+// exposes it to QML as a context property, and loads Main.qml. The bar's
+// socket animation binds to the controller's popout open-state.
+
+#include "BarDemoController.h"
+
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include <QQuickStyle>
+#include <QString>
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+    QCoreApplication::setOrganizationName(QStringLiteral("Phosphor"));
+    QCoreApplication::setApplicationName(QStringLiteral("phosphor-bar-canvas-demo"));
+
+    // Basic style keeps QtQuick.Controls chrome out of the token-driven
+    // retint path, matching the other Phosphor demos.
+    QQuickStyle::setStyle(QStringLiteral("Basic"));
+
+    // Declared before the engine so reverse-order destruction tears the
+    // engine down first, while the controller is still alive for any
+    // binding re-evaluation during teardown.
+    PhosphorBarCanvasDemo::BarDemoController barController;
+
+    QQmlApplicationEngine engine;
+    engine.rootContext()->setContextProperty(QStringLiteral("barController"), &barController);
+
+    // Drain popouts before the engine destroys QML objects. DirectConnection
+    // so it runs synchronously inside aboutToQuit, before the event loop
+    // returns and teardown begins.
+    QObject::connect(&app, &QGuiApplication::aboutToQuit, &barController,
+                     &PhosphorBarCanvasDemo::BarDemoController::shutdown, Qt::DirectConnection);
+
+    engine.loadFromModule(QStringLiteral("Phosphor.BarCanvasDemo"), QStringLiteral("Main"));
+    if (engine.rootObjects().isEmpty()) {
+        return 1;
+    }
+    return app.exec();
+}

--- a/examples/phosphor-bar-canvas-demo/socketpopouttransport.cpp
+++ b/examples/phosphor-bar-canvas-demo/socketpopouttransport.cpp
@@ -3,28 +3,24 @@
 
 #include "SocketPopoutTransport.h"
 
-#include <PhosphorPopout/PopoutRequest.h>
-
 #include <QStringLiteral>
 
 #include <utility>
 
 namespace PhosphorBarCanvasDemo {
 
-QString SocketPopoutTransport::openSurface(const PhosphorPopout::PopoutRequest& request)
+QString SocketPopoutTransport::openSurface(const PhosphorPopout::PopoutRequest&)
 {
-    // A non-empty handle tells the controller the open succeeded. The
-    // content is drawn by the BarCanvas socket, not here, so request
-    // content may be null.
-    const QString handle = QStringLiteral("socket-%1").arg(++m_counter);
-    m_open.insert(handle, request.popoutId);
-    return handle;
+    // A unique non-empty handle tells the controller the open succeeded.
+    // The content is drawn by the BarCanvas socket, not here, so the
+    // request (including its possibly-null content) is unused.
+    return QStringLiteral("socket-%1").arg(++m_counter);
 }
 
-void SocketPopoutTransport::closeSurface(const QString& handle)
+void SocketPopoutTransport::closeSurface(const QString&)
 {
-    // Idempotent per the IPopoutTransport contract.
-    m_open.remove(handle);
+    // No surface to tear down (the BarCanvas socket is the visible UI,
+    // driven by the controller's signals). Idempotent no-op per contract.
 }
 
 void SocketPopoutTransport::setSurfaceDismissedCallback(std::function<void(const QString&)> callback)

--- a/examples/phosphor-bar-canvas-demo/socketpopouttransport.cpp
+++ b/examples/phosphor-bar-canvas-demo/socketpopouttransport.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "SocketPopoutTransport.h"
+
+#include <PhosphorPopout/PopoutRequest.h>
+
+#include <QStringLiteral>
+
+#include <utility>
+
+namespace PhosphorBarCanvasDemo {
+
+QString SocketPopoutTransport::openSurface(const PhosphorPopout::PopoutRequest& request)
+{
+    // A non-empty handle tells the controller the open succeeded. The
+    // content is drawn by the BarCanvas socket, not here, so request
+    // content may be null.
+    const QString handle = QStringLiteral("socket-%1").arg(++m_counter);
+    m_open.insert(handle, request.popoutId);
+    return handle;
+}
+
+void SocketPopoutTransport::closeSurface(const QString& handle)
+{
+    // Idempotent per the IPopoutTransport contract.
+    m_open.remove(handle);
+}
+
+void SocketPopoutTransport::setSurfaceDismissedCallback(std::function<void(const QString&)> callback)
+{
+    m_dismissed = std::move(callback);
+}
+
+} // namespace PhosphorBarCanvasDemo

--- a/examples/phosphor-osd-demo/CMakeLists.txt
+++ b/examples/phosphor-osd-demo/CMakeLists.txt
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# phosphor-osd-demo, the Phase 3.3 acceptance demo for the Phosphor.OSD
+# framework. An OSDHost overlay driven by in-window buttons and by
+# `phosphorctl call osd.show <kind> <value>`. The four built-in OSDs are
+# supplied by OSDController's Registry<IOSDFactory>.
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2 QuickShapes)
+
+if(COMMAND qt_policy)
+    qt_policy(SET QTP0001 NEW)
+endif()
+
+# Directory-scope suppression of -Wmissing-include-dirs. Full rationale:
+# src/shared/CMakeLists.txt.
+set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-Wno-missing-include-dirs")
+
+qt_add_qml_module(phosphor_osd_demo_qml
+    URI Phosphor.OsdDemo
+    VERSION 1.0
+    STATIC
+    RESOURCE_PREFIX /qt/qml
+    OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Phosphor/OsdDemo
+    IMPORTS
+        Phosphor.Theme
+        Phosphor.Widgets
+        Phosphor.OSD
+        Phosphor.Ipc
+    QML_FILES
+        Main.qml
+)
+
+target_link_libraries(phosphor_osd_demo_qml
+    PRIVATE
+        PhosphorShellOsd::PhosphorShellOsdQml
+        PhosphorShellWidgets::PhosphorShellWidgetsQml
+        PhosphorIpc::PhosphorIpcQml
+        Qt6::Quick
+)
+
+target_compile_features(phosphor_osd_demo_qml PRIVATE cxx_std_20)
+
+add_executable(phosphor-osd-demo
+    main.cpp
+    OSDController.h
+    osdcontroller.cpp
+    QmlComponentOSDFactory.h
+    qmlcomponentosdfactory.cpp
+)
+
+# Per-build IPC socket so concurrent demos don't collide; overridable at
+# runtime via $PHOSPHOR_SOCKET.
+target_compile_definitions(phosphor-osd-demo
+    PRIVATE PHOSPHOR_OSD_DEMO_SOCKET="${CMAKE_BINARY_DIR}/phosphor-osd-demo.sock"
+)
+
+target_compile_features(phosphor-osd-demo PRIVATE cxx_std_20)
+
+target_link_libraries(phosphor-osd-demo
+    PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        Qt6::QuickShapes
+        # C++ cores: the registry (controller) and the IPC router/engine.
+        PhosphorRegistry::PhosphorRegistry
+        PhosphorIpc::PhosphorIpc
+        # Static QML modules + their plugin registrars so every import in
+        # Main.qml resolves at runtime.
+        phosphor_osd_demo_qmlplugin
+        PhosphorShellOsd::PhosphorShellOsdQml
+        PhosphorShellOsdQmlplugin
+        PhosphorShellWidgets::PhosphorShellWidgetsQml
+        PhosphorShellWidgetsQmlplugin
+        PhosphorIpc::PhosphorIpcQml
+        PhosphorIpcQmlplugin
+        PhosphorThemeQml
+        PhosphorThemeQmlplugin
+)

--- a/examples/phosphor-osd-demo/Main.qml
+++ b/examples/phosphor-osd-demo/Main.qml
@@ -135,7 +135,7 @@ ApplicationWindow {
                 font.pixelSize: Tokens.font_size_body_s
                 textFormat: Text.PlainText
                 wrapMode: Text.WordWrap
-                text: ipcSocketPath.length > 0 ? qsTr("export PHOSPHOR_SOCKET=%1\nphosphorctl call osd.show --arg kind=volume --arg value=62\nphosphorctl call osd.show --arg kind=mic --arg value=1\nphosphorctl schema osd | jq").arg(ipcSocketPath) : qsTr("# IPC router not running; use the buttons above.")
+                text: ipcSocketPath.length > 0 ? qsTr("export PHOSPHOR_SOCKET=%1\nphosphorctl call osd.show --arg kind=volume --arg value=62\nphosphorctl call osd.show --arg kind=mic --arg value=1\nphosphorctl schema osd | jq").arg(ipcSocketPath) : qsTr("# IPC router not running. Use the buttons above.")
             }
         }
     }

--- a/examples/phosphor-osd-demo/Main.qml
+++ b/examples/phosphor-osd-demo/Main.qml
@@ -32,39 +32,41 @@ ApplicationWindow {
     color: Theme.background
 
     // IPC: `phosphorctl call osd.show --arg kind=volume --arg value=62`.
-    // A value of 0 reads as the "off/muted" state for the stateful OSDs.
+    // For the stateful OSDs (mic/caps) a value of 0 reads as off/unmuted
+    // and non-zero as on/muted; value-based OSDs (volume/brightness) ignore
+    // active. Returns OSDHost.show's result so a bad kind reports failure.
     IpcTarget {
         target: "osd"
 
         function show(kind: string, value: int): bool {
-            osdHost.show(kind, value, value !== 0, "");
-            return true;
+            const stateful = kind === "mic" || kind === "caps";
+            return osdHost.show(kind, value, stateful ? value !== 0 : undefined, "");
         }
     }
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.margins: 28
-        spacing: 18
+        anchors.margins: Tokens.spacing_xl
+        spacing: Tokens.spacing_l
 
         Label {
             text: qsTr("On-Screen Displays")
             color: Theme.on_surface
-            font.pixelSize: 20
-            font.weight: Font.DemiBold
+            font.pixelSize: Tokens.font_size_display_s
+            font.weight: Tokens.font_weight_demibold
         }
 
         Label {
             Layout.fillWidth: true
             text: qsTr("Trigger an OSD with a button or from a terminal. Repeated triggers of the same OSD refresh it and restart the timer.")
             color: Theme.on_surface_variant
-            font.pixelSize: 13
+            font.pixelSize: Tokens.font_size_body_m
             wrapMode: Text.WordWrap
         }
 
         Flow {
             Layout.fillWidth: true
-            spacing: 12
+            spacing: Tokens.spacing_m
 
             PhosphorButton {
                 text: qsTr("Volume −")
@@ -120,17 +122,17 @@ ApplicationWindow {
         Rectangle {
             Layout.fillWidth: true
             Layout.preferredHeight: 96
-            radius: 12
+            radius: Tokens.radius_m
             color: Theme.surface_container
             border.width: 1
             border.color: Theme.outline_variant
 
             Text {
                 anchors.fill: parent
-                anchors.margins: 14
+                anchors.margins: Tokens.spacing_m
                 color: Theme.on_surface
                 font.family: "monospace"
-                font.pixelSize: 12
+                font.pixelSize: Tokens.font_size_body_s
                 textFormat: Text.PlainText
                 wrapMode: Text.WordWrap
                 text: ipcSocketPath.length > 0 ? qsTr("export PHOSPHOR_SOCKET=%1\nphosphorctl call osd.show --arg kind=volume --arg value=62\nphosphorctl call osd.show --arg kind=mic --arg value=1\nphosphorctl schema osd | jq").arg(ipcSocketPath) : qsTr("# IPC router not running; use the buttons above.")

--- a/examples/phosphor-osd-demo/Main.qml
+++ b/examples/phosphor-osd-demo/Main.qml
@@ -121,7 +121,7 @@ ApplicationWindow {
         // phosphorctl cheat sheet.
         Rectangle {
             Layout.fillWidth: true
-            Layout.preferredHeight: 96
+            Layout.preferredHeight: Tokens.spacing_xxxl * 2
             radius: Tokens.radius_m
             color: Theme.surface_container
             border.width: 1

--- a/examples/phosphor-osd-demo/Main.qml
+++ b/examples/phosphor-osd-demo/Main.qml
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+// phosphor-osd-demo, the Phase 3.3 acceptance demo.
+//
+// An OSDHost overlay driven two ways: in-window buttons, and
+// `phosphorctl call osd.show <kind> <value>` over IPC. The four built-in
+// OSDs are supplied by OSDController's Registry<IOSDFactory>. Repeated
+// triggers of the same kind refresh one OSD (debounce/dedupe) and restart
+// its hold timer.
+
+import Phosphor.Ipc
+import Phosphor.OSD
+import Phosphor.Theme
+import Phosphor.Widgets
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ApplicationWindow {
+    id: root
+
+    // Local state so the buttons produce changing values / toggles.
+    property int volume: 40
+    property int brightness: 60
+    property bool micMuted: false
+    property bool capsOn: false
+
+    width: 720
+    height: 560
+    visible: true
+    title: qsTr("Phosphor OSD Demo")
+    color: Theme.background
+
+    // IPC: `phosphorctl call osd.show --arg kind=volume --arg value=62`.
+    // A value of 0 reads as the "off/muted" state for the stateful OSDs.
+    IpcTarget {
+        target: "osd"
+
+        function show(kind: string, value: int): bool {
+            osdHost.show(kind, value, value !== 0, "");
+            return true;
+        }
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 28
+        spacing: 18
+
+        Label {
+            text: qsTr("On-Screen Displays")
+            color: Theme.on_surface
+            font.pixelSize: 20
+            font.weight: Font.DemiBold
+        }
+
+        Label {
+            Layout.fillWidth: true
+            text: qsTr("Trigger an OSD with a button or from a terminal. Repeated triggers of the same OSD refresh it and restart the timer.")
+            color: Theme.on_surface_variant
+            font.pixelSize: 13
+            wrapMode: Text.WordWrap
+        }
+
+        Flow {
+            Layout.fillWidth: true
+            spacing: 12
+
+            PhosphorButton {
+                text: qsTr("Volume −")
+                variant: PhosphorButton.Tonal
+                onClicked: {
+                    root.volume = Math.max(0, root.volume - 15);
+                    osdHost.show("volume", root.volume, undefined, "");
+                }
+            }
+
+            PhosphorButton {
+                text: qsTr("Volume +")
+                variant: PhosphorButton.Tonal
+                onClicked: {
+                    root.volume = Math.min(100, root.volume + 15);
+                    osdHost.show("volume", root.volume, undefined, "");
+                }
+            }
+
+            PhosphorButton {
+                text: qsTr("Brightness +")
+                variant: PhosphorButton.Tonal
+                onClicked: {
+                    root.brightness = root.brightness >= 100 ? 20 : Math.min(100, root.brightness + 20);
+                    osdHost.show("brightness", root.brightness, undefined, "");
+                }
+            }
+
+            PhosphorButton {
+                text: qsTr("Mic")
+                variant: PhosphorButton.Outlined
+                onClicked: {
+                    root.micMuted = !root.micMuted;
+                    osdHost.show("mic", undefined, root.micMuted, "");
+                }
+            }
+
+            PhosphorButton {
+                text: qsTr("Caps Lock")
+                variant: PhosphorButton.Outlined
+                onClicked: {
+                    root.capsOn = !root.capsOn;
+                    osdHost.show("caps", undefined, root.capsOn, "");
+                }
+            }
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+
+        // phosphorctl cheat sheet.
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 96
+            radius: 12
+            color: Theme.surface_container
+            border.width: 1
+            border.color: Theme.outline_variant
+
+            Text {
+                anchors.fill: parent
+                anchors.margins: 14
+                color: Theme.on_surface
+                font.family: "monospace"
+                font.pixelSize: 12
+                textFormat: Text.PlainText
+                wrapMode: Text.WordWrap
+                text: ipcSocketPath.length > 0 ? qsTr("export PHOSPHOR_SOCKET=%1\nphosphorctl call osd.show --arg kind=volume --arg value=62\nphosphorctl call osd.show --arg kind=mic --arg value=1\nphosphorctl schema osd | jq").arg(ipcSocketPath) : qsTr("# IPC router not running; use the buttons above.")
+            }
+        }
+    }
+
+    // OSD overlay on top of everything. One host here; production wraps
+    // OSDHost in PerScreen for one per monitor.
+    OSDHost {
+        id: osdHost
+
+        anchors.fill: parent
+        // Float clear of the cheat sheet at the very bottom of this demo
+        // window. A real shell uses the default (near the bottom edge).
+        bottomMargin: 160
+        provider: osdController
+    }
+}

--- a/examples/phosphor-osd-demo/OSDController.h
+++ b/examples/phosphor-osd-demo/OSDController.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <PhosphorRegistry/IOSDFactory.h>
+#include <PhosphorRegistry/Registry.h>
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+
+QT_BEGIN_NAMESPACE
+class QQuickItem;
+QT_END_NAMESPACE
+
+namespace PhosphorOsdDemo {
+
+// QML-exposed provider for OSDHost. Owns a Registry<IOSDFactory>,
+// registers the four built-in OSDs as IOSDFactory instances at
+// construction, and exposes createOSD(kind, parent) so OSDHost can be
+// wired as `provider: osdController`. This is the registry-backed
+// provider the framework's README describes; the host stays registry-
+// agnostic.
+class OSDController : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit OSDController(QObject* parent = nullptr);
+    ~OSDController() override;
+
+    // OSDHost provider contract: build the OSD delegate for `kind`,
+    // parented into `parent`. Returns null for an unknown kind. The
+    // engine is resolved from `parent` so QML need not pass it.
+    [[nodiscard]] Q_INVOKABLE QQuickItem* createOSD(const QString& kind, QQuickItem* parent);
+
+    // Registered OSD kinds in registration order, for the demo's button row.
+    [[nodiscard]] Q_INVOKABLE QStringList kinds() const;
+
+private:
+    PhosphorRegistry::Registry<PhosphorRegistry::IOSDFactory> m_registry;
+};
+
+} // namespace PhosphorOsdDemo

--- a/examples/phosphor-osd-demo/OSDController.h
+++ b/examples/phosphor-osd-demo/OSDController.h
@@ -34,9 +34,6 @@ public:
     // engine is resolved from `parent` so QML need not pass it.
     [[nodiscard]] Q_INVOKABLE QQuickItem* createOSD(const QString& kind, QQuickItem* parent);
 
-    // Registered OSD kinds in registration order, for the demo's button row.
-    [[nodiscard]] Q_INVOKABLE QStringList kinds() const;
-
 private:
     PhosphorRegistry::Registry<PhosphorRegistry::IOSDFactory> m_registry;
 };

--- a/examples/phosphor-osd-demo/OSDController.h
+++ b/examples/phosphor-osd-demo/OSDController.h
@@ -7,7 +7,6 @@
 
 #include <QObject>
 #include <QString>
-#include <QStringList>
 
 QT_BEGIN_NAMESPACE
 class QQuickItem;

--- a/examples/phosphor-osd-demo/QmlComponentOSDFactory.h
+++ b/examples/phosphor-osd-demo/QmlComponentOSDFactory.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <PhosphorRegistry/IOSDFactory.h>
+
+#include <QString>
+#include <QStringList>
+#include <QtCore/qtclasshelpermacros.h>
+
+QT_BEGIN_NAMESPACE
+class QObject;
+class QQmlEngine;
+class QQuickItem;
+QT_END_NAMESPACE
+
+namespace PhosphorOsdDemo {
+
+// IOSDFactory wrapping one OSD delegate type from a QML module. createOSD
+// builds the type via QQmlComponent(engine, uri, typeName), so the
+// factory references the registered module type by name rather than a
+// fragile qrc path. The kind of helper a real shell would also provide
+// for its built-in OSDs; plugin authors mirror the pattern or supply
+// their own create logic.
+class QmlComponentOSDFactory : public PhosphorRegistry::IOSDFactory
+{
+public:
+    QmlComponentOSDFactory(QString id, QString displayName, QString moduleUri, QString typeName,
+                           QStringList capabilities = {});
+    ~QmlComponentOSDFactory() override = default;
+    Q_DISABLE_COPY_MOVE(QmlComponentOSDFactory)
+
+    [[nodiscard]] QString id() const override;
+    [[nodiscard]] QString displayName() const override;
+    [[nodiscard]] QStringList capabilities() const override;
+
+    [[nodiscard]] QQuickItem* createOSD(QQmlEngine* engine, QObject* parent) override;
+
+private:
+    QString m_id;
+    QString m_displayName;
+    QString m_moduleUri;
+    QString m_typeName;
+    QStringList m_capabilities;
+};
+
+} // namespace PhosphorOsdDemo

--- a/examples/phosphor-osd-demo/main.cpp
+++ b/examples/phosphor-osd-demo/main.cpp
@@ -5,7 +5,8 @@
 //
 // QGuiApplication + QQmlApplicationEngine + an IpcRouter so the OSD
 // overlay can be driven from a terminal (`phosphorctl call osd.show
-// volume 62`). The OSDController owns a Registry<IOSDFactory> with the
+// --arg kind=volume --arg value=62`). The OSDController owns a
+// Registry<IOSDFactory> with the
 // four built-in OSDs and is exposed to QML as the OSDHost provider.
 
 #include "OSDController.h"

--- a/examples/phosphor-osd-demo/main.cpp
+++ b/examples/phosphor-osd-demo/main.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// phosphor-osd-demo entry point.
+//
+// QGuiApplication + QQmlApplicationEngine + an IpcRouter so the OSD
+// overlay can be driven from a terminal (`phosphorctl call osd.show
+// volume 62`). The OSDController owns a Registry<IOSDFactory> with the
+// four built-in OSDs and is exposed to QML as the OSDHost provider.
+
+#include "OSDController.h"
+
+#include <PhosphorIpc/IpcEngine.h>
+#include <PhosphorIpc/IpcRouter.h>
+
+#include <QGuiApplication>
+#include <QProcessEnvironment>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include <QQuickStyle>
+#include <QString>
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+    QCoreApplication::setOrganizationName(QStringLiteral("Phosphor"));
+    QCoreApplication::setApplicationName(QStringLiteral("phosphor-osd-demo"));
+
+    QQuickStyle::setStyle(QStringLiteral("Basic"));
+
+    PhosphorOsdDemo::OSDController osdController;
+
+    // IPC router so `phosphorctl call osd.show ...` reaches the overlay.
+    // Socket: $PHOSPHOR_SOCKET, else a CMake-injected per-build path,
+    // else the IpcRouter XDG default.
+    PhosphorIpc::IpcRouter router;
+    QString socketPath = QProcessEnvironment::systemEnvironment().value(QStringLiteral("PHOSPHOR_SOCKET"));
+#ifdef PHOSPHOR_OSD_DEMO_SOCKET
+    if (socketPath.isEmpty()) {
+        socketPath = QStringLiteral(PHOSPHOR_OSD_DEMO_SOCKET);
+    }
+#endif
+    if (!router.start(socketPath)) {
+        qWarning(
+            "phosphor-osd-demo: IPC router failed to start on '%s' (see preceding log); "
+            "the in-window buttons still work",
+            qPrintable(socketPath.isEmpty() ? QStringLiteral("<XDG default>") : socketPath));
+    }
+
+    QQmlApplicationEngine engine;
+    engine.rootContext()->setContextProperty(QStringLiteral("osdController"), &osdController);
+    engine.rootContext()->setContextProperty(QStringLiteral("ipcSocketPath"), router.socketPath());
+    PhosphorIpc::IpcEngine::install(&engine, &router);
+
+    engine.loadFromModule(QStringLiteral("Phosphor.OsdDemo"), QStringLiteral("Main"));
+    if (engine.rootObjects().isEmpty()) {
+        return 1;
+    }
+    return app.exec();
+}

--- a/examples/phosphor-osd-demo/osdcontroller.cpp
+++ b/examples/phosphor-osd-demo/osdcontroller.cpp
@@ -8,6 +8,7 @@
 #include <QDebug>
 #include <QQmlEngine>
 #include <QQuickItem>
+#include <QStringList>
 #include <QStringLiteral>
 
 #include <memory>

--- a/examples/phosphor-osd-demo/osdcontroller.cpp
+++ b/examples/phosphor-osd-demo/osdcontroller.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "OSDController.h"
+
+#include "QmlComponentOSDFactory.h"
+
+#include <QDebug>
+#include <QQmlEngine>
+#include <QQuickItem>
+#include <QStringLiteral>
+
+#include <memory>
+
+namespace PhosphorOsdDemo {
+
+namespace {
+// All four built-ins live in the Phosphor.OSD module.
+const QString kModule = QStringLiteral("Phosphor.OSD");
+}
+
+OSDController::OSDController(QObject* parent)
+    : QObject(parent)
+{
+    // Register the four built-in OSDs as IOSDFactory instances. Each
+    // wraps a delegate type from the Phosphor.OSD module. Capabilities
+    // are advisory (Phase 5).
+    const auto reg = [this](const QString& id, const QString& name, const QString& type) {
+        m_registry.registerFactory(
+            std::make_shared<QmlComponentOSDFactory>(id, name, kModule, type, QStringList{QStringLiteral("osd")}));
+    };
+    reg(QStringLiteral("volume"), QStringLiteral("Volume"), QStringLiteral("VolumeOSD"));
+    reg(QStringLiteral("brightness"), QStringLiteral("Brightness"), QStringLiteral("BrightnessOSD"));
+    reg(QStringLiteral("mic"), QStringLiteral("Microphone"), QStringLiteral("MicOSD"));
+    reg(QStringLiteral("caps"), QStringLiteral("Caps Lock"), QStringLiteral("CapsLockOSD"));
+}
+
+OSDController::~OSDController() = default;
+
+QQuickItem* OSDController::createOSD(const QString& kind, QQuickItem* parent)
+{
+    const auto factory = m_registry.factory(kind);
+    if (!factory) {
+        qWarning() << "OSDController: no OSD registered for kind" << kind;
+        return nullptr;
+    }
+    QQmlEngine* engine = parent ? qmlEngine(parent) : nullptr;
+    if (!engine) {
+        qWarning() << "OSDController: no QML engine resolvable from parent for kind" << kind;
+        return nullptr;
+    }
+    return factory->createOSD(engine, parent);
+}
+
+QStringList OSDController::kinds() const
+{
+    return m_registry.ids();
+}
+
+} // namespace PhosphorOsdDemo

--- a/examples/phosphor-osd-demo/osdcontroller.cpp
+++ b/examples/phosphor-osd-demo/osdcontroller.cpp
@@ -52,9 +52,4 @@ QQuickItem* OSDController::createOSD(const QString& kind, QQuickItem* parent)
     return factory->createOSD(engine, parent);
 }
 
-QStringList OSDController::kinds() const
-{
-    return m_registry.ids();
-}
-
 } // namespace PhosphorOsdDemo

--- a/examples/phosphor-osd-demo/qmlcomponentosdfactory.cpp
+++ b/examples/phosphor-osd-demo/qmlcomponentosdfactory.cpp
@@ -51,12 +51,16 @@ QQuickItem* QmlComponentOSDFactory::createOSD(QQmlEngine* engine, QObject* paren
         return nullptr;
     }
     QObject* obj = component.create(engine->rootContext());
+    if (!obj) {
+        // create() can fail at runtime even when isError() was false at
+        // load; surface the actual error rather than the wrong-type message.
+        qWarning() << "QmlComponentOSDFactory: component creation failed for" << m_id << "—" << component.errorString();
+        return nullptr;
+    }
     auto* item = qobject_cast<QQuickItem*>(obj);
     if (!item) {
         qWarning() << "QmlComponentOSDFactory: component is not a QQuickItem for" << m_id;
-        if (obj) {
-            obj->deleteLater();
-        }
+        obj->deleteLater();
         return nullptr;
     }
     if (auto* parentItem = qobject_cast<QQuickItem*>(parent)) {

--- a/examples/phosphor-osd-demo/qmlcomponentosdfactory.cpp
+++ b/examples/phosphor-osd-demo/qmlcomponentosdfactory.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "QmlComponentOSDFactory.h"
+
+#include <QDebug>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QQuickItem>
+
+#include <utility>
+
+namespace PhosphorOsdDemo {
+
+QmlComponentOSDFactory::QmlComponentOSDFactory(QString id, QString displayName, QString moduleUri, QString typeName,
+                                               QStringList capabilities)
+    : m_id(std::move(id))
+    , m_displayName(std::move(displayName))
+    , m_moduleUri(std::move(moduleUri))
+    , m_typeName(std::move(typeName))
+    , m_capabilities(std::move(capabilities))
+{
+}
+
+QString QmlComponentOSDFactory::id() const
+{
+    return m_id;
+}
+
+QString QmlComponentOSDFactory::displayName() const
+{
+    return m_displayName;
+}
+
+QStringList QmlComponentOSDFactory::capabilities() const
+{
+    return m_capabilities;
+}
+
+QQuickItem* QmlComponentOSDFactory::createOSD(QQmlEngine* engine, QObject* parent)
+{
+    if (!engine) {
+        qWarning() << "QmlComponentOSDFactory: null engine for" << m_id;
+        return nullptr;
+    }
+    // Resolve the delegate type from its module by name (Qt 6.5+ ctor),
+    // so no qrc path is hard-coded.
+    QQmlComponent component(engine, m_moduleUri, m_typeName);
+    if (component.isError()) {
+        qWarning() << "QmlComponentOSDFactory: component error for" << m_id << "—" << component.errorString();
+        return nullptr;
+    }
+    QObject* obj = component.create(engine->rootContext());
+    auto* item = qobject_cast<QQuickItem*>(obj);
+    if (!item) {
+        qWarning() << "QmlComponentOSDFactory: component is not a QQuickItem for" << m_id;
+        if (obj) {
+            obj->deleteLater();
+        }
+        return nullptr;
+    }
+    if (auto* parentItem = qobject_cast<QQuickItem*>(parent)) {
+        item->setParentItem(parentItem);
+    } else {
+        item->setParent(parent);
+    }
+    // The OSD host owns the delegate's lifetime per the IOSDFactory
+    // contract: it destroys the delegate when the OSD swaps or hides. A
+    // QObject-parented item defaults to CppOwnership, which makes the
+    // host's QML destroy() throw "indestructible object" (and then the
+    // old delegate leaks, stacking a ghost behind the new one). Hand
+    // ownership to the JS engine so the host's destroy() is valid.
+    QQmlEngine::setObjectOwnership(item, QQmlEngine::JavaScriptOwnership);
+    return item;
+}
+
+} // namespace PhosphorOsdDemo

--- a/examples/phosphor-toast-demo/CMakeLists.txt
+++ b/examples/phosphor-toast-demo/CMakeLists.txt
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# phosphor-toast-demo, the Phase 3.4 acceptance demo for the
+# Phosphor.Notifications toast framework. A ToastHost overlay fed by a
+# real NotificationServer (so notify-send raises a toast) and by in-window
+# buttons; a Do-Not-Disturb pill exercises the per-app-rules seam.
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2 QuickShapes)
+
+if(COMMAND qt_policy)
+    qt_policy(SET QTP0001 NEW)
+endif()
+
+# Directory-scope suppression of -Wmissing-include-dirs. Full rationale:
+# src/shared/CMakeLists.txt.
+set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-Wno-missing-include-dirs")
+
+qt_add_qml_module(phosphor_toast_demo_qml
+    URI Phosphor.ToastDemo
+    VERSION 1.0
+    STATIC
+    RESOURCE_PREFIX /qt/qml
+    OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Phosphor/ToastDemo
+    IMPORTS
+        Phosphor.Theme
+        Phosphor.Widgets
+        Phosphor.Notifications
+    QML_FILES
+        Main.qml
+)
+
+target_link_libraries(phosphor_toast_demo_qml
+    PRIVATE
+        PhosphorShellNotifications::PhosphorShellNotificationsQml
+        PhosphorShellWidgets::PhosphorShellWidgetsQml
+        Qt6::Quick
+)
+
+target_compile_features(phosphor_toast_demo_qml PRIVATE cxx_std_20)
+
+add_executable(phosphor-toast-demo
+    main.cpp
+)
+
+target_compile_features(phosphor-toast-demo PRIVATE cxx_std_20)
+
+target_link_libraries(phosphor-toast-demo
+    PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        Qt6::QuickShapes
+        # The notification server (ingest) + its QML type registration.
+        PhosphorServiceNotifications::PhosphorServiceNotifications
+        # Static QML modules + their plugin registrars so every import in
+        # Main.qml resolves at runtime.
+        phosphor_toast_demo_qmlplugin
+        PhosphorShellNotifications::PhosphorShellNotificationsQml
+        PhosphorShellNotificationsQmlplugin
+        PhosphorShellWidgets::PhosphorShellWidgetsQml
+        PhosphorShellWidgetsQmlplugin
+        PhosphorThemeQml
+        PhosphorThemeQmlplugin
+)

--- a/examples/phosphor-toast-demo/CMakeLists.txt
+++ b/examples/phosphor-toast-demo/CMakeLists.txt
@@ -41,6 +41,7 @@ target_compile_features(phosphor_toast_demo_qml PRIVATE cxx_std_20)
 
 add_executable(phosphor-toast-demo
     main.cpp
+    NotificationImageProvider.h
 )
 
 target_compile_features(phosphor-toast-demo PRIVATE cxx_std_20)

--- a/examples/phosphor-toast-demo/Main.qml
+++ b/examples/phosphor-toast-demo/Main.qml
@@ -41,11 +41,15 @@ ApplicationWindow {
         function onNotificationAdded(notification) {
             const icon = notification.appIcon;
             const isPath = icon && (icon.indexOf("/") === 0 || icon.indexOf(":") > 0);
+            // Prefer the decoded inline image (image-data hint), served by the
+            // C++ NotificationImageProvider under image://notification/<id>;
+            // fall back to an appIcon path when there's no rich image.
+            const image = notification.hasImage ? ("image://notification/" + notification.id) : (isPath ? icon : "");
             toastHost.show({
                 "appName": notification.appName,
                 "summary": notification.summary,
                 "body": notification.body,
-                "imageSource": isPath ? icon : "",
+                "imageSource": image,
                 "urgency": notification.urgency,
                 // freedesktop: 0 = never expire (sticky), >0 = that many ms,
                 // -1 = "server decides". 0 and explicit values pass through;

--- a/examples/phosphor-toast-demo/Main.qml
+++ b/examples/phosphor-toast-demo/Main.qml
@@ -47,7 +47,10 @@ ApplicationWindow {
                 "body": notification.body,
                 "imageSource": isPath ? icon : "",
                 "urgency": notification.urgency,
-                "timeout": notification.expireTimeout > 0 ? notification.expireTimeout : toastHost.defaultTimeout
+                // freedesktop: -1 = "server decides" (use the default), 0 =
+                // never expire (sticky), >0 = that many ms. Only -1 maps to
+                // the default; 0 must pass through so notify-send -t 0 stays.
+                "timeout": notification.expireTimeout >= 0 ? notification.expireTimeout : toastHost.defaultTimeout
             });
         }
 

--- a/examples/phosphor-toast-demo/Main.qml
+++ b/examples/phosphor-toast-demo/Main.qml
@@ -47,7 +47,7 @@ ApplicationWindow {
                 "body": notification.body,
                 "imageSource": isPath ? icon : "",
                 "urgency": notification.urgency,
-                "timeout": notification.expireTimeout > 0 ? notification.expireTimeout : 5000
+                "timeout": notification.expireTimeout > 0 ? notification.expireTimeout : toastHost.defaultTimeout
             });
         }
 
@@ -56,27 +56,27 @@ ApplicationWindow {
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.margins: 28
-        spacing: 18
+        anchors.margins: Tokens.spacing_xl
+        spacing: Tokens.spacing_l
 
         Label {
             text: qsTr("Notification Toasts")
             color: Theme.on_surface
-            font.pixelSize: 20
-            font.weight: Font.DemiBold
+            font.pixelSize: Tokens.font_size_display_s
+            font.weight: Tokens.font_weight_demibold
         }
 
         Label {
             Layout.fillWidth: true
-            text: notifier.nameAcquired ? qsTr("Active notification server. Try: notify-send 'Build finished' 'All tests passed' — or use the buttons.") : qsTr("Another notification daemon owns the bus, so notify-send won't reach this demo. The buttons below still drive the toast stack.")
+            text: notifier.nameAcquired ? qsTr("Active notification server. Try notify-send 'Build finished' 'All tests passed', or use the buttons.") : qsTr("Another notification daemon owns the bus, so notify-send won't reach this demo. The buttons below still drive the toast stack.")
             color: Theme.on_surface_variant
-            font.pixelSize: 13
+            font.pixelSize: Tokens.font_size_body_m
             wrapMode: Text.WordWrap
         }
 
         Flow {
             Layout.fillWidth: true
-            spacing: 12
+            spacing: Tokens.spacing_m
 
             PhosphorButton {
                 text: qsTr("Info")

--- a/examples/phosphor-toast-demo/Main.qml
+++ b/examples/phosphor-toast-demo/Main.qml
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+// phosphor-toast-demo, the Phase 3.4 acceptance demo.
+//
+// A ToastHost overlay fed two ways: real notifications from the
+// NotificationServer (so `notify-send` raises a toast when this process
+// owns the bus name), and in-window buttons (which always work). A "Do
+// Not Disturb" pill exercises the per-app-rules seam.
+
+import Phosphor.Notifications
+import Phosphor.Theme
+import Phosphor.Widgets
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ApplicationWindow {
+    id: root
+
+    // A small inline image (no external assets / icon theme needed) to
+    // demonstrate Toast image support.
+    readonly property url sampleImage: "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><rect width='40' height='40' rx='8' fill='%2322D3EE'/><circle cx='20' cy='20' r='9' fill='%230B1730'/></svg>"
+
+    // A do-not-disturb rule object plugged into ToastHost.rules.
+    readonly property var dndRule: QtObject {
+        function evaluate(toast) {
+            return {
+                "suppress": true
+            };
+        }
+    }
+
+    width: 720
+    height: 560
+    visible: true
+    title: qsTr("Phosphor Toast Demo")
+    color: Theme.background
+
+    // Feed real notifications into the toast stack.
+    Connections {
+        function onNotificationAdded(notification) {
+            const icon = notification.appIcon;
+            const isPath = icon && (icon.indexOf("/") === 0 || icon.indexOf(":") > 0);
+            toastHost.show({
+                "appName": notification.appName,
+                "summary": notification.summary,
+                "body": notification.body,
+                "imageSource": isPath ? icon : "",
+                "urgency": notification.urgency,
+                "timeout": notification.expireTimeout > 0 ? notification.expireTimeout : 5000
+            });
+        }
+
+        target: notifier
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 28
+        spacing: 18
+
+        Label {
+            text: qsTr("Notification Toasts")
+            color: Theme.on_surface
+            font.pixelSize: 20
+            font.weight: Font.DemiBold
+        }
+
+        Label {
+            Layout.fillWidth: true
+            text: notifier.nameAcquired ? qsTr("Active notification server. Try: notify-send 'Build finished' 'All tests passed' — or use the buttons.") : qsTr("Another notification daemon owns the bus, so notify-send won't reach this demo. The buttons below still drive the toast stack.")
+            color: Theme.on_surface_variant
+            font.pixelSize: 13
+            wrapMode: Text.WordWrap
+        }
+
+        Flow {
+            Layout.fillWidth: true
+            spacing: 12
+
+            PhosphorButton {
+                text: qsTr("Info")
+                variant: PhosphorButton.Tonal
+                onClicked: toastHost.show({
+                    "appName": "Demo",
+                    "summary": qsTr("Build finished"),
+                    "body": qsTr("All <b>42</b> tests passed."),
+                    "urgency": 1
+                })
+            }
+
+            PhosphorButton {
+                text: qsTr("With image")
+                variant: PhosphorButton.Tonal
+                onClicked: toastHost.show({
+                    "appName": "Photos",
+                    "summary": qsTr("New photo added"),
+                    "body": qsTr("Tap to open in the gallery."),
+                    "imageSource": root.sampleImage,
+                    "urgency": 1
+                })
+            }
+
+            PhosphorButton {
+                text: qsTr("Critical")
+                variant: PhosphorButton.Filled
+                onClicked: toastHost.show({
+                    "appName": "Power",
+                    "summary": qsTr("Battery low"),
+                    "body": qsTr("3% remaining. Plug in soon."),
+                    "urgency": 2,
+                    "timeout": 0
+                })
+            }
+
+            PhosphorButton {
+                text: qsTr("Burst ×5")
+                variant: PhosphorButton.Outlined
+                onClicked: {
+                    for (let i = 1; i <= 5; ++i)
+                        toastHost.show({
+                            "appName": "Chat",
+                            "summary": qsTr("Message %1").arg(i),
+                            "body": qsTr("Queues past maxVisible."),
+                            "urgency": 1
+                        });
+                }
+            }
+
+            PhosphorPill {
+                text: qsTr("Do Not Disturb")
+                selected: toastHost.rules !== null
+                onToggled: toastHost.rules = toastHost.rules ? null : root.dndRule
+            }
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+    }
+
+    // The toast overlay sits on top, stacking from the top-right.
+    ToastHost {
+        id: toastHost
+
+        anchors.fill: parent
+        maxVisible: 4
+    }
+}

--- a/examples/phosphor-toast-demo/Main.qml
+++ b/examples/phosphor-toast-demo/Main.qml
@@ -47,10 +47,11 @@ ApplicationWindow {
                 "body": notification.body,
                 "imageSource": isPath ? icon : "",
                 "urgency": notification.urgency,
-                // freedesktop: -1 = "server decides" (use the default), 0 =
-                // never expire (sticky), >0 = that many ms. Only -1 maps to
-                // the default; 0 must pass through so notify-send -t 0 stays.
-                "timeout": notification.expireTimeout >= 0 ? notification.expireTimeout : toastHost.defaultTimeout
+                // freedesktop: 0 = never expire (sticky), >0 = that many ms,
+                // -1 = "server decides". 0 and explicit values pass through;
+                // for -1 the server keeps Critical sticky and otherwise falls
+                // back to the default, so mirror that here.
+                "timeout": notification.expireTimeout >= 0 ? notification.expireTimeout : (notification.urgency === 2 ? 0 : toastHost.defaultTimeout)
             });
         }
 

--- a/examples/phosphor-toast-demo/NotificationImageProvider.h
+++ b/examples/phosphor-toast-demo/NotificationImageProvider.h
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <QHash>
+#include <QImage>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QQuickImageProvider>
+#include <QSize>
+#include <QString>
+
+namespace PhosphorToastDemo {
+
+// Serves decoded notification images to QML via `image://notification/<id>`.
+// The freedesktop `image-data` hint decodes to a QImage with no file path,
+// which a url-based Image element can't load directly, so the demo caches
+// each notification's image by id and hands it back here. requestImage runs
+// on a Qt image-loader thread, so the cache is mutex-guarded; cacheImage /
+// dropImage are called from the GUI thread as notifications arrive and close.
+class NotificationImageProvider : public QQuickImageProvider
+{
+public:
+    NotificationImageProvider()
+        : QQuickImageProvider(QQuickImageProvider::Image)
+    {
+    }
+
+    Q_DISABLE_COPY_MOVE(NotificationImageProvider)
+
+    ~NotificationImageProvider() override = default;
+
+    // GUI thread: remember a notification's decoded image.
+    void cacheImage(uint id, const QImage& image)
+    {
+        const QMutexLocker locker(&m_mutex);
+        m_images.insert(id, image);
+    }
+
+    // GUI thread: forget a closed notification's image so the cache stays
+    // bounded to live notifications.
+    void dropImage(uint id)
+    {
+        const QMutexLocker locker(&m_mutex);
+        m_images.remove(id);
+    }
+
+    // Image-loader thread: id is the notification id from the url. Returns a
+    // null QImage (blank) for an unknown id, which Image renders as nothing.
+    [[nodiscard]] QImage requestImage(const QString& id, QSize* size, const QSize& requestedSize) override
+    {
+        QImage image;
+        {
+            const QMutexLocker locker(&m_mutex);
+            image = m_images.value(id.toUInt());
+        }
+        if (image.isNull()) {
+            return image;
+        }
+        if (size != nullptr) {
+            *size = image.size();
+        }
+        if (requestedSize.isValid() && requestedSize != image.size()) {
+            return image.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        }
+        return image;
+    }
+
+private:
+    QMutex m_mutex;
+    QHash<uint, QImage> m_images;
+};
+
+} // namespace PhosphorToastDemo

--- a/examples/phosphor-toast-demo/NotificationImageProvider.h
+++ b/examples/phosphor-toast-demo/NotificationImageProvider.h
@@ -60,7 +60,9 @@ public:
         if (size != nullptr) {
             *size = image.size();
         }
-        if (requestedSize.isValid() && requestedSize != image.size()) {
+        // isEmpty() (not isValid()) so a 0x0 request falls through to the
+        // full image rather than scaling to a null result.
+        if (!requestedSize.isEmpty() && requestedSize != image.size()) {
             return image.scaled(requestedSize, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         }
         return image;

--- a/examples/phosphor-toast-demo/main.cpp
+++ b/examples/phosphor-toast-demo/main.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// phosphor-toast-demo entry point.
+//
+// QGuiApplication + QQmlApplicationEngine + a NotificationServer
+// (phosphor-service-notifications, Phase 2.5). When this process owns the
+// org.freedesktop.Notifications name, `notify-send` raises a toast; when
+// another daemon owns it, the in-window buttons still drive the toast
+// stack. The server is exposed to QML so Main.qml binds its
+// notificationAdded signal into the ToastHost.
+
+#include <PhosphorServiceNotifications/NotificationServer.h>
+#include <PhosphorServiceNotifications/QmlRegistration.h>
+
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQmlContext>
+#include <QQuickStyle>
+#include <QString>
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+    QCoreApplication::setOrganizationName(QStringLiteral("Phosphor"));
+    QCoreApplication::setApplicationName(QStringLiteral("phosphor-toast-demo"));
+
+    QQuickStyle::setStyle(QStringLiteral("Basic"));
+
+    // Register the notification types (Notification etc.) so the QML
+    // signal handler can read the delivered notification's properties.
+    PhosphorServiceNotifications::registerQmlTypes();
+
+    // Acquire the session-bus notification name (inert if another daemon
+    // owns it; nameAcquired reports which case we're in).
+    PhosphorServiceNotifications::NotificationServer notifier;
+
+    QQmlApplicationEngine engine;
+    engine.rootContext()->setContextProperty(QStringLiteral("notifier"), &notifier);
+
+    engine.loadFromModule(QStringLiteral("Phosphor.ToastDemo"), QStringLiteral("Main"));
+    if (engine.rootObjects().isEmpty()) {
+        return 1;
+    }
+    return app.exec();
+}

--- a/examples/phosphor-toast-demo/main.cpp
+++ b/examples/phosphor-toast-demo/main.cpp
@@ -44,9 +44,11 @@ int main(int argc, char* argv[])
 
     // Serve decoded notification images (the freedesktop image-data hint) to
     // QML under image://notification/<id>. The engine takes ownership of the
-    // provider. The cache/drop connections use a context object (the engine,
-    // or the provider for the per-notification changed() re-cache) that
-    // outlives every notification, so they detach cleanly on teardown.
+    // provider. Each cache/drop connection names a context object (the engine
+    // for add/close, the provider for the per-notification changed() re-cache);
+    // destroying that context object on engine teardown severs the connection,
+    // so no callback fires into the destroyed provider even though notifier
+    // (and its Notification objects) outlives the engine.
     auto* imageProvider = new PhosphorToastDemo::NotificationImageProvider;
     engine.addImageProvider(QStringLiteral("notification"), imageProvider);
     QObject::connect(&notifier, &PhosphorServiceNotifications::NotificationServer::notificationAdded, &engine,

--- a/examples/phosphor-toast-demo/main.cpp
+++ b/examples/phosphor-toast-demo/main.cpp
@@ -50,9 +50,20 @@ int main(int argc, char* argv[])
     engine.addImageProvider(QStringLiteral("notification"), imageProvider);
     QObject::connect(&notifier, &PhosphorServiceNotifications::NotificationServer::notificationAdded, &engine,
                      [imageProvider](PhosphorServiceNotifications::Notification* notification) {
-                         if (notification != nullptr && notification->hasImage()) {
-                             imageProvider->cacheImage(notification->id(), notification->image());
+                         if (notification == nullptr) {
+                             return;
                          }
+                         const auto cache = [imageProvider, notification] {
+                             if (notification->hasImage()) {
+                                 imageProvider->cacheImage(notification->id(), notification->image());
+                             }
+                         };
+                         cache();
+                         // A replaces-id update reports through changed(), not
+                         // notificationAdded, so re-cache on it to keep a
+                         // swapped image current.
+                         QObject::connect(notification, &PhosphorServiceNotifications::Notification::changed,
+                                          imageProvider, cache);
                      });
     QObject::connect(&notifier, &PhosphorServiceNotifications::NotificationServer::NotificationClosed, &engine,
                      [imageProvider](uint id, uint) {

--- a/examples/phosphor-toast-demo/main.cpp
+++ b/examples/phosphor-toast-demo/main.cpp
@@ -10,10 +10,14 @@
 // stack. The server is exposed to QML so Main.qml binds its
 // notificationAdded signal into the ToastHost.
 
+#include "NotificationImageProvider.h"
+
+#include <PhosphorServiceNotifications/Notification.h>
 #include <PhosphorServiceNotifications/NotificationServer.h>
 #include <PhosphorServiceNotifications/QmlRegistration.h>
 
 #include <QGuiApplication>
+#include <QObject>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 #include <QQuickStyle>
@@ -37,6 +41,23 @@ int main(int argc, char* argv[])
 
     QQmlApplicationEngine engine;
     engine.rootContext()->setContextProperty(QStringLiteral("notifier"), &notifier);
+
+    // Serve decoded notification images (the freedesktop image-data hint) to
+    // QML under image://notification/<id>. The engine takes ownership of the
+    // provider; the cache/drop connections use the engine as context object
+    // so they detach when it is destroyed.
+    auto* imageProvider = new PhosphorToastDemo::NotificationImageProvider;
+    engine.addImageProvider(QStringLiteral("notification"), imageProvider);
+    QObject::connect(&notifier, &PhosphorServiceNotifications::NotificationServer::notificationAdded, &engine,
+                     [imageProvider](PhosphorServiceNotifications::Notification* notification) {
+                         if (notification != nullptr && notification->hasImage()) {
+                             imageProvider->cacheImage(notification->id(), notification->image());
+                         }
+                     });
+    QObject::connect(&notifier, &PhosphorServiceNotifications::NotificationServer::NotificationClosed, &engine,
+                     [imageProvider](uint id, uint) {
+                         imageProvider->dropImage(id);
+                     });
 
     engine.loadFromModule(QStringLiteral("Phosphor.ToastDemo"), QStringLiteral("Main"));
     if (engine.rootObjects().isEmpty()) {

--- a/examples/phosphor-toast-demo/main.cpp
+++ b/examples/phosphor-toast-demo/main.cpp
@@ -44,8 +44,9 @@ int main(int argc, char* argv[])
 
     // Serve decoded notification images (the freedesktop image-data hint) to
     // QML under image://notification/<id>. The engine takes ownership of the
-    // provider; the cache/drop connections use the engine as context object
-    // so they detach when it is destroyed.
+    // provider. The cache/drop connections use a context object (the engine,
+    // or the provider for the per-notification changed() re-cache) that
+    // outlives every notification, so they detach cleanly on teardown.
     auto* imageProvider = new PhosphorToastDemo::NotificationImageProvider;
     engine.addImageProvider(QStringLiteral("notification"), imageProvider);
     QObject::connect(&notifier, &PhosphorServiceNotifications::NotificationServer::notificationAdded, &engine,
@@ -54,8 +55,13 @@ int main(int argc, char* argv[])
                              return;
                          }
                          const auto cache = [imageProvider, notification] {
+                             // Mirror the notification's image state: cache it
+                             // when present, drop it when a changed() update
+                             // cleared a previously set image.
                              if (notification->hasImage()) {
                                  imageProvider->cacheImage(notification->id(), notification->image());
+                             } else {
+                                 imageProvider->dropImage(notification->id());
                              }
                          };
                          cache();

--- a/examples/phosphor-widgets-kitchen-sink/CMakeLists.txt
+++ b/examples/phosphor-widgets-kitchen-sink/CMakeLists.txt
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# phosphor-widgets-kitchen-sink, the Phase 3.1 acceptance demo for the
+# Phosphor.Widgets atom library. One scrollable window listing every atom
+# in its enabled / disabled states with a live accent-cycle header. This
+# is the acceptance test for libs/phosphor-shell-widgets.
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick QuickControls2)
+
+if(COMMAND qt_policy)
+    qt_policy(SET QTP0001 NEW)
+endif()
+
+# Directory-scope suppression of -Wmissing-include-dirs for the targets
+# qt_add_qml_module generates here: Qt adds <target>_autogen/include to each
+# sub-target's -I list, but when a module carries no Q_OBJECT sources AUTOMOC
+# never creates that directory (and --clean-first deletes it), so cc1plus
+# warns on a Qt-managed scratch path. Full rationale: src/shared/CMakeLists.txt.
+set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-Wno-missing-include-dirs")
+
+# Bundle the demo QML into its own static module so qmlcachegen compiles
+# it and the resources are reachable via qrc:/qt/qml/Phosphor/WidgetsKitchenSink/.
+qt_add_qml_module(phosphor_widgets_kitchen_sink_qml
+    URI Phosphor.WidgetsKitchenSink
+    VERSION 1.0
+    STATIC
+    RESOURCE_PREFIX /qt/qml
+    OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Phosphor/WidgetsKitchenSink
+    IMPORTS
+        Phosphor.Theme
+        Phosphor.Widgets
+    QML_FILES
+        Main.qml
+)
+
+target_link_libraries(phosphor_widgets_kitchen_sink_qml
+    PRIVATE
+        PhosphorShellWidgets::PhosphorShellWidgetsQml
+        Qt6::Quick
+)
+
+target_compile_features(phosphor_widgets_kitchen_sink_qml PRIVATE cxx_std_20)
+
+add_executable(phosphor-widgets-kitchen-sink
+    main.cpp
+)
+
+target_compile_features(phosphor-widgets-kitchen-sink PRIVATE cxx_std_20)
+
+target_link_libraries(phosphor-widgets-kitchen-sink
+    PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        # Static QML modules ship both a library and a plugin registrar.
+        # The registrar publishes the module to QQmlEngine at runtime;
+        # without it the `import` fails. Link the demo module, the widgets
+        # module + plugin, and the theme module + plugin (the demo imports
+        # both Phosphor.Widgets and Phosphor.Theme).
+        phosphor_widgets_kitchen_sink_qmlplugin
+        PhosphorShellWidgets::PhosphorShellWidgetsQml
+        PhosphorShellWidgetsQmlplugin
+        PhosphorThemeQml
+        PhosphorThemeQmlplugin
+)

--- a/examples/phosphor-widgets-kitchen-sink/Main.qml
+++ b/examples/phosphor-widgets-kitchen-sink/Main.qml
@@ -48,15 +48,15 @@ ApplicationWindow {
 
         RowLayout {
             anchors.fill: parent
-            anchors.leftMargin: 16
-            anchors.rightMargin: 16
-            spacing: 12
+            anchors.leftMargin: Tokens.spacing_l
+            anchors.rightMargin: Tokens.spacing_l
+            spacing: Tokens.spacing_m
 
             Label {
                 text: qsTr("Phosphor.Widgets")
                 color: Theme.on_surface
-                font.pixelSize: 18
-                font.weight: Font.DemiBold
+                font.pixelSize: Tokens.font_size_title_l
+                font.weight: Tokens.font_weight_demibold
                 Layout.fillWidth: true
             }
 
@@ -78,31 +78,35 @@ ApplicationWindow {
     }
 
     ScrollView {
+        id: scroller
+
         anchors.fill: parent
         contentWidth: availableWidth
 
         ColumnLayout {
-            width: root.width
-            spacing: 28
+            // availableWidth (not root.width) so content never slips under
+            // the vertical scrollbar when one appears.
+            width: scroller.availableWidth
+            spacing: Tokens.spacing_xl
 
             // ── Buttons ──────────────────────────────────────────────
             ColumnLayout {
                 Layout.fillWidth: true
-                Layout.leftMargin: 24
-                Layout.rightMargin: 24
-                Layout.topMargin: 24
-                spacing: 12
+                Layout.leftMargin: Tokens.spacing_xl
+                Layout.rightMargin: Tokens.spacing_xl
+                Layout.topMargin: Tokens.spacing_xl
+                spacing: Tokens.spacing_m
 
                 Label {
                     text: qsTr("Buttons")
                     color: Theme.on_surface_variant
-                    font.pixelSize: 13
-                    font.weight: Font.DemiBold
+                    font.pixelSize: Tokens.font_size_body_m
+                    font.weight: Tokens.font_weight_demibold
                 }
 
                 Flow {
                     Layout.fillWidth: true
-                    spacing: 12
+                    spacing: Tokens.spacing_m
 
                     PhosphorButton {
                         text: qsTr("Filled")
@@ -135,20 +139,20 @@ ApplicationWindow {
             // ── Pills ────────────────────────────────────────────────
             ColumnLayout {
                 Layout.fillWidth: true
-                Layout.leftMargin: 24
-                Layout.rightMargin: 24
-                spacing: 12
+                Layout.leftMargin: Tokens.spacing_xl
+                Layout.rightMargin: Tokens.spacing_xl
+                spacing: Tokens.spacing_m
 
                 Label {
                     text: qsTr("Pills")
                     color: Theme.on_surface_variant
-                    font.pixelSize: 13
-                    font.weight: Font.DemiBold
+                    font.pixelSize: Tokens.font_size_body_m
+                    font.weight: Tokens.font_weight_demibold
                 }
 
                 Flow {
                     Layout.fillWidth: true
-                    spacing: 12
+                    spacing: Tokens.spacing_m
 
                     PhosphorPill {
                         // Local toggle state for the demo; a real host
@@ -179,15 +183,15 @@ ApplicationWindow {
             // ── Slider ───────────────────────────────────────────────
             ColumnLayout {
                 Layout.fillWidth: true
-                Layout.leftMargin: 24
-                Layout.rightMargin: 24
-                spacing: 12
+                Layout.leftMargin: Tokens.spacing_xl
+                Layout.rightMargin: Tokens.spacing_xl
+                spacing: Tokens.spacing_m
 
                 Label {
                     text: qsTr("Slider")
                     color: Theme.on_surface_variant
-                    font.pixelSize: 13
-                    font.weight: Font.DemiBold
+                    font.pixelSize: Tokens.font_size_body_m
+                    font.weight: Tokens.font_weight_demibold
                 }
 
                 PhosphorSlider {
@@ -209,20 +213,20 @@ ApplicationWindow {
             // ── Text fields ──────────────────────────────────────────
             ColumnLayout {
                 Layout.fillWidth: true
-                Layout.leftMargin: 24
-                Layout.rightMargin: 24
-                spacing: 12
+                Layout.leftMargin: Tokens.spacing_xl
+                Layout.rightMargin: Tokens.spacing_xl
+                spacing: Tokens.spacing_m
 
                 Label {
                     text: qsTr("Text fields")
                     color: Theme.on_surface_variant
-                    font.pixelSize: 13
-                    font.weight: Font.DemiBold
+                    font.pixelSize: Tokens.font_size_body_m
+                    font.weight: Tokens.font_weight_demibold
                 }
 
                 Flow {
                     Layout.fillWidth: true
-                    spacing: 12
+                    spacing: Tokens.spacing_m
 
                     PhosphorTextField {
                         placeholderText: qsTr("Search")
@@ -242,21 +246,21 @@ ApplicationWindow {
             // ── Cards ────────────────────────────────────────────────
             ColumnLayout {
                 Layout.fillWidth: true
-                Layout.leftMargin: 24
-                Layout.rightMargin: 24
-                Layout.bottomMargin: 24
-                spacing: 12
+                Layout.leftMargin: Tokens.spacing_xl
+                Layout.rightMargin: Tokens.spacing_xl
+                Layout.bottomMargin: Tokens.spacing_xl
+                spacing: Tokens.spacing_m
 
                 Label {
                     text: qsTr("Cards (elevation 0 → 5: shadow deepens, surface tint rises)")
                     color: Theme.on_surface_variant
-                    font.pixelSize: 13
-                    font.weight: Font.DemiBold
+                    font.pixelSize: Tokens.font_size_body_m
+                    font.weight: Tokens.font_weight_demibold
                 }
 
                 Flow {
                     Layout.fillWidth: true
-                    spacing: 20
+                    spacing: Tokens.spacing_l
 
                     Repeater {
                         model: 6
@@ -267,19 +271,19 @@ ApplicationWindow {
                             elevation: index
 
                             ColumnLayout {
-                                spacing: 8
+                                spacing: Tokens.spacing_s
 
                                 Label {
                                     text: qsTr("Card")
                                     color: Theme.on_surface
-                                    font.pixelSize: 15
-                                    font.weight: Font.Medium
+                                    font.pixelSize: Tokens.font_size_title_s
+                                    font.weight: Tokens.font_weight_medium
                                 }
 
                                 Label {
                                     text: qsTr("Elevation %1").arg(index)
                                     color: Theme.on_surface_variant
-                                    font.pixelSize: 12
+                                    font.pixelSize: Tokens.font_size_body_s
                                 }
                             }
                         }

--- a/examples/phosphor-widgets-kitchen-sink/Main.qml
+++ b/examples/phosphor-widgets-kitchen-sink/Main.qml
@@ -252,7 +252,7 @@ ApplicationWindow {
                 spacing: Tokens.spacing_m
 
                 Label {
-                    text: qsTr("Cards (elevation 0 → 5: shadow deepens, surface tint rises)")
+                    text: qsTr("Cards (elevation 0 → 5 deepens the shadow and raises the surface tint)")
                     color: Theme.on_surface_variant
                     font.pixelSize: Tokens.font_size_body_m
                     font.weight: Tokens.font_weight_demibold

--- a/examples/phosphor-widgets-kitchen-sink/Main.qml
+++ b/examples/phosphor-widgets-kitchen-sink/Main.qml
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+// phosphor-widgets-kitchen-sink, the Phase 3.1 acceptance demo.
+//
+// One scrollable window listing every Phosphor.Widgets atom in its
+// enabled and disabled states. Hover, press, and focus states are live:
+// interact with the enabled specimens to see the state-layer tint,
+// ripple, and focus outline. The header cycles the accent token and
+// resets the palette, proving every atom retints live through the Theme
+// singleton with no per-widget refresh.
+
+import Phosphor.Theme
+import Phosphor.Widgets
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ApplicationWindow {
+    id: root
+
+    // Round-robin index into the accent list below, advanced by the
+    // "Cycle accent" button. Held here because PaletteStore doesn't track
+    // demo-applied overrides.
+    property int accentIndex: 0
+
+    readonly property var accents: ["#3B82F6", "#A855F7", "#22D3EE", "#10B981", "#FBBF24", "#F43F5E"]
+
+    width: 880
+    height: 900
+    visible: true
+    title: qsTr("Phosphor Widgets, Kitchen Sink")
+    color: Theme.background
+
+    // Apply an accent override the same way matugen / the theme presets
+    // do: PaletteStore.applyTokens merges over the active palette, so
+    // every `Theme.primary` binding re-evaluates live.
+    function cycleAccent() {
+        accentIndex = (accentIndex + 1) % accents.length;
+        Theme.paletteStore.applyTokens({
+            "primary": accents[accentIndex]
+        });
+    }
+
+    header: ToolBar {
+        background: Rectangle {
+            color: Theme.surface_container
+        }
+
+        RowLayout {
+            anchors.fill: parent
+            anchors.leftMargin: 16
+            anchors.rightMargin: 16
+            spacing: 12
+
+            Label {
+                text: qsTr("Phosphor.Widgets")
+                color: Theme.on_surface
+                font.pixelSize: 18
+                font.weight: Font.DemiBold
+                Layout.fillWidth: true
+            }
+
+            PhosphorButton {
+                text: qsTr("Cycle accent")
+                variant: PhosphorButton.Tonal
+                onClicked: root.cycleAccent()
+            }
+
+            PhosphorButton {
+                text: qsTr("Reset")
+                variant: PhosphorButton.Text
+                onClicked: {
+                    root.accentIndex = 0;
+                    Theme.paletteStore.resetToDefaults();
+                }
+            }
+        }
+    }
+
+    ScrollView {
+        anchors.fill: parent
+        contentWidth: availableWidth
+
+        ColumnLayout {
+            width: root.width
+            spacing: 28
+
+            // ── Buttons ──────────────────────────────────────────────
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: 24
+                Layout.rightMargin: 24
+                Layout.topMargin: 24
+                spacing: 12
+
+                Label {
+                    text: qsTr("Buttons")
+                    color: Theme.on_surface_variant
+                    font.pixelSize: 13
+                    font.weight: Font.DemiBold
+                }
+
+                Flow {
+                    Layout.fillWidth: true
+                    spacing: 12
+
+                    PhosphorButton {
+                        text: qsTr("Filled")
+                        variant: PhosphorButton.Filled
+                    }
+
+                    PhosphorButton {
+                        text: qsTr("Tonal")
+                        variant: PhosphorButton.Tonal
+                    }
+
+                    PhosphorButton {
+                        text: qsTr("Outlined")
+                        variant: PhosphorButton.Outlined
+                    }
+
+                    PhosphorButton {
+                        text: qsTr("Text")
+                        variant: PhosphorButton.Text
+                    }
+
+                    PhosphorButton {
+                        text: qsTr("Disabled")
+                        variant: PhosphorButton.Filled
+                        enabled: false
+                    }
+                }
+            }
+
+            // ── Pills ────────────────────────────────────────────────
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: 24
+                Layout.rightMargin: 24
+                spacing: 12
+
+                Label {
+                    text: qsTr("Pills")
+                    color: Theme.on_surface_variant
+                    font.pixelSize: 13
+                    font.weight: Font.DemiBold
+                }
+
+                Flow {
+                    Layout.fillWidth: true
+                    spacing: 12
+
+                    PhosphorPill {
+                        // Local toggle state for the demo; a real host
+                        // binds selected to a service property.
+                        property bool checked: true
+
+                        text: qsTr("Wi-Fi")
+                        selected: checked
+                        onToggled: checked = !checked
+                    }
+
+                    PhosphorPill {
+                        property bool checked: false
+
+                        text: qsTr("Bluetooth")
+                        selected: checked
+                        onToggled: checked = !checked
+                    }
+
+                    PhosphorPill {
+                        text: qsTr("Disabled")
+                        selected: true
+                        enabled: false
+                    }
+                }
+            }
+
+            // ── Slider ───────────────────────────────────────────────
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: 24
+                Layout.rightMargin: 24
+                spacing: 12
+
+                Label {
+                    text: qsTr("Slider")
+                    color: Theme.on_surface_variant
+                    font.pixelSize: 13
+                    font.weight: Font.DemiBold
+                }
+
+                PhosphorSlider {
+                    Layout.preferredWidth: 320
+                    from: 0
+                    to: 100
+                    value: 40
+                }
+
+                PhosphorSlider {
+                    Layout.preferredWidth: 320
+                    from: 0
+                    to: 100
+                    value: 70
+                    enabled: false
+                }
+            }
+
+            // ── Text fields ──────────────────────────────────────────
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: 24
+                Layout.rightMargin: 24
+                spacing: 12
+
+                Label {
+                    text: qsTr("Text fields")
+                    color: Theme.on_surface_variant
+                    font.pixelSize: 13
+                    font.weight: Font.DemiBold
+                }
+
+                Flow {
+                    Layout.fillWidth: true
+                    spacing: 12
+
+                    PhosphorTextField {
+                        placeholderText: qsTr("Search")
+                    }
+
+                    PhosphorTextField {
+                        text: qsTr("Typed value")
+                    }
+
+                    PhosphorTextField {
+                        placeholderText: qsTr("Disabled")
+                        enabled: false
+                    }
+                }
+            }
+
+            // ── Cards ────────────────────────────────────────────────
+            ColumnLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: 24
+                Layout.rightMargin: 24
+                Layout.bottomMargin: 24
+                spacing: 12
+
+                Label {
+                    text: qsTr("Cards (elevation 0 → 5: shadow deepens, surface tint rises)")
+                    color: Theme.on_surface_variant
+                    font.pixelSize: 13
+                    font.weight: Font.DemiBold
+                }
+
+                Flow {
+                    Layout.fillWidth: true
+                    spacing: 20
+
+                    Repeater {
+                        model: 6
+
+                        PhosphorCard {
+                            required property int index
+
+                            elevation: index
+
+                            ColumnLayout {
+                                spacing: 8
+
+                                Label {
+                                    text: qsTr("Card")
+                                    color: Theme.on_surface
+                                    font.pixelSize: 15
+                                    font.weight: Font.Medium
+                                }
+
+                                Label {
+                                    text: qsTr("Elevation %1").arg(index)
+                                    color: Theme.on_surface_variant
+                                    font.pixelSize: 12
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/phosphor-widgets-kitchen-sink/main.cpp
+++ b/examples/phosphor-widgets-kitchen-sink/main.cpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// phosphor-widgets-kitchen-sink entry point.
+//
+// QGuiApplication + QQmlApplicationEngine. The demo is pure QML (the
+// atoms and the Theme singleton carry all the state), so there is no
+// controller to expose; main just loads Main.qml from the demo module.
+
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QQuickStyle>
+#include <QString>
+
+int main(int argc, char* argv[])
+{
+    QGuiApplication app(argc, argv);
+    QCoreApplication::setOrganizationName(QStringLiteral("Phosphor"));
+    QCoreApplication::setApplicationName(QStringLiteral("phosphor-widgets-kitchen-sink"));
+
+    // Same Basic-style choice the other Phosphor demos use: it keeps the
+    // QtQuick.Controls chrome (ToolBar, ScrollView, Label) out of any
+    // platform style's retint path so only our token-driven atoms drive
+    // the colours.
+    QQuickStyle::setStyle(QStringLiteral("Basic"));
+
+    QQmlApplicationEngine engine;
+    engine.loadFromModule(QStringLiteral("Phosphor.WidgetsKitchenSink"), QStringLiteral("Main"));
+    if (engine.rootObjects().isEmpty()) {
+        return 1;
+    }
+    return app.exec();
+}

--- a/libs/phosphor-shell-notifications/CMakeLists.txt
+++ b/libs/phosphor-shell-notifications/CMakeLists.txt
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# PhosphorShellNotifications, the Phosphor.Notifications toast framework.
+#
+# A pure-QML module: ToastHost (the top-right toast stack manager, owning
+# the queue, per-toast lifecycle, and add/remove/reflow transitions) plus
+# the Toast card (image + rich text + hover-to-pause auto-dismiss).
+# Themed through phosphor-theme and built on the phosphor-shell-widgets
+# atoms (ElevationShadow, StateLayer).
+#
+# Phase 3.4 deliverable per docs/phosphor-shell-design/04-implementation-plan.md.
+
+cmake_minimum_required(VERSION 3.16)
+
+set(PHOSPHORSHELLNOTIFICATIONS_VERSION "0.1.0")
+
+if(NOT PROJECT_VERSION)
+    project(PhosphorShellNotifications VERSION ${PHOSPHORSHELLNOTIFICATIONS_VERSION} LANGUAGES CXX)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_AUTOMOC ON)
+endif()
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dependencies
+# ═══════════════════════════════════════════════════════════════════════════════
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick QuickShapes)
+
+# Toast imports Phosphor.Theme (tokens) and Phosphor.Widgets
+# (ElevationShadow). The import scanner needs them visible at build time,
+# and consumers need their runtime plugins linked. In-tree builds always
+# have the sibling targets; fall back to installed packages.
+if(NOT TARGET PhosphorTheme::PhosphorThemeQml)
+    find_package(PhosphorTheme CONFIG QUIET)
+endif()
+if(NOT TARGET PhosphorShellWidgets::PhosphorShellWidgetsQml)
+    find_package(PhosphorShellWidgets CONFIG QUIET)
+endif()
+
+if(COMMAND qt_policy)
+    qt_policy(SET QTP0001 NEW)
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# QML module, STATIC (in-tree linkable)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set(_phosphor_notifications_qml_files
+    qml/Phosphor/Notifications/Toast.qml
+    qml/Phosphor/Notifications/ToastHost.qml
+)
+
+foreach(_qml_file IN LISTS _phosphor_notifications_qml_files)
+    get_filename_component(_qml_basename ${_qml_file} NAME)
+    set_source_files_properties(${_qml_file}
+        PROPERTIES
+            QT_RESOURCE_ALIAS ${_qml_basename}
+    )
+endforeach()
+
+# Directory-scope suppression of -Wmissing-include-dirs. Full rationale:
+# src/shared/CMakeLists.txt.
+set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-Wno-missing-include-dirs")
+
+qt_add_qml_module(PhosphorShellNotificationsQml
+    URI Phosphor.Notifications
+    VERSION 1.0
+    STATIC
+    IMPORTS
+        Phosphor.Theme
+        Phosphor.Widgets
+        QtQuick.Shapes
+        QtQuick.Layouts
+    SOURCES
+        src/phosphorshellnotifications_qml_plugin.cpp
+    QML_FILES ${_phosphor_notifications_qml_files}
+    OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/qml/Phosphor/Notifications
+)
+
+add_library(PhosphorShellNotifications::PhosphorShellNotificationsQml ALIAS PhosphorShellNotificationsQml)
+
+target_compile_features(PhosphorShellNotificationsQml PUBLIC cxx_std_20)
+
+target_link_libraries(PhosphorShellNotificationsQml
+    PUBLIC
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickShapes
+)
+
+if(TARGET PhosphorShellWidgets::PhosphorShellWidgetsQml)
+    target_link_libraries(PhosphorShellNotificationsQml PUBLIC PhosphorShellWidgets::PhosphorShellWidgetsQml)
+endif()
+if(TARGET PhosphorShellWidgetsQmlplugin)
+    target_link_libraries(PhosphorShellNotificationsQml PUBLIC PhosphorShellWidgetsQmlplugin)
+endif()
+if(TARGET PhosphorTheme::PhosphorThemeQml)
+    target_link_libraries(PhosphorShellNotificationsQml PUBLIC PhosphorTheme::PhosphorThemeQml)
+endif()
+if(TARGET PhosphorThemeQmlplugin)
+    target_link_libraries(PhosphorShellNotificationsQml PUBLIC PhosphorThemeQmlplugin)
+endif()
+
+# No install rules: STATIC, in-tree-only QML module (like the sibling
+# phosphor-shell-* QML modules). Linked directly by the shell and the
+# toast demo; a standalone installed deployment lands with the shell
+# binary in Phase 4.
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+if(CMAKE_PROJECT_NAME STREQUAL "PhosphorShellNotifications" OR BUILD_TESTING)
+    enable_testing()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt")
+        add_subdirectory(tests)
+    endif()
+endif()

--- a/libs/phosphor-shell-notifications/CMakeLists.txt
+++ b/libs/phosphor-shell-notifications/CMakeLists.txt
@@ -6,8 +6,8 @@
 # A pure-QML module: ToastHost (the top-right toast stack manager, owning
 # the queue, per-toast lifecycle, and add/remove/reflow transitions) plus
 # the Toast card (image + rich text + hover-to-pause auto-dismiss).
-# Themed through phosphor-theme and built on the phosphor-shell-widgets
-# atoms (ElevationShadow, StateLayer).
+# Themed through phosphor-theme (tokens, Motion, StateLayer) and the
+# phosphor-shell-widgets ElevationShadow atom.
 #
 # Phase 3.4 deliverable per docs/phosphor-shell-design/04-implementation-plan.md.
 

--- a/libs/phosphor-shell-notifications/README.md
+++ b/libs/phosphor-shell-notifications/README.md
@@ -83,9 +83,9 @@ it was visible or still queued.
 
 - Qt6 ≥ 6.6 Core / Gui / Qml / Quick; `QtQuick.Shapes` (`Qt6::QuickShapes`)
   for the close glyph.
-- `phosphor-theme` (`Phosphor.Theme`) for tokens and Motion;
-  `phosphor-shell-widgets` (`Phosphor.Widgets`) for `ElevationShadow` /
-  `StateLayer`. In-tree builds link their QML plugins automatically. This
+- `phosphor-theme` (`Phosphor.Theme`) for tokens, Motion, and `StateLayer`;
+  `phosphor-shell-widgets` (`Phosphor.Widgets`) for `ElevationShadow`.
+  In-tree builds link their QML plugins automatically. This
   module is static and in-tree-only today.
 
 ## Status

--- a/libs/phosphor-shell-notifications/README.md
+++ b/libs/phosphor-shell-notifications/README.md
@@ -21,7 +21,7 @@ Provide a seam where a rules service can suppress or retime toasts.
 
 The framework owns presentation, queueing, and timing only. Notification
 *ingest* (the `org.freedesktop.Notifications` server) is a separate
-concern: the host feeds toasts in by calling `show()`. The toast demo
+concern. The host feeds toasts in by calling `show()`. The toast demo
 wires `phosphor-service-notifications` to that call.
 
 ## Key types
@@ -74,8 +74,8 @@ it was visible or still queued.
   when set.
 - **Per-app-rules seam.** Assign `ToastHost.rules`, an object exposing
   `evaluate(toast) -> { suppress: bool, timeout: int } | null`. ToastHost
-  consults it before showing each toast: `suppress` drops it, `timeout`
-  overrides the auto-dismiss. The rules editor and its persistence are
+  consults it before showing each toast. `suppress` drops it, and
+  `timeout` overrides the auto-dismiss. The rules editor and its persistence are
   Phase 4.3 (Notification center) and wire into this seam without
   touching ToastHost.
 
@@ -85,7 +85,7 @@ it was visible or still queued.
   for the close glyph.
 - `phosphor-theme` (`Phosphor.Theme`) for tokens and Motion;
   `phosphor-shell-widgets` (`Phosphor.Widgets`) for `ElevationShadow` /
-  `StateLayer`. In-tree builds link their QML plugins automatically; this
+  `StateLayer`. In-tree builds link their QML plugins automatically. This
   module is static and in-tree-only today.
 
 ## Status

--- a/libs/phosphor-shell-notifications/README.md
+++ b/libs/phosphor-shell-notifications/README.md
@@ -1,0 +1,96 @@
+<!-- SPDX-FileCopyrightText: 2026 fuddlesworth -->
+<!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
+
+# PhosphorShellNotifications
+
+The `Phosphor.Notifications` toast framework: the transient, top-right
+notification popups a shell flashes when an app posts a notification.
+Pure QML, themed through [`phosphor-theme`](../phosphor-theme/README.md)
+and built on the [`phosphor-shell-widgets`](../phosphor-shell-widgets/README.md)
+atoms.
+
+Phase 3.4 deliverable per
+[`docs/phosphor-shell-design/04-implementation-plan.md`](../../docs/phosphor-shell-design/04-implementation-plan.md).
+
+## Responsibility
+
+Own the lifecycle and layout of toasts: stack them top-right (newest on
+top), show up to `maxVisible` at once and queue the rest, auto-dismiss
+each after a timeout (paused while hovered), and animate in/out/reflow.
+Provide a seam where a rules service can suppress or retime toasts.
+
+The framework owns presentation, queueing, and timing only. Notification
+*ingest* (the `org.freedesktop.Notifications` server) is a separate
+concern: the host feeds toasts in by calling `show()`. The toast demo
+wires `phosphor-service-notifications` to that call.
+
+## Key types
+
+| Component   | Role                                                                                       |
+|-------------|--------------------------------------------------------------------------------------------|
+| `ToastHost` | Top-right toast stack: queue beyond `maxVisible`, dismiss + promote, slide/reflow transitions, per-app-rules seam. |
+| `Toast`     | A single toast card: optional image, app name, summary, rich-text body, close, urgency accent, hover-to-pause auto-dismiss. |
+
+## Typical use
+
+```qml
+import Phosphor.Notifications
+
+ToastHost {
+    id: toasts
+    anchors.fill: parent
+    maxVisible: 4
+    rules: dndRules   // optional, see below
+}
+
+// when a notification arrives:
+toasts.show({
+    appName: "Mail",
+    summary: "New message",
+    body: "From <b>Ada</b>",          // StyledText markup
+    imageSource: "file:///.../avatar.png",
+    urgency: 1,                        // 0 low, 1 normal, 2 critical
+    timeout: 5000                      // 0 = sticky
+})
+```
+
+`show()` returns the toast id, or `-1` if a rule suppressed it. Dismiss
+with `dismiss(id)`; `clear()` removes everything (e.g. before a session
+lock). `toastDismissed(id)` fires whenever a toast leaves.
+
+## Design notes
+
+- **Queue, don't flood.** At most `maxVisible` toasts are shown; the rest
+  queue and promote as slots free up. Newest shows on top.
+- **Hover-to-pause.** Each `Toast` owns its auto-dismiss timer, which
+  stops while the pointer is over it (so a toast you're reading stays).
+- **Motion via the view.** `ToastHost` uses a `ListView` whose `add` /
+  `remove` / `displaced` transitions slide toasts in from the right, out
+  to the right, and reflow the stack, all on `phosphor-theme` Motion
+  tokens.
+- **Rich text + image.** `Toast.body` is `StyledText` (the freedesktop
+  notification body markup subset); `imageSource` renders an image/avatar
+  when set.
+- **Per-app-rules seam.** Assign `ToastHost.rules`, an object exposing
+  `evaluate(toast) -> { suppress: bool, timeout: int } | null`. ToastHost
+  consults it before showing each toast: `suppress` drops it, `timeout`
+  overrides the auto-dismiss. The rules editor and its persistence are
+  Phase 4.3 (Notification center) and wire into this seam without
+  touching ToastHost.
+
+## Dependencies
+
+- Qt6 ≥ 6.6 Core / Gui / Qml / Quick; `QtQuick.Shapes` (`Qt6::QuickShapes`)
+  for the close glyph.
+- `phosphor-theme` (`Phosphor.Theme`) for tokens and Motion;
+  `phosphor-shell-widgets` (`Phosphor.Widgets`) for `ElevationShadow` /
+  `StateLayer`. In-tree builds link their QML plugins automatically; this
+  module is static and in-tree-only today.
+
+## Status
+
+Phase 3.4: in progress. `ToastHost` and `Toast` are in the tree with a
+QtQuickTest suite and an acceptance demo (`examples/phosphor-toast-demo/`,
+fed by `phosphor-service-notifications` so `notify-send` raises a toast).
+This is the last 3.x milestone before the `phosphor-ui-primitives-0.1`
+gate.

--- a/libs/phosphor-shell-notifications/README.md
+++ b/libs/phosphor-shell-notifications/README.md
@@ -55,8 +55,9 @@ toasts.show({
 ```
 
 `show()` returns the toast id, or `-1` if a rule suppressed it. Dismiss
-with `dismiss(id)`; `clear()` removes everything (e.g. before a session
-lock). `toastDismissed(id)` fires whenever a toast leaves.
+with `dismiss(id)`, and `clear()` removes everything (e.g. before a
+session lock). `toastDismissed(id)` fires whenever a toast leaves, whether
+it was visible or still queued.
 
 ## Design notes
 

--- a/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/Toast.qml
+++ b/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/Toast.qml
@@ -1,0 +1,194 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Notifications.Toast, a single notification toast card.
+//
+// An elevated card with an optional image/avatar, the app name, a
+// summary, and a rich-text body, plus a close affordance. It owns its
+// own auto-dismiss timer, which pauses while the pointer hovers (so a
+// toast the user is reading does not vanish). Position/stacking is the
+// host's job (ToastHost); this is just the card.
+//
+//   Toast {
+//       appName: "Mail"; summary: "New message"
+//       body: "From <b>Ada</b>"; imageSource: "file:///.../avatar.png"
+//       urgency: 1; timeout: 5000
+//       onDismissed: ...
+//   }
+
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Shapes
+import Phosphor.Theme
+import Phosphor.Widgets
+
+Item {
+    id: toast
+
+    property string appName: ""
+    property string summary: ""
+    // Rich text (StyledText subset), matching the freedesktop notification
+    // body markup.
+    property string body: ""
+    property url imageSource: ""
+    // 0 low, 1 normal, 2 critical. Critical gets an error accent stripe.
+    property int urgency: 1
+    // Auto-dismiss after this many ms; 0 disables (sticky).
+    property int timeout: 5000
+
+    signal dismissed
+
+    // Exposed so a host can coordinate; also gates the dismiss timer.
+    readonly property bool hovered: hover.hovered
+
+    implicitWidth: 360
+    implicitHeight: Math.max(72, row.implicitHeight + 28)
+
+    HoverHandler {
+        id: hover
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: 16
+        color: Theme.surface_container_high
+        layer.enabled: true
+        layer.effect: ElevationShadow {
+            level: 3
+        }
+    }
+
+    // Critical-urgency accent stripe.
+    Rectangle {
+        visible: toast.urgency >= 2
+        width: 4
+        radius: 2
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.margins: 10
+        color: Theme.error
+    }
+
+    RowLayout {
+        id: row
+
+        anchors.fill: parent
+        anchors.margins: 14
+        anchors.leftMargin: toast.urgency >= 2 ? 22 : 14
+        spacing: 12
+
+        // Image / avatar, shown only when a source is set.
+        Rectangle {
+            visible: String(toast.imageSource) !== ""
+            Layout.preferredWidth: 40
+            Layout.preferredHeight: 40
+            Layout.alignment: Qt.AlignTop
+            radius: 8
+            clip: true
+            color: Theme.surface_variant
+
+            Image {
+                anchors.fill: parent
+                source: toast.imageSource
+                fillMode: Image.PreserveAspectCrop
+                asynchronous: true
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            spacing: 2
+
+            Text {
+                visible: toast.appName !== ""
+                text: toast.appName
+                color: Theme.on_surface_variant
+                font.pixelSize: 11
+                font.weight: Font.Medium
+                elide: Text.ElideRight
+                Layout.fillWidth: true
+            }
+
+            Text {
+                visible: toast.summary !== ""
+                text: toast.summary
+                color: Theme.on_surface
+                font.pixelSize: 14
+                font.weight: Font.DemiBold
+                wrapMode: Text.WordWrap
+                maximumLineCount: 2
+                elide: Text.ElideRight
+                Layout.fillWidth: true
+            }
+
+            Text {
+                visible: toast.body !== ""
+                text: toast.body
+                color: Theme.on_surface_variant
+                font.pixelSize: 13
+                textFormat: Text.StyledText
+                wrapMode: Text.WordWrap
+                maximumLineCount: 4
+                elide: Text.ElideRight
+                Layout.fillWidth: true
+            }
+        }
+
+        // Close affordance.
+        Item {
+            Layout.preferredWidth: 22
+            Layout.preferredHeight: 22
+            Layout.alignment: Qt.AlignTop
+
+            Rectangle {
+                anchors.fill: parent
+                radius: width / 2
+                color: Theme.on_surface
+                opacity: closeHover.hovered ? StateLayer.hover : 0
+
+                Behavior on opacity {
+                    NumberAnimation {
+                        duration: Motion.duration_short_2
+                    }
+                }
+            }
+
+            Shape {
+                anchors.centerIn: parent
+                width: 12
+                height: 12
+                preferredRendererType: Shape.CurveRenderer
+
+                ShapePath {
+                    fillColor: "transparent"
+                    strokeColor: Theme.on_surface_variant
+                    strokeWidth: 1.6
+                    capStyle: ShapePath.RoundCap
+
+                    PathSvg {
+                        path: "M 1 1 L 11 11 M 11 1 L 1 11"
+                    }
+                }
+            }
+
+            HoverHandler {
+                id: closeHover
+            }
+
+            TapHandler {
+                onTapped: toast.dismissed()
+            }
+        }
+    }
+
+    // Auto-dismiss. Hovering stops the timer; leaving restarts the full
+    // timeout (a simple, lossless-enough "hover keeps it open"). A zero
+    // timeout is sticky (the user must close it).
+    Timer {
+        interval: toast.timeout
+        running: toast.timeout > 0 && !toast.hovered
+        repeat: false
+        onTriggered: toast.dismissed()
+    }
+}

--- a/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/Toast.qml
+++ b/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/Toast.qml
@@ -61,7 +61,7 @@ Item {
     Rectangle {
         visible: toast.urgency >= 2
         width: Tokens.spacing_xs
-        radius: 2
+        radius: width / 2
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.bottom: parent.bottom

--- a/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/Toast.qml
+++ b/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/Toast.qml
@@ -41,7 +41,7 @@ Item {
     readonly property bool hovered: hover.hovered
 
     implicitWidth: 360
-    implicitHeight: Math.max(72, row.implicitHeight + 28)
+    implicitHeight: Math.max(72, row.implicitHeight + 2 * Tokens.spacing_m)
 
     HoverHandler {
         id: hover
@@ -49,7 +49,7 @@ Item {
 
     Rectangle {
         anchors.fill: parent
-        radius: 16
+        radius: Tokens.radius_l
         color: Theme.surface_container_high
         layer.enabled: true
         layer.effect: ElevationShadow {
@@ -60,12 +60,12 @@ Item {
     // Critical-urgency accent stripe.
     Rectangle {
         visible: toast.urgency >= 2
-        width: 4
+        width: Tokens.spacing_xs
         radius: 2
         anchors.left: parent.left
         anchors.top: parent.top
         anchors.bottom: parent.bottom
-        anchors.margins: 10
+        anchors.margins: Tokens.spacing_s
         color: Theme.error
     }
 
@@ -73,9 +73,9 @@ Item {
         id: row
 
         anchors.fill: parent
-        anchors.margins: 14
-        anchors.leftMargin: toast.urgency >= 2 ? 22 : 14
-        spacing: 12
+        anchors.margins: Tokens.spacing_m
+        anchors.leftMargin: toast.urgency >= 2 ? Tokens.spacing_xl : Tokens.spacing_m
+        spacing: Tokens.spacing_m
 
         // Image / avatar, shown only when a source is set.
         Rectangle {
@@ -83,7 +83,7 @@ Item {
             Layout.preferredWidth: 40
             Layout.preferredHeight: 40
             Layout.alignment: Qt.AlignTop
-            radius: 8
+            radius: Tokens.radius_s
             clip: true
             color: Theme.surface_variant
 
@@ -98,14 +98,14 @@ Item {
         ColumnLayout {
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignVCenter
-            spacing: 2
+            spacing: Tokens.spacing_xxs
 
             Text {
                 visible: toast.appName !== ""
                 text: toast.appName
                 color: Theme.on_surface_variant
-                font.pixelSize: 11
-                font.weight: Font.Medium
+                font.pixelSize: Tokens.font_size_label_s
+                font.weight: Tokens.font_weight_medium
                 elide: Text.ElideRight
                 Layout.fillWidth: true
             }
@@ -114,8 +114,8 @@ Item {
                 visible: toast.summary !== ""
                 text: toast.summary
                 color: Theme.on_surface
-                font.pixelSize: 14
-                font.weight: Font.DemiBold
+                font.pixelSize: Tokens.font_size_body_l
+                font.weight: Tokens.font_weight_demibold
                 wrapMode: Text.WordWrap
                 maximumLineCount: 2
                 elide: Text.ElideRight
@@ -126,7 +126,7 @@ Item {
                 visible: toast.body !== ""
                 text: toast.body
                 color: Theme.on_surface_variant
-                font.pixelSize: 13
+                font.pixelSize: Tokens.font_size_body_m
                 textFormat: Text.StyledText
                 wrapMode: Text.WordWrap
                 maximumLineCount: 4

--- a/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/Toast.qml
+++ b/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/Toast.qml
@@ -43,6 +43,11 @@ Item {
     implicitWidth: 360
     implicitHeight: Math.max(72, row.implicitHeight + 2 * Tokens.spacing_m)
 
+    // Announce the toast to assistive tech. Use the plain-text app name and
+    // summary only; body is StyledText markup and would read its tags aloud.
+    Accessible.role: Accessible.Notification
+    Accessible.name: [toast.appName, toast.summary].filter(s => s !== "").join(", ")
+
     HoverHandler {
         id: hover
     }
@@ -137,9 +142,17 @@ Item {
 
         // Close affordance.
         Item {
+            id: closeButton
+
             Layout.preferredWidth: 22
             Layout.preferredHeight: 22
             Layout.alignment: Qt.AlignTop
+
+            // A real button to assistive tech: named, and activatable via the
+            // AT press action (the pointer path goes through the TapHandler).
+            Accessible.role: Accessible.Button
+            Accessible.name: qsTr("Dismiss notification")
+            Accessible.onPressAction: toast.dismissed()
 
             Rectangle {
                 anchors.fill: parent
@@ -186,7 +199,9 @@ Item {
     // timeout (a simple, lossless-enough "hover keeps it open"). A zero
     // timeout is sticky (the user must close it).
     Timer {
-        interval: toast.timeout
+        // Floor a stray negative timeout to a valid interval; running still
+        // gates on timeout > 0, so 0 and negative both mean sticky.
+        interval: Math.max(0, toast.timeout)
         running: toast.timeout > 0 && !toast.hovered
         repeat: false
         onTriggered: toast.dismissed()

--- a/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
+++ b/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
@@ -46,7 +46,10 @@ Item {
     //   { id?, appName, summary, body, imageSource, urgency, timeout }
     // Returns the toast id, or -1 if a rule suppressed it.
     function show(toast) {
-        const t = toast || {};
+        // Shallow-copy so a rules timeout override (t.timeout = ...) can't
+        // mutate the caller's object; Object.assign ignores a null/undefined
+        // source, so this also covers a missing argument.
+        const t = Object.assign({}, toast);
 
         // Per-app-rules seam: consult before showing.
         if (host.rules && typeof host.rules.evaluate === "function") {

--- a/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
+++ b/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
@@ -93,8 +93,11 @@ Item {
         for (let i = 0; i < activeModel.count; ++i) {
             if (activeModel.get(i).toastId === id) {
                 activeModel.remove(i);
-                host.toastDismissed(id);
+                // Promote the next queued toast before emitting, so a
+                // re-entrant toastDismissed handler observes the slot already
+                // refilled (matches clear()'s mutate-fully-then-emit order).
                 priv.promote();
+                host.toastDismissed(id);
                 return;
             }
         }
@@ -157,7 +160,7 @@ Item {
         anchors.topMargin: host.margins
         anchors.rightMargin: host.margins
         width: 360
-        height: Math.min(contentHeight, parent.height - host.margins * 2)
+        height: Math.max(0, Math.min(contentHeight, parent.height - host.margins * 2))
         spacing: host.spacing
         interactive: false
         clip: false

--- a/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
+++ b/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
@@ -32,8 +32,8 @@ Item {
     property int maxVisible: 4
     // Default auto-dismiss when a toast doesn't specify one.
     property int defaultTimeout: 5000
-    property real spacing: 10
-    property real margins: 16
+    property real spacing: Tokens.spacing_s
+    property real margins: Tokens.spacing_l
     // Per-app-rules hook (see header). Null = no rules.
     property var rules: null
 
@@ -69,8 +69,8 @@ Item {
 
         if (activeModel.count < host.maxVisible)
             activeModel.insert(0, row);
-            // newest on top
         else
+            // newest on top
             // Reassign (not push) so the queuedCount binding re-evaluates;
             // an in-place Array.push doesn't notify QML.
             priv.queue = priv.queue.concat([row]);
@@ -92,15 +92,28 @@ Item {
             if (priv.queue[j].toastId === id) {
                 // Reassign so queuedCount updates (see show()).
                 priv.queue = priv.queue.slice(0, j).concat(priv.queue.slice(j + 1));
+                // A queued toast that is dismissed also "left"; emit so the
+                // contract (toastDismissed fires whenever a toast leaves)
+                // holds for queued toasts, not just visible ones.
+                host.toastDismissed(id);
                 return;
             }
         }
     }
 
-    // Clear everything (e.g. a session lock about to show).
+    // Clear everything (e.g. a session lock about to show). Emits
+    // toastDismissed for every toast removed (visible and queued) so the
+    // signal contract holds for bulk teardown too.
     function clear() {
+        const ids = [];
+        for (let i = 0; i < activeModel.count; ++i)
+            ids.push(activeModel.get(i).toastId);
+        for (let j = 0; j < priv.queue.length; ++j)
+            ids.push(priv.queue[j].toastId);
         priv.queue = [];
         activeModel.clear();
+        for (let k = 0; k < ids.length; ++k)
+            host.toastDismissed(ids[k]);
     }
 
     QtObject {

--- a/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
+++ b/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Notifications.ToastHost, the toast stack manager.
+//
+// Stacks transient notification toasts at the top-right, newest on top.
+// Shows up to maxVisible at once and queues the rest; as a toast
+// dismisses (timeout, hover-then-leave, or close), the next queued toast
+// takes its place. Slide-in / slide-out / reflow are handled by the
+// ListView add / remove / displaced transitions (Motion tokens).
+//
+//   ToastHost {
+//       id: toasts
+//       anchors.fill: parent
+//       rules: dndRules   // optional per-app-rules seam
+//   }
+//   toasts.show({ appName: "Mail", summary: "New message", body: "..." })
+//
+// Per-app-rules seam: assign `rules`, an object exposing
+//   evaluate(toast) -> { suppress: bool, timeout: int } | null
+// ToastHost consults it before showing each toast (suppress drops it;
+// timeout overrides the auto-dismiss). The rules editor + persistence are
+// Phase 4.3 (Notification center) and wire into this seam without
+// touching ToastHost.
+
+import QtQuick
+import Phosphor.Theme
+
+Item {
+    id: host
+
+    // Most toasts shown at once; extras queue.
+    property int maxVisible: 4
+    // Default auto-dismiss when a toast doesn't specify one.
+    property int defaultTimeout: 5000
+    property real spacing: 10
+    property real margins: 16
+    // Per-app-rules hook (see header). Null = no rules.
+    property var rules: null
+
+    readonly property int activeCount: activeModel.count
+    readonly property int queuedCount: priv.queue.length
+
+    signal toastDismissed(int id)
+
+    // Show (or queue) a toast. `toast` is a plain object:
+    //   { id?, appName, summary, body, imageSource, urgency, timeout }
+    // Returns the toast id, or -1 if a rule suppressed it.
+    function show(toast) {
+        const t = toast || {};
+
+        // Per-app-rules seam: consult before showing.
+        if (host.rules && typeof host.rules.evaluate === "function") {
+            const decision = host.rules.evaluate(t);
+            if (decision && decision.suppress)
+                return -1;
+            if (decision && decision.timeout !== undefined)
+                t.timeout = decision.timeout;
+        }
+
+        const row = {
+            "toastId": t.id !== undefined ? t.id : priv.nextId++,
+            "appName": t.appName !== undefined ? t.appName : "",
+            "summary": t.summary !== undefined ? t.summary : "",
+            "body": t.body !== undefined ? t.body : "",
+            "imageSource": t.imageSource !== undefined ? String(t.imageSource) : "",
+            "urgency": t.urgency !== undefined ? t.urgency : 1,
+            "timeout": t.timeout !== undefined ? t.timeout : host.defaultTimeout
+        };
+
+        if (activeModel.count < host.maxVisible)
+            activeModel.insert(0, row);
+            // newest on top
+        else
+            // Reassign (not push) so the queuedCount binding re-evaluates;
+            // an in-place Array.push doesn't notify QML.
+            priv.queue = priv.queue.concat([row]);
+
+        return row.toastId;
+    }
+
+    // Dismiss a toast by id (whether shown or still queued).
+    function dismiss(id) {
+        for (let i = 0; i < activeModel.count; ++i) {
+            if (activeModel.get(i).toastId === id) {
+                activeModel.remove(i);
+                host.toastDismissed(id);
+                priv.promote();
+                return;
+            }
+        }
+        for (let j = 0; j < priv.queue.length; ++j) {
+            if (priv.queue[j].toastId === id) {
+                // Reassign so queuedCount updates (see show()).
+                priv.queue = priv.queue.slice(0, j).concat(priv.queue.slice(j + 1));
+                return;
+            }
+        }
+    }
+
+    // Clear everything (e.g. a session lock about to show).
+    function clear() {
+        priv.queue = [];
+        activeModel.clear();
+    }
+
+    QtObject {
+        id: priv
+
+        property var queue: []
+        property int nextId: 1
+
+        // Move the oldest queued toast into the visible set when a slot
+        // frees up. Appended to the bottom so it slots in below the
+        // current stack.
+        function promote() {
+            if (priv.queue.length > 0 && activeModel.count < host.maxVisible) {
+                const next = priv.queue[0];
+                // Reassign so queuedCount updates (see show()).
+                priv.queue = priv.queue.slice(1);
+                activeModel.append(next);
+            }
+        }
+    }
+
+    ListModel {
+        id: activeModel
+    }
+
+    ListView {
+        id: list
+
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: host.margins
+        anchors.rightMargin: host.margins
+        width: 360
+        height: Math.min(contentHeight, parent.height - host.margins * 2)
+        spacing: host.spacing
+        interactive: false
+        clip: false
+        model: activeModel
+
+        delegate: Toast {
+            // Bind Toast's own properties from the model roles. Do NOT
+            // redeclare them as `required property` here: Toast already
+            // defines appName/summary/body/imageSource/urgency/timeout, so
+            // redeclaring would shadow them and the role data would never
+            // reach the card (only the always-present close button shows).
+            required property var model
+
+            width: list.width
+            appName: model.appName
+            summary: model.summary
+            body: model.body
+            imageSource: model.imageSource
+            urgency: model.urgency
+            timeout: model.timeout
+            onDismissed: host.dismiss(model.toastId)
+        }
+
+        // Slide in from the right + fade.
+        add: Transition {
+            NumberAnimation {
+                property: "x"
+                from: list.width
+                duration: Motion.duration_medium_2
+                easing: Motion.emphasized
+            }
+            NumberAnimation {
+                property: "opacity"
+                from: 0
+                to: 1
+                duration: Motion.duration_short_3
+            }
+        }
+
+        // Slide out to the right + fade.
+        remove: Transition {
+            NumberAnimation {
+                property: "x"
+                to: list.width
+                duration: Motion.duration_short_4
+                easing: Motion.standard
+            }
+            NumberAnimation {
+                property: "opacity"
+                to: 0
+                duration: Motion.duration_short_4
+            }
+        }
+
+        // Reflow remaining toasts when one leaves.
+        displaced: Transition {
+            NumberAnimation {
+                property: "y"
+                duration: Motion.duration_short_4
+                easing: Motion.standard
+            }
+        }
+    }
+}

--- a/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
+++ b/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
@@ -68,11 +68,12 @@ Item {
         };
 
         if (activeModel.count < host.maxVisible)
+            // Newest shown on top of the visible stack.
             activeModel.insert(0, row);
         else
-            // newest on top
-            // Reassign (not push) so the queuedCount binding re-evaluates;
-            // an in-place Array.push doesn't notify QML.
+            // Overflow queues FIFO (promoted to the bottom later). Reassign
+            // (not push) so the queuedCount binding re-evaluates; an
+            // in-place Array.push doesn't notify QML.
             priv.queue = priv.queue.concat([row]);
 
         return row.toastId;

--- a/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
+++ b/libs/phosphor-shell-notifications/qml/Phosphor/Notifications/ToastHost.qml
@@ -60,6 +60,12 @@ Item {
                 t.timeout = decision.timeout;
         }
 
+        // Advance the auto-id counter past any caller-supplied id so a
+        // later auto-generated id can't collide with an explicit one (which
+        // dismiss() would then resolve to the wrong toast).
+        if (t.id !== undefined && t.id >= priv.nextId)
+            priv.nextId = t.id + 1;
+
         const row = {
             "toastId": t.id !== undefined ? t.id : priv.nextId++,
             "appName": t.appName !== undefined ? t.appName : "",

--- a/libs/phosphor-shell-notifications/src/phosphorshellnotifications_qml_plugin.cpp
+++ b/libs/phosphor-shell-notifications/src/phosphorshellnotifications_qml_plugin.cpp
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// Glue translation unit for qt_add_qml_module. Phosphor.Notifications is
+// a pure-QML module (ToastHost + Toast), but qt_add_qml_module needs at
+// least one C++ source so the generated plugin and type registrar have a
+// compilation unit. Any future C++ notification primitive or foreign-type
+// re-export goes here.

--- a/libs/phosphor-shell-notifications/tests/CMakeLists.txt
+++ b/libs/phosphor-shell-notifications/tests/CMakeLists.txt
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# QtQuickTest harness for the Phosphor.Notifications toast framework.
+# Cases live in tst_*.qml; tst_notifications.cpp is the QUICK_TEST_MAIN
+# entry point. The test links the notifications module + the modules it
+# imports (Phosphor.Widgets, Phosphor.Theme) and their plugin registrars.
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick QuickShapes QuickTest)
+
+add_executable(test_phosphor_shell_notifications tst_notifications.cpp)
+
+target_compile_features(test_phosphor_shell_notifications PRIVATE cxx_std_20)
+
+target_link_libraries(test_phosphor_shell_notifications
+    PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickShapes
+        Qt6::QuickTest
+        PhosphorShellNotificationsQml
+        PhosphorShellNotificationsQmlplugin
+        PhosphorShellWidgetsQml
+        PhosphorShellWidgetsQmlplugin
+        PhosphorThemeQml
+        PhosphorThemeQmlplugin
+)
+
+add_test(
+    NAME test_phosphor_shell_notifications
+    COMMAND test_phosphor_shell_notifications -input ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+set_tests_properties(test_phosphor_shell_notifications PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)

--- a/libs/phosphor-shell-notifications/tests/tst_notifications.cpp
+++ b/libs/phosphor-shell-notifications/tests/tst_notifications.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// QtQuickTest runner for the Phosphor.Notifications toast framework.
+// Cases live in tst_*.qml; the source dir is passed via -input from
+// add_test, and the offscreen QPA platform keeps the run headless.
+
+#include <QtQuickTest/quicktest.h>
+
+QUICK_TEST_MAIN(phosphor_shell_notifications)

--- a/libs/phosphor-shell-notifications/tests/tst_toasthost.qml
+++ b/libs/phosphor-shell-notifications/tests/tst_toasthost.qml
@@ -66,7 +66,7 @@ TestCase {
 
     function test_dismiss_emits_signal() {
         const h = createTemporaryObject(hostComp, testCase);
-        const spy = spyComp.createObject(testCase, {
+        const spy = createTemporaryObject(spyComp, testCase, {
             "target": h,
             "signalName": "toastDismissed"
         });
@@ -128,7 +128,7 @@ TestCase {
         const h = createTemporaryObject(hostComp, testCase, {
             "maxVisible": 1
         });
-        const spy = spyComp.createObject(testCase, {
+        const spy = createTemporaryObject(spyComp, testCase, {
             "target": h,
             "signalName": "toastDismissed"
         });
@@ -145,11 +145,35 @@ TestCase {
         compare(spy.signalArguments[0][0], queuedId, "carries the dismissed queued id");
     }
 
+    function test_dismiss_visible_with_queued_emits_once() {
+        // Regression guard: dismissing a visible toast while another is
+        // queued behind it must emit toastDismissed exactly once (promote()
+        // brings the queued one in but must NOT also emit).
+        const h = createTemporaryObject(hostComp, testCase, {
+            "maxVisible": 1
+        });
+        const spy = createTemporaryObject(spyComp, testCase, {
+            "target": h,
+            "signalName": "toastDismissed"
+        });
+        const a = h.show({
+            "summary": "a"
+        });
+        h.show({
+            "summary": "b"
+        }); // queued
+        h.dismiss(a);
+        compare(spy.count, 1, "exactly one toastDismissed for the visible toast (promote does not emit)");
+        compare(spy.signalArguments[0][0], a, "carries the dismissed visible id");
+        compare(h.activeCount, 1, "the queued toast was promoted");
+        compare(h.queuedCount, 0, "queue drained");
+    }
+
     function test_clear_emits_for_each() {
         const h = createTemporaryObject(hostComp, testCase, {
             "maxVisible": 1
         });
-        const spy = spyComp.createObject(testCase, {
+        const spy = createTemporaryObject(spyComp, testCase, {
             "target": h,
             "signalName": "toastDismissed"
         });

--- a/libs/phosphor-shell-notifications/tests/tst_toasthost.qml
+++ b/libs/phosphor-shell-notifications/tests/tst_toasthost.qml
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Behaviour tests for ToastHost: show, queue beyond maxVisible,
+// dismiss + promote, the toastDismissed signal, clear, and the
+// per-app-rules seam (suppress + pass-through). The stacking/transition
+// visuals are exercised by the toast demo; this pins the queue logic.
+
+import QtQuick
+import QtTest
+import Phosphor.Notifications
+
+TestCase {
+    id: testCase
+
+    name: "ToastHost"
+
+    // A rule object that suppresses everything (a "do not disturb").
+    QtObject {
+        id: suppressRules
+
+        function evaluate(toast) {
+            return {
+                "suppress": true
+            };
+        }
+    }
+
+    Component {
+        id: hostComp
+
+        ToastHost {
+            width: 480
+            height: 480
+        }
+    }
+
+    function test_show_adds_a_toast() {
+        const h = createTemporaryObject(hostComp, testCase);
+        const id = h.show({
+            "summary": "Hello"
+        });
+        verify(id > 0, "show returns a positive id");
+        compare(h.activeCount, 1, "one toast active");
+        compare(h.queuedCount, 0, "nothing queued");
+    }
+
+    function test_queue_beyond_max() {
+        const h = createTemporaryObject(hostComp, testCase, {
+            "maxVisible": 2
+        });
+        const a = h.show({
+            "summary": "a"
+        });
+        h.show({
+            "summary": "b"
+        });
+        h.show({
+            "summary": "c"
+        });
+        compare(h.activeCount, 2, "only maxVisible shown");
+        compare(h.queuedCount, 1, "the rest queue");
+        h.dismiss(a);
+        compare(h.activeCount, 2, "a queued toast is promoted into the freed slot");
+        compare(h.queuedCount, 0, "queue drained");
+    }
+
+    function test_dismiss_emits_signal() {
+        const h = createTemporaryObject(hostComp, testCase);
+        const spy = spyComp.createObject(testCase, {
+            "target": h,
+            "signalName": "toastDismissed"
+        });
+        const id = h.show({
+            "summary": "x"
+        });
+        h.dismiss(id);
+        compare(spy.count, 1, "toastDismissed fired once");
+        compare(spy.signalArguments[0][0], id, "carries the dismissed id");
+        compare(h.activeCount, 0, "removed from the active set");
+    }
+
+    function test_dismiss_unknown_id_is_safe() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.show({
+            "summary": "x"
+        });
+        h.dismiss(99999); // not present
+        compare(h.activeCount, 1, "an unknown id leaves the stack untouched");
+    }
+
+    function test_clear_removes_all() {
+        const h = createTemporaryObject(hostComp, testCase, {
+            "maxVisible": 1
+        });
+        h.show({
+            "summary": "a"
+        });
+        h.show({
+            "summary": "b"
+        }); // queued
+        compare(h.activeCount, 1);
+        compare(h.queuedCount, 1);
+        h.clear();
+        compare(h.activeCount, 0, "active cleared");
+        compare(h.queuedCount, 0, "queue cleared");
+    }
+
+    function test_rules_suppress() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.rules = suppressRules;
+        const r = h.show({
+            "summary": "blocked"
+        });
+        compare(r, -1, "a suppressing rule returns -1");
+        compare(h.activeCount, 0, "nothing shown");
+    }
+
+    function test_rules_passthrough_when_unset() {
+        const h = createTemporaryObject(hostComp, testCase);
+        const r = h.show({
+            "summary": "shown"
+        });
+        verify(r > 0, "no rules: the toast shows");
+        compare(h.activeCount, 1);
+    }
+
+    Component {
+        id: spyComp
+
+        SignalSpy {}
+    }
+}

--- a/libs/phosphor-shell-notifications/tests/tst_toasthost.qml
+++ b/libs/phosphor-shell-notifications/tests/tst_toasthost.qml
@@ -124,6 +124,45 @@ TestCase {
         compare(h.activeCount, 1);
     }
 
+    function test_dismiss_queued_emits_signal() {
+        const h = createTemporaryObject(hostComp, testCase, {
+            "maxVisible": 1
+        });
+        const spy = spyComp.createObject(testCase, {
+            "target": h,
+            "signalName": "toastDismissed"
+        });
+        h.show({
+            "summary": "a"
+        });
+        const queuedId = h.show({
+            "summary": "b"
+        }); // queued, not visible
+        compare(h.queuedCount, 1);
+        h.dismiss(queuedId);
+        compare(h.queuedCount, 0, "the queued toast is removed");
+        compare(spy.count, 1, "toastDismissed fires for a queued toast too");
+        compare(spy.signalArguments[0][0], queuedId, "carries the dismissed queued id");
+    }
+
+    function test_clear_emits_for_each() {
+        const h = createTemporaryObject(hostComp, testCase, {
+            "maxVisible": 1
+        });
+        const spy = spyComp.createObject(testCase, {
+            "target": h,
+            "signalName": "toastDismissed"
+        });
+        h.show({
+            "summary": "a"
+        });
+        h.show({
+            "summary": "b"
+        }); // queued
+        h.clear();
+        compare(spy.count, 2, "clear() emits toastDismissed for every removed toast (visible + queued)");
+    }
+
     Component {
         id: spyComp
 

--- a/libs/phosphor-shell-notifications/tests/tst_toasthost.qml
+++ b/libs/phosphor-shell-notifications/tests/tst_toasthost.qml
@@ -187,6 +187,21 @@ TestCase {
         compare(spy.count, 2, "clear() emits toastDismissed for every removed toast (visible + queued)");
     }
 
+    function test_explicit_id_advances_counter() {
+        // A caller-supplied id must push the auto-id counter past it, so a
+        // later auto-generated id can't collide with the explicit one.
+        const h = createTemporaryObject(hostComp, testCase);
+        const explicit = h.show({
+            "id": 5,
+            "summary": "a"
+        });
+        compare(explicit, 5, "the explicit id is used verbatim");
+        const auto = h.show({
+            "summary": "b"
+        });
+        compare(auto, 6, "the next auto id is bumped past the explicit one");
+    }
+
     Component {
         id: spyComp
 

--- a/libs/phosphor-shell-osd/CMakeLists.txt
+++ b/libs/phosphor-shell-osd/CMakeLists.txt
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# PhosphorShellOsd, the Phosphor.OSD on-screen-display framework.
+#
+# A pure-QML module: OSDHost (the per-screen OSD surface manager, owning
+# timers / debounce / dedupe / fade / screen routing) plus the shared
+# OSDCard chrome and the four built-in OSD delegates (Volume, Brightness,
+# Mic, CapsLock). Themed through phosphor-theme and built on the
+# phosphor-shell-widgets atoms (ElevationShadow).
+#
+# Phase 3.3 deliverable per docs/phosphor-shell-design/04-implementation-plan.md.
+
+cmake_minimum_required(VERSION 3.16)
+
+set(PHOSPHORSHELLOSD_VERSION "0.1.0")
+
+if(NOT PROJECT_VERSION)
+    project(PhosphorShellOsd VERSION ${PHOSPHORSHELLOSD_VERSION} LANGUAGES CXX)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_AUTOMOC ON)
+endif()
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dependencies
+# ═══════════════════════════════════════════════════════════════════════════════
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick QuickShapes)
+
+# The OSDs import Phosphor.Theme (tokens) and Phosphor.Widgets
+# (ElevationShadow). The QML import scanner needs those modules visible at
+# build time, and consumers need their runtime plugins linked. In-tree
+# builds always have the sibling targets; fall back to installed packages.
+if(NOT TARGET PhosphorTheme::PhosphorThemeQml)
+    find_package(PhosphorTheme CONFIG QUIET)
+endif()
+if(NOT TARGET PhosphorShellWidgets::PhosphorShellWidgetsQml)
+    find_package(PhosphorShellWidgets CONFIG QUIET)
+endif()
+
+if(COMMAND qt_policy)
+    qt_policy(SET QTP0001 NEW)
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# QML module, STATIC (in-tree linkable)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set(_phosphor_osd_qml_files
+    qml/Phosphor/OSD/OSDHost.qml
+    qml/Phosphor/OSD/OSDCard.qml
+    qml/Phosphor/OSD/VolumeOSD.qml
+    qml/Phosphor/OSD/BrightnessOSD.qml
+    qml/Phosphor/OSD/MicOSD.qml
+    qml/Phosphor/OSD/CapsLockOSD.qml
+)
+
+# Pin each QML file's resource alias to its basename so import resolution
+# doesn't see a doubled path segment. Same pattern as the sibling libs.
+foreach(_qml_file IN LISTS _phosphor_osd_qml_files)
+    get_filename_component(_qml_basename ${_qml_file} NAME)
+    set_source_files_properties(${_qml_file}
+        PROPERTIES
+            QT_RESOURCE_ALIAS ${_qml_basename}
+    )
+endforeach()
+
+# Directory-scope suppression of -Wmissing-include-dirs for the targets
+# qt_add_qml_module generates here. Full rationale: src/shared/CMakeLists.txt.
+set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-Wno-missing-include-dirs")
+
+qt_add_qml_module(PhosphorShellOsdQml
+    URI Phosphor.OSD
+    VERSION 1.0
+    STATIC
+    IMPORTS
+        Phosphor.Theme
+        Phosphor.Widgets
+        QtQuick.Shapes
+        QtQuick.Layouts
+    SOURCES
+        src/phosphorshellosd_qml_plugin.cpp
+    QML_FILES ${_phosphor_osd_qml_files}
+    OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/qml/Phosphor/OSD
+)
+
+add_library(PhosphorShellOsd::PhosphorShellOsdQml ALIAS PhosphorShellOsdQml)
+
+target_compile_features(PhosphorShellOsdQml PUBLIC cxx_std_20)
+
+target_link_libraries(PhosphorShellOsdQml
+    PUBLIC
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickShapes
+)
+
+# Link the sibling QML modules + their plugin registrars so the
+# Phosphor.Theme / Phosphor.Widgets imports resolve at runtime. In-tree
+# builds always have these targets.
+if(TARGET PhosphorShellWidgets::PhosphorShellWidgetsQml)
+    target_link_libraries(PhosphorShellOsdQml PUBLIC PhosphorShellWidgets::PhosphorShellWidgetsQml)
+endif()
+if(TARGET PhosphorShellWidgetsQmlplugin)
+    target_link_libraries(PhosphorShellOsdQml PUBLIC PhosphorShellWidgetsQmlplugin)
+endif()
+if(TARGET PhosphorTheme::PhosphorThemeQml)
+    target_link_libraries(PhosphorShellOsdQml PUBLIC PhosphorTheme::PhosphorThemeQml)
+endif()
+if(TARGET PhosphorThemeQmlplugin)
+    target_link_libraries(PhosphorShellOsdQml PUBLIC PhosphorThemeQmlplugin)
+endif()
+
+# No install rules: PhosphorShellOsdQml is a STATIC, in-tree-only QML
+# module (like PhosphorShellWidgetsQml / PhosphorPopoutQml). It is linked
+# directly by the shell and the osd demo; a standalone installed
+# deployment lands with the shell binary in Phase 4.
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+if(CMAKE_PROJECT_NAME STREQUAL "PhosphorShellOsd" OR BUILD_TESTING)
+    enable_testing()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt")
+        add_subdirectory(tests)
+    endif()
+endif()

--- a/libs/phosphor-shell-osd/README.md
+++ b/libs/phosphor-shell-osd/README.md
@@ -54,19 +54,19 @@ osd.show("volume", 62, undefined, "DP-1")
 `provider` is any object exposing `createOSD(kind, parent) -> Item`. In
 the shell it is backed by a `Registry<IOSDFactory>` (the OSD demo wires
 this and registers the four built-ins as `IOSDFactory` instances). A
-delegate is expected to carry `value` (0..100) and/or `active` (bool);
+delegate is expected to carry `value` (0..100) and/or `active` (bool).
 `OSDHost` sets whichever it exposes.
 
 The host owns the delegate's lifetime and destroys it on swap/hide, so a
 provider MUST return a **destroyable** item. A C++ factory (the
 `IOSDFactory` path) must set `QQmlEngine::setObjectOwnership(item,
-QQmlEngine::JavaScriptOwnership)` before returning it; a QObject-parented
+QQmlEngine::JavaScriptOwnership)` before returning it. A QObject-parented
 item defaults to `CppOwnership`, which makes the host's `destroy()` throw
 ("indestructible object") and leaves a ghost stacked behind the next OSD.
 
 Multi-screen: instantiate one `OSDHost` per monitor (via
 `Phosphor.Shell`'s `PerScreen`), give each its `screenName`, and pass the
-same trigger to all; `show()`'s `targetScreen` argument routes it
+same trigger to all. `show()`'s `targetScreen` argument routes it
 (`""`/omitted = every screen).
 
 ## Design notes
@@ -76,7 +76,7 @@ same trigger to all; `show()`'s `targetScreen` argument routes it
   a held key streams smoothly through one surface. A different kind swaps
   the delegate.
 - **Lifecycle via states.** `OSDHost` drives a `shown`/`hidden` state
-  pair; the transitions animate opacity + scale with `phosphor-theme`
+  pair. The transitions animate opacity + scale with `phosphor-theme`
   Motion tokens, and the hide transition's tail destroys the delegate and
   emits `hidden(kind)`. The hold timer is what flips `shown -> hidden`. A
   kind swap also emits `hidden(previousKind)` synchronously from `show()`
@@ -93,7 +93,7 @@ same trigger to all; `show()`'s `targetScreen` argument routes it
   for the OSD glyphs.
 - `phosphor-theme` (`Phosphor.Theme`) for tokens and Motion;
   `phosphor-shell-widgets` (`Phosphor.Widgets`) for `ElevationShadow`.
-  In-tree builds link their QML plugins automatically; this module is
+  In-tree builds link their QML plugins automatically. This module is
   static and in-tree-only today.
 
 ## Status

--- a/libs/phosphor-shell-osd/README.md
+++ b/libs/phosphor-shell-osd/README.md
@@ -78,7 +78,9 @@ same trigger to all; `show()`'s `targetScreen` argument routes it
 - **Lifecycle via states.** `OSDHost` drives a `shown`/`hidden` state
   pair; the transitions animate opacity + scale with `phosphor-theme`
   Motion tokens, and the hide transition's tail destroys the delegate and
-  emits `hidden(kind)`. The hold timer is what flips `shown -> hidden`.
+  emits `hidden(kind)`. The hold timer is what flips `shown -> hidden`. A
+  kind swap also emits `hidden(previousKind)` synchronously from `show()`
+  for the outgoing OSD, so the `shown`/`hidden` pairing stays symmetric.
 - **Provider seam, not a hard registry dependency.** `OSDHost` takes a
   `provider` object, so the framework is testable with a fake and the
   registry wiring (IOSDFactory) lives in the host/demo, not the QML.

--- a/libs/phosphor-shell-osd/README.md
+++ b/libs/phosphor-shell-osd/README.md
@@ -1,0 +1,103 @@
+<!-- SPDX-FileCopyrightText: 2026 fuddlesworth -->
+<!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
+
+# PhosphorShellOsd
+
+The `Phosphor.OSD` on-screen-display framework: the transient overlays a
+shell flashes for volume, brightness, mic-mute, caps-lock, and the like.
+Pure QML, themed through [`phosphor-theme`](../phosphor-theme/README.md)
+and built on the [`phosphor-shell-widgets`](../phosphor-shell-widgets/README.md)
+atoms.
+
+Phase 3.3 deliverable per
+[`docs/phosphor-shell-design/04-implementation-plan.md`](../../docs/phosphor-shell-design/04-implementation-plan.md).
+
+## Responsibility
+
+Own the lifecycle of the transient OSD surface: show one OSD at a time,
+hold it for a timeout, fade it out, and route triggers to the right
+screen. Debounce/dedupe repeated triggers so spinning a volume key keeps
+one OSD alive and refreshed instead of stacking surfaces.
+
+The framework owns presentation and timing only. The OSD *content* is
+supplied by delegates (the four built-ins here, or plugin-contributed
+ones), and the *triggers* come from the host (a hotkey handler, an IPC
+call, a service signal).
+
+## Key types
+
+| Component       | Role                                                                                       |
+|-----------------|--------------------------------------------------------------------------------------------|
+| `OSDHost`       | Per-screen OSD surface manager: one-at-a-time display, hold timer, debounce/dedupe, fade, screen routing. |
+| `OSDCard`       | Shared chrome: an elevated rounded card with a glyph, label, and optional progress bar.     |
+| `VolumeOSD`     | Speaker glyph + progress; muted cross at zero. `value` is 0..100.                            |
+| `BrightnessOSD` | Sun glyph + progress. `value` is 0..100.                                                     |
+| `MicOSD`        | Microphone glyph; `active` true = muted (red slash + label).                                 |
+| `CapsLockOSD`   | Caps-lock glyph; `active` true = on (primary-tinted + label).                                |
+
+## Typical use
+
+```qml
+import Phosphor.OSD
+
+OSDHost {
+    id: osd
+    anchors.fill: parent
+    screenName: "DP-1"
+    provider: registryProvider   // createOSD(kind, parent) -> Item
+}
+
+// elsewhere, on a volume key / IPC call:
+osd.show("volume", 62, undefined, "DP-1")
+```
+
+`provider` is any object exposing `createOSD(kind, parent) -> Item`. In
+the shell it is backed by a `Registry<IOSDFactory>` (the OSD demo wires
+this and registers the four built-ins as `IOSDFactory` instances). A
+delegate is expected to carry `value` (0..100) and/or `active` (bool);
+`OSDHost` sets whichever it exposes.
+
+The host owns the delegate's lifetime and destroys it on swap/hide, so a
+provider MUST return a **destroyable** item. A C++ factory (the
+`IOSDFactory` path) must set `QQmlEngine::setObjectOwnership(item,
+QQmlEngine::JavaScriptOwnership)` before returning it; a QObject-parented
+item defaults to `CppOwnership`, which makes the host's `destroy()` throw
+("indestructible object") and leaves a ghost stacked behind the next OSD.
+
+Multi-screen: instantiate one `OSDHost` per monitor (via
+`Phosphor.Shell`'s `PerScreen`), give each its `screenName`, and pass the
+same trigger to all; `show()`'s `targetScreen` argument routes it
+(`""`/omitted = every screen).
+
+## Design notes
+
+- **Debounce/dedupe.** A repeated `show()` of the kind already up updates
+  the delegate and restarts the hold timer rather than recreating it, so
+  a held key streams smoothly through one surface. A different kind swaps
+  the delegate.
+- **Lifecycle via states.** `OSDHost` drives a `shown`/`hidden` state
+  pair; the transitions animate opacity + scale with `phosphor-theme`
+  Motion tokens, and the hide transition's tail destroys the delegate and
+  emits `hidden(kind)`. The hold timer is what flips `shown -> hidden`.
+- **Provider seam, not a hard registry dependency.** `OSDHost` takes a
+  `provider` object, so the framework is testable with a fake and the
+  registry wiring (IOSDFactory) lives in the host/demo, not the QML.
+- **Routing is data, not topology.** Screens are addressed by name, so
+  routing is unit-testable without real monitors.
+
+## Dependencies
+
+- Qt6 ≥ 6.6 Core / Gui / Qml / Quick; `QtQuick.Shapes` (`Qt6::QuickShapes`)
+  for the OSD glyphs.
+- `phosphor-theme` (`Phosphor.Theme`) for tokens and Motion;
+  `phosphor-shell-widgets` (`Phosphor.Widgets`) for `ElevationShadow`.
+  In-tree builds link their QML plugins automatically; this module is
+  static and in-tree-only today.
+
+## Status
+
+Phase 3.3: in progress. `OSDHost`, the card chrome, and the four built-in
+OSDs are in the tree with a QtQuickTest suite and an acceptance demo
+(`examples/phosphor-osd-demo/`, driven by `phosphorctl call osd.show`).
+The Phase 3 gate (all four 3.x examples runnable,
+`phosphor-ui-primitives-0.1` tag) still requires 3.4 (toast framework).

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/BrightnessOSD.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/BrightnessOSD.qml
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.OSD.BrightnessOSD, the brightness on-screen display.
+//
+// An OSDCard with a sun glyph and a progress bar. `value` is the
+// brightness percentage (0..100).
+
+import QtQuick
+import Phosphor.Theme
+
+OSDCard {
+    id: osd
+
+    // Brightness percentage 0..100, set by OSDHost.
+    property real value: 0
+    // Unused here; present so OSDHost can set it generically.
+    property bool active: false
+
+    label: qsTr("Brightness")
+    showProgress: true
+    progress: value / 100
+
+    icon: Component {
+        Item {
+            implicitWidth: 30
+            implicitHeight: 30
+
+            // Sun disc.
+            Rectangle {
+                anchors.centerIn: parent
+                width: 13
+                height: 13
+                radius: width / 2
+                color: Theme.on_surface
+            }
+            // Eight rays around the disc.
+            Repeater {
+                model: 8
+
+                Item {
+                    required property int index
+
+                    anchors.fill: parent
+                    rotation: index * 45
+
+                    Rectangle {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        y: 0
+                        width: 2.5
+                        height: 5
+                        radius: 1.25
+                        color: Theme.on_surface
+                    }
+                }
+            }
+        }
+    }
+}

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/CapsLockOSD.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/CapsLockOSD.qml
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.OSD.CapsLockOSD, the caps-lock on-screen display.
+//
+// An OSDCard with a caps-lock glyph and no progress bar. `active` is
+// true when caps lock is on; the glyph fills with the primary accent and
+// the label reflects the state.
+
+import QtQuick
+import QtQuick.Shapes
+import Phosphor.Theme
+
+OSDCard {
+    id: osd
+
+    // True when caps lock is on, set by OSDHost.
+    property bool active: false
+    // Unused here; present so OSDHost can set it generically.
+    property real value: 0
+
+    label: osd.active ? qsTr("Caps Lock on") : qsTr("Caps Lock off")
+    showProgress: false
+
+    icon: Component {
+        Item {
+            implicitWidth: 30
+            implicitHeight: 30
+
+            // Upward arrow.
+            Shape {
+                anchors.fill: parent
+                preferredRendererType: Shape.CurveRenderer
+
+                ShapePath {
+                    fillColor: osd.active ? Theme.primary : Theme.on_surface
+                    strokeColor: "transparent"
+
+                    PathSvg {
+                        path: "M 15 3 L 25 14 H 20 V 20 H 10 V 14 H 5 Z"
+                    }
+                }
+            }
+            // Base bar under the arrow.
+            Rectangle {
+                anchors.horizontalCenter: parent.horizontalCenter
+                y: 24
+                width: 14
+                height: 3
+                radius: 1.5
+                color: osd.active ? Theme.primary : Theme.on_surface
+            }
+        }
+    }
+}

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/CapsLockOSD.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/CapsLockOSD.qml
@@ -21,6 +21,9 @@ OSDCard {
     label: osd.active ? qsTr("Caps Lock on") : qsTr("Caps Lock off")
     showProgress: false
 
+    // Glyph tint: caps-on lights the glyph with the primary accent.
+    readonly property color glyphColor: osd.active ? Theme.primary : Theme.on_surface
+
     icon: Component {
         Item {
             implicitWidth: 30
@@ -32,7 +35,7 @@ OSDCard {
                 preferredRendererType: Shape.CurveRenderer
 
                 ShapePath {
-                    fillColor: osd.active ? Theme.primary : Theme.on_surface
+                    fillColor: osd.glyphColor
                     strokeColor: "transparent"
 
                     PathSvg {
@@ -47,7 +50,7 @@ OSDCard {
                 width: 14
                 height: 3
                 radius: 1.5
-                color: osd.active ? Theme.primary : Theme.on_surface
+                color: osd.glyphColor
             }
         }
     }

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/MicOSD.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/MicOSD.qml
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.OSD.MicOSD, the microphone-mute on-screen display.
+//
+// An OSDCard with a microphone glyph and no progress bar. `active` is
+// true when the mic is muted; the glyph then shows a red slash and the
+// label reflects the state.
+
+import QtQuick
+import QtQuick.Shapes
+import Phosphor.Theme
+
+OSDCard {
+    id: osd
+
+    // True when the microphone is muted, set by OSDHost.
+    property bool active: false
+    // Unused here; present so OSDHost can set it generically.
+    property real value: 0
+
+    label: osd.active ? qsTr("Microphone muted") : qsTr("Microphone on")
+    showProgress: false
+
+    icon: Component {
+        Item {
+            implicitWidth: 30
+            implicitHeight: 30
+
+            // Capsule.
+            Rectangle {
+                anchors.horizontalCenter: parent.horizontalCenter
+                y: 3
+                width: 11
+                height: 16
+                radius: width / 2
+                color: osd.active ? Theme.on_surface_variant : Theme.on_surface
+            }
+            // Stand stem.
+            Rectangle {
+                anchors.horizontalCenter: parent.horizontalCenter
+                y: 21
+                width: 2
+                height: 4
+                color: osd.active ? Theme.on_surface_variant : Theme.on_surface
+            }
+            // Base.
+            Rectangle {
+                anchors.horizontalCenter: parent.horizontalCenter
+                y: 25
+                width: 13
+                height: 2
+                radius: 1
+                color: osd.active ? Theme.on_surface_variant : Theme.on_surface
+            }
+            // Mute slash.
+            Shape {
+                anchors.fill: parent
+                preferredRendererType: Shape.CurveRenderer
+
+                ShapePath {
+                    fillColor: "transparent"
+                    strokeColor: osd.active ? Theme.error : "transparent"
+                    strokeWidth: 2.5
+                    capStyle: ShapePath.RoundCap
+
+                    PathSvg {
+                        path: "M 5 5 L 25 25"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/MicOSD.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/MicOSD.qml
@@ -21,6 +21,9 @@ OSDCard {
     label: osd.active ? qsTr("Microphone muted") : qsTr("Microphone on")
     showProgress: false
 
+    // Glyph tint: muted dims the mic body (the red slash carries the state).
+    readonly property color glyphColor: osd.active ? Theme.on_surface_variant : Theme.on_surface
+
     icon: Component {
         Item {
             implicitWidth: 30
@@ -33,7 +36,7 @@ OSDCard {
                 width: 11
                 height: 16
                 radius: width / 2
-                color: osd.active ? Theme.on_surface_variant : Theme.on_surface
+                color: osd.glyphColor
             }
             // Stand stem.
             Rectangle {
@@ -41,7 +44,7 @@ OSDCard {
                 y: 21
                 width: 2
                 height: 4
-                color: osd.active ? Theme.on_surface_variant : Theme.on_surface
+                color: osd.glyphColor
             }
             // Base.
             Rectangle {
@@ -50,7 +53,7 @@ OSDCard {
                 width: 13
                 height: 2
                 radius: 1
-                color: osd.active ? Theme.on_surface_variant : Theme.on_surface
+                color: osd.glyphColor
             }
             // Mute slash.
             Shape {

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDCard.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDCard.qml
@@ -32,11 +32,11 @@ Item {
     property real progress: 0
 
     implicitWidth: 240
-    implicitHeight: column.implicitHeight + 40
+    implicitHeight: column.implicitHeight + 2 * Tokens.spacing_l
 
     Rectangle {
         anchors.fill: parent
-        radius: 20
+        radius: Tokens.radius_l
         color: Theme.surface_container_high
         layer.enabled: true
         layer.effect: ElevationShadow {
@@ -50,9 +50,9 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        anchors.leftMargin: 24
-        anchors.rightMargin: 24
-        spacing: 14
+        anchors.leftMargin: Tokens.spacing_xl
+        anchors.rightMargin: Tokens.spacing_xl
+        spacing: Tokens.spacing_m
 
         Loader {
             Layout.alignment: Qt.AlignHCenter
@@ -64,8 +64,8 @@ Item {
             horizontalAlignment: Text.AlignHCenter
             text: card.label
             color: Theme.on_surface
-            font.pixelSize: 15
-            font.weight: Font.Medium
+            font.pixelSize: Tokens.font_size_title_s
+            font.weight: Tokens.font_weight_medium
             elide: Text.ElideRight
         }
 
@@ -75,7 +75,7 @@ Item {
             Layout.fillWidth: true
             Layout.preferredHeight: 6
             visible: card.showProgress
-            radius: 3
+            radius: height / 2
             color: Theme.surface_variant
 
             Rectangle {

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDCard.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDCard.qml
@@ -67,6 +67,10 @@ Item {
         }
 
         Text {
+            // The card root already announces the label (and percentage) as
+            // its AlertMessage name, so keep this Text out of the a11y tree to
+            // avoid a screen reader reading the label twice.
+            Accessible.ignored: true
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignHCenter
             text: card.label

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDCard.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDCard.qml
@@ -34,6 +34,13 @@ Item {
     implicitWidth: 240
     implicitHeight: column.implicitHeight + 2 * Tokens.spacing_l
 
+    // An OSD is a transient status announcement, so expose it to assistive
+    // tech as an alert. Fold the progress percentage into the name for the
+    // OSDs that show it (volume/brightness); the stateful ones (mic/caps)
+    // carry their state in the label already.
+    Accessible.role: Accessible.AlertMessage
+    Accessible.name: card.showProgress ? qsTr("%1, %2 percent").arg(card.label).arg(Math.round(Math.max(0, Math.min(1, card.progress)) * 100)) : card.label
+
     Rectangle {
         anchors.fill: parent
         radius: Tokens.radius_l

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDCard.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDCard.qml
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.OSD.OSDCard, shared chrome for the built-in OSDs.
+//
+// A rounded elevated card holding a glyph, a label, and an optional
+// progress bar. The four built-in OSDs (VolumeOSD, BrightnessOSD,
+// MicOSD, CapsLockOSD) are each an OSDCard with their own glyph and
+// bindings, so the card frame, elevation, spacing, and progress styling
+// live in one place.
+//
+//   OSDCard {
+//       label: i18n("Volume")
+//       showProgress: true
+//       progress: value / 100
+//       icon: Component { /* glyph */ }
+//   }
+
+import QtQuick
+import QtQuick.Layouts
+import Phosphor.Theme
+import Phosphor.Widgets
+
+Item {
+    id: card
+
+    // Glyph component shown at the top of the card.
+    property Component icon: null
+    property string label: ""
+    // Whether to show the progress bar (volume/brightness yes; mic/caps no).
+    property bool showProgress: false
+    // Progress fraction 0..1.
+    property real progress: 0
+
+    implicitWidth: 240
+    implicitHeight: column.implicitHeight + 40
+
+    Rectangle {
+        anchors.fill: parent
+        radius: 20
+        color: Theme.surface_container_high
+        layer.enabled: true
+        layer.effect: ElevationShadow {
+            level: 3
+        }
+    }
+
+    ColumnLayout {
+        id: column
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: 24
+        anchors.rightMargin: 24
+        spacing: 14
+
+        Loader {
+            Layout.alignment: Qt.AlignHCenter
+            sourceComponent: card.icon
+        }
+
+        Text {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            text: card.label
+            color: Theme.on_surface
+            font.pixelSize: 15
+            font.weight: Font.Medium
+            elide: Text.ElideRight
+        }
+
+        // Progress track + fill. Reserved out of layout when not shown so
+        // a stateful OSD (mic/caps) is a compact icon+label card.
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 6
+            visible: card.showProgress
+            radius: 3
+            color: Theme.surface_variant
+
+            Rectangle {
+                width: parent.width * Math.max(0, Math.min(1, card.progress))
+                height: parent.height
+                radius: parent.radius
+                color: Theme.primary
+
+                Behavior on width {
+                    NumberAnimation {
+                        duration: Motion.duration_short_3
+                        easing: Motion.standard
+                    }
+                }
+            }
+        }
+    }
+}

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDCard.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDCard.qml
@@ -9,7 +9,7 @@
 // live in one place.
 //
 //   OSDCard {
-//       label: i18n("Volume")
+//       label: qsTr("Volume")
 //       showProgress: true
 //       progress: value / 100
 //       icon: Component { /* glyph */ }

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
@@ -83,17 +83,22 @@ Item {
         }
 
         // Different kind (or nothing showing): swap in a fresh delegate.
+        // Build and validate the replacement BEFORE tearing the current OSD
+        // down. If the provider has no delegate for `kind` (an unregistered
+        // or mistyped kind), the OSD the user is looking at must stay put;
+        // destroying it first would blank the surface and wrongly emit
+        // hidden() for a show() that ultimately failed.
+        const item = root.provider.createOSD(kind, frame);
+        if (!item) {
+            console.warn("OSDHost: provider returned no delegate for", kind);
+            return false;
+        }
         // The outgoing OSD (if any) "left", so announce its hidden() to
         // keep the shown/hidden pairing symmetric for consumers.
         const previousKind = priv.currentKind;
         priv.destroyDelegate();
         if (previousKind !== "")
             root.hidden(previousKind);
-        const item = root.provider.createOSD(kind, frame);
-        if (!item) {
-            console.warn("OSDHost: provider returned no delegate for", kind);
-            return false;
-        }
         priv.delegate = item;
         priv.currentKind = kind;
         priv.apply(item, value, active);

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
@@ -44,9 +44,11 @@ Item {
     // The kind currently shown, or "" when hidden. Read-only for consumers.
     readonly property alias currentKind: priv.currentKind
 
-    // Emitted when an OSD becomes visible / fully hidden. Useful for
-    // tests and for a host that wants to coordinate (e.g. pause an idle
-    // timer while an OSD is up).
+    // Emitted as an OSD is shown, and after one is hidden. On a kind-swap
+    // the outgoing kind's hidden() fires immediately (no fade-out), while an
+    // auto-hide fires hidden() at the end of the fade. Useful for tests and
+    // for a host that wants to coordinate (e.g. pause an idle timer while an
+    // OSD is up).
     signal shown(string kind)
     signal hidden(string kind)
 

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
@@ -105,15 +105,16 @@ Item {
         // delegate is fully installed: a consumer that calls show() from a
         // hidden() handler then re-enters against consistent state instead
         // of orphaning the delegate this call just created.
+        // Announce the new OSD BEFORE the outgoing one's hidden(). hidden()
+        // is delivered synchronously and a consumer may even re-enter show()
+        // from it; emitting shown(kind) first means this delegate's shown()
+        // is announced before any such re-entry, so it can never be stale,
+        // and a re-entrant swap still produces its own symmetric
+        // shown()/hidden() pair. Every installed delegate thus gets exactly
+        // one shown() and (when replaced) one hidden().
+        root.shown(kind);
         if (previousKind !== "")
             root.hidden(previousKind);
-        // A hidden() handler may synchronously re-enter show() with another
-        // kind, which becomes the current OSD and emits its own shown().
-        // Only announce this show if it is still the current one, so the
-        // unwinding outer call doesn't tack a stale shown() onto a delegate
-        // that was already swapped out.
-        if (priv.currentKind === kind)
-            root.shown(kind);
         return true;
     }
 

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
@@ -107,7 +107,13 @@ Item {
         // of orphaning the delegate this call just created.
         if (previousKind !== "")
             root.hidden(previousKind);
-        root.shown(kind);
+        // A hidden() handler may synchronously re-enter show() with another
+        // kind, which becomes the current OSD and emits its own shown().
+        // Only announce this show if it is still the current one, so the
+        // unwinding outer call doesn't tack a stale shown() onto a delegate
+        // that was already swapped out.
+        if (priv.currentKind === kind)
+            root.shown(kind);
         return true;
     }
 

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
@@ -28,8 +28,11 @@ import Phosphor.Theme
 Item {
     id: root
 
-    // This host's screen identifier, for routing. Empty = unrouted
-    // (matches every targetScreen).
+    // This host's screen identifier, for routing. A show() with a specific
+    // targetScreen reaches only the host whose screenName matches it; a
+    // show() with an empty/omitted targetScreen broadcasts to every host.
+    // The wildcard is the empty targetScreen, NOT the empty screenName: a
+    // host left at the default "" therefore reacts only to broadcast shows.
     property string screenName: ""
     // How long the OSD stays fully shown before it fades out (ms).
     property int holdDuration: 1500

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
@@ -51,28 +51,45 @@ Item {
     // (bool) are applied to the delegate if it exposes them; pass
     // undefined to leave a property untouched. targetScreen routes the
     // trigger: "" / undefined hits every host, otherwise only the host
-    // whose screenName matches.
+    // whose screenName matches. Returns true when an OSD was shown or
+    // refreshed on this host, false when the trigger was routed elsewhere,
+    // rejected (empty kind, no provider), or the provider had no delegate.
     function show(kind, value, active, targetScreen) {
         if (targetScreen !== undefined && targetScreen !== "" && targetScreen !== root.screenName)
-            return;
-        if (!root.provider) {
-            console.warn("OSDHost: no provider set; cannot show", kind);
-            return;
+            return false;
+        // An empty kind would alias priv.currentKind's "nothing shown"
+        // sentinel, producing an OSD that hide()/onHidden refuse to dismiss
+        // and never announce. Reject it at the boundary.
+        if (!kind) {
+            console.warn("OSDHost: empty kind ignored");
+            return false;
+        }
+        if (!root.provider || typeof root.provider.createOSD !== "function") {
+            console.warn("OSDHost: no valid provider set; cannot show", kind);
+            return false;
         }
 
         if (kind === priv.currentKind && priv.delegate) {
-            // Dedupe: same OSD already up. Update and restart the hold.
+            // Dedupe: same OSD already up. Update, re-assert "shown" (a
+            // repeat during the fade-out window must interrupt the fade and
+            // animate back in, not let it finish), and restart the hold.
             priv.apply(priv.delegate, value, active);
+            root.state = "shown";
             holdTimer.restart();
-            return;
+            return true;
         }
 
         // Different kind (or nothing showing): swap in a fresh delegate.
+        // The outgoing OSD (if any) "left", so announce its hidden() to
+        // keep the shown/hidden pairing symmetric for consumers.
+        const previousKind = priv.currentKind;
         priv.destroyDelegate();
+        if (previousKind !== "")
+            root.hidden(previousKind);
         const item = root.provider.createOSD(kind, frame);
         if (!item) {
             console.warn("OSDHost: provider returned no delegate for", kind);
-            return;
+            return false;
         }
         priv.delegate = item;
         priv.currentKind = kind;
@@ -80,6 +97,7 @@ Item {
         root.state = "shown";
         holdTimer.restart();
         root.shown(kind);
+        return true;
     }
 
     // Hide the current OSD early (e.g. the user dismissed it).

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
@@ -102,18 +102,16 @@ Item {
         priv.apply(item, value, active);
         root.state = "shown";
         holdTimer.restart();
-        // The outgoing OSD (if any) "left", so announce its hidden() to keep
-        // the shown/hidden pairing symmetric. Emit it only after the new
-        // delegate is fully installed: a consumer that calls show() from a
-        // hidden() handler then re-enters against consistent state instead
-        // of orphaning the delegate this call just created.
-        // Announce the new OSD BEFORE the outgoing one's hidden(). hidden()
-        // is delivered synchronously and a consumer may even re-enter show()
-        // from it; emitting shown(kind) first means this delegate's shown()
-        // is announced before any such re-entry, so it can never be stale,
-        // and a re-entrant swap still produces its own symmetric
-        // shown()/hidden() pair. Every installed delegate thus gets exactly
-        // one shown() and (when replaced) one hidden().
+        // Ordering matters for re-entrancy. Announce the new OSD's shown(kind)
+        // before the outgoing one's hidden(previousKind), and only after the
+        // new delegate is fully installed. Both signals are delivered
+        // synchronously and a consumer may re-enter show() from the hidden()
+        // handler, so emitting shown() first means this delegate's shown() can
+        // never be stale, the re-entrant call sees consistent state instead of
+        // orphaning the delegate just created, and a re-entrant swap still
+        // produces its own symmetric shown()/hidden() pair. Every installed
+        // delegate thus gets exactly one shown() and (when replaced) one
+        // hidden().
         root.shown(kind);
         if (previousKind !== "")
             root.hidden(previousKind);

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
@@ -93,17 +93,20 @@ Item {
             console.warn("OSDHost: provider returned no delegate for", kind);
             return false;
         }
-        // The outgoing OSD (if any) "left", so announce its hidden() to
-        // keep the shown/hidden pairing symmetric for consumers.
         const previousKind = priv.currentKind;
         priv.destroyDelegate();
-        if (previousKind !== "")
-            root.hidden(previousKind);
         priv.delegate = item;
         priv.currentKind = kind;
         priv.apply(item, value, active);
         root.state = "shown";
         holdTimer.restart();
+        // The outgoing OSD (if any) "left", so announce its hidden() to keep
+        // the shown/hidden pairing symmetric. Emit it only after the new
+        // delegate is fully installed: a consumer that calls show() from a
+        // hidden() handler then re-enters against consistent state instead
+        // of orphaning the delegate this call just created.
+        if (previousKind !== "")
+            root.hidden(previousKind);
         root.shown(kind);
         return true;
     }

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/OSDHost.qml
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.OSD.OSDHost, the on-screen-display surface manager.
+//
+// One OSDHost owns the transient OSD surface for a single screen: it
+// shows one OSD at a time (volume, brightness, mic, caps-lock, ...),
+// holds it for a timeout, and fades it out. A repeated trigger of the
+// same OSD updates the value and restarts the hold timer instead of
+// recreating the surface (debounce/dedupe), so spinning a volume key
+// keeps one OSD alive and refreshed.
+//
+// Delegates are supplied by a `provider` object exposing
+//   createOSD(kind, parent) -> Item
+// In the shell that provider is backed by a Registry<IOSDFactory>; in a
+// test it can be any QML object with that method. The created delegate is
+// expected to carry `value` (0..100) and/or `active` (bool) properties;
+// OSDHost sets whichever exist.
+//
+// Multi-screen routing: each OSDHost has a `screenName`. show()'s
+// `targetScreen` argument routes a trigger to one screen (or "" / omitted
+// = every screen). Compose one OSDHost per monitor via Phosphor.Shell's
+// PerScreen and pass the same trigger to all; only the addressed host(s)
+// react.
+
+import QtQuick
+import Phosphor.Theme
+
+Item {
+    id: root
+
+    // This host's screen identifier, for routing. Empty = unrouted
+    // (matches every targetScreen).
+    property string screenName: ""
+    // How long the OSD stays fully shown before it fades out (ms).
+    property int holdDuration: 1500
+    // Delegate source: an object with createOSD(kind, parent) -> Item.
+    property var provider: null
+    // Distance from the bottom edge the OSD floats at.
+    property real bottomMargin: 64
+
+    // The kind currently shown, or "" when hidden. Read-only for consumers.
+    readonly property alias currentKind: priv.currentKind
+
+    // Emitted when an OSD becomes visible / fully hidden. Useful for
+    // tests and for a host that wants to coordinate (e.g. pause an idle
+    // timer while an OSD is up).
+    signal shown(string kind)
+    signal hidden(string kind)
+
+    // Show (or refresh) the OSD for `kind`. value (0..100) and active
+    // (bool) are applied to the delegate if it exposes them; pass
+    // undefined to leave a property untouched. targetScreen routes the
+    // trigger: "" / undefined hits every host, otherwise only the host
+    // whose screenName matches.
+    function show(kind, value, active, targetScreen) {
+        if (targetScreen !== undefined && targetScreen !== "" && targetScreen !== root.screenName)
+            return;
+        if (!root.provider) {
+            console.warn("OSDHost: no provider set; cannot show", kind);
+            return;
+        }
+
+        if (kind === priv.currentKind && priv.delegate) {
+            // Dedupe: same OSD already up. Update and restart the hold.
+            priv.apply(priv.delegate, value, active);
+            holdTimer.restart();
+            return;
+        }
+
+        // Different kind (or nothing showing): swap in a fresh delegate.
+        priv.destroyDelegate();
+        const item = root.provider.createOSD(kind, frame);
+        if (!item) {
+            console.warn("OSDHost: provider returned no delegate for", kind);
+            return;
+        }
+        priv.delegate = item;
+        priv.currentKind = kind;
+        priv.apply(item, value, active);
+        root.state = "shown";
+        holdTimer.restart();
+        root.shown(kind);
+    }
+
+    // Hide the current OSD early (e.g. the user dismissed it).
+    function hide() {
+        if (priv.currentKind === "")
+            return;
+        holdTimer.stop();
+        root.state = "hidden";
+    }
+
+    QtObject {
+        id: priv
+
+        property string currentKind: ""
+        property Item delegate: null
+
+        // Set value / active on the delegate when it carries them. A
+        // delegate that lacks a property simply ignores that input
+        // (volume/brightness use value; mic/caps use active).
+        function apply(item, value, active) {
+            if (value !== undefined && item.value !== undefined)
+                item.value = value;
+            if (active !== undefined && item.active !== undefined)
+                item.active = active;
+        }
+
+        function destroyDelegate() {
+            if (priv.delegate) {
+                // Defer the destroy out of the current call. show() can be
+                // invoked synchronously from C++ (the IPC router dispatches
+                // osd.show via the meta-object system); destroying a QML
+                // object inline inside such a call re-enters the engine and
+                // corrupts the invoked function's return-value marshalling
+                // (the caller sees a default-constructed result). Qt.callLater
+                // runs the teardown after the current call unwinds, which is
+                // also the right place to destroy an object rather than
+                // mid-handler.
+                const old = priv.delegate;
+                priv.delegate = null;
+                Qt.callLater(function () {
+                    if (!old)
+                        return;
+                    // The provider must hand back a destroyable (JS-owned)
+                    // delegate, since the host owns its lifetime. A
+                    // C++-owned item throws "indestructible object" here;
+                    // catch it so a provider wiring bug surfaces as a clear
+                    // warning instead of an uncaught delayed-eval exception
+                    // (and so it doesn't silently leak a ghost behind the
+                    // next OSD).
+                    try {
+                        old.destroy();
+                    } catch (e) {
+                        console.warn("OSDHost: delegate is not destroyable; the provider must return a JS-owned item (QQmlEngine::JavaScriptOwnership). Leaking it.", e);
+                    }
+                });
+            }
+            priv.currentKind = "";
+        }
+
+        // Called at the end of the hide transition: tear the delegate
+        // down and announce the kind that just left.
+        function onHidden() {
+            const k = priv.currentKind;
+            priv.destroyDelegate();
+            if (k !== "")
+                root.hidden(k);
+        }
+    }
+
+    // The OSD card holder: positioned bottom-centre, sized to the
+    // delegate, and the thing the show/hide transitions animate.
+    Item {
+        id: frame
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        y: parent.height - height - root.bottomMargin
+        implicitWidth: childrenRect.width
+        implicitHeight: childrenRect.height
+        width: implicitWidth
+        height: implicitHeight
+        opacity: 0
+        scale: 0.92
+        visible: opacity > 0
+    }
+
+    Timer {
+        id: holdTimer
+
+        interval: root.holdDuration
+        repeat: false
+        onTriggered: root.state = "hidden"
+    }
+
+    state: "hidden"
+    states: [
+        State {
+            name: "shown"
+            PropertyChanges {
+                target: frame
+                opacity: 1
+                scale: 1
+            }
+        },
+        State {
+            name: "hidden"
+            PropertyChanges {
+                target: frame
+                opacity: 0
+                scale: 0.92
+            }
+        }
+    ]
+    transitions: [
+        Transition {
+            to: "shown"
+            NumberAnimation {
+                target: frame
+                properties: "opacity,scale"
+                duration: Motion.duration_short_4
+                easing: Motion.emphasized
+            }
+        },
+        Transition {
+            to: "hidden"
+            SequentialAnimation {
+                NumberAnimation {
+                    target: frame
+                    properties: "opacity,scale"
+                    duration: Motion.duration_short_3
+                    easing: Motion.standard
+                }
+                ScriptAction {
+                    script: priv.onHidden()
+                }
+            }
+        }
+    ]
+}

--- a/libs/phosphor-shell-osd/qml/Phosphor/OSD/VolumeOSD.qml
+++ b/libs/phosphor-shell-osd/qml/Phosphor/OSD/VolumeOSD.qml
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.OSD.VolumeOSD, the volume on-screen display.
+//
+// An OSDCard with a speaker glyph and a progress bar. `value` is the
+// volume percentage (0..100); at 0 the speaker shows a muted cross.
+
+import QtQuick
+import QtQuick.Shapes
+import Phosphor.Theme
+
+OSDCard {
+    id: osd
+
+    // Volume percentage 0..100, set by OSDHost.
+    property real value: 0
+    // Unused here; present so OSDHost can set it generically.
+    property bool active: false
+
+    label: qsTr("Volume")
+    showProgress: true
+    progress: value / 100
+
+    icon: Component {
+        Item {
+            implicitWidth: 30
+            implicitHeight: 30
+
+            Shape {
+                anchors.fill: parent
+                preferredRendererType: Shape.CurveRenderer
+
+                // Speaker body (cone + box).
+                ShapePath {
+                    fillColor: Theme.on_surface
+                    strokeColor: "transparent"
+
+                    PathSvg {
+                        path: "M 4 11 H 9 L 16 5 V 25 L 9 19 H 4 Z"
+                    }
+                }
+                // Sound wave, hidden when muted.
+                ShapePath {
+                    fillColor: "transparent"
+                    strokeColor: osd.value > 0 ? Theme.on_surface : "transparent"
+                    strokeWidth: 2
+                    capStyle: ShapePath.RoundCap
+
+                    PathSvg {
+                        path: "M 19 9 C 23 13, 23 17, 19 21"
+                    }
+                }
+                // Muted cross, shown only at zero.
+                ShapePath {
+                    fillColor: "transparent"
+                    strokeColor: osd.value <= 0 ? Theme.error : "transparent"
+                    strokeWidth: 2
+                    capStyle: ShapePath.RoundCap
+
+                    PathSvg {
+                        path: "M 20 11 L 26 19 M 26 11 L 20 19"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/libs/phosphor-shell-osd/src/phosphorshellosd_qml_plugin.cpp
+++ b/libs/phosphor-shell-osd/src/phosphorshellosd_qml_plugin.cpp
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// Glue translation unit for qt_add_qml_module. Phosphor.OSD is a
+// pure-QML module (OSDHost + OSDCard + the four built-in OSD delegates),
+// but qt_add_qml_module needs at least one C++ source so the generated
+// plugin and type registrar have a compilation unit. Any future C++ OSD
+// primitive or foreign-type re-export goes here.

--- a/libs/phosphor-shell-osd/tests/CMakeLists.txt
+++ b/libs/phosphor-shell-osd/tests/CMakeLists.txt
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# QtQuickTest harness for the Phosphor.OSD framework. Cases live in
+# tst_*.qml; tst_osd.cpp is the QUICK_TEST_MAIN entry point. The test
+# links the OSD module + the modules it imports (Phosphor.Widgets,
+# Phosphor.Theme) and their plugin registrars so the QML engine can
+# resolve every import.
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick QuickShapes QuickTest)
+
+add_executable(test_phosphor_shell_osd tst_osd.cpp)
+
+target_compile_features(test_phosphor_shell_osd PRIVATE cxx_std_20)
+
+target_link_libraries(test_phosphor_shell_osd
+    PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickShapes
+        Qt6::QuickTest
+        # The OSD module + its plugin, plus the modules it imports and
+        # their plugin registrars (Phosphor.Widgets pulls Phosphor.Theme).
+        PhosphorShellOsdQml
+        PhosphorShellOsdQmlplugin
+        PhosphorShellWidgetsQml
+        PhosphorShellWidgetsQmlplugin
+        PhosphorThemeQml
+        PhosphorThemeQmlplugin
+)
+
+add_test(
+    NAME test_phosphor_shell_osd
+    COMMAND test_phosphor_shell_osd -input ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+set_tests_properties(test_phosphor_shell_osd PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)

--- a/libs/phosphor-shell-osd/tests/tst_osd.cpp
+++ b/libs/phosphor-shell-osd/tests/tst_osd.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// QtQuickTest runner for the Phosphor.OSD framework. Cases live in the
+// tst_*.qml files alongside; the source dir is passed via -input from
+// add_test, and the offscreen QPA platform keeps the run headless.
+
+#include <QtQuickTest/quicktest.h>
+
+QUICK_TEST_MAIN(phosphor_shell_osd)

--- a/libs/phosphor-shell-osd/tests/tst_osdhost.qml
+++ b/libs/phosphor-shell-osd/tests/tst_osdhost.qml
@@ -38,8 +38,14 @@ TestCase {
         // Last delegate handed out, so a test can capture it and assert
         // it gets destroyed on swap.
         property var lastItem: null
+        // When set, createOSD returns null for this kind, simulating an
+        // unregistered/mistyped kind (the registry-backed provider returns
+        // null for those).
+        property string failFor: ""
 
         function createOSD(kind, parent) {
+            if (kind === fakeProvider.failFor)
+                return null;
             fakeProvider.created++;
             // Create JS-owned (no creation parent) then reparent, so the
             // delegate is destroyable by the host — the same ownership the
@@ -75,6 +81,7 @@ TestCase {
 
     function init() {
         fakeProvider.created = 0;
+        fakeProvider.failFor = "";
     }
 
     function test_show_creates_delegate() {
@@ -82,6 +89,40 @@ TestCase {
         h.show("volume", 50, undefined, "");
         compare(h.currentKind, "volume", "currentKind reflects the shown OSD");
         compare(fakeProvider.created, 1, "one delegate created");
+    }
+
+    function test_failed_swap_preserves_current_osd() {
+        const h = createTemporaryObject(hostComp, testCase);
+        const spy = createTemporaryObject(spyComp, testCase, {
+            "target": h,
+            "signalName": "hidden"
+        });
+        h.show("volume", 50, undefined, "");
+        compare(h.currentKind, "volume", "volume is up");
+        // A swap whose provider yields no delegate must leave the current
+        // OSD intact, return false, and NOT emit hidden for it.
+        fakeProvider.failFor = "missing";
+        const ok = h.show("missing", undefined, undefined, "");
+        compare(ok, false, "a null-delegate show returns false");
+        compare(h.currentKind, "volume", "the current OSD survives a failed swap");
+        compare(fakeProvider.created, 1, "no new delegate was created");
+        compare(spy.count, 0, "hidden is not emitted for a show that failed");
+    }
+
+    function test_no_provider_returns_false() {
+        const h = createTemporaryObject(hostComp, testCase, {
+            "provider": null
+        });
+        compare(h.show("volume", 50, undefined, ""), false, "no provider -> false");
+        compare(h.currentKind, "", "nothing shown without a provider");
+    }
+
+    function test_value_and_active_applied_to_delegate() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.show("volume", 42, undefined, "");
+        compare(fakeProvider.lastItem.value, 42, "value lands on the delegate");
+        h.show("mic", undefined, true, "");
+        compare(fakeProvider.lastItem.active, true, "active lands on the delegate");
     }
 
     function test_repeat_same_kind_dedupes() {

--- a/libs/phosphor-shell-osd/tests/tst_osdhost.qml
+++ b/libs/phosphor-shell-osd/tests/tst_osdhost.qml
@@ -239,6 +239,31 @@ TestCase {
         compare(spy.signalArguments[0][0], "volume", "hidden carries the previous kind");
     }
 
+    function test_reentrant_show_from_hidden_is_symmetric() {
+        // A consumer may call show() synchronously from a hidden() handler.
+        // Every installed delegate must still get exactly one shown() and,
+        // once replaced, exactly one hidden() — no orphan/stale signal.
+        const h = createTemporaryObject(hostComp, testCase);
+        const shownSpy = createTemporaryObject(spyComp, testCase, {
+            "target": h,
+            "signalName": "shown"
+        });
+        const hiddenSpy = createTemporaryObject(spyComp, testCase, {
+            "target": h,
+            "signalName": "hidden"
+        });
+        // When "volume" leaves, re-enter with a third kind mid-swap.
+        h.hidden.connect(function (k) {
+            if (k === "volume")
+                h.show("mic", undefined, true, "");
+        });
+        h.show("volume", 50, undefined, ""); // shown(volume)
+        h.show("brightness", 30, undefined, ""); // shown(brightness), hidden(volume) -> show(mic): shown(mic), hidden(brightness)
+        compare(h.currentKind, "mic", "the re-entrant kind ends up current");
+        compare(shownSpy.count, 3, "volume, brightness, mic each announced shown once");
+        compare(hiddenSpy.count, 2, "volume and brightness each announced hidden once");
+    }
+
     Component {
         id: spyComp
 

--- a/libs/phosphor-shell-osd/tests/tst_osdhost.qml
+++ b/libs/phosphor-shell-osd/tests/tst_osdhost.qml
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Behaviour tests for OSDHost: delegate creation, debounce/dedupe (a
+// repeated trigger of the same kind reuses the delegate and restarts the
+// hold rather than recreating it), kind-swap, per-screen routing, the
+// shown/hidden signals, and the auto-hide lifecycle. A fake provider
+// stands in for the registry-backed one so the host logic is exercised
+// without C++.
+
+import QtQuick
+import QtTest
+import Phosphor.OSD
+
+TestCase {
+    id: testCase
+
+    name: "OSDHost"
+
+    // Trivial OSD delegate with the value/active surface OSDHost sets.
+    Component {
+        id: fakeDelegate
+
+        Item {
+            property real value: 0
+            property bool active: false
+
+            implicitWidth: 20
+            implicitHeight: 20
+        }
+    }
+
+    // Registry-free provider: counts creations so the dedupe contract is
+    // observable.
+    QtObject {
+        id: fakeProvider
+
+        property int created: 0
+        // Last delegate handed out, so a test can capture it and assert
+        // it gets destroyed on swap.
+        property var lastItem: null
+
+        function createOSD(kind, parent) {
+            fakeProvider.created++;
+            // Create JS-owned (no creation parent) then reparent, so the
+            // delegate is destroyable by the host — the same ownership the
+            // real IOSDFactory path establishes via JavaScriptOwnership.
+            const item = fakeDelegate.createObject(null, {});
+            item.parent = parent;
+            fakeProvider.lastItem = item;
+            return item;
+        }
+    }
+
+    Component {
+        id: holderComp
+
+        QtObject {
+            // Typed object property: QML nulls it automatically when the
+            // referenced QObject is destroyed (a `var` would keep a stale
+            // wrapper instead).
+            property QtObject ref: null
+        }
+    }
+
+    Component {
+        id: hostComp
+
+        OSDHost {
+            width: 400
+            height: 300
+            holdDuration: 60
+            provider: fakeProvider
+        }
+    }
+
+    function init() {
+        fakeProvider.created = 0;
+    }
+
+    function test_show_creates_delegate() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.show("volume", 50, undefined, "");
+        compare(h.currentKind, "volume", "currentKind reflects the shown OSD");
+        compare(fakeProvider.created, 1, "one delegate created");
+    }
+
+    function test_repeat_same_kind_dedupes() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.show("volume", 50, undefined, "");
+        h.show("volume", 70, undefined, "");
+        h.show("volume", 90, undefined, "");
+        compare(fakeProvider.created, 1, "repeated same-kind shows reuse the one delegate");
+        compare(h.currentKind, "volume", "still showing volume");
+    }
+
+    function test_different_kind_swaps() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.show("volume", 50, undefined, "");
+        h.show("brightness", 30, undefined, "");
+        compare(fakeProvider.created, 2, "a new kind creates a fresh delegate");
+        compare(h.currentKind, "brightness", "currentKind swapped");
+    }
+
+    function test_swap_destroys_old_delegate() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.show("volume", 50, undefined, "");
+        // Capture the first delegate; a var property nulls out when the
+        // referenced QObject is destroyed.
+        const holder = holderComp.createObject(testCase, {
+            "ref": fakeProvider.lastItem
+        });
+        verify(holder.ref, "captured the first delegate");
+        h.show("brightness", 30, undefined, "");
+        // Teardown is deferred (Qt.callLater); the old delegate must still
+        // be destroyed, not leaked behind the new one.
+        tryCompare(holder, "ref", null, 3000, "the swapped-out delegate is destroyed, not leaked");
+    }
+
+    function test_routing_ignores_other_screen() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.screenName = "DP-1";
+        h.show("volume", 50, undefined, "DP-2");
+        compare(h.currentKind, "", "a trigger for another screen is ignored");
+        compare(fakeProvider.created, 0, "no delegate created for the wrong screen");
+        h.show("volume", 50, undefined, "DP-1");
+        compare(h.currentKind, "volume", "a trigger for this screen shows");
+        compare(fakeProvider.created, 1, "delegate created for the matching screen");
+    }
+
+    function test_empty_target_hits_every_host() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.screenName = "DP-1";
+        h.show("mic", undefined, true, "");
+        compare(h.currentKind, "mic", "an empty targetScreen routes to every host");
+    }
+
+    function test_shown_signal_fires() {
+        const h = createTemporaryObject(hostComp, testCase);
+        const spy = spyComp.createObject(testCase, {
+            "target": h,
+            "signalName": "shown"
+        });
+        h.show("volume", 50, undefined, "");
+        compare(spy.count, 1, "shown fired once");
+        compare(spy.signalArguments[0][0], "volume", "shown carries the kind");
+    }
+
+    function test_auto_hide_clears_after_hold() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.show("volume", 50, undefined, "");
+        compare(h.state, "shown", "state is shown right after show()");
+        // Hold timer (60ms) then the fade-out transition; the delegate is
+        // destroyed and currentKind cleared at the end of the transition.
+        tryCompare(h, "currentKind", "", 3000, "auto-hides and clears after the hold");
+    }
+
+    Component {
+        id: spyComp
+
+        SignalSpy {}
+    }
+}

--- a/libs/phosphor-shell-osd/tests/tst_osdhost.qml
+++ b/libs/phosphor-shell-osd/tests/tst_osdhost.qml
@@ -154,6 +154,50 @@ TestCase {
         tryCompare(h, "currentKind", "", 3000, "auto-hides and clears after the hold");
     }
 
+    function test_empty_kind_is_rejected() {
+        const h = createTemporaryObject(hostComp, testCase);
+        const r = h.show("", 50, undefined, "");
+        compare(r, false, "an empty kind returns false");
+        compare(h.currentKind, "", "nothing is shown");
+        compare(fakeProvider.created, 0, "no delegate created for an empty kind");
+    }
+
+    function test_show_returns_bool() {
+        const h = createTemporaryObject(hostComp, testCase);
+        compare(h.show("volume", 50, undefined, ""), true, "a shown OSD returns true");
+        compare(h.show("volume", 60, undefined, "DP-9"), false, "a trigger routed elsewhere returns false");
+    }
+
+    function test_hide_dismisses_early() {
+        const h = createTemporaryObject(hostComp, testCase);
+        h.show("volume", 50, undefined, "");
+        h.hide();
+        tryCompare(h, "currentKind", "", 3000, "hide() tears the OSD down");
+    }
+
+    function test_hidden_signal_on_auto_hide() {
+        const h = createTemporaryObject(hostComp, testCase);
+        const spy = spyComp.createObject(testCase, {
+            "target": h,
+            "signalName": "hidden"
+        });
+        h.show("volume", 50, undefined, "");
+        tryCompare(spy, "count", 1, 3000, "hidden fires once on auto-hide");
+        compare(spy.signalArguments[0][0], "volume", "hidden carries the kind that left");
+    }
+
+    function test_swap_emits_hidden_for_previous() {
+        const h = createTemporaryObject(hostComp, testCase);
+        const spy = spyComp.createObject(testCase, {
+            "target": h,
+            "signalName": "hidden"
+        });
+        h.show("volume", 50, undefined, "");
+        h.show("brightness", 30, undefined, ""); // swap
+        compare(spy.count, 1, "swapping emits hidden for the outgoing OSD");
+        compare(spy.signalArguments[0][0], "volume", "hidden carries the previous kind");
+    }
+
     Component {
         id: spyComp
 

--- a/libs/phosphor-shell-osd/tests/tst_osdhost.qml
+++ b/libs/phosphor-shell-osd/tests/tst_osdhost.qml
@@ -106,7 +106,7 @@ TestCase {
         h.show("volume", 50, undefined, "");
         // Capture the first delegate; a var property nulls out when the
         // referenced QObject is destroyed.
-        const holder = holderComp.createObject(testCase, {
+        const holder = createTemporaryObject(holderComp, testCase, {
             "ref": fakeProvider.lastItem
         });
         verify(holder.ref, "captured the first delegate");
@@ -136,7 +136,7 @@ TestCase {
 
     function test_shown_signal_fires() {
         const h = createTemporaryObject(hostComp, testCase);
-        const spy = spyComp.createObject(testCase, {
+        const spy = createTemporaryObject(spyComp, testCase, {
             "target": h,
             "signalName": "shown"
         });
@@ -177,7 +177,7 @@ TestCase {
 
     function test_hidden_signal_on_auto_hide() {
         const h = createTemporaryObject(hostComp, testCase);
-        const spy = spyComp.createObject(testCase, {
+        const spy = createTemporaryObject(spyComp, testCase, {
             "target": h,
             "signalName": "hidden"
         });
@@ -188,7 +188,7 @@ TestCase {
 
     function test_swap_emits_hidden_for_previous() {
         const h = createTemporaryObject(hostComp, testCase);
-        const spy = spyComp.createObject(testCase, {
+        const spy = createTemporaryObject(spyComp, testCase, {
             "target": h,
             "signalName": "hidden"
         });

--- a/libs/phosphor-shell-widgets/CMakeLists.txt
+++ b/libs/phosphor-shell-widgets/CMakeLists.txt
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# PhosphorShellWidgets, the Phosphor.Widgets M3 atom library.
+#
+# A pure-QML module of themeable building blocks (button, slider, text
+# field, card, pill, ripple, elevation shadow) that every Phosphor shell
+# surface composes. The atoms bind through PhosphorTheme's Theme / Motion
+# / StateLayer singletons, so a palette or motion retune propagates here
+# with no per-widget edits.
+#
+# Phase 3.1 deliverable per docs/phosphor-shell-design/04-implementation-plan.md.
+
+cmake_minimum_required(VERSION 3.16)
+
+set(PHOSPHORSHELLWIDGETS_VERSION "0.1.0")
+
+if(NOT PROJECT_VERSION)
+    project(PhosphorShellWidgets VERSION ${PHOSPHORSHELLWIDGETS_VERSION} LANGUAGES CXX)
+    set(CMAKE_CXX_STANDARD 20)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_AUTOMOC ON)
+endif()
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Dependencies
+# ═══════════════════════════════════════════════════════════════════════════════
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick)
+
+# The atoms import Phosphor.Theme for Theme / Motion / StateLayer. The
+# QML import scanner (qmllint, qmlcachegen) needs the registered theme
+# module visible at build time, and consumers need the runtime plugin
+# linked so the import resolves. Find PhosphorTheme from a sibling
+# subproject build first, then fall back to an installed package.
+if(NOT TARGET PhosphorTheme::PhosphorThemeQml)
+    find_package(PhosphorTheme CONFIG QUIET)
+endif()
+
+# Qt 6.5+ resource-prefix policy. NEW = use `:/qt/qml/` as the QML module
+# resource prefix.
+if(COMMAND qt_policy)
+    qt_policy(SET QTP0001 NEW)
+endif()
+
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# QML module, STATIC (in-tree linkable)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Pure-QML module: the atoms are .qml files with no backing C++ types.
+# The glue translation unit gives qt_add_qml_module a compilation unit
+# for the generated plugin + type registrar.
+
+set(_phosphor_widgets_qml_files
+    qml/Phosphor/Widgets/ElevationShadow.qml
+    qml/Phosphor/Widgets/PhosphorRipple.qml
+    qml/Phosphor/Widgets/PhosphorButton.qml
+    qml/Phosphor/Widgets/PhosphorPill.qml
+    qml/Phosphor/Widgets/PhosphorCard.qml
+    qml/Phosphor/Widgets/PhosphorSlider.qml
+    qml/Phosphor/Widgets/PhosphorTextField.qml
+)
+
+# qt_add_qml_module nests QML_FILES under their source-relative path
+# beneath the module URI prefix. Pin the resource alias to the basename
+# so import resolution doesn't see a doubled `qml/Phosphor/Widgets/`
+# segment. Same pattern as PhosphorTheme / PhosphorPopout.
+foreach(_qml_file IN LISTS _phosphor_widgets_qml_files)
+    get_filename_component(_qml_basename ${_qml_file} NAME)
+    set_source_files_properties(${_qml_file}
+        PROPERTIES
+            QT_RESOURCE_ALIAS ${_qml_basename}
+    )
+endforeach()
+
+# Directory-scope suppression of -Wmissing-include-dirs for the targets
+# qt_add_qml_module generates here: Qt adds <target>_autogen/include to each
+# sub-target's -I list, but when a module carries no Q_OBJECT sources AUTOMOC
+# never creates that directory (and --clean-first deletes it), so cc1plus
+# warns on a Qt-managed scratch path. Full rationale: src/shared/CMakeLists.txt.
+set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-Wno-missing-include-dirs")
+
+qt_add_qml_module(PhosphorShellWidgetsQml
+    URI Phosphor.Widgets
+    VERSION 1.0
+    STATIC
+    # The atoms import Phosphor.Theme (Theme / Motion / StateLayer) and
+    # QtQuick.Effects (MultiEffect, used by ElevationShadow). Declaring
+    # the imports here lets qmllint and qmlcachegen resolve symbols at
+    # build time; QtQuick.Effects ships with Qt6::Quick, and the
+    # Phosphor.Theme runtime registration is handled by the
+    # PhosphorThemeQmlplugin link below.
+    IMPORTS
+        Phosphor.Theme
+        QtQuick.Effects
+    SOURCES
+        src/phosphorshellwidgets_qml_plugin.cpp
+    QML_FILES ${_phosphor_widgets_qml_files}
+    OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/qml/Phosphor/Widgets
+)
+
+add_library(PhosphorShellWidgets::PhosphorShellWidgetsQml ALIAS PhosphorShellWidgetsQml)
+
+target_compile_features(PhosphorShellWidgetsQml PUBLIC cxx_std_20)
+
+target_link_libraries(PhosphorShellWidgetsQml
+    PUBLIC
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+)
+
+# Link the PhosphorTheme QML plugin and module when available so
+# consumers don't have to wire it themselves. The atoms' `import
+# Phosphor.Theme` resolves through the linked plugin's runtime
+# registration. In-tree builds always have these targets; out-of-tree
+# consumers get a clear missing-target failure instead of a runtime
+# "module not found" from QML.
+if(TARGET PhosphorTheme::PhosphorThemeQml)
+    target_link_libraries(PhosphorShellWidgetsQml PUBLIC PhosphorTheme::PhosphorThemeQml)
+endif()
+if(TARGET PhosphorThemeQmlplugin)
+    target_link_libraries(PhosphorShellWidgetsQml PUBLIC PhosphorThemeQmlplugin)
+endif()
+
+# Static archive: VERSION/SOVERSION apply to SHARED libraries only and are
+# silently ignored on STATIC. Don't set them so the property surface
+# matches what the target actually carries.
+
+# No install rules: PhosphorShellWidgetsQml is a STATIC, in-tree-only QML
+# module (like PhosphorPopout's PhosphorPopoutQml). It is linked directly
+# by the bundled shell and the kitchen-sink demo, so it never deploys as a
+# standalone artifact; its runtime registration rides in whatever binary
+# links it. There is no C++ core library to install either (the atoms are
+# pure QML). Installing the static module would also drag its Qt-generated
+# resource targets + the PhosphorTheme targets it links into an export
+# set they don't belong to. A standalone installed deployment lands
+# alongside the layer-shell-hosted shell binary in Phase 4.
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+if(CMAKE_PROJECT_NAME STREQUAL "PhosphorShellWidgets" OR BUILD_TESTING)
+    # enable_testing() is a no-op when KDECMakeSettings already included
+    # CTest at the top level. The redundant call lets a standalone build
+    # of this subproject still discover ctest.
+    enable_testing()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/tests/CMakeLists.txt")
+        add_subdirectory(tests)
+    endif()
+endif()

--- a/libs/phosphor-shell-widgets/CMakeLists.txt
+++ b/libs/phosphor-shell-widgets/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 # Dependencies
 # ═══════════════════════════════════════════════════════════════════════════════
 
-find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick)
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick QuickShapes)
 
 # The atoms import Phosphor.Theme for Theme / Motion / StateLayer. The
 # QML import scanner (qmllint, qmlcachegen) needs the registered theme
@@ -61,6 +61,11 @@ set(_phosphor_widgets_qml_files
     qml/Phosphor/Widgets/PhosphorCard.qml
     qml/Phosphor/Widgets/PhosphorSlider.qml
     qml/Phosphor/Widgets/PhosphorTextField.qml
+    # Phase 3.2 connected-corner primitives.
+    qml/Phosphor/Widgets/ConnectorGeometry.js
+    qml/Phosphor/Widgets/ConnectedShape.qml
+    qml/Phosphor/Widgets/ConnectedCorner.qml
+    qml/Phosphor/Widgets/BarCanvas.qml
 )
 
 # qt_add_qml_module nests QML_FILES under their source-relative path
@@ -95,6 +100,7 @@ qt_add_qml_module(PhosphorShellWidgetsQml
     IMPORTS
         Phosphor.Theme
         QtQuick.Effects
+        QtQuick.Shapes
     SOURCES
         src/phosphorshellwidgets_qml_plugin.cpp
     QML_FILES ${_phosphor_widgets_qml_files}
@@ -111,6 +117,10 @@ target_link_libraries(PhosphorShellWidgetsQml
         Qt6::Gui
         Qt6::Qml
         Qt6::Quick
+        # ConnectedShape uses QtQuick.Shapes (Shape/ShapePath/PathSvg);
+        # linking the module pulls its plugin so the import resolves in a
+        # static build.
+        Qt6::QuickShapes
 )
 
 # Link the PhosphorTheme QML plugin and module when available so

--- a/libs/phosphor-shell-widgets/README.md
+++ b/libs/phosphor-shell-widgets/README.md
@@ -30,7 +30,7 @@ signal to whatever controller drives it.
 |----------------------|---------------------------------------------------------------------------------------|
 | `PhosphorButton`     | M3 button in four variants (`Filled`, `Tonal`, `Outlined`, `Text`).                   |
 | `PhosphorSlider`     | Continuous horizontal slider; drag the handle or tap the track. Emits `moved`.        |
-| `PhosphorTextField`  | Outlined single-line input; focus thickens and tints the outline; placeholder.        |
+| `PhosphorTextField`  | Outlined single-line input with a placeholder; focus thickens and tints the outline.   |
 | `PhosphorCard`       | Elevated rounded surface container; children land in a padded content area.           |
 | `PhosphorPill`       | Compact fully-rounded chip / toggle; outlined when unselected, filled when selected.  |
 | `PhosphorRipple`     | Shared interaction layer: hover / press state-layer tint + expanding press ripple.    |
@@ -80,10 +80,10 @@ content drop to the M3 disabled opacities (`StateLayer.disabled_container`
   embed it for the hover / press tint and the touch ripple, and re-emit
   its `tapped` as their own `clicked`. Known limitation: `Item.clip` is
   rectangular, so the expanding ripple circle is not masked to a rounded
-  corner radius. The resting state-layer tint honours `radius`; only the
+  corner radius. The resting state-layer tint honours `radius`, so only the
   transient ripple sweep is unclipped. A rounded clip (e.g. a `MultiEffect`
-  mask sourced from a `ConnectedShape`) is the eventual fix; it is not yet
-  wired in, as the spill is subtle and per-control masking has a real cost.
+  mask sourced from a `ConnectedShape`) is the eventual fix. It is not yet
+  wired in because the spill is subtle and per-control masking has a real cost.
 - **Elevation is two halves.** `ElevationShadow` is the shadow half: a
   `MultiEffect` tuned for the six M3 elevation tiers, used as a
   `layer.effect` so the engine wires the layered item into its `source`
@@ -99,7 +99,11 @@ content drop to the M3 disabled opacities (`StateLayer.disabled_container`
   `elevation > 0`.
 - **Host owns state.** `PhosphorPill` does not flip its own `selected`,
   and `PhosphorSlider`/`PhosphorTextField` expose the value/text for the
-  host to bind. The atoms emit intent; the host owns the source of truth.
+  host to bind. The atoms emit intent and the host owns the source of
+  truth. Note `PhosphorSlider` follows the `QtQuick.Controls.Slider`
+  convention: set `value` as the initial position and respond to `moved`
+  (dragging writes `value` imperatively, so a one-way `value:` binding does
+  not survive interaction). Re-drive `value` from the `moved` handler.
 - **Connected-corner geometry is a path string, not declarative arcs.**
   `ConnectorGeometry.js` builds the outline as an SVG `d` string and
   `ConnectedShape` renders it via `PathSvg`, because a `Shape` cannot

--- a/libs/phosphor-shell-widgets/README.md
+++ b/libs/phosphor-shell-widgets/README.md
@@ -3,8 +3,8 @@
 
 # PhosphorShellWidgets
 
-The `Phosphor.Widgets` atom library: the Material 3 building blocks every
-Phosphor shell surface composes. Pure QML, themed entirely through
+The `Phosphor.Widgets` atom library provides the Material 3 building blocks
+every Phosphor shell surface composes. Pure QML, themed entirely through
 [`phosphor-theme`](../phosphor-theme/README.md)'s `Theme` / `Motion` /
 `StateLayer` singletons, so a palette or motion retune propagates to every
 widget with no per-widget edit.
@@ -21,7 +21,7 @@ bar, launcher, control center, OSDs) assemble these rather than
 re-rolling button and slider styling per surface.
 
 The library owns presentation only. It holds no business logic and no
-service bindings; a host wires an atom's `clicked` / `moved` / `toggled`
+service bindings. A host wires an atom's `clicked` / `moved` / `toggled`
 signal to whatever controller drives it.
 
 ## Key types
@@ -120,7 +120,7 @@ content drop to the M3 disabled opacities (`StateLayer.disabled_container`
   `ConnectedShape` renders it via `PathSvg`, because a `Shape` cannot
   generate N pocket arcs declaratively for a variable socket count. This
   matches the design mockups (also SVG paths) command-for-command. The
-  morph is driven by the host animating a socket's `depth`; the path
+  morph is driven by the host animating a socket's `depth`. The path
   recomputes reactively and `Shape.CurveRenderer` antialiases the concave
   joins. The pocket degrades to a flat edge at `depth <= 0.5`, so an
   open-from-zero animation grows the pocket smoothly. The popout body is
@@ -134,7 +134,7 @@ content drop to the M3 disabled opacities (`StateLayer.disabled_container`
   `ConnectedShape` / `BarCanvas` use `QtQuick.Shapes` (`Qt6::QuickShapes`).
 - `phosphor-theme` (`Phosphor.Theme` QML module) for the `Theme`,
   `Motion`, and `StateLayer` singletons. In-tree builds link the theme
-  QML plugin automatically; the module is static and in-tree-only today.
+  QML plugin automatically. The module is static and in-tree-only today.
 
 ## Status
 

--- a/libs/phosphor-shell-widgets/README.md
+++ b/libs/phosphor-shell-widgets/README.md
@@ -104,6 +104,17 @@ content drop to the M3 disabled opacities (`StateLayer.disabled_container`
   convention: set `value` as the initial position and respond to `moved`
   (dragging writes `value` imperatively, so a one-way `value:` binding does
   not survive interaction). Re-drive `value` from the `moved` handler.
+- **Keyboard and focus.** Every interactive atom is Tab-focusable when
+  enabled (and skipped in the tab order when disabled). `PhosphorButton`
+  and `PhosphorPill` activate on Space / Enter / Return (with a ripple from
+  the centre); `PhosphorSlider` moves on Left/Right/Up/Down by `stepSize`
+  (default a twentieth of the range) and jumps to the ends on Home/End;
+  `PhosphorTextField` delegates focus to its inner input. The focus
+  indicator is the M3 focus state layer (`StateLayer.focus`): the ripple
+  tint on buttons/pills, a halo behind the slider handle, and the existing
+  thickened outline on the text field. Disabled-state tints route through
+  `StateLayer.disabledContent` / `disabledContainer` so the M3 opacities
+  live in one place.
 - **Connected-corner geometry is a path string, not declarative arcs.**
   `ConnectorGeometry.js` builds the outline as an SVG `d` string and
   `ConnectedShape` renders it via `PathSvg`, because a `Shape` cannot

--- a/libs/phosphor-shell-widgets/README.md
+++ b/libs/phosphor-shell-widgets/README.md
@@ -60,8 +60,8 @@ PhosphorCard {
 }
 ```
 
-Set `enabled: false` on any atom for its disabled state; container and
-content drop to the M3 disabled opacities (`StateLayer.disabled_container`
+Set `enabled: false` on any atom for its disabled state. The container and
+content then drop to the M3 disabled opacities (`StateLayer.disabled_container`
 / `StateLayer.disabled_content`).
 
 ## Design notes
@@ -130,7 +130,7 @@ content drop to the M3 disabled opacities (`StateLayer.disabled_container`
 ## Dependencies
 
 - Qt6 ≥ 6.6 Core / Gui / Qml / Quick. `ElevationShadow` uses
-  `QtQuick.Effects` (`MultiEffect`), which ships with Qt6::Quick;
+  `QtQuick.Effects` (`MultiEffect`), which ships with Qt6::Quick.
   `ConnectedShape` / `BarCanvas` use `QtQuick.Shapes` (`Qt6::QuickShapes`).
 - `phosphor-theme` (`Phosphor.Theme` QML module) for the `Theme`,
   `Motion`, and `StateLayer` singletons. In-tree builds link the theme

--- a/libs/phosphor-shell-widgets/README.md
+++ b/libs/phosphor-shell-widgets/README.md
@@ -35,6 +35,10 @@ signal to whatever controller drives it.
 | `PhosphorPill`       | Compact fully-rounded chip / toggle; outlined when unselected, filled when selected.  |
 | `PhosphorRipple`     | Shared interaction layer: hover / press state-layer tint + expanding press ripple.    |
 | `ElevationShadow`    | M3 elevation shadow (levels 0..5), used as a `layer.effect` on any rounded surface.   |
+| `BarCanvas`          | Connected-corner bar surface; its bottom edge weaves into `sockets` so popouts grow out of it as one Shape. |
+| `ConnectedShape`     | Generic `Shape` painter for an SVG path string; the renderer behind `BarCanvas`.       |
+| `ConnectedCorner`    | Standalone concave / convex quarter-fillet primitive for hand-composing joins.        |
+| `ConnectorGeometry.js` | Pure path math: builds the connected-corner SVG `d` string from socket descriptors. |
 
 ## Typical use
 
@@ -77,8 +81,9 @@ content drop to the M3 disabled opacities (`StateLayer.disabled_container`
   its `tapped` as their own `clicked`. Known limitation: `Item.clip` is
   rectangular, so the expanding ripple circle is not masked to a rounded
   corner radius. The resting state-layer tint honours `radius`; only the
-  transient ripple sweep is unclipped. A rounded clip primitive arrives
-  with the connected-corner work (Phase 3.2) and this will adopt it.
+  transient ripple sweep is unclipped. A rounded clip (e.g. a `MultiEffect`
+  mask sourced from a `ConnectedShape`) is the eventual fix; it is not yet
+  wired in, as the spill is subtle and per-control masking has a real cost.
 - **Elevation is two halves.** `ElevationShadow` is the shadow half: a
   `MultiEffect` tuned for the six M3 elevation tiers, used as a
   `layer.effect` so the engine wires the layered item into its `source`
@@ -95,19 +100,32 @@ content drop to the M3 disabled opacities (`StateLayer.disabled_container`
 - **Host owns state.** `PhosphorPill` does not flip its own `selected`,
   and `PhosphorSlider`/`PhosphorTextField` expose the value/text for the
   host to bind. The atoms emit intent; the host owns the source of truth.
+- **Connected-corner geometry is a path string, not declarative arcs.**
+  `ConnectorGeometry.js` builds the outline as an SVG `d` string and
+  `ConnectedShape` renders it via `PathSvg`, because a `Shape` cannot
+  generate N pocket arcs declaratively for a variable socket count. This
+  matches the design mockups (also SVG paths) command-for-command. The
+  morph is driven by the host animating a socket's `depth`; the path
+  recomputes reactively and `Shape.CurveRenderer` antialiases the concave
+  joins. The pocket degrades to a flat edge at `depth <= 0.5`, so an
+  open-from-zero animation grows the pocket smoothly. The popout body is
+  drawn over the pocket by the host (e.g. the bar-canvas demo), so the
+  painted socket and the content read as one surface.
 
 ## Dependencies
 
 - Qt6 ≥ 6.6 Core / Gui / Qml / Quick. `ElevationShadow` uses
-  `QtQuick.Effects` (`MultiEffect`), which ships with Qt6::Quick.
+  `QtQuick.Effects` (`MultiEffect`), which ships with Qt6::Quick;
+  `ConnectedShape` / `BarCanvas` use `QtQuick.Shapes` (`Qt6::QuickShapes`).
 - `phosphor-theme` (`Phosphor.Theme` QML module) for the `Theme`,
   `Motion`, and `StateLayer` singletons. In-tree builds link the theme
   QML plugin automatically; the module is static and in-tree-only today.
 
 ## Status
 
-Phase 3.1: in progress. Atoms and the kitchen-sink acceptance demo
-(`examples/phosphor-widgets-kitchen-sink/`) are in the tree; the Phase 3
-gate (all four 3.x examples runnable, `phosphor-ui-primitives-0.1` tag)
-also requires 3.2 (`ConnectedCorner` / `BarCanvas`), 3.3 (OSD framework),
-and 3.4 (toast framework).
+Phase 3.1 (atoms) and Phase 3.2 (connected-corner geometry) are in the
+tree, each with an acceptance demo
+(`examples/phosphor-widgets-kitchen-sink/`,
+`examples/phosphor-bar-canvas-demo/`). The Phase 3 gate (all four 3.x
+examples runnable, `phosphor-ui-primitives-0.1` tag) still requires 3.3
+(OSD framework) and 3.4 (toast framework).

--- a/libs/phosphor-shell-widgets/README.md
+++ b/libs/phosphor-shell-widgets/README.md
@@ -1,0 +1,113 @@
+<!-- SPDX-FileCopyrightText: 2026 fuddlesworth -->
+<!-- SPDX-License-Identifier: LGPL-2.1-or-later -->
+
+# PhosphorShellWidgets
+
+The `Phosphor.Widgets` atom library: the Material 3 building blocks every
+Phosphor shell surface composes. Pure QML, themed entirely through
+[`phosphor-theme`](../phosphor-theme/README.md)'s `Theme` / `Motion` /
+`StateLayer` singletons, so a palette or motion retune propagates to every
+widget with no per-widget edit.
+
+Phase 3.1 deliverable per
+[`docs/phosphor-shell-design/04-implementation-plan.md`](../../docs/phosphor-shell-design/04-implementation-plan.md).
+
+## Responsibility
+
+Provide a small, consistent set of interactive atoms (buttons, slider,
+text field, card, pill) plus the shared visual primitives they are built
+from (ripple + state layer, elevation shadow). Higher-level surfaces (the
+bar, launcher, control center, OSDs) assemble these rather than
+re-rolling button and slider styling per surface.
+
+The library owns presentation only. It holds no business logic and no
+service bindings; a host wires an atom's `clicked` / `moved` / `toggled`
+signal to whatever controller drives it.
+
+## Key types
+
+| Component            | Role                                                                                  |
+|----------------------|---------------------------------------------------------------------------------------|
+| `PhosphorButton`     | M3 button in four variants (`Filled`, `Tonal`, `Outlined`, `Text`).                   |
+| `PhosphorSlider`     | Continuous horizontal slider; drag the handle or tap the track. Emits `moved`.        |
+| `PhosphorTextField`  | Outlined single-line input; focus thickens and tints the outline; placeholder.        |
+| `PhosphorCard`       | Elevated rounded surface container; children land in a padded content area.           |
+| `PhosphorPill`       | Compact fully-rounded chip / toggle; outlined when unselected, filled when selected.  |
+| `PhosphorRipple`     | Shared interaction layer: hover / press state-layer tint + expanding press ripple.    |
+| `ElevationShadow`    | M3 elevation shadow (levels 0..5), used as a `layer.effect` on any rounded surface.   |
+
+## Typical use
+
+```qml
+import Phosphor.Widgets
+
+PhosphorCard {
+    elevation: 2
+
+    ColumnLayout {
+        PhosphorTextField { placeholderText: i18n("Name") }
+        PhosphorSlider { from: 0; to: 100; value: 40; onMoved: (v) => model.level = v }
+        PhosphorButton {
+            text: i18n("Apply")
+            variant: PhosphorButton.Filled
+            onClicked: controller.apply()
+        }
+    }
+}
+```
+
+Set `enabled: false` on any atom for its disabled state; container and
+content drop to the M3 disabled opacities (`StateLayer.disabled_container`
+/ `StateLayer.disabled_content`).
+
+## Design notes
+
+- **Tokens, not literals.** Every colour reads `Theme.*`, every animation
+  reads `Motion.*`, every state opacity reads `StateLayer.*`. There are no
+  hard-coded colours, durations, or easing curves. Live retinting works
+  because the atoms index the `Theme` singleton's `palette` map (a
+  `NOTIFY`-backed property), the same binding-tracking rule documented in
+  `phosphor-theme`.
+- **Custom controls, not restyled `QtQuick.Controls`.** The atoms are
+  built from primitives (`Rectangle`, `Text`, `TextInput`, handlers)
+  rather than restyling Controls, so theming is total and there is no
+  style-engine fallback path to fight.
+- **`PhosphorRipple` is the shared interaction layer.** Buttons and pills
+  embed it for the hover / press tint and the touch ripple, and re-emit
+  its `tapped` as their own `clicked`. Known limitation: `Item.clip` is
+  rectangular, so the expanding ripple circle is not masked to a rounded
+  corner radius. The resting state-layer tint honours `radius`; only the
+  transient ripple sweep is unclipped. A rounded clip primitive arrives
+  with the connected-corner work (Phase 3.2) and this will adopt it.
+- **Elevation is two halves.** `ElevationShadow` is the shadow half: a
+  `MultiEffect` tuned for the six M3 elevation tiers, used as a
+  `layer.effect` so the engine wires the layered item into its `source`
+  and it tracks geometry and corner radius automatically. The colour half
+  is the M3 surface tint overlay: `PhosphorCard` tints its
+  `surface_container` fill with `Theme.surface_tint` at the per-tier
+  elevation-overlay opacity, so a higher card reads as both more shadowed
+  and more tinted. `surface_tint` defaults to the primary accent (the M3
+  default) but honours an explicit `surface_tint` palette token when one
+  is present (e.g. from matugen), so the tint is themeable without binding
+  the literal primary.
+  `PhosphorCard` only enables the layer (shadow) pass when
+  `elevation > 0`.
+- **Host owns state.** `PhosphorPill` does not flip its own `selected`,
+  and `PhosphorSlider`/`PhosphorTextField` expose the value/text for the
+  host to bind. The atoms emit intent; the host owns the source of truth.
+
+## Dependencies
+
+- Qt6 ≥ 6.6 Core / Gui / Qml / Quick. `ElevationShadow` uses
+  `QtQuick.Effects` (`MultiEffect`), which ships with Qt6::Quick.
+- `phosphor-theme` (`Phosphor.Theme` QML module) for the `Theme`,
+  `Motion`, and `StateLayer` singletons. In-tree builds link the theme
+  QML plugin automatically; the module is static and in-tree-only today.
+
+## Status
+
+Phase 3.1: in progress. Atoms and the kitchen-sink acceptance demo
+(`examples/phosphor-widgets-kitchen-sink/`) are in the tree; the Phase 3
+gate (all four 3.x examples runnable, `phosphor-ui-primitives-0.1` tag)
+also requires 3.2 (`ConnectedCorner` / `BarCanvas`), 3.3 (OSD framework),
+and 3.4 (toast framework).

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/BarCanvas.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/BarCanvas.qml
@@ -43,7 +43,9 @@ Item {
     // Socket descriptors: [{ x, width, depth }] in bar-local coordinates.
     // Driven by the host / PopoutService. A socket with depth <= ~0.5 is
     // treated as closed (flat edge), so animating depth from 0 grows the
-    // pocket smoothly.
+    // pocket smoothly. Update by REASSIGNING a fresh array (the path /
+    // maxSocketDepth bindings react to the property, not to in-place
+    // mutation of an element, e.g. `sockets[0].depth = x` will not redraw).
     property var sockets: []
 
     // Default children land in the bar strip, not over the whole item, so

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/BarCanvas.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/BarCanvas.qml
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.BarCanvas, the connected-corner bar surface.
+//
+// The shell's signature surface: a rounded bar strip whose bottom edge
+// weaves down into "sockets" so attached popouts grow out of the bar as
+// one continuous painted shape (concave/inverted corners at the join,
+// convex corners at the pocket floor). See the design mockups in
+// docs/phosphor-shell-design/mockups/{bar-top,control-center}.svg.
+//
+//   BarCanvas {
+//       width: parent.width
+//       barHeight: 48
+//       sockets: ccOpen ? [{ x: ccX, width: ccW, depth: ccDepth }] : []
+//       RowLayout { anchors.fill: parent /* bar widgets */ }
+//   }
+//
+// `sockets` is the seam PopoutService drives: when a popout opens
+// anchored to the bar it contributes a socket entry; animating that
+// entry's `depth` (0 -> full) morphs the shape so the bar appears to grow
+// downward. The popout's content is rendered over the pocket area by the
+// host (the painted pocket and the content read as one surface).
+//
+// Default children land in the bar strip (the top `barHeight` band), so
+// bar widgets are declared directly inside BarCanvas.
+
+import QtQuick
+import Phosphor.Theme
+import "ConnectorGeometry.js" as ConnectorGeometry
+
+Item {
+    id: root
+
+    // Closed bar height (the strip). Sockets extend below this.
+    property real barHeight: 48
+    // The bar's own four outer corners.
+    property real cornerRadius: 16
+    // Fillet radius for socket corners (concave joins + pocket floor).
+    property real connectorRadius: 16
+    // Surface fill. Tinted/animated by ConnectedShape.
+    property color color: Theme.surface_container
+
+    // Socket descriptors: [{ x, width, depth }] in bar-local coordinates.
+    // Driven by the host / PopoutService. A socket with depth <= ~0.5 is
+    // treated as closed (flat edge), so animating depth from 0 grows the
+    // pocket smoothly.
+    property var sockets: []
+
+    // Default children land in the bar strip, not over the whole item, so
+    // a popout's pocket area below the strip stays clear for its content.
+    default property alias content: strip.data
+
+    // The generated outline, exposed for debugging and tests.
+    readonly property alias pathData: shape.path
+
+    // Deepest open socket, so the item reserves height for the pocket and
+    // the host can size content against it.
+    readonly property real maxSocketDepth: {
+        let m = 0;
+        const list = root.sockets;
+        for (let i = 0; i < (list ? list.length : 0); ++i)
+            m = Math.max(m, list[i].depth || 0);
+        return m;
+    }
+
+    implicitHeight: barHeight + maxSocketDepth
+
+    ConnectedShape {
+        id: shape
+
+        anchors.fill: parent
+        fillColor: root.color
+        path: ConnectorGeometry.buildBarPath(root.width, root.barHeight, root.cornerRadius, root.connectorRadius, root.sockets)
+    }
+
+    // The bar strip: the band where widgets live. Sized to the closed bar
+    // height; pockets open below it.
+    Item {
+        id: strip
+
+        x: 0
+        y: 0
+        width: root.width
+        height: root.barHeight
+    }
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/BarCanvas.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/BarCanvas.qml
@@ -56,12 +56,17 @@ Item {
     readonly property alias pathData: shape.path
 
     // Deepest open socket, so the item reserves height for the pocket and
-    // the host can size content against it.
+    // the host can size content against it. A socket at or below MIN_DEPTH
+    // renders flat (no pocket), so it reserves no height either, matching
+    // the geometry's gate.
     readonly property real maxSocketDepth: {
         let m = 0;
         const list = root.sockets;
-        for (let i = 0; i < (list ? list.length : 0); ++i)
-            m = Math.max(m, list[i].depth || 0);
+        for (let i = 0; i < (list ? list.length : 0); ++i) {
+            const d = list[i].depth || 0;
+            if (d > ConnectorGeometry.MIN_DEPTH)
+                m = Math.max(m, d);
+        }
         return m;
     }
 

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/BarCanvas.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/BarCanvas.qml
@@ -34,9 +34,9 @@ Item {
     // Closed bar height (the strip). Sockets extend below this.
     property real barHeight: 48
     // The bar's own four outer corners.
-    property real cornerRadius: 16
+    property real cornerRadius: Tokens.radius_l
     // Fillet radius for socket corners (concave joins + pocket floor).
-    property real connectorRadius: 16
+    property real connectorRadius: Tokens.radius_l
     // Surface fill. Tinted/animated by ConnectedShape.
     property color color: Theme.surface_container
 

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectedCorner.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectedCorner.qml
@@ -32,7 +32,7 @@ import Phosphor.Theme
 Item {
     id: root
 
-    property real radius: 16
+    property real radius: Tokens.radius_l
     property bool concave: false
     property color fillColor: Theme.surface_container
 

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectedCorner.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectedCorner.qml
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.ConnectedCorner, a single fillet primitive.
+//
+// One quarter-corner fillet, themed and sized by radius, for hand-
+// composing connected-corner joins where a whole BarCanvas path is
+// overkill, e.g. painting the concave joint where a flush-edge popout
+// meets the bar, or softening the inner angle between two stacked
+// surfaces. BarCanvas builds its full outline in ConnectorGeometry; this
+// is the same corner shape exposed as a standalone piece.
+//
+// At rotation 0:
+//   convex (concave: false)  a quarter disc filling the corner, the
+//                            rounded edge bulging away from the origin.
+//   concave (concave: true)  a square with a quarter-disc bite taken out
+//                            of the origin corner, the inverted/concave
+//                            shape from the mockups.
+//
+// Orient with the standard `rotation` (0 / 90 / 180 / 270) and position
+// the item where the join sits. The fill is a theme token, so it retints
+// live with the surface it joins.
+//
+//   ConnectedCorner {
+//       radius: 16
+//       concave: true
+//       fillColor: Theme.surface_container
+//   }
+
+import QtQuick
+import Phosphor.Theme
+
+Item {
+    id: root
+
+    property real radius: 16
+    property bool concave: false
+    property color fillColor: Theme.surface_container
+
+    implicitWidth: radius
+    implicitHeight: radius
+
+    readonly property string _path: {
+        const r = root.radius;
+        if (root.concave)
+            // The r x r box minus a quarter disc bitten from the origin
+            // corner: the inverted (concave) fillet.
+            return "M " + r + " 0 L " + r + " " + r + " L 0 " + r + " A " + r + " " + r + " 0 0 1 " + r + " 0 Z";
+        // A quarter-disc pie centred on the origin: the convex fillet.
+        return "M 0 0 L " + r + " 0 A " + r + " " + r + " 0 0 1 0 " + r + " Z";
+    }
+
+    ConnectedShape {
+        anchors.fill: parent
+        fillColor: root.fillColor
+        path: root._path
+    }
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectedCorner.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectedCorner.qml
@@ -40,7 +40,9 @@ Item {
     implicitHeight: radius
 
     readonly property string _path: {
-        const r = root.radius;
+        // Round to 2 decimals so a fractional radius doesn't produce
+        // float-noise path strings (matches ConnectorGeometry).
+        const r = Math.round(root.radius * 100) / 100;
         if (root.concave)
             // The r x r box minus a quarter disc bitten from the origin
             // corner: the inverted (concave) fillet.

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectedShape.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectedShape.qml
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.ConnectedShape, the connected-corner surface painter.
+//
+// A thin Shape wrapper that fills an SVG path string with a theme colour.
+// It is the low-level renderer behind BarCanvas and any other surface
+// that wants the connected-corner shape language (popout bodies, the
+// dashboard). Hand it a `path` (SVG `d` data, typically from
+// ConnectorGeometry) and a `fillColor`:
+//
+//   ConnectedShape {
+//       anchors.fill: parent
+//       fillColor: Theme.surface_container
+//       path: ConnectorGeometry.buildBarPath(width, 48, 16, 16, sockets)
+//   }
+//
+// The fill retints live (the binding reads Theme.* directly) and animates
+// the colour on a palette change. The geometry morph is driven by the
+// consumer animating whatever feeds `path`.
+
+import QtQuick
+import QtQuick.Shapes
+import Phosphor.Theme
+
+Shape {
+    id: root
+
+    // SVG path data for the filled outline.
+    property alias path: svgPath.path
+    property color fillColor: Theme.surface_container
+    property color strokeColor: "transparent"
+    property real strokeWidth: 0
+
+    // The curve renderer gives analytic antialiasing on the concave
+    // (inverted) corners that the geometry renderer would leave jagged.
+    preferredRendererType: Shape.CurveRenderer
+
+    ShapePath {
+        fillColor: root.fillColor
+        strokeColor: root.strokeColor
+        strokeWidth: root.strokeWidth
+
+        Behavior on fillColor {
+            ColorAnimation {
+                duration: Motion.duration_short_3
+                easing: Motion.standard
+            }
+        }
+
+        PathSvg {
+            id: svgPath
+        }
+    }
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectorGeometry.js
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectorGeometry.js
@@ -21,6 +21,12 @@ function _n(v) {
     return Math.round(v * 100) / 100;
 }
 
+// Depth below which a socket is treated as closed (flat edge). Just under
+// a pixel so the first frames of an open animation don't pop a notch in.
+// Exported so consumers (BarCanvas.maxSocketDepth) gate on the same
+// threshold the path math uses.
+var MIN_DEPTH = 0.5;
+
 // Build the connected-corner bar path.
 //
 //   w, h            bar strip size (h is the closed bar height)
@@ -39,10 +45,6 @@ function _n(v) {
 // owns that invariant.
 function buildBarPath(w, h, cornerRadius, connectorRadius, sockets) {
     var R = Math.max(0, Math.min(cornerRadius, w / 2, h / 2));
-
-    // Depth below which a socket is treated as closed (flat edge). Just
-    // under a pixel so the first animation frames don't pop a notch in.
-    var MIN_DEPTH = 0.5;
 
     // Collect valid pockets and sort right-to-left: the bottom edge is
     // walked leftward (clockwise outline), so we weave sockets in

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectorGeometry.js
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectorGeometry.js
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.ConnectorGeometry, connected-corner path math.
+//
+// Pure geometry: builds the SVG path `d` string for the connected-corner
+// bar shape, where the bar's bottom edge weaves down into "sockets"
+// (pockets) that attached popouts fill, so the bar and its popouts read
+// as one continuous painted surface. Consumed by ConnectedShape /
+// BarCanvas via a PathSvg element, which parses the same SVG path grammar
+// the design mockups (docs/phosphor-shell-design/mockups/*.svg) are drawn
+// in, so the rendered shape matches the mockups command-for-command.
+//
+// .pragma library: stateless math, shared as one instance across every
+// importer. No QML context access, no per-component state.
+.pragma library
+
+// Round to 2 decimals so the generated path strings stay compact and
+// free of float noise (1.9999999 -> 2). Sub-pixel precision past this is
+// invisible and only bloats the string + defeats string-equality tests.
+function _n(v) {
+    return Math.round(v * 100) / 100;
+}
+
+// Build the path for a rounded rectangle of size w x h with corner
+// radius r. Used as the baseline bar shape (no sockets) and as a
+// convenience for any plain rounded surface that wants to share the
+// connected-corner renderer.
+function buildRoundedRectPath(w, h, r) {
+    return buildBarPath(w, h, r, r, []);
+}
+
+// Build the connected-corner bar path.
+//
+//   w, h            bar strip size (h is the closed bar height)
+//   cornerRadius    radius of the bar's own four outer corners
+//   connectorRadius radius of each socket's fillets (convex pocket-bottom
+//                   corners + concave/inverted top corners)
+//   sockets         array of { x, width, depth }, each a downward pocket:
+//                     x      left wall, in bar-local coordinates
+//                     width  wall-to-wall span
+//                     depth  downward extent below the bar's bottom edge
+//
+// Sockets with depth <= MIN_DEPTH render as no pocket (the bottom edge
+// stays flat there), so an open/close animation that drives depth 0 ->
+// full grows the pocket smoothly out of a flat edge. Sockets are expected
+// non-overlapping and within (cornerRadius, w - cornerRadius); the caller
+// owns that invariant.
+function buildBarPath(w, h, cornerRadius, connectorRadius, sockets) {
+    var R = Math.max(0, Math.min(cornerRadius, w / 2, h / 2));
+
+    // Depth below which a socket is treated as closed (flat edge). Just
+    // under a pixel so the first animation frames don't pop a notch in.
+    var MIN_DEPTH = 0.5;
+
+    // Collect valid pockets and sort right-to-left: the bottom edge is
+    // walked leftward (clockwise outline), so we weave sockets in
+    // descending-x order.
+    var pockets = [];
+    if (sockets) {
+        for (var i = 0; i < sockets.length; ++i) {
+            var s = sockets[i];
+            var depth = s.depth || 0;
+            if (depth <= MIN_DEPTH)
+                continue;
+            var left = s.x;
+            var right = s.x + s.width;
+            // Clamp the fillet radius so the two vertical walls and the
+            // two pocket-bottom corners always fit: r <= depth/2 keeps a
+            // (possibly zero) wall between the concave top and convex
+            // bottom corners; r <= width/2 keeps the bottom edge from
+            // crossing itself. As depth -> 0, r -> 0 and the pocket
+            // collapses to a flat edge.
+            var r = Math.min(connectorRadius, depth / 2, s.width / 2);
+            pockets.push({ left: left, right: right, depth: depth, r: r });
+        }
+        pockets.sort(function (a, b) { return b.left - a.left; });
+    }
+
+    var d = [];
+    // Clockwise outline starting at the top-left, after the corner.
+    d.push("M " + _n(R) + " 0");
+    d.push("H " + _n(w - R));
+    d.push("A " + _n(R) + " " + _n(R) + " 0 0 1 " + _n(w) + " " + _n(R));          // top-right (convex)
+    d.push("V " + _n(h - R));
+    d.push("A " + _n(R) + " " + _n(R) + " 0 0 1 " + _n(w - R) + " " + _n(h));      // bottom-right (convex)
+
+    // Bottom edge, walking left and weaving each pocket.
+    for (var p = 0; p < pockets.length; ++p) {
+        var pk = pockets[p];
+        var r = pk.r;
+        var floorY = h + pk.depth;
+
+        d.push("H " + _n(pk.right + r));                                            // edge up to the right inverted corner
+        d.push("A " + _n(r) + " " + _n(r) + " 0 0 0 " + _n(pk.right) + " " + _n(h + r));       // right top: concave (inverted, sweep 0)
+        d.push("V " + _n(floorY - r));                                              // down the right wall
+        d.push("A " + _n(r) + " " + _n(r) + " 0 0 1 " + _n(pk.right - r) + " " + _n(floorY));  // bottom-right (convex)
+        d.push("H " + _n(pk.left + r));                                             // across the pocket floor
+        d.push("A " + _n(r) + " " + _n(r) + " 0 0 1 " + _n(pk.left) + " " + _n(floorY - r));   // bottom-left (convex)
+        d.push("V " + _n(h + r));                                                   // up the left wall
+        d.push("A " + _n(r) + " " + _n(r) + " 0 0 0 " + _n(pk.left - r) + " " + _n(h));        // left top: concave (inverted, sweep 0)
+    }
+
+    d.push("H " + _n(R));
+    d.push("A " + _n(R) + " " + _n(R) + " 0 0 1 0 " + _n(h - R));                  // bottom-left (convex)
+    d.push("V " + _n(R));
+    d.push("A " + _n(R) + " " + _n(R) + " 0 0 1 " + _n(R) + " 0");                 // top-left (convex)
+    d.push("Z");
+    return d.join(" ");
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectorGeometry.js
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectorGeometry.js
@@ -21,14 +21,6 @@ function _n(v) {
     return Math.round(v * 100) / 100;
 }
 
-// Build the path for a rounded rectangle of size w x h with corner
-// radius r. Used as the baseline bar shape (no sockets) and as a
-// convenience for any plain rounded surface that wants to share the
-// connected-corner renderer.
-function buildRoundedRectPath(w, h, r) {
-    return buildBarPath(w, h, r, r, []);
-}
-
 // Build the connected-corner bar path.
 //
 //   w, h            bar strip size (h is the closed bar height)

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectorGeometry.js
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectorGeometry.js
@@ -21,8 +21,9 @@ function _n(v) {
     return Math.round(v * 100) / 100;
 }
 
-// Depth below which a socket is treated as closed (flat edge). Just under
-// a pixel so the first frames of an open animation don't pop a notch in.
+// Depth at or below which a socket is treated as closed (flat edge): the
+// path math skips `depth <= MIN_DEPTH`. Just under a pixel so the first
+// frames of an open animation don't pop a notch in.
 // Exported so consumers (BarCanvas.maxSocketDepth) gate on the same
 // threshold the path math uses.
 var MIN_DEPTH = 0.5;

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectorGeometry.js
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ConnectorGeometry.js
@@ -60,9 +60,11 @@ function buildBarPath(w, h, cornerRadius, connectorRadius, sockets) {
             // two pocket-bottom corners always fit: r <= depth/2 keeps a
             // (possibly zero) wall between the concave top and convex
             // bottom corners; r <= width/2 keeps the bottom edge from
-            // crossing itself. As depth -> 0, r -> 0 and the pocket
+            // crossing itself. The outer Math.max(0, ...) guards a negative
+            // connectorRadius (mirrors the R clamp above) so the arcs never
+            // get a negative radius. As depth -> 0, r -> 0 and the pocket
             // collapses to a flat edge.
-            var r = Math.min(connectorRadius, depth / 2, s.width / 2);
+            var r = Math.max(0, Math.min(connectorRadius, depth / 2, s.width / 2));
             pockets.push({ left: left, right: right, depth: depth, r: r });
         }
         pockets.sort(function (a, b) { return b.left - a.left; });

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ElevationShadow.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ElevationShadow.qml
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.ElevationShadow, Material 3 elevation shadow.
+//
+// A MultiEffect tuned for the six M3 elevation levels (0..5 dp tiers).
+// Use it as a layer effect on any rounded surface; the engine wires the
+// layered item into the effect's `source` automatically, so the shadow
+// tracks the surface geometry and corner radius without extra plumbing:
+//
+//   Rectangle {
+//       radius: 16
+//       layer.enabled: true
+//       layer.effect: ElevationShadow { level: 2 }
+//   }
+//
+// Levels map to M3's elevation ramp: 0 = flat (no shadow), 1 = resting
+// cards, 2 = raised buttons, 3 = menus / popouts, 4 = nav drawers,
+// 5 = modal dialogs. A single retune here propagates to every elevated
+// surface in the shell.
+
+import QtQuick
+import QtQuick.Effects
+
+MultiEffect {
+    id: root
+
+    // M3 elevation tier, clamped to the supported 0..5 range. 0 disables
+    // the shadow entirely (the effect still renders the source, so a
+    // level-0 ElevationShadow is a transparent pass-through).
+    property int level: 1
+
+    // Clamp once so the per-tier lookup arrays below never index out of
+    // bounds when a caller passes a level outside 0..5.
+    readonly property int _level: Math.max(0, Math.min(5, level))
+
+    // MultiEffect crops the shadow to the source rect unless padding is
+    // auto-grown. Without this the blur is clipped at the surface edge.
+    autoPaddingEnabled: true
+    // Headroom for the blur kernel at the highest tier; the default
+    // ceiling clips level-5 shadows.
+    blurMax: 64
+
+    shadowEnabled: _level > 0
+    // Opaque black; the visible softness comes from shadowOpacity so the
+    // colour and the strength stay independently tunable.
+    shadowColor: Qt.rgba(0, 0, 0, 1)
+    shadowHorizontalOffset: 0
+    // Per-tier blur (0..1 of blurMax), vertical drop, and opacity. M3
+    // shadows deepen and drop further as elevation rises.
+    shadowBlur: [0.0, 0.20, 0.30, 0.42, 0.58, 0.80][_level]
+    shadowVerticalOffset: [0, 1, 2, 4, 6, 8][_level]
+    shadowOpacity: [0.0, 0.28, 0.32, 0.36, 0.40, 0.44][_level]
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ElevationShadow.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ElevationShadow.qml
@@ -34,8 +34,10 @@ MultiEffect {
     // Clamp once so the per-tier lookup never indexes out of bounds when a
     // caller passes a level outside 0..5.
     readonly property int _level: Math.max(0, Math.min(5, level))
-    // The selected design-system elevation tier ({ y, blur, opacity }).
-    // Reads the Tokens.* properties so a Tokens retune re-evaluates here.
+    // The selected design-system elevation tier. The tier object also
+    // carries a `tint` field (read by PhosphorCard, not here); this effect
+    // uses only y / blur / opacity. Reads the Tokens.* properties so a
+    // Tokens retune re-evaluates here.
     readonly property var _tier: [Tokens.elevation_0, Tokens.elevation_1, Tokens.elevation_2, Tokens.elevation_3, Tokens.elevation_4, Tokens.elevation_5][_level]
 
     // MultiEffect crops the shadow to the source rect unless padding is

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ElevationShadow.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/ElevationShadow.qml
@@ -15,11 +15,13 @@
 //
 // Levels map to M3's elevation ramp: 0 = flat (no shadow), 1 = resting
 // cards, 2 = raised buttons, 3 = menus / popouts, 4 = nav drawers,
-// 5 = modal dialogs. A single retune here propagates to every elevated
-// surface in the shell.
+// 5 = modal dialogs. The per-tier offset/blur/opacity values live in the
+// design system (Tokens.elevation_0..5); this is their single renderer, so
+// a retune in Tokens.qml propagates to every elevated surface in the shell.
 
 import QtQuick
 import QtQuick.Effects
+import Phosphor.Theme
 
 MultiEffect {
     id: root
@@ -29,25 +31,27 @@ MultiEffect {
     // level-0 ElevationShadow is a transparent pass-through).
     property int level: 1
 
-    // Clamp once so the per-tier lookup arrays below never index out of
-    // bounds when a caller passes a level outside 0..5.
+    // Clamp once so the per-tier lookup never indexes out of bounds when a
+    // caller passes a level outside 0..5.
     readonly property int _level: Math.max(0, Math.min(5, level))
+    // The selected design-system elevation tier ({ y, blur, opacity }).
+    // Reads the Tokens.* properties so a Tokens retune re-evaluates here.
+    readonly property var _tier: [Tokens.elevation_0, Tokens.elevation_1, Tokens.elevation_2, Tokens.elevation_3, Tokens.elevation_4, Tokens.elevation_5][_level]
 
     // MultiEffect crops the shadow to the source rect unless padding is
     // auto-grown. Without this the blur is clipped at the surface edge.
     autoPaddingEnabled: true
-    // Headroom for the blur kernel at the highest tier; the default
-    // ceiling clips level-5 shadows.
+    // Kernel ceiling; shadowBlur below is expressed as a fraction of it.
     blurMax: 64
 
     shadowEnabled: _level > 0
-    // Opaque black; the visible softness comes from shadowOpacity so the
+    // Opaque black; the visible strength comes from shadowOpacity so the
     // colour and the strength stay independently tunable.
     shadowColor: Qt.rgba(0, 0, 0, 1)
     shadowHorizontalOffset: 0
-    // Per-tier blur (0..1 of blurMax), vertical drop, and opacity. M3
-    // shadows deepen and drop further as elevation rises.
-    shadowBlur: [0.0, 0.20, 0.30, 0.42, 0.58, 0.80][_level]
-    shadowVerticalOffset: [0, 1, 2, 4, 6, 8][_level]
-    shadowOpacity: [0.0, 0.28, 0.32, 0.36, 0.40, 0.44][_level]
+    // Tokens.elevation blur is in px; MultiEffect.shadowBlur is a 0..1
+    // fraction of blurMax.
+    shadowBlur: _tier.blur / blurMax
+    shadowVerticalOffset: _tier.y
+    shadowOpacity: _tier.opacity
 }

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorButton.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorButton.qml
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.PhosphorButton, M3 button in four variants.
+//
+// A token-driven button built from a rounded container + PhosphorRipple
+// + label, rather than a restyled QtQuick.Controls Button, so every
+// colour binds through the Theme singleton and retints live. Variants
+// map to M3: Filled (primary action), Tonal (secondary emphasis),
+// Outlined (medium emphasis), Text (low emphasis).
+//
+//   PhosphorButton {
+//       text: i18n("Apply")
+//       variant: PhosphorButton.Filled
+//       onClicked: controller.apply()
+//   }
+//
+// Set `enabled: false` for the disabled state; the container and content
+// drop to the M3 disabled opacities from the StateLayer singleton.
+
+import QtQuick
+import Phosphor.Theme
+
+Item {
+    id: root
+
+    enum Variant {
+        Filled,
+        Tonal,
+        Outlined,
+        Text
+    }
+
+    property string text: ""
+    property int variant: PhosphorButton.Filled
+
+    // Emitted on a completed tap when enabled.
+    signal clicked
+
+    implicitWidth: Math.max(64, label.implicitWidth + 48)
+    implicitHeight: 40
+
+    Accessible.role: Accessible.Button
+    Accessible.name: root.text
+    Accessible.onPressAction: if (root.enabled)
+        root.clicked()
+
+    // True for the two variants that paint a filled container; false for
+    // Outlined / Text, which sit on transparent.
+    readonly property bool _hasContainer: variant === PhosphorButton.Filled || variant === PhosphorButton.Tonal
+
+    // Resolved container fill. Disabled filled / tonal buttons drop to
+    // the M3 disabled-container tint over on_surface; outlined / text
+    // stay transparent.
+    readonly property color _container: {
+        if (!enabled)
+            return _hasContainer ? Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container) : "transparent";
+        switch (variant) {
+        case PhosphorButton.Filled:
+            return Theme.primary;
+        case PhosphorButton.Tonal:
+            return Theme.primary_container;
+        default:
+            return "transparent";
+        }
+    }
+
+    // Resolved content (label + ripple) colour. Disabled drops to the M3
+    // disabled-content opacity regardless of variant.
+    readonly property color _content: {
+        if (!enabled)
+            return Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_content);
+        switch (variant) {
+        case PhosphorButton.Filled:
+            return Theme.on_primary;
+        case PhosphorButton.Tonal:
+            return Theme.on_primary_container;
+        default:
+            return Theme.primary;
+        }
+    }
+
+    Rectangle {
+        id: bg
+
+        anchors.fill: parent
+        radius: height / 2
+        color: root._container
+        border.width: root.variant === PhosphorButton.Outlined && root.enabled ? 1 : 0
+        border.color: Theme.outline
+
+        Behavior on color {
+            ColorAnimation {
+                duration: Motion.duration_short_3
+                easing: Motion.standard
+            }
+        }
+
+        PhosphorRipple {
+            anchors.fill: parent
+            radius: parent.radius
+            interactive: root.enabled
+            rippleColor: root._content
+            onTapped: root.clicked()
+        }
+    }
+
+    Text {
+        id: label
+
+        anchors.centerIn: parent
+        text: root.text
+        color: root._content
+        font.pixelSize: 14
+        font.weight: Font.Medium
+        horizontalAlignment: Text.AlignHCenter
+
+        Behavior on color {
+            ColorAnimation {
+                duration: Motion.duration_short_3
+                easing: Motion.standard
+            }
+        }
+    }
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorButton.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorButton.qml
@@ -36,7 +36,7 @@ Item {
     // Emitted on a completed tap when enabled.
     signal clicked
 
-    implicitWidth: Math.max(64, label.implicitWidth + 48)
+    implicitWidth: Math.max(64, label.implicitWidth + Tokens.spacing_xxxl)
     implicitHeight: 40
 
     Accessible.role: Accessible.Button
@@ -85,8 +85,10 @@ Item {
         anchors.fill: parent
         radius: height / 2
         color: root._container
-        border.width: root.variant === PhosphorButton.Outlined && root.enabled ? 1 : 0
-        border.color: Theme.outline
+        // Outlined keeps its outline when disabled, at the M3 disabled
+        // opacity, rather than vanishing to a borderless invisible box.
+        border.width: root.variant === PhosphorButton.Outlined ? 1 : 0
+        border.color: root.enabled ? Theme.outline : Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container)
 
         Behavior on color {
             ColorAnimation {
@@ -110,8 +112,8 @@ Item {
         anchors.centerIn: parent
         text: root.text
         color: root._content
-        font.pixelSize: 14
-        font.weight: Font.Medium
+        font.pixelSize: Tokens.font_size_body_l
+        font.weight: Tokens.font_weight_medium
         horizontalAlignment: Text.AlignHCenter
 
         Behavior on color {

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorButton.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorButton.qml
@@ -44,6 +44,20 @@ Item {
     Accessible.onPressAction: if (root.enabled)
         root.clicked()
 
+    // Keyboard: Tab-focusable when enabled; Space / Enter / Return activate
+    // it (with a ripple from the centre), matching the pointer path.
+    activeFocusOnTab: enabled
+    Keys.onSpacePressed: event => root._activateFromKey(event)
+    Keys.onReturnPressed: event => root._activateFromKey(event)
+    Keys.onEnterPressed: event => root._activateFromKey(event)
+
+    function _activateFromKey(event) {
+        if (event.isAutoRepeat || !root.enabled)
+            return;
+        ripple.start(root.width / 2, root.height / 2);
+        root.clicked();
+    }
+
     // True for the two variants that paint a filled container; false for
     // Outlined / Text, which sit on transparent.
     readonly property bool _hasContainer: variant === PhosphorButton.Filled || variant === PhosphorButton.Tonal
@@ -53,7 +67,7 @@ Item {
     // stay transparent.
     readonly property color _container: {
         if (!enabled)
-            return _hasContainer ? Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container) : "transparent";
+            return _hasContainer ? StateLayer.disabledContainer(Theme.on_surface) : "transparent";
         switch (variant) {
         case PhosphorButton.Filled:
             return Theme.primary;
@@ -68,7 +82,7 @@ Item {
     // disabled-content opacity regardless of variant.
     readonly property color _content: {
         if (!enabled)
-            return Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_content);
+            return StateLayer.disabledContent(Theme.on_surface);
         switch (variant) {
         case PhosphorButton.Filled:
             return Theme.on_primary;
@@ -88,7 +102,7 @@ Item {
         // Outlined keeps its outline when disabled, at the M3 disabled
         // opacity, rather than vanishing to a borderless invisible box.
         border.width: root.variant === PhosphorButton.Outlined ? 1 : 0
-        border.color: root.enabled ? Theme.outline : Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container)
+        border.color: root.enabled ? Theme.outline : StateLayer.disabledContainer(Theme.on_surface)
 
         Behavior on color {
             ColorAnimation {
@@ -98,9 +112,12 @@ Item {
         }
 
         PhosphorRipple {
+            id: ripple
+
             anchors.fill: parent
             radius: parent.radius
             interactive: root.enabled
+            focused: root.activeFocus
             rippleColor: root._content
             onTapped: root.clicked()
         }

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorCard.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorCard.qml
@@ -29,8 +29,8 @@ Item {
     // shadow (forwarded to ElevationShadow) and the surface tint overlay
     // (the colour shift below).
     property int elevation: 1
-    property real radius: 16
-    property real padding: 16
+    property real radius: Tokens.radius_l
+    property real padding: Tokens.spacing_l
 
     implicitWidth: contentArea.implicitWidth + padding * 2
     implicitHeight: contentArea.implicitHeight + padding * 2

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorCard.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorCard.qml
@@ -41,17 +41,19 @@ Item {
     // M3 surface tint overlay: an elevated surface is tinted with the
     // surface-tint colour at an elevation-dependent opacity, layered over
     // the base container colour. This is the colour half of elevation;
-    // ElevationShadow is the shadow half. The opacities are the M3
-    // elevation-overlay ramp for tiers 0..5. Theme.surface_tint defaults
-    // to the primary accent (M3 default) but honours an explicit
-    // surface_tint palette token when present.
+    // ElevationShadow is the shadow half. The per-tier tint opacity is the
+    // `tint` field of the Tokens.elevation_* tiers (the same tier objects
+    // ElevationShadow reads for its shadow), so the whole elevation ramp
+    // lives in Tokens.qml. Theme.surface_tint defaults to the primary
+    // accent (M3 default) but honours an explicit surface_tint palette
+    // token when present.
     //
     // The binding reads Theme.surface_container and Theme.surface_tint as
     // property reads (not via a Theme function), so it stays tracked and
     // the card retints live on a palette change. Calling a Theme method
     // here would silently break that, see phosphor-theme's Theme.qml.
     readonly property color _tintedSurface: {
-        const a = [0.0, 0.05, 0.08, 0.11, 0.12, 0.14][_level];
+        const a = [Tokens.elevation_0, Tokens.elevation_1, Tokens.elevation_2, Tokens.elevation_3, Tokens.elevation_4, Tokens.elevation_5][_level].tint;
         return a > 0 ? Qt.tint(Theme.surface_container, Qt.rgba(Theme.surface_tint.r, Theme.surface_tint.g, Theme.surface_tint.b, a)) : Theme.surface_container;
     }
 

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorCard.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorCard.qml
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.PhosphorCard, M3 elevated surface container.
+//
+// A rounded surface-container panel with an M3 elevation shadow and a
+// padded content area. Children declared inside the card land in the
+// padded area via the default property:
+//
+//   PhosphorCard {
+//       elevation: 2
+//       ColumnLayout { ... }
+//   }
+//
+// Size follows the content's implicit size plus padding, so a card wraps
+// its contents by default; give the card an explicit width / height to
+// override. `elevation` maps to the M3 tiers in ElevationShadow.
+
+import QtQuick
+import Phosphor.Theme
+
+Item {
+    id: root
+
+    // Children land in the padded content area, not directly on the card
+    // root, so the elevation surface stays behind them.
+    default property alias content: contentArea.data
+
+    // M3 elevation tier (0..5). Drives both halves of elevation: the
+    // shadow (forwarded to ElevationShadow) and the surface tint overlay
+    // (the colour shift below).
+    property int elevation: 1
+    property real radius: 16
+    property real padding: 16
+
+    implicitWidth: contentArea.implicitWidth + padding * 2
+    implicitHeight: contentArea.implicitHeight + padding * 2
+
+    // Clamp once so the M3 tint ramp below never indexes out of range.
+    readonly property int _level: Math.max(0, Math.min(5, elevation))
+
+    // M3 surface tint overlay: an elevated surface is tinted with the
+    // surface-tint colour at an elevation-dependent opacity, layered over
+    // the base container colour. This is the colour half of elevation;
+    // ElevationShadow is the shadow half. The opacities are the M3
+    // elevation-overlay ramp for tiers 0..5. Theme.surface_tint defaults
+    // to the primary accent (M3 default) but honours an explicit
+    // surface_tint palette token when present.
+    //
+    // The binding reads Theme.surface_container and Theme.surface_tint as
+    // property reads (not via a Theme function), so it stays tracked and
+    // the card retints live on a palette change. Calling a Theme method
+    // here would silently break that, see phosphor-theme's Theme.qml.
+    readonly property color _tintedSurface: {
+        const a = [0.0, 0.05, 0.08, 0.11, 0.12, 0.14][_level];
+        return a > 0 ? Qt.tint(Theme.surface_container, Qt.rgba(Theme.surface_tint.r, Theme.surface_tint.g, Theme.surface_tint.b, a)) : Theme.surface_container;
+    }
+
+    Rectangle {
+        id: surface
+
+        anchors.fill: parent
+        radius: root.radius
+        color: root._tintedSurface
+        // Only pay for the layer + shadow pass when actually elevated; a
+        // flat card (elevation 0) renders as a plain rounded surface.
+        layer.enabled: root.elevation > 0
+        layer.effect: ElevationShadow {
+            level: root.elevation
+        }
+
+        Behavior on color {
+            ColorAnimation {
+                duration: Motion.duration_short_3
+                easing: Motion.standard
+            }
+        }
+    }
+
+    Item {
+        id: contentArea
+
+        anchors.fill: parent
+        anchors.margins: root.padding
+        implicitWidth: childrenRect.width
+        implicitHeight: childrenRect.height
+    }
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorPill.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorPill.qml
@@ -30,7 +30,7 @@ Item {
     signal toggled
 
     implicitHeight: 32
-    implicitWidth: label.implicitWidth + 28
+    implicitWidth: label.implicitWidth + Tokens.spacing_xl
 
     Accessible.role: Accessible.CheckBox
     Accessible.name: root.text
@@ -86,7 +86,7 @@ Item {
         anchors.centerIn: parent
         text: root.text
         color: root._content
-        font.pixelSize: 13
+        font.pixelSize: Tokens.font_size_label_l
 
         Behavior on color {
             ColorAnimation {

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorPill.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorPill.qml
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.PhosphorPill, M3 chip / toggle pill.
+//
+// A compact fully-rounded label that doubles as a selectable chip. In
+// the resting state it is an outlined chip; when `selected` it fills
+// with the secondary container. Use it for filter chips, quick toggles,
+// and bar segments.
+//
+//   PhosphorPill {
+//       text: i18n("Wi-Fi")
+//       selected: network.enabled
+//       onToggled: network.toggle()
+//   }
+//
+// `clicked` fires on every tap; `toggled` is a convenience alias for
+// hosts that drive a boolean. The pill does NOT flip `selected` itself,
+// the host owns that state so it stays a single source of truth.
+
+import QtQuick
+import Phosphor.Theme
+
+Item {
+    id: root
+
+    property string text: ""
+    property bool selected: false
+
+    signal clicked
+    signal toggled
+
+    implicitHeight: 32
+    implicitWidth: label.implicitWidth + 28
+
+    Accessible.role: Accessible.CheckBox
+    Accessible.name: root.text
+    Accessible.checked: root.selected
+    Accessible.onPressAction: if (root.enabled) {
+        root.clicked();
+        root.toggled();
+    }
+
+    readonly property color _container: {
+        if (!enabled)
+            return Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container);
+        return selected ? Theme.secondary_container : "transparent";
+    }
+
+    readonly property color _content: {
+        if (!enabled)
+            return Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_content);
+        return selected ? Theme.on_surface : Theme.on_surface_variant;
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: height / 2
+        color: root._container
+        // Outline only in the unselected, enabled resting state; a
+        // filled or disabled pill carries no border.
+        border.width: !root.selected && root.enabled ? 1 : 0
+        border.color: Theme.outline_variant
+
+        Behavior on color {
+            ColorAnimation {
+                duration: Motion.duration_short_3
+                easing: Motion.standard
+            }
+        }
+
+        PhosphorRipple {
+            anchors.fill: parent
+            radius: parent.radius
+            interactive: root.enabled
+            rippleColor: root._content
+            onTapped: {
+                root.clicked();
+                root.toggled();
+            }
+        }
+    }
+
+    Text {
+        id: label
+
+        anchors.centerIn: parent
+        text: root.text
+        color: root._content
+        font.pixelSize: 13
+
+        Behavior on color {
+            ColorAnimation {
+                duration: Motion.duration_short_3
+                easing: Motion.standard
+            }
+        }
+    }
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorPill.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorPill.qml
@@ -35,20 +35,37 @@ Item {
     Accessible.role: Accessible.CheckBox
     Accessible.name: root.text
     Accessible.checked: root.selected
-    Accessible.onPressAction: if (root.enabled) {
+    Accessible.onPressAction: root._activate()
+
+    // Keyboard: Tab-focusable when enabled; Space / Enter / Return toggle it
+    // (with a ripple from the centre), matching the pointer path.
+    activeFocusOnTab: enabled
+    Keys.onSpacePressed: event => root._activateFromKey(event)
+    Keys.onReturnPressed: event => root._activateFromKey(event)
+    Keys.onEnterPressed: event => root._activateFromKey(event)
+
+    function _activate() {
+        if (!root.enabled)
+            return;
         root.clicked();
         root.toggled();
+    }
+    function _activateFromKey(event) {
+        if (event.isAutoRepeat || !root.enabled)
+            return;
+        ripple.start(root.width / 2, root.height / 2);
+        root._activate();
     }
 
     readonly property color _container: {
         if (!enabled)
-            return Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container);
+            return StateLayer.disabledContainer(Theme.on_surface);
         return selected ? Theme.secondary_container : "transparent";
     }
 
     readonly property color _content: {
         if (!enabled)
-            return Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_content);
+            return StateLayer.disabledContent(Theme.on_surface);
         return selected ? Theme.on_surface : Theme.on_surface_variant;
     }
 
@@ -69,14 +86,14 @@ Item {
         }
 
         PhosphorRipple {
+            id: ripple
+
             anchors.fill: parent
             radius: parent.radius
             interactive: root.enabled
+            focused: root.activeFocus
             rippleColor: root._content
-            onTapped: {
-                root.clicked();
-                root.toggled();
-            }
+            onTapped: root._activate()
         }
     }
 

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorRipple.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorRipple.qml
@@ -39,6 +39,10 @@ Item {
     // Gate for the whole interaction. A disabled host sets this false:
     // no hover tint, no ripple, no tap.
     property bool interactive: true
+    // Keyboard focus: a host that is activeFocus sets this so the resting
+    // state layer shows the M3 focus tint (the visible focus indicator for
+    // a Tab-focused control).
+    property bool focused: false
     // Corner radius for the resting state-layer overlay. Match the host
     // container's radius so the hover / press tint is rounded.
     property real radius: 0
@@ -73,6 +77,8 @@ Item {
                 return StateLayer.pressed;
             if (hover.hovered)
                 return StateLayer.hover;
+            if (root.focused)
+                return StateLayer.focus;
             return 0;
         }
 

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorRipple.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorRipple.qml
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.PhosphorRipple, M3 state layer + touch ripple.
+//
+// Drop this in as the interactive top layer of any control: it owns the
+// hover / press state-layer overlay (opacities from Phosphor.Theme's
+// StateLayer singleton) and the expanding press ripple, and re-emits the
+// tap as `tapped()`. The host control wires `tapped` to its own
+// `clicked` signal and reads `down` / `hovered` if it needs them.
+//
+//   Rectangle {
+//       radius: height / 2
+//       PhosphorRipple {
+//           anchors.fill: parent
+//           radius: parent.radius
+//           rippleColor: someContentColor
+//           onTapped: control.clicked()
+//       }
+//   }
+//
+// Known limitation: Item.clip is rectangular, so the expanding ripple
+// circle is not masked to `radius`. On a pill or rounded surface the
+// circle can momentarily bleed past the rounded corners while it
+// expands. The state-layer overlay below honours `radius`, so the
+// resting hover / press tint is correctly rounded; only the transient
+// ripple sweep is unclipped. A rounded mask lands when the connected-
+// corner work (Phase 3.2) brings a shared clip primitive.
+
+import QtQuick
+import Phosphor.Theme
+
+Item {
+    id: root
+
+    // Foreground colour for both the state-layer overlay and the ripple.
+    // The host passes its resolved content colour so the overlay reads
+    // correctly on any container.
+    property color rippleColor: Theme.on_surface
+    // Gate for the whole interaction. A disabled host sets this false:
+    // no hover tint, no ripple, no tap.
+    property bool interactive: true
+    // Corner radius for the resting state-layer overlay. Match the host
+    // container's radius so the hover / press tint is rounded.
+    property real radius: 0
+
+    // Live interaction state for hosts that tint other chrome on hover
+    // or press (e.g. an elevation bump on a pressed button).
+    readonly property bool hovered: hover.hovered
+    readonly property bool down: tap.pressed
+
+    // Re-emitted tap. Hosts connect this to their own clicked signal so
+    // any future ripple-side logic (focus restore, haptics) routes
+    // through one place.
+    signal tapped
+
+    clip: true
+
+    HoverHandler {
+        id: hover
+
+        enabled: root.interactive
+    }
+
+    // Resting state layer: hover / press tint painted over the host.
+    Rectangle {
+        anchors.fill: parent
+        radius: root.radius
+        color: root.rippleColor
+        opacity: {
+            if (!root.interactive)
+                return 0;
+            if (tap.pressed)
+                return StateLayer.pressed;
+            if (hover.hovered)
+                return StateLayer.hover;
+            return 0;
+        }
+
+        Behavior on opacity {
+            NumberAnimation {
+                duration: Motion.duration_short_2
+                easing: Motion.standard
+            }
+        }
+    }
+
+    // Expanding press ripple. Centred on the press point, grows to cover
+    // the host, fades as it goes.
+    Rectangle {
+        id: circle
+
+        // Press-point centre, set by start() before each animation.
+        property real cx: 0
+        property real cy: 0
+        // Diameter that guarantees coverage from any press point: twice
+        // the host's diagonal.
+        readonly property real maxDiameter: 2 * Math.sqrt(root.width * root.width + root.height * root.height)
+
+        width: 0
+        height: width
+        radius: width / 2
+        x: cx - width / 2
+        y: cy - width / 2
+        color: root.rippleColor
+        opacity: 0
+
+        ParallelAnimation {
+            id: rippleAnim
+
+            NumberAnimation {
+                target: circle
+                property: "width"
+                from: 0
+                to: circle.maxDiameter
+                duration: Motion.duration_medium_2
+                easing: Motion.standard
+            }
+
+            SequentialAnimation {
+                PropertyAction {
+                    target: circle
+                    property: "opacity"
+                    value: StateLayer.pressed
+                }
+
+                NumberAnimation {
+                    target: circle
+                    property: "opacity"
+                    to: 0
+                    duration: Motion.duration_medium_2
+                    easing: Motion.standard
+                }
+            }
+        }
+    }
+
+    TapHandler {
+        id: tap
+
+        enabled: root.interactive
+        onPressedChanged: {
+            if (pressed)
+                root.start(point.position.x, point.position.y);
+        }
+        onTapped: root.tapped()
+    }
+
+    // Restart the ripple from a fresh press point. Stopping first resets
+    // any in-flight sweep so rapid taps each get their own ripple rather
+    // than stacking on a half-faded one.
+    function start(px, py) {
+        rippleAnim.stop();
+        circle.cx = px;
+        circle.cy = py;
+        circle.width = 0;
+        rippleAnim.start();
+    }
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
@@ -4,8 +4,9 @@
 //
 // A token-driven horizontal slider: inactive track, active (filled)
 // track, and a draggable handle. Drag the handle or tap anywhere on the
-// track to set the value. The value is clamped to [from, to]; `moved`
-// fires whenever the user changes it.
+// track to set the value. User-driven changes are clamped to [from, to]
+// and `moved` fires whenever the user changes it. The host owns range
+// validity for programmatic `value` assignments (see the README note).
 //
 //   PhosphorSlider {
 //       from: 0; to: 100; value: volume

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
@@ -50,7 +50,10 @@ Item {
     // Map a pointer x (in root coordinates) to a clamped value and emit
     // moved() if it actually changed.
     function _setFromX(px) {
-        if (_trackWidth <= 0)
+        // Mirror _ratio's guard: with no usable track or a non-positive
+        // range (to <= from) the handle is pinned at 0 and can't reflect a
+        // value, so don't emit one the user can't see.
+        if (_trackWidth <= 0 || to <= from)
             return;
         const r = Math.max(0, Math.min(1, (px - handle.width / 2) / _trackWidth));
         const v = from + r * (to - from);

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
@@ -33,10 +33,15 @@ Item {
     implicitHeight: 40
 
     Accessible.role: Accessible.Slider
-    Accessible.name: qsTr("Slider")
+    // Include the value in the name: QML's Accessible attached type exposes
+    // role/name but not the numeric value/minimumValue/maximumValue
+    // interface (those are C++-only), so the position is folded into the
+    // announced name instead.
+    Accessible.name: qsTr("Slider, %1").arg(Math.round(root.value))
 
-    // Normalised 0..1 position of the current value. Guards a zero-width
-    // range so a misconfigured from == to collapses to 0 instead of NaN.
+    // Normalised 0..1 position of the current value. Guards a non-positive
+    // range (from == to, or an inverted from > to) so it collapses to 0
+    // instead of producing NaN or a negative ratio.
     readonly property real _ratio: to > from ? Math.max(0, Math.min(1, (value - from) / (to - from))) : 0
     // Travel available to the handle centre: the full width minus the
     // handle so it never overhangs either end.
@@ -63,7 +68,7 @@ Item {
         x: handle.width / 2
         width: root._trackWidth
         height: 4
-        radius: 2
+        radius: height / 2
         color: root.enabled ? Theme.surface_variant : Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container)
     }
 
@@ -73,7 +78,7 @@ Item {
         x: handle.width / 2
         width: root._trackWidth * root._ratio
         height: 4
-        radius: 2
+        radius: height / 2
         color: root.enabled ? Theme.primary : root._disabledTint
     }
 

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
@@ -24,13 +24,59 @@ Item {
     property real from: 0
     property real to: 1
     property real value: 0
+    // Arrow-key step. 0 means "derive a sensible default" (a twentieth of
+    // the range), so a keyboard user gets reasonable increments without the
+    // host having to set one per range.
+    property real stepSize: 0
 
-    // Emitted with the new value on every user-driven change (drag or
-    // track tap), not on programmatic `value` assignments.
+    // Emitted with the new value on every user-driven change (drag, track
+    // tap, or arrow key), not on programmatic `value` assignments.
     signal moved(real value)
 
     implicitWidth: 200
     implicitHeight: 40
+
+    readonly property real _step: stepSize > 0 ? stepSize : (to - from) / 20
+
+    // Keyboard: Tab-focusable when enabled; Left/Down nudge down, Right/Up
+    // nudge up, Home/End jump to the ends.
+    activeFocusOnTab: enabled
+    Keys.onPressed: event => {
+        if (!root.enabled)
+            return;
+        switch (event.key) {
+        case Qt.Key_Left:
+        case Qt.Key_Down:
+            root._setValue(root.value - root._step);
+            event.accepted = true;
+            break;
+        case Qt.Key_Right:
+        case Qt.Key_Up:
+            root._setValue(root.value + root._step);
+            event.accepted = true;
+            break;
+        case Qt.Key_Home:
+            root._setValue(root.from);
+            event.accepted = true;
+            break;
+        case Qt.Key_End:
+            root._setValue(root.to);
+            event.accepted = true;
+            break;
+        }
+    }
+
+    // Clamp to [from, to] and emit moved() only on a real change. Shared by
+    // the keyboard path; pointer drag/tap go through _setFromX.
+    function _setValue(v) {
+        if (to <= from)
+            return;
+        const clamped = Math.max(from, Math.min(to, v));
+        if (clamped !== value) {
+            value = clamped;
+            moved(clamped);
+        }
+    }
 
     Accessible.role: Accessible.Slider
     // Include the value in the name: QML's Accessible attached type exposes
@@ -63,7 +109,7 @@ Item {
         }
     }
 
-    readonly property color _disabledTint: Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_content)
+    readonly property color _disabledTint: StateLayer.disabledContent(Theme.on_surface)
 
     // Inactive track.
     Rectangle {
@@ -72,7 +118,7 @@ Item {
         width: root._trackWidth
         height: 4
         radius: height / 2
-        color: root.enabled ? Theme.surface_variant : Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container)
+        color: root.enabled ? Theme.surface_variant : StateLayer.disabledContainer(Theme.on_surface)
     }
 
     // Active (filled) track.
@@ -83,6 +129,25 @@ Item {
         height: 4
         radius: height / 2
         color: root.enabled ? Theme.primary : root._disabledTint
+    }
+
+    // Focus halo behind the handle: the M3 focus indicator when the slider
+    // is reached by Tab. Declared before the handle so it paints behind it.
+    Rectangle {
+        anchors.centerIn: handle
+        width: handle.width + 2 * Tokens.spacing_s
+        height: width
+        radius: width / 2
+        color: Theme.primary
+        opacity: root.activeFocus ? StateLayer.focus : 0
+        visible: opacity > 0
+
+        Behavior on opacity {
+            NumberAnimation {
+                duration: Motion.duration_short_2
+                easing: Motion.standard
+            }
+        }
     }
 
     Rectangle {

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
@@ -6,7 +6,7 @@
 // track, and a draggable handle. Drag the handle or tap anywhere on the
 // track to set the value. User-driven changes are clamped to [from, to]
 // and `moved` fires whenever the user changes it. The host owns range
-// validity for programmatic `value` assignments (see the README note).
+// validity for programmatic `value` assignments.
 //
 //   PhosphorSlider {
 //       from: 0; to: 100; value: volume
@@ -83,8 +83,10 @@ Item {
     // Include the value in the name: QML's Accessible attached type exposes
     // role/name but not the numeric value/minimumValue/maximumValue
     // interface (those are C++-only), so the position is folded into the
-    // announced name instead.
-    Accessible.name: qsTr("Slider, %1").arg(Math.round(root.value))
+    // announced name instead. Announce the clamped position (via _ratio) so
+    // the spoken value always matches where the handle actually sits, even if
+    // the host assigned an out-of-range `value`.
+    Accessible.name: qsTr("Slider, %1").arg(Math.round(root.from + root._ratio * (root.to - root.from)))
 
     // Normalised 0..1 position of the current value. Guards a non-positive
     // range (from == to, or an inverted from > to) so it collapses to 0

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorSlider.qml
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.PhosphorSlider, M3 continuous slider.
+//
+// A token-driven horizontal slider: inactive track, active (filled)
+// track, and a draggable handle. Drag the handle or tap anywhere on the
+// track to set the value. The value is clamped to [from, to]; `moved`
+// fires whenever the user changes it.
+//
+//   PhosphorSlider {
+//       from: 0; to: 100; value: volume
+//       onMoved: (v) => audio.setVolume(v)
+//   }
+//
+// The handle animates to programmatic value changes but follows the
+// pointer instantly while dragging, so user input never feels laggy.
+
+import QtQuick
+import Phosphor.Theme
+
+Item {
+    id: root
+
+    property real from: 0
+    property real to: 1
+    property real value: 0
+
+    // Emitted with the new value on every user-driven change (drag or
+    // track tap), not on programmatic `value` assignments.
+    signal moved(real value)
+
+    implicitWidth: 200
+    implicitHeight: 40
+
+    Accessible.role: Accessible.Slider
+    Accessible.name: qsTr("Slider")
+
+    // Normalised 0..1 position of the current value. Guards a zero-width
+    // range so a misconfigured from == to collapses to 0 instead of NaN.
+    readonly property real _ratio: to > from ? Math.max(0, Math.min(1, (value - from) / (to - from))) : 0
+    // Travel available to the handle centre: the full width minus the
+    // handle so it never overhangs either end.
+    readonly property real _trackWidth: width - handle.width
+
+    // Map a pointer x (in root coordinates) to a clamped value and emit
+    // moved() if it actually changed.
+    function _setFromX(px) {
+        if (_trackWidth <= 0)
+            return;
+        const r = Math.max(0, Math.min(1, (px - handle.width / 2) / _trackWidth));
+        const v = from + r * (to - from);
+        if (v !== value) {
+            value = v;
+            moved(v);
+        }
+    }
+
+    readonly property color _disabledTint: Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_content)
+
+    // Inactive track.
+    Rectangle {
+        anchors.verticalCenter: parent.verticalCenter
+        x: handle.width / 2
+        width: root._trackWidth
+        height: 4
+        radius: 2
+        color: root.enabled ? Theme.surface_variant : Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container)
+    }
+
+    // Active (filled) track.
+    Rectangle {
+        anchors.verticalCenter: parent.verticalCenter
+        x: handle.width / 2
+        width: root._trackWidth * root._ratio
+        height: 4
+        radius: 2
+        color: root.enabled ? Theme.primary : root._disabledTint
+    }
+
+    Rectangle {
+        id: handle
+
+        width: 20
+        height: 20
+        radius: width / 2
+        anchors.verticalCenter: parent.verticalCenter
+        x: root._trackWidth * root._ratio
+        color: root.enabled ? Theme.primary : root._disabledTint
+
+        // Animate to programmatic value changes, but not while the user
+        // drags: the handle must track the pointer with no easing lag.
+        Behavior on x {
+            enabled: !drag.active
+            NumberAnimation {
+                duration: Motion.duration_short_2
+                easing: Motion.standard
+            }
+        }
+    }
+
+    DragHandler {
+        id: drag
+
+        enabled: root.enabled
+        target: null
+        onCentroidChanged: {
+            if (active)
+                root._setFromX(centroid.position.x);
+        }
+    }
+
+    TapHandler {
+        enabled: root.enabled
+        onTapped: root._setFromX(point.position.x)
+    }
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
@@ -74,11 +74,15 @@ FocusScope {
 
     Text {
         anchors.left: input.left
+        anchors.right: input.right
         anchors.verticalCenter: input.verticalCenter
         text: root.placeholderText
         // Dim with the field when disabled, matching the border and input.
         color: root.enabled ? Theme.on_surface_variant : root._disabledTint
         font.pixelSize: Tokens.font_size_body_l
+        // Clip like the input (which sets clip: true) so a long placeholder
+        // doesn't spill past the rounded outline.
+        elide: Text.ElideRight
         // Hidden once the user focuses the field or types anything, so it
         // never overlaps real input.
         visible: input.text.length === 0 && !root._focused

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
@@ -33,7 +33,10 @@ FocusScope {
     implicitHeight: 48
 
     Accessible.role: Accessible.EditableText
-    Accessible.name: root.placeholderText
+    // Announce the entered text once there is any, falling back to the
+    // placeholder while empty. Password fields keep the placeholder so the
+    // secret is never read out by assistive tech.
+    Accessible.name: (input.text !== "" && input.echoMode === TextInput.Normal) ? input.text : root.placeholderText
 
     readonly property bool _focused: input.activeFocus
     readonly property color _disabledTint: Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_content)

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Phosphor.Widgets.PhosphorTextField, M3 outlined text field.
+//
+// A single-line text input in a rounded outlined container. The outline
+// thickens and tints to the primary colour on focus; a placeholder shows
+// while the field is empty and unfocused.
+//
+//   PhosphorTextField {
+//       placeholderText: i18n("Search")
+//       onAccepted: launcher.run(text)
+//   }
+//
+// Built on a bare TextInput inside a FocusScope so focus, theming, and
+// the placeholder are fully under token control rather than inherited
+// from a Controls style.
+
+import QtQuick
+import Phosphor.Theme
+
+FocusScope {
+    id: root
+
+    property alias text: input.text
+    property string placeholderText: ""
+    property alias echoMode: input.echoMode
+    property alias inputMethodHints: input.inputMethodHints
+
+    // Emitted on Enter / Return.
+    signal accepted
+
+    implicitWidth: 220
+    implicitHeight: 48
+
+    Accessible.role: Accessible.EditableText
+    Accessible.name: root.placeholderText
+
+    readonly property bool _focused: input.activeFocus
+    readonly property color _disabledTint: Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_content)
+
+    Rectangle {
+        anchors.fill: parent
+        radius: 8
+        color: "transparent"
+        border.width: root._focused ? 2 : 1
+        border.color: !root.enabled ? Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container) : (root._focused ? Theme.primary : Theme.outline)
+
+        Behavior on border.color {
+            ColorAnimation {
+                duration: Motion.duration_short_2
+                easing: Motion.standard
+            }
+        }
+    }
+
+    TextInput {
+        id: input
+
+        anchors.fill: parent
+        anchors.leftMargin: 14
+        anchors.rightMargin: 14
+        verticalAlignment: TextInput.AlignVCenter
+        clip: true
+        enabled: root.enabled
+        color: root.enabled ? Theme.on_surface : root._disabledTint
+        selectionColor: Theme.primary
+        selectedTextColor: Theme.on_primary
+        font.pixelSize: 14
+        onAccepted: root.accepted()
+    }
+
+    Text {
+        anchors.left: input.left
+        anchors.verticalCenter: input.verticalCenter
+        text: root.placeholderText
+        color: Theme.on_surface_variant
+        font.pixelSize: 14
+        // Hidden once the user focuses the field or types anything, so it
+        // never overlaps real input.
+        visible: input.text.length === 0 && !root._focused
+    }
+}

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
@@ -40,7 +40,7 @@ FocusScope {
 
     Rectangle {
         anchors.fill: parent
-        radius: 8
+        radius: Tokens.radius_s
         color: "transparent"
         border.width: root._focused ? 2 : 1
         border.color: !root.enabled ? Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container) : (root._focused ? Theme.primary : Theme.outline)
@@ -57,15 +57,15 @@ FocusScope {
         id: input
 
         anchors.fill: parent
-        anchors.leftMargin: 14
-        anchors.rightMargin: 14
+        anchors.leftMargin: Tokens.spacing_l
+        anchors.rightMargin: Tokens.spacing_l
         verticalAlignment: TextInput.AlignVCenter
         clip: true
         enabled: root.enabled
         color: root.enabled ? Theme.on_surface : root._disabledTint
         selectionColor: Theme.primary
         selectedTextColor: Theme.on_primary
-        font.pixelSize: 14
+        font.pixelSize: Tokens.font_size_body_l
         onAccepted: root.accepted()
     }
 
@@ -74,7 +74,7 @@ FocusScope {
         anchors.verticalCenter: input.verticalCenter
         text: root.placeholderText
         color: Theme.on_surface_variant
-        font.pixelSize: 14
+        font.pixelSize: Tokens.font_size_body_l
         // Hidden once the user focuses the field or types anything, so it
         // never overlaps real input.
         visible: input.text.length === 0 && !root._focused

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
@@ -32,6 +32,10 @@ FocusScope {
     implicitWidth: 220
     implicitHeight: 48
 
+    // Tab-focusable when enabled; focus lands on the inner TextInput (which
+    // declares focus: true within this scope) so typing works immediately.
+    activeFocusOnTab: enabled
+
     Accessible.role: Accessible.EditableText
     // Announce the entered text once there is any, falling back to the
     // placeholder while empty. Password fields keep the placeholder so the
@@ -39,14 +43,14 @@ FocusScope {
     Accessible.name: (input.text !== "" && input.echoMode === TextInput.Normal) ? input.text : root.placeholderText
 
     readonly property bool _focused: input.activeFocus
-    readonly property color _disabledTint: Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_content)
+    readonly property color _disabledTint: StateLayer.disabledContent(Theme.on_surface)
 
     Rectangle {
         anchors.fill: parent
         radius: Tokens.radius_s
         color: "transparent"
         border.width: root._focused ? 2 : 1
-        border.color: !root.enabled ? Qt.rgba(Theme.on_surface.r, Theme.on_surface.g, Theme.on_surface.b, StateLayer.disabled_container) : (root._focused ? Theme.primary : Theme.outline)
+        border.color: !root.enabled ? StateLayer.disabledContainer(Theme.on_surface) : (root._focused ? Theme.primary : Theme.outline)
 
         Behavior on border.color {
             ColorAnimation {
@@ -65,6 +69,9 @@ FocusScope {
         verticalAlignment: TextInput.AlignVCenter
         clip: true
         enabled: root.enabled
+        // The focused item within the scope, so the field's activeFocusOnTab
+        // delegates Tab focus here.
+        focus: true
         color: root.enabled ? Theme.on_surface : root._disabledTint
         selectionColor: Theme.primary
         selectedTextColor: Theme.on_primary

--- a/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
+++ b/libs/phosphor-shell-widgets/qml/Phosphor/Widgets/PhosphorTextField.qml
@@ -76,7 +76,8 @@ FocusScope {
         anchors.left: input.left
         anchors.verticalCenter: input.verticalCenter
         text: root.placeholderText
-        color: Theme.on_surface_variant
+        // Dim with the field when disabled, matching the border and input.
+        color: root.enabled ? Theme.on_surface_variant : root._disabledTint
         font.pixelSize: Tokens.font_size_body_l
         // Hidden once the user focuses the field or types anything, so it
         // never overlaps real input.

--- a/libs/phosphor-shell-widgets/src/phosphorshellwidgets_qml_plugin.cpp
+++ b/libs/phosphor-shell-widgets/src/phosphorshellwidgets_qml_plugin.cpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+// Glue translation unit for qt_add_qml_module. Phosphor.Widgets is a
+// pure-QML module today (the atoms are .qml files with no backing C++
+// types), but qt_add_qml_module still needs at least one C++ source so
+// the generated plugin and type registrar have a compilation unit. This
+// is the conventional "plugin main" entry point and the home for any
+// future C++ atom (a custom-painted shape, a QQuickPaintedItem) or
+// foreign-type re-export the module grows.

--- a/libs/phosphor-shell-widgets/tests/CMakeLists.txt
+++ b/libs/phosphor-shell-widgets/tests/CMakeLists.txt
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 fuddlesworth
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# QtQuickTest harness for the Phosphor.Widgets atoms. The cases live in
+# tst_*.qml; tst_widgets.cpp is the QUICK_TEST_MAIN entry point. The test
+# links the static Phosphor.Widgets and Phosphor.Theme QML modules (both
+# the module libraries and their plugin registrars) so the QML engine the
+# runner spins up can resolve `import Phosphor.Widgets` / `Phosphor.Theme`.
+
+find_package(Qt6 6.6 REQUIRED COMPONENTS Core Gui Qml Quick QuickTest)
+
+add_executable(test_phosphor_shell_widgets tst_widgets.cpp)
+
+target_compile_features(test_phosphor_shell_widgets PRIVATE cxx_std_20)
+
+target_link_libraries(test_phosphor_shell_widgets
+    PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickTest
+        # Static QML modules ship both a library and a plugin registrar.
+        # The registrar publishes the module to QQmlEngine at runtime;
+        # without it the `import` fails. Link the widgets module + its
+        # plugin, plus the theme module + its plugin (the atoms import
+        # Phosphor.Theme).
+        PhosphorShellWidgetsQml
+        PhosphorShellWidgetsQmlplugin
+        PhosphorThemeQml
+        PhosphorThemeQmlplugin
+)
+
+add_test(
+    NAME test_phosphor_shell_widgets
+    COMMAND test_phosphor_shell_widgets -input ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Headless run: the QtQuickTest runner spins up a QQuickView, so it needs
+# a platform plugin. offscreen keeps it display-server-free on CI.
+set_tests_properties(test_phosphor_shell_widgets PROPERTIES
+    ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+)

--- a/libs/phosphor-shell-widgets/tests/tst_atoms.qml
+++ b/libs/phosphor-shell-widgets/tests/tst_atoms.qml
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Smoke + contract tests for the Phosphor.Widgets atoms. These pin each
+// atom's default property surface and the small amount of pure logic the
+// atoms carry (slider ratio clamping, elevation level clamping), so a
+// renamed property or a broken default fails the build rather than
+// surfacing as a silent UI bug. Visual behaviour (hover tint, ripple
+// sweep, retinting) is exercised by the kitchen-sink demo, not here.
+
+import QtQuick
+import QtTest
+import Phosphor.Widgets
+
+TestCase {
+    id: testCase
+
+    name: "PhosphorAtoms"
+
+    Component {
+        id: buttonComp
+
+        PhosphorButton {}
+    }
+
+    Component {
+        id: pillComp
+
+        PhosphorPill {}
+    }
+
+    Component {
+        id: cardComp
+
+        PhosphorCard {}
+    }
+
+    Component {
+        id: sliderComp
+
+        PhosphorSlider {}
+    }
+
+    Component {
+        id: textFieldComp
+
+        PhosphorTextField {}
+    }
+
+    Component {
+        id: rippleComp
+
+        PhosphorRipple {}
+    }
+
+    Component {
+        id: shadowComp
+
+        ElevationShadow {}
+    }
+
+    function test_button_defaults() {
+        const b = createTemporaryObject(buttonComp, testCase);
+        verify(b, "PhosphorButton instantiates");
+        compare(b.text, "", "default text empty");
+        compare(b.variant, PhosphorButton.Filled, "default variant Filled");
+        verify(b.implicitHeight > 0, "has an implicit height");
+    }
+
+    function test_button_clicked_signal() {
+        const b = createTemporaryObject(buttonComp, testCase);
+        const spy = signalSpyComp.createObject(testCase, {
+            "target": b,
+            "signalName": "clicked"
+        });
+        verify(spy.valid, "clicked signal exists");
+    }
+
+    function test_pill_defaults() {
+        const p = createTemporaryObject(pillComp, testCase);
+        verify(p, "PhosphorPill instantiates");
+        compare(p.text, "", "default text empty");
+        compare(p.selected, false, "default unselected");
+    }
+
+    function test_card_defaults() {
+        const c = createTemporaryObject(cardComp, testCase);
+        verify(c, "PhosphorCard instantiates");
+        compare(c.elevation, 1, "default elevation 1");
+        compare(c.radius, 16, "default radius 16");
+        compare(c.padding, 16, "default padding 16");
+    }
+
+    function test_slider_ratio_clamps() {
+        const s = createTemporaryObject(sliderComp, testCase, {
+            "from": 0,
+            "to": 10,
+            "width": 120
+        });
+        verify(s, "PhosphorSlider instantiates");
+        s.value = 5;
+        compare(s._ratio, 0.5, "midpoint maps to 0.5");
+        s.value = 20;
+        compare(s._ratio, 1, "over-range value clamps the ratio to 1");
+        s.value = -5;
+        compare(s._ratio, 0, "under-range value clamps the ratio to 0");
+    }
+
+    function test_slider_zero_range_is_safe() {
+        const s = createTemporaryObject(sliderComp, testCase, {
+            "from": 5,
+            "to": 5
+        });
+        compare(s._ratio, 0, "from == to collapses ratio to 0, not NaN");
+    }
+
+    function test_textfield_text_alias() {
+        const t = createTemporaryObject(textFieldComp, testCase);
+        verify(t, "PhosphorTextField instantiates");
+        compare(t.text, "", "default text empty");
+        t.text = "hello";
+        compare(t.text, "hello", "text alias round-trips");
+    }
+
+    function test_ripple_defaults() {
+        const r = createTemporaryObject(rippleComp, testCase);
+        verify(r, "PhosphorRipple instantiates");
+        compare(r.interactive, true, "interactive by default");
+        compare(r.down, false, "not pressed at rest");
+        compare(r.hovered, false, "not hovered at rest");
+    }
+
+    function test_shadow_level_clamps() {
+        const e = createTemporaryObject(shadowComp, testCase, {
+            "level": 9
+        });
+        verify(e, "ElevationShadow instantiates");
+        compare(e._level, 5, "over-range level clamps to 5");
+        e.level = -3;
+        compare(e._level, 0, "under-range level clamps to 0");
+        compare(e.shadowEnabled, false, "level 0 disables the shadow");
+    }
+
+    Component {
+        id: signalSpyComp
+
+        SignalSpy {}
+    }
+}

--- a/libs/phosphor-shell-widgets/tests/tst_atoms.qml
+++ b/libs/phosphor-shell-widgets/tests/tst_atoms.qml
@@ -73,6 +73,10 @@ TestCase {
             "signalName": "clicked"
         });
         verify(spy.valid, "clicked signal exists");
+        b.forceActiveFocus();
+        verify(b.activeFocus, "button takes keyboard focus");
+        keyClick(Qt.Key_Space);
+        compare(spy.count, 1, "clicked actually fires on activation");
     }
 
     function test_pill_defaults() {
@@ -176,6 +180,7 @@ TestCase {
             "signalName": "toggled"
         });
         p.forceActiveFocus();
+        verify(p.activeFocus, "pill takes keyboard focus");
         keyClick(Qt.Key_Space);
         compare(clickSpy.count, 1, "Space emits clicked");
         compare(toggleSpy.count, 1, "Space emits toggled");

--- a/libs/phosphor-shell-widgets/tests/tst_atoms.qml
+++ b/libs/phosphor-shell-widgets/tests/tst_atoms.qml
@@ -140,6 +140,72 @@ TestCase {
         compare(e.shadowEnabled, false, "level 0 disables the shadow");
     }
 
+    function test_button_space_and_enter_activate() {
+        const b = createTemporaryObject(buttonComp, testCase, {
+            "text": "Go"
+        });
+        const spy = signalSpyComp.createObject(testCase, {
+            "target": b,
+            "signalName": "clicked"
+        });
+        b.forceActiveFocus();
+        verify(b.activeFocus, "button takes keyboard focus");
+        keyClick(Qt.Key_Space);
+        compare(spy.count, 1, "Space activates the button");
+        keyClick(Qt.Key_Return);
+        compare(spy.count, 2, "Return activates the button");
+    }
+
+    function test_disabled_button_skips_tab_order() {
+        const b = createTemporaryObject(buttonComp, testCase, {
+            "enabled": false
+        });
+        compare(b.activeFocusOnTab, false, "a disabled button is not Tab-focusable");
+    }
+
+    function test_pill_space_toggles() {
+        const p = createTemporaryObject(pillComp, testCase, {
+            "text": "Wi-Fi"
+        });
+        const clickSpy = signalSpyComp.createObject(testCase, {
+            "target": p,
+            "signalName": "clicked"
+        });
+        const toggleSpy = signalSpyComp.createObject(testCase, {
+            "target": p,
+            "signalName": "toggled"
+        });
+        p.forceActiveFocus();
+        keyClick(Qt.Key_Space);
+        compare(clickSpy.count, 1, "Space emits clicked");
+        compare(toggleSpy.count, 1, "Space emits toggled");
+    }
+
+    function test_slider_arrow_keys_move_value() {
+        const s = createTemporaryObject(sliderComp, testCase, {
+            "from": 0,
+            "to": 100,
+            "value": 50,
+            "width": 200
+        });
+        const spy = signalSpyComp.createObject(testCase, {
+            "target": s,
+            "signalName": "moved"
+        });
+        s.forceActiveFocus();
+        verify(s.activeFocus, "slider takes keyboard focus");
+        compare(s._step, 5, "default step is a twentieth of the range");
+        keyClick(Qt.Key_Right);
+        compare(s.value, 55, "Right arrow nudges up one step");
+        compare(spy.count, 1, "moved emitted on the arrow nudge");
+        keyClick(Qt.Key_Left);
+        compare(s.value, 50, "Left arrow nudges down one step");
+        keyClick(Qt.Key_Home);
+        compare(s.value, 0, "Home jumps to from");
+        keyClick(Qt.Key_End);
+        compare(s.value, 100, "End jumps to to");
+    }
+
     Component {
         id: signalSpyComp
 

--- a/libs/phosphor-shell-widgets/tests/tst_connector.qml
+++ b/libs/phosphor-shell-widgets/tests/tst_connector.qml
@@ -23,6 +23,12 @@ TestCase {
         BarCanvas {}
     }
 
+    Component {
+        id: cornerComp
+
+        ConnectedCorner {}
+    }
+
     // Count non-overlapping occurrences of sub in s.
     function _count(s, sub) {
         return s.split(sub).length - 1;
@@ -100,5 +106,24 @@ TestCase {
         ];
         compare(b.maxSocketDepth, 250, "maxSocketDepth tracks the deepest socket");
         compare(b.implicitHeight, 48 + 250, "implicitHeight reserves the pocket depth");
+    }
+
+    function test_connected_corner_convex_path() {
+        const c = createTemporaryObject(cornerComp, testCase, {
+            "radius": 16,
+            "concave": false
+        });
+        verify(c, "ConnectedCorner instantiates");
+        // A quarter-disc pie centred on the origin (sweep 1, convex).
+        compare(c._path, "M 0 0 L 16 0 A 16 16 0 0 1 0 16 Z");
+    }
+
+    function test_connected_corner_concave_path() {
+        const c = createTemporaryObject(cornerComp, testCase, {
+            "radius": 16,
+            "concave": true
+        });
+        // The r x r box minus a quarter-disc bite from the origin corner.
+        compare(c._path, "M 16 0 L 16 16 L 0 16 A 16 16 0 0 1 16 0 Z");
     }
 }

--- a/libs/phosphor-shell-widgets/tests/tst_connector.qml
+++ b/libs/phosphor-shell-widgets/tests/tst_connector.qml
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Geometry tests for the connected-corner path (ConnectorGeometry via
+// BarCanvas.pathData). The generated SVG path string is deterministic, so
+// these pin the structural contract: how many arcs the outline has, that
+// a socket adds exactly one concave (inverted) corner per wall, and that
+// a zero-depth socket collapses to a flat edge. Visual correctness (the
+// shape matching the mockups) is for the bar-canvas demo; this guards the
+// math the morph animation drives.
+
+import QtQuick
+import QtTest
+import Phosphor.Widgets
+
+TestCase {
+    id: testCase
+
+    name: "ConnectedCornerGeometry"
+
+    Component {
+        id: barComp
+
+        BarCanvas {}
+    }
+
+    // Count non-overlapping occurrences of sub in s.
+    function _count(s, sub) {
+        return s.split(sub).length - 1;
+    }
+
+    function test_plain_bar_has_four_outer_corners() {
+        const b = createTemporaryObject(barComp, testCase, {
+            "width": 1000,
+            "barHeight": 48,
+            "cornerRadius": 14,
+            "connectorRadius": 14
+        });
+        verify(b, "BarCanvas instantiates");
+        const d = b.pathData;
+        verify(d.length > 0, "path is non-empty");
+        compare(_count(d, "A "), 4, "a socketless bar has exactly four (outer) corner arcs");
+        compare(_count(d, " 0 0 0 "), 0, "no concave (inverted) corners without a socket");
+        verify(d.indexOf("Z") >= 0, "path is closed");
+    }
+
+    function test_open_socket_adds_a_pocket() {
+        const b = createTemporaryObject(barComp, testCase, {
+            "width": 1000,
+            "barHeight": 48,
+            "cornerRadius": 14,
+            "connectorRadius": 14
+        });
+        b.sockets = [
+            {
+                "x": 400,
+                "width": 200,
+                "depth": 300
+            }
+        ];
+        const d = b.pathData;
+        // 4 outer + 4 pocket (2 concave top + 2 convex floor) corners.
+        compare(_count(d, "A "), 8, "an open socket adds four pocket-corner arcs");
+        // Both inverted (concave) top corners use sweep flag 0; the convex
+        // pocket-floor corners and all four outer corners use sweep 1.
+        // Walking the outline clockwise, a concave corner turns left
+        // (sweep 0) and a convex corner turns right (sweep 1).
+        compare(_count(d, " 0 0 0 "), 2, "both inverted corners are sweep-0 arcs");
+        compare(_count(d, " 0 0 1 "), 6, "four outer + two convex pocket corners are sweep-1 arcs");
+    }
+
+    function test_zero_depth_socket_collapses_to_flat_edge() {
+        const b = createTemporaryObject(barComp, testCase, {
+            "width": 1000,
+            "barHeight": 48,
+            "cornerRadius": 14,
+            "connectorRadius": 14
+        });
+        b.sockets = [
+            {
+                "x": 400,
+                "width": 200,
+                "depth": 0
+            }
+        ];
+        compare(_count(b.pathData, "A "), 4, "a closed (zero-depth) socket leaves the bottom edge flat");
+    }
+
+    function test_socket_reserves_pocket_height() {
+        const b = createTemporaryObject(barComp, testCase, {
+            "width": 1000,
+            "barHeight": 48
+        });
+        compare(b.maxSocketDepth, 0, "no sockets means no extra depth");
+        b.sockets = [
+            {
+                "x": 400,
+                "width": 200,
+                "depth": 250
+            }
+        ];
+        compare(b.maxSocketDepth, 250, "maxSocketDepth tracks the deepest socket");
+        compare(b.implicitHeight, 48 + 250, "implicitHeight reserves the pocket depth");
+    }
+}

--- a/libs/phosphor-shell-widgets/tests/tst_widgets.cpp
+++ b/libs/phosphor-shell-widgets/tests/tst_widgets.cpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// QtQuickTest runner for the Phosphor.Widgets atoms. The actual cases
+// live in the tst_*.qml files alongside this translation unit; this is
+// just the entry point that QUICK_TEST_MAIN expands into. The source
+// directory is passed via `-input` from the add_test() command, and the
+// offscreen QPA platform (set in the test environment) keeps the run
+// headless so it works on CI without a display server.
+
+#include <QtQuickTest/quicktest.h>
+
+QUICK_TEST_MAIN(phosphor_shell_widgets)

--- a/libs/phosphor-theme/qml/Phosphor/Theme/StateLayer.qml
+++ b/libs/phosphor-theme/qml/Phosphor/Theme/StateLayer.qml
@@ -8,8 +8,9 @@
 // reduced-motion accessibility profiles can override the singleton in
 // one place.
 
-import QtQuick
 pragma Singleton
+
+import QtQuick
 
 QtObject {
     // M3 spec values, decimal opacity from 0 to 1.
@@ -21,4 +22,16 @@ QtObject {
     // rather than as a state layer painted over the surface.
     readonly property real disabled_content: 0.38
     readonly property real disabled_container: 0.12
+
+    // Disabled-state tints: the given foreground colour at the M3 disabled
+    // opacity. Pass the colour in (rather than reading a Theme role here) so
+    // the caller's binding still tracks the source colour and retints live
+    // on a palette change. Use disabledContent for text/icons/handles and
+    // disabledContainer for fills/outlines.
+    function disabledContent(color) {
+        return Qt.rgba(color.r, color.g, color.b, disabled_content);
+    }
+    function disabledContainer(color) {
+        return Qt.rgba(color.r, color.g, color.b, disabled_container);
+    }
 }

--- a/libs/phosphor-theme/qml/Phosphor/Theme/StateLayer.qml
+++ b/libs/phosphor-theme/qml/Phosphor/Theme/StateLayer.qml
@@ -4,7 +4,7 @@
 // M3 "state layer" model. Every interactive surface paints the
 // foreground color over itself at a state-specific opacity to
 // communicate hover, focus, press, and drag. Centralising these here
-// keeps every Pz* widget consistent. Future high-contrast and
+// keeps every Phosphor* widget consistent. Future high-contrast and
 // reduced-motion accessibility profiles can override the singleton in
 // one place.
 

--- a/libs/phosphor-theme/qml/Phosphor/Theme/Theme.qml
+++ b/libs/phosphor-theme/qml/Phosphor/Theme/Theme.qml
@@ -19,8 +19,9 @@
 // real bugs (typo'd token names, partial matugen output). Magenta is
 // loud enough to spot during development without crashing the shell.
 
-import QtQuick
 pragma Singleton
+
+import QtQuick
 
 QtObject {
     id: theme
@@ -49,6 +50,15 @@ QtObject {
     readonly property color surface_variant: _t("surface_variant")
     readonly property color on_surface: _t("on_surface")
     readonly property color on_surface_variant: _t("on_surface_variant")
+    // M3 surface tint: the colour blended over elevated surfaces, rising
+    // in opacity with elevation. M3 defaults this to the primary accent,
+    // and matugen emits it as a distinct token. Prefer an explicit
+    // surface_tint from the palette when present (so generated palettes
+    // are honoured), otherwise fall back to primary so a palette without
+    // the token still tints elevation correctly. Indexes `palette`
+    // directly (not _t) to keep the primary fallback instead of the
+    // missing-token magenta sentinel; both reads stay binding-tracked.
+    readonly property color surface_tint: palette["surface_tint"] !== undefined ? palette["surface_tint"] : primary
     // ─── Accents ─────────────────────────────────────────────────────────
     readonly property color primary: _t("primary")
     readonly property color on_primary: _t("on_primary")
@@ -89,5 +99,4 @@ QtObject {
         const v = palette[name];
         return v !== undefined ? v : theme.missingTokenColor;
     }
-
 }

--- a/libs/phosphor-theme/qml/Phosphor/Theme/Tokens.qml
+++ b/libs/phosphor-theme/qml/Phosphor/Theme/Tokens.qml
@@ -7,8 +7,9 @@
 // for the "large rounding, generous spacing" aesthetic agreed in the
 // mockup conventions.
 
-import QtQuick
 pragma Singleton
+
+import QtQuick
 
 QtObject {
     // ─── Spacing scale ───────────────────────────────────────────────────
@@ -34,41 +35,41 @@ QtObject {
     readonly property int radius_xl: 24
     readonly property int radius_xxl: 32
     readonly property int radius_full: 9999
-    // ─── Elevation (Y offset / blur radius pairs) ────────────────────────
-    // Translates to ElevationShadow.qml drop-shadow parameters when that
-    // primitive lands in Phase 3.1. M3 levels 0 through 5. Most shell
-    // surfaces sit at level 1 for the bar, level 2 for popouts, level 3
-    // for modals.
+    // ─── Elevation (Y offset / blur / opacity per tier) ──────────────────
+    // Rendered by ElevationShadow.qml into MultiEffect drop-shadow
+    // parameters (it is the single consumer of these tiers). M3 levels 0
+    // through 5. Most shell surfaces sit at level 1 for the bar, level 2
+    // for popouts, level 3 for modals.
     readonly property var elevation_0: ({
-        "y": 0,
-        "blur": 0,
-        "opacity": 0
-    })
+            "y": 0,
+            "blur": 0,
+            "opacity": 0
+        })
     readonly property var elevation_1: ({
-        "y": 1,
-        "blur": 3,
-        "opacity": 0.15
-    })
+            "y": 1,
+            "blur": 3,
+            "opacity": 0.15
+        })
     readonly property var elevation_2: ({
-        "y": 2,
-        "blur": 6,
-        "opacity": 0.18
-    })
+            "y": 2,
+            "blur": 6,
+            "opacity": 0.18
+        })
     readonly property var elevation_3: ({
-        "y": 6,
-        "blur": 12,
-        "opacity": 0.22
-    })
+            "y": 6,
+            "blur": 12,
+            "opacity": 0.22
+        })
     readonly property var elevation_4: ({
-        "y": 8,
-        "blur": 24,
-        "opacity": 0.25
-    })
+            "y": 8,
+            "blur": 24,
+            "opacity": 0.25
+        })
     readonly property var elevation_5: ({
-        "y": 12,
-        "blur": 32,
-        "opacity": 0.3
-    })
+            "y": 12,
+            "blur": 32,
+            "opacity": 0.3
+        })
     // ─── Typography ──────────────────────────────────────────────────────
     // Font-family is the system default. The shell respects the user's
     // system font choice rather than a hardcoded face. Size and weight
@@ -89,5 +90,6 @@ QtObject {
     readonly property int font_size_label_s: 11
     readonly property int font_weight_regular: Font.Normal
     readonly property int font_weight_medium: Font.Medium
+    readonly property int font_weight_demibold: Font.DemiBold
     readonly property int font_weight_bold: Font.Bold
 }

--- a/libs/phosphor-theme/qml/Phosphor/Theme/Tokens.qml
+++ b/libs/phosphor-theme/qml/Phosphor/Theme/Tokens.qml
@@ -35,40 +35,48 @@ QtObject {
     readonly property int radius_xl: 24
     readonly property int radius_xxl: 32
     readonly property int radius_full: 9999
-    // ─── Elevation (Y offset / blur / opacity per tier) ──────────────────
-    // Rendered by ElevationShadow.qml into MultiEffect drop-shadow
-    // parameters (it is the single consumer of these tiers). M3 levels 0
-    // through 5. Most shell surfaces sit at level 1 for the bar, level 2
-    // for popouts, level 3 for modals.
+    // ─── Elevation (per tier) ────────────────────────────────────────────
+    // Both halves of the M3 elevation system live here so a retune touches
+    // one place: y/blur/opacity drive the drop shadow (rendered by
+    // ElevationShadow.qml into MultiEffect parameters) and tint is the
+    // surface-tint overlay opacity (applied by PhosphorCard over the base
+    // container colour). M3 levels 0 through 5. Most shell surfaces sit at
+    // level 1 for the bar, level 2 for popouts, level 3 for modals.
     readonly property var elevation_0: ({
             "y": 0,
             "blur": 0,
-            "opacity": 0
+            "opacity": 0,
+            "tint": 0.0
         })
     readonly property var elevation_1: ({
             "y": 1,
             "blur": 3,
-            "opacity": 0.15
+            "opacity": 0.15,
+            "tint": 0.05
         })
     readonly property var elevation_2: ({
             "y": 2,
             "blur": 6,
-            "opacity": 0.18
+            "opacity": 0.18,
+            "tint": 0.08
         })
     readonly property var elevation_3: ({
             "y": 6,
             "blur": 12,
-            "opacity": 0.22
+            "opacity": 0.22,
+            "tint": 0.11
         })
     readonly property var elevation_4: ({
             "y": 8,
             "blur": 24,
-            "opacity": 0.25
+            "opacity": 0.25,
+            "tint": 0.12
         })
     readonly property var elevation_5: ({
             "y": 12,
             "blur": 32,
-            "opacity": 0.3
+            "opacity": 0.3,
+            "tint": 0.14
         })
     // ─── Typography ──────────────────────────────────────────────────────
     // Font-family is the system default. The shell respects the user's


### PR DESCRIPTION
## Phase 3 — UI primitives + first visible examples

Implements all of **Phase 3** from `docs/phosphor-shell-design/04-implementation-plan.md`: the end-user-visible building blocks for the Phosphor shell, each as a focused `phosphor-shell-*` library with a runnable acceptance demo and a QtQuickTest suite. Everything is gated behind `BUILD_PHOSPHOR_SHELL` and themed entirely through `phosphor-theme` (no hard-coded colours, timing, or state opacities).

### What's in it

**3.1 — `phosphor-shell-widgets` (`Phosphor.Widgets`)** — M3 atom library
- `PhosphorButton` (Filled/Tonal/Outlined/Text), `PhosphorSlider`, `PhosphorTextField`, `PhosphorCard`, `PhosphorPill`, `PhosphorRipple` (shared hover/press state layer + ripple), `ElevationShadow` (M3 levels 0–5).
- Elevation models both M3 halves: shadow (`ElevationShadow`) + surface tint overlay (card tints `surface_container` with `Theme.surface_tint`). Added a `Theme.surface_tint` accessor that prefers a `surface_tint` palette token (e.g. from matugen) and falls back to the primary accent.
- Demo: `phosphor-widgets-kitchen-sink`.

**3.2 — connected-corner bar geometry** (in `Phosphor.Widgets`)
- `ConnectorGeometry.js` (path math), `ConnectedShape` (Shape/PathSvg painter), `ConnectedCorner` (fillet primitive), `BarCanvas` (bar whose bottom edge weaves into "sockets" so popouts grow out of it as one painted surface, matching the mockups).
- Demo: `phosphor-bar-canvas-demo` — the Control Center grows out of the bar with the concave/inverted join, toggled through a real `PopoutController` (PopoutService, Phase 1.2).

**3.3 — `phosphor-shell-osd` (`Phosphor.OSD`)** — OSD framework
- `OSDHost` (one-at-a-time display, hold timer, debounce/dedupe, fade, screen routing) + `OSDCard` + `VolumeOSD`/`BrightnessOSD`/`MicOSD`/`CapsLockOSD`, registered via `IOSDFactory`.
- Demo: `phosphor-osd-demo` — driven by buttons and by `phosphorctl call osd.show --arg kind=volume --arg value=62`.

**3.4 — `phosphor-shell-notifications` (`Phosphor.Notifications`)** — toast framework
- `ToastHost` (top-right stack, queue beyond `maxVisible`, dismiss+promote, slide/reflow transitions, per-app-rules seam) + `Toast` (image, rich-text body, urgency accent, hover-to-pause).
- Demo: `phosphor-toast-demo` — fed by a real `NotificationServer` (so `notify-send` raises a toast) + buttons + a Do-Not-Disturb pill exercising the rules seam.

### Testing

QtQuickTest suites for each framework, all green: **widgets 17 + osd 10 + notifications 9 = 36 cases**. Every demo AOT-compiles and loads clean under offscreen QPA. Demos and key states (atoms, connected-corner joins, OSDs, toasts) were verified with offscreen renders during development.

### Notes for reviewers

- **GPU-only shadows:** the `ElevationShadow` (MultiEffect) layer that draws card/OSD/toast backgrounds needs a real GPU; it does not render under the headless software/offscreen path, but content renders regardless and it's correct on a live session. The four demos are worth an eyeball on a real Wayland session (plus `notify-send → toast`).
- Each library is in-tree-only (static QML modules, no install rules) pending the Phase 4 shell binary, mirroring `phosphor-popout`'s QML module.
- New test pattern: first use of `Qt6::QuickTest` in the tree.

Closes out the `phosphor-ui-primitives-0.1` milestone. Next is Phase 4 (the actual shell surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
