### PR TITLE
fix(rules): standardize boolean values across the rule builder

### DIFF
--- a/cmake/PhosphorTranslations.cmake
+++ b/cmake/PhosphorTranslations.cmake
@@ -54,11 +54,20 @@ file(GLOB_RECURSE KCM_PLASMAZONES_QML "${CMAKE_SOURCE_DIR}/kcm/*.qml")
 list(APPEND KCM_PLASMAZONES_QML ${CMAKE_SOURCE_DIR}/src/shared/AspectRatioBadge.qml)
 list(APPEND KCM_PLASMAZONES_QML ${CMAKE_SOURCE_DIR}/src/shared/CategoryBadge.qml)
 
-# All sources for lupdate (daemon + editor + KCM - same translation context)
+# Standalone settings app — all of its C++ (PhosphorI18n::tr) and QML (i18n)
+# strings. Globbed recursively so a newly-added controller or page is picked up
+# without touching this list. The settings app already installs the plasmazones
+# catalog at runtime via PlasmaZones::loadTranslations(), so these strings are
+# the same translation context as the daemon / editor / KCM.
+file(GLOB_RECURSE PLASMAZONES_SETTINGS_I18N_SOURCES "${CMAKE_SOURCE_DIR}/src/settings/*.cpp")
+file(GLOB_RECURSE PLASMAZONES_SETTINGS_QML "${CMAKE_SOURCE_DIR}/src/settings/*.qml")
+
+# All sources for lupdate (daemon + editor + KCM + settings - same translation context)
 set(_all_i18n_sources
     ${PLASMAZONESD_I18N_SOURCES} ${PLASMAZONESD_QML}
     ${PLASMAZONES_EDITOR_I18N_SOURCES} ${PLASMAZONES_EDITOR_QML}
     ${KCM_PLASMAZONES_QML}
+    ${PLASMAZONES_SETTINGS_I18N_SOURCES} ${PLASMAZONES_SETTINGS_QML}
 )
 
 # Collect per-language .ts files (plasmazones_de.ts, plasmazones_fr.ts, etc.)

--- a/src/settings/qml/ActionListView.qml
+++ b/src/settings/qml/ActionListView.qml
@@ -213,6 +213,12 @@ ColumnLayout {
             // actual swatch is rendered alongside this pill).
             return rawStr === "accent" ? i18n("Accent") : rawStr.toUpperCase();
         }
+        if (kind === "bool") {
+            // Render the JSON bool as On / Off — without this branch a bool
+            // param fell through to the raw lowercase "true" / "false". Matches
+            // the editor toggle and the WHEN-side value pill.
+            return (raw === true || raw === "true") ? i18n("On") : i18n("Off");
+        }
         return rawStr;
     }
 

--- a/src/settings/qml/ActionListView.qml
+++ b/src/settings/qml/ActionListView.qml
@@ -214,9 +214,11 @@ ColumnLayout {
             return rawStr === "accent" ? i18n("Accent") : rawStr.toUpperCase();
         }
         if (kind === "bool") {
-            // Render the JSON bool as On / Off — without this branch a bool
-            // param fell through to the raw lowercase "true" / "false". Matches
-            // the editor toggle and the WHEN-side value pill.
+            // Render the JSON bool as On / Off for the value pill — without this
+            // branch it fell through to the raw lowercase "true" / "false". The
+            // collapsed rule list and the action editor's toggle caption use the
+            // action's polarity phrase ("Hide border") instead; this terser On /
+            // Off is the tabular pill form, matching the WHEN-side value pills.
             return (raw === true || raw === "true") ? i18n("On") : i18n("Off");
         }
         return rawStr;

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -594,6 +594,14 @@ ColumnLayout {
                 anchors.verticalCenter: parent.verticalCenter
                 checked: row.action[_param.key] === true
                 accessibleName: _param.label
+                // Caption the toggle with the action's polarity-aware phrase
+                // ("Show border" / "Hide border", "Lock layout" / "Don't lock
+                // layout") so its current effect is legible, not just whether it
+                // is on. The wording comes from the param descriptor's
+                // onLabel/offLabel (RuleAuthoring::boolActionStateLabel, shared
+                // with the rule-list summary); a bool param without a curated
+                // phrase falls back to plain On / Off.
+                label: checked ? (_param.onLabel !== undefined ? _param.onLabel : i18n("On")) : (_param.offLabel !== undefined ? _param.offLabel : i18n("Off"))
                 onToggled: function (newValue) {
                     row.actionEdited(row._withParam(_param.key, newValue));
                 }

--- a/src/settings/qml/MatchExpressionView.qml
+++ b/src/settings/qml/MatchExpressionView.qml
@@ -96,7 +96,7 @@ ColumnLayout {
 
     /// Localize a leaf's value for display, mirroring `MatchLeafEditor`'s
     /// per-kind editors so the read-only preview agrees with the editor:
-    ///   - bool → "True" / "False" (i18n'd)
+    ///   - bool → "On" / "Off" (i18n'd)
     ///   - screen → `appSettings.screens.displayLabel` for the matching name
     ///   - activity → `appSettings.activities.name` for the matching id
     ///   - everything else (string, number) → `String(value)`
@@ -109,7 +109,7 @@ ColumnLayout {
 
         var kind = root._valueKind(fieldWire);
         if (kind === "bool")
-            return value === true || value === "true" ? i18n("True") : i18n("False");
+            return value === true || value === "true" ? i18n("On") : i18n("Off");
 
         if (kind === "screen" && root.appSettings) {
             var screens = root.appSettings.screens;

--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -278,7 +278,12 @@ RowLayout {
 
     Loader {
         Layout.fillWidth: true
-        Layout.alignment: Qt.AlignTop
+        // Most value editors top-align so a string editor's wrapped operator hint
+        // can grow downward without dragging the combos with it. The bool toggle
+        // is a short fixed-height control with no hint line, so it vertically
+        // centers against the taller field / operator combos instead of clinging
+        // to their top edge (which read as "not centered").
+        Layout.alignment: leaf._valueKind === "bool" ? Qt.AlignVCenter : Qt.AlignTop
         sourceComponent: {
             if (leaf._valueKind === "bool")
                 return boolValueEditor;
@@ -392,11 +397,32 @@ RowLayout {
     Component {
         id: boolValueEditor
 
-        CheckBox {
-            checked: leaf.node.value === true
-            text: checked ? i18n("True") : i18n("False")
-            Accessible.name: i18n("Match value")
-            onToggled: leaf._emit(leaf.node.field, leaf.node.op, checked)
+        // SettingsSwitch is a fixed-size custom Item whose track fills its
+        // bounds, but the hosting Loader is Layout.fillWidth (for the text /
+        // combo editors), which would stretch the toggle into a full-width pill.
+        // Host it in a fill wrapper and keep the toggle at its implicit size,
+        // left- and vertically-centered — the same control and wrapper the
+        // action editor's bool param uses (ActionRow's _boolParamEditor), so
+        // a WHEN bool value and a THEN bool value share one widget.
+        Item {
+            implicitHeight: boolToggle.implicitHeight
+
+            SettingsSwitch {
+                id: boolToggle
+
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                checked: leaf.node.value === true
+                accessibleName: i18n("Match value")
+                // Echo the toggle's state as On / Off so the predicate value is
+                // legible at a glance (the field and operator to the left say
+                // what is being matched, this says to what). Same On / Off
+                // vocabulary as the read-only match summary.
+                label: checked ? i18n("On") : i18n("Off")
+                onToggled: function (newValue) {
+                    leaf._emit(leaf.node.field, leaf.node.op, newValue);
+                }
+            }
         }
     }
 

--- a/src/settings/qml/SettingsSwitch.qml
+++ b/src/settings/qml/SettingsSwitch.qml
@@ -11,10 +11,16 @@ Item {
 
     property bool checked: false
     property string accessibleName: ""
+    // Optional caption rendered to the right of the toggle. Empty by default, so
+    // every existing call site (which already carries its own row label to the
+    // left) keeps the bare toggle and its prior implicit size. The rule-builder
+    // bool editors set it to a per-instance On/Off state read so a lone toggle
+    // standing in a value column still says what is or isn't happening.
+    property string label: ""
 
     signal toggled(bool newValue)
 
-    implicitWidth: Kirigami.Units.gridUnit * 2
+    implicitWidth: track.width + (stateLabel.visible ? Kirigami.Units.smallSpacing + stateLabel.implicitWidth : 0)
     implicitHeight: Kirigami.Units.gridUnit
     Accessible.role: Accessible.CheckBox
     Accessible.name: root.accessibleName
@@ -22,7 +28,12 @@ Item {
 
     // Track
     Rectangle {
-        anchors.fill: parent
+        id: track
+
+        width: Kirigami.Units.gridUnit * 2
+        height: Kirigami.Units.gridUnit
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
         radius: height / 2
         color: root.checked ? Kirigami.Theme.highlightColor : Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.2)
 
@@ -45,9 +56,7 @@ Item {
                     // root.checked has already flipped to the destination state.
                     profile: root.checked ? "widget.toggleOn" : "widget.toggleOff"
                 }
-
             }
-
         }
 
         // Color uses widget.tint (no overshoot) — overshooting a colour
@@ -57,9 +66,24 @@ Item {
             PhosphorMotionAnimation {
                 profile: "widget.tint"
             }
-
         }
+    }
 
+    // Optional state caption. Mirrors the toggle's emphasis: full text colour
+    // when on, muted when off, so the word reads as part of the live state.
+    Label {
+        id: stateLabel
+
+        visible: root.label.length > 0
+        text: root.label
+        anchors.left: track.right
+        anchors.leftMargin: Kirigami.Units.smallSpacing
+        anchors.verticalCenter: track.verticalCenter
+        color: root.checked ? Kirigami.Theme.textColor : Kirigami.Theme.disabledTextColor
+        // The toggle already exposes its state through Accessible.checked; the
+        // caption is a visual echo, so keep it out of the a11y tree to avoid a
+        // duplicate "On/Off" reading.
+        Accessible.ignored: true
     }
 
     MouseArea {
@@ -67,5 +91,4 @@ Item {
         cursorShape: Qt.PointingHandCursor
         onClicked: root.toggled(!root.checked)
     }
-
 }

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -253,8 +253,11 @@ QString paramLabel(const QString& type, const QString& key)
         return PhosphorI18n::tr("Zones");
     }
     // Unsnapped-position restore override (window-domain, single bool value).
+    // off is not inert: it force-suppresses restore for matched windows,
+    // overriding the per-engine restore-on-login setting, so the off meaning
+    // is spelled out the same way the other bool actions do.
     if (type == ActionType::RestorePosition && key == ActionParam::Value) {
-        return PhosphorI18n::tr("Restore position on login");
+        return PhosphorI18n::tr("Restore position on login (off = don't restore)");
     }
     // Border / title-bar overrides (all single-value, keyed ActionParam::Value).
     // SetHideTitleBar is tri-state at the effect: rule absent = mode decides,
@@ -264,7 +267,7 @@ QString paramLabel(const QString& type, const QString& key)
         return PhosphorI18n::tr("Hide title bars (off = force visible)");
     }
     if (type == ActionType::SetBorderVisible && key == ActionParam::Value) {
-        return PhosphorI18n::tr("Show border");
+        return PhosphorI18n::tr("Show border (off = hide)");
     }
     if (type == ActionType::SetBorderWidth && key == ActionParam::Value) {
         return PhosphorI18n::tr("Border width (px)");
@@ -286,7 +289,7 @@ QString paramLabel(const QString& type, const QString& key)
         return PhosphorI18n::tr("Outer gap (px)");
     }
     if (type == ActionType::SetUsePerSideOuterGap && key == ActionParam::Value) {
-        return PhosphorI18n::tr("Per-side outer gaps");
+        return PhosphorI18n::tr("Use per-side outer gaps (off = one uniform gap)");
     }
     if (type == ActionType::LockContext && key == ActionParam::Value) {
         // The action is the rule-driven counterpart to the ToggleLayoutLock
@@ -415,6 +418,18 @@ QVariantList paramsForActionTypeImpl(const QString& type)
         if (const QString hint = paramHint(type, schema.key); !hint.isEmpty()) {
             p[QStringLiteral("hint")] = hint;
         }
+        // Bool params carry a polarity-aware on/off caption (e.g. "Show border" /
+        // "Hide border") so the editor toggle reads out its current effect rather
+        // than a bare On/Off. Shared with the rule-list summary through
+        // boolActionStateLabel, so the editor and the summary never diverge.
+        if (schema.kind == QLatin1String("bool")) {
+            if (const QString onLabel = boolActionStateLabel(type, true); !onLabel.isEmpty()) {
+                p[QStringLiteral("onLabel")] = onLabel;
+            }
+            if (const QString offLabel = boolActionStateLabel(type, false); !offLabel.isEmpty()) {
+                p[QStringLiteral("offLabel")] = offLabel;
+            }
+        }
         if (schema.min.has_value()) {
             p[QStringLiteral("min")] = *schema.min;
         }
@@ -497,11 +512,12 @@ QString actionTypeLabelImpl(const QString& type)
         return PhosphorI18n::tr("Exclude from animations");
     }
     if (type == ActionType::SetHideTitleBar) {
-        // Tri-state at the effect (true = hide, false = force visible) — the
-        // picker label hints both directions so a user looking to FORCE a
-        // title bar finds the action; the parameter toggle's "(off = force
-        // visible)" wording carries the detail.
-        return PhosphorI18n::tr("Hide or show title bars");
+        // Affirmative verb phrase like the other boolean action labels (e.g.
+        // SetBorderVisible's "Show border"); the on-state is "hide". The
+        // parameter toggle's "(off = force visible)" wording carries the
+        // tri-state detail (off forces the title bar visible even where the
+        // mode would otherwise hide it).
+        return PhosphorI18n::tr("Hide title bars");
     }
     if (type == ActionType::SetBorderVisible) {
         return PhosphorI18n::tr("Show border");
@@ -575,6 +591,30 @@ QString operatorLabelImpl(Operator op)
 }
 
 } // namespace
+
+QString boolActionStateLabel(const QString& type, bool on)
+{
+    namespace ActionType = PhosphorRules::ActionType;
+    if (type == ActionType::RestorePosition) {
+        return on ? PhosphorI18n::tr("Restore position on login") : PhosphorI18n::tr("Don't restore position on login");
+    }
+    if (type == ActionType::SetHideTitleBar) {
+        return on ? PhosphorI18n::tr("Hide title bars") : PhosphorI18n::tr("Show title bars");
+    }
+    if (type == ActionType::LockContext) {
+        return on ? PhosphorI18n::tr("Lock layout") : PhosphorI18n::tr("Don't lock layout");
+    }
+    if (type == ActionType::DefaultLayoutAssignment) {
+        return on ? PhosphorI18n::tr("Assign default layout") : PhosphorI18n::tr("Don't assign default layout");
+    }
+    if (type == ActionType::SetBorderVisible) {
+        return on ? PhosphorI18n::tr("Show border") : PhosphorI18n::tr("Hide border");
+    }
+    if (type == ActionType::SetUsePerSideOuterGap) {
+        return on ? PhosphorI18n::tr("Per-side outer gaps") : PhosphorI18n::tr("Uniform outer gap");
+    }
+    return QString();
+}
 
 QVariantList matchFields()
 {

--- a/src/settings/ruleauthoring.h
+++ b/src/settings/ruleauthoring.h
@@ -41,6 +41,13 @@ QString matchValueHint(const QString& op);
 /// here and surfaces this list verbatim.
 QVariantList actionTypes();
 
+/// Polarity-aware phrase for a boolean action's current value — e.g.
+/// `SetBorderVisible` → "Show border" when @p on, "Hide border" when off. The
+/// single source of truth shared by the rule-list summary (`RuleModel`) and the
+/// editor toggle caption (`ActionRow`), so the two never drift. Returns an empty
+/// string for a non-boolean or unknown action type.
+QString boolActionStateLabel(const QString& typeWire, bool on);
+
 /// A complete, default-seeded action payload for @p typeWire — a JSON map of
 /// the form `{ type: <typeWire>, ...defaults }` ready to drop into a rule's
 /// `actions` list. See `RuleController::defaultPayloadFor` for the

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -3,6 +3,8 @@
 
 #include "rulemodel.h"
 
+#include "ruleauthoring.h"
+
 #include "../phosphor_i18n.h"
 
 #include <PhosphorRules/ContextRuleBridge.h>
@@ -158,6 +160,16 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::
             label = PhosphorI18n::tr("Tiling");
         }
         return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field), label);
+    }
+
+    // Boolean fields (Maximized, Keep above, Skip taskbar, …) render their
+    // value as On / Off instead of the raw JSON "true" / "false" the generic
+    // toString() fallback would emit, matching the editor toggle and the
+    // expanded match tree (MatchExpressionView).
+    if (PhosphorRules::fieldIsBool(predicate.field)) {
+        return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field),
+                                              predicate.value.toBool() ? PhosphorI18n::tr("On")
+                                                                       : PhosphorI18n::tr("Off"));
     }
 
     return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field),
