### PR TITLE
feat(settings): per-page reset & discard, and rule-backed Restore Defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Separate focused and unfocused border colors**: the border color is now two actions, "Set focused border color" and "Set unfocused border color", each with its own swatch ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **App-managed default rules**: the default rules (Default borders, Default title bars, Default gaps) cannot be deleted and stay pinned to the lowest priority ([#699](https://github.com/fuddlesworth/PlasmaZones/pull/699)).
 - **Choose which windows the appearance defaults apply to**: the Borders and Title bars cards on the Appearance Windows page have an "Apply to" option with three scopes, tiled and snapped windows, all normal windows, and all windows. New installs default to tiled and snapped windows, so the default border and hidden title bar stay off the desktop, panels, popups, and on-screen displays. Existing setups keep their current scope and can switch at any time ([#721](https://github.com/fuddlesworth/PlasmaZones/pull/721)).
+- **Reset or discard one settings page at a time**: most settings pages now have a menu in the breadcrumb row with "Reset page to defaults" and "Discard changes on this page". Both stage the change so you can review it and then Save or Discard like any other edit, and discarding one page leaves your edits on other pages alone. The global Restore Defaults now also resets the rule-backed window appearance and gap defaults ([#726](https://github.com/fuddlesworth/PlasmaZones/pull/726)).
 
 ### Changed
 

--- a/dbus/org.plasmazones.Rules.xml
+++ b/dbus/org.plasmazones.Rules.xml
@@ -75,7 +75,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
             </arg>
         </method>
         <method name="resetManagedDefaults">
-            <annotation name="org.gtk.GDBus.DocString" value="Reset the three managed baseline appearance/gap rules (Default borders, Default title bars, Default gaps) to their factory definitions, preserving every user-authored rule. Persists once and emits rulesChanged. Backs the settings app's global Restore Defaults for the rule-backed appearance/gap surface."/>
+            <annotation name="org.gtk.GDBus.DocString" value="Reset the three managed baseline appearance/gap rules (Default borders, Default title bars, Default gaps) to their factory definitions, preserving every user-authored rule. Reloads the store from disk first, then persists the merged set, so rulesChanged may fire up to twice (reload + write). Backs the settings app's global Restore Defaults for the rule-backed appearance/gap surface."/>
         </method>
         <signal name="rulesChanged">
             <annotation name="org.gtk.GDBus.DocString" value="Emitted whenever the store's rule set changes (add, update, remove, enable, priority, or full replace)."/>

--- a/dbus/org.plasmazones.Rules.xml
+++ b/dbus/org.plasmazones.Rules.xml
@@ -74,6 +74,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
                 <annotation name="org.gtk.GDBus.DocString" value="True if the rule's priority was updated."/>
             </arg>
         </method>
+        <method name="resetManagedDefaults">
+            <annotation name="org.gtk.GDBus.DocString" value="Reset the three managed baseline appearance/gap rules (Default borders, Default title bars, Default gaps) to their factory definitions, preserving every user-authored rule. Persists once and emits rulesChanged. Backs the settings app's global Restore Defaults for the rule-backed appearance/gap surface."/>
+        </method>
         <signal name="rulesChanged">
             <annotation name="org.gtk.GDBus.DocString" value="Emitted whenever the store's rule set changes (add, update, remove, enable, priority, or full replace)."/>
             <arg name="persisted" type="b">

--- a/docs/restore-defaults-rule-reset-design.md
+++ b/docs/restore-defaults-rule-reset-design.md
@@ -5,7 +5,7 @@
 
 | | |
 |---|---|
-| **Status** | Both tracks IMPLEMENTED — **(A) per-page Reset+Discard for the Windows appearance page**; **(B) global Restore Defaults daemon-side reset** (`RuleAdaptor::resetManagedDefaults`, called from `SettingsController::defaults()`). §5.3 below records the original callback proposal; the shipped code instead shares the baseline makers via `plasmazones_core/baselinerules.h` and has `RuleAdaptor` call them directly (no callback needed). |
+| **Status** | Both tracks IMPLEMENTED — **(A) per-page Reset+Discard for the Windows appearance page**; **(B) global Restore Defaults daemon-side reset** (`SettingsController::defaults()` → `RuleController::resetManagedDefaults()` over D-Bus → daemon-side `RuleAdaptor::resetManagedDefaults`). §5.3 below records the original callback proposal; the shipped code instead shares the baseline makers via `plasmazones_core/baselinerules.h` and has `RuleAdaptor` call them directly (no callback needed). |
 | **Author** | — |
 | **Date** | 2026-06-28 (updated 2026-07-01) |
 | **Schema impact** | None (no config or rules-file schema change) |

--- a/docs/restore-defaults-rule-reset-design.md
+++ b/docs/restore-defaults-rule-reset-design.md
@@ -5,11 +5,100 @@
 
 | | |
 |---|---|
-| **Status** | Draft / proposal |
+| **Status** | Two tracks — **(A) per-page Reset+Discard for the Windows appearance page: designed & being implemented** (this session); **(B) global Restore Defaults daemon-side reset: still deferred** |
 | **Author** | — |
-| **Date** | 2026-06-28 |
+| **Date** | 2026-06-28 (updated 2026-07-01) |
 | **Schema impact** | None (no config or rules-file schema change) |
 | **Origin** | Descoped item from the PR #699 audit ("everything is a rule" refactor) |
+
+---
+
+## 0. Update (2026-07-01) — chosen approach for the per-page feature
+
+This section supersedes the framing below for the **per-page Reset/Discard** work
+that is actually being built. Sections 1–9 remain the design for the **global**
+Restore Defaults path (track B), which is still deferred.
+
+### 0.1 Corrected premise: appearance edits are STAGED, not live
+
+The original doc reasoned from "`window-appearance`'s commit is a no-op." That is
+true only of `WindowAppearanceController` itself, which is stateless
+(`windowappearancecontroller.h`: `isDirty()` returns false, `apply()`/`discard()`
+are empty). It is **misleading**: appearance edits are NOT written live. Every
+Windows-page control routes through `RuleController` (`WindowAppearancePage.qml`
+binds `ruleController: settingsController.rulesPage`, reads `ruleJson(id)`, writes
+`updateRuleFromJson(...)`). Those edits mutate the in-memory `RuleController::m_model`
+and flip a dirty bit; nothing reaches the daemon's `rules.json` until the **global
+Save** pushes the staged set via `setAllRules`. So the Windows page is already a
+proper staged surface — it just happens to share one `RuleModel` with the Rules
+page, and its edits currently mark the **`rules`** page dirty.
+
+### 0.2 Scope decided this session
+
+- **Windows (`window-appearance`)** → per-page **Reset + Discard**, staged (commits
+  on Save, revertible before it), via the breadcrumb kebab.
+- **Rules** → **nothing** (no per-page Reset/Discard — user rules are the page's
+  content, not resettable "settings"; a full wipe would be a separate, explicit,
+  destructive action).
+- **Attribution** → split so appearance edits badge **Windows** and user-rule edits
+  badge **Rules**.
+
+### 0.3 Design (per-page, staged — track A)
+
+Because both pages stage into one shared `RuleController::m_model`, and the existing
+per-page Reset/Discard machinery is stage-only (mutates in-memory, defers to Save),
+the Windows reset/discard operate on `m_model` — **not** the daemon-side live
+primitive of §5 (that is for the global path, track B).
+
+1. **Shared baseline definitions.** Move `makeBaselineSkeleton` +
+   `makeBaseline{Border,TitleBar,Gap}Rule()` out of `daemon.cpp`'s anonymous
+   namespace into `src/core/baselinerules.{h,cpp}` (part of `plasmazones_core`,
+   which both the daemon and the settings app link, and which already links
+   `PhosphorRules` + `PhosphorCompositor` (`DecorationDefaults`) + `ConfigDefaults`
+   + `PhosphorI18n`). `daemon.cpp` includes it and drops its local copies —
+   single source of truth for the seeding path and the reset path (matches §5.2).
+
+2. **`RuleController` value-based split dirty (against a saved snapshot).** Keep the
+   existing `m_dirty` bit for the async apply/revert machinery; add
+   `m_savedRules = m_model.rules()` captured at each daemon sync (the `fetchAndLoad`
+   reply after `setRules`, and the successful `pushToDaemonAsync` reply). Derive two
+   value-based queries by comparing `m_model.rules()` to `m_savedRules`
+   (`Rule::operator==` exists):
+   - `baselinesDirty()` — any of the 3 managed baseline rules (by id) differs from
+     the snapshot → drives **window-appearance** dirty.
+   - `userRulesDirty()` — the ordered list of non-managed rules differs → drives
+     **rules** dirty.
+
+3. **Baseline-scoped ops on `RuleController`** (mutate `m_model` directly, then
+   `setDirty(baselinesDirty() || userRulesDirty())` to recompute the global bit):
+   - `resetBaselines()` → `m_model.updateRule(makeBaseline*Rule())` for the 3 ids
+     (restores factory match + actions, dropping any per-side gap actions the page
+     added — `updateRule` replaces the managed rule in place, no renormalize).
+   - `discardBaselineEdits()` → `m_model.updateRule(savedRuleById(id))` for the 3
+     ids, leaving user rules untouched.
+
+4. **`SettingsController` wiring.** A `reconcileRuleBackedDirty()` helper sets
+   `m_dirtyPages` membership for `window-appearance` (= `baselinesDirty()`) and
+   `rules` (= `userRulesDirty()`), emitting `dirtyPagesChanged` on a change. It
+   replaces the three existing `RuleController` handlers (`dirtyChanged` guarded by
+   `!m_loading && !m_saving`, plus `revertFinished`/`applyResult`) that today mark
+   only `"rules"`. `pageSupportsReset`/`pageSupportsDiscard` gain `window-appearance`;
+   `resetPage`/`discardPage("window-appearance")` call the baseline ops then
+   `reconcileRuleBackedDirty()` (explicit, because a scoped op that leaves the global
+   bit unchanged would not re-fire `dirtyChanged`). `isPageDirty` is unchanged — it
+   reads `m_dirtyPages`, which reconcile keeps accurate.
+
+5. **No new D-Bus, no daemon primitive** for track A. Save/Discard already flow
+   through the registered `RuleController` staging domain; Save pushes `setAllRules`,
+   Discard runs `revert()`.
+
+### 0.4 What track A does NOT do
+
+The **global Restore Defaults** (`SettingsController::defaults()`) still does not
+reset the rule-backed appearance/gaps baselines — it continues to exclude
+`window-appearance` and `rules` from its blanket mark. Fixing that is track B
+(§2–§9): a daemon-side, live-persisting reset primitive. The two are independent;
+track A ships the per-page affordance without it.
 
 ---
 

--- a/docs/restore-defaults-rule-reset-design.md
+++ b/docs/restore-defaults-rule-reset-design.md
@@ -5,7 +5,7 @@
 
 | | |
 |---|---|
-| **Status** | Two tracks — **(A) per-page Reset+Discard for the Windows appearance page: designed & being implemented** (this session); **(B) global Restore Defaults daemon-side reset: still deferred** |
+| **Status** | Both tracks IMPLEMENTED — **(A) per-page Reset+Discard for the Windows appearance page**; **(B) global Restore Defaults daemon-side reset** (`RuleAdaptor::resetManagedDefaults`, called from `SettingsController::defaults()`). §5.3 below records the original callback proposal; the shipped code instead shares the baseline makers via `plasmazones_core/baselinerules.h` and has `RuleAdaptor` call them directly (no callback needed). |
 | **Author** | — |
 | **Date** | 2026-06-28 (updated 2026-07-01) |
 | **Schema impact** | None (no config or rules-file schema change) |
@@ -92,13 +92,18 @@ primitive of §5 (that is for the global path, track B).
    through the registered `RuleController` staging domain; Save pushes `setAllRules`,
    Discard runs `revert()`.
 
-### 0.4 What track A does NOT do
+### 0.4 Track A vs track B (both shipped)
 
-The **global Restore Defaults** (`SettingsController::defaults()`) still does not
-reset the rule-backed appearance/gaps baselines — it continues to exclude
-`window-appearance` and `rules` from its blanket mark. Fixing that is track B
-(§2–§9): a daemon-side, live-persisting reset primitive. The two are independent;
-track A ships the per-page affordance without it.
+Track A is the per-page (staged) affordance. Track B is the global
+**Restore Defaults** (`SettingsController::defaults()`) resetting the rule-backed
+appearance/gaps baselines — now implemented via a daemon-side, live-persisting
+primitive (`org.plasmazones.Rules.resetManagedDefaults()`), which `defaults()`
+invokes and then `revert()`s the model to pick up. `window-appearance` and `rules`
+stay excluded from `defaults()`'s dirty blanket-mark: the reset is live +
+reloaded, so those pages land clean rather than staged-dirty. The two tracks are
+independent; §2–§9 record the original track-B design (the shipped primitive lives
+on `RuleAdaptor` and reloads the store first — see §0.3 and the code — rather than
+the §5.3 callback).
 
 ---
 

--- a/libs/phosphor-control/qml/SettingsAppWindow.qml
+++ b/libs/phosphor-control/qml/SettingsAppWindow.qml
@@ -404,12 +404,16 @@ Kirigami.ApplicationWindow {
                         }
 
                         // Page-scoped trailing slot (e.g. a per-page overflow
-                        // menu). Adopts its loaded item's implicit size; the
-                        // row collapses it to zero width when unfilled.
+                        // menu). Adopts its loaded item's implicit size. Collapses
+                        // to zero width both when unfilled and when the loaded item
+                        // hides itself (a self-gating slot shown only on some pages)
+                        // — without gating the Loader's own visibility the row would
+                        // still reserve the hidden item's implicit width.
                         Loader {
                             id: breadcrumbTrailingLoader
 
                             Layout.alignment: Qt.AlignVCenter
+                            visible: item !== null && item.visible
                         }
                     }
 

--- a/libs/phosphor-control/qml/SettingsAppWindow.qml
+++ b/libs/phosphor-control/qml/SettingsAppWindow.qml
@@ -26,6 +26,11 @@ Kirigami.ApplicationWindow {
     //* Optional content pinned to the RIGHT of the header-extras row (e.g. a
     //  status toggle), sharing the row with the centered headerExtras.
     property alias headerTrailing: headerTrailingLoader.sourceComponent
+    //* Optional content pinned to the RIGHT of the per-page breadcrumb row
+    //  (e.g. a page-scoped overflow/kebab menu). Sits on the same line as the
+    //  breadcrumbs, right-aligned; the row already reserves the leading space
+    //  via Breadcrumbs' Layout.fillWidth. Empty by default.
+    property alias breadcrumbTrailing: breadcrumbTrailingLoader.sourceComponent
     /** Alias onto the chrome Sidebar item so consumers can configure
      *  the two delegate slots and drive navigation:
      *
@@ -396,6 +401,15 @@ Kirigami.ApplicationWindow {
                             Layout.fillWidth: true
                             Layout.alignment: Qt.AlignVCenter
                             controller: root.controller
+                        }
+
+                        // Page-scoped trailing slot (e.g. a per-page overflow
+                        // menu). Adopts its loaded item's implicit size; the
+                        // row collapses it to zero width when unfilled.
+                        Loader {
+                            id: breadcrumbTrailingLoader
+
+                            Layout.alignment: Qt.AlignVCenter
                         }
                     }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,8 @@ add_subdirectory(shared)
 set(plasmazones_core_SRCS
     phosphor_qml_i18n.h
     core/constants.h
+    core/baselinerules.h
+    core/baselinerules.cpp
     core/logging.h
     core/logging.cpp
     core/translationloader.h

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -166,16 +166,7 @@ void Settings::load()
     // QVariant comparison is meaningful (Qt builtins, POD enums,
     // QVariantMap, QStringList). Custom Q_GADGETs without a registered
     // operator== will silently miscompare here.
-    const QMetaObject* mo = metaObject();
-    const int propCount = mo->propertyCount();
-    const int firstOwnProp = QObject::staticMetaObject.propertyCount();
-    QVector<QVariant> snapshot;
-    snapshot.resize(propCount);
-    for (int i = firstOwnProp; i < propCount; ++i) {
-        const QMetaProperty prop = mo->property(i);
-        if (prop.hasNotifySignal() && prop.isReadable())
-            snapshot[i] = prop.read(this);
-    }
+    const QVector<QVariant> propSnapshot = snapshotNotifyProperties();
 
     // Per-mode disable lists are NOT Q_PROPERTYs (their getters take a Mode
     // argument, which Q_PROPERTY can't express). Snapshot them explicitly
@@ -253,18 +244,7 @@ void Settings::load()
     // Emit NOTIFY signals for every Q_PROPERTY whose value changed. load()
     // sets members directly (not via setters), so without this loop QML
     // bindings would never see reloaded values after discard / reset.
-    bool anyChanged = false;
-    for (int i = firstOwnProp; i < propCount; ++i) {
-        const QMetaProperty prop = mo->property(i);
-        if (!prop.hasNotifySignal() || !prop.isReadable())
-            continue;
-        const QVariant newValue = prop.read(this);
-        if (newValue != snapshot[i]) {
-            anyChanged = true;
-            const QMetaMethod notify = prop.notifySignal();
-            notify.invoke(this, Qt::DirectConnection);
-        }
-    }
+    const bool anyChanged = emitChangedNotifyProperties(propSnapshot);
 
     // Per-mode disable lists: emit one signal per Mode whose list changed.
     // Mirrors the Q_PROPERTY loop above but keyed by (signal, mode) instead
@@ -305,6 +285,10 @@ void Settings::load()
 
     if (anyChanged || anyDisableChanged || perScreenChanged)
         Q_EMIT settingsChanged();
+
+    // The store now mirrors disk — refresh the committed baseline that
+    // per-page Discard reverts to and isKeyModified() compares against.
+    captureBaseline();
 }
 
 // ── save() dispatcher ────────────────────────────────────────────────────────
@@ -534,6 +518,94 @@ void Settings::save()
     saveVirtualScreenConfigs(m_configBackend);
 
     m_configBackend->sync();
+
+    // Disk now holds the flushed store — the just-saved values become the new
+    // committed baseline for per-page Discard / dirty checks.
+    captureBaseline();
+}
+
+// ── Per-page reset / discard support ────────────────────────────────────────
+
+QVector<QVariant> Settings::snapshotNotifyProperties() const
+{
+    // Index-aligned to the metaobject property table so the paired
+    // emitChangedNotifyProperties() can compare position-for-position.
+    // Inherited QObject properties (objectName) are skipped — only Settings'
+    // own NOTIFY-able readable properties participate.
+    const QMetaObject* mo = metaObject();
+    const int propCount = mo->propertyCount();
+    const int firstOwnProp = QObject::staticMetaObject.propertyCount();
+    QVector<QVariant> snapshot;
+    snapshot.resize(propCount);
+    for (int i = firstOwnProp; i < propCount; ++i) {
+        const QMetaProperty prop = mo->property(i);
+        if (prop.hasNotifySignal() && prop.isReadable())
+            snapshot[i] = prop.read(this);
+    }
+    return snapshot;
+}
+
+bool Settings::emitChangedNotifyProperties(const QVector<QVariant>& before)
+{
+    const QMetaObject* mo = metaObject();
+    const int propCount = mo->propertyCount();
+    const int firstOwnProp = QObject::staticMetaObject.propertyCount();
+    bool anyChanged = false;
+    for (int i = firstOwnProp; i < propCount; ++i) {
+        const QMetaProperty prop = mo->property(i);
+        if (!prop.hasNotifySignal() || !prop.isReadable())
+            continue;
+        const QVariant newValue = prop.read(this);
+        if (newValue != before.value(i)) {
+            anyChanged = true;
+            const QMetaMethod notify = prop.notifySignal();
+            notify.invoke(this, Qt::DirectConnection);
+        }
+    }
+    return anyChanged;
+}
+
+void Settings::captureBaseline()
+{
+    m_baseline.clear();
+    const auto& schema = m_store->schema();
+    for (auto it = schema.groups.constBegin(); it != schema.groups.constEnd(); ++it) {
+        QVariantMap groupMap;
+        for (const auto& def : it.value()) {
+            // readVariant returns the schema default for never-written keys, so
+            // the baseline always carries a concrete value per declared key.
+            groupMap.insert(def.key, m_store->readVariant(it.key(), def.key));
+        }
+        m_baseline.insert(it.key(), groupMap);
+    }
+}
+
+bool Settings::isKeyModified(const QString& group, const QString& key) const
+{
+    return m_store->readVariant(group, key) != m_baseline.value(group).value(key);
+}
+
+void Settings::discardKeys(const ConfigKeyList& keys)
+{
+    const QVector<QVariant> before = snapshotNotifyProperties();
+    for (const ConfigKey& gk : keys) {
+        // Revert to the committed baseline. write() runs the schema validator,
+        // so the reverted value lands in its canonical form (matching what a
+        // fresh load() would produce).
+        m_store->write(gk.first, gk.second, m_baseline.value(gk.first).value(gk.second));
+    }
+    if (emitChangedNotifyProperties(before))
+        Q_EMIT settingsChanged();
+}
+
+void Settings::resetKeys(const ConfigKeyList& keys)
+{
+    const QVector<QVariant> before = snapshotNotifyProperties();
+    for (const ConfigKey& gk : keys) {
+        m_store->reset(gk.first, gk.second);
+    }
+    if (emitChangedNotifyProperties(before))
+        Q_EMIT settingsChanged();
 }
 
 // ── Shaders (PhosphorConfig::Store-backed) ──────────────────────────────────

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -589,10 +589,21 @@ void Settings::discardKeys(const ConfigKeyList& keys)
 {
     const QVector<QVariant> before = snapshotNotifyProperties();
     for (const ConfigKey& gk : keys) {
-        // Revert to the committed baseline. write() runs the schema validator,
-        // so the reverted value lands in its canonical form (matching what a
-        // fresh load() would produce).
-        m_store->write(gk.first, gk.second, m_baseline.value(gk.first).value(gk.second));
+        // Only keys captured in the committed baseline (i.e. schema-declared) can
+        // be reverted; a mistyped manifest entry would otherwise write a default-
+        // constructed QVariant() over a live value. Skip it instead.
+        const auto groupIt = m_baseline.constFind(gk.first);
+        if (groupIt == m_baseline.constEnd())
+            continue;
+        const auto keyIt = groupIt->constFind(gk.second);
+        if (keyIt == groupIt->constEnd())
+            continue;
+        // Revert to the committed baseline, but only when it actually differs, so
+        // an unmodified key in the list is not needlessly re-written. write() runs
+        // the schema validator, so the reverted value lands in its canonical form
+        // (matching what a fresh load() would produce).
+        if (m_store->readVariant(gk.first, gk.second) != *keyIt)
+            m_store->write(gk.first, gk.second, *keyIt);
     }
     if (emitChangedNotifyProperties(before))
         Q_EMIT settingsChanged();

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -1106,12 +1106,6 @@ public:
     using ConfigKey = QPair<QString, QString>;
     using ConfigKeyList = QList<ConfigKey>;
 
-    /// Refresh the committed baseline — the last-persisted value of every
-    /// schema-declared key. Called automatically at the end of load() and
-    /// save() (the only points where the in-memory store equals disk).
-    /// discardKeys() reverts to this baseline; isKeyModified() compares to it.
-    void captureBaseline();
-
     /// True when the current in-memory value of (@p group, @p key) differs
     /// from the committed baseline — i.e. the key carries an unsaved edit.
     bool isKeyModified(const QString& group, const QString& key) const;
@@ -1215,6 +1209,13 @@ private:
     // whose value changed and returns whether any fired.
     QVector<QVariant> snapshotNotifyProperties() const;
     bool emitChangedNotifyProperties(const QVector<QVariant>& before);
+
+    // Refresh the committed baseline — the last-persisted value of every
+    // schema-declared key. Called at the end of load() and save() (the only
+    // points where the in-memory store equals disk); discardKeys() reverts to
+    // this baseline and isKeyModified() compares against it. Private: mutating
+    // the baseline anywhere but a load/save commit point desyncs dirty tracking.
+    void captureBaseline();
 
     // Groups that save() writes exhaustively (excludes unmanaged groups).
     static QStringList managedGroupNames();

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -22,8 +22,11 @@
 #include <QFont>
 #include <QHash>
 #include <QJsonValue>
+#include <QList>
+#include <QPair>
 #include <QUuid>
 #include <QVariantMap>
+#include <QVector>
 
 namespace PlasmaZones {
 
@@ -1096,6 +1099,32 @@ public:
     void save() override;
     void reset() override;
 
+    // ── Per-page reset / discard support (settings app) ─────────────────────
+    // A config key addressed as (group, key). A page "owns" a list of these;
+    // SettingsController holds the page→keys manifest and drives the two
+    // mutators below for the active page.
+    using ConfigKey = QPair<QString, QString>;
+    using ConfigKeyList = QList<ConfigKey>;
+
+    /// Refresh the committed baseline — the last-persisted value of every
+    /// schema-declared key. Called automatically at the end of load() and
+    /// save() (the only points where the in-memory store equals disk).
+    /// discardKeys() reverts to this baseline; isKeyModified() compares to it.
+    void captureBaseline();
+
+    /// True when the current in-memory value of (@p group, @p key) differs
+    /// from the committed baseline — i.e. the key carries an unsaved edit.
+    bool isKeyModified(const QString& group, const QString& key) const;
+
+    /// Per-page Discard: revert each key to the committed baseline. Bracketed
+    /// by the same Q_PROPERTY NOTIFY re-emit as load() so QML bindings update,
+    /// and emits settingsChanged() once if anything actually changed.
+    void discardKeys(const ConfigKeyList& keys);
+
+    /// Per-page Reset: set each key to its schema default. Same NOTIFY /
+    /// settingsChanged() re-emit contract as discardKeys().
+    void resetKeys(const ConfigKeyList& keys);
+
     // Additional methods
     Q_INVOKABLE QString loadColorsFromFile(const QString& filePath) override;
     Q_INVOKABLE void applySystemColorScheme();
@@ -1169,6 +1198,16 @@ private:
     void saveAllPerScreenOverrides(PhosphorConfig::IBackend* backend);
     void saveVirtualScreenConfigs(PhosphorConfig::IBackend* backend);
 
+    // ── NOTIFY re-emit machinery (shared by load / discardKeys / resetKeys) ──
+    // load() and the per-page mutators write backing state directly (bypassing
+    // the property setters), so they must re-emit NOTIFY by hand or QML
+    // bindings never refresh. snapshotNotifyProperties() captures every own
+    // NOTIFY-able Q_PROPERTY value (index-aligned to the metaobject) BEFORE the
+    // mutation; emitChangedNotifyProperties() fires the NOTIFY of each property
+    // whose value changed and returns whether any fired.
+    QVector<QVariant> snapshotNotifyProperties() const;
+    bool emitChangedNotifyProperties(const QVector<QVariant>& before);
+
     // Groups that save() writes exhaustively (excludes unmanaged groups).
     static QStringList managedGroupNames();
     // Delete all per-screen override groups (ZoneSelector:*, AutotileScreen:*, SnappingScreen:*).
@@ -1221,6 +1260,13 @@ private:
     // from hand-written load*/save* functions routes through here. See
     // settingsschema.cpp for the current list of migrated groups.
     std::unique_ptr<PhosphorConfig::Store> m_store;
+
+    // Committed baseline: the last-persisted value of every schema-declared
+    // key, keyed group → {key → value}. Refreshed by captureBaseline() at the
+    // end of load() and save(). Backs per-page Discard (revert to baseline)
+    // and value-based per-page dirty checks (isKeyModified).
+    QHash<QString, QVariantMap> m_baseline;
+
     static QString normalizeUuidString(const QString& uuidStr);
 
     // Per-mode disable lists are stored as `DisableEngine` context rules in

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -1119,10 +1119,18 @@ public:
     /// Per-page Discard: revert each key to the committed baseline. Bracketed
     /// by the same Q_PROPERTY NOTIFY re-emit as load() so QML bindings update,
     /// and emits settingsChanged() once if anything actually changed.
+    ///
+    /// SCOPE: re-emits only Q_PROPERTY NOTIFY signals (+ settingsChanged). It
+    /// does NOT re-emit the non-Q_PROPERTY change signals load() also fires —
+    /// the per-mode disable-list signals (disabled*Changed) and the per-screen
+    /// signals (perScreen*SettingsChanged). This is correct for the current
+    /// per-page manifest (all Q_PROPERTY-backed keys); if a future page ever
+    /// owns a disable-list or per-screen key, extend this to re-emit those.
     void discardKeys(const ConfigKeyList& keys);
 
     /// Per-page Reset: set each key to its schema default. Same NOTIFY /
-    /// settingsChanged() re-emit contract as discardKeys().
+    /// settingsChanged() re-emit contract — and the same scope limit — as
+    /// discardKeys().
     void resetKeys(const ConfigKeyList& keys);
 
     // Additional methods

--- a/src/core/baselinerules.cpp
+++ b/src/core/baselinerules.cpp
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// The three managed baseline appearance/gap rule definitions. Moved out of the
+// daemon's anonymous namespace so the settings app's per-page reset shares one
+// source of truth with the daemon's startup seeding (see baselinerules.h).
+
+#include "baselinerules.h"
+
+#include "../config/configdefaults.h"
+#include "../phosphor_i18n.h"
+
+#include <PhosphorCompositor/DecorationDefaults.h>
+#include <PhosphorRules/MatchExpression.h>
+#include <PhosphorRules/RuleAction.h>
+
+#include <QJsonValue>
+#include <QLatin1StringView>
+
+#include <limits>
+
+namespace PlasmaZones {
+
+PhosphorRules::Rule makeBaselineSkeleton(const QUuid& id, const QString& name)
+{
+    using namespace PhosphorRules;
+    Rule rule;
+    rule.id = id;
+    rule.name = name;
+    rule.managed = true;
+    // Lowest possible precedence — any user rule (all of which carry a higher
+    // priority) overrides the baseline per slot. renormalizePriorities in the
+    // settings controller deliberately leaves managed rules pinned here.
+    rule.priority = std::numeric_limits<int>::min();
+    rule.match = MatchExpression{}; // empty All{} — matches every window
+    return rule;
+}
+
+// Build the managed baseline BORDER rule: the lowest-priority baseline rule
+// carrying only the "show border" parent action, which defaults OFF (opt-in).
+// Its match is scoped to tiled / snapped windows on a fresh install, so it is no
+// longer a catch-all. The dependent border details (width, radius, colours) are
+// not seeded here — the Appearance page adds them when "show border" turns on
+// and removes them when it turns off, so the baseline stays minimal.
+PhosphorRules::Rule makeBaselineBorderRule()
+{
+    using namespace PhosphorRules;
+    namespace DD = PhosphorCompositor::DecorationDefaults;
+
+    const auto action = [](QLatin1StringView type, QLatin1StringView key, const QJsonValue& value) {
+        RuleAction a;
+        a.type = QString(type);
+        a.params.insert(QString(key), value);
+        return a;
+    };
+
+    Rule rule = makeBaselineSkeleton(ConfigDefaults::baselineBorderRuleId(), PhosphorI18n::tr("Default borders"));
+    // Fresh-install default: draw the baseline border only on tiled / snapped
+    // windows, the behaviour before appearance moved onto rules. The Appearance
+    // page's "Apply to" selector rewrites this match; the seeder never re-pins it,
+    // so an existing install keeps whatever scope it already carries.
+    rule.match = ConfigDefaults::tiledAndSnappedScopeMatch();
+    rule.actions = {
+        action(ActionType::SetBorderVisible, ActionParam::Value, DD::ShowBorder),
+    };
+    return rule;
+}
+
+// Build the managed baseline TITLE BAR rule: the lowest-priority baseline rule
+// carrying the default hide-title-bar value. Its match is scoped to tiled /
+// snapped windows on a fresh install, so it is not a catch-all.
+PhosphorRules::Rule makeBaselineTitleBarRule()
+{
+    using namespace PhosphorRules;
+    namespace DD = PhosphorCompositor::DecorationDefaults;
+
+    const auto action = [](QLatin1StringView type, QLatin1StringView key, const QJsonValue& value) {
+        RuleAction a;
+        a.type = QString(type);
+        a.params.insert(QString(key), value);
+        return a;
+    };
+
+    Rule rule = makeBaselineSkeleton(ConfigDefaults::baselineTitleBarRuleId(), PhosphorI18n::tr("Default title bars"));
+    // Fresh-install default: hide the title bar only on tiled / snapped windows,
+    // the behaviour before appearance moved onto rules. The Appearance page's
+    // "Apply to" selector rewrites this match; the seeder never re-pins it, so an
+    // existing install keeps whatever scope it already carries.
+    rule.match = ConfigDefaults::tiledAndSnappedScopeMatch();
+    rule.actions = {
+        action(ActionType::SetHideTitleBar, ActionParam::Value, DD::HideTitleBars),
+    };
+    return rule;
+}
+
+// Build the managed baseline GAP rule: the catch-all, lowest-priority rule that
+// is the single source of truth for the shared inner/outer gap model (Settings
+// reads these actions back as its innerGap()/outerGap*() getters). Only the
+// parent actions (inner gap, outer gap, and the per-side toggle, which defaults
+// off) are seeded. The four per-side outer-gap actions are added by the
+// Appearance page when the user turns per-side gaps on and removed when off, so
+// an absent per-side action falls back to the uniform outer gap.
+PhosphorRules::Rule makeBaselineGapRule()
+{
+    using namespace PhosphorRules;
+
+    const auto action = [](QLatin1StringView type, QLatin1StringView key, const QJsonValue& value) {
+        RuleAction a;
+        a.type = QString(type);
+        a.params.insert(QString(key), value);
+        return a;
+    };
+
+    Rule rule = makeBaselineSkeleton(ConfigDefaults::baselineGapRuleId(), PhosphorI18n::tr("Default gaps"));
+    rule.actions = {
+        action(ActionType::SetInnerGap, ActionParam::Value, ConfigDefaults::innerGap()),
+        action(ActionType::SetOuterGap, ActionParam::Value, ConfigDefaults::outerGap()),
+        action(ActionType::SetUsePerSideOuterGap, ActionParam::Value, ConfigDefaults::usePerSideOuterGap()),
+    };
+    return rule;
+}
+
+} // namespace PlasmaZones

--- a/src/core/baselinerules.cpp
+++ b/src/core/baselinerules.cpp
@@ -95,11 +95,13 @@ PhosphorRules::Rule makeBaselineTitleBarRule()
 
 // Build the managed baseline GAP rule: the catch-all, lowest-priority rule that
 // is the single source of truth for the shared inner/outer gap model (Settings
-// reads these actions back as its innerGap()/outerGap*() getters). Only the
-// parent actions (inner gap, outer gap, and the per-side toggle, which defaults
-// off) are seeded. The four per-side outer-gap actions are added by the
-// Appearance page when the user turns per-side gaps on and removed when off, so
-// an absent per-side action falls back to the uniform outer gap.
+// reads these actions back as its innerGap()/outerGap*() getters). These are
+// Context-domain actions; resolveContextGaps EXCLUDES this managed rule so the
+// values surface only as the level-4 global default, never as a top-tier context
+// override. Only the parent actions (inner gap, outer gap, and the per-side
+// toggle, which defaults off) are seeded. The four per-side outer-gap actions are
+// added by the Appearance page when the user turns per-side gaps on and removed
+// when off, so an absent per-side action falls back to the uniform outer gap.
 PhosphorRules::Rule makeBaselineGapRule()
 {
     using namespace PhosphorRules;

--- a/src/core/baselinerules.h
+++ b/src/core/baselinerules.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "plasmazones_export.h"
+
+#include <PhosphorRules/Rule.h>
+
+#include <QString>
+#include <QUuid>
+
+namespace PlasmaZones {
+
+// The three managed baseline appearance/gap rules. Single source of truth for
+// BOTH the daemon's startup seeding (ensureManagedRule) AND the settings app's
+// per-page "Reset to defaults" on the Windows appearance page — keeping the two
+// from drifting. They are catch-all (border/title-bar narrowed to tiled/snapped
+// on a fresh install), managed = true, pinned to the lowest priority so any user
+// rule overrides them per slot. The Appearance page rewrites their action
+// values; a reset restores exactly these definitions.
+
+/// Common skeleton: empty catch-all match, managed, lowest priority.
+PLASMAZONES_EXPORT PhosphorRules::Rule makeBaselineSkeleton(const QUuid& id, const QString& name);
+
+/// Baseline BORDER rule (id ConfigDefaults::baselineBorderRuleId()) — carries the
+/// "show border" parent action (default OFF), scoped to tiled/snapped windows.
+PLASMAZONES_EXPORT PhosphorRules::Rule makeBaselineBorderRule();
+
+/// Baseline TITLE BAR rule (id baselineTitleBarRuleId()) — carries the default
+/// hide-title-bar value, scoped to tiled/snapped windows.
+PLASMAZONES_EXPORT PhosphorRules::Rule makeBaselineTitleBarRule();
+
+/// Baseline GAP rule (id baselineGapRuleId()) — the catch-all source of truth for
+/// the shared inner/outer gap model. Seeds only the parent actions (inner gap,
+/// outer gap, per-side toggle); the four per-side outer-gap actions are added by
+/// the Appearance page on demand, so a reset naturally drops them.
+PLASMAZONES_EXPORT PhosphorRules::Rule makeBaselineGapRule();
+
+} // namespace PlasmaZones

--- a/src/core/baselinerules.h
+++ b/src/core/baselinerules.h
@@ -15,10 +15,11 @@ namespace PlasmaZones {
 // The three managed baseline appearance/gap rules. Single source of truth for
 // BOTH the daemon's startup seeding (ensureManagedRule) AND the settings app's
 // per-page "Reset to defaults" on the Windows appearance page — keeping the two
-// from drifting. They are catch-all (border/title-bar narrowed to tiled/snapped
-// on a fresh install), managed = true, pinned to the lowest priority so any user
-// rule overrides them per slot. The Appearance page rewrites their action
-// values; a reset restores exactly these definitions.
+// from drifting. The gap rule is a true catch-all; the border and title-bar
+// rules are narrowed to tiled/snapped windows on a fresh install. All three are
+// managed = true, pinned to the lowest priority so any user rule overrides them
+// per slot. The Appearance page rewrites their action values; a reset restores
+// exactly these definitions.
 
 /// Common skeleton: empty catch-all match, managed, lowest priority.
 PLASMAZONES_EXPORT PhosphorRules::Rule makeBaselineSkeleton(const QUuid& id, const QString& name);

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -70,6 +70,7 @@
 #include "../core/utils.h"
 #include "../phosphor_i18n.h"
 #include "../config/configdefaults.h"
+#include "../core/baselinerules.h"
 #include "../config/settingsconfigstore.h"
 #include <PhosphorScreens/DBusScreenAdaptor.h>
 #include <PhosphorScreens/Swapper.h>
@@ -120,117 +121,11 @@ static_assert(Defaults::MaxGap == PhosphorTiles::AutotileDefaults::MaxGap,
 
 namespace {
 
-// Common skeleton for the three managed baseline rules: catch-all match by
-// default (the border and title-bar makers below narrow it to tiled / snapped
-// windows), lowest priority, managed. Each is a focused fallback resolved
-// against per concern now that the per-mode global appearance settings are gone.
-// The Appearance settings page rewrites these actions; per-window overrides are
-// ordinary higher-priority rules that win per slot.
-PhosphorRules::Rule makeBaselineSkeleton(const QUuid& id, const QString& name)
-{
-    using namespace PhosphorRules;
-    Rule rule;
-    rule.id = id;
-    rule.name = name;
-    rule.managed = true;
-    // Lowest possible precedence — any user rule (all of which carry a higher
-    // priority) overrides the baseline per slot. renormalizePriorities in the
-    // settings controller deliberately leaves managed rules pinned here.
-    rule.priority = std::numeric_limits<int>::min();
-    rule.match = MatchExpression{}; // empty All{} — matches every window
-    return rule;
-}
-
-// Build the managed baseline BORDER rule: the lowest-priority baseline rule
-// carrying only the "show border" parent action, which defaults OFF (opt-in).
-// Its match is scoped to tiled / snapped windows on a fresh install (see below),
-// so it is no longer a catch-all.
-// The dependent border details (width, radius, active/inactive colour) are not
-// seeded here. The Appearance page adds them when the user turns "show border"
-// on and removes them when it is turned off, so the baseline stays minimal.
-// Consumers that read an absent detail fall back to their own defaults, and a
-// hidden border draws nothing regardless.
-PhosphorRules::Rule makeBaselineBorderRule()
-{
-    using namespace PhosphorRules;
-    namespace DD = PhosphorCompositor::DecorationDefaults;
-
-    const auto action = [](QLatin1StringView type, QLatin1StringView key, const QJsonValue& value) {
-        RuleAction a;
-        a.type = QString(type);
-        a.params.insert(QString(key), value);
-        return a;
-    };
-
-    Rule rule = makeBaselineSkeleton(ConfigDefaults::baselineBorderRuleId(), PhosphorI18n::tr("Default borders"));
-    // Fresh-install default: draw the baseline border only on tiled / snapped
-    // windows, the behaviour before appearance moved onto rules. The Appearance
-    // page's "Apply to" selector rewrites this match; the seeder never re-pins it,
-    // so an existing install keeps whatever scope it already carries.
-    rule.match = ConfigDefaults::tiledAndSnappedScopeMatch();
-    rule.actions = {
-        action(ActionType::SetBorderVisible, ActionParam::Value, DD::ShowBorder),
-    };
-    return rule;
-}
-
-// Build the managed baseline TITLE BAR rule: the lowest-priority baseline rule
-// carrying the default hide-title-bar value. Its match is scoped to tiled /
-// snapped windows on a fresh install (see below), so it is not a catch-all.
-PhosphorRules::Rule makeBaselineTitleBarRule()
-{
-    using namespace PhosphorRules;
-    namespace DD = PhosphorCompositor::DecorationDefaults;
-
-    const auto action = [](QLatin1StringView type, QLatin1StringView key, const QJsonValue& value) {
-        RuleAction a;
-        a.type = QString(type);
-        a.params.insert(QString(key), value);
-        return a;
-    };
-
-    Rule rule = makeBaselineSkeleton(ConfigDefaults::baselineTitleBarRuleId(), PhosphorI18n::tr("Default title bars"));
-    // Fresh-install default: hide the title bar only on tiled / snapped windows,
-    // the behaviour before appearance moved onto rules. The Appearance page's
-    // "Apply to" selector rewrites this match; the seeder never re-pins it, so an
-    // existing install keeps whatever scope it already carries.
-    rule.match = ConfigDefaults::tiledAndSnappedScopeMatch();
-    rule.actions = {
-        action(ActionType::SetHideTitleBar, ActionParam::Value, DD::HideTitleBars),
-    };
-    return rule;
-}
-
-// Build the managed baseline GAP rule: the catch-all, lowest-priority rule that
-// is the single source of truth for the shared inner/outer gap model (Settings
-// reads these actions back as its innerGap()/outerGap*() getters). These are
-// Context-domain actions; resolveContextGaps EXCLUDES this managed rule so the
-// values surface only as the level-4 global default, never as a top-tier
-// context override. Seeded from the same ConfigDefaults accessors the schema
-// validators and the compile-time defaults use. Only the parent actions
-// (inner gap, outer gap, and the per-side toggle, which defaults off) are
-// seeded. The four per-side outer gap actions are added by the Appearance page
-// when the user turns per-side gaps on and removed when it is turned off, so an
-// absent per-side action falls back to the uniform outer gap.
-PhosphorRules::Rule makeBaselineGapRule()
-{
-    using namespace PhosphorRules;
-
-    const auto action = [](QLatin1StringView type, QLatin1StringView key, const QJsonValue& value) {
-        RuleAction a;
-        a.type = QString(type);
-        a.params.insert(QString(key), value);
-        return a;
-    };
-
-    Rule rule = makeBaselineSkeleton(ConfigDefaults::baselineGapRuleId(), PhosphorI18n::tr("Default gaps"));
-    rule.actions = {
-        action(ActionType::SetInnerGap, ActionParam::Value, ConfigDefaults::innerGap()),
-        action(ActionType::SetOuterGap, ActionParam::Value, ConfigDefaults::outerGap()),
-        action(ActionType::SetUsePerSideOuterGap, ActionParam::Value, ConfigDefaults::usePerSideOuterGap()),
-    };
-    return rule;
-}
+// The three managed baseline rule makers (makeBaselineSkeleton /
+// makeBaseline{Border,TitleBar,Gap}Rule) moved to src/core/baselinerules.{h,cpp}
+// so the settings app's per-page appearance reset shares one source of truth
+// with the seeding below. They are PlasmaZones-namespace free functions, so the
+// unqualified calls in ensureManagedRule resolve to them unchanged.
 
 // Debounce interval (ms): coalesce rapid geometry changes (multi-screen, panel editor) into one update.
 // Conceptually distinct from DELAYED_PANEL_REQUERY_MS in autotile.cpp (which schedules a

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -89,14 +89,11 @@
 #include "../dbus/compositorbridgeadaptor.h"
 #include "../dbus/controladaptor.h"
 #include "../dbus/ruleadaptor.h"
-#include <PhosphorCompositor/DecorationDefaults.h>
 #include <PhosphorRules/ExclusionRules.h>
-#include <PhosphorRules/MatchExpression.h>
 #include <PhosphorRules/RuleAction.h>
 #include <PhosphorRules/Rule.h>
 #include <PhosphorRules/RuleStore.h>
 
-#include <limits>
 #include "enginefactory.h"
 #include <PhosphorTileEngine/AutotileEngine.h>
 #include <PhosphorTiles/ScriptedAlgorithmLoader.h>

--- a/src/dbus/ruleadaptor.cpp
+++ b/src/dbus/ruleadaptor.cpp
@@ -3,6 +3,7 @@
 
 #include "ruleadaptor.h"
 
+#include "core/baselinerules.h"
 #include "core/logging.h"
 
 #include <PhosphorRules/Rule.h>
@@ -195,6 +196,41 @@ bool RuleAdaptor::setRulePriority(const QString& ruleId, int priority)
         return false;
     }
     return m_store->setRulePriority(id, priority);
+}
+
+void RuleAdaptor::resetManagedDefaults()
+{
+    if (!m_store) {
+        return;
+    }
+    // Reload from disk first so we operate on the CURRENTLY PERSISTED set. The
+    // global Restore Defaults calls Settings::reset() (which writes rules.json
+    // from the settings process to drop the per-mode DisableEngine rules) just
+    // before this; the daemon's borrowed rule store is NOT refreshed by the
+    // reloadSettings() that follows (only an owned store reloads there), so its
+    // in-memory set is stale. Without this reload, the setAllRules below would
+    // write those dropped disable rules back. load() is idempotent (emits only
+    // on a real change).
+    m_store->load();
+
+    // Policy A: reset ONLY the three managed baseline rules to their factory
+    // definitions; every user-authored rule is preserved. Build the merged set
+    // and persist it in one setAllRules so the store emits a single rulesChanged.
+    QList<PhosphorRules::Rule> rules = m_store->ruleSet().rules();
+    const auto upsertBaseline = [&rules](const PhosphorRules::Rule& factory) {
+        for (PhosphorRules::Rule& existing : rules) {
+            if (existing.id == factory.id) {
+                existing = factory;
+                return;
+            }
+        }
+        // Seed if the baseline is somehow absent (e.g. a config predating it).
+        rules.append(factory);
+    };
+    upsertBaseline(makeBaselineBorderRule());
+    upsertBaseline(makeBaselineTitleBarRule());
+    upsertBaseline(makeBaselineGapRule());
+    m_store->setAllRules(rules);
 }
 
 } // namespace PlasmaZones

--- a/src/dbus/ruleadaptor.cpp
+++ b/src/dbus/ruleadaptor.cpp
@@ -232,7 +232,12 @@ void RuleAdaptor::resetManagedDefaults()
     upsertBaseline(makeBaselineBorderRule());
     upsertBaseline(makeBaselineTitleBarRule());
     upsertBaseline(makeBaselineGapRule());
-    m_store->setAllRules(rules);
+    // setAllRules returns false when the merged set could not be persisted to
+    // disk; every other mutator slot here propagates that bool, so surface it in
+    // the log rather than silently claiming a successful Restore Defaults.
+    if (!m_store->setAllRules(rules)) {
+        qCWarning(lcDbus) << "RuleAdaptor::resetManagedDefaults: failed to persist reset baseline rules";
+    }
 }
 
 } // namespace PlasmaZones

--- a/src/dbus/ruleadaptor.cpp
+++ b/src/dbus/ruleadaptor.cpp
@@ -215,7 +215,9 @@ void RuleAdaptor::resetManagedDefaults()
 
     // Policy A: reset ONLY the three managed baseline rules to their factory
     // definitions; every user-authored rule is preserved. Build the merged set
-    // and persist it in one setAllRules so the store emits a single rulesChanged.
+    // and persist it in one setAllRules (the load() above may already have emitted
+    // a rulesChanged if the on-disk set had changed, so this call can be the
+    // second broadcast — harmless, the consumers are idempotent).
     QList<PhosphorRules::Rule> rules = m_store->ruleSet().rules();
     const auto upsertBaseline = [&rules](const PhosphorRules::Rule& factory) {
         for (PhosphorRules::Rule& existing : rules) {

--- a/src/dbus/ruleadaptor.h
+++ b/src/dbus/ruleadaptor.h
@@ -75,9 +75,12 @@ public Q_SLOTS:
 
     /// Reset the three managed baseline appearance/gap rules to their factory
     /// definitions (core/baselinerules.h), preserving every user-authored rule
-    /// (Policy A). Persists once and emits rulesChanged. Drives the settings
-    /// app's global Restore Defaults for the rule-backed appearance/gap surface,
-    /// which Settings::reset() (the KConfig path) cannot reach.
+    /// (Policy A). Reloads the store first (to pick up an out-of-process write
+    /// such as Settings::reset()'s disable-rule drop), then persists the merged
+    /// set. May emit rulesChanged up to twice — once from the reload if the
+    /// on-disk set changed, once from the write. Drives the settings app's global
+    /// Restore Defaults for the rule-backed appearance/gap surface, which
+    /// Settings::reset() (the KConfig path) cannot reach.
     void resetManagedDefaults();
 
 Q_SIGNALS:

--- a/src/dbus/ruleadaptor.h
+++ b/src/dbus/ruleadaptor.h
@@ -73,6 +73,13 @@ public Q_SLOTS:
     /// rule exists.
     bool setRulePriority(const QString& ruleId, int priority);
 
+    /// Reset the three managed baseline appearance/gap rules to their factory
+    /// definitions (core/baselinerules.h), preserving every user-authored rule
+    /// (Policy A). Persists once and emits rulesChanged. Drives the settings
+    /// app's global Restore Defaults for the rule-backed appearance/gap surface,
+    /// which Settings::reset() (the KConfig path) cannot reach.
+    void resetManagedDefaults();
+
 Q_SIGNALS:
     /// Emitted whenever the store's rule set changes. @p persisted forwards
     /// the upstream contract: true means the change is on disk, false means

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -140,6 +140,9 @@ set(plasmazones_settings_SRCS
     # Five tiny pass-throughs into RuleModel; split out so
     # rulecontroller.cpp stays under the project's 800-line cap.
     rulecontroller_lookups.cpp
+    # RuleController per-page dirty split + managed-baseline reset/discard,
+    # split out so rulecontroller.cpp stays under the project's 800-line cap.
+    rulecontroller_baseline.cpp
     # RuleController authoring metadata + templates — pure read-only
     # helpers split out so rulecontroller.cpp stays under the project's
     # 800-line cap. The controller's Q_INVOKABLE entry points (matchFields,

--- a/src/settings/animationspagecontroller.h
+++ b/src/settings/animationspagecontroller.h
@@ -169,6 +169,15 @@ public:
     /// as `setOverride`. @return true when a file was removed.
     Q_INVOKABLE bool clearOverride(const QString& path);
 
+    /// Clear every per-event override file (each built-in event path falls back
+    /// to its built-in default). Backs the settings app's per-page "Reset to
+    /// defaults" for the animation pages: each cleared file is snapshotted like
+    /// a normal edit, so the change stages and a subsequent Discard restores it.
+    /// The shader tree, animation Profile blob, and window filtering are separate
+    /// Settings keys the caller resets alongside this. @return the number of
+    /// override files actually removed.
+    int clearAllOverrides();
+
     /// Library of user-saved Profile presets. Each entry is a Profile JSON
     /// (`curve`, `duration`, `name`, …) sitting in the same `profiles/`
     /// dir as overrides — distinguished by the `name` field NOT matching

--- a/src/settings/animationspagecontroller_overrides.cpp
+++ b/src/settings/animationspagecontroller_overrides.cpp
@@ -249,4 +249,19 @@ bool AnimationsPageController::clearOverride(const QString& path)
     return true;
 }
 
+int AnimationsPageController::clearAllOverrides()
+{
+    // Clear every built-in event path. clearOverride is a no-op (returns false)
+    // for paths without an override file, so only real overrides are removed and
+    // snapshotted; it emits overrideChanged / pendingChangesChanged per removed
+    // file so the pages refresh and the staged-changes state updates.
+    int cleared = 0;
+    const QStringList paths = PhosphorAnimation::ProfilePaths::allBuiltInPaths();
+    for (const QString& path : paths) {
+        if (clearOverride(path))
+            ++cleared;
+    }
+    return cleared;
+}
+
 } // namespace PlasmaZones

--- a/src/settings/animationspagecontroller_overrides.cpp
+++ b/src/settings/animationspagecontroller_overrides.cpp
@@ -243,8 +243,9 @@ bool AnimationsPageController::clearOverride(const QString& path)
             m_pendingFileSnapshots.remove(filePath);
         return false;
     }
+    const bool nowPending = hasPendingChanges();
     Q_EMIT overrideChanged(path);
-    if (wasPending != hasPendingChanges())
+    if (wasPending != nowPending)
         Q_EMIT pendingChangesChanged();
     return true;
 }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -186,9 +186,10 @@ PhosphorUi.SettingsAppWindow {
 
     // Per-page overflow (kebab) in the breadcrumb row: Reset this page to
     // defaults / Discard this page's unsaved changes. Shown on any page that
-    // supports at least one action; the two items appear independently off
-    // pageSupportsReset / pageSupportsDiscard (e.g. animation pages can Discard
-    // but have no reset-to-defaults). Both route through a window-scoped confirm.
+    // supports at least one action. The two items query pageSupportsReset /
+    // pageSupportsDiscard separately so a future discard-only page can show just
+    // Discard; today every resettable page is also discardable, so the two
+    // predicates match. Both route through a window-scoped confirm.
     breadcrumbTrailing: Component {
         ToolButton {
             id: pageActionsButton
@@ -208,6 +209,7 @@ PhosphorUi.SettingsAppWindow {
 
                 MenuItem {
                     text: i18n("Reset page to defaults")
+                    Accessible.name: text
                     icon.name: "document-revert"
                     visible: settingsController.pageSupportsReset(settingsController.activePage)
                     // Disabled while a global Save/Discard batch is in flight: a
@@ -220,6 +222,7 @@ PhosphorUi.SettingsAppWindow {
 
                 MenuItem {
                     text: i18n("Discard changes on this page")
+                    Accessible.name: text
                     icon.name: "edit-undo"
                     visible: settingsController.pageSupportsDiscard(settingsController.activePage)
                     // Enabled only when the page carries unsaved edits and no

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -210,6 +210,11 @@ PhosphorUi.SettingsAppWindow {
                     text: i18n("Reset page to defaults")
                     icon.name: "document-revert"
                     visible: settingsController.pageSupportsReset(settingsController.activePage)
+                    // Disabled while a global Save/Discard batch is in flight: a
+                    // per-page reset mid-batch could race the async revert (e.g.
+                    // the animation controller's async file restore) and leave a
+                    // partial reset.
+                    enabled: !settingsController.app.applying && !settingsController.app.discarding
                     onTriggered: resetPageConfirmDialog.open()
                 }
 
@@ -217,14 +222,14 @@ PhosphorUi.SettingsAppWindow {
                     text: i18n("Discard changes on this page")
                     icon.name: "edit-undo"
                     visible: settingsController.pageSupportsDiscard(settingsController.activePage)
-                    // Only meaningful when the page carries unsaved edits.
-                    // `dirtyPages` is referenced purely to re-run this binding
-                    // on dirtyPagesChanged (isPageDirty itself is a function
-                    // call whose only QML dependency would otherwise be
-                    // activePage).
+                    // Enabled only when the page carries unsaved edits and no
+                    // global Save/Discard batch is in flight. `dirtyPages` is
+                    // referenced purely to re-run this binding on
+                    // dirtyPagesChanged (isPageDirty itself is a function call
+                    // whose only QML dependency would otherwise be activePage).
                     enabled: {
                         void settingsController.dirtyPages;
-                        return settingsController.isPageDirty(settingsController.activePage);
+                        return !settingsController.app.applying && !settingsController.app.discarding && settingsController.isPageDirty(settingsController.activePage);
                     }
                     onTriggered: discardPageConfirmDialog.open()
                 }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -184,6 +184,54 @@ PhosphorUi.SettingsAppWindow {
         }
     }
 
+    // Per-page overflow (kebab) in the breadcrumb row: Reset this page to
+    // defaults / Discard this page's unsaved changes. Shown on any page that
+    // supports at least one action; the two items appear independently off
+    // pageSupportsReset / pageSupportsDiscard (e.g. animation pages can Discard
+    // but have no reset-to-defaults). Both route through a window-scoped confirm.
+    breadcrumbTrailing: Component {
+        ToolButton {
+            id: pageActionsButton
+
+            // Re-evaluates on activePageChanged (activePage is referenced), so
+            // the button appears/disappears as the user moves between pages.
+            visible: settingsController.pageSupportsReset(settingsController.activePage) || settingsController.pageSupportsDiscard(settingsController.activePage)
+            icon.name: "overflow-menu"
+            display: AbstractButton.IconOnly
+            text: i18n("Page actions")
+            Accessible.name: i18n("Page actions")
+
+            onClicked: pageActionsMenu.popup()
+
+            Menu {
+                id: pageActionsMenu
+
+                MenuItem {
+                    text: i18n("Reset page to defaults")
+                    icon.name: "document-revert"
+                    visible: settingsController.pageSupportsReset(settingsController.activePage)
+                    onTriggered: resetPageConfirmDialog.open()
+                }
+
+                MenuItem {
+                    text: i18n("Discard changes on this page")
+                    icon.name: "edit-undo"
+                    visible: settingsController.pageSupportsDiscard(settingsController.activePage)
+                    // Only meaningful when the page carries unsaved edits.
+                    // `dirtyPages` is referenced purely to re-run this binding
+                    // on dirtyPagesChanged (isPageDirty itself is a function
+                    // call whose only QML dependency would otherwise be
+                    // activePage).
+                    enabled: {
+                        void settingsController.dirtyPages;
+                        return settingsController.isPageDirty(settingsController.activePage);
+                    }
+                    onTriggered: discardPageConfirmDialog.open()
+                }
+            }
+        }
+    }
+
     Component.onCompleted: {
         // The header search supersedes the sidebar's page-tree search.
         window.sidebar.searchEnabled = false;
@@ -370,7 +418,7 @@ PhosphorUi.SettingsAppWindow {
     // Shared enable-guard for page-navigation shortcuts. Hoisted from
     // the two identical inline expressions so a future dialog addition
     // doesn't drift between Ctrl+PgUp / Ctrl+PgDown.
-    readonly property bool _navShortcutsEnabled: window.active && !whatsNewDialog.visible && !resetConfirmDialog.visible && !defaultsConfirmDialog.visible && !sectionToggleDiscardConfirm.visible && !daemonStopConfirm.visible && !window._showShortcuts && !window._pageOwnedModalOpen && !window._searchOpen
+    readonly property bool _navShortcutsEnabled: window.active && !whatsNewDialog.visible && !resetConfirmDialog.visible && !defaultsConfirmDialog.visible && !resetPageConfirmDialog.visible && !discardPageConfirmDialog.visible && !sectionToggleDiscardConfirm.visible && !daemonStopConfirm.visible && !window._showShortcuts && !window._pageOwnedModalOpen && !window._searchOpen
 
     Shortcut {
         sequence: "Ctrl+PgUp"
@@ -817,6 +865,56 @@ PhosphorUi.SettingsAppWindow {
         ]
     }
 
+    // Per-page Reset — restores just the active page's settings to their
+    // defaults, staged for Save/Discard (opened from the breadcrumb kebab).
+    Kirigami.PromptDialog {
+        id: resetPageConfirmDialog
+
+        title: i18n("Reset Page to Defaults")
+        subtitle: i18n("Reset the settings on this page to their default values? You can still review the result and Save or Discard afterwards.")
+        standardButtons: Kirigami.Dialog.NoButton
+        customFooterActions: [
+            Kirigami.Action {
+                text: i18n("Reset Page")
+                icon.name: "document-revert"
+                onTriggered: {
+                    resetPageConfirmDialog.close();
+                    settingsController.resetPage(settingsController.activePage);
+                }
+            },
+            Kirigami.Action {
+                text: i18n("Cancel")
+                icon.name: "dialog-cancel"
+                onTriggered: resetPageConfirmDialog.close()
+            }
+        ]
+    }
+
+    // Per-page Discard — reverts just the active page's unsaved edits to the
+    // last-saved values, leaving other pages' changes intact.
+    Kirigami.PromptDialog {
+        id: discardPageConfirmDialog
+
+        title: i18n("Discard Page Changes")
+        subtitle: i18n("Discard the unsaved changes on this page? Changes on other pages are kept.")
+        standardButtons: Kirigami.Dialog.NoButton
+        customFooterActions: [
+            Kirigami.Action {
+                text: i18n("Discard")
+                icon.name: "edit-undo"
+                onTriggered: {
+                    discardPageConfirmDialog.close();
+                    settingsController.discardPage(settingsController.activePage);
+                }
+            },
+            Kirigami.Action {
+                text: i18n("Cancel")
+                icon.name: "dialog-cancel"
+                onTriggered: discardPageConfirmDialog.close()
+            }
+        ]
+    }
+
     // Confirm dialog for the sidebar's inline snapping/tiling toggle when
     // the relevant page has unsaved edits. Disabling the section through
     // beginExternalEdit/endExternalEdit commits the *_Enabled flag plus
@@ -842,15 +940,15 @@ PhosphorUi.SettingsAppWindow {
                     const section = sectionToggleDiscardConfirm.pendingSection;
                     const value = sectionToggleDiscardConfirm.pendingValue;
                     sectionToggleDiscardConfirm.close();
-                    // Discard the dirty page first, THEN flip the enable
-                    // flag — otherwise the inline beginExternalEdit /
-                    // endExternalEdit pair would surface the still-staged
-                    // edits alongside the disable. PageRegistry.controller
-                    // returns the StagingDomain whose discard() slot
-                    // reloads the backing store and clears the dirty flag.
-                    const ctrl = settingsController.app.registry.controller(section);
-                    if (ctrl)
-                        ctrl.discard();
+                    // Discard the section's staged edits first, THEN flip the
+                    // enable flag — otherwise the inline beginExternalEdit /
+                    // endExternalEdit pair would surface the still-staged edits
+                    // alongside the disable. discardPage("snapping"/"tiling")
+                    // reverts every manifest-backed leaf under that mode back to
+                    // the committed baseline (the framework PageAdapter.discard()
+                    // for these virtual parents is a no-op, so the old
+                    // registry.controller(section).discard() call did nothing).
+                    settingsController.discardPage(section);
                     settingsController.beginExternalEdit(section);
                     if (section === "snapping")
                         appSettings.snappingEnabled = value;

--- a/src/settings/qml/VirtualScreensPage.qml
+++ b/src/settings/qml/VirtualScreensPage.qml
@@ -430,13 +430,16 @@ SettingsFlickable {
         target: settingsController
     }
 
-    // Refresh when a global discard resets needsSave to false. The `needsSave`
-    // property's NOTIFY is `dirtyPagesChanged` (there is no `needsSaveChanged`
-    // signal), so the handler must listen to that.
+    // Re-read the selected screen's config whenever the dirty set changes.
+    // Covers a global discard (needsSave → false), a global save, AND the
+    // per-page Reset/Discard of this page (which revert the staged VS configs
+    // and emit dirtyPagesChanged even when other pages keep the global flag
+    // dirty). Unconditional is safe: every editor mutation stages immediately
+    // (_stageCurrentConfig), so _refreshConfig always reads back the staged
+    // value that mirrors _pendingScreens — never clobbering an in-progress edit.
     Connections {
         function onDirtyPagesChanged() {
-            if (!settingsController.needsSave)
-                root._refreshConfig();
+            root._refreshConfig();
         }
 
         target: settingsController

--- a/src/settings/qml/WindowAppearancePage.qml
+++ b/src/settings/qml/WindowAppearancePage.qml
@@ -382,6 +382,11 @@ SettingsFlickable {
         function onRulesLoaded() {
             root.reloadTick++;
         }
+        // The per-page Reset / Discard rewrite the managed baselines in place
+        // (no rulesLoaded), so re-read the controls when that fires.
+        function onBaselinesChanged() {
+            root.reloadTick++;
+        }
     }
 
     // Re-evaluate the gap value bindings when the monitor scope chip changes the

--- a/src/settings/rulecontroller.cpp
+++ b/src/settings/rulecontroller.cpp
@@ -253,6 +253,13 @@ bool RuleController::pushToDaemonAsync(const QList<Rule>& rules)
         // may carry a CRUD edit that landed during the wire round-trip and was
         // NOT persisted). Baselining the pushed set keeps such an in-flight edit
         // correctly dirty (the applyResult → reconcile re-marks it).
+        //
+        // `rules` equals what the daemon persisted: pushToDaemonAsync above
+        // pre-validated with the SAME PhosphorRules::Rule::fromJson the daemon's
+        // setAllRules uses and bailed unless every rule was accepted, so the
+        // daemon cannot silently drop one (no client/daemon schema skew). As a
+        // backstop, the daemon's rulesChanged broadcast drives reload() →
+        // fetchAndLoad, which re-baselines from the daemon's authoritative set.
         m_savedRules = rules;
         setDirty(false);
         setDaemonChangedWhileDirty(false);

--- a/src/settings/rulecontroller.cpp
+++ b/src/settings/rulecontroller.cpp
@@ -478,6 +478,16 @@ void RuleController::resetBaselines()
     Q_EMIT baselinesChanged();
 }
 
+void RuleController::resetManagedDefaults()
+{
+    // Fire-and-forget: no out-args, and the model refresh comes from the daemon's
+    // rulesChanged broadcast + the revert() the caller issues. Ordered before any
+    // subsequent getAllRules on this connection, so a paired revert() sees the
+    // reset set.
+    PhosphorProtocol::ClientHelpers::asyncCall(QString(PhosphorProtocol::Service::Interface::Rules),
+                                               QStringLiteral("resetManagedDefaults"));
+}
+
 void RuleController::discardBaselineEdits()
 {
     // Restore each managed baseline from the last synced snapshot, leaving every

--- a/src/settings/rulecontroller.cpp
+++ b/src/settings/rulecontroller.cpp
@@ -230,7 +230,7 @@ bool RuleController::pushToDaemonAsync(const QList<Rule>& rules)
     // setAllRules. Cleared in the reply lambda below before every
     // applyResult emit.
     m_asyncCommitInFlight = true;
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this](QDBusPendingCallWatcher* w) {
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, rules](QDBusPendingCallWatcher* w) {
         w->deleteLater();
         m_asyncCommitInFlight = false;
         QDBusPendingReply<bool> reply = *w;
@@ -249,9 +249,11 @@ bool RuleController::pushToDaemonAsync(const QList<Rule>& rules)
             Q_EMIT applyResult(false, PhosphorI18n::tr("The daemon rejected one or more rules."));
             return;
         }
-        // The staged set is now the daemon's persisted set — re-baseline the
-        // per-page dirty snapshot so baselinesDirty/userRulesDirty read clean.
-        captureSavedSnapshot();
+        // Re-baseline to the set we actually PUSHED (not m_model.rules(), which
+        // may carry a CRUD edit that landed during the wire round-trip and was
+        // NOT persisted). Baselining the pushed set keeps such an in-flight edit
+        // correctly dirty (the applyResult → reconcile re-marks it).
+        m_savedRules = rules;
         setDirty(false);
         setDaemonChangedWhileDirty(false);
         Q_EMIT applyResult(true, QString());
@@ -413,91 +415,10 @@ void RuleController::revert()
     fetchAndLoad(/*fromRevert=*/true);
 }
 
-// ── Per-page dirty split + baseline ops ──────────────────────────────────────
-
-namespace {
-// Partition helpers: managed rules are the appearance baselines; the rest are
-// user rules. Order is preserved so the user-rules comparison catches reorders.
-QList<PhosphorRules::Rule> managedSubset(const QList<PhosphorRules::Rule>& rules)
-{
-    QList<PhosphorRules::Rule> out;
-    for (const PhosphorRules::Rule& r : rules) {
-        if (r.managed)
-            out.append(r);
-    }
-    return out;
-}
-QList<PhosphorRules::Rule> userSubset(const QList<PhosphorRules::Rule>& rules)
-{
-    QList<PhosphorRules::Rule> out;
-    for (const PhosphorRules::Rule& r : rules) {
-        if (!r.managed)
-            out.append(r);
-    }
-    return out;
-}
-} // namespace
-
-void RuleController::captureSavedSnapshot()
-{
-    m_savedRules = m_model.rules();
-}
-
-bool RuleController::baselinesDirty() const
-{
-    return managedSubset(m_model.rules()) != managedSubset(m_savedRules);
-}
-
-bool RuleController::userRulesDirty() const
-{
-    return userSubset(m_model.rules()) != userSubset(m_savedRules);
-}
-
-void RuleController::recomputeDirtyFromSnapshot()
-{
-    setDirty(baselinesDirty() || userRulesDirty());
-}
-
-void RuleController::upsertRule(const PhosphorRules::Rule& rule)
-{
-    if (m_model.contains(rule.id))
-        m_model.updateRule(rule);
-    else
-        m_model.addRule(rule);
-}
-
-void RuleController::resetBaselines()
-{
-    // Rewrite the three managed baselines to their factory definitions. Managed
-    // rules stay in the System section, so updateRule replaces them in place
-    // (no priority renormalize). Staged — the global Save flushes it.
-    upsertRule(makeBaselineBorderRule());
-    upsertRule(makeBaselineTitleBarRule());
-    upsertRule(makeBaselineGapRule());
-    recomputeDirtyFromSnapshot();
-    Q_EMIT baselinesChanged();
-}
-
-void RuleController::resetManagedDefaults()
-{
-    // Fire-and-forget: no out-args, and the model refresh comes from the daemon's
-    // rulesChanged broadcast + the revert() the caller issues. Ordered before any
-    // subsequent getAllRules on this connection, so a paired revert() sees the
-    // reset set.
-    PhosphorProtocol::ClientHelpers::asyncCall(QString(PhosphorProtocol::Service::Interface::Rules),
-                                               QStringLiteral("resetManagedDefaults"));
-}
-
-void RuleController::discardBaselineEdits()
-{
-    // Restore each managed baseline from the last synced snapshot, leaving every
-    // user rule untouched.
-    const QList<PhosphorRules::Rule> savedBaselines = managedSubset(m_savedRules);
-    for (const PhosphorRules::Rule& saved : savedBaselines)
-        upsertRule(saved);
-    recomputeDirtyFromSnapshot();
-    Q_EMIT baselinesChanged();
-}
+// NOTE: the per-page dirty split + managed-baseline reset/discard methods
+// (captureSavedSnapshot, baselinesDirty, userRulesDirty, recomputeDirtyFromSnapshot,
+// upsertRule, resetBaselines, resetManagedDefaults, discardBaselineEdits) live in
+// rulecontroller_baseline.cpp — split out to keep this TU under the 800-line cap.
 
 int RuleController::bandBaseForSection(RuleModel::Section section)
 {

--- a/src/settings/rulecontroller.cpp
+++ b/src/settings/rulecontroller.cpp
@@ -6,6 +6,7 @@
 #include "ruleauthoring.h"
 #include "ruletemplates.h"
 
+#include "../core/baselinerules.h"
 #include "../core/logging.h"
 #include "../phosphor_i18n.h"
 
@@ -248,6 +249,9 @@ bool RuleController::pushToDaemonAsync(const QList<Rule>& rules)
             Q_EMIT applyResult(false, PhosphorI18n::tr("The daemon rejected one or more rules."));
             return;
         }
+        // The staged set is now the daemon's persisted set — re-baseline the
+        // per-page dirty snapshot so baselinesDirty/userRulesDirty read clean.
+        captureSavedSnapshot();
         setDirty(false);
         setDaemonChangedWhileDirty(false);
         Q_EMIT applyResult(true, QString());
@@ -323,6 +327,8 @@ void RuleController::fetchAndLoad(bool fromRevert)
             return;
         }
         m_model.setRules(set.rules());
+        // Re-baseline the per-page dirty snapshot to the daemon's authoritative set.
+        captureSavedSnapshot();
         setDirty(false);
         setDaemonChangedWhileDirty(false);
         Q_EMIT rulesLoaded();
@@ -405,6 +411,82 @@ void RuleController::revert()
     // mid-revert would read m_pendingRevertFetches > 0 and tag itself
     // as fromRevert, emitting a spurious revertFinished(true).
     fetchAndLoad(/*fromRevert=*/true);
+}
+
+// ── Per-page dirty split + baseline ops ──────────────────────────────────────
+
+namespace {
+// Partition helpers: managed rules are the appearance baselines; the rest are
+// user rules. Order is preserved so the user-rules comparison catches reorders.
+QList<PhosphorRules::Rule> managedSubset(const QList<PhosphorRules::Rule>& rules)
+{
+    QList<PhosphorRules::Rule> out;
+    for (const PhosphorRules::Rule& r : rules) {
+        if (r.managed)
+            out.append(r);
+    }
+    return out;
+}
+QList<PhosphorRules::Rule> userSubset(const QList<PhosphorRules::Rule>& rules)
+{
+    QList<PhosphorRules::Rule> out;
+    for (const PhosphorRules::Rule& r : rules) {
+        if (!r.managed)
+            out.append(r);
+    }
+    return out;
+}
+} // namespace
+
+void RuleController::captureSavedSnapshot()
+{
+    m_savedRules = m_model.rules();
+}
+
+bool RuleController::baselinesDirty() const
+{
+    return managedSubset(m_model.rules()) != managedSubset(m_savedRules);
+}
+
+bool RuleController::userRulesDirty() const
+{
+    return userSubset(m_model.rules()) != userSubset(m_savedRules);
+}
+
+void RuleController::recomputeDirtyFromSnapshot()
+{
+    setDirty(baselinesDirty() || userRulesDirty());
+}
+
+void RuleController::upsertRule(const PhosphorRules::Rule& rule)
+{
+    if (m_model.contains(rule.id))
+        m_model.updateRule(rule);
+    else
+        m_model.addRule(rule);
+}
+
+void RuleController::resetBaselines()
+{
+    // Rewrite the three managed baselines to their factory definitions. Managed
+    // rules stay in the System section, so updateRule replaces them in place
+    // (no priority renormalize). Staged — the global Save flushes it.
+    upsertRule(makeBaselineBorderRule());
+    upsertRule(makeBaselineTitleBarRule());
+    upsertRule(makeBaselineGapRule());
+    recomputeDirtyFromSnapshot();
+    Q_EMIT baselinesChanged();
+}
+
+void RuleController::discardBaselineEdits()
+{
+    // Restore each managed baseline from the last synced snapshot, leaving every
+    // user rule untouched.
+    const QList<PhosphorRules::Rule> savedBaselines = managedSubset(m_savedRules);
+    for (const PhosphorRules::Rule& saved : savedBaselines)
+        upsertRule(saved);
+    recomputeDirtyFromSnapshot();
+    Q_EMIT baselinesChanged();
 }
 
 int RuleController::bandBaseForSection(RuleModel::Section section)

--- a/src/settings/rulecontroller.h
+++ b/src/settings/rulecontroller.h
@@ -180,6 +180,41 @@ public:
         return m_dirty;
     }
 
+    // ── Per-page dirty split + baseline ops (rule-backed settings pages) ──────
+    //
+    // The Windows appearance page and the Rules page stage into this ONE model,
+    // so the single dirty bit can't tell them apart. These value-based queries
+    // compare the current model to the last daemon-synced snapshot
+    // (`m_savedRules`) so `SettingsController` can badge each page independently:
+    // the managed baseline rules are "appearance", everything else is "rules".
+
+    /// True iff any managed baseline rule differs from the last synced snapshot
+    /// (drives the Windows appearance page's dirty state).
+    bool baselinesDirty() const;
+
+    /// True iff the non-managed (user) rules differ from the last synced
+    /// snapshot, including order (drives the Rules page's dirty state).
+    bool userRulesDirty() const;
+
+    /// Snapshot the current staged model as the committed baseline that
+    /// baselinesDirty/userRulesDirty compare against and discardBaselineEdits
+    /// restores to. Called internally wherever the model becomes equal to the
+    /// daemon's persisted set (the fetchAndLoad reply and a successful commit).
+    /// Public so headless tests can establish a baseline without a live daemon.
+    void captureSavedSnapshot();
+
+    /// Per-page "Reset to defaults" for the Windows appearance page: rewrite the
+    /// three managed baseline rules to their factory definitions
+    /// (core/baselinerules.h) — restoring the fresh-install match + actions and
+    /// dropping any per-side gap actions the page added. Staged; the global Save
+    /// flushes it. Leaves user rules untouched.
+    void resetBaselines();
+
+    /// Per-page "Discard changes" for the Windows appearance page: restore the
+    /// three managed baseline rules from the last synced snapshot, leaving every
+    /// user rule untouched.
+    void discardBaselineEdits();
+
     // ── Rule CRUD — keyed by UUID, never by index ─────────────────────────
 
     /// Build a fresh, never-yet-stored rule for the given guided subject and
@@ -359,6 +394,11 @@ Q_SIGNALS:
     /// "rules" entry to its dirty-pages set when revert failed during
     /// the `setNeedsSave(false)` blanket-clear it does for every other page.
     void revertFinished(bool success);
+    /// Emitted when the managed appearance baselines are programmatically
+    /// rewritten by `resetBaselines()` / `discardBaselineEdits()` (in-place
+    /// `updateRule`s that don't fire `rulesLoaded`). The Windows appearance page
+    /// listens so it re-reads its controls; not emitted on ordinary user edits.
+    void baselinesChanged();
 
 private:
     void setDirty(bool dirty);
@@ -435,7 +475,18 @@ private:
     /// user can then freely drag it anywhere; this only seeds the default.
     int bandSeededInsertIndex(const PhosphorRules::Rule& rule) const;
 
+    /// Recompute the global dirty bit from the snapshot after a scoped baseline
+    /// reset/discard, which mutate the model directly and so bypass the
+    /// setDirty(true) the CRUD paths call.
+    void recomputeDirtyFromSnapshot();
+    /// Replace the rule by id if present, else append it. Used by the baseline
+    /// reset/discard so a (theoretically) unseeded baseline is still restored.
+    void upsertRule(const PhosphorRules::Rule& rule);
+
     RuleModel m_model;
+    /// The rule set as last synced with the daemon. Backs the value-based
+    /// baselinesDirty/userRulesDirty split and discardBaselineEdits' restore.
+    QList<PhosphorRules::Rule> m_savedRules;
     bool m_dirty = false;
     bool m_daemonReachable = false;
     bool m_daemonChangedWhileDirty = false;

--- a/src/settings/rulecontroller.h
+++ b/src/settings/rulecontroller.h
@@ -215,6 +215,14 @@ public:
     /// user rule untouched.
     void discardBaselineEdits();
 
+    /// Fire-and-forget D-Bus call asking the daemon to reset the three managed
+    /// baseline rules to factory (org.plasmazones.Rules.resetManagedDefaults),
+    /// preserving user rules. The daemon persists + broadcasts rulesChanged;
+    /// SettingsController::defaults() pairs this with revert() to reload the
+    /// model from the reset set. This is the GLOBAL Restore Defaults path (live,
+    /// daemon-persisted) — distinct from the staged per-page resetBaselines().
+    void resetManagedDefaults();
+
     // ── Rule CRUD — keyed by UUID, never by index ─────────────────────────
 
     /// Build a fresh, never-yet-stored rule for the given guided subject and

--- a/src/settings/rulecontroller_baseline.cpp
+++ b/src/settings/rulecontroller_baseline.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Per-page dirty split + managed-baseline reset/discard for RuleController.
+// Split out of rulecontroller.cpp to keep that TU under the project's 800-line
+// cap (see CLAUDE.md); the controller's class definition spans both TUs.
+//
+// Covers: the value-based baseline/user dirty split (baselinesDirty /
+// userRulesDirty against the last daemon-synced snapshot), the staged per-page
+// reset/discard of the three managed appearance baselines (resetBaselines /
+// discardBaselineEdits), and the fire-and-forget global daemon reset
+// (resetManagedDefaults).
+
+#include "rulecontroller.h"
+
+#include "../core/baselinerules.h"
+
+#include <PhosphorProtocol/ClientHelpers.h>
+#include <PhosphorProtocol/ServiceConstants.h>
+#include <PhosphorRules/Rule.h>
+
+#include <QList>
+#include <QString>
+
+namespace PlasmaZones {
+
+namespace {
+// Partition helpers: managed rules are the appearance baselines; the rest are
+// user rules. Order is preserved so the user-rules comparison catches reorders.
+QList<PhosphorRules::Rule> managedSubset(const QList<PhosphorRules::Rule>& rules)
+{
+    QList<PhosphorRules::Rule> out;
+    for (const PhosphorRules::Rule& r : rules) {
+        if (r.managed)
+            out.append(r);
+    }
+    return out;
+}
+QList<PhosphorRules::Rule> userSubset(const QList<PhosphorRules::Rule>& rules)
+{
+    QList<PhosphorRules::Rule> out;
+    for (const PhosphorRules::Rule& r : rules) {
+        if (!r.managed)
+            out.append(r);
+    }
+    return out;
+}
+} // namespace
+
+void RuleController::captureSavedSnapshot()
+{
+    m_savedRules = m_model.rules();
+}
+
+bool RuleController::baselinesDirty() const
+{
+    return managedSubset(m_model.rules()) != managedSubset(m_savedRules);
+}
+
+bool RuleController::userRulesDirty() const
+{
+    return userSubset(m_model.rules()) != userSubset(m_savedRules);
+}
+
+void RuleController::recomputeDirtyFromSnapshot()
+{
+    setDirty(baselinesDirty() || userRulesDirty());
+}
+
+void RuleController::upsertRule(const PhosphorRules::Rule& rule)
+{
+    if (m_model.contains(rule.id))
+        m_model.updateRule(rule);
+    else
+        m_model.addRule(rule);
+}
+
+void RuleController::resetBaselines()
+{
+    // Rewrite the three managed baselines to their factory definitions. Managed
+    // rules stay in the System section, so updateRule replaces them in place
+    // (no priority renormalize). Staged — the global Save flushes it.
+    upsertRule(makeBaselineBorderRule());
+    upsertRule(makeBaselineTitleBarRule());
+    upsertRule(makeBaselineGapRule());
+    recomputeDirtyFromSnapshot();
+    Q_EMIT baselinesChanged();
+}
+
+void RuleController::resetManagedDefaults()
+{
+    // Fire-and-forget: no out-args, and the model refresh comes from the daemon's
+    // rulesChanged broadcast + the revert() the caller issues. Ordered before any
+    // subsequent getAllRules on this connection, so a paired revert() sees the
+    // reset set.
+    PhosphorProtocol::ClientHelpers::asyncCall(QString(PhosphorProtocol::Service::Interface::Rules),
+                                               QStringLiteral("resetManagedDefaults"));
+}
+
+void RuleController::discardBaselineEdits()
+{
+    // Restore each managed baseline from the last synced snapshot, leaving every
+    // user rule untouched.
+    const QList<PhosphorRules::Rule> savedBaselines = managedSubset(m_savedRules);
+    for (const PhosphorRules::Rule& saved : savedBaselines)
+        upsertRule(saved);
+    recomputeDirtyFromSnapshot();
+    Q_EMIT baselinesChanged();
+}
+
+} // namespace PlasmaZones

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -487,20 +487,35 @@ SettingsController::SettingsController(QObject* parent)
     // reconcileRuleBackedDirty() is value-based — it compares the staged model
     // to the last daemon-synced snapshot — so it stays correct even when the
     // shared dirty bit does not transition (e.g. editing a baseline while user
-    // rules are already dirty). It is driven off the model's own change signals
-    // so every edit re-attributes, plus revert/apply completion for the async
-    // failure paths where the model itself did not change but the page's
-    // blanket-cleared dirty entry must be restored.
+    // rules are already dirty). It is driven off the model's per-EDIT signals
+    // (dataChanged / rows{Inserted,Removed,Moved}), plus revert/apply/load
+    // completion.
+    //
+    // NOTE: modelReset is deliberately NOT wired here. The only source of a
+    // model reset is RuleController::fetchAndLoad's setRules(), whose
+    // beginResetModel/endResetModel fires modelReset SYNCHRONOUSLY *before* the
+    // controller re-baselines its saved snapshot (captureSavedSnapshot runs on
+    // the next line). Reconciling on modelReset would therefore compare the
+    // fresh model against the STALE snapshot and spuriously mark both rule-backed
+    // pages dirty on every startup / daemon rulesChanged broadcast. That
+    // repopulation is instead handled by the rulesLoaded / revertFinished
+    // connections below, which fire AFTER the re-baseline.
     const auto reattributeRuleDirty = [this]() {
         if (m_loading || m_saving)
             return;
         reconcileRuleBackedDirty();
     };
     connect(m_rulesPage, &RuleController::dirtyChanged, this, reattributeRuleDirty);
+    // rulesLoaded fires after fetchAndLoad re-baselines the snapshot (both the
+    // initial/broadcast reload and the revert path), so reconciling here sees the
+    // fresh snapshot and clears any dirty the daemon set didn't actually change.
     // revertFinished / applyResult land after load()/save() have run their
     // setNeedsSave(false) blanket-clear; reconcile unconditionally so a failed
     // revert/push (model still divergent from the snapshot) re-marks the right
     // page, and a successful one leaves both clean.
+    connect(m_rulesPage, &RuleController::rulesLoaded, this, [this]() {
+        reconcileRuleBackedDirty();
+    });
     connect(m_rulesPage, &RuleController::revertFinished, this, [this](bool) {
         reconcileRuleBackedDirty();
     });
@@ -513,7 +528,6 @@ SettingsController::SettingsController(QObject* parent)
         connect(ruleModel, &QAbstractItemModel::rowsInserted, this, reattributeRuleDirty);
         connect(ruleModel, &QAbstractItemModel::rowsRemoved, this, reattributeRuleDirty);
         connect(ruleModel, &QAbstractItemModel::rowsMoved, this, reattributeRuleDirty);
-        connect(ruleModel, &QAbstractItemModel::modelReset, this, reattributeRuleDirty);
     }
 
     // Wire screen / activity / layout label resolvers so the rule model and

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -481,61 +481,40 @@ SettingsController::SettingsController(QObject* parent)
     if (m_rulesPage->model() != nullptr) {
         connect(m_rulesPage->model(), &RuleModel::countChanged, this, &SettingsController::perScreenOverridesChanged);
     }
-    connect(m_rulesPage, &RuleController::dirtyChanged, this, [this]() {
+    // Attribute rule-model dirtiness to the two rule-backed pages that share
+    // this one controller: appearance (managed baseline) edits mark
+    // "window-appearance", user-rule edits mark "rules".
+    // reconcileRuleBackedDirty() is value-based — it compares the staged model
+    // to the last daemon-synced snapshot — so it stays correct even when the
+    // shared dirty bit does not transition (e.g. editing a baseline while user
+    // rules are already dirty). It is driven off the model's own change signals
+    // so every edit re-attributes, plus revert/apply completion for the async
+    // failure paths where the model itself did not change but the page's
+    // blanket-cleared dirty entry must be restored.
+    const auto reattributeRuleDirty = [this]() {
         if (m_loading || m_saving)
             return;
-        if (m_rulesPage->isDirty()) {
-            // A window-rule edit can be driven by a background daemon signal, not
-            // just by the user viewing the page — so mark the "rules" page
-            // explicitly rather than letting setNeedsSave() target m_activePage.
-            beginExternalEdit(QStringLiteral("rules"));
-            setNeedsSave(true);
-            endExternalEdit();
-            return;
-        }
-        // Controller transitioned to clean (e.g. a successful fetchAndLoad
-        // flipped m_dirty false→true→false during initial async load, or a
-        // direct revert from QML). Mirror the dirty-side behaviour: remove
-        // "rules" from m_dirtyPages and emit dirtyPagesChanged when
-        // the set actually shrinks. setNeedsSave(false) cannot be used here
-        // — it blanket-clears every page, which would wipe other unrelated
-        // dirty leaves.
-        if (m_dirtyPages.remove(QStringLiteral("rules"))) {
-            Q_EMIT dirtyPagesChanged();
-        }
+        reconcileRuleBackedDirty();
+    };
+    connect(m_rulesPage, &RuleController::dirtyChanged, this, reattributeRuleDirty);
+    // revertFinished / applyResult land after load()/save() have run their
+    // setNeedsSave(false) blanket-clear; reconcile unconditionally so a failed
+    // revert/push (model still divergent from the snapshot) re-marks the right
+    // page, and a successful one leaves both clean.
+    connect(m_rulesPage, &RuleController::revertFinished, this, [this](bool) {
+        reconcileRuleBackedDirty();
     });
-    // A user-driven Discard fires RuleController::revert() inside our
-    // load() under m_loading=true, which suppresses the dirtyChanged → dirty
-    // pages plumbing for the duration of the call. The async re-fetch lands
-    // AFTER load() has already done `setNeedsSave(false)` (which blanket-
-    // clears m_dirtyPages). If the re-fetch *fails*, the controller's m_dirty
-    // stays true per its documented contract — but its dirtyChanged signal
-    // never fires (value didn't change) and the cleared dirty-page entry is
-    // never re-added. Listen to revertFinished here so a failed revert can
-    // re-mark the page dirty.
-    connect(m_rulesPage, &RuleController::revertFinished, this, [this](bool success) {
-        if (success || !m_rulesPage->isDirty()) {
-            return;
-        }
-        // m_loading is already false by the time this async reply lands.
-        beginExternalEdit(QStringLiteral("rules"));
-        setNeedsSave(true);
-        endExternalEdit();
+    connect(m_rulesPage, &RuleController::applyResult, this, [this](bool, const QString&) {
+        reconcileRuleBackedDirty();
     });
-    // Same asymmetry on the SAVE path: a failed/partial daemon rules push keeps
-    // RuleController m_dirty=true per its contract, but its dirtyChanged signal
-    // never fires (the value didn't change false→true), so the "rules" entry
-    // that save()'s setNeedsSave(false) blanket-cleared is never re-added — the
-    // per-page badge wrongly clears while the domain stays dirty. Re-mark on a
-    // failed apply so isPageDirty("rules") stays true, mirroring revertFinished.
-    connect(m_rulesPage, &RuleController::applyResult, this, [this](bool ok, const QString&) {
-        if (ok || !m_rulesPage->isDirty()) {
-            return;
-        }
-        beginExternalEdit(QStringLiteral("rules"));
-        setNeedsSave(true);
-        endExternalEdit();
-    });
+    if (m_rulesPage->model() != nullptr) {
+        RuleModel* ruleModel = m_rulesPage->model();
+        connect(ruleModel, &QAbstractItemModel::dataChanged, this, reattributeRuleDirty);
+        connect(ruleModel, &QAbstractItemModel::rowsInserted, this, reattributeRuleDirty);
+        connect(ruleModel, &QAbstractItemModel::rowsRemoved, this, reattributeRuleDirty);
+        connect(ruleModel, &QAbstractItemModel::rowsMoved, this, reattributeRuleDirty);
+        connect(ruleModel, &QAbstractItemModel::modelReset, this, reattributeRuleDirty);
+    }
 
     // Wire screen / activity / layout label resolvers so the rule model and
     // monitor-overview render friendly names instead of raw connector strings,

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -211,8 +211,9 @@ public:
 
     /// The per-page config-key manifest: page id → the (group, key) pairs that
     /// page owns. Phase-1 scope is the KConfig-backed settings pages; pages not
-    /// listed here have no per-page Reset/Discard. Public + static so the unit
-    /// tests can assert the partition/schema invariants.
+    /// listed here have no per-page Reset/Discard. Public + static so the manifest
+    /// (and its hand-maintained partition/schema invariants — see the definition)
+    /// can be inspected without a SettingsController instance.
     static const QHash<QString, Settings::ConfigKeyList>& pageOwnedConfigKeys();
 
     /// Override the page that the next setNeedsSave(true) calls (and any

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -650,8 +650,8 @@ private:
     // Sync m_dirtyPages membership for @p page to its value-based dirty state
     // (isPageDirty) after a per-page Reset/Discard, emitting dirtyPagesChanged
     // when it flips so the footer's global needsSave stays consistent. Used for
-    // any page whose isPageDirty is value-based — manifest, shortcuts, and
-    // animation pages.
+    // any page whose isPageDirty is value-based — manifest, ordering, shortcuts,
+    // and animation pages.
     void reconcilePageDirty(const QString& page);
     // Value-based attribution for the two rule-backed pages sharing one
     // RuleController model: set m_dirtyPages membership for "window-appearance"

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -642,6 +642,12 @@ private:
     // dirty state after a per-page Reset/Discard, emitting dirtyPagesChanged
     // when it flips so the footer's global needsSave stays consistent.
     void reconcilePageDirty(const QString& page);
+    // Value-based attribution for the two rule-backed pages sharing one
+    // RuleController model: set m_dirtyPages membership for "window-appearance"
+    // (= baselinesDirty) and "rules" (= userRulesDirty), emitting
+    // dirtyPagesChanged on a change. Called on every rule-model mutation and on
+    // revert/apply completion so the badges follow which subset actually changed.
+    void reconcileRuleBackedDirty();
     void refreshVirtualDesktops();
     void refreshActivities();
 

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -178,8 +178,40 @@ public:
     }
     QStringList dirtyPages() const;
     /// Returns true if the page (or any of its children, for parent categories
-    /// like "snapping" / "tiling") currently has unsaved changes.
+    /// like "snapping" / "tiling") currently has unsaved changes. For pages in
+    /// the per-page config manifest (@ref pageOwnedConfigKeys) the answer is
+    /// value-based — any owned key differing from the committed baseline —
+    /// which stays correct across a per-page Discard/Reset. Non-manifest pages
+    /// fall back to the m_dirtyPages membership set.
     Q_INVOKABLE bool isPageDirty(const QString& page) const;
+
+    // ── Per-page Reset / Discard (kebab menu in the breadcrumb row) ──────────
+    /// True when @p page can be reset to defaults: config-manifest pages
+    /// (write schema defaults) and the ordering pages (drop the custom order).
+    /// Animation pages have no reset-to-defaults path, so they return false.
+    Q_INVOKABLE bool pageSupportsReset(const QString& page) const;
+
+    /// True when @p page can discard its own unsaved edits: everything
+    /// pageSupportsReset covers PLUS the animation pages (which revert through
+    /// the shared AnimationsPageController staging domain). The kebab shows the
+    /// two menu items independently off these two capabilities.
+    Q_INVOKABLE bool pageSupportsDiscard(const QString& page) const;
+
+    /// Reset every config key owned by @p page to its schema default, staged
+    /// for the user to Save or Discard (never persisted here). No-op for
+    /// pages absent from the manifest.
+    Q_INVOKABLE void resetPage(const QString& page);
+
+    /// Revert every config key owned by @p page to the committed baseline,
+    /// dropping that page's unsaved edits while leaving other pages untouched.
+    /// No-op for pages absent from the manifest.
+    Q_INVOKABLE void discardPage(const QString& page);
+
+    /// The per-page config-key manifest: page id → the (group, key) pairs that
+    /// page owns. Phase-1 scope is the KConfig-backed settings pages; pages not
+    /// listed here have no per-page Reset/Discard. Public + static so the unit
+    /// tests can assert the partition/schema invariants.
+    static const QHash<QString, Settings::ConfigKeyList>& pageOwnedConfigKeys();
 
     /// Override the page that the next setNeedsSave(true) calls (and any
     /// property NOTIFY routed through onSettingsPropertyChanged) will mark
@@ -606,6 +638,10 @@ private Q_SLOTS:
 
 private:
     void setNeedsSave(bool needs);
+    // Sync m_dirtyPages membership for a manifest page to its value-based
+    // dirty state after a per-page Reset/Discard, emitting dirtyPagesChanged
+    // when it flips so the footer's global needsSave stays consistent.
+    void reconcilePageDirty(const QString& page);
     void refreshVirtualDesktops();
     void refreshActivities();
 

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -186,15 +186,17 @@ public:
     Q_INVOKABLE bool isPageDirty(const QString& page) const;
 
     // ── Per-page Reset / Discard (kebab menu in the breadcrumb row) ──────────
-    /// True when @p page can be reset to defaults: config-manifest pages
-    /// (write schema defaults) and the ordering pages (drop the custom order).
-    /// Animation pages have no reset-to-defaults path, so they return false.
+    /// True when @p page can be reset to defaults: config-manifest pages (schema
+    /// defaults), the ordering pages (drop the custom order), the shortcuts pages
+    /// (unassign every quick slot), the virtual screens page (unsplit every
+    /// monitor), the Windows appearance page (reset the 3 managed baseline
+    /// rules), and the animation pages (clear overrides + reset animation keys).
     Q_INVOKABLE bool pageSupportsReset(const QString& page) const;
 
-    /// True when @p page can discard its own unsaved edits: everything
-    /// pageSupportsReset covers PLUS the animation pages (which revert through
-    /// the shared AnimationsPageController staging domain). The kebab shows the
-    /// two menu items independently off these two capabilities.
+    /// True when @p page can discard its own unsaved edits. Currently every page
+    /// that supports reset also supports discard, so this mirrors
+    /// pageSupportsReset. Kept as a separate query so the kebab can show the two
+    /// items independently if the sets ever diverge.
     Q_INVOKABLE bool pageSupportsDiscard(const QString& page) const;
 
     /// Reset every config key owned by @p page to its schema default, staged

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -640,9 +640,11 @@ private Q_SLOTS:
 
 private:
     void setNeedsSave(bool needs);
-    // Sync m_dirtyPages membership for a manifest page to its value-based
-    // dirty state after a per-page Reset/Discard, emitting dirtyPagesChanged
-    // when it flips so the footer's global needsSave stays consistent.
+    // Sync m_dirtyPages membership for @p page to its value-based dirty state
+    // (isPageDirty) after a per-page Reset/Discard, emitting dirtyPagesChanged
+    // when it flips so the footer's global needsSave stays consistent. Used for
+    // any page whose isPageDirty is value-based — manifest, shortcuts, and
+    // animation pages.
     void reconcilePageDirty(const QString& page);
     // Value-based attribution for the two rule-backed pages sharing one
     // RuleController model: set m_dirtyPages membership for "window-appearance"

--- a/src/settings/settingscontroller.h
+++ b/src/settings/settingscontroller.h
@@ -200,20 +200,26 @@ public:
     Q_INVOKABLE bool pageSupportsDiscard(const QString& page) const;
 
     /// Reset every config key owned by @p page to its schema default, staged
-    /// for the user to Save or Discard (never persisted here). No-op for
-    /// pages absent from the manifest.
+    /// for the user to Save or Discard (never persisted here). Manifest pages
+    /// reset their keys; the ordering / shortcuts / virtual-screens / window-
+    /// appearance / animation pages reset through their own staged machinery.
+    /// No-op only for a page with none of those.
     Q_INVOKABLE void resetPage(const QString& page);
 
     /// Revert every config key owned by @p page to the committed baseline,
     /// dropping that page's unsaved edits while leaving other pages untouched.
-    /// No-op for pages absent from the manifest.
+    /// Handles the same special pages as resetPage, plus parent categories
+    /// (discards every discardable child leaf). No-op only for a page with
+    /// neither a manifest entry, a special-case branch, nor a child group.
     Q_INVOKABLE void discardPage(const QString& page);
 
     /// The per-page config-key manifest: page id → the (group, key) pairs that
     /// page owns. Phase-1 scope is the KConfig-backed settings pages; pages not
-    /// listed here have no per-page Reset/Discard. Public + static so the manifest
-    /// (and its hand-maintained partition/schema invariants — see the definition)
-    /// can be inspected without a SettingsController instance.
+    /// listed here revert through their own staged machinery rather than the
+    /// config manifest (see resetPage / discardPage), not because they lack
+    /// Reset/Discard. Public + static so the manifest (and its hand-maintained
+    /// partition/schema invariants — see the definition) can be inspected
+    /// without a SettingsController instance.
     static const QHash<QString, Settings::ConfigKeyList>& pageOwnedConfigKeys();
 
     /// Override the page that the next setNeedsSave(true) calls (and any

--- a/src/settings/settingscontroller_lifecycle.cpp
+++ b/src/settings/settingscontroller_lifecycle.cpp
@@ -269,6 +269,18 @@ void SettingsController::defaults()
     // Notify daemon to reload — reset() wrote defaults to disk
     DaemonDBus::notifyReload();
 
+    // Reset the rule-backed appearance/gap baselines to factory. The KConfig
+    // reset() above cannot reach them — window border / title bar / gaps live on
+    // the daemon's managed baseline rules in rules.json. resetManagedDefaults()
+    // asks the daemon to overwrite just those three (preserving user rules) and
+    // broadcast rulesChanged; the paired revert() reloads the model from the
+    // reset set (ordered after the reset on the same D-Bus connection) and drops
+    // any staged rule edits, so the Windows appearance page shows factory values.
+    if (m_rulesPage) {
+        m_rulesPage->resetManagedDefaults();
+        m_rulesPage->revert();
+    }
+
     // Defaults is a global action — mark every valid page dirty so the
     // unsaved indicator appears next to each of them. Guard the emit
     // on actual change so a back-to-back `defaults()` (or one called
@@ -278,13 +290,11 @@ void SettingsController::defaults()
     //
     // "rules" and "window-appearance" are INTENTIONALLY excluded from the
     // blanket-mark: both are rule-backed (their source of truth is the daemon's
-    // `rules.json`, not the KConfig store reset() clears), and their commit is a
-    // no-op when clean (RuleController::asyncCommit short-circuits; the appearance
-    // page edits managed baseline rules directly). Marking them dirty here would
-    // surface a stale "unsaved changes" indicator that a subsequent Save could
-    // never clear, leaving the page dirty in perpetuity until the user touches it.
-    // Resetting rule-backed defaults (window appearance / gaps) is out of scope
-    // for this entry point — it requires a separate daemon-side "reset rules" path.
+    // `rules.json`, not the KConfig store reset() clears). The appearance/gap
+    // baselines ARE reset above (resetManagedDefaults + revert), but that path is
+    // LIVE (daemon-persisted, model reloaded) rather than staged — so the pages
+    // land clean, not dirty. Marking them here would surface a stale "unsaved
+    // changes" indicator a subsequent Save could never clear.
     QSet<QString> fullSet = validPageNames();
     fullSet.remove(QStringLiteral("rules"));
     fullSet.remove(QStringLiteral("window-appearance"));

--- a/src/settings/settingscontroller_pageregistration.cpp
+++ b/src/settings/settingscontroller_pageregistration.cpp
@@ -513,8 +513,10 @@ const QHash<QString, Settings::ConfigKeyList>& SettingsController::pageOwnedConf
     // Phase-1 scope: KConfig-backed settings pages only. Rule-backed pages
     // (window-appearance, rules), separate-store pages (layouts), the
     // controller-mediated ordering/shortcuts pages, and the Animations tree are
-    // deliberately absent — they revert through their own machinery, so their
-    // kebab items stay disabled (pageSupportsReset returns false).
+    // deliberately absent because they revert through their own machinery
+    // (the special-case branches in reset/discardPage), not because Reset/Discard
+    // is unsupported — pageSupportsReset returns true for all but the pure
+    // separate-store pages (layouts, rules).
     using CD = ConfigDefaults;
     static const QHash<QString, Settings::ConfigKeyList> manifest{
         {QStringLiteral("general"),

--- a/src/settings/settingscontroller_pageregistration.cpp
+++ b/src/settings/settingscontroller_pageregistration.cpp
@@ -502,8 +502,13 @@ const QHash<QString, Settings::ConfigKeyList>& SettingsController::pageOwnedConf
     // reverts each to the committed baseline (see Settings::resetKeys /
     // discardKeys). ALWAYS express keys through ConfigDefaults accessors — never
     // inline literals (CLAUDE.md). The pairs mirror the store-backed getters in
-    // settings.cpp; test_settingscontroller_pagereset.cpp asserts every pair is
-    // a declared schema key and that no key is owned by two pages.
+    // settings.cpp.
+    //
+    // INVARIANTS (maintained by hand — a unit guard would have to link the whole
+    // SettingsController TU): every pair must be a schema-declared key, and no
+    // key may be owned by two pages (a shared key would let one page's Discard
+    // revert another page's edit). When adding a page, copy the (group, key)
+    // accessors verbatim from that page's getter in settings.cpp.
     //
     // Phase-1 scope: KConfig-backed settings pages only. Rule-backed pages
     // (window-appearance, rules), separate-store pages (layouts), the

--- a/src/settings/settingscontroller_pageregistration.cpp
+++ b/src/settings/settingscontroller_pageregistration.cpp
@@ -494,6 +494,133 @@ const QHash<QString, QSet<QString>>& SettingsController::pageGroupChildren()
     return groups;
 }
 
+const QHash<QString, Settings::ConfigKeyList>& SettingsController::pageOwnedConfigKeys()
+{
+    // Per-page config-key manifest driving the breadcrumb kebab's Reset /
+    // Discard actions. Each leaf lists the (group, key) pairs it edits; a
+    // per-page Reset writes each key's schema default and a per-page Discard
+    // reverts each to the committed baseline (see Settings::resetKeys /
+    // discardKeys). ALWAYS express keys through ConfigDefaults accessors — never
+    // inline literals (CLAUDE.md). The pairs mirror the store-backed getters in
+    // settings.cpp; test_settingscontroller_pagereset.cpp asserts every pair is
+    // a declared schema key and that no key is owned by two pages.
+    //
+    // Phase-1 scope: KConfig-backed settings pages only. Rule-backed pages
+    // (window-appearance, rules), separate-store pages (layouts), the
+    // controller-mediated ordering/shortcuts pages, and the Animations tree are
+    // deliberately absent — they revert through their own machinery, so their
+    // kebab items stay disabled (pageSupportsReset returns false).
+    using CD = ConfigDefaults;
+    static const QHash<QString, Settings::ConfigKeyList> manifest{
+        {QStringLiteral("general"),
+         {
+             {CD::renderingGroup(), CD::backendKey()},
+             {CD::snappingBehaviorWindowHandlingGroup(), CD::suppressDefaultLayoutAssignmentKey()},
+             {CD::exclusionsGroup(), CD::transientWindowsKey()},
+             {CD::exclusionsGroup(), CD::minimumWindowWidthKey()},
+             {CD::exclusionsGroup(), CD::minimumWindowHeightKey()},
+         }},
+        {QStringLiteral("snapping-overlay-behavior"),
+         {
+             {CD::snappingBehaviorGroup(), CD::toggleActivationKey()},
+             {CD::snappingBehaviorZoneSpanGroup(), CD::enabledKey()},
+             {CD::snappingBehaviorZoneSpanGroup(), CD::toggleActivationKey()},
+             {CD::snappingGapsGroup(), CD::adjacentThresholdKey()},
+             {CD::snappingBehaviorDisplayGroup(), CD::showOnAllMonitorsKey()},
+             {CD::snappingBehaviorDisplayGroup(), CD::filterByAspectRatioKey()},
+         }},
+        {QStringLiteral("snapping-overlay-appearance"),
+         {
+             {CD::snappingZonesColorsGroup(), CD::useSystemKey()},
+             {CD::snappingZonesColorsGroup(), CD::highlightKey()},
+             {CD::snappingZonesColorsGroup(), CD::inactiveKey()},
+             {CD::snappingZonesColorsGroup(), CD::borderKey()},
+             {CD::snappingZonesLabelsGroup(), CD::fontColorKey()},
+             {CD::snappingZonesLabelsGroup(), CD::fontFamilyKey()},
+             {CD::snappingZonesLabelsGroup(), CD::fontSizeScaleKey()},
+             {CD::snappingZonesLabelsGroup(), CD::fontWeightKey()},
+             {CD::snappingZonesLabelsGroup(), CD::fontItalicKey()},
+             {CD::snappingZonesLabelsGroup(), CD::fontUnderlineKey()},
+             {CD::snappingZonesLabelsGroup(), CD::fontStrikeoutKey()},
+             {CD::snappingZonesOpacityGroup(), CD::activeKey()},
+             {CD::snappingZonesOpacityGroup(), CD::inactiveKey()},
+             {CD::snappingZonesBorderGroup(), CD::widthKey()},
+             {CD::snappingZonesBorderGroup(), CD::radiusKey()},
+             {CD::snappingEffectsGroup(), CD::blurKey()},
+             {CD::snappingEffectsGroup(), CD::showNumbersKey()},
+             {CD::snappingEffectsGroup(), CD::flashOnSwitchKey()},
+             {CD::shadersGroup(), CD::enabledKey()},
+             {CD::shadersGroup(), CD::frameRateKey()},
+             {CD::shadersGroup(), CD::audioVisualizerKey()},
+             {CD::shadersGroup(), CD::audioSpectrumBarCountKey()},
+         }},
+        {QStringLiteral("snapping-zoneselector"),
+         {
+             {CD::snappingZoneSelectorGroup(), CD::enabledKey()},
+             {CD::snappingZoneSelectorGroup(), CD::triggerDistanceKey()},
+             {CD::snappingZoneSelectorGroup(), CD::positionKey()},
+             {CD::snappingZoneSelectorGroup(), CD::layoutModeKey()},
+             {CD::snappingZoneSelectorGroup(), CD::sizeModeKey()},
+             {CD::snappingZoneSelectorGroup(), CD::gridColumnsKey()},
+             {CD::snappingZoneSelectorGroup(), CD::maxRowsKey()},
+             {CD::snappingZoneSelectorGroup(), CD::previewWidthKey()},
+             {CD::snappingZoneSelectorGroup(), CD::previewHeightKey()},
+         }},
+        {QStringLiteral("snapping-window-behavior"),
+         {
+             {CD::snappingBehaviorSnapAssistGroup(), CD::featureEnabledKey()},
+             {CD::snappingBehaviorSnapAssistGroup(), CD::enabledKey()},
+             {CD::snappingBehaviorWindowHandlingGroup(), CD::keepOnResolutionChangeKey()},
+             {CD::snappingBehaviorWindowHandlingGroup(), CD::moveNewToLastZoneKey()},
+             {CD::snappingBehaviorWindowHandlingGroup(), CD::autoAssignAllLayoutsKey()},
+             {CD::snappingBehaviorWindowHandlingGroup(), CD::restoreOnUnsnapKey()},
+             {CD::snappingBehaviorWindowHandlingGroup(), CD::restoreOnLoginKey()},
+             {CD::snappingBehaviorWindowHandlingGroup(), CD::restoreFloatedOnLoginKey()},
+             {CD::snappingBehaviorWindowHandlingGroup(), CD::unfloatFallbackToZoneKey()},
+             {CD::snappingBehaviorWindowHandlingGroup(), CD::stickyWindowHandlingKey()},
+             {CD::snappingBehaviorGroup(), CD::focusNewWindowsKey()},
+             {CD::snappingBehaviorGroup(), CD::focusFollowsMouseKey()},
+         }},
+        {QStringLiteral("tiling-behavior"),
+         {
+             {CD::tilingBehaviorGroup(), CD::toggleActivationKey()},
+             {CD::tilingBehaviorGroup(), CD::insertPositionKey()},
+             {CD::tilingBehaviorGroup(), CD::respectMinimumSizeKey()},
+             {CD::tilingBehaviorGroup(), CD::stickyWindowHandlingKey()},
+             {CD::tilingBehaviorGroup(), CD::dragBehaviorKey()},
+             {CD::tilingBehaviorGroup(), CD::overflowBehaviorKey()},
+             {CD::tilingBehaviorGroup(), CD::focusNewWindowsKey()},
+             {CD::tilingBehaviorGroup(), CD::focusFollowsMouseKey()},
+             {CD::tilingBehaviorGroup(), CD::restoreFloatedOnLoginKey()},
+             {CD::tilingGapsGroup(), CD::smartGapsKey()},
+         }},
+        {QStringLiteral("tiling-algorithm"),
+         {
+             {CD::tilingAlgorithmGroup(), CD::defaultKey()},
+             {CD::tilingAlgorithmGroup(), CD::splitRatioKey()},
+             {CD::tilingAlgorithmGroup(), CD::splitRatioStepKey()},
+             {CD::tilingAlgorithmGroup(), CD::masterCountKey()},
+             {CD::tilingAlgorithmGroup(), CD::maxWindowsKey()},
+             {CD::tilingAlgorithmGroup(), CD::perAlgorithmSettingsKey()},
+         }},
+        {QStringLiteral("editor"),
+         {
+             {CD::editorShortcutsGroup(), CD::duplicateKey()},
+             {CD::editorShortcutsGroup(), CD::splitHorizontalKey()},
+             {CD::editorShortcutsGroup(), CD::splitVerticalKey()},
+             {CD::editorShortcutsGroup(), CD::fillKey()},
+             {CD::editorSnappingGroup(), CD::gridEnabledKey()},
+             {CD::editorSnappingGroup(), CD::edgeEnabledKey()},
+             {CD::editorSnappingGroup(), CD::intervalXKey()},
+             {CD::editorSnappingGroup(), CD::intervalYKey()},
+             {CD::editorSnappingGroup(), CD::overrideModifierKey()},
+             {CD::editorFillOnDropGroup(), CD::enabledKey()},
+             {CD::editorFillOnDropGroup(), CD::modifierKey()},
+         }},
+    };
+    return manifest;
+}
+
 const QSet<QString>& SettingsController::validPageNames()
 {
     // Keep in sync with the `regPage` / `regVirtual` registrations in

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -17,6 +17,7 @@
 #include "../core/logging.h"
 
 #include <QDebug>
+#include <QScopeGuard>
 
 namespace PlasmaZones {
 
@@ -339,9 +340,11 @@ void SettingsController::resetPage(const QString& page)
         if (m_animationsPage != nullptr) {
             const bool wasLoading = m_loading;
             m_loading = true;
+            const auto restoreLoading = qScopeGuard([this, wasLoading] {
+                m_loading = wasLoading;
+            });
             m_animationsPage->clearAllOverrides();
             m_settings.resetKeys(animationConfigKeys());
-            m_loading = wasLoading;
         }
         // isPageDirty(animation) is value-based (hasPendingChanges || any
         // animation key modified), so reconcilePageDirty syncs the active page's
@@ -418,10 +421,14 @@ void SettingsController::resetPage(const QString& page)
     // Suppress onSettingsPropertyChanged for the reset's NOTIFY storm — it
     // would otherwise mark the ACTIVE page dirty (which may differ from the
     // page being reset). We reconcile `page`'s dirty state explicitly below.
-    const bool wasLoading = m_loading;
-    m_loading = true;
-    m_settings.resetKeys(*it);
-    m_loading = wasLoading;
+    {
+        const bool wasLoading = m_loading;
+        m_loading = true;
+        const auto restoreLoading = qScopeGuard([this, wasLoading] {
+            m_loading = wasLoading;
+        });
+        m_settings.resetKeys(*it);
+    }
     // Resetting to defaults usually diverges from the saved baseline, so the
     // page normally becomes dirty (stage → Save/Discard). If the defaults
     // already matched the baseline it stays clean — reconcile handles both.
@@ -443,10 +450,14 @@ void SettingsController::discardPage(const QString& page)
     const auto& manifest = pageOwnedConfigKeys();
     const auto it = manifest.constFind(page);
     if (it != manifest.constEnd()) {
-        const bool wasLoading = m_loading;
-        m_loading = true;
-        m_settings.discardKeys(*it);
-        m_loading = wasLoading;
+        {
+            const bool wasLoading = m_loading;
+            m_loading = true;
+            const auto restoreLoading = qScopeGuard([this, wasLoading] {
+                m_loading = wasLoading;
+            });
+            m_settings.discardKeys(*it);
+        }
         // Every owned key is back at the committed baseline, so the page is clean.
         reconcilePageDirty(page);
         return;
@@ -507,10 +518,14 @@ void SettingsController::discardPage(const QString& page)
         if (m_animationsPage != nullptr) {
             m_animationsPage->revertPending();
         }
-        const bool wasLoading = m_loading;
-        m_loading = true;
-        m_settings.discardKeys(animationConfigKeys());
-        m_loading = wasLoading;
+        {
+            const bool wasLoading = m_loading;
+            m_loading = true;
+            const auto restoreLoading = qScopeGuard([this, wasLoading] {
+                m_loading = wasLoading;
+            });
+            m_settings.discardKeys(animationConfigKeys());
+        }
         // revertPending() left hasPendingChanges() false; clear every animation
         // leaf's m_dirtyPages marker so the global needsSave drops the entries
         // the pendingChangesChanged handler had attributed to the tree.

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -541,17 +541,25 @@ void SettingsController::discardPage(const QString& page)
     }
 
     // Parent category (e.g. "snapping" / "tiling" / "placement"): discard every
-    // manifest-backed leaf beneath it. Lets the sidebar's section-disable
-    // confirm drop a whole mode's staged edits before flipping the enable flag,
-    // rather than relying on the framework PageAdapter::discard() no-op.
+    // discardable leaf beneath it. Lets the sidebar's section-disable confirm
+    // drop a whole mode's staged edits before flipping the enable flag, rather
+    // than relying on the framework PageAdapter::discard() no-op.
     const auto& groups = pageGroupChildren();
     const auto git = groups.constFind(page);
     if (git == groups.constEnd()) {
         qCWarning(PlasmaZones::lcCore) << "discardPage: no config manifest or child group for page" << page;
         return;
     }
+    // Dispatch on pageSupportsDiscard, not manifest membership: the ordering and
+    // Quick Shortcuts children are deliberately absent from the config manifest
+    // (they revert through their own staged machinery) yet isPageDirty recurses
+    // into them, so a parent is reported dirty when only they are edited. A
+    // manifest-only walk would leave those staged edits in place, and the
+    // section-disable confirm would then apply a partial edit — exactly what that
+    // confirm exists to prevent. Non-discardable children (e.g. shaders browser)
+    // return false and are skipped.
     for (const QString& child : *git) {
-        if (manifest.contains(child))
+        if (pageSupportsDiscard(child))
             discardPage(child);
     }
 }

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -257,10 +257,10 @@ bool SettingsController::pageSupportsReset(const QString& page) const
 {
     // Config-manifest pages write schema defaults; ordering pages drop the
     // custom order; shortcuts pages unassign every quick slot; the virtual
-    // screens page unsplits every monitor. Animation pages have no
-    // reset-to-defaults path.
+    // screens page unsplits every monitor; the Windows appearance page resets
+    // its 3 managed baseline rules. Animation pages have no reset-to-defaults path.
     return pageOwnedConfigKeys().contains(page) || isOrderingPage(page) || isShortcutsPage(page)
-        || page == QLatin1String("virtualscreens");
+        || page == QLatin1String("virtualscreens") || page == QLatin1String("window-appearance");
 }
 
 bool SettingsController::pageSupportsDiscard(const QString& page) const
@@ -284,8 +284,46 @@ void SettingsController::reconcilePageDirty(const QString& page)
     }
 }
 
+void SettingsController::reconcileRuleBackedDirty()
+{
+    if (m_rulesPage == nullptr)
+        return;
+    // The Windows appearance page and the Rules page stage into one shared
+    // RuleController model; attribute the two independently from the value-based
+    // subset-dirty queries so an appearance edit badges Windows and a user-rule
+    // edit badges Rules — even when the shared dirty bit does not transition.
+    bool changed = false;
+    const auto sync = [this, &changed](const QString& page, bool dirty) {
+        if (dirty) {
+            if (!m_dirtyPages.contains(page)) {
+                m_dirtyPages.insert(page);
+                changed = true;
+            }
+        } else if (m_dirtyPages.remove(page)) {
+            changed = true;
+        }
+    };
+    sync(QStringLiteral("window-appearance"), m_rulesPage->baselinesDirty());
+    sync(QStringLiteral("rules"), m_rulesPage->userRulesDirty());
+    if (changed) {
+        Q_EMIT dirtyPagesChanged();
+    }
+}
+
 void SettingsController::resetPage(const QString& page)
 {
+    // Windows appearance: reset the 3 managed baseline rules to factory (staged),
+    // then re-attribute. reconcileRuleBackedDirty is explicit because the reset
+    // may leave the shared dirty bit unchanged (user rules already dirty), so it
+    // can't rely on a dirtyChanged transition.
+    if (page == QLatin1String("window-appearance")) {
+        if (m_rulesPage != nullptr) {
+            m_rulesPage->resetBaselines();
+        }
+        reconcileRuleBackedDirty();
+        return;
+    }
+
     // Ordering pages: "reset to defaults" means dropping the custom order.
     // resetSnappingOrder/resetTilingOrder stage the empty (default) order and
     // mark the active page dirty themselves.
@@ -361,6 +399,16 @@ void SettingsController::resetPage(const QString& page)
 
 void SettingsController::discardPage(const QString& page)
 {
+    // Windows appearance: restore the 3 managed baseline rules from the last
+    // saved snapshot (leaving user rules untouched), then re-attribute.
+    if (page == QLatin1String("window-appearance")) {
+        if (m_rulesPage != nullptr) {
+            m_rulesPage->discardBaselineEdits();
+        }
+        reconcileRuleBackedDirty();
+        return;
+    }
+
     const auto& manifest = pageOwnedConfigKeys();
     const auto it = manifest.constFind(page);
     if (it != manifest.constEnd()) {

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -258,9 +258,11 @@ bool SettingsController::pageSupportsReset(const QString& page) const
     // Config-manifest pages write schema defaults; ordering pages drop the
     // custom order; shortcuts pages unassign every quick slot; the virtual
     // screens page unsplits every monitor; the Windows appearance page resets
-    // its 3 managed baseline rules. Animation pages have no reset-to-defaults path.
+    // its 3 managed baseline rules; animation pages clear every per-event
+    // override and reset the animation config keys.
     return pageOwnedConfigKeys().contains(page) || isOrderingPage(page) || isShortcutsPage(page)
-        || page == QLatin1String("virtualscreens") || page == QLatin1String("window-appearance");
+        || page == QLatin1String("virtualscreens") || page == QLatin1String("window-appearance")
+        || isAnimationPage(page);
 }
 
 bool SettingsController::pageSupportsDiscard(const QString& page) const
@@ -321,6 +323,40 @@ void SettingsController::resetPage(const QString& page)
             m_rulesPage->resetBaselines();
         }
         reconcileRuleBackedDirty();
+        return;
+    }
+
+    // Animation pages (whole tree, shared domain): reset to defaults =
+    // clear every per-event override file AND reset the animation config keys
+    // (Profile, ShaderProfileTree, WindowFiltering, Enabled, Backend) to their
+    // schema defaults. Both are STAGED like ordinary animation edits — the
+    // cleared files are snapshotted, so a subsequent Discard restores them, and
+    // Save commits. User presets / motion-set libraries are left alone (like
+    // user rules on the Rules page). Suppress onSettingsPropertyChanged during
+    // the config reset; mark the active page dirty explicitly below.
+    if (isAnimationPage(page)) {
+        if (m_animationsPage != nullptr) {
+            const bool wasLoading = m_loading;
+            m_loading = true;
+            m_animationsPage->clearAllOverrides();
+            m_settings.resetKeys(animationConfigKeys());
+            m_loading = wasLoading;
+        }
+        // isPageDirty(animation) is value-based (hasPendingChanges || any
+        // animation key modified); sync the active page's m_dirtyPages entry.
+        const bool nowDirty = isPageDirty(page);
+        bool changed = false;
+        if (nowDirty) {
+            if (!m_dirtyPages.contains(page)) {
+                m_dirtyPages.insert(page);
+                changed = true;
+            }
+        } else if (m_dirtyPages.remove(page)) {
+            changed = true;
+        }
+        if (changed) {
+            Q_EMIT dirtyPagesChanged();
+        }
         return;
     }
 

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -210,6 +210,12 @@ bool SettingsController::isPageDirty(const QString& page) const
         return m_staging.hasStagedTilingQuickSlots();
     }
 
+    // Virtual Screens page: dirty iff any physical screen has a staged
+    // virtual-screen edit (a split or a removal).
+    if (page == QLatin1String("virtualscreens")) {
+        return m_staging.hasStagedVirtualScreenConfigs();
+    }
+
     // Animation pages share one staging domain, so any of them is dirty exactly
     // when the tree has unsaved edits. Value-based like the manifest pages, so
     // the badge and the kebab's Discard-enabled state stay correct on every
@@ -250,9 +256,11 @@ bool SettingsController::isPageDirty(const QString& page) const
 bool SettingsController::pageSupportsReset(const QString& page) const
 {
     // Config-manifest pages write schema defaults; ordering pages drop the
-    // custom order; shortcuts pages unassign every quick slot. Animation pages
-    // have no reset-to-defaults path.
-    return pageOwnedConfigKeys().contains(page) || isOrderingPage(page) || isShortcutsPage(page);
+    // custom order; shortcuts pages unassign every quick slot; the virtual
+    // screens page unsplits every monitor. Animation pages have no
+    // reset-to-defaults path.
+    return pageOwnedConfigKeys().contains(page) || isOrderingPage(page) || isShortcutsPage(page)
+        || page == QLatin1String("virtualscreens");
 }
 
 bool SettingsController::pageSupportsDiscard(const QString& page) const
@@ -303,6 +311,32 @@ void SettingsController::resetPage(const QString& page)
         }
         Q_EMIT quickLayoutSlotsChanged();
         reconcilePageDirty(page);
+        return;
+    }
+
+    // Virtual Screens: "reset to defaults" unsplits every monitor. Drop any
+    // in-progress split edits, then stage a removal for each physical screen
+    // that currently HAS virtual screens (a >1-entry config). save() flushes
+    // the removals to the daemon + Settings. dirtyPagesChanged (emitted below)
+    // drives the page's _refreshConfig so the editor re-reads the reverted state.
+    if (page == QLatin1String("virtualscreens")) {
+        m_staging.clearVirtualScreenConfigs();
+        const QVariantList physicalScreens = screens();
+        for (const QVariant& entry : physicalScreens) {
+            const QString name = entry.toMap().value(QStringLiteral("name")).toString();
+            if (name.isEmpty())
+                continue;
+            const QString physId = physicalScreenId(name);
+            // A >1-entry config means the physical screen is split into virtual
+            // screens; single/empty means it is already at the native default.
+            if (!physId.isEmpty() && getVirtualScreenConfig(physId).size() > 1)
+                m_staging.stageVirtualScreenRemoval(physId);
+        }
+        if (m_staging.hasStagedVirtualScreenConfigs())
+            m_dirtyPages.insert(page);
+        else
+            m_dirtyPages.remove(page);
+        Q_EMIT dirtyPagesChanged();
         return;
     }
 
@@ -368,6 +402,18 @@ void SettingsController::discardPage(const QString& page)
             Q_EMIT quickLayoutSlotsChanged();
         }
         reconcilePageDirty(page);
+        return;
+    }
+
+    // Virtual Screens: drop every staged virtual-screen edit so the editor
+    // falls back to the daemon's saved configs. The Discard menu item is only
+    // enabled while staged edits exist, so there is always something to clear.
+    if (page == QLatin1String("virtualscreens")) {
+        m_staging.clearVirtualScreenConfigs();
+        m_dirtyPages.remove(page);
+        // Always emit so the page's dirtyPagesChanged handler re-reads the
+        // reverted config, even if other pages keep the global flag dirty.
+        Q_EMIT dirtyPagesChanged();
         return;
     }
 

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -20,6 +20,50 @@
 
 namespace PlasmaZones {
 
+namespace {
+
+// The two drag-to-reorder pages. Their state is the staged order optional
+// (m_stagedSnappingOrder / m_stagedTilingOrder), not config-manifest keys, so
+// per-page Reset/Discard dispatches to the ordering helpers rather than
+// resetKeys/discardKeys.
+bool isOrderingPage(const QString& page)
+{
+    return page == QLatin1String("snapping-ordering") || page == QLatin1String("tiling-ordering");
+}
+
+// Every animation leaf shares the single AnimationsPageController staging
+// domain (there is no per-subpage granularity), so pageGroupChildren("animations")
+// — the canonical leaf set — identifies them all. Discard reverts the whole tree.
+bool isAnimationPage(const QString& page)
+{
+    return SettingsController::pageGroupChildren().value(QStringLiteral("animations")).contains(page);
+}
+
+// The animation-tree config keys (Animations + Animations.WindowFiltering
+// groups). revertPending() covers the per-event override FILES and the
+// shader-tree dirty flag, but the caller contract (see revertPending()) says
+// the in-memory Settings keys — shader tree, animation Profile blob, window
+// filtering — are NOT reverted there; a follow-up must revert them, exactly
+// what discardKeys() does. Kept together here as the animation "value" surface,
+// paired with revertPending() for the full discard.
+const Settings::ConfigKeyList& animationConfigKeys()
+{
+    using CD = ConfigDefaults;
+    static const Settings::ConfigKeyList keys{
+        {CD::animationsGroup(), CD::backendKey()},
+        {CD::animationsGroup(), CD::enabledKey()},
+        {CD::animationsGroup(), CD::animationProfileKey()},
+        {CD::animationsGroup(), CD::shaderProfileTreeKey()},
+        {CD::animationsWindowFilteringGroup(), CD::transientWindowsKey()},
+        {CD::animationsWindowFilteringGroup(), CD::notificationsAndOsdKey()},
+        {CD::animationsWindowFilteringGroup(), CD::minimumWindowWidthKey()},
+        {CD::animationsWindowFilteringGroup(), CD::minimumWindowHeightKey()},
+    };
+    return keys;
+}
+
+} // namespace
+
 void SettingsController::navigateTo(const QString& address)
 {
     // Split the optional "#anchor" fragment. The page part flows through the
@@ -123,6 +167,45 @@ QStringList SettingsController::dirtyPages() const
 
 bool SettingsController::isPageDirty(const QString& page) const
 {
+    // Manifest-backed leaf: value-based — dirty iff any owned config key
+    // differs from the committed baseline. This stays correct across a
+    // per-page Discard/Reset (which mutate the store directly) without relying
+    // on the m_dirtyPages active-page heuristic.
+    const auto& manifest = pageOwnedConfigKeys();
+    const auto ownedIt = manifest.constFind(page);
+    if (ownedIt != manifest.constEnd()) {
+        for (const auto& gk : *ownedIt) {
+            if (m_settings.isKeyModified(gk.first, gk.second))
+                return true;
+        }
+        return false;
+    }
+
+    // Ordering pages: dirty iff a custom order is staged that differs from the
+    // saved order (a staged value equal to the saved order is not a change).
+    if (page == QLatin1String("snapping-ordering")) {
+        return m_stagedSnappingOrder.has_value() && *m_stagedSnappingOrder != m_settings.snappingLayoutOrder();
+    }
+    if (page == QLatin1String("tiling-ordering")) {
+        return m_stagedTilingOrder.has_value() && *m_stagedTilingOrder != m_settings.tilingAlgorithmOrder();
+    }
+
+    // Animation pages share one staging domain, so any of them is dirty exactly
+    // when the tree has unsaved edits. Value-based like the manifest pages, so
+    // the badge and the kebab's Discard-enabled state stay correct on every
+    // subpage. Two sources: the controller's file/shader-tree pending state
+    // (hasPendingChanges) AND the plain animation Settings keys (profile,
+    // shader tree value, window filtering) tracked against the baseline.
+    if (isAnimationPage(page)) {
+        if (m_animationsPage != nullptr && m_animationsPage->hasPendingChanges())
+            return true;
+        for (const auto& gk : animationConfigKeys()) {
+            if (m_settings.isKeyModified(gk.first, gk.second))
+                return true;
+        }
+        return false;
+    }
+
     if (m_dirtyPages.contains(page))
         return true;
     // Parent / virtual-parent category: dirty if any child leaf in
@@ -130,16 +213,153 @@ bool SettingsController::isPageDirty(const QString& page) const
     // `pageGroupChildren()` rather than the old prefix-walk-or-hash-
     // lookup branch — top-level parents (snapping / tiling /
     // animations) and virtual mid-level parents (animations-surfaces /
-    // animations-library) share the same code path now.
+    // animations-library) share the same code path now. Recurse through
+    // isPageDirty (not a bare m_dirtyPages lookup) so a manifest-backed child
+    // contributes its value-based dirty state to the collapsed parent badge.
     const auto& groups = pageGroupChildren();
     const auto it = groups.constFind(page);
     if (it != groups.constEnd()) {
         for (const QString& child : *it) {
-            if (m_dirtyPages.contains(child))
+            if (isPageDirty(child))
                 return true;
         }
     }
     return false;
+}
+
+bool SettingsController::pageSupportsReset(const QString& page) const
+{
+    // Config-manifest pages write schema defaults; ordering pages drop the
+    // custom order. Animation pages have no reset-to-defaults path.
+    return pageOwnedConfigKeys().contains(page) || isOrderingPage(page);
+}
+
+bool SettingsController::pageSupportsDiscard(const QString& page) const
+{
+    // Everything resettable can also discard, plus the animation pages (revert
+    // via the shared staging domain).
+    return pageSupportsReset(page) || isAnimationPage(page);
+}
+
+void SettingsController::reconcilePageDirty(const QString& page)
+{
+    // Match m_dirtyPages to the value-based truth for this manifest page.
+    const bool dirty = isPageDirty(page);
+    const bool had = m_dirtyPages.contains(page);
+    if (dirty && !had) {
+        m_dirtyPages.insert(page);
+        Q_EMIT dirtyPagesChanged();
+    } else if (!dirty && had) {
+        m_dirtyPages.remove(page);
+        Q_EMIT dirtyPagesChanged();
+    }
+}
+
+void SettingsController::resetPage(const QString& page)
+{
+    // Ordering pages: "reset to defaults" means dropping the custom order.
+    // resetSnappingOrder/resetTilingOrder stage the empty (default) order and
+    // mark the active page dirty themselves.
+    if (page == QLatin1String("snapping-ordering")) {
+        resetSnappingOrder();
+        return;
+    }
+    if (page == QLatin1String("tiling-ordering")) {
+        resetTilingOrder();
+        return;
+    }
+
+    const auto& manifest = pageOwnedConfigKeys();
+    const auto it = manifest.constFind(page);
+    if (it == manifest.constEnd()) {
+        qCWarning(PlasmaZones::lcCore) << "resetPage: no config manifest for page" << page;
+        return;
+    }
+    // Suppress onSettingsPropertyChanged for the reset's NOTIFY storm — it
+    // would otherwise mark the ACTIVE page dirty (which may differ from the
+    // page being reset). We reconcile `page`'s dirty state explicitly below.
+    const bool wasLoading = m_loading;
+    m_loading = true;
+    m_settings.resetKeys(*it);
+    m_loading = wasLoading;
+    // Resetting to defaults usually diverges from the saved baseline, so the
+    // page normally becomes dirty (stage → Save/Discard). If the defaults
+    // already matched the baseline it stays clean — reconcile handles both.
+    reconcilePageDirty(page);
+}
+
+void SettingsController::discardPage(const QString& page)
+{
+    const auto& manifest = pageOwnedConfigKeys();
+    const auto it = manifest.constFind(page);
+    if (it != manifest.constEnd()) {
+        const bool wasLoading = m_loading;
+        m_loading = true;
+        m_settings.discardKeys(*it);
+        m_loading = wasLoading;
+        // Every owned key is back at the committed baseline, so the page is clean.
+        reconcilePageDirty(page);
+        return;
+    }
+
+    // Ordering pages: drop the staged custom order so the effective order falls
+    // back to the saved value.
+    if (page == QLatin1String("snapping-ordering") || page == QLatin1String("tiling-ordering")) {
+        auto& staged = (page == QLatin1String("snapping-ordering")) ? m_stagedSnappingOrder : m_stagedTilingOrder;
+        if (staged.has_value()) {
+            staged.reset();
+            if (page == QLatin1String("snapping-ordering"))
+                Q_EMIT stagedSnappingOrderChanged();
+            else
+                Q_EMIT stagedTilingOrderChanged();
+        }
+        reconcilePageDirty(page);
+        return;
+    }
+
+    // Animation pages share one staging domain — discard reverts the whole tree
+    // in two halves. revertPending() restores the per-event override FILES and
+    // clears the shader-tree dirty flag; discardKeys() reverts the in-memory
+    // animation Settings keys (shader-tree value, Profile blob, window filtering)
+    // the revertPending() contract explicitly leaves for a follow-up. Reverting
+    // shaderProfileTree re-emits shaderProfileTreeChanged, which the controller
+    // observes to refresh — the load()-equivalent that contract requires.
+    if (isAnimationPage(page)) {
+        if (m_animationsPage != nullptr) {
+            m_animationsPage->revertPending();
+        }
+        const bool wasLoading = m_loading;
+        m_loading = true;
+        m_settings.discardKeys(animationConfigKeys());
+        m_loading = wasLoading;
+        // revertPending() left hasPendingChanges() false; clear every animation
+        // leaf's m_dirtyPages marker so the global needsSave drops the entries
+        // the pendingChangesChanged handler had attributed to the tree.
+        bool changed = false;
+        for (const QString& leaf : pageGroupChildren().value(QStringLiteral("animations"))) {
+            if (m_dirtyPages.remove(leaf))
+                changed = true;
+        }
+        if (changed) {
+            Q_EMIT dirtyPagesChanged();
+        }
+        return;
+    }
+
+    // Parent category (e.g. "snapping" / "tiling" / "placement"): discard every
+    // manifest-backed leaf beneath it. Lets the sidebar's section-disable
+    // confirm drop a whole mode's staged edits before flipping the enable flag,
+    // rather than relying on the framework PageAdapter::discard() no-op.
+    const auto& groups = pageGroupChildren();
+    const auto git = groups.constFind(page);
+    if (git == groups.constEnd()) {
+        qCWarning(PlasmaZones::lcCore) << "discardPage: no config manifest or child group for page" << page;
+        return;
+    }
+    for (const QString& child : *git) {
+        if (manifest.contains(child))
+            discardPage(child);
+    }
 }
 
 void SettingsController::beginExternalEdit(const QString& page)

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -267,9 +267,10 @@ bool SettingsController::pageSupportsReset(const QString& page) const
 
 bool SettingsController::pageSupportsDiscard(const QString& page) const
 {
-    // Everything resettable can also discard, plus the animation pages (revert
-    // via the shared staging domain).
-    return pageSupportsReset(page) || isAnimationPage(page);
+    // Every page that supports reset also supports discard (animation pages are
+    // already covered by pageSupportsReset). Kept as a distinct query so the two
+    // kebab items can diverge if a future page becomes discard-only.
+    return pageSupportsReset(page);
 }
 
 void SettingsController::reconcilePageDirty(const QString& page)
@@ -343,20 +344,9 @@ void SettingsController::resetPage(const QString& page)
             m_loading = wasLoading;
         }
         // isPageDirty(animation) is value-based (hasPendingChanges || any
-        // animation key modified); sync the active page's m_dirtyPages entry.
-        const bool nowDirty = isPageDirty(page);
-        bool changed = false;
-        if (nowDirty) {
-            if (!m_dirtyPages.contains(page)) {
-                m_dirtyPages.insert(page);
-                changed = true;
-            }
-        } else if (m_dirtyPages.remove(page)) {
-            changed = true;
-        }
-        if (changed) {
-            Q_EMIT dirtyPagesChanged();
-        }
+        // animation key modified), so reconcilePageDirty syncs the active page's
+        // m_dirtyPages entry against the post-reset truth.
+        reconcilePageDirty(page);
         return;
     }
 
@@ -373,11 +363,16 @@ void SettingsController::resetPage(const QString& page)
     }
 
     // Quick Shortcuts: "reset to defaults" unassigns every slot (the default is
-    // no assignment). Stage an empty id for each slot; save() flushes the clears
-    // to the daemon. quickLayoutSlotsChanged refreshes the slot cards.
+    // no assignment). Stage an empty id ONLY for slots that currently hold an
+    // assignment — an already-empty slot needs no change, so resetting an
+    // all-default page stages nothing (stays clean) and Save flushes no no-op
+    // clears. quickLayoutSlotsChanged refreshes the slot cards.
     if (isShortcutsPage(page)) {
         const bool snapping = (page == QLatin1String("snapping-shortcuts"));
         for (int slot = 1; slot <= kQuickLayoutSlotCount; ++slot) {
+            const QString current = snapping ? getQuickLayoutSlot(slot) : getTilingQuickLayoutSlot(slot);
+            if (current.isEmpty())
+                continue;
             if (snapping)
                 m_staging.stageSnappingQuickSlot(slot, QString());
             else

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -31,6 +31,18 @@ bool isOrderingPage(const QString& page)
     return page == QLatin1String("snapping-ordering") || page == QLatin1String("tiling-ordering");
 }
 
+// The two Quick Shortcuts pages. Their editable state is the per-mode staged
+// quick-slot layout assignments in StagingService (daemon-backed); the shortcut
+// keysequence is a read-only default in the standalone. Reset unassigns every
+// slot (the default), Discard drops the staged edits.
+bool isShortcutsPage(const QString& page)
+{
+    return page == QLatin1String("snapping-shortcuts") || page == QLatin1String("tiling-shortcuts");
+}
+
+// Quick-layout slots are numbered 1..9 (see SettingsController::getQuickLayoutSlot).
+constexpr int kQuickLayoutSlotCount = 9;
+
 // Every animation leaf shares the single AnimationsPageController staging
 // domain (there is no per-subpage granularity), so pageGroupChildren("animations")
 // — the canonical leaf set — identifies them all. Discard reverts the whole tree.
@@ -190,6 +202,14 @@ bool SettingsController::isPageDirty(const QString& page) const
         return m_stagedTilingOrder.has_value() && *m_stagedTilingOrder != m_settings.tilingAlgorithmOrder();
     }
 
+    // Quick Shortcuts pages: dirty iff a quick-slot edit is staged for the mode.
+    if (page == QLatin1String("snapping-shortcuts")) {
+        return m_staging.hasStagedSnappingQuickSlots();
+    }
+    if (page == QLatin1String("tiling-shortcuts")) {
+        return m_staging.hasStagedTilingQuickSlots();
+    }
+
     // Animation pages share one staging domain, so any of them is dirty exactly
     // when the tree has unsaved edits. Value-based like the manifest pages, so
     // the badge and the kebab's Discard-enabled state stay correct on every
@@ -230,8 +250,9 @@ bool SettingsController::isPageDirty(const QString& page) const
 bool SettingsController::pageSupportsReset(const QString& page) const
 {
     // Config-manifest pages write schema defaults; ordering pages drop the
-    // custom order. Animation pages have no reset-to-defaults path.
-    return pageOwnedConfigKeys().contains(page) || isOrderingPage(page);
+    // custom order; shortcuts pages unassign every quick slot. Animation pages
+    // have no reset-to-defaults path.
+    return pageOwnedConfigKeys().contains(page) || isOrderingPage(page) || isShortcutsPage(page);
 }
 
 bool SettingsController::pageSupportsDiscard(const QString& page) const
@@ -266,6 +287,22 @@ void SettingsController::resetPage(const QString& page)
     }
     if (page == QLatin1String("tiling-ordering")) {
         resetTilingOrder();
+        return;
+    }
+
+    // Quick Shortcuts: "reset to defaults" unassigns every slot (the default is
+    // no assignment). Stage an empty id for each slot; save() flushes the clears
+    // to the daemon. quickLayoutSlotsChanged refreshes the slot cards.
+    if (isShortcutsPage(page)) {
+        const bool snapping = (page == QLatin1String("snapping-shortcuts"));
+        for (int slot = 1; slot <= kQuickLayoutSlotCount; ++slot) {
+            if (snapping)
+                m_staging.stageSnappingQuickSlot(slot, QString());
+            else
+                m_staging.stageTilingQuickSlot(slot, QString());
+        }
+        Q_EMIT quickLayoutSlotsChanged();
+        reconcilePageDirty(page);
         return;
     }
 
@@ -312,6 +349,23 @@ void SettingsController::discardPage(const QString& page)
                 Q_EMIT stagedSnappingOrderChanged();
             else
                 Q_EMIT stagedTilingOrderChanged();
+        }
+        reconcilePageDirty(page);
+        return;
+    }
+
+    // Quick Shortcuts: drop the mode's staged quick-slot edits so the getters
+    // fall back to the daemon's saved slots.
+    if (isShortcutsPage(page)) {
+        const bool snapping = (page == QLatin1String("snapping-shortcuts"));
+        const bool hadStaged =
+            snapping ? m_staging.hasStagedSnappingQuickSlots() : m_staging.hasStagedTilingQuickSlots();
+        if (hadStaged) {
+            if (snapping)
+                m_staging.clearSnappingQuickSlots();
+            else
+                m_staging.clearTilingQuickSlots();
+            Q_EMIT quickLayoutSlotsChanged();
         }
         reconcilePageDirty(page);
         return;

--- a/src/settings/stagingservice.cpp
+++ b/src/settings/stagingservice.cpp
@@ -397,6 +397,11 @@ bool StagingService::stagedTilingQuickSlot(int slotNumber, QString& out) const
     return true;
 }
 
+void StagingService::clearVirtualScreenConfigs()
+{
+    m_virtualScreenConfigs.clear();
+}
+
 void StagingService::clearSnappingQuickSlots()
 {
     m_snappingQuickSlots.clear();

--- a/src/settings/stagingservice.cpp
+++ b/src/settings/stagingservice.cpp
@@ -365,6 +365,11 @@ void StagingService::flushVirtualScreensToDaemon()
     m_virtualScreenConfigs.clear();
 }
 
+void StagingService::clearVirtualScreenConfigs()
+{
+    m_virtualScreenConfigs.clear();
+}
+
 // ─── Quick layout slots ──────────────────────────────────────────────
 
 void StagingService::stageSnappingQuickSlot(int slotNumber, const QString& layoutId)
@@ -395,11 +400,6 @@ bool StagingService::stagedTilingQuickSlot(int slotNumber, QString& out) const
     }
     out = *it;
     return true;
-}
-
-void StagingService::clearVirtualScreenConfigs()
-{
-    m_virtualScreenConfigs.clear();
 }
 
 void StagingService::clearSnappingQuickSlots()

