### PR TITLE
fix(daemon): resnap/retile when a rule changes the active layout

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -1521,6 +1521,21 @@ bool Daemon::init()
                 }
             });
 
+    // A rule edit that changes the ACTIVE context's resolved assignment (engine
+    // mode / snapping layout / tiling algorithm) must move live windows — resnap
+    // snapping screens, retile autotile screens. The legacy assignment-apply path
+    // (assignmentChangesApplied) only fires for setAssignmentEntry-driven edits,
+    // so rule-driven changes were silently not applied. reconcileActiveAssignments
+    // diffs the per-screen active assignment and drives the same apply path for
+    // the screens that actually changed (a no-op for appearance/exclude/lock
+    // edits, which don't alter the active assignment).
+    connect(m_ruleStore.get(), &PhosphorRules::RuleStore::rulesChanged, this, [this](bool /*persisted*/) {
+        reconcileActiveAssignments();
+    });
+    // Prime the snapshot from the initial rule set so the first real rule edit
+    // diffs against the live assignments rather than an empty baseline.
+    diffActiveAssignments();
+
     // Wire persistence delegate — SnapEngine delegates save/load to WTA's KConfig layer.
     // QPointer guards against late calls during shutdown if WTA is destroyed first.
     snapEngine->setPersistenceDelegate(
@@ -1837,6 +1852,12 @@ bool Daemon::init()
                         showLayoutOsd(layout, osd.screenId);
                 }
             }
