### PR TITLE
fix(borders): restore distinct focused/unfocused system border colors with alpha

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -647,11 +647,15 @@ private:
 
     QHash<QString, WindowBorder> m_windowBorders; // windowId → border
 
-    // Live system accent colour that a `BorderColorToken::Accent` sentinel in a
-    // border-colour rule resolves to. Pushed from the daemon, which tracks the
-    // Plasma colour scheme; invalid until the first push (sentinel then yields
-    // no colour). See resolveWindowAppearance.
+    // Live system colours that a `BorderColorToken::Accent` sentinel in a
+    // border-colour rule resolves to. The sentinel tracks the system colour
+    // scheme per focus state: the focused (active) slot adopts the accent /
+    // highlight colour, the unfocused (inactive) slot adopts the inactive
+    // colour. Both are pushed from the daemon, which tracks the Plasma colour
+    // scheme; invalid until the first push (sentinel then yields no colour).
+    // See resolveWindowAppearance.
     QColor m_borderAccentColor;
+    QColor m_borderInactiveColor;
 
     // The window most recently passed to slotWindowActivated — i.e. the
     // "previously active" window on the next focus change. Used to repaint the

--- a/kwin-effect/plasmazoneseffect/borders.cpp
+++ b/kwin-effect/plasmazoneseffect/borders.cpp
@@ -96,7 +96,7 @@ void PlasmaZonesEffect::updateWindowBorder(const QString& windowId, KWin::Effect
     // opt-in, the baseline defaults them off.
     std::optional<ResolvedWindowAppearance> ovr;
     if (w && !m_shaderManager.animationRuleSet().isEmpty()) {
-        ovr = resolveWindowAppearance(resolveRuleActions(w, windowId), m_borderAccentColor);
+        ovr = resolveWindowAppearance(resolveRuleActions(w, windowId), m_borderAccentColor, m_borderInactiveColor);
     }
 
     if (!ovr || !ovr->showBorder || !*ovr->showBorder) {
@@ -130,7 +130,16 @@ void PlasmaZonesEffect::updateWindowBorder(const QString& windowId, KWin::Effect
     const QRectF frame = w->frameGeometry();
     const KWin::RectF innerRect(bw, bw, frame.width() - 2.0 * bw, frame.height() - 2.0 * bw);
     const int br = ovr->borderRadius.value_or(0);
-    const KWin::BorderOutline outline(bw, bc, KWin::BorderRadius(br));
+    // BorderOutline / OutlinedBorderItem paint the outline colour OPAQUE — the
+    // scene ignores the QColor alpha channel (verified: a #80…/#40… border drew
+    // fully solid). The scene DOES honour a per-item opacity, so split the colour:
+    // hand the outline an opaque RGB and drive the translucency through the item's
+    // setOpacity(). This makes a focused #80…/unfocused #40… border render at its
+    // intended 50% / 25% strength instead of a solid swatch.
+    const qreal borderOpacity = bc.alphaF();
+    QColor opaqueBc = bc;
+    opaqueBc.setAlpha(255);
+    const KWin::BorderOutline outline(bw, opaqueBc, KWin::BorderRadius(br));
 
     KWin::WindowItem* windowItem = w->windowItem();
     if (!windowItem) {
@@ -139,6 +148,7 @@ void PlasmaZonesEffect::updateWindowBorder(const QString& windowId, KWin::Effect
 
     WindowBorder wb;
     wb.item = new KWin::OutlinedBorderItem(innerRect, outline, windowItem);
+    wb.item->setOpacity(borderOpacity);
 
     // Clip the window contents so they don't poke past the rounded outline
     // at the corners (dark pixels leaking past the border).
@@ -267,7 +277,7 @@ void PlasmaZonesEffect::reconcileRuleHiddenTitleBar(const QString& windowId, KWi
     // The manager owns the capability gate and the geometry re-assert across
     // veto-driven decoration flips.
     const std::optional<ResolvedWindowAppearance> ovr =
-        resolveWindowAppearance(resolveRuleActions(w, windowId), m_borderAccentColor);
+        resolveWindowAppearance(resolveRuleActions(w, windowId), m_borderAccentColor, m_borderInactiveColor);
     m_decorationManager->setRuleOverride(windowId, ovr ? ovr->hideTitleBar : std::nullopt);
 }
 

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -598,15 +598,26 @@ void PlasmaZonesEffect::loadCachedSettings()
             m_cachedMinWindowHeight = qMax(0, v.toInt());
         }
     });
-    // System accent colour for window-border rules: the zone highlight colour
-    // tracks the Plasma accent (when "use system colours" is on the daemon keeps
-    // it in sync), and it is what a border-colour `accent` sentinel resolves to
-    // in updateWindowBorder. Re-fetched on every settingsChanged, so an accent /
-    // colour-scheme change repaints accent-following borders without a relog.
+    // System colours for window-border rules: the zone highlight / inactive
+    // colours track the Plasma colour scheme (when "use system colours" is on the
+    // daemon keeps them in sync), and they are what a border-colour `accent`
+    // sentinel resolves to in updateWindowBorder — highlight for the focused
+    // (active) slot, inactive for the unfocused (inactive) slot, mirroring the
+    // distinct active/inactive system border colours the per-mode appearance
+    // settings used before they folded into rules. Both are re-fetched on every
+    // settingsChanged, so an accent / colour-scheme change repaints accent-
+    // following borders without a relog.
     loadSettingAsync(QStringLiteral("highlightColor"), [this](const QVariant& v) {
         const QColor c(v.toString());
         if (m_borderAccentColor != c) {
             m_borderAccentColor = c;
+            updateAllBorders();
+        }
+    });
+    loadSettingAsync(QStringLiteral("inactiveColor"), [this](const QVariant& v) {
+        const QColor c(v.toString());
+        if (m_borderInactiveColor != c) {
+            m_borderInactiveColor = c;
             updateAllBorders();
         }
     });

--- a/kwin-effect/plasmazoneseffect/shader_resolve.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.cpp
@@ -223,7 +223,7 @@ std::optional<qreal> resolveWindowOpacity(const PhosphorRules::ResolvedActions& 
 }
 
 std::optional<ResolvedWindowAppearance> resolveWindowAppearance(const PhosphorRules::ResolvedActions& resolved,
-                                                                const QColor& accentColor)
+                                                                const QColor& accentColor, const QColor& inactiveColor)
 {
     // Each reader re-validates the param type even though the load-time
     // descriptor validators already did — defence in depth against a
@@ -263,9 +263,12 @@ std::optional<ResolvedWindowAppearance> resolveWindowAppearance(const PhosphorRu
     };
     // The focused and unfocused colours live on two separate single-colour slots
     // (SetBorderColorActive / SetBorderColorInactive), each carrying its colour in
-    // the `value` param. The accent sentinel resolves to the live accent; anything
-    // else parses as a hex colour.
-    const auto borderColorSlot = [&resolved, &accentColor](QLatin1StringView slot) -> std::optional<QColor> {
+    // the `value` param. The accent sentinel resolves to the matching system
+    // colour passed in @p systemColor (the accent/highlight for the active slot,
+    // the inactive colour for the inactive slot); anything else parses as a hex
+    // colour.
+    const auto borderColorSlot = [&resolved](QLatin1StringView slot,
+                                             const QColor& systemColor) -> std::optional<QColor> {
         const auto action = resolved.slot(QString(slot));
         if (!action) {
             return std::nullopt;
@@ -276,7 +279,7 @@ std::optional<ResolvedWindowAppearance> resolveWindowAppearance(const PhosphorRu
         }
         const QString s = v.toString();
         if (s == PhosphorRules::BorderColorToken::Accent) {
-            return accentColor.isValid() ? std::optional<QColor>(accentColor) : std::nullopt;
+            return systemColor.isValid() ? std::optional<QColor>(systemColor) : std::nullopt;
         }
         const QColor color(s);
         if (!color.isValid()) {
@@ -290,8 +293,8 @@ std::optional<ResolvedWindowAppearance> resolveWindowAppearance(const PhosphorRu
     out.showBorder = boolSlot(PhosphorRules::ActionSlot::BorderVisible);
     out.borderWidth = intSlot(PhosphorRules::ActionSlot::BorderWidth, kMaxBorderWidth);
     out.borderRadius = intSlot(PhosphorRules::ActionSlot::BorderRadius, kMaxBorderRadius);
-    out.activeColor = borderColorSlot(PhosphorRules::ActionSlot::BorderColorActive);
-    out.inactiveColor = borderColorSlot(PhosphorRules::ActionSlot::BorderColorInactive);
+    out.activeColor = borderColorSlot(PhosphorRules::ActionSlot::BorderColorActive, accentColor);
+    out.inactiveColor = borderColorSlot(PhosphorRules::ActionSlot::BorderColorInactive, inactiveColor);
     // An omitted `inactive` mirrors the active colour, matching the retired
     // global behaviour where a window with no distinct inactive colour kept its
     // active border when unfocused.

--- a/kwin-effect/plasmazoneseffect/shader_resolve.h
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.h
@@ -164,7 +164,8 @@ struct ResolvedWindowAppearance
     // `activeColor` is the focused colour (from SetBorderColorActive),
     // `inactiveColor` the unfocused one (from SetBorderColorInactive, already
     // defaulted to active when that action was omitted). The accent sentinel has
-    // been resolved to the live accent by the time it lands here.
+    // been resolved to the matching system colour by the time it lands here —
+    // the accent/highlight in activeColor, the inactive colour in inactiveColor.
     // updateWindowBorder picks by the window's focus state. A focus-scoped
     // single-colour rule (matching IsFocused) still works — it just fills
     // activeColor in its matching state.
@@ -177,10 +178,12 @@ struct ResolvedWindowAppearance
     }
 };
 
-/// @p accentColor is the live system accent the `BorderColorToken::Accent`
-/// sentinel resolves to; pass an invalid QColor when none is known (the
-/// sentinel then contributes no colour).
+/// @p accentColor / @p inactiveColor are the live system colours the
+/// `BorderColorToken::Accent` sentinel resolves to per focus state: @p accentColor
+/// (the system accent / highlight) fills the focused/active slot, @p inactiveColor
+/// the unfocused/inactive slot. Pass an invalid QColor for either when none is
+/// known (the sentinel then contributes no colour for that state).
 std::optional<ResolvedWindowAppearance> resolveWindowAppearance(const PhosphorRules::ResolvedActions& resolved,
-                                                                const QColor& accentColor);
+                                                                const QColor& accentColor, const QColor& inactiveColor);
 
 } // namespace PlasmaZones

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -607,16 +607,23 @@ ColumnLayout {
             readonly property string _hex: (row.action[_param.key] !== undefined && row.action[_param.key] !== "") ? String(row.action[_param.key]) : "#FF3DAEE9"
             // A border-colour action's single `value` param may carry the "accent"
             // sentinel ("follow the system accent") instead of a hex string. It is
-            // not a QColor, so render the live accent colour for the swatch and a
+            // not a QColor, so render the live system colour for the swatch and a
             // word for the label rather than letting QColor("accent") fall to black.
             readonly property bool _isAccent: _hex === "accent"
+            // The accent sentinel follows the system colour scheme per focus state,
+            // the same split updateWindowBorder applies: the focused (active) slot
+            // adopts the highlight colour, the unfocused (inactive) slot the inactive
+            // colour. Preview the matching system colour WITH its alpha so the swatch
+            // shows what the border will actually draw instead of one opaque accent
+            // for both. Falls back to the theme highlight when settings are absent.
+            readonly property color _accentColor: !row.appSettings ? Kirigami.Theme.highlightColor : (row.action.type === "setBorderColorInactive" ? row.appSettings.inactiveColor : row.appSettings.highlightColor)
 
             spacing: Kirigami.Units.smallSpacing
 
             ColorButton {
                 id: swatch
 
-                color: parent._isAccent ? Kirigami.Theme.highlightColor : parent._hex
+                color: parent._isAccent ? parent._accentColor : parent._hex
                 Accessible.name: _param.label
                 onClicked: colorDialog.open()
             }

--- a/src/settings/qml/RulesPage.qml
+++ b/src/settings/qml/RulesPage.qml
@@ -97,6 +97,13 @@ SettingsFlickable {
         readonly property string defaultLayoutId: appSettings.defaultLayoutId
         readonly property string defaultAutotileAlgorithm: appSettings.defaultAutotileAlgorithm
         readonly property bool autoAssignAllLayouts: appSettings.autoAssignAllLayouts === true
+        // System highlight / inactive colours (alpha included), proxied from the
+        // real Settings object so ActionRow's border-colour swatch can preview the
+        // "accent" sentinel as the colour the border actually draws — highlight for
+        // the focused (active) slot, inactive for the unfocused one. Without these
+        // the composite would return undefined and the swatch would paint black.
+        readonly property color highlightColor: appSettings.highlightColor
+        readonly property color inactiveColor: appSettings.inactiveColor
     }
     // ── Filter state ──
 

--- a/src/settings/qml/WindowAppearancePage.qml
+++ b/src/settings/qml/WindowAppearancePage.qml
@@ -520,14 +520,16 @@ SettingsFlickable {
                     ColorSwatchRow {
                         color: {
                             root.reloadTick;
-                            // Map the accent sentinel to the live accent colour,
-                            // mirroring the inactive swatch — a stored "accent"
-                            // value would otherwise coerce to black.
+                            // Map the accent sentinel to the live system highlight
+                            // colour (alpha included) — the colour the focused border
+                            // actually draws. A stored "accent" value would otherwise
+                            // coerce to black.
                             const raw = root.actionValue(root.actBorderColorActive, "value", root.defaultBorderHex);
-                            return raw === root.accentToken ? Kirigami.Theme.highlightColor : raw;
+                            return raw === root.accentToken ? (appSettings ? appSettings.highlightColor : Kirigami.Theme.highlightColor) : raw;
                         }
                         onClicked: {
-                            activeBorderColorDialog.selectedColor = root.actionValue(root.actBorderColorActive, "value", root.defaultBorderHex);
+                            const raw = root.actionValue(root.actBorderColorActive, "value", root.defaultBorderHex);
+                            activeBorderColorDialog.selectedColor = raw === root.accentToken ? (appSettings ? appSettings.highlightColor : root.defaultBorderHex) : raw;
                             activeBorderColorDialog.open();
                         }
                     }
@@ -546,12 +548,15 @@ SettingsFlickable {
                     ColorSwatchRow {
                         color: {
                             root.reloadTick;
+                            // The unfocused border follows the system INACTIVE colour
+                            // (alpha included), not the accent, matching what the
+                            // border actually draws.
                             const raw = root.actionValue(root.actBorderColorInactive, "value", root.defaultBorderHex);
-                            return raw === root.accentToken ? Kirigami.Theme.highlightColor : raw;
+                            return raw === root.accentToken ? (appSettings ? appSettings.inactiveColor : Kirigami.Theme.highlightColor) : raw;
                         }
                         onClicked: {
                             const raw = root.actionValue(root.actBorderColorInactive, "value", root.defaultBorderHex);
-                            inactiveBorderColorDialog.selectedColor = raw === root.accentToken ? root.defaultBorderHex : raw;
+                            inactiveBorderColorDialog.selectedColor = raw === root.accentToken ? (appSettings ? appSettings.inactiveColor : root.defaultBorderHex) : raw;
                             inactiveBorderColorDialog.open();
                         }
                     }


### PR DESCRIPTION
## Summary

Window border colors that "follow the system" were broken in three ways: focused and unfocused borders drew the same color, the colors rendered fully opaque (no alpha), and the rule-editor color swatches previewed as black. This restores the distinct, translucent active/inactive system border colors that existed before the v3.2 rules refactor.

## Root causes and fixes

**1. Render: borders drew opaque (`borders.cpp`)**
KWin's `OutlinedBorderItem` / `BorderOutline` paints the outline color opaque and ignores the `QColor` alpha channel, so a translucent border (e.g. `#80cbbeff` / `#40e6e0eb`) drew solid. The scene *does* honor a per-item opacity, so we now hand `BorderOutline` an opaque RGB and drive translucency through `Item::setOpacity(bc.alphaF())`.

**2. Resolution: focused == unfocused (`shader_resolve.{h,cpp}`, `daemon_bringup.cpp`, `plasmazoneseffect.h`)**
The `accent` border-color sentinel resolved to a single color (`highlightColor`) for both focus states. It now resolves per focus state: `highlightColor` for the focused (active) slot and `inactiveColor` for the unfocused one. The effect fetches both colors from the daemon and threads `inactiveColor` through `resolveWindowAppearance`. This mirrors the distinct active/inactive system border colors `main` had before they folded into the rule store.

**3. Settings: black swatches (`ActionRow.qml`, `RulesPage.qml`, `WindowAppearancePage.qml`)**
The rule editor read border colors off the `_editorAppSettings` composite, which never proxied `highlightColor` / `inactiveColor`, so they resolved to `undefined` and the swatches painted black. Added the proxies, and mirrored the per-state resolution in the Window Appearance page swatches so the preview matches the rendered border.

## Verification

- Confirmed end to end with a temporary draw-point log (since removed): the daemon serves `highlightColor=#80cbbeff` / `inactiveColor=#40e6e0eb`, the effect resolves and draws `#80cbbeff` when focused and `#40e6e0eb` when unfocused.
- Build clean, all 246 tests pass.
- Manually verified borders render with the correct distinct colors and intended translucency.

## Notes

The unfocused border follows the system *inactive* color (the colorscheme Text color at the zone-overlay inactive alpha), so it is intentionally faint. Two pre-existing, non-regression robustness items were found during investigation and left out of scope: a transient startup race where the effect's inactive color is briefly invalid, and the daemon writing black colors if its `QGuiApplication` ever lacks the KDE palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
