### PR TITLE
feat(appearance): scope window border and title-bar defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Per-monitor gaps**: pick a monitor from the scope chip on the Gaps card to set that screen's gaps independently. The values are stored as a screen-scoped rule ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **Separate focused and unfocused border colors**: the border color is now two actions, "Set focused border color" and "Set unfocused border color", each with its own swatch ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **App-managed default rules**: the default rules (Default borders, Default title bars, Default gaps) cannot be deleted and stay pinned to the lowest priority ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
+- **Choose which windows the appearance defaults apply to**: the Borders and Title bars cards on the Appearance Windows page have an "Apply to" option with three scopes, tiled and snapped windows, all normal windows, and all windows. New installs default to tiled and snapped windows, so the default border and hidden title bar stay off the desktop, panels, popups, and on-screen displays. Existing setups keep their current scope and can switch at any time ([#721](https://github.com/fuddlesworth/PlasmaZones/pull/721)).
 
 ### Changed
 

--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -195,6 +195,16 @@ public:
         return AutotileStateHelpers::isTiledWindow(m_border, windowId);
     }
 
+    // Tiled-set mutators that re-resolve the window's rules whenever its overall
+    // tiled status flips (IsTiled is a match field). Welding the invalidation to
+    // the write mirrors NavigationHandler's snap/float setters, so a caller can't
+    // change tiling membership and forget to re-resolve a tiled-scoped border /
+    // title-bar / opacity rule. A pure screen-to-screen move (still tiled) does
+    // not flip the status, so it does not invalidate.
+    void markWindowTiled(const QString& screenId, const QString& windowId);
+    void clearWindowTiledAllScreens(const QString& windowId);
+    void clearWindowTiledOnScreen(const QString& screenId, const QString& windowId);
+
     // Set a window to re-activate after the next autotile raise loop completes.
     // Used by slotDaemonReady() to preserve focus of non-tiled windows (e.g. KCM).
     void setPendingReactivateWindow(KWin::EffectWindow* w)

--- a/kwin-effect/autotilehandler.h
+++ b/kwin-effect/autotilehandler.h
@@ -199,8 +199,11 @@ public:
     // tiled status flips (IsTiled is a match field). Welding the invalidation to
     // the write mirrors NavigationHandler's snap/float setters, so a caller can't
     // change tiling membership and forget to re-resolve a tiled-scoped border /
-    // title-bar / opacity rule. A pure screen-to-screen move (still tiled) does
-    // not flip the status, so it does not invalidate.
+    // title-bar / opacity rule. markWindowTiled only invalidates on a genuine
+    // not-tiled→tiled transition (re-adding an already-tiled window is a no-op),
+    // so a cross-screen transfer that first runs removeFromOtherScreens does
+    // invalidate (the window is briefly not-tiled), while a same-screen re-assert
+    // does not.
     void markWindowTiled(const QString& screenId, const QString& windowId);
     void clearWindowTiledAllScreens(const QString& windowId);
     void clearWindowTiledOnScreen(const QString& screenId, const QString& windowId);

--- a/kwin-effect/autotilehandler/signals.cpp
+++ b/kwin-effect/autotilehandler/signals.cpp
@@ -197,7 +197,7 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
                 }
                 // Drop autotile tiled tracking on every screen (title-bar
                 // restores flow through the rule path).
-                AutotileStateHelpers::removeFromAllScreens(m_border, windowId);
+                clearWindowTiledAllScreens(windowId);
                 unmaximizeMonocleWindow(windowId);
                 // Drop stale zone-centering tracking so a later
                 // frameGeometryChanged does not re-snap the window into an
@@ -285,7 +285,7 @@ void AutotileHandler::slotScreensChanged(const QStringList& screenIds, bool isDe
             // should not keep autotile borders through the transition.
             // Title-bar restores flow through the rule path.
             for (const QString& wid : std::as_const(windowsOnRemovedScreens)) {
-                AutotileStateHelpers::removeFromAllScreens(m_border, wid);
+                clearWindowTiledAllScreens(wid);
             }
 
             // Save autotile stacking order before restoring snap-mode order.
@@ -840,14 +840,14 @@ void AutotileHandler::slotWindowFullScreenChanged(KWin::EffectWindow* w)
         if (m_effect->isWindowFloating(windowId)) {
             return;
         }
-        AutotileStateHelpers::addTiledOnScreen(m_border, screenId, windowId);
+        markWindowTiled(screenId, windowId);
         // Title-bar (borderless) state is driven by rules.
         m_effect->updateAllBorders();
         return;
     }
     // Clear border tracking so borders are not drawn over fullscreen content
     // (title-bar restores flow through the rule path).
-    AutotileStateHelpers::removeFromAllScreens(m_border, windowId);
+    clearWindowTiledAllScreens(windowId);
     if (m_monocleMaximizedWindows.remove(windowId)) {
         qCInfo(lcEffect) << "Monocle window went fullscreen:" << windowId << "- removed from tracking";
     }

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -312,6 +312,16 @@ void AutotileHandler::applyFloatCleanup(const QString& windowId)
     // A floating window is no longer tile-managed on any screen — clear tiled
     // tracking (title-bar restores flow through the rule path).
     AutotileStateHelpers::removeFromAllScreens(m_border, windowId);
+    // Re-resolve the appearance rules now that IsTiled / IsFloating have flipped,
+    // co-located with the state write so the flush reads the fresh tiled state
+    // (the snap path does the same in slotWindowStateChanged). Without this a
+    // baseline border / title-bar rule scoped to tiled windows keeps drawing /
+    // hiding on the now-floating window: the autotile float signal is on a
+    // separate D-Bus interface from the WindowTracking one that would otherwise
+    // enqueue the flush, and the synchronous drag-to-float path's signal "may
+    // never arrive". invalidateRuleCacheForStateChange coalesces, so the
+    // redundant call from the WindowTracking backstop is harmless.
+    m_effect->invalidateRuleCacheForStateChange(windowId);
     // Drop centering/target tracking too — a floated window isn't being
     // tiled anymore so a stale entry here would trigger centering on the
     // next frameGeometryChanged, snapping the floated window back into an

--- a/kwin-effect/autotilehandler/state.cpp
+++ b/kwin-effect/autotilehandler/state.cpp
@@ -310,18 +310,11 @@ void AutotileHandler::applyFloatCleanup(const QString& windowId)
 {
     m_effect->m_navigationHandler->setWindowFloating(windowId, true);
     // A floating window is no longer tile-managed on any screen — clear tiled
-    // tracking (title-bar restores flow through the rule path).
-    AutotileStateHelpers::removeFromAllScreens(m_border, windowId);
-    // Re-resolve the appearance rules now that IsTiled / IsFloating have flipped,
-    // co-located with the state write so the flush reads the fresh tiled state
-    // (the snap path does the same in slotWindowStateChanged). Without this a
-    // baseline border / title-bar rule scoped to tiled windows keeps drawing /
-    // hiding on the now-floating window: the autotile float signal is on a
-    // separate D-Bus interface from the WindowTracking one that would otherwise
-    // enqueue the flush, and the synchronous drag-to-float path's signal "may
-    // never arrive". invalidateRuleCacheForStateChange coalesces, so the
-    // redundant call from the WindowTracking backstop is harmless.
-    m_effect->invalidateRuleCacheForStateChange(windowId);
+    // tracking. clearWindowTiledAllScreens re-resolves the window's rules when the
+    // tiled status flips, so a baseline border / title-bar rule scoped to tiled
+    // windows stops drawing / hiding on the now-floating window (the setWindowFloating
+    // above also re-resolves on the IsFloating flip; both coalesce).
+    clearWindowTiledAllScreens(windowId);
     // Drop centering/target tracking too — a floated window isn't being
     // tiled anymore so a stale entry here would trigger centering on the
     // next frameGeometryChanged, snapping the floated window back into an
@@ -332,6 +325,33 @@ void AutotileHandler::applyFloatCleanup(const QString& windowId)
     m_centeredWaylandZones.remove(windowId);
     m_effect->removeWindowBorder(windowId);
     unmaximizeMonocleWindow(windowId);
+}
+
+void AutotileHandler::markWindowTiled(const QString& screenId, const QString& windowId)
+{
+    const bool wasTiled = isTiledWindow(windowId);
+    AutotileStateHelpers::addTiledOnScreen(m_border, screenId, windowId);
+    // Re-resolve only on the false→true transition: a window already tiled on
+    // another screen stays tiled, so re-adding it changes no rule outcome.
+    if (!wasTiled) {
+        m_effect->invalidateRuleCacheForStateChange(windowId);
+    }
+}
+
+void AutotileHandler::clearWindowTiledAllScreens(const QString& windowId)
+{
+    if (AutotileStateHelpers::removeFromAllScreens(m_border, windowId)) {
+        // Was tiled on at least one screen and now is not — IsTiled flipped.
+        m_effect->invalidateRuleCacheForStateChange(windowId);
+    }
+}
+
+void AutotileHandler::clearWindowTiledOnScreen(const QString& screenId, const QString& windowId)
+{
+    if (AutotileStateHelpers::removeTiledOnScreen(m_border, screenId, windowId) && !isTiledWindow(windowId)) {
+        // Removed from this screen and not tiled on any other — IsTiled flipped.
+        m_effect->invalidateRuleCacheForStateChange(windowId);
+    }
 }
 
 } // namespace PlasmaZones