--- a/src/settings/stagingservice.cpp
+++ b/src/settings/stagingservice.cpp
@@ -397,6 +397,16 @@ bool StagingService::stagedTilingQuickSlot(int slotNumber, QString& out) const
     return true;
 }
 
+void StagingService::clearSnappingQuickSlots()
+{
+    m_snappingQuickSlots.clear();
+}
+
+void StagingService::clearTilingQuickSlots()
+{
+    m_tilingQuickSlots.clear();
+}
+
 void StagingService::flushQuickSlotsToDaemon()
 {
     // Quick slots are mode-keyed in the daemon's LayoutRegistry: snapping

--- a/src/settings/stagingservice.h
+++ b/src/settings/stagingservice.h
@@ -122,6 +122,17 @@ public:
     bool hasUnsavedVirtualScreenConfig(const QString& physicalScreenId) const;
     QVariantList stagedVirtualScreenConfig(const QString& physicalScreenId) const;
 
+    /// True if any virtual-screen edit is staged (any physical screen). Backs
+    /// the per-page dirty check for the Virtual Screens page.
+    bool hasStagedVirtualScreenConfigs() const
+    {
+        return !m_virtualScreenConfigs.isEmpty();
+    }
+
+    /// Drop all staged virtual-screen edits (per-page Discard reverts to the
+    /// saved configs; the getters fall back to the daemon otherwise).
+    void clearVirtualScreenConfigs();
+
     /// Persist staged VS configs to Settings (KConfig) for on-disk
     /// durability. Runs BEFORE `Settings::save()` — the subsequent save
     /// writes everything out in one go.

--- a/src/settings/stagingservice.h
+++ b/src/settings/stagingservice.h
@@ -143,6 +143,23 @@ public:
     bool stagedSnappingQuickSlot(int slotNumber, QString& out) const;
     bool stagedTilingQuickSlot(int slotNumber, QString& out) const;
 
+    /// True if any quick-slot edit is staged for the mode. Backs the per-page
+    /// dirty check for the Quick Shortcuts pages.
+    bool hasStagedSnappingQuickSlots() const
+    {
+        return !m_snappingQuickSlots.isEmpty();
+    }
+    bool hasStagedTilingQuickSlots() const
+    {
+        return !m_tilingQuickSlots.isEmpty();
+    }
+
+    /// Drop all staged quick-slot edits for the mode (per-page Discard reverts
+    /// to the daemon's saved slots; the getters fall back to the daemon when a
+    /// slot is not staged).
+    void clearSnappingQuickSlots();
+    void clearTilingQuickSlots();
+
     /// Push staged quick-layout slots (both snapping and tiling modes) to the
     /// daemon's mode-keyed LayoutRegistry via D-Bus. Runs AFTER `notifyReload`
     /// so the daemon has the fresh config. Clears both staging maps on

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -832,6 +832,29 @@ target_link_libraries(test_rule_controller
 )
 add_test(NAME test_rule_controller COMMAND test_rule_controller)
 
+# Per-page appearance Reset/Discard: shared baseline makers (in plasmazones_core)
+# + RuleController's baseline/user dirty split and resetBaselines/discardBaselineEdits.
+# Same RuleController TU set as test_rule_controller (the class spans several TUs).
+add_executable(test_baseline_reset
+    settings/test_baseline_reset.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings/rulemodel.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings/rulecontroller.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings/rulecontroller_views.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings/rulecontroller_lookups.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings/ruleauthoring.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings/ruletemplates.cpp
+)
+target_link_libraries(test_baseline_reset
+    PRIVATE
+        Qt6::Test
+        Qt6::Core
+        Qt6::DBus
+        PhosphorRules::PhosphorRules
+        PhosphorControl::PhosphorControl
+        plasmazones_core
+)
+add_test(NAME test_baseline_reset COMMAND test_baseline_reset)
+
 # Validation methods on D-Bus struct types - pins the accept/reject table
 # for validationError() so cross-field invariants (DragOutcome action range,
 # ApplySnap zoneId, TileRequestEntry tiled/floating size semantics, etc.)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -818,6 +818,7 @@ add_executable(test_rule_controller
     # rulecontroller.cpp stays under the 800-line cap; the
     # controller's class definition spans both TUs.
     ${CMAKE_SOURCE_DIR}/src/settings/rulecontroller_lookups.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings/rulecontroller_baseline.cpp
     ${CMAKE_SOURCE_DIR}/src/settings/ruleauthoring.cpp
     ${CMAKE_SOURCE_DIR}/src/settings/ruletemplates.cpp
 )