+
+            // Refresh the active-assignment snapshot to what was just applied,
+            // so a later rule edit diffs against reality (this path also runs
+            // for legacy setAssignmentEntry-driven applies, which bypass
+            // reconcileActiveAssignments and would otherwise leave it stale).
+            diffActiveAssignments();
         });
 
     // Register D-Bus service and object with error handling and retry logic

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -497,6 +497,30 @@ private:
     void updateAutotileScreens();
 
     /**
+     * @brief React to a rule change that may have altered active assignments.
+     *
+     * The unified rule store emits rulesChanged on any rule edit, but only a
+     * change to the ACTIVE context's resolved assignment needs windows moved.
+     * Diffs each screen's resolved assignment id against the snapshot; for the
+     * screens that changed, retiles autotile screens (updateAutotileScreens
+     * self-diffs) and drives the legacy resnap/OSD path via the LayoutAdaptor
+     * (markScreensChanged + applyAssignmentChanges). A no-op when nothing
+     * assignment-affecting changed (appearance / exclude / lock edits, etc.).
+     */
+    void reconcileActiveAssignments();
+
+    /**
+     * @brief Recompute each effective screen's active assignment id and return
+     *        the set whose id differs from @ref m_activeAssignmentByScreen,
+     *        updating the snapshot to the new values (dropping removed screens).
+     *
+     * Called by reconcileActiveAssignments (with apply) and, with the result
+     * discarded, to refresh the snapshot after a context switch or a legacy
+     * apply so a later rule edit doesn't falsely re-resnap those screens.
+     */
+    QSet<QString> diffActiveAssignments();
+
+    /**
      * @brief Respond to a PhosphorScreens::ScreenManager VS cache change for a physical screen
      *
      * Wired to PhosphorScreens::ScreenManager::virtualScreensChanged. Performs the post-change
@@ -909,6 +933,13 @@ private:
     // Keyed by TilingStateKey (not plain screen name) so cross-desktop toggles
     // don't overwrite each other's ordering.
     QHash<TilingStateKey, QStringList> m_lastAutotileOrders;
+
+    // Last-applied active assignment id per effective screen (resolved for that
+    // screen's current desktop/activity). Diffed on rulesChanged to find the
+    // screens a rule edit actually moved; refreshed on context switches and
+    // after any apply so a later edit doesn't falsely re-resnap. See
+    // reconcileActiveAssignments / diffActiveAssignments.
+    QHash<QString, QString> m_activeAssignmentByScreen;
 
     // Last observed tiled-window count per screen, tracked so the engine's
     // placementChanged stream only re-resolves the per-screen tiling algorithm

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -17,6 +17,7 @@
 #include <PhosphorPlacement/WindowTrackingService.h>
 #include <PhosphorContext/ContextResolver.h>
 #include "../../config/settings.h"
+#include "../../dbus/layoutadaptor.h"
 #include "../../dbus/windowtrackingadaptor.h"
 #include <PhosphorEngine/PlacementEngineBase.h>
 #include <PhosphorEngine/IPlacementEngine.h>
@@ -220,6 +221,52 @@ void Daemon::updateAutotileScreens()
     }
 
     qCDebug(lcDaemon) << "Updated autotile screens=" << autotileScreens;
+}
+
+QSet<QString> Daemon::diffActiveAssignments()
+{
+    QSet<QString> changed;
+    if (!m_screenManager || !m_layoutManager) {
+        return changed;
+    }
+    const QString activity = currentActivity();
+    QHash<QString, QString> next;
+    const QStringList effectiveIds = m_screenManager->effectiveScreenIds();
+    next.reserve(effectiveIds.size());
+    for (const QString& screenId : effectiveIds) {
+        // Per-output virtual desktops (#648): each screen resolves its own desktop.
+        const int desktop = currentDesktopForScreen(screenId);
+        // assignmentIdForScreen returns the ACTIVE id (snapping layout uuid, or
+        // "autotile:<algo>"), so this fires only when the visible layout changes
+        // — e.g. a tiling-algorithm edit while the screen is in snapping mode
+        // resolves to the same snapping id and is correctly ignored.
+        const QString id = m_layoutManager->assignmentIdForScreen(screenId, desktop, activity);
+        next.insert(screenId, id);
+        if (m_activeAssignmentByScreen.value(screenId) != id) {
+            changed.insert(screenId);
+        }
+    }
+    // Replace wholesale so screens that went away drop out of the snapshot.
+    m_activeAssignmentByScreen = std::move(next);
+    return changed;
+}
+
+void Daemon::reconcileActiveAssignments()
+{
+    const QSet<QString> changed = diffActiveAssignments();
+    if (changed.isEmpty()) {
+        return;
+    }
+    // Autotile screens retile inside updateAutotileScreens() (it self-diffs each
+    // screen's resolved algorithm/overrides). Snapping screens resnap via the
+    // shared legacy apply path: mark the changed screens on the adaptor and
+    // trigger the same assignmentChangesApplied handler the KCM batch uses, so
+    // rule-driven and assignment-driven changes run identical code.
+    updateAutotileScreens();
+    if (m_layoutAdaptor) {
+        m_layoutAdaptor->markScreensChanged(changed);
+        m_layoutAdaptor->applyAssignmentChanges();
+    }
 }
 
 /**

--- a/src/daemon/daemon/signals.cpp
+++ b/src/daemon/daemon/signals.cpp
@@ -931,6 +931,11 @@ void Daemon::finalizeStartup()
             });
         }
     }
+
+    // Prime the active-assignment snapshot now that screens and initial layouts
+    // are applied, so the first rule edit diffs against the live assignments
+    // (not an empty baseline, which would resnap every screen once).
+    diffActiveAssignments();
 }
 
 void Daemon::syncAutotileFloatState(const QString& windowId, bool floating, const QString& screenId)

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -266,6 +266,11 @@ void Daemon::connectDesktopActivity()
                 }
                 // OSD on the ONE screen that switched (#648).
                 showDesktopSwitchOsdForScreen(screenId, currentActivity());
+                // A context switch lays out its own (different) windows, so
+                // refresh the active-assignment snapshot without applying —
+                // otherwise the next rule edit would diff the new-context
+                // assignment against the old and falsely re-resnap this screen.
+                diffActiveAssignments();
             });
 
     // Prune stale PhosphorTiles::TilingState entries and disabled-desktop numbers when desktops are removed
@@ -395,6 +400,11 @@ void Daemon::connectDesktopActivity()
                     }
 
                     showDesktopSwitchOsd(activityId);
+                    // Refresh the active-assignment snapshot for the new activity
+                    // context (no apply — the switch handles its own windows) so a
+                    // later rule edit doesn't falsely re-resnap. Mirrors the
+                    // per-screen desktop-switch handler above.
+                    diffActiveAssignments();
                 });
     }
 }

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -137,6 +137,10 @@ void Daemon::connectScreenSignals()
                             GeometryUtils::effectiveScreenGeometry(m_screenManager.get(), screenLayout, sid));
                     }
                 }
+                // Record the new screen's resolved assignment so a later
+                // (unrelated) rule edit doesn't diff it as a change and
+                // spuriously resnap it — the screen-add path lays it out here.
+                diffActiveAssignments();
             });
 
     connect(m_screenManager.get(), &PhosphorScreens::ScreenManager::screenRemoved, this,
@@ -179,6 +183,10 @@ void Daemon::connectScreenSignals()
                         layout->setAllowedScreens(allowed);
                     }
                 }
+                // Drop the removed screen from the assignment snapshot so it
+                // doesn't linger as a stale entry (kept consistent with the
+                // add / context-switch / apply refresh points).
+                diffActiveAssignments();
             });
 
     connect(m_screenManager.get(), &PhosphorScreens::ScreenManager::screenGeometryChanged, this, [this] {

--- a/src/dbus/layoutadaptor.h
+++ b/src/dbus/layoutadaptor.h
@@ -400,6 +400,12 @@ private Q_SLOTS:
 public:
     void invalidateCache();
 
+    // Mark screens as changed for the next applyAssignmentChanges(), without
+    // going through setAssignmentEntry. Internal (NOT bus-exposed): the daemon
+    // calls this to drive the same resnap/retile path when a RULE edit (not a
+    // legacy assignment edit) changes the active assignment for some screens.
+    void markScreensChanged(const QSet<QString>& screenIds);
+
     /**
      * @brief Notify consumers that the layout list data has changed
      *

--- a/src/dbus/layoutadaptor/assignment.cpp
+++ b/src/dbus/layoutadaptor/assignment.cpp
@@ -731,6 +731,11 @@ void LayoutAdaptor::setSaveBatchMode(bool enabled)
     m_suppressScreenLayoutSignal = enabled;
 }
 
+void LayoutAdaptor::markScreensChanged(const QSet<QString>& screenIds)
+{
+    m_changedScreenIds.unite(screenIds);
+}
+
 void LayoutAdaptor::applyAssignmentChanges()
 {
     QSet<QString> changed = std::move(m_changedScreenIds);


### PR DESCRIPTION
## Problem

Editing a rule that changes the **active context's** layout assignment (engine mode / snapping layout / tiling algorithm) didn't move any windows — the new layout resolved, but live windows weren't resnapped/retiled.

**Root cause:** the resnap/retile machinery is driven by `LayoutAdaptor::assignmentChangesApplied(changedScreenIds)`, whose changed-screen set (`m_changedScreenIds`) is populated **only** by the legacy `setAssignmentEntry`/`clearAssignment` calls, and `applyAssignmentChanges()` is only invoked by the settings save when the legacy assignment staging `hasPendingAssignments()`. A rule edit goes through `setAllRules` → `RuleStore::rulesChanged`, which the daemon only consumed for exclude-refilter and overlay-refresh. Nothing re-resolved or applied the new assignment.

## Fix

Wire `rulesChanged` → `Daemon::reconcileActiveAssignments()`:

1. **Diff** each effective screen's active assignment id (`assignmentIdForScreen` — the *active* id, so a tiling-algo edit while in snapping mode resolves to the same id and is correctly ignored) against a per-screen snapshot.
2. For the screens that changed: **retile** autotile screens via `updateAutotileScreens()` (already self-diffs), and **resnap** snapping screens via the existing apply path — a new internal `LayoutAdaptor::markScreensChanged()` + `applyAssignmentChanges()`, so rule-driven and legacy assignment-driven changes run the **exact same code**.

The diff **gates** the work: appearance/exclude/lock edits don't touch the active assignment, so they're a no-op with no OSD spam.

**Snapshot freshness:** primed in `finalizeStartup`, refreshed after every apply and on desktop/activity context switches, so a context switch doesn't make the next rule edit falsely re-resnap that screen.

`markScreensChanged` is an internal (non-bus-exposed) adaptor helper — kept out of the D-Bus contract.

## Testing

Build clean, **245/245 tests pass** (incl. `test_dbus_contract_sync`). This path is hard to unit-test; the real verification is live:
- Snap a window, edit a Monitor/context rule to a different snapping layout, Save → the window resnaps to the new zones (OSD on that screen only).
- Change a tiling algorithm on an autotile screen → it retiles.
- An unrelated rule edit (appearance/exclude) resnaps nothing, no OSD.
- Switch desktop/activity, then edit an unrelated rule → no spurious resnap of the switched screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)