--- a/kwin-effect/autotilehandler/tiling.cpp
+++ b/kwin-effect/autotilehandler/tiling.cpp
@@ -328,10 +328,10 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
                 if (!win || win->isMinimized()) {
                     // Minimized windows keep their tracking quiescent: the
                     // re-tile on unminimize re-asserts.
-                    AutotileStateHelpers::removeTiledOnScreen(m_border, screenId, wid);
+                    clearWindowTiledOnScreen(screenId, wid);
                     continue;
                 }
-                AutotileStateHelpers::removeTiledOnScreen(m_border, screenId, wid);
+                clearWindowTiledOnScreen(screenId, wid);
                 // A daemon-initiated untile that is not a float/fullscreen/
                 // close/desktop-switch (e.g. a rule change dropping the
                 // window from the layout) must not leave a stale centering
@@ -464,7 +464,7 @@ void AutotileHandler::slotWindowsTileRequested(const PhosphorProtocol::TileReque
             // keeps the tracking map coherent when e.g. a window drags
             // from an autotile VS onto a sibling autotile VS.
             AutotileStateHelpers::removeFromOtherScreens(m_border, snap.windowId, snap.screenId);
-            AutotileStateHelpers::addTiledOnScreen(m_border, snap.screenId, snap.windowId);
+            markWindowTiled(snap.screenId, snap.windowId);
             // Title-bar (borderless) state is driven by rules through the
             // effect's reconcileRuleHiddenTitleBar → DecorationManager path.
 

--- a/kwin-effect/navigationhandler.cpp
+++ b/kwin-effect/navigationhandler.cpp
@@ -26,37 +26,21 @@ NavigationHandler::NavigationHandler(PlasmaZonesEffect* effect, QObject* parent)
 // Floating window tracking — sync methods use D-Bus helpers
 // ═══════════════════════════════════════════════════════════════════════════════
 
-void NavigationHandler::syncFloatingWindowsFromDaemon()
+void NavigationHandler::seedFloatingWindows(const QStringList& floatingIds)
 {
-    if (!m_effect->isDaemonReady("sync floating windows")) {
-        return;
+    // Bulk re-seed from a daemon snapshot: clear stale entries (so a reconnect
+    // drops windows the daemon no longer reports as floating) and write the cache
+    // DIRECTLY, without the per-window rule invalidation setWindowFloating would
+    // run. The caller pairs this with a single invalidateAllRuleCaches, mirroring
+    // the direct m_zoneCache writes in syncZonesFromDaemon.
+    m_floatingCache.clear();
+    for (const QString& id : floatingIds) {
+        m_floatingCache.insert(id);
     }
-
-    QDBusPendingCall pendingCall = PhosphorProtocol::ClientHelpers::asyncCall(
-        PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getFloatingWindows"));
-    auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
-
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
-        w->deleteLater();
-
-        QDBusPendingReply<QStringList> reply = *w;
-        if (!reply.isValid()) {
-            qCDebug(lcEffect) << "Failed to get floating windows from daemon";
-            return;
-        }
-
-        QStringList floatingIds = reply.value();
-        m_floatingCache.clear();
-
-        for (const QString& id : floatingIds) {
-            m_floatingCache.insert(id);
-        }
-
-        // Report the count of synced entries, not m_floatingCache.size() — the
-        // latter sums the instance and app-wide keyspaces and would misreport when
-        // both carry entries for the same app.
-        qCDebug(lcEffect) << "Synced" << floatingIds.size() << "floating windows from daemon";
-    });
+    // Report the count of synced entries, not m_floatingCache.size() — the latter
+    // sums the instance and app-wide keyspaces and would misreport when both
+    // carry entries for the same app.
+    qCDebug(lcEffect) << "Synced" << floatingIds.size() << "floating windows from daemon";
 }
 
 void NavigationHandler::syncFloatingStateForWindow(const QString& windowId)

--- a/kwin-effect/navigationhandler.cpp
+++ b/kwin-effect/navigationhandler.cpp
@@ -77,11 +77,11 @@ void NavigationHandler::syncFloatingStateForWindow(const QString& windowId)
         QDBusPendingReply<bool> reply = *w;
         if (reply.isValid()) {
             bool floating = reply.value();
+            // Per-window sync goes through setWindowFloating so a real change
+            // re-resolves this window's IsFloating-scoped rules.
+            setWindowFloating(windowId, floating);
             if (floating) {
-                m_floatingCache.insert(windowId);
                 qCDebug(lcEffect) << "Synced floating state for window" << windowId << "- is floating";
-            } else {
-                m_floatingCache.remove(windowId);
             }
         }
         w->deleteLater();
@@ -114,11 +114,14 @@ void NavigationHandler::syncZonesFromDaemon()
         }
 
         // Seed every snapped window's zone. A window with an empty zoneId (floating
-        // / unmanaged) carries no entry. setWindowZone keys by instanceId (see header).
+        // / unmanaged) carries no entry. Write the cache DIRECTLY (not setWindowZone)
+        // so this bulk re-seed doesn't enqueue a per-window rule invalidation for
+        // each window — the single invalidateAllRuleCaches below covers the whole
+        // batch. setZone keys by instanceId (see ZoneCache).
         const PhosphorProtocol::WindowStateList states = reply.value();
         for (const PhosphorProtocol::WindowStateEntry& state : states) {
             if (!state.zoneId.isEmpty()) {
-                setWindowZone(state.windowId, state.zoneId);
+                m_zoneCache.setZone(state.windowId, state.zoneId);
             }
         }
         qCDebug(lcEffect) << "Synced" << zoneEntryCount() << "snapped-window zones from daemon";
@@ -128,6 +131,38 @@ void NavigationHandler::syncZonesFromDaemon()
         // next frame (mirrors the daemon-loss invalidation).
         m_effect->invalidateAllRuleCaches();
     });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Placement-state writes — each re-resolves the window's rules on a real change.
+//
+// These are the single chokepoints for the IsFloating / IsSnapped / Zone / Mode
+// rule-match inputs. Welding the invalidation to the write (rather than asking
+// every caller to remember a follow-up invalidateRuleCacheForStateChange) is what
+// keeps a placement change from silently leaving a scoped border / title-bar /
+// opacity rule resolved against stale state. The cache setters return whether the
+// value actually changed, so a redundant re-assert costs nothing.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+void NavigationHandler::setWindowFloating(const QString& windowId, bool floating)
+{
+    if (m_floatingCache.setFloating(windowId, floating)) {
+        m_effect->invalidateRuleCacheForStateChange(windowId);
+    }
+}
+
+void NavigationHandler::setWindowZone(const QString& windowId, const QString& zoneId)
+{
+    if (m_zoneCache.setZone(windowId, zoneId)) {
+        m_effect->invalidateRuleCacheForStateChange(windowId);
+    }
+}
+
+void NavigationHandler::clearWindowZone(const QString& windowId)
+{
+    if (m_zoneCache.remove(windowId)) {
+        m_effect->invalidateRuleCacheForStateChange(windowId);
+    }
 }
 
 } // namespace PlasmaZones

--- a/kwin-effect/navigationhandler.h
+++ b/kwin-effect/navigationhandler.h
@@ -42,10 +42,12 @@ public:
     {
         return m_floatingCache.isFloating(windowId);
     }
