### PR TITLE
fix(rules): explicit action/condition selection + clearer category picker

### DIFF
--- a/src/settings/qml/ActionListEditor.qml
+++ b/src/settings/qml/ActionListEditor.qml
@@ -29,25 +29,9 @@ ColumnLayout {
     required property var appSettings
     /// True when the current match expression references only context fields.
     /// When false, every context-domain action (SetEngineMode, layout/tiling,
-    /// DisableEngine) silently never fires — so the type-picker disables those
-    /// entries with a tooltip and the default "Add action" picks the first
-    /// **compatible** entry instead of always index 0.
+    /// DisableEngine) silently never fires — so the type-picker dims those
+    /// entries with a warning tooltip. Threaded through to every ActionRow.
     required property bool matchIsContextOnly
-    /// First entry in `actionTypeOptions` whose domain is compatible with the
-    /// current match. Used as the default for a freshly-added action so the
-    /// user is not handed an incompatible type by default. Falls back to the
-    /// first entry when nothing is compatible — that case is impossible today
-    /// (window-domain actions are always compatible) but the fallback keeps
-    /// the picker non-empty if the future schema ever introduces a domain
-    /// that is constrained both ways.
-    readonly property var _firstCompatibleType: {
-        for (var i = 0; i < editor.actionTypeOptions.length; ++i) {
-            var entry = editor.actionTypeOptions[i];
-            if (entry.domain !== "context" || editor.matchIsContextOnly)
-                return entry;
-        }
-        return editor.actionTypeOptions.length > 0 ? editor.actionTypeOptions[0] : undefined;
-    }
 
     signal actionsEdited(var updatedActions)
 
@@ -64,20 +48,18 @@ ColumnLayout {
     }
 
     function _append() {
-        // Guarded by the Add-action button's enabled state — there is always
-        // at least one registered type when this runs. Pre-seed every param
-        // declared by the type's descriptor via the controller's
-        // `defaultPayloadFor` so a freshly-added action carries a complete
-        // (if not yet user-filled) param set. The default type is the first
-        // **compatible** entry so a window-property match doesn't auto-stamp
-        // a context action the picker would then flag as invalid. Defaults
-        // live in the controller (not duplicated here) so a type switch in
-        // ActionRow and a fresh append hit the same seeding path — adding
-        // a new param kind only requires updating the C++ default map.
-        var typeEntry = editor._firstCompatibleType || editor.actionTypeOptions[0];
-        var action = editor.controller.defaultPayloadFor(typeEntry.value);
+        // Append a type-less placeholder so the user must explicitly choose
+        // the action from the picker. Auto-seeding a concrete type (the first
+        // compatible entry) made every new action silently default to — and
+        // look like — that type. The row renders just the "Choose…" picker
+        // until a type is picked; ActionRow's onSelected then seeds that
+        // type's param defaults via the controller's `defaultPayloadFor`
+        // (the same path a type switch uses). `canSave` gates on every action
+        // carrying a type, so an unfilled placeholder can't be saved.
         var next = editor.actions.slice();
-        next.push(action);
+        next.push({
+            "type": ""
+        });
         editor.actionsEdited(next);
     }
 

--- a/src/settings/qml/MatchExpressionEditor.qml
+++ b/src/settings/qml/MatchExpressionEditor.qml
@@ -76,15 +76,16 @@ ColumnLayout {
     }
 
     function _addLeafChild() {
-        // Derive the starting leaf from the controller's authoring metadata so
-        // QML never reconstructs the field/operator wire table itself. The
-        // "Add condition" button is gated on a non-empty list, so [0] is safe.
-        var firstField = matchEditor.matchFieldOptions[0];
-        var operators = matchEditor.controller.operatorsForField(firstField.value);
+        // Start the condition fully unselected so the user must pick a field
+        // rather than being handed the first field by default. MatchLeafEditor
+        // renders the "Choose…" field picker and hides the operator / value
+        // editors until a field is chosen (at which point its onSelected seeds
+        // a valid operator and a typed value). `_matchHasFilledLeaves` gates
+        // save on a filled leaf, so an unfilled placeholder can't be saved.
         var children = matchEditor._children.slice();
         children.push({
-            "field": firstField.wire,
-            "op": operators[0].wire,
+            "field": "",
+            "op": "",
             "value": ""
         });
         matchEditor._emitChildren(matchEditor._compositeKind, children);
@@ -261,8 +262,9 @@ ColumnLayout {
                             text: i18n("Add condition")
                             icon.name: "list-add"
                             flat: true
-                            // No registered match fields ⇒ nothing to seed a leaf
-                            // from; disable rather than dereferencing an empty list.
+                            // No registered match fields ⇒ nothing for the user
+                            // to ever pick; disable the button rather than adding
+                            // a condition whose field picker would be empty.
                             enabled: matchEditor.matchFieldOptions.length > 0
                             Accessible.name: i18n("Add a condition to this group")
                             onClicked: matchEditor._addLeafChild()

--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -31,6 +31,13 @@ RowLayout {
     // The current field's descriptor (by wire string), or undefined if the
     // stored field is unknown / legacy.
     readonly property var _fieldEntry: leaf._entryForWire(leaf.fieldOptions, leaf.node.field)
+    // True once a field is chosen. A freshly-added condition seeds an empty
+    // field so the picker shows its placeholder and the user must select one;
+    // the operator / value editors stay hidden until then (mirroring how an
+    // action row shows no param editors until its type is picked). Keyed on
+    // the field STRING being non-empty — not on `_fieldEntry` — so a legacy /
+    // unknown field (non-empty but unrecognised) still shows its editors.
+    readonly property bool _hasField: leaf.node.field !== undefined && String(leaf.node.field).length > 0
     // Operator options depend on the current field's enum value.
     readonly property var _operatorOptions: leaf._fieldEntry !== undefined ? controller.operatorsForField(leaf._fieldEntry.value) : []
     readonly property string _valueKind: leaf._fieldEntry !== undefined ? leaf._fieldEntry.valueKind : "string"
@@ -257,6 +264,9 @@ RowLayout {
     WideComboBox {
         id: opCombo
 
+        // Hidden until a field is chosen — a field-less placeholder has no
+        // operator vocabulary to offer yet.
+        visible: leaf._hasField
         Layout.alignment: Qt.AlignTop
         // Fixed to the widest operator label across ALL fields' operator sets
         // (plus chrome for the dropdown indicator + padding) instead of the
@@ -278,6 +288,10 @@ RowLayout {
 
     Loader {
         Layout.fillWidth: true
+        // Hidden until a field is chosen — there is no value to type against a
+        // field-less placeholder (mirrors the operator combo above).
+        visible: leaf._hasField
+        active: leaf._hasField
         // Most value editors top-align so a string editor's wrapped operator hint
         // can grow downward without dragging the combos with it. The bool toggle
         // is a short fixed-height control with no hint line, so it vertically

--- a/src/settings/qml/RuleEditorBody.qml
+++ b/src/settings/qml/RuleEditorBody.qml
@@ -98,7 +98,23 @@ ColumnLayout {
     /// True iff the working rule is structurally complete (≥1 action,
     /// every leaf filled) AND semantically clean (no action/match domain
     /// mismatches). The consumer's Save button binds its `enabled` to this.
-    readonly property bool canSave: root.workingRule.actions !== undefined && root.workingRule.actions.length > 0 && root._matchHasFilledLeaves(root.workingRule.match) && root.validationIssues.length === 0
+    readonly property bool canSave: root.workingRule.actions !== undefined && root.workingRule.actions.length > 0 && root._actionsAllHaveType(root.workingRule.actions) && root._matchHasFilledLeaves(root.workingRule.match) && root.validationIssues.length === 0
+
+    /// True iff every action carries a non-empty type. A freshly-added action
+    /// is a type-less placeholder ("Choose…" in the picker) until the user
+    /// picks one — block saving that incomplete action. The rule library's
+    /// validator deliberately treats an empty-type slot as a benign
+    /// placeholder (see validationIssuesForJson), so the completeness gate has
+    /// to live here rather than surfacing as a validation issue.
+    function _actionsAllHaveType(actions) {
+        if (actions === undefined || actions === null)
+            return false;
+        for (var i = 0; i < actions.length; ++i) {
+            if (!actions[i] || actions[i].type === undefined || String(actions[i].type).length === 0)
+                return false;
+        }
+        return true;
+    }
 
     function _patch(key, value) {
         // Shallow clone via Object.assign — we replace `key`'s value
@@ -134,6 +150,14 @@ ColumnLayout {
             return true;
 
         if (node.field !== undefined) {
+            // A freshly-added condition seeds an empty field / operator; block
+            // save until the user picks a field (which auto-seeds a valid
+            // operator) and fills the value.
+            if (String(node.field).length === 0)
+                return false;
+            if (node.op === undefined || String(node.op).length === 0)
+                return false;
+
             var v = node.value;
             if (v === undefined || v === null)
                 return false;

--- a/src/settings/qml/RuleEditorBody.qml
+++ b/src/settings/qml/RuleEditorBody.qml
@@ -138,9 +138,10 @@ ColumnLayout {
     /// generous for any human-authored rule.
     readonly property int _maxMatchDepth: 64
 
-    /// True if every leaf predicate in @p node carries a non-empty value.
-    /// A leaf with an empty string / missing value would match an empty-string
-    /// id (e.g. the guided `ScreenId == ""` seed) — block saving that.
+    /// True if every leaf predicate in @p node is complete: a non-empty field,
+    /// a non-empty operator, and a non-empty value. A freshly-added leaf seeds
+    /// all three empty, and an empty-string value would match an empty-string
+    /// id (e.g. the guided `ScreenId == ""` seed) — block saving either.
     function _matchHasFilledLeaves(node, depth) {
         if (depth === undefined)
             depth = 0;

--- a/src/settings/qml/RuleEditorStatusBar.qml
+++ b/src/settings/qml/RuleEditorStatusBar.qml
@@ -25,8 +25,23 @@ ColumnLayout {
     /// actionType, message }`. Non-empty triggers the Warning message.
     required property var validationIssues
     /// The working rule itself — read to disambiguate the completeness
-    /// message between "no actions" and "blank match leaf".
+    /// message between "no actions", "action without a type" and "blank
+    /// match leaf".
     required property var workingRule
+    /// True when at least one action is still a type-less placeholder (the
+    /// user added it but hasn't picked a type). Drives a distinct completeness
+    /// hint so the message doesn't misreport it as a blank condition.
+    readonly property bool _someActionMissingType: {
+        var a = root.workingRule.actions;
+        if (!a)
+            return false;
+
+        for (var i = 0; i < a.length; ++i) {
+            if (!a[i] || a[i].type === undefined || String(a[i].type).length === 0)
+                return true;
+        }
+        return false;
+    }
 
     spacing: Kirigami.Units.smallSpacing
 
@@ -52,7 +67,15 @@ ColumnLayout {
         Layout.preferredWidth: 0
         type: Kirigami.MessageType.Information
         visible: !root.canSave && root.validationIssues.length === 0
-        text: !root.workingRule.actions || root.workingRule.actions.length === 0 ? i18n("Add at least one action before saving.") : i18n("Every condition needs a value before this rule can be saved.")
+        text: {
+            if (!root.workingRule.actions || root.workingRule.actions.length === 0)
+                return i18n("Add at least one action before saving.");
+
+            if (root._someActionMissingType)
+                return i18n("Choose a type for every action before saving.");
+
+            return i18n("Every condition needs a value before this rule can be saved.");
+        }
     }
 
     // Semantic-validation surface — lifts the rule library's diagnostics into the

--- a/src/shared/CategoryMenuButton.qml
+++ b/src/shared/CategoryMenuButton.qml
@@ -102,9 +102,9 @@ ComboBox {
     // The category path ({ top, sub }) of the currently-selected item, or null
     // when nothing is selected or the selection is uncategorised (those items
     // live in the flat tail and carry their own checkmark). Drives the
-    // "your selection is in here" marker on the category submenu titles so the
-    // user can tell which submenu holds the current value without hovering into
-    // each one. `sub` is "" for a single-level category.
+    // "your selection is in here" checkmark icon on the category submenu that
+    // contains it, so the user can tell which submenu holds the current value
+    // without hovering into each one. `sub` is "" for a single-level category.
     readonly property var _selectedCategoryPath: {
         if (!items || !currentId)
             return null;
@@ -118,8 +118,14 @@ ComboBox {
                 return null;
 
             var slashIdx = cat.indexOf("/");
+            var top = slashIdx >= 0 ? cat.substring(0, slashIdx).trim() : cat;
+            // Mirror _categoryTree: a leading-slash / empty-top category is
+            // treated as uncategorised (flat tail), so it has no submenu to mark.
+            if (top === "")
+                return null;
+
             return {
-                "top": slashIdx >= 0 ? cat.substring(0, slashIdx).trim() : cat,
+                "top": top,
                 "sub": slashIdx >= 0 ? cat.substring(slashIdx + 1).trim() : ""
             };
         }

--- a/src/shared/CategoryMenuButton.qml
+++ b/src/shared/CategoryMenuButton.qml
@@ -92,6 +92,35 @@ ComboBox {
         }
         return null;
     }
+    // The category path ({ top, sub }) of the currently-selected item, or null
+    // when nothing is selected or the selection is uncategorised (those items
+    // live in the flat tail and carry their own checkmark). Drives the
+    // "your selection is in here" marker on the category submenu titles so the
+    // user can tell which submenu holds the current value without hovering into
+    // each one. `sub` is "" for a single-level category.
+    readonly property var _selectedCategoryPath: {
+        if (!items || !currentId)
+            return null;
+
+        for (var i = 0; i < items.length; i++) {
+            if (!items[i] || items[i].id !== currentId)
+                continue;
+
+            var cat = (items[i].category || "").trim();
+            if (cat === "")
+                return null;
+
+            var slashIdx = cat.indexOf("/");
+            return {
+                "top": slashIdx >= 0 ? cat.substring(0, slashIdx).trim() : cat,
+                "sub": slashIdx >= 0 ? cat.substring(slashIdx + 1).trim() : ""
+            };
+        }
+        return null;
+    }
+    // Leading glyph prepended to the title of the category submenu that holds
+    // the current selection.
+    readonly property string _selectedCategoryMarker: "✓ "
     readonly property var _sortedItems: {
         if (!items || items.length === 0)
             return [];
@@ -330,6 +359,12 @@ ComboBox {
         // avoids the parent-pointer ambiguity entirely.
         property var _allItems: []
         property var _owned: []
+        // Category/subcategory submenus tracked with their identity
+        // (`{ obj, baseTitle, top, sub }`) so updateChecks() can (re)apply the
+        // selected-category marker to their titles on every open. The menu is
+        // built once and kept alive, so a selection change between opens must
+        // refresh the markers without a full rebuild.
+        property var _categorySubmenus: []
         property bool _built: false
         // Set when `items` changes while the menu is open; consumed by
         // onClosed to rebuild against a hidden tree (see onItemsChanged).
@@ -355,6 +390,7 @@ ComboBox {
             }
             _owned = [];
             _allItems = [];
+            _categorySubmenus = [];
             _built = false;
             root._opening = false;
         }
@@ -390,6 +426,28 @@ ComboBox {
                 else
                     sel = (it.itemId === root.currentId);
                 it.isSelected = sel;
+            }
+            // Mark the category (and subcategory) submenu that holds the
+            // current selection so the user can see where their value lives
+            // without hovering into each submenu. Recomputed on every open
+            // because the menu persists across selection changes. A top-level
+            // submenu is marked whenever the selection is anywhere inside it
+            // (including a nested subcategory); the subcategory submenu is
+            // marked only on an exact top+sub match.
+            var path = root._selectedCategoryPath;
+            for (var k = 0; k < _categorySubmenus.length; k++) {
+                var cs = _categorySubmenus[k];
+                if (!cs || !cs.obj)
+                    continue;
+
+                var holdsSelection = false;
+                if (path) {
+                    if (cs.sub === "")
+                        holdsSelection = (path.top === cs.top);
+                    else
+                        holdsSelection = (path.top === cs.top && path.sub === cs.sub);
+                }
+                cs.obj.title = holdsSelection ? (root._selectedCategoryMarker + cs.baseTitle) : cs.baseTitle;
             }
         }
 
@@ -480,6 +538,12 @@ ComboBox {
                     var subMenu = _addSubmenu(categoryMenu, {
                         "title": cat.name
                     });
+                    _categorySubmenus.push({
+                        "obj": subMenu,
+                        "baseTitle": cat.name,
+                        "top": cat.name,
+                        "sub": ""
+                    });
                     for (var s = 0; s < catItems.length; s++)
                         _addItem(subMenu, _itemProps(catItems[s]));
                     for (var sc = 0; sc < subcats.length; sc++) {
@@ -489,6 +553,12 @@ ComboBox {
 
                         var subSubMenu = _addSubmenu(subMenu, {
                             "title": subcats[sc].name
+                        });
+                        _categorySubmenus.push({
+                            "obj": subSubMenu,
+                            "baseTitle": subcats[sc].name,
+                            "top": cat.name,
+                            "sub": subcats[sc].name
                         });
                         for (var ss = 0; ss < subItems.length; ss++)
                             _addItem(subSubMenu, _itemProps(subItems[ss]));

--- a/src/shared/CategoryMenuButton.qml
+++ b/src/shared/CategoryMenuButton.qml
@@ -78,6 +78,13 @@ ComboBox {
     property bool includeNoneEntry: false
     property string noneText: i18nc("@item:inlistbox", "None")
     property string placeholderText: i18nc("@action:button", "Select…")
+    // Icon size for the leaf ItemDelegates' checkmark. The org.kde.desktop
+    // MenuItem sizes its content icon from a fixed style metric (this exact
+    // expression) and ignores `icon.width`, so the category-submenu checkmark
+    // is that size no matter what. Mirror the expression here so the leaf
+    // ItemDelegates — whose IconLabel DOES honour `icon.width` — render their
+    // checkmark at the identical size in both pointer and touch modes.
+    readonly property real _menuIconSize: Kirigami.Settings.hasTransientTouchInput ? Kirigami.Units.iconSizes.smallMedium : Kirigami.Units.iconSizes.small
     // Re-entry guard against rapid press / Space-down events queueing two
     // `showMenu` callbacks before the first one returns. `_opening` is set
     // when we hand off to `Qt.callLater` and cleared on `aboutToShow`.
@@ -118,9 +125,6 @@ ComboBox {
         }
         return null;
     }
-    // Leading glyph prepended to the title of the category submenu that holds
-    // the current selection.
-    readonly property string _selectedCategoryMarker: "✓ "
     readonly property var _sortedItems: {
         if (!items || items.length === 0)
             return [];
@@ -312,6 +316,8 @@ ComboBox {
 
             opacity: itemDimmed ? 0.45 : 1
             icon.name: isSelected ? "checkmark" : (itemDimmed ? "dialog-warning" : "")
+            icon.width: root._menuIconSize
+            icon.height: root._menuIconSize
             ToolTip.text: dimReason
             ToolTip.visible: itemDimmed && hovered && dimReason !== ""
             ToolTip.delay: Kirigami.Units.toolTipDelay
@@ -359,11 +365,14 @@ ComboBox {
         // avoids the parent-pointer ambiguity entirely.
         property var _allItems: []
         property var _owned: []
-        // Category/subcategory submenus tracked with their identity
-        // (`{ obj, baseTitle, top, sub }`) so updateChecks() can (re)apply the
-        // selected-category marker to their titles on every open. The menu is
-        // built once and kept alive, so a selection change between opens must
-        // refresh the markers without a full rebuild.
+        // Category/subcategory submenu items tracked with their identity
+        // (`{ menuItem, top, sub }`) so updateChecks() can (re)apply the
+        // selected-category checkmark icon on every open. `menuItem` is the
+        // MenuItem the parent menu auto-creates for the submenu — we set its
+        // `icon.name` to the same themed "checkmark" the leaf ItemDelegates
+        // use, so the "your selection is in here" mark is visually identical at
+        // both levels. The menu is built once and kept alive, so a selection
+        // change between opens must refresh the marks without a full rebuild.
         property var _categorySubmenus: []
         property bool _built: false
         // Set when `items` changes while the menu is open; consumed by
@@ -414,6 +423,20 @@ ComboBox {
             });
         }
 
+        // Request the shared menu icon size on an auto-created submenu
+        // MenuItem. Styles that size a MenuItem's icon from `icon.width` pick
+        // this up; styles that use a fixed metric (org.kde.desktop) ignore it,
+        // which is why the leaf ItemDelegates are pinned to that same metric
+        // (`_menuIconSize`) instead of the submenu being pinned to theirs. The
+        // size is constant; updateChecks() only toggles icon.name on / off.
+        function _sizeSubmenuIcon(menuItem) {
+            if (!menuItem)
+                return;
+
+            menuItem.icon.width = root._menuIconSize;
+            menuItem.icon.height = root._menuIconSize;
+        }
+
         function updateChecks() {
             for (var i = 0; i < _allItems.length; i++) {
                 var it = _allItems[i];
@@ -428,16 +451,17 @@ ComboBox {
                 it.isSelected = sel;
             }
             // Mark the category (and subcategory) submenu that holds the
-            // current selection so the user can see where their value lives
-            // without hovering into each submenu. Recomputed on every open
-            // because the menu persists across selection changes. A top-level
-            // submenu is marked whenever the selection is anywhere inside it
-            // (including a nested subcategory); the subcategory submenu is
-            // marked only on an exact top+sub match.
+            // current selection with the same "checkmark" icon the leaf items
+            // use, so the user can see where their value lives without hovering
+            // into each submenu. Recomputed on every open because the menu
+            // persists across selection changes. A top-level submenu is marked
+            // whenever the selection is anywhere inside it (including a nested
+            // subcategory); the subcategory submenu is marked only on an exact
+            // top+sub match.
             var path = root._selectedCategoryPath;
             for (var k = 0; k < _categorySubmenus.length; k++) {
                 var cs = _categorySubmenus[k];
-                if (!cs || !cs.obj)
+                if (!cs || !cs.menuItem)
                     continue;
 
                 var holdsSelection = false;
@@ -447,7 +471,7 @@ ComboBox {
                     else
                         holdsSelection = (path.top === cs.top && path.sub === cs.sub);
                 }
-                cs.obj.title = holdsSelection ? (root._selectedCategoryMarker + cs.baseTitle) : cs.baseTitle;
+                cs.menuItem.icon.name = holdsSelection ? "checkmark" : "";
             }
         }
 
@@ -538,9 +562,14 @@ ComboBox {
                     var subMenu = _addSubmenu(categoryMenu, {
                         "title": cat.name
                     });
+                    // The MenuItem the parent auto-creates for the submenu is
+                    // the item just appended — capture it so updateChecks() can
+                    // toggle its checkmark icon, and pin its icon size to match
+                    // the leaf ItemDelegates.
+                    var topMenuItem = categoryMenu.itemAt(categoryMenu.count - 1);
+                    _sizeSubmenuIcon(topMenuItem);
                     _categorySubmenus.push({
-                        "obj": subMenu,
-                        "baseTitle": cat.name,
+                        "menuItem": topMenuItem,
                         "top": cat.name,
                         "sub": ""
                     });
@@ -554,9 +583,10 @@ ComboBox {
                         var subSubMenu = _addSubmenu(subMenu, {
                             "title": subcats[sc].name
                         });
+                        var subMenuItem = subMenu.itemAt(subMenu.count - 1);
+                        _sizeSubmenuIcon(subMenuItem);
                         _categorySubmenus.push({
-                            "obj": subSubMenu,
-                            "baseTitle": subcats[sc].name,
+                            "menuItem": subMenuItem,
                             "top": cat.name,
                             "sub": subcats[sc].name
                         });


### PR DESCRIPTION
## Summary

Three related rule-editor selection-UX fixes so the WHEN/THEN builder never pre-fills a choice the user didn't make, and the category pickers clearly show the current selection.

### 1. Require an explicit type/field for new actions and conditions
Adding an action pre-seeded the first compatible action type, so every new action silently defaulted to (and looked like) "Override animation shader"; adding a condition pre-seeded the first match field the same way. The user never chose either, and the pre-filled value read as a real selection.

- New actions append a **type-less placeholder** and new conditions a **field-less placeholder**. Both pickers show their "Choose…" placeholder, and the dependent editors stay hidden (an action's params; a condition's operator and value) until the user picks. On selection the existing paths seed the chosen type's/field's defaults.
- `canSave` now requires every action to carry a type and every match leaf a non-empty field + operator (the rule library treats an empty-type slot as benign, so the completeness check lives in the editor). Both the edit sheet and the Add-rule wizard gate on it. The status bar gains a distinct "Choose a type for every action" hint.

### 2. Show which category submenu holds the current selection
The action-type and match-field pickers use a cascading category menu, so the checkmark on the selected value sat inside a collapsed submenu with no hint which category to expand. The containing category (and subcategory) submenu is now marked, refreshed on every open so it tracks selection changes.

### 3. Use the themed checkmark icon for the category marker
The category marker first used a plain `✓` text glyph, which rendered differently from the themed `checkmark` icon the leaf items use (two different check marks in one open menu). It now uses the same themed icon. The `org.kde.desktop` `MenuItem` sizes its content icon from a fixed style metric (`hasTransientTouchInput ? smallMedium : small`) and ignores `icon.width`, so the leaf `ItemDelegate` checkmarks are pinned to that identical expression — matching size in both pointer and touch modes.

## Files
- `src/settings/qml/ActionListEditor.qml`, `MatchExpressionEditor.qml`, `MatchLeafEditor.qml`, `RuleEditorBody.qml`, `RuleEditorStatusBar.qml` — placeholder actions/conditions + save gating.
- `src/shared/CategoryMenuButton.qml` — category-selection marker with the themed, size-matched checkmark.

## Testing
QML-only changes, validated with `qmllint` (parses clean). Verified visually in the running settings app: new actions/conditions start unselected, save stays disabled until filled, and the category marker matches the leaf checkmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
