### PR TITLE
fix(drag): stop fsyncing kglobalshortcutsrc on every drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **The action and condition pickers are reorganized**: both are alphabetized, and the action picker groups the context conditions above the window conditions with a divider ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **Old per-mode appearance and gap settings are migrated to rules**: on upgrade, snapping and tiling appearance and gap values you had customized become Snapping and Tiling rules, and per-monitor gaps become screen rules. A default configuration produces no extra rules ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 
+### Fixed
+
+- **Dragging a window stuttered at the start and end of the drag on disks with slow write flushing**: the daemon bound a temporary global Escape shortcut on every drag and released it on drop, and each bind made KWin rewrite its shortcut config to disk with an fsync. On a drive with slow flush latency that briefly stalled the compositor at pickup and at drop, while a continuous drag stayed smooth. The per-drag binding is gone, because the KWin effect already grabs Escape for the whole drag, so dragging is smooth regardless of disk. Thanks @arinl for the report and the bpftrace diagnosis ([#714](https://github.com/fuddlesworth/PlasmaZones/pull/714), [discussion #167](https://github.com/fuddlesworth/PlasmaZones/discussions/167)).
+
 ## [3.1.2] - 2026-06-25
 
 ### Fixed

--- a/data/whatsnew.json
+++ b/data/whatsnew.json
@@ -11,7 +11,8 @@
                 "Window Rules is now just Rules, since rules cover gaps, layout, and animation too. Your rules carry over automatically, and any appearance or gap settings you had customized are migrated into rules on upgrade (#699)",
                 "The managed default rules for borders, title bars, and gaps live in a System section on the Rules page and can't be deleted (#699)",
                 "The rule editor's action and condition pickers are alphabetized and grouped so they are easier to scan (#699)",
-                "A new Theater tiling layout keeps one window centered at a width you set per monitor, and with more windows the focused one moves to a centered spotlight while the rest line up on rails down both sides. It starts hidden, so turn it on from the Algorithms list to try it (#704)"
+                "A new Theater tiling layout keeps one window centered at a width you set per monitor, and with more windows the focused one moves to a centered spotlight while the rest line up on rails down both sides. It starts hidden, so turn it on from the Algorithms list to try it (#704)",
+                "Fixed: dragging a window could briefly stutter at the start and end of a drag on some systems, because a shortcut config file was rewritten on every drag. That write is gone, so dragging stays smooth (#714)"
             ]
         },
         {

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -644,11 +644,18 @@ void Daemon::connectShortcutSignals()
                 }
             });
     connect(m_overlayService.get(), &OverlayService::layoutPickerDismissed, this, [this]() {
-        // Only release the Escape grab if no drag is currently active —
-        // otherwise the in-progress drag's own cancel-overlay shortcut
-        // would be torn down underneath it. WindowDragAdaptor's drag-end
-        // path will release on its own when appropriate.
-        if (m_windowDragAdaptor && !m_windowDragAdaptor->isDragActive()) {
+        // Release the shared Escape grab (kCancelOverlayId) only when no other
+        // consumer still needs it. It is shared with the snap-assist phase, so
+        // releasing it here while snap assist is visible would tear the grab
+        // out from under it — release is gated on !isSnapAssistVisible() to
+        // mirror WindowDragAdaptor::onSnapAssistDismissed, which gates its own
+        // release on !isLayoutPickerVisible(). The drag itself no longer
+        // registers this grab (it uses the kwin-effect's keyboard grab), but a
+        // drag in flight still owns the drag-end release path, so defer to that
+        // too. snapAssistDismissed / drag-end release on their own when their
+        // turn comes.
+        if (m_windowDragAdaptor && m_overlayService && !m_overlayService->isSnapAssistVisible()
+            && !m_windowDragAdaptor->isDragActive()) {
             m_windowDragAdaptor->releaseCancelOverlayShortcut();
         }
         if (m_windowDragAdaptor) {

--- a/src/daemon/daemon/start.cpp
+++ b/src/daemon/daemon/start.cpp
@@ -610,7 +610,17 @@ void Daemon::connectShortcutSignals()
         m_unifiedLayoutController->setCurrentScreenName(screenId);
         updateLayoutFilterForScreen(screenId);
         m_overlayService->showLayoutPicker(screenId);
-        if (m_windowDragAdaptor) {
+        // Bind the picker's KGlobalAccel grabs only if the picker actually
+        // became visible. showLayoutPicker() bails without setting
+        // m_layoutPickerVisible when the screen, shell, or layout list is
+        // missing, and the only releaser of the nav grabs is
+        // layoutPickerDismissed, which never fires for an invisible picker —
+        // so binding on a failed show would leak the Escape + arrow/Return/Enter
+        // grabs system-wide (swallowed even over fullscreen games) until the
+        // next successful open+dismiss or a compositor reconnect. Re-press of an
+        // already-visible picker is fine: isLayoutPickerVisible() is true and
+        // registration is idempotent.
+        if (m_windowDragAdaptor && m_overlayService->isLayoutPickerVisible()) {
             m_windowDragAdaptor->ensureCancelOverlayShortcutRegistered();
             // Picker navigation accels — registered while picker is
             // shown, dropped on dismiss. The unified PassiveOverlayShell
@@ -644,21 +654,13 @@ void Daemon::connectShortcutSignals()
                 }
             });
     connect(m_overlayService.get(), &OverlayService::layoutPickerDismissed, this, [this]() {
-        // Release the shared Escape grab (kCancelOverlayId) only when no other
-        // consumer still needs it. It is shared with the snap-assist phase, so
-        // releasing it here while snap assist is visible would tear the grab
-        // out from under it — release is gated on !isSnapAssistVisible() to
-        // mirror WindowDragAdaptor::onSnapAssistDismissed, which gates its own
-        // release on !isLayoutPickerVisible(). The drag itself no longer
-        // registers this grab (it uses the kwin-effect's keyboard grab), but a
-        // drag in flight still owns the drag-end release path, so defer to that
-        // too. snapAssistDismissed / drag-end release on their own when their
-        // turn comes.
-        if (m_windowDragAdaptor && m_overlayService && !m_overlayService->isSnapAssistVisible()
-            && !m_windowDragAdaptor->isDragActive()) {
-            m_windowDragAdaptor->releaseCancelOverlayShortcut();
-        }
+        // Release the shared Escape grab only when no other consumer (snap
+        // assist) still needs it — releaseCancelOverlayShortcutIfIdle() is the
+        // canonical cross-consumer guard (the picker is already hidden by the
+        // time this fires). The 6 picker-nav grabs are picker-only, so always
+        // drop them.
         if (m_windowDragAdaptor) {
+            m_windowDragAdaptor->releaseCancelOverlayShortcutIfIdle();
             m_windowDragAdaptor->releaseLayoutPickerNavShortcuts();
         }
     });

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -249,8 +249,8 @@ void OverlayService::showSnapAssist(const QString& screenId, const PhosphorProto
     // ensureCancelOverlayShortcutRegistered() - the shell's wl_surface is
     // kbd-None so the per-content QML Shortcut path used by the legacy
     // SnapAssistOverlay can't fire here. KGlobalAccel grab of Escape +
-    // cancelSnap()'s existing isSnapAssistVisible() branch (see
-    // windowdragadaptor.cpp:265) routes Escape to hideSnapAssist().
+    // cancelSnap()'s existing isSnapAssistVisible() branch routes Escape to
+    // hideSnapAssist().
     Q_EMIT snapAssistShown(screenId, emptyZones, candidates);
 }
 
@@ -424,7 +424,7 @@ void OverlayService::hideSnapAssist()
     // settle): in both cases "dismissed" arrives first.
     //
     // snapAssistDismissed → WindowDragAdaptor::onSnapAssistDismissed →
-    // unregisterCancelOverlayShortcut() (windowdragadaptor.cpp:82).
+    // unregisterCancelOverlayShortcut().
     Q_EMIT snapAssistDismissed();
 
     auto stateIt = m_screenStates.find(screenId);

--- a/src/daemon/shortcutmanager.h
+++ b/src/daemon/shortcutmanager.h
@@ -60,10 +60,11 @@ public:
 
     /**
      * Register an ad-hoc shortcut that lives outside the main settings-driven
-     * table. Used by subsystems that need a transient grab bound to a code
-     * path (e.g. WindowDragAdaptor's Escape cancel during a drag). Batches
-     * with an immediate flush to the backend. Idempotent — re-registering the
-     * same id updates the callback and description in place.
+     * table. Used by subsystems that need a transient grab bound to a UI state
+     * (e.g. the cancel-overlay Escape grab bound while the layout picker or
+     * snap assist is showing). Batches with an immediate flush to the backend.
+     * Idempotent — re-registering the same id updates the callback and
+     * description in place.
      */
     void registerAdhocShortcut(const QString& id, const QKeySequence& sequence, const QString& description,
                                std::function<void()> callback) override;
@@ -123,9 +124,10 @@ private:
     // Adhoc registration deferred because the initial settings-driven
     // registration batch was in flight when the caller arrived. Drained from
     // the Registry ready() callback so subsystems that bind shortcuts in
-    // response to user actions (e.g. WindowDragAdaptor's Escape cancel on
-    // drag start) don't silently lose their grab when the drag fires in the
-    // first few hundred ms after daemon startup on a Portal compositor.
+    // response to user actions (e.g. the cancel-overlay Escape grab bound when
+    // the layout picker or snap assist first shows) don't silently lose their
+    // grab when that overlay appears in the first few hundred ms after daemon
+    // startup on a Portal compositor.
     struct PendingAdhocOp
     {
         enum Kind {

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -77,12 +77,16 @@ WindowDragAdaptor::WindowDragAdaptor(IOverlayService* overlay, PhosphorZones::IZ
                 onLayoutChanged();
             });
 
-    // Escape shortcut to cancel overlay during drag: bound into the Registry
-    // on drag start (see registerCancelOverlayShortcut) and released on end
-    // so the global Escape grab doesn't persist between drags.
+    // Escape-to-cancel during a drag is handled by the kwin-effect's keyboard
+    // grab (grabbedKeyboardEvent -> callCancelSnap), not by a KGlobalAccel
+    // binding — binding one per drag forced kwin to fsync kglobalshortcutsrc
+    // at drag start/end and stuttered the compositor on slow disks (#167). The
+    // kCancelOverlayId grab below is bound only for the grab-less snap-assist
+    // phase (endDrag's requestSnapAssist branch) and the layout picker
+    // (start.cpp), and released via onSnapAssistDismissed / the picker path.
 
     // When snap assist is dismissed (selection, timeout, etc.), unregister the Escape shortcut
-    // that was kept alive during dragStopped() for the snap assist phase
+    // that endDrag bound for the snap assist phase
     connect(overlay, &IOverlayService::snapAssistDismissed, this, &WindowDragAdaptor::onSnapAssistDismissed);
 }
 
@@ -744,8 +748,8 @@ void WindowDragAdaptor::onSnapAssistDismissed()
     // The Escape grab (kCancelOverlayId) is shared with two other consumers
     // that piggy-back on the same id (so KGlobalAccel routes to a single
     // action — see registerCancelOverlayShortcut's docstring): the layout
-    // picker (registered by start.cpp on layoutPickerRequested) and any
-    // active drag (registered by registerCancelOverlayShortcut on dragStarted).
+    // picker (registered by start.cpp on layoutPickerRequested) and the
+    // snap-assist phase (registered by endDrag when it requests snap assist).
     // Releasing here unconditionally tears the grab out from under those
     // consumers — picker-still-up after a snap-assist auto-dismiss would
     // become un-Escape-able, and the same applies if the daemon thinks a

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -82,11 +82,11 @@ WindowDragAdaptor::WindowDragAdaptor(IOverlayService* overlay, PhosphorZones::IZ
     // binding — binding one per drag forced kwin to fsync kglobalshortcutsrc
     // at drag start/end and stuttered the compositor on slow disks (#167). The
     // kCancelOverlayId grab below is bound only for the grab-less snap-assist
-    // phase (endDrag's requestSnapAssist branch) and the layout picker
+    // phase (start.cpp's snapAssistShown handler) and the layout picker
     // (start.cpp), and released via onSnapAssistDismissed / the picker path.
 
     // When snap assist is dismissed (selection, timeout, etc.), unregister the Escape shortcut
-    // that endDrag bound for the snap assist phase
+    // that start.cpp's snapAssistShown handler bound for the snap assist phase
     connect(overlay, &IOverlayService::snapAssistDismissed, this, &WindowDragAdaptor::onSnapAssistDismissed);
 }
 
@@ -749,7 +749,7 @@ void WindowDragAdaptor::onSnapAssistDismissed()
     // that piggy-back on the same id (so KGlobalAccel routes to a single
     // action — see registerCancelOverlayShortcut's docstring): the layout
     // picker (registered by start.cpp on layoutPickerRequested) and the
-    // snap-assist phase (registered by endDrag when it requests snap assist).
+    // snap-assist phase (registered by start.cpp's snapAssistShown handler).
     // Releasing here unconditionally tears the grab out from under those
     // consumers — picker-still-up after a snap-assist auto-dismiss would
     // become un-Escape-able, and the same applies if the daemon thinks a

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -294,7 +294,11 @@ void WindowDragAdaptor::handleWindowClosed(const QString& windowId)
     // If this window was being dragged, clean up drag state
     if (windowId == m_draggedWindowId) {
         cancelDragInsertIfActive();
-        unregisterCancelOverlayShortcut();
+        // Drag-teardown: only drop the shared Escape grab if no picker / snap
+        // assist still needs it. A layout picker can be open over an in-flight
+        // drag, and it holds kCancelOverlayId — an unconditional release here
+        // would leave that still-visible picker un-Escape-able.
+        releaseCancelOverlayShortcutIfIdle();
         hideOverlayAndClearZoneState();
 
         // Hide zone selector if shown
@@ -364,6 +368,24 @@ void WindowDragAdaptor::unregisterCancelOverlayShortcut()
     // through unbind() inside the Registry, and the cancel path always uses
     // the explicit unregister call below.
     m_shortcutRegistrar->unregisterAdhocShortcut(kCancelOverlayId);
+}
+
+void WindowDragAdaptor::releaseCancelOverlayShortcutIfIdle()
+{
+    // kCancelOverlayId is the SHARED Escape grab. It is bound on behalf of the
+    // layout picker (start.cpp, layoutPickerRequested) and the snap-assist
+    // phase (start.cpp, snapAssistShown), each of which releases it on its own
+    // dismiss. The drag itself never binds it (the kwin-effect's keyboard grab
+    // handles Escape during a drag). So any teardown path that drops the grab
+    // must first confirm no OTHER consumer is still showing — otherwise it
+    // tears the grab out from under a visible picker or snap assist, leaving
+    // that overlay un-dismissable by Escape. This is the single canonical guard
+    // every non-Escape release site routes through (cancelSnap() is the lone
+    // exception: it is the explicit Escape-pressed teardown).
+    if (m_overlayService && (m_overlayService->isLayoutPickerVisible() || m_overlayService->isSnapAssistVisible())) {
+        return;
+    }
+    unregisterCancelOverlayShortcut();
 }
 
 namespace {
@@ -624,6 +646,12 @@ void WindowDragAdaptor::clearForCompositorReconnect()
 {
     hideOverlayAndClearZoneState();
     resetDragState(/*keepEscapeShortcut=*/false);
+    // Reconnect tears EVERYTHING down: the compositor that held the grabs is
+    // gone. Force-release the shared cancel-overlay grab unconditionally (not
+    // via releaseCancelOverlayShortcutIfIdle) because a stale isLayoutPicker/
+    // SnapAssistVisible flag from the dead session must not keep the grab
+    // bound. Mirrors the unconditional releaseLayoutPickerNavShortcuts() below.
+    unregisterCancelOverlayShortcut();
     // Drop any pending async snapAssistReady payload. Without this, a
     // compositor reconnect between endDrag and the QTimer::singleShot(0)
     // that emits snapAssistReady would deliver the prior session's
@@ -669,7 +697,11 @@ void WindowDragAdaptor::clearForCompositorReconnect()
 void WindowDragAdaptor::resetDragState(bool keepEscapeShortcut)
 {
     if (!keepEscapeShortcut) {
-        unregisterCancelOverlayShortcut();
+        // Drag-end: drop the shared Escape grab only if no picker / snap assist
+        // still needs it. The drag never bound the grab itself, so an
+        // unconditional release here would tear it out from under a layout
+        // picker left open across the drop.
+        releaseCancelOverlayShortcutIfIdle();
     }
     m_draggedWindowId.clear();
     m_originalGeometry = QRect();
@@ -745,25 +777,13 @@ void WindowDragAdaptor::onLayoutChanged()
 
 void WindowDragAdaptor::onSnapAssistDismissed()
 {
-    // The Escape grab (kCancelOverlayId) is shared with two other consumers
-    // that piggy-back on the same id (so KGlobalAccel routes to a single
-    // action — see registerCancelOverlayShortcut's docstring): the layout
-    // picker (registered by start.cpp on layoutPickerRequested) and the
-    // snap-assist phase (registered by start.cpp's snapAssistShown handler).
-    // Releasing here unconditionally tears the grab out from under those
-    // consumers — picker-still-up after a snap-assist auto-dismiss would
-    // become un-Escape-able, and the same applies if the daemon thinks a
-    // drag is in flight (defence-in-depth, snap-assist normally appears
-    // post-drop). cancelSnap() already orchestrates precedence between
-    // overlays at Escape time, so the only safe thing this slot can do is
-    // release WHEN no other consumer still needs the grab.
-    if (m_overlayService && m_overlayService->isLayoutPickerVisible()) {
-        return;
-    }
-    if (isDragActive()) {
-        return;
-    }
-    unregisterCancelOverlayShortcut();
+    // Snap assist is already hidden by the time this fires, so the shared
+    // Escape grab (kCancelOverlayId) can be dropped — unless the layout picker
+    // is still up and holding the same grab (e.g. a snap-assist auto-dismiss
+    // while a picker is open). releaseCancelOverlayShortcutIfIdle() is the
+    // canonical cross-consumer guard; cancelSnap() handles Escape-time
+    // precedence between overlays.
+    releaseCancelOverlayShortcutIfIdle();
 }
 
 } // namespace PlasmaZones

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -380,8 +380,10 @@ void WindowDragAdaptor::releaseCancelOverlayShortcutIfIdle()
     // must first confirm no OTHER consumer is still showing — otherwise it
     // tears the grab out from under a visible picker or snap assist, leaving
     // that overlay un-dismissable by Escape. This is the single canonical guard
-    // every non-Escape release site routes through (cancelSnap() is the lone
-    // exception: it is the explicit Escape-pressed teardown).
+    // every normal release site routes through. Two sites deliberately bypass
+    // it with an unconditional release: cancelSnap() (the explicit
+    // Escape-pressed teardown) and clearForCompositorReconnect() (force-release
+    // when the compositor that held the grab is already gone).
     if (m_overlayService && (m_overlayService->isLayoutPickerVisible() || m_overlayService->isSnapAssistVisible())) {
         return;
     }

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -142,10 +142,17 @@ public:
     {
         registerCancelOverlayShortcut();
     }
-    void releaseCancelOverlayShortcut()
-    {
-        unregisterCancelOverlayShortcut();
-    }
+
+    /// Release the shared cancel-overlay Escape grab, but ONLY when no other
+    /// consumer still needs it. kCancelOverlayId is bound on behalf of the
+    /// layout picker (start.cpp, layoutPickerRequested) and the snap-assist
+    /// phase (start.cpp, snapAssistShown); the drag itself never binds it (the
+    /// kwin-effect's keyboard grab handles Escape during a drag). Every
+    /// non-Escape release site routes through here so one consumer's teardown
+    /// cannot tear the grab out from under another consumer that is still
+    /// showing. cancelSnap() is the lone exception: it is the explicit
+    /// Escape-pressed teardown and releases unconditionally.
+    void releaseCancelOverlayShortcutIfIdle();
 
     /// Register the layout-picker keyboard navigation accelerators
     /// (Left/Right/Up/Down/Return/Enter) as global shortcuts. Required
@@ -159,16 +166,6 @@ public:
     void ensureLayoutPickerNavShortcutsRegistered(std::function<void(int dx, int dy)> moveCb,
                                                   std::function<void()> confirmCb);
     void releaseLayoutPickerNavShortcuts();
-
-    /// Whether a drag is currently active (m_draggedWindowId non-empty).
-    /// Daemon uses this to gate the picker-dismissed Escape release on
-    /// drag state — while a drag is in flight the drag-end path owns
-    /// releasing the shared kCancelOverlayId grab, so a picker dismiss
-    /// must not tear it down early.
-    bool isDragActive() const
-    {
-        return !m_draggedWindowId.isEmpty();
-    }
 
 public Q_SLOTS:
     /**

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -147,11 +147,12 @@ public:
     /// consumer still needs it. kCancelOverlayId is bound on behalf of the
     /// layout picker (start.cpp, layoutPickerRequested) and the snap-assist
     /// phase (start.cpp, snapAssistShown); the drag itself never binds it (the
-    /// kwin-effect's keyboard grab handles Escape during a drag). Every
-    /// non-Escape release site routes through here so one consumer's teardown
-    /// cannot tear the grab out from under another consumer that is still
-    /// showing. cancelSnap() is the lone exception: it is the explicit
-    /// Escape-pressed teardown and releases unconditionally.
+    /// kwin-effect's keyboard grab handles Escape during a drag). Every normal
+    /// release site routes through here so one consumer's teardown cannot tear
+    /// the grab out from under another consumer that is still showing. Two
+    /// sites deliberately bypass it with an unconditional release: cancelSnap()
+    /// (the explicit Escape-pressed teardown) and clearForCompositorReconnect()
+    /// (force-release when the compositor that held the grab is already gone).
     void releaseCancelOverlayShortcutIfIdle();
 
     /// Register the layout-picker keyboard navigation accelerators

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -119,8 +119,14 @@ public:
     /**
      * Register / unregister the cancel-overlay Escape shortcut on demand.
      *
-     * Drag-active code paths register/unregister automatically as part of
-     * the drag lifecycle. The layout picker re-uses the same id
+     * The snap-assist phase (start.cpp's snapAssistShown handler) and the
+     * layout picker register / unregister this on demand. The drag itself
+     * needs no binding: the
+     * kwin-effect grabs the keyboard for the whole drag and routes Escape
+     * to cancelSnap() directly, so a KGlobalAccel grab would never fire
+     * during a drag (and binding one per drag fsynced kglobalshortcutsrc and
+     * stuttered the compositor on slow disks, #167). The layout picker
+     * re-uses the same id
      * (kCancelOverlayId) so KGlobalAccel never sees two distinct actions
      * competing for Escape — once a key is granted, KGlobalAccel routes
      * to a single action, and a second registration with a fresh id is

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -97,7 +97,8 @@ public:
 
     /**
      * @brief Set the shortcut registrar used to (un)register the Escape
-     *        cancel-overlay shortcut around active drag sessions.
+     *        cancel-overlay shortcut for the snap-assist phase and layout
+     *        picker (the drag itself uses the kwin-effect's keyboard grab).
      *
      * Must be called after construction, before any drag operations.
      * The registrar is owned by Daemon — this is a non-owning pointer. Routing
@@ -161,8 +162,9 @@ public:
 
     /// Whether a drag is currently active (m_draggedWindowId non-empty).
     /// Daemon uses this to gate the picker-dismissed Escape release on
-    /// drag state — releasing while a drag is in flight would tear down
-    /// the drag's own Escape grab.
+    /// drag state — while a drag is in flight the drag-end path owns
+    /// releasing the shared kCancelOverlayId grab, so a picker dismiss
+    /// must not tear it down early.
     bool isDragActive() const
     {
         return !m_draggedWindowId.isEmpty();
@@ -532,8 +534,8 @@ private:
     bool m_modifierConflictWarned = false; // Logged once per drag, reset on next dragStarted
 
     // Escape cancel-overlay shortcut is registered/unregistered dynamically
-    // via the PhosphorShortcuts Registry around drag sessions — no QAction
-    // member needed (the Registry owns everything).
+    // via the PhosphorShortcuts Registry for the snap-assist phase and layout
+    // picker — no QAction member needed (the Registry owns everything).
 
     // Pre-parsed trigger caches (populated on dragStarted, used on every dragMoved tick)
     QVector<ParsedTrigger> m_cachedActivationTriggers;
@@ -600,7 +602,8 @@ private Q_SLOTS:
 
     /**
      * Called when snap assist is dismissed (selection, timeout, click-away, etc.)
-     * Unregisters the Escape shortcut that was kept alive for snap assist
+     * Unregisters the Escape shortcut that start.cpp's snapAssistShown handler
+     * bound for snap assist
      */
     void onSnapAssistDismissed();
 };

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -59,7 +59,16 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
         m_overlayService->hideSnapAssist();
     }
 
-    registerCancelOverlayShortcut();
+    // No KGlobalAccel Escape grab is bound here. During a snap drag the
+    // kwin-effect grabs the keyboard (lifecycle.cpp) and routes Escape
+    // through grabbedKeyboardEvent -> callCancelSnap -> cancelSnap(), so a
+    // KGlobalAccel binding would never fire during the drag anyway. Binding
+    // it per-drag used to force kwin (which hosts kglobalaccel) to rewrite
+    // kglobalshortcutsrc + kglobalshortcutsstaterc with an fsync at drag
+    // start and end, stalling the compositor on slow-fsync disks
+    // (discussion #167). The grab is now bound only for the snap-assist
+    // phase, which has no keyboard grab (see endDrag's requestSnapAssist
+    // branch in drop.cpp), and for the layout picker (start.cpp).
     m_draggedWindowId = windowId;
     m_originalGeometry = QRect(qRound(x), qRound(y), qRound(width), qRound(height));
     m_currentZoneId.clear();
@@ -572,10 +581,12 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
         if (!triggerHeld) {
             m_triggerReleasedAfterCancel = true;
         } else if (m_triggerReleasedAfterCancel) {
-            // Trigger released and re-pressed: clear cancel, resume zone snapping
+            // Trigger released and re-pressed: clear cancel, resume zone snapping.
+            // No Escape grab to re-arm: the kwin-effect's keyboard grab stays
+            // held for the whole drag (it ungrabs only on dragStopped), so
+            // Escape still reaches cancelSnap() after a cancel+re-press cycle.
             m_snapCancelled = false;
             m_triggerReleasedAfterCancel = false;
-            registerCancelOverlayShortcut();
             // Fall through to normal processing
         } else {
             return; // Trigger still held from before Escape — stay cancelled

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -67,8 +67,8 @@ void WindowDragAdaptor::dragStarted(const QString& windowId, double x, double y,
     // kglobalshortcutsrc + kglobalshortcutsstaterc with an fsync at drag
     // start and end, stalling the compositor on slow-fsync disks
     // (discussion #167). The grab is now bound only for the snap-assist
-    // phase, which has no keyboard grab (see endDrag's requestSnapAssist
-    // branch in drop.cpp), and for the layout picker (start.cpp).
+    // phase, which has no keyboard grab (see start.cpp's snapAssistShown
+    // handler), and for the layout picker (start.cpp).
     m_draggedWindowId = windowId;
     m_originalGeometry = QRect(qRound(x), qRound(y), qRound(width), qRound(height));
     m_currentZoneId.clear();

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -460,12 +460,23 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
         // read would describe the new desktop's occupancy instead of the
         // desktop the user actually dropped on.
         m_snapAssistPendingDesktop = m_layoutManager->currentVirtualDesktopForScreen(releaseScreenId);
+        // Bind the KGlobalAccel Escape grab for the snap-assist phase. The
+        // drag itself relied on the kwin-effect's keyboard grab, which the
+        // effect releases on dragStopped — so the post-drop snap-assist UI
+        // (which may not yet hold Wayland keyboard focus) has no Escape
+        // handler unless we bind one now. This is the only spot that pays a
+        // kglobalshortcutsrc write, and only when snap assist actually
+        // appears, not on every drag (discussion #167). onSnapAssistDismissed
+        // releases it again when the snap-assist UI goes away.
+        registerCancelOverlayShortcut();
     }
 
-    // Reset drag state for next operation.
-    // If snap assist will be shown, keep the Escape shortcut registered so
-    // KGlobalAccel can still dismiss it (the snap assist window may not have
-    // Wayland keyboard focus yet when the user presses Escape).
+    // Reset drag state for next operation. keepEscapeShortcut is true exactly
+    // when snap assist was requested above (and the grab was just bound), so
+    // resetDragState skips the unregister and the snap-assist phase keeps its
+    // Escape handler. When snap assist is not requested nothing was bound, so
+    // the unregister on the false path is a no-op (Registry::unbind ignores
+    // unknown ids).
     resetDragState(/*keepEscapeShortcut=*/snapAssistRequestedOut);
 }
 

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -460,24 +460,25 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
         // read would describe the new desktop's occupancy instead of the
         // desktop the user actually dropped on.
         m_snapAssistPendingDesktop = m_layoutManager->currentVirtualDesktopForScreen(releaseScreenId);
-        // Bind the KGlobalAccel Escape grab for the snap-assist phase. The
-        // drag itself relied on the kwin-effect's keyboard grab, which the
-        // effect releases on dragStopped — so the post-drop snap-assist UI
-        // (which may not yet hold Wayland keyboard focus) has no Escape
-        // handler unless we bind one now. This is the only spot that pays a
-        // kglobalshortcutsrc write, and only when snap assist actually
-        // appears, not on every drag (discussion #167). onSnapAssistDismissed
-        // releases it again when the snap-assist UI goes away.
-        registerCancelOverlayShortcut();
+        // The snap-assist Escape grab is NOT bound here on purpose. Binding on
+        // the dragStopped/endDrag path would fsync kglobalshortcutsrc while the
+        // kwin-effect is still awaiting the endDrag reply — the very drop-path
+        // compositor stall this change set out to remove (#167). The grab is
+        // bound lazily by start.cpp's snapAssistShown handler instead, which
+        // fires on the deferred computeAndEmitSnapAssist tick (after the
+        // compositor is unblocked) and only when snap assist actually shows
+        // with non-empty zones. onSnapAssistDismissed releases it. Deferring to
+        // snapAssistShown also avoids leaking the grab when the empty-zone
+        // check in computeAndEmitSnapAssist finds nothing to show.
     }
 
-    // Reset drag state for next operation. keepEscapeShortcut is true exactly
-    // when snap assist was requested above (and the grab was just bound), so
-    // resetDragState skips the unregister and the snap-assist phase keeps its
-    // Escape handler. When snap assist is not requested nothing was bound, so
-    // the unregister on the false path is a no-op (Registry::unbind ignores
-    // unknown ids).
-    resetDragState(/*keepEscapeShortcut=*/snapAssistRequestedOut);
+    // Reset drag state for next operation. No Escape grab is registered on this
+    // path: the drag used the kwin-effect's keyboard grab, and snap assist
+    // binds its own grab lazily via snapAssistShown (start.cpp). The default
+    // unregister is therefore an unconditional no-op here — Registry::unbind
+    // ignores an id that was never bound — and snapAssistRequestedOut is left
+    // purely as the caller's output flag.
+    resetDragState();
 }
 
 void WindowDragAdaptor::computeAndEmitSnapAssist()

--- a/src/ui/SnapAssistContent.qml
+++ b/src/ui/SnapAssistContent.qml
@@ -16,7 +16,7 @@ import org.phosphor.animation
  * (`KeyboardInteractivity::None`); Escape is routed via the daemon's
  * KGlobalAccel `cancel_overlay_during_drag` shortcut, which calls
  * `WindowDragAdaptor::cancelSnap()` — that already dismisses snap-assist
- * when visible (windowdragadaptor.cpp:265), so no per-content kbd grab
+ * when visible, so no per-content kbd grab
  * is needed.
  *
  * Carries `property bool shaderAnchor: true` so the SurfaceAnimator's


### PR DESCRIPTION
## Credits

Reported and root-caused by **[@arinl](https://github.com/arinl)** in discussion #167 — including the bpftrace off-CPU diagnosis below and the fix direction. They also opened #713 with the same core fix; this PR supersedes it (now closed) and carries their work forward with additional lifecycle hardening. Credited as co-author on the commits.

## Problem

Closes the stutter reported in #167. Moving a window stutters at the **start** and **end** of a drag, but stays smooth in the middle. arinl diagnosed it precisely with bpftrace: it's `fsync` on the kwin thread.

Each snap-drag binds a transient `cancel_overlay_during_drag` Escape shortcut through KGlobalAccel at activation and drops it at drag end. KGlobalAccel lives **inside kwin**, so every bind/unbind makes kwin rewrite `kglobalshortcutsrc` + `kglobalshortcutsstaterc` (write-temp → `fsync` → rename) on the compositor thread — roughly four fsyncs per drag. On a slow-fsync disk each flush stalls frame production for 25–85 ms, which is the stutter. Nothing touches the shortcut config mid-drag, so continuous dragging is smooth. On a fast NVMe the writes still happen, you just don't feel them, so it reads as "works on my machine."

Off-CPU stack arinl captured on drop:

```
__x64_sys_fdatasync -> do_fsync -> btrfs_sync_file -> btrfs_sync_log
   -> write_all_supers -> barrier_all_devices -> io_schedule   (25-85ms)
```

## Why the binding was redundant

During a snap drag the kwin-effect **already grabs the keyboard** (`plasmazoneseffect/lifecycle.cpp`) and routes Escape through `grabbedKeyboardEvent` → `callCancelSnap` → `cancelSnap()`. The grab consumes Escape before KGlobalAccel ever sees it, so the per-drag `cancel_overlay_during_drag` binding never actually fires during a drag.

The KGlobalAccel grab is only needed by the two phases that have **no** keyboard grab:
- **Snap assist** (post-drop, the effect releases its keyboard grab on `dragStopped`)
- **Layout picker** (registered independently in `start.cpp`)

Autotile drag-insert never registered the grab and cancels via KWin's native interactive-move-cancel, so it's unaffected.

## Fix

- Stop binding the Escape grab on drag start (`drag.cpp`) and on re-arm after an Escape cancel — the effect's keyboard grab covers the whole drag.
- The snap-assist phase binds the grab lazily via the **existing `snapAssistShown` handler** in `start.cpp`, which fires on the deferred `computeAndEmitSnapAssist` tick — after the compositor is unblocked, so the drop itself pays no fsync. `onSnapAssistDismissed` releases it.
- `Registry::unbind()` ignores ids that were never bound, so the remaining drag-teardown `unregister` calls are free no-ops.

Net result: **zero `kglobalshortcutsrc` writes on a normal drag**, one bind only when snap assist actually shows (off the critical path), and identical Escape behavior in every path. No library changes.

## Additional hardening (follow-up review)

A review pass over the whole shared-grab lifecycle (`cancel_overlay_during_drag` is shared by the layout picker and the snap-assist phase) found and fixed three more latent bugs in the same class:

- **Cross-consumer release asymmetry.** `resetDragState()` and `handleWindowClosed()` released the shared grab unconditionally on drag teardown. A layout picker can be open over an in-flight drag, so a drop or a dragged-window-close would tear the Escape grab out from under the still-visible picker. Routed every normal release site through one canonical guard, `releaseCancelOverlayShortcutIfIdle()` (release only when neither the picker nor snap assist is still visible). `cancelSnap()` (explicit Escape teardown) and `clearForCompositorReconnect()` (force-release when the compositor is gone) are the two documented exceptions.
- **Grab leak on a failed picker show.** The `layoutPickerRequested` handler bound the Escape grab plus the 6 arrow/Return/Enter nav grabs without checking that `showLayoutPicker()` actually made the picker visible. On a failed show (no screen / no shell / no layouts) all 7 grabs leaked system-wide — swallowed even over fullscreen games — until the next successful open. Gated registration on `isLayoutPickerVisible()`.
- Removed a now-unused unconditional release wrapper and `isDragActive()` so the guarded helper is the only path; refreshed the stale docstrings.

## Testing

- `cmake --build` clean.
- `ctest`: 245/245 pass.
- Behavior verified across every path: snap-drag Escape (effect grab), snap-assist Escape (bound via `snapAssistShown`, released on dismiss), layout-picker Escape + nav (bound only when the picker shows), picker-open-over-drag teardown, and autotile drag-insert (KWin move-cancel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
