### PR TITLE
feat(rules): redo the rules page as one flat priority list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- **The Rules page is one flat priority list**: rules show in a single, drag-reorderable list ordered by precedence, with the highest-priority rule on top, instead of per-section groups. Drag any rule up or down to set which one wins. The filter button narrows the list by source (system or user-created), category, and status, and search and the monitor strip narrow it further ([#720](https://github.com/fuddlesworth/PlasmaZones/pull/720)).
+- **The Rules page is one flat priority list**: rules show in a single, drag-reorderable list ordered by precedence, with the highest-priority rule on top, instead of per-section groups. Drag any rule up or down to set which one wins. The filter button narrows the list by source (system or user-created), category, and status. Search and the monitor strip narrow it further ([#720](https://github.com/fuddlesworth/PlasmaZones/pull/720)).
 - **"Window Rules" is now "Rules"**: the page and the config file (`windowrules.json` becomes `rules.json`) are renamed, because rules now cover gaps, layout, and animation as well as windows. Existing rules carry over automatically ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **Window Appearance and Animations are grouped under an Appearance category** in the settings sidebar ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **Gaps use one shared model**: snapping zone padding and tiling inner gap are now the same setting. Use Mode or per-monitor rules where they should differ ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Match by placement mode**: a new Mode match condition matches snapped or tiled windows, so snapping and tiling can carry different gaps or appearance. Mode is a context condition, resolved per screen and layout ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **Per-monitor gaps**: pick a monitor from the scope chip on the Gaps card to set that screen's gaps independently. The values are stored as a screen-scoped rule ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **Separate focused and unfocused border colors**: the border color is now two actions, "Set focused border color" and "Set unfocused border color", each with its own swatch ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
-- **System section on the Rules page**: the app-managed default rules (Default borders, Default title bars, Default gaps) are grouped in their own System section and cannot be deleted ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
+- **App-managed default rules**: the default rules (Default borders, Default title bars, Default gaps) cannot be deleted and stay pinned to the lowest priority ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 
 ### Changed
 
+- **The Rules page is one flat priority list**: rules show in a single, drag-reorderable list ordered by precedence, with the highest-priority rule on top, instead of per-section groups. Drag any rule up or down to set which one wins. The filter button narrows the list by source (system or user-created), category, and status, and search and the monitor strip narrow it further ([#720](https://github.com/fuddlesworth/PlasmaZones/pull/720)).
 - **"Window Rules" is now "Rules"**: the page and the config file (`windowrules.json` becomes `rules.json`) are renamed, because rules now cover gaps, layout, and animation as well as windows. Existing rules carry over automatically ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **Window Appearance and Animations are grouped under an Appearance category** in the settings sidebar ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **Gaps use one shared model**: snapping zone padding and tiling inner gap are now the same setting. Use Mode or per-monitor rules where they should differ ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -292,9 +292,12 @@ qt_add_qml_module(plasmazones-settings
         qml/MonitorScopeChip.qml
         qml/LayoutGridDelegate.qml
         qml/LayoutManageCard.qml
-        qml/LayoutViewSwitch.qml
+        qml/SegmentedViewSwitch.qml
         qml/LayoutFilterBar.qml
         qml/LayoutFilterLogic.js
+        # Shared group/sort infrastructure (Layouts + Rules pages)
+        qml/GroupSortBar.qml
+        qml/GroupSortLogic.js
         qml/ZoneSelectorSection.qml
         qml/EasingPreview.qml
         qml/EasingSettings.qml

--- a/src/settings/qml/GroupSortBar.qml
+++ b/src/settings/qml/GroupSortBar.qml
@@ -9,14 +9,15 @@ import org.kde.kirigami as Kirigami
 /**
  * @brief Reusable "Group by / Sort by / direction" toolbar row.
  *
- * The shared group/sort affordance behind every listing page (Layouts, Tiling
- * algorithms, Rules). Driven entirely by injected data:
+ * A reusable group/sort affordance for the settings listing pages; the Layouts
+ * page (snapping layouts + tiling algorithms) is the current consumer. Driven
+ * entirely by injected data:
  *
  *   - `groupModel` / `sortModel`: arrays of already-localized option labels.
  *   - `groupByIndex` / `sortByIndex` / `sortAscending`: the live selection,
  *     read AND written here. The host owns persistence — this component holds
- *     no Settings of its own — so each page can persist however it likes
- *     (per-view-mode for Layouts, a single category for Rules).
+ *     no Settings of its own — so each page persists however it likes (the
+ *     Layouts page persists per view mode).
  *   - `sortItemAvailable`: optional per-sort-option enablement. A `false` entry
  *     greys that option, suppresses its hover highlight, shows
  *     `disabledSortTooltip`, and makes selecting it a no-op (the Layouts page

--- a/src/settings/qml/GroupSortBar.qml
+++ b/src/settings/qml/GroupSortBar.qml
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+/**
+ * @brief Reusable "Group by / Sort by / direction" toolbar row.
+ *
+ * The shared group/sort affordance behind every listing page (Layouts, Tiling
+ * algorithms, Rules). Driven entirely by injected data:
+ *
+ *   - `groupModel` / `sortModel`: arrays of already-localized option labels.
+ *   - `groupByIndex` / `sortByIndex` / `sortAscending`: the live selection,
+ *     read AND written here. The host owns persistence — this component holds
+ *     no Settings of its own — so each page can persist however it likes
+ *     (per-view-mode for Layouts, a single category for Rules).
+ *   - `sortItemAvailable`: optional per-sort-option enablement. A `false` entry
+ *     greys that option, suppresses its hover highlight, shows
+ *     `disabledSortTooltip`, and makes selecting it a no-op (the Layouts page
+ *     uses this for "Priority", which needs an order set on the Priority page).
+ *
+ * Emits `changed()` on every user-driven edit. After the host imperatively
+ * rewrites the index properties (e.g. loading persisted state), it must call
+ * `syncFromState()` — the ComboBox `currentIndex` bindings are initial-only and
+ * a user interaction breaks them, exactly as the prior inline LayoutFilterBar
+ * combos behaved.
+ */
+RowLayout {
+    id: root
+
+    property var groupModel: []
+    property var sortModel: []
+    property int groupByIndex: 0
+    property int sortByIndex: 0
+    property bool sortAscending: true
+    // Optional `[bool]` parallel to `sortModel`. A missing or `true` entry means
+    // available; `false` greys + disables that sort option. Empty = all available.
+    property var sortItemAvailable: []
+    property string disabledSortTooltip: ""
+
+    signal changed
+
+    // Re-point the combos at the current index properties. Call after any
+    // imperative write to groupByIndex / sortByIndex (the combo currentIndex
+    // binding is initial-only and breaks on user interaction).
+    function syncFromState() {
+        groupCombo.currentIndex = root.groupByIndex;
+        sortCombo.currentIndex = root.sortByIndex;
+    }
+
+    function _sortAvailable(index) {
+        return !(root.sortItemAvailable.length > index && root.sortItemAvailable[index] === false);
+    }
+
+    spacing: Kirigami.Units.smallSpacing
+
+    // ── Group By ──────────────────────────────────────────────────────────────
+    Label {
+        text: i18n("Group:")
+        font: Kirigami.Theme.smallFont
+        color: Kirigami.Theme.disabledTextColor
+    }
+
+    ComboBox {
+        id: groupCombo
+
+        Layout.preferredWidth: Kirigami.Units.gridUnit * 8
+        model: root.groupModel
+        // Initial-only binding — syncFromState() re-syncs after host writes.
+        currentIndex: root.groupByIndex
+        Accessible.name: i18n("Group by")
+        onActivated: index => {
+            if (index < 0 || index >= count)
+                return;
+
+            root.groupByIndex = index;
+            root.changed();
+        }
+    }
+
+    // ── Sort By ───────────────────────────────────────────────────────────────
+    Label {
+        text: i18n("Sort:")
+        font: Kirigami.Theme.smallFont
+        color: Kirigami.Theme.disabledTextColor
+    }
+
+    ComboBox {
+        id: sortCombo
+
+        Layout.preferredWidth: Kirigami.Units.gridUnit * 8
+        model: root.sortModel
+        // Initial-only binding — syncFromState() re-syncs after host writes.
+        currentIndex: root.sortByIndex
+        Accessible.name: i18n("Sort by")
+        onActivated: index => {
+            if (index < 0 || index >= count)
+                return;
+
+            // Unavailable option — swallow the selection and revert the visible
+            // value rather than applying a sort the host can't honour yet.
+            if (!root._sortAvailable(index)) {
+                currentIndex = root.sortByIndex;
+                return;
+            }
+            root.sortByIndex = index;
+            root.changed();
+        }
+
+        // Keep unavailable delegates ENABLED — a disabled delegate receives no
+        // hover events, so the explanatory tooltip would never show. Grey it,
+        // suppress the hover highlight, and let onActivated swallow the pick.
+        delegate: ItemDelegate {
+            required property int index
+            required property var modelData
+
+            readonly property bool unavailable: !root._sortAvailable(index)
+
+            width: sortCombo.width
+            text: modelData
+            opacity: unavailable ? 0.5 : 1
+            highlighted: !unavailable && sortCombo.highlightedIndex === index
+            ToolTip.visible: hovered && unavailable && root.disabledSortTooltip.length > 0
+            ToolTip.delay: Kirigami.Units.toolTipDelay
+            ToolTip.text: root.disabledSortTooltip
+        }
+    }
+
+    ToolButton {
+        icon.name: root.sortAscending ? "view-sort-ascending" : "view-sort-descending"
+        icon.width: Kirigami.Units.iconSizes.smallMedium
+        icon.height: Kirigami.Units.iconSizes.smallMedium
+        onClicked: {
+            root.sortAscending = !root.sortAscending;
+            root.changed();
+        }
+        Accessible.name: root.sortAscending ? i18n("Sort ascending") : i18n("Sort descending")
+        ToolTip.visible: hovered
+        ToolTip.text: root.sortAscending ? i18n("Ascending") : i18n("Descending")
+    }
+}

--- a/src/settings/qml/GroupSortLogic.js
+++ b/src/settings/qml/GroupSortLogic.js
@@ -4,10 +4,11 @@
 .pragma library
 
 /**
- * Neutral grouping / sorting primitives shared by every listing page (Layouts,
- * Tiling algorithms, Rules). Functions take plain data and caller-supplied,
- * i18n-resolved labels — they never touch any QML context, so the same code
- * backs both the layout grid and the rule list.
+ * Neutral grouping / sorting primitives for the settings listing pages.
+ * Functions take plain data and caller-supplied, i18n-resolved labels and never
+ * touch any QML context, so they're page-agnostic. The Layouts page (snapping
+ * layouts + tiling algorithms) is the current consumer; the primitives are kept
+ * here as a small reusable library for any future grouped/sorted listing.
  *
  * Group shape: an object keyed by group id, each value `{ items, order, label }`.
  * `order` drives inter-group ordering; `label` is the (already localized) header.
@@ -36,9 +37,12 @@ function groupByBoolKey(items, testFn, trueKey, trueLabel, falseKey, falseLabel)
     return groups;
 }
 
-// General N-bucket grouping. `keyFn(item)` returns `{ key, order, label }`
-// describing the bucket the item belongs to. Items mapping to the same `key`
-// share a bucket; the first occurrence's `order`/`label` win.
+// General N-bucket grouping — the multi-bucket generalization of
+// groupByBoolKey, provided by the library for reuse (no page consumes it today;
+// the Layouts page only needs the two-bucket split). `keyFn(item)` returns
+// `{ key, order, label }` describing the bucket the item belongs to. Items
+// mapping to the same `key` share a bucket; the first occurrence's
+// `order`/`label` win.
 function groupByKeyed(items, keyFn) {
     var groups = {};
     for (var i = 0; i < items.length; i++) {
@@ -82,9 +86,10 @@ function applySort(groups, comparator, ascending) {
 
 // Flatten the group map into an ordered, non-empty `[{ label, items }]` array.
 // When only one non-empty group remains its header is dropped — UNLESS
-// `keepSingleLabel` is true (the Rules page always wants its section header,
-// even when a single section is populated). The grid pages leave it false so a
-// lone group renders header-less.
+// `keepSingleLabel` is true. The Layouts page passes true for its "None"
+// grouping (so the lone "All layouts" card keeps its header) and false
+// otherwise (so a real grouping that happens to collapse to one group renders
+// header-less).
 function finalizeGroups(groups, keepSingleLabel) {
     var sorted = Object.values(groups).sort(function(a, b) {
         return a.order - b.order;

--- a/src/settings/qml/GroupSortLogic.js
+++ b/src/settings/qml/GroupSortLogic.js
@@ -78,7 +78,7 @@ function applySort(groups, comparator, ascending) {
     return groups;
 }
 
-// ── Finalization ──────────────────────────────────────────────────────────--
+// ── Finalization ─────────────────────────────────────────────────────────────
 
 // Flatten the group map into an ordered, non-empty `[{ label, items }]` array.
 // When only one non-empty group remains its header is dropped — UNLESS

--- a/src/settings/qml/GroupSortLogic.js
+++ b/src/settings/qml/GroupSortLogic.js
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+.pragma library
+
+/**
+ * Neutral grouping / sorting primitives shared by every listing page (Layouts,
+ * Tiling algorithms, Rules). Functions take plain data and caller-supplied,
+ * i18n-resolved labels — they never touch any QML context, so the same code
+ * backs both the layout grid and the rule list.
+ *
+ * Group shape: an object keyed by group id, each value `{ items, order, label }`.
+ * `order` drives inter-group ordering; `label` is the (already localized) header.
+ *
+ * NOTE: applySort() sorts the per-group item arrays in place for efficiency.
+ */
+
+// ── Grouping ────────────────────────────────────────────────────────────────
+
+// Two-bucket boolean split. `testFn(item)` true → trueKey bucket (order 0),
+// false → falseKey bucket (order 1).
+function groupByBoolKey(items, testFn, trueKey, trueLabel, falseKey, falseLabel) {
+    var groups = {};
+    for (var i = 0; i < items.length; i++) {
+        var item = items[i];
+        var match = testFn(item);
+        var key = match ? trueKey : falseKey;
+        if (!groups[key])
+            groups[key] = {
+                items: [],
+                order: match ? 0 : 1,
+                label: match ? trueLabel : falseLabel
+            };
+        groups[key].items.push(item);
+    }
+    return groups;
+}
+
+// General N-bucket grouping. `keyFn(item)` returns `{ key, order, label }`
+// describing the bucket the item belongs to. Items mapping to the same `key`
+// share a bucket; the first occurrence's `order`/`label` win.
+function groupByKeyed(items, keyFn) {
+    var groups = {};
+    for (var i = 0; i < items.length; i++) {
+        var d = keyFn(items[i]);
+        var key = d.key;
+        if (!groups[key])
+            groups[key] = {
+                items: [],
+                order: d.order,
+                label: d.label
+            };
+        groups[key].items.push(items[i]);
+    }
+    return groups;
+}
+
+// Single bucket — used by the "None" grouping option. `label` is the (already
+// localized) header the caller wants on the lone card (e.g. "All layouts");
+// pass "" / omit for a header-less card. finalizeGroups still drops an empty
+// label, so the card only renders a header when a real label is supplied.
+function ungrouped(items, label) {
+    return { "all": { items: items, order: 0, label: label || "" } };
+}
+
+// ── Sorting ─────────────────────────────────────────────────────────────────
+
+// Sort every group's items in place with `comparator(a, b)` (ascending sense).
+// `ascending === false` negates the result. Qt's V4 sort is stable, so equal
+// keys preserve input order (e.g. the evaluator's own priority tie-break).
+function applySort(groups, comparator, ascending) {
+    for (var key in groups) {
+        groups[key].items.sort(function(a, b) {
+            var cmp = comparator(a, b);
+            return ascending ? cmp : -cmp;
+        });
+    }
+    return groups;
+}
+
+// ── Finalization ──────────────────────────────────────────────────────────--
+
+// Flatten the group map into an ordered, non-empty `[{ label, items }]` array.
+// When only one non-empty group remains its header is dropped — UNLESS
+// `keepSingleLabel` is true (the Rules page always wants its section header,
+// even when a single section is populated). The grid pages leave it false so a
+// lone group renders header-less.
+function finalizeGroups(groups, keepSingleLabel) {
+    var sorted = Object.values(groups).sort(function(a, b) {
+        return a.order - b.order;
+    });
+    var nonEmpty = sorted.filter(function(g) {
+        return g.items.length > 0;
+    });
+    var showLabel = keepSingleLabel === true || nonEmpty.length > 1;
+    return nonEmpty.map(function(g) {
+        return {
+            label: showLabel ? g.label : "",
+            items: g.items
+        };
+    });
+}

--- a/src/settings/qml/LayoutFilterBar.qml
+++ b/src/settings/qml/LayoutFilterBar.qml
@@ -82,6 +82,15 @@ RowLayout {
     // Guard to suppress redundant filterSettingsChanged during batch resets
     property bool _resetting: false
     property int _previousViewMode: 0
+    // Cached "a priority order exists for the current mode" — hasCustom*Order()
+    // is a non-reactive Q_INVOKABLE, so refresh it on completion, mode switch,
+    // and the staged-order signals. Drives the Priority sort option's availability
+    // in the GroupSortBar (its last sort entry).
+    property bool _hasPriorityOrder: false
+
+    function _refreshHasPriorityOrder() {
+        _hasPriorityOrder = viewMode === 0 ? settingsController.hasCustomSnappingOrder() : settingsController.hasCustomTilingOrder();
+    }
     // Property-name maps for data-driven save/load.
     // Each entry: [rootPropertyName, persistedStatePropertyName].
     // NOTE: adding a filter requires updating ALL of: property declaration,
@@ -185,8 +194,10 @@ RowLayout {
                 val = Math.max(0, Math.min(val, maxSort));
             root[prop] = val;
         }
-        groupByCombo.currentIndex = groupByIndex;
-        sortByCombo.currentIndex = sortByIndex;
+        groupSort.groupByIndex = groupByIndex;
+        groupSort.sortByIndex = sortByIndex;
+        groupSort.sortAscending = sortAscending;
+        groupSort.syncFromState();
         _resetting = false;
         filterSettingsChanged();
     }
@@ -205,131 +216,50 @@ RowLayout {
         saveState(_previousViewMode);
         _previousViewMode = viewMode;
         loadState(viewMode);
+        // The new mode has its own priority order — refresh the Priority sort
+        // option's availability for the mode we just switched to.
+        _refreshHasPriorityOrder();
     }
     Component.onCompleted: {
         _previousViewMode = viewMode;
         loadState(viewMode);
+        _refreshHasPriorityOrder();
     }
 
-    // ── Group By ────────────────────────────────────────────────────────────
-    Label {
-        text: i18n("Group:")
-        font: Kirigami.Theme.smallFont
-        color: Kirigami.Theme.disabledTextColor
+    // Priority order can be staged on the Configuration → Priority page while
+    // this bar is alive — refresh the cached availability so the Priority sort
+    // option ungreys without a mode switch.
+    Connections {
+        function onStagedSnappingOrderChanged() {
+            root._refreshHasPriorityOrder();
+        }
+
+        function onStagedTilingOrderChanged() {
+            root._refreshHasPriorityOrder();
+        }
+
+        target: settingsController
     }
 
-    ComboBox {
-        id: groupByCombo
+    // ── Group / Sort / direction ─────────────────────────────────────────────
+    // The shared GroupSortBar owns the combos + direction toggle; this bar keeps
+    // ownership of the persisted state (per view mode) and pushes it in via
+    // syncFromState() on load / mode switch, pulling user edits back out in
+    // onChanged. "Priority" (the last sort option) is unavailable until an order
+    // is set on the Configuration → Priority page; _hasPriorityOrder tracks that.
+    GroupSortBar {
+        id: groupSort
 
-        Layout.preferredWidth: Kirigami.Units.gridUnit * 8
-        model: root.viewMode === 0 ? root.snappingGroupModel : root.tilingGroupModel
-        // Binding is initial-only — user interaction breaks it; loadState()
-        // re-syncs imperatively via groupByCombo.currentIndex = ...
-        currentIndex: root.groupByIndex
-        Accessible.name: i18n("Group by")
-        onActivated: index => {
-            if (index < 0 || index >= model.length)
-                return;
-
-            root.groupByIndex = index;
+        groupModel: root.viewMode === 0 ? root.snappingGroupModel : root.tilingGroupModel
+        sortModel: root.viewMode === 0 ? root.snappingSortModel : root.tilingSortModel
+        sortItemAvailable: [true, true, root._hasPriorityOrder]
+        disabledSortTooltip: i18n("Set a layout order on the Priority page first")
+        onChanged: {
+            root.groupByIndex = groupByIndex;
+            root.sortByIndex = sortByIndex;
+            root.sortAscending = sortAscending;
             root.filterSettingsChanged();
         }
-    }
-
-    // ── Sort By ─────────────────────────────────────────────────────────────
-    Label {
-        text: i18n("Sort:")
-        font: Kirigami.Theme.smallFont
-        color: Kirigami.Theme.disabledTextColor
-    }
-
-    ComboBox {
-        id: sortByCombo
-
-        // Whether a priority order exists for the current mode. hasCustom*Order()
-        // is a non-reactive Q_INVOKABLE, so cache it and refresh on the staged-
-        // order signals and on the mode switch (model change).
-        property bool hasPriorityOrder: false
-
-        function refreshHasPriorityOrder() {
-            hasPriorityOrder = root.viewMode === 0 ? settingsController.hasCustomSnappingOrder() : settingsController.hasCustomTilingOrder();
-        }
-
-        Layout.preferredWidth: Kirigami.Units.gridUnit * 8
-        model: root.viewMode === 0 ? root.snappingSortModel : root.tilingSortModel
-        // Binding is initial-only — user interaction breaks it; loadState()
-        // re-syncs imperatively via sortByCombo.currentIndex = ...
-        currentIndex: root.sortByIndex
-        Accessible.name: i18n("Sort by")
-        Component.onCompleted: refreshHasPriorityOrder()
-        // Fires on the mode switch (the model binding re-evaluates to the other
-        // mode's sort array), so the Priority item's enabled state tracks the
-        // mode's own order.
-        onModelChanged: refreshHasPriorityOrder()
-        onActivated: index => {
-            if (index < 0 || index >= model.length)
-                return;
-
-            // The last option ("Priority") is unavailable until an order is set
-            // on the Priority page. Swallow the selection and revert the visible
-            // value rather than applying a sort that would silently fall back to
-            // Name order.
-            if (index === count - 1 && !hasPriorityOrder) {
-                currentIndex = root.sortByIndex;
-                return;
-            }
-
-            root.sortByIndex = index;
-            root.filterSettingsChanged();
-        }
-
-        // The "Priority" item (the last sort option) is unavailable until an
-        // order has been set on the Configuration → Priority page. Keep the
-        // delegate ENABLED — a disabled delegate receives no hover events, so the
-        // explanatory tooltip would never show. Gray it, suppress the hover
-        // highlight, and let onActivated above swallow the selection.
-        delegate: ItemDelegate {
-            id: sortItemDelegate
-
-            required property int index
-            required property var modelData
-
-            readonly property bool isPriority: index === sortByCombo.count - 1
-            readonly property bool unavailable: isPriority && !sortByCombo.hasPriorityOrder
-
-            width: sortByCombo.width
-            text: modelData
-            opacity: unavailable ? 0.5 : 1
-            highlighted: !unavailable && sortByCombo.highlightedIndex === index
-            ToolTip.visible: hovered && unavailable
-            ToolTip.delay: Kirigami.Units.toolTipDelay
-            ToolTip.text: i18n("Set a layout order on the Priority page first")
-        }
-
-        Connections {
-            function onStagedSnappingOrderChanged() {
-                sortByCombo.refreshHasPriorityOrder();
-            }
-
-            function onStagedTilingOrderChanged() {
-                sortByCombo.refreshHasPriorityOrder();
-            }
-
-            target: settingsController
-        }
-    }
-
-    ToolButton {
-        icon.name: root.sortAscending ? "view-sort-ascending" : "view-sort-descending"
-        icon.width: Kirigami.Units.iconSizes.smallMedium
-        icon.height: Kirigami.Units.iconSizes.smallMedium
-        onClicked: {
-            root.sortAscending = !root.sortAscending;
-            root.filterSettingsChanged();
-        }
-        Accessible.name: root.sortAscending ? i18n("Sort ascending") : i18n("Sort descending")
-        ToolTip.visible: hovered
-        ToolTip.text: root.sortAscending ? i18n("Ascending") : i18n("Descending")
     }
 
     Timer {

--- a/src/settings/qml/LayoutFilterLogic.js
+++ b/src/settings/qml/LayoutFilterLogic.js
@@ -7,9 +7,8 @@
 /**
  * Layout/algorithm-specific filtering, grouping, and sorting helpers for the
  * layout grid. The neutral, page-agnostic primitives (groupByBoolKey,
- * groupByKeyed, ungrouped, applySort, finalizeGroups) live in GroupSortLogic.js
- * and are shared with the Rules page; this file holds only what is specific to
- * layouts and tiling algorithms.
+ * groupByKeyed, ungrouped, applySort, finalizeGroups) live in GroupSortLogic.js;
+ * this file holds only what is specific to layouts and tiling algorithms.
  *
  * Functions receive data and filter config without accessing any QML context.
  * i18n-dependent labels are passed in by the caller.

--- a/src/settings/qml/LayoutFilterLogic.js
+++ b/src/settings/qml/LayoutFilterLogic.js
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 .pragma library
+.import "GroupSortLogic.js" as Core
 
 /**
- * Shared filtering, grouping, and sorting helpers for the layout/algorithm grid.
+ * Layout/algorithm-specific filtering, grouping, and sorting helpers for the
+ * layout grid. The neutral, page-agnostic primitives (groupByBoolKey,
+ * groupByKeyed, ungrouped, applySort, finalizeGroups) live in GroupSortLogic.js
+ * and are shared with the Rules page; this file holds only what is specific to
+ * layouts and tiling algorithms.
  *
  * Functions receive data and filter config without accessing any QML context.
  * i18n-dependent labels are passed in by the caller.
@@ -94,23 +99,8 @@ function applyTilingFilters(items, search, f) {
 }
 
 // ── Grouping ────────────────────────────────────────────────────────────────
-
-function groupByBoolKey(items, testFn, trueKey, trueLabel, falseKey, falseLabel) {
-    var groups = {};
-    for (var i = 0; i < items.length; i++) {
-        var item = items[i];
-        var match = testFn(item);
-        var key = match ? trueKey : falseKey;
-        if (!groups[key])
-            groups[key] = {
-                items: [],
-                order: match ? 0 : 1,
-                label: match ? trueLabel : falseLabel
-            };
-        groups[key].items.push(item);
-    }
-    return groups;
-}
+// groupByBoolKey / ungrouped live in GroupSortLogic.js (Core). The remaining
+// groupers here are layout-specific (aspect ratio, zone count, capability).
 
 function groupByAspectRatio(items) {
     var groups = {};
@@ -173,57 +163,40 @@ function groupByCapability(items, capGroups, otherLabel) {
     return groups;
 }
 
-function ungrouped(items) {
-    return { "all": { items: items, order: 0, label: "" } };
-}
-
 // ── Sorting ─────────────────────────────────────────────────────────────────
 
 // sortIdx 0 = Name (both modes), 1 = Zone Count, 2 = Priority order.
 // Priority order uses the provided customOrder array of IDs (the order set on
-// the Configuration → Priority page).
+// the Configuration → Priority page). Delegates the per-group, asc/desc, stable
+// sort machinery to Core.applySort; only the comparator is layout-specific.
 function sortItems(groups, sortIdx, ascending, customOrder) {
     // Build index map for custom order (O(1) lookup)
     var orderMap = {};
-    if (sortIdx === 2 && customOrder && customOrder.length > 0) {
+    var hasCustomOrder = sortIdx === 2 && customOrder && customOrder.length > 0;
+    if (hasCustomOrder) {
         for (var i = 0; i < customOrder.length; i++)
             orderMap[customOrder[i]] = i;
     }
 
-    for (var key in groups) {
-        groups[key].items.sort(function(a, b) {
-            var cmp;
-            if (sortIdx === 2 && customOrder && customOrder.length > 0) {
-                var aIdx = (a.id in orderMap) ? orderMap[a.id] : Number.MAX_SAFE_INTEGER;
-                var bIdx = (b.id in orderMap) ? orderMap[b.id] : Number.MAX_SAFE_INTEGER;
-                if (aIdx !== bIdx)
-                    cmp = aIdx - bIdx;
-                else
-                    cmp = (a.displayName || "").localeCompare(b.displayName || "");
-            } else if (sortIdx === 1) {
-                cmp = Math.max(0, a.zoneCount || 0) - Math.max(0, b.zoneCount || 0);
-                if (cmp === 0)
-                    cmp = (a.displayName || "").localeCompare(b.displayName || "");
-            } else {
-                cmp = (a.displayName || "").localeCompare(b.displayName || "");
-            }
-            return ascending ? cmp : -cmp;
-        });
+    function byName(a, b) {
+        return (a.displayName || "").localeCompare(b.displayName || "");
     }
-    return groups;
-}
 
-function finalizeGroups(groups) {
-    var sorted = Object.values(groups).sort(function(a, b) {
-        return a.order - b.order;
-    });
-    var nonEmpty = sorted.filter(function(g) {
-        return g.items.length > 0;
-    });
-    return nonEmpty.map(function(g) {
-        return {
-            label: nonEmpty.length > 1 ? g.label : "",
-            layouts: g.items
+    var comparator;
+    if (hasCustomOrder) {
+        comparator = function(a, b) {
+            var aIdx = (a.id in orderMap) ? orderMap[a.id] : Number.MAX_SAFE_INTEGER;
+            var bIdx = (b.id in orderMap) ? orderMap[b.id] : Number.MAX_SAFE_INTEGER;
+            return (aIdx !== bIdx) ? aIdx - bIdx : byName(a, b);
         };
-    });
+    } else if (sortIdx === 1) {
+        comparator = function(a, b) {
+            var cmp = Math.max(0, a.zoneCount || 0) - Math.max(0, b.zoneCount || 0);
+            return cmp !== 0 ? cmp : byName(a, b);
+        };
+    } else {
+        comparator = byName;
+    }
+
+    return Core.applySort(groups, comparator, ascending);
 }

--- a/src/settings/qml/LayoutsPage.qml
+++ b/src/settings/qml/LayoutsPage.qml
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 fuddlesworth
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import "GroupSortLogic.js" as Core
 import "LayoutFilterLogic.js" as Logic
 import QtQuick
 import QtQuick.Controls
@@ -148,7 +149,13 @@ SettingsFlickable {
         // Priority sort silently no-ops for the tiling view.
         let customOrder = root.viewMode === 0 ? settingsController.effectiveSnappingOrder() : settingsController.effectiveTilingOrder().map(id => "autotile:" + id);
         Logic.sortItems(groups, filterBar.sortByIndex, filterBar.sortAscending, customOrder);
-        root.groupsModel = Logic.finalizeGroups(groups);
+        // "None" is the one grouping that should still show its (single) card
+        // header — the user wants the title + count even with no grouping. Every
+        // other grouping keeps the legacy "drop the header when it collapses to a
+        // single group" behaviour (a lone "Built-in" card needs no redundant
+        // header).
+        let isNoneGroup = root.viewMode === 0 ? filterBar.groupByIndex === filterBar.groupSnappingNone : filterBar.groupByIndex === filterBar.groupTilingNone;
+        root.groupsModel = Core.finalizeGroups(groups, isNoneGroup);
     }
 
     function selectDefaultLayout(mode) {
@@ -174,7 +181,7 @@ SettingsFlickable {
         // autotile mode doesn't accidentally select a bare snap layout.
         const sections = root.groupsModel || [];
         for (let i = 0; i < sections.length; ++i) {
-            const items = sections[i].layouts || [];
+            const items = sections[i].items || [];
             for (let j = 0; j < items.length; ++j) {
                 const item = items[j];
                 const itemIsAutotile = item.isAutotile === true;
@@ -200,14 +207,14 @@ SettingsFlickable {
             if (groupIdx === filterBar.groupCapability)
                 return Logic.groupByCapability(filtered, root.tilingCapabilityGroups, i18n("Other"));
             else if (groupIdx === filterBar.groupTilingSource)
-                return Logic.groupByBoolKey(filtered, item => {
+                return Core.groupByBoolKey(filtered, item => {
                     return Logic.isBuiltIn(item);
                 }, "builtin", i18n("Built-in"), "user", i18n("User Scripts"));
             else if (groupIdx === filterBar.groupTilingVisibility)
-                return Logic.groupByBoolKey(filtered, item => {
+                return Core.groupByBoolKey(filtered, item => {
                     return item.hiddenFromSelector !== true;
                 }, "visible", i18n("Visible"), "hidden", i18n("Hidden"));
-            return Logic.ungrouped(filtered);
+            return Core.ungrouped(filtered, i18n("All algorithms"));
         }
         // Snapping grouping
         if (groupIdx === filterBar.groupAspectRatio)
@@ -217,18 +224,18 @@ SettingsFlickable {
                 return i18np("%n zone", "%n zones", count);
             }, i18n("Unknown"));
         else if (groupIdx === filterBar.groupAutoManual)
-            return Logic.groupByBoolKey(filtered, item => {
+            return Core.groupByBoolKey(filtered, item => {
                 return item.autoAssign === true;
             }, "auto", i18n("Auto"), "manual", i18n("Manual"));
         else if (groupIdx === filterBar.groupSource)
-            return Logic.groupByBoolKey(filtered, item => {
+            return Core.groupByBoolKey(filtered, item => {
                 return Logic.isBuiltIn(item);
             }, "builtin", i18n("Built-in"), "user", i18n("User Layouts"));
         else if (groupIdx === filterBar.groupVisibility)
-            return Logic.groupByBoolKey(filtered, item => {
+            return Core.groupByBoolKey(filtered, item => {
                 return item.hiddenFromSelector !== true;
             }, "visible", i18n("Visible"), "hidden", i18n("Hidden"));
-        return Logic.ungrouped(filtered);
+        return Core.ungrouped(filtered, i18n("All layouts"));
     }
 
     contentHeight: content.implicitHeight
@@ -277,10 +284,11 @@ SettingsFlickable {
         spacing: Kirigami.Units.largeSpacing
 
         // ─── View switch (Snapping / Tiling) — only when autotiling is on ──
-        // Centered monitor-switcher-style tiles (see LayoutViewSwitch).
-        LayoutViewSwitch {
+        // Centered monitor-switcher-style tiles (shared SegmentedViewSwitch).
+        SegmentedViewSwitch {
             Layout.fillWidth: true
             visible: root.settingsBridge.autotileEnabled
+            modes: [i18n("Snapping"), i18n("Tiling")]
             currentIndex: root.viewMode
             onIndexChanged: index => {
                 root.viewMode = index;
@@ -400,7 +408,7 @@ SettingsFlickable {
 
                 Layout.fillWidth: true
                 headerText: modelData.label
-                headerTrailingText: root.viewMode === 1 ? i18np("%n algorithm", "%n algorithms", modelData.layouts.length) : i18np("%n layout", "%n layouts", modelData.layouts.length)
+                headerTrailingText: root.viewMode === 1 ? i18np("%n algorithm", "%n algorithms", modelData.items.length) : i18np("%n layout", "%n layouts", modelData.items.length)
                 // Only labelled groups get a collapse affordance — a header-less
                 // ungrouped card has nothing to click to toggle.
                 collapsible: modelData.label.length > 0
@@ -423,7 +431,7 @@ SettingsFlickable {
                         readonly property real _cardWidth: (width - spacing * (_columns - 1)) / _columns
 
                         Repeater {
-                            model: groupCard.modelData.layouts
+                            model: groupCard.modelData.items
 
                             LayoutGridDelegate {
                                 appSettings: root.settingsBridge

--- a/src/settings/qml/LayoutsPage.qml
+++ b/src/settings/qml/LayoutsPage.qml
@@ -33,8 +33,8 @@ SettingsFlickable {
     property int viewMode: 0
     // Selected layout id (tracked across group cards).
     property string selectedLayoutId: ""
-    // Grouped, filtered, sorted layouts — `[{ label, layouts: [...] }]` from
-    // LayoutFilterLogic.finalizeGroups. Rebuilt by rebuildModel().
+    // Grouped, filtered, sorted layouts — `[{ label, items: [...] }]` from
+    // GroupSortLogic.finalizeGroups (Core). Rebuilt by rebuildModel().
     property var groupsModel: []
 
     // Capability group definitions for tiling view — hoisted to avoid

--- a/src/settings/qml/RuleEditorBody.qml
+++ b/src/settings/qml/RuleEditorBody.qml
@@ -193,10 +193,9 @@ ColumnLayout {
             }
         }
 
-        // Priority + band-name hint. Bare integers like "610" are
-        // meaningless without the band scheme; the inline label maps the
-        // current value back to its semantic band. Bands defined in
-        // rulecontroller.cpp.
+        // Priority. The value is a position in one flat, global precedence list
+        // (higher wins). Reordering rules on the Rules page renumbers them by list
+        // order, so an explicit value set here holds only until the next reorder.
         RowLayout {
             id: priorityRow
 
@@ -208,19 +207,12 @@ ColumnLayout {
             SpinBox {
                 Accessible.name: i18n("Rule priority. Higher rules are evaluated first.")
                 ToolTip.delay: Kirigami.Units.toolTipDelay
-                ToolTip.text: i18n("Priority bands. 100: Animation, 200: Application, 300: Context, 500: Advanced. Higher numbers win within a band.")
+                ToolTip.text: i18n("Higher priority is evaluated first. Reordering rules on the Rules page renumbers them by list order.")
                 ToolTip.visible: hovered
                 from: 0
                 to: 100000
                 value: priorityRow._priority
                 onValueModified: root._patch("priority", value)
-            }
-
-            Label {
-                Layout.alignment: Qt.AlignVCenter
-                font.italic: true
-                opacity: 0.65
-                text: priorityRow._priority >= 500 ? i18n("Advanced") : priorityRow._priority >= 300 ? i18n("Context") : priorityRow._priority >= 200 ? i18n("Application") : priorityRow._priority >= 100 ? i18n("Animation") : i18n("Custom")
             }
         }
     }

--- a/src/settings/qml/RuleRow.qml
+++ b/src/settings/qml/RuleRow.qml
@@ -10,20 +10,19 @@ import org.phosphor.animation
 import org.plasmazones.settings
 
 /**
- * @brief One rule row in the grouped RulesPage list.
+ * @brief One rule row in the flat RulesPage priority list.
  *
- * Layout mirrors the SVG mockup: enabled dot · match summary · `→` · action
- * summary · edit / delete. Composite rules show condition / action-count
- * badges. The enabled dot is a toggle; edit / delete are buttons.
+ * Layout: enabled toggle · name + match summary · `→` · action summary · badges
+ * · edit / duplicate / delete. Composite rules show condition / action-count
+ * badges. The enabled dot is a toggle; edit / duplicate / delete are buttons.
  */
 ItemDelegate {
-    // Drag-reorder for the Animation section lives in RulesPage's
-    // dedicated drag container (mirrors OrderingPage's pattern), NOT here:
-    // a ColumnLayout-based Repeater snaps items back to their layout
-    // position the instant a MouseArea sets `drag.target`, so any drag
-    // mechanics on the row itself silently fail. Keeping drag concerns out
-    // of this delegate also means the row stays usable in non-reorderable
-    // contexts (other sections) without an "if draggable" branch.
+    // Drag-reorder lives in the RuleSectionList container (which owns the grip
+    // column and the drop cascade), NOT in this delegate: a ColumnLayout-based
+    // Repeater snaps items back to their layout position the instant a MouseArea
+    // sets `drag.target`, so drag mechanics on the row itself would silently
+    // fail. Keeping drag out of this delegate also lets the row stay usable in a
+    // non-reorderable host without an "if draggable" branch.
 
     id: row
 
@@ -54,9 +53,8 @@ ItemDelegate {
     /// are non-deletable and pinned, so the delete affordance is shown but
     /// disabled (kept visible to preserve column alignment).
     property bool managed: false
-    /// Localized section name shown as a small category badge. The flat list
-    /// passes it so category stays legible without grouping; empty hides the
-    /// badge (e.g. when the cards already group by section).
+    /// Localized section name shown as a small category badge, so category stays
+    /// legible in the flat (ungrouped) list. Empty hides the badge.
     property string sectionLabel: ""
     /// RuleController — needed to resolve a rule's match JSON
     /// on-demand for the expansion view (`controller.ruleJson(ruleId).match`).
@@ -77,11 +75,6 @@ ItemDelegate {
     /// events, shader effects, curves) to the same labels the rule
     /// editor shows.
     property var appSettings: null
-    /// True when the row should surface its expand affordance. The Animation
-    /// drag container depends on a fixed row height and sets this to false
-    /// so an expanded row can't break the drag math; every other section
-    /// keeps the default (true).
-    property bool expandable: true
     /// Current expansion state — toggled by the chevron on the row. Lives
     /// on the delegate so each row expands independently; resets on page
     /// reload (acceptable — the rule list is the page's primary content
@@ -134,8 +127,7 @@ ItemDelegate {
     // up here, so clicking the body of the row toggles expansion. The
     // `arrow-right` icon's rotation signals the state.
     onClicked: {
-        if (row.expandable)
-            row.expanded = !row.expanded;
+        row.expanded = !row.expanded;
     }
 
     contentItem: ColumnLayout {
@@ -407,7 +399,7 @@ ItemDelegate {
             // user would see the viewport blank before the height finished
             // shrinking. Re-expanding mid-collapse keeps the Loader active
             // (no reload thrash) because the height never reaches 0.
-            property bool _active: row.expandable && row.controller !== null && (row.expanded || Layout.preferredHeight > 0)
+            property bool _active: row.controller !== null && (row.expanded || Layout.preferredHeight > 0)
 
             Layout.fillWidth: true
             Layout.leftMargin: Kirigami.Units.gridUnit * 2

--- a/src/settings/qml/RuleRow.qml
+++ b/src/settings/qml/RuleRow.qml
@@ -43,14 +43,21 @@ ItemDelegate {
     /// knows the rule never fires (the picker now prevents the combination
     /// for new rules, but a hand-edited JSON store keeps the offending rule).
     required property int validationIssueCount
-    /// The rule's raw priority integer — surfaced as a `Priority N` badge in
-    /// the badge cluster on every row, so each rule's effective ordering
-    /// priority is visible regardless of section.
+    /// The rule's raw priority integer — surfaced as a `Priority N` badge on
+    /// every row. In the flat list a rule's position already conveys precedence,
+    /// but the number stays important when the filter hides categories: the
+    /// visible rows are then a subset, so the badge is what tells the user the
+    /// true precedence of (and gaps between) the rules still on screen. Matches
+    /// the value the Advanced editor exposes and edits.
     required property int priority
     /// True for app-managed System rules (the seeded baseline defaults). They
     /// are non-deletable and pinned, so the delete affordance is shown but
     /// disabled (kept visible to preserve column alignment).
     property bool managed: false
+    /// Localized section name shown as a small category badge. The flat list
+    /// passes it so category stays legible without grouping; empty hides the
+    /// badge (e.g. when the cards already group by section).
+    property string sectionLabel: ""
     /// RuleController — needed to resolve a rule's match JSON
     /// on-demand for the expansion view (`controller.ruleJson(ruleId).match`).
     /// `null` disables expansion entirely; expansion-capable callers must
@@ -195,6 +202,29 @@ ItemDelegate {
                 }
             }
 
+            // Section badge — the rule's category (Monitor / Application / …),
+            // shown first in the cluster so the flat priority list stays legible
+            // by category without grouping. Highlight-tinted (theme-derived, not
+            // hardcoded) to read as a category marker distinct from the neutral
+            // metadata badges that follow.
+            Rectangle {
+                visible: row.sectionLabel.length > 0
+                Layout.alignment: Qt.AlignVCenter
+                implicitWidth: sectionBadgeLabel.implicitWidth + Kirigami.Units.largeSpacing
+                implicitHeight: sectionBadgeLabel.implicitHeight + Kirigami.Units.smallSpacing
+                radius: Kirigami.Units.smallSpacing
+                color: Qt.rgba(Kirigami.Theme.highlightColor.r, Kirigami.Theme.highlightColor.g, Kirigami.Theme.highlightColor.b, 0.18)
+
+                Label {
+                    id: sectionBadgeLabel
+
+                    anchors.centerIn: parent
+                    text: row.sectionLabel
+                    font.pointSize: Kirigami.Theme.smallFont.pointSize
+                    opacity: 0.85
+                }
+            }
+
             // "Composite" badge — paired with the conditions count for composite
             // rules. Surfaces the kind of rule the user is looking at without
             // making them open the editor. Sentence case (project convention; the
@@ -259,11 +289,10 @@ ItemDelegate {
                 }
             }
 
-            // Priority badge — sits with the other metadata badges (Composite,
-            // Conditions, Actions). Shown on every row so each rule's effective
-            // ordering priority is visible across all sections, not just
-            // Advanced (other sections derive their priority from cascade bands,
-            // but surfacing the resolved number is still informative).
+            // Priority badge — kept on every row so precedence stays legible even
+            // when the filter hides categories (the visible rows are then a subset,
+            // so position alone can't convey the true ordering). Managed System
+            // rules are pinned to INT_MIN, so show that intent, not the raw number.
             Rectangle {
                 Layout.alignment: Qt.AlignVCenter
                 implicitWidth: priorityLabel.implicitWidth + Kirigami.Units.largeSpacing
@@ -275,8 +304,6 @@ ItemDelegate {
                     id: priorityLabel
 
                     anchors.centerIn: parent
-                    // Managed System rules are pinned to INT_MIN so they always
-                    // sort below user rules — show that intent, not the raw number.
                     text: row.managed ? i18nc("Priority badge for a managed baseline rule that always sorts last", "Lowest priority") : i18nc("Badge showing the rule's raw priority integer", "Priority %1", row.priority)
                     font.pointSize: Kirigami.Theme.smallFont.pointSize
                     opacity: 0.7

--- a/src/settings/qml/RuleSectionList.qml
+++ b/src/settings/qml/RuleSectionList.qml
@@ -50,6 +50,34 @@ Item {
     /// activities + window picker) threaded into MatchLeafEditor and
     /// ActionListView. May be null while the page is still wiring up.
     property var appSettings: null
+    /// Whether drag / keyboard reordering is offered. Reordering maps list order
+    /// onto the priority bands `renormalizePriorities` stamps, so the host only
+    /// enables it in its Reorder mode (Section grouping + Priority sort); a plain
+    /// browse/filter view is static.
+    property bool reorderingEnabled: true
+    /// Whether the list is shown lowest-priority-first. The drag/keyboard commit
+    /// maps a drop position onto a `beforeId` for `moveRule`; that mapping is
+    /// mirrored when the list is ascending so dragging works in both directions.
+    property bool ascending: false
+    /// Whether each row shows its section as a small badge. The flat list shows
+    /// it (so category stays legible without grouping); the page suppresses it
+    /// when the cards already group by section.
+    property bool showSectionBadge: false
+
+    /// Resolve the `beforeId` to hand `moveRule` for moving `list[from]` to slot
+    /// `to`. `moveRule` inserts immediately BEFORE `beforeId` (empty = end, i.e.
+    /// lowest priority). The model is kept in priority-descending row order, so an
+    /// ascending display is its reverse and the neighbour math inverts.
+    function beforeIdFor(list, from, to) {
+        if (root.ascending) {
+            if (from < to)
+                return list[to].ruleId;
+            return to - 1 >= 0 ? list[to - 1].ruleId : "";
+        }
+        if (from < to)
+            return to + 1 < list.length ? list[to + 1].ruleId : "";
+        return list[to].ruleId;
+    }
 
     /// Emitted when the row's enable switch is toggled. Page-level
     /// handler routes to `controller.setRuleEnabled`.
@@ -159,10 +187,11 @@ Item {
             required property var modelData
             required property int index
 
-            // Managed System rules have a fixed precedence (INT_MIN), so they
-            // show no drag affordance — the controller rejects reordering them
-            // anyway.
-            readonly property bool reorderable: modelData.managed !== true
+            // A row is reorderable only when the list as a whole offers
+            // reordering (canonical view) AND this is not a managed System rule
+            // — managed rules have a fixed precedence (INT_MIN) and the
+            // controller rejects reordering them anyway.
+            readonly property bool reorderable: root.reorderingEnabled && modelData.managed !== true
 
             readonly property real baseY: root.cumulativeY(index)
             // Cascade displacement = ± the dragged row's own height
@@ -259,15 +288,8 @@ Item {
                     return;
                 }
                 var movedId = rulesSnapshot[from].ruleId;
-                // Mirror the drag-release beforeId math.
-                var beforeId = "";
-                if (from < to) {
-                    if (to + 1 < rulesSnapshot.length)
-                        beforeId = rulesSnapshot[to + 1].ruleId;
-                } else {
-                    beforeId = rulesSnapshot[to].ruleId;
-                }
-                root.controller.moveRule(movedId, beforeId);
+                // Same neighbour resolution as the drag release (direction-aware).
+                root.controller.moveRule(movedId, root.beforeIdFor(rulesSnapshot, from, to));
             }
 
             RowLayout {
@@ -306,6 +328,18 @@ Item {
                         source: "handle-sort"
                         visible: delegateRoot.reorderable
                         opacity: dragArea.containsMouse || dragArea.drag.active ? 0.7 : 0.3
+                    }
+
+                    // Pinned indicator for non-reorderable rows (managed System
+                    // rules at INT_MIN) — replaces the drag grip so it reads as
+                    // "fixed at the bottom" rather than just missing a handle.
+                    Kirigami.Icon {
+                        anchors.centerIn: parent
+                        width: Kirigami.Units.iconSizes.small
+                        height: Kirigami.Units.iconSizes.small
+                        source: "lock"
+                        visible: !delegateRoot.reorderable && delegateRoot.modelData.managed === true
+                        opacity: 0.3
                     }
 
                     MouseArea {
@@ -357,21 +391,11 @@ Item {
                                 return delegateRoot.baseY + delegateRoot.visualOffset;
                             });
                             if (movedId !== "" && from >= 0 && to >= 0 && from !== to && to < rulesSnapshot.length) {
-                                // controller.moveRule positions
-                                // movedId immediately BEFORE
-                                // beforeId. To move down (from <
-                                // to), beforeId is the rule at
-                                // (to + 1) so the moved rule lands
-                                // after the target; if dropping at
-                                // the end, pass empty.
-                                var beforeId = "";
-                                if (from < to) {
-                                    if (to + 1 < rulesSnapshot.length)
-                                        beforeId = rulesSnapshot[to + 1].ruleId;
-                                } else {
-                                    beforeId = rulesSnapshot[to].ruleId;
-                                }
-                                root.controller.moveRule(movedId, beforeId);
+                                // controller.moveRule positions movedId
+                                // immediately BEFORE beforeId; beforeIdFor
+                                // resolves the right neighbour for the current
+                                // list direction (see its doc).
+                                root.controller.moveRule(movedId, root.beforeIdFor(rulesSnapshot, from, to));
                             }
                         }
                         onPositionChanged: {
@@ -413,6 +437,7 @@ Item {
                     validationIssueCount: delegateRoot.modelData.validationIssueCount
                     priority: delegateRoot.modelData.priority
                     managed: delegateRoot.modelData.managed === true
+                    sectionLabel: root.showSectionBadge ? (delegateRoot.modelData.sectionLabel || "") : ""
                     controller: root.controller
                     matchFieldOptions: root.matchFieldOptions
                     actionTypeOptions: root.actionTypeOptions

--- a/src/settings/qml/RuleSectionList.qml
+++ b/src/settings/qml/RuleSectionList.qml
@@ -221,7 +221,8 @@ Item {
 
             // Register a per-rule deep-link anchor ("rule:<id>") with the host
             // page's reveal registry so a window-rule search result scrolls to
-            // and pulses this exact row (expanding its section card if collapsed).
+            // and pulses this exact row (expanding the rule list's card if
+            // collapsed).
             Component.onCompleted: {
                 root.setDelegateHeight(modelData.ruleId, actualHeight);
                 Qt.callLater(function () {

--- a/src/settings/qml/RuleSectionList.qml
+++ b/src/settings/qml/RuleSectionList.qml
@@ -12,31 +12,29 @@ import "SearchAnchorHelpers.js" as SearchAnchors
 /**
  * @brief Drag-reorderable, variable-height list of RuleRow delegates.
  *
- * Hosts one rule-section's rows, shown highest priority first. Each row can
- * independently expand its WHEN/THEN preview, and rows can be reordered by
- * dragging the grip handle column or by Alt+Up / Alt+Down on a focused row.
- * A drop reorders the model via `controller.moveRule(movedId, beforeId)`, which
- * renormalizes priorities so list order maps onto evaluation order. The
- * resulting `dataChanged`/`rowsMoved` is what `RulesPage` listens for to rebuild
- * and re-sort its bucketed `sectionModel`.
+ * Hosts the rule rows, shown highest priority first. Each row can independently
+ * expand its WHEN/THEN preview, and rows can be reordered by dragging the grip
+ * handle column or by Alt+Up / Alt+Down on a focused row. A drop reorders the
+ * model via `controller.moveRule(movedId, beforeId)`, which renormalizes
+ * priorities so list order maps onto evaluation order. The resulting
+ * `dataChanged`/`rowsMoved` is what `RulesPage` listens for to rebuild its
+ * `filteredRules`.
  *
  * Variable-height invariant: each delegate publishes its actual rendered
  * height (header row + expansion contribution) back to the container via
- * `setDelegateHeight(ruleId, h)`. The container's `cumulativeY`,
- * `totalHeight`, and `slotIndexAt` walk that map so the drag cascade
- * matches the layout even when rows differ in size — fixed-stride math
- * (the prior shape) wouldn't survive an expanded source row leaving a
- * gap larger than the displaced rows' shift, breaking the slot-in
- * preview.
+ * `setDelegateHeight(ruleId, h)`. The container caches a prefix sum of those
+ * heights (`_offsets`) so the drag cascade matches the layout even when rows
+ * differ in size — fixed-stride math (the prior shape) wouldn't survive an
+ * expanded source row leaving a gap larger than the displaced rows' shift,
+ * breaking the slot-in preview.
  */
 Item {
     id: root
 
-    /// The section's rule entries — `[{ ruleId, name, enabled, ... }, ...]`
-    /// as produced by `RulesPage.sectionModel`. The container snapshots
-    /// the array here so the Repeater delegate's `modelData` (which the
-    /// delegate scope rebinds to the row, not the section) doesn't collide
-    /// with the array reference.
+    /// The rule entries — `[{ ruleId, name, enabled, ... }, ...]` as produced by
+    /// `RulesPage.filteredRules`. The container snapshots the array here so the
+    /// Repeater delegate's `modelData` (which the delegate scope rebinds to the
+    /// row) doesn't collide with the array reference.
     required property var rules
     /// The RuleController — supplies match-field and operator tables
     /// to the row's expansion view and owns `moveRule` for drag commits.
@@ -50,30 +48,21 @@ Item {
     /// activities + window picker) threaded into MatchLeafEditor and
     /// ActionListView. May be null while the page is still wiring up.
     property var appSettings: null
-    /// Whether drag / keyboard reordering is offered. Reordering maps list order
-    /// onto the priority bands `renormalizePriorities` stamps, so the host only
-    /// enables it in its Reorder mode (Section grouping + Priority sort); a plain
-    /// browse/filter view is static.
+    /// Whether drag / keyboard reordering is offered. The host disables it only
+    /// for a non-reorderable hosting context; the Rules page leaves it on (the
+    /// flat priority list is always reorderable). Managed System rows are still
+    /// pinned per-row regardless.
     property bool reorderingEnabled: true
-    /// Whether the list is shown lowest-priority-first. The drag/keyboard commit
-    /// maps a drop position onto a `beforeId` for `moveRule`; that mapping is
-    /// mirrored when the list is ascending so dragging works in both directions.
-    property bool ascending: false
-    /// Whether each row shows its section as a small badge. The flat list shows
-    /// it (so category stays legible without grouping); the page suppresses it
-    /// when the cards already group by section.
+    /// Whether each row shows its section as a small badge, so category stays
+    /// legible in the flat (ungrouped) list.
     property bool showSectionBadge: false
 
     /// Resolve the `beforeId` to hand `moveRule` for moving `list[from]` to slot
     /// `to`. `moveRule` inserts immediately BEFORE `beforeId` (empty = end, i.e.
-    /// lowest priority). The model is kept in priority-descending row order, so an
-    /// ascending display is its reverse and the neighbour math inverts.
+    /// lowest priority). The list is shown highest-priority-first and the model is
+    /// kept in that same row order, so moving down (from < to) lands before the
+    /// slot after the target, and moving up lands before the target.
     function beforeIdFor(list, from, to) {
-        if (root.ascending) {
-            if (from < to)
-                return list[to].ruleId;
-            return to - 1 >= 0 ? list[to - 1].ruleId : "";
-        }
         if (from < to)
             return to + 1 < list.length ? list[to + 1].ruleId : "";
         return list[to].ruleId;
@@ -106,8 +95,8 @@ Item {
     // Per-ruleId published height. Keyed by ruleId (not index) so
     // reorders don't invalidate the map. The whole object is
     // reassigned on each publish so QML bindings that read it
-    // (heightOf / totalHeight / cumulativeY) re-evaluate — partial
-    // mutation `delegateHeights[k] = v` wouldn't notify dependents.
+    // (heightOf / `_offsets`) re-evaluate — partial mutation
+    // `delegateHeights[k] = v` wouldn't notify dependents.
     property var delegateHeights: ({})
 
     function setDelegateHeight(ruleId, h) {
@@ -141,36 +130,37 @@ Item {
         return (h !== undefined && h > 0) ? h : headerRowHeight;
     }
 
-    function cumulativeY(idx) {
-        var y = 0;
-        for (var i = 0; i < idx; ++i)
-            y += heightOf(i);
-        return y;
+    // Prefix-sum of row heights, recomputed once whenever `rules` or
+    // `delegateHeights` changes: `_offsets[i]` is the cumulative Y of row i and
+    // `_offsets[rules.length]` is the total height. Reading the cache keeps
+    // baseY / totalHeight / slotIndexAt at O(1) / O(n) instead of each delegate
+    // re-walking the heights from 0 — which made one relayout O(n²) and a full
+    // load O(n³). That was bounded when each section was its own short list, but
+    // the unified flat list now puts every rule through this one container.
+    readonly property var _offsets: {
+        var arr = [0];
+        for (var i = 0; i < rules.length; ++i)
+            arr.push(arr[i] + heightOf(i));
+        return arr;
     }
 
-    // Find the slot whose original (pre-cascade) range contains @p
-    // centerY — used by the drag MouseArea to resolve dropTargetIndex
-    // against variable heights. Walking the cumulative sum once per
-    // pointer event is cheap for typical rule counts; the prior
-    // fixed-stride formula `floor(centerY / rowHeight)` only worked
-    // when every row was the same height.
+    function cumulativeY(idx) {
+        return root._offsets[Math.max(0, Math.min(idx, rules.length))] || 0;
+    }
+
+    // Find the slot whose original (pre-cascade) range contains @p centerY —
+    // used by the drag MouseArea to resolve dropTargetIndex against variable
+    // heights. Reads the cached prefix sums; the prior fixed-stride formula
+    // `floor(centerY / rowHeight)` only worked when every row was the same height.
     function slotIndexAt(centerY) {
-        var y = 0;
         for (var i = 0; i < rules.length; ++i) {
-            var h = heightOf(i);
-            if (centerY < y + h)
+            if (centerY < root._offsets[i + 1])
                 return i;
-            y += h;
         }
         return Math.max(0, rules.length - 1);
     }
 
-    readonly property real totalHeight: {
-        var y = 0;
-        for (var i = 0; i < rules.length; ++i)
-            y += heightOf(i);
-        return y;
-    }
+    readonly property real totalHeight: root._offsets[rules.length] || 0
 
     readonly property real draggedHeight: dragFromIndex >= 0 ? heightOf(dragFromIndex) : headerRowHeight
 
@@ -188,9 +178,9 @@ Item {
             required property int index
 
             // A row is reorderable only when the list as a whole offers
-            // reordering (canonical view) AND this is not a managed System rule
-            // — managed rules have a fixed precedence (INT_MIN) and the
-            // controller rejects reordering them anyway.
+            // reordering AND this is not a managed System rule — managed rules
+            // have a fixed precedence (INT_MIN) and the controller rejects
+            // reordering them anyway.
             readonly property bool reorderable: root.reorderingEnabled && modelData.managed !== true
 
             readonly property real baseY: root.cumulativeY(index)

--- a/src/settings/qml/RulesPage.qml
+++ b/src/settings/qml/RulesPage.qml
@@ -13,11 +13,23 @@ import org.plasmazones.settings
  *
  * One surface for every window-matching rule — monitors, applications,
  * activities, animations. Backed by a single `RuleModel` exposed by
- * `SettingsController.rulesPage`; section grouping, search and section
- * filtering are all derived here in QML over that one model — there are no
- * per-section proxy models.
+ * `SettingsController.rulesPage`.
  *
- * The monitor overview strip is read-only; clicking a tile filters the list.
+ * The page is ONE flat, drag-reorderable priority list — highest precedence on
+ * top. A drop re-stamps the single GLOBAL priority sequence
+ * (`RuleController::renormalizePriorities`), so the user freely interleaves
+ * rules from any section and position alone decides who wins. There are no
+ * priority bands in evaluation (the daemon only reads the priority integer); the
+ * old section "bands" survive only as a default-seeding hint for newly added
+ * rules. Managed System rules pin to the bottom (INT_MIN) and are non-draggable.
+ *
+ * There is deliberately NO grouping/sorting on this page — precedence is only
+ * meaningful in priority order, so a re-grouped/re-sorted view would fight the
+ * drag. Browsing is served by narrowing instead: the search field, the section
+ * filter button, and the read-only monitor overview strip (clicking a tile
+ * filters the list). Category stays legible via a per-row section badge. (The
+ * reusable GroupSortBar / GroupSortLogic / SegmentedViewSwitch components live on
+ * for the Layouts page and any future use.)
  */
 SettingsFlickable {
     id: page
@@ -108,40 +120,51 @@ SettingsFlickable {
     // ── Filter state ──
 
     property string searchText: ""
-    // Section filter (multi-select): the set of RuleModel.Section enum
-    // values (as ints) the user has unchecked. Empty = show every section.
-    // The filter button owns this state; the page reads it one-way.
-    readonly property var excludedSections: rulesFilterButton.excluded
+    // Multi-select filter state: the set of filter KEYS the user has unchecked
+    // (empty = show everything). Keys are mixed across three groups — section
+    // values (ints), source ("src:system"/"src:user"), and status
+    // ("status:active"/"status:disabled"). The filter button owns this; the page
+    // reads it one-way.
+    readonly property var excludedFilters: rulesFilterButton.excluded
     property string monitorFilter: ""
     // Ordered section descriptors — `[{ value: int, label }]` straight from
-    // the controller. The C++ Section enum order is never duplicated in QML.
+    // the controller. Drives the section filter menu; the C++ Section enum
+    // order is never duplicated in QML.
     readonly property var sectionDescriptors: page.controller.sections()
-    // Cached `matchFields()` table — threaded down to every RuleRow's
-    // expansion view so the per-row Q_INVOKABLE doesn't fire on every expand.
-    // The authoring catalogue is static, so this is a one-shot read.
+
+    // Cached `matchFields()` / `actionTypes()` tables — threaded down to every
+    // RuleRow's expansion view so the per-row Q_INVOKABLE doesn't fire on every
+    // expand. The authoring catalogue is static, so this is a one-shot read.
     property var matchFieldOptions: page.controller.matchFields()
-    // Cached `actionTypes()` — same caching rationale as matchFieldOptions;
-    // threaded down to RuleRow's expansion so each row doesn't re-invoke
-    // the Q_INVOKABLE.
     property var actionTypeOptions: page.controller.actionTypes()
-    // Bumped whenever the underlying model changes so sectionModel re-evaluates
+    // Bumped whenever the underlying model changes so filteredRules re-evaluates
     // without QML hardcoding the model's role layout.
     property int modelRevision: 0
-    /// Build a `[ { section, label, rules: [...] } ]` array over the flat
-    /// model, applying search / section / monitor filters. Reactive: depends on
-    /// searchText / excludedSections / monitorFilter and `modelRevision`.
-    readonly property var sectionModel: {
-        // Touch the revision so the binding re-evaluates on any model change.
+
+    /// The flat, filtered, priority-ordered rule list — highest precedence first.
+    /// This is the page's single view: precedence only has meaning in priority
+    /// order, so there is no grouping/sorting UI — the list is always the
+    /// drag-reorderable priority sequence. Search + the filter button (section /
+    /// source / status) + the monitor strip narrow it without changing order.
+    /// Managed System rules pin to the bottom for free (their priority is
+    /// INT_MIN). Reactive on searchText / excludedFilters / monitorFilter and
+    /// `modelRevision`.
+    readonly property var filteredRules: {
         var rev = page.modelRevision;
         var snapshot = page.controller.rulesSnapshot();
-        var buckets = {};
-        for (var s = 0; s < page.sectionDescriptors.length; ++s)
-            buckets[page.sectionDescriptors[s].value] = [];
         var search = page.searchText.toLowerCase();
+        var excluded = page.excludedFilters;
+        var out = [];
         for (var i = 0; i < snapshot.length; ++i) {
             var entry = snapshot[i];
-            // Section filter — hide entries whose section the user unchecked.
-            if (page.excludedSections.indexOf(entry.section) >= 0)
+            // Section filter — hide entries whose category the user unchecked.
+            if (excluded.indexOf(entry.section) >= 0)
+                continue;
+            // Source filter — built-in (managed) vs user-created.
+            if (excluded.indexOf(entry.managed === true ? "src:system" : "src:user") >= 0)
+                continue;
+            // Status filter — active (enabled) vs disabled.
+            if (excluded.indexOf(entry.enabled === true ? "status:active" : "status:disabled") >= 0)
                 continue;
 
             // Search filter — match name / match summary / action summary.
@@ -150,36 +173,21 @@ SettingsFlickable {
                 if (hay.indexOf(search) < 0)
                     continue;
             }
-            // Monitor filter — keep only rules whose ScreenId predicate(s)
-            // name the selected monitor (an exact id match, not a substring
-            // scan of the localized summary).
+            // Monitor filter — keep only rules whose ScreenId predicate(s) name
+            // the selected monitor (an exact id match, not a substring scan).
             if (page.monitorFilter.length > 0) {
                 if (!entry.screenIds || entry.screenIds.indexOf(page.monitorFilter) < 0)
                     continue;
             }
-            if (buckets[entry.section] !== undefined)
-                buckets[entry.section].push(entry);
+            out.push(entry);
         }
-        var out = [];
-        for (var so = 0; so < page.sectionDescriptors.length; ++so) {
-            var sec = page.sectionDescriptors[so];
-            if (buckets[sec.value].length === 0)
-                continue;
-
-            // Within a section, show highest priority first — the winning rule
-            // on top, matching the priority-wins precedence. Qt's V4 sort is
-            // stable, so equal priorities keep model order (the evaluator's
-            // own tie-break). Lower-priority rules sort to the bottom.
-            var bucket = buckets[sec.value];
-            bucket.sort(function (l, r) {
-                return r.priority - l.priority;
-            });
-            out.push({
-                "section": sec.value,
-                "label": sec.label,
-                "rules": bucket
-            });
-        }
+        // Highest priority first. Qt's V4 sort is stable, so equal priorities keep
+        // snapshot (model) order — which the global renormalize keeps in sync with
+        // priority order, so display order == model row order (the invariant the
+        // drag commit relies on).
+        out.sort(function (a, b) {
+            return (b.priority || 0) - (a.priority || 0);
+        });
         return out;
     }
     // Bump `tilesRevision` whenever the upstream lists change. The tile
@@ -188,11 +196,11 @@ SettingsFlickable {
     // unchanged), leaving the tile caption stale. Listening to the change
     // signals directly invalidates on any structural OR content change.
     property int tilesRevision: 0
-    // Roles the sectionModel reads (bucketing, filtering, summary cards, and
-    // the per-row badges including Priority). The sectionModel is built from
-    // `rulesSnapshot()` — a frozen QVariantList — so a row only reflects a role
-    // change once the snapshot is rebuilt. The onDataChanged handler below
-    // bumps modelRevision (→ rebuild) when EITHER:
+    // Roles the filteredRules list reads (filtering, the row summaries, and the
+    // priority sort). filteredRules is built from `rulesSnapshot()` — a frozen
+    // QVariantList — so a row only reflects a role change once the snapshot is
+    // rebuilt. The onDataChanged handler below bumps modelRevision (→ rebuild)
+    // when EITHER:
     //   (a) the dataChanged roles vector is empty — Qt's "any role" convention,
     //       which every updateRule() mutation uses, so enabled / name / match /
     //       action / in-place-priority edits already rebuild this way; OR
@@ -201,10 +209,10 @@ SettingsFlickable {
     //       refreshLabels() → {NameRole, MatchSummaryRole, ActionSummaryRole}.
     // PriorityRole MUST be listed: a drag-reorder runs renormalizePriorities()
     // → setPriorities(), whose targeted dataChanged({PriorityRole}) the
-    // empty-roles fallback never sees — omitting it left the reordered rows'
-    // Priority badges showing their stale pre-move numbers. The remaining
-    // entries (Section / ScreenIds / ConditionCount / ActionCount / IsComposite
-    // / ValidationIssueCount) are also read by the sectionModel but currently
+    // empty-roles fallback never sees — omitting it would leave the reordered
+    // rows in their stale pre-move order. The remaining entries (Section /
+    // ScreenIds / ConditionCount / ActionCount / IsComposite /
+    // ValidationIssueCount) are also read when building the rows but currently
     // change only through the roles-less updateRule path; they're kept so a
     // future targeted emitter carrying them rebuilds without a second edit here.
     readonly property var _summaryRoles: [RuleModel.SectionRole, RuleModel.MatchSummaryRole, RuleModel.ActionSummaryRole, RuleModel.ScreenIdsRole, RuleModel.ConditionCountRole, RuleModel.ActionCountRole, RuleModel.IsCompositeRole, RuleModel.ValidationIssueCountRole, RuleModel.PriorityRole]
@@ -443,19 +451,45 @@ SettingsFlickable {
                 onTextChanged: page.searchText = text
             }
 
-            // Multi-select section filter, modeled on the Layouts page filter
-            // button. Section labels/order come from the controller (C++), not
-            // hardcoded here. `excluded` is the page's section filter state.
+            // Multi-select filter, modeled on the Layouts page filter button —
+            // same group ORDER as the Layouts menu: source first (built-in before
+            // user), then the categories, then the status/type pair. Three groups:
+            // source (system vs user-created), category sections, status (active
+            // vs disabled). Section labels/order come from the controller (C++).
+            // System is dropped from the section group because a System rule is
+            // exactly a managed rule (sectionFor maps managed → System), so the
+            // Source group's "System" already covers it — listing it twice would
+            // be redundant.
             FilterMenuButton {
                 id: rulesFilterButton
 
                 menuTitle: i18nc("@title:menu", "Filter Rules")
-                groups: [page.sectionDescriptors.map(function (s) {
+                groups: [[
+                        {
+                            "key": "src:system",
+                            "label": i18nc("@option:check filter rules by source", "System")
+                        },
+                        {
+                            "key": "src:user",
+                            "label": i18nc("@option:check filter rules by source", "User-created")
+                        }
+                    ], page.sectionDescriptors.filter(function (s) {
+                        return s.value !== RuleModel.System;
+                    }).map(function (s) {
                         return {
                             "key": s.value,
                             "label": s.label
                         };
-                    })]
+                    }), [
+                        {
+                            "key": "status:active",
+                            "label": i18nc("@option:check filter rules by status", "Active")
+                        },
+                        {
+                            "key": "status:disabled",
+                            "label": i18nc("@option:check filter rules by status", "Disabled")
+                        }
+                    ]]
             }
 
             Button {
@@ -477,73 +511,53 @@ SettingsFlickable {
 
             Layout.fillWidth: true
             Layout.topMargin: Kirigami.Units.gridUnit * 2
-            visible: page.sectionModel.length === 0 && !_daemonDown
+            visible: page.filteredRules.length === 0 && !_daemonDown
             icon.name: "view-list-details"
             text: _trulyEmpty ? i18n("No rules yet") : i18n("No rules match the current filter")
             explanation: _trulyEmpty ? i18n("Add a rule to assign layouts to monitors, float application windows, or override animations.") : i18n("Try a different filter or search term.")
         }
 
-        // ── Grouped rule list ──
-        // Each section renders as a standard `SettingsCard` with `headerText`
-        // — same visual treatment as the rest of the app (Animations Presets,
-        // Virtual Screens, General). The card carries the section label as
-        // its header and the rule rows as its body.
-        Repeater {
-            model: page.sectionModel
+        // ── The flat priority list ──
+        // One drag-reorderable list, highest precedence on top — there is no
+        // grouping, so a single card hosts every (filtered) rule. The header
+        // carries the count and the reorder hint; the section badge on each row
+        // keeps category legible without grouping.
+        SettingsCard {
+            Layout.fillWidth: true
+            visible: page.filteredRules.length > 0
+            headerText: i18n("All rules")
+            headerTrailingText: {
+                var base = i18np("%n rule", "%n rules", page.filteredRules.length);
+                return i18nc("Suffix in the rule list header showing the count and a reorder hint", "%1 · drag to set precedence", base);
+            }
 
-            delegate: SettingsCard {
-                required property var modelData
+            contentItem: ColumnLayout {
+                spacing: 0
 
-                Layout.fillWidth: true
-                headerText: modelData.label
-                // Collapsible sections — clicking the header chevron toggles
-                // visibility of the section's rule list. State lives on the
-                // delegate so each section collapses independently; resets on
-                // page reload (acceptable — recovering the list is one click
-                // away and the page's rule count makes empty sections honest).
-                collapsible: true
-                // Right-aligned rule count in the section header — matches
-                // the mockup's "MONITOR & LAYOUT  4 rules" pattern and gives
-                // the user a quick scan of how many rules are bucketed where.
-                // The "drag to set precedence" hint applies to every section:
-                // priority within a section is uniformly list-order driven
-                // (`renormalizePriorities` stamps band-base + per-band offset
-                // for ALL sections), so the drag affordance and its hint are
-                // section-agnostic.
-                headerTrailingText: {
-                    var count = modelData.rules ? modelData.rules.length : 0;
-                    var base = i18np("%n rule", "%n rules", count);
-                    return i18nc("Suffix in a section header showing the count and a reorder hint", "%1 · drag to set precedence", base);
-                }
-
-                contentItem: ColumnLayout {
-                    spacing: 0
-
-                    // One drag-reorderable, variable-height list for every
-                    // section. Priorities within each cascade band are
-                    // computed from list order by the C++ controller's
-                    // `renormalizePriorities` (called on every moveRule),
-                    // so the same drag UX applies uniformly across Monitor,
-                    // Application, Activity, Animation, and Advanced.
-                    RuleSectionList {
-                        Layout.fillWidth: true
-                        rules: modelData.rules
-                        controller: page.controller
-                        matchFieldOptions: page.matchFieldOptions
-                        actionTypeOptions: page.actionTypeOptions
-                        appSettings: page._editorAppSettings
-                        onToggleRequested: function (ruleId, enabled) {
-                            page.controller.setRuleEnabled(ruleId, enabled);
-                        }
-                        onEditRequested: function (ruleId) {
-                            ruleEditorSheet.openFor(page.controller.ruleJson(ruleId));
-                        }
-                        onDuplicateRequested: function (ruleId) {
-                            page.controller.duplicateRule(ruleId);
-                        }
-                        onDeleteRequested: function (ruleId) {
-                            page.controller.removeRule(ruleId);
-                        }
+                // A drop re-stamps the global priority sequence via the
+                // controller's `renormalizePriorities`; managed System rules pin
+                // to the bottom and are non-draggable (handled per-row).
+                RuleSectionList {
+                    Layout.fillWidth: true
+                    rules: page.filteredRules
+                    reorderingEnabled: true
+                    ascending: false
+                    showSectionBadge: true
+                    controller: page.controller
+                    matchFieldOptions: page.matchFieldOptions
+                    actionTypeOptions: page.actionTypeOptions
+                    appSettings: page._editorAppSettings
+                    onToggleRequested: function (ruleId, enabled) {
+                        page.controller.setRuleEnabled(ruleId, enabled);
+                    }
+                    onEditRequested: function (ruleId) {
+                        ruleEditorSheet.openFor(page.controller.ruleJson(ruleId));
+                    }
+                    onDuplicateRequested: function (ruleId) {
+                        page.controller.duplicateRule(ruleId);
+                    }
+                    onDeleteRequested: function (ruleId) {
+                        page.controller.removeRule(ruleId);
                     }
                 }
             }

--- a/src/settings/qml/RulesPage.qml
+++ b/src/settings/qml/RulesPage.qml
@@ -234,12 +234,11 @@ SettingsFlickable {
 
         // moveRule fires through beginMoveRows / endMoveRows, which emits
         // rowsMoved (and never countChanged / dataChanged on a summary role).
-        // Without this handler the section buckets stay frozen on the
+        // Without this handler the flat priority list stays frozen on the
         // pre-move ordering: the dragged row's `y` re-binds to its OLD
         // cumulative position and the user sees a snap-back even though the
-        // C++ model has accepted the move. The Animation section's drag
-        // container is the only place this surfaces today, but the bump is
-        // model-wide so future reorderable sections inherit the fix.
+        // C++ model has accepted the move. The single drag container hosts
+        // every rule, so this covers all reorders.
         function onRowsMoved() {
             page.modelRevision++;
         }

--- a/src/settings/qml/RulesPage.qml
+++ b/src/settings/qml/RulesPage.qml
@@ -182,9 +182,10 @@ SettingsFlickable {
             out.push(entry);
         }
         // Highest priority first. Qt's V4 sort is stable, so equal priorities keep
-        // snapshot (model) order — which the global renormalize keeps in sync with
-        // priority order, so display order == model row order (the invariant the
-        // drag commit relies on).
+        // snapshot (model) order — the only ties are the managed System rules,
+        // which all share INT_MIN and sort to the bottom. The global renormalize
+        // keeps model row order in sync with priority order, so display order ==
+        // model row order (the invariant the drag commit relies on).
         out.sort(function (a, b) {
             return (b.priority || 0) - (a.priority || 0);
         });
@@ -541,7 +542,6 @@ SettingsFlickable {
                     Layout.fillWidth: true
                     rules: page.filteredRules
                     reorderingEnabled: true
-                    ascending: false
                     showSectionBadge: true
                     controller: page.controller
                     matchFieldOptions: page.matchFieldOptions

--- a/src/settings/qml/RulesPage.qml
+++ b/src/settings/qml/RulesPage.qml
@@ -221,8 +221,8 @@ SettingsFlickable {
     contentHeight: mainCol.implicitHeight
     clip: true
 
-    // Re-derive the section model on every structural or per-rule change so a
-    // rule that changes section is re-bucketed.
+    // Re-derive filteredRules on every structural or per-rule change so a rule
+    // that changes section gets its updated badge / filter classification.
     Connections {
         function onCountChanged() {
             page.modelRevision++;

--- a/src/settings/qml/SegmentedViewSwitch.qml
+++ b/src/settings/qml/SegmentedViewSwitch.qml
@@ -9,26 +9,27 @@ import org.kde.kirigami as Kirigami
 import org.phosphor.animation
 
 /**
- * @brief Snapping / Tiling mode switch styled as the RulesPage monitor
- *        switcher.
+ * @brief Centered radio-tile mode switch.
  *
  * A centered row of soft-highlight, label-only tiles mirroring
  * MonitorOverviewTile's visual treatment — selected tint + border, hover wash,
  * focus ring, and the shared widget.hover motion — instead of a segmented
- * button group, so the Layouts page reads consistently with the monitor pickers
- * elsewhere in the app. Radio semantics: exactly one mode is active and clicking
- * the active tile is a no-op.
+ * button group, so pages read consistently with the monitor pickers elsewhere
+ * in the app. Radio semantics: exactly one mode is active and clicking the
+ * active tile is a no-op. The labels are injected via `modes`, so the same
+ * switch backs the Layouts page (Snapping / Tiling) and the Rules page
+ * (Edit / View).
  */
 Item {
     id: root
 
-    // Selected mode index (0 = Snapping, 1 = Tiling). Bound by the host page.
+    /// Localized tile labels, one per mode.
+    property var modes: []
+    /// Selected mode index. Bound by the host page.
     property int currentIndex: 0
 
-    // Emitted when the user picks a different mode.
+    /// Emitted when the user picks a different mode.
     signal indexChanged(int index)
-
-    readonly property var _modes: [i18n("Snapping"), i18n("Tiling")]
 
     implicitHeight: tileRow.implicitHeight
 
@@ -39,7 +40,7 @@ Item {
         spacing: Kirigami.Units.largeSpacing
 
         Repeater {
-            model: root._modes
+            model: root.modes
 
             Rectangle {
                 id: tile

--- a/src/settings/qml/SegmentedViewSwitch.qml
+++ b/src/settings/qml/SegmentedViewSwitch.qml
@@ -17,8 +17,8 @@ import org.phosphor.animation
  * button group, so pages read consistently with the monitor pickers elsewhere
  * in the app. Radio semantics: exactly one mode is active and clicking the
  * active tile is a no-op. The labels are injected via `modes`, so the same
- * switch backs the Layouts page (Snapping / Tiling) and the Rules page
- * (Edit / View).
+ * switch is reusable across pages — the Layouts page uses it for its
+ * Snapping / Tiling mode switch.
  */
 Item {
     id: root

--- a/src/settings/rulecontroller.cpp
+++ b/src/settings/rulecontroller.cpp
@@ -23,6 +23,8 @@
 #include <QJsonObject>
 #include <QUuid>
 
+#include <limits>
+
 namespace PlasmaZones {
 
 namespace {
@@ -406,89 +408,92 @@ void RuleController::revert()
     fetchAndLoad(/*fromRevert=*/true);
 }
 
+int RuleController::bandBaseForSection(RuleModel::Section section)
+{
+    switch (section) {
+    case RuleModel::Section::Advanced:
+        return kAdvancedBandBase;
+    case RuleModel::Section::Monitor:
+    case RuleModel::Section::Activity:
+        return kContextBandBase;
+    case RuleModel::Section::Application:
+        return kApplicationBandBase;
+    case RuleModel::Section::Animation:
+        return kAnimationBandBase;
+    case RuleModel::Section::System:
+        // Managed System rules keep their pinned INT_MIN priority — they are
+        // never stamped a band by renormalizePriorities (the managed guard skips
+        // them). Report INT_MIN so section ordering places System last.
+        return std::numeric_limits<int>::min();
+    }
+    return kAnimationBandBase;
+}
+
 void RuleController::renormalizePriorities()
 {
-    // Walk the model's list order and re-stamp priority so list order maps
-    // monotonically onto evaluation order. Higher list index ⇒ lower
-    // priority within the rule's band; the bands keep the section ordering
-    // (Advanced > Monitor/Activity > Application > Animation; Monitor and
-    // Activity share the Context band) stable.
+    // Priority is a single GLOBAL list-order sequence: earlier list row ⇒ higher
+    // priority, full stop. There are no priority bands — a rule's precedence is
+    // purely its position in the one flat list, and the user can freely
+    // interleave rules from what used to be separate "sections" (sections are
+    // now only a display label + a default-seeding hint, see
+    // bandSeededInsertIndex). The evaluator only ever reads this integer
+    // (descending, list-order tie-break), so a flat global sequence evaluates
+    // identically to the old banded scheme — it just lets cross-section drags
+    // actually change who wins.
     //
-    // This is invoked ONLY when list order changes — on a drag-reorder
-    // (moveRule) and when a new rule is appended (addRuleFromJson). An in-place
-    // edit (updateRuleFromJson) never reorders the list, so it does not call
-    // this: the Advanced editor exposes `priority` directly, and an explicit
-    // priority edit there is honoured verbatim rather than being overwritten by
-    // the band-derived value. A non-priority in-place edit likewise leaves
-    // priority untouched, so list order and PriorityRole stay consistent.
-    //
-    // Only the priority changes — push the new values through setPriorities()
-    // so the model emits a single dataChanged(PriorityRole) instead of a full
-    // reset (which would tear down and rebuild every QML delegate).
+    // Invoked ONLY when list order changes — on a drag-reorder (moveRule) and
+    // when a rule is added (addRuleFromJson). An in-place edit
+    // (updateRuleFromJson) never reorders the list, so it does not call this:
+    // the Advanced editor exposes `priority` directly and an explicit edit there
+    // is honoured verbatim until the next reorder. Only the priority changes —
+    // push through setPriorities() so the model emits a single
+    // dataChanged(PriorityRole) instead of a full reset.
     const QList<Rule>& rules = m_model.rules();
     const int n = rules.size();
     QList<int> priorities;
     priorities.resize(n);
-    // Bands are spaced 100 apart (Animation=100, Application=200,
-    // Context=300, Advanced=500). The per-rule offset is BAND-LOCAL — each
-    // band re-starts the offset countdown from the band-width cap (99) and
-    // decrements as later entries within the same band are encountered. This
-    // gives a contiguous "earlier list index ⇒ higher priority within the
-    // band" property: the global `i` would only do that if every band were
-    // dense, but with sparse bands (one Animation rule near the bottom of
-    // the list) the global index dropped the bottom rule below other rules
-    // in its own band. Bands run independent counters.
-    //
-    // Each band's offset starts at `kBandWidth - 1` and decrements; capped
-    // at 0 so a band with >100 rules ties at the floor (list order is
-    // preserved by setPriorities's stable application).
-    constexpr int kBandWidth = 100;
-    const auto baseFor = [](const Rule& rule) {
-        switch (RuleModel::sectionFor(rule)) {
-        case RuleModel::Section::Advanced:
-            return kAdvancedBandBase;
-        case RuleModel::Section::Monitor:
-        case RuleModel::Section::Activity:
-            return kContextBandBase;
-        case RuleModel::Section::Application:
-            return kApplicationBandBase;
-        case RuleModel::Section::Animation:
-            return kAnimationBandBase;
-        case RuleModel::Section::System:
-            // Managed System rules keep their pinned INT_MIN priority and are
-            // skipped before this runs (see the managed guard in the loop); this
-            // case only keeps the switch exhaustive.
-            return kAdvancedBandBase;
-        }
-        return kAnimationBandBase;
-    };
-
-    // Per-band offset counter — base address → next available offset. Each
-    // band seeds at `kBandWidth - 1` on first encounter and decrements as
-    // later entries within the same band are stamped. Absence in the hash
-    // (`find() == end()`) signals not-yet-seeded; the explicit
-    // find/insert flow disambiguates from the value-initialised 0 that
-    // `operator[]` on QHash would otherwise produce.
-    QHash<int, int> nextOffset;
+    // Spaced by kStep so a manual Advanced-editor priority edit has room to land
+    // between two neighbours before the next reorder renumbers. Start from the
+    // top (highest priority = first row) and step down.
+    constexpr int kStep = 16;
+    int userCount = 0;
+    for (int i = 0; i < n; ++i) {
+        if (!rules.at(i).managed)
+            ++userCount;
+    }
+    int rank = userCount;
     for (int i = 0; i < n; ++i) {
         // Managed rules (the baseline appearance rule) carry a pinned priority
-        // that fixes them at the bottom of evaluation regardless of list
-        // position — never re-stamp them with a band value, or they'd jump
-        // above user rules.
+        // (INT_MIN) that fixes them below every user rule regardless of list
+        // position — never re-stamp them, or they'd jump above user rules.
         if (rules.at(i).managed) {
             priorities[i] = rules.at(i).priority;
             continue;
         }
-        const int base = baseFor(rules.at(i));
-        auto it = nextOffset.find(base);
-        if (it == nextOffset.end()) {
-            it = nextOffset.insert(base, kBandWidth - 1);
-        }
-        const int offset = qMax(0, it.value());
-        it.value() = offset - 1;
-        priorities[i] = base + offset;
+        priorities[i] = rank * kStep;
+        --rank;
     }
     m_model.setPriorities(priorities);
+}
+
+int RuleController::bandSeededInsertIndex(const Rule& rule) const
+{
+    // Seed the new rule's DEFAULT position by band so defaults stay sensible (a
+    // new Advanced rule starts high, a new Animation rule starts low) even
+    // though priority is now one free-form global sequence. Insert above the
+    // first existing rule of a strictly lower band, or above the managed block —
+    // i.e. at the top of the new rule's band tier. The user can drag it anywhere
+    // afterwards.
+    const int band = bandBaseForSection(RuleModel::sectionFor(rule));
+    const QList<Rule>& rules = m_model.rules();
+    for (int i = 0; i < rules.size(); ++i) {
+        const Rule& r = rules.at(i);
+        if (r.managed)
+            return i;
+        if (bandBaseForSection(RuleModel::sectionFor(r)) < band)
+            return i;
+    }
+    return rules.size();
 }
 
 QVariantMap RuleController::newEmptyRule(const QString& subject) const
@@ -522,14 +527,16 @@ QString RuleController::addRuleFromJson(const QVariantMap& ruleJson)
         qCWarning(lcConfig) << "RuleController::addRuleFromJson: rejecting malformed rule payload";
         return QString();
     }
-    if (!m_model.addRule(*parsed)) {
+    // Insert at the band-seeded position so a new rule's DEFAULT precedence
+    // reflects its section (Advanced high, Animation low) rather than always
+    // landing at the bottom of the flat list. The user can drag it afterwards.
+    if (!m_model.addRuleAt(*parsed, bandSeededInsertIndex(*parsed))) {
         qCWarning(lcConfig) << "RuleController::addRuleFromJson: model rejected rule" << parsed->id.toString()
                             << "(id collision or invalid)";
         return QString();
     }
-    // Re-stamp priorities so two rules added back-to-back in the same band do
-    // not collide on the band-base priority — list order maps onto evaluation
-    // order exactly as it does after a drag-reorder.
+    // Re-stamp priorities so list order maps onto evaluation order exactly as it
+    // does after a drag-reorder.
     renormalizePriorities();
     setDirty(true);
     return parsed->id.toString();

--- a/src/settings/rulecontroller.cpp
+++ b/src/settings/rulecontroller.cpp
@@ -32,12 +32,11 @@ namespace {
 using PhosphorRules::Rule;
 using PhosphorRules::RuleSet;
 
-// Priority bands live next to the seeded templates (ruletemplates.h) so
-// the renormalize logic here shares the exact bands the templates /
-// empty-rule seeds land in — a single source of truth keeps section ordering
-// (Advanced > Monitor/Activity > Application > Animation; Monitor and Activity
-// share the Context band) consistent between newly-authored rules and
-// post-reorder priority stamps.
+// Default priority bases by section, shared with the seeded templates
+// (ruletemplates.h). Priority renormalization is flat global list-order and does
+// NOT use these; they feed only `bandBaseForSection`, which seeds where a newly
+// added rule inserts (a new Advanced rule starts above Application, etc.) before
+// the user reorders freely.
 using RuleTemplates::kAdvancedBandBase;
 using RuleTemplates::kAnimationBandBase;
 using RuleTemplates::kApplicationBandBase;
@@ -422,8 +421,8 @@ int RuleController::bandBaseForSection(RuleModel::Section section)
         return kAnimationBandBase;
     case RuleModel::Section::System:
         // Managed System rules keep their pinned INT_MIN priority — they are
-        // never stamped a band by renormalizePriorities (the managed guard skips
-        // them). Report INT_MIN so section ordering places System last.
+        // never renumbered by renormalizePriorities (the managed guard skips
+        // them). Report INT_MIN so a System rule seeds below every user rule.
         return std::numeric_limits<int>::min();
     }
     return kAnimationBandBase;
@@ -669,10 +668,10 @@ QString RuleController::duplicateRule(const QString& ruleId)
         qCWarning(lcConfig) << "RuleController::duplicateRule: model rejected clone" << clone.id.toString();
         return QString();
     }
-    // The clone inherited the source's priority verbatim; without
-    // re-stamping the two would collide on the band-base value and the
-    // daemon's section-ordering would treat them as indistinguishable.
-    // Mirrors the renormalize call addRuleFromJson does after appending.
+    // The clone inherited the source's priority verbatim. Re-stamp the global
+    // list-order priorities so the clone, inserted directly after the source,
+    // gets a distinct rank and evaluates immediately after it instead of tying on
+    // the inherited integer. Mirrors the renormalize call addRuleFromJson does.
     renormalizePriorities();
     setDirty(true);
     return clone.id.toString();

--- a/src/settings/rulecontroller.cpp
+++ b/src/settings/rulecontroller.cpp
@@ -481,9 +481,11 @@ int RuleController::bandSeededInsertIndex(const Rule& rule) const
     // Seed the new rule's DEFAULT position by band so defaults stay sensible (a
     // new Advanced rule starts high, a new Animation rule starts low) even
     // though priority is now one free-form global sequence. Insert above the
-    // first existing rule of a strictly lower band, or above the managed block —
-    // i.e. at the top of the new rule's band tier. The user can drag it anywhere
-    // afterwards.
+    // first existing rule of a strictly lower band, or above the managed block.
+    // Existing same-band rules are stepped over, so the new rule lands at the
+    // bottom of its own tier (just above the next lower band), keeping
+    // earlier-added rules ahead of it within the tier. The user can drag it
+    // anywhere afterwards.
     const int band = bandBaseForSection(RuleModel::sectionFor(rule));
     const QList<Rule>& rules = m_model.rules();
     for (int i = 0; i < rules.size(); ++i) {
@@ -574,12 +576,14 @@ bool RuleController::updateRuleFromJson(const QVariantMap& ruleJson)
         setDirty(true);
         return true;
     case RuleModel::UpdateResult::AppliedSectionChanged:
-        // The edit moved the rule into a different section, so its stored
-        // priority is now in the wrong band (e.g. adding an animation action
-        // reclassifies a Monitor rule to Animation). Re-stamp band priorities so
-        // evaluation order matches the rule's new section. This runs only on a
-        // section change, so a same-section Advanced edit still keeps its
-        // explicitly chosen priority verbatim.
+        // The edit reclassified the rule's section (e.g. adding an animation
+        // action moves a Monitor rule to Animation). Section no longer feeds
+        // priority (only list position does) and the in-place edit leaves the
+        // row where it was, so this re-stamp is normally a no-op. It is kept to
+        // re-sync PriorityRole with model row order in case an earlier explicit
+        // priority edit (the Applied path, which does not renormalize) had
+        // diverged the two. A same-section edit keeps any explicit priority
+        // verbatim.
         renormalizePriorities();
         setDirty(true);
         return true;

--- a/src/settings/rulecontroller.h
+++ b/src/settings/rulecontroller.h
@@ -218,11 +218,11 @@ public:
     /// Remove the rule with @p ruleId (a UUID string). Returns false if absent.
     Q_INVOKABLE bool removeRule(const QString& ruleId);
 
-    /// Clone the rule with @p ruleId. The clone gets a fresh UUID, the same
-    /// priority as the source (so its evaluation order is unchanged), and an
-    /// auto-suffixed name ("X (copy)") when the source's name is non-empty so
-    /// the two are distinguishable in the list. The clone is inserted just
-    /// after the source so it appears next to it in the section.
+    /// Clone the rule with @p ruleId. The clone gets a fresh UUID and an
+    /// auto-suffixed name ("X (copy)") when the source's name is non-empty so the
+    /// two are distinguishable in the list. It is inserted directly after the
+    /// source and the global list-order priorities are re-stamped, so it
+    /// evaluates immediately after the source.
     ///
     /// Returns the new rule's UUID string on success, or an empty string if
     /// the source id is unknown or the clone could not be added (id collision
@@ -244,7 +244,8 @@ public:
 
     // ── List / section metadata for the page ──────────────────────────────
 
-    /// The ordered section descriptors for the grouped list and chip filter.
+    /// The ordered section descriptors for the section filter menu and the
+    /// per-row section badge labels.
     /// Each entry: `{ value: int (Section enum), label }`. The order is the
     /// canonical display order; QML must not hardcode the enum values.
     Q_INVOKABLE QVariantList sections() const;

--- a/src/settings/rulecontroller.h
+++ b/src/settings/rulecontroller.h
@@ -415,6 +415,21 @@ private:
     /// list-ordered, context rules keep their derived bands.
     void renormalizePriorities();
 
+    /// Priority-band base for a section — used now only to (a) order section
+    /// cards by precedence in `sections()` and (b) seed a sensible DEFAULT
+    /// position for a newly added rule (see `bandSeededInsertIndex`). Priority
+    /// itself is a single global list-order sequence (`renormalizePriorities`),
+    /// no longer banded — a rule's precedence is its position in the one flat
+    /// list. Managed System rules are pinned at INT_MIN, so System reports the
+    /// lowest base.
+    static int bandBaseForSection(RuleModel::Section section);
+
+    /// Row index at which a freshly added rule should be inserted so its default
+    /// precedence reflects its section's band — above the first existing rule of
+    /// a lower band (or the first managed rule), i.e. the top of its band tier.
+    /// The user can then freely drag it anywhere; this only seeds the default.
+    int bandSeededInsertIndex(const PhosphorRules::Rule& rule) const;
+
     RuleModel m_model;
     bool m_dirty = false;
     bool m_daemonReachable = false;

--- a/src/settings/rulecontroller.h
+++ b/src/settings/rulecontroller.h
@@ -208,9 +208,11 @@ public:
     Q_INVOKABLE QString addRuleFromJson(const QVariantMap& ruleJson);
 
     /// Replace the rule with the matching id from its JSON map. Returns false
-    /// on a malformed map or an unknown id. An in-place edit never reorders the
-    /// list, so priorities are NOT renormalized — an explicit `priority` edit
-    /// in the Advanced editor is honoured verbatim.
+    /// on a malformed map or an unknown id. An in-place edit leaves the rule's
+    /// row position unchanged, so a same-section edit does NOT renormalize and an
+    /// explicit `priority` edit in the Advanced editor is honoured verbatim. An
+    /// edit that reclassifies the rule's section re-syncs the global list-order
+    /// priorities (see the AppliedSectionChanged path).
     Q_INVOKABLE bool updateRuleFromJson(const QVariantMap& ruleJson);
 
     /// Remove the rule with @p ruleId (a UUID string). Returns false if absent.
@@ -248,10 +250,11 @@ public:
     Q_INVOKABLE QVariantList sections() const;
 
     /// A snapshot of every rule as a map keyed by the model's role names
-    /// (`ruleId`, `name`, `enabled`, `priority`, `section`, `matchSummary`,
-    /// `actionSummary`, `conditionCount`, `actionCount`, `isComposite`,
-    /// `screenIds`, `validationIssueCount`, `managed`). Lets the page bucket / filter
-    /// rules without ever referencing raw `Qt.UserRole + N` integers.
+    /// (`ruleId`, `name`, `enabled`, `priority`, `section`, `sectionLabel`,
+    /// `matchSummary`, `actionSummary`, `conditionCount`, `actionCount`,
+    /// `isComposite`, `screenIds`, `validationIssueCount`, `managed`). Lets the
+    /// page filter / sort rules without ever referencing raw `Qt.UserRole + N`
+    /// integers.
     Q_INVOKABLE QVariantList rulesSnapshot() const;
 
     // ── Monitor overview strip ────────────────────────────────────────────
@@ -409,25 +412,26 @@ private:
     /// covers transport errors via the applyResult signal.
     bool pushToDaemonAsync(const QList<PhosphorRules::Rule>& rules);
 
-    /// Renormalize every rule's priority so descending list order ⇒
-    /// descending priority. Keeps the migrated-context bands roughly intact
-    /// by scaling rather than flattening: animation/application rules are
-    /// list-ordered, context rules keep their derived bands.
+    /// Re-stamp every rule's priority as one global descending list-order
+    /// sequence (earlier row ⇒ higher priority, spaced by a fixed step). There
+    /// are no priority bands: a rule's precedence is purely its position in the
+    /// one flat list. Managed rules keep their pinned INT_MIN priority and are
+    /// skipped, so they never consume a rank and always sort below user rules.
     void renormalizePriorities();
 
-    /// Priority-band base for a section — used now only to (a) order section
-    /// cards by precedence in `sections()` and (b) seed a sensible DEFAULT
-    /// position for a newly added rule (see `bandSeededInsertIndex`). Priority
-    /// itself is a single global list-order sequence (`renormalizePriorities`),
-    /// no longer banded — a rule's precedence is its position in the one flat
-    /// list. Managed System rules are pinned at INT_MIN, so System reports the
-    /// lowest base.
+    /// Priority-band base for a section — used now ONLY to seed a sensible
+    /// DEFAULT position for a newly added rule (see `bandSeededInsertIndex`), so
+    /// a new Advanced rule starts high and a new Animation rule starts low.
+    /// Priority itself is a single global list-order sequence
+    /// (`renormalizePriorities`), no longer banded. Managed System rules are
+    /// pinned at INT_MIN, so System reports the lowest base.
     static int bandBaseForSection(RuleModel::Section section);
 
     /// Row index at which a freshly added rule should be inserted so its default
     /// precedence reflects its section's band — above the first existing rule of
-    /// a lower band (or the first managed rule), i.e. the top of its band tier.
-    /// The user can then freely drag it anywhere; this only seeds the default.
+    /// a lower band (or the first managed rule). Existing same-band rules are
+    /// stepped over, so the new rule lands at the bottom of its own tier. The
+    /// user can then freely drag it anywhere; this only seeds the default.
     int bandSeededInsertIndex(const PhosphorRules::Rule& rule) const;
 
     RuleModel m_model;

--- a/src/settings/rulecontroller_views.cpp
+++ b/src/settings/rulecontroller_views.cpp
@@ -52,11 +52,6 @@ QVariantList RuleController::sections() const
         QVariantMap entry;
         entry[QStringLiteral("value")] = static_cast<int>(s);
         entry[QStringLiteral("label")] = RuleModel::sectionLabel(s);
-        // Priority-band base (higher ⇒ higher precedence) so the page can order
-        // section cards by evaluation precedence. The `value`/`kOrder` index
-        // still breaks ties between sections that share a band (Monitor and
-        // Activity both sit in the Context band).
-        entry[QStringLiteral("band")] = RuleController::bandBaseForSection(s);
         out.append(entry);
     }
     return out;

--- a/src/settings/rulecontroller_views.cpp
+++ b/src/settings/rulecontroller_views.cpp
@@ -52,6 +52,11 @@ QVariantList RuleController::sections() const
         QVariantMap entry;
         entry[QStringLiteral("value")] = static_cast<int>(s);
         entry[QStringLiteral("label")] = RuleModel::sectionLabel(s);
+        // Priority-band base (higher ⇒ higher precedence) so the page can order
+        // section cards by evaluation precedence. The `value`/`kOrder` index
+        // still breaks ties between sections that share a band (Monitor and
+        // Activity both sit in the Context band).
+        entry[QStringLiteral("band")] = RuleController::bandBaseForSection(s);
         out.append(entry);
     }
     return out;
@@ -71,8 +76,11 @@ QVariantList RuleController::rulesSnapshot() const
         entry[QStringLiteral("name")] = m_model.data(idx, RuleModel::NameRole);
         entry[QStringLiteral("enabled")] = m_model.data(idx, RuleModel::EnabledRole);
         entry[QStringLiteral("priority")] = m_model.data(idx, RuleModel::PriorityRole);
-        entry[QStringLiteral("section")] =
-            static_cast<int>(m_model.data(idx, RuleModel::SectionRole).value<RuleModel::Section>());
+        const auto section = m_model.data(idx, RuleModel::SectionRole).value<RuleModel::Section>();
+        entry[QStringLiteral("section")] = static_cast<int>(section);
+        // Localized section name, for the per-row badge the flat list shows so
+        // category stays legible without grouping.
+        entry[QStringLiteral("sectionLabel")] = RuleModel::sectionLabel(section);
         entry[QStringLiteral("matchSummary")] = m_model.data(idx, RuleModel::MatchSummaryRole);
         entry[QStringLiteral("actionSummary")] = m_model.data(idx, RuleModel::ActionSummaryRole);
         entry[QStringLiteral("conditionCount")] = m_model.data(idx, RuleModel::ConditionCountRole);

--- a/src/settings/rulemodel.h
+++ b/src/settings/rulemodel.h
@@ -21,8 +21,9 @@ namespace PlasmaZones {
  * @brief A single flat list model over the unified Rule set.
  *
  * This is the *only* model behind the Rules page. There are no
- * per-section proxy models — `RulesPage.qml` derives section buckets,
- * search filtering, and chip filtering in QML over this one model.
+ * per-section proxy models — `RulesPage.qml` derives its flat,
+ * priority-ordered view, search filtering, and the section / source / status
+ * filters in QML over this one model.
  *
  * The model is staging: it holds an in-memory `QList<Rule>` that the
  * `RuleController` populates from the daemon's `org.plasmazones.Rules`
@@ -31,8 +32,8 @@ namespace PlasmaZones {
  *
  * ## SectionRole — derived in C++
  *
- * Every rule is bucketed into exactly one section, computed from its match
- * expression + actions:
+ * Every rule is classified into exactly one section, computed from its match
+ * expression + actions (the section drives the per-row badge and the filter):
  *   - `monitor`     — context-only rule (ScreenId / VirtualDesktop / Activity)
  *                     whose actions are layout / engine / disable. The
  *                     "Monitor & Layout" group.
@@ -149,14 +150,15 @@ public:
         NotFound, ///< no rule with that id, or @p rule is invalid
         Unchanged, ///< the rule was already identical — nothing applied
         Applied, ///< the rule was replaced and a change signal emitted
-        AppliedSectionChanged, ///< replaced AND the edit moved it to a different section/band
+        AppliedSectionChanged, ///< replaced AND the edit moved it to a different section
     };
 
     /// Replace the rule with the same id. Returns `NotFound` for an unknown id
     /// or an invalid rule, `Unchanged` for an identical rule (no signal),
     /// `Applied` when the rule was replaced in place, and
     /// `AppliedSectionChanged` when the replacement also moved the rule into a
-    /// different section (its priority band must be re-stamped by the caller).
+    /// different section (its global list-order priority must be re-stamped by
+    /// the caller).
     UpdateResult updateRule(const PhosphorRules::Rule& rule);
 
     /// Remove the rule with @p id. Returns false if no such rule.
@@ -266,7 +268,8 @@ Q_SIGNALS:
     void countChanged();
     /// Emitted when an `updateRule()` moved a rule into a different section
     /// (its `sectionFor()` changed). A plain `dataChanged` does not prompt the
-    /// QML section view to re-bucket the rule, so the page listens for this.
+    /// QML view to re-derive the rule's section (its badge / filter
+    /// classification), so the page listens for this.
     void ruleSectionChanged();
 
 private:

--- a/src/settings/ruletemplates.h
+++ b/src/settings/ruletemplates.h
@@ -9,11 +9,12 @@
 
 namespace PlasmaZones::RuleTemplates {
 
-/// Priority bands. Context rules keep the migration's cascade bands;
-/// application/animation rules are list-ordered within their band so the
-/// drag-to-reorder is meaningful. Shared with `RuleController`'s
-/// `renormalizePriorities` so list-order ↔ priority renormalization uses
-/// the same bands the seeded templates / empty rules land in.
+/// Default priority bases by section. They seed the starting priority of the
+/// seeded templates / empty rules, and `RuleController::bandBaseForSection`
+/// reuses them to seed where a newly added rule inserts (so a new Advanced rule
+/// starts high). Priority renormalization itself is flat global list-order, not
+/// banded (see `RuleController::renormalizePriorities`); these only set sensible
+/// defaults, the user reorders freely afterwards.
 constexpr int kContextBandBase = 300;
 constexpr int kApplicationBandBase = 200;
 constexpr int kAnimationBandBase = 100;

--- a/tests/unit/settings/test_rule_controller.cpp
+++ b/tests/unit/settings/test_rule_controller.cpp
@@ -56,6 +56,7 @@ private Q_SLOTS:
     void engineModePickerExposesAllVocabularyTokens();
     void userAuthorableFilterHidesInternalActions();
     void moveRuleReorders();
+    void flatPriorityIgnoresBandsOnReorder();
     void authoringMetadata();
     void inputHints();
     void templatesProduceSeededRules();
@@ -252,9 +253,9 @@ void TestRuleController::monitorOverviewLockPriorityResolution()
     // report the HIGHEST-PRIORITY rule's value (first-wins), not last-wins and
     // not mere presence — mirroring resolveContextLocked's single-winner Locked
     // slot (cf. testContextLock_priorityResolution at the registry level).
-    // addRuleFromJson appends and renormalizePriorities makes the earlier-added
-    // rule the higher-priority one within the Context band, so the FIRST rule
-    // added for a screen is its winner. Run both value directions so a
+    // Each added rule seeds at the top of its (Context) band tier, so within a
+    // band the earlier-added rule keeps the higher global priority — the FIRST
+    // rule added for a screen is its winner. Run both value directions so a
     // "true-always-wins" / "false-always-wins" bug fails one of the two.
     RuleController controller;
 
@@ -735,10 +736,65 @@ void TestRuleController::moveRuleReorders()
     QCOMPARE(model->index(1, 0).data(RuleModel::IdRole).toString(), a);
     QCOMPARE(model->index(2, 0).data(RuleModel::IdRole).toString(), b);
 
-    // Earlier list index maps to higher priority within the band.
+    // Earlier list index maps to higher (global) priority.
     const int prioFirst = model->index(0, 0).data(RuleModel::PriorityRole).toInt();
     const int prioLast = model->index(2, 0).data(RuleModel::PriorityRole).toInt();
     QVERIFY(prioFirst > prioLast);
+}
+
+void TestRuleController::flatPriorityIgnoresBandsOnReorder()
+{
+    // Priority is one flat global sequence — section "bands" only seed a new
+    // rule's default position, they do NOT cap precedence. A cross-band drag
+    // must let a lower-band rule outrank a higher-band one.
+    RuleController controller;
+
+    // Application rule (float action → Applications band) and a Monitor rule
+    // (context match + lockContext → Context band, which seeds higher).
+    QVariantMap appRule = controller.newEmptyRule(QStringLiteral("application"));
+    {
+        QVariantMap match = appRule.value(QStringLiteral("match")).toMap();
+        match[QStringLiteral("value")] = QStringLiteral("firefox");
+        appRule[QStringLiteral("match")] = match;
+        appRule[QStringLiteral("actions")] =
+            QVariantList{QVariantMap{{QStringLiteral("type"), QStringLiteral("float")}}};
+    }
+    const QString appId = controller.addRuleFromJson(appRule);
+    QVERIFY(!appId.isEmpty());
+
+    QVariantMap monRule = controller.newEmptyRule(QStringLiteral("monitor"));
+    {
+        QVariantMap match = monRule.value(QStringLiteral("match")).toMap();
+        match[QStringLiteral("value")] = QStringLiteral("DP-1");
+        monRule[QStringLiteral("match")] = match;
+        monRule[QStringLiteral("actions")] = QVariantList{
+            QVariantMap{{QStringLiteral("type"), QStringLiteral("lockContext")}, {QStringLiteral("value"), true}}};
+    }
+    const QString monId = controller.addRuleFromJson(monRule);
+    QVERIFY(!monId.isEmpty());
+
+    RuleModel* model = controller.model();
+    const auto rowOf = [&](const QString& id) {
+        for (int i = 0; i < model->rowCount(); ++i)
+            if (model->index(i, 0).data(RuleModel::IdRole).toString() == id)
+                return i;
+        return -1;
+    };
+    const auto prioOf = [&](const QString& id) {
+        return model->index(rowOf(id), 0).data(RuleModel::PriorityRole).toInt();
+    };
+
+    // Band-seeded insert: the Monitor rule (higher band) seeds ABOVE the
+    // Application rule even though it was added second.
+    QVERIFY(rowOf(monId) < rowOf(appId));
+    QVERIFY(prioOf(monId) > prioOf(appId));
+
+    // Cross-band drag: drop the Application rule above the Monitor rule. Position
+    // now decides — the Application rule outranks the Monitor rule despite its
+    // lower band. (The old banded scheme would have snapped it back below.)
+    QVERIFY(controller.moveRule(appId, monId));
+    QVERIFY(rowOf(appId) < rowOf(monId));
+    QVERIFY(prioOf(appId) > prioOf(monId));
 }
 
 void TestRuleController::authoringMetadata()

--- a/tests/unit/settings/test_rule_controller.cpp
+++ b/tests/unit/settings/test_rule_controller.cpp
@@ -253,8 +253,8 @@ void TestRuleController::monitorOverviewLockPriorityResolution()
     // report the HIGHEST-PRIORITY rule's value (first-wins), not last-wins and
     // not mere presence — mirroring resolveContextLocked's single-winner Locked
     // slot (cf. testContextLock_priorityResolution at the registry level).
-    // Each added rule seeds at the top of its (Context) band tier, so within a
-    // band the earlier-added rule keeps the higher global priority — the FIRST
+    // Each added rule seeds at the bottom of its (Context) band tier, so within
+    // a band the earlier-added rule keeps the higher global priority — the FIRST
     // rule added for a screen is its winner. Run both value directions so a
     // "true-always-wins" / "false-always-wins" bug fails one of the two.
     RuleController controller;


### PR DESCRIPTION
## Summary

Redo the Rules page as **one flat, always-drag-reorderable priority list** (highest precedence on top), and extract the group/sort affordance into reusable components shared with the Layouts page.

### Why

The old Rules page grouped rules into per-section cards and only let you drag-reorder within a section, in a specific view. Reordering precedence felt awkward and hard to discover. An investigation confirmed the section "bands" are **purely a settings-UI convention** — the evaluator only ever reads the `priority` integer (descending, list-order tie-break); no section/band is stored, serialized, or seen by the daemon. So a single flat priority list evaluates identically and removes the friction.

### What changed

**Rules page is now one flat priority list**
- Drag any rule anywhere to set precedence. A drop re-stamps a single **global** priority sequence (`renormalizePriorities`), so rules from any section freely interleave and position alone decides who wins.
- Section "bands" survive only as a default-seeding hint for newly added rules (`bandSeededInsertIndex`), so a new Advanced rule still starts high.
- Managed System rules pin to the bottom (INT_MIN) and show a lock instead of a drag grip.
- No grouping/sorting UI on the page (it would fight the drag). Browsing is narrowing only: search, the filter button, and the monitor strip.
- Per-row **section badge** keeps category legible, and the **priority badge** stays so precedence is clear when the filter hides categories.

**Filter button** gained two dimensions, ordered to match the Layouts filter (source first, then categories, then status): **Source** (System / User-created), **Categories** (sections), **Status** (Active / Disabled).

**Reusable group/sort infrastructure (shared with Layouts)**
- `GroupSortLogic.js` — neutral grouping/sorting primitives.
- `GroupSortBar.qml` — Group / Sort / direction toolbar.
- `SegmentedViewSwitch.qml` — generalized former `LayoutViewSwitch` (injected `modes`), now used by the Layouts Snapping/Tiling switch.
- `LayoutFilterBar` composes `GroupSortBar`; `LayoutFilterLogic` delegates to the shared primitives. The Layouts page behavior is unchanged.

### Tests

- Adds `flatPriorityIgnoresBandsOnReorder` to the rule controller test: proves band-seeded insert **and** that a cross-band drag lets a lower-band rule outrank a higher-band one (the old scheme would snap it back).
- Full suite green: 246/246.

### Notes / behavior changes
- Cross-section property conflicts now resolve by list position rather than a fixed band precedence (by design).
- Context-cascade specificity is no longer auto-maintained after a manual drag (position takes over).
- "System" was dropped from the category filter group because a System rule is exactly a managed rule (covered by the Source filter); listing it twice would be redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