@@ -841,6 +842,7 @@ add_executable(test_baseline_reset
     ${CMAKE_SOURCE_DIR}/src/settings/rulecontroller.cpp
     ${CMAKE_SOURCE_DIR}/src/settings/rulecontroller_views.cpp
     ${CMAKE_SOURCE_DIR}/src/settings/rulecontroller_lookups.cpp
+    ${CMAKE_SOURCE_DIR}/src/settings/rulecontroller_baseline.cpp
     ${CMAKE_SOURCE_DIR}/src/settings/ruleauthoring.cpp
     ${CMAKE_SOURCE_DIR}/src/settings/ruletemplates.cpp
 )

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -266,6 +266,12 @@ p_add_test(test_settings_animation_profile config/test_settings_animation_profil
 # keep each test file under the project's <800-line guideline.
 p_add_test(test_settings_shader_tree config/test_settings_shader_tree.cpp)
 
+# Companion test executable: per-page Discard/Reset primitives — committed
+# baseline capture, isKeyModified, discardKeys (revert-to-baseline) and
+# resetKeys (revert-to-default) with NOTIFY re-emission. Split from
+# test_settings_core to keep each test file under the <800-line guideline.
+p_add_test(test_settings_pagereset config/test_settings_pagereset.cpp)
+
 p_add_test(test_settings_validation config/test_settings_validation.cpp)
 
 p_add_test(test_settings_perscreen config/test_settings_perscreen.cpp)

--- a/tests/unit/config/test_settings_pagereset.cpp
+++ b/tests/unit/config/test_settings_pagereset.cpp
@@ -152,6 +152,45 @@ private Q_SLOTS:
         QCOMPARE(spy.count(), 0);
         QVERIFY(!s.isKeyModified(key.first, key.second));
     }
