### PR TITLE
fix(build): eliminate all compiler warnings

### DIFF
--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -34,30 +34,30 @@ struct WindowMetadata
     // compositor could not report it — e.g. no underlying KWin::Window) leaves the
     // corresponding WindowQuery field disengaged, keeping a predicate over it inert,
     // mirroring window_query.cpp's engage-only-when-known contract. ──
-    std::optional<bool> isMinimized;
-    std::optional<bool> isFullscreen;
-    std::optional<bool> isSticky; ///< on all virtual desktops
-    std::optional<bool> isMaximized; ///< MaximizeFull (both axes)
-    std::optional<bool> isFocused; ///< focused at metadata-push time (point-in-time, NOT
-                                   ///< refreshed on focus change) — the open-path Float /
-                                   ///< RestorePosition resolvers read it at window-open, where
-                                   ///< it is fresh; the effect path reads live isFocused for
-                                   ///< continuously-evaluated border / opacity rules.
-    std::optional<bool> isTransient; ///< dialog/utility/popup/menu/tooltip/splash family or has a transient parent
-    std::optional<bool> isNotification; ///< notification / critical-notification / on-screen-display
-    std::optional<bool> keepAbove;
-    std::optional<bool> keepBelow;
-    std::optional<bool> skipTaskbar;
-    std::optional<bool> skipPager;
-    std::optional<bool> skipSwitcher;
-    std::optional<bool> isModal;
-    std::optional<bool> hasDecoration; ///< server-side title-bar / border
-    std::optional<bool> isResizable;
-    std::optional<int> width; ///< frame width in px
-    std::optional<int> height; ///< frame height in px
-    std::optional<int> positionX; ///< frame left edge X in px
-    std::optional<int> positionY; ///< frame top edge Y in px
-    std::optional<QString> captionNormal; ///< title without the WM-added app-name suffix
+    std::optional<bool> isMinimized{};
+    std::optional<bool> isFullscreen{};
+    std::optional<bool> isSticky{}; ///< on all virtual desktops
+    std::optional<bool> isMaximized{}; ///< MaximizeFull (both axes)
+    std::optional<bool> isFocused{}; ///< focused at metadata-push time (point-in-time, NOT
+                                     ///< refreshed on focus change) — the open-path Float /
+                                     ///< RestorePosition resolvers read it at window-open, where
+                                     ///< it is fresh; the effect path reads live isFocused for
+                                     ///< continuously-evaluated border / opacity rules.
+    std::optional<bool> isTransient{}; ///< dialog/utility/popup/menu/tooltip/splash family or has a transient parent
+    std::optional<bool> isNotification{}; ///< notification / critical-notification / on-screen-display
+    std::optional<bool> keepAbove{};
+    std::optional<bool> keepBelow{};
+    std::optional<bool> skipTaskbar{};
+    std::optional<bool> skipPager{};
+    std::optional<bool> skipSwitcher{};
+    std::optional<bool> isModal{};
+    std::optional<bool> hasDecoration{}; ///< server-side title-bar / border
+    std::optional<bool> isResizable{};
+    std::optional<int> width{}; ///< frame width in px
+    std::optional<int> height{}; ///< frame height in px
+    std::optional<int> positionX{}; ///< frame left edge X in px
+    std::optional<int> positionY{}; ///< frame top edge Y in px
+    std::optional<QString> captionNormal{}; ///< title without the WM-added app-name suffix
 
     bool operator==(const WindowMetadata& other) const
     {

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/PlacementDirective.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/PlacementDirective.h
@@ -32,8 +32,8 @@ namespace PhosphorSnapEngine {
  */
 struct PlacementDirective
 {
-    QList<int> zoneOrdinals;
-    QString targetScreenId;
+    QList<int> zoneOrdinals{};
+    QString targetScreenId{};
     int targetDesktop = 0;
 };
 

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapEngine.h
@@ -440,7 +440,10 @@ public:
     /// (the per-screen stores, the global-scalar holder, and any created later)
     /// plus the engine's own canonicalization so the reverse map keys on the same
     /// stable first-seen composite the stores do (issue #628). Not owned.
-    void setWindowRegistry(PhosphorEngine::IWindowRegistry* registry);
+    ///
+    /// Overrides IPlacementEngine::setWindowRegistry(QObject*): the interface hands
+    /// engines a QObject carrying the registry and each casts to its concrete type.
+    void setWindowRegistry(QObject* registry) override;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Per-screen state resolution

--- a/libs/phosphor-snap-engine/src/SnapEngine.cpp
+++ b/libs/phosphor-snap-engine/src/SnapEngine.cpp
@@ -42,8 +42,12 @@ SnapEngine::SnapEngine(PhosphorZones::LayoutRegistry* layoutManager,
     m_states.insertState(PhosphorEngine::PlacementStateKey{}, m_globals);
 }
 
-void SnapEngine::setWindowRegistry(PhosphorEngine::IWindowRegistry* registry)
+void SnapEngine::setWindowRegistry(QObject* registryObject)
 {
+    // The interface passes a QObject carrying the registry; cast to the concrete
+    // interface (IWindowRegistry is not itself a QObject, so dynamic_cast, matching
+    // AutotileEngine). A null cast clears the registry, same as the old signature.
+    auto* registry = dynamic_cast<PhosphorEngine::IWindowRegistry*>(registryObject);
     m_windowRegistry = registry;
     for (SnapState* state : m_states.states()) {
         if (state) {


### PR DESCRIPTION
## Summary

A clean build with `-DBUILD_TESTING=ON` surfaced **443 compiler warnings**. This fixes both root causes at the source. Result: clean full build with tests enabled is **0 warnings, 0 errors, 252/252 tests passing**.

## Changes

**`-Woverloaded-virtual` (1) — `SnapEngine`**
The interface exposes `IPlacementEngine::setWindowRegistry(QObject*)`, and each engine `dynamic_cast`s to its concrete registry type internally (as `AutotileEngine` does). `SnapEngine` had declared `setWindowRegistry(IWindowRegistry*)`, a different signature that *hid* the base virtual instead of overriding it. Now it overrides the `QObject*` signature and casts internally. The daemon call site is unchanged (`WindowRegistry*` converts implicitly to `QObject*`).

**`-Wmissing-field-initializers` (442) — `WindowMetadata` and `PlacementDirective`**
These aggregates are brace-initialized in tests with only their leading fields. Members *with* default initializers (`pid = 0`, `targetDesktop = 0`, `windowRole{}`) were silent, but the `std::optional<>` members and `zoneOrdinals` / `targetScreenId` lacked one, so omitting them warned. Gave those members explicit `{}` defaults, consistent with the rest of each struct. No behavior change (`optional{}` is `nullopt`; `QList{}`/`QString{}` are empty).

## Testing

- Clean full build (`-DBUILD_TESTING=ON`): 0 warnings, 0 errors
- `ctest`: 100% passed, 0 failed out of 252

🤖 Generated with [Claude Code](https://claude.com/claude-code)