### PR TITLE
fix(autotile): preserve floating window size when dragged on autotile screens

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1010,6 +1010,15 @@ private:
     // the geometry restore for a drag-floated window.
     QSet<QString> m_dragFloatedWindowIds;
 
+    // Whether the window being dragged was ALREADY floating when the drag
+    // began. Captured once in the DragTracker::dragStarted handler before any
+    // float transition runs. The drag-stop ApplyFloat path consults it: a
+    // window that was already floating is just being moved, so its current
+    // (user-chosen) size must be preserved — re-applying the stale
+    // pre-autotile size would clobber any resize the user made while floating.
+    // Only the tiled→float transition wants the pre-autotile size restore.
+    bool m_dragStartedFloating = false;
+
     // Per-rule-cache invalidations accumulated within one event-loop turn,
     // flushed once by flushPendingRuleInvalidations(). Coalesces the double
     // invalidation a float toggle triggers (windowFloatingChanged + windowStateChanged).

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1011,12 +1011,15 @@ private:
     QSet<QString> m_dragFloatedWindowIds;
 
     // Whether the window being dragged was ALREADY floating when the drag
-    // began. Captured once in the DragTracker::dragStarted handler before any
-    // float transition runs. The drag-stop ApplyFloat path consults it: a
-    // window that was already floating is just being moved, so its current
-    // (user-chosen) size must be preserved — re-applying the stale
-    // pre-autotile size would clobber any resize the user made while floating.
-    // Only the tiled→float transition wants the pre-autotile size restore.
+    // began. Written in the DragTracker::dragStarted handler before any float
+    // transition runs, then snapshotted into a local at callEndDrag dispatch
+    // (the async endDrag reply may land after the next dragStarted has already
+    // overwritten this member, so the reply lambda must not read it directly).
+    // The drag-stop ApplyFloat path consults that snapshot: a window that was
+    // already floating is just being moved, so its current (user-chosen) size
+    // must be preserved. Re-applying the stale pre-autotile size would clobber
+    // any resize the user made while floating. Only the tiled→float transition
+    // wants the pre-autotile size restore.
     bool m_dragStartedFloating = false;
 
     // Per-rule-cache invalidations accumulated within one event-loop turn,

--- a/kwin-effect/plasmazoneseffect/drag_end.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_end.cpp
@@ -47,6 +47,15 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
     // shape was a 9-tuple of out-params) with a typed struct.
     QPointF cursorAtRelease = m_dragTracker->lastCursorPos();
 
+    // Snapshot the drag-start floating state NOW, synchronously at dispatch.
+    // The ApplyFloat branch in the async reply lambda below consults it, but
+    // the member is overwritten by the next DragTracker::dragStarted — if a
+    // successive drag starts before this endDrag reply lands (the daemon may
+    // take up to EndDragTimeoutMs), reading the member there would see the
+    // wrong drag's state. Capturing a local is the same staleness guard the
+    // beginDrag reply gets from m_dragGeneration.
+    const bool startedFloating = m_dragStartedFloating;
+
     // qRound the cursor coords (not truncation): the hot-path updateDragCursor
     // stream rounds, so on fractional-scale outputs the release coordinate the
     // daemon resolves the drop zone against must round too, or it can differ by