+
+    // resetKeys() touches only the listed keys — a sibling edit survives.
+    void testResetKeys_leavesOtherKeysUntouched()
+    {
+        IsolatedConfigGuard guard;
+        Settings s;
+        const auto width = widthKey();
+        const auto radius = radiusKey();
+
+        const int w0 = s.borderWidth();
+        const int r0 = s.borderRadius();
+        const int wEdit = (w0 == 3) ? 4 : 3;
+        const int rEdit = (r0 == 20) ? 21 : 20;
+        s.setBorderWidth(wEdit);
+        s.setBorderRadius(rEdit);
+        s.save(); // baseline = the edited values
+
+        s.resetKeys({width}); // reset width to its schema default only
+
+        QCOMPARE(s.borderWidth(), w0); // schema default
+        QCOMPARE(s.borderRadius(), rEdit); // untouched
+        QVERIFY(s.isKeyModified(width.first, width.second)); // default != saved (wEdit)
+        QVERIFY(!s.isKeyModified(radius.first, radius.second));
+    }
+
+    // resetKeys() on a key already at its schema default emits no NOTIFY.
+    void testResetKeys_noopWhenAtDefault()
+    {
+        IsolatedConfigGuard guard;
+        Settings s;
+        const auto key = widthKey();
+        // Fresh Settings: borderWidth is already the schema default.
+        const int def = s.borderWidth();
+        QSignalSpy spy(&s, &Settings::borderWidthChanged);
+        s.resetKeys({key});
+
+        QCOMPARE(spy.count(), 0);
+        QCOMPARE(s.borderWidth(), def); // unchanged
+    }
 };
 
 QTEST_MAIN(TestSettingsPageReset)

