### PR TITLE
fix(autotile): reseed focus when it arrives before the window is tracked

### DIFF
--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1530,6 +1530,15 @@ private:
     // windows in tiling order). Without this, the raise loop buries the new window.
     QString m_pendingFocusWindowId;
 
+    // Focus-before-track reseed: a windowFocused() notification can arrive before
+    // the window it names is tracked in a TilingState — most visibly on daemon
+    // restart, where the effect re-notifies the active window during bring-up but
+    // the window re-announce (windowsOpenedBatch) lands afterwards. onWindowFocused
+    // would otherwise drop that focus, leaving a focus-driven layout (Theater) with
+    // no focused window until the user clicks around. Stash the dropped id here and
+    // replay it in onWindowAdded once the window is tracked.
+    QString m_pendingFocusReseedWindowId;
+
     // Drag-insert preview state. When set, applyTiling() filters the dragged
     // window out of the windowsTiled batch so the KWin interactive move isn't
     // fought, while the remaining windows animate into their new positions.

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -2684,7 +2684,7 @@ void AutotileEngine::onWindowAdded(const QString& windowId)
     // the pre-restart active window without a second, competing retile.
     if (inserted && windowId == m_pendingFocusReseedWindowId) {
         m_pendingFocusReseedWindowId.clear();
-        m_activeScreen = m_windowToStateKey.value(windowId).screenId;
+        m_activeScreen = screenId;
         if (state) {
             state->setFocusedWindow(windowId);
         }

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -2676,6 +2676,20 @@ void AutotileEngine::onWindowAdded(const QString& windowId)
         m_pendingFocusWindowId = windowId;
     }
 
+    // Replay a focus notification that arrived before this window was tracked (see
+    // m_pendingFocusReseedWindowId). Seed the focus state directly rather than
+    // re-entering onWindowFocused: the scheduleRetileForScreen() below already
+    // reflows the screen, and a focus-driven layout (Theater) reads focusedIndex
+    // from focusedWindow() at that retile — so seeding here lands the spotlight on
+    // the pre-restart active window without a second, competing retile.
+    if (inserted && windowId == m_pendingFocusReseedWindowId) {
+        m_pendingFocusReseedWindowId.clear();
+        m_activeScreen = m_windowToStateKey.value(windowId).screenId;
+        if (state) {
+            state->setFocusedWindow(windowId);
+        }
+    }
+
     if (inserted) {
         // Notify algorithm via lifecycle hook before retile
         PhosphorTiles::TilingAlgorithm* algo = effectiveAlgorithm(screenId);
@@ -2737,10 +2751,22 @@ void AutotileEngine::onWindowFocused(const QString& windowId)
     PhosphorTiles::TilingState* state = stateForWindow(windowId);
     if (!state) {
         // Not an error — non-autotiled windows (dialogs, floating, etc.) report
-        // focus changes too, so this is the normal case for most window activations
-        qCDebug(PhosphorTileEngine::lcTileEngine) << "onWindowFocused: window not tracked" << windowId;
+        // focus changes too, so this is the normal case for most window activations.
+        // Stash the id so that if this window is a tiled window whose tracking just
+        // hasn't landed yet (daemon-restart re-announce ordering: the effect
+        // re-notifies the active window during bring-up, before windowsOpenedBatch),
+        // onWindowAdded can replay the focus once the window is tracked. A stash for a
+        // window that never gets tiled (a genuine dialog) is inert — it only replays
+        // on an exact-id add — and is overwritten by the next such notification.
+        qCDebug(PhosphorTileEngine::lcTileEngine)
+            << "onWindowFocused: window not tracked, stashing for reseed" << windowId;
+        m_pendingFocusReseedWindowId = windowId;
         return;
     }
+
+    // A tracked window took focus through the normal path — any earlier stash for a
+    // yet-untracked window is stale now, so drop it rather than let it replay later.
+    m_pendingFocusReseedWindowId.clear();
 
     // Track which screen has the active focus (used by tiledWindowsForFocusedScreen
     // to avoid non-deterministic QHash iteration when multiple screens have focused windows)

--- a/tests/unit/autotile/test_autotile_focus_retile.cpp
+++ b/tests/unit/autotile/test_autotile_focus_retile.cpp
@@ -82,6 +82,39 @@ private Q_SLOTS:
         QVERIFY2(tiledSpy.count() > 0, "focus change did not emit a retile to the compositor");
     }
 