@@ -82,7 +91,7 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
     timeoutTimer->start(EndDragTimeoutMs);
 
     connect(watcher, &QDBusPendingCallWatcher::finished, this,
-            [this, safeWindow, windowId, handled, timeoutTimer](QDBusPendingCallWatcher* w) {
+            [this, safeWindow, windowId, handled, timeoutTimer, startedFloating](QDBusPendingCallWatcher* w) {
                 w->deleteLater();
                 if (*handled) {
                     // Timeout already fired; this is a late reply — discard.
@@ -157,7 +166,7 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
                     // while it was floating. The float-screen reassignment
                     // (setWindowFloatingForScreen) below still runs so a
                     // cross-screen move updates the daemon's float tracking.
-                    if (!m_dragStartedFloating) {
+                    if (!startedFloating) {
                         m_autotileHandler->handleDragToFloat(safeWindow, windowId);
                     }
                     // Window is now floating — drop it from snapping's set.

--- a/kwin-effect/plasmazoneseffect/drag_end.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_end.cpp
@@ -149,7 +149,17 @@ void PlasmaZonesEffect::callEndDrag(KWin::EffectWindow* window, const QString& w
                     if (dropScreenId.isEmpty()) {
                         break;
                     }
-                    m_autotileHandler->handleDragToFloat(safeWindow, windowId);
+                    // Only run the float transition (which restores the
+                    // pre-autotile size) when the window was TILED at drag
+                    // start. A window that was already floating is merely being
+                    // moved — handleDragToFloat would re-apply the stale
+                    // pre-autotile rect and clobber any resize the user made
+                    // while it was floating. The float-screen reassignment
+                    // (setWindowFloatingForScreen) below still runs so a
+                    // cross-screen move updates the daemon's float tracking.
+                    if (!m_dragStartedFloating) {
+                        m_autotileHandler->handleDragToFloat(safeWindow, windowId);
+                    }
                     // Window is now floating — drop it from snapping's set.
                     m_snapHandler->clearWindowSnapped(windowId);
                     // Now floating — flips the Mode / IsSnapped / IsFloating rule

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -220,6 +220,14 @@ PlasmaZonesEffect::PlasmaZonesEffect()
             qCDebug(lcEffect) << "Window move started -" << w->windowClass()
                               << "current modifiers:" << static_cast<int>(m_currentModifiers);
 
+            // Capture the floating state at drag start, before any float
+            // transition (the autotile-bypass fast path below floats tiled
+            // windows). The drag-stop ApplyFloat path uses this to decide
+            // whether to restore the pre-autotile size: a window that was
+            // already floating is just being moved and must keep its current
+            // user-chosen size, not snap back to the stale pre-autotile rect.
+            m_dragStartedFloating = isWindowFloating(windowId);
+
             // Note: `cursor.drag` is intentionally NOT wired here. The
             // OffscreenEffect pipeline operates on window content; firing
             // a shader at drag start through it is indistinguishable from


### PR DESCRIPTION
## Problem

In autotile algorithms (reported with **theater**), dragging an already-floating window reset it to a stale size, making floating windows feel impossible to resize or reposition. Any move reverted the window to the size it had *before it was first tiled*.

The `dolphin` logs showed it exactly:

```
endDrag: org.kde.dolphin… bypass= DragBypassReason::AutotileScreen
endDrag ApplyFloat: org.kde.dolphin…
floatWindow: already floating - org.kde.dolphin…           ← already floating
Drag-to-float: restored pre-autotile size for … 1158 x 794 ← size reset anyway
```

## Root cause

On an autotile-screen drag the daemon returns an `ApplyFloat` outcome, and the effect's drag-stop handler unconditionally called `handleDragToFloat()`, which restores the **pre-autotile size**. That restore is only correct for the genuine **tiled → floating** transition. For a window that was already floating, it's just being moved, so re-applying the old rect clobbers any resize the user made while floating (the stored size never updates on resize).

The drag-**start** path already guarded this with `!isWindowFloating(windowId)`; the drag-**stop** path did not.

## Fix

- `plasmazoneseffect.h` — add `m_dragStartedFloating`.
- `lifecycle.cpp` — capture the floating state once in the `dragStarted` handler, before any float transition runs.
- `drag_end.cpp` — in the `ApplyFloat` branch, only run the pre-autotile size restore when the window was tiled at drag start. The float-screen reassignment (`setWindowFloatingForScreen`) still runs, so cross-screen moves of a floating window keep correct daemon tracking.

Genuine drag-to-float of a tiled window still restores its original floating size as before.

## Testing

- `cmake --build build` — clean, including `kwin_effect_plasmazones.so`.
- `ctest` — 246/246 pass.
- Verified live: floating windows in theater now move and resize freely without snapping back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)