--- a/tests/unit/config/test_settings_pagereset.cpp
+++ b/tests/unit/config/test_settings_pagereset.cpp
@@ -191,6 +191,51 @@ private Q_SLOTS:
         QCOMPARE(spy.count(), 0);
         QCOMPARE(s.borderWidth(), def); // unchanged
     }
+
+    // An empty key list is a no-op for both primitives: no settingsChanged, no
+    // property NOTIFY, nothing modified. Guards the "reset a page that owns no
+    // keys" path.
+    void testEmptyList_isNoop()
+    {
+        IsolatedConfigGuard guard;
+        Settings s;
+        s.save(); // baseline = defaults
+
+        QSignalSpy settingsSpy(&s, &Settings::settingsChanged);
+        QSignalSpy widthSpy(&s, &Settings::borderWidthChanged);
+        s.discardKeys({});
+        s.resetKeys({});
+
+        QCOMPARE(settingsSpy.count(), 0);
+        QCOMPARE(widthSpy.count(), 0);
+    }
+
+    // A key absent from the schema (and thus the captured baseline) is silently
+    // skipped by discardKeys — no crash, no spurious write clobbering a live
+    // sibling, no NOTIFY. resetKeys likewise leaves the store untouched (reset()
+    // is a no-op on an undeclared key). The synthetic key is intentionally not a
+    // ConfigDefaults accessor: it names a group/key the schema does not declare.
+    void testUnknownKey_isIgnored()
+    {
+        IsolatedConfigGuard guard;
+        Settings s;
+        const auto width = widthKey();
+        const Settings::ConfigKey bogus{QStringLiteral("NoSuchGroup"), QStringLiteral("NoSuchKey")};
+
+        const int w0 = s.borderWidth();
+        const int wEdit = (w0 == 3) ? 4 : 3;
+        s.setBorderWidth(wEdit);
+        s.save(); // baseline = wEdit
+
+        QSignalSpy widthSpy(&s, &Settings::borderWidthChanged);
+        s.discardKeys({bogus});
+        s.resetKeys({bogus});
+
+        // The unknown key never reports modified, and the real sibling is intact.
+        QVERIFY(!s.isKeyModified(bogus.first, bogus.second));
+        QCOMPARE(s.borderWidth(), wEdit);
+        QCOMPARE(widthSpy.count(), 0);
+    }
 };
 
 QTEST_MAIN(TestSettingsPageReset)