-    void setWindowFloating(const QString& windowId, bool floating)
-    {
-        m_floatingCache.setFloating(windowId, floating);
-    }
+    /// Set @p windowId's floating state and, when it actually changes, re-resolve
+    /// the window's appearance / animation rules (IsFloating is a match field).
+    /// Out-of-line so the invalidation is welded to the write — no caller has to
+    /// remember it. Bulk re-seeds use the cache directly (see the .cpp) because
+    /// they pair with invalidateAllRuleCaches instead.
+    void setWindowFloating(const QString& windowId, bool floating);
     void clearAllFloatingState()
     {
         m_floatingCache.clear();
@@ -71,15 +73,13 @@ public:
         return m_zoneCache.isSnapped(windowId);
     }
     /// Record @p windowId's zone. An empty @p zoneId removes the entry (the
-    /// window left its zone — unsnapped / floated / screen-changed).
-    void setWindowZone(const QString& windowId, const QString& zoneId)
-    {
-        m_zoneCache.setZone(windowId, zoneId);
-    }
-    void clearWindowZone(const QString& windowId)
-    {
-        m_zoneCache.remove(windowId);
-    }
+    /// window left its zone — unsnapped / floated / screen-changed). When the
+    /// zone actually changes, re-resolves the window's rules (IsSnapped / Zone /
+    /// Mode are match fields). Out-of-line so the invalidation is welded to the
+    /// write; bulk re-seeds use the cache directly (see the .cpp).
+    void setWindowZone(const QString& windowId, const QString& zoneId);
+    /// Remove @p windowId's zone entry, re-resolving its rules iff one existed.
+    void clearWindowZone(const QString& windowId);
     void clearAllZoneState()
     {
         m_zoneCache.clear();

--- a/kwin-effect/navigationhandler.h
+++ b/kwin-effect/navigationhandler.h
@@ -8,6 +8,7 @@
 
 #include <QObject>
 #include <QString>
+#include <QStringList>
 
 class QDBusPendingCallWatcher;
 
@@ -52,7 +53,10 @@ public:
     {
         m_floatingCache.clear();
     }
-    void syncFloatingWindowsFromDaemon();
+    /// Bulk re-seed the floating set from a daemon snapshot (clear + direct
+    /// insert, no per-window rule invalidation). Callers pair this with a single
+    /// invalidateAllRuleCaches.
+    void seedFloatingWindows(const QStringList& floatingIds);
     void syncFloatingStateForWindow(const QString& windowId);
     void syncZonesFromDaemon();
 

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -412,7 +412,6 @@ private:
      */
     void callEndDrag(KWin::EffectWindow* window, const QString& windowId, bool cancelled);
     void connectNavigationSignals();
-    void syncFloatingWindowsFromDaemon();
 
     /**
      * @brief Check if daemon is registered and ready for D-Bus calls

--- a/kwin-effect/plasmazoneseffect/borders.cpp
+++ b/kwin-effect/plasmazoneseffect/borders.cpp
@@ -89,11 +89,11 @@ void PlasmaZonesEffect::updateWindowBorder(const QString& windowId, KWin::Effect
     // Remove existing border for this window first
     removeWindowBorder(windowId);
 
-    // Border appearance is resolved entirely from rules. The managed
-    // baseline rule (catch-all, lowest priority) supplies the default for every
-    // window; higher-priority per-rules override per slot. A window whose
-    // resolved appearance does not show a border draws nothing — borders are
-    // opt-in, the baseline defaults them off.
+    // Border appearance is resolved entirely from rules. The managed baseline
+    // border rule (lowest priority, scoped to tiled / snapped windows by default)
+    // supplies the default for the windows it matches, and higher-priority rules
+    // override per slot. A window whose resolved appearance does not show a border
+    // draws nothing — borders are opt-in, the baseline defaults them off.
     std::optional<ResolvedWindowAppearance> ovr;
     if (w && !m_shaderManager.animationRuleSet().isEmpty()) {
         ovr = resolveWindowAppearance(resolveRuleActions(w, windowId), m_borderAccentColor, m_borderInactiveColor);

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -487,8 +487,8 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
         // cache). Without this, a float path that doesn't emit windowStateChanged
         // with an empty zone leaves the zone entry stale, so IsSnapped stays true
         // and a baseline border / title-bar rule scoped to snapped windows keeps
-        // drawing / hiding on the now-floating window. The invalidate below then
-        // re-resolves against the cleared zone.
+        // drawing / hiding on the now-floating window. clearWindowZone re-resolves
+        // the rules when it actually drops an entry.
         m_navigationHandler->clearWindowZone(windowId);
 
         // Invalidate any stale instant-restore entry for this app. The snap
@@ -504,9 +504,10 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
         // appId to survive the window's identity change across close/reopen.
         m_snapHandler->invalidateRestore(::PhosphorIdentity::WindowId::extractAppId(windowId));
     }
-    // isFloating is now a rule MATCH field — re-resolve appearance / animation
-    // rules for this window so a `WHEN isFloating` border / opacity re-applies.
-    invalidateRuleCacheForStateChange(windowId);
+    // Re-resolution is welded to the writes: setWindowFloating above and (in the
+    // float branch) clearWindowZone each re-resolve this window's rules when the
+    // IsFloating / IsSnapped / Zone match field actually flips. No separate
+    // invalidate call is needed here.
 }
 
 void PlasmaZonesEffect::slotWindowStateChanged(const QString& windowId, const PhosphorProtocol::WindowStateEntry& state)
@@ -520,12 +521,11 @@ void PlasmaZonesEffect::slotWindowStateChanged(const QString& windowId, const Ph
     }
     // Keep the effect-side zone cache current so the IsSnapped / Zone rule-match
     // fields resolve against the live placement. An empty zoneId (unsnapped /
-    // floated / screen-changed) removes the entry. The isFloating cache WRITE lives
-    // on the separate windowFloatingChanged path, so it is not duplicated here; the
-    // rule-cache invalidation below coalesces with the floating path's (a float
-    // toggle emits both signals — see flushPendingRuleInvalidations).
+    // floated / screen-changed) removes the entry. setWindowZone re-resolves this
+    // window's rules when the zone actually changes (coalescing with the floating
+    // path's invalidation when a float toggle emits both signals — see
+    // flushPendingRuleInvalidations), so no separate invalidate call is needed.
     m_navigationHandler->setWindowZone(windowId, state.zoneId);
-    invalidateRuleCacheForStateChange(windowId);
 }
 
 void PlasmaZonesEffect::invalidateRuleCacheForStateChange(const QString& windowId)

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -482,6 +482,14 @@ void PlasmaZonesEffect::slotWindowFloatingChanged(const QString& windowId, bool 
         // stored, so applyGeometryForFloat sends nothing). Idempotent — a
         // no-op if the window wasn't snap-tracked.
         m_snapHandler->clearWindowSnapped(windowId);
+        // Same backstop for the ZoneCache, the source of the IsSnapped / Zone
+        // rule-match fields (m_snapHandler's set is a separate border-tracking
+        // cache). Without this, a float path that doesn't emit windowStateChanged
+        // with an empty zone leaves the zone entry stale, so IsSnapped stays true
+        // and a baseline border / title-bar rule scoped to snapped windows keeps
+        // drawing / hiding on the now-floating window. The invalidate below then
+        // re-resolves against the cleared zone.
+        m_navigationHandler->clearWindowZone(windowId);
 
         // Invalidate any stale instant-restore entry for this app. The snap
         // restore cache (SnapHandler) is a single-shot latency cache populated at

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -261,12 +261,10 @@ void PlasmaZonesEffect::continueDaemonReadySetup()
             w->deleteLater();
             QDBusPendingReply<QStringList> reply = *w;
             if (reply.isValid()) {
-                m_navigationHandler->clearAllFloatingState();
-                QStringList floatingIds = reply.value();
-                for (const QString& id : floatingIds) {
-                    m_navigationHandler->setWindowFloating(id, true);
-                }
-                qCDebug(lcEffect) << "Synced" << floatingIds.size() << "floating windows from daemon";
+                // Bulk re-seed via the direct-write path (no per-window rule
+                // invalidation), then drop every placement-scoped verdict once
+                // below — mirrors syncZonesFromDaemon.
+                m_navigationHandler->seedFloatingWindows(reply.value());
                 // Re-seeding the float cache changes the IsFloating match input for
                 // these windows; drop the stale placement-scoped opacity verdicts so
                 // a `WHEN isFloating` SetOpacity rule re-resolves against the fresh

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -838,8 +838,8 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                                               QStringLiteral("daemonReady"), this, SLOT(slotDaemonReady()));
     });
 
-    // NOTE: syncFloatingWindowsFromDaemon() and loadCachedSettings() are NOT
-    // called here. m_daemonServiceRegistered is false at this point (set only by
+    // NOTE: daemon state sync (floating windows, cached settings) is NOT done
+    // here. m_daemonServiceRegistered is false at this point (set only by
     // slotDaemonReady), so any ensureInterface() call would bail out immediately.
     // All daemon state sync is deferred to slotDaemonReady().
 

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -479,12 +479,6 @@ bool PlasmaZonesEffect::isDaemonReady(const char* methodName) const
     return true;
 }
 
-void PlasmaZonesEffect::syncFloatingWindowsFromDaemon()
-{
-    // Delegate to NavigationHandler
-    m_navigationHandler->syncFloatingWindowsFromDaemon();
-}
-
 KWin::EffectWindow* PlasmaZonesEffect::getActiveWindow() const
 {
     // Prefer KWin's active (focused) window when it is manageable and on current desktop

--- a/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
@@ -49,7 +49,7 @@ public:
 
     /// Set @p windowId's floating state. Returns true iff a tracked entry was
     /// actually added or removed, so a caller can drive a side effect (e.g.
-    /// re-resolving IsFloating rules) only on a real transition.
+    /// re-resolving IsFloating rules) only when the tracked set changed.
     bool setFloating(const QString& windowId, bool floating)
     {
         const QString appId = ::PhosphorIdentity::WindowId::extractAppId(windowId);
@@ -76,6 +76,12 @@ public:
             const bool removedAppId = m_byAppId.remove(appId);
             return removedInstance || removedAppId;
         }
+        // Bare appId keyspace. Reject an empty id (no separator, nothing before
+        // it) the same way the composite branch rejects an empty instanceId —
+        // an empty key would alias every empty-id window onto one wildcard slot.
+        if (windowId.isEmpty()) {
+            return false;
+        }
         if (floating) {
             if (m_byAppId.contains(windowId)) {
                 return false;
@@ -95,8 +101,7 @@ public:
     /// Total entries across BOTH keyspaces (instance floats + app-wide floats).
     /// Not a window count: an app floated both app-wide and per-instance counts
     /// in each. Diagnostics that want "how many windows did the daemon report
-    /// floating" should log the source list size, not this (see
-    /// NavigationHandler::syncFloatingWindowsFromDaemon).
+    /// floating" should log the source list size, not this.
     int size() const
     {
         return m_byInstance.size() + m_byAppId.size();

--- a/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/FloatingCache.h
@@ -47,7 +47,10 @@ public:
         return m_byAppId.contains(::PhosphorIdentity::WindowId::extractAppId(windowId));
     }
 
-    void setFloating(const QString& windowId, bool floating)
+    /// Set @p windowId's floating state. Returns true iff a tracked entry was
+    /// actually added or removed, so a caller can drive a side effect (e.g.
+    /// re-resolving IsFloating rules) only on a real transition.
+    bool setFloating(const QString& windowId, bool floating)
     {
         const QString appId = ::PhosphorIdentity::WindowId::extractAppId(windowId);
         const bool isComposite = (appId != windowId); // bare appId has no separator
@@ -57,22 +60,30 @@ public:
             // it would alias every other empty-instance window onto one wildcard
             // slot. Reject rather than corrupt the cache.
             if (instanceId.isEmpty()) {
-                return;
+                return false;
             }
             if (floating) {
+                if (m_byInstance.contains(instanceId)) {
+                    return false;
+                }
                 m_byInstance.insert(instanceId);
-            } else {
-                m_byInstance.remove(instanceId);
-                // Mirror WindowTrackingService::setFloating: an explicit instance
-                // unfloat also drops the coarse app-wide fallback. Siblings keep
-                // their own instance entries, so this only clears the appId marker.
-                m_byAppId.remove(appId);
+                return true;
             }
-        } else if (floating) {
-            m_byAppId.insert(windowId);
-        } else {
-            m_byAppId.remove(windowId);
+            const bool removedInstance = m_byInstance.remove(instanceId);
+            // Mirror WindowTrackingService::setFloating: an explicit instance
+            // unfloat also drops the coarse app-wide fallback. Siblings keep
+            // their own instance entries, so this only clears the appId marker.
+            const bool removedAppId = m_byAppId.remove(appId);
+            return removedInstance || removedAppId;
         }
+        if (floating) {
+            if (m_byAppId.contains(windowId)) {
+                return false;
+            }
+            m_byAppId.insert(windowId);
+            return true;
+        }
+        return m_byAppId.remove(windowId);
     }
 
     void clear()
@@ -92,16 +103,18 @@ public:
     }
 
     /// Convenience alias for setFloating(windowId, true). Kept symmetric
-    /// with remove() so both entry points share the same guard logic.
-    void insert(const QString& windowId)
+    /// with remove() so both entry points share the same guard logic. Returns
+    /// true iff a tracked entry was actually added.
+    bool insert(const QString& windowId)
     {
-        setFloating(windowId, true);
+        return setFloating(windowId, true);
     }
 
-    /// Convenience alias for setFloating(windowId, false).
-    void remove(const QString& windowId)
+    /// Convenience alias for setFloating(windowId, false). Returns true iff a
+    /// tracked entry was actually removed.
+    bool remove(const QString& windowId)
     {
-        setFloating(windowId, false);
+        return setFloating(windowId, false);
     }
 
 private:

--- a/libs/phosphor-compositor/include/PhosphorCompositor/ZoneCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/ZoneCache.h
@@ -46,25 +46,32 @@ public:
     }
 
     /// Record @p windowId's zone. An empty @p zoneId removes the entry (the
-    /// window left its zone — unsnapped / floated / screen-changed).
-    void setZone(const QString& windowId, const QString& zoneId)
+    /// window left its zone — unsnapped / floated / screen-changed). Returns true
+    /// iff the stored zone actually changed, so a caller can drive a side effect
+    /// (e.g. re-resolving IsSnapped / Zone rules) only on a real transition.
+    bool setZone(const QString& windowId, const QString& zoneId)
     {
         const QString instanceId = ::PhosphorIdentity::WindowId::extractInstanceId(windowId);
         // A composite with an empty instanceId ("appId|") is malformed: keying it
         // would alias every empty-instance window onto one wildcard slot. Ignore.
         if (instanceId.isEmpty()) {
-            return;
+            return false;
         }
         if (zoneId.isEmpty()) {
-            m_byInstance.remove(instanceId);
-        } else {
-            m_byInstance.insert(instanceId, zoneId);
+            return m_byInstance.remove(instanceId) > 0;
         }
+        const auto it = m_byInstance.constFind(instanceId);
+        if (it != m_byInstance.constEnd() && it.value() == zoneId) {
+            return false;
+        }
+        m_byInstance.insert(instanceId, zoneId);
+        return true;
     }
 
-    void remove(const QString& windowId)
+    /// Remove @p windowId's entry. Returns true iff an entry was actually removed.
+    bool remove(const QString& windowId)
     {
-        m_byInstance.remove(::PhosphorIdentity::WindowId::extractInstanceId(windowId));
+        return m_byInstance.remove(::PhosphorIdentity::WindowId::extractInstanceId(windowId)) > 0;
     }
 
     void clear()

--- a/libs/phosphor-compositor/include/PhosphorCompositor/ZoneCache.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/ZoneCache.h
@@ -48,7 +48,7 @@ public:
     /// Record @p windowId's zone. An empty @p zoneId removes the entry (the
     /// window left its zone — unsnapped / floated / screen-changed). Returns true
     /// iff the stored zone actually changed, so a caller can drive a side effect
-    /// (e.g. re-resolving IsSnapped / Zone rules) only on a real transition.
+    /// (e.g. re-resolving IsSnapped / Zone rules) only when the stored zone changed.
     bool setZone(const QString& windowId, const QString& zoneId)
     {
         const QString instanceId = ::PhosphorIdentity::WindowId::extractInstanceId(windowId);

--- a/src/config/configdefaults.cpp
+++ b/src/config/configdefaults.cpp
@@ -5,6 +5,9 @@
 
 #include <PhosphorAnimation/CurveRegistry.h>
 #include <PhosphorAnimation/Profile.h>
+#include <PhosphorProtocol/WindowTypeEnum.h>
+#include <PhosphorRules/MatchExpression.h>
+#include <PhosphorRules/MatchTypes.h>
 
 #include <QDir>
 #include <QFile>
@@ -27,6 +30,34 @@ static QString configDir()
 QString ConfigDefaults::configFilePath()
 {
     return configDir() + QStringLiteral("/plasmazones/config.json");
+}
+
+PhosphorRules::MatchExpression ConfigDefaults::tiledAndSnappedScopeMatch()
+{
+    using namespace PhosphorRules;
+    // Either snapped into a zone OR managed by the autotile engine. IsSnapped and
+    // IsTiled are distinct window-property fields, so an OR over both covers a
+    // window placed by either subsystem.
+    return MatchExpression::makeAny({
+        MatchExpression::makeLeaf(Field::IsSnapped, Operator::Equals, QVariant(true)),
+        MatchExpression::makeLeaf(Field::IsTiled, Operator::Equals, QVariant(true)),
+    });
+}
+
+PhosphorRules::MatchExpression ConfigDefaults::normalWindowsScopeMatch()
+{
+    using namespace PhosphorRules;
+    // WindowType is matched by its underlying int (the rule engine compares
+    // WindowType leaves numerically), so the leaf carries the enum value, not the
+    // wire token. IsTransient folds the whole dialog / utility / popup / menu /
+    // tooltip / splash family plus transient-child surfaces into one flag, so
+    // pairing it with WindowType == Normal excludes both the non-Normal types and
+    // the Electron-style children that report Normal but have a transient parent.
+    return MatchExpression::makeAll({
+        MatchExpression::makeLeaf(Field::WindowType, Operator::Equals,
+                                  QVariant(static_cast<int>(PhosphorProtocol::WindowType::Normal))),
+        MatchExpression::makeLeaf(Field::IsTransient, Operator::Equals, QVariant(false)),
+    });
 }
 
 QString ConfigDefaults::sessionFilePath()

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -28,6 +28,10 @@ namespace PhosphorAnimation {
 class CurveRegistry;
 }
 
+namespace PhosphorRules {
+class MatchExpression;
+}
+
 namespace PlasmaZones {
 
 /**
@@ -714,6 +718,23 @@ public:
     {
         return QUuid(QStringLiteral("{0a5e1b00-0000-4000-8000-000000000004}"));
     }
+
+    // Window-property match expressions that scope which windows the managed
+    // baseline BORDER and TITLE BAR rules apply to. These are the canonical wire
+    // shapes shared by the daemon's seeder (the fresh-install default) and the
+    // Appearance page's "Apply to" selector, so the two never drift.
+    //
+    // "Tiled and snapped" — `Any{ IsSnapped == true, IsTiled == true }` — the
+    // fresh-install default: borders and hidden title bars apply only to a window
+    // actually placed in a snap zone or managed by the autotile engine, matching
+    // the behaviour before appearance moved onto rules.
+    PLASMAZONES_EXPORT static PhosphorRules::MatchExpression tiledAndSnappedScopeMatch();
+
+    // "All normal windows" — `All{ WindowType == Normal, IsTransient == false }`
+    // — every ordinary application toplevel, excluding desktop / docks /
+    // notifications / OSDs (non-Normal types) and dialog / utility / popup / menu
+    // / tooltip / transient-child surfaces. The wider scope a user can opt into.
+    PLASMAZONES_EXPORT static PhosphorRules::MatchExpression normalWindowsScopeMatch();
 
     // Returns the absolute path to quicklayouts.json (the numbered quick-layout
     // shortcut slots 1..9). Quick-layout slots are NOT rules, so they

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -691,19 +691,23 @@ public:
     // "Default appearance" baseline rule, since split into the three focused
     // baselines below (`...002`/`...003`/`...004`). Do not reuse it.
     //
-    // Stable id of the managed baseline BORDER rule: the catch-all,
-    // lowest-priority Rule whose actions hold the default window border
-    // appearance (visible / width / radius / colour) the Appearance settings
-    // page edits. Fixed so the daemon can re-find (and idempotently re-seed) it
-    // across restarts and the settings UI can bind to the same rule.
+    // Stable id of the managed baseline BORDER rule: the lowest-priority Rule
+    // whose actions hold the default window border appearance (visible / width /
+    // radius / colour) the Appearance settings page edits. Its match is scoped to
+    // tiled / snapped windows on a fresh install and widened by the Appearance
+    // page's "Apply to" selector, so it is not a catch-all. Fixed so the daemon
+    // can re-find (and idempotently re-seed) it across restarts and the settings
+    // UI can bind to the same rule.
     static QUuid baselineBorderRuleId()
     {
         return QUuid(QStringLiteral("{0a5e1b00-0000-4000-8000-000000000002}"));
     }
 
-    // Stable id of the managed baseline TITLE BAR rule: the catch-all,
-    // lowest-priority Rule whose single action holds the default
-    // hide-title-bar value the Appearance settings page edits.
+    // Stable id of the managed baseline TITLE BAR rule: the lowest-priority Rule
+    // whose single action holds the default hide-title-bar value the Appearance
+    // settings page edits. Like the border baseline, its match is scoped to tiled
+    // / snapped windows on a fresh install (widened via "Apply to"), not a
+    // catch-all.
     static QUuid baselineTitleBarRuleId()
     {
         return QUuid(QStringLiteral("{0a5e1b00-0000-4000-8000-000000000003}"));

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -120,10 +120,11 @@ static_assert(Defaults::MaxGap == PhosphorTiles::AutotileDefaults::MaxGap,
 
 namespace {
 
-// Common skeleton for the three managed baseline rules: catch-all, lowest
-// priority, managed. Each is a focused fallback every window resolves against
-// per concern now that the per-mode global appearance settings are gone. The
-// Appearance settings page rewrites these actions; per-window overrides are
+// Common skeleton for the three managed baseline rules: catch-all match by
+// default (the border and title-bar makers below narrow it to tiled / snapped
+// windows), lowest priority, managed. Each is a focused fallback resolved
+// against per concern now that the per-mode global appearance settings are gone.
+// The Appearance settings page rewrites these actions; per-window overrides are
 // ordinary higher-priority rules that win per slot.
 PhosphorRules::Rule makeBaselineSkeleton(const QUuid& id, const QString& name)
 {
@@ -140,8 +141,10 @@ PhosphorRules::Rule makeBaselineSkeleton(const QUuid& id, const QString& name)
     return rule;
 }
 
-// Build the managed baseline BORDER rule: the catch-all, lowest-priority rule
+// Build the managed baseline BORDER rule: the lowest-priority baseline rule
 // carrying only the "show border" parent action, which defaults OFF (opt-in).
+// Its match is scoped to tiled / snapped windows on a fresh install (see below),
+// so it is no longer a catch-all.
 // The dependent border details (width, radius, active/inactive colour) are not
 // seeded here. The Appearance page adds them when the user turns "show border"
 // on and removes them when it is turned off, so the baseline stays minimal.
@@ -171,8 +174,9 @@ PhosphorRules::Rule makeBaselineBorderRule()
     return rule;
 }
 
-// Build the managed baseline TITLE BAR rule: the catch-all, lowest-priority
-// rule carrying the default hide-title-bar value.
+// Build the managed baseline TITLE BAR rule: the lowest-priority baseline rule
+// carrying the default hide-title-bar value. Its match is scoped to tiled /
+// snapped windows on a fresh install (see below), so it is not a catch-all.
 PhosphorRules::Rule makeBaselineTitleBarRule()
 {
     using namespace PhosphorRules;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -160,6 +160,11 @@ PhosphorRules::Rule makeBaselineBorderRule()
     };
 
     Rule rule = makeBaselineSkeleton(ConfigDefaults::baselineBorderRuleId(), PhosphorI18n::tr("Default borders"));
+    // Fresh-install default: draw the baseline border only on tiled / snapped
+    // windows, the behaviour before appearance moved onto rules. The Appearance
+    // page's "Apply to" selector rewrites this match; the seeder never re-pins it,
+    // so an existing install keeps whatever scope it already carries.
+    rule.match = ConfigDefaults::tiledAndSnappedScopeMatch();
     rule.actions = {
         action(ActionType::SetBorderVisible, ActionParam::Value, DD::ShowBorder),
     };
@@ -181,6 +186,11 @@ PhosphorRules::Rule makeBaselineTitleBarRule()
     };
 
     Rule rule = makeBaselineSkeleton(ConfigDefaults::baselineTitleBarRuleId(), PhosphorI18n::tr("Default title bars"));
+    // Fresh-install default: hide the title bar only on tiled / snapped windows,
+    // the behaviour before appearance moved onto rules. The Appearance page's
+    // "Apply to" selector rewrites this match; the seeder never re-pins it, so an
+    // existing install keeps whatever scope it already carries.
+    rule.match = ConfigDefaults::tiledAndSnappedScopeMatch();
     rule.actions = {
         action(ActionType::SetHideTitleBar, ActionParam::Value, DD::HideTitleBars),
     };

--- a/src/settings/qml/WindowAppearancePage.qml
+++ b/src/settings/qml/WindowAppearancePage.qml
@@ -71,6 +71,61 @@ SettingsFlickable {
         return root.actionValue(root.actBorderVisible, "value", false) === true;
     }
 
+    // True when the baseline hides title bars (the scope row is only meaningful
+    // while it does).
+    readonly property bool hideTitleBarsOn: {
+        root.reloadTick;
+        return root.actionValue(root.actHideTitleBar, "value", false) === true;
+    }
+
+    // "Apply to" scope options for the border / title-bar baselines, in display
+    // order. `scope` is the token the controller's matchJsonForScope/scopeOfMatch
+    // speak; `label` is the user-facing text.
+    readonly property var scopeOptions: [
+        {
+            "scope": "tiled",
+            "label": i18n("Tiled and snapped windows")
+        },
+        {
+            "scope": "normal",
+            "label": i18n("All normal windows")
+        },
+        {
+            "scope": "all",
+            "label": i18n("All windows")
+        }
+    ]
+
+    // The current scope token of the baseline rule @p ruleId, derived from its
+    // stored match expression.
+    function scopeOf(ruleId) {
+        const rule = ruleController.ruleJson(ruleId);
+        return root.bounds.scopeOfMatch((rule && rule.match) || ({}));
+    }
+
+    // Index of @p scope in scopeOptions, or -1 when it is not a listed preset
+    // (e.g. a "custom" match authored on the Rules page).
+    function scopeIndex(scope) {
+        for (var i = 0; i < root.scopeOptions.length; ++i) {
+            if (root.scopeOptions[i].scope === scope) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    // Rewrite the match of baseline rule @p ruleId to @p scope, preserving every
+    // other field of the rule (actions, managed flag, priority).
+    function writeScope(ruleId, scope) {
+        const rule = ruleController.ruleJson(ruleId);
+        if (!rule || !rule.id) {
+            return;
+        }
+        rule.match = root.bounds.matchJsonForScope(scope);
+        ruleController.updateRuleFromJson(rule);
+        root.reloadTick++;
+    }
+
     contentHeight: content.implicitHeight
     clip: true
 
@@ -402,6 +457,36 @@ SettingsFlickable {
 
                 SettingsRow {
                     visible: root.borderVisible
+                    title: i18n("Apply to")
+                    searchAnchor: "borderScope"
+                    description: i18n("Which windows get a border")
+
+                    WideComboBox {
+                        id: borderScopeCombo
+
+                        readonly property string currentScope: {
+                            root.reloadTick;
+                            return root.scopeOf(root.borderId);
+                        }
+
+                        Accessible.name: i18n("Apply borders to")
+                        textRole: "label"
+                        model: root.scopeOptions
+                        currentIndex: root.scopeIndex(borderScopeCombo.currentScope)
+                        // A "custom" match (authored on the Rules page) is not a
+                        // listed preset, so currentIndex is -1; show it as Custom
+                        // rather than a blank box.
+                        displayText: borderScopeCombo.currentScope === "custom" ? i18n("Custom (set on the Rules page)") : borderScopeCombo.currentText
+                        onActivated: index => root.writeScope(root.borderId, root.scopeOptions[index].scope)
+                    }
+                }
+
+                SettingsSeparator {
+                    visible: root.borderVisible
+                }
+
+                SettingsRow {
+                    visible: root.borderVisible
                     title: i18n("Border width")
                     searchAnchor: "borderWidth"
                     description: i18n("Thickness of the colored border around windows")
@@ -592,6 +677,33 @@ SettingsFlickable {
                                 "value": newValue
                             });
                         }
+                    }
+                }
+
+                SettingsSeparator {
+                    visible: root.hideTitleBarsOn
+                }
+
+                SettingsRow {
+                    visible: root.hideTitleBarsOn
+                    title: i18n("Apply to")
+                    searchAnchor: "hideTitleBarsScope"
+                    description: i18n("Which windows lose their title bar")
+
+                    WideComboBox {
+                        id: titleBarScopeCombo
+
+                        readonly property string currentScope: {
+                            root.reloadTick;
+                            return root.scopeOf(root.titleBarId);
+                        }
+
+                        Accessible.name: i18n("Hide title bars on")
+                        textRole: "label"
+                        model: root.scopeOptions
+                        currentIndex: root.scopeIndex(titleBarScopeCombo.currentScope)
+                        displayText: titleBarScopeCombo.currentScope === "custom" ? i18n("Custom (set on the Rules page)") : titleBarScopeCombo.currentText
+                        onActivated: index => root.writeScope(root.titleBarId, root.scopeOptions[index].scope)
                     }
                 }
             }

--- a/src/settings/qml/WindowAppearancePage.qml
+++ b/src/settings/qml/WindowAppearancePage.qml
@@ -814,32 +814,6 @@ SettingsFlickable {
                 });
             }
         }
-
-        // =================================================================
-        // Per-window overrides — link to the Rules page.
-        // =================================================================
-        SettingsCard {
-            Layout.fillWidth: true
-            headerText: i18n("Per-window appearance")
-            searchAnchor: "perWindow"
-            collapsible: false
-
-            contentItem: ColumnLayout {
-                spacing: Kirigami.Units.smallSpacing
-
-                SettingsRow {
-                    title: i18n("Override per app or monitor")
-                    description: i18n("These settings apply to every window. Add a rule to override the border or title bar for a specific app or monitor.")
-                    searchAnchor: "perRules"
-
-                    Button {
-                        text: i18n("Open Rules")
-                        icon.name: "view-list-details"
-                        onClicked: settingsController.activePage = "rules"
-                    }
-                }
-            }
-        }
     }
 
     // =====================================================================

--- a/src/settings/qml/WindowAppearancePage.qml
+++ b/src/settings/qml/WindowAppearancePage.qml
@@ -8,12 +8,12 @@ import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
 
 // Slim "Window Appearance" page. The window border, title-bar, and gap defaults
-// are resolved from three managed baseline appearance Rules (the
-// catch-all, lowest-priority rules the daemon seeds, one per concern). This page
-// is a friendly editor for those three rules: each action's read/write routes to
-// the matching baseline rule through the Rules controller. Per-window
-// overrides are ordinary higher-priority rules edited on the Rules page
-// (the link at the bottom).
+// are resolved from three managed baseline appearance Rules (the lowest-priority
+// rules the daemon seeds, one per concern). This page is a friendly editor for
+// those three rules: each action's read/write routes to the matching baseline
+// rule through the Rules controller, and the "Apply to" selector edits the
+// border / title-bar baseline's match. Per-window overrides are ordinary
+// higher-priority rules edited on the Rules page.
 SettingsFlickable {
     id: root
 

--- a/src/settings/windowappearancecontroller.cpp
+++ b/src/settings/windowappearancecontroller.cpp
@@ -5,7 +5,18 @@
 
 #include "../config/settings.h"
 
+#include <PhosphorRules/MatchExpression.h>
+
+#include <optional>
+
 namespace PlasmaZones {
+
+namespace {
+constexpr QLatin1StringView kScopeTiled{"tiled"};
+constexpr QLatin1StringView kScopeNormal{"normal"};
+constexpr QLatin1StringView kScopeAll{"all"};
+constexpr QLatin1StringView kScopeCustom{"custom"};
+} // namespace
 
 QString WindowAppearanceController::perScreenGapRuleId(const QString& screenId) const
 {
@@ -22,6 +33,38 @@ QString WindowAppearanceController::perScreenGapRuleId(const QString& screenId) 
 QString WindowAppearanceController::canonicalScreenId(const QString& screenId) const
 {
     return Settings::canonicalPerScreenKey(screenId);
+}
+
+QJsonObject WindowAppearanceController::matchJsonForScope(const QString& scope) const
+{
+    if (scope == kScopeTiled) {
+        return ConfigDefaults::tiledAndSnappedScopeMatch().toJson();
+    }
+    if (scope == kScopeNormal) {
+        return ConfigDefaults::normalWindowsScopeMatch().toJson();
+    }
+    // "all" (and any unrecognized token) is the catch-all empty All{}.
+    return PhosphorRules::MatchExpression{}.toJson();
+}
+
+QString WindowAppearanceController::scopeOfMatch(const QJsonObject& match) const
+{
+    const std::optional<PhosphorRules::MatchExpression> parsed = PhosphorRules::MatchExpression::fromJson(match);
+    // An absent / empty / unparseable match, or any catch-all, is the "all" scope:
+    // the baseline applies to every window.
+    if (!parsed || parsed->isCatchAll()) {
+        return QString(kScopeAll);
+    }
+    if (*parsed == ConfigDefaults::tiledAndSnappedScopeMatch()) {
+        return QString(kScopeTiled);
+    }
+    if (*parsed == ConfigDefaults::normalWindowsScopeMatch()) {
+        return QString(kScopeNormal);
+    }
+    // A valid but non-preset expression — e.g. a match hand-authored on the Rules
+    // page. Report it as custom so the picker shows it rather than silently
+    // coercing it to a preset and clobbering the user's intent on the next write.
+    return QString(kScopeCustom);
 }
 
 } // namespace PlasmaZones

--- a/src/settings/windowappearancecontroller.h
+++ b/src/settings/windowappearancecontroller.h
@@ -17,8 +17,9 @@ namespace PlasmaZones {
 /// Q_PROPERTY surface for the slim "Window Appearance" settings page.
 ///
 /// The page is a friendly editor for the three managed baseline appearance
-/// Rules (borders, title bars, gaps — the catch-all, lowest-priority
-/// rules the daemon seeds, one per concern). It reads and writes those rules'
+/// Rules (borders, title bars, gaps — the lowest-priority rules the daemon
+/// seeds, one per concern; borders and title bars are scoped to tiled/snapped
+/// windows by default while gaps stays the catch-all). It reads and writes those rules'
 /// actions through `settingsController.rulesPage` (RuleController),
 /// so this controller only carries the CONSTANT slider bounds and the three
 /// baseline rule ids. It holds no editable state of its own, so it is never

--- a/src/settings/windowappearancecontroller.h
+++ b/src/settings/windowappearancecontroller.h
@@ -7,6 +7,7 @@
 
 #include <PhosphorCompositor/DecorationDefaults.h>
 #include <PhosphorControl/PageController.h>
+#include <QJsonObject>
 #include <QObject>
 #include <QString>
 #include <QUuid>
@@ -130,6 +131,27 @@ public:
     /// QML uses this to author a per-monitor gap rule's `ScreenId Equals` match
     /// in the same canonical form the rule id is keyed by.
     Q_INVOKABLE QString canonicalScreenId(const QString& screenId) const;
+
+    // ── "Apply to" scope selector for the border / title-bar baselines ────────
+    //
+    // The baseline border and title-bar rules carry a window-property match that
+    // scopes which windows their appearance applies to. The Appearance page
+    // exposes this as an "Apply to" picker; these two helpers translate between
+    // the picker's scope token and the rule's `match` JSON so the QML never has
+    // to author the wire shape (and so the WindowType-as-int encoding stays in
+    // C++). Scope tokens: "tiled" (snapped or autotile-managed), "normal" (all
+    // ordinary application windows), "all" (every window — the catch-all).
+
+    /// The `match` JSON for @p scope, ready to drop onto a rule. An unrecognized
+    /// token returns the catch-all (the "all" scope), so a bad value never
+    /// narrows the baseline unexpectedly.
+    Q_INVOKABLE QJsonObject matchJsonForScope(const QString& scope) const;
+
+    /// Classify a rule's @p match JSON back to its scope token: "tiled",
+    /// "normal", "all" (catch-all or unparseable), or "custom" (a recognized but
+    /// non-preset expression, e.g. one hand-authored on the Rules page).
+    Q_INVOKABLE QString scopeOfMatch(const QJsonObject& match) const;
+
     int innerGapMin() const
     {
         return ConfigDefaults::innerGapMin();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -702,6 +702,14 @@ target_link_libraries(test_snapping_behavior_controller PRIVATE Qt6::Test Qt6::C
     PhosphorControl::PhosphorControl)
 add_test(NAME test_snapping_behavior_controller COMMAND test_snapping_behavior_controller)
 
+add_executable(test_window_appearance_controller
+    settings/test_window_appearance_controller.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings/windowappearancecontroller.cpp
+)
+target_link_libraries(test_window_appearance_controller PRIVATE Qt6::Test Qt6::Core plasmazones_core
+    PhosphorControl::PhosphorControl PhosphorRules::PhosphorRules)
+add_test(NAME test_window_appearance_controller COMMAND test_window_appearance_controller)
+
 # Animations-controller sources shared by the three test executables below
 # (page controller / motion sets / shader overrides). One list so a new
 # controller source file can't silently miss one of the three.

--- a/tests/unit/compositor-common/test_floating_cache.cpp
+++ b/tests/unit/compositor-common/test_floating_cache.cpp
@@ -133,6 +133,34 @@ private Q_SLOTS:
     }
 
     // =================================================================
+    // FloatingCache: setFloating reports whether the state actually changed
+    // (drives the NavigationHandler rule-invalidation — a no-op re-assert must
+    // not re-resolve).
+    // =================================================================
+
+    void testFloatingCacheChangedReturn()
+    {
+        PhosphorCompositor::FloatingCache cache;
+        // First float of an instance is a change; re-floating it is not.
+        QVERIFY(cache.setFloating(QStringLiteral("app|1"), true));
+        QVERIFY(!cache.setFloating(QStringLiteral("app|1"), true));
+        // Unfloat is a change; unfloating again is not.
+        QVERIFY(cache.setFloating(QStringLiteral("app|1"), false));
+        QVERIFY(!cache.setFloating(QStringLiteral("app|1"), false));
+        // insert / remove aliases report the same.
+        QVERIFY(cache.insert(QStringLiteral("firefox"))); // bare appId, new
+        QVERIFY(!cache.insert(QStringLiteral("firefox"))); // already present
+        QVERIFY(cache.remove(QStringLiteral("firefox")));
+        QVERIFY(!cache.remove(QStringLiteral("firefox")));
+        // Unfloating an instance that also clears a bare appId marker is a change.
+        cache.insert(QStringLiteral("slack")); // app-wide
+        cache.insert(QStringLiteral("slack|7")); // instance
+        QVERIFY(cache.setFloating(QStringLiteral("slack|7"), false)); // removed both
+        // Malformed id never changes anything.
+        QVERIFY(!cache.setFloating(QStringLiteral("bad|"), true));
+    }
+
+    // =================================================================
     // ZoneCache: basic set / get / unsnap
     // =================================================================
 
@@ -210,6 +238,31 @@ private Q_SLOTS:
         QCOMPARE(cache.size(), 0);
         QVERIFY(!cache.isSnapped(QStringLiteral("app|")));
         QVERIFY(!cache.isSnapped(QStringLiteral("other|")));
+    }
+
+    // =================================================================
+    // ZoneCache: setZone / remove report whether the entry actually changed
+    // (drives the NavigationHandler rule-invalidation — a no-op re-assert must
+    // not re-resolve).
+    // =================================================================
+
+    void testZoneCacheChangedReturn()
+    {
+        PhosphorCompositor::ZoneCache cache;
+        // New zone is a change; re-asserting the same zone is not.
+        QVERIFY(cache.setZone(QStringLiteral("app|1"), QStringLiteral("{z1}")));
+        QVERIFY(!cache.setZone(QStringLiteral("app|1"), QStringLiteral("{z1}")));
+        // Moving to a different zone is a change.
+        QVERIFY(cache.setZone(QStringLiteral("app|1"), QStringLiteral("{z2}")));
+        // Clearing an existing entry is a change; clearing again is not.
+        QVERIFY(cache.setZone(QStringLiteral("app|1"), QString()));
+        QVERIFY(!cache.setZone(QStringLiteral("app|1"), QString()));
+        // remove() reports the same.
+        cache.setZone(QStringLiteral("app|2"), QStringLiteral("{z}"));
+        QVERIFY(cache.remove(QStringLiteral("app|2")));
+        QVERIFY(!cache.remove(QStringLiteral("app|2")));
+        // Malformed id never changes anything.
+        QVERIFY(!cache.setZone(QStringLiteral("bad|"), QStringLiteral("{z}")));
     }
 
     // =================================================================

--- a/tests/unit/compositor-common/test_floating_cache.cpp
+++ b/tests/unit/compositor-common/test_floating_cache.cpp
@@ -156,8 +156,14 @@ private Q_SLOTS:
         cache.insert(QStringLiteral("slack")); // app-wide
         cache.insert(QStringLiteral("slack|7")); // instance
         QVERIFY(cache.setFloating(QStringLiteral("slack|7"), false)); // removed both
-        // Malformed id never changes anything.
+        // The app-wide marker is genuinely gone, not just the instance entry — a
+        // sibling instance no longer resolves as floating via the appId fallback.
+        QVERIFY(!cache.isFloating(QStringLiteral("slack|other")));
+        // Malformed ids never change anything: a trailing-separator composite and
+        // an empty bare appId are both rejected.
         QVERIFY(!cache.setFloating(QStringLiteral("bad|"), true));
+        QVERIFY(!cache.setFloating(QString(), true));
+        QVERIFY(!cache.isFloating(QString()));
     }
 
     // =================================================================

--- a/tests/unit/settings/test_window_appearance_controller.cpp
+++ b/tests/unit/settings/test_window_appearance_controller.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_window_appearance_controller.cpp
+ * @brief Round-trip tests for the "Apply to" scope selector helpers on
+ *        @c WindowAppearanceController (the border / title-bar baseline scope).
+ *
+ * The Appearance page's scope picker translates between a scope token and a
+ * rule's `match` JSON via matchJsonForScope() / scopeOfMatch(). These pin:
+ *   1. Each preset token round-trips (token -> match JSON -> token).
+ *   2. The "tiled" preset matches the daemon's seeded default
+ *      (ConfigDefaults::tiledAndSnappedScopeMatch) so the UI and the seeder
+ *      never drift.
+ *   3. An empty / catch-all match classifies as "all", and a recognized but
+ *      non-preset expression classifies as "custom" rather than being coerced.
+ */
+
+#include <QTest>
+
+#include <PhosphorProtocol/WindowTypeEnum.h>
+#include <PhosphorRules/MatchExpression.h>
+#include <PhosphorRules/MatchTypes.h>
+
+#include "config/configdefaults.h"
+#include "settings/windowappearancecontroller.h"
+
+using namespace PlasmaZones;
+using PhosphorRules::Field;
+using PhosphorRules::MatchExpression;
+using PhosphorRules::Operator;
+
+class TestWindowAppearanceController : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void scopeTokensRoundTrip_data()
+    {
+        QTest::addColumn<QString>("scope");
+        QTest::newRow("tiled") << QStringLiteral("tiled");
+        QTest::newRow("normal") << QStringLiteral("normal");
+        QTest::newRow("all") << QStringLiteral("all");
+    }
+
+    void scopeTokensRoundTrip()
+    {
+        QFETCH(QString, scope);
+        WindowAppearanceController controller;
+        const QJsonObject match = controller.matchJsonForScope(scope);
+        QCOMPARE(controller.scopeOfMatch(match), scope);
+    }
+
+    void tiledPresetMatchesSeededDefault()
+    {
+        WindowAppearanceController controller;
+        // The UI preset and the daemon's fresh-install seed must be byte-identical
+        // so a freshly seeded baseline reads back as "tiled" in the picker.
+        QCOMPARE(controller.matchJsonForScope(QStringLiteral("tiled")),
+                 ConfigDefaults::tiledAndSnappedScopeMatch().toJson());
+    }
+
+    void unknownTokenIsCatchAll()
+    {
+        WindowAppearanceController controller;
+        // A bad token must never narrow the baseline — it falls back to the
+        // catch-all, which classifies as "all".
+        const QJsonObject match = controller.matchJsonForScope(QStringLiteral("bogus"));
+        QCOMPARE(controller.scopeOfMatch(match), QStringLiteral("all"));
+    }
+
+    void emptyMatchIsAll()
+    {
+        WindowAppearanceController controller;
+        // An absent / empty match object (the QML fallback for a rule with no
+        // stored match) is the catch-all "all" scope.
+        QCOMPARE(controller.scopeOfMatch(QJsonObject{}), QStringLiteral("all"));
+        QCOMPARE(controller.scopeOfMatch(MatchExpression{}.toJson()), QStringLiteral("all"));
+    }
+
+    void nonPresetExpressionIsCustom()
+    {
+        WindowAppearanceController controller;
+        // A valid match that is not one of the presets (e.g. a single AppId leaf
+        // authored on the Rules page) is reported as custom, not coerced.
+        const QJsonObject custom =
+            MatchExpression::makeLeaf(Field::AppId, Operator::Equals, QVariant(QStringLiteral("org.kde.konsole")))
+                .toJson();
+        QCOMPARE(controller.scopeOfMatch(custom), QStringLiteral("custom"));
+    }
+
+    void normalPresetExcludesTransients()
+    {
+        WindowAppearanceController controller;
+        const QJsonObject match = controller.matchJsonForScope(QStringLiteral("normal"));
+        const auto parsed = MatchExpression::fromJson(match);
+        QVERIFY(parsed.has_value());
+        // WindowType is encoded as the underlying int, not the wire token — a
+        // leaf carrying "normal" as a string would compare as 0 (Unknown).
+        const QJsonObject expected =
+            MatchExpression::makeAll(
+                {MatchExpression::makeLeaf(Field::WindowType, Operator::Equals,
+                                           QVariant(static_cast<int>(PhosphorProtocol::WindowType::Normal))),
+                 MatchExpression::makeLeaf(Field::IsTransient, Operator::Equals, QVariant(false))})
+                .toJson();
+        QCOMPARE(match, expected);
+    }
+};
+
+QTEST_MAIN(TestWindowAppearanceController)
+#include "test_window_appearance_controller.moc"