+    void theater_focusBeforeTrack_seedsSpotlightOnAdd()
+    {
+        // Daemon-restart ordering: the effect re-notifies the active window during
+        // bring-up (windowFocused) BEFORE the window re-announce (windowOpened)
+        // lands. The focused id names a window the engine doesn't track yet, so the
+        // notification must be stashed and replayed once the window is added —
+        // otherwise Theater has no focused window and defaults the spotlight to
+        // index 0 until the user clicks around.
+        PhosphorScreens::FakeScreenProvider provider;
+        provider.addScreen(QStringLiteral("DP-1"), QRect(0, 0, 1920, 1080));
+        PhosphorScreens::ScreenManager manager(
+            PhosphorScreens::ScreenManagerConfig{.screenProvider = &provider, .useGeometrySensors = false});
+        manager.start();
+
+        AutotileEngine engine(nullptr, nullptr, &manager, PlasmaZones::TestHelpers::testRegistry());
+        engine.setAutotileScreens({QStringLiteral("DP-1")});
+        engine.setAlgorithm(QLatin1String("theater"));
+
+        // Focus arrives for a window that is not yet tracked (pre-announce).
+        engine.windowFocused(QStringLiteral("a2"), QStringLiteral("DP-1"));
+
+        // Windows are (re)announced afterwards. a2 is neither first nor last, so a
+        // spotlight on a2 can only come from the replayed focus, not a default.
+        engine.windowOpened(QStringLiteral("a1"), QStringLiteral("DP-1"));
+        engine.windowOpened(QStringLiteral("a2"), QStringLiteral("DP-1"));
+        engine.windowOpened(QStringLiteral("a3"), QStringLiteral("DP-1"));
+
+        PhosphorTiles::TilingState* d1 = engine.tilingStateForScreen(QStringLiteral("DP-1"));
+        QTRY_COMPARE(d1->calculatedZones().size(), 3);
+        QCOMPARE(d1->focusedWindow(), QStringLiteral("a2"));
+        QTRY_COMPARE(spotlightWindow(d1), QStringLiteral("a2"));
+    }
+
     void columns_focusChange_doesNotRetile()
     {
         PhosphorScreens::FakeScreenProvider provider;


### PR DESCRIPTION
## Problem

With the **theater** script, stopping and restarting the daemon leaves the focused window unregistered — it takes several window clicks before the spotlight lands on the actually-focused window.

## Root cause

An ordering race on daemon bring-up:

1. The KWin effect re-notifies the active window during bring-up (`daemon_bringup.cpp` → `notifyWindowActivated` → `Autotile.notifyWindowFocused`).
2. That focus notification reaches the engine **before** the windows are re-announced (`windowsOpenedBatch`, sent later from the async `loadSettings` reply).
3. `AutotileEngine::onWindowFocused` early-returned for a not-yet-tracked window, so the focus was **silently dropped**.
4. The re-announce path seeds window *order* but never *focus*, so `state->focusedWindow()` stayed empty.

Theater has `retileOnFocus = true` and reads `focusedIndex`; with focus unknown it defaults to index 0, so the spotlight sat on the wrong window until a fresh click regenerated a focus event after tracking existed.

## Fix

Treat a focus notification for a not-yet-tracked window as **deferred** instead of lost:

- `onWindowFocused`: stash the id in `m_pendingFocusReseedWindowId` when the window isn't tracked (and clear the stash on any normal tracked focus so a stale id can't replay).
- `onWindowAdded`: once that window is inserted, replay the focus by seeding `m_activeScreen` + `state->setFocusedWindow()`. The retile already scheduled there then reflows with the correct spotlight — no click needed, no competing second retile.

Robust to the daemon's `deferUntilPanelReady()` queuing: the replay fires whenever the window finally lands.

## Tests

- Added `theater_focusBeforeTrack_seedsSpotlightOnAdd` reproducing the restart ordering (focus for `a2` arrives before any window opens, then `a1`/`a2`/`a3` open) and asserting the spotlight lands on `a2`.
- Full suite passes (the sole failure, `bench_dbus_adaptors`, is a pre-existing 0-byte non-executable benchmark placeholder, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)