--- a/tests/unit/config/test_settings_pagereset.cpp
+++ b/tests/unit/config/test_settings_pagereset.cpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_settings_pagereset.cpp
+ * @brief Unit tests for the per-page Discard/Reset primitives on Settings.
+ *
+ * Covers the mutation engine the SettingsController per-page kebab drives:
+ *   - captureBaseline() (via load()/save()) + isKeyModified() value tracking
+ *   - discardKeys() — revert listed keys to the committed baseline
+ *   - resetKeys()   — set listed keys to their schema default
+ *   - NOTIFY re-emission so QML bindings refresh, and no-op when unchanged
+ *   - key isolation: touching one key never disturbs a sibling
+ *
+ * Split from test_settings_core.cpp to stay under the <800-line guideline.
+ */
+
+#include <QTest>
+#include <QSignalSpy>
+
+#include "../../../src/config/settings.h"
+#include "../../../src/config/configdefaults.h"
+#include "../helpers/IsolatedConfigGuard.h"
+
+using namespace PlasmaZones;
+using PlasmaZones::TestHelpers::IsolatedConfigGuard;
+
+class TestSettingsPageReset : public QObject
+{
+    Q_OBJECT
+
+    // Two scalar keys in the same group, both with wide integer ranges
+    // (border width 0-10, radius 0-50) so the test's chosen values never clamp.
+    static Settings::ConfigKey widthKey()
+    {
+        return {ConfigDefaults::snappingZonesBorderGroup(), ConfigDefaults::widthKey()};
+    }
+    static Settings::ConfigKey radiusKey()
+    {
+        return {ConfigDefaults::snappingZonesBorderGroup(), ConfigDefaults::radiusKey()};
+    }
+
+private Q_SLOTS:
+
+    // isKeyModified() reports the difference from the last committed baseline,
+    // which load() (here, construction) and save() refresh.
+    void testIsKeyModified_tracksBaseline()
+    {
+        IsolatedConfigGuard guard;
+        Settings s;
+        const auto key = widthKey();
+
+        // Freshly constructed: store equals the on-disk baseline.
+        QVERIFY(!s.isKeyModified(key.first, key.second));
+
+        const int def = s.borderWidth();
+        const int edited = (def == 3) ? 4 : 3;
+        s.setBorderWidth(edited);
+        QVERIFY(s.isKeyModified(key.first, key.second));
+
+        // Saving re-baselines: the edited value is now the committed value.
+        s.save();
+        QVERIFY(!s.isKeyModified(key.first, key.second));
+    }
+
+    // discardKeys() reverts the key to the committed baseline, fires the
+    // property NOTIFY exactly once, and clears the modified flag.
+    void testDiscardKeys_revertsToBaselineAndEmits()
+    {
+        IsolatedConfigGuard guard;
+        Settings s;
+        const auto key = widthKey();
+
+        const int def = s.borderWidth();
+        const int saved = (def == 3) ? 4 : 3;
+        const int edited = (def == 7) ? 6 : 7;
+        s.setBorderWidth(saved);
+        s.save(); // baseline = saved
+
+        s.setBorderWidth(edited);
+        QVERIFY(s.isKeyModified(key.first, key.second));
+
+        QSignalSpy spy(&s, &Settings::borderWidthChanged);
+        s.discardKeys({key});
+
+        QCOMPARE(s.borderWidth(), saved);
+        QCOMPARE(spy.count(), 1);
+        QVERIFY(!s.isKeyModified(key.first, key.second));
+    }
+
+    // resetKeys() sets the key to its schema default, NOT the saved baseline;
+    // when the default differs from the baseline the key reads as modified
+    // (the reset itself is a staged change awaiting Save/Discard).
+    void testResetKeys_setsSchemaDefault()
+    {
+        IsolatedConfigGuard guard;
+        Settings s;
+        const auto key = widthKey();
+
+        const int def = s.borderWidth();
+        const int saved = (def == 3) ? 4 : 3; // != def, in [0,10]
+        const int edited = (def == 7) ? 6 : 7; // != def and != saved
+        s.setBorderWidth(saved);
+        s.save(); // baseline = saved
+
+        s.setBorderWidth(edited);
+        QSignalSpy spy(&s, &Settings::borderWidthChanged);
+        s.resetKeys({key});
+
+        QCOMPARE(s.borderWidth(), def); // schema default, not the baseline
+        QCOMPARE(spy.count(), 1);
+        QVERIFY(s.isKeyModified(key.first, key.second)); // def != saved baseline
+    }
+
+    // discardKeys()/resetKeys() touch only the listed keys — a sibling key's
+    // unsaved edit in the same group survives.
+    void testDiscardKeys_leavesOtherKeysUntouched()
+    {
+        IsolatedConfigGuard guard;
+        Settings s;
+        const auto width = widthKey();
+        const auto radius = radiusKey();
+
+        const int w0 = s.borderWidth();
+        const int r0 = s.borderRadius();
+        s.save(); // baseline = defaults
+
+        const int wEdit = (w0 == 3) ? 4 : 3;
+        const int rEdit = (r0 == 20) ? 21 : 20;
+        s.setBorderWidth(wEdit);
+        s.setBorderRadius(rEdit);
+
+        s.discardKeys({width}); // revert width only
+
+        QCOMPARE(s.borderWidth(), w0); // reverted
+        QCOMPARE(s.borderRadius(), rEdit); // untouched
+        QVERIFY(!s.isKeyModified(width.first, width.second));
+        QVERIFY(s.isKeyModified(radius.first, radius.second));
+    }
+
+    // Reverting a key already at the baseline is a no-op: no NOTIFY, no change.
+    void testDiscardKeys_noopWhenAtBaseline()
+    {
+        IsolatedConfigGuard guard;
+        Settings s;
+        const auto key = widthKey();
+        s.save(); // baseline = current value, nothing dirty
+
+        QSignalSpy spy(&s, &Settings::borderWidthChanged);
+        s.discardKeys({key});
+
+        QCOMPARE(spy.count(), 0);
+        QVERIFY(!s.isKeyModified(key.first, key.second));
+    }
+};
+
+QTEST_MAIN(TestSettingsPageReset)
+#include "test_settings_pagereset.moc"