### PR DESCRIPTION
## Summary

Follow-up to the appearance-as-rules migration (#699). That migration routed border drawing and title-bar hiding entirely through a catch-all baseline rule, dropping the implicit gate that previously restricted both to tiled/snapped windows. As a result, turning on the global border or hide-title-bar default applied it to **every surface**, including the desktop, docks, popups, and OSDs.

This restores the old behavior as a proper, user-facing setting rather than a hardcoded gate.

## What changed

A new **"Apply to"** selector on the Borders and Decorations cards of the **Appearance → Windows** page scopes each managed baseline rule by rewriting its `match` expression. Three presets:

- **Tiled and snapped windows** (default) — `Any{IsSnapped, IsTiled}`, restoring the pre-migration behavior
- **All normal windows** — `All{WindowType==Normal, IsTransient==false}`, every ordinary app window (excludes desktop/docks/popups/OSDs/dialogs)
- **All windows** — the catch-all

Because the scope edits the baseline rule's match, it composes with the priority cascade: explicit user rules still win per-slot, so nothing is restricted.

## Notes

- Scope presets are centralized in `ConfigDefaults` so the daemon seeder (fresh-install default) and the settings UI share one wire shape.
- **Existing installs keep their current scope** — the seeder reconciles actions only and never re-pins the match. The new selector is the opt-in mechanism. New installs default to tiled/snapped.
- A `WindowType` match leaf stores the enum **int**, not the wire token (the engine compares numerically); kept in C++ so QML can't author the wrong shape.

## Test plan

- New `test_window_appearance_controller` covers token↔match round-trips, the tiled-preset/seeded-default equality, catch-all and custom classification.
- Full suite: **247/247 passing**, build clean.
- Manually verified in the settings app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)