### PR TITLE
fix(settings): tiling algorithm preview custom params + persist algorithm selection

### DIFF
--- a/libs/phosphor-tiles/src/autotilelayoutsource.cpp
+++ b/libs/phosphor-tiles/src/autotilelayoutsource.cpp
@@ -117,6 +117,11 @@ PhosphorLayout::LayoutPreview previewFromAlgorithm(const QString& algorithmId,
     if (registry) {
         const auto& params = registry->previewParams();
         const bool isActive = !params.algorithmId.isEmpty() && registry->algorithm(params.algorithmId) == algorithm;
+        // The per-algorithm saved entry feeds both the inactive-algorithm
+        // master/split fallback and the custom-param resolution below, so look
+        // it up once here.
+        const auto savedIt = params.savedAlgorithmSettings.constFind(algorithmId);
+        const bool hasSaved = savedIt != params.savedAlgorithmSettings.constEnd();
         if (isActive) {
             if (params.masterCount > 0) {
                 masterCount = params.masterCount;
@@ -127,18 +132,15 @@ PhosphorLayout::LayoutPreview previewFromAlgorithm(const QString& algorithmId,
             if (effectiveCount <= 0 && params.maxWindows > 0) {
                 effectiveCount = params.maxWindows;
             }
-        } else {
-            auto it = params.savedAlgorithmSettings.constFind(algorithmId);
-            if (it != params.savedAlgorithmSettings.constEnd()) {
-                const QVariantMap& saved = it.value();
-                const int savedMaster = saved.value(PhosphorTiles::AutotileJsonKeys::MasterCount, -1).toInt();
-                const qreal savedRatio = saved.value(PhosphorTiles::AutotileJsonKeys::SplitRatio, -1.0).toDouble();
-                if (savedMaster > 0) {
-                    masterCount = savedMaster;
-                }
-                if (savedRatio > 0.0) {
-                    splitRatio = savedRatio;
-                }
+        } else if (hasSaved) {
+            const QVariantMap& saved = savedIt.value();
+            const int savedMaster = saved.value(PhosphorTiles::AutotileJsonKeys::MasterCount, -1).toInt();
+            const qreal savedRatio = saved.value(PhosphorTiles::AutotileJsonKeys::SplitRatio, -1.0).toDouble();
+            if (savedMaster > 0) {
+                masterCount = savedMaster;
+            }
+            if (savedRatio > 0.0) {
+                splitRatio = savedRatio;
             }
         }
         // Custom params live in the per-algorithm saved entry regardless of
@@ -146,8 +148,7 @@ PhosphorLayout::LayoutPreview previewFromAlgorithm(const QString& algorithmId,
         // active/saved split above. Filter to the algorithm's currently
         // declared params (mirrors AutotileEngine::recalculateLayout) so a stale
         // value from an edited script can't reach calculateZones.
-        const auto savedIt = params.savedAlgorithmSettings.constFind(algorithmId);
-        if (savedIt != params.savedAlgorithmSettings.constEnd() && algorithm->supportsCustomParams()) {
+        if (hasSaved && algorithm->supportsCustomParams()) {
             const QVariantMap declared = savedIt.value().value(PhosphorTiles::AutotileJsonKeys::CustomParams).toMap();
             for (auto pit = declared.constBegin(); pit != declared.constEnd(); ++pit) {
                 if (algorithm->hasCustomParam(pit.key())) {

--- a/libs/phosphor-tiles/src/autotilelayoutsource.cpp
+++ b/libs/phosphor-tiles/src/autotilelayoutsource.cpp
@@ -108,6 +108,12 @@ PhosphorLayout::LayoutPreview previewFromAlgorithm(const QString& algorithmId,
     int masterCount = PhosphorTiles::AutotileDefaults::DefaultMasterCount;
     qreal splitRatio = algorithm->defaultSplitRatio();
     int effectiveCount = windowCount;
+    // Per-algorithm custom-param values for the preview. Sourced below from the
+    // saved per-algorithm entry (which the engine serialises for EVERY
+    // algorithm, active or not), then handed to calculateZones — without this
+    // the thumbnail/list previews ignored custom parameters entirely while the
+    // live tiler honoured them.
+    QVariantMap customParams;
     if (registry) {
         const auto& params = registry->previewParams();
         const bool isActive = !params.algorithmId.isEmpty() && registry->algorithm(params.algorithmId) == algorithm;
@@ -135,6 +141,20 @@ PhosphorLayout::LayoutPreview previewFromAlgorithm(const QString& algorithmId,
                 }
             }
         }
+        // Custom params live in the per-algorithm saved entry regardless of
+        // whether this is the active algorithm, so resolve them outside the
+        // active/saved split above. Filter to the algorithm's currently
+        // declared params (mirrors AutotileEngine::recalculateLayout) so a stale
+        // value from an edited script can't reach calculateZones.
+        const auto savedIt = params.savedAlgorithmSettings.constFind(algorithmId);
+        if (savedIt != params.savedAlgorithmSettings.constEnd() && algorithm->supportsCustomParams()) {
+            const QVariantMap declared = savedIt.value().value(PhosphorTiles::AutotileJsonKeys::CustomParams).toMap();
+            for (auto pit = declared.constBegin(); pit != declared.constEnd(); ++pit) {
+                if (algorithm->hasCustomParam(pit.key())) {
+                    customParams.insert(pit.key(), pit.value());
+                }
+            }
+        }
     }
     if (effectiveCount <= 0) {
         effectiveCount = algorithm->defaultMaxWindows();
@@ -144,6 +164,7 @@ PhosphorLayout::LayoutPreview previewFromAlgorithm(const QString& algorithmId,
     previewState.setMasterCount(masterCount);
     previewState.setSplitRatio(splitRatio);
     PhosphorTiles::TilingParams params = PhosphorTiles::TilingParams::forPreview(effectiveCount, canvas, &previewState);
+    params.customParams = customParams;
 
     const QVector<QRect> rects = algorithm->calculateZones(params);
 

--- a/src/settings/qml/TilingAlgorithmPage.qml
+++ b/src/settings/qml/TilingAlgorithmPage.qml
@@ -17,22 +17,26 @@ SettingsFlickable {
     // Q_PROPERTY and a same-named Q_INVOKABLE, so the `()` form errors with
     // "is not a function"). Refreshed via the Connections below on its NOTIFY.
     property var _cachedAlgos: settingsController.availableAlgorithms || []
-    readonly property string effectiveAlgorithm: settingValue("Algorithm", appSettings.defaultAutotileAlgorithm)
-    // Derive algorithm ID from the combo's current selection (tracks UI immediately,
-    // not delayed by D-Bus round-trip to daemon)
-    readonly property string selectedAlgorithm: {
-        if (!algorithmCombo)
-            return root.effectiveAlgorithm;
+    // The ISettings object (the `appSettings` context property), captured at page
+    // scope. LayoutComboBox declares its own `appSettings: settingsController`,
+    // which SHADOWS the context property inside the combo's onActivated — writing
+    // `appSettings.defaultAutotileAlgorithm` there hit a nonexistent property on
+    // the controller and silently dropped every algorithm change. Read/write the
+    // algorithm through this reference so it always targets ISettings.
+    readonly property var appSettingsObj: appSettings
+    readonly property string effectiveAlgorithm: settingValue("Algorithm", appSettingsObj.defaultAutotileAlgorithm)
+    // Working algorithm for the whole page (preview, custom-param controls,
+    // capability lookups). Driven imperatively rather than bound to
+    // algorithmCombo.currentValue: that value transiently resets to the first
+    // list entry (BSP) whenever the combo rebuilds its model — e.g. the layout
+    // reload that follows a Save — which used to drag the entire page onto BSP.
+    // It is set the instant the user picks an algorithm (the combo's
+    // onActivated, below) so switching is immediate, and re-synced to the
+    // persisted setting on load / external edits / per-screen scope changes via
+    // onEffectiveAlgorithmChanged.
+    property string selectedAlgorithm: root.effectiveAlgorithm
 
-        let val = algorithmCombo.currentValue;
-        if (!val || val === "")
-            return root.effectiveAlgorithm;
-
-        if (val.startsWith("autotile:"))
-            return val.substring(9);
-
-        return val;
-    }
+    onEffectiveAlgorithmChanged: root.selectedAlgorithm = root.effectiveAlgorithm
     // Data-driven algorithm capabilities (lookup from cached availableAlgorithms by ID)
     readonly property var algoCapabilities: {
         const algos = root._cachedAlgos;
@@ -262,17 +266,18 @@ SettingsFlickable {
                             // Extract algorithm ID from autotile: prefixed value
                             let selectedId = algorithmCombo.currentValue;
                             if (selectedId === "")
-                                selectedId = appSettings.defaultAutotileAlgorithm;
+                                selectedId = root.appSettingsObj.defaultAutotileAlgorithm;
                             else if (selectedId.startsWith("autotile:"))
                                 selectedId = selectedId.substring(9);
-                            // Just change the algorithm. Max windows / split ratio /
-                            // master count are per-algorithm now: selectedAlgorithm
-                            // updates from the combo, re-seeding liveAlgoSettings from
-                            // the new algorithm's saved tuning, and the daemon performs
-                            // the same save/restore on its side. Resetting global
-                            // values here would clobber a sibling algorithm's slot.
+                            // Drive the page off the user's pick immediately, then
+                            // persist. Both go through root.appSettingsObj — NOT the
+                            // bare `appSettings`, which the combo shadows with the
+                            // controller in this scope (see appSettingsObj above).
+                            // Resetting global max-windows / split-ratio / master-count
+                            // here would clobber a sibling algorithm's per-algorithm slot.
+                            root.selectedAlgorithm = selectedId;
                             root.writeSetting("Algorithm", selectedId, function (v) {
-                                appSettings.defaultAutotileAlgorithm = v;
+                                root.appSettingsObj.defaultAutotileAlgorithm = v;
                             });
                         }
                     }

--- a/tests/unit/autotile/test_algorithm_registry_custom.cpp
+++ b/tests/unit/autotile/test_algorithm_registry_custom.cpp
@@ -5,9 +5,12 @@
 #include <QSignalSpy>
 
 #include <PhosphorTiles/AlgorithmRegistry.h>
+#include <PhosphorTiles/AutotilePreviewRender.h>
 #include <PhosphorTiles/TilingAlgorithm.h>
 #include <PhosphorTiles/TilingState.h>
 #include "core/constants.h"
+
+#include <QVariantMap>
 
 #include "../helpers/ScriptedAlgoTestSetup.h"
 #include "../helpers/TilingTestHelpers.h"
@@ -51,6 +54,39 @@ public:
 
 private:
     QString m_name;
+};
+
+/**
+ * @brief Test algorithm whose single zone's width tracks a "widthRatio" custom
+ *        param, so a preview that ignores custom params is observably wrong.
+ */
+class CustomParamTestAlgorithm : public PhosphorTiles::TilingAlgorithm
+{
+    Q_OBJECT
+public:
+    QString name() const noexcept override
+    {
+        return QStringLiteral("Custom Param Test");
+    }
+    QString description() const override
+    {
+        return QStringLiteral("Width tracks the widthRatio custom param");
+    }
+    bool supportsCustomParams() const noexcept override
+    {
+        return true;
+    }
+    bool hasCustomParam(const QString& paramName) const override
+    {
+        return paramName == QLatin1String("widthRatio");
+    }
+    QVector<QRect> calculateZones(const PhosphorTiles::TilingParams& params) const override
+    {
+        const QRect& screen = params.screenGeometry;
+        const double widthRatio = params.customParams.value(QStringLiteral("widthRatio"), 0.5).toDouble();
+        const int w = static_cast<int>(screen.width() * widthRatio);
+        return {QRect(screen.x(), screen.y(), w, screen.height())};
+    }
 };
 
 /**
@@ -345,6 +381,49 @@ private Q_SLOTS:
                 QVERIFY(zone.height() > 0);
             }
         }
+    }
+
+    // =========================================================================
+    // Preview honours per-algorithm custom params
+    // =========================================================================
+
+    // previewFromAlgorithm() must feed the algorithm's saved custom params into
+    // calculateZones(), so a thumbnail / list preview reflects the user's
+    // configured parameters exactly as the live tiler does. Regression guard for
+    // the bug where the preview path read masterCount/splitRatio from the
+    // preview params but dropped customParams entirely.
+    void testPreview_appliesSavedCustomParams()
+    {
+        auto* registry = m_scriptSetup.registry();
+        const QString id = QStringLiteral("test-customparam");
+        registry->registerAlgorithm(id, new CustomParamTestAlgorithm());
+        auto* algo = registry->algorithm(id);
+        QVERIFY(algo != nullptr);
+        QVERIFY(algo->supportsCustomParams());
+
+        const auto relativeWidthForRatio = [&](double widthRatio) -> qreal {
+            PhosphorTiles::AlgorithmPreviewParams pp;
+            pp.algorithmId = id; // active-algorithm branch
+            QVariantMap custom;
+            custom.insert(QStringLiteral("widthRatio"), widthRatio);
+            QVariantMap entry;
+            entry.insert(QStringLiteral("customParams"), custom);
+            pp.savedAlgorithmSettings.insert(id, entry);
+            registry->setPreviewParams(pp);
+
+            const PhosphorLayout::LayoutPreview preview =
+                PhosphorTiles::previewFromAlgorithm(id, algo, 1, registry, QSize());
+            return preview.zones.isEmpty() ? -1.0 : preview.zones.first().width();
+        };
+
+        const qreal narrow = relativeWidthForRatio(0.25);
+        const qreal wide = relativeWidthForRatio(0.75);
+
+        QVERIFY2(qAbs(narrow - 0.25) < 0.05, "preview zone width should track widthRatio=0.25");
+        QVERIFY2(qAbs(wide - 0.75) < 0.05, "preview zone width should track widthRatio=0.75");
+
+        registry->setPreviewParams(PhosphorTiles::AlgorithmPreviewParams{});
+        registry->unregisterAlgorithm(id);
     }
 };
 

--- a/tests/unit/autotile/test_algorithm_registry_custom.cpp
+++ b/tests/unit/autotile/test_algorithm_registry_custom.cpp
@@ -111,9 +111,16 @@ private Q_SLOTS:
         // Clean up any test algorithms that might still be registered
         auto* registry = m_scriptSetup.registry();
         const QStringList testIds = {
-            QStringLiteral("test-replace"),  QStringLiteral("test-signal"),     QStringLiteral("test-double-1"),
-            QStringLiteral("test-double-2"), QStringLiteral("test-unregister"), QStringLiteral("test-order-remove"),
-            QStringLiteral("test-null"),     QStringLiteral("test-clearid"),    QStringLiteral("test-replace-clearid"),
+            QStringLiteral("test-replace"),
+            QStringLiteral("test-signal"),
+            QStringLiteral("test-double-1"),
+            QStringLiteral("test-double-2"),
+            QStringLiteral("test-unregister"),
+            QStringLiteral("test-order-remove"),
+            QStringLiteral("test-null"),
+            QStringLiteral("test-clearid"),
+            QStringLiteral("test-replace-clearid"),
+            QStringLiteral("test-customparam"),
         };
         for (const auto& id : testIds) {
             if (registry->hasAlgorithm(id)) {


### PR DESCRIPTION
## Summary
Fixes three runtime bugs in the per-algorithm tiling settings page (scripted/Luau algorithms with custom params, e.g. Theater).

### 1. Thumbnail/list previews ignored custom parameters
The slider-driven `AlgorithmPreview` already passed `customParams` through `generateAlgorithmPreview`, but `previewFromAlgorithm` (combo-dropdown thumbnails and the layout list) read `masterCount`/`splitRatio`/`maxWindows` from the preview params and **dropped `customParams`** — so a scripted algorithm's previews rendered with defaults while the live tiler honoured the saved values. It now resolves each algorithm's saved `customParams` (filtered to currently-declared params, mirroring `AutotileEngine::recalculateLayout`) and feeds them into `calculateZones`.

### 2. Selecting an algorithm never persisted; dropdown reverted to BSP on Save
`LayoutComboBox` declares its own `appSettings: settingsController`, which **shadows** the context-property `appSettings` (the `ISettings` object) inside the combo's `onActivated`. So `appSettings.defaultAutotileAlgorithm = v` wrote a nonexistent property on the *controller* and the real setting never changed. The combo faithfully showed the (unchanged) persisted algorithm after any model rebuild, which surfaced as "reverts to Binary Split" once a Save-triggered layout reload re-synced it. Fix: capture the `ISettings` object at page scope (`appSettingsObj`) and read/write the algorithm through it.

### 3. Page content snapped to BSP transiently
`selectedAlgorithm` was derived from the combo's live `currentValue`, which resets during model rebuilds (the trace showed a `modelLen=0` transient). Drive `selectedAlgorithm` imperatively from `onActivated` (immediate on a pick) and re-sync from the persisted setting via `onEffectiveAlgorithmChanged`, so it no longer tracks the combo's transient value.

## Diagnosis note
Root-caused with runtime QML logging: `onActivated` reported `defaultBefore= undefined` (proving the shadowed `appSettings`) and `updateSelection` always matched `currentLayoutId` correctly (so the combo was never the problem — the setting simply never changed). The logging and an interim `Qt.callLater` symptom-fix were removed before finalizing.

## Tests
Adds `testPreview_appliesSavedCustomParams` proving `previewFromAlgorithm` feeds saved custom params into `calculateZones` (fails without the fix). Autotile/settings suites green.

## Verified
Picking an algorithm updates the page immediately and the dropdown stays put; the selection persists across Save and reopening Settings; scripted-algorithm previews reflect saved custom params.

## Out of scope
A separate, deferred issue (Theater `widthRatio` not live-updating real windows because a per-screen resized `singleW` in `ctx.state` overrides it) is **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)