--- a/tests/unit/config/test_settings_pagereset.cpp
+++ b/tests/unit/config/test_settings_pagereset.cpp
@@ -231,9 +231,11 @@ private Q_SLOTS:
         s.discardKeys({bogus});
         s.resetKeys({bogus});
 
-        // The unknown key never reports modified, and the real sibling is intact.
+        // The unknown key never reports modified, and the real sibling is intact
+        // (value and modified-flag both undisturbed by the bogus operations).
         QVERIFY(!s.isKeyModified(bogus.first, bogus.second));
         QCOMPARE(s.borderWidth(), wEdit);
+        QVERIFY(!s.isKeyModified(width.first, width.second));
         QCOMPARE(widthSpy.count(), 0);
     }
 };

--- a/tests/unit/settings/test_animations_page_controller.cpp
+++ b/tests/unit/settings/test_animations_page_controller.cpp
@@ -275,6 +275,29 @@ private Q_SLOTS:
         QCOMPARE(spy.count(), 0);
     }
 
+    // Backs the per-page "Reset to defaults" on the animation pages: clears
+    // every per-event override file, returning them to built-in defaults.
+    void clearAllOverrides_removesEveryOverrideFile()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        AnimationsPageController c;
+        c.setUserProfilesDirOverride(tmp.path());
+
+        const QVariantMap profile{{QStringLiteral("duration"), 250},
+                                  {QStringLiteral("curve"), QStringLiteral("0.33,1,0.68,1")}};
+        QVERIFY(c.setOverride(QStringLiteral("editor.snapIn"), profile));
+        QVERIFY(c.setOverride(QStringLiteral("osd.show"), profile));
+        QVERIFY(c.hasOverride(QStringLiteral("editor.snapIn")));
+        QVERIFY(c.hasOverride(QStringLiteral("osd.show")));
+
+        QCOMPARE(c.clearAllOverrides(), 2);
+        QVERIFY(!c.hasOverride(QStringLiteral("editor.snapIn")));
+        QVERIFY(!c.hasOverride(QStringLiteral("osd.show")));
+        // Nothing left — a second sweep removes zero files.
+        QCOMPARE(c.clearAllOverrides(), 0);
+    }
+
     // ─── Effective resolution ─────────────────────────────────────────────
 
     void resolvedProfile_unsetReturnsLibraryDefaults()