@@ -327,22 +339,13 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
     //    border / title-bar overrides, per-context gap overrides) ──
     {
         const QJsonValue raw = action.params.value(PhosphorRules::ActionParam::Value);
-        if (action.type == ActionType::RestorePosition) {
-            return raw.toBool() ? PhosphorI18n::tr("Restore position on login")
-                                : PhosphorI18n::tr("Don't restore position on login");
-        }
-        if (action.type == ActionType::SetHideTitleBar) {
-            return raw.toBool() ? PhosphorI18n::tr("Hide title bars") : PhosphorI18n::tr("Show title bars");
-        }
-        if (action.type == ActionType::LockContext) {
-            return raw.toBool() ? PhosphorI18n::tr("Lock layout") : PhosphorI18n::tr("Don't lock layout");
-        }
-        if (action.type == ActionType::DefaultLayoutAssignment) {
-            return raw.toBool() ? PhosphorI18n::tr("Assign default layout")
-                                : PhosphorI18n::tr("Don't assign default layout");
-        }
-        if (action.type == ActionType::SetBorderVisible) {
-            return raw.toBool() ? PhosphorI18n::tr("Show border") : PhosphorI18n::tr("Hide border");
+        // Boolean actions render their polarity-aware phrase ("Show border" /
+        // "Hide border", …). The wording lives in RuleAuthoring so the editor
+        // toggle caption and this summary always read the same; a non-boolean
+        // action type returns empty and falls through to the cases below.
+        if (const QString boolLabel = RuleAuthoring::boolActionStateLabel(action.type, raw.toBool());
+            !boolLabel.isEmpty()) {
+            return boolLabel;
         }
         if (action.type == ActionType::SetBorderWidth) {
             return PhosphorI18n::tr("Border width: %1 px").arg(raw.toInt());
@@ -367,9 +370,6 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
         }
         if (action.type == ActionType::SetOuterGap) {
             return PhosphorI18n::tr("Outer gap: %1 px").arg(raw.toInt());
-        }
-        if (action.type == ActionType::SetUsePerSideOuterGap) {
-            return raw.toBool() ? PhosphorI18n::tr("Per-side outer gaps") : PhosphorI18n::tr("Uniform outer gap");
         }
         if (action.type == ActionType::SetOuterGapTop) {
             return PhosphorI18n::tr("Top gap: %1 px").arg(raw.toInt());

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -778,6 +778,9 @@ add_test(NAME test_animations_shader_overrides COMMAND test_animations_shader_ov
 add_executable(test_rule_model
     settings/test_rule_model.cpp
     ${CMAKE_SOURCE_DIR}/src/settings/rulemodel.cpp
+    # rulemodel's action summary now shares its boolean polarity phrasing with
+    # the editor via RuleAuthoring::boolActionStateLabel.
+    ${CMAKE_SOURCE_DIR}/src/settings/ruleauthoring.cpp
 )
 target_link_libraries(test_rule_model
     PRIVATE

--- a/tests/unit/settings/test_rule_model.cpp
+++ b/tests/unit/settings/test_rule_model.cpp
@@ -112,6 +112,7 @@ private Q_SLOTS:
     void disableEngineNamesTheModeBeingDisabled();
     void setOpacityRendersValidValuesAndGuardsRejectPaths();
     void restorePositionRendersValueAwareLabel();
+    void boolMatchConditionRendersOnOff();
     void shaderAndCurveLabelsResolveThroughLookups();
     void routeActionsRenderFriendlyLabels();
 };
@@ -492,6 +493,38 @@ void TestRuleModel::restorePositionRendersValueAwareLabel()
     // affirmative "Restore …", false as the negated "Don't restore …".
     QVERIFY2(labelAt(0).contains(QStringLiteral("Restore position")), qPrintable(labelAt(0)));
     QVERIFY2(labelAt(1).contains(QStringLiteral("Don't")), qPrintable(labelAt(1)));
+}
+
+void TestRuleModel::boolMatchConditionRendersOnOff()
+{
+    // A boolean match condition (e.g. Maximized) renders its value as On / Off in
+    // the rule's match summary, not the raw JSON "true" / "false" the generic
+    // toString() fallback would emit. Mirrors the editor toggle and the expanded
+    // match tree so the three boolean surfaces read the same.
+    const auto buildRule = [](bool value) {
+        Rule rule;
+        rule.id = QUuid::createUuid();
+        rule.priority = 150;
+        rule.match = MatchExpression::makeLeaf(Field::IsMaximized, Operator::Equals, value);
+        RuleAction action;
+        action.type = QString(ActionType::Float);
+        rule.actions = {action};
+        return rule;
+    };
+
+    RuleModel model;
+    model.setRules({buildRule(true), buildRule(false)});
+
+    const auto summaryAt = [&](int row) {
+        return model.data(model.index(row, 0), RuleModel::MatchSummaryRole).toString();
+    };
+    // Never the raw JSON bool token.
+    QVERIFY2(!summaryAt(0).contains(QStringLiteral("true")), qPrintable(summaryAt(0)));
+    QVERIFY2(!summaryAt(1).contains(QStringLiteral("false")), qPrintable(summaryAt(1)));
+    // The field label is carried, with the value rendered as On / Off.
+    QVERIFY2(summaryAt(0).contains(QStringLiteral("On")), qPrintable(summaryAt(0)));
+    QVERIFY2(summaryAt(1).contains(QStringLiteral("Off")), qPrintable(summaryAt(1)));
+    QVERIFY(summaryAt(0) != summaryAt(1));
 }
 
 void TestRuleModel::shaderAndCurveLabelsResolveThroughLookups()

--- a/translations/plasmazones_de.ts
+++ b/translations/plasmazones_de.ts
@@ -318,33 +318,34 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="123"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="138"/>
         <source>Layout: %1</source>
         <translation>Layout: %1</translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="150"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="165"/>
         <source>Layout Locked</source>
         <translation>Layout gesperrt</translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="199"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="214"/>
         <source>Disabled on this monitor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="212"/>
-        <location filename="../src/daemon/daemon/osd.cpp" line="223"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="227"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="238"/>
         <source>Disabled on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="221"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="236"/>
         <source>Disabled on this activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="280"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="295"/>
+        <location filename="../src/settings/rulemodel.cpp" line="240"/>
         <source>Tiling: %1</source>
         <translation>Tiling: %1</translation>
     </message>
@@ -359,33 +360,33 @@
         <translation>In Zone %1 einrasten</translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="346"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="354"/>
         <source>Cancel Zone Overlay</source>
         <translation>Zonen-Overlay abbrechen</translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="381"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="409"/>
         <source>Layout Picker: Move Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="385"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="413"/>
         <source>Layout Picker: Move Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="389"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="417"/>
         <source>Layout Picker: Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="393"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="421"/>
         <source>Layout Picker: Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="397"/>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="399"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="425"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="427"/>
         <source>Layout Picker: Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -467,8 +468,14 @@
         <translation type="vanished">Rotiert</translation>
     </message>
     <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="595"/>
         <source>Zone %1</source>
-        <translation type="vanished">Zone %1</translation>
+        <translation>Zone %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="597"/>
+        <source>%1 — %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Moved</source>
@@ -479,8 +486,11 @@
         <translation type="vanished">Fokus: Zone %1</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="177"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="182"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="479"/>
         <source>Focus</source>
-        <translation type="vanished">Fokus</translation>
+        <translation>Fokus</translation>
     </message>
     <message>
         <source>Zone %1 ↔ Zone %2</source>
@@ -503,16 +513,442 @@
         <translation type="vanished">Wiederhergestellt</translation>
     </message>
     <message>
+        <location filename="../src/settings/rulemodel.cpp" line="774"/>
         <source>Tiled</source>
-        <translation type="vanished">Gekachelt</translation>
+        <translation>Gekachelt</translation>
     </message>
     <message>
+        <location filename="../src/settings/rulemodel.cpp" line="772"/>
         <source>Snapped</source>
-        <translation type="vanished">Eingerastet</translation>
+        <translation>Eingerastet</translation>
     </message>
     <message>
+        <location filename="../src/settings/rulemodel.cpp" line="162"/>
+        <location filename="../src/settings/rulemodel.cpp" line="170"/>
+        <location filename="../src/settings/rulemodel.cpp" line="175"/>
+        <source>%1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="171"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="172"/>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="227"/>
+        <source>Engine: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="232"/>
+        <source>Snapping: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="253"/>
+        <source>Disable: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="256"/>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="259"/>
+        <source>Float</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="269"/>
+        <source>Snap to zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="272"/>
+        <source>Snap to zone %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="274"/>
+        <source>Snap to zones %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="283"/>
+        <source>Open on monitor: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="287"/>
+        <source>Open on desktop %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="296"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="189"/>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="300"/>
+        <location filename="../src/settings/rulemodel.cpp" line="305"/>
+        <source>Opacity (invalid)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="307"/>
+        <source>Opacity: %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="311"/>
+        <source>Block animation shader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="312"/>
+        <source>Shader: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="316"/>
+        <source>Duration: %1 ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="320"/>
+        <source>Animation curve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="321"/>
+        <source>Curve: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="326"/>
+        <source>Overlay shader: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="331"/>
+        <source>Overlay style: Zone rectangles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="334"/>
+        <source>Overlay style: Layout preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="600"/>
+        <source>Don&apos;t restore position on login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="603"/>
+        <source>Show title bars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="606"/>
+        <source>Don&apos;t lock layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="609"/>
+        <source>Assign default layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="609"/>
+        <source>Don&apos;t assign default layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="612"/>
+        <source>Hide border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="351"/>
+        <source>Border width: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="354"/>
+        <source>Corner radius: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="361"/>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="363"/>
+        <source>Focused border: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="365"/>
+        <source>Unfocused border: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="369"/>
+        <source>Gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="372"/>
+        <source>Outer gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="615"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="279"/>
+        <source>Per-side outer gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="615"/>
+        <source>Uniform outer gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="375"/>
+        <source>Top gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="378"/>
+        <source>Bottom gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="381"/>
+        <source>Left gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="384"/>
+        <source>Right gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="459"/>
+        <source>Everywhere</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="691"/>
+        <source>Monitor &amp; Layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="693"/>
+        <source>Applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="695"/>
+        <source>Activities</source>
+        <translation type="unfinished">Aktivitäten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="699"/>
+        <source>Advanced / Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="701"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="710"/>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="712"/>
+        <source>Window class</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="714"/>
+        <source>Desktop file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="716"/>
+        <source>Window role</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="718"/>
+        <source>Process ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="720"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="722"/>
+        <source>Window type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="724"/>
+        <source>Sticky</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="726"/>
+        <source>Fullscreen</source>
+        <translation type="unfinished">Vollbild</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="728"/>
+        <source>Maximized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="730"/>
+        <source>Minimized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="732"/>
+        <source>Focused</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="738"/>
+        <source>Activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="740"/>
+        <source>Transient</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="744"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="746"/>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="748"/>
+        <source>Keep above</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="750"/>
+        <source>Keep below</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="752"/>
+        <source>Skip taskbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="754"/>
+        <source>Skip pager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="756"/>
+        <source>Skip switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="758"/>
+        <source>Modal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="760"/>
+        <source>Decorated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="762"/>
+        <source>Resizable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="764"/>
+        <source>Position X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="766"/>
+        <source>Position Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="768"/>
+        <source>Title (no suffix)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="770"/>
         <source>Floating</source>
-        <translation type="vanished">Schwebend</translation>
+        <translation>Schwebend</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="776"/>
+        <source>Zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="778"/>
+        <source>Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="780"/>
+        <source>Tiled window count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="788"/>
+        <source>Any window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="800"/>
+        <source>(condition group)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/rulemodel.cpp" line="807"/>
+        <source>%n condition(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="813"/>
+        <source>No action</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Snapped: Zone %1</source>
@@ -656,6 +1092,8 @@
     </message>
     <message>
         <location filename="../src/editor/controller/layout.cpp" line="315"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="201"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="209"/>
         <source>New Layout</source>
         <translation>Neues Layout</translation>
     </message>
@@ -668,8 +1106,693 @@
         <translation type="vanished">Ordner öffnen</translation>
     </message>
     <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="60"/>
+        <source>Identity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="66"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="77"/>
+        <source>State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="83"/>
+        <source>Taskbar &amp; switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="89"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="737"/>
+        <location filename="../src/settings/rulemodel.cpp" line="160"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="138"/>
         <source>Tiling</source>
-        <translation type="vanished">Kachelung</translation>
+        <translation>Kachelung</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="94"/>
+        <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="100"/>
+        <source>Context</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="102"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="199"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="224"/>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="113"/>
+        <source>The application&apos;s ID (Wayland app_id / desktop entry), e.g. org.kde.konsole.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="115"/>
+        <source>The window&apos;s class (WM_CLASS resource class), e.g. konsole.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="117"/>
+        <source>The application&apos;s desktop entry file name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="119"/>
+        <source>The window&apos;s X11 role (WM_WINDOW_ROLE). Empty for Wayland-native windows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="121"/>
+        <source>The window&apos;s process ID.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="123"/>
+        <source>The window&apos;s title-bar text.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="125"/>
+        <source>The window&apos;s type (Normal, Dialog, Utility, Notification, …).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="127"/>
+        <source>Whether the window is shown on all virtual desktops.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="129"/>
+        <source>Whether the window is fullscreen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="131"/>
+        <source>Whether the window is minimized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="133"/>
+        <source>Whether the window is maximized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="135"/>
+        <source>Whether the window currently has keyboard focus.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="137"/>
+        <source>Whether the window is a transient (a dialog or popup owned by another window).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="139"/>
+        <source>Whether the window is a notification or on-screen display.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="141"/>
+        <source>The window&apos;s width in pixels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="143"/>
+        <source>The window&apos;s height in pixels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="145"/>
+        <source>Whether the window is set to stay above other windows (always on top).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="147"/>
+        <source>Whether the window is set to stay below other windows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="149"/>
+        <source>Whether the window is hidden from the taskbar.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="151"/>
+        <source>Whether the window is hidden from the pager.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="153"/>
+        <source>Whether the window is hidden from the window switcher (Alt+Tab).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="155"/>
+        <source>Whether the window is a modal dialog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="157"/>
+        <source>Whether the window has a server-side title-bar and border.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="159"/>
+        <source>Whether the window can be resized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="161"/>
+        <source>The window&apos;s left-edge X position in pixels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="163"/>
+        <source>The window&apos;s top-edge Y position in pixels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="165"/>
+        <source>The window&apos;s title without the application-name suffix the window manager adds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="167"/>
+        <source>Whether the window has been floated out of tiling (snap or autotile).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="169"/>
+        <source>Whether the window is snapped into a zone (manual-zone mode, where tiled windows are not snapped).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="172"/>
+        <source>Whether the window is managed by the autotile engine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="174"/>
+        <source>The zone the window is snapped into (manual-zone mode only).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="176"/>
+        <source>The monitor the window is on.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="178"/>
+        <source>The virtual desktop the window is on.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="180"/>
+        <source>The KDE Activity the window is on.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="182"/>
+        <source>The engine mode the window is placed by (snapping or tiling).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="184"/>
+        <source>How many windows are tiled on this monitor and desktop. Lets a rule switch the tiling algorithm as windows open and close, for example a centered single-window layout that gives way once a second window opens.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="210"/>
+        <source>Layout &amp; engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="213"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="159"/>
+        <source>Overlay</source>
+        <translation type="unfinished">Overlay</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="216"/>
+        <source>Animation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="222"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="179"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="203"/>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="238"/>
+        <source>Engine mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="241"/>
+        <location filename="../src/settings/rulemodel.cpp" line="231"/>
+        <source>Snapping layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="247"/>
+        <source>Engine to disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="250"/>
+        <source>Opacity (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="260"/>
+        <source>Restore position on login (off = don&apos;t restore)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="267"/>
+        <source>Hide title bars (off = force visible)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="270"/>
+        <source>Show border (off = hide)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="273"/>
+        <source>Border width (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="276"/>
+        <source>Corner radius (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="282"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="207"/>
+        <source>Border color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="286"/>
+        <source>Inner gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="289"/>
+        <source>Outer gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="292"/>
+        <source>Use per-side outer gaps (off = one uniform gap)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="299"/>
+        <source>Lock the layout (off = don&apos;t lock)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="306"/>
+        <source>Assign a default layout (off = leave unassigned)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="309"/>
+        <source>Top gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="312"/>
+        <source>Bottom gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="315"/>
+        <source>Left gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="318"/>
+        <source>Right gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="323"/>
+        <location filename="../src/settings/rulemodel.cpp" line="325"/>
+        <source>Overlay shader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="326"/>
+        <location filename="../src/settings/rulemodel.cpp" line="336"/>
+        <source>Overlay style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="332"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="689"/>
+        <location filename="../src/settings/rulemodel.cpp" line="736"/>
+        <source>Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="335"/>
+        <source>Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="338"/>
+        <source>Shader effect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="341"/>
+        <source>Duration (ms)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="344"/>
+        <source>Curve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="359"/>
+        <source>Zone numbers like “1, 2”, or a range like “1-3”. Multiple zones snap the window to their combined area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="377"/>
+        <location filename="../src/settings/rulemodel.cpp" line="199"/>
+        <source>Autotile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="380"/>
+        <location filename="../src/settings/rulemodel.cpp" line="201"/>
+        <source>Scrolling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="385"/>
+        <source>Zone rectangles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="388"/>
+        <source>Layout preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="464"/>
+        <source>Set engine mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="467"/>
+        <source>Set snapping layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="470"/>
+        <source>Set tiling algorithm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="473"/>
+        <source>Disable engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="476"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="606"/>
+        <source>Lock layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="479"/>
+        <source>Default layout assignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="482"/>
+        <source>Exclude window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="485"/>
+        <source>Float window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="488"/>
+        <source>Snap to zone(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="491"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="599"/>
+        <source>Restore position on login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="494"/>
+        <source>Override animation shader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="497"/>
+        <source>Override animation duration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="500"/>
+        <source>Override animation curve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="503"/>
+        <source>Set opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="506"/>
+        <source>Set overlay shader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="509"/>
+        <source>Set overlay style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="512"/>
+        <source>Exclude from animations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="520"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="603"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="265"/>
+        <source>Hide title bars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="523"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="612"/>
+        <source>Show border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="526"/>
+        <source>Set border width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="529"/>
+        <source>Set corner radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="532"/>
+        <source>Set focused border color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="535"/>
+        <source>Set unfocused border color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="538"/>
+        <source>Set inner gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="541"/>
+        <source>Set outer gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="544"/>
+        <source>Use per-side outer gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="547"/>
+        <source>Set top gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="550"/>
+        <source>Set bottom gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="553"/>
+        <source>Set left gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="556"/>
+        <source>Set right gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="559"/>
+        <location filename="../src/settings/rulemodel.cpp" line="282"/>
+        <source>Open on monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="562"/>
+        <location filename="../src/settings/rulemodel.cpp" line="287"/>
+        <source>Open on desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="571"/>
+        <source>is</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="573"/>
+        <source>contains</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="575"/>
+        <source>starts with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="577"/>
+        <source>ends with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="579"/>
+        <source>matches regex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="581"/>
+        <source>matches app-id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="583"/>
+        <source>greater than</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="585"/>
+        <source>less than</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="679"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="680"/>
+        <source>Normal window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="681"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="682"/>
+        <source>Utility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="683"/>
+        <source>Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="684"/>
+        <source>Splash screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="685"/>
+        <source>Menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="686"/>
+        <source>Tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="687"/>
+        <location filename="../src/settings/rulemodel.cpp" line="742"/>
+        <source>Notification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="688"/>
+        <source>Dock / panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="690"/>
+        <source>On-screen display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="691"/>
+        <source>Popup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="816"/>
+        <source>Regular expression, e.g. ^(firefox|chromium)$</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="819"/>
+        <source>Matches by reverse-DNS segments, so “firefox” also matches “org.mozilla.firefox”.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/editor/controller/layout.cpp" line="375"/>
@@ -699,6 +1822,7 @@
     </message>
     <message>
         <location filename="../src/editor/controller/layout.cpp" line="927"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="405"/>
         <source>Failed to import layout: %1</source>
         <translation type="unfinished">Layout konnte nicht importiert werden: %1</translation>
     </message>
@@ -3243,8 +4367,10 @@
         <translation type="vanished">KDE-Aktivitäten-Unterstützung ist nicht verfügbar. Aktivitätsbasierte Layout-Zuweisungen erfordern, dass der KDE-Aktivitäten-Dienst läuft.</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="342"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="210"/>
         <source>Algorithm</source>
-        <translation type="vanished">Algorithmus</translation>
+        <translation>Algorithmus</translation>
     </message>
     <message numerus="yes">
         <source>Max %1 window</source>
@@ -3255,8 +4381,9 @@
         <extra-po-msgid_plural>Max %1 windows</extra-po-msgid_plural>
     </message>
     <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="244"/>
         <source>Tiling algorithm</source>
-        <translation type="vanished">Kachelungsalgorithmus</translation>
+        <translation>Kachelungsalgorithmus</translation>
     </message>
     <message>
         <source>Select how windows are automatically arranged on screen</source>
@@ -3303,8 +4430,9 @@
         <translation type="vanished">Mittenanzahl</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="356"/>
         <source>Master count</source>
-        <translation type="vanished">Hauptbereich-Anzahl</translation>
+        <translation>Hauptbereich-Anzahl</translation>
     </message>
     <message>
         <source>Number of windows in the center area</source>
@@ -3323,20 +4451,26 @@
         <translation type="vanished">Automatische Kachelung aktivieren</translation>
     </message>
     <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="219"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="99"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="165"/>
         <source>Appearance</source>
-        <translation type="vanished">Darstellung</translation>
+        <translation>Darstellung</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="187"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
         <source>Colors</source>
-        <translation type="vanished">Farben</translation>
+        <translation>Farben</translation>
     </message>
     <message>
         <source>Color scheme:</source>
         <translation type="vanished">Farbschema:</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="256"/>
         <source>Use system accent color</source>
-        <translation type="vanished">Systemakzentfarbe verwenden</translation>
+        <translation>Systemakzentfarbe verwenden</translation>
     </message>
     <message>
         <source>Active color:</source>
@@ -3347,8 +4481,9 @@
         <translation type="vanished">Inaktive Farbe:</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="250"/>
         <source>Decorations</source>
-        <translation type="vanished">Dekorationen</translation>
+        <translation>Dekorationen</translation>
     </message>
     <message>
         <source>Title bars:</source>
@@ -3363,8 +4498,9 @@
         <translation type="vanished">Entfernt Titelleisten bei automatisch gekachelten Fenstern. Wird beim Schweben oder Verlassen des Autotile-Modus wiederhergestellt.</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="247"/>
         <source>Borders</source>
-        <translation type="vanished">Ränder</translation>
+        <translation>Ränder</translation>
     </message>
     <message>
         <source>Border:</source>
@@ -3399,8 +4535,109 @@
         <translation type="vanished">Eckenradius für den Rand (0 für eckige Ecken)</translation>
     </message>
     <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="80"/>
+        <source>Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="84"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="223"/>
+        <source>General</source>
+        <translation type="unfinished">Allgemein</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="94"/>
+        <source>Placement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="104"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="231"/>
+        <source>Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="123"/>
+        <source>Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="142"/>
+        <source>Virtual Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="162"/>
         <source>Behavior</source>
-        <translation type="vanished">Verhalten</translation>
+        <translation>Verhalten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="172"/>
+        <source>Zone Selector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="185"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="216"/>
+        <source>Priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="188"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="219"/>
+        <source>Quick Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="190"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="252"/>
+        <source>Shaders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="226"/>
+        <source>Surfaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="228"/>
+        <source>Library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="233"/>
+        <source>OSDs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="236"/>
+        <source>Overlays</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="239"/>
+        <source>Side Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="241"/>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="244"/>
+        <source>Layout Editor</source>
+        <translation type="unfinished">Layout-Editor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="247"/>
+        <source>Presets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="250"/>
+        <source>Motion Sets</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>New windows:</source>
@@ -3447,8 +4684,10 @@
         <translation type="vanished">Fenster werden nicht unter ihre Mindestgröße verkleinert. Dies kann Lücken im Layout hinterlassen.</translation>
     </message>
     <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="207"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="270"/>
         <source>Gaps</source>
-        <translation type="vanished">Abstände</translation>
+        <translation>Abstände</translation>
     </message>
     <message>
         <source>Inner gap:</source>
@@ -3575,8 +4814,13 @@
         <translation type="vanished">Alle Editor-Tastenkombinationen auf ihre Standardwerte zurücksetzen</translation>
     </message>
     <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="374"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="736"/>
+        <location filename="../src/settings/rulemodel.cpp" line="158"/>
+        <location filename="../src/settings/rulemodel.cpp" line="197"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="136"/>
         <source>Snapping</source>
-        <translation type="vanished">Einrasten</translation>
+        <translation>Einrasten</translation>
     </message>
     <message>
         <source>Grid snapping:</source>
@@ -3639,8 +4883,9 @@
         <translation type="vanished">Fenster von ausgeschlossenen Anwendungen oder mit ausgeschlossenen Fensterklassen werden vom Einrasten und Autotiling ignoriert.</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="399"/>
         <source>Window Filtering</source>
-        <translation type="vanished">Fensterfilterung</translation>
+        <translation>Fensterfilterung</translation>
     </message>
     <message>
         <source>Exclude transient windows (dialogs, popups, toolbars)</source>
@@ -3651,8 +4896,9 @@
         <translation type="vanished">Minimale Fenstergröße für Zonenverwaltung:</translation>
     </message>
     <message>
+        <location filename="../src/settings/rulemodel.cpp" line="251"/>
         <source>Disabled</source>
-        <translation type="vanished">Deaktiviert</translation>
+        <translation>Deaktiviert</translation>
     </message>
     <message>
         <source>Height:</source>
@@ -3815,8 +5061,9 @@
         <translation type="vanished">Dauer:</translation>
     </message>
     <message>
+        <location filename="../src/settings/rulemodel.cpp" line="316"/>
         <source>Animation duration</source>
-        <translation type="vanished">Animationsdauer</translation>
+        <translation>Animationsdauer</translation>
     </message>
     <message>
         <source>How long window animations take to complete (milliseconds)</source>
@@ -3859,8 +5106,9 @@
         <translation type="vanished">Mindestabstand:</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="396"/>
         <source>Minimum distance</source>
-        <translation type="vanished">Mindestabstand</translation>
+        <translation>Mindestabstand</translation>
     </message>
     <message>
         <source>Skip animation when the geometry change is smaller than this many pixels. Prevents jittery micro-animations.</source>
@@ -3871,8 +5119,10 @@
         <translation type="vanished">(immer animieren)</translation>
     </message>
     <message>
+        <location filename="../src/settings/rulemodel.cpp" line="697"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="114"/>
         <source>Animations</source>
-        <translation type="vanished">Animationen</translation>
+        <translation>Animationen</translation>
     </message>
     <message>
         <source>Smooth window geometry transitions</source>
@@ -4032,28 +5282,33 @@
         <translation type="vanished">Deckkraft der inaktiven Zone</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="191"/>
         <source>Border</source>
-        <translation type="vanished">Rand</translation>
+        <translation>Rand</translation>
     </message>
     <message>
         <source>Border width:</source>
         <translation type="vanished">Randbreite:</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="217"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="252"/>
         <source>Border width</source>
-        <translation type="vanished">Randbreite</translation>
+        <translation>Randbreite</translation>
     </message>
     <message>
         <source>Border radius:</source>
         <translation type="vanished">Randradius:</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="219"/>
         <source>Border radius</source>
-        <translation type="vanished">Randradius</translation>
+        <translation>Randradius</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="193"/>
         <source>Zone Labels</source>
-        <translation type="vanished">Zonenbeschriftungen</translation>
+        <translation>Zonenbeschriftungen</translation>
     </message>
     <message>
         <source>Color:</source>
@@ -4076,8 +5331,9 @@
         <translation type="vanished">Skalierung der Beschriftungsschriftgröße</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
         <source>Effects</source>
-        <translation type="vanished">Effekte</translation>
+        <translation>Effekte</translation>
     </message>
     <message>
         <source>Visual Effects</source>
@@ -4108,8 +5364,9 @@
         <translation type="vanished">Zonen beim Layout-Wechsel aufleuchten lassen</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="197"/>
         <source>Shader Effects</source>
-        <translation type="vanished">Shader-Effekte</translation>
+        <translation>Shader-Effekte</translation>
     </message>
     <message>
         <source>Shaders:</source>
@@ -4192,8 +5449,10 @@
         <translation type="vanished">Aktivierung</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="179"/>
         <source>Triggers</source>
-        <translation type="vanished">Auslöser</translation>
+        <translation>Auslöser</translation>
     </message>
     <message>
         <source>Zone activation:</source>
@@ -4228,8 +5487,9 @@
         <translation type="vanished">Wenn aktiviert, drücken Sie den Aktivierungsauslöser einmal, um das Overlay anzuzeigen, und erneut, um es auszublenden. Wenn deaktiviert, halten Sie den Auslöser gedrückt.</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
         <source>Zone Span</source>
-        <translation type="vanished">Zonenübergreifend</translation>
+        <translation>Zonenübergreifend</translation>
     </message>
     <message>
         <source>Paint-to-span:</source>
@@ -4252,16 +5512,18 @@
         <translation type="vanished">Kantenschwelle:</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
         <source>Edge threshold</source>
-        <translation type="vanished">Kantenschwelle</translation>
+        <translation>Kantenschwelle</translation>
     </message>
     <message>
         <source>Distance from zone edge for multi-zone selection</source>
         <translation type="vanished">Abstand vom Zonenrand für Mehrfachzonenauswahl</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="174"/>
         <source>Snap Assist</source>
-        <translation type="vanished">Einrasthilfe</translation>
+        <translation>Einrasthilfe</translation>
     </message>
     <message>
         <source>Window picker:</source>
@@ -4280,8 +5542,9 @@
         <translation type="vanished">Verhalten:</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
         <source>Always show after snapping</source>
-        <translation type="vanished">Immer nach dem Einrasten anzeigen</translation>
+        <translation>Immer nach dem Einrasten anzeigen</translation>
     </message>
     <message>
         <source>When enabled, a window picker appears after every snap. When disabled, hold the trigger below while dropping to show the picker for that snap only.</source>
@@ -4328,8 +5591,9 @@
         <translation type="vanished">Wiederöffnen:</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
         <source>Restore windows to their previous zone</source>
-        <translation type="vanished">Fenster in ihrer vorherigen Zone wiederherstellen</translation>
+        <translation>Fenster in ihrer vorherigen Zone wiederherstellen</translation>
     </message>
     <message>
         <source>When enabled, windows return to their previous zone when reopened, including after login or session restart.</source>
@@ -4508,7 +5772,7 @@
         <translation type="vanished">Klicken, um Tastenkombination festzulegen</translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="251"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="266"/>
         <source>No layout assigned</source>
         <translation>Kein Layout zugewiesen</translation>
     </message>
@@ -4621,8 +5885,10 @@
         <translation type="vanished">Einstellungen pro Bildschirm — Alle Bildschirme</translation>
     </message>
     <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="329"/>
+        <location filename="../src/settings/rulemodel.cpp" line="734"/>
         <source>Monitor</source>
-        <translation type="vanished">Bildschirm</translation>
+        <translation>Bildschirm</translation>
     </message>
     <message>
         <source>All Monitors (Default)</source>
@@ -4945,7 +6211,7 @@
         <translation type="vanished">Überschreibungen pro Arbeitsfläche</translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="210"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="225"/>
         <source>Desktop %1</source>
         <translation>Arbeitsfläche %1</translation>
     </message>
@@ -4962,8 +6228,9 @@
         <translation type="vanished">Zuweisungen pro Arbeitsfläche sind bei mehreren virtuellen Arbeitsflächen verfügbar.</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="453"/>
         <source>Tiling Quick Shortcuts</source>
-        <translation type="vanished">Kachelungs-Schnelltasten</translation>
+        <translation>Kachelungs-Schnelltasten</translation>
     </message>
     <message>
         <source>Quick Layout Shortcuts</source>
@@ -5042,8 +6309,9 @@
         <translation type="vanished">Zonenauswahl-Popup aktivieren</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="427"/>
         <source>Position &amp; Trigger</source>
-        <translation type="vanished">Position und Auslöser</translation>
+        <translation>Position und Auslöser</translation>
     </message>
     <message>
         <source>Choose where the popup appears on screen</source>
@@ -5058,12 +6326,1815 @@
         <translation type="vanished">Wie nah am Bildschirmrand, bevor das Popup erscheint</translation>
     </message>
     <message>
-        <source>Trigger distance</source>
-        <translation type="vanished">Auslöseabstand</translation>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="64"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="139"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="305"/>
+        <source>monitor</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="303"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <source>mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="57"/>
+        <source>active layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>rendering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>backend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="154"/>
+        <source>opengl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="154"/>
+        <source>vulkan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <source>backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="420"/>
+        <source>import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <source>reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="350"/>
+        <source>split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>subdivide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <source>zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <source>grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="124"/>
+        <source>preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <source>template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="68"/>
+        <source>aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="72"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="115"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <source>overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="72"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <source>trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="72"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="277"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="281"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <source>edge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="73"/>
+        <source>magnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="73"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>snap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <source>color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="200"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="205"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="207"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="222"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="257"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="260"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="263"/>
+        <source>colour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <source>opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="215"/>
+        <source>transparency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="200"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="257"/>
+        <source>theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="254"/>
+        <source>border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <source>zone selector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="310"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="425"/>
+        <source>picker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <source>chooser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>popup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <source>window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>drag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="82"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="365"/>
+        <source>modifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="82"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="139"/>
+        <source>priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="369"/>
+        <source>order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>precedence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="86"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="101"/>
+        <source>shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="86"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="101"/>
+        <source>hotkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="86"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="101"/>
+        <source>keybind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <source>keyboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="129"/>
+        <source>shader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="129"/>
+        <source>effect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <source>glow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="93"/>
+        <source>tile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="93"/>
+        <source>tiling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="93"/>
+        <source>auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="94"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="135"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="272"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="275"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="280"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <source>gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="94"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="272"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="275"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="280"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <source>spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>algorithm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>bsp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>binary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <source>spiral</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="362"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="365"/>
+        <source>stack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="106"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="115"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="122"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="237"/>
+        <source>animation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="106"/>
+        <source>duration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="106"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="124"/>
+        <source>easing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="107"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="124"/>
+        <source>curve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="107"/>
+        <source>spring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="107"/>
+        <source>speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <source>open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <source>close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>osd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>notification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="406"/>
+        <source>on-screen display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>side panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>drawer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <source>widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="122"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="122"/>
+        <source>layout editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>motion set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="134"/>
+        <source>title bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="134"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="266"/>
+        <source>decoration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="135"/>
+        <source>appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="135"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="272"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="275"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="280"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="371"/>
+        <source>gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="273"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="276"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="281"/>
+        <source>padding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="273"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="276"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="281"/>
+        <source>margin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>exclude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>float</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="139"/>
+        <source>activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>design</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="142"/>
+        <source>zones</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="144"/>
+        <source>about</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="144"/>
+        <source>version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="144"/>
+        <source>license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="145"/>
+        <source>credits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <source>Rendering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <source>Rendering backend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="154"/>
+        <source>graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="156"/>
+        <source>Window filtering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="401"/>
+        <source>Exclude transient windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="160"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="161"/>
+        <source>reset to defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="161"/>
+        <source>defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="161"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="327"/>
+        <source>restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="176"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="181"/>
+        <source>Window Handling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="199"/>
+        <source>System accent color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="200"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="211"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="257"/>
+        <source>scheme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="202"/>
+        <source>Highlight color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>hover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="205"/>
+        <source>Inactive color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="205"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="263"/>
+        <source>unfocused</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="207"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="260"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="263"/>
+        <source>outline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="210"/>
+        <source>Import colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="211"/>
+        <source>pywal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="211"/>
+        <source>json</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="211"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="420"/>
+        <source>load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <source>Active opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="215"/>
+        <source>alpha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="215"/>
+        <source>Inactive opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="217"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="252"/>
+        <source>thickness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="217"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="227"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="252"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="409"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <source>size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="219"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="254"/>
+        <source>rounding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="219"/>
+        <source>corner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <source>Label color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="222"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="227"/>
+        <source>text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="222"/>
+        <source>font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="224"/>
+        <source>typeface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="224"/>
+        <source>family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="224"/>
+        <source>style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="226"/>
+        <source>Label scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="227"/>
+        <source>multiplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="229"/>
+        <source>Blur behind zones</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="229"/>
+        <source>frost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="229"/>
+        <source>background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="231"/>
+        <source>Zone numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="232"/>
+        <source>index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="232"/>
+        <source>digit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="232"/>
+        <source>label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>Flash on layout switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>blink</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="236"/>
+        <source>Frame rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="237"/>
+        <source>fps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="237"/>
+        <source>refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="239"/>
+        <source>Audio spectrum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="244"/>
+        <source>cava</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>visualizer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="241"/>
+        <source>sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <source>Spectrum bars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="244"/>
+        <source>bands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="244"/>
+        <source>frequency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="254"/>
+        <source>Corner radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="259"/>
+        <source>Active border color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="260"/>
+        <source>focused</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="262"/>
+        <source>Inactive border color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="266"/>
+        <source>titlebar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="266"/>
+        <source>header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="271"/>
+        <source>Inner gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="273"/>
+        <source>inner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="274"/>
+        <source>Outer gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="276"/>
+        <source>outer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="282"/>
+        <source>side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="284"/>
+        <source>Smart gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="286"/>
+        <source>smart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="286"/>
+        <source>single</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <source>Activate on every drag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <source>Hold to activate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <source>deactivate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="294"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="367"/>
+        <source>Toggle mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="294"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="367"/>
+        <source>tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="294"/>
+        <source>activation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>Span modifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>zone span</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>paint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <source>span</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <source>distance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>multi-zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <source>Show zones on all monitors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="303"/>
+        <source>screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="305"/>
+        <source>Filter by aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="305"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="321"/>
+        <source>layouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="310"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>snap assist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>Hold to enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="314"/>
+        <source>Re-snap on resolution change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>Open new windows in the last-used zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="318"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="337"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="382"/>
+        <source>new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="318"/>
+        <source>last zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="320"/>
+        <source>Auto-assign new windows for all layouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="321"/>
+        <source>auto-assign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="323"/>
+        <source>Restore size on unsnap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>unsnap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>original size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="327"/>
+        <source>login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <source>Restore unsnapped windows to their previous position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="330"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <source>floated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="330"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="369"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <source>position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <source>Unfloat to a zone when there is no previous zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="333"/>
+        <source>unfloat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="333"/>
+        <source>fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="376"/>
+        <source>Sticky windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="376"/>
+        <source>all desktops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="376"/>
+        <source>sticky</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="337"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="382"/>
+        <source>Focus new windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="337"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="339"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="382"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="384"/>
+        <source>focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="339"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="384"/>
+        <source>Focus follows mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="339"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="384"/>
+        <source>pointer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="344"/>
+        <source>Max windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="345"/>
+        <source>windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="345"/>
+        <source>maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="345"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="438"/>
+        <source>count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <source>limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="348"/>
+        <source>Master ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="350"/>
+        <source>proportion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="353"/>
+        <source>Ratio step size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>increment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="358"/>
+        <source>number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="362"/>
+        <source>Always re-insert on drag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="362"/>
+        <source>insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="364"/>
+        <source>Hold to re-insert into stack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="367"/>
+        <source>stack preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="369"/>
+        <source>New window placement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="371"/>
+        <source>Respect minimum size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="371"/>
+        <source>minimum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <source>Restore untiled windows to their previous position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>Drag behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="380"/>
+        <source>Overflow behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="380"/>
+        <source>max windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="380"/>
+        <source>unlimited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="388"/>
+        <source>Global animation defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="390"/>
+        <source>Multiple windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <source>sequence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <source>simultaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <source>one by one</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="393"/>
+        <source>Stagger delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="394"/>
+        <source>pause</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="394"/>
+        <source>interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="394"/>
+        <source>delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="397"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="409"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <source>threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="397"/>
+        <source>skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="397"/>
+        <source>geometry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="402"/>
+        <source>dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="402"/>
+        <source>popups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="402"/>
+        <source>tooltips</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="403"/>
+        <source>menus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <source>Exclude notifications and OSDs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="406"/>
+        <source>volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="406"/>
+        <source>brightness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <source>Minimum window width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="409"/>
+        <source>narrow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="411"/>
+        <source>Minimum window height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <source>short</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="416"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="183"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="214"/>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="420"/>
+        <source>data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="419"/>
+        <source>Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <source>Zone selector popup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="425"/>
+        <source>enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="425"/>
+        <source>toggle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="429"/>
+        <source>Trigger distance</source>
+        <translation>Auslöseabstand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <source>proximity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
         <source>Layout Arrangement</source>
-        <translation type="vanished">Layout-Anordnung</translation>
+        <translation>Layout-Anordnung</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="434"/>
+        <source>Arrangement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <source>horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <source>vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <source>Grid columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="438"/>
+        <source>columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="438"/>
+        <source>per row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="440"/>
+        <source>Max visible rows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="441"/>
+        <source>rows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="441"/>
+        <source>scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="441"/>
+        <source>visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="447"/>
+        <source>Snapping Layout Priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="449"/>
+        <source>Tiling Algorithm Priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="451"/>
+        <source>Snapping Quick Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="457"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="459"/>
+        <source>User shaders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="461"/>
+        <source>Easing Presets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="463"/>
+        <source>Spring Presets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="465"/>
+        <source>Save current state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <source>Saved sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="470"/>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <source>Close</source>
+        <translation type="unfinished">Schließen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="473"/>
+        <source>Minimize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="475"/>
+        <source>Maximize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="476"/>
+        <source>Move</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="478"/>
+        <source>Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <source>Snap Into Zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="483"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="549"/>
+        <source>Snap Out of Zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="485"/>
+        <source>Layout Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="487"/>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <source>Zone Selector: Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="491"/>
+        <source>Zone Selector: Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="493"/>
+        <source>Layout Picker: Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="495"/>
+        <source>Layout Picker: Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="497"/>
+        <source>Snap Assist: Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>Snap Assist: Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <source>Slide In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>Slide Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="505"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>Fade In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="507"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="525"/>
+        <source>Fade Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>Hover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="509"/>
+        <source>Press</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="511"/>
+        <source>Toggle On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="513"/>
+        <source>Toggle Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="515"/>
+        <source>Show (badge)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="517"/>
+        <source>Hide (badge)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="519"/>
+        <source>Pulse (badge)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="520"/>
+        <source>Tint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="521"/>
+        <source>Dim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="527"/>
+        <source>Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <source>Expand (accordion)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="531"/>
+        <source>Collapse (accordion)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="533"/>
+        <source>Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="535"/>
+        <source>Zone Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="537"/>
+        <source>Zone Highlight: Pop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="539"/>
+        <source>Zone Highlight: Border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <source>Zone Overlay: Layout-Switch Flash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="543"/>
+        <source>Cursor Hover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="545"/>
+        <source>Cursor Click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="547"/>
+        <source>Snap Into Zone (Fill Preview)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="551"/>
+        <source>Snap Resize (Drag Preview)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Arrangement:</source>
@@ -5090,8 +8161,9 @@
         <translation type="vanished">Scrollen wird aktiviert, wenn weitere Zeilen vorhanden sind</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="443"/>
         <source>Preview Size</source>
-        <translation type="vanished">Vorschaugröße</translation>
+        <translation>Vorschaugröße</translation>
     </message>
     <message>
         <source>Auto</source>
@@ -5243,12 +8315,14 @@ Seitenverhältnis: %3</translation>
         <translation type="vanished">Sie können auch die Layout-JSON-Dateien direkt bearbeiten:</translation>
     </message>
     <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="144"/>
         <source>Layouts</source>
-        <translation type="vanished">Layouts</translation>
+        <translation>Layouts</translation>
     </message>
     <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="127"/>
         <source>Editor</source>
-        <translation type="vanished">Editor</translation>
+        <translation>Editor</translation>
     </message>
     <message>
         <source>Assignments</source>
@@ -5259,8 +8333,9 @@ Seitenverhältnis: %3</translation>
         <translation type="vanished">Ausnahmen</translation>
     </message>
     <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="129"/>
         <source>About</source>
-        <translation type="vanished">Über</translation>
+        <translation>Über</translation>
     </message>
     <message>
         <source>Delete the selected layout</source>
@@ -5287,12 +8362,15 @@ Seitenverhältnis: %3</translation>
         <translation type="vanished">Auf Standard zurücksetzen</translation>
     </message>
     <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="253"/>
         <source>Zones</source>
-        <translation type="vanished">Zonen</translation>
+        <translation>Zonen</translation>
     </message>
     <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="171"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="88"/>
         <source>Display</source>
-        <translation type="vanished">Anzeige</translation>
+        <translation>Anzeige</translation>
     </message>
     <message>
         <source>Update available!</source>
@@ -5356,23 +8434,514 @@ Seitenverhältnis: %3</translation>
         </translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon.cpp" line="1772"/>
+        <location filename="../src/daemon/daemon.cpp" line="162"/>
+        <source>Default borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="183"/>
+        <source>Default title bars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="212"/>
+        <source>Default gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2080"/>
         <source>The PlasmaZones KWin effect plugin is not installed where KWin can find it. Reinstall PlasmaZones.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon.cpp" line="1811"/>
+        <location filename="../src/daemon/daemon.cpp" line="2119"/>
         <source>The PlasmaZones KWin effect was built for KWin %1 but KWin %2 is running, so KWin will not load it. Rebuild and reinstall PlasmaZones against the running KWin. On NixOS, install via the flake&apos;s nixosModules or overlay (not packages.default).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon.cpp" line="1840"/>
+        <location filename="../src/daemon/daemon.cpp" line="2148"/>
         <source>The PlasmaZones KWin effect has not registered with the daemon, so window dragging and shortcuts will not work. Make sure it is enabled in System Settings &gt; Desktop Effects, then restart the Plasma session.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon.cpp" line="1859"/>
+        <location filename="../src/daemon/daemon.cpp" line="2167"/>
         <source>PlasmaZones: window manager integration inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="323"/>
+        <source>Only Luau algorithm files (.luau) can be imported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="329"/>
+        <source>Algorithm file names may contain only letters, digits, hyphens, and underscores.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="354"/>
+        <source>Too many algorithms share this name. Remove some and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="362"/>
+        <source>Could not copy the algorithm file. Check available disk space and permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="426"/>
+        <source>Algorithm was created but not picked up by the registry. Try refreshing or restarting the application.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="487"/>
+        <source>No algorithm is selected to delete.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="495"/>
+        <source>Only user-created algorithms can be deleted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="502"/>
+        <source>Algorithm file not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="516"/>
+        <source>The user algorithms directory does not exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="517"/>
+        <source>That file is outside the user algorithms directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="530"/>
+        <source>Could not delete algorithm file. Check file permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="540"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="660"/>
+        <source>The algorithm file could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="547"/>
+        <source>That algorithm is no longer registered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="562"/>
+        <source>Too many copies of this algorithm already exist. Rename or delete some before duplicating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="570"/>
+        <source>The algorithm file path could not be resolved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="577"/>
+        <source>Could not read source algorithm file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="610"/>
+        <source>Could not duplicate the algorithm. Its metadata format is not recognised. Expected `name = &quot;...&quot;` and `id = &quot;...&quot;` on separate lines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="621"/>
+        <source>Could not rewrite the algorithm&apos;s metadata.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="631"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="642"/>
+        <source>Could not write duplicate algorithm file. Check disk space and permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="654"/>
+        <source>No export destination specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="675"/>
+        <source>Could not copy algorithm file for export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="682"/>
+        <source>Could not replace existing file at export destination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="694"/>
+        <source>Could not write to export destination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="738"/>
+        <source>Too many algorithms already share this name. Rename or delete some before creating another.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="801"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="812"/>
+        <source>Could not write algorithm file. Check disk space and permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="261"/>
+        <source>Cannot save while a discard is in progress.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="408"/>
+        <location filename="../src/settings/rulecontroller.cpp" line="150"/>
+        <source>Discard already in flight.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="480"/>
+        <source>Failed to restore %1 profile file(s). They remain pending.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="615"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="625"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="642"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="652"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="662"/>
+        <source>Cannot modify presets while a discard is in progress.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="99"/>
+        <source>“%1” only applies to move, resize, snap, and tile events.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="102"/>
+        <source>“%1” only applies to show and hide events, not move, resize, snap, or tile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="192"/>
+        <source>Could not create the user shader directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="62"/>
+        <source>No KZones configuration found in kwinrc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="68"/>
+        <source>Failed to parse KZones layoutsJson: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="73"/>
+        <source>Imported %n layout(s) from KZones</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="75"/>
+        <source>No layouts found in KZones configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="83"/>
+        <source>No file path specified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="88"/>
+        <source>Could not open file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="101"/>
+        <source>Failed to parse KZones JSON: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="111"/>
+        <source>KZones file does not contain a JSON array or object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="116"/>
+        <source>Imported %n layout(s) from KZones file</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="118"/>
+        <source>No valid layouts found in file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="102"/>
+        <source>PlasmaZones Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="107"/>
+        <source>Open a specific settings page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="110"/>
+        <source>Reveal a specific setting on the page (deep link)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="114"/>
+        <source>Reveal a specific section on the page (deep link)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="165"/>
+        <source>Failed to fetch the daemon&apos;s rule set.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="247"/>
+        <source>The daemon rejected one or more rules.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="361"/>
+        <source>A save is already in flight.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="372"/>
+        <source>The daemon&apos;s rules changed while you were editing. Review or use Save anyway to overwrite.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="383"/>
+        <source>One or more rules failed validation and could not be saved. See the log for details.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="629"/>
+        <source>%1 (copy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="39"/>
+        <source>New monitor rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="43"/>
+        <source>New desktop rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="50"/>
+        <source>New application rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="54"/>
+        <source>New activity rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="58"/>
+        <source>New animation rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="68"/>
+        <source>New custom rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="93"/>
+        <source>Set a layout on a monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="94"/>
+        <source>Pick a snapping layout to use on one monitor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="95"/>
+        <source>Set a tiling algorithm on a monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="96"/>
+        <source>Pick an autotile algorithm to use on one monitor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="98"/>
+        <source>Lock the layout on a monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="99"/>
+        <source>Pin the active layout on one monitor so it can&apos;t be switched. This is the rule-driven version of the lock-layout shortcut.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="102"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="163"/>
+        <source>Exclude an app from tiling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="103"/>
+        <source>Keep one application&apos;s windows out of the snap and autotile engines entirely.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="105"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="170"/>
+        <source>Don&apos;t animate small windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="106"/>
+        <source>Skip open and close animations for windows narrower than a chosen width. Handy for tiny popups and tool windows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="119"/>
+        <source>Snapping layout on monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="137"/>
+        <source>Tiling algorithm on monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="152"/>
+        <source>Lock layout on monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="230"/>
+        <source>Layout created, but aspect-ratio class could not be applied: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="244"/>
+        <source>Could not create the layout. The daemon returned an empty layout ID.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="252"/>
+        <source>Could not create the layout. The daemon may not be running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="271"/>
+        <source>Could not delete layout: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="287"/>
+        <source>Could not duplicate layout: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="388"/>
+        <source>Import refused: unsafe path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="432"/>
+        <source>Failed to update layout visibility: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="445"/>
+        <source>Failed to update auto-assign: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="459"/>
+        <source>Failed to update aspect ratio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_lifecycle.cpp" line="172"/>
+        <source>Failed to apply assignment changes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="303"/>
+        <source>Shader pack installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="305"/>
+        <source>The dropped path is not a valid shader pack directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="307"/>
+        <source>The shader pack is missing metadata.json (or it is a symlink).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="309"/>
+        <source>The user shader directory could not be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="311"/>
+        <source>A shader pack with this name is already installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="313"/>
+        <source>The shader pack exceeds the maximum allowed size or file count.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="315"/>
+        <source>Copying the shader pack failed. The partial install was rolled back.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="317"/>
+        <source>Unknown shader pack installer error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="78"/>
+        <source>Color import file does not exist: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="96"/>
+        <source>Color import file does not resolve to a regular file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="101"/>
+        <source>Color import file must be a .json file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/plasmazones_en.ts
+++ b/translations/plasmazones_en.ts
@@ -38,33 +38,33 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="346"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="354"/>
         <source>Cancel Zone Overlay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="381"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="409"/>
         <source>Layout Picker: Move Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="385"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="413"/>
         <source>Layout Picker: Move Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="389"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="417"/>
         <source>Layout Picker: Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="393"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="421"/>
         <source>Layout Picker: Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="397"/>
-        <location filename="../src/dbus/windowdragadaptor.cpp" line="399"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="425"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="427"/>
         <source>Layout Picker: Confirm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -207,6 +207,7 @@
     </message>
     <message>
         <location filename="../src/editor/controller/layout.cpp" line="927"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="405"/>
         <source>Failed to import layout: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -236,33 +237,33 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="150"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="165"/>
         <source>Layout Locked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="199"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="214"/>
         <source>Disabled on this monitor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="210"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="225"/>
         <source>Desktop %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="212"/>
-        <location filename="../src/daemon/daemon/osd.cpp" line="223"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="227"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="238"/>
         <source>Disabled on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="221"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="236"/>
         <source>Disabled on this activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="251"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="266"/>
         <source>No layout assigned</source>
         <translation type="unfinished"></translation>
     </message>
@@ -272,7 +273,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="123"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="138"/>
         <source>Layout: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -291,6 +292,8 @@
     </message>
     <message>
         <location filename="../src/editor/controller/layout.cpp" line="315"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="201"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="209"/>
         <source>New Layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -408,7 +411,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon/osd.cpp" line="280"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="295"/>
+        <location filename="../src/settings/rulemodel.cpp" line="240"/>
         <source>Tiling: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -526,23 +530,3768 @@
         </translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon.cpp" line="1772"/>
+        <location filename="../src/daemon/daemon.cpp" line="162"/>
+        <source>Default borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="183"/>
+        <source>Default title bars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="212"/>
+        <source>Default gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2080"/>
         <source>The PlasmaZones KWin effect plugin is not installed where KWin can find it. Reinstall PlasmaZones.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon.cpp" line="1811"/>
+        <location filename="../src/daemon/daemon.cpp" line="2119"/>
         <source>The PlasmaZones KWin effect was built for KWin %1 but KWin %2 is running, so KWin will not load it. Rebuild and reinstall PlasmaZones against the running KWin. On NixOS, install via the flake&apos;s nixosModules or overlay (not packages.default).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon.cpp" line="1840"/>
+        <location filename="../src/daemon/daemon.cpp" line="2148"/>
         <source>The PlasmaZones KWin effect has not registered with the daemon, so window dragging and shortcuts will not work. Make sure it is enabled in System Settings &gt; Desktop Effects, then restart the Plasma session.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/daemon/daemon.cpp" line="1859"/>
+        <location filename="../src/daemon/daemon.cpp" line="2167"/>
         <source>PlasmaZones: window manager integration inactive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="323"/>
+        <source>Only Luau algorithm files (.luau) can be imported.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="329"/>
+        <source>Algorithm file names may contain only letters, digits, hyphens, and underscores.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="354"/>
+        <source>Too many algorithms share this name. Remove some and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="362"/>
+        <source>Could not copy the algorithm file. Check available disk space and permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="426"/>
+        <source>Algorithm was created but not picked up by the registry. Try refreshing or restarting the application.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="487"/>
+        <source>No algorithm is selected to delete.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="495"/>
+        <source>Only user-created algorithms can be deleted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="502"/>
+        <source>Algorithm file not found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="516"/>
+        <source>The user algorithms directory does not exist.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="517"/>
+        <source>That file is outside the user algorithms directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="530"/>
+        <source>Could not delete algorithm file. Check file permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="540"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="660"/>
+        <source>The algorithm file could not be found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="547"/>
+        <source>That algorithm is no longer registered.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="562"/>
+        <source>Too many copies of this algorithm already exist. Rename or delete some before duplicating.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="570"/>
+        <source>The algorithm file path could not be resolved.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="577"/>
+        <source>Could not read source algorithm file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="610"/>
+        <source>Could not duplicate the algorithm. Its metadata format is not recognised. Expected `name = &quot;...&quot;` and `id = &quot;...&quot;` on separate lines.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="621"/>
+        <source>Could not rewrite the algorithm&apos;s metadata.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="631"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="642"/>
+        <source>Could not write duplicate algorithm file. Check disk space and permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="654"/>
+        <source>No export destination specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="675"/>
+        <source>Could not copy algorithm file for export.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="682"/>
+        <source>Could not replace existing file at export destination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="694"/>
+        <source>Could not write to export destination.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="738"/>
+        <source>Too many algorithms already share this name. Rename or delete some before creating another.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="801"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="812"/>
+        <source>Could not write algorithm file. Check disk space and permissions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="261"/>
+        <source>Cannot save while a discard is in progress.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="408"/>
+        <location filename="../src/settings/rulecontroller.cpp" line="150"/>
+        <source>Discard already in flight.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="480"/>
+        <source>Failed to restore %1 profile file(s). They remain pending.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="615"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="625"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="642"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="652"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="662"/>
+        <source>Cannot modify presets while a discard is in progress.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="99"/>
+        <source>“%1” only applies to move, resize, snap, and tile events.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="102"/>
+        <source>“%1” only applies to show and hide events, not move, resize, snap, or tile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="192"/>
+        <source>Could not create the user shader directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="62"/>
+        <source>No KZones configuration found in kwinrc</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="68"/>
+        <source>Failed to parse KZones layoutsJson: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="73"/>
+        <source>Imported %n layout(s) from KZones</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="75"/>
+        <source>No layouts found in KZones configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="83"/>
+        <source>No file path specified</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="88"/>
+        <source>Could not open file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="101"/>
+        <source>Failed to parse KZones JSON: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="111"/>
+        <source>KZones file does not contain a JSON array or object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="116"/>
+        <source>Imported %n layout(s) from KZones file</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="118"/>
+        <source>No valid layouts found in file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="102"/>
+        <source>PlasmaZones Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="107"/>
+        <source>Open a specific settings page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="110"/>
+        <source>Reveal a specific setting on the page (deep link)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="114"/>
+        <source>Reveal a specific section on the page (deep link)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="60"/>
+        <source>Identity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="66"/>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="77"/>
+        <source>State</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="83"/>
+        <source>Taskbar &amp; switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="89"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="737"/>
+        <location filename="../src/settings/rulemodel.cpp" line="160"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="138"/>
+        <source>Tiling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="94"/>
+        <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="100"/>
+        <source>Context</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="102"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="199"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="224"/>
+        <source>Other</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="113"/>
+        <source>The application&apos;s ID (Wayland app_id / desktop entry), e.g. org.kde.konsole.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="115"/>
+        <source>The window&apos;s class (WM_CLASS resource class), e.g. konsole.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="117"/>
+        <source>The application&apos;s desktop entry file name.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="119"/>
+        <source>The window&apos;s X11 role (WM_WINDOW_ROLE). Empty for Wayland-native windows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="121"/>
+        <source>The window&apos;s process ID.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="123"/>
+        <source>The window&apos;s title-bar text.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="125"/>
+        <source>The window&apos;s type (Normal, Dialog, Utility, Notification, …).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="127"/>
+        <source>Whether the window is shown on all virtual desktops.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="129"/>
+        <source>Whether the window is fullscreen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="131"/>
+        <source>Whether the window is minimized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="133"/>
+        <source>Whether the window is maximized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="135"/>
+        <source>Whether the window currently has keyboard focus.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="137"/>
+        <source>Whether the window is a transient (a dialog or popup owned by another window).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="139"/>
+        <source>Whether the window is a notification or on-screen display.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="141"/>
+        <source>The window&apos;s width in pixels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="143"/>
+        <source>The window&apos;s height in pixels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="145"/>
+        <source>Whether the window is set to stay above other windows (always on top).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="147"/>
+        <source>Whether the window is set to stay below other windows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="149"/>
+        <source>Whether the window is hidden from the taskbar.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="151"/>
+        <source>Whether the window is hidden from the pager.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="153"/>
+        <source>Whether the window is hidden from the window switcher (Alt+Tab).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="155"/>
+        <source>Whether the window is a modal dialog.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="157"/>
+        <source>Whether the window has a server-side title-bar and border.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="159"/>
+        <source>Whether the window can be resized.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="161"/>
+        <source>The window&apos;s left-edge X position in pixels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="163"/>
+        <source>The window&apos;s top-edge Y position in pixels.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="165"/>
+        <source>The window&apos;s title without the application-name suffix the window manager adds.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="167"/>
+        <source>Whether the window has been floated out of tiling (snap or autotile).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="169"/>
+        <source>Whether the window is snapped into a zone (manual-zone mode, where tiled windows are not snapped).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="172"/>
+        <source>Whether the window is managed by the autotile engine.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="174"/>
+        <source>The zone the window is snapped into (manual-zone mode only).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="176"/>
+        <source>The monitor the window is on.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="178"/>
+        <source>The virtual desktop the window is on.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="180"/>
+        <source>The KDE Activity the window is on.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="182"/>
+        <source>The engine mode the window is placed by (snapping or tiling).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="184"/>
+        <source>How many windows are tiled on this monitor and desktop. Lets a rule switch the tiling algorithm as windows open and close, for example a centered single-window layout that gives way once a second window opens.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="207"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="270"/>
+        <source>Gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="210"/>
+        <source>Layout &amp; engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="213"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="159"/>
+        <source>Overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="216"/>
+        <source>Animation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="219"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="99"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="165"/>
+        <source>Appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="222"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="179"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="203"/>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="238"/>
+        <source>Engine mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="241"/>
+        <location filename="../src/settings/rulemodel.cpp" line="231"/>
+        <source>Snapping layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="244"/>
+        <source>Tiling algorithm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="247"/>
+        <source>Engine to disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="250"/>
+        <source>Opacity (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="253"/>
+        <source>Zones</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="260"/>
+        <source>Restore position on login (off = don&apos;t restore)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="267"/>
+        <source>Hide title bars (off = force visible)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="270"/>
+        <source>Show border (off = hide)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="273"/>
+        <source>Border width (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="276"/>
+        <source>Corner radius (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="282"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="207"/>
+        <source>Border color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="286"/>
+        <source>Inner gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="289"/>
+        <source>Outer gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="292"/>
+        <source>Use per-side outer gaps (off = one uniform gap)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="299"/>
+        <source>Lock the layout (off = don&apos;t lock)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="306"/>
+        <source>Assign a default layout (off = leave unassigned)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="309"/>
+        <source>Top gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="312"/>
+        <source>Bottom gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="315"/>
+        <source>Left gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="318"/>
+        <source>Right gap (px)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="323"/>
+        <location filename="../src/settings/rulemodel.cpp" line="325"/>
+        <source>Overlay shader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="326"/>
+        <location filename="../src/settings/rulemodel.cpp" line="336"/>
+        <source>Overlay style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="329"/>
+        <location filename="../src/settings/rulemodel.cpp" line="734"/>
+        <source>Monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="332"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="689"/>
+        <location filename="../src/settings/rulemodel.cpp" line="736"/>
+        <source>Desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="335"/>
+        <source>Event</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="338"/>
+        <source>Shader effect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="341"/>
+        <source>Duration (ms)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="344"/>
+        <source>Curve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="359"/>
+        <source>Zone numbers like “1, 2”, or a range like “1-3”. Multiple zones snap the window to their combined area.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="374"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="736"/>
+        <location filename="../src/settings/rulemodel.cpp" line="158"/>
+        <location filename="../src/settings/rulemodel.cpp" line="197"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="136"/>
+        <source>Snapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="377"/>
+        <location filename="../src/settings/rulemodel.cpp" line="199"/>
+        <source>Autotile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="380"/>
+        <location filename="../src/settings/rulemodel.cpp" line="201"/>
+        <source>Scrolling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="385"/>
+        <source>Zone rectangles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="388"/>
+        <source>Layout preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="464"/>
+        <source>Set engine mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="467"/>
+        <source>Set snapping layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="470"/>
+        <source>Set tiling algorithm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="473"/>
+        <source>Disable engine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="476"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="606"/>
+        <source>Lock layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="479"/>
+        <source>Default layout assignment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="482"/>
+        <source>Exclude window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="485"/>
+        <source>Float window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="488"/>
+        <source>Snap to zone(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="491"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="599"/>
+        <source>Restore position on login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="494"/>
+        <source>Override animation shader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="497"/>
+        <source>Override animation duration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="500"/>
+        <source>Override animation curve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="503"/>
+        <source>Set opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="506"/>
+        <source>Set overlay shader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="509"/>
+        <source>Set overlay style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="512"/>
+        <source>Exclude from animations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="520"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="603"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="265"/>
+        <source>Hide title bars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="523"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="612"/>
+        <source>Show border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="526"/>
+        <source>Set border width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="529"/>
+        <source>Set corner radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="532"/>
+        <source>Set focused border color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="535"/>
+        <source>Set unfocused border color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="538"/>
+        <source>Set inner gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="541"/>
+        <source>Set outer gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="544"/>
+        <source>Use per-side outer gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="547"/>
+        <source>Set top gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="550"/>
+        <source>Set bottom gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="553"/>
+        <source>Set left gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="556"/>
+        <source>Set right gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="559"/>
+        <location filename="../src/settings/rulemodel.cpp" line="282"/>
+        <source>Open on monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="562"/>
+        <location filename="../src/settings/rulemodel.cpp" line="287"/>
+        <source>Open on desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="571"/>
+        <source>is</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="573"/>
+        <source>contains</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="575"/>
+        <source>starts with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="577"/>
+        <source>ends with</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="579"/>
+        <source>matches regex</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="581"/>
+        <source>matches app-id</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="583"/>
+        <source>greater than</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="585"/>
+        <source>less than</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="679"/>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="680"/>
+        <source>Normal window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="681"/>
+        <source>Dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="682"/>
+        <source>Utility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="683"/>
+        <source>Toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="684"/>
+        <source>Splash screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="685"/>
+        <source>Menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="686"/>
+        <source>Tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="687"/>
+        <location filename="../src/settings/rulemodel.cpp" line="742"/>
+        <source>Notification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="688"/>
+        <source>Dock / panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="690"/>
+        <source>On-screen display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="691"/>
+        <source>Popup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="816"/>
+        <source>Regular expression, e.g. ^(firefox|chromium)$</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="819"/>
+        <source>Matches by reverse-DNS segments, so “firefox” also matches “org.mozilla.firefox”.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="165"/>
+        <source>Failed to fetch the daemon&apos;s rule set.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="247"/>
+        <source>The daemon rejected one or more rules.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="361"/>
+        <source>A save is already in flight.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="372"/>
+        <source>The daemon&apos;s rules changed while you were editing. Review or use Save anyway to overwrite.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="383"/>
+        <source>One or more rules failed validation and could not be saved. See the log for details.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="629"/>
+        <source>%1 (copy)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="162"/>
+        <location filename="../src/settings/rulemodel.cpp" line="170"/>
+        <location filename="../src/settings/rulemodel.cpp" line="175"/>
+        <source>%1: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="171"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="172"/>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="227"/>
+        <source>Engine: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="232"/>
+        <source>Snapping: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="251"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="253"/>
+        <source>Disable: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="256"/>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="259"/>
+        <source>Float</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="269"/>
+        <source>Snap to zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="272"/>
+        <source>Snap to zone %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="274"/>
+        <source>Snap to zones %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="283"/>
+        <source>Open on monitor: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="287"/>
+        <source>Open on desktop %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="296"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="189"/>
+        <source>Opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="300"/>
+        <location filename="../src/settings/rulemodel.cpp" line="305"/>
+        <source>Opacity (invalid)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="307"/>
+        <source>Opacity: %1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="311"/>
+        <source>Block animation shader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="312"/>
+        <source>Shader: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="316"/>
+        <source>Duration: %1 ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="316"/>
+        <source>Animation duration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="320"/>
+        <source>Animation curve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="321"/>
+        <source>Curve: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="326"/>
+        <source>Overlay shader: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="331"/>
+        <source>Overlay style: Zone rectangles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="334"/>
+        <source>Overlay style: Layout preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="600"/>
+        <source>Don&apos;t restore position on login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="603"/>
+        <source>Show title bars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="606"/>
+        <source>Don&apos;t lock layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="609"/>
+        <source>Assign default layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="609"/>
+        <source>Don&apos;t assign default layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="612"/>
+        <source>Hide border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="351"/>
+        <source>Border width: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="354"/>
+        <source>Corner radius: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="361"/>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="363"/>
+        <source>Focused border: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="365"/>
+        <source>Unfocused border: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="369"/>
+        <source>Gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="372"/>
+        <source>Outer gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="615"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="279"/>
+        <source>Per-side outer gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="615"/>
+        <source>Uniform outer gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="375"/>
+        <source>Top gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="378"/>
+        <source>Bottom gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="381"/>
+        <source>Left gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="384"/>
+        <source>Right gap: %1 px</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="459"/>
+        <source>Everywhere</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="691"/>
+        <source>Monitor &amp; Layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="693"/>
+        <source>Applications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="695"/>
+        <source>Activities</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="697"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="114"/>
+        <source>Animations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="699"/>
+        <source>Advanced / Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="701"/>
+        <source>System</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="710"/>
+        <source>Application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="712"/>
+        <source>Window class</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="714"/>
+        <source>Desktop file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="716"/>
+        <source>Window role</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="718"/>
+        <source>Process ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="720"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="722"/>
+        <source>Window type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="724"/>
+        <source>Sticky</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="726"/>
+        <source>Fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="728"/>
+        <source>Maximized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="730"/>
+        <source>Minimized</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="732"/>
+        <source>Focused</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="738"/>
+        <source>Activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="740"/>
+        <source>Transient</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="744"/>
+        <source>Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="746"/>
+        <source>Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="748"/>
+        <source>Keep above</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="750"/>
+        <source>Keep below</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="752"/>
+        <source>Skip taskbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="754"/>
+        <source>Skip pager</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="756"/>
+        <source>Skip switcher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="758"/>
+        <source>Modal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="760"/>
+        <source>Decorated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="762"/>
+        <source>Resizable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="764"/>
+        <source>Position X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="766"/>
+        <source>Position Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="768"/>
+        <source>Title (no suffix)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="770"/>
+        <source>Floating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="772"/>
+        <source>Snapped</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="774"/>
+        <source>Tiled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="776"/>
+        <source>Zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="778"/>
+        <source>Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="780"/>
+        <source>Tiled window count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="788"/>
+        <source>Any window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="800"/>
+        <source>(condition group)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/rulemodel.cpp" line="807"/>
+        <source>%n condition(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="813"/>
+        <source>No action</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="39"/>
+        <source>New monitor rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="43"/>
+        <source>New desktop rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="50"/>
+        <source>New application rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="54"/>
+        <source>New activity rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="58"/>
+        <source>New animation rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="68"/>
+        <source>New custom rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="93"/>
+        <source>Set a layout on a monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="94"/>
+        <source>Pick a snapping layout to use on one monitor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="95"/>
+        <source>Set a tiling algorithm on a monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="96"/>
+        <source>Pick an autotile algorithm to use on one monitor.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="98"/>
+        <source>Lock the layout on a monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="99"/>
+        <source>Pin the active layout on one monitor so it can&apos;t be switched. This is the rule-driven version of the lock-layout shortcut.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="102"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="163"/>
+        <source>Exclude an app from tiling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="103"/>
+        <source>Keep one application&apos;s windows out of the snap and autotile engines entirely.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="105"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="170"/>
+        <source>Don&apos;t animate small windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="106"/>
+        <source>Skip open and close animations for windows narrower than a chosen width. Handy for tiny popups and tool windows.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="119"/>
+        <source>Snapping layout on monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="137"/>
+        <source>Tiling algorithm on monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="152"/>
+        <source>Lock layout on monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="64"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="139"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="305"/>
+        <source>monitor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="303"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <source>mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="57"/>
+        <source>active layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>rendering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>backend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="154"/>
+        <source>opengl</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="154"/>
+        <source>vulkan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <source>backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="420"/>
+        <source>import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <source>reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="350"/>
+        <source>split</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>subdivide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>region</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <source>zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <source>grid</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="124"/>
+        <source>preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <source>template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="68"/>
+        <source>aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="72"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="115"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <source>overlay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="72"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <source>trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="72"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="277"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="281"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <source>edge</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="73"/>
+        <source>magnet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="73"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>snap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <source>color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="200"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="205"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="207"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="222"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="257"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="260"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="263"/>
+        <source>colour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <source>opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="215"/>
+        <source>transparency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="200"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="257"/>
+        <source>theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="254"/>
+        <source>border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <source>zone selector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="310"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="425"/>
+        <source>picker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <source>chooser</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>popup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <source>window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>drag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="82"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="365"/>
+        <source>modifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="82"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <source>key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="139"/>
+        <source>priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="369"/>
+        <source>order</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>precedence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="86"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="101"/>
+        <source>shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="86"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="101"/>
+        <source>hotkey</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="86"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="101"/>
+        <source>keybind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <source>keyboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="129"/>
+        <source>shader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="129"/>
+        <source>effect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <source>glow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="93"/>
+        <source>tile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="93"/>
+        <source>tiling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="93"/>
+        <source>auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="94"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="135"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="272"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="275"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="280"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <source>gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="94"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="272"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="275"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="280"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <source>spacing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>algorithm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>bsp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>binary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <source>spiral</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="362"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="365"/>
+        <source>stack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="106"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="115"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="122"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="237"/>
+        <source>animation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="106"/>
+        <source>duration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="106"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="124"/>
+        <source>easing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="107"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="124"/>
+        <source>curve</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="107"/>
+        <source>spring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="107"/>
+        <source>speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <source>open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <source>close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>osd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>notification</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="406"/>
+        <source>on-screen display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>side panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>panel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>drawer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <source>widget</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="122"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="122"/>
+        <source>layout editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>motion set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>motion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="134"/>
+        <source>title bar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="134"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="266"/>
+        <source>decoration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="135"/>
+        <source>appearance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="135"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="272"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="275"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="280"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="371"/>
+        <source>gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="273"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="276"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="281"/>
+        <source>padding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="273"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="276"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="281"/>
+        <source>margin</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>rule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>exclude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>float</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="139"/>
+        <source>activity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>design</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="142"/>
+        <source>zones</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="144"/>
+        <source>about</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="144"/>
+        <source>version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="144"/>
+        <source>license</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="145"/>
+        <source>credits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <source>Rendering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <source>Rendering backend</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="154"/>
+        <source>graphics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="156"/>
+        <source>Window filtering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="401"/>
+        <source>Exclude transient windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="160"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="161"/>
+        <source>reset to defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="161"/>
+        <source>defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="161"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="327"/>
+        <source>restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="179"/>
+        <source>Triggers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <source>Zone Span</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="171"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="88"/>
+        <source>Display</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="174"/>
+        <source>Snap Assist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="176"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="181"/>
+        <source>Window Handling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="177"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="182"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="479"/>
+        <source>Focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="187"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <source>Colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="191"/>
+        <source>Border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="193"/>
+        <source>Zone Labels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <source>Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="197"/>
+        <source>Shader Effects</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="199"/>
+        <source>System accent color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="200"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="211"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="257"/>
+        <source>scheme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="202"/>
+        <source>Highlight color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>active</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>hover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="205"/>
+        <source>Inactive color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="205"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="263"/>
+        <source>unfocused</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="207"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="260"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="263"/>
+        <source>outline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="210"/>
+        <source>Import colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="211"/>
+        <source>pywal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="211"/>
+        <source>json</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="211"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="420"/>
+        <source>load</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <source>Active opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="215"/>
+        <source>alpha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="215"/>
+        <source>Inactive opacity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="217"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="252"/>
+        <source>Border width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="217"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="252"/>
+        <source>thickness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="217"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="227"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="252"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="409"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <source>size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="219"/>
+        <source>Border radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="219"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="254"/>
+        <source>rounding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="219"/>
+        <source>corner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <source>Label color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="222"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="227"/>
+        <source>text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="222"/>
+        <source>font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <source>Font</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="224"/>
+        <source>typeface</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="224"/>
+        <source>family</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="224"/>
+        <source>style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="226"/>
+        <source>Label scale</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="227"/>
+        <source>multiplier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="229"/>
+        <source>Blur behind zones</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="229"/>
+        <source>frost</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="229"/>
+        <source>background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="231"/>
+        <source>Zone numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="232"/>
+        <source>index</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="232"/>
+        <source>digit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="232"/>
+        <source>label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>Flash on layout switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>blink</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="236"/>
+        <source>Frame rate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="237"/>
+        <source>fps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="237"/>
+        <source>refresh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="239"/>
+        <source>Audio spectrum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="244"/>
+        <source>cava</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>music</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>visualizer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="241"/>
+        <source>sound</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <source>Spectrum bars</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="244"/>
+        <source>bands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="244"/>
+        <source>frequency</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="247"/>
+        <source>Borders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="250"/>
+        <source>Decorations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="254"/>
+        <source>Corner radius</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="256"/>
+        <source>Use system accent color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="259"/>
+        <source>Active border color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="260"/>
+        <source>focused</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="262"/>
+        <source>Inactive border color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="266"/>
+        <source>titlebar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="266"/>
+        <source>header</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="271"/>
+        <source>Inner gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="273"/>
+        <source>inner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="274"/>
+        <source>Outer gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="276"/>
+        <source>outer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="282"/>
+        <source>side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="284"/>
+        <source>Smart gaps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="286"/>
+        <source>smart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="286"/>
+        <source>single</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <source>Activate on every drag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <source>Hold to activate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <source>deactivate</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="294"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="367"/>
+        <source>Toggle mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="294"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="367"/>
+        <source>tap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="294"/>
+        <source>activation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>Span modifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>zone span</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>paint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <source>span</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>Edge threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <source>distance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>multi-zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <source>Show zones on all monitors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="303"/>
+        <source>screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="305"/>
+        <source>Filter by aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="305"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="321"/>
+        <source>layouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>Always show after snapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="310"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>snap assist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>Hold to enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="314"/>
+        <source>Re-snap on resolution change</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>resolution</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>Open new windows in the last-used zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="318"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="337"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="382"/>
+        <source>new window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="318"/>
+        <source>last zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="320"/>
+        <source>Auto-assign new windows for all layouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="321"/>
+        <source>auto-assign</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="323"/>
+        <source>Restore size on unsnap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>unsnap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>original size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <source>Restore windows to their previous zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="327"/>
+        <source>login</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <source>Restore unsnapped windows to their previous position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="330"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <source>floated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="330"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="369"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <source>position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <source>Unfloat to a zone when there is no previous zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="333"/>
+        <source>unfloat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="333"/>
+        <source>fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="376"/>
+        <source>Sticky windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="376"/>
+        <source>all desktops</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="376"/>
+        <source>sticky</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="337"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="382"/>
+        <source>Focus new windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="337"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="339"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="382"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="384"/>
+        <source>focus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="339"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="384"/>
+        <source>Focus follows mouse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="339"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="384"/>
+        <source>pointer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="342"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="210"/>
+        <source>Algorithm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="344"/>
+        <source>Max windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="345"/>
+        <source>windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="345"/>
+        <source>maximum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="345"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="438"/>
+        <source>count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <source>limit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="348"/>
+        <source>Master ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="350"/>
+        <source>proportion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="353"/>
+        <source>Ratio step size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>increment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="356"/>
+        <source>Master count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="358"/>
+        <source>number</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="362"/>
+        <source>Always re-insert on drag</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="362"/>
+        <source>insert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="364"/>
+        <source>Hold to re-insert into stack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="367"/>
+        <source>stack preview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="369"/>
+        <source>New window placement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="371"/>
+        <source>Respect minimum size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="371"/>
+        <source>minimum</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <source>Restore untiled windows to their previous position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>Drag behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="380"/>
+        <source>Overflow behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="380"/>
+        <source>max windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="380"/>
+        <source>unlimited</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="388"/>
+        <source>Global animation defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="390"/>
+        <source>Multiple windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <source>sequence</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <source>simultaneous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <source>one by one</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="393"/>
+        <source>Stagger delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="394"/>
+        <source>pause</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="394"/>
+        <source>interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="394"/>
+        <source>delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="396"/>
+        <source>Minimum distance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="397"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="409"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <source>threshold</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="397"/>
+        <source>skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="397"/>
+        <source>geometry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="399"/>
+        <source>Window Filtering</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="402"/>
+        <source>dialogs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="402"/>
+        <source>popups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="402"/>
+        <source>tooltips</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="403"/>
+        <source>menus</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <source>Exclude notifications and OSDs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="406"/>
+        <source>volume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="406"/>
+        <source>brightness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <source>Minimum window width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="409"/>
+        <source>narrow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="411"/>
+        <source>Minimum window height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <source>short</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="416"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="183"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="214"/>
+        <source>Configuration</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <source>Backup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="420"/>
+        <source>data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="419"/>
+        <source>Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <source>Zone selector popup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="425"/>
+        <source>enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="425"/>
+        <source>toggle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="427"/>
+        <source>Position &amp; Trigger</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="429"/>
+        <source>Trigger distance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <source>proximity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <source>Layout Arrangement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="434"/>
+        <source>Arrangement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <source>horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <source>vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <source>Grid columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="438"/>
+        <source>columns</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="438"/>
+        <source>per row</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="440"/>
+        <source>Max visible rows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="441"/>
+        <source>rows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="441"/>
+        <source>scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="441"/>
+        <source>visible</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="443"/>
+        <source>Preview Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="447"/>
+        <source>Snapping Layout Priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="449"/>
+        <source>Tiling Algorithm Priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="451"/>
+        <source>Snapping Quick Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="453"/>
+        <source>Tiling Quick Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="457"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="459"/>
+        <source>User shaders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="461"/>
+        <source>Easing Presets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="463"/>
+        <source>Spring Presets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="465"/>
+        <source>Save current state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <source>Saved sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="470"/>
+        <source>Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="473"/>
+        <source>Minimize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="475"/>
+        <source>Maximize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="476"/>
+        <source>Move</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="478"/>
+        <source>Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <source>Snap Into Zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="483"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="549"/>
+        <source>Snap Out of Zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="485"/>
+        <source>Layout Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="487"/>
+        <source>Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <source>Zone Selector: Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="491"/>
+        <source>Zone Selector: Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="493"/>
+        <source>Layout Picker: Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="495"/>
+        <source>Layout Picker: Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="497"/>
+        <source>Snap Assist: Show</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>Snap Assist: Hide</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <source>Slide In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>Slide Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="505"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>Fade In</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="507"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="525"/>
+        <source>Fade Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>Hover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="509"/>
+        <source>Press</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="511"/>
+        <source>Toggle On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="513"/>
+        <source>Toggle Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="515"/>
+        <source>Show (badge)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="517"/>
+        <source>Hide (badge)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="519"/>
+        <source>Pulse (badge)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="520"/>
+        <source>Tint</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="521"/>
+        <source>Dim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="527"/>
+        <source>Reorder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <source>Expand (accordion)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="531"/>
+        <source>Collapse (accordion)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="533"/>
+        <source>Progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="535"/>
+        <source>Zone Highlight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="537"/>
+        <source>Zone Highlight: Pop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="539"/>
+        <source>Zone Highlight: Border</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <source>Zone Overlay: Layout-Switch Flash</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="543"/>
+        <source>Cursor Hover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="545"/>
+        <source>Cursor Click</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="547"/>
+        <source>Snap Into Zone (Fill Preview)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="551"/>
+        <source>Snap Resize (Drag Preview)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="595"/>
+        <source>Zone %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="597"/>
+        <source>%1 — %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="230"/>
+        <source>Layout created, but aspect-ratio class could not be applied: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="244"/>
+        <source>Could not create the layout. The daemon returned an empty layout ID.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="252"/>
+        <source>Could not create the layout. The daemon may not be running.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="271"/>
+        <source>Could not delete layout: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="287"/>
+        <source>Could not duplicate layout: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="388"/>
+        <source>Import refused: unsafe path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="432"/>
+        <source>Failed to update layout visibility: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="445"/>
+        <source>Failed to update auto-assign: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="459"/>
+        <source>Failed to update aspect ratio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_lifecycle.cpp" line="172"/>
+        <source>Failed to apply assignment changes: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="80"/>
+        <source>Overview</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="84"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="223"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="94"/>
+        <source>Placement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="104"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="231"/>
+        <source>Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="123"/>
+        <source>Rules</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="127"/>
+        <source>Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="129"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="142"/>
+        <source>Virtual Screens</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="144"/>
+        <source>Layouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="162"/>
+        <source>Behavior</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="172"/>
+        <source>Zone Selector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="185"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="216"/>
+        <source>Priority</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="188"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="219"/>
+        <source>Quick Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="190"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="252"/>
+        <source>Shaders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="226"/>
+        <source>Surfaces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="228"/>
+        <source>Library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="233"/>
+        <source>OSDs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="236"/>
+        <source>Overlays</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="239"/>
+        <source>Side Panels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="241"/>
+        <source>Widgets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="244"/>
+        <source>Layout Editor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="247"/>
+        <source>Presets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="250"/>
+        <source>Motion Sets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="303"/>
+        <source>Shader pack installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="305"/>
+        <source>The dropped path is not a valid shader pack directory.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="307"/>
+        <source>The shader pack is missing metadata.json (or it is a symlink).</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="309"/>
+        <source>The user shader directory could not be created.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="311"/>
+        <source>A shader pack with this name is already installed.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="313"/>
+        <source>The shader pack exceeds the maximum allowed size or file count.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="315"/>
+        <source>Copying the shader pack failed. The partial install was rolled back.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="317"/>
+        <source>Unknown shader pack installer error.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="78"/>
+        <source>Color import file does not exist: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="96"/>
+        <source>Color import file does not resolve to a regular file: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="101"/>
+        <source>Color import file must be a .json file: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
## Summary

The rule builder rendered booleans inconsistently across **WHEN** conditions and **THEN** actions. This standardizes the control, the vocabulary, and the labelling so every boolean's state and meaning is legible, and (separately) brings the whole settings app into the translation scope.

### The inconsistencies
- WHEN used a `CheckBox`, THEN used a toggle — two controls for one data type.
- Two summary renderers printed raw lowercase `true`/`false` (the THEN editor tree and the WHEN collapsed list).
- Three bool action labels never said what "off" does, while three did.
- `SetHideTitleBar`'s type label (`Hide or show title bars`) broke the affirmative verb-phrase convention the other bool actions follow.

### Changes
- **One control**: `SettingsSwitch` for booleans on both sides. The WHEN `CheckBox` is replaced and the toggle now vertically centers against the field / operator combos.
- **State caption**: `SettingsSwitch` gains an optional `label` (empty by default, so the 50+ existing call sites are untouched).
  - WHEN toggle + every summary read **On / Off**; the two renderers that printed raw `true`/`false` are fixed.
  - THEN action toggles caption with their **polarity-aware phrase** (`Show border`/`Hide border`, `Lock layout`/`Don't lock layout`), sourced from a single shared helper `RuleAuthoring::boolActionStateLabel` so the editor and the rule-list summary can't drift. Exposed to QML as `onLabel`/`offLabel` on bool param descriptors; `RuleModel::describeAction` now calls the same helper.
- **Labels**: every bool action whose off-state is non-inert now spells it out (`(off = …)`); `SetHideTitleBar` becomes the affirmative `Hide title bars`.
- **i18n**: `update-ts` only scanned daemon / autotile / editor / KCM, so the entire settings app (rule builder included) was outside the translation scope. `src/settings` C++ and QML are now globbed into the lupdate source list (the app already loads the catalog at runtime). Catalog grows **93 → 801** source strings.

### Notes
- WHEN intentionally keeps **On / Off** rather than a descriptive phrase: its grammar is `Field is <value>`, so a field-restating phrase would clash with the field + operator already shown.

## Test plan
- `cmake --build build` clean.
- `ctest` — **246/246 pass** (including `test_rule_model`, `test_rule_controller`).
- `test_rule_model` now also compiles `ruleauthoring.cpp` (link dep on the shared helper).
- `update-ts` re-run: 0 new strings after the helper refactor (phrases were already extracted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)