### PR TITLE
fix(drag): drop redundant per-drag KGlobalAccel Escape grab

### DIFF
--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-FileCopyrightText: 2026 arinl
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "../windowdragadaptor.h"
@@ -59,7 +60,6 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
         m_overlayService->hideSnapAssist();
     }
 
-    registerCancelOverlayShortcut();
     m_draggedWindowId = windowId;
     m_originalGeometry = QRect(qRound(x), qRound(y), qRound(width), qRound(height));
     m_currentZoneId.clear();
@@ -575,7 +575,8 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
             // Trigger released and re-pressed: clear cancel, resume zone snapping
             m_snapCancelled = false;
             m_triggerReleasedAfterCancel = false;
-            registerCancelOverlayShortcut();
+            // No re-grab: the effect's keyboard grab persists until dragStopped,
+            // so Escape is still caught after a cancel->retrigger. See dragStarted.
             // Fall through to normal processing
         } else {
             return; // Trigger still held from before Escape — stay cancelled

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-FileCopyrightText: 2026 arinl
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "../windowdragadaptor.h"
@@ -463,9 +464,14 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
     }
 
     // Reset drag state for next operation.
-    // If snap assist will be shown, keep the Escape shortcut registered so
-    // KGlobalAccel can still dismiss it (the snap assist window may not have
-    // Wayland keyboard focus yet when the user presses Escape).
+    // Snap assist runs after drag end, once the effect has ungrabbed the
+    // keyboard (at dragStopped), so it needs its own Escape grab to be
+    // dismissable. Register it only when assist will show and keep it across
+    // the reset for onSnapAssistDismissed to release. The drag itself relies on
+    // the effect grab instead (see drag.cpp::dragStarted).
+    if (snapAssistRequestedOut) {
+        registerCancelOverlayShortcut();
+    }
     resetDragState(/*keepEscapeShortcut=*/snapAssistRequestedOut);
 }
 


### PR DESCRIPTION
## Summary

The daemon binds an ad-hoc global Escape shortcut (`cancel_overlay_during_drag`) via `WindowDragAdaptor::registerCancelOverlayShortcut()` on every snap-drag activation and releases it on drop. That duplicates the kwin effect's own keyboard grab and costs a per-drag disk write that stutters dragging on drives with slow fsync latency.

## Root cause

`registerCancelOverlayShortcut()` runs each drag via `beginDrag` → `updateDragCursor` → `activateSnapDragIfNeeded` → `dragStarted`, and again on the `dragMoved` cancel→retrigger path. Each bind/unbind goes through KGlobalAccel, so `kglobalacceld` (in-process in `kwin_wayland`) rewrites `kglobalshortcutsrc` + `kglobalshortcutsstaterc` via `QSaveFile`, fsyncing ~4 times per pickup/drop on the compositor thread.

Escape-during-drag is already handled compositor-side: the effect grabs the keyboard for the whole snap-path drag (`PlasmaZonesEffect::grabbedKeyboardEvent`) and calls `SnapHandler::callCancelSnap` → the same `cancelSnap()`. Its comment notes the grab must run ahead of KWin's `MoveResizeFilter`, which a KGlobalAccel shortcut can't guarantee, so the effect grab is the authoritative path and the daemon grab is redundant. On a drive with ~25–85 ms QD1 flush latency this is a visible pickup/drop hitch, while continuous dragging (which writes nothing) stays smooth.

## Fix

Stop binding Escape in `dragStarted` and on the `dragMoved` retrigger path; the effect grab covers the whole drag and only releases at `dragStopped`. Register the grab only for the snap-assist phase in `drop.cpp`, which runs after drag end once the effect has ungrabbed the keyboard. Layout-picker registration is unchanged. `Registry::unbind` of an unbound id skips the backend and `KGlobalAccelBackend::flush()` is a no-op, so the drag-end unregister becomes zero-fsync.

## Behavior preserved

Escape-cancel mid-drag, Escape after cancel→retrigger, autotile→snap mid-drag transitions (the effect re-grabs the keyboard on the transition), and Escape-dismiss of snap assist and the layout picker. No stale system-wide Escape grab remains in `kglobalshortcutsrc`.

## Testing

`test_registry` passes and a `-DBUILD_TESTING=ON` build succeeds. Verified by hand on Plasma 6 Wayland: discrete drags are smooth and Escape-cancel and snap behavior are unchanged. I didn't add a unit test because `WindowDragAdaptor`'s drag/drop Escape lifecycle isn't currently unit-covered (it needs D-Bus + compositor mocks) and the shortcut-library behavior it relies on is already covered by `test_registry`. Happy to add a mocked test if you'd like.