--- a/tests/unit/settings/test_baseline_reset.cpp
+++ b/tests/unit/settings/test_baseline_reset.cpp
@@ -188,9 +188,50 @@ private Q_SLOTS:
         const auto resetBorder = store.ruleSet().ruleById(ConfigDefaults::baselineBorderRuleId());
         QVERIFY(resetBorder.has_value());
         QCOMPARE(resetBorder.value(), makeBaselineBorderRule());
-        // User rule preserved, total count unchanged.
-        QVERIFY(store.ruleSet().ruleById(user.id).has_value());
+        // User rule preserved byte-for-byte (Policy A), total count unchanged.
+        const auto keptUser = store.ruleSet().ruleById(user.id);
+        QVERIFY(keptUser.has_value());
+        QCOMPARE(keptUser.value(), user);
         QCOMPARE(store.ruleSet().rules().size(), 4);
+    }
+
+    // resetManagedDefaults must operate on the CURRENTLY PERSISTED set, not the
+    // adaptor store's (possibly stale) in-memory set. Reproduces the real
+    // scenario: the settings process rewrote rules.json out-of-band (as
+    // Settings::reset() does to drop disable rules) while the daemon's borrowed
+    // store still holds the old in-memory set. The m_store->load() at the top of
+    // resetManagedDefaults must pick up the on-disk set first. Without it, this
+    // test fails (the stale user rule survives / the on-disk one is lost).
+    void daemonResetReloadsOnDiskSetFirst()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const QString path = dir.filePath(QStringLiteral("rules.json"));
+
+        // Adaptor's store: in-memory set carries userStale.
+        PhosphorRules::RuleStore store(path);
+        const Rule userStale = makeUserRule(QStringLiteral("stale"));
+        store.setAllRules({makeBaselineBorderRule(), makeBaselineTitleBarRule(), makeBaselineGapRule(), userStale});
+
+        // Out-of-band write (a second process/store) replaces userStale with
+        // userDisk on disk. The adaptor's `store` does NOT see this yet.
+        const Rule userDisk = makeUserRule(QStringLiteral("on-disk"));
+        {
+            PhosphorRules::RuleStore external(path);
+            external.setAllRules(
+                {makeBaselineBorderRule(), makeBaselineTitleBarRule(), makeBaselineGapRule(), userDisk});
+        }
+
+        QObject holder;
+        RuleAdaptor adaptor(&store, &holder);
+        adaptor.resetManagedDefaults();
+
+        // The reload must have run: the on-disk user rule wins, the stale one is gone.
+        QVERIFY(store.ruleSet().ruleById(userDisk.id).has_value());
+        QVERIFY(!store.ruleSet().ruleById(userStale.id).has_value());
+        QCOMPARE(store.ruleSet().rules().size(), 4);
+        // Baselines still reset to factory.
+        QCOMPARE(store.ruleSet().ruleById(ConfigDefaults::baselineBorderRuleId()).value(), makeBaselineBorderRule());
     }
 };
 

--- a/tests/unit/settings/test_baseline_reset.cpp
+++ b/tests/unit/settings/test_baseline_reset.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * @file test_baseline_reset.cpp
+ * @brief Coverage for the per-page appearance Reset/Discard primitives:
+ *        the shared baseline-rule makers (core/baselinerules.h) and
+ *        RuleController's value-based baseline/user dirty split plus
+ *        resetBaselines() / discardBaselineEdits().
+ *
+ * All exercised without a live daemon: the model is populated directly and
+ * captureSavedSnapshot() establishes the "last saved" baseline.
+ */
+
+#include <QTest>
+
+#include <PhosphorRules/MatchExpression.h>
+#include <PhosphorRules/Rule.h>
+#include <PhosphorRules/RuleAction.h>
+
+#include "../../../src/core/baselinerules.h"
+#include "../../../src/config/configdefaults.h"
+#include "../../../src/settings/rulecontroller.h"
+#include "../../../src/settings/rulemodel.h"
+
+using namespace PlasmaZones;
+using PhosphorRules::Rule;
+
+namespace {
+
+// A minimal non-managed user rule, distinct from the managed baselines.
+Rule makeUserRule(const QString& name)
+{
+    Rule r;
+    r.id = QUuid::createUuid();
+    r.name = name;
+    r.managed = false;
+    r.priority = 100;
+    r.match = PhosphorRules::MatchExpression{}; // empty = matches all, valid
+    // A rule needs at least one registered action to be valid (Rule::isValid).
+    PhosphorRules::RuleAction a;
+    a.type = QString(PhosphorRules::ActionType::SetBorderVisible);
+    a.params.insert(QString(PhosphorRules::ActionParam::Value), true);
+    r.actions = {a};
+    return r;
+}
+
+// The full seeded rule set: the 3 managed baselines + one user rule.
+QList<Rule> seededSet(const Rule& user)
+{
+    return {makeBaselineBorderRule(), makeBaselineTitleBarRule(), makeBaselineGapRule(), user};
+}
+
+} // namespace
+
+class TestBaselineReset : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+
+    // The moved makers keep their canonical ids, managed flag, and action shape.
+    void makersProduceExpectedShape()
+    {
+        const Rule border = makeBaselineBorderRule();
+        QCOMPARE(border.id, ConfigDefaults::baselineBorderRuleId());
+        QVERIFY(border.managed);
+        QCOMPARE(border.actions.size(), 1);
+        QCOMPARE(border.actions.at(0).type, QString(PhosphorRules::ActionType::SetBorderVisible));
+
+        const Rule titleBar = makeBaselineTitleBarRule();
+        QCOMPARE(titleBar.id, ConfigDefaults::baselineTitleBarRuleId());
+        QVERIFY(titleBar.managed);
+
+        const Rule gap = makeBaselineGapRule();
+        QCOMPARE(gap.id, ConfigDefaults::baselineGapRuleId());
+        QVERIFY(gap.managed);
+        // Inner gap, outer gap, per-side toggle — the three parent actions only.
+        QCOMPARE(gap.actions.size(), 3);
+    }
+
+    // baselinesDirty tracks the managed subset; userRulesDirty the rest.
+    void dirtySplitAttributesCorrectly()
+    {
+        RuleController controller;
+        const Rule user = makeUserRule(QStringLiteral("u"));
+        controller.model()->setRules(seededSet(user));
+        controller.captureSavedSnapshot();
+
+        QVERIFY(!controller.baselinesDirty());
+        QVERIFY(!controller.userRulesDirty());
+
+        // Editing a managed baseline dirties appearance only.
+        Rule border = makeBaselineBorderRule();
+        border.actions[0].params.insert(QString(PhosphorRules::ActionParam::Value), true);
+        controller.model()->updateRule(border);
+        QVERIFY(controller.baselinesDirty());
+        QVERIFY(!controller.userRulesDirty());
+
+        // Restore appearance, then edit the user rule — dirties rules only.
+        controller.discardBaselineEdits();
+        QVERIFY(!controller.baselinesDirty());
+        Rule editedUser = user;
+        editedUser.name = QStringLiteral("renamed");
+        controller.model()->updateRule(editedUser);
+        QVERIFY(!controller.baselinesDirty());
+        QVERIFY(controller.userRulesDirty());
+    }
+
+    // resetBaselines rewrites the 3 baselines to factory and leaves user rules.
+    void resetBaselinesRestoresFactoryAndKeepsUserRules()
+    {
+        RuleController controller;
+        const Rule user = makeUserRule(QStringLiteral("keep-me"));
+
+        // Seed with a border baseline flipped ON and a gap baseline carrying an
+        // extra per-side action — both diverge from factory.
+        Rule border = makeBaselineBorderRule();
+        border.actions[0].params.insert(QString(PhosphorRules::ActionParam::Value), true);
+        Rule gap = makeBaselineGapRule();
+        PhosphorRules::RuleAction perSide;
+        perSide.type = QString(PhosphorRules::ActionType::SetOuterGapTop);
+        perSide.params.insert(QString(PhosphorRules::ActionParam::Value), 7);
+        gap.actions.append(perSide);
+        controller.model()->setRules({border, makeBaselineTitleBarRule(), gap, user});
+        controller.captureSavedSnapshot();
+
+        controller.resetBaselines();
+
+        // Baselines back to factory (gap's per-side action dropped).
+        QCOMPARE(controller.model()->ruleById(ConfigDefaults::baselineBorderRuleId()), makeBaselineBorderRule());
+        QCOMPARE(controller.model()->ruleById(ConfigDefaults::baselineGapRuleId()), makeBaselineGapRule());
+        QCOMPARE(controller.model()->ruleById(ConfigDefaults::baselineGapRuleId()).actions.size(), 3);
+        // User rule untouched, count unchanged.
+        QCOMPARE(controller.model()->rowCount(), 4);
+        QCOMPARE(controller.model()->ruleById(user.id), user);
+    }
+
+    // discardBaselineEdits restores baselines from the snapshot without touching
+    // a concurrently-edited user rule.
+    void discardBaselineEditsIsolatesUserRules()
+    {
+        RuleController controller;
+        const Rule user = makeUserRule(QStringLiteral("mine"));
+        controller.model()->setRules(seededSet(user));
+        controller.captureSavedSnapshot();
+
+        // Edit both a baseline and the user rule.
+        Rule border = makeBaselineBorderRule();
+        border.actions[0].params.insert(QString(PhosphorRules::ActionParam::Value), true);
+        controller.model()->updateRule(border);
+        Rule editedUser = user;
+        editedUser.name = QStringLiteral("edited");
+        controller.model()->updateRule(editedUser);
+
+        controller.discardBaselineEdits();
+
+        // Baseline reverted to the snapshot (factory OFF), user edit preserved.
+        QCOMPARE(controller.model()->ruleById(ConfigDefaults::baselineBorderRuleId()), makeBaselineBorderRule());
+        QCOMPARE(controller.model()->ruleById(user.id).name, QStringLiteral("edited"));
+        QVERIFY(!controller.baselinesDirty());
+        QVERIFY(controller.userRulesDirty());
+    }
+};
+
+QTEST_MAIN(TestBaselineReset)
+#include "test_baseline_reset.moc"

--- a/tests/unit/settings/test_baseline_reset.cpp
+++ b/tests/unit/settings/test_baseline_reset.cpp
@@ -12,14 +12,18 @@
  * captureSavedSnapshot() establishes the "last saved" baseline.
  */
 
+#include <QObject>
+#include <QTemporaryDir>
 #include <QTest>
 
 #include <PhosphorRules/MatchExpression.h>
 #include <PhosphorRules/Rule.h>
 #include <PhosphorRules/RuleAction.h>
+#include <PhosphorRules/RuleStore.h>
 
-#include "../../../src/core/baselinerules.h"
 #include "../../../src/config/configdefaults.h"
+#include "../../../src/core/baselinerules.h"
+#include "../../../src/dbus/ruleadaptor.h"
 #include "../../../src/settings/rulecontroller.h"
 #include "../../../src/settings/rulemodel.h"
 
@@ -160,6 +164,33 @@ private Q_SLOTS:
         QCOMPARE(controller.model()->ruleById(user.id).name, QStringLiteral("edited"));
         QVERIFY(!controller.baselinesDirty());
         QVERIFY(controller.userRulesDirty());
+    }
+
+    // Track B: the daemon-side reset (RuleAdaptor::resetManagedDefaults) restores
+    // the 3 baselines to factory in the store and preserves user rules (Policy A),
+    // persisting once.
+    void daemonResetRestoresBaselinesPreservesUserRules()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        PhosphorRules::RuleStore store(dir.filePath(QStringLiteral("rules.json")));
+
+        // Seed a border baseline flipped ON (diverges from factory) + a user rule.
+        Rule border = makeBaselineBorderRule();
+        border.actions[0].params.insert(QString(PhosphorRules::ActionParam::Value), true);
+        const Rule user = makeUserRule(QStringLiteral("keep"));
+        store.setAllRules({border, makeBaselineTitleBarRule(), makeBaselineGapRule(), user});
+
+        QObject holder; // QDBusAbstractAdaptor needs a parent object.
+        RuleAdaptor adaptor(&store, &holder);
+        adaptor.resetManagedDefaults();
+
+        const auto resetBorder = store.ruleSet().ruleById(ConfigDefaults::baselineBorderRuleId());
+        QVERIFY(resetBorder.has_value());
+        QCOMPARE(resetBorder.value(), makeBaselineBorderRule());
+        // User rule preserved, total count unchanged.
+        QVERIFY(store.ruleSet().ruleById(user.id).has_value());
+        QCOMPARE(store.ruleSet().rules().size(), 4);
     }
 };
 


### PR DESCRIPTION
## Summary

Adds per-page **Reset to defaults** and **Discard changes** across the settings app, plus fixes the global **Restore Defaults** regression for rule-backed appearance. Previously there was no way to return a settings page to its defaults; now a breadcrumb-row kebab (⋮) offers the two actions, staged through the normal Save/Discard footer, on every page that has resettable state.

## UX

A ⋮ overflow in the breadcrumb row shows two items, gated per page:
- **Reset page to defaults** — restore this page's settings to factory (staged).
- **Discard changes on this page** — drop this page's unsaved edits, leaving other pages untouched.

Both go through confirm dialogs and commit only on the global Save.

## Coverage

| Page(s) | Reset | Discard | Backing |
|---|:---:|:---:|---|
| General, Snapping (overlay behavior/appearance, zone selector, window behavior), Tiling (behavior, algorithm), Editor | ✅ | ✅ | KConfig manifest |
| Snapping/Tiling → Priority (ordering) | ✅ | ✅ | staged order |
| Snapping/Tiling → Quick Shortcuts | ✅ | ✅ | daemon quick-slot staging |
| Display → Virtual Screens | ✅ | ✅ | `StagingService` + daemon |
| Appearance → Windows | ✅ | ✅ | daemon `rules.json` baselines |
| Animations (all subpages) | ✅ | ✅ | override files + shader tree + config keys |

Not applicable (no kebab): Rules (user content), Layouts (CRUD), snapping-shaders (browser), Overview, About.

## How it works

- **Value-based dirty + committed baseline** in `Settings` (`captureBaseline` at load/save; `discardKeys`/`resetKeys` reuse `load()`'s NOTIFY re-emit). A partitioned page→keys manifest (`pageOwnedConfigKeys`, all via `ConfigDefaults` accessors) drives the KConfig pages.
- **Rule-backed pages** (Windows appearance) share one `RuleController` model. A value-based split (`baselinesDirty` vs `userRulesDirty`, against a saved snapshot) attributes appearance edits to Windows and rule edits to Rules; `resetBaselines`/`discardBaselineEdits` operate on the 3 managed baselines only. Baseline makers were moved to a shared `plasmazones_core/baselinerules` unit.
- **Global Restore Defaults** now also resets the rule-backed appearance/gap baselines via a new daemon-side `org.plasmazones.Rules.resetManagedDefaults()` (reloads first so it can't rewrite the disable-rules `Settings::reset()` just dropped; preserves user rules — Policy A). Implements the deferred track B of `docs/restore-defaults-rule-reset-design.md`.
- **Animations** reset clears every per-event override file + resets the animation config keys, staged (Discard restores, Save commits); user preset/motion-set libraries are preserved.
- A generic `breadcrumbTrailing` slot was added to the framework `SettingsAppWindow`.

## Tests

New `test_settings_pagereset` (baseline/discard/reset/NOTIFY/isolation), `test_baseline_reset` (rule split + daemon reset), and a `clearAllOverrides` case. Full suite: **249/249 passing**, build clean, clang-format + qmllint clean.

## Notes

- Design doc `docs/restore-defaults-rule-reset-design.md` updated (§0) to reflect the staged per-page approach and mark track B implemented.
- Not exercised in a live session — worth a manual click-through of the daemon round-trips (Windows appearance reset, global Restore Defaults, animations reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
