### PR TITLE
fix(window-picker): stop auto-selecting top row, align highlight styling

### DIFF
--- a/src/settings/qml/WindowPickerDialog.qml
+++ b/src/settings/qml/WindowPickerDialog.qml
@@ -212,6 +212,13 @@ Kirigami.Dialog {
             Layout.fillHeight: true
             Layout.preferredHeight: Kirigami.Units.gridUnit * 14
             clip: true
+            // Don't auto-highlight the first row on open. Rows commit on
+            // click, so there's no keyboard cursor to seed — a pre-selected
+            // top item just reads as a mistaken default. Re-clear after every
+            // model change, since reassigning the model snaps currentIndex
+            // back to 0.
+            currentIndex: -1
+            onCountChanged: currentIndex = -1
             model: {
                 // `_baseRows` is the mode-stable pre-pruned list (titles mode
                 // drops captionless rows; other modes keep everything). It
@@ -243,6 +250,8 @@ Kirigami.Dialog {
             }
 
             delegate: ItemDelegate {
+                id: windowDelegate
+
                 // Strict QML requires the delegate's context property to be
                 // declared before it's read in bindings.
                 required property var modelData
@@ -279,6 +288,9 @@ Kirigami.Dialog {
                         Layout.preferredWidth: Kirigami.Units.iconSizes.small
                         Layout.preferredHeight: Kirigami.Units.iconSizes.small
                         Layout.alignment: Qt.AlignVCenter
+                        // Recolors symbolic icons to track the (highlighted)
+                        // text; full-color icons ignore `color`.
+                        color: windowDelegate.highlighted ? Kirigami.Theme.highlightedTextColor : Kirigami.Theme.textColor
                     }
 
                     ColumnLayout {
@@ -289,13 +301,15 @@ Kirigami.Dialog {
                             text: primaryText
                             Layout.fillWidth: true
                             elide: Text.ElideRight
+                            color: windowDelegate.highlighted ? Kirigami.Theme.highlightedTextColor : Kirigami.Theme.textColor
                         }
 
                         Label {
                             text: secondaryText
                             Layout.fillWidth: true
                             font: Kirigami.Theme.smallFont
-                            opacity: 0.7
+                            color: windowDelegate.highlighted ? Kirigami.Theme.highlightedTextColor : Kirigami.Theme.disabledTextColor
+                            opacity: windowDelegate.highlighted ? 0.85 : 0.7
                             elide: Text.ElideRight
                             visible: secondaryText.length > 0
                         }

--- a/src/settings/qml/WindowPickerDialog.qml
+++ b/src/settings/qml/WindowPickerDialog.qml
@@ -271,13 +271,22 @@ Kirigami.Dialog {
                 readonly property string secondaryText: !valueAvailable ? (dialog.mode === "desktopFiles" ? i18n("(no desktop file)") : dialog.mode === "titles" ? i18n("(no title)") : "") : dialog.mode === "titles" ? (modelData.windowClass || "") : (modelData.caption || "")
 
                 width: ListView.view.width
-                highlighted: ListView.isCurrentItem
+                // Rows commit on click, so hovering is how a row gets
+                // "selected" — highlight on hover too, not just the keyboard
+                // current item, so the active row always reads as the target.
+                highlighted: ListView.isCurrentItem || hovered
                 enabled: valueAvailable
                 opacity: valueAvailable ? 1 : 0.5
                 Accessible.name: primaryText + (secondaryText.length > 0 ? ", " + secondaryText : "")
                 onClicked: {
                     dialog.picked(rawValue);
                     dialog.close();
+                }
+
+                // Use the accent fill from the combo/list convention rather
+                // than the default ItemDelegate selection wash.
+                background: Rectangle {
+                    color: windowDelegate.highlighted ? Kirigami.Theme.highlightColor : "transparent"
                 }
 
                 contentItem: RowLayout {


### PR DESCRIPTION
## Summary

Fixes the highlight behavior of the running-window picker dialog ("Pick Window Class from Running Windows" and its sibling modes).

1. **Auto-selected top row.** The `ListView` left `currentIndex` at its default of `0`, so the top row opened pre-highlighted as if it were a chosen default. Rows commit on click and there's no keyboard cursor to seed, so the selection was meaningless. Set `currentIndex: -1` and re-clear it via `onCountChanged`, since reassigning the filtered model on each keystroke snaps `currentIndex` back to 0.

2. **Non-standard selection highlight.** The delegate relied on the default `ItemDelegate` selection wash instead of the codebase accent convention, and only highlighted the keyboard current item. Since rows commit on click, hovering is how a row gets targeted, so the delegate now highlights on `hovered` as well as the current item, paints a custom `background` with `Kirigami.Theme.highlightColor` (matching `WideComboBox`/the combo-popup convention), and recolors the icon and labels to `highlightedTextColor`/`disabledTextColor` to track the highlighted state (matching `GlobalSearchField`).

## Testing

- `cmake --build build` succeeds, including the AOT QML cache compilation of `WindowPickerDialog_qml.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)