### PR TITLE
feat(rules): additive rule action + match-field expansion (config-authoritative)

### DIFF
--- a/docs/rule-expansion-plan.md
+++ b/docs/rule-expansion-plan.md
@@ -1,0 +1,200 @@
+# Rule Expansion Plan (v3.2, branch: rule-expansion)
+
+Expand the rules ACTION/FIELD vocabulary so power users can author more per-window / per-context
+rules, WITHOUT retiring config. This is the opposite of the busted `feat/config-rules-fold-v5`
+branch, which turned config purely rule-backed. We do NOT want that.
+
+## Core invariant
+
+Every consumer reads **`rule-slot ?? config-getter`** — the rule slot is optional, the config
+getter is the fallback. Config stays authoritative for the global default. Per-screen behavior is
+expressed as a `WHEN ScreenId Equals <edid>` rule on top of the global config default (option "ii":
+no new per-screen config stores; existing per-screen config stores for gaps/zone-selector stay
+untouched).
+
+Consequences:
+- No config group is retired. No `finalizeV5Conversion`/strip pattern.
+- No config schema migration. `RuleSet::SchemaVersion` untouched (new fields: unknown tokens are
+  dropped by the loader; new actions that don't retire config cost nothing).
+- `phosphor-rules` / `phosphor-zones` edits are LGPL (SPDX `LGPL-2.1-or-later`). Translated labels
+  live in the GPL `src/settings` layer (`ruleauthoring.cpp`), NEVER in the lib.
+- Every step ends with `cmake --build build --parallel $(nproc)` + `ctest --output-on-failure` green,
+  and the ~3 QML render sites + `ruleauthoring.cpp` labels wired (else raw/untranslated UI).
+
+## Generic recipe — new ACTION (5 edit points)
+
+1. `libs/phosphor-rules/include/PhosphorRules/RuleAction.h` — add `ActionType::X`, any
+   `ActionParam::*` key, `ActionSlot::X`.
+2. `libs/phosphor-rules/src/ruleaction.cpp` `registerBuiltins()` — one `registerAction(ActionDescriptor{...})`.
+3. Consumer — resolve the slot, `slot ?? config`.
+4. QML 3-place value renderer:
+   - `src/settings/qml/ActionRow.qml` (editor input, dispatch on `ParamSchema.kind`)
+   - `src/settings/qml/ActionListView.qml` (read-only summary)
+   - `src/settings/ruleauthoring.cpp` (`defaultPayloadFor()` default seeding + translated labels)
+   A new `kind` string needs a branch in all three; reusing an existing kind needs only labels/default.
+
+## Generic recipe — new FIELD (WHEN side)
+
+1. `libs/phosphor-rules/include/PhosphorRules/MatchTypes.h` — enum `Field` + `kFieldTable` row.
+2. `libs/phosphor-rules/include/PhosphorRules/WindowQuery.h` — struct field + `valueForField()` case.
+3. Populate at the query-build site.
+4. QML 3-place: `src/settings/qml/MatchLeafEditor.qml`, `src/settings/qml/MatchExpressionView.qml`,
+   `src/settings/ruleauthoring.cpp` (label + `valueKind` seeding).
+5. WINDOW fields consumed daemon-side additionally need the 4-stage metadata plumb:
+   effect query (`kwin-effect/plasmazoneseffect/window_query.cpp`) → a{sv} push
+   (`window_identity.cpp`) → `WindowMetadata` struct/parse
+   (`PhosphorEngine/WindowRegistry.h` + `windowtrackingadaptor.cpp` ~:858) → `buildRuleQueryForWindow`
+   (`enginewiring.cpp:385-440`).
+   CONTEXT fields populate at `makeContextQuery` (`layoutregistry_rulehelpers.cpp:21-30`) and
+   `ContextResolver::handleFor` (`contextresolver.cpp:36-51`).
+
+---
+
+## STATUS
+
+- **Tier 1 overlay appearance: DONE** (uncommitted, branch `rule-expansion`). 8 Context actions
+  (`SetOverlay{HighlightColor,InactiveColor,BorderColor,ActiveOpacity,InactiveOpacity,BorderWidth,
+  BorderRadius,ShowZoneNumbers}`) registered; `ContextOverlayOverride` extended + populated in
+  `resolveContextOverlay`; consumers layered `rule ?? config` at the main overlay (QML-property +
+  shader-texture paths), snap-assist, and layout picker; labels/seeding in `ruleauthoring.cpp`
+  (overlay colours seed a concrete hex, NOT the accent sentinel — validator is `hasHexColor`). No
+  new QML kind (reused color/percent/number/bool → zero `ActionRow.qml`/`ActionListView.qml`
+  changes). Tests: domain-pin list + validation (`test_ruleaction.cpp`) + resolution
+  (`test_rule_cascade_fidelity.cpp::testContextOverlay_appearanceOverrides`). Full suite 251/251
+  green. NOT yet runtime-verified in-app; NOT committed.
+- **Tier 3 window bool fields: DONE** (uncommitted). `IsMovable` (36) + `IsMaximizable` (37) added:
+  `MatchTypes.h` enum+table+FieldCount(38), `WindowQuery` field+valueForField, full 4-stage window
+  plumb (window_query.cpp `kw->isMovable()`/`isMaximizable()` → window_identity a{sv} → ServiceConstants
+  keys → WindowRegistry struct+operator== → windowtrackingadaptor parse+copy → enginewiring
+  buildRuleQueryForWindow), labels (rulemodel fieldLabel, ruleauthoring fieldCategory "State" +
+  fieldDescription). Auto-render as `bool` kind (no QML change). Tests: matchtypes FieldCount canary
+  36→38, test_windowquery capability-field coverage. 251/251 green. NOT runtime-verified; NOT committed.
+- **Tier 3 ScreenOrientation: DONE** (uncommitted). Field 38 (Context/String "portrait"/"landscape").
+  Provider `LayoutRegistry::setScreenOrientationProvider` (mirrors setTiledWindowCountProvider) +
+  private `stampScreenOrientation` helper called at ALL 5 makeContextQuery sites (orientation is
+  layout-independent → safe in the assignment cascade too). Daemon wires it from
+  `ScreenManager::screenGeometry` (height>width → portrait; invalid → nullopt/inert); cleared on
+  teardown. Effect per-window query stamps it from `w->screen()->geometry()`. QML: `orientation`
+  valueKind → dropdown (mirrors `mode`), summary label branches in rulemodel matchSummary +
+  MatchExpressionView. Tests: FieldCount 38→39, valueForField context, rule_controller kind whitelist,
+  and `testContextOrientation_stampedAndGatesRule` (provider→stamp→gap-rule match, portrait fires /
+  landscape+unknown inert). 251/251 green. NOT runtime-verified; NOT committed.
+- **Tier 3 ActiveLayout: pending — decision refined.** User chose "full context + picker + caveat", but
+  the recursion is REAL not just oscillation: the assignment cascade (assignmentEntryForScreen, the
+  makeContextQuery site at layoutregistry_assignments.cpp:167) is what `layoutForScreen` calls, so
+  reading active-layout there via layoutForScreen infinitely recurses. Safe design = stamp activeLayout
+  at the 4 NON-assignment sites (overlay/gap/lock/default, which run post-resolution) via
+  `layoutForScreen`, and EXCLUDE the assignment site (documented like tiledWindowCount's inverse). Still
+  needs a match-side layout picker (new `layout` valueKind + editor + `settingsController.layouts`
+  source). This is the "caveat": ActiveLayout can gate overlay/gap/lock/per-window, but cannot drive the
+  layout assignment itself (circular). `ColorScheme` still deferred (no source in pipeline).
+- Remaining: Tier 3 ActiveLayout → Tier 2 restore → Tier 1 tiling → deferred tail.
+
+## Tier 1 — Overlay appearance Context actions  ★ START HERE
+
+Cleanest seam: `resolveContextOverlay` already exists; the override object is already in scope at
+every config read site.
+
+Backend (phosphor-zones, LGPL):
+- Extend `ContextOverlayOverride` (`libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h:218-228`)
+  with optional fields: `highlightColor, inactiveColor, borderColor` (QColor), `activeOpacity,
+  inactiveOpacity` (double), `borderWidth, borderRadius` (int), `showZoneNumbers` (bool).
+- Populate in `LayoutRegistry::resolveContextOverlay`
+  (`libs/phosphor-zones/src/layoutregistry_assignments.cpp:422-462`), mirroring the existing
+  `OverlayShader`/`OverlayStyle` blocks, off 8 new `ActionSlot`s.
+
+Actions (phosphor-rules, LGPL) — category `overlay`, Context domain, `Tag::Overlay`:
+`SetOverlayHighlightColor`, `SetOverlayInactiveColor`, `SetOverlayBorderColor`,
+`SetOverlayActiveOpacity`, `SetOverlayInactiveOpacity`, `SetOverlayBorderWidth`,
+`SetOverlayBorderRadius`, `SetOverlayShowZoneNumbers`.
+Reuse existing param kinds (`color`, `percent`/`number`, `bool`) → NO new QML kind; 3-place renderer
+needs only label/default entries.
+
+Consumer splices (daemon):
+- QML-property path: give `writeColorSettings` (`src/daemon/overlayservice/internal.h:342-352`) an
+  optional `const ContextOverlayOverride*`; `override.highlightColor.value_or(settings->highlightColor())`.
+  Hoist the already-present `overlayOverrideForScreen` resolve above `overlay.cpp:740`.
+  `borderWidth`→`overlay.cpp:742`, `borderRadius`→`:743`, `showZoneNumbers`→`:745`.
+  Secondary call sites: `snapassist.cpp:209/:573`, `selector_update.cpp:153`.
+- Shader-texture path: `overlay_data.cpp:317-327`, insert between `zone->useCustomColors()` and the
+  `m_settings->…()` fallback (override already resolved at `:279`). Leave the unconditional per-zone
+  custom writes at `:264-272` alone (they win via `useCustomColors`).
+
+Config getters (fallbacks, `src/core/settings_interfaces.h`): `highlightColor()`:197,
+`inactiveColor()`:199, `borderColor()`:201, `activeOpacity()`:205, `inactiveOpacity()`:207,
+`borderWidth()`:209, `borderRadius()`:211, `showZoneNumbers()`:179.
+
+### Tier 1b — OSD suppression (DEFERRED tail)
+`SuppressOsd` (+ per-toggle). No existing rule seam; the 3 OSD gates read Settings directly:
+`showOsdOnLayoutSwitch()` (`daemon.cpp:1747`, `signals.cpp:66/:666/:699`), `showOsdOnDesktopSwitch()`
+(`signals.cpp:878`, `osd.cpp:521/:538`), `showNavigationOsd()` (`navigation.cpp:375/:496/:526`,
+`signals.cpp:784/:1001/:1076`). Needs a new resolver path analogous to `resolveContextOverlay`.
+Lower value, more plumbing.
+
+## Tier 1 (tiling) — Context param actions
+
+Decode in `entryFromRuleMatchActions` (`libs/phosphor-zones/src/layoutregistry_rulehelpers.cpp:141-173`),
+carry on `AssignmentEntry`, inject via one of two seams.
+
+Seam A — per-screen override map (`src/daemon/daemon/autotile.cpp:127-135`; base =
+`getPerScreenAutotileSettings(screenId)`, algo injected at `:133-135`, pushed via
+`applyPerScreenConfig`):
+- `SetMaxWindows` — EASIEST; inject into `overrides`; `effectiveMaxWindows`
+  (`PerScreenConfigResolver.cpp:284-327`) already reads the map, no resolver change.
+- `SetSplitRatio` — inject; pushed to `TilingState` at `PerScreenConfigResolver.cpp:51`.
+- `SetMasterCount` — inject; `PerScreenConfigResolver.cpp:57`.
+- `SetInsertPosition` — inject **+ add `effectiveInsertPosition(screenId)`** on the resolver and
+  switch the consumer at `AutotileEngine.cpp:3225` off `m_config->insertPosition` (ignores per-screen today).
+
+Seam B — context-provider closure (gap template, `PerScreenConfigResolver.h:106-110`,
+`setContextGapProvider` consulted first in `effectiveInnerGap`/etc.):
+- `SetOverflowBehavior` — add `setContextOverflowProvider`; consult in `effectiveMaxWindows` /
+  `AutotileEngine.cpp:1363`.
+- `SetDragBehavior` — consumer `drag_protocol.cpp:66/:181` reads Settings directly; resolve
+  daemon-side or via closure.
+- `SetAlgorithmParam` — MOST COMPLEX. Context-param closure; layer at `AutotileEngine.cpp:3379-3392`
+  before the `hasCustomParam` filter; GUARD on `effectiveAlgorithmId(screenId)` matching the param's
+  target algorithm (params are algo-scoped). Dynamic param schema in QML reuses the shader-uniform
+  render path (`customParamsForAlgorithm` at `tilingalgorithmcontroller.cpp:115` + `ActionRow.qml`
+  shader-param branch).
+
+Precedent: `SetTilingAlgorithm`/`SetEngineMode` decode at `rulehelpers.cpp:170-171` →
+`AssignmentEntry` → `assignmentIdForScreen` (`autotile.cpp:73-75`) → `overrides[Algorithm]` (`:135`).
+
+## Tier 2 — Window restore actions
+
+Template: `WindowTrackingAdaptor::shouldRestoreFloatedPosition()` (`enginewiring.cpp:443-478`) —
+resolve slot, else per-engine config default. Query built by `buildRuleQueryForWindow`
+(`enginewiring.cpp:385-440`). Existing `RestorePosition` action registered `ruleaction.cpp:753-761`.
+
+- `SetRestoreToZoneOnLogin` — EASIEST; the `ManagedRestorePredicate` at `enginewiring.cpp:181`
+  already receives `windowId` (comment says shaped for exactly this). Resolve
+  `ActionSlot::SetRestoreToZoneOnLogin ?? restoreWindowsToZonesOnLogin()`.
+- `SetRestoreSizeOnUnsnap` — 3 sites: `float.cpp:44` (same class, direct), `drop.cpp:413` +
+  `drag.cpp:727` (in `WindowDragAdaptor`, resolve through `m_windowTracking`). Add
+  `shouldRestoreSizeOnUnsnap(windowId)` on `WindowTrackingAdaptor`. Fallback getter
+  `restoreOriginalSizeOnUnsnap()`.
+- `UnfloatFallbackToZone` — FLAGGED / likely DEFER. Consumer engine-internal (`float.cpp:301` via
+  `ISnapSettings`), no daemon evaluator seam. Needs a new `SnapEngine` predicate or daemon-side
+  pre-resolve. Config-only for now.
+
+## Tier 3 — New match FIELDS (WHEN side)
+
+- `IsMovable` (Window/bool) — effect: `query.isMovable = kw->isMovable()` at `window_query.cpp:172`;
+  daemon: 4-stage plumb.
+- `IsMaximizable` (Window/bool) — effect: `window_query.cpp:167`; daemon: 4-stage plumb.
+- `ScreenOrientation` (Context/enum) — compute from `ScreenManager::screenGeometry(screenId)` (same
+  source as `AutotileEngine.cpp:3356`) into `makeContextQuery`. Pairs with per-screen story.
+- `ActiveLayout` (Context/string) — source local to `LayoutRegistry` (`layoutForScreen`); thread into
+  `makeContextQuery`. Effect path stays disengaged (context-only).
+- `ColorScheme` (Context/enum) — DEFER; no source in the pipeline today, needs a new system-scheme
+  watcher (`KColorSchemeManager`/appearance portal).
+
+## Sequencing
+
+1. Tier 1 overlay appearance (8 actions) — highest value, cleanest seam, no new QML kind/resolver.
+2. Tier 3 cheap fields — `IsMovable`, `IsMaximizable`, `ScreenOrientation`, `ActiveLayout` (skip `ColorScheme`).
+3. Tier 2 restore — `SetRestoreToZoneOnLogin` + `SetRestoreSizeOnUnsnap` (skip `UnfloatFallbackToZone`).
+4. Tier 1 tiling — Seam A (`SetMaxWindows`/`SetSplitRatio`/`SetMasterCount`/`SetInsertPosition`),
+   then Seam B (`SetOverflowBehavior`/`SetDragBehavior`), then `SetAlgorithmParam`.
+5. Deferred tail — Tier 1b OSD, `ColorScheme`, `UnfloatFallbackToZone` (each needs a net-new seam).

--- a/docs/rule-expansion-plan.md
+++ b/docs/rule-expansion-plan.md
@@ -113,8 +113,15 @@ Consequences:
   These 3 work inject-only: applyPerScreenConfig pushes split/master to TilingState, effectiveMaxWindows
   reads the map. No QML change (number/percent kinds). Tests: kContextDomainTypes canary, validation
   ranges, resolveContextTilingParams per-slot composition. 251/251 green.
-- Remaining: Tier 1 tiling Seam A InsertPosition (needs effectiveInsertPosition resolver +
-  AutotileEngine consumer switch + an enum picker) → Seam B (SetOverflowBehavior/SetDragBehavior) →
+- **Tier 1 tiling Seam A InsertPosition: DONE** (committed). SetInsertPosition Context action (enum,
+  tokens end/afterFocused/asMaster via InsertPositionToken, mapped to AutotileInsertPosition int 0/1/2 in
+  resolveContextTilingParams → ContextTilingParams.insertPosition). New PerScreenConfigResolver::
+  effectiveInsertPosition + AutotileEngine::effectiveInsertPosition delegating; consumer
+  insertWindowByConfigOrder switched from m_config->insertPosition to
+  effectiveInsertPosition(screenForWindow(windowId)) — which ALSO makes the previously-dead per-screen
+  InsertPosition config live (latent-bug fix). Daemon injects into the override map. No QML change (enum
+  kind). Tests: domain canary, enum validation, resolver mapping asMaster→2. 251/251 green.
+- Remaining: Tier 1 tiling Seam B (SetOverflowBehavior/SetDragBehavior via context-provider closure) →
   SetAlgorithmParam → deferred tail (ColorScheme, OSD, UnfloatFallbackToZone).
 
 ## Tier 1 — Overlay appearance Context actions  ★ START HERE

--- a/docs/rule-expansion-plan.md
+++ b/docs/rule-expansion-plan.md
@@ -94,7 +94,16 @@ Consequences:
   no recursion by completing). 251/251 green. NOT runtime-verified.
   The caveat holds: ActiveLayout gates gaps/lock/overlay, but cannot drive the layout assignment itself.
 - `ColorScheme` still deferred (no source in pipeline).
-- Remaining: Tier 2 restore → Tier 1 tiling → deferred tail (ColorScheme, OSD, UnfloatFallbackToZone).
+- **Tier 2 restore actions: DONE** (committed). Two Window-domain bool actions mirroring RestorePosition:
+  `SetRestoreToZoneOnLogin` and `SetRestoreSizeOnUnsnap` (both seed FALSE = opt-out, since the governing
+  settings default ON). New resolvers `shouldRestoreToZoneOnLogin` / `shouldRestoreSizeOnUnsnap` on
+  WindowTrackingAdaptor (public; clone shouldRestoreFloatedPosition, resolve slot ?? global getter).
+  Consumers: ManagedRestorePredicate (enginewiring) now calls shouldRestoreToZoneOnLogin;
+  restore-size at float.cpp (direct), drop.cpp + drag.cpp (through m_windowTracking). No QML change
+  (bool kind); labels + boolActionStateLabel in ruleauthoring. Tests: kWindowDomainTypes canary + a
+  wta resolution test (rule(false) overrides global ON; unmatched falls back). 251/251 green.
+  `UnfloatFallbackToZone` stays deferred (engine-internal via ISnapSettings, no daemon evaluator seam).
+- Remaining: Tier 1 tiling → deferred tail (ColorScheme, OSD, UnfloatFallbackToZone).
 
 ## Tier 1 — Overlay appearance Context actions  ★ START HERE
 

--- a/docs/rule-expansion-plan.md
+++ b/docs/rule-expansion-plan.md
@@ -79,16 +79,22 @@ Consequences:
   MatchExpressionView. Tests: FieldCount 38→39, valueForField context, rule_controller kind whitelist,
   and `testContextOrientation_stampedAndGatesRule` (provider→stamp→gap-rule match, portrait fires /
   landscape+unknown inert). 251/251 green. NOT runtime-verified; NOT committed.
-- **Tier 3 ActiveLayout: pending — decision refined.** User chose "full context + picker + caveat", but
-  the recursion is REAL not just oscillation: the assignment cascade (assignmentEntryForScreen, the
-  makeContextQuery site at layoutregistry_assignments.cpp:167) is what `layoutForScreen` calls, so
-  reading active-layout there via layoutForScreen infinitely recurses. Safe design = stamp activeLayout
-  at the 4 NON-assignment sites (overlay/gap/lock/default, which run post-resolution) via
-  `layoutForScreen`, and EXCLUDE the assignment site (documented like tiledWindowCount's inverse). Still
-  needs a match-side layout picker (new `layout` valueKind + editor + `settingsController.layouts`
-  source). This is the "caveat": ActiveLayout can gate overlay/gap/lock/per-window, but cannot drive the
-  layout assignment itself (circular). `ColorScheme` still deferred (no source in pipeline).
-- Remaining: Tier 3 ActiveLayout → Tier 2 restore → Tier 1 tiling → deferred tail.
+- **Tier 3 ActiveLayout: DONE** (committed). Field 39 (Context/String; snap UUID or "autotile:<algo>").
+  Stamped in the 3 daemon-facing NON-assignment resolvers only — resolveContextGaps/Locked/Overlay —
+  via `assignmentIdForScreen` (accurate for snap+autotile incl. global-default fallback; safe from
+  these resolvers, which are not in its call chain). EXCLUDED from resolveAssignmentEntry and
+  resolveContextDefaultAssignment (both in the assignmentIdForScreen chain → would recurse; documented
+  inline). The active layout is a NON-rule-set input (global default can change without a rule-set
+  revision bump), so it is folded into each resolver's cache KEY via `contextCacheKeyToken` (mirrors the
+  tiledWindowCount "twc:" token) to avoid stale hits. Match-side layout picker: new `layout` valueKind →
+  `layoutValueEditor` over `appSettings.layouts` (MatchLeafEditor), expanded-tree + collapsed-summary
+  resolution (MatchExpressionView; rulemodel leafLabel threads m_snappingLayoutLookup, autotile ids show
+  raw). Tests: FieldCount 39→40, valueForField, rule_controller `layout` kind, and
+  `testContextActiveLayout_stampedAndGatesRule` (default-provider layout id gates a gap rule; proves
+  no recursion by completing). 251/251 green. NOT runtime-verified.
+  The caveat holds: ActiveLayout gates gaps/lock/overlay, but cannot drive the layout assignment itself.
+- `ColorScheme` still deferred (no source in pipeline).
+- Remaining: Tier 2 restore → Tier 1 tiling → deferred tail (ColorScheme, OSD, UnfloatFallbackToZone).
 
 ## Tier 1 — Overlay appearance Context actions  ★ START HERE
 

--- a/docs/rule-expansion-plan.md
+++ b/docs/rule-expansion-plan.md
@@ -121,8 +121,18 @@ Consequences:
   effectiveInsertPosition(screenForWindow(windowId)) — which ALSO makes the previously-dead per-screen
   InsertPosition config live (latent-bug fix). Daemon injects into the override map. No QML change (enum
   kind). Tests: domain canary, enum validation, resolver mapping asMaster→2. 251/251 green.
-- Remaining: Tier 1 tiling Seam B (SetOverflowBehavior/SetDragBehavior via context-provider closure) →
-  SetAlgorithmParam → deferred tail (ColorScheme, OSD, UnfloatFallbackToZone).
+- **Tier 1 tiling Seam B OverflowBehavior: DONE** (committed). SetOverflowBehavior Context action (enum
+  float/unlimited via OverflowBehaviorToken → AutotileOverflowBehavior int 0/1). Reused the SAME
+  override-map path as Seam A (NOT a context-provider closure — the earlier trace suggested one, but the
+  override map reaches the tile-engine consumer cleanly and is consistent): ContextTilingParams gained
+  overflowBehavior; resolveContextTilingParams reads the slot; new PerScreenKeys::OverflowBehavior; daemon
+  injects; new PerScreenConfigResolver::effectiveOverflowBehavior; effectiveMaxWindows now checks
+  effectiveOverflowBehavior(screenId) instead of the global config (also revives per-screen overflow
+  config). No QML change (enum). 251/251 green.
+- Remaining: Tier 1 tiling Seam B SetDragBehavior (consumer is the STATIC WindowDragAdaptor::computeDragPolicy,
+  2 callers at drag_protocol.cpp:143/539 — resolve effective drag behavior at the caller via m_layoutManager
+  and thread it into computeDragPolicy) → SetAlgorithmParam → deferred tail (ColorScheme, OSD,
+  UnfloatFallbackToZone).
 
 ## Tier 1 — Overlay appearance Context actions  ★ START HERE
 

--- a/docs/rule-expansion-plan.md
+++ b/docs/rule-expansion-plan.md
@@ -103,7 +103,19 @@ Consequences:
   (bool kind); labels + boolActionStateLabel in ruleauthoring. Tests: kWindowDomainTypes canary + a
   wta resolution test (rule(false) overrides global ON; unmatched falls back). 251/251 green.
   `UnfloatFallbackToZone` stays deferred (engine-internal via ISnapSettings, no daemon evaluator seam).
-- Remaining: Tier 1 tiling → deferred tail (ColorScheme, OSD, UnfloatFallbackToZone).
+- **Tier 1 tiling Seam A (max/split/master): DONE** (committed). Three Context actions SetMaxWindows
+  (number 1-12), SetSplitRatio (percent, wire [0.1,0.9]), SetMasterCount (number 1-5), category
+  "layoutEngine". New `ContextTilingParams` struct + `LayoutRegistry::resolveContextTilingParams`
+  (concrete, NOT on interface since the daemon holds a concrete LayoutRegistry; NON-cached since it runs
+  on screen/layout changes not per-cursor — which also lets it stamp activeLayout with no cache-key
+  fold). Daemon updateAutotileScreens (autotile.cpp) layers the resolved values onto the config-derived
+  per-screen override map AFTER the algorithm block (rule wins over config + algo-default MaxWindows).
+  These 3 work inject-only: applyPerScreenConfig pushes split/master to TilingState, effectiveMaxWindows
+  reads the map. No QML change (number/percent kinds). Tests: kContextDomainTypes canary, validation
+  ranges, resolveContextTilingParams per-slot composition. 251/251 green.
+- Remaining: Tier 1 tiling Seam A InsertPosition (needs effectiveInsertPosition resolver +
+  AutotileEngine consumer switch + an enum picker) → Seam B (SetOverflowBehavior/SetDragBehavior) →
+  SetAlgorithmParam → deferred tail (ColorScheme, OSD, UnfloatFallbackToZone).
 
 ## Tier 1 — Overlay appearance Context actions  ★ START HERE
 

--- a/docs/rule-expansion-plan.md
+++ b/docs/rule-expansion-plan.md
@@ -137,7 +137,24 @@ Consequences:
   drag_protocol.cpp resolve+pass effectiveReorderMode); the member-method site (:181) calls it directly.
   test_drag_policy call sites updated to pass reorderMode. No QML change (enum). 251/251 green.
   **Tier 1 tiling COMPLETE** (all of Seam A + Seam B).
-- Remaining: SetAlgorithmParam → deferred tail (ColorScheme, OSD, UnfloatFallbackToZone).
+- **SetAlgorithmParam: DONE** (committed). Context action mirroring OverrideOverlayShader: carries the
+  target algorithm token (ActionParam::Algorithm, kind "tilingAlgorithm" picker) + a free-form params
+  blob (ActionParam::Params, allowed-but-undeclared). resolveContextTilingParams reads algorithmParamTarget
+  + algorithmParams into ContextTilingParams. Daemon injects overrides[PerScreenKeys::CustomParams] ONLY
+  when the target == the screen's effective algorithm (guard lives daemon-side where both are known); the
+  engine (AutotileEngine recalculateLayout) layers the per-screen override map over config customParams via
+  new PerScreenConfigResolver::effectiveCustomParamsOverride, filtered again by algo->hasCustomParam. QML:
+  dedicated inline `_algorithmParamsEditor` in ActionRow.qml (a Repeater over
+  tilingAlgorithmPage.customParamsForAlgorithm(algorithm) rendering SettingsSlider/SettingsSwitch/
+  WideComboBox per number/bool/enum, writing to action.params via _writeAlgorithmParam) — a dedicated
+  editor NOT the shader one (schema field names name/minValue/maxValue + number/bool/enum vocab differ);
+  tilingAlgorithmPage exposed in RulesPage.qml _editorAppSettings. Tests: domain canary, validation
+  (algorithm required, params free-form, strict allowedKeys), resolver mapping (target=bsp, ratio=0.7).
+  251/251 green; QML compiles (qmlcachegen). NOT runtime-verified in-app.
+  **ADDITIVE RULE EXPANSION COMPLETE** — all planned actions/fields shipped.
+- Deferred tail (each needs a net-new seam, revisit if wanted): OSD suppression (SuppressOsd — no rule
+  seam, daemon gates read Settings directly), ColorScheme match field (no source in the pipeline; needs a
+  system-scheme watcher), UnfloatFallbackToZone (engine-internal via ISnapSettings, no daemon evaluator seam).
 
 ## Tier 1 — Overlay appearance Context actions  ★ START HERE
 

--- a/docs/rule-expansion-plan.md
+++ b/docs/rule-expansion-plan.md
@@ -129,10 +129,15 @@ Consequences:
   injects; new PerScreenConfigResolver::effectiveOverflowBehavior; effectiveMaxWindows now checks
   effectiveOverflowBehavior(screenId) instead of the global config (also revives per-screen overflow
   config). No QML change (enum). 251/251 green.
-- Remaining: Tier 1 tiling Seam B SetDragBehavior (consumer is the STATIC WindowDragAdaptor::computeDragPolicy,
-  2 callers at drag_protocol.cpp:143/539 — resolve effective drag behavior at the caller via m_layoutManager
-  and thread it into computeDragPolicy) → SetAlgorithmParam → deferred tail (ColorScheme, OSD,
-  UnfloatFallbackToZone).
+- **Tier 1 tiling Seam B SetDragBehavior: DONE** (committed). SetDragBehavior Context action (enum
+  float/reorder via DragBehaviorToken → AutotileDragBehavior int 0/1). ContextTilingParams gained
+  dragBehavior; resolveContextTilingParams reads the slot. Consumer is the drag adaptor, NOT the tile
+  engine: new WindowDragAdaptor::effectiveReorderMode(screenId) resolves via m_layoutManager (rule else
+  global setting). The static computeDragPolicy gained a `bool reorderMode` param (its 2 callers at
+  drag_protocol.cpp resolve+pass effectiveReorderMode); the member-method site (:181) calls it directly.
+  test_drag_policy call sites updated to pass reorderMode. No QML change (enum). 251/251 green.
+  **Tier 1 tiling COMPLETE** (all of Seam A + Seam B).
+- Remaining: SetAlgorithmParam → deferred tail (ColorScheme, OSD, UnfloatFallbackToZone).
 
 ## Tier 1 — Overlay appearance Context actions  ★ START HERE
 

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -192,6 +192,12 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w, bool includeEx
         if (props.isResizable) {
             extended.insert(Key::IsResizable, *props.isResizable);
         }
+        if (props.isMovable) {
+            extended.insert(Key::IsMovable, *props.isMovable);
+        }
+        if (props.isMaximizable) {
+            extended.insert(Key::IsMaximizable, *props.isMaximizable);
+        }
         if (props.width) {
             extended.insert(Key::Width, *props.width);
         }

--- a/kwin-effect/plasmazoneseffect/window_query.cpp
+++ b/kwin-effect/plasmazoneseffect/window_query.cpp
@@ -98,6 +98,16 @@ PhosphorRules::WindowQuery ruleQueryFor(KWin::EffectWindow* w, const QString& sc
     // virtualDesktop / activity are derived here, mirroring the daemon-side
     // setWindowMetadata derivation in window_identity.cpp (0 / "" = all/unknown).
     query.screenId = screenId;
+    // Orientation of the window's screen ("portrait" when taller than wide), so a
+    // window rule can match ScreenOrientation the same way a context rule does.
+    // Left empty (inert) when the output or its geometry is unavailable; a square
+    // screen counts as landscape, matching the daemon-side orientation provider.
+    if (const auto* output = w->screen()) {
+        const QRect g = output->geometry();
+        if (g.isValid()) {
+            query.screenOrientation = g.height() > g.width() ? QStringLiteral("portrait") : QStringLiteral("landscape");
+        }
+    }
     // `WindowQuery` fields are `std::optional` — leaving a field disengaged
     // makes a predicate over it inert (returns false). Engaging it with an
     // empty string instead would silently match `Equals ""` and `Regex "^$"`,
@@ -170,6 +180,8 @@ PhosphorRules::WindowQuery ruleQueryFor(KWin::EffectWindow* w, const QString& sc
         query.skipTaskbar = kw->skipTaskbar();
         query.skipPager = kw->skipPager();
         query.isResizable = kw->isResizable();
+        query.isMovable = kw->isMovable();
+        query.isMaximizable = kw->isMaximizable();
         // captionNormal is the raw WM_NAME without the WM-added " — App" suffix
         // that caption() (used for Title above) includes. Gate non-empty like
         // the other string fields so a disengaged optional stays a non-match.

--- a/libs/phosphor-engine/include/PhosphorEngine/PerScreenKeys.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/PerScreenKeys.h
@@ -28,6 +28,7 @@ inline constexpr QLatin1String RespectMinimumSize{"RespectMinimumSize"};
 inline constexpr QLatin1String AnimationsEnabled{"AnimationsEnabled"};
 inline constexpr QLatin1String AnimationDuration{"AnimationDuration"};
 inline constexpr QLatin1String AnimationEasingCurve{"AnimationEasingCurve"};
+inline constexpr QLatin1String OverflowBehavior{"OverflowBehavior"};
 
 } // namespace PerScreenKeys
 } // namespace PhosphorEngine

--- a/libs/phosphor-engine/include/PhosphorEngine/PerScreenKeys.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/PerScreenKeys.h
@@ -29,6 +29,7 @@ inline constexpr QLatin1String AnimationsEnabled{"AnimationsEnabled"};
 inline constexpr QLatin1String AnimationDuration{"AnimationDuration"};
 inline constexpr QLatin1String AnimationEasingCurve{"AnimationEasingCurve"};
 inline constexpr QLatin1String OverflowBehavior{"OverflowBehavior"};
+inline constexpr QLatin1String CustomParams{"CustomParams"};
 
 } // namespace PerScreenKeys
 } // namespace PhosphorEngine

--- a/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
+++ b/libs/phosphor-engine/include/PhosphorEngine/WindowRegistry.h
@@ -53,6 +53,8 @@ struct WindowMetadata
     std::optional<bool> isModal{};
     std::optional<bool> hasDecoration{}; ///< server-side title-bar / border
     std::optional<bool> isResizable{};
+    std::optional<bool> isMovable{}; ///< window can be moved
+    std::optional<bool> isMaximizable{}; ///< window can be maximized
     std::optional<int> width{}; ///< frame width in px
     std::optional<int> height{}; ///< frame height in px
     std::optional<int> positionX{}; ///< frame left edge X in px
@@ -69,8 +71,9 @@ struct WindowMetadata
             && isNotification == other.isNotification && keepAbove == other.keepAbove && keepBelow == other.keepBelow
             && skipTaskbar == other.skipTaskbar && skipPager == other.skipPager && skipSwitcher == other.skipSwitcher
             && isModal == other.isModal && hasDecoration == other.hasDecoration && isResizable == other.isResizable
-            && width == other.width && height == other.height && positionX == other.positionX
-            && positionY == other.positionY && captionNormal == other.captionNormal;
+            && isMovable == other.isMovable && isMaximizable == other.isMaximizable && width == other.width
+            && height == other.height && positionX == other.positionX && positionY == other.positionY
+            && captionNormal == other.captionNormal;
     }
     bool operator!=(const WindowMetadata& other) const
     {

--- a/libs/phosphor-protocol/include/PhosphorProtocol/ServiceConstants.h
+++ b/libs/phosphor-protocol/include/PhosphorProtocol/ServiceConstants.h
@@ -72,6 +72,8 @@ inline constexpr QLatin1String SkipSwitcher("skipSwitcher");
 inline constexpr QLatin1String IsModal("isModal");
 inline constexpr QLatin1String HasDecoration("hasDecoration");
 inline constexpr QLatin1String IsResizable("isResizable");
+inline constexpr QLatin1String IsMovable("isMovable");
+inline constexpr QLatin1String IsMaximizable("isMaximizable");
 inline constexpr QLatin1String Width("width");
 inline constexpr QLatin1String Height("height");
 inline constexpr QLatin1String PositionX("positionX");

--- a/libs/phosphor-rules/include/PhosphorRules/MatchTypes.h
+++ b/libs/phosphor-rules/include/PhosphorRules/MatchTypes.h
@@ -63,12 +63,14 @@ enum class Field : int {
     IsMaximizable = 37, ///< window can be maximized
     // ── Context screen-orientation field [38] ────────────────────────────
     ScreenOrientation = 38, ///< context — "portrait" / "landscape" of the resolving screen
+    // ── Context active-layout field [39] ─────────────────────────────────
+    ActiveLayout = 39, ///< context — the layout id currently resolved for the screen (snap UUID or "autotile:<algo>")
 };
 
 /// The number of distinct `Field` enumerators. `Field` is a contiguous range
 /// `[0, FieldCount)`; bump this whenever an enumerator is added — round-trip
 /// tests iterate the range using it as the upper bound.
-inline constexpr int FieldCount = static_cast<int>(Field::ScreenOrientation) + 1;
+inline constexpr int FieldCount = static_cast<int>(Field::ActiveLayout) + 1;
 
 // ── Field descriptor table ──────────────────────────────────────────────────
 // Single source of truth for every field's wire string, value-kind, and
@@ -162,6 +164,12 @@ inline constexpr FieldDescriptor kFieldTable[] = {
     // orientation rule drive the layout/algorithm assignment for a rotated
     // monitor. Empty (predicate false) when no geometry provider is wired.
     {Field::ScreenOrientation, QLatin1StringView("screenOrientation"), FieldType::String, FieldSource::Context},
+    // [39] — The layout id currently resolved for the screen (snap UUID or
+    // "autotile:<algo>"). String-valued (Equals against the id) and Context-
+    // sourced. Populated only by the daemon-facing resolvers (gap / lock /
+    // overlay), NOT the assignment cascade — reading the active layout while
+    // resolving it would recurse. Empty (predicate false) where unpopulated.
+    {Field::ActiveLayout, QLatin1StringView("activeLayout"), FieldType::String, FieldSource::Context},
 };
 static_assert(sizeof(kFieldTable) / sizeof(kFieldTable[0]) == static_cast<unsigned>(FieldCount),
               "kFieldTable must have one entry per Field");

--- a/libs/phosphor-rules/include/PhosphorRules/MatchTypes.h
+++ b/libs/phosphor-rules/include/PhosphorRules/MatchTypes.h
@@ -58,12 +58,17 @@ enum class Field : int {
     Mode = 34, ///< context — current placement mode (snapping / tiling)
     // ── Context tiling-environment field [35] ────────────────────────────
     TiledWindowCount = 35, ///< context — tiled windows on this screen + desktop
+    // ── Window capability fields [36, 37] ────────────────────────────────
+    IsMovable = 36, ///< window can be moved
+    IsMaximizable = 37, ///< window can be maximized
+    // ── Context screen-orientation field [38] ────────────────────────────
+    ScreenOrientation = 38, ///< context — "portrait" / "landscape" of the resolving screen
 };
 
 /// The number of distinct `Field` enumerators. `Field` is a contiguous range
 /// `[0, FieldCount)`; bump this whenever an enumerator is added — round-trip
 /// tests iterate the range using it as the upper bound.
-inline constexpr int FieldCount = static_cast<int>(Field::TiledWindowCount) + 1;
+inline constexpr int FieldCount = static_cast<int>(Field::ScreenOrientation) + 1;
 
 // ── Field descriptor table ──────────────────────────────────────────────────
 // Single source of truth for every field's wire string, value-kind, and
@@ -147,6 +152,16 @@ inline constexpr FieldDescriptor kFieldTable[] = {
     // tiling-algorithm slot of the assignment cascade. Absent (predicate
     // false) when the resolving screen is not actively tiling.
     {Field::TiledWindowCount, QLatin1StringView("tiledWindowCount"), FieldType::Int, FieldSource::Context},
+    // [36, 37] — Window capability flags (can the window be moved / maximized).
+    // Window-sourced like IsResizable, so inert during windowless context queries.
+    {Field::IsMovable, QLatin1StringView("isMovable"), FieldType::Bool, FieldSource::Window},
+    {Field::IsMaximizable, QLatin1StringView("isMaximizable"), FieldType::Bool, FieldSource::Window},
+    // [38] — Screen orientation ("portrait" / "landscape") of the screen being
+    // resolved. String-valued (Equals against the token) and Context-sourced so
+    // it is present during windowless context resolution — which lets an
+    // orientation rule drive the layout/algorithm assignment for a rotated
+    // monitor. Empty (predicate false) when no geometry provider is wired.
+    {Field::ScreenOrientation, QLatin1StringView("screenOrientation"), FieldType::String, FieldSource::Context},
 };
 static_assert(sizeof(kFieldTable) / sizeof(kFieldTable[0]) == static_cast<unsigned>(FieldCount),
               "kFieldTable must have one entry per Field");

--- a/libs/phosphor-rules/include/PhosphorRules/MatchTypes.h
+++ b/libs/phosphor-rules/include/PhosphorRules/MatchTypes.h
@@ -90,8 +90,8 @@ enum class FieldType : int {
 enum class FieldSource : int {
     Window, ///< absent during windowless context queries
     Context, ///< resolvable during a windowless context query (screen / desktop /
-             ///< activity / mode are always set; tiledWindowCount is optional and
-             ///< absent when the count is unknown)
+             ///< activity / mode / screen orientation / active layout are always set;
+             ///< tiledWindowCount is optional and absent when the count is unknown)
 };
 
 /// Compile-time descriptor for one Field.
@@ -231,8 +231,8 @@ inline bool fieldIsBool(Field field)
 }
 
 /// True if @p field describes the **context** a window appears in
-/// (screen / virtual desktop / activity / placement mode / tiled-window count)
-/// rather than a property of the window itself.
+/// (screen / virtual desktop / activity / placement mode / tiled-window count /
+/// screen orientation / active layout) rather than a property of the window itself.
 inline bool fieldIsContext(Field field)
 {
     const int idx = static_cast<int>(field);

--- a/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
+++ b/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
@@ -428,6 +428,15 @@ inline constexpr QLatin1StringView SetOuterGapTop{"setOuterGapTop"};
 inline constexpr QLatin1StringView SetOuterGapBottom{"setOuterGapBottom"};
 inline constexpr QLatin1StringView SetOuterGapLeft{"setOuterGapLeft"};
 inline constexpr QLatin1StringView SetOuterGapRight{"setOuterGapRight"};
+
+// ── Per-context autotile parameter overrides (domain Context) ──
+// Override the global (or per-screen config) tiling parameters for the matched
+// screen / desktop / activity. Layered ON TOP of config by the daemon when it
+// builds the per-screen autotile override map (config stays authoritative; the
+// rule wins where present). Each carries a single numeric `value`.
+inline constexpr QLatin1StringView SetMaxWindows{"setMaxWindows"};
+inline constexpr QLatin1StringView SetSplitRatio{"setSplitRatio"};
+inline constexpr QLatin1StringView SetMasterCount{"setMasterCount"};
 } // namespace ActionType
 
 // ── Action param keys — canonical wire strings ──
@@ -556,6 +565,13 @@ inline constexpr QLatin1StringView OuterGapTop{"outer-gap-top"};
 inline constexpr QLatin1StringView OuterGapBottom{"outer-gap-bottom"};
 inline constexpr QLatin1StringView OuterGapLeft{"outer-gap-left"};
 inline constexpr QLatin1StringView OuterGapRight{"outer-gap-right"};
+// Per-context autotile parameter slots (one per param). Filled by
+// SetMaxWindows / SetSplitRatio / SetMasterCount, read by
+// LayoutRegistry::resolveContextTilingParams and layered onto the per-screen
+// autotile override map daemon-side.
+inline constexpr QLatin1StringView MaxWindows{"max-windows"};
+inline constexpr QLatin1StringView SplitRatio{"split-ratio"};
+inline constexpr QLatin1StringView MasterCount{"master-count"};
 // Per-context overlay-property slots (one per property so independent rules
 // cascade per-property). Filled by the OverrideOverlay* context actions, read
 // by `LayoutRegistry::resolveContextOverlay`. OverlayShader carries the shader

--- a/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
+++ b/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
@@ -441,6 +441,10 @@ inline constexpr QLatin1StringView SetMasterCount{"setMasterCount"};
 /// closed enum token (`ActionParam::Value`, InsertPositionToken). Context domain;
 /// layered onto the per-screen override map like the other tiling params.
 inline constexpr QLatin1StringView SetInsertPosition{"setInsertPosition"};
+/// How the autotile stack handles windows beyond the max: float the overflow, or
+/// go unlimited (ignore the cap). Closed enum token (OverflowBehaviorToken).
+/// Context domain; layered onto the per-screen override map like the other params.
+inline constexpr QLatin1StringView SetOverflowBehavior{"setOverflowBehavior"};
 } // namespace ActionType
 
 // ── Action param keys — canonical wire strings ──
@@ -519,6 +523,13 @@ inline constexpr QLatin1StringView AfterFocused{"afterFocused"}; ///< AfterFocus
 inline constexpr QLatin1StringView AsMaster{"asMaster"}; ///< AsMaster (2)
 } // namespace InsertPositionToken
 
+/// Wire tokens for SetOverflowBehavior's `value` param. Ints match
+/// PhosphorTiles::AutotileOverflowBehavior (Float 0 / Unlimited 1).
+namespace OverflowBehaviorToken {
+inline constexpr QLatin1StringView Float{"float"}; ///< AutotileOverflowBehavior::Float (0)
+inline constexpr QLatin1StringView Unlimited{"unlimited"}; ///< Unlimited (1)
+} // namespace OverflowBehaviorToken
+
 /// Sentinel value a `SetBorderColorActive` / `SetBorderColorInactive` `value`
 /// param may carry instead of a hex string, meaning "track the live system
 /// accent colour". The
@@ -587,6 +598,7 @@ inline constexpr QLatin1StringView MaxWindows{"max-windows"};
 inline constexpr QLatin1StringView SplitRatio{"split-ratio"};
 inline constexpr QLatin1StringView MasterCount{"master-count"};
 inline constexpr QLatin1StringView InsertPosition{"insert-position"};
+inline constexpr QLatin1StringView OverflowBehavior{"overflow-behavior"};
 // Per-context overlay-property slots (one per property so independent rules
 // cascade per-property). Filled by the OverrideOverlay* context actions, read
 // by `LayoutRegistry::resolveContextOverlay`. OverlayShader carries the shader

--- a/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
+++ b/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
@@ -445,6 +445,11 @@ inline constexpr QLatin1StringView SetInsertPosition{"setInsertPosition"};
 /// go unlimited (ignore the cap). Closed enum token (OverflowBehaviorToken).
 /// Context domain; layered onto the per-screen override map like the other params.
 inline constexpr QLatin1StringView SetOverflowBehavior{"setOverflowBehavior"};
+/// How dragging a tiled window behaves: float it out, or reorder it within the
+/// stack (Krohnkite-style drag-to-swap). Closed enum token (DragBehaviorToken).
+/// Context domain; consumed by the drag adaptor (NOT the tile-engine override
+/// map) — it resolves the effective behavior for the drag's screen.
+inline constexpr QLatin1StringView SetDragBehavior{"setDragBehavior"};
 } // namespace ActionType
 
 // ── Action param keys — canonical wire strings ──
@@ -530,6 +535,13 @@ inline constexpr QLatin1StringView Float{"float"}; ///< AutotileOverflowBehavior
 inline constexpr QLatin1StringView Unlimited{"unlimited"}; ///< Unlimited (1)
 } // namespace OverflowBehaviorToken
 
+/// Wire tokens for SetDragBehavior's `value` param. Ints match
+/// PhosphorTiles::AutotileDragBehavior (Float 0 / Reorder 1).
+namespace DragBehaviorToken {
+inline constexpr QLatin1StringView Float{"float"}; ///< AutotileDragBehavior::Float (0)
+inline constexpr QLatin1StringView Reorder{"reorder"}; ///< Reorder (1)
+} // namespace DragBehaviorToken
+
 /// Sentinel value a `SetBorderColorActive` / `SetBorderColorInactive` `value`
 /// param may carry instead of a hex string, meaning "track the live system
 /// accent colour". The
@@ -599,6 +611,7 @@ inline constexpr QLatin1StringView SplitRatio{"split-ratio"};
 inline constexpr QLatin1StringView MasterCount{"master-count"};
 inline constexpr QLatin1StringView InsertPosition{"insert-position"};
 inline constexpr QLatin1StringView OverflowBehavior{"overflow-behavior"};
+inline constexpr QLatin1StringView DragBehavior{"drag-behavior"};
 // Per-context overlay-property slots (one per property so independent rules
 // cascade per-property). Filled by the OverrideOverlay* context actions, read
 // by `LayoutRegistry::resolveContextOverlay`. OverlayShader carries the shader

--- a/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
+++ b/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
@@ -382,6 +382,21 @@ inline constexpr QLatin1StringView ExcludeAnimations{"excludeAnimations"};
 /// Window (matches window properties).
 inline constexpr QLatin1StringView RestorePosition{"restorePosition"};
 
+/// Per-window override for the "restore snapped windows to their zone on login"
+/// setting. A boolean `value`: false suppresses zone restore for the matched
+/// window (it reopens wherever the session put it), true forces it on even when
+/// the global `restoreWindowsToZonesOnLogin` setting is off. Resolved by the
+/// daemon-injected managed-restore predicate. Domain Window. The snapped-to-zone
+/// analogue of RestorePosition (which covers FLOATED windows).
+inline constexpr QLatin1StringView SetRestoreToZoneOnLogin{"setRestoreToZoneOnLogin"};
+
+/// Per-window override for the "restore original size when unsnapped" setting. A
+/// boolean `value`: false suppresses the pre-snap size restore for the matched
+/// window (it keeps the zone size after unsnap), true forces it on even when the
+/// global `restoreOriginalSizeOnUnsnap` setting is off. Consulted daemon-side on
+/// the drag-out / drop / cursor-left-zones unsnap paths. Domain Window.
+inline constexpr QLatin1StringView SetRestoreSizeOnUnsnap{"setRestoreSizeOnUnsnap"};
+
 // ── Per-window border / title-bar appearance overrides (domain Window) ──
 // Effect-side per-window overrides of the global snap appearance. Each is its
 // own slot so independent rules cascade per-property (a width rule and a
@@ -521,6 +536,10 @@ inline constexpr QLatin1StringView RouteScreen{"route-screen"};
 inline constexpr QLatin1StringView RouteDesktop{"route-desktop"};
 inline constexpr QLatin1StringView Opacity{"opacity"};
 inline constexpr QLatin1StringView RestorePosition{"restore-position"};
+// Per-window restore-policy overrides (one slot each). Filled by
+// SetRestoreToZoneOnLogin / SetRestoreSizeOnUnsnap, read daemon-side.
+inline constexpr QLatin1StringView RestoreToZoneOnLogin{"restore-to-zone-on-login"};
+inline constexpr QLatin1StringView RestoreSizeOnUnsnap{"restore-size-on-unsnap"};
 // Per-window border / title-bar appearance slots (one per property so
 // independent rules cascade per-property).
 inline constexpr QLatin1StringView HideTitleBar{"hide-title-bar"};

--- a/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
+++ b/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
@@ -450,6 +450,13 @@ inline constexpr QLatin1StringView SetOverflowBehavior{"setOverflowBehavior"};
 /// Context domain; consumed by the drag adaptor (NOT the tile-engine override
 /// map) — it resolves the effective behavior for the drag's screen.
 inline constexpr QLatin1StringView SetDragBehavior{"setDragBehavior"};
+/// Override an autotile algorithm's custom (Luau-declared) parameters for the
+/// matched context. Carries the target algorithm token (`ActionParam::Algorithm`)
+/// and a free-form nested `params` object (`ActionParam::Params`) of the custom
+/// parameter values — the same shape OverrideOverlayShader uses for shader
+/// uniforms. Applied only when the target algorithm is the screen's effective
+/// algorithm; layered over the global per-algorithm config. Context domain.
+inline constexpr QLatin1StringView SetAlgorithmParam{"setAlgorithmParam"};
 } // namespace ActionType
 
 // ── Action param keys — canonical wire strings ──
@@ -612,6 +619,7 @@ inline constexpr QLatin1StringView MasterCount{"master-count"};
 inline constexpr QLatin1StringView InsertPosition{"insert-position"};
 inline constexpr QLatin1StringView OverflowBehavior{"overflow-behavior"};
 inline constexpr QLatin1StringView DragBehavior{"drag-behavior"};
+inline constexpr QLatin1StringView AlgorithmParams{"algorithm-params"};
 // Per-context overlay-property slots (one per property so independent rules
 // cascade per-property). Filled by the OverrideOverlay* context actions, read
 // by `LayoutRegistry::resolveContextOverlay`. OverlayShader carries the shader

--- a/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
+++ b/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
@@ -341,6 +341,27 @@ inline constexpr QLatin1StringView SetOpacity{"setOpacity"};
 /// zone overlay. Resolved daemon-side via `LayoutRegistry::resolveContextOverlay`.
 inline constexpr QLatin1StringView OverrideOverlayShader{"overrideOverlayShader"};
 inline constexpr QLatin1StringView OverrideOverlayStyle{"overrideOverlayStyle"};
+/// Context-domain overrides of the active layout's zone-overlay APPEARANCE —
+/// the colours, opacities, border dimensions and zone-number visibility that
+/// the global `Snapping.Zones.*` config sets. Each is its own slot so
+/// independent rules cascade per-property, mirroring the per-window border
+/// family. A matched context rule (screen / desktop / activity) overrides the
+/// corresponding global setting for that context's overlay; an unset property
+/// falls through to the global config value (config stays authoritative — these
+/// only layer on top). Resolved daemon-side via
+/// `LayoutRegistry::resolveContextOverlay` and consumed by the overlay service.
+/// Colours carry a `#AARRGGBB` hex (`ActionParam::Value`); opacities a [0,1]
+/// double; widths/radii a number; show-zone-numbers a bool. Unlike the border
+/// colour actions there is NO accent sentinel — the overlay consumer resolves
+/// no token, so the value is always a concrete hex.
+inline constexpr QLatin1StringView SetOverlayHighlightColor{"setOverlayHighlightColor"};
+inline constexpr QLatin1StringView SetOverlayInactiveColor{"setOverlayInactiveColor"};
+inline constexpr QLatin1StringView SetOverlayBorderColor{"setOverlayBorderColor"};
+inline constexpr QLatin1StringView SetOverlayActiveOpacity{"setOverlayActiveOpacity"};
+inline constexpr QLatin1StringView SetOverlayInactiveOpacity{"setOverlayInactiveOpacity"};
+inline constexpr QLatin1StringView SetOverlayBorderWidth{"setOverlayBorderWidth"};
+inline constexpr QLatin1StringView SetOverlayBorderRadius{"setOverlayBorderRadius"};
+inline constexpr QLatin1StringView SetOverlayShowZoneNumbers{"setOverlayShowZoneNumbers"};
 /// Disable every animation override on a matched window. The opposite of
 /// the OverrideAnimation* family — the effect's shouldAnimateWindow gate
 /// surfaces this as "no animation for this window, regardless of other
@@ -523,6 +544,17 @@ inline constexpr QLatin1StringView OuterGapRight{"outer-gap-right"};
 // (ActionParam::Value).
 inline constexpr QLatin1StringView OverlayShader{"overlay-shader"};
 inline constexpr QLatin1StringView OverlayStyle{"overlay-style"};
+// Per-context overlay-APPEARANCE slots (one per property so independent rules
+// cascade per-property). Filled by the SetOverlay* appearance context actions,
+// read by `LayoutRegistry::resolveContextOverlay` into ContextOverlayOverride.
+inline constexpr QLatin1StringView OverlayHighlightColor{"overlay-highlight-color"};
+inline constexpr QLatin1StringView OverlayInactiveColor{"overlay-inactive-color"};
+inline constexpr QLatin1StringView OverlayBorderColor{"overlay-border-color"};
+inline constexpr QLatin1StringView OverlayActiveOpacity{"overlay-active-opacity"};
+inline constexpr QLatin1StringView OverlayInactiveOpacity{"overlay-inactive-opacity"};
+inline constexpr QLatin1StringView OverlayBorderWidth{"overlay-border-width"};
+inline constexpr QLatin1StringView OverlayBorderRadius{"overlay-border-radius"};
+inline constexpr QLatin1StringView OverlayShowZoneNumbers{"overlay-show-zone-numbers"};
 // Animation slots are event-scoped: "anim-shader:<event>" / "anim-timing:<event>"
 // / "anim-curve:<event>". Curve and timing are split so they can be overridden
 // independently per event — `resolveAnimationMotionProfile` reads the curve

--- a/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
+++ b/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
@@ -610,9 +610,11 @@ inline constexpr QLatin1StringView OuterGapBottom{"outer-gap-bottom"};
 inline constexpr QLatin1StringView OuterGapLeft{"outer-gap-left"};
 inline constexpr QLatin1StringView OuterGapRight{"outer-gap-right"};
 // Per-context autotile parameter slots (one per param). Filled by
-// SetMaxWindows / SetSplitRatio / SetMasterCount, read by
+// SetMaxWindows / SetSplitRatio / SetMasterCount / SetInsertPosition /
+// SetOverflowBehavior / SetDragBehavior / SetAlgorithmParam, read by
 // LayoutRegistry::resolveContextTilingParams and layered onto the per-screen
-// autotile override map daemon-side.
+// autotile override map daemon-side (drag behavior via the drag adaptor;
+// AlgorithmParams carries a target algorithm token plus a free-form params blob).
 inline constexpr QLatin1StringView MaxWindows{"max-windows"};
 inline constexpr QLatin1StringView SplitRatio{"split-ratio"};
 inline constexpr QLatin1StringView MasterCount{"master-count"};

--- a/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
+++ b/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
@@ -437,6 +437,10 @@ inline constexpr QLatin1StringView SetOuterGapRight{"setOuterGapRight"};
 inline constexpr QLatin1StringView SetMaxWindows{"setMaxWindows"};
 inline constexpr QLatin1StringView SetSplitRatio{"setSplitRatio"};
 inline constexpr QLatin1StringView SetMasterCount{"setMasterCount"};
+/// Where a newly-opened window is inserted into the autotile stack. Carries a
+/// closed enum token (`ActionParam::Value`, InsertPositionToken). Context domain;
+/// layered onto the per-screen override map like the other tiling params.
+inline constexpr QLatin1StringView SetInsertPosition{"setInsertPosition"};
 } // namespace ActionType
 
 // ── Action param keys — canonical wire strings ──
@@ -505,6 +509,16 @@ inline constexpr QLatin1StringView Rectangles{"rectangles"}; ///< OverlayDisplay
 inline constexpr QLatin1StringView Preview{"preview"}; ///< OverlayDisplayMode::LayoutPreview (1)
 } // namespace OverlayStyleToken
 
+/// Wire tokens for SetInsertPosition's `value` param — the closed vocabulary the
+/// descriptor validator, the daemon consumer (LayoutRegistry::resolveContextTilingParams
+/// maps token → the AutotileInsertPosition int), and the settings label layers all
+/// read from this single source. Ints match PhosphorTiles::AutotileInsertPosition.
+namespace InsertPositionToken {
+inline constexpr QLatin1StringView End{"end"}; ///< AutotileInsertPosition::End (0)
+inline constexpr QLatin1StringView AfterFocused{"afterFocused"}; ///< AfterFocused (1)
+inline constexpr QLatin1StringView AsMaster{"asMaster"}; ///< AsMaster (2)
+} // namespace InsertPositionToken
+
 /// Sentinel value a `SetBorderColorActive` / `SetBorderColorInactive` `value`
 /// param may carry instead of a hex string, meaning "track the live system
 /// accent colour". The
@@ -572,6 +586,7 @@ inline constexpr QLatin1StringView OuterGapRight{"outer-gap-right"};
 inline constexpr QLatin1StringView MaxWindows{"max-windows"};
 inline constexpr QLatin1StringView SplitRatio{"split-ratio"};
 inline constexpr QLatin1StringView MasterCount{"master-count"};
+inline constexpr QLatin1StringView InsertPosition{"insert-position"};
 // Per-context overlay-property slots (one per property so independent rules
 // cascade per-property). Filled by the OverrideOverlay* context actions, read
 // by `LayoutRegistry::resolveContextOverlay`. OverlayShader carries the shader

--- a/libs/phosphor-rules/include/PhosphorRules/WindowQuery.h
+++ b/libs/phosphor-rules/include/PhosphorRules/WindowQuery.h
@@ -55,6 +55,8 @@ struct WindowQuery
     std::optional<bool> isModal; ///< modal dialog
     std::optional<bool> hasDecoration; ///< has a server-side title-bar / border
     std::optional<bool> isResizable; ///< window can be resized
+    std::optional<bool> isMovable; ///< window can be moved
+    std::optional<bool> isMaximizable; ///< window can be maximized
     std::optional<int> positionX; ///< frame left edge X in px
     std::optional<int> positionY; ///< frame top edge Y in px
     std::optional<QString> captionNormal; ///< title without the WM-added app-name suffix
@@ -68,6 +70,8 @@ struct WindowQuery
     int virtualDesktop = 0; ///< 0 = all desktops
     QString activity; ///< empty = all activities
     QString mode; ///< current placement mode wire token ("snapping" / "tiling"); a floating window has no mode (empty)
+    QString
+        screenOrientation; ///< "portrait" / "landscape" of the resolving screen; empty = unknown (no geometry provider)
 
     /// Tiled-window count for the screen + desktop being resolved. Optional
     /// rather than defaulted because 0 is a meaningful value (an empty tiled
@@ -130,6 +134,8 @@ struct WindowQuery
             return std::optional<QVariant>(activity);
         case Field::Mode:
             return std::optional<QVariant>(mode);
+        case Field::ScreenOrientation:
+            return std::optional<QVariant>(screenOrientation);
         case Field::TiledWindowCount:
             return tiledWindowCount ? std::optional<QVariant>(*tiledWindowCount) : std::nullopt;
         case Field::IsMaximized:
@@ -160,6 +166,10 @@ struct WindowQuery
             return hasDecoration ? std::optional<QVariant>(*hasDecoration) : std::nullopt;
         case Field::IsResizable:
             return isResizable ? std::optional<QVariant>(*isResizable) : std::nullopt;
+        case Field::IsMovable:
+            return isMovable ? std::optional<QVariant>(*isMovable) : std::nullopt;
+        case Field::IsMaximizable:
+            return isMaximizable ? std::optional<QVariant>(*isMaximizable) : std::nullopt;
         case Field::PositionX:
             return positionX ? std::optional<QVariant>(*positionX) : std::nullopt;
         case Field::PositionY:

--- a/libs/phosphor-rules/include/PhosphorRules/WindowQuery.h
+++ b/libs/phosphor-rules/include/PhosphorRules/WindowQuery.h
@@ -72,6 +72,8 @@ struct WindowQuery
     QString mode; ///< current placement mode wire token ("snapping" / "tiling"); a floating window has no mode (empty)
     QString
         screenOrientation; ///< "portrait" / "landscape" of the resolving screen; empty = unknown (no geometry provider)
+    QString
+        activeLayout; ///< layout id resolved for the screen (snap UUID / "autotile:<algo>"); empty where unpopulated
 
     /// Tiled-window count for the screen + desktop being resolved. Optional
     /// rather than defaulted because 0 is a meaningful value (an empty tiled
@@ -136,6 +138,8 @@ struct WindowQuery
             return std::optional<QVariant>(mode);
         case Field::ScreenOrientation:
             return std::optional<QVariant>(screenOrientation);
+        case Field::ActiveLayout:
+            return std::optional<QVariant>(activeLayout);
         case Field::TiledWindowCount:
             return tiledWindowCount ? std::optional<QVariant>(*tiledWindowCount) : std::nullopt;
         case Field::IsMaximized:

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -1241,6 +1241,25 @@ void ActionRegistry::registerBuiltins()
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 12,
     });
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetInsertPosition),
+        .slotFor = constantSlot(ActionSlot::InsertPosition),
+        .validate =
+            [](const QJsonObject& p) {
+                const QString v = p.value(ActionParam::Value).toString();
+                return v == InsertPositionToken::End || v == InsertPositionToken::AfterFocused
+                    || v == InsertPositionToken::AsMaster;
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value),
+                     .kind = QStringLiteral("enum"),
+                     .enumWireValues = {QString(InsertPositionToken::End), QString(InsertPositionToken::AfterFocused),
+                                        QString(InsertPositionToken::AsMaster)}}},
+        .category = QStringLiteral("layoutEngine"),
+        .displayOrder = 13,
+    });
 }
 
 } // namespace PhosphorRules

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -916,6 +916,40 @@ void ActionRegistry::registerBuiltins()
         .displayOrder = 2,
     });
 
+    // Two more per-window restore-policy overrides, same shape as RestorePosition
+    // (bool, seeds FALSE because both governing settings default ON — the only
+    // meaningful fresh-rule value is "opt this window OUT"). Consumed daemon-side
+    // (the managed-restore predicate / the drag-out unsnap paths), not the effect.
+    struct RestorePolicy
+    {
+        QLatin1StringView type;
+        QLatin1StringView slot;
+        int order;
+    };
+    for (const RestorePolicy& rp : {
+             RestorePolicy{ActionType::SetRestoreToZoneOnLogin, ActionSlot::RestoreToZoneOnLogin, 3},
+             RestorePolicy{ActionType::SetRestoreSizeOnUnsnap, ActionSlot::RestoreSizeOnUnsnap, 4},
+         }) {
+        const QString slot = QString(rp.slot);
+        registerAction(ActionDescriptor{
+            .type = QString(rp.type),
+            .slotFor =
+                [slot](const QJsonObject&) {
+                    return slot;
+                },
+            .validate =
+                [](const QJsonObject& p) {
+                    return hasBool(p, ActionParam::Value);
+                },
+            .terminal = false,
+            .allowedKeys = {QString(ActionParam::Value)},
+            .domain = ActionDomain::Window,
+            .params = {P{.key = QString(ActionParam::Value), .kind = QStringLiteral("bool"), .defaultDisplay = 0.0}},
+            .category = QStringLiteral("windowManagement"),
+            .displayOrder = rp.order,
+        });
+    }
+
     // ── per-window border / title-bar appearance slots (domain Window) ──
     // One slot per property so independent rules cascade per-property. The
     // effect (resolveWindowAppearance) reads these slots and merges them over

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -99,6 +99,11 @@ constexpr double kMaxGap = 500.0;
 // `Snapping.Zones.Border` config ranges (width 0-10, radius 0-50) — the overlay
 // radius goes wider than the per-window `kMaxBorderRadius` (20).
 constexpr double kMaxOverlayBorderRadius = 50.0;
+// Autotile parameter bounds (display units), mirroring the AutotileDefaults
+// clamps the engine applies on consumption. These only reject grossly malformed
+// hand-edited payloads.
+constexpr double kMaxTiledWindows = 12.0;
+constexpr double kMaxMasterCount = 5.0;
 
 } // namespace
 
@@ -1157,6 +1162,85 @@ void ActionRegistry::registerBuiltins()
             .tags = {QString(Tag::Gap)},
         });
     }
+
+    // ── per-context autotile parameter slots (domain Context) ──
+    // Resolved daemon-side by LayoutRegistry::resolveContextTilingParams and
+    // layered onto the per-screen autotile override map (config stays the base;
+    // the rule wins where present). Category "layoutEngine" — these configure the
+    // tiling engine for the matched context.
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetMaxWindows),
+        .slotFor = constantSlot(ActionSlot::MaxWindows),
+        .validate =
+            [](const QJsonObject& p) {
+                // 1..12; the consumer clamps to AutotileDefaults, so the lower
+                // bound is not enforced here (0 is rejected as grossly malformed).
+                const QJsonValue v = p.value(ActionParam::Value);
+                if (!v.isDouble()) {
+                    return false;
+                }
+                const double d = v.toDouble();
+                return d >= 1.0 && d <= kMaxTiledWindows;
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value),
+                     .kind = QStringLiteral("number"),
+                     .min = 1.0,
+                     .max = kMaxTiledWindows,
+                     .defaultDisplay = 5.0}},
+        .category = QStringLiteral("layoutEngine"),
+        .displayOrder = 10,
+    });
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetSplitRatio),
+        .slotFor = constantSlot(ActionSlot::SplitRatio),
+        .validate =
+            [](const QJsonObject& p) {
+                // Wire is the [0.1, 0.9] ratio; edited as a percent (10-90%).
+                const QJsonValue v = p.value(ActionParam::Value);
+                if (!v.isDouble()) {
+                    return false;
+                }
+                const double d = v.toDouble();
+                return d >= 0.1 && d <= 0.9;
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value),
+                     .kind = QStringLiteral("percent"),
+                     .min = 10.0,
+                     .max = 90.0,
+                     .scale = 0.01,
+                     .defaultDisplay = 50.0}},
+        .category = QStringLiteral("layoutEngine"),
+        .displayOrder = 11,
+    });
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetMasterCount),
+        .slotFor = constantSlot(ActionSlot::MasterCount),
+        .validate =
+            [](const QJsonObject& p) {
+                const QJsonValue v = p.value(ActionParam::Value);
+                if (!v.isDouble()) {
+                    return false;
+                }
+                const double d = v.toDouble();
+                return d >= 1.0 && d <= kMaxMasterCount;
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value),
+                     .kind = QStringLiteral("number"),
+                     .min = 1.0,
+                     .max = kMaxMasterCount,
+                     .defaultDisplay = 1.0}},
+        .category = QStringLiteral("layoutEngine"),
+        .displayOrder = 12,
+    });
 }
 
 } // namespace PhosphorRules

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -95,6 +95,10 @@ bool hasHexColorOrAccent(const QJsonObject& params, QLatin1StringView key)
 constexpr double kMaxBorderWidth = 10.0;
 constexpr double kMaxBorderRadius = 20.0;
 constexpr double kMaxGap = 500.0;
+// Zone-overlay border dimensions have their own bounds mirroring the global
+// `Snapping.Zones.Border` config ranges (width 0-10, radius 0-50) — the overlay
+// radius goes wider than the per-window `kMaxBorderRadius` (20).
+constexpr double kMaxOverlayBorderRadius = 50.0;
 
 } // namespace
 
@@ -747,6 +751,147 @@ void ActionRegistry::registerBuiltins()
                      .enumWireValues = {QString(OverlayStyleToken::Rectangles), QString(OverlayStyleToken::Preview)}}},
         .category = QStringLiteral("overlay"),
         .displayOrder = 1,
+        .tags = {QString(Tag::Overlay)},
+    });
+
+    // ── per-context overlay-APPEARANCE slots (domain Context) ──
+    // Colours / opacities / border dimensions / zone-number visibility that
+    // override the global Snapping.Zones.* config for a matched context. One
+    // slot per property so independent rules cascade. Resolved daemon-side by
+    // LayoutRegistry::resolveContextOverlay; an unset property falls through to
+    // the global config value (config stays authoritative). No Tag::Effect —
+    // these are overlay-service reads, not KWin-effect window appearance.
+    //
+    // The three colour actions share a shape, so a small table keeps type and
+    // slot in lockstep per row (mirroring the per-side gap loop). Colours use
+    // the plain hex validator — NO accent sentinel, since the overlay consumer
+    // resolves no token.
+    struct OverlayColor
+    {
+        QLatin1StringView type;
+        QLatin1StringView slot;
+        int order;
+    };
+    for (const OverlayColor& c : {
+             OverlayColor{ActionType::SetOverlayHighlightColor, ActionSlot::OverlayHighlightColor, 2},
+             OverlayColor{ActionType::SetOverlayInactiveColor, ActionSlot::OverlayInactiveColor, 3},
+             OverlayColor{ActionType::SetOverlayBorderColor, ActionSlot::OverlayBorderColor, 4},
+         }) {
+        const QString slot = QString(c.slot);
+        registerAction(ActionDescriptor{
+            .type = QString(c.type),
+            .slotFor =
+                [slot](const QJsonObject&) {
+                    return slot;
+                },
+            .validate =
+                [](const QJsonObject& p) {
+                    return hasHexColor(p, ActionParam::Value);
+                },
+            .terminal = false,
+            .allowedKeys = {QString(ActionParam::Value)},
+            .domain = ActionDomain::Context,
+            .params = {P{.key = QString(ActionParam::Value), .kind = QStringLiteral("color")}},
+            .category = QStringLiteral("overlay"),
+            .displayOrder = c.order,
+            .tags = {QString(Tag::Overlay)},
+        });
+    }
+    // Active / inactive overlay opacity — [0, 1] double on the wire, edited as a
+    // percent (scale 0.01), mirroring SetOpacity. Defaults match the global
+    // config (activeOpacity 0.5, inactiveOpacity 0.3).
+    struct OverlayOpacity
+    {
+        QLatin1StringView type;
+        QLatin1StringView slot;
+        double defaultDisplay;
+        int order;
+    };
+    for (const OverlayOpacity& o : {
+             OverlayOpacity{ActionType::SetOverlayActiveOpacity, ActionSlot::OverlayActiveOpacity, 50.0, 5},
+             OverlayOpacity{ActionType::SetOverlayInactiveOpacity, ActionSlot::OverlayInactiveOpacity, 30.0, 6},
+         }) {
+        const QString slot = QString(o.slot);
+        registerAction(ActionDescriptor{
+            .type = QString(o.type),
+            .slotFor =
+                [slot](const QJsonObject&) {
+                    return slot;
+                },
+            .validate =
+                [](const QJsonObject& p) {
+                    const QJsonValue v = p.value(ActionParam::Value);
+                    if (!v.isDouble()) {
+                        return false;
+                    }
+                    const double d = v.toDouble();
+                    return d >= 0.0 && d <= 1.0;
+                },
+            .terminal = false,
+            .allowedKeys = {QString(ActionParam::Value)},
+            .domain = ActionDomain::Context,
+            .params = {P{.key = QString(ActionParam::Value),
+                         .kind = QStringLiteral("percent"),
+                         .min = 0.0,
+                         .max = 100.0,
+                         .scale = 0.01,
+                         .defaultDisplay = o.defaultDisplay}},
+            .category = QStringLiteral("overlay"),
+            .displayOrder = o.order,
+            .tags = {QString(Tag::Overlay)},
+        });
+    }
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetOverlayBorderWidth),
+        .slotFor = constantSlot(ActionSlot::OverlayBorderWidth),
+        .validate =
+            [](const QJsonObject& p) {
+                return hasNumberInRange(p, ActionParam::Value, kMaxBorderWidth);
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value),
+                     .kind = QStringLiteral("number"),
+                     .min = 0.0,
+                     .max = kMaxBorderWidth,
+                     .defaultDisplay = 2.0}},
+        .category = QStringLiteral("overlay"),
+        .displayOrder = 7,
+        .tags = {QString(Tag::Overlay)},
+    });
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetOverlayBorderRadius),
+        .slotFor = constantSlot(ActionSlot::OverlayBorderRadius),
+        .validate =
+            [](const QJsonObject& p) {
+                return hasNumberInRange(p, ActionParam::Value, kMaxOverlayBorderRadius);
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value),
+                     .kind = QStringLiteral("number"),
+                     .min = 0.0,
+                     .max = kMaxOverlayBorderRadius,
+                     .defaultDisplay = 8.0}},
+        .category = QStringLiteral("overlay"),
+        .displayOrder = 8,
+        .tags = {QString(Tag::Overlay)},
+    });
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetOverlayShowZoneNumbers),
+        .slotFor = constantSlot(ActionSlot::OverlayShowZoneNumbers),
+        .validate =
+            [](const QJsonObject& p) {
+                return hasBool(p, ActionParam::Value);
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value), .kind = QStringLiteral("bool"), .defaultDisplay = 1.0}},
+        .category = QStringLiteral("overlay"),
+        .displayOrder = 9,
         .tags = {QString(Tag::Overlay)},
     });
 

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -1278,6 +1278,23 @@ void ActionRegistry::registerBuiltins()
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 14,
     });
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetDragBehavior),
+        .slotFor = constantSlot(ActionSlot::DragBehavior),
+        .validate =
+            [](const QJsonObject& p) {
+                const QString v = p.value(ActionParam::Value).toString();
+                return v == DragBehaviorToken::Float || v == DragBehaviorToken::Reorder;
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Value),
+                     .kind = QStringLiteral("enum"),
+                     .enumWireValues = {QString(DragBehaviorToken::Float), QString(DragBehaviorToken::Reorder)}}},
+        .category = QStringLiteral("layoutEngine"),
+        .displayOrder = 15,
+    });
 }
 
 } // namespace PhosphorRules

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -1295,6 +1295,24 @@ void ActionRegistry::registerBuiltins()
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 15,
     });
+    // SetAlgorithmParam mirrors OverrideOverlayShader: a picker param (the target
+    // algorithm) plus a free-form `params` blob (the custom-parameter values,
+    // validated against the algorithm's declared schema at apply time via
+    // hasCustomParam — so the wire validator only requires the algorithm token).
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetAlgorithmParam),
+        .slotFor = constantSlot(ActionSlot::AlgorithmParams),
+        .validate =
+            [](const QJsonObject& p) {
+                return hasNonEmptyString(p, ActionParam::Algorithm);
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Algorithm), QString(ActionParam::Params)},
+        .domain = ActionDomain::Context,
+        .params = {P{.key = QString(ActionParam::Algorithm), .kind = QStringLiteral("tilingAlgorithm")}},
+        .category = QStringLiteral("layoutEngine"),
+        .displayOrder = 16,
+    });
 }
 
 } // namespace PhosphorRules

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -104,6 +104,10 @@ constexpr double kMaxOverlayBorderRadius = 50.0;
 // hand-edited payloads.
 constexpr double kMaxTiledWindows = 12.0;
 constexpr double kMaxMasterCount = 5.0;
+// Split-ratio wire bounds ([0.1, 0.9]); the percent-editor schema derives its
+// display range from these (× 100) so the two never drift.
+constexpr double kMinSplitRatio = 0.1;
+constexpr double kMaxSplitRatio = 0.9;
 
 } // namespace
 
@@ -544,7 +548,7 @@ void ActionRegistry::registerBuiltins()
         // No tags: SnapToZone is daemon-placement only (consumed by the SnapEngine
         // open path), not an Effect / Border / Animation / Overlay action.
         .category = QStringLiteral("windowManagement"),
-        .displayOrder = 0,
+        .displayOrder = 2,
     });
 
     // ── open-routing: send a matched window to a target monitor / desktop ──
@@ -568,7 +572,7 @@ void ActionRegistry::registerBuiltins()
         // No tags: RouteToScreen is daemon open-path routing only, not an
         // Effect / Border / Animation / Overlay / Gap action.
         .category = QStringLiteral("windowManagement"),
-        .displayOrder = 1,
+        .displayOrder = 3,
     });
     registerAction(ActionDescriptor{
         .type = QString(ActionType::RouteToDesktop),
@@ -596,7 +600,7 @@ void ActionRegistry::registerBuiltins()
                      .min = 1.0,
                      .max = static_cast<double>(MaxVirtualDesktopOrdinal)}},
         .category = QStringLiteral("windowManagement"),
-        .displayOrder = 2,
+        .displayOrder = 4,
     });
 
     // ── animation slots — event-scoped: "anim-shader:<event>" ──
@@ -918,7 +922,7 @@ void ActionRegistry::registerBuiltins()
         .domain = ActionDomain::Window,
         .params = {P{.key = QString(ActionParam::Value), .kind = QStringLiteral("bool"), .defaultDisplay = 0.0}},
         .category = QStringLiteral("windowManagement"),
-        .displayOrder = 2,
+        .displayOrder = 5,
     });
 
     // Two more per-window restore-policy overrides, same shape as RestorePosition
@@ -932,8 +936,8 @@ void ActionRegistry::registerBuiltins()
         int order;
     };
     for (const RestorePolicy& rp : {
-             RestorePolicy{ActionType::SetRestoreToZoneOnLogin, ActionSlot::RestoreToZoneOnLogin, 3},
-             RestorePolicy{ActionType::SetRestoreSizeOnUnsnap, ActionSlot::RestoreSizeOnUnsnap, 4},
+             RestorePolicy{ActionType::SetRestoreToZoneOnLogin, ActionSlot::RestoreToZoneOnLogin, 6},
+             RestorePolicy{ActionType::SetRestoreSizeOnUnsnap, ActionSlot::RestoreSizeOnUnsnap, 7},
          }) {
         const QString slot = QString(rp.slot);
         registerAction(ActionDescriptor{
@@ -1173,8 +1177,9 @@ void ActionRegistry::registerBuiltins()
         .slotFor = constantSlot(ActionSlot::MaxWindows),
         .validate =
             [](const QJsonObject& p) {
-                // 1..12; the consumer clamps to AutotileDefaults, so the lower
-                // bound is not enforced here (0 is rejected as grossly malformed).
+                // 1..12; the consumer re-clamps to AutotileDefaults, so this only
+                // enforces a sanity floor of 1 (0 and negatives are rejected as
+                // grossly malformed) and the upper bound.
                 const QJsonValue v = p.value(ActionParam::Value);
                 if (!v.isDouble()) {
                     return false;
@@ -1192,31 +1197,33 @@ void ActionRegistry::registerBuiltins()
                      .defaultDisplay = 5.0}},
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 10,
+        .tags = {QString(Tag::LayoutEngine)},
     });
     registerAction(ActionDescriptor{
         .type = QString(ActionType::SetSplitRatio),
         .slotFor = constantSlot(ActionSlot::SplitRatio),
         .validate =
             [](const QJsonObject& p) {
-                // Wire is the [0.1, 0.9] ratio; edited as a percent (10-90%).
+                // Wire is the [kMinSplitRatio, kMaxSplitRatio] ratio; edited as a percent.
                 const QJsonValue v = p.value(ActionParam::Value);
                 if (!v.isDouble()) {
                     return false;
                 }
                 const double d = v.toDouble();
-                return d >= 0.1 && d <= 0.9;
+                return d >= kMinSplitRatio && d <= kMaxSplitRatio;
             },
         .terminal = false,
         .allowedKeys = {QString(ActionParam::Value)},
         .domain = ActionDomain::Context,
         .params = {P{.key = QString(ActionParam::Value),
                      .kind = QStringLiteral("percent"),
-                     .min = 10.0,
-                     .max = 90.0,
+                     .min = kMinSplitRatio * 100.0,
+                     .max = kMaxSplitRatio * 100.0,
                      .scale = 0.01,
                      .defaultDisplay = 50.0}},
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 11,
+        .tags = {QString(Tag::LayoutEngine)},
     });
     registerAction(ActionDescriptor{
         .type = QString(ActionType::SetMasterCount),
@@ -1240,6 +1247,7 @@ void ActionRegistry::registerBuiltins()
                      .defaultDisplay = 1.0}},
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 12,
+        .tags = {QString(Tag::LayoutEngine)},
     });
     registerAction(ActionDescriptor{
         .type = QString(ActionType::SetInsertPosition),
@@ -1259,6 +1267,7 @@ void ActionRegistry::registerBuiltins()
                                         QString(InsertPositionToken::AsMaster)}}},
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 13,
+        .tags = {QString(Tag::LayoutEngine)},
     });
     registerAction(ActionDescriptor{
         .type = QString(ActionType::SetOverflowBehavior),
@@ -1277,6 +1286,7 @@ void ActionRegistry::registerBuiltins()
             .enumWireValues = {QString(OverflowBehaviorToken::Float), QString(OverflowBehaviorToken::Unlimited)}}},
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 14,
+        .tags = {QString(Tag::LayoutEngine)},
     });
     registerAction(ActionDescriptor{
         .type = QString(ActionType::SetDragBehavior),
@@ -1294,6 +1304,7 @@ void ActionRegistry::registerBuiltins()
                      .enumWireValues = {QString(DragBehaviorToken::Float), QString(DragBehaviorToken::Reorder)}}},
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 15,
+        .tags = {QString(Tag::LayoutEngine)},
     });
     // SetAlgorithmParam mirrors OverrideOverlayShader: a picker param (the target
     // algorithm) plus a free-form `params` blob (the custom-parameter values,
@@ -1312,6 +1323,7 @@ void ActionRegistry::registerBuiltins()
         .params = {P{.key = QString(ActionParam::Algorithm), .kind = QStringLiteral("tilingAlgorithm")}},
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 16,
+        .tags = {QString(Tag::LayoutEngine)},
     });
 }
 

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -104,10 +104,13 @@ constexpr double kMaxOverlayBorderRadius = 50.0;
 // hand-edited payloads.
 constexpr double kMaxTiledWindows = 12.0;
 constexpr double kMaxMasterCount = 5.0;
-// Split-ratio wire bounds ([0.1, 0.9]); the percent-editor schema derives its
-// display range from these (× 100) so the two never drift.
-constexpr double kMinSplitRatio = 0.1;
-constexpr double kMaxSplitRatio = 0.9;
+// Split-ratio bounds. The percent-editor display range is the exact primary pair
+// ([10, 90] %); the wire ratio is derived (÷ 100) so the two never drift and the
+// display bounds stay exact (0.1 * 100.0 is not exactly 10.0 in IEEE-754).
+constexpr double kMinSplitPercent = 10.0;
+constexpr double kMaxSplitPercent = 90.0;
+constexpr double kMinSplitRatio = kMinSplitPercent / 100.0;
+constexpr double kMaxSplitRatio = kMaxSplitPercent / 100.0;
 
 } // namespace
 
@@ -1217,8 +1220,8 @@ void ActionRegistry::registerBuiltins()
         .domain = ActionDomain::Context,
         .params = {P{.key = QString(ActionParam::Value),
                      .kind = QStringLiteral("percent"),
-                     .min = kMinSplitRatio * 100.0,
-                     .max = kMaxSplitRatio * 100.0,
+                     .min = kMinSplitPercent,
+                     .max = kMaxSplitPercent,
                      .scale = 0.01,
                      .defaultDisplay = 50.0}},
         .category = QStringLiteral("layoutEngine"),

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -1260,6 +1260,24 @@ void ActionRegistry::registerBuiltins()
         .category = QStringLiteral("layoutEngine"),
         .displayOrder = 13,
     });
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetOverflowBehavior),
+        .slotFor = constantSlot(ActionSlot::OverflowBehavior),
+        .validate =
+            [](const QJsonObject& p) {
+                const QString v = p.value(ActionParam::Value).toString();
+                return v == OverflowBehaviorToken::Float || v == OverflowBehaviorToken::Unlimited;
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Context,
+        .params = {P{
+            .key = QString(ActionParam::Value),
+            .kind = QStringLiteral("enum"),
+            .enumWireValues = {QString(OverflowBehaviorToken::Float), QString(OverflowBehaviorToken::Unlimited)}}},
+        .category = QStringLiteral("layoutEngine"),
+        .displayOrder = 14,
+    });
 }
 
 } // namespace PhosphorRules

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -1180,15 +1180,20 @@ void ActionRegistry::registerBuiltins()
         .slotFor = constantSlot(ActionSlot::MaxWindows),
         .validate =
             [](const QJsonObject& p) {
-                // 1..12; the consumer re-clamps to AutotileDefaults, so this only
-                // enforces a sanity floor of 1 (0 and negatives are rejected as
-                // grossly malformed) and the upper bound.
+                // 1..12, integral; the consumer re-clamps to AutotileDefaults, so
+                // this only enforces a sanity floor of 1 (0 and negatives are rejected
+                // as grossly malformed) and the upper bound. Reject non-integral like
+                // the sibling count validators (SnapToZone / RouteToDesktop) rather
+                // than silently truncating a hand-edited fractional count.
                 const QJsonValue v = p.value(ActionParam::Value);
                 if (!v.isDouble()) {
                     return false;
                 }
                 const double d = v.toDouble();
-                return d >= 1.0 && d <= kMaxTiledWindows;
+                if (d < 1.0 || d > kMaxTiledWindows) {
+                    return false;
+                }
+                return static_cast<double>(static_cast<int>(d)) == d;
             },
         .terminal = false,
         .allowedKeys = {QString(ActionParam::Value)},
@@ -1233,12 +1238,16 @@ void ActionRegistry::registerBuiltins()
         .slotFor = constantSlot(ActionSlot::MasterCount),
         .validate =
             [](const QJsonObject& p) {
+                // 1..kMaxMasterCount, integral (mirrors SetMaxWindows / SnapToZone).
                 const QJsonValue v = p.value(ActionParam::Value);
                 if (!v.isDouble()) {
                     return false;
                 }
                 const double d = v.toDouble();
-                return d >= 1.0 && d <= kMaxMasterCount;
+                if (d < 1.0 || d > kMaxMasterCount) {
+                    return false;
+                }
+                return static_cast<double>(static_cast<int>(d)) == d;
             },
         .terminal = false,
         .allowedKeys = {QString(ActionParam::Value)},

--- a/libs/phosphor-rules/tests/test_matchtypes.cpp
+++ b/libs/phosphor-rules/tests/test_matchtypes.cpp
@@ -18,7 +18,7 @@ private Q_SLOTS:
         // Canary: the loop bound is derived from FieldCount, not hard-coded.
         // If this fails, an enumerator was added/removed without updating
         // FieldCount in MatchTypes.h.
-        QCOMPARE(FieldCount, 39);
+        QCOMPARE(FieldCount, 40);
         QTest::addColumn<int>("fieldValue");
         for (int v = 0; v < FieldCount; ++v) {
             QTest::addRow("field-%d", v) << v;

--- a/libs/phosphor-rules/tests/test_matchtypes.cpp
+++ b/libs/phosphor-rules/tests/test_matchtypes.cpp
@@ -18,7 +18,7 @@ private Q_SLOTS:
         // Canary: the loop bound is derived from FieldCount, not hard-coded.
         // If this fails, an enumerator was added/removed without updating
         // FieldCount in MatchTypes.h.
-        QCOMPARE(FieldCount, 36);
+        QCOMPARE(FieldCount, 39);
         QTest::addColumn<int>("fieldValue");
         for (int v = 0; v < FieldCount; ++v) {
             QTest::addRow("field-%d", v) << v;

--- a/libs/phosphor-rules/tests/test_matchtypes.cpp
+++ b/libs/phosphor-rules/tests/test_matchtypes.cpp
@@ -101,10 +101,11 @@ private Q_SLOTS:
 
     void testFieldIsContext()
     {
-        // Exactly the five context fields are context (screen / desktop /
-        // activity, the placement Mode, and the tiled-window count) — everything
-        // else is a window property. Action/match compatibility hinges on this
-        // split, so pin it down explicitly rather than re-deriving it from
+        // Exactly the seven context fields are context (screen / desktop /
+        // activity, the placement Mode, the tiled-window count, the screen
+        // orientation, and the active layout) — everything else is a window
+        // property. Action/match compatibility hinges on this split, so pin it
+        // down explicitly rather than re-deriving it from
         // fieldIsString/fieldIsBool/fieldIsNumeric.
         QVERIFY(fieldIsContext(Field::ScreenId));
         QVERIFY(fieldIsContext(Field::VirtualDesktop));
@@ -118,7 +119,16 @@ private Q_SLOTS:
         // on it during windowless context resolution.
         QVERIFY(fieldIsContext(Field::TiledWindowCount));
         QVERIFY(fieldIsNumeric(Field::TiledWindowCount));
+        // ScreenOrientation and ActiveLayout are geometry/layout context fields,
+        // stamped during windowless context resolution so an orientation- or
+        // layout-keyed gap/overlay/assignment rule participates in the cascade.
+        QVERIFY(fieldIsContext(Field::ScreenOrientation));
+        QVERIFY(fieldIsContext(Field::ActiveLayout));
 
+        // The capability fields added alongside them are window properties, not
+        // context, so a rule keying on them is a per-window match.
+        QVERIFY(!fieldIsContext(Field::IsMovable));
+        QVERIFY(!fieldIsContext(Field::IsMaximizable));
         QVERIFY(!fieldIsContext(Field::AppId));
         QVERIFY(!fieldIsContext(Field::WindowClass));
         QVERIFY(!fieldIsContext(Field::DesktopFile));

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -71,6 +71,7 @@ const QList<QLatin1StringView> kContextDomainTypes = {
     ActionType::SetInsertPosition,
     ActionType::SetOverflowBehavior,
     ActionType::SetDragBehavior,
+    ActionType::SetAlgorithmParam,
 };
 const QList<QLatin1StringView> kWindowDomainTypes = {
     ActionType::Exclude,
@@ -567,6 +568,28 @@ private Q_SLOTS:
                 o.insert(QStringLiteral("value"), QString::fromLatin1(token));
                 QVERIFY2(RuleAction::fromJson(o).has_value(), token.data());
             }
+        }
+        // SetAlgorithmParam: requires a non-empty algorithm token; the params blob
+        // is free-form (validated against the algorithm schema at apply time).
+        {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(ActionType::SetAlgorithmParam));
+            QVERIFY(!RuleAction::fromJson(o).has_value()); // no algorithm → rejected
+            o.insert(QStringLiteral("algorithm"), QString()); // empty → rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("algorithm"), QStringLiteral("bsp"));
+            QVERIFY(RuleAction::fromJson(o).has_value()); // algorithm alone → accepted
+            QJsonObject blob;
+            blob.insert(QStringLiteral("ratio"), 0.7);
+            o.insert(QStringLiteral("params"), blob); // params allowed alongside
+            const auto reloaded = RuleAction::fromJson(o);
+            QVERIFY(reloaded.has_value());
+            QCOMPARE(
+                reloaded->params.value(QStringLiteral("params")).toObject().value(QStringLiteral("ratio")).toDouble(),
+                0.7);
+            // An unexpected key is still rejected (strict allowedKeys = {algorithm, params}).
+            o.insert(QStringLiteral("bogus"), 1);
+            QVERIFY(!RuleAction::fromJson(o).has_value());
         }
     }
 

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -496,6 +496,54 @@ private Q_SLOTS:
         }
     }
 
+    void testOverlayDimensionActions_range()
+    {
+        // Overlay border width (0-10) and radius (0-50) carry a number; reject
+        // out-of-range and non-numeric, accept in-range.
+        struct DimCase
+        {
+            QLatin1StringView type;
+            double over;
+        };
+        for (const DimCase& c :
+             {DimCase{ActionType::SetOverlayBorderWidth, 11.0}, DimCase{ActionType::SetOverlayBorderRadius, 51.0}}) {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(c.type));
+            o.insert(QStringLiteral("value"), c.over); // above max rejected
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), c.type.data());
+            o.insert(QStringLiteral("value"), -1.0); // negative rejected
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), c.type.data());
+            o.insert(QStringLiteral("value"), QStringLiteral("2")); // non-numeric rejected
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), c.type.data());
+            o.insert(QStringLiteral("value"), 4); // in range accepted
+            QVERIFY2(RuleAction::fromJson(o).has_value(), c.type.data());
+        }
+        // SetOverlayShowZoneNumbers requires a JSON bool.
+        {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(ActionType::SetOverlayShowZoneNumbers));
+            o.insert(QStringLiteral("value"), 1); // number rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("value"), true);
+            QVERIFY(RuleAction::fromJson(o).has_value());
+        }
+    }
+
+    void testRestorePolicyActions_requireBool()
+    {
+        // The per-window restore-policy actions carry a JSON bool; a non-bool
+        // payload is rejected at load, a bool accepted.
+        for (const QLatin1StringView type : {ActionType::SetRestoreToZoneOnLogin, ActionType::SetRestoreSizeOnUnsnap}) {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(type));
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), type.data()); // missing value
+            o.insert(QStringLiteral("value"), 1); // number rejected
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), type.data());
+            o.insert(QStringLiteral("value"), false);
+            QVERIFY2(RuleAction::fromJson(o).has_value(), type.data());
+        }
+    }
+
     // ── autotile parameter actions (context-domain) ──
 
     void testTilingParamActions_range()

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -85,6 +85,10 @@ const QList<QLatin1StringView> kWindowDomainTypes = {
     ActionType::SetBorderRadius,
     ActionType::SetBorderColorActive,
     ActionType::SetBorderColorInactive,
+    // Per-window restore-policy overrides — window-domain, resolved daemon-side
+    // (managed-restore predicate / drag-out unsnap paths), like RestorePosition.
+    ActionType::SetRestoreToZoneOnLogin,
+    ActionType::SetRestoreSizeOnUnsnap,
 };
 } // namespace
 

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -63,6 +63,11 @@ const QList<QLatin1StringView> kContextDomainTypes = {
     ActionType::SetOverlayBorderWidth,
     ActionType::SetOverlayBorderRadius,
     ActionType::SetOverlayShowZoneNumbers,
+    // Autotile parameter overrides are context-domain — resolved per
+    // screen/desktop/activity and layered onto the per-screen override map.
+    ActionType::SetMaxWindows,
+    ActionType::SetSplitRatio,
+    ActionType::SetMasterCount,
 };
 const QList<QLatin1StringView> kWindowDomainTypes = {
     ActionType::Exclude,
@@ -484,6 +489,47 @@ private Q_SLOTS:
             QVERIFY2(!RuleAction::fromJson(o).has_value(), type.data());
             o.insert(QStringLiteral("value"), 0.5); // in range accepted
             QVERIFY2(RuleAction::fromJson(o).has_value(), type.data());
+        }
+    }
+
+    // ── autotile parameter actions (context-domain) ──
+
+    void testTilingParamActions_range()
+    {
+        // SetMaxWindows: 1..12, integer count.
+        {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(ActionType::SetMaxWindows));
+            o.insert(QStringLiteral("value"), 0); // below 1 rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("value"), 13); // above 12 rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("value"), 4); // in range accepted
+            QVERIFY(RuleAction::fromJson(o).has_value());
+        }
+        // SetSplitRatio: wire is the [0.1, 0.9] ratio.
+        {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(ActionType::SetSplitRatio));
+            o.insert(QStringLiteral("value"), 0.05); // below 0.1 rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("value"), 0.95); // above 0.9 rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("value"), QStringLiteral("0.5")); // non-numeric rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("value"), 0.6); // in range accepted
+            QVERIFY(RuleAction::fromJson(o).has_value());
+        }
+        // SetMasterCount: 1..5, integer count.
+        {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(ActionType::SetMasterCount));
+            o.insert(QStringLiteral("value"), 0); // below 1 rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("value"), 6); // above 5 rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("value"), 2); // in range accepted
+            QVERIFY(RuleAction::fromJson(o).has_value());
         }
     }
 

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -68,6 +68,7 @@ const QList<QLatin1StringView> kContextDomainTypes = {
     ActionType::SetMaxWindows,
     ActionType::SetSplitRatio,
     ActionType::SetMasterCount,
+    ActionType::SetInsertPosition,
 };
 const QList<QLatin1StringView> kWindowDomainTypes = {
     ActionType::Exclude,
@@ -530,6 +531,18 @@ private Q_SLOTS:
             QVERIFY(!RuleAction::fromJson(o).has_value());
             o.insert(QStringLiteral("value"), 2); // in range accepted
             QVERIFY(RuleAction::fromJson(o).has_value());
+        }
+        // SetInsertPosition: closed enum vocabulary.
+        {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(ActionType::SetInsertPosition));
+            o.insert(QStringLiteral("value"), QStringLiteral("middle")); // unknown token rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            for (const QLatin1StringView token :
+                 {InsertPositionToken::End, InsertPositionToken::AfterFocused, InsertPositionToken::AsMaster}) {
+                o.insert(QStringLiteral("value"), QString::fromLatin1(token));
+                QVERIFY2(RuleAction::fromJson(o).has_value(), token.data());
+            }
         }
     }
 

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -556,6 +556,8 @@ private Q_SLOTS:
             QVERIFY(!RuleAction::fromJson(o).has_value());
             o.insert(QStringLiteral("value"), 13); // above 12 rejected
             QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("value"), 4.5); // non-integral rejected (not truncated)
+            QVERIFY(!RuleAction::fromJson(o).has_value());
             o.insert(QStringLiteral("value"), 4); // in range accepted
             QVERIFY(RuleAction::fromJson(o).has_value());
         }
@@ -579,6 +581,8 @@ private Q_SLOTS:
             o.insert(QStringLiteral("value"), 0); // below 1 rejected
             QVERIFY(!RuleAction::fromJson(o).has_value());
             o.insert(QStringLiteral("value"), 6); // above 5 rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            o.insert(QStringLiteral("value"), 2.5); // non-integral rejected (not truncated)
             QVERIFY(!RuleAction::fromJson(o).has_value());
             o.insert(QStringLiteral("value"), 2); // in range accepted
             QVERIFY(RuleAction::fromJson(o).has_value());

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -69,6 +69,7 @@ const QList<QLatin1StringView> kContextDomainTypes = {
     ActionType::SetSplitRatio,
     ActionType::SetMasterCount,
     ActionType::SetInsertPosition,
+    ActionType::SetOverflowBehavior,
 };
 const QList<QLatin1StringView> kWindowDomainTypes = {
     ActionType::Exclude,
@@ -540,6 +541,17 @@ private Q_SLOTS:
             QVERIFY(!RuleAction::fromJson(o).has_value());
             for (const QLatin1StringView token :
                  {InsertPositionToken::End, InsertPositionToken::AfterFocused, InsertPositionToken::AsMaster}) {
+                o.insert(QStringLiteral("value"), QString::fromLatin1(token));
+                QVERIFY2(RuleAction::fromJson(o).has_value(), token.data());
+            }
+        }
+        // SetOverflowBehavior: closed enum vocabulary.
+        {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(ActionType::SetOverflowBehavior));
+            o.insert(QStringLiteral("value"), QStringLiteral("cap")); // unknown token rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            for (const QLatin1StringView token : {OverflowBehaviorToken::Float, OverflowBehaviorToken::Unlimited}) {
                 o.insert(QStringLiteral("value"), QString::fromLatin1(token));
                 QVERIFY2(RuleAction::fromJson(o).has_value(), token.data());
             }

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -52,6 +52,17 @@ const QList<QLatin1StringView> kContextDomainTypes = {
     // never per-window.
     ActionType::OverrideOverlayShader,
     ActionType::OverrideOverlayStyle,
+    // Overlay-APPEARANCE overrides (colours / opacities / border dimensions /
+    // zone-number visibility) are context-domain too — resolved in the same
+    // resolveContextOverlay pass, layered over the global Snapping.Zones.* config.
+    ActionType::SetOverlayHighlightColor,
+    ActionType::SetOverlayInactiveColor,
+    ActionType::SetOverlayBorderColor,
+    ActionType::SetOverlayActiveOpacity,
+    ActionType::SetOverlayInactiveOpacity,
+    ActionType::SetOverlayBorderWidth,
+    ActionType::SetOverlayBorderRadius,
+    ActionType::SetOverlayShowZoneNumbers,
 };
 const QList<QLatin1StringView> kWindowDomainTypes = {
     ActionType::Exclude,
@@ -423,6 +434,52 @@ private Q_SLOTS:
             const auto roundTripped = RuleAction::fromJson(reloaded->toJson());
             QVERIFY2(roundTripped.has_value(), type.data());
             QCOMPARE(*roundTripped, *reloaded);
+        }
+    }
+
+    // ── overlay-appearance actions (context-domain) ──
+
+    void testOverlayColorActions_hexOnlyNoAccent()
+    {
+        // The overlay colour actions require a concrete hex — unlike the border
+        // colour actions they REJECT the accent sentinel (their consumer resolves
+        // no token). This is the load-time guard behind that contract.
+        for (const QLatin1StringView type : {ActionType::SetOverlayHighlightColor, ActionType::SetOverlayInactiveColor,
+                                             ActionType::SetOverlayBorderColor}) {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(type));
+            // Missing value — rejected.
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), type.data());
+            // The accent sentinel is rejected here (accepted only for border colours).
+            o.insert(QStringLiteral("value"), QString(BorderColorToken::Accent));
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), type.data());
+            o.insert(QStringLiteral("value"), QStringLiteral("red")); // named colour rejected
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), type.data());
+            // Standard QColor hex shapes accepted.
+            for (const QString& good :
+                 {QStringLiteral("#abc"), QStringLiteral("#FF0000"), QStringLiteral("#80FF0000")}) {
+                o.insert(QStringLiteral("value"), good);
+                QVERIFY2(RuleAction::fromJson(o).has_value(), qPrintable(good));
+            }
+        }
+    }
+
+    void testOverlayOpacityActions_range()
+    {
+        // Active / inactive overlay opacity carry a [0, 1] double, same shape as
+        // SetOpacity — reject out-of-range and non-numeric payloads.
+        for (const QLatin1StringView type :
+             {ActionType::SetOverlayActiveOpacity, ActionType::SetOverlayInactiveOpacity}) {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(type));
+            o.insert(QStringLiteral("value"), 1.5); // > 1 rejected
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), type.data());
+            o.insert(QStringLiteral("value"), -0.1); // < 0 rejected
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), type.data());
+            o.insert(QStringLiteral("value"), QStringLiteral("0.5")); // non-numeric rejected
+            QVERIFY2(!RuleAction::fromJson(o).has_value(), type.data());
+            o.insert(QStringLiteral("value"), 0.5); // in range accepted
+            QVERIFY2(RuleAction::fromJson(o).has_value(), type.data());
         }
     }
 

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -70,6 +70,7 @@ const QList<QLatin1StringView> kContextDomainTypes = {
     ActionType::SetMasterCount,
     ActionType::SetInsertPosition,
     ActionType::SetOverflowBehavior,
+    ActionType::SetDragBehavior,
 };
 const QList<QLatin1StringView> kWindowDomainTypes = {
     ActionType::Exclude,
@@ -552,6 +553,17 @@ private Q_SLOTS:
             o.insert(QStringLiteral("value"), QStringLiteral("cap")); // unknown token rejected
             QVERIFY(!RuleAction::fromJson(o).has_value());
             for (const QLatin1StringView token : {OverflowBehaviorToken::Float, OverflowBehaviorToken::Unlimited}) {
+                o.insert(QStringLiteral("value"), QString::fromLatin1(token));
+                QVERIFY2(RuleAction::fromJson(o).has_value(), token.data());
+            }
+        }
+        // SetDragBehavior: closed enum vocabulary.
+        {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString::fromLatin1(ActionType::SetDragBehavior));
+            o.insert(QStringLiteral("value"), QStringLiteral("swap")); // unknown token rejected
+            QVERIFY(!RuleAction::fromJson(o).has_value());
+            for (const QLatin1StringView token : {DragBehaviorToken::Float, DragBehaviorToken::Reorder}) {
                 o.insert(QStringLiteral("value"), QString::fromLatin1(token));
                 QVERIFY2(RuleAction::fromJson(o).has_value(), token.data());
             }

--- a/libs/phosphor-rules/tests/test_windowquery.cpp
+++ b/libs/phosphor-rules/tests/test_windowquery.cpp
@@ -37,12 +37,14 @@ private Q_SLOTS:
         q.virtualDesktop = 3;
         q.activity = QStringLiteral("{act}");
         q.screenOrientation = QStringLiteral("portrait");
+        q.activeLayout = QStringLiteral("autotile:bsp");
 
         QCOMPARE(q.valueForField(Field::ScreenId)->toString(), QStringLiteral("DP-1"));
         QCOMPARE(q.valueForField(Field::VirtualDesktop)->toInt(), 3);
         QCOMPARE(q.valueForField(Field::Activity)->toString(), QStringLiteral("{act}"));
-        // Context field, always present — empty when no geometry provider stamped it.
+        // Context fields, always present — empty when unpopulated by a resolver.
         QCOMPARE(q.valueForField(Field::ScreenOrientation)->toString(), QStringLiteral("portrait"));
+        QCOMPARE(q.valueForField(Field::ActiveLayout)->toString(), QStringLiteral("autotile:bsp"));
         // A windowless query carrying only context fields is still not a window.
         QVERIFY(!q.hasWindow());
     }

--- a/libs/phosphor-rules/tests/test_windowquery.cpp
+++ b/libs/phosphor-rules/tests/test_windowquery.cpp
@@ -36,10 +36,15 @@ private Q_SLOTS:
         q.screenId = QStringLiteral("DP-1");
         q.virtualDesktop = 3;
         q.activity = QStringLiteral("{act}");
+        q.screenOrientation = QStringLiteral("portrait");
 
         QCOMPARE(q.valueForField(Field::ScreenId)->toString(), QStringLiteral("DP-1"));
         QCOMPARE(q.valueForField(Field::VirtualDesktop)->toInt(), 3);
         QCOMPARE(q.valueForField(Field::Activity)->toString(), QStringLiteral("{act}"));
+        // Context field, always present — empty when no geometry provider stamped it.
+        QCOMPARE(q.valueForField(Field::ScreenOrientation)->toString(), QStringLiteral("portrait"));
+        // A windowless query carrying only context fields is still not a window.
+        QVERIFY(!q.hasWindow());
     }
 
     void testValueForField_absentWindowAttribute()
@@ -113,6 +118,8 @@ private Q_SLOTS:
         QVERIFY(!q.valueForField(Field::IsModal).has_value());
         QVERIFY(!q.valueForField(Field::HasDecoration).has_value());
         QVERIFY(!q.valueForField(Field::IsResizable).has_value());
+        QVERIFY(!q.valueForField(Field::IsMovable).has_value());
+        QVERIFY(!q.valueForField(Field::IsMaximizable).has_value());
         QVERIFY(!q.valueForField(Field::PositionX).has_value());
         QVERIFY(!q.valueForField(Field::PositionY).has_value());
         QVERIFY(!q.valueForField(Field::CaptionNormal).has_value());
@@ -126,6 +133,8 @@ private Q_SLOTS:
         q.isModal = false;
         q.hasDecoration = true;
         q.isResizable = false;
+        q.isMovable = true;
+        q.isMaximizable = false;
         q.positionX = -50; // a negative X is valid (window straddling the left edge)
         q.positionY = 100;
         q.captionNormal = QStringLiteral("Firefox");
@@ -140,6 +149,10 @@ private Q_SLOTS:
         QCOMPARE(q.valueForField(Field::IsModal)->toBool(), false);
         QCOMPARE(q.valueForField(Field::HasDecoration)->toBool(), true);
         QCOMPARE(q.valueForField(Field::IsResizable)->toBool(), false);
+        QCOMPARE(q.valueForField(Field::IsMovable)->toBool(), true);
+        // Present even though false (the bool-field contract).
+        QVERIFY(q.valueForField(Field::IsMaximizable).has_value());
+        QCOMPARE(q.valueForField(Field::IsMaximizable)->toBool(), false);
         QCOMPARE(q.valueForField(Field::PositionX)->toInt(), -50);
         QCOMPARE(q.valueForField(Field::PositionY)->toInt(), 100);
         QCOMPARE(q.valueForField(Field::CaptionNormal)->toString(), QStringLiteral("Firefox"));

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -1128,7 +1128,7 @@ private:
     /// Add @p windowId to @p state at the position dictated by the
     /// insertion-order setting (End / AfterFocused / AsMaster). Shared by
     /// insertWindow's new-window path and handoffReceive's cross-engine adopt.
-    void insertWindowByConfigOrder(PhosphorTiles::TilingState* state, const QString& windowId);
+    void insertWindowByConfigOrder(PhosphorTiles::TilingState* state, const QString& windowId, const QString& screenId);
     void removeWindow(const QString& windowId);
 
     /// Algorithm lifecycle REMOVE hook + state removal for a tracked window,

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/AutotileEngine.h
@@ -557,6 +557,7 @@ public:
     bool effectiveSmartGaps(const QString& screenId) const;
     bool effectiveRespectMinimumSize(const QString& screenId) const;
     int effectiveMaxWindows(const QString& screenId) const;
+    PhosphorTiles::AutotileInsertPosition effectiveInsertPosition(const QString& screenId) const;
     qreal effectiveSplitRatioStep(const QString& screenId) const override;
     int runtimeMaxWindows() const override;
     QString effectiveAlgorithmId(const QString& screenId) const;

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
@@ -119,6 +119,7 @@ public:
     bool effectiveSmartGaps(const QString& screenId) const;
     bool effectiveRespectMinimumSize(const QString& screenId) const;
     int effectiveMaxWindows(const QString& screenId) const;
+    PhosphorTiles::AutotileOverflowBehavior effectiveOverflowBehavior(const QString& screenId) const;
     PhosphorTiles::AutotileInsertPosition effectiveInsertPosition(const QString& screenId) const;
     qreal effectiveSplitRatioStep(const QString& screenId) const;
     QString effectiveAlgorithmId(const QString& screenId) const;

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
@@ -119,6 +119,7 @@ public:
     bool effectiveSmartGaps(const QString& screenId) const;
     bool effectiveRespectMinimumSize(const QString& screenId) const;
     int effectiveMaxWindows(const QString& screenId) const;
+    PhosphorTiles::AutotileInsertPosition effectiveInsertPosition(const QString& screenId) const;
     qreal effectiveSplitRatioStep(const QString& screenId) const;
     QString effectiveAlgorithmId(const QString& screenId) const;
     PhosphorTiles::TilingAlgorithm* effectiveAlgorithm(const QString& screenId) const;

--- a/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
+++ b/libs/phosphor-tile-engine/include/PhosphorTileEngine/PerScreenConfigResolver.h
@@ -121,6 +121,11 @@ public:
     int effectiveMaxWindows(const QString& screenId) const;
     PhosphorTiles::AutotileOverflowBehavior effectiveOverflowBehavior(const QString& screenId) const;
     PhosphorTiles::AutotileInsertPosition effectiveInsertPosition(const QString& screenId) const;
+    /// The per-screen custom-parameter override map (a SetAlgorithmParam rule the
+    /// daemon injected), or an empty map when none. Layered over the global
+    /// per-algorithm config by the engine; the daemon has already gated it on the
+    /// screen's effective algorithm.
+    QVariantMap effectiveCustomParamsOverride(const QString& screenId) const;
     qreal effectiveSplitRatioStep(const QString& screenId) const;
     QString effectiveAlgorithmId(const QString& screenId) const;
     PhosphorTiles::TilingAlgorithm* effectiveAlgorithm(const QString& screenId) const;

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -1464,6 +1464,11 @@ int AutotileEngine::effectiveMaxWindows(const QString& screenId) const
     return m_configResolver->effectiveMaxWindows(screenId);
 }
 
+PhosphorTiles::AutotileInsertPosition AutotileEngine::effectiveInsertPosition(const QString& screenId) const
+{
+    return m_configResolver->effectiveInsertPosition(screenId);
+}
+
 qreal AutotileEngine::effectiveSplitRatioStep(const QString& screenId) const
 {
     return m_configResolver->effectiveSplitRatioStep(screenId);
@@ -3222,7 +3227,9 @@ bool AutotileEngine::insertWindow(const QString& windowId, const QString& screen
 
 void AutotileEngine::insertWindowByConfigOrder(PhosphorTiles::TilingState* state, const QString& windowId)
 {
-    switch (m_config->insertPosition) {
+    // Per-screen resolution: a per-screen config override or a context
+    // SetInsertPosition rule wins over the global config for this window's screen.
+    switch (effectiveInsertPosition(screenForWindow(windowId))) {
     case AutotileConfig::InsertPosition::End:
         state->addWindow(windowId);
         break;

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -1988,7 +1988,7 @@ void AutotileEngine::handoffReceive(const HandoffContext& ctx)
     if (ctx.insertIndex >= 0 && ctx.dropPos.isNull()) {
         state->addWindow(windowId, ctx.insertIndex);
     } else if (ctx.dropPos.isNull()) {
-        insertWindowByConfigOrder(state, windowId);
+        insertWindowByConfigOrder(state, windowId, ctx.toScreenId);
     } else {
         state->addWindow(windowId);
     }
@@ -3203,7 +3203,7 @@ bool AutotileEngine::insertWindow(const QString& windowId, const QString& screen
 
     if (!inserted) {
         // Insert based on config preference
-        insertWindowByConfigOrder(state, windowId);
+        insertWindowByConfigOrder(state, windowId, screenId);
     }
 
     // Float restore is handled entirely by the record take() above (a floating
@@ -3225,11 +3225,15 @@ bool AutotileEngine::insertWindow(const QString& windowId, const QString& screen
     return true;
 }
 
-void AutotileEngine::insertWindowByConfigOrder(PhosphorTiles::TilingState* state, const QString& windowId)
+void AutotileEngine::insertWindowByConfigOrder(PhosphorTiles::TilingState* state, const QString& windowId,
+                                               const QString& screenId)
 {
     // Per-screen resolution: a per-screen config override or a context
     // SetInsertPosition rule wins over the global config for this window's screen.
-    switch (effectiveInsertPosition(screenForWindow(windowId))) {
+    // The screen is passed in (NOT derived via screenForWindow) because the window
+    // is not yet keyed at either call site — screenForWindow would fall back to the
+    // primary screen and both ignore a non-primary override and spam a warning.
+    switch (effectiveInsertPosition(screenId)) {
     case AutotileConfig::InsertPosition::End:
         state->addWindow(windowId);
         break;

--- a/libs/phosphor-tile-engine/src/AutotileEngine.cpp
+++ b/libs/phosphor-tile-engine/src/AutotileEngine.cpp
@@ -3397,6 +3397,18 @@ bool AutotileEngine::recalculateLayout(const QString& screenId)
             // else: algorithm doesn't support custom params — don't pass any
         }
     }
+    // Layer a per-context SetAlgorithmParam rule override on top of the config
+    // (rule wins per-param). The daemon injected these only when the rule's target
+    // algorithm is this screen's effective algorithm; the hasCustomParam filter is
+    // a second guard so a stale key for another algorithm is dropped.
+    if (m_configResolver && algo->supportsCustomParams()) {
+        const QVariantMap ruleParams = m_configResolver->effectiveCustomParamsOverride(screenId);
+        for (auto pit = ruleParams.constBegin(); pit != ruleParams.constEnd(); ++pit) {
+            if (algo->hasCustomParam(pit.key())) {
+                customParams[pit.key()] = pit.value();
+            }
+        }
+    }
 
     // Let memory-based algorithms prepare their state (e.g., lazily create a PhosphorTiles::SplitTree)
     // before calculateZones(). Virtual dispatch avoids concrete type casts here.

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -274,6 +274,14 @@ bool PerScreenConfigResolver::effectiveSmartGaps(const QString& screenId) const
     return m_engine->config()->smartGaps;
 }
 
+QVariantMap PerScreenConfigResolver::effectiveCustomParamsOverride(const QString& screenId) const
+{
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::CustomParams))) {
+        return v->toMap();
+    }
+    return {};
+}
+
 PhosphorTiles::AutotileOverflowBehavior
 PerScreenConfigResolver::effectiveOverflowBehavior(const QString& screenId) const
 {

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -287,7 +287,8 @@ PerScreenConfigResolver::effectiveOverflowBehavior(const QString& screenId) cons
 {
     // Per-screen override (config store OR a folded-in context rule) → global config.
     if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::OverflowBehavior))) {
-        const int clamped = qBound(0, v->toInt(), 1);
+        const int clamped = qBound(PhosphorTiles::AutotileDefaults::MinOverflowBehavior, v->toInt(),
+                                   PhosphorTiles::AutotileDefaults::MaxOverflowBehavior);
         return static_cast<PhosphorTiles::AutotileOverflowBehavior>(clamped);
     }
     return m_engine->config()->overflowBehavior;

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -36,6 +36,11 @@ void PerScreenConfigResolver::applyPerScreenConfig(const QString& screenId, cons
         return;
     }
 
+    // Capture the previous override map BEFORE overwriting so removed stateful
+    // keys can be reverted below (splitRatio / masterCount live on TilingState,
+    // not re-resolved per retile like maxWindows / insertPosition / overflow).
+    const QVariantMap previous = m_perScreenOverrides.value(screenId);
+
     // Store overrides so effective*() helpers and connectToSettings handlers
     // can resolve per-screen values and skip screens with overrides.
     m_perScreenOverrides[screenId] = overrides;
@@ -45,35 +50,65 @@ void PerScreenConfigResolver::applyPerScreenConfig(const QString& screenId, cons
         return;
     }
 
-    // Apply PhosphorTiles::TilingState-level overrides (splitRatio, masterCount)
+    // Apply PhosphorTiles::TilingState-level overrides (splitRatio, masterCount).
+    // These are STATEFUL: an unset key normally means "leave the state alone" so a
+    // user's live drag-adjusted split / master count survives an unrelated
+    // updateAutotileScreens pass. But if the key was PRESENT in the previous map
+    // and is now gone (a SetSplitRatio / SetMasterCount rule was removed while the
+    // map stayed non-empty), the state would keep the stale rule value — so revert
+    // it to the global config baseline, matching clearPerScreenConfig.
     auto it = overrides.constFind(QString(PerScreenKeys::SplitRatio));
     if (it != overrides.constEnd()) {
         state->setSplitRatio(qBound(PhosphorTiles::AutotileDefaults::MinSplitRatio, it->toDouble(),
                                     PhosphorTiles::AutotileDefaults::MaxSplitRatio));
+    } else if (previous.contains(QString(PerScreenKeys::SplitRatio))) {
+        // Removed (was an override, now gone) → revert to the config baseline. NOT
+        // gated on the Algorithm key: concrete-algorithm screens ALWAYS carry the
+        // injected Algorithm key, so an Algorithm-presence guard would leave the stale
+        // removed-rule ratio on exactly those screens. Branch 3 below runs AFTER this,
+        // so on a GENUINE algorithm change it overwrites this baseline with the new
+        // algo's default (the correct end state); on an unchanged / absent algorithm
+        // this baseline stands. A never-was-an-override live value is untouched (the
+        // previous.contains guard).
+        state->setSplitRatio(m_engine->config()->splitRatio);
     }
 
     it = overrides.constFind(QString(PerScreenKeys::MasterCount));
     if (it != overrides.constEnd()) {
         state->setMasterCount(qBound(PhosphorTiles::AutotileDefaults::MinMasterCount, it->toInt(),
                                      PhosphorTiles::AutotileDefaults::MaxMasterCount));
+    } else if (previous.contains(QString(PerScreenKeys::MasterCount))) {
+        // Removed → revert to the global config baseline (no per-algorithm default).
+        state->setMasterCount(m_engine->config()->masterCount);
     }
 
-    // If algorithm changed and split ratio wasn't explicitly overridden,
-    // reset to the new algorithm's default (matching setAlgorithm() logic).
+    // If the per-screen algorithm ACTUALLY CHANGED and split ratio wasn't
+    // explicitly overridden, reset it to the new algorithm's default — matching
+    // setAlgorithm(), which early-returns when the id is unchanged. The daemon
+    // always injects the Algorithm key for concrete-algorithm autotile screens, so
+    // gating on mere key PRESENCE would reset the split ratio on every unrelated
+    // override change (e.g. a SetMaxWindows rule edit, now that a rule edit rebuilds
+    // the overrides map and re-applies), silently discarding a user's live
+    // drag-tuned ratio. Comparing against the previous override map's algorithm
+    // fires the reset only on a genuine switch, where dropping the tuning is correct
+    // (setAlgorithm clears user tunings on a real change too).
     it = overrides.constFind(QString(PerScreenKeys::Algorithm));
     if (it != overrides.constEnd()) {
-        QString algoId = it->toString();
-        auto* registry = m_engine->algorithmRegistry();
-        PhosphorTiles::TilingAlgorithm* newAlgo = registry->algorithm(algoId);
-        if (newAlgo) {
-            if (!overrides.contains(QString(PerScreenKeys::SplitRatio))) {
+        const QString algoId = it->toString();
+        const QString previousAlgo = previous.value(QString(PerScreenKeys::Algorithm)).toString();
+        if (algoId != previousAlgo && !overrides.contains(QString(PerScreenKeys::SplitRatio))) {
+            if (auto* newAlgo = m_engine->algorithmRegistry()->algorithm(algoId)) {
                 state->setSplitRatio(newAlgo->defaultSplitRatio());
             }
         }
     }
 
-    // Gap overrides (InnerGap, OuterGap, SmartGaps) and RespectMinimumSize are
-    // resolved at retile time via effective*() helpers in recalculateLayout().
+    // The remaining overrides are NOT written to the state here — they are
+    // resolved at retile time via effective*() helpers in recalculateLayout():
+    // gaps (InnerGap, OuterGap, SmartGaps), RespectMinimumSize, MaxWindows,
+    // InsertPosition, OverflowBehavior, and CustomParams. Only SplitRatio and
+    // MasterCount are stateful (handled above), which is why only those two need
+    // an explicit revert-on-removal.
 
     // Schedule a deferred retile so the new config takes effect. Deferred (not
     // immediate) to coalesce with other pending retiles — e.g., when applyEntry()
@@ -319,7 +354,7 @@ int PerScreenConfigResolver::effectiveMaxWindows(const QString& screenId) const
     //    over global Unlimited mode so users can clamp individual screens
     //    (e.g. keep a secondary monitor at maxWindows=3 while the primary
     //    runs unlimited).
-    if (auto v = perScreenOverride(screenId, PerScreenKeys::MaxWindows))
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::MaxWindows)))
         return qBound(PhosphorTiles::AutotileDefaults::MinMaxWindows, v->toInt(),
                       PhosphorTiles::AutotileDefaults::MaxMaxWindows);
 
@@ -361,7 +396,7 @@ int PerScreenConfigResolver::effectiveMaxWindows(const QString& screenId) const
 
 qreal PerScreenConfigResolver::effectiveSplitRatioStep(const QString& screenId) const
 {
-    if (auto v = perScreenOverride(screenId, PerScreenKeys::SplitRatioStep))
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::SplitRatioStep)))
         return qBound(PhosphorTiles::AutotileDefaults::MinSplitRatioStep, v->toDouble(),
                       PhosphorTiles::AutotileDefaults::MaxSplitRatioStep);
     return m_engine->config()->splitRatioStep;
@@ -369,7 +404,7 @@ qreal PerScreenConfigResolver::effectiveSplitRatioStep(const QString& screenId) 
 
 QString PerScreenConfigResolver::effectiveAlgorithmId(const QString& screenId) const
 {
-    if (auto v = perScreenOverride(screenId, PerScreenKeys::Algorithm))
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::Algorithm)))
         return v->toString();
     return m_engine->m_algorithmId;
 }

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -274,6 +274,18 @@ bool PerScreenConfigResolver::effectiveSmartGaps(const QString& screenId) const
     return m_engine->config()->smartGaps;
 }
 
+PhosphorTiles::AutotileInsertPosition PerScreenConfigResolver::effectiveInsertPosition(const QString& screenId) const
+{
+    // Per-screen override (config store OR a folded-in tiling rule) → global config.
+    // The stored value is the enum's underlying int, clamped to the valid range.
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::InsertPosition))) {
+        const int clamped = qBound(PhosphorTiles::AutotileDefaults::MinInsertPosition, v->toInt(),
+                                   PhosphorTiles::AutotileDefaults::MaxInsertPosition);
+        return static_cast<PhosphorTiles::AutotileInsertPosition>(clamped);
+    }
+    return m_engine->config()->insertPosition;
+}
+
 bool PerScreenConfigResolver::effectiveRespectMinimumSize(const QString& screenId) const
 {
     if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::RespectMinimumSize)))

--- a/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
+++ b/libs/phosphor-tile-engine/src/PerScreenConfigResolver.cpp
@@ -274,6 +274,17 @@ bool PerScreenConfigResolver::effectiveSmartGaps(const QString& screenId) const
     return m_engine->config()->smartGaps;
 }
 
+PhosphorTiles::AutotileOverflowBehavior
+PerScreenConfigResolver::effectiveOverflowBehavior(const QString& screenId) const
+{
+    // Per-screen override (config store OR a folded-in context rule) → global config.
+    if (auto v = perScreenOverride(screenId, QString(PerScreenKeys::OverflowBehavior))) {
+        const int clamped = qBound(0, v->toInt(), 1);
+        return static_cast<PhosphorTiles::AutotileOverflowBehavior>(clamped);
+    }
+    return m_engine->config()->overflowBehavior;
+}
+
 PhosphorTiles::AutotileInsertPosition PerScreenConfigResolver::effectiveInsertPosition(const QString& screenId) const
 {
     // Per-screen override (config store OR a folded-in tiling rule) → global config.
@@ -303,11 +314,12 @@ int PerScreenConfigResolver::effectiveMaxWindows(const QString& screenId) const
         return qBound(PhosphorTiles::AutotileDefaults::MinMaxWindows, v->toInt(),
                       PhosphorTiles::AutotileDefaults::MaxMaxWindows);
 
-    // 2. Global Unlimited: Krohnkite-style "no cap". The sentinel
-    //    (PhosphorTiles::AutotileDefaults::UnlimitedMaxWindowsSentinel) is passed to std::min
-    //    in recalculateLayout, making the clamp idempotent. Also opens
-    //    onWindowAdded's gate (tiledWindowCount >= maxWin is never true).
-    if (m_engine->config()->overflowBehavior == PhosphorTiles::AutotileOverflowBehavior::Unlimited) {
+    // 2. Unlimited: Krohnkite-style "no cap". Per-screen (a context
+    //    SetOverflowBehavior rule or per-screen config override else global). The
+    //    sentinel (PhosphorTiles::AutotileDefaults::UnlimitedMaxWindowsSentinel) is
+    //    passed to std::min in recalculateLayout, making the clamp idempotent. Also
+    //    opens onWindowAdded's gate (tiledWindowCount >= maxWin is never true).
+    if (effectiveOverflowBehavior(screenId) == PhosphorTiles::AutotileOverflowBehavior::Unlimited) {
         return PhosphorTiles::AutotileDefaults::UnlimitedMaxWindowsSentinel;
     }
 

--- a/libs/phosphor-tiles/include/PhosphorTiles/AutotileConstants.h
+++ b/libs/phosphor-tiles/include/PhosphorTiles/AutotileConstants.h
@@ -83,6 +83,11 @@ constexpr int MinMetadataWindows = 1;
 constexpr int MaxMetadataWindows = 100;
 constexpr int MinInsertPosition = 0;
 constexpr int MaxInsertPosition = 2;
+// Bounds for AutotileOverflowBehavior (Float=0 .. Unlimited=1), defined below.
+// Kept in lockstep with that enum so a per-screen override clamp has a named
+// range like MinInsertPosition/MaxInsertPosition rather than a bare literal.
+constexpr int MinOverflowBehavior = 0;
+constexpr int MaxOverflowBehavior = 1;
 // Animation duration + stagger limits previously lived here for
 // historical reasons but are NOT autotile-specific — they bound every
 // animation in the system. Moved to

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -266,10 +266,17 @@ struct ContextTilingParams
     /// The AutotileDragBehavior int (0 = Float, 1 = Reorder). Consumed by the drag
     /// adaptor (not the tile-engine override map) unlike the other params.
     std::optional<int> dragBehavior;
+    /// A SetAlgorithmParam override: the target algorithm id and the custom-param
+    /// values to layer over that algorithm's config. Empty target = no override.
+    /// The daemon applies @c algorithmParams only when @c algorithmParamTarget is
+    /// the screen's effective algorithm.
+    QString algorithmParamTarget;
+    QVariantMap algorithmParams;
 
     bool isEmpty() const
     {
-        return !maxWindows && !splitRatio && !masterCount && !insertPosition && !overflowBehavior && !dragBehavior;
+        return !maxWindows && !splitRatio && !masterCount && !insertPosition && !overflowBehavior && !dragBehavior
+            && algorithmParamTarget.isEmpty();
     }
 };
 

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -257,10 +257,14 @@ struct ContextTilingParams
     std::optional<int> maxWindows;
     std::optional<double> splitRatio;
     std::optional<int> masterCount;
+    /// The AutotileInsertPosition int (0 = End, 1 = AfterFocused, 2 = AsMaster);
+    /// the resolver maps the wire token to this int so the daemon stores the same
+    /// value the per-screen config store uses.
+    std::optional<int> insertPosition;
 
     bool isEmpty() const
     {
-        return !maxWindows && !splitRatio && !masterCount;
+        return !maxWindows && !splitRatio && !masterCount && !insertPosition;
     }
 };
 

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -247,10 +247,12 @@ struct ContextOverlayOverride
  * @brief Per-context autotile parameter overrides resolved from context rules.
  *
  * Each field is set only when a matching context rule fills the corresponding
- * slot (SetMaxWindows / SetSplitRatio / SetMasterCount); an unset field means
- * "use the config value". Consumed daemon-side: the values are layered onto the
- * per-screen autotile override map (config stays the base, the rule wins where
- * present). Resolved by @c LayoutRegistry::resolveContextTilingParams.
+ * slot (SetMaxWindows / SetSplitRatio / SetMasterCount / SetInsertPosition /
+ * SetOverflowBehavior / SetDragBehavior / SetAlgorithmParam); an unset field
+ * means "use the config value". Consumed daemon-side: the values are layered onto
+ * the per-screen autotile override map (config stays the base, the rule wins where
+ * present). @c dragBehavior is consumed by the drag adaptor rather than the
+ * override map. Resolved by @c LayoutRegistry::resolveContextTilingParams.
  */
 struct ContextTilingParams
 {

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -263,10 +263,13 @@ struct ContextTilingParams
     std::optional<int> insertPosition;
     /// The AutotileOverflowBehavior int (0 = Float, 1 = Unlimited).
     std::optional<int> overflowBehavior;
+    /// The AutotileDragBehavior int (0 = Float, 1 = Reorder). Consumed by the drag
+    /// adaptor (not the tile-engine override map) unlike the other params.
+    std::optional<int> dragBehavior;
 
     bool isEmpty() const
     {
-        return !maxWindows && !splitRatio && !masterCount && !insertPosition && !overflowBehavior;
+        return !maxWindows && !splitRatio && !masterCount && !insertPosition && !overflowBehavior && !dragBehavior;
     }
 };
 

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -5,6 +5,7 @@
 
 #include <PhosphorLayoutApi/LayoutId.h>
 
+#include <QColor>
 #include <QHash>
 #include <QList>
 #include <QString>
@@ -204,9 +205,9 @@ struct ContextGapOverride
  * @brief Per-context overlay-property overrides resolved from window-rule actions.
  *
  * Each field is set only when a matching context rule fills the corresponding
- * overlay slot (OverrideOverlayShader / OverrideOverlayStyle); an unset field falls through to
- * the active layout's own value. Consumed daemon-side by the overlay service —
- * see @c LayoutRegistry::resolveContextOverlay.
+ * overlay slot; an unset field falls through to the active layout's own value
+ * (shader / style) or the global config value (appearance). Consumed daemon-side
+ * by the overlay service — see @c LayoutRegistry::resolveContextOverlay.
  *
  * @c style is the @c OverlayDisplayMode int (0 = ZoneRectangles, 1 =
  * LayoutPreview); the resolver maps the wire token ("rectangles" / "preview")
@@ -214,16 +215,31 @@ struct ContextGapOverride
  * @c shaderParams holds the overridden shader's uniform values (translated by
  * the overlay service); it is only meaningful when @c shaderId is set and is
  * empty when the rule overrides only the shader id (shader defaults apply).
+ *
+ * The appearance fields (colours / opacities / border dimensions / zone-number
+ * visibility) layer over the global @c Snapping.Zones.* config: each is filled
+ * only by its @c SetOverlay* context action, and an unset field means "use the
+ * global config value" — config stays authoritative, the rule only overrides.
+ * Colours are concrete (no accent sentinel). Opacities are [0, 1].
  */
 struct ContextOverlayOverride
 {
     std::optional<QString> shaderId;
     QVariantMap shaderParams;
     std::optional<int> style;
+    std::optional<QColor> highlightColor;
+    std::optional<QColor> inactiveColor;
+    std::optional<QColor> borderColor;
+    std::optional<double> activeOpacity;
+    std::optional<double> inactiveOpacity;
+    std::optional<int> borderWidth;
+    std::optional<int> borderRadius;
+    std::optional<bool> showZoneNumbers;
 
     bool isEmpty() const
     {
-        return !shaderId && !style;
+        return !shaderId && !style && !highlightColor && !inactiveColor && !borderColor && !activeOpacity
+            && !inactiveOpacity && !borderWidth && !borderRadius && !showZoneNumbers;
     }
 };
 

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -244,6 +244,27 @@ struct ContextOverlayOverride
 };
 
 /**
+ * @brief Per-context autotile parameter overrides resolved from context rules.
+ *
+ * Each field is set only when a matching context rule fills the corresponding
+ * slot (SetMaxWindows / SetSplitRatio / SetMasterCount); an unset field means
+ * "use the config value". Consumed daemon-side: the values are layered onto the
+ * per-screen autotile override map (config stays the base, the rule wins where
+ * present). Resolved by @c LayoutRegistry::resolveContextTilingParams.
+ */
+struct ContextTilingParams
+{
+    std::optional<int> maxWindows;
+    std::optional<double> splitRatio;
+    std::optional<int> masterCount;
+
+    bool isEmpty() const
+    {
+        return !maxWindows && !splitRatio && !masterCount;
+    }
+};
+
+/**
  * @brief Canonical wire-string for an @ref AssignmentEntry::Mode.
  *
  * The wire vocabulary lives next to the enum so every persister/consumer

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -238,8 +238,10 @@ struct ContextOverlayOverride
 
     bool isEmpty() const
     {
-        return !shaderId && !style && !highlightColor && !inactiveColor && !borderColor && !activeOpacity
-            && !inactiveOpacity && !borderWidth && !borderRadius && !showZoneNumbers;
+        // shaderParams is only ever populated alongside shaderId, but check it too so
+        // isEmpty() stays honest if a future writer sets the map without the gate.
+        return !shaderId && shaderParams.isEmpty() && !style && !highlightColor && !inactiveColor && !borderColor
+            && !activeOpacity && !inactiveOpacity && !borderWidth && !borderRadius && !showZoneNumbers;
     }
 };
 
@@ -277,8 +279,11 @@ struct ContextTilingParams
 
     bool isEmpty() const
     {
+        // algorithmParams is only ever populated alongside algorithmParamTarget, but
+        // check it too so isEmpty() stays honest if a future writer sets it without the
+        // target.
         return !maxWindows && !splitRatio && !masterCount && !insertPosition && !overflowBehavior && !dragBehavior
-            && algorithmParamTarget.isEmpty();
+            && algorithmParamTarget.isEmpty() && algorithmParams.isEmpty();
     }
 };
 

--- a/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/AssignmentEntry.h
@@ -261,10 +261,12 @@ struct ContextTilingParams
     /// the resolver maps the wire token to this int so the daemon stores the same
     /// value the per-screen config store uses.
     std::optional<int> insertPosition;
+    /// The AutotileOverflowBehavior int (0 = Float, 1 = Unlimited).
+    std::optional<int> overflowBehavior;
 
     bool isEmpty() const
     {
-        return !maxWindows && !splitRatio && !masterCount && !insertPosition;
+        return !maxWindows && !splitRatio && !masterCount && !insertPosition && !overflowBehavior;
     }
 };
 

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -263,6 +263,22 @@ public:
             provider);
 
     /**
+     * @brief Inject a callback that returns a screen's orientation token
+     * ("portrait" / "landscape"), or std::nullopt when the geometry is unknown
+     * (so an orientation predicate stays inert there).
+     *
+     * The token is stamped onto every windowless context WindowQuery this
+     * registry builds (assignment, gap, lock, overlay, default-assignment), so an
+     * orientation rule can drive any context slot — for example a different
+     * tiling algorithm on a rotated (portrait) monitor. Orientation derives from
+     * screen geometry alone, independent of the resolved layout, so it carries no
+     * recursion risk (unlike an active-layout query). The daemon wires this to
+     * @c ScreenManager::screenGeometry. Same threading contract as
+     * @ref setTiledWindowCountProvider.
+     */
+    void setScreenOrientationProvider(std::function<std::optional<QString>(const QString& screenId)> provider);
+
+    /**
      * @brief Inject a callback that returns true when Snapping is the
      * user's preferred default mode (regardless of whether a default
      * snapping layout id is configured).
@@ -397,6 +413,22 @@ public:
     /// registry.
     ContextOverlayOverride resolveContextOverlay(const QString& screenId, int virtualDesktop,
                                                  const QString& activity) const override;
+
+    /// Stamp the screen-orientation token onto @p query from
+    /// @ref m_screenOrientationProvider (a no-op when the provider is unset or
+    /// returns nullopt). Called at every windowless-context query build site so a
+    /// @c Field::ScreenOrientation predicate can match regardless of which
+    /// context slot (assignment / gap / lock / overlay) is being resolved.
+    /// Orientation is geometry-derived and layout-independent, so this is safe to
+    /// call from the assignment cascade (no recursion, unlike an active-layout read).
+    void stampScreenOrientation(PhosphorRules::WindowQuery& query, const QString& screenId) const
+    {
+        if (m_screenOrientationProvider) {
+            if (const auto token = m_screenOrientationProvider(screenId)) {
+                query.screenOrientation = *token;
+            }
+        }
+    }
 
     Q_INVOKABLE void clearAssignment(const QString& screenId, int virtualDesktop = 0,
                                      const QString& activity = QString());
@@ -960,6 +992,11 @@ private:
     /// can match @c Field::TiledWindowCount. See @ref setTiledWindowCountProvider.
     std::function<std::optional<int>(const QString& screenId, int virtualDesktop, const QString& activity)>
         m_tiledWindowCountProvider;
+    /// Empty = provider unset. Returns a screen's orientation token
+    /// ("portrait" / "landscape"), or nullopt when geometry is unknown. Stamped
+    /// onto every windowless context query so a Field::ScreenOrientation predicate
+    /// can match. See @ref setScreenOrientationProvider.
+    std::function<std::optional<QString>(const QString& screenId)> m_screenOrientationProvider;
     /// Empty = provider unset (legacy behaviour). Returns true when
     /// the user has snapping mode enabled in settings, regardless of
     /// whether a global default snap layout id is configured. See

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -430,6 +430,18 @@ public:
         }
     }
 
+    /// Compose the extra cache-key token a daemon-facing context resolver (gap /
+    /// lock / overlay) passes to @ref resolveCachedContext, folding in the placement
+    /// @p modeToken (empty for the non-gap resolvers) and the @p activeLayoutId.
+    /// The active layout is a NON-rule-set input — it can change via the external
+    /// global-default provider without a rule-set revision bump — so, exactly like
+    /// the tiledWindowCount "twc:" token, it must ride the cache KEY rather than the
+    /// value, or a layout change would return a stale hit. See resolveCachedContext.
+    static QString contextCacheKeyToken(const QString& modeToken, const QString& activeLayoutId)
+    {
+        return modeToken + QLatin1String("|al:") + activeLayoutId;
+    }
+
     Q_INVOKABLE void clearAssignment(const QString& screenId, int virtualDesktop = 0,
                                      const QString& activity = QString());
     /// True iff a context-assignment rule whose match is exactly this

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -268,8 +268,8 @@ public:
      * (so an orientation predicate stays inert there).
      *
      * The token is stamped onto every windowless context WindowQuery this
-     * registry builds (assignment, gap, lock, overlay, default-assignment), so an
-     * orientation rule can drive any context slot — for example a different
+     * registry builds (assignment, gap, lock, overlay, default-assignment,
+     * tiling-params), so an orientation rule can drive any context slot — for example a different
      * tiling algorithm on a rotated (portrait) monitor. Orientation derives from
      * screen geometry alone, independent of the resolved layout, so it carries no
      * recursion risk (unlike an active-layout query). The daemon wires this to
@@ -749,9 +749,10 @@ private:
     /// the caller's (layoutForScreen) retry loop.
     ///
     /// Hot-path cache: the result is memoized in @c m_contextResolveCache keyed
-    /// by (screenId, virtualDesktop, activity) plus a "twc:N" tiled-window-count
-    /// token (empty when the count is unknown), so a count change yields a fresh
-    /// entry rather than a stale hit while count-steady callers keep hitting the
+    /// by (screenId, virtualDesktop, activity) plus a "twc:N|or:<token>"
+    /// composite of the tiled-window-count and screen-orientation tokens (each
+    /// empty when unknown), so a count or rotation change yields a fresh entry
+    /// rather than a stale hit while steady callers keep hitting the
     /// cache. The cache is invalidated
     /// lazily by comparing the bound rule set's monotonic
     /// @c RuleSet::revision() against the snapshot taken on the last
@@ -882,16 +883,20 @@ private:
         QString screenId;
         int virtualDesktop = 0;
         QString activity;
-        // A free-form fourth key dimension, used by two resolvers that share the
-        // ContextResolveKey type but never the same cache container. For the gap
-        // cascade it carries the placement-mode wire token, because the SAME
-        // (screen, desktop, activity) resolves DIFFERENT gaps per mode and
-        // caching without it would return the snapping result for a subsequent
-        // tiling query. For the assignment resolver it carries a "twc:N"
-        // tiled-window-count token (empty when the count is unknown), so a count
-        // change yields a fresh entry rather than a stale hit. The lock,
-        // default-assignment, and overlay resolvers leave it empty. Each resolver
-        // owns its own cache hash, so the two token vocabularies never collide.
+        // A free-form fourth key dimension, used by the context resolvers that
+        // share the ContextResolveKey type but never the same cache container. It
+        // folds in every non-rule-set input the resolved value depends on, so a
+        // change in one yields a fresh entry rather than a stale hit:
+        //   - gap cascade: contextCacheKeyToken(mode, activeLayout, orientation) —
+        //     the SAME (screen, desktop, activity) resolves DIFFERENT gaps per
+        //     placement mode, active layout, and screen orientation.
+        //   - lock / default-assignment / overlay: contextCacheKeyToken with an
+        //     empty mode (they are mode-agnostic) plus activeLayout (except
+        //     default-assignment, which omits it to avoid recursion) and orientation.
+        //   - assignment resolver: "twc:N|or:<token>" — the tiled-window-count and
+        //     the screen orientation (it does not read the active layout).
+        // Each resolver owns its own cache hash, so the token vocabularies never
+        // collide.
         QString mode;
         bool operator==(const ContextResolveKey& other) const noexcept
         {
@@ -951,9 +956,10 @@ private:
     /// Holds ONLY what the rule set produced for each of the three independent
     /// slots. Given a fixed cache key the value is a pure function of the rule
     /// set (the cache's revision-invalidation contract). The live tiled-window
-    /// count is the one non-rule-set input that affects the result; rather than
-    /// break that contract it participates in the cache KEY (the "twc:N" token),
-    /// so each count resolves its own entry. The global default — an external
+    /// count and the screen orientation are the non-rule-set inputs that affect
+    /// the result; rather than break that contract they participate in the cache
+    /// KEY (the "twc:N" and "|or:<token>" components), so each combination resolves
+    /// its own entry. The global default — an external
     /// provider, not part of the rule set and not revision-tracked — is folded
     /// in AFTER the cache returns, so a default-setting change is reflected
     /// immediately without a rule-set revision bump (a settings edit produces

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -432,25 +432,38 @@ public:
     /// context slot (assignment / gap / lock / overlay) is being resolved.
     /// Orientation is geometry-derived and layout-independent, so this is safe to
     /// call from the assignment cascade (no recursion, unlike an active-layout read).
-    void stampScreenOrientation(PhosphorRules::WindowQuery& query, const QString& screenId) const
+    /// The screen-orientation token from @ref m_screenOrientationProvider ("portrait"
+    /// / "landscape"), or an empty string when the provider is unset or returns
+    /// nullopt. Shared by @ref stampScreenOrientation (the query value) and the
+    /// cache-key fold (see @ref contextCacheKeyToken) so both read the same source.
+    QString screenOrientationToken(const QString& screenId) const
     {
         if (m_screenOrientationProvider) {
             if (const auto token = m_screenOrientationProvider(screenId)) {
-                query.screenOrientation = *token;
+                return *token;
             }
         }
+        return QString();
+    }
+
+    void stampScreenOrientation(PhosphorRules::WindowQuery& query, const QString& screenId) const
+    {
+        query.screenOrientation = screenOrientationToken(screenId);
     }
 
     /// Compose the extra cache-key token a daemon-facing context resolver (gap /
-    /// lock / overlay) passes to @ref resolveCachedContext, folding in the placement
-    /// @p modeToken (empty for the non-gap resolvers) and the @p activeLayoutId.
-    /// The active layout is a NON-rule-set input — it can change via the external
-    /// global-default provider without a rule-set revision bump — so, exactly like
-    /// the tiledWindowCount "twc:" token, it must ride the cache KEY rather than the
-    /// value, or a layout change would return a stale hit. See resolveCachedContext.
-    static QString contextCacheKeyToken(const QString& modeToken, const QString& activeLayoutId)
+    /// lock / overlay / default-assignment) passes to @ref resolveCachedContext,
+    /// folding in the placement @p modeToken (empty for the non-gap resolvers), the
+    /// @p activeLayoutId, and the @p orientationToken. Both the active layout AND
+    /// the screen orientation are NON-rule-set inputs — each can change without a
+    /// rule-set revision bump (the layout via the external global-default provider,
+    /// the orientation via a live monitor rotation) — so, exactly like the
+    /// tiledWindowCount "twc:" token, they must ride the cache KEY rather than the
+    /// value, or the change would return a stale hit. See resolveCachedContext.
+    static QString contextCacheKeyToken(const QString& modeToken, const QString& activeLayoutId,
+                                        const QString& orientationToken)
     {
-        return modeToken + QLatin1String("|al:") + activeLayoutId;
+        return modeToken + QLatin1String("|al:") + activeLayoutId + QLatin1String("|or:") + orientationToken;
     }
 
     Q_INVOKABLE void clearAssignment(const QString& screenId, int virtualDesktop = 0,

--- a/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
+++ b/libs/phosphor-zones/include/PhosphorZones/LayoutRegistry.h
@@ -414,6 +414,17 @@ public:
     ContextOverlayOverride resolveContextOverlay(const QString& screenId, int virtualDesktop,
                                                  const QString& activity) const override;
 
+    /// Resolve the per-context autotile parameter overrides (max windows / split
+    /// ratio / master count) for (screen, desktop, activity) — a per-slot read
+    /// like @ref resolveContextGaps. The daemon layers the returned values onto
+    /// the per-screen autotile override map (config stays the base; the rule wins
+    /// where present). NOT cached: called on screen / layout changes, not the hot
+    /// per-cursor path — which also lets it stamp the active layout onto the query
+    /// without a cache-key fold (there is no cache entry to go stale). Concrete
+    /// (not on the interface): the daemon holds a concrete LayoutRegistry.
+    ContextTilingParams resolveContextTilingParams(const QString& screenId, int virtualDesktop,
+                                                   const QString& activity) const;
+
     /// Stamp the screen-orientation token onto @p query from
     /// @ref m_screenOrientationProvider (a no-op when the provider is unset or
     /// returns nullopt). Called at every windowless-context query build site so a

--- a/libs/phosphor-zones/src/layoutregistry.cpp
+++ b/libs/phosphor-zones/src/layoutregistry.cpp
@@ -28,7 +28,12 @@ LayoutRegistry::LayoutRegistry(PhosphorRules::RuleStore* ruleStore, QString layo
     if (m_ruleStore == nullptr) {
         qFatal("LayoutRegistry: ruleStore is required — assignment resolution dereferences it");
     }
-    Q_ASSERT_X(!m_layoutSubdirectory.isEmpty(), "LayoutRegistry", "layoutSubdirectory is required");
+    // qFatal, not Q_ASSERT_X: an empty subdirectory concatenates to the bare XDG
+    // data root (a trailing slash), so — like the absolute / ".." checks in
+    // initCommon — it must fail in release too, not compile out.
+    if (m_layoutSubdirectory.isEmpty()) {
+        qFatal("LayoutRegistry: layoutSubdirectory is required");
+    }
     initCommon();
 }
 

--- a/libs/phosphor-zones/src/layoutregistry.cpp
+++ b/libs/phosphor-zones/src/layoutregistry.cpp
@@ -86,6 +86,12 @@ void LayoutRegistry::setTiledWindowCountProvider(
     m_tiledWindowCountProvider = std::move(provider);
 }
 
+void LayoutRegistry::setScreenOrientationProvider(
+    std::function<std::optional<QString>(const QString& screenId)> provider)
+{
+    m_screenOrientationProvider = std::move(provider);
+}
+
 void LayoutRegistry::setSnappingPreferredProvider(std::function<bool()> provider)
 {
     m_snappingPreferredProvider = std::move(provider);

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -581,6 +581,13 @@ ContextTilingParams LayoutRegistry::resolveContextTilingParams(const QString& sc
             params.dragBehavior = 1;
         }
     }
+    if (const auto action = resolved.slot(QString(PWR::ActionSlot::AlgorithmParams))) {
+        // Target algorithm token + free-form custom-param blob (mirrors the
+        // overlay shader-uniform override). The daemon applies the params only
+        // when the target matches the screen's effective algorithm.
+        params.algorithmParamTarget = action->params.value(PWR::ActionParam::Algorithm).toString();
+        params.algorithmParams = action->params.value(PWR::ActionParam::Params).toObject().toVariantMap();
+    }
     return params;
 }
 

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -563,6 +563,15 @@ ContextTilingParams LayoutRegistry::resolveContextTilingParams(const QString& sc
             params.insertPosition = 2;
         }
     }
+    if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverflowBehavior))) {
+        // Wire token → AutotileOverflowBehavior int (Float 0 / Unlimited 1).
+        const QString token = action->params.value(PWR::ActionParam::Value).toString();
+        if (token == PWR::OverflowBehaviorToken::Float) {
+            params.overflowBehavior = 0;
+        } else if (token == PWR::OverflowBehaviorToken::Unlimited) {
+            params.overflowBehavior = 1;
+        }
+    }
     return params;
 }
 

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -524,6 +524,36 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
         });
 }
 
+ContextTilingParams LayoutRegistry::resolveContextTilingParams(const QString& screenId, int virtualDesktop,
+                                                               const QString& activity) const
+{
+    if (!m_evaluator) {
+        return {};
+    }
+    // Per-slot read (mirrors resolveContextGaps), but NOT cached: this runs on
+    // screen / layout changes via the daemon's updateAutotileScreens, not the hot
+    // per-cursor path. Being uncached lets us stamp the active layout onto the
+    // query without folding it into a cache key (no cached entry to go stale).
+    // Safe from recursion: assignmentIdForScreen routes through
+    // resolveAssignmentEntry, which never calls this resolver.
+    PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+    stampScreenOrientation(query, screenId);
+    query.activeLayout = assignmentIdForScreen(screenId, virtualDesktop, activity);
+    const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
+
+    ContextTilingParams params;
+    if (const auto action = resolved.slot(QString(PWR::ActionSlot::MaxWindows))) {
+        params.maxWindows = action->params.value(PWR::ActionParam::Value).toInt();
+    }
+    if (const auto action = resolved.slot(QString(PWR::ActionSlot::SplitRatio))) {
+        params.splitRatio = action->params.value(PWR::ActionParam::Value).toDouble();
+    }
+    if (const auto action = resolved.slot(QString(PWR::ActionSlot::MasterCount))) {
+        params.masterCount = action->params.value(PWR::ActionParam::Value).toInt();
+    }
+    return params;
+}
+
 bool LayoutRegistry::hasExactContextRule(const QString& screenId, int virtualDesktop, const QString& activity) const
 {
     return findExactContextRule(screenId, virtualDesktop, activity) != nullptr;

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -176,6 +176,11 @@ std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QStr
             // query (unlike tiledWindowCount / activeLayout) — an orientation rule
             // can drive the assignment itself (portrait monitor → different layout).
             stampScreenOrientation(query, screenId);
+            // Field::ActiveLayout is deliberately NOT stamped here: the active
+            // layout IS this resolver's output, and reading it (assignmentIdForScreen
+            // → resolveAssignmentEntry) would recurse. So an ActiveLayout rule cannot
+            // drive the layout assignment (a circular request); it is populated only
+            // by the post-assignment resolvers (gap / lock / overlay).
 
             // Highest-priority matching rule per slot wins (ties by list order).
             const auto slotMatch = [&](bool (*carriesSlot)(const PWR::Rule&)) -> const PWR::Rule* {
@@ -254,18 +259,26 @@ ContextGapOverride LayoutRegistry::resolveContextGaps(const QString& screenId, i
         return ContextGapOverride{};
     }
 
+    // The active layout is folded into the cache key (see contextCacheKeyToken)
+    // so a Field::ActiveLayout gap rule refreshes when the layout changes; it is
+    // stamped onto the query below. Safe from recursion: assignmentIdForScreen
+    // routes through resolveAssignmentEntry, which never calls back into the gap
+    // resolver.
+    const QString activeLayoutId = assignmentIdForScreen(screenId, virtualDesktop, activity);
+
     // Hot-path cache via the shared revision-invalidated memoizer: the geometry
     // path resolves the same context twice per op (zone padding + outer gaps)
     // and N× inside a multi-zone snap, all with identical arguments.
     return resolveCachedContext(
-        m_contextGapCache, m_contextGapCacheRevision, screenId, virtualDesktop, activity, mode,
-        [&]() -> ContextGapOverride {
+        m_contextGapCache, m_contextGapCacheRevision, screenId, virtualDesktop, activity,
+        contextCacheKeyToken(mode, activeLayoutId), [&]() -> ContextGapOverride {
             ContextGapOverride gaps;
             // Thread the placement mode into the query so a per-mode `Mode
             // Equals "snapping"/"tiling"` gap rule resolves for the asking
             // engine and stays inert for the other.
             PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity, mode);
             stampScreenOrientation(query, screenId);
+            query.activeLayout = activeLayoutId;
 
             // Resolve each gap slot from the highest-priority matching rule that
             // carries that slot's action. The CATCH-ALL managed baseline rule is
@@ -367,13 +380,18 @@ bool LayoutRegistry::resolveContextLocked(const QString& screenId, int virtualDe
         return false;
     }
 
+    // Active layout folded into the cache key + stamped onto the query, so a
+    // Field::ActiveLayout lock rule works and refreshes on a layout change.
+    const QString activeLayoutId = assignmentIdForScreen(screenId, virtualDesktop, activity);
+
     // Hot-path cache via the shared revision-invalidated memoizer: the lock
     // check runs per cursor-move while a selector is open and on every
     // layout-switch attempt.
     return resolveCachedContext(m_contextLockCache, m_contextLockCacheRevision, screenId, virtualDesktop, activity,
-                                QString(), [&]() -> bool {
+                                contextCacheKeyToken(QString(), activeLayoutId), [&]() -> bool {
                                     PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
                                     stampScreenOrientation(query, screenId);
+                                    query.activeLayout = activeLayoutId;
                                     const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
                                     if (const auto action = resolved.slot(QString(PWR::ActionSlot::Locked))) {
                                         return action->params.value(PWR::ActionParam::Value).toBool();
@@ -401,6 +419,10 @@ std::optional<bool> LayoutRegistry::resolveContextDefaultAssignment(const QStrin
                                 virtualDesktop, activity, QString(), [&]() -> std::optional<bool> {
                                     PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
                                     stampScreenOrientation(query, screenId);
+                                    // Field::ActiveLayout NOT stamped here: this resolver is part of the
+                                    // assignment cascade (assignmentIdForScreen reaches it via
+                                    // resolveDefaultAssignmentEntryForContext), so stamping the active
+                                    // layout here would recurse. See resolveAssignmentEntry.
                                     const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
                                     if (const auto action =
                                             resolved.slot(QString(PWR::ActionSlot::DefaultAssignment))) {
@@ -437,12 +459,17 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
         return ContextOverlayOverride{};
     }
 
+    // Active layout folded into the cache key + stamped onto the query, so a
+    // Field::ActiveLayout overlay rule works and refreshes on a layout change.
+    const QString activeLayoutId = assignmentIdForScreen(screenId, virtualDesktop, activity);
+
     return resolveCachedContext(
-        m_contextOverlayCache, m_contextOverlayCacheRevision, screenId, virtualDesktop, activity, QString(),
-        [&]() -> ContextOverlayOverride {
+        m_contextOverlayCache, m_contextOverlayCacheRevision, screenId, virtualDesktop, activity,
+        contextCacheKeyToken(QString(), activeLayoutId), [&]() -> ContextOverlayOverride {
             ContextOverlayOverride overlay;
             PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
             stampScreenOrientation(query, screenId);
+            query.activeLayout = activeLayoutId;
             const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
 
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayShader))) {

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -572,6 +572,15 @@ ContextTilingParams LayoutRegistry::resolveContextTilingParams(const QString& sc
             params.overflowBehavior = 1;
         }
     }
+    if (const auto action = resolved.slot(QString(PWR::ActionSlot::DragBehavior))) {
+        // Wire token → AutotileDragBehavior int (Float 0 / Reorder 1).
+        const QString token = action->params.value(PWR::ActionParam::Value).toString();
+        if (token == PWR::DragBehaviorToken::Float) {
+            params.dragBehavior = 0;
+        } else if (token == PWR::DragBehaviorToken::Reorder) {
+            params.dragBehavior = 1;
+        }
+    }
     return params;
 }
 

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -159,7 +159,12 @@ std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QStr
     // OSD per cursor-move, where the count is steady) keep hitting the cache.
     const std::optional<int> tiledCount =
         m_tiledWindowCountProvider ? m_tiledWindowCountProvider(screenId, virtualDesktop, activity) : std::nullopt;
-    const QString countCacheKey = tiledCount ? (QLatin1String("twc:") + QString::number(*tiledCount)) : QString();
+    // Both the tiled count and the screen orientation are non-rule-set inputs the
+    // stamped query depends on, so both must ride the cache KEY (the assignment
+    // resolver stamps orientation but not activeLayout, so no "al:" component here).
+    const QString orientationToken = screenOrientationToken(screenId);
+    const QString countCacheKey = (tiledCount ? (QLatin1String("twc:") + QString::number(*tiledCount)) : QString())
+        + QLatin1String("|or:") + orientationToken;
 
     const std::optional<RuleSlotResolution> rules = resolveCachedContext(
         m_contextResolveCache, m_contextResolveCacheRevision, screenId, virtualDesktop, activity, countCacheKey,
@@ -259,19 +264,20 @@ ContextGapOverride LayoutRegistry::resolveContextGaps(const QString& screenId, i
         return ContextGapOverride{};
     }
 
-    // The active layout is folded into the cache key (see contextCacheKeyToken)
-    // so a Field::ActiveLayout gap rule refreshes when the layout changes; it is
-    // stamped onto the query below. Safe from recursion: assignmentIdForScreen
-    // routes through resolveAssignmentEntry, which never calls back into the gap
-    // resolver.
+    // The active layout AND the screen orientation are folded into the cache key
+    // (see contextCacheKeyToken) so a Field::ActiveLayout / Field::ScreenOrientation
+    // gap rule refreshes when either changes; both are stamped onto the query below.
+    // Safe from recursion: assignmentIdForScreen routes through resolveAssignmentEntry,
+    // which never calls back into the gap resolver.
     const QString activeLayoutId = assignmentIdForScreen(screenId, virtualDesktop, activity);
+    const QString orientationToken = screenOrientationToken(screenId);
 
     // Hot-path cache via the shared revision-invalidated memoizer: the geometry
     // path resolves the same context twice per op (zone padding + outer gaps)
     // and N× inside a multi-zone snap, all with identical arguments.
     return resolveCachedContext(
         m_contextGapCache, m_contextGapCacheRevision, screenId, virtualDesktop, activity,
-        contextCacheKeyToken(mode, activeLayoutId), [&]() -> ContextGapOverride {
+        contextCacheKeyToken(mode, activeLayoutId, orientationToken), [&]() -> ContextGapOverride {
             ContextGapOverride gaps;
             // Thread the placement mode into the query so a per-mode `Mode
             // Equals "snapping"/"tiling"` gap rule resolves for the asking
@@ -380,15 +386,17 @@ bool LayoutRegistry::resolveContextLocked(const QString& screenId, int virtualDe
         return false;
     }
 
-    // Active layout folded into the cache key + stamped onto the query, so a
-    // Field::ActiveLayout lock rule works and refreshes on a layout change.
+    // Active layout + orientation folded into the cache key + stamped onto the
+    // query, so a Field::ActiveLayout / ScreenOrientation lock rule works and
+    // refreshes when either changes.
     const QString activeLayoutId = assignmentIdForScreen(screenId, virtualDesktop, activity);
+    const QString orientationToken = screenOrientationToken(screenId);
 
     // Hot-path cache via the shared revision-invalidated memoizer: the lock
     // check runs per cursor-move while a selector is open and on every
     // layout-switch attempt.
     return resolveCachedContext(m_contextLockCache, m_contextLockCacheRevision, screenId, virtualDesktop, activity,
-                                contextCacheKeyToken(QString(), activeLayoutId), [&]() -> bool {
+                                contextCacheKeyToken(QString(), activeLayoutId, orientationToken), [&]() -> bool {
                                     PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
                                     stampScreenOrientation(query, screenId);
                                     query.activeLayout = activeLayoutId;
@@ -415,21 +423,25 @@ std::optional<bool> LayoutRegistry::resolveContextDefaultAssignment(const QStrin
         return std::nullopt;
     }
 
-    return resolveCachedContext(m_contextDefaultAssignmentCache, m_contextDefaultAssignmentCacheRevision, screenId,
-                                virtualDesktop, activity, QString(), [&]() -> std::optional<bool> {
-                                    PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
-                                    stampScreenOrientation(query, screenId);
-                                    // Field::ActiveLayout NOT stamped here: this resolver is part of the
-                                    // assignment cascade (assignmentIdForScreen reaches it via
-                                    // resolveDefaultAssignmentEntryForContext), so stamping the active
-                                    // layout here would recurse. See resolveAssignmentEntry.
-                                    const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
-                                    if (const auto action =
-                                            resolved.slot(QString(PWR::ActionSlot::DefaultAssignment))) {
-                                        return action->params.value(PWR::ActionParam::Value).toBool();
-                                    }
-                                    return std::nullopt;
-                                });
+    // Orientation folded into the cache key so a Field::ScreenOrientation
+    // default-assignment rule refreshes on rotation (activeLayout is deliberately
+    // NOT stamped/folded here — see the recursion note in the lambda below).
+    const QString orientationToken = screenOrientationToken(screenId);
+    return resolveCachedContext(
+        m_contextDefaultAssignmentCache, m_contextDefaultAssignmentCacheRevision, screenId, virtualDesktop, activity,
+        contextCacheKeyToken(QString(), QString(), orientationToken), [&]() -> std::optional<bool> {
+            PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+            stampScreenOrientation(query, screenId);
+            // Field::ActiveLayout NOT stamped here: this resolver is part of the
+            // assignment cascade (assignmentIdForScreen reaches it via
+            // resolveDefaultAssignmentEntryForContext), so stamping the active
+            // layout here would recurse. See resolveAssignmentEntry.
+            const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::DefaultAssignment))) {
+                return action->params.value(PWR::ActionParam::Value).toBool();
+            }
+            return std::nullopt;
+        });
 }
 
 AssignmentEntry LayoutRegistry::resolveDefaultAssignmentEntryForContext(const QString& screenId, int virtualDesktop,
@@ -459,13 +471,15 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
         return ContextOverlayOverride{};
     }
 
-    // Active layout folded into the cache key + stamped onto the query, so a
-    // Field::ActiveLayout overlay rule works and refreshes on a layout change.
+    // Active layout + orientation folded into the cache key + stamped onto the
+    // query, so a Field::ActiveLayout / ScreenOrientation overlay rule works and
+    // refreshes when either changes.
     const QString activeLayoutId = assignmentIdForScreen(screenId, virtualDesktop, activity);
+    const QString orientationToken = screenOrientationToken(screenId);
 
     return resolveCachedContext(
         m_contextOverlayCache, m_contextOverlayCacheRevision, screenId, virtualDesktop, activity,
-        contextCacheKeyToken(QString(), activeLayoutId), [&]() -> ContextOverlayOverride {
+        contextCacheKeyToken(QString(), activeLayoutId, orientationToken), [&]() -> ContextOverlayOverride {
             ContextOverlayOverride overlay;
             PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
             stampScreenOrientation(query, screenId);
@@ -495,21 +509,31 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
             // Appearance overrides — each fills its own optional so an unset
             // property falls through to the global config value at the consumer.
             // Colours are parsed from the `#AARRGGBB` wire hex; QColor reads a
-            // 9-digit hex alpha-first, matching the picker's toHexArgb output.
+            // 9-digit hex alpha-first, matching the picker's toHexArgb output. The
+            // descriptor validators reject malformed values at load; the isValid /
+            // clamp guards here are defense in depth so a hand-edited rules.json that
+            // slipped a bad value can only fall through to config, never apply an
+            // invalid colour or an out-of-range opacity as an override.
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayHighlightColor))) {
-                overlay.highlightColor = QColor(action->params.value(PWR::ActionParam::Value).toString());
+                if (const QColor c(action->params.value(PWR::ActionParam::Value).toString()); c.isValid()) {
+                    overlay.highlightColor = c;
+                }
             }
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayInactiveColor))) {
-                overlay.inactiveColor = QColor(action->params.value(PWR::ActionParam::Value).toString());
+                if (const QColor c(action->params.value(PWR::ActionParam::Value).toString()); c.isValid()) {
+                    overlay.inactiveColor = c;
+                }
             }
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayBorderColor))) {
-                overlay.borderColor = QColor(action->params.value(PWR::ActionParam::Value).toString());
+                if (const QColor c(action->params.value(PWR::ActionParam::Value).toString()); c.isValid()) {
+                    overlay.borderColor = c;
+                }
             }
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayActiveOpacity))) {
-                overlay.activeOpacity = action->params.value(PWR::ActionParam::Value).toDouble();
+                overlay.activeOpacity = qBound(0.0, action->params.value(PWR::ActionParam::Value).toDouble(), 1.0);
             }
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayInactiveOpacity))) {
-                overlay.inactiveOpacity = action->params.value(PWR::ActionParam::Value).toDouble();
+                overlay.inactiveOpacity = qBound(0.0, action->params.value(PWR::ActionParam::Value).toDouble(), 1.0);
             }
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayBorderWidth))) {
                 overlay.borderWidth = action->params.value(PWR::ActionParam::Value).toInt();

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -551,6 +551,18 @@ ContextTilingParams LayoutRegistry::resolveContextTilingParams(const QString& sc
     if (const auto action = resolved.slot(QString(PWR::ActionSlot::MasterCount))) {
         params.masterCount = action->params.value(PWR::ActionParam::Value).toInt();
     }
+    if (const auto action = resolved.slot(QString(PWR::ActionSlot::InsertPosition))) {
+        // Wire token → AutotileInsertPosition int (End 0 / AfterFocused 1 / AsMaster 2),
+        // the same value the per-screen config store holds.
+        const QString token = action->params.value(PWR::ActionParam::Value).toString();
+        if (token == PWR::InsertPositionToken::End) {
+            params.insertPosition = 0;
+        } else if (token == PWR::InsertPositionToken::AfterFocused) {
+            params.insertPosition = 1;
+        } else if (token == PWR::InsertPositionToken::AsMaster) {
+            params.insertPosition = 2;
+        }
+    }
     return params;
 }
 

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -172,6 +172,10 @@ std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QStr
             // on a rule carrying one of those actions stays inert (the field is
             // absent there) by design.
             query.tiledWindowCount = tiledCount;
+            // Orientation is layout-independent, so it is stamped on EVERY context
+            // query (unlike tiledWindowCount / activeLayout) — an orientation rule
+            // can drive the assignment itself (portrait monitor → different layout).
+            stampScreenOrientation(query, screenId);
 
             // Highest-priority matching rule per slot wins (ties by list order).
             const auto slotMatch = [&](bool (*carriesSlot)(const PWR::Rule&)) -> const PWR::Rule* {
@@ -260,7 +264,8 @@ ContextGapOverride LayoutRegistry::resolveContextGaps(const QString& screenId, i
             // Thread the placement mode into the query so a per-mode `Mode
             // Equals "snapping"/"tiling"` gap rule resolves for the asking
             // engine and stays inert for the other.
-            const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity, mode);
+            PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity, mode);
+            stampScreenOrientation(query, screenId);
 
             // Resolve each gap slot from the highest-priority matching rule that
             // carries that slot's action. The CATCH-ALL managed baseline rule is
@@ -367,7 +372,8 @@ bool LayoutRegistry::resolveContextLocked(const QString& screenId, int virtualDe
     // layout-switch attempt.
     return resolveCachedContext(m_contextLockCache, m_contextLockCacheRevision, screenId, virtualDesktop, activity,
                                 QString(), [&]() -> bool {
-                                    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+                                    PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+                                    stampScreenOrientation(query, screenId);
                                     const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
                                     if (const auto action = resolved.slot(QString(PWR::ActionSlot::Locked))) {
                                         return action->params.value(PWR::ActionParam::Value).toBool();
@@ -393,7 +399,8 @@ std::optional<bool> LayoutRegistry::resolveContextDefaultAssignment(const QStrin
 
     return resolveCachedContext(m_contextDefaultAssignmentCache, m_contextDefaultAssignmentCacheRevision, screenId,
                                 virtualDesktop, activity, QString(), [&]() -> std::optional<bool> {
-                                    const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+                                    PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+                                    stampScreenOrientation(query, screenId);
                                     const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
                                     if (const auto action =
                                             resolved.slot(QString(PWR::ActionSlot::DefaultAssignment))) {
@@ -434,7 +441,8 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
         m_contextOverlayCache, m_contextOverlayCacheRevision, screenId, virtualDesktop, activity, QString(),
         [&]() -> ContextOverlayOverride {
             ContextOverlayOverride overlay;
-            const PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+            PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
+            stampScreenOrientation(query, screenId);
             const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
 
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayShader))) {
@@ -456,6 +464,34 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
                 } else if (token == PWR::OverlayStyleToken::Preview) {
                     overlay.style = 1;
                 }
+            }
+            // Appearance overrides — each fills its own optional so an unset
+            // property falls through to the global config value at the consumer.
+            // Colours are parsed from the `#AARRGGBB` wire hex; QColor reads a
+            // 9-digit hex alpha-first, matching the picker's toHexArgb output.
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayHighlightColor))) {
+                overlay.highlightColor = QColor(action->params.value(PWR::ActionParam::Value).toString());
+            }
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayInactiveColor))) {
+                overlay.inactiveColor = QColor(action->params.value(PWR::ActionParam::Value).toString());
+            }
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayBorderColor))) {
+                overlay.borderColor = QColor(action->params.value(PWR::ActionParam::Value).toString());
+            }
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayActiveOpacity))) {
+                overlay.activeOpacity = action->params.value(PWR::ActionParam::Value).toDouble();
+            }
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayInactiveOpacity))) {
+                overlay.inactiveOpacity = action->params.value(PWR::ActionParam::Value).toDouble();
+            }
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayBorderWidth))) {
+                overlay.borderWidth = action->params.value(PWR::ActionParam::Value).toInt();
+            }
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayBorderRadius))) {
+                overlay.borderRadius = action->params.value(PWR::ActionParam::Value).toInt();
+            }
+            if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayShowZoneNumbers))) {
+                overlay.showZoneNumbers = action->params.value(PWR::ActionParam::Value).toBool();
             }
             return overlay;
         });

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -180,7 +180,9 @@ std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QStr
             // Orientation is layout-independent, so it is stamped on EVERY context
             // query (unlike tiledWindowCount / activeLayout) — an orientation rule
             // can drive the assignment itself (portrait monitor → different layout).
-            stampScreenOrientation(query, screenId);
+            // Reuse the token already captured for the cache key (mirrors the
+            // gap/lock/overlay lambdas) rather than re-reading the provider.
+            query.screenOrientation = orientationToken;
             // Field::ActiveLayout is deliberately NOT stamped here: the active
             // layout IS this resolver's output, and reading it (assignmentIdForScreen
             // → resolveAssignmentEntry) would recurse. So an ActiveLayout rule cannot
@@ -431,7 +433,7 @@ std::optional<bool> LayoutRegistry::resolveContextDefaultAssignment(const QStrin
         m_contextDefaultAssignmentCache, m_contextDefaultAssignmentCacheRevision, screenId, virtualDesktop, activity,
         contextCacheKeyToken(QString(), QString(), orientationToken), [&]() -> std::optional<bool> {
             PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
-            stampScreenOrientation(query, screenId);
+            query.screenOrientation = orientationToken; // reuse the cache-key token
             // Field::ActiveLayout NOT stamped here: this resolver is part of the
             // assignment cascade (assignmentIdForScreen reaches it via
             // resolveDefaultAssignmentEntryForContext), so stamping the active
@@ -556,10 +558,10 @@ ContextTilingParams LayoutRegistry::resolveContextTilingParams(const QString& sc
     }
     // Per-slot read (mirrors resolveContextGaps), but NOT cached: this runs on
     // screen / layout changes via the daemon's updateAutotileScreens, not the hot
-    // per-cursor path. Being uncached lets us stamp the active layout onto the
-    // query without folding it into a cache key (no cached entry to go stale).
-    // Safe from recursion: assignmentIdForScreen routes through
-    // resolveAssignmentEntry, which never calls this resolver.
+    // per-cursor path. Being uncached lets us stamp the active layout AND the
+    // screen orientation onto the query without folding either into a cache key
+    // (no cached entry to go stale). Safe from recursion: assignmentIdForScreen
+    // routes through resolveAssignmentEntry, which never calls this resolver.
     PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
     stampScreenOrientation(query, screenId);
     query.activeLayout = assignmentIdForScreen(screenId, virtualDesktop, activity);

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -283,7 +283,7 @@ ContextGapOverride LayoutRegistry::resolveContextGaps(const QString& screenId, i
             // Equals "snapping"/"tiling"` gap rule resolves for the asking
             // engine and stays inert for the other.
             PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity, mode);
-            stampScreenOrientation(query, screenId);
+            query.screenOrientation = orientationToken;
             query.activeLayout = activeLayoutId;
 
             // Resolve each gap slot from the highest-priority matching rule that
@@ -398,7 +398,7 @@ bool LayoutRegistry::resolveContextLocked(const QString& screenId, int virtualDe
     return resolveCachedContext(m_contextLockCache, m_contextLockCacheRevision, screenId, virtualDesktop, activity,
                                 contextCacheKeyToken(QString(), activeLayoutId, orientationToken), [&]() -> bool {
                                     PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
-                                    stampScreenOrientation(query, screenId);
+                                    query.screenOrientation = orientationToken;
                                     query.activeLayout = activeLayoutId;
                                     const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
                                     if (const auto action = resolved.slot(QString(PWR::ActionSlot::Locked))) {
@@ -482,7 +482,7 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
         contextCacheKeyToken(QString(), activeLayoutId, orientationToken), [&]() -> ContextOverlayOverride {
             ContextOverlayOverride overlay;
             PWR::WindowQuery query = makeContextQuery(screenId, virtualDesktop, activity);
-            stampScreenOrientation(query, screenId);
+            query.screenOrientation = orientationToken;
             query.activeLayout = activeLayoutId;
             const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
 

--- a/libs/phosphor-zones/src/layoutregistry_assignments.cpp
+++ b/libs/phosphor-zones/src/layoutregistry_assignments.cpp
@@ -153,10 +153,11 @@ std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QStr
     // Live tiled-window count for this context (nullopt when not actively
     // tiling). It is NOT part of the rule set, so it cannot ride the cache's
     // revision-invalidation contract like the global default does. Instead it
-    // is folded into the cache KEY (via the `mode` slot of this cache, which is
-    // otherwise always empty for the assignment resolver) so a count change yields a fresh
-    // entry rather than a stale hit, while count-independent callers (overlay /
-    // OSD per cursor-move, where the count is steady) keep hitting the cache.
+    // is folded into the cache KEY (the `mode` slot of this cache, which for the
+    // assignment resolver carries only the count + orientation composite below) so a
+    // count change yields a fresh entry rather than a stale hit, while
+    // count-independent callers (overlay / OSD per cursor-move, where the count is
+    // steady) keep hitting the cache.
     const std::optional<int> tiledCount =
         m_tiledWindowCountProvider ? m_tiledWindowCountProvider(screenId, virtualDesktop, activity) : std::nullopt;
     // Both the tiled count and the screen orientation are non-rule-set inputs the
@@ -190,9 +191,17 @@ std::optional<AssignmentEntry> LayoutRegistry::resolveAssignmentEntry(const QStr
             // by the post-assignment resolvers (gap / lock / overlay).
 
             // Highest-priority matching rule per slot wins (ties by list order).
+            // A rule that REFERENCES Field::ActiveLayout is structurally excluded from
+            // the assignment path: activeLayout is left unstamped above, so such a
+            // rule evaluates against a placeholder empty value. A positive leaf
+            // (ActiveLayout Equals X) never matches that placeholder, but a negated
+            // predicate (None{ActiveLayout Equals X}) WOULD spuriously match and force
+            // a wrong assignment. Dropping any ActiveLayout-referencing rule here keeps
+            // ActiveLayout a strictly post-assignment field regardless of predicate
+            // polarity, not merely by relying on the empty-value coincidence.
             const auto slotMatch = [&](bool (*carriesSlot)(const PWR::Rule&)) -> const PWR::Rule* {
                 return m_evaluator->highestPriorityMatch(query, [carriesSlot](const PWR::Rule& rule) {
-                    return carriesSlot(rule);
+                    return carriesSlot(rule) && !rule.match.referencesAnyField({PWR::Field::ActiveLayout});
                 });
             };
 
@@ -438,9 +447,30 @@ std::optional<bool> LayoutRegistry::resolveContextDefaultAssignment(const QStrin
             // assignment cascade (assignmentIdForScreen reaches it via
             // resolveDefaultAssignmentEntryForContext), so stamping the active
             // layout here would recurse. See resolveAssignmentEntry.
-            const PWR::ResolvedActions resolved = m_evaluator->resolve(query);
-            if (const auto action = resolved.slot(QString(PWR::ActionSlot::DefaultAssignment))) {
-                return action->params.value(PWR::ActionParam::Value).toBool();
+            //
+            // Because activeLayout is unstamped, an ActiveLayout-referencing rule
+            // must be structurally excluded from this no-stamp resolver too (the
+            // exact symmetry resolveAssignmentEntry's slotMatch enforces): a negated
+            // None{ActiveLayout Equals X} predicate would otherwise spuriously match
+            // the empty placeholder and wrongly force/suppress the default. Use a
+            // filtered highestPriorityMatch rather than the unfiltered resolve().
+            const PWR::Rule* rule = m_evaluator->highestPriorityMatch(query, [](const PWR::Rule& r) {
+                if (r.match.referencesAnyField({PWR::Field::ActiveLayout})) {
+                    return false;
+                }
+                for (const PWR::RuleAction& action : r.actions) {
+                    if (action.type == QLatin1String(PWR::ActionType::DefaultLayoutAssignment)) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+            if (rule != nullptr) {
+                for (const PWR::RuleAction& action : rule->actions) {
+                    if (action.type == QLatin1String(PWR::ActionType::DefaultLayoutAssignment)) {
+                        return action.params.value(PWR::ActionParam::Value).toBool();
+                    }
+                }
             }
             return std::nullopt;
         });
@@ -512,10 +542,12 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
             // property falls through to the global config value at the consumer.
             // Colours are parsed from the `#AARRGGBB` wire hex; QColor reads a
             // 9-digit hex alpha-first, matching the picker's toHexArgb output. The
-            // descriptor validators reject malformed values at load; the isValid /
-            // clamp guards here are defense in depth so a hand-edited rules.json that
-            // slipped a bad value can only fall through to config, never apply an
-            // invalid colour or an out-of-range opacity as an override.
+            // descriptor validators reject malformed values at load; the guards here
+            // are defense in depth so a hand-edited rules.json that slipped a bad value
+            // can only fall through to config or a sane bound, never apply a broken
+            // override: colours are validity-checked, opacities clamped to [0, 1], and
+            // border width / radius floored at 0 (negatives are nonsensical; the load
+            // validator enforces the upper bounds, which the shared constants own).
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayHighlightColor))) {
                 if (const QColor c(action->params.value(PWR::ActionParam::Value).toString()); c.isValid()) {
                     overlay.highlightColor = c;
@@ -538,10 +570,10 @@ ContextOverlayOverride LayoutRegistry::resolveContextOverlay(const QString& scre
                 overlay.inactiveOpacity = qBound(0.0, action->params.value(PWR::ActionParam::Value).toDouble(), 1.0);
             }
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayBorderWidth))) {
-                overlay.borderWidth = action->params.value(PWR::ActionParam::Value).toInt();
+                overlay.borderWidth = std::max(0, action->params.value(PWR::ActionParam::Value).toInt());
             }
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayBorderRadius))) {
-                overlay.borderRadius = action->params.value(PWR::ActionParam::Value).toInt();
+                overlay.borderRadius = std::max(0, action->params.value(PWR::ActionParam::Value).toInt());
             }
             if (const auto action = resolved.slot(QString(PWR::ActionSlot::OverlayShowZoneNumbers))) {
                 overlay.showZoneNumbers = action->params.value(PWR::ActionParam::Value).toBool();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -811,6 +811,20 @@ bool Daemon::init()
             }
             return state->tiledWindowCount();
         });
+    // Orientation provider — derives "portrait" / "landscape" from the screen's
+    // geometry so a Field::ScreenOrientation rule can drive any context slot on a
+    // rotated monitor. Returns nullopt for an unknown / invalid geometry (the
+    // predicate then stays inert). A square screen is treated as landscape.
+    m_layoutManager->setScreenOrientationProvider([this](const QString& screenId) -> std::optional<QString> {
+        if (!m_screenManager) {
+            return std::nullopt;
+        }
+        const QRect geom = m_screenManager->screenGeometry(screenId);
+        if (!geom.isValid()) {
+            return std::nullopt;
+        }
+        return geom.height() > geom.width() ? QStringLiteral("portrait") : QStringLiteral("landscape");
+    });
     // Snapping-preferred provider — separate from defaultLayoutIdProvider
     // because the user can have snapping enabled WITHOUT a global default
     // snap layout id (per-screen assignments cover everything). Without
@@ -2106,6 +2120,7 @@ void Daemon::stop()
         m_layoutManager->setDefaultLayoutIdProvider({});
         m_layoutManager->setDefaultAutotileAlgorithmProvider({});
         m_layoutManager->setTiledWindowCountProvider({});
+        m_layoutManager->setScreenOrientationProvider({});
         m_layoutManager->setSnappingPreferredProvider({});
         m_layoutManager->setDefaultAssignmentSuppressedProvider({});
     }

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -194,6 +194,9 @@ void Daemon::updateAutotileScreens()
             if (tilingParams.masterCount) {
                 overrides[PerScreenKeys::MasterCount] = *tilingParams.masterCount;
             }
+            if (tilingParams.insertPosition) {
+                overrides[PerScreenKeys::InsertPosition] = *tilingParams.insertPosition;
+            }
 
             // Compare against currently applied overrides to avoid redundant retiles
             QVariantMap current = m_autotileEngine->perScreenOverrides(screenId);

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -200,6 +200,14 @@ void Daemon::updateAutotileScreens()
             if (tilingParams.overflowBehavior) {
                 overrides[PerScreenKeys::OverflowBehavior] = *tilingParams.overflowBehavior;
             }
+            // Custom-parameter override applies only when the rule's target
+            // algorithm is this screen's effective algorithm — the daemon knows
+            // both, so the algorithm guard lives here. The engine's hasCustomParam
+            // filter is a second guard for the current algo's declared params.
+            if (!tilingParams.algorithmParamTarget.isEmpty() && screenAlgorithms.contains(screenId)
+                && tilingParams.algorithmParamTarget == screenAlgorithms.value(screenId)) {
+                overrides[PerScreenKeys::CustomParams] = tilingParams.algorithmParams;
+            }
 
             // Compare against currently applied overrides to avoid redundant retiles
             QVariantMap current = m_autotileEngine->perScreenOverrides(screenId);

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -176,6 +176,25 @@ void Daemon::updateAutotileScreens()
                     }
                 }
             }
+            // Layer per-context tiling-parameter RULES on top of the config-derived
+            // override map (config stays the base; a matched SetMaxWindows /
+            // SetSplitRatio / SetMasterCount rule wins, and also overrides the
+            // algorithm-default MaxWindows injected above). Resolved for the
+            // screen's current context.
+            const int ctxDesktop = m_layoutManager->currentVirtualDesktopForScreen(screenId);
+            const QString ctxActivity = m_layoutManager->currentActivity();
+            const PhosphorZones::ContextTilingParams tilingParams =
+                m_layoutManager->resolveContextTilingParams(screenId, ctxDesktop, ctxActivity);
+            if (tilingParams.maxWindows) {
+                overrides[PerScreenKeys::MaxWindows] = *tilingParams.maxWindows;
+            }
+            if (tilingParams.splitRatio) {
+                overrides[PerScreenKeys::SplitRatio] = *tilingParams.splitRatio;
+            }
+            if (tilingParams.masterCount) {
+                overrides[PerScreenKeys::MasterCount] = *tilingParams.masterCount;
+            }
+
             // Compare against currently applied overrides to avoid redundant retiles
             QVariantMap current = m_autotileEngine->perScreenOverrides(screenId);
             if (overrides != current) {

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -264,26 +264,25 @@ void Daemon::updateAutotileScreens()
     // any already created by applyPerScreenConfig above) and retiles them.
     // Because per-screen overrides are set first, retileAfterOperation inside
     // setActiveScreens uses effectiveAlgorithm() with the correct per-screen algo.
-    const bool setChanged = (m_autotileEngine->activeScreens() != autotileScreens);
     m_autotileEngine->setActiveScreens(autotileScreens);
 
-    // When the autotile set didn't change (e.g., VS inherited autotile from
-    // the physical screen's cascade before the explicit assignment was written),
-    // setActiveScreens early-returns without retiling. Force a retile for every
-    // screen in the set so mode-swap toggles always take effect AND so a rule edit
-    // that changes tiling GEOMETRY without changing the per-screen overrides map is
-    // still applied live. That second case is load-bearing for GAP rules
-    // (SetInnerGap / SetOuterGap*): they resolve through the context-gap PROVIDER at
-    // retile time, not the overrides map, so `overrides != current` above never sees
-    // them — only a retile pulls the fresh gaps (via the provider's authoritative
-    // "tiling"-mode context). Diffing gaps here to skip the retile on truly-unrelated
-    // edits (appearance/lock/exclude) would have to replicate that exact provider
-    // context and risk silently dropping gap application; the blanket retile is the
-    // simple correct choice. Cost is bounded: rulesChanged fires only on a user rule
-    // save, the retile is deferred + coalesced, and it produces identical geometry
-    // (no window movement) when nothing actually changed.
-    if (!setChanged) {
-        for (const QString& screenId : autotileScreens) {
+    // setActiveScreens only retiles screens that were newly ADDED to the set; a
+    // screen that was already active gets no retile from it. Force a retile for
+    // every ALREADY-ACTIVE screen so (1) a mode-swap toggle with a stable set takes
+    // effect, and (2) a rule edit that changes tiling GEOMETRY without changing the
+    // per-screen overrides map is still applied live. Case (2) is load-bearing for
+    // GAP rules (SetInnerGap / SetOuterGap*): they resolve through the context-gap
+    // PROVIDER at retile time, not the overrides map, so `overrides != current` above
+    // never sees them — only a retile pulls the fresh gaps (via the provider's
+    // authoritative "tiling"-mode context). Skipping the added screens avoids
+    // retiling them twice (setActiveScreens already did). Diffing gaps here to skip
+    // the retile on truly-unrelated edits (appearance/lock/exclude) would have to
+    // replicate that exact provider context and risk silently dropping gap
+    // application; the blanket retile is the simple correct choice. Cost is bounded:
+    // rulesChanged fires only on a user rule save, the retile is deferred + coalesced,
+    // and it produces identical geometry (no window movement) when nothing changed.
+    for (const QString& screenId : autotileScreens) {
+        if (!addedScreens.contains(screenId)) {
             m_autotileEngine->scheduleRetileForScreen(screenId);
         }
     }

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -204,8 +204,15 @@ void Daemon::updateAutotileScreens()
             // algorithm is this screen's effective algorithm — the daemon knows
             // both, so the algorithm guard lives here. The engine's hasCustomParam
             // filter is a second guard for the current algo's declared params.
-            if (!tilingParams.algorithmParamTarget.isEmpty() && screenAlgorithms.contains(screenId)
-                && tilingParams.algorithmParamTarget == screenAlgorithms.value(screenId)) {
+            //
+            // A bare-autotile screen (mode on, no concrete assigned algorithm) is
+            // absent from screenAlgorithms yet still runs the global-default
+            // algorithm (m_autotileEngine->algorithmId(), the same value the engine's
+            // effectiveAlgorithm resolves), so fall back to it rather than gating on
+            // contains() — otherwise a rule targeting the default algorithm is
+            // silently dropped on those screens.
+            const QString effectiveAlgo = screenAlgorithms.value(screenId, m_autotileEngine->algorithmId());
+            if (!tilingParams.algorithmParamTarget.isEmpty() && tilingParams.algorithmParamTarget == effectiveAlgo) {
                 overrides[PerScreenKeys::CustomParams] = tilingParams.algorithmParams;
             }
 

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -212,9 +212,12 @@ void Daemon::updateAutotileScreens()
             // than gating on contains() — otherwise a rule targeting the default
             // algorithm is silently dropped on those screens. During a mid-cycle
             // applyEntry this runs before setAlgorithm() updates the global id, so a
-            // bare screen may see the prior algorithm for one pass; it self-corrects
-            // on the next updateAutotileScreens (window open, desktop switch, cycle),
-            // mirroring the MaxWindows staleness noted above.
+            // bare screen may see the prior algorithm for one pass. Unlike the
+            // MaxWindows staleness above (which the engine re-derives at retile time
+            // via effectiveMaxWindows), the engine has no retile-time re-resolution
+            // for custom params, so a dropped CustomParams override persists until the
+            // next updateAutotileScreens (window open, desktop switch, cycle) rather
+            // than healing at the next retile.
             const QString effectiveAlgo = screenAlgorithms.value(screenId, m_autotileEngine->algorithmId());
             if (!tilingParams.algorithmParamTarget.isEmpty() && tilingParams.algorithmParamTarget == effectiveAlgo) {
                 overrides[PerScreenKeys::CustomParams] = tilingParams.algorithmParams;

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -129,6 +129,26 @@ void Daemon::updateAutotileScreens()
                 overrides = m_settings->getPerScreenAutotileSettings(
                     PhosphorIdentity::VirtualScreenId::extractPhysicalId(screenId));
             }
+            // Resolve per-context tiling-parameter RULES up front — the effective
+            // overflow behavior gates the algorithm-default MaxWindows injection
+            // below (an Unlimited context must not receive a finite injected cap).
+            const int ctxDesktop = m_layoutManager->currentVirtualDesktopForScreen(screenId);
+            const QString ctxActivity = m_layoutManager->currentActivity();
+            const PhosphorZones::ContextTilingParams tilingParams =
+                m_layoutManager->resolveContextTilingParams(screenId, ctxDesktop, ctxActivity);
+            // Effective overflow mirrors effectiveOverflowBehavior's cascade: a
+            // SetOverflowBehavior rule wins, else a per-screen config override, else
+            // global config. Clamp before the enum compare exactly as the resolver
+            // does (qBound), so a corrupt out-of-range stored value can't make the two
+            // determinations drift (which would reintroduce the injected-cap defeat).
+            const int effectiveOverflow = qBound(
+                PhosphorTiles::AutotileDefaults::MinOverflowBehavior,
+                tilingParams.overflowBehavior.value_or(overrides.contains(PerScreenKeys::OverflowBehavior)
+                                                           ? overrides.value(PerScreenKeys::OverflowBehavior).toInt()
+                                                           : m_settings->autotileOverflowBehaviorInt()),
+                PhosphorTiles::AutotileDefaults::MaxOverflowBehavior);
+            const bool contextUnlimited =
+                effectiveOverflow == static_cast<int>(PhosphorTiles::AutotileOverflowBehavior::Unlimited);
             // Inject algorithm from layout assignment (authoritative source)
             if (screenAlgorithms.contains(screenId)) {
                 const QString screenAlgo = screenAlgorithms.value(screenId);
@@ -153,8 +173,17 @@ void Daemon::updateAutotileScreens()
                 // effectiveMaxWindows() has identical fallback logic (step 2) that
                 // dynamically derives the correct MaxWindows at retile time even
                 // without a per-screen override. The override here is an optimization.
+                //
+                // Skip the injection entirely when the context is Unlimited: the
+                // injected finite default would sit at effectiveMaxWindows step 1,
+                // ahead of the Unlimited sentinel at step 2, silently defeating the
+                // SetOverflowBehavior=Unlimited request. The injection is only an
+                // optimization for the mixed-algorithm case (step 3), which never
+                // applies under Unlimited (step 2 returns first). A user's explicit
+                // per-screen-config or rule MaxWindows still caps even under Unlimited
+                // — those land in `overrides` directly and are untouched here.
                 const QString globalAlgo = m_autotileEngine->algorithmId();
-                if (screenAlgo != globalAlgo && !overrides.contains(PerScreenKeys::MaxWindows)) {
+                if (screenAlgo != globalAlgo && !overrides.contains(PerScreenKeys::MaxWindows) && !contextUnlimited) {
                     auto* screenAlgoPtr = m_algorithmRegistry->algorithm(screenAlgo);
                     auto* globalAlgoPtr = m_algorithmRegistry->algorithm(globalAlgo);
                     if (screenAlgoPtr) {
@@ -179,12 +208,8 @@ void Daemon::updateAutotileScreens()
             // Layer per-context tiling-parameter RULES on top of the config-derived
             // override map (config stays the base; a matched SetMaxWindows /
             // SetSplitRatio / SetMasterCount rule wins, and also overrides the
-            // algorithm-default MaxWindows injected above). Resolved for the
-            // screen's current context.
-            const int ctxDesktop = m_layoutManager->currentVirtualDesktopForScreen(screenId);
-            const QString ctxActivity = m_layoutManager->currentActivity();
-            const PhosphorZones::ContextTilingParams tilingParams =
-                m_layoutManager->resolveContextTilingParams(screenId, ctxDesktop, ctxActivity);
+            // algorithm-default MaxWindows injected above). Resolved above (the
+            // overflow result gated the MaxWindows injection).
             if (tilingParams.maxWindows) {
                 overrides[PerScreenKeys::MaxWindows] = *tilingParams.maxWindows;
             }
@@ -244,8 +269,19 @@ void Daemon::updateAutotileScreens()
 
     // When the autotile set didn't change (e.g., VS inherited autotile from
     // the physical screen's cascade before the explicit assignment was written),
-    // setActiveScreens early-returns without retiling. Force a retile for
-    // screens that are in the set so mode-swap toggles always take effect.
+    // setActiveScreens early-returns without retiling. Force a retile for every
+    // screen in the set so mode-swap toggles always take effect AND so a rule edit
+    // that changes tiling GEOMETRY without changing the per-screen overrides map is
+    // still applied live. That second case is load-bearing for GAP rules
+    // (SetInnerGap / SetOuterGap*): they resolve through the context-gap PROVIDER at
+    // retile time, not the overrides map, so `overrides != current` above never sees
+    // them — only a retile pulls the fresh gaps (via the provider's authoritative
+    // "tiling"-mode context). Diffing gaps here to skip the retile on truly-unrelated
+    // edits (appearance/lock/exclude) would have to replicate that exact provider
+    // context and risk silently dropping gap application; the blanket retile is the
+    // simple correct choice. Cost is bounded: rulesChanged fires only on a user rule
+    // save, the retile is deferred + coalesced, and it produces identical geometry
+    // (no window movement) when nothing actually changed.
     if (!setChanged) {
         for (const QString& screenId : autotileScreens) {
             m_autotileEngine->scheduleRetileForScreen(screenId);
@@ -301,15 +337,24 @@ QSet<QString> Daemon::diffActiveAssignments()
 void Daemon::reconcileActiveAssignments()
 {
     const QSet<QString> changed = diffActiveAssignments();
+    // Per-context tiling rules change a screen's resolved layout WITHOUT changing
+    // its assignment id, so they never appear in `changed` (diffActiveAssignments
+    // only tracks the active snapping-layout uuid / "autotile:<algo>" id). Two
+    // families need updateAutotileScreens() to apply them live: tiling-PARAM rules
+    // (SetMaxWindows / SetSplitRatio / SetMasterCount / SetInsertPosition /
+    // SetOverflowBehavior / SetAlgorithmParam), which land in the per-screen overrides
+    // map and self-retile via applyPerScreenConfig; and GAP rules, which resolve
+    // through the context-gap provider at retile time and rely on the force-retile
+    // inside updateAutotileScreens (see the comment there). SetDragBehavior needs no
+    // retile — it is read live by the drag adaptor.
+    updateAutotileScreens();
     if (changed.isEmpty()) {
         return;
     }
-    // Autotile screens retile inside updateAutotileScreens() (it self-diffs each
-    // screen's resolved algorithm/overrides). Snapping screens resnap via the
-    // shared legacy apply path: mark the changed screens on the adaptor and
-    // trigger the same assignmentChangesApplied handler the KCM batch uses, so
-    // rule-driven and assignment-driven changes run identical code.
-    updateAutotileScreens();
+    // Snapping screens resnap via the shared legacy apply path: mark the changed
+    // screens on the adaptor and trigger the same assignmentChangesApplied handler
+    // the KCM batch uses, so rule-driven and assignment-driven changes run identical
+    // code. Gated on `changed` because only an assignment-id change moves windows.
     if (m_layoutAdaptor) {
         m_layoutAdaptor->markScreensChanged(changed);
         m_layoutAdaptor->applyAssignmentChanges();

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -197,6 +197,9 @@ void Daemon::updateAutotileScreens()
             if (tilingParams.insertPosition) {
                 overrides[PerScreenKeys::InsertPosition] = *tilingParams.insertPosition;
             }
+            if (tilingParams.overflowBehavior) {
+                overrides[PerScreenKeys::OverflowBehavior] = *tilingParams.overflowBehavior;
+            }
 
             // Compare against currently applied overrides to avoid redundant retiles
             QVariantMap current = m_autotileEngine->perScreenOverrides(screenId);

--- a/src/daemon/daemon/autotile.cpp
+++ b/src/daemon/daemon/autotile.cpp
@@ -207,10 +207,14 @@ void Daemon::updateAutotileScreens()
             //
             // A bare-autotile screen (mode on, no concrete assigned algorithm) is
             // absent from screenAlgorithms yet still runs the global-default
-            // algorithm (m_autotileEngine->algorithmId(), the same value the engine's
-            // effectiveAlgorithm resolves), so fall back to it rather than gating on
-            // contains() — otherwise a rule targeting the default algorithm is
-            // silently dropped on those screens.
+            // algorithm (m_autotileEngine->algorithmId(), the value the engine's
+            // effectiveAlgorithm resolves at steady state), so fall back to it rather
+            // than gating on contains() — otherwise a rule targeting the default
+            // algorithm is silently dropped on those screens. During a mid-cycle
+            // applyEntry this runs before setAlgorithm() updates the global id, so a
+            // bare screen may see the prior algorithm for one pass; it self-corrects
+            // on the next updateAutotileScreens (window open, desktop switch, cycle),
+            // mirroring the MaxWindows staleness noted above.
             const QString effectiveAlgo = screenAlgorithms.value(screenId, m_autotileEngine->algorithmId());
             if (!tilingParams.algorithmParamTarget.isEmpty() && tilingParams.algorithmParamTarget == effectiveAlgo) {
                 overrides[PerScreenKeys::CustomParams] = tilingParams.algorithmParams;

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -45,6 +45,7 @@ class PhosphorProfileRegistry;
 namespace PhosphorZones {
 class IZoneLayoutRegistry;
 class Zone;
+struct ContextOverlayOverride;
 }
 
 namespace PhosphorLayout {
@@ -569,8 +570,11 @@ private:
     LayoutIncludeFlags resolvePerScreenLayoutInclude(const QString& screenId) const;
     QVariantMap zoneToVariantMap(PhosphorZones::Zone* zone, QScreen* screen,
                                  PhosphorZones::Layout* layout = nullptr) const;
+    // overlayOverride is resolved once per screen by the caller (screen-invariant
+    // across zones) and threaded in, rather than re-resolved per zone.
     QVariantMap zoneToVariantMap(PhosphorZones::Zone* zone, const QString& screenId, QScreen* physScreen,
-                                 const QRect& overlayGeometry, PhosphorZones::Layout* layout = nullptr) const;
+                                 const QRect& overlayGeometry, PhosphorZones::Layout* layout,
+                                 const PhosphorZones::ContextOverlayOverride& overlayOverride) const;
 
     /**
      * @brief Resolve the layout for a given screen with fallback chain

--- a/src/daemon/overlayservice.h
+++ b/src/daemon/overlayservice.h
@@ -568,8 +568,6 @@ private:
     /// the keep-visible bar) both go through here so the trigger geometry
     /// matches the rendered popup row count.
     LayoutIncludeFlags resolvePerScreenLayoutInclude(const QString& screenId) const;
-    QVariantMap zoneToVariantMap(PhosphorZones::Zone* zone, QScreen* screen,
-                                 PhosphorZones::Layout* layout = nullptr) const;
     // overlayOverride is resolved once per screen by the caller (screen-invariant
     // across zones) and threaded in, rather than re-resolved per zone.
     QVariantMap zoneToVariantMap(PhosphorZones::Zone* zone, const QString& screenId, QScreen* physScreen,

--- a/src/daemon/overlayservice/internal.h
+++ b/src/daemon/overlayservice/internal.h
@@ -339,16 +339,28 @@ inline QQuickItem* findQmlItemByName(QQuickItem* item, const QString& objectName
 
 /// Write common zone color/opacity appearance settings to a QML window.
 /// Used by snap assist and layout picker to avoid duplicating the 5-7 property writes.
-inline void writeColorSettings(QObject* window, const IZoneVisualizationSettings* settings)
+///
+/// When @p overlayOverride is non-null, each property it fills wins over the
+/// global @p settings value — a context overlay-appearance rule (SetOverlay*)
+/// layering on top of config. An unset override field falls through to the
+/// global setting, so config stays authoritative.
+inline void writeColorSettings(QObject* window, const IZoneVisualizationSettings* settings,
+                               const PhosphorZones::ContextOverlayOverride* overlayOverride = nullptr)
 {
     if (!window || !settings) {
         return;
     }
-    writeQmlProperty(window, QStringLiteral("highlightColor"), settings->highlightColor());
-    writeQmlProperty(window, QStringLiteral("inactiveColor"), settings->inactiveColor());
-    writeQmlProperty(window, QStringLiteral("borderColor"), settings->borderColor());
-    writeQmlProperty(window, QStringLiteral("activeOpacity"), settings->activeOpacity());
-    writeQmlProperty(window, QStringLiteral("inactiveOpacity"), settings->inactiveOpacity());
+    const auto ov = overlayOverride;
+    writeQmlProperty(window, QStringLiteral("highlightColor"),
+                     ov && ov->highlightColor ? *ov->highlightColor : settings->highlightColor());
+    writeQmlProperty(window, QStringLiteral("inactiveColor"),
+                     ov && ov->inactiveColor ? *ov->inactiveColor : settings->inactiveColor());
+    writeQmlProperty(window, QStringLiteral("borderColor"),
+                     ov && ov->borderColor ? *ov->borderColor : settings->borderColor());
+    writeQmlProperty(window, QStringLiteral("activeOpacity"),
+                     ov && ov->activeOpacity ? *ov->activeOpacity : settings->activeOpacity());
+    writeQmlProperty(window, QStringLiteral("inactiveOpacity"),
+                     ov && ov->inactiveOpacity ? *ov->inactiveOpacity : settings->inactiveOpacity());
 }
 
 // patchZonesWithHighlight, parseZonesJson, ensureShaderTimerStarted, getAnchorsForPosition

--- a/src/daemon/overlayservice/internal.h
+++ b/src/daemon/overlayservice/internal.h
@@ -282,15 +282,15 @@ inline bool isAnyModeLocked(ISettings* settings, PhosphorZones::IZoneLayoutRegis
         || settings->isContextLocked(Utils::contextLockKey(1, screenId), desktop, activity);
 }
 
-/// Resolve the per-context overlay-property override (shader / style)
+/// Resolve the per-context overlay-property override (shader / style / appearance)
 /// for @p screenId at that screen's current virtual desktop + activity. A thin
 /// wrapper over IZoneLayoutRegistry::resolveContextOverlay that supplies the live
 /// context, mirroring how @ref isAnyModeLocked routes the lock check. Under
 /// per-output virtual desktops (#648) the desktop is resolved per-screen so the
 /// override matches the desktop actually shown on @p screenId, not the active
 /// monitor's. Returns an empty override when there is no registry or no matching
-/// overlay rule, so the overlay falls through to the active layout's own
-/// shader / display-mode.
+/// overlay rule, so each field falls through to the active layout's own shader /
+/// display-mode or the global appearance config.
 inline PhosphorZones::ContextOverlayOverride
 overlayOverrideForScreen(PhosphorZones::IZoneLayoutRegistry* layoutRegistry, const QString& screenId)
 {
@@ -334,11 +334,12 @@ inline QQuickItem* findQmlItemByName(QQuickItem* item, const QString& objectName
 // m_screenStates[screenId] fields directly.
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Shared color/opacity settings push for snap assist and layout picker
+// Shared color/opacity settings push for the overlay surfaces
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Write common zone color/opacity appearance settings to a QML window.
-/// Used by snap assist and layout picker to avoid duplicating the 5-7 property writes.
+/// Write the common zone color/opacity appearance settings to a QML window.
+/// Used by the main overlay, zone selector, snap assist, and layout picker to
+/// avoid duplicating the 5 colour/opacity property writes.
 ///
 /// When @p overlayOverride is non-null, each property it fills wins over the
 /// global @p settings value — a context overlay-appearance rule (SetOverlay*)

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -810,7 +810,7 @@ void OverlayService::updateOverlayWindow(const QString& screenId, QScreen* physS
         writeQmlProperty(slot, QStringLiteral("highlightedCount"), highlightedCount);
         updateLabelsTextureForWindow(slot, patched, physScreen, screenLayout);
         // Note: zoneDataVersion is bumped and broadcast to all windows in
-        // updateGeometries() after all per-screen updates complete. Do not
+        // updateZonesForAllWindows() after all per-screen updates complete. Do not
         // write it here - updateOverlayWindow() is called per-screen, and
         // writing the version mid-loop would cause inconsistent state across
         // windows (some see the new version, others the old one).

--- a/src/daemon/overlayservice/overlay.cpp
+++ b/src/daemon/overlayservice/overlay.cpp
@@ -737,12 +737,22 @@ void OverlayService::updateOverlayWindow(const QString& screenId, QScreen* physS
 
     PhosphorZones::Layout* screenLayout = resolveScreenLayout(screenId);
 
+    // Per-context overlay overrides (shader / style + appearance) resolved once
+    // for this screen's live context; layered over config below and reused by
+    // the shader block further down.
+    const PhosphorZones::ContextOverlayOverride overlayOverride = overlayOverrideForScreen(m_layoutManager, screenId);
+
     if (m_settings) {
-        writeColorSettings(slot, m_settings);
-        writeQmlProperty(slot, QStringLiteral("borderWidth"), m_settings->borderWidth());
-        writeQmlProperty(slot, QStringLiteral("borderRadius"), m_settings->borderRadius());
+        writeColorSettings(slot, m_settings, &overlayOverride);
+        writeQmlProperty(slot, QStringLiteral("borderWidth"),
+                         overlayOverride.borderWidth.value_or(m_settings->borderWidth()));
+        writeQmlProperty(slot, QStringLiteral("borderRadius"),
+                         overlayOverride.borderRadius.value_or(m_settings->borderRadius()));
         writeQmlProperty(slot, QStringLiteral("enableBlur"), m_settings->enableBlur());
-        bool showNumbers = m_settings->showZoneNumbers() && (!screenLayout || screenLayout->showZoneNumbers());
+        // The rule overrides the global show-numbers setting; the per-layout
+        // gate still wins (a layout that hides numbers keeps them hidden).
+        bool showNumbers = overlayOverride.showZoneNumbers.value_or(m_settings->showZoneNumbers())
+            && (!screenLayout || screenLayout->showZoneNumbers());
         writeQmlProperty(slot, QStringLiteral("showNumbers"), showNumbers);
         writeFontProperties(slot, m_settings);
     }
@@ -752,8 +762,6 @@ void OverlayService::updateOverlayWindow(const QString& screenId, QScreen* physS
     if (windowIsShader && screenUsesShader && screenLayout) {
         auto* registry = m_shaderRegistry;
         if (registry) {
-            const PhosphorZones::ContextOverlayOverride overlayOverride =
-                overlayOverrideForScreen(m_layoutManager, screenId);
             const QString shaderId = overlayOverride.shaderId.value_or(screenLayout->shaderId());
             const QVariantMap rawParams =
                 overlayOverride.shaderId ? overlayOverride.shaderParams : screenLayout->shaderParams();

--- a/src/daemon/overlayservice/overlay_data.cpp
+++ b/src/daemon/overlayservice/overlay_data.cpp
@@ -200,9 +200,12 @@ QVariantList OverlayService::buildZonesList(const QString& screenId, QScreen* ph
     qCDebug(lcOverlay) << "buildZonesList: screenId=" << screenId << "overlayGeom=" << overlayGeom
                        << "layout=" << screenLayout->name() << "zones=" << screenLayout->zones().size();
 
+    // Resolve the per-context overlay override ONCE for the screen (it is invariant
+    // across the screen's zones) and thread it into each zoneToVariantMap call.
+    const PhosphorZones::ContextOverlayOverride overlayOverride = overlayOverrideForScreen(m_layoutManager, screenId);
     for (auto* zone : screenLayout->zones()) {
         if (zone) {
-            zonesList.append(zoneToVariantMap(zone, screenId, physScreen, overlayGeom, screenLayout));
+            zonesList.append(zoneToVariantMap(zone, screenId, physScreen, overlayGeom, screenLayout, overlayOverride));
         }
     }
 
@@ -228,11 +231,13 @@ QVariantMap OverlayService::zoneToVariantMap(PhosphorZones::Zone* zone, QScreen*
     QRect overlayGeom = (m_screenStates.contains(screenId) && m_screenStates[screenId].overlayGeometry.isValid()
                              ? m_screenStates[screenId].overlayGeometry
                              : screen->geometry());
-    return zoneToVariantMap(zone, screenId, screen, overlayGeom, layout);
+    return zoneToVariantMap(zone, screenId, screen, overlayGeom, layout,
+                            overlayOverrideForScreen(m_layoutManager, screenId));
 }
 
 QVariantMap OverlayService::zoneToVariantMap(PhosphorZones::Zone* zone, const QString& screenId, QScreen* physScreen,
-                                             const QRect& overlayGeometry, PhosphorZones::Layout* layout) const
+                                             const QRect& overlayGeometry, PhosphorZones::Layout* layout,
+                                             const PhosphorZones::ContextOverlayOverride& overlayOverride) const
 {
     QVariantMap map;
 
@@ -284,8 +289,9 @@ QVariantMap OverlayService::zoneToVariantMap(PhosphorZones::Zone* zone, const QS
     // Overlay display mode cascade: zone → context rule → layout → global
     // ═══════════════════════════════════════════════════════════════════════════════
     // A context overlay-style rule slots between the per-zone override and the
-    // layout value, mirroring the precedence useShaderForScreen applies.
-    const PhosphorZones::ContextOverlayOverride overlayOverride = overlayOverrideForScreen(m_layoutManager, screenId);
+    // layout value, mirroring the precedence useShaderForScreen applies. The override
+    // is screen-invariant across zones, so the caller resolves it once and passes it
+    // in rather than re-resolving (and re-deriving the cache key) per zone.
     int resolvedDisplayMode = 0; // default: ZoneRectangles
     if (zone->overlayDisplayMode() >= 0) {
         resolvedDisplayMode = zone->overlayDisplayMode();
@@ -329,10 +335,12 @@ QVariantMap OverlayService::zoneToVariantMap(PhosphorZones::Zone* zone, const QS
     // own alpha is stripped here — no double-apply.
     QColor fillColor = zone->useCustomColors()
         ? zone->highlightColor()
-        : overlayOverride.highlightColor.value_or(m_settings ? m_settings->highlightColor() : QColor(Qt::blue));
+        : overlayOverride.highlightColor.value_or(m_settings ? m_settings->highlightColor()
+                                                             : ConfigDefaults::highlightColor());
     qreal alpha = zone->useCustomColors()
         ? zone->activeOpacity()
-        : overlayOverride.activeOpacity.value_or(m_settings ? m_settings->activeOpacity() : 0.5);
+        : overlayOverride.activeOpacity.value_or(m_settings ? m_settings->activeOpacity()
+                                                            : ConfigDefaults::activeOpacity());
     map[FillR] = fillColor.redF() * alpha;
     map[FillG] = fillColor.greenF() * alpha;
     map[FillB] = fillColor.blueF() * alpha;
@@ -341,7 +349,7 @@ QVariantMap OverlayService::zoneToVariantMap(PhosphorZones::Zone* zone, const QS
     // Border color (RGBA) for shader
     QColor borderClr = zone->useCustomColors()
         ? zone->borderColor()
-        : overlayOverride.borderColor.value_or(m_settings ? m_settings->borderColor() : QColor(Qt::white));
+        : overlayOverride.borderColor.value_or(m_settings ? m_settings->borderColor() : ConfigDefaults::borderColor());
     map[BorderR] = borderClr.redF();
     map[BorderG] = borderClr.greenF();
     map[BorderB] = borderClr.blueF();
@@ -350,10 +358,11 @@ QVariantMap OverlayService::zoneToVariantMap(PhosphorZones::Zone* zone, const QS
     // Shader params: borderRadius, borderWidth (zone → context rule → global)
     map[ShaderBorderRadius] = zone->useCustomColors()
         ? zone->borderRadius()
-        : overlayOverride.borderRadius.value_or(m_settings ? m_settings->borderRadius() : 8);
+        : overlayOverride.borderRadius.value_or(m_settings ? m_settings->borderRadius()
+                                                           : ConfigDefaults::borderRadius());
     map[ShaderBorderWidth] = zone->useCustomColors()
         ? zone->borderWidth()
-        : overlayOverride.borderWidth.value_or(m_settings ? m_settings->borderWidth() : 2);
+        : overlayOverride.borderWidth.value_or(m_settings ? m_settings->borderWidth() : ConfigDefaults::borderWidth());
 
     return map;
 }

--- a/src/daemon/overlayservice/overlay_data.cpp
+++ b/src/daemon/overlayservice/overlay_data.cpp
@@ -212,29 +212,6 @@ QVariantList OverlayService::buildZonesList(const QString& screenId, QScreen* ph
     return zonesList;
 }
 
-QVariantMap OverlayService::zoneToVariantMap(PhosphorZones::Zone* zone, QScreen* screen,
-                                             PhosphorZones::Layout* layout) const
-{
-    // Physical screen overload: delegates to screenId overload.
-    // Defensive check: if virtual screens are configured for this physical screen,
-    // screen center disambiguation always resolves to the same VS. Callers must
-    // use the QString overload instead.
-    const QString physId = PhosphorScreens::ScreenIdentity::identifierFor(screen);
-    auto* mgr = m_screenManager;
-    if (mgr && mgr->hasVirtualScreens(physId)) {
-        qCWarning(lcOverlay) << "zoneToVariantMap(Zone*, QScreen*, Layout*): physical screen" << physId
-                             << "has virtual screens configured - caller should use QString overload.";
-    }
-
-    const QPoint screenCenter = screen->geometry().center();
-    QString screenId = Utils::effectiveScreenIdAt(m_screenManager, screenCenter, screen);
-    QRect overlayGeom = (m_screenStates.contains(screenId) && m_screenStates[screenId].overlayGeometry.isValid()
-                             ? m_screenStates[screenId].overlayGeometry
-                             : screen->geometry());
-    return zoneToVariantMap(zone, screenId, screen, overlayGeom, layout,
-                            overlayOverrideForScreen(m_layoutManager, screenId));
-}
-
 QVariantMap OverlayService::zoneToVariantMap(PhosphorZones::Zone* zone, const QString& screenId, QScreen* physScreen,
                                              const QRect& overlayGeometry, PhosphorZones::Layout* layout,
                                              const PhosphorZones::ContextOverlayOverride& overlayOverride) const

--- a/src/daemon/overlayservice/overlay_data.cpp
+++ b/src/daemon/overlayservice/overlay_data.cpp
@@ -313,28 +313,38 @@ QVariantMap OverlayService::zoneToVariantMap(PhosphorZones::Zone* zone, const QS
     map[NormalizedWidth] = overlayGeom.width() / ow;
     map[NormalizedHeight] = overlayGeom.height() / oh;
 
-    // Fill color (RGBA premultiplied alpha) for shader
-    QColor fillColor = zone->useCustomColors() ? zone->highlightColor()
-                                               : (m_settings ? m_settings->highlightColor() : QColor(Qt::blue));
-    qreal alpha = zone->useCustomColors() ? zone->activeOpacity() : (m_settings ? m_settings->activeOpacity() : 0.5);
+    // Fill / border reads cascade zone-custom → context rule → global config.
+    // A per-zone custom value wins outright; otherwise the context overlay rule
+    // (overlayOverride, resolved above) overrides the global setting. Only the
+    // fill RGB is used (premultiplied by the separate opacity), so the colour's
+    // own alpha is stripped here — no double-apply.
+    QColor fillColor = zone->useCustomColors()
+        ? zone->highlightColor()
+        : overlayOverride.highlightColor.value_or(m_settings ? m_settings->highlightColor() : QColor(Qt::blue));
+    qreal alpha = zone->useCustomColors()
+        ? zone->activeOpacity()
+        : overlayOverride.activeOpacity.value_or(m_settings ? m_settings->activeOpacity() : 0.5);
     map[FillR] = fillColor.redF() * alpha;
     map[FillG] = fillColor.greenF() * alpha;
     map[FillB] = fillColor.blueF() * alpha;
     map[FillA] = alpha;
 
     // Border color (RGBA) for shader
-    QColor borderClr =
-        zone->useCustomColors() ? zone->borderColor() : (m_settings ? m_settings->borderColor() : QColor(Qt::white));
+    QColor borderClr = zone->useCustomColors()
+        ? zone->borderColor()
+        : overlayOverride.borderColor.value_or(m_settings ? m_settings->borderColor() : QColor(Qt::white));
     map[BorderR] = borderClr.redF();
     map[BorderG] = borderClr.greenF();
     map[BorderB] = borderClr.blueF();
     map[BorderA] = borderClr.alphaF();
 
-    // Shader params: borderRadius, borderWidth (from zone or settings)
-    map[ShaderBorderRadius] =
-        zone->useCustomColors() ? zone->borderRadius() : (m_settings ? m_settings->borderRadius() : 8);
-    map[ShaderBorderWidth] =
-        zone->useCustomColors() ? zone->borderWidth() : (m_settings ? m_settings->borderWidth() : 2);
+    // Shader params: borderRadius, borderWidth (zone → context rule → global)
+    map[ShaderBorderRadius] = zone->useCustomColors()
+        ? zone->borderRadius()
+        : overlayOverride.borderRadius.value_or(m_settings ? m_settings->borderRadius() : 8);
+    map[ShaderBorderWidth] = zone->useCustomColors()
+        ? zone->borderWidth()
+        : overlayOverride.borderWidth.value_or(m_settings ? m_settings->borderWidth() : 2);
 
     return map;
 }

--- a/src/daemon/overlayservice/overlay_data.cpp
+++ b/src/daemon/overlayservice/overlay_data.cpp
@@ -111,17 +111,17 @@ void OverlayService::updateLabelsTextureForWindow(QQuickItem* slot, const QVaria
     if (!slot) {
         return;
     }
-    const bool showNumbers =
-        (m_settings ? m_settings->showZoneNumbers() : true) && (!screenLayout || screenLayout->showZoneNumbers());
     const LabelFontSettings lfs = extractLabelFontSettings(m_settings);
     // Slot is anchors.fill: parent on the shell window, so its size
     // matches the shell - which has been sized to the per-screen rect.
     const QSize size(qMax(1, static_cast<int>(slot->width())), qMax(1, static_cast<int>(slot->height())));
 
     PerScreenOverlayState* state = nullptr;
+    QString screenId;
     for (auto it = m_screenStates.begin(); it != m_screenStates.end(); ++it) {
         if (it.value().mainOverlaySlot() == slot) {
             state = &it.value();
+            screenId = it.key();
             break;
         }
     }
@@ -129,6 +129,15 @@ void OverlayService::updateLabelsTextureForWindow(QQuickItem* slot, const QVaria
         qCWarning(lcOverlay) << "updateLabelsTextureForWindow: slot not tracked in m_screenStates - "
                                 "labels-texture cache bypassed";
     }
+
+    // A SetOverlayShowZoneNumbers context rule overrides the global setting for this
+    // screen, matching the QML `showNumbers` property set in updateOverlayWindow so
+    // both the property and the label-texture path agree. An empty screenId (slot
+    // untracked) resolves to no override, i.e. the global setting. The per-layout
+    // hide still wins (a layout that hides numbers keeps them hidden).
+    const PhosphorZones::ContextOverlayOverride overlayOverride = overlayOverrideForScreen(m_layoutManager, screenId);
+    const bool showNumbers = overlayOverride.showZoneNumbers.value_or(m_settings ? m_settings->showZoneNumbers() : true)
+        && (!screenLayout || screenLayout->showZoneNumbers());
 
     const quint64 newHash = hashLabelsTextureInputs(patched, size, showNumbers, lfs);
     if (state && state->labelsTextureHash == newHash) {

--- a/src/daemon/overlayservice/selector.cpp
+++ b/src/daemon/overlayservice/selector.cpp
@@ -477,13 +477,19 @@ void OverlayService::createZoneSelectorWindow(const QString& screenId, QScreen* 
         // Zone padding honors per-monitor gap RULES (context-rule override →
         // global → default) via the layout registry's current context. The
         // selector preview passes no layout, so the per-layout tier does not
-        // apply here; border width/radius are global-only (no per-screen key).
+        // apply here; border width/radius layer the context overlay rule over
+        // the global config value, matching updateZoneSelectorWindow (every show
+        // path re-runs the update, so these seed values are consistent with it).
+        const PhosphorZones::ContextOverlayOverride overlayOverride =
+            overlayOverrideForScreen(m_layoutManager, screenId);
         writeQmlProperty(
             slot, QStringLiteral("zonePadding"),
             GeometryUtils::getEffectiveInnerGap(
                 nullptr, m_settings, GeometryUtils::currentContextGapOverride(m_layoutManager, m_settings, screenId)));
-        writeQmlProperty(slot, QStringLiteral("zoneBorderWidth"), m_settings->borderWidth());
-        writeQmlProperty(slot, QStringLiteral("zoneBorderRadius"), m_settings->borderRadius());
+        writeQmlProperty(slot, QStringLiteral("zoneBorderWidth"),
+                         overlayOverride.borderWidth.value_or(m_settings->borderWidth()));
+        writeQmlProperty(slot, QStringLiteral("zoneBorderRadius"),
+                         overlayOverride.borderRadius.value_or(m_settings->borderRadius()));
     }
     const ZoneSelectorConfig config =
         m_settings ? m_settings->resolvedZoneSelectorConfig(screenId) : defaultZoneSelectorConfig();

--- a/src/daemon/overlayservice/selector_update.cpp
+++ b/src/daemon/overlayservice/selector_update.cpp
@@ -47,14 +47,17 @@ void updateZoneSelectorComputedProperties(PhosphorScreens::ScreenManager* mgr, Q
 
     // Compute scaled zone appearance values. Zone padding honors per-monitor gap
     // RULES (cascade: context-rule override → global → default) via the layout
-    // registry's current context. This preview passes no layout, so the
-    // per-layout tier does not apply here; border width/radius are global-only
-    // settings (no per-screen key exists).
+    // registry's current context. This preview passes no layout, so the per-layout
+    // tier does not apply here; border width/radius honor a SetOverlayBorderWidth /
+    // SetOverlayBorderRadius context rule over the global setting, matching the
+    // zoneBorderWidth/Radius written for the same window in updateZoneSelectorWindow.
     if (settings) {
+        const PhosphorZones::ContextOverlayOverride overlayOverride =
+            overlayOverrideForScreen(layoutRegistry, virtualScreenId);
         const int zonePadding = GeometryUtils::getEffectiveInnerGap(
             nullptr, settings, GeometryUtils::currentContextGapOverride(layoutRegistry, settings, virtualScreenId));
-        const int zoneBorderWidth = settings->borderWidth();
-        const int zoneBorderRadius = settings->borderRadius();
+        const int zoneBorderWidth = overlayOverride.borderWidth.value_or(settings->borderWidth());
+        const int zoneBorderRadius = overlayOverride.borderRadius.value_or(settings->borderRadius());
 
         const int scaledPadding = std::max(1, qRound(zonePadding * previewScale));
         const int scaledBorderWidth = std::max(1, qRound(zoneBorderWidth * previewScale * 2));

--- a/src/daemon/overlayservice/selector_update.cpp
+++ b/src/daemon/overlayservice/selector_update.cpp
@@ -150,18 +150,24 @@ void OverlayService::updateZoneSelectorWindow(const QString& screenId)
 
     // Update settings-based properties
     if (m_settings) {
-        writeColorSettings(window, m_settings);
+        // Context overlay-appearance overrides layer over config for this
+        // screen's live context, matching the main zone overlay.
+        const PhosphorZones::ContextOverlayOverride overlayOverride =
+            overlayOverrideForScreen(m_layoutManager, screenId);
+        writeColorSettings(window, m_settings, &overlayOverride);
         // PhosphorZones::Zone appearance for the scaled preview. Zone padding
         // honors per-monitor gap RULES (context-rule override → global → default)
         // via the layout registry's current context. This preview passes no
         // layout, so the per-layout tier does not apply here; border width/radius
-        // are global-only (no per-screen key exists).
+        // layer the context overlay rule over the global config value.
         writeQmlProperty(
             window, QStringLiteral("zonePadding"),
             GeometryUtils::getEffectiveInnerGap(
                 nullptr, m_settings, GeometryUtils::currentContextGapOverride(m_layoutManager, m_settings, screenId)));
-        writeQmlProperty(window, QStringLiteral("zoneBorderWidth"), m_settings->borderWidth());
-        writeQmlProperty(window, QStringLiteral("zoneBorderRadius"), m_settings->borderRadius());
+        writeQmlProperty(window, QStringLiteral("zoneBorderWidth"),
+                         overlayOverride.borderWidth.value_or(m_settings->borderWidth()));
+        writeQmlProperty(window, QStringLiteral("zoneBorderRadius"),
+                         overlayOverride.borderRadius.value_or(m_settings->borderRadius()));
         // Font settings for zone number labels
         writeFontProperties(window, m_settings);
     }

--- a/src/daemon/overlayservice/snapassist.cpp
+++ b/src/daemon/overlayservice/snapassist.cpp
@@ -206,10 +206,13 @@ void OverlayService::showSnapAssist(const QString& screenId, const PhosphorProto
     writeQmlProperty(slot, QStringLiteral("screenWidth"), screenGeom.width());
     writeQmlProperty(slot, QStringLiteral("screenHeight"), screenGeom.height());
 
-    writeColorSettings(slot, m_settings);
+    const PhosphorZones::ContextOverlayOverride overlayOverride = overlayOverrideForScreen(m_layoutManager, screenId);
+    writeColorSettings(slot, m_settings, &overlayOverride);
     if (m_settings) {
-        writeQmlProperty(slot, QStringLiteral("borderWidth"), m_settings->borderWidth());
-        writeQmlProperty(slot, QStringLiteral("borderRadius"), m_settings->borderRadius());
+        writeQmlProperty(slot, QStringLiteral("borderWidth"),
+                         overlayOverride.borderWidth.value_or(m_settings->borderWidth()));
+        writeQmlProperty(slot, QStringLiteral("borderRadius"),
+                         overlayOverride.borderRadius.value_or(m_settings->borderRadius()));
     }
 
     // Resize the shell window to the target screen geometry (matches
@@ -570,7 +573,8 @@ void OverlayService::showLayoutPicker(const QString& screenId)
         locked = isAnyModeLocked(m_settings, m_layoutManager, resolvedId, curDesktop, curActivity);
     }
     writeQmlProperty(slot, QStringLiteral("locked"), locked);
-    writeColorSettings(slot, m_settings);
+    const PhosphorZones::ContextOverlayOverride overlayOverride = overlayOverrideForScreen(m_layoutManager, resolvedId);
+    writeColorSettings(slot, m_settings, &overlayOverride);
 
     if (shellWindow) {
         assertWindowOnScreen(shellWindow, screen, screenGeom);

--- a/src/dbus/windowdragadaptor.cpp
+++ b/src/dbus/windowdragadaptor.cpp
@@ -255,6 +255,9 @@ void WindowDragAdaptor::cancelSnap()
     m_triggerReleasedAfterCancel = false;
     m_activationToggled = false;
     m_prevTriggerHeld = false;
+    // Clear the reorder latch alongside the other per-drag latches so cancelSnap
+    // is symmetric with resetDragState (it doesn't route through resetDragState).
+    m_dragReorderActive = false;
     m_currentZoneId.clear();
     m_currentZoneGeometry = QRect();
     m_currentAdjacentZoneIds.clear();
@@ -718,6 +721,11 @@ void WindowDragAdaptor::resetDragState(bool keepEscapeShortcut)
     m_activationToggled = false;
     m_prevTriggerHeld = false;
     m_wasSnapped = false;
+    // Per-drag reorder latch: cleared here alongside the sibling latches so the
+    // shared teardown (cancelSnap, clearForCompositorReconnect) leaves no stale
+    // true for the next drag. endDrag also clears it directly before its own
+    // early-return branches that don't route through resetDragState.
+    m_dragReorderActive = false;
     m_lastEmittedZoneGeometry = QRect();
     m_restoreSizeEmittedDuringDrag = false;
     // m_overlayIdled is intentionally NOT cleared here. Each drag-end

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -396,9 +396,16 @@ public:
     static PhosphorProtocol::DragPolicy computeDragPolicy(const ISettings* settings,
                                                           const PhosphorEngine::IPlacementEngine* autotileEngine,
                                                           const QString& windowId, const QString& screenId,
-                                                          const PhosphorContext::IContextResolver* resolver);
+                                                          const PhosphorContext::IContextResolver* resolver,
+                                                          bool reorderMode);
 
 private:
+    /// Whether reorder (drag-to-swap) mode is effective for @p screenId: a matched
+    /// context SetDragBehavior rule wins, otherwise the global
+    /// `autotileDragBehavior` setting. Resolves through m_layoutManager (which the
+    /// static computeDragPolicy can't reach), so callers pass the result in.
+    bool effectiveReorderMode(const QString& screenId) const;
+
     // Helper: Find screen containing a point (returns primary screen if not found)
     QScreen* screenAtPoint(int x, int y) const;
 

--- a/src/dbus/windowdragadaptor.h
+++ b/src/dbus/windowdragadaptor.h
@@ -507,11 +507,18 @@ private:
     bool m_prevAutotileDragInsertHeld = false; // Previous frame's autotile drag-insert trigger state
     bool m_zoneSpanToggled = false; // Current toggle state for zone span (toggle mode)
     bool m_prevZoneSpanTriggerHeld = false; // Previous frame's zone span trigger state for edge detection
-    // Drag-to-reorder mode is active for the current drag: cached at beginDrag
-    // time so per-tick dragMoved work (60+ Hz) doesn't have to re-query the
-    // settings + engine on every cursor update. Requires (a) autotile-bypass
-    // path, (b) AutotileDragBehavior::Reorder, and (c) window was tracked+tiled
-    // at drag-start. Cleared by endDrag / clearPendingSnapDragState.
+    // Drag-to-reorder mode is active for the current autotile screen: cached so
+    // per-tick dragMoved work (60+ Hz) doesn't have to re-query the settings +
+    // engine on every cursor update. Seeded at beginDrag from the start screen
+    // (requires (a) autotile-bypass path, (b) AutotileDragBehavior::Reorder,
+    // (c) window tiled at drag-start) and RE-LATCHED to the cursor's current screen
+    // on each policy flip in updateDragCursor under the SAME conditions (destination
+    // bypassReason == AutotileScreen AND isWindowTiled), so a mid-drag crossing
+    // between screens with divergent per-context SetDragBehavior rules applies the
+    // destination screen's mode without ever adopting a floating window into the
+    // stack or forcing a preview on a context-disabled screen. Cleared by endDrag,
+    // clearPendingSnapDragState, cancelSnap, handleWindowClosed, and the shared
+    // resetDragState teardown.
     bool m_dragReorderActive = false;
     bool m_overlayShown = false;
     // Overlay was blanked mid-drag via IOverlayService::setIdleForDragPause()

--- a/src/dbus/windowdragadaptor/drag.cpp
+++ b/src/dbus/windowdragadaptor/drag.cpp
@@ -724,8 +724,8 @@ void WindowDragAdaptor::dragMoved(const QString& windowId, int cursorX, int curs
         }
     } else {
         // Cursor left all zones: restore pre-snap size immediately if window was snapped
-        if (m_wasSnapped && !m_restoreSizeEmittedDuringDrag && m_settings && m_settings->restoreOriginalSizeOnUnsnap()
-            && m_windowTracking) {
+        if (m_wasSnapped && !m_restoreSizeEmittedDuringDrag && m_windowTracking
+            && m_windowTracking->shouldRestoreSizeOnUnsnap(windowId)) {
             int origX, origY, origW, origH;
             if (m_windowTracking->getValidatedPreTileGeometry(windowId, origX, origY, origW, origH)) {
                 m_restoreSizeEmittedDuringDrag = true;

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -296,10 +296,10 @@ bool WindowDragAdaptor::activateSnapDragIfNeeded(int modifiers, int mouseButtons
     // Drop the wasSnapped latch after dragStarted has re-derived live
     // m_wasSnapped from the tracking state — its single consumer (the
     // endDrag pending-never-activated branch) is now unreachable for
-    // this drag. Leaving the latch set would bleed across the NEXT
-    // bypass beginDrag (which doesn't overwrite the field) and a
-    // later endDrag's pending-branch could read a stale-true value
-    // for a window that wasn't actually snapped at start.
+    // this drag. This is defensive: the next beginDrag re-clears the
+    // field via clearPendingSnapDragState() regardless, so a stale-true
+    // value can't actually bleed into a later drag; the reset just keeps
+    // the field honest for the remainder of this now-activated drag.
     m_pendingSnapDragWasSnapped = false;
     return !m_draggedWindowId.isEmpty();
 }

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -336,40 +336,25 @@ PhosphorProtocol::DragOutcome WindowDragAdaptor::endDrag(const QString& windowId
     // on the window-tracking side so the window unsnaps and floats at
     // the drop location — otherwise the stale zone assignment persists.
     if (m_draggedWindowId.isEmpty() && m_pendingSnapDragWindowId == windowId) {
+        // A pending drag is always on the SNAP path: beginDrag's snap path sets
+        // m_currentDragPolicy.bypassReason == None, and the only mutator of that field
+        // afterwards (the policy-flip in updateDragCursor) runs solely when
+        // m_draggedWindowId == windowId (line ~535 guard) — i.e. never while the drag
+        // is still pending. So there is no bypass to promote here; a pending
+        // never-activated drag can only unsnap-and-NoOp.
         const bool wasSnapped = m_pendingSnapDragWasSnapped;
-        // Snapshot the bypass reason BEFORE clearing m_currentDragPolicy.
-        // updateDragCursor may have flipped the policy to a non-None
-        // bypassReason (e.g. cursor crossed onto an autotile screen)
-        // while m_draggedWindowId was still empty because activation
-        // never triggered. Treat that exactly like the non-pending bypass
-        // paths below — drop to the dispatch matrix instead of forcing
-        // the unsnap-only NoOp branch.
-        const PhosphorProtocol::DragBypassReason pendingBypass = m_currentDragPolicy.bypassReason;
         qCInfo(lcDbusWindow) << "endDrag: pending snap drag never activated" << windowId << "wasSnapped=" << wasSnapped
-                             << "cancelled=" << cancelled << "bypass=" << pendingBypass;
+                             << "cancelled=" << cancelled;
         clearPendingSnapDragState();
-        if (pendingBypass != PhosphorProtocol::DragBypassReason::None) {
-            // Promote to a bypass drop so the matrix below
-            // (AutotileScreen → ApplyFloat at release cursor;
-            // SnappingDisabled / ContextDisabled → NoOp) decides the
-            // final outcome. Populate m_draggedWindowId so the matrix
-            // branches that check it (e.g. the autotile drag-insert
-            // commit) see a consistent state. The matching clears live
-            // in those branches.
-            m_draggedWindowId = windowId;
-            if (!cancelled && wasSnapped && m_windowTracking) {
-                m_windowTracking->notifyDragOutUnsnap(windowId);
-            }
-            // Fall through — outcome is decided by the bypass dispatch
-            // matrix below.
-        } else {
-            m_currentDragPolicy = {};
-            if (!cancelled && wasSnapped && m_windowTracking) {
-                m_windowTracking->notifyDragOutUnsnap(windowId);
-            }
-            outcome.action = PhosphorProtocol::DragOutcome::NoOp;
-            return outcome;
+        m_currentDragPolicy = {};
+        // If the window was snapped at drag start and dragged without holding the
+        // activation trigger, unsnap it so it floats at the drop location instead of
+        // leaving a stale zone assignment.
+        if (!cancelled && wasSnapped && m_windowTracking) {
+            m_windowTracking->notifyDragOutUnsnap(windowId);
         }
+        outcome.action = PhosphorProtocol::DragOutcome::NoOp;
+        return outcome;
     }
 
     if (m_draggedWindowId != windowId) {
@@ -580,16 +565,23 @@ void WindowDragAdaptor::updateDragCursor(const QString& windowId, int cursorX, i
             // preview off this latch, so tracking the current screen restores correct
             // Reorder-vs-Float behavior across a mid-drag screen crossing.
             //
-            // Match beginDrag's eager-preview seed (drag_protocol.cpp ~200-201) EXACTLY:
-            // (1) the destination policy is the autotile-bypass path — bypassReason ==
-            // AutotileScreen excludes a context-DISABLED autotile screen (computeDragPolicy
-            // evaluates ContextDisabled first), so the latch never forces a preview on a
-            // dead/excluded screen; and (2) the window is still tiled — beginDragInsertPreview
-            // would otherwise ADOPT a floating/untracked window into the stack
-            // (fresh-adoption branch), silently tiling a window dragged onto a Reorder
-            // screen with no trigger held, defeating the "floating windows drag free"
-            // invariant. A genuinely tiled window crossing Float→Reorder is still tiled at
-            // the flip, so this stays true for the case that should reorder.
+            // The GATE mirrors beginDrag's eager-preview seed (drag_protocol.cpp
+            // ~200-201): (1) the destination policy is the autotile-bypass path —
+            // bypassReason == AutotileScreen excludes a context-DISABLED autotile screen
+            // (computeDragPolicy evaluates ContextDisabled first), so the latch never
+            // forces a preview on a dead/excluded screen; and (2) the window is still
+            // tiled — beginDragInsertPreview would otherwise ADOPT a floating/untracked
+            // window into the stack (fresh-adoption branch), silently tiling a window
+            // dragged onto a Reorder screen with no trigger held, defeating the "floating
+            // windows drag free" invariant. A genuinely tiled window crossing Float→Reorder
+            // is still tiled at the flip, so this stays true for the case that should reorder.
+            //
+            // Unlike the seed, this only sets the latch; it does NOT eagerly call
+            // beginDragInsertPreview or restore a float-on-start fallback. The next
+            // dragMoved tick begins the preview off the latch (drag.cpp), so on a mid-drag
+            // cross to a Reorder screen where that begin fails the window float-drops on
+            // release rather than during the drag — an acceptable degradation for a
+            // transient begin failure (the common case begins successfully).
             m_dragReorderActive = candidate.bypassReason == PhosphorProtocol::DragBypassReason::AutotileScreen
                 && reorderMode && m_autotileEngine && m_autotileEngine->isWindowTiled(windowId);
             Q_EMIT dragPolicyChanged(windowId, candidate);

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -338,10 +338,10 @@ PhosphorProtocol::DragOutcome WindowDragAdaptor::endDrag(const QString& windowId
     if (m_draggedWindowId.isEmpty() && m_pendingSnapDragWindowId == windowId) {
         // A pending drag is always on the SNAP path: beginDrag's snap path sets
         // m_currentDragPolicy.bypassReason == None, and the only mutator of that field
-        // afterwards (the policy-flip in updateDragCursor) runs solely when
-        // m_draggedWindowId == windowId (line ~535 guard) — i.e. never while the drag
-        // is still pending. So there is no bypass to promote here; a pending
-        // never-activated drag can only unsnap-and-NoOp.
+        // afterwards (the policy-flip in updateDragCursor) runs solely after the early
+        // `windowId != m_draggedWindowId` return there, i.e. only when m_draggedWindowId
+        // is non-empty — never while the drag is still pending. So there is no bypass to
+        // promote here; a pending never-activated drag can only unsnap-and-NoOp.
         const bool wasSnapped = m_pendingSnapDragWasSnapped;
         qCInfo(lcDbusWindow) << "endDrag: pending snap drag never activated" << windowId << "wasSnapped=" << wasSnapped
                              << "cancelled=" << cancelled;
@@ -598,13 +598,12 @@ void WindowDragAdaptor::updateDragCursor(const QString& windowId, int cursorX, i
 
     // Snap path: forward to legacy dragMoved so overlay/zone-detection
     // state stays current. Bypass paths still run dragMoved because it
-    // also drives the autotile drag-insert preview block (drag.cpp
-    // ~501-564). beginDrag's bypass branch (line ~145) DOES set
-    // m_draggedWindowId, so dragMoved's `windowId != m_draggedWindowId`
-    // guard would NOT early-return. The snap-side overlay branches
-    // inside dragMoved instead become no-ops because `prepareHandlerContext`
-    // (drag.cpp:166,180) suppresses the overlay path when the cursor
-    // screen is in autotile mode or context-disabled — the same gate
+    // also drives the autotile drag-insert preview block in dragMoved.
+    // beginDrag's bypass branch DOES set m_draggedWindowId, so dragMoved's
+    // `windowId != m_draggedWindowId` guard would NOT early-return. The
+    // snap-side overlay branches inside dragMoved instead become no-ops
+    // because `prepareHandlerContext` suppresses the overlay path when the
+    // cursor screen is in autotile mode or context-disabled — the same gate
     // that decided the bypass branch at beginDrag.
     dragMoved(windowId, cursorX, cursorY, modifiers, mouseButtons);
 }

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -156,8 +156,11 @@ PhosphorProtocol::DragPolicy WindowDragAdaptor::beginDrag(const QString& windowI
         m_cachedAutotileDragInsertTriggers = parseTriggers(m_settings->autotileDragInsertTriggers());
     }
 
-    const PhosphorProtocol::DragPolicy policy = computeDragPolicy(
-        m_settings, m_autotileEngine, windowId, startScreenId, m_contextResolver, effectiveReorderMode(startScreenId));
+    // Resolve once and reuse: effectiveReorderMode runs a full context rule
+    // resolve, and the reorder-fallback branch below needs the same answer.
+    const bool startReorderMode = effectiveReorderMode(startScreenId);
+    const PhosphorProtocol::DragPolicy policy =
+        computeDragPolicy(m_settings, m_autotileEngine, windowId, startScreenId, m_contextResolver, startReorderMode);
 
     // Reusable mutable copy — the reorder fallback path below may need to
     // restore immediateFloatOnStart that computeDragPolicy proactively cleared.
@@ -195,7 +198,7 @@ PhosphorProtocol::DragPolicy WindowDragAdaptor::beginDrag(const QString& windowI
         // legacy float-on-start behavior here so the UX matches the Float
         // mode default for the rest of this drag.
         if (effectivePolicy.bypassReason == PhosphorProtocol::DragBypassReason::AutotileScreen && m_autotileEngine
-            && effectiveReorderMode(startScreenId) && m_autotileEngine->isWindowTiled(windowId)) {
+            && startReorderMode && m_autotileEngine->isWindowTiled(windowId)) {
             if (m_autotileEngine->beginDragInsertPreview(windowId, startScreenId)) {
                 m_dragReorderActive = true;
             } else {
@@ -551,9 +554,15 @@ void WindowDragAdaptor::updateDragCursor(const QString& windowId, int cursorX, i
     auto resolved = resolveScreenAt(QPointF(cursorX, cursorY));
     const QString cursorScreenId = resolved.screenId;
     if (!cursorScreenId.isEmpty()) {
+        // effectiveReorderMode runs a full context rule resolve; on this ~30 Hz
+        // path its result only matters on autotile screens (computeDragPolicy reads
+        // reorderMode solely in its autotile-screen branch). Gate on the cheap
+        // isActiveOnScreen set-lookup so snap-only drags don't pay a per-motion-event
+        // rule evaluation for a value that would be discarded.
+        const bool reorderMode = m_autotileEngine && m_autotileEngine->isActiveOnScreen(cursorScreenId)
+            && effectiveReorderMode(cursorScreenId);
         const PhosphorProtocol::DragPolicy candidate =
-            computeDragPolicy(m_settings, m_autotileEngine, windowId, cursorScreenId, m_contextResolver,
-                              effectiveReorderMode(cursorScreenId));
+            computeDragPolicy(m_settings, m_autotileEngine, windowId, cursorScreenId, m_contextResolver, reorderMode);
         if (candidate != m_currentDragPolicy) {
             // Log both bypass reason and screenId on each side so same-reason
             // flips (snap→snap or autotile→autotile cross-VS) aren't opaque in
@@ -562,6 +571,27 @@ void WindowDragAdaptor::updateDragCursor(const QString& windowId, int cursorX, i
                                  << m_currentDragPolicy.screenId << "->" << candidate.bypassReason << "@"
                                  << cursorScreenId;
             m_currentDragPolicy = candidate;
+            // Re-latch reorder mode to the CURRENT autotile screen. Per-context
+            // SetDragBehavior means two autotile screens can differ (start Reorder,
+            // destination Float, or vice versa); without this the beginDrag-time
+            // start-screen snapshot would keep forcing the start screen's mode on the
+            // destination (dragMoved reads m_dragReorderActive at drag.cpp). The
+            // per-tick preview lifecycle in dragMoved begins/cancels the drag-insert
+            // preview off this latch, so tracking the current screen restores correct
+            // Reorder-vs-Float behavior across a mid-drag screen crossing.
+            //
+            // Match beginDrag's eager-preview seed (drag_protocol.cpp ~200-201) EXACTLY:
+            // (1) the destination policy is the autotile-bypass path — bypassReason ==
+            // AutotileScreen excludes a context-DISABLED autotile screen (computeDragPolicy
+            // evaluates ContextDisabled first), so the latch never forces a preview on a
+            // dead/excluded screen; and (2) the window is still tiled — beginDragInsertPreview
+            // would otherwise ADOPT a floating/untracked window into the stack
+            // (fresh-adoption branch), silently tiling a window dragged onto a Reorder
+            // screen with no trigger held, defeating the "floating windows drag free"
+            // invariant. A genuinely tiled window crossing Float→Reorder is still tiled at
+            // the flip, so this stays true for the case that should reorder.
+            m_dragReorderActive = candidate.bypassReason == PhosphorProtocol::DragBypassReason::AutotileScreen
+                && reorderMode && m_autotileEngine && m_autotileEngine->isWindowTiled(windowId);
             Q_EMIT dragPolicyChanged(windowId, candidate);
             // After the flip, fall through: if we're now on the snap path
             // we still want to call legacy dragMoved below for overlay

--- a/src/dbus/windowdragadaptor/drag_protocol.cpp
+++ b/src/dbus/windowdragadaptor/drag_protocol.cpp
@@ -26,7 +26,7 @@ namespace PlasmaZones {
 PhosphorProtocol::DragPolicy
 WindowDragAdaptor::computeDragPolicy(const ISettings* settings, const PhosphorEngine::IPlacementEngine* autotileEngine,
                                      const QString& windowId, const QString& screenId,
-                                     const PhosphorContext::IContextResolver* resolver)
+                                     const PhosphorContext::IContextResolver* resolver, bool reorderMode)
 {
     PhosphorProtocol::DragPolicy policy;
     policy.screenId = screenId;
@@ -63,7 +63,8 @@ WindowDragAdaptor::computeDragPolicy(const ISettings* settings, const PhosphorEn
     if (autotileEngine && !screenId.isEmpty() && autotileEngine->isActiveOnScreen(screenId)) {
         policy.bypassReason = PhosphorProtocol::DragBypassReason::AutotileScreen;
         policy.captureGeometry = true; // preserve pre-autotile size for unfloat restore
-        const bool reorderMode = settings && settings->autotileDragBehavior() == AutotileDragBehavior::Reorder;
+        // reorderMode is resolved by the caller (effectiveReorderMode): a matched
+        // context SetDragBehavior rule wins over the global setting for this screen.
         if (!windowId.isEmpty() && !reorderMode) {
             policy.immediateFloatOnStart = autotileEngine->isWindowTracked(windowId);
         }
@@ -88,6 +89,22 @@ WindowDragAdaptor::computeDragPolicy(const ISettings* settings, const PhosphorEn
     policy.captureGeometry = true;
     policy.bypassReason = PhosphorProtocol::DragBypassReason::None;
     return policy;
+}
+
+bool WindowDragAdaptor::effectiveReorderMode(const QString& screenId) const
+{
+    // A matched context SetDragBehavior rule wins over the global setting for this
+    // screen; resolved through the layout registry (which the static
+    // computeDragPolicy can't reach, so it takes the result as a param).
+    if (m_layoutManager && !screenId.isEmpty()) {
+        const int vd = m_layoutManager->currentVirtualDesktopForScreen(screenId);
+        const PhosphorZones::ContextTilingParams params =
+            m_layoutManager->resolveContextTilingParams(screenId, vd, m_layoutManager->currentActivity());
+        if (params.dragBehavior) {
+            return static_cast<AutotileDragBehavior>(*params.dragBehavior) == AutotileDragBehavior::Reorder;
+        }
+    }
+    return m_settings && m_settings->autotileDragBehavior() == AutotileDragBehavior::Reorder;
 }
 
 PhosphorProtocol::DragPolicy WindowDragAdaptor::beginDrag(const QString& windowId, int frameX, int frameY,
@@ -139,8 +156,8 @@ PhosphorProtocol::DragPolicy WindowDragAdaptor::beginDrag(const QString& windowI
         m_cachedAutotileDragInsertTriggers = parseTriggers(m_settings->autotileDragInsertTriggers());
     }
 
-    const PhosphorProtocol::DragPolicy policy =
-        computeDragPolicy(m_settings, m_autotileEngine, windowId, startScreenId, m_contextResolver);
+    const PhosphorProtocol::DragPolicy policy = computeDragPolicy(
+        m_settings, m_autotileEngine, windowId, startScreenId, m_contextResolver, effectiveReorderMode(startScreenId));
 
     // Reusable mutable copy — the reorder fallback path below may need to
     // restore immediateFloatOnStart that computeDragPolicy proactively cleared.
@@ -178,8 +195,7 @@ PhosphorProtocol::DragPolicy WindowDragAdaptor::beginDrag(const QString& windowI
         // legacy float-on-start behavior here so the UX matches the Float
         // mode default for the rest of this drag.
         if (effectivePolicy.bypassReason == PhosphorProtocol::DragBypassReason::AutotileScreen && m_autotileEngine
-            && m_settings && m_settings->autotileDragBehavior() == AutotileDragBehavior::Reorder
-            && m_autotileEngine->isWindowTiled(windowId)) {
+            && effectiveReorderMode(startScreenId) && m_autotileEngine->isWindowTiled(windowId)) {
             if (m_autotileEngine->beginDragInsertPreview(windowId, startScreenId)) {
                 m_dragReorderActive = true;
             } else {
@@ -536,7 +552,8 @@ void WindowDragAdaptor::updateDragCursor(const QString& windowId, int cursorX, i
     const QString cursorScreenId = resolved.screenId;
     if (!cursorScreenId.isEmpty()) {
         const PhosphorProtocol::DragPolicy candidate =
-            computeDragPolicy(m_settings, m_autotileEngine, windowId, cursorScreenId, m_contextResolver);
+            computeDragPolicy(m_settings, m_autotileEngine, windowId, cursorScreenId, m_contextResolver,
+                              effectiveReorderMode(cursorScreenId));
         if (candidate != m_currentDragPolicy) {
             // Log both bypass reason and screenId on each side so same-reason
             // flips (snap→snap or autotile→autotile cross-VS) aren't opaque in

--- a/src/dbus/windowdragadaptor/drop.cpp
+++ b/src/dbus/windowdragadaptor/drop.cpp
@@ -410,7 +410,7 @@ void WindowDragAdaptor::dragStopped(const QString& windowId, int cursorX, int cu
         // toggle path passes screenId to validatedUnmanagedGeometry; without it,
         // coordinates captured on another screen may fail the service's on-screen
         // visibility check and not restore).
-        if (m_settings && m_settings->restoreOriginalSizeOnUnsnap() && m_windowTracking) {
+        if (m_windowTracking && m_windowTracking->shouldRestoreSizeOnUnsnap(windowId)) {
             auto* wts = m_windowTracking->service();
             auto geo = wts->validatedUnmanagedGeometry(windowId, releaseScreenId);
             // Require strictly-positive dimensions: a degenerate stored

--- a/src/dbus/windowtrackingadaptor.cpp
+++ b/src/dbus/windowtrackingadaptor.cpp
@@ -821,6 +821,8 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
             meta.isModal = existing->isModal;
             meta.hasDecoration = existing->hasDecoration;
             meta.isResizable = existing->isResizable;
+            meta.isMovable = existing->isMovable;
+            meta.isMaximizable = existing->isMaximizable;
             meta.width = existing->width;
             meta.height = existing->height;
             meta.positionX = existing->positionX;
@@ -856,6 +858,8 @@ void WindowTrackingAdaptor::setWindowMetadata(const QString& instanceId, const Q
         meta.isModal = optBool(Key::IsModal);
         meta.hasDecoration = optBool(Key::HasDecoration);
         meta.isResizable = optBool(Key::IsResizable);
+        meta.isMovable = optBool(Key::IsMovable);
+        meta.isMaximizable = optBool(Key::IsMaximizable);
         meta.width = optInt(Key::Width);
         meta.height = optInt(Key::Height);
         meta.positionX = optInt(Key::PositionX);

--- a/src/dbus/windowtrackingadaptor.h
+++ b/src/dbus/windowtrackingadaptor.h
@@ -674,6 +674,20 @@ public:
     /// WindowQuery from the window registry metadata.
     bool shouldRestoreFloatedPosition(const QString& windowId, PhosphorZones::AssignmentEntry::Mode mode);
 
+    /// Resolve whether a SNAPPED window should be restored to its zone on login.
+    /// The snapped-to-zone analogue of shouldRestoreFloatedPosition: a matched
+    /// SetRestoreToZoneOnLogin rule wins, otherwise the global
+    /// `restoreWindowsToZonesOnLogin` setting decides. Consulted by the
+    /// managed-restore predicate the daemon injects into the SnapEngine.
+    bool shouldRestoreToZoneOnLogin(const QString& windowId);
+
+    /// Resolve whether a window's ORIGINAL (pre-snap) size should be restored when
+    /// it is unsnapped. A matched SetRestoreSizeOnUnsnap rule wins, otherwise the
+    /// global `restoreOriginalSizeOnUnsnap` setting decides. Consulted on the
+    /// drag-out / drop / cursor-left-zones unsnap paths (the latter two live in
+    /// WindowDragAdaptor and call through here), so this is public.
+    bool shouldRestoreSizeOnUnsnap(const QString& windowId);
+
     /// Resolve whether an opening window should start FLOATING because a "Float
     /// this app" rule matched it. Consulted by the float predicate the
     /// daemon injects into BOTH engines (in-process, not via D-Bus). Unlike

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -413,6 +413,14 @@ buildRuleQueryForWindow(const QPointer<PhosphorEngine::WindowRegistry>& registry
     query.windowType = meta->windowType;
     query.virtualDesktop = meta->virtualDesktop;
     query.activity = meta->activity;
+    // Screen-derived context fields (ScreenId, Mode, ScreenOrientation, ActiveLayout)
+    // are intentionally NOT stamped here: the window metadata does not carry the
+    // window's screen geometry / active layout, and this daemon-side query feeds the
+    // open-path Float / Restore / placement resolvers only. A rule that combines one
+    // of those fields with a window property therefore resolves in the effect's live
+    // per-window query (ruleQueryFor, which does stamp them) but not on this path.
+    // Context-scoped rules over these fields resolve through the windowless context
+    // cascade, which is their primary use.
     // Extended properties — optional→optional copy preserves engagement exactly,
     // so a field the effect could not observe stays disengaged and inert here too.
     query.isMinimized = meta->isMinimized;

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -416,11 +416,12 @@ buildRuleQueryForWindow(const QPointer<PhosphorEngine::WindowRegistry>& registry
     // Screen-derived context fields (ScreenId, Mode, ScreenOrientation, ActiveLayout)
     // are intentionally NOT stamped here: the window metadata does not carry the
     // window's screen geometry / active layout, and this daemon-side query feeds the
-    // open-path Float / Restore / placement resolvers only. A rule that combines one
-    // of those fields with a window property therefore resolves in the effect's live
-    // per-window query (ruleQueryFor, which does stamp them) but not on this path.
-    // Context-scoped rules over these fields resolve through the windowless context
-    // cascade, which is their primary use.
+    // open-path Float / Restore / placement resolvers only. The effect's live
+    // per-window query (ruleQueryFor) stamps ScreenId / Mode / ScreenOrientation, so
+    // a rule pairing one of those with a window property resolves there but not on
+    // this path. ActiveLayout is populated only by the windowless context cascade
+    // (never by either per-window query), so it is context-scoped in practice —
+    // which is the primary use of all four of these fields anyway.
     // Extended properties — optional→optional copy preserves engagement exactly,
     // so a field the effect could not observe stays disengaged and inert here too.
     query.isMinimized = meta->isMinimized;

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -512,8 +512,7 @@ bool WindowTrackingAdaptor::shouldRestoreToZoneOnLogin(const QString& windowId)
 
 bool WindowTrackingAdaptor::shouldRestoreSizeOnUnsnap(const QString& windowId)
 {
-    // Mirror shouldRestoreFloatedPosition for the restore-size-on-unsnap policy: a
-    // matched SetRestoreSizeOnUnsnap rule wins, otherwise the global setting decides.
+    // A matched SetRestoreSizeOnUnsnap rule wins, otherwise the global setting decides.
     const bool globalDefault = m_settings->restoreOriginalSizeOnUnsnap();
     if (!m_ruleStore) {
         return globalDefault;
@@ -525,7 +524,19 @@ bool WindowTrackingAdaptor::shouldRestoreSizeOnUnsnap(const QString& windowId)
     if (!m_ruleEvaluator) {
         m_ruleEvaluator = std::make_unique<PhosphorRules::RuleEvaluator>(m_ruleStore->ruleSet());
     }
-    const PhosphorRules::ResolvedActions resolved = m_ruleEvaluator->resolveCached(windowId, *query);
+    // Unlike the open-path resolvers above, this fires MID-SESSION on every unsnap
+    // (drag-out / drop / cursor-left-zones), long after the window opened. A fresh
+    // uncached resolve is required: resolveCached is keyed on (windowId, ruleSet
+    // revision) and returns the OPEN-TIME verdict on a hit, so a rule whose WHEN
+    // references a property the registry refreshes mid-session (VirtualDesktop /
+    // Activity, re-pushed on desktopsChanged / activitiesChanged) would resolve
+    // stale. resolve() honours the freshly built query and does not pollute the
+    // open-path cache. (Properties the effect does not re-push on a dedicated
+    // maximize / geometry change — e.g. IsMaximized / width — are only as fresh as
+    // the registry's last extended push, so resolve() reads that same value either
+    // way: neutral, not stale, for those; a strict improvement for the refreshed
+    // ones.)
+    const PhosphorRules::ResolvedActions resolved = m_ruleEvaluator->resolve(*query);
     if (const std::optional<PhosphorRules::RuleAction> action =
             resolved.slot(QString(PhosphorRules::ActionSlot::RestoreSizeOnUnsnap))) {
         return action->params.value(QString(PhosphorRules::ActionParam::Value)).toBool();

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -397,7 +397,14 @@ buildRuleQueryForWindow(const QPointer<PhosphorEngine::WindowRegistry>& registry
         return std::nullopt;
     }
     PhosphorRules::WindowQuery query;
-    query.appId = meta->appId;
+    // Engage appId only when known, matching the effect-side builder (window_query.cpp)
+    // and the sibling string fields below. Engaging an empty appId here would make a
+    // degenerate `AppId Equals ""` / negated-appId predicate resolve differently on the
+    // daemon open-path than on the effect live-path (WindowQuery::appId is optional, so
+    // an unknown appId must stay disengaged per the engage-only-when-known contract).
+    if (!meta->appId.isEmpty()) {
+        query.appId = meta->appId;
+    }
     if (!meta->title.isEmpty()) {
         query.title = meta->title;
     }

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -431,6 +431,8 @@ buildRuleQueryForWindow(const QPointer<PhosphorEngine::WindowRegistry>& registry
     query.isModal = meta->isModal;
     query.hasDecoration = meta->hasDecoration;
     query.isResizable = meta->isResizable;
+    query.isMovable = meta->isMovable;
+    query.isMaximizable = meta->isMaximizable;
     query.width = meta->width;
     query.height = meta->height;
     query.positionX = meta->positionX;

--- a/src/dbus/windowtrackingadaptor/enginewiring.cpp
+++ b/src/dbus/windowtrackingadaptor/enginewiring.cpp
@@ -173,12 +173,11 @@ void WindowTrackingAdaptor::setEngines(PhosphorEngine::PlacementEngineBase* snap
         // Managed (snapped-to-zone) restore gate. The snapped-to-zone analogue of
         // the floated-position predicate above: when the user disables
         // `restoreWindowsToZonesOnLogin`, a window that was snapped at logout is
-        // not auto-restored to its recorded zone on reopen. Settings-gated, so the
-        // engine stays settings-agnostic. windowId is unused today (the policy is a
-        // single global toggle) but keeps the signature aligned with the floated
-        // predicate for a future per-window override.
-        snap->setManagedRestorePredicate([this](const QString& /*windowId*/) -> bool {
-            return m_settings->restoreWindowsToZonesOnLogin();
+        // not auto-restored to its recorded zone on reopen. A matched
+        // SetRestoreToZoneOnLogin rule overrides that per window; otherwise the
+        // global setting decides. Engine stays settings-agnostic.
+        snap->setManagedRestorePredicate([this](const QString& windowId) -> bool {
+            return shouldRestoreToZoneOnLogin(windowId);
         });
 
         // Full-query exclusion provider. The snap engine owns the Exclude rule
@@ -474,6 +473,52 @@ bool WindowTrackingAdaptor::shouldRestoreFloatedPosition(const QString& windowId
     if (const std::optional<PhosphorRules::RuleAction> action =
             resolved.slot(QString(PhosphorRules::ActionSlot::RestorePosition))) {
         // A matched RestorePosition rule overrides the global setting.
+        return action->params.value(QString(PhosphorRules::ActionParam::Value)).toBool();
+    }
+    return globalDefault;
+}
+
+bool WindowTrackingAdaptor::shouldRestoreToZoneOnLogin(const QString& windowId)
+{
+    // Mirror shouldRestoreFloatedPosition for the snapped-to-zone policy: a matched
+    // SetRestoreToZoneOnLogin rule wins, otherwise the global setting decides.
+    const bool globalDefault = m_settings->restoreWindowsToZonesOnLogin();
+    if (!m_ruleStore) {
+        return globalDefault;
+    }
+    const std::optional<PhosphorRules::WindowQuery> query = buildRuleQueryForWindow(m_windowRegistry, windowId);
+    if (!query) {
+        return globalDefault;
+    }
+    if (!m_ruleEvaluator) {
+        m_ruleEvaluator = std::make_unique<PhosphorRules::RuleEvaluator>(m_ruleStore->ruleSet());
+    }
+    const PhosphorRules::ResolvedActions resolved = m_ruleEvaluator->resolveCached(windowId, *query);
+    if (const std::optional<PhosphorRules::RuleAction> action =
+            resolved.slot(QString(PhosphorRules::ActionSlot::RestoreToZoneOnLogin))) {
+        return action->params.value(QString(PhosphorRules::ActionParam::Value)).toBool();
+    }
+    return globalDefault;
+}
+
+bool WindowTrackingAdaptor::shouldRestoreSizeOnUnsnap(const QString& windowId)
+{
+    // Mirror shouldRestoreFloatedPosition for the restore-size-on-unsnap policy: a
+    // matched SetRestoreSizeOnUnsnap rule wins, otherwise the global setting decides.
+    const bool globalDefault = m_settings->restoreOriginalSizeOnUnsnap();
+    if (!m_ruleStore) {
+        return globalDefault;
+    }
+    const std::optional<PhosphorRules::WindowQuery> query = buildRuleQueryForWindow(m_windowRegistry, windowId);
+    if (!query) {
+        return globalDefault;
+    }
+    if (!m_ruleEvaluator) {
+        m_ruleEvaluator = std::make_unique<PhosphorRules::RuleEvaluator>(m_ruleStore->ruleSet());
+    }
+    const PhosphorRules::ResolvedActions resolved = m_ruleEvaluator->resolveCached(windowId, *query);
+    if (const std::optional<PhosphorRules::RuleAction> action =
+            resolved.slot(QString(PhosphorRules::ActionSlot::RestoreSizeOnUnsnap))) {
         return action->params.value(QString(PhosphorRules::ActionParam::Value)).toBool();
     }
     return globalDefault;

--- a/src/dbus/windowtrackingadaptor/float.cpp
+++ b/src/dbus/windowtrackingadaptor/float.cpp
@@ -40,8 +40,9 @@ void WindowTrackingAdaptor::notifyDragOutUnsnap(const QString& windowId)
     setWindowFloating(windowId, true);
 
     // Restore pre-snap size (not position — window stays where the user dropped it).
-    // This mirrors the activated-drag path in WindowDragAdaptor::dragStopped.
-    if (m_settings && m_settings->restoreOriginalSizeOnUnsnap()) {
+    // This mirrors the activated-drag path in WindowDragAdaptor::dragStopped. A
+    // matched SetRestoreSizeOnUnsnap rule overrides the global setting per window.
+    if (shouldRestoreSizeOnUnsnap(windowId)) {
         auto geo = m_service->validatedUnmanagedGeometry(windowId, screenId);
         if (geo) {
             Q_EMIT applyGeometryRequested(windowId, 0, 0, geo->width(), geo->height(), QString(), screenId, true);

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -125,15 +125,24 @@ ColumnLayout {
             return row._overlayShaderParamSchema;
         return [];
     }
+    /// The target algorithm id for a SetAlgorithmParam action, or "" otherwise.
+    /// A `string` property so its change signal fires only when the VALUE changes —
+    /// `_withParam` replaces the whole `row.action` object on every nested-param
+    /// write, so a binding reading `row.action.algorithm` directly would re-fire on
+    /// each write; routing the schema through this value-stable id keeps the params
+    /// editor from rebuilding its sliders mid-drag (matching the shader editor,
+    /// whose schema binding returns a cached-identity array).
+    readonly property string _algorithmParamAlgoId: (row.action.type === "setAlgorithmParam" && row.action.algorithm) ? row.action.algorithm : ""
     /// The custom-parameter schema for the SetAlgorithmParam action's currently
     /// selected algorithm — drives the inline algorithm-params editor below the
     /// row (the autotile analogue of _activeShaderParamSchema). Returns the
     /// Luau-declared param descriptors ({name, type, value, defaultValue,
     /// minValue, maxValue, enumOptions, description}); empty until an algorithm
-    /// is picked.
+    /// is picked. Depends only on _algorithmParamAlgoId (not row.action), so it
+    /// re-resolves on algorithm change, not on every param write.
     readonly property var _activeAlgorithmParamSchema: {
-        if (row.action.type === "setAlgorithmParam" && row.action.algorithm && row.appSettings && row.appSettings.tilingAlgorithmPage)
-            return row.appSettings.tilingAlgorithmPage.customParamsForAlgorithm(row.action.algorithm);
+        if (row._algorithmParamAlgoId.length > 0 && row.appSettings && row.appSettings.tilingAlgorithmPage)
+            return row.appSettings.tilingAlgorithmPage.customParamsForAlgorithm(row._algorithmParamAlgoId);
         return [];
     }
     /// Write one custom-param value into the action's nested `params` object
@@ -1112,7 +1121,7 @@ ColumnLayout {
                     SettingsSlider {
                         visible: modelData.type === "number"
                         Layout.preferredWidth: Kirigami.Units.gridUnit * 8
-                        Accessible.name: modelData.name
+                        Accessible.name: modelData.description ? modelData.description : modelData.name
                         from: parent._pMin
                         to: parent._pMax
                         stepSize: parent._pRange <= 1 ? 0.01 : (parent._pRange <= 10 ? 0.1 : 1)
@@ -1129,7 +1138,7 @@ ColumnLayout {
 
                     SettingsSwitch {
                         visible: modelData.type === "bool"
-                        accessibleName: modelData.name
+                        accessibleName: modelData.description ? modelData.description : modelData.name
                         checked: parent._pValue === true
                         onToggled: function (newValue) {
                             row._writeAlgorithmParam(modelData.name, newValue);
@@ -1139,13 +1148,22 @@ ColumnLayout {
                     WideComboBox {
                         visible: modelData.type === "enum"
                         Layout.preferredWidth: Kirigami.Units.gridUnit * 8
-                        Accessible.name: modelData.name
+                        Accessible.name: modelData.description ? modelData.description : modelData.name
                         model: modelData.enumOptions || []
                         currentIndex: {
+                            // -1 (not 0) when the stored value is out of vocabulary
+                            // (e.g. the algorithm's schema changed and dropped an
+                            // option), matching the sibling pickers (screen/activity/
+                            // layout/mode). Falling back to 0 would silently display a
+                            // different option than the rule holds until the user
+                            // touches the control.
                             var opts = modelData.enumOptions || [];
-                            var idx = opts.indexOf(parent._pValue);
-                            return idx >= 0 ? idx : 0;
+                            return opts.indexOf(parent._pValue);
                         }
+                        // On an out-of-vocab miss (currentIndex -1) surface the stored
+                        // raw value rather than a blank combo, matching the sibling
+                        // pickers' dangling-value fallback.
+                        displayText: currentIndex >= 0 ? currentText : (parent._pValue !== undefined ? String(parent._pValue) : "")
                         onActivated: row._writeAlgorithmParam(modelData.name, currentText)
                     }
                 }

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -129,7 +129,8 @@ ColumnLayout {
     /// selected algorithm — drives the inline algorithm-params editor below the
     /// row (the autotile analogue of _activeShaderParamSchema). Returns the
     /// Luau-declared param descriptors ({name, type, value, defaultValue,
-    /// minValue, maxValue, enumOptions}); empty until an algorithm is picked.
+    /// minValue, maxValue, enumOptions, description}); empty until an algorithm
+    /// is picked.
     readonly property var _activeAlgorithmParamSchema: {
         if (row.action.type === "setAlgorithmParam" && row.action.algorithm && row.appSettings && row.appSettings.tilingAlgorithmPage)
             return row.appSettings.tilingAlgorithmPage.customParamsForAlgorithm(row.action.algorithm);

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -125,6 +125,27 @@ ColumnLayout {
             return row._overlayShaderParamSchema;
         return [];
     }
+    /// The custom-parameter schema for the SetAlgorithmParam action's currently
+    /// selected algorithm — drives the inline algorithm-params editor below the
+    /// row (the autotile analogue of _activeShaderParamSchema). Returns the
+    /// Luau-declared param descriptors ({name, type, value, defaultValue,
+    /// minValue, maxValue, enumOptions}); empty until an algorithm is picked.
+    readonly property var _activeAlgorithmParamSchema: {
+        if (row.action.type === "setAlgorithmParam" && row.action.algorithm && row.appSettings && row.appSettings.tilingAlgorithmPage)
+            return row.appSettings.tilingAlgorithmPage.customParamsForAlgorithm(row.action.algorithm);
+        return [];
+    }
+    /// Write one custom-param value into the action's nested `params` object
+    /// (shallow-cloned so the binding re-triggers), mirroring the shader editor's
+    /// per-uniform write via _withParam("params", …).
+    function _writeAlgorithmParam(name, value) {
+        var next = {};
+        if (row.action.params)
+            for (var k in row.action.params)
+                next[k] = row.action.params[k];
+        next[name] = value;
+        row.actionEdited(row._withParam("params", next));
+    }
     /// Working-state lock map for the shader-params editor — mirrors the
     /// per-event animation editor's behaviour. Locks influence randomize
     /// (locked params are kept) but are NOT persisted to the rule, so a
@@ -185,6 +206,13 @@ ColumnLayout {
     // writes it back to `action.params`. Image picking is disabled because
     // shader-image uniforms aren't part of the rule wire format here.
     property Component _shaderParamsEditor
+    // Inline custom-parameter editor for SetAlgorithmParam — a Repeater over the
+    // algorithm's Luau-declared param schema (`_activeAlgorithmParamSchema`),
+    // rendering a slider / switch / combo per param type and writing each value
+    // into the action's nested `params` object via `_writeAlgorithmParam`. The
+    // autotile analogue of `_shaderParamsEditor`; mirrors the per-algorithm
+    // editor on the tiling settings page (TilingAlgorithmPage.qml).
+    property Component _algorithmParamsEditor
     // Toggle editor for `kind == "bool"` params (e.g. SetHideTitleBar /
     // SetBorderVisible / SetUsePerSideOuterGap / RestorePosition — dispatch is by
     // `kind`, not this list). Stores a JSON bool.
@@ -476,6 +504,20 @@ ColumnLayout {
         active: row._activeShaderParamSchema.length > 0
         visible: active
         sourceComponent: row._shaderParamsEditor
+    }
+
+    // ── Bottom: custom-parameter editor for SetAlgorithmParam ────────────────
+    // Surfaces when the action is `setAlgorithmParam`, the user has picked an
+    // algorithm, and that algorithm declares custom params. The autotile analogue
+    // of the shader-params editor above; a dedicated editor rather than the
+    // shader one because the schema shape (name / type / minValue / maxValue) and
+    // the number/bool/enum vocabulary differ.
+    Loader {
+        Layout.fillWidth: true
+        Layout.leftMargin: Kirigami.Units.iconSizes.small + Kirigami.Units.smallSpacing
+        active: row._activeAlgorithmParamSchema.length > 0
+        visible: active
+        sourceComponent: row._algorithmParamsEditor
     }
 
     _stringParamEditor: Component {
@@ -1027,6 +1069,85 @@ ColumnLayout {
                 // current value, the rest are rolled per their schema range.
                 var rolled = paramEditor.computeRandomized();
                 row.actionEdited(row._withParam("params", rolled));
+            }
+        }
+    }
+
+    _algorithmParamsEditor: Component {
+        ColumnLayout {
+            spacing: Kirigami.Units.smallSpacing
+
+            Repeater {
+                model: row._activeAlgorithmParamSchema
+
+                delegate: RowLayout {
+                    required property var modelData
+
+                    // Current value: the rule's stored override, else the
+                    // algorithm's saved/default value from the schema.
+                    readonly property var _pValue: {
+                        if (row.action.params && row.action.params[modelData.name] !== undefined)
+                            return row.action.params[modelData.name];
+                        return modelData.value !== undefined ? modelData.value : modelData.defaultValue;
+                    }
+                    readonly property real _pMin: modelData.minValue !== undefined ? modelData.minValue : 0
+                    readonly property real _pMax: {
+                        var mx = modelData.maxValue !== undefined ? modelData.maxValue : 1;
+                        return mx > _pMin ? mx : _pMin + 1; // guard degenerate range
+                    }
+                    readonly property real _pRange: _pMax - _pMin
+
+                    Layout.fillWidth: true
+                    spacing: Kirigami.Units.smallSpacing
+
+                    Label {
+                        text: modelData.description ? modelData.description : modelData.name
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                    }
+
+                    // Number → slider (fractional-range aware, mirroring the
+                    // per-algorithm editor on the tiling settings page).
+                    SettingsSlider {
+                        visible: modelData.type === "number"
+                        Layout.preferredWidth: Kirigami.Units.gridUnit * 8
+                        Accessible.name: modelData.name
+                        from: parent._pMin
+                        to: parent._pMax
+                        stepSize: parent._pRange <= 1 ? 0.01 : (parent._pRange <= 10 ? 0.1 : 1)
+                        value: parent._pValue
+                        formatValue: function (v) {
+                            if (parent._pRange <= 1)
+                                return Math.round(v * 100) + "%";
+                            if (parent._pRange <= 10)
+                                return v.toFixed(1);
+                            return Math.round(v).toString();
+                        }
+                        onMoved: value => row._writeAlgorithmParam(modelData.name, value)
+                    }
+
+                    SettingsSwitch {
+                        visible: modelData.type === "bool"
+                        accessibleName: modelData.name
+                        checked: parent._pValue === true
+                        onToggled: function (newValue) {
+                            row._writeAlgorithmParam(modelData.name, newValue);
+                        }
+                    }
+
+                    WideComboBox {
+                        visible: modelData.type === "enum"
+                        Layout.preferredWidth: Kirigami.Units.gridUnit * 8
+                        Accessible.name: modelData.name
+                        model: modelData.enumOptions || []
+                        currentIndex: {
+                            var opts = modelData.enumOptions || [];
+                            var idx = opts.indexOf(parent._pValue);
+                            return idx >= 0 ? idx : 0;
+                        }
+                        onActivated: row._writeAlgorithmParam(modelData.name, currentText)
+                    }
+                }
             }
         }
     }

--- a/src/settings/qml/MatchExpressionView.qml
+++ b/src/settings/qml/MatchExpressionView.qml
@@ -82,9 +82,10 @@ ColumnLayout {
         return opWire;
     }
 
-    /// Wire→valueKind helper for `_valueLabel`. Returns the controller-side
-    /// kind string ("string" / "number" / "bool" / "screen" / "activity") or
-    /// "string" for unknown fields — the safest default since `String(value)`
+    /// Wire→valueKind helper for `_valueLabel`. Returns the field's controller-side
+    /// kind string (any of the kinds MatchLeafEditor dispatches on: string, number,
+    /// bool, screen, activity, windowType, virtualDesktop, mode, orientation, layout)
+    /// or "string" for unknown fields — the safest default since `String(value)`
     /// is what a plain-string render would do anyway.
     function _valueKind(wire) {
         for (var i = 0; i < root.matchFieldOptions.length; ++i) {
@@ -99,6 +100,9 @@ ColumnLayout {
     ///   - bool → "On" / "Off" (i18n'd)
     ///   - screen → `appSettings.screens.displayLabel` for the matching name
     ///   - activity → `appSettings.activities.name` for the matching id
+    ///   - windowType → the enum option's label from the field entry
+    ///   - layout → `appSettings.layouts.displayName` for the matching id
+    ///   - mode / orientation → the token's option label from the field entry
     ///   - everything else (string, number) → `String(value)`
     /// Falls back to the raw wire value when a lookup misses (e.g. the
     /// rule references an unplugged monitor or removed activity), matching

--- a/src/settings/qml/MatchExpressionView.qml
+++ b/src/settings/qml/MatchExpressionView.qml
@@ -135,6 +135,15 @@ ColumnLayout {
                 }
             }
         }
+        if (kind === "layout" && root.appSettings) {
+            var layouts = root.appSettings.layouts;
+            if (layouts) {
+                for (var L = 0; L < layouts.length; ++L) {
+                    if (layouts[L].id === value)
+                        return layouts[L].displayName || String(value);
+                }
+            }
+        }
         if (kind === "windowType") {
             // The field entry's `options` carry the {value, label} pairs the
             // editor surfaces; reuse them so the read-only summary shows

--- a/src/settings/qml/MatchExpressionView.qml
+++ b/src/settings/qml/MatchExpressionView.qml
@@ -151,6 +151,22 @@ ColumnLayout {
                 break;
             }
         }
+        // Closed string-token dropdowns (Mode, Screen orientation) — resolve the
+        // token to its friendly label from the field entry's options, the same way
+        // windowType does, so the tree shows "Portrait" not the raw "portrait".
+        if (kind === "mode" || kind === "orientation") {
+            for (var m = 0; m < root.matchFieldOptions.length; ++m) {
+                var modeEntry = root.matchFieldOptions[m];
+                if (modeEntry.wire !== fieldWire)
+                    continue;
+                var modeOpts = modeEntry.options || [];
+                for (var mo = 0; mo < modeOpts.length; ++mo) {
+                    if (modeOpts[mo].value === value)
+                        return modeOpts[mo].label || String(value);
+                }
+                break;
+            }
+        }
         return String(value);
     }
 

--- a/src/settings/qml/MatchExpressionView.qml
+++ b/src/settings/qml/MatchExpressionView.qml
@@ -107,7 +107,7 @@ ColumnLayout {
     /// Falls back to the raw wire value when a lookup misses (e.g. the
     /// rule references an unplugged monitor or removed activity), matching
     /// the editor's dangling-pin fallback.
-    function _valueLabel(value, fieldWire) {
+    function _valueLabel(value, fieldWire, opWire) {
         if (value === undefined || value === null)
             return "";
 
@@ -183,8 +183,10 @@ ColumnLayout {
         // Virtual desktop — resolve the 1-based number to its name via
         // `appSettings.virtualDesktopNames` (0-indexed) so the tree shows "Work"
         // rather than the bare number, matching the editor picker and the collapsed
-        // rule-list summary. An out-of-range / unnamed desktop keeps the number.
-        if (kind === "virtualDesktop" && root.appSettings) {
+        // rule-list summary. Only for `equals` — under greaterThan/lessThan the value
+        // is a numeric threshold where a name reads as nonsense, so those keep the
+        // number. An out-of-range / unnamed desktop also keeps the number.
+        if (kind === "virtualDesktop" && opWire === "equals" && root.appSettings) {
             var names = root.appSettings.virtualDesktopNames || [];
             var idx = parseInt(value, 10) - 1;
             if (idx >= 0 && idx < names.length && names[idx])
@@ -594,7 +596,7 @@ ColumnLayout {
                             id: valueLabel
 
                             anchors.centerIn: parent
-                            text: root._valueLabel(delegate.value, delegate.fieldWire)
+                            text: root._valueLabel(delegate.value, delegate.fieldWire, delegate.opWire)
                             font.family: Kirigami.Theme.smallFont.family
                         }
                     }

--- a/src/settings/qml/MatchExpressionView.qml
+++ b/src/settings/qml/MatchExpressionView.qml
@@ -180,6 +180,16 @@ ColumnLayout {
                 break;
             }
         }
+        // Virtual desktop — resolve the 1-based number to its name via
+        // `appSettings.virtualDesktopNames` (0-indexed) so the tree shows "Work"
+        // rather than the bare number, matching the editor picker and the collapsed
+        // rule-list summary. An out-of-range / unnamed desktop keeps the number.
+        if (kind === "virtualDesktop" && root.appSettings) {
+            var names = root.appSettings.virtualDesktopNames || [];
+            var idx = parseInt(value, 10) - 1;
+            if (idx >= 0 && idx < names.length && names[idx])
+                return names[idx];
+        }
         return String(value);
     }
 

--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -320,6 +320,9 @@ RowLayout {
             if (leaf._valueKind === "mode")
                 return modeValueEditor;
 
+            if (leaf._valueKind === "orientation")
+                return orientationValueEditor;
+
             return stringValueEditor;
         }
     }
@@ -644,6 +647,42 @@ RowLayout {
                 return String(v);
             }
             Accessible.name: i18n("Placement mode")
+            onActivated: function (index) {
+                if (currentValue !== leaf.node.value)
+                    leaf._emit(leaf.node.field, leaf.node.op, currentValue);
+            }
+        }
+    }
+
+    Component {
+        id: orientationValueEditor
+
+        WideComboBox {
+            // Screen orientation is a string field whose value IS the wire token
+            // ("portrait" / "landscape"); the options carry {value, wire, label}
+            // triples, same shape as the mode editor above.
+            readonly property var _options: leaf._fieldEntry !== undefined ? (leaf._fieldEntry.options || []) : []
+
+            model: _options
+            textRole: "label"
+            valueRole: "value"
+            currentIndex: {
+                var target = leaf.node.value;
+                for (var i = 0; i < _options.length; ++i) {
+                    if (_options[i].value === target)
+                        return i;
+                }
+                return -1;
+            }
+            displayText: {
+                if (currentIndex >= 0)
+                    return currentText;
+                var v = leaf.node.value;
+                if (v === undefined || v === null || v === "")
+                    return i18n("Choose an orientation…");
+                return String(v);
+            }
+            Accessible.name: i18n("Screen orientation")
             onActivated: function (index) {
                 if (currentValue !== leaf.node.value)
                     leaf._emit(leaf.node.field, leaf.node.op, currentValue);

--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -323,6 +323,9 @@ RowLayout {
             if (leaf._valueKind === "orientation")
                 return orientationValueEditor;
 
+            if (leaf._valueKind === "layout")
+                return layoutValueEditor;
+
             return stringValueEditor;
         }
     }
@@ -683,6 +686,40 @@ RowLayout {
                 return String(v);
             }
             Accessible.name: i18n("Screen orientation")
+            onActivated: function (index) {
+                if (currentValue !== leaf.node.value)
+                    leaf._emit(leaf.node.field, leaf.node.op, currentValue);
+            }
+        }
+    }
+
+    Component {
+        id: layoutValueEditor
+
+        WideComboBox {
+            id: layoutCombo
+
+            // Picker over `appSettings.layouts` (snapping layouts and autotile
+            // entries); the wire value stays the layout id (snap UUID or
+            // "autotile:<algo>") so it matches the id the daemon resolves for the
+            // screen. Mirrors the activity picker.
+            readonly property var _layouts: leaf.appSettings ? leaf.appSettings.layouts : []
+
+            model: _layouts
+            textRole: "displayName"
+            valueRole: "id"
+            currentIndex: {
+                var target = leaf.node.value;
+                for (var i = 0; i < layoutCombo._layouts.length; ++i) {
+                    if (layoutCombo._layouts[i].id === target)
+                        return i;
+                }
+                return -1;
+            }
+            // Fall back to the raw id (e.g. a deleted layout) so the rule's pin
+            // stays visible even when no current layout matches.
+            displayText: currentIndex >= 0 ? currentText : (leaf.node.value || i18n("Choose a layout…"))
+            Accessible.name: i18n("Active layout")
             onActivated: function (index) {
                 if (currentValue !== leaf.node.value)
                     leaf._emit(leaf.node.field, leaf.node.op, currentValue);

--- a/src/settings/qml/RulesPage.qml
+++ b/src/settings/qml/RulesPage.qml
@@ -99,6 +99,10 @@ SettingsFlickable {
         // (the overlay/snapping shader catalog) for the overlayShader picker
         // editor (OverrideOverlayShader) and its read-only name resolution.
         readonly property var snappingShadersPage: settingsController.snappingShadersPage
+        // `TilingAlgorithmController` — exposes `customParamsForAlgorithm(id)` (the
+        // Luau-declared custom-param schema) for the SetAlgorithmParam inline
+        // params editor in ActionRow.
+        readonly property var tilingAlgorithmPage: settingsController.tilingAlgorithmPage
         // Reference to the page-level WindowPickerDialog — exposed via the
         // bridge so MatchLeafEditor can open the picker without having to
         // own its own instance. Hosting the picker inside the OverlaySheet

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -74,6 +74,8 @@ PickerCategory fieldCategory(Field f)
     case Field::IsSticky:
     case Field::HasDecoration:
     case Field::IsResizable:
+    case Field::IsMovable:
+    case Field::IsMaximizable:
         return {PhosphorI18n::tr("State"), 3};
     // NETWM "skip" hints — whether the window opts out of the taskbar, pager,
     // or Alt+Tab switcher.
@@ -97,6 +99,7 @@ PickerCategory fieldCategory(Field f)
     case Field::Activity:
     case Field::Mode:
     case Field::TiledWindowCount:
+    case Field::ScreenOrientation:
         return {PhosphorI18n::tr("Context"), 0};
     }
     return {PhosphorI18n::tr("Other"), 99};
@@ -157,6 +160,10 @@ QString fieldDescription(Field f)
         return PhosphorI18n::tr("Whether the window has a server-side title-bar and border.");
     case Field::IsResizable:
         return PhosphorI18n::tr("Whether the window can be resized.");
+    case Field::IsMovable:
+        return PhosphorI18n::tr("Whether the window can be moved.");
+    case Field::IsMaximizable:
+        return PhosphorI18n::tr("Whether the window can be maximized.");
     case Field::PositionX:
         return PhosphorI18n::tr("The window's left-edge X position in pixels.");
     case Field::PositionY:
@@ -185,6 +192,10 @@ QString fieldDescription(Field f)
             "How many windows are tiled on this monitor and desktop. Lets a rule switch the tiling algorithm as "
             "windows open and close, for example a centered single-window layout that gives way once a second window "
             "opens.");
+    case Field::ScreenOrientation:
+        return PhosphorI18n::tr(
+            "Whether the monitor is in portrait or landscape orientation. Lets a rule pick a different layout or "
+            "algorithm on a rotated screen.");
     }
     return QString();
 }
@@ -324,6 +335,31 @@ QString paramLabel(const QString& type, const QString& key)
     }
     if (type == ActionType::OverrideOverlayStyle && key == ActionParam::Value) {
         return PhosphorI18n::tr("Overlay style");
+    }
+    // Context overlay-appearance overrides (all single-value, keyed ActionParam::Value).
+    if (type == ActionType::SetOverlayHighlightColor && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Highlight color");
+    }
+    if (type == ActionType::SetOverlayInactiveColor && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Inactive zone color");
+    }
+    if (type == ActionType::SetOverlayBorderColor && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Border color");
+    }
+    if (type == ActionType::SetOverlayActiveOpacity && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Active opacity (%)");
+    }
+    if (type == ActionType::SetOverlayInactiveOpacity && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Inactive opacity (%)");
+    }
+    if (type == ActionType::SetOverlayBorderWidth && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Border width (px)");
+    }
+    if (type == ActionType::SetOverlayBorderRadius && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Corner radius (px)");
+    }
+    if (type == ActionType::SetOverlayShowZoneNumbers && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Show zone numbers (off = hide)");
     }
     if (type == ActionType::RouteToScreen && key == ActionParam::TargetScreenId) {
         return PhosphorI18n::tr("Monitor");
@@ -508,6 +544,30 @@ QString actionTypeLabelImpl(const QString& type)
     if (type == ActionType::OverrideOverlayStyle) {
         return PhosphorI18n::tr("Set overlay style");
     }
+    if (type == ActionType::SetOverlayHighlightColor) {
+        return PhosphorI18n::tr("Set overlay highlight color");
+    }
+    if (type == ActionType::SetOverlayInactiveColor) {
+        return PhosphorI18n::tr("Set overlay inactive color");
+    }
+    if (type == ActionType::SetOverlayBorderColor) {
+        return PhosphorI18n::tr("Set overlay border color");
+    }
+    if (type == ActionType::SetOverlayActiveOpacity) {
+        return PhosphorI18n::tr("Set overlay active opacity");
+    }
+    if (type == ActionType::SetOverlayInactiveOpacity) {
+        return PhosphorI18n::tr("Set overlay inactive opacity");
+    }
+    if (type == ActionType::SetOverlayBorderWidth) {
+        return PhosphorI18n::tr("Set overlay border width");
+    }
+    if (type == ActionType::SetOverlayBorderRadius) {
+        return PhosphorI18n::tr("Set overlay corner radius");
+    }
+    if (type == ActionType::SetOverlayShowZoneNumbers) {
+        return PhosphorI18n::tr("Show zone numbers");
+    }
     if (type == ActionType::ExcludeAnimations) {
         return PhosphorI18n::tr("Exclude from animations");
     }
@@ -612,6 +672,9 @@ QString boolActionStateLabel(const QString& type, bool on)
     }
     if (type == ActionType::SetUsePerSideOuterGap) {
         return on ? PhosphorI18n::tr("Per-side outer gaps") : PhosphorI18n::tr("Uniform outer gap");
+    }
+    if (type == ActionType::SetOverlayShowZoneNumbers) {
+        return on ? PhosphorI18n::tr("Show zone numbers") : PhosphorI18n::tr("Hide zone numbers");
     }
     return QString();
 }
@@ -736,6 +799,30 @@ QVariantList matchFields()
                 {QLatin1StringView("tiling"), PhosphorI18n::tr("Tiling")},
             });
             for (const auto& opt : kModes) {
+                QVariantMap option;
+                const QString wire = QString(opt.wire);
+                option[QStringLiteral("value")] = wire;
+                option[QStringLiteral("wire")] = wire;
+                option[QStringLiteral("label")] = opt.label;
+                options.append(option);
+            }
+            entry[QStringLiteral("options")] = options;
+        } else if (f == Field::ScreenOrientation) {
+            // String-valued on the wire (the orientation token), closed vocabulary
+            // — a dropdown of the friendly tokens, same shape as Mode. The value IS
+            // the wire token ("portrait" / "landscape").
+            kind = QStringLiteral("orientation");
+            QVariantList options;
+            struct OrientationEntry
+            {
+                QLatin1StringView wire;
+                QString label;
+            };
+            const std::array kOrientations = std::to_array<OrientationEntry>({
+                {QLatin1StringView("landscape"), PhosphorI18n::tr("Landscape")},
+                {QLatin1StringView("portrait"), PhosphorI18n::tr("Portrait")},
+            });
+            for (const auto& opt : kOrientations) {
                 QVariantMap option;
                 const QString wire = QString(opt.wire);
                 option[QStringLiteral("value")] = wire;
@@ -947,11 +1034,16 @@ QVariantMap defaultPayloadFor(const QString& typeWire)
             payload[key] = defaultDisplay.isValid() ? QVariant(defaultDisplay.toBool()) : QVariant(false);
         } else if (kind == QLatin1String("color")) {
             // Colour kind has no numeric `defaultDisplay` (that field is a
-            // double); seed the accent sentinel so a fresh border-colour rule
-            // (SetBorderColorActive / SetBorderColorInactive) passes the
-            // validator and follows the system accent until the user picks a
-            // concrete colour.
-            payload[key] = QString(PhosphorRules::BorderColorToken::Accent);
+            // double). The border-colour actions seed the accent sentinel so a
+            // fresh rule follows the system accent until the user picks a colour.
+            // The overlay-colour actions have NO accent concept (their consumer
+            // resolves no token — validator is plain hex), so seed a concrete
+            // hex (the Plasma default blue, matching the colour picker's own
+            // empty-value fallback) that passes `hasHexColor`.
+            const bool isBorderColor = typeWire == QString(PhosphorRules::ActionType::SetBorderColorActive)
+                || typeWire == QString(PhosphorRules::ActionType::SetBorderColorInactive);
+            payload[key] =
+                isBorderColor ? QString(PhosphorRules::BorderColorToken::Accent) : QStringLiteral("#FF3DAEE9");
         } else if (kind == QLatin1String("zoneOrdinals")) {
             // Seed a valid single-zone default ([1]) so a fresh SnapToZone rule
             // passes the validator (non-empty array of positive ordinals) before

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -275,6 +275,12 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::RestorePosition && key == ActionParam::Value) {
         return PhosphorI18n::tr("Restore position on login (off = don't restore)");
     }
+    if (type == ActionType::SetRestoreToZoneOnLogin && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Restore to zone on login (off = don't restore)");
+    }
+    if (type == ActionType::SetRestoreSizeOnUnsnap && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Restore size on unsnap (off = keep zone size)");
+    }
     // Border / title-bar overrides (all single-value, keyed ActionParam::Value).
     // SetHideTitleBar is tri-state at the effect: rule absent = mode decides,
     // ON = hide, OFF = force the title bar visible even where the mode hides
@@ -531,6 +537,12 @@ QString actionTypeLabelImpl(const QString& type)
     if (type == ActionType::RestorePosition) {
         return PhosphorI18n::tr("Restore position on login");
     }
+    if (type == ActionType::SetRestoreToZoneOnLogin) {
+        return PhosphorI18n::tr("Restore to zone on login");
+    }
+    if (type == ActionType::SetRestoreSizeOnUnsnap) {
+        return PhosphorI18n::tr("Restore size on unsnap");
+    }
     if (type == ActionType::OverrideAnimationShader) {
         return PhosphorI18n::tr("Override animation shader");
     }
@@ -662,6 +674,12 @@ QString boolActionStateLabel(const QString& type, bool on)
     namespace ActionType = PhosphorRules::ActionType;
     if (type == ActionType::RestorePosition) {
         return on ? PhosphorI18n::tr("Restore position on login") : PhosphorI18n::tr("Don't restore position on login");
+    }
+    if (type == ActionType::SetRestoreToZoneOnLogin) {
+        return on ? PhosphorI18n::tr("Restore to zone on login") : PhosphorI18n::tr("Don't restore to zone on login");
+    }
+    if (type == ActionType::SetRestoreSizeOnUnsnap) {
+        return on ? PhosphorI18n::tr("Restore size on unsnap") : PhosphorI18n::tr("Keep zone size on unsnap");
     }
     if (type == ActionType::SetHideTitleBar) {
         return on ? PhosphorI18n::tr("Hide title bars") : PhosphorI18n::tr("Show title bars");

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -431,61 +431,6 @@ QString paramHint(const QString& type, const QString& key)
     return {};
 }
 
-/// Translated label for one enum wire value on action @p type, param @p key.
-/// Mirrors paramLabel — structural enum membership lives on the descriptor;
-/// the human-facing label is per `(type, key, wireValue)`.
-QString enumOptionLabel(const QString& type, const QString& key, const QString& wireValue)
-{
-    namespace ActionParam = PhosphorRules::ActionParam;
-    if ((type == ActionType::SetEngineMode || type == ActionType::DisableEngine) && key == ActionParam::Mode) {
-        if (wireValue == QLatin1String("snapping")) {
-            return PhosphorI18n::tr("Snapping");
-        }
-        if (wireValue == QLatin1String("autotile")) {
-            return PhosphorI18n::tr("Autotile");
-        }
-        if (wireValue == QLatin1String("scrolling")) {
-            return PhosphorI18n::tr("Scrolling");
-        }
-    }
-    if (type == ActionType::OverrideOverlayStyle && key == ActionParam::Value) {
-        if (wireValue == PhosphorRules::OverlayStyleToken::Rectangles) {
-            return PhosphorI18n::tr("Zone rectangles");
-        }
-        if (wireValue == PhosphorRules::OverlayStyleToken::Preview) {
-            return PhosphorI18n::tr("Layout preview");
-        }
-    }
-    if (type == ActionType::SetInsertPosition && key == ActionParam::Value) {
-        if (wireValue == PhosphorRules::InsertPositionToken::End) {
-            return PhosphorI18n::tr("End of stack");
-        }
-        if (wireValue == PhosphorRules::InsertPositionToken::AfterFocused) {
-            return PhosphorI18n::tr("After focused window");
-        }
-        if (wireValue == PhosphorRules::InsertPositionToken::AsMaster) {
-            return PhosphorI18n::tr("As master");
-        }
-    }
-    if (type == ActionType::SetOverflowBehavior && key == ActionParam::Value) {
-        if (wireValue == PhosphorRules::OverflowBehaviorToken::Float) {
-            return PhosphorI18n::tr("Float overflow windows");
-        }
-        if (wireValue == PhosphorRules::OverflowBehaviorToken::Unlimited) {
-            return PhosphorI18n::tr("Unlimited (no cap)");
-        }
-    }
-    if (type == ActionType::SetDragBehavior && key == ActionParam::Value) {
-        if (wireValue == PhosphorRules::DragBehaviorToken::Float) {
-            return PhosphorI18n::tr("Float on drag");
-        }
-        if (wireValue == PhosphorRules::DragBehaviorToken::Reorder) {
-            return PhosphorI18n::tr("Reorder in stack");
-        }
-    }
-    return wireValue;
-}
-
 /// The parameter schema for @p type, derived from the LGPL ActionDescriptor's
 /// structural `params` and supplemented by GPL-side translated labels. The
 /// QML editor's per-param Loader dispatches on `kind`, so the wire shape
@@ -737,6 +682,58 @@ QString operatorLabelImpl(Operator op)
 }
 
 } // namespace
+
+QString enumOptionLabel(const QString& type, const QString& key, const QString& wireValue)
+{
+    namespace ActionParam = PhosphorRules::ActionParam;
+    if ((type == ActionType::SetEngineMode || type == ActionType::DisableEngine) && key == ActionParam::Mode) {
+        if (wireValue == QLatin1String("snapping")) {
+            return PhosphorI18n::tr("Snapping");
+        }
+        if (wireValue == QLatin1String("autotile")) {
+            return PhosphorI18n::tr("Autotile");
+        }
+        if (wireValue == QLatin1String("scrolling")) {
+            return PhosphorI18n::tr("Scrolling");
+        }
+    }
+    if (type == ActionType::OverrideOverlayStyle && key == ActionParam::Value) {
+        if (wireValue == PhosphorRules::OverlayStyleToken::Rectangles) {
+            return PhosphorI18n::tr("Zone rectangles");
+        }
+        if (wireValue == PhosphorRules::OverlayStyleToken::Preview) {
+            return PhosphorI18n::tr("Layout preview");
+        }
+    }
+    if (type == ActionType::SetInsertPosition && key == ActionParam::Value) {
+        if (wireValue == PhosphorRules::InsertPositionToken::End) {
+            return PhosphorI18n::tr("End of stack");
+        }
+        if (wireValue == PhosphorRules::InsertPositionToken::AfterFocused) {
+            return PhosphorI18n::tr("After focused window");
+        }
+        if (wireValue == PhosphorRules::InsertPositionToken::AsMaster) {
+            return PhosphorI18n::tr("As master");
+        }
+    }
+    if (type == ActionType::SetOverflowBehavior && key == ActionParam::Value) {
+        if (wireValue == PhosphorRules::OverflowBehaviorToken::Float) {
+            return PhosphorI18n::tr("Float overflow windows");
+        }
+        if (wireValue == PhosphorRules::OverflowBehaviorToken::Unlimited) {
+            return PhosphorI18n::tr("Unlimited (no cap)");
+        }
+    }
+    if (type == ActionType::SetDragBehavior && key == ActionParam::Value) {
+        if (wireValue == PhosphorRules::DragBehaviorToken::Float) {
+            return PhosphorI18n::tr("Float on drag");
+        }
+        if (wireValue == PhosphorRules::DragBehaviorToken::Reorder) {
+            return PhosphorI18n::tr("Reorder in stack");
+        }
+    }
+    return wireValue;
+}
 
 QString boolActionStateLabel(const QString& type, bool on)
 {

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -271,6 +271,9 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::SetInsertPosition && key == ActionParam::Value) {
         return PhosphorI18n::tr("Insert position");
     }
+    if (type == ActionType::SetOverflowBehavior && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Overflow behavior");
+    }
     if (type == ActionType::DisableEngine && key == ActionParam::Mode) {
         return PhosphorI18n::tr("Engine to disable");
     }
@@ -458,6 +461,14 @@ QString enumOptionLabel(const QString& type, const QString& key, const QString& 
             return PhosphorI18n::tr("As master");
         }
     }
+    if (type == ActionType::SetOverflowBehavior && key == ActionParam::Value) {
+        if (wireValue == PhosphorRules::OverflowBehaviorToken::Float) {
+            return PhosphorI18n::tr("Float overflow windows");
+        }
+        if (wireValue == PhosphorRules::OverflowBehaviorToken::Unlimited) {
+            return PhosphorI18n::tr("Unlimited (no cap)");
+        }
+    }
     return wireValue;
 }
 
@@ -550,6 +561,9 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::SetInsertPosition) {
         return PhosphorI18n::tr("Set insert position");
+    }
+    if (type == ActionType::SetOverflowBehavior) {
+        return PhosphorI18n::tr("Set overflow behavior");
     }
     if (type == ActionType::DisableEngine) {
         return PhosphorI18n::tr("Disable engine");

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -268,6 +268,9 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::SetMasterCount && key == ActionParam::Value) {
         return PhosphorI18n::tr("Master count");
     }
+    if (type == ActionType::SetInsertPosition && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Insert position");
+    }
     if (type == ActionType::DisableEngine && key == ActionParam::Mode) {
         return PhosphorI18n::tr("Engine to disable");
     }
@@ -444,6 +447,17 @@ QString enumOptionLabel(const QString& type, const QString& key, const QString& 
             return PhosphorI18n::tr("Layout preview");
         }
     }
+    if (type == ActionType::SetInsertPosition && key == ActionParam::Value) {
+        if (wireValue == PhosphorRules::InsertPositionToken::End) {
+            return PhosphorI18n::tr("End of stack");
+        }
+        if (wireValue == PhosphorRules::InsertPositionToken::AfterFocused) {
+            return PhosphorI18n::tr("After focused window");
+        }
+        if (wireValue == PhosphorRules::InsertPositionToken::AsMaster) {
+            return PhosphorI18n::tr("As master");
+        }
+    }
     return wireValue;
 }
 
@@ -533,6 +547,9 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::SetMasterCount) {
         return PhosphorI18n::tr("Set master count");
+    }
+    if (type == ActionType::SetInsertPosition) {
+        return PhosphorI18n::tr("Set insert position");
     }
     if (type == ActionType::DisableEngine) {
         return PhosphorI18n::tr("Disable engine");

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -259,6 +259,15 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::SetTilingAlgorithm && key == ActionParam::Algorithm) {
         return PhosphorI18n::tr("Tiling algorithm");
     }
+    if (type == ActionType::SetMaxWindows && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Max tiled windows");
+    }
+    if (type == ActionType::SetSplitRatio && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Split ratio (%)");
+    }
+    if (type == ActionType::SetMasterCount && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Master count");
+    }
     if (type == ActionType::DisableEngine && key == ActionParam::Mode) {
         return PhosphorI18n::tr("Engine to disable");
     }
@@ -515,6 +524,15 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::SetTilingAlgorithm) {
         return PhosphorI18n::tr("Set tiling algorithm");
+    }
+    if (type == ActionType::SetMaxWindows) {
+        return PhosphorI18n::tr("Set max tiled windows");
+    }
+    if (type == ActionType::SetSplitRatio) {
+        return PhosphorI18n::tr("Set split ratio");
+    }
+    if (type == ActionType::SetMasterCount) {
+        return PhosphorI18n::tr("Set master count");
     }
     if (type == ActionType::DisableEngine) {
         return PhosphorI18n::tr("Disable engine");

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -259,6 +259,9 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::SetTilingAlgorithm && key == ActionParam::Algorithm) {
         return PhosphorI18n::tr("Tiling algorithm");
     }
+    if (type == ActionType::SetAlgorithmParam && key == ActionParam::Algorithm) {
+        return PhosphorI18n::tr("Algorithm");
+    }
     if (type == ActionType::SetMaxWindows && key == ActionParam::Value) {
         return PhosphorI18n::tr("Max tiled windows");
     }
@@ -578,6 +581,9 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::SetDragBehavior) {
         return PhosphorI18n::tr("Set drag behavior");
+    }
+    if (type == ActionType::SetAlgorithmParam) {
+        return PhosphorI18n::tr("Set algorithm parameter");
     }
     if (type == ActionType::DisableEngine) {
         return PhosphorI18n::tr("Disable engine");

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -274,6 +274,9 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::SetOverflowBehavior && key == ActionParam::Value) {
         return PhosphorI18n::tr("Overflow behavior");
     }
+    if (type == ActionType::SetDragBehavior && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Drag behavior");
+    }
     if (type == ActionType::DisableEngine && key == ActionParam::Mode) {
         return PhosphorI18n::tr("Engine to disable");
     }
@@ -469,6 +472,14 @@ QString enumOptionLabel(const QString& type, const QString& key, const QString& 
             return PhosphorI18n::tr("Unlimited (no cap)");
         }
     }
+    if (type == ActionType::SetDragBehavior && key == ActionParam::Value) {
+        if (wireValue == PhosphorRules::DragBehaviorToken::Float) {
+            return PhosphorI18n::tr("Float on drag");
+        }
+        if (wireValue == PhosphorRules::DragBehaviorToken::Reorder) {
+            return PhosphorI18n::tr("Reorder in stack");
+        }
+    }
     return wireValue;
 }
 
@@ -564,6 +575,9 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::SetOverflowBehavior) {
         return PhosphorI18n::tr("Set overflow behavior");
+    }
+    if (type == ActionType::SetDragBehavior) {
+        return PhosphorI18n::tr("Set drag behavior");
     }
     if (type == ActionType::DisableEngine) {
         return PhosphorI18n::tr("Disable engine");

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -100,6 +100,7 @@ PickerCategory fieldCategory(Field f)
     case Field::Mode:
     case Field::TiledWindowCount:
     case Field::ScreenOrientation:
+    case Field::ActiveLayout:
         return {PhosphorI18n::tr("Context"), 0};
     }
     return {PhosphorI18n::tr("Other"), 99};
@@ -196,6 +197,10 @@ QString fieldDescription(Field f)
         return PhosphorI18n::tr(
             "Whether the monitor is in portrait or landscape orientation. Lets a rule pick a different layout or "
             "algorithm on a rotated screen.");
+    case Field::ActiveLayout:
+        return PhosphorI18n::tr(
+            "The layout currently active on the monitor. Lets a rule change gaps, the overlay or the lock state for "
+            "the screen showing a given layout. It cannot change which layout is assigned (that would be circular).");
     }
     return QString();
 }
@@ -831,6 +836,12 @@ QVariantList matchFields()
                 options.append(option);
             }
             entry[QStringLiteral("options")] = options;
+        } else if (f == Field::ActiveLayout) {
+            // The value is a layout id (snap UUID or "autotile:<algo>"). The QML
+            // editor swaps this for a layout-picker ComboBox driven by
+            // `settingsController.layouts` (like the screen / activity pickers), so
+            // the user picks a friendly name while the wire value stays the id.
+            kind = QStringLiteral("layout");
         }
         entry[QStringLiteral("valueKind")] = kind;
         out.append(entry);

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -681,7 +681,60 @@ QString operatorLabelImpl(Operator op)
     return PhosphorRules::operatorToString(op);
 }
 
+/// Single source of truth for WindowType → { int value, wire token, display label },
+/// shared by matchFields() (the editor dropdown options) and windowTypeLabel() (the
+/// collapsed rule-list summary). Order mirrors WindowTypeEnum.h — Unknown first as
+/// the safe default, then Normal as the most common authoring choice.
+struct WindowTypeOption
+{
+    int value;
+    QString wire;
+    QString label;
+};
+QList<WindowTypeOption> windowTypeOptions()
+{
+    struct Entry
+    {
+        PhosphorProtocol::WindowType type;
+        QString label;
+    };
+    // CTAD deduces the array size from the brace-list, so a new enum value can't
+    // silently drop the trailing entry by mismatching a hardcoded size.
+    const std::array entries = std::to_array<Entry>({
+        {PhosphorProtocol::WindowType::Unknown, PhosphorI18n::tr("Unknown")},
+        {PhosphorProtocol::WindowType::Normal, PhosphorI18n::tr("Normal window")},
+        {PhosphorProtocol::WindowType::Dialog, PhosphorI18n::tr("Dialog")},
+        {PhosphorProtocol::WindowType::Utility, PhosphorI18n::tr("Utility")},
+        {PhosphorProtocol::WindowType::Toolbar, PhosphorI18n::tr("Toolbar")},
+        {PhosphorProtocol::WindowType::Splash, PhosphorI18n::tr("Splash screen")},
+        {PhosphorProtocol::WindowType::Menu, PhosphorI18n::tr("Menu")},
+        {PhosphorProtocol::WindowType::Tooltip, PhosphorI18n::tr("Tooltip")},
+        {PhosphorProtocol::WindowType::Notification, PhosphorI18n::tr("Notification")},
+        {PhosphorProtocol::WindowType::Dock, PhosphorI18n::tr("Dock / panel")},
+        {PhosphorProtocol::WindowType::Desktop, PhosphorI18n::tr("Desktop")},
+        {PhosphorProtocol::WindowType::OnScreenDisplay, PhosphorI18n::tr("On-screen display")},
+        {PhosphorProtocol::WindowType::Popup, PhosphorI18n::tr("Popup")},
+    });
+    QList<WindowTypeOption> out;
+    out.reserve(static_cast<int>(entries.size()));
+    for (const auto& e : entries) {
+        out.append({static_cast<int>(e.type), PhosphorProtocol::windowTypeToString(e.type), e.label});
+    }
+    return out;
+}
+
 } // namespace
+
+QString windowTypeLabel(int windowTypeValue)
+{
+    for (const WindowTypeOption& opt : windowTypeOptions()) {
+        if (opt.value == windowTypeValue) {
+            return opt.label;
+        }
+    }
+    // Unknown value (hand-edited rule): show the raw int rather than a blank.
+    return QString::number(windowTypeValue);
+}
 
 QString enumOptionLabel(const QString& type, const QString& key, const QString& wireValue)
 {
@@ -813,38 +866,17 @@ QVariantList matchFields()
             // each value meant ("2" — Dialog? Utility?). Surface the
             // friendly token instead via a dedicated kind that the
             // editor renders as a dropdown.
+            // WindowType is stored as the int underlying the
+            // PhosphorProtocol::WindowType enum on the wire. A plain "number" SpinBox
+            // left users with no idea what each value meant ("2" — Dialog? Utility?),
+            // so a dedicated kind renders a dropdown. Options come from the single-source
+            // windowTypeOptions() table (also used by the collapsed-summary label).
             kind = QStringLiteral("windowType");
             QVariantList options;
-            // Order mirrors the enum declaration in WindowTypeEnum.h —
-            // Unknown first as the safe default, then Normal as the
-            // most common authoring choice.
-            struct WindowTypeEntry
-            {
-                PhosphorProtocol::WindowType type;
-                QString label;
-            };
-            // Use CTAD so the array size is deduced from the brace-list
-            // — adding a new WindowType enum value here can't silently
-            // drop the trailing entry by mismatching a hardcoded size.
-            const std::array kWindowTypes = std::to_array<WindowTypeEntry>({
-                {PhosphorProtocol::WindowType::Unknown, PhosphorI18n::tr("Unknown")},
-                {PhosphorProtocol::WindowType::Normal, PhosphorI18n::tr("Normal window")},
-                {PhosphorProtocol::WindowType::Dialog, PhosphorI18n::tr("Dialog")},
-                {PhosphorProtocol::WindowType::Utility, PhosphorI18n::tr("Utility")},
-                {PhosphorProtocol::WindowType::Toolbar, PhosphorI18n::tr("Toolbar")},
-                {PhosphorProtocol::WindowType::Splash, PhosphorI18n::tr("Splash screen")},
-                {PhosphorProtocol::WindowType::Menu, PhosphorI18n::tr("Menu")},
-                {PhosphorProtocol::WindowType::Tooltip, PhosphorI18n::tr("Tooltip")},
-                {PhosphorProtocol::WindowType::Notification, PhosphorI18n::tr("Notification")},
-                {PhosphorProtocol::WindowType::Dock, PhosphorI18n::tr("Dock / panel")},
-                {PhosphorProtocol::WindowType::Desktop, PhosphorI18n::tr("Desktop")},
-                {PhosphorProtocol::WindowType::OnScreenDisplay, PhosphorI18n::tr("On-screen display")},
-                {PhosphorProtocol::WindowType::Popup, PhosphorI18n::tr("Popup")},
-            });
-            for (const auto& opt : kWindowTypes) {
+            for (const WindowTypeOption& opt : windowTypeOptions()) {
                 QVariantMap option;
-                option[QStringLiteral("value")] = static_cast<int>(opt.type);
-                option[QStringLiteral("wire")] = PhosphorProtocol::windowTypeToString(opt.type);
+                option[QStringLiteral("value")] = opt.value;
+                option[QStringLiteral("wire")] = opt.wire;
                 option[QStringLiteral("label")] = opt.label;
                 options.append(option);
             }

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -945,10 +945,12 @@ QVariantList operatorsForField(int fieldValue)
     }
     const Field field = static_cast<Field>(fieldValue);
     QList<Operator> ops;
-    if (field == Field::Mode) {
-        // Mode is string-valued but its vocabulary is a closed dropdown — only
-        // an exact-token Equals is meaningful (a substring / regex against a
-        // three-token set is a footgun). Mirrors the WindowType enum treatment.
+    if (field == Field::Mode || field == Field::ScreenOrientation || field == Field::ActiveLayout) {
+        // These are string-valued but their vocabulary is a closed single-select
+        // dropdown (placement mode, portrait/landscape, a concrete layout id) — only
+        // an exact-token Equals is meaningful. A substring / regex against a closed
+        // token set (or a layout UUID) is a footgun the picker cannot author
+        // sensibly. Mirrors the WindowType enum treatment.
         ops = {Operator::Equals};
     } else if (PhosphorRules::fieldIsString(field)) {
         ops = {Operator::Equals, Operator::Contains, Operator::StartsWith, Operator::EndsWith, Operator::Regex};

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -723,6 +723,36 @@ QList<WindowTypeOption> windowTypeOptions()
     return out;
 }
 
+/// Single source for the closed Mode / ScreenOrientation token vocabularies (the
+/// stored value IS the wire token), shared by matchFields() (the editor dropdown
+/// options) and modeLabel() / orientationLabel() (the collapsed rule-list summary),
+/// so the picker and the summary can never drift.
+struct ClosedTokenOption
+{
+    QString wire;
+    QString label;
+};
+QList<ClosedTokenOption> modeOptions()
+{
+    return {{QStringLiteral("snapping"), PhosphorI18n::tr("Snapping")},
+            {QStringLiteral("tiling"), PhosphorI18n::tr("Tiling")}};
+}
+QList<ClosedTokenOption> orientationOptions()
+{
+    return {{QStringLiteral("landscape"), PhosphorI18n::tr("Landscape")},
+            {QStringLiteral("portrait"), PhosphorI18n::tr("Portrait")}};
+}
+QString closedTokenLabel(const QList<ClosedTokenOption>& opts, const QString& token)
+{
+    for (const ClosedTokenOption& o : opts) {
+        if (o.wire == token) {
+            return o.label;
+        }
+    }
+    // Unknown token (hand-edited rule): round-trip verbatim.
+    return token;
+}
+
 } // namespace
 
 QString windowTypeLabel(int windowTypeValue)
@@ -734,6 +764,16 @@ QString windowTypeLabel(int windowTypeValue)
     }
     // Unknown value (hand-edited rule): show the raw int rather than a blank.
     return QString::number(windowTypeValue);
+}
+
+QString modeLabel(const QString& modeToken)
+{
+    return closedTokenLabel(modeOptions(), modeToken);
+}
+
+QString orientationLabel(const QString& orientationToken)
+{
+    return closedTokenLabel(orientationOptions(), orientationToken);
 }
 
 QString enumOptionLabel(const QString& type, const QString& key, const QString& wireValue)
@@ -861,12 +901,6 @@ QVariantList matchFields()
         QString kind = QStringLiteral("string");
         if (f == Field::WindowType) {
             // WindowType is stored as the int underlying the
-            // PhosphorProtocol::WindowType enum on the wire. Rendering it
-            // as a plain "number" SpinBox left users with no idea what
-            // each value meant ("2" — Dialog? Utility?). Surface the
-            // friendly token instead via a dedicated kind that the
-            // editor renders as a dropdown.
-            // WindowType is stored as the int underlying the
             // PhosphorProtocol::WindowType enum on the wire. A plain "number" SpinBox
             // left users with no idea what each value meant ("2" — Dialog? Utility?),
             // so a dedicated kind renders a dropdown. Options come from the single-source
@@ -910,20 +944,10 @@ QVariantList matchFields()
             // verbatim).
             kind = QStringLiteral("mode");
             QVariantList options;
-            struct ModeEntry
-            {
-                QLatin1StringView wire;
-                QString label;
-            };
-            const std::array kModes = std::to_array<ModeEntry>({
-                {QLatin1StringView("snapping"), PhosphorI18n::tr("Snapping")},
-                {QLatin1StringView("tiling"), PhosphorI18n::tr("Tiling")},
-            });
-            for (const auto& opt : kModes) {
+            for (const ClosedTokenOption& opt : modeOptions()) {
                 QVariantMap option;
-                const QString wire = QString(opt.wire);
-                option[QStringLiteral("value")] = wire;
-                option[QStringLiteral("wire")] = wire;
+                option[QStringLiteral("value")] = opt.wire;
+                option[QStringLiteral("wire")] = opt.wire;
                 option[QStringLiteral("label")] = opt.label;
                 options.append(option);
             }
@@ -931,23 +955,14 @@ QVariantList matchFields()
         } else if (f == Field::ScreenOrientation) {
             // String-valued on the wire (the orientation token), closed vocabulary
             // — a dropdown of the friendly tokens, same shape as Mode. The value IS
-            // the wire token ("portrait" / "landscape").
+            // the wire token ("portrait" / "landscape"). Options come from the
+            // single-source orientationOptions() table (also used by the summary).
             kind = QStringLiteral("orientation");
             QVariantList options;
-            struct OrientationEntry
-            {
-                QLatin1StringView wire;
-                QString label;
-            };
-            const std::array kOrientations = std::to_array<OrientationEntry>({
-                {QLatin1StringView("landscape"), PhosphorI18n::tr("Landscape")},
-                {QLatin1StringView("portrait"), PhosphorI18n::tr("Portrait")},
-            });
-            for (const auto& opt : kOrientations) {
+            for (const ClosedTokenOption& opt : orientationOptions()) {
                 QVariantMap option;
-                const QString wire = QString(opt.wire);
-                option[QStringLiteral("value")] = wire;
-                option[QStringLiteral("wire")] = wire;
+                option[QStringLiteral("value")] = opt.wire;
+                option[QStringLiteral("wire")] = opt.wire;
                 option[QStringLiteral("label")] = opt.label;
                 options.append(option);
             }

--- a/src/settings/ruleauthoring.h
+++ b/src/settings/ruleauthoring.h
@@ -61,6 +61,13 @@ QString enumOptionLabel(const QString& typeWire, const QString& key, const QStri
 /// so the two never drift. Returns the raw int as a string for an unknown value.
 QString windowTypeLabel(int windowTypeValue);
 
+/// Translated label for a Mode / ScreenOrientation match token (e.g. "tiling" →
+/// "Tiling", "portrait" → "Portrait"). Single source shared by the editor dropdown
+/// (matchFields) and the collapsed rule-list summary (RuleModel) so they never drift.
+/// An unknown token round-trips verbatim.
+QString modeLabel(const QString& modeToken);
+QString orientationLabel(const QString& orientationToken);
+
 /// A complete, default-seeded action payload for @p typeWire — a JSON map of
 /// the form `{ type: <typeWire>, ...defaults }` ready to drop into a rule's
 /// `actions` list. See `RuleController::defaultPayloadFor` for the

--- a/src/settings/ruleauthoring.h
+++ b/src/settings/ruleauthoring.h
@@ -48,6 +48,13 @@ QVariantList actionTypes();
 /// string for a non-boolean or unknown action type.
 QString boolActionStateLabel(const QString& typeWire, bool on);
 
+/// Translated label for one enum wire value on action @p typeWire, param @p key.
+/// Structural enum membership lives on the descriptor; the human-facing label is
+/// per `(type, key, wireValue)`. Shared by the action editor's enum options and
+/// the rule-list summary (`RuleModel`) so the picker and the summary never drift.
+/// Returns @p wireValue unchanged for an action/param without a translated vocab.
+QString enumOptionLabel(const QString& typeWire, const QString& key, const QString& wireValue);
+
 /// A complete, default-seeded action payload for @p typeWire — a JSON map of
 /// the form `{ type: <typeWire>, ...defaults }` ready to drop into a rule's
 /// `actions` list. See `RuleController::defaultPayloadFor` for the

--- a/src/settings/ruleauthoring.h
+++ b/src/settings/ruleauthoring.h
@@ -10,10 +10,11 @@
 namespace PlasmaZones::RuleAuthoring {
 
 /// Match fields suitable for the leaf-editor field dropdown. Each entry:
-/// `{ value: int (Field enum), wire: QString (JSON wire string),
-///    label, valueKind: "string"|"number"|"bool"|"screen"|"activity" }`.
-/// QML keys off `wire` so it never has to reconstruct the enum↔wire-string
-/// table.
+/// `{ value: int (Field enum), wire: QString (JSON wire string), label,
+///    valueKind: "string"|"number"|"bool"|"screen"|"activity"|"windowType"|
+///    "virtualDesktop"|"mode"|"orientation"|"layout" }`. Closed-vocab kinds
+///    (windowType/mode/orientation) also carry an `options` array. QML keys off
+///    `wire` so it never has to reconstruct the enum↔wire-string table.
 QVariantList matchFields();
 
 /// Operators valid for @p fieldValue (a `PhosphorRules::Field` enum int).

--- a/src/settings/ruleauthoring.h
+++ b/src/settings/ruleauthoring.h
@@ -55,6 +55,12 @@ QString boolActionStateLabel(const QString& typeWire, bool on);
 /// Returns @p wireValue unchanged for an action/param without a translated vocab.
 QString enumOptionLabel(const QString& typeWire, const QString& key, const QString& wireValue);
 
+/// Translated label for a WindowType match value (the int underlying the
+/// PhosphorProtocol::WindowType enum) — e.g. 2 → "Dialog". Single source shared by
+/// the editor dropdown (matchFields) and the collapsed rule-list summary (RuleModel)
+/// so the two never drift. Returns the raw int as a string for an unknown value.
+QString windowTypeLabel(int windowTypeValue);
+
 /// A complete, default-seeded action payload for @p typeWire — a JSON map of
 /// the form `{ type: <typeWire>, ...defaults }` ready to drop into a rule's
 /// `actions` list. See `RuleController::defaultPayloadFor` for the

--- a/src/settings/rulecontroller.h
+++ b/src/settings/rulecontroller.h
@@ -300,9 +300,11 @@ public:
 
     /// Match fields suitable for the leaf-editor field dropdown. Each entry:
     /// `{ value: int (Field enum), wire: QString (JSON wire string), label,
-    ///    valueKind: "string"|"number"|"bool"|"windowType"|"screen"|"activity" }`
-    /// (the latter three drive dedicated pickers; "windowType" also carries an
-    /// `options` list). QML keys off `wire` so it never has to reconstruct the
+    ///    valueKind: "string"|"number"|"bool"|"windowType"|"virtualDesktop"|
+    ///    "screen"|"activity"|"mode"|"orientation"|"layout" }`. The screen /
+    /// activity / virtualDesktop / layout kinds drive dedicated pickers; the
+    /// closed-vocab kinds (windowType / mode / orientation) also carry an
+    /// `options` list. QML keys off `wire` so it never has to reconstruct the
     /// enum↔wire-string table.
     Q_INVOKABLE QVariantList matchFields() const;
 
@@ -326,9 +328,13 @@ public:
     /// Registered action types for the action-editor dropdown. Each entry:
     /// `{ value: QString (action type id), label, params: [ ... ],
     ///   domain: "context"|"window" }` where each param descriptor is
-    /// `{ key, kind: "string"|"number"|"enum"|"percent", label }` plus, for
-    /// `kind == "enum"`, an `options` string list, and for `kind == "number"`
-    /// /`"percent"`, `min`/`max`/`scale` (the value stored is `display * scale`).
+    /// `{ key, kind, label }`. `kind` is one of the descriptor kinds the
+    /// ActionRow editor dispatches on (enum, number, percent, bool, color,
+    /// zoneOrdinals, screenId, virtualDesktop, snappingLayout, tilingAlgorithm,
+    /// animationEvent, shaderEffect, overlayShader, curveEditor); for
+    /// `kind == "enum"` there is also an `options` string list, and for
+    /// `kind == "number"`/`"percent"`, `min`/`max`/`scale` (the value stored is
+    /// `display * scale`).
     /// QML drives the per-type editor entirely from this descriptor; the
     /// `domain` field lets the picker disable types incompatible with the
     /// current match expression (a context-domain action against a

--- a/src/settings/rulecontroller.h
+++ b/src/settings/rulecontroller.h
@@ -89,6 +89,8 @@ public:
     void setActivityLookup(RuleModel::LabelLookup fn);
     /// zone UUID → zone-name resolver for `Zone` match-leaf labels.
     void setZoneLookup(RuleModel::LabelLookup fn);
+    /// desktop number → name resolver for `VirtualDesktop` match-leaf labels.
+    void setVirtualDesktopLookup(RuleModel::LabelLookup fn);
     /// layoutId UUID → display label resolver for SetSnappingLayout actions.
     void setSnappingLayoutLookup(RuleModel::LabelLookup fn);
     /// Algorithm token ("bsp", …) → display label resolver for SetTilingAlgorithm actions.

--- a/src/settings/rulecontroller_lookups.cpp
+++ b/src/settings/rulecontroller_lookups.cpp
@@ -26,6 +26,11 @@ void RuleController::setZoneLookup(RuleModel::LabelLookup fn)
     m_model.setZoneLabelLookup(std::move(fn));
 }
 
+void RuleController::setVirtualDesktopLookup(RuleModel::LabelLookup fn)
+{
+    m_model.setVirtualDesktopLabelLookup(std::move(fn));
+}
+
 void RuleController::setSnappingLayoutLookup(RuleModel::LabelLookup fn)
 {
     m_snappingLayoutLookup = std::move(fn);

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -127,7 +127,8 @@ bool matchIsSimpleConjunction(const MatchExpression& match)
 /// "identity" so the function stays usable in code paths that have not yet
 /// wired the SettingsController-backed resolvers.
 QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::LabelLookup& screenLookup,
-                  const RuleModel::LabelLookup& activityLookup, const RuleModel::LabelLookup& zoneLookup)
+                  const RuleModel::LabelLookup& activityLookup, const RuleModel::LabelLookup& zoneLookup,
+                  const RuleModel::LabelLookup& layoutLookup)
 {
     // Pick the lookup matching the leaf's field. An empty lookup degenerates
     // to identity so this stays usable from code paths that have not yet
@@ -139,6 +140,11 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::
         lookup = &activityLookup;
     } else if (predicate.field == Field::Zone) {
         lookup = &zoneLookup;
+    } else if (predicate.field == Field::ActiveLayout) {
+        // Resolve a snap layout id to its friendly name via the same lookup the
+        // SetSnappingLayout action uses. An autotile id ("autotile:<algo>") won't
+        // match and round-trips verbatim, which is still readable.
+        lookup = &layoutLookup;
     }
     const auto resolveOne = [lookup](const QString& raw) {
         if (!lookup || !*lookup) {
@@ -797,6 +803,8 @@ QString RuleModel::fieldLabel(Field field)
         return PhosphorI18n::tr("Tiled window count");
     case Field::ScreenOrientation:
         return PhosphorI18n::tr("Screen orientation");
+    case Field::ActiveLayout:
+        return PhosphorI18n::tr("Active layout");
     }
     return QString();
 }
@@ -807,14 +815,15 @@ QString RuleModel::matchSummary(const MatchExpression& match) const
         return PhosphorI18n::tr("Any window");
     }
     if (match.isLeaf()) {
-        return leafLabel(match.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup);
+        return leafLabel(match.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup, m_snappingLayoutLookup);
     }
     // A simple AND renders its leaves joined by " · ".
     if (match.kind() == MatchExpression::Kind::All) {
         QStringList parts;
         for (const MatchExpression& child : match.children()) {
             if (child.isLeaf()) {
-                parts.append(leafLabel(child.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup));
+                parts.append(leafLabel(child.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup,
+                                       m_snappingLayoutLookup));
             } else {
                 parts.append(PhosphorI18n::tr("(condition group)"));
             }

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -295,6 +295,10 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
     if (action.type == ActionType::Exclude) {
         return PhosphorI18n::tr("Excluded");
     }
+    if (action.type == ActionType::ExcludeAnimations) {
+        // Terminal, no Value param — like Exclude, its presence IS the effect.
+        return PhosphorI18n::tr("No animations");
+    }
     if (action.type == ActionType::Float) {
         return PhosphorI18n::tr("Float");
     }
@@ -375,6 +379,13 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
         }
         return PhosphorI18n::tr("Overlay style");
     }
+    if (action.type == ActionType::SetAlgorithmParam) {
+        // Keyed on ActionParam::Algorithm (the target algorithm token), not Value;
+        // the free-form params blob is summarized by naming the algorithm it tunes.
+        const QString algo = action.params.value(PhosphorRules::ActionParam::Algorithm).toString();
+        return algo.isEmpty() ? PhosphorI18n::tr("Algorithm parameter")
+                              : PhosphorI18n::tr("Algorithm: %1").arg(resolveWith(algo, tilingAlgorithmLookup));
+    }
     // ── single-value actions keyed on ActionParam::Value (restore-position,
     //    border / title-bar overrides, per-context gap overrides) ──
     {
@@ -403,6 +414,52 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
                 return PhosphorI18n::tr("Focused border: %1").arg(shown);
             }
             return PhosphorI18n::tr("Unfocused border: %1").arg(shown);
+        }
+        // ── autotile parameter overrides ──
+        if (action.type == ActionType::SetMaxWindows) {
+            return PhosphorI18n::tr("Max tiled windows: %1").arg(raw.toInt());
+        }
+        if (action.type == ActionType::SetMasterCount) {
+            return PhosphorI18n::tr("Master count: %1").arg(raw.toInt());
+        }
+        if (action.type == ActionType::SetSplitRatio) {
+            // Wire value is the [0,1] ratio; shown as a percent to match the editor.
+            return PhosphorI18n::tr("Split ratio: %1%").arg(qRound(raw.toDouble() * 100.0));
+        }
+        if (action.type == ActionType::SetInsertPosition) {
+            return PhosphorI18n::tr("Insert: %1")
+                .arg(RuleAuthoring::enumOptionLabel(action.type, PhosphorRules::ActionParam::Value, raw.toString()));
+        }
+        if (action.type == ActionType::SetOverflowBehavior) {
+            return PhosphorI18n::tr("Overflow: %1")
+                .arg(RuleAuthoring::enumOptionLabel(action.type, PhosphorRules::ActionParam::Value, raw.toString()));
+        }
+        if (action.type == ActionType::SetDragBehavior) {
+            return PhosphorI18n::tr("Drag: %1")
+                .arg(RuleAuthoring::enumOptionLabel(action.type, PhosphorRules::ActionParam::Value, raw.toString()));
+        }
+        // ── overlay-appearance overrides (colours upper-cased hex; opacities
+        //    are [0,1] on the wire, shown as a percent to match the editor) ──
+        if (action.type == ActionType::SetOverlayHighlightColor) {
+            return PhosphorI18n::tr("Highlight color: %1").arg(raw.toString().toUpper());
+        }
+        if (action.type == ActionType::SetOverlayInactiveColor) {
+            return PhosphorI18n::tr("Inactive zone color: %1").arg(raw.toString().toUpper());
+        }
+        if (action.type == ActionType::SetOverlayBorderColor) {
+            return PhosphorI18n::tr("Overlay border color: %1").arg(raw.toString().toUpper());
+        }
+        if (action.type == ActionType::SetOverlayActiveOpacity) {
+            return PhosphorI18n::tr("Active opacity: %1%").arg(qRound(raw.toDouble() * 100.0));
+        }
+        if (action.type == ActionType::SetOverlayInactiveOpacity) {
+            return PhosphorI18n::tr("Inactive opacity: %1%").arg(qRound(raw.toDouble() * 100.0));
+        }
+        if (action.type == ActionType::SetOverlayBorderWidth) {
+            return PhosphorI18n::tr("Overlay border width: %1 px").arg(raw.toInt());
+        }
+        if (action.type == ActionType::SetOverlayBorderRadius) {
+            return PhosphorI18n::tr("Overlay corner radius: %1 px").arg(raw.toInt());
         }
         // ── per-context gap overrides ──
         if (action.type == ActionType::SetInnerGap) {

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -128,7 +128,7 @@ bool matchIsSimpleConjunction(const MatchExpression& match)
 /// wired the SettingsController-backed resolvers.
 QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::LabelLookup& screenLookup,
                   const RuleModel::LabelLookup& activityLookup, const RuleModel::LabelLookup& zoneLookup,
-                  const RuleModel::LabelLookup& layoutLookup)
+                  const RuleModel::LabelLookup& layoutLookup, const RuleModel::LabelLookup& tilingAlgorithmLookup)
 {
     // Pick the lookup matching the leaf's field. An empty lookup degenerates
     // to identity so this stays usable from code paths that have not yet
@@ -140,11 +140,6 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::
         lookup = &activityLookup;
     } else if (predicate.field == Field::Zone) {
         lookup = &zoneLookup;
-    } else if (predicate.field == Field::ActiveLayout) {
-        // Resolve a snap layout id to its friendly name via the same lookup the
-        // SetSnappingLayout action uses. An autotile id ("autotile:<algo>") won't
-        // match and round-trips verbatim, which is still readable.
-        lookup = &layoutLookup;
     }
     const auto resolveOne = [lookup](const QString& raw) {
         if (!lookup || !*lookup) {
@@ -177,6 +172,32 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::
             label = PhosphorI18n::tr("Portrait");
         } else if (token == QLatin1String("landscape")) {
             label = PhosphorI18n::tr("Landscape");
+        }
+        return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field), label);
+    }
+
+    // Active layout: a snap layout id resolves via the SetSnappingLayout lookup;
+    // an autotile id ("autotile:<algo>") resolves its algorithm via the tiling
+    // lookup after stripping the prefix (mirroring the settings controller's
+    // prefixing), so the collapsed summary matches the expanded tree — which
+    // resolves both id shapes through appSettings.layouts. Unknown ids round-trip
+    // verbatim.
+    if (predicate.field == Field::ActiveLayout) {
+        const QString value = predicate.value.toString();
+        QString label = value;
+        static const QString autotilePrefix = QStringLiteral("autotile:");
+        if (value.startsWith(autotilePrefix)) {
+            if (tilingAlgorithmLookup) {
+                const QString resolved = tilingAlgorithmLookup(value.mid(autotilePrefix.size()));
+                if (!resolved.isEmpty()) {
+                    label = resolved;
+                }
+            }
+        } else if (layoutLookup) {
+            const QString resolved = layoutLookup(value);
+            if (!resolved.isEmpty()) {
+                label = resolved;
+            }
         }
         return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field), label);
     }
@@ -815,7 +836,8 @@ QString RuleModel::matchSummary(const MatchExpression& match) const
         return PhosphorI18n::tr("Any window");
     }
     if (match.isLeaf()) {
-        return leafLabel(match.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup, m_snappingLayoutLookup);
+        return leafLabel(match.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup, m_snappingLayoutLookup,
+                         m_tilingAlgorithmLookup);
     }
     // A simple AND renders its leaves joined by " · ".
     if (match.kind() == MatchExpression::Kind::All) {
@@ -823,7 +845,7 @@ QString RuleModel::matchSummary(const MatchExpression& match) const
         for (const MatchExpression& child : match.children()) {
             if (child.isLeaf()) {
                 parts.append(leafLabel(child.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup,
-                                       m_snappingLayoutLookup));
+                                       m_snappingLayoutLookup, m_tilingAlgorithmLookup));
             } else {
                 parts.append(PhosphorI18n::tr("(condition group)"));
             }

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -141,9 +141,12 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::
         lookup = &activityLookup;
     } else if (predicate.field == Field::Zone) {
         lookup = &zoneLookup;
-    } else if (predicate.field == Field::VirtualDesktop) {
+    } else if (predicate.field == Field::VirtualDesktop && predicate.op == Operator::Equals) {
         // Resolves the desktop number to its name ("2" → "Work"); an unnamed or
-        // unknown desktop falls back to the bare number via resolveOne below.
+        // unknown desktop falls back to the bare number via resolveOne below. Only
+        // for Equals — under GreaterThan/LessThan the value is a numeric threshold,
+        // where a name ("greater than Work") would read as nonsense, so those keep
+        // the bare number.
         lookup = &virtualDesktopLookup;
     }
     const auto resolveOne = [lookup](const QString& raw) {
@@ -155,30 +158,18 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::
     };
 
     // Mode is a closed wire-token vocabulary — render the friendly label
-    // ("Mode: Snapping") rather than the raw token. An unknown token (a
-    // hand-edited rule) round-trips verbatim.
+    // ("Mode: Snapping") via the same single-source table the editor dropdown uses,
+    // rather than a second hardcoded copy. An unknown token round-trips verbatim.
     if (predicate.field == Field::Mode) {
-        const QString token = predicate.value.toString();
-        QString label = token;
-        if (token == QLatin1String("snapping")) {
-            label = PhosphorI18n::tr("Snapping");
-        } else if (token == QLatin1String("tiling")) {
-            label = PhosphorI18n::tr("Tiling");
-        }
-        return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field), label);
+        return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field),
+                                              RuleAuthoring::modeLabel(predicate.value.toString()));
     }
 
-    // Screen orientation is a closed wire-token vocabulary too — render the
-    // friendly label ("Screen orientation: Portrait") like Mode above.
+    // Screen orientation is a closed wire-token vocabulary too — resolve via the
+    // shared orientationLabel() table like Mode above.
     if (predicate.field == Field::ScreenOrientation) {
-        const QString token = predicate.value.toString();
-        QString label = token;
-        if (token == QLatin1String("portrait")) {
-            label = PhosphorI18n::tr("Portrait");
-        } else if (token == QLatin1String("landscape")) {
-            label = PhosphorI18n::tr("Landscape");
-        }
-        return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field), label);
+        return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field),
+                                              RuleAuthoring::orientationLabel(predicate.value.toString()));
     }
 
     // Window type is the int underlying the WindowType enum — resolve it to the

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -128,7 +128,8 @@ bool matchIsSimpleConjunction(const MatchExpression& match)
 /// wired the SettingsController-backed resolvers.
 QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::LabelLookup& screenLookup,
                   const RuleModel::LabelLookup& activityLookup, const RuleModel::LabelLookup& zoneLookup,
-                  const RuleModel::LabelLookup& layoutLookup, const RuleModel::LabelLookup& tilingAlgorithmLookup)
+                  const RuleModel::LabelLookup& layoutLookup, const RuleModel::LabelLookup& tilingAlgorithmLookup,
+                  const RuleModel::LabelLookup& virtualDesktopLookup)
 {
     // Pick the lookup matching the leaf's field. An empty lookup degenerates
     // to identity so this stays usable from code paths that have not yet
@@ -140,6 +141,10 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::
         lookup = &activityLookup;
     } else if (predicate.field == Field::Zone) {
         lookup = &zoneLookup;
+    } else if (predicate.field == Field::VirtualDesktop) {
+        // Resolves the desktop number to its name ("2" → "Work"); an unnamed or
+        // unknown desktop falls back to the bare number via resolveOne below.
+        lookup = &virtualDesktopLookup;
     }
     const auto resolveOne = [lookup](const QString& raw) {
         if (!lookup || !*lookup) {
@@ -174,6 +179,14 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::
             label = PhosphorI18n::tr("Landscape");
         }
         return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field), label);
+    }
+
+    // Window type is the int underlying the WindowType enum — resolve it to the
+    // friendly label ("Window type: Dialog") via the same single-source table the
+    // editor dropdown uses, rather than showing the bare int.
+    if (predicate.field == Field::WindowType) {
+        return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field),
+                                              RuleAuthoring::windowTypeLabel(predicate.value.toInt()));
     }
 
     // Active layout: a snap layout id resolves via the SetSnappingLayout lookup;
@@ -371,13 +384,14 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
     }
     if (action.type == ActionType::OverrideOverlayStyle) {
         const QString v = action.params.value(PhosphorRules::ActionParam::Value).toString();
-        if (v == PhosphorRules::OverlayStyleToken::Rectangles) {
-            return PhosphorI18n::tr("Overlay style: Zone rectangles");
+        if (v.isEmpty()) {
+            return PhosphorI18n::tr("Overlay style");
         }
-        if (v == PhosphorRules::OverlayStyleToken::Preview) {
-            return PhosphorI18n::tr("Overlay style: Layout preview");
-        }
-        return PhosphorI18n::tr("Overlay style");
+        // Delegate the token→label to the shared enumOptionLabel (the same source the
+        // editor uses) instead of re-hardcoding the vocabulary here, like the sibling
+        // SetInsertPosition / SetOverflowBehavior / SetDragBehavior cases below.
+        return PhosphorI18n::tr("Overlay style: %1")
+            .arg(RuleAuthoring::enumOptionLabel(action.type, PhosphorRules::ActionParam::Value, v));
     }
     if (action.type == ActionType::SetAlgorithmParam) {
         // Keyed on ActionParam::Algorithm (the target algorithm token), not Value;
@@ -894,7 +908,7 @@ QString RuleModel::matchSummary(const MatchExpression& match) const
     }
     if (match.isLeaf()) {
         return leafLabel(match.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup, m_snappingLayoutLookup,
-                         m_tilingAlgorithmLookup);
+                         m_tilingAlgorithmLookup, m_virtualDesktopLookup);
     }
     // A simple AND renders its leaves joined by " · ".
     if (match.kind() == MatchExpression::Kind::All) {
@@ -902,7 +916,7 @@ QString RuleModel::matchSummary(const MatchExpression& match) const
         for (const MatchExpression& child : match.children()) {
             if (child.isLeaf()) {
                 parts.append(leafLabel(child.predicate(), m_screenLookup, m_activityLookup, m_zoneLookup,
-                                       m_snappingLayoutLookup, m_tilingAlgorithmLookup));
+                                       m_snappingLayoutLookup, m_tilingAlgorithmLookup, m_virtualDesktopLookup));
             } else {
                 parts.append(PhosphorI18n::tr("(condition group)"));
             }
@@ -968,6 +982,11 @@ void RuleModel::setActivityLabelLookup(LabelLookup fn)
 void RuleModel::setZoneLabelLookup(LabelLookup fn)
 {
     m_zoneLookup = std::move(fn);
+}
+
+void RuleModel::setVirtualDesktopLabelLookup(LabelLookup fn)
+{
+    m_virtualDesktopLookup = std::move(fn);
 }
 
 void RuleModel::setSnappingLayoutLabelLookup(LabelLookup fn)

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -162,6 +162,19 @@ QString leafLabel(const MatchExpression::Predicate& predicate, const RuleModel::
         return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field), label);
     }
 
+    // Screen orientation is a closed wire-token vocabulary too — render the
+    // friendly label ("Screen orientation: Portrait") like Mode above.
+    if (predicate.field == Field::ScreenOrientation) {
+        const QString token = predicate.value.toString();
+        QString label = token;
+        if (token == QLatin1String("portrait")) {
+            label = PhosphorI18n::tr("Portrait");
+        } else if (token == QLatin1String("landscape")) {
+            label = PhosphorI18n::tr("Landscape");
+        }
+        return PhosphorI18n::tr("%1: %2").arg(RuleModel::fieldLabel(predicate.field), label);
+    }
+
     // Boolean fields (Maximized, Keep above, Skip taskbar, …) render their
     // value as On / Off instead of the raw JSON "true" / "false" the generic
     // toString() fallback would emit, matching the editor toggle and the
@@ -760,6 +773,10 @@ QString RuleModel::fieldLabel(Field field)
         return PhosphorI18n::tr("Decorated");
     case Field::IsResizable:
         return PhosphorI18n::tr("Resizable");
+    case Field::IsMovable:
+        return PhosphorI18n::tr("Movable");
+    case Field::IsMaximizable:
+        return PhosphorI18n::tr("Maximizable");
     case Field::PositionX:
         return PhosphorI18n::tr("Position X");
     case Field::PositionY:
@@ -778,6 +795,8 @@ QString RuleModel::fieldLabel(Field field)
         return PhosphorI18n::tr("Mode");
     case Field::TiledWindowCount:
         return PhosphorI18n::tr("Tiled window count");
+    case Field::ScreenOrientation:
+        return PhosphorI18n::tr("Screen orientation");
     }
     return QString();
 }

--- a/src/settings/rulemodel.h
+++ b/src/settings/rulemodel.h
@@ -226,6 +226,12 @@ public:
     /// @ref refreshLabels.
     void setZoneLabelLookup(LabelLookup fn);
 
+    /// Inject the virtual-desktop-number → name resolver used when rendering a
+    /// `VirtualDesktop` leaf predicate, so the collapsed and expanded summaries show
+    /// "Work" rather than the bare number "2" (matching the editor's desktop picker).
+    /// Install-once setter; read live on every `data()`. Unknown numbers round-trip.
+    void setVirtualDesktopLabelLookup(LabelLookup fn);
+
     /// Inject the layoutId / algorithm-token → display-name resolvers used by
     /// the action summary so `SetSnappingLayout` and `SetTilingAlgorithm`
     /// render "Binary Split" rather than the wire token / UUID. Split into a
@@ -290,6 +296,7 @@ private:
     LabelLookup m_screenLookup;
     LabelLookup m_activityLookup;
     LabelLookup m_zoneLookup;
+    LabelLookup m_virtualDesktopLookup;
     // Split so a SetSnappingLayout action whose layoutId happens to
     // tokenise (e.g. matches an algorithm token by coincidence) and a
     // SetTilingAlgorithm action with a UUID-shaped algorithm name

--- a/src/settings/settingscontroller.cpp
+++ b/src/settings/settingscontroller.cpp
@@ -119,6 +119,7 @@ SettingsController::~SettingsController()
         m_rulesPage->setScreenLookup({});
         m_rulesPage->setActivityLookup({});
         m_rulesPage->setZoneLookup({});
+        m_rulesPage->setVirtualDesktopLookup({});
         m_rulesPage->setSnappingLayoutLookup({});
         m_rulesPage->setTilingAlgorithmLookup({});
         // The shader resolver captures `this` and reaches m_animationShaderRegistry;
@@ -561,6 +562,17 @@ SettingsController::SettingsController(QObject* parent)
             }
         }
         return activityId;
+    });
+    m_rulesPage->setVirtualDesktopLookup([this](const QString& desktopNumber) -> QString {
+        // Desktop numbers are 1-based; the names list is 0-indexed. Return the name
+        // for a valid in-range number; an out-of-range / unnamed / unparseable value
+        // returns empty so the summary falls back to the bare number.
+        bool ok = false;
+        const int num = desktopNumber.toInt(&ok);
+        if (ok && num >= 1 && num <= m_virtualDesktopNames.size()) {
+            return m_virtualDesktopNames.at(num - 1);
+        }
+        return QString();
     });
     // Zone (snap-zone UUID) → friendly "<layout> — <zone>" label, walking the
     // local manual layouts for the zone whose id matches. Resolved live so a

--- a/tests/unit/autotile/test_per_screen_config.cpp
+++ b/tests/unit/autotile/test_per_screen_config.cpp
@@ -268,6 +268,110 @@ private Q_SLOTS:
         QVERIFY(!engine.hasPerScreenOverride(screen, QStringLiteral("SplitRatio")));
     }
 
+    // A SetSplitRatio / SetMasterCount rule removed while the override map stays
+    // NON-EMPTY (another override survives) routes through applyPerScreenConfig,
+    // not clearPerScreenConfig. The stateful splitRatio / masterCount must revert
+    // to the config baseline rather than keep the stale removed-rule value.
+    void testPerScreen_removeSplitRatioAndMasterCount_whileMapNonEmpty_revertsToBaseline()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("eDP-1");
+        engine.setAutotileScreens({screen});
+
+        engine.config()->splitRatio = 0.6;
+        engine.config()->masterCount = 1;
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        state->addWindow(QStringLiteral("win1"));
+        state->addWindow(QStringLiteral("win2"));
+
+        // Include the (unchanged) Algorithm key — concrete-algorithm autotile screens
+        // ALWAYS carry it (the daemon injects it), which is the shape that exposes the
+        // SplitRatio revert bug if it were gated on Algorithm-key presence.
+        QVariantMap overrides;
+        overrides[QStringLiteral("Algorithm")] = QLatin1String("bsp");
+        overrides[QStringLiteral("SplitRatio")] = 0.8;
+        overrides[QStringLiteral("MasterCount")] = 2;
+        overrides[QStringLiteral("MaxWindows")] = 4;
+        engine.applyPerScreenConfig(screen, overrides);
+        QVERIFY(qFuzzyCompare(state->splitRatio(), 0.8));
+        QCOMPARE(state->masterCount(), 2);
+
+        // Drop SplitRatio + MasterCount but keep the (unchanged) Algorithm + MaxWindows
+        // → still non-empty, and the algorithm did NOT change, so both stateful values
+        // must revert to the config baseline (not stay stuck at the removed values).
+        QVariantMap reduced;
+        reduced[QStringLiteral("Algorithm")] = QLatin1String("bsp");
+        reduced[QStringLiteral("MaxWindows")] = 4;
+        engine.applyPerScreenConfig(screen, reduced);
+
+        QVERIFY(qFuzzyCompare(state->splitRatio(), 0.6));
+        QCOMPARE(state->masterCount(), 1);
+    }
+
+    // The revert-on-removal path must NOT clobber a value the user live-adjusted
+    // (drag-to-resize) when that key was NEVER an override: an unrelated override
+    // apply with no prior SplitRatio key leaves the live-tuned split ratio intact.
+    void testPerScreen_liveAdjustedSplitRatio_notClobberedByUnrelatedOverride()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("eDP-1");
+        engine.setAutotileScreens({screen});
+        engine.config()->splitRatio = 0.6;
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        state->addWindow(QStringLiteral("win1"));
+        state->addWindow(QStringLiteral("win2"));
+        state->setSplitRatio(0.42); // live drag-adjust, no override key involved
+
+        // Apply an unrelated override (MaxWindows only). No prior SplitRatio override
+        // existed, so the guard must leave the live-adjusted value untouched.
+        QVariantMap overrides;
+        overrides[QStringLiteral("MaxWindows")] = 4;
+        engine.applyPerScreenConfig(screen, overrides);
+
+        QVERIFY(qFuzzyCompare(state->splitRatio(), 0.42));
+    }
+
+    // Concrete-algorithm screens ALWAYS carry the injected Algorithm key. An
+    // unrelated tiling-param rule edit re-applies the overrides map with that
+    // (unchanged) key, which must NOT re-fire the algorithm split-ratio reset and
+    // clobber a live drag-tuned ratio — the reset fires only on a genuine algorithm
+    // switch (compared against the previous override map's algorithm).
+    void testPerScreen_liveAdjustedSplitRatio_survivesUnrelatedOverride_concreteAlgorithm()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screen = QStringLiteral("eDP-1");
+        engine.setAutotileScreens({screen});
+
+        PhosphorTiles::TilingState* state = engine.tilingStateForScreen(screen);
+        state->addWindow(QStringLiteral("win1"));
+        state->addWindow(QStringLiteral("win2"));
+
+        // Non-vacuity precondition: the tuned value must differ from bsp's default,
+        // else "survives" would pass even if the reset wrongly fired.
+        auto* bspAlgo = m_scriptSetup.registry()->algorithm(QLatin1String("bsp"));
+        QVERIFY(bspAlgo);
+        QVERIFY(!qFuzzyCompare(bspAlgo->defaultSplitRatio(), 0.42));
+
+        // Establish the concrete algorithm. The first apply legitimately resets to
+        // the algo default (previous map had no algorithm → genuine switch).
+        QVariantMap first;
+        first[QStringLiteral("Algorithm")] = QLatin1String("bsp");
+        engine.applyPerScreenConfig(screen, first);
+
+        // User live-adjusts the split ratio (drag-resize) — no SplitRatio override.
+        state->setSplitRatio(0.42);
+
+        // Unrelated rule edit re-applies with the SAME (unchanged) Algorithm key.
+        QVariantMap second;
+        second[QStringLiteral("Algorithm")] = QLatin1String("bsp");
+        second[QStringLiteral("MaxWindows")] = 4;
+        engine.applyPerScreenConfig(screen, second);
+
+        QVERIFY(qFuzzyCompare(state->splitRatio(), 0.42));
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // effectiveOuterGaps — per-side overrides
     // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/autotile/test_per_screen_config.cpp
+++ b/tests/unit/autotile/test_per_screen_config.cpp
@@ -171,6 +171,38 @@ private Q_SLOTS:
         QCOMPARE(engine.effectiveMaxWindows(screenB), engine.config()->maxWindows);
     }
 
+    // A per-screen InsertPosition override wins over the global config value, and an
+    // out-of-range stored value is clamped. Exercises the resolver's per-screen
+    // override + qBound branch (effectiveInsertPosition), the same override-then-clamp
+    // shape effectiveOverflowBehavior uses, which the effectiveMaxWindows tests above
+    // don't reach.
+    void testPerScreen_effectiveInsertPosition_perScreenOverrideAndClamp()
+    {
+        AutotileEngine engine(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
+        const QString screenA = QStringLiteral("eDP-1");
+        const QString screenB = QStringLiteral("HDMI-1");
+        engine.setAutotileScreens({screenA, screenB});
+        engine.setAlgorithm(QLatin1String("master-stack"));
+
+        engine.config()->insertPosition = PhosphorTiles::AutotileInsertPosition::End;
+
+        // Screen A overrides to AsMaster; screen B inherits the global End.
+        QVariantMap overrides;
+        overrides[QStringLiteral("InsertPosition")] = static_cast<int>(PhosphorTiles::AutotileInsertPosition::AsMaster);
+        engine.applyPerScreenConfig(screenA, overrides);
+        QCOMPARE(engine.effectiveInsertPosition(screenA), PhosphorTiles::AutotileInsertPosition::AsMaster);
+        QCOMPARE(engine.effectiveInsertPosition(screenB), PhosphorTiles::AutotileInsertPosition::End);
+
+        // An out-of-range stored int clamps into the valid enum range rather than
+        // producing an invalid enumerator.
+        QVariantMap bogus;
+        bogus[QStringLiteral("InsertPosition")] = 999;
+        engine.applyPerScreenConfig(screenA, bogus);
+        const int clamped = static_cast<int>(engine.effectiveInsertPosition(screenA));
+        QVERIFY(clamped >= PhosphorTiles::AutotileDefaults::MinInsertPosition);
+        QVERIFY(clamped <= PhosphorTiles::AutotileDefaults::MaxInsertPosition);
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // applyOverrides
     // ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/core/test_rule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_rule_cascade_fidelity.cpp
@@ -1007,7 +1007,15 @@ private Q_SLOTS:
         const PWR::Rule db =
             tilingRule(QStringLiteral("db"), 25, QStringLiteral("DP-1"),
                        {valueAction(PWR::ActionType::SetDragBehavior, QString(PWR::DragBehaviorToken::Reorder))});
-        QVERIFY(f.store->setAllRules({mw, sr, mc, ip, ob, db}));
+        // SetAlgorithmParam carries a target algorithm token + a free-form params blob.
+        PWR::RuleAction apAction;
+        apAction.type = QString(PWR::ActionType::SetAlgorithmParam);
+        apAction.params.insert(QString(PWR::ActionParam::Algorithm), QStringLiteral("bsp"));
+        QJsonObject apParams;
+        apParams.insert(QStringLiteral("ratio"), 0.7);
+        apAction.params.insert(QString(PWR::ActionParam::Params), apParams);
+        const PWR::Rule ap = tilingRule(QStringLiteral("ap"), 10, QStringLiteral("DP-1"), {apAction});
+        QVERIFY(f.store->setAllRules({mw, sr, mc, ip, ob, db, ap}));
 
         const PhosphorZones::ContextTilingParams p =
             f.registry->resolveContextTilingParams(QStringLiteral("DP-1"), 0, QString());
@@ -1023,6 +1031,8 @@ private Q_SLOTS:
         QCOMPARE(*p.overflowBehavior, 1); // "unlimited" → AutotileOverflowBehavior::Unlimited (1)
         QVERIFY(p.dragBehavior.has_value());
         QCOMPARE(*p.dragBehavior, 1); // "reorder" → AutotileDragBehavior::Reorder (1)
+        QCOMPARE(p.algorithmParamTarget, QStringLiteral("bsp"));
+        QCOMPARE(p.algorithmParams.value(QStringLiteral("ratio")).toDouble(), 0.7);
 
         // A screen the rules do not pin → all-unset (the daemon then leaves the
         // config-derived override map untouched for that screen).

--- a/tests/unit/core/test_rule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_rule_cascade_fidelity.cpp
@@ -963,6 +963,125 @@ private Q_SLOTS:
         QVERIFY(f.registry->resolveContextGaps(QStringLiteral("DP-1"), 0, QString()).isEmpty());
     }
 
+    // ─── An ActiveLayout-referencing rule must NOT drive the assignment ───────
+    // The assignment resolver leaves Field::ActiveLayout unstamped (it IS the
+    // resolver's output — stamping would recurse). An assignment rule whose match
+    // references ActiveLayout is therefore structurally excluded from the
+    // assignment path. This matters most for a NEGATED predicate: a positive
+    // `ActiveLayout Equals X` leaf never matches the unstamped placeholder, but a
+    // `None{ActiveLayout Equals X}` ("active layout is NOT X") would spuriously
+    // match the empty placeholder and force a wrong assignment without the guard.
+    // The resolve also completing at all proves the no-recursion contract.
+    void testActiveLayoutRuleExcludedFromAssignment()
+    {
+        RegistryFixture f = makeRegistryFixture();
+        // Snap default so a leaked autotile assignment is unambiguously visible.
+        f.registry->setDefaultLayoutIdProvider([]() {
+            return QStringLiteral("{provider-snap-default}");
+        });
+
+        // Positive control: an assignment rule pinned by ScreenId DOES drive the
+        // assignment — proving the harness observes assignment-driving, so the
+        // negative assertions below are meaningful (not vacuously always-Snapping).
+        PWR::Rule screenPinned;
+        screenPinned.id = QUuid::createUuid();
+        screenPinned.name = QStringLiteral("screen-pinned-autotile");
+        screenPinned.enabled = true;
+        screenPinned.priority = 500;
+        screenPinned.match =
+            PWR::MatchExpression::makeLeaf(PWR::Field::ScreenId, PWR::Operator::Equals, QStringLiteral("DP-1"));
+        screenPinned.actions =
+            CRB::makeAssignmentActions(QStringLiteral("autotile"), QString(), QStringLiteral("dwindle"));
+        QVERIFY(f.store->setAllRules({screenPinned}));
+        QCOMPARE(f.registry->assignmentEntryForScreen(QStringLiteral("DP-1"), 0, QString()).mode,
+                 PhosphorZones::AssignmentEntry::Autotile);
+
+        // Build the same autotile assignment rule but match on ActiveLayout, once
+        // positively and once negated. Neither may drive the assignment: the
+        // resolver must fall through to the Snapping gated default.
+        const QString someLayout = QStringLiteral("{11111111-1111-1111-1111-111111111111}");
+        const auto activeLayoutAssignmentRule = [&](const PWR::MatchExpression& match) {
+            PWR::Rule r;
+            r.id = QUuid::createUuid();
+            r.name = QStringLiteral("active-layout assignment");
+            r.enabled = true;
+            r.priority = 500;
+            r.match = match;
+            r.actions = CRB::makeAssignmentActions(QStringLiteral("autotile"), QString(), QStringLiteral("dwindle"));
+            return r;
+        };
+
+        // Positive ActiveLayout leaf — excluded (also never matched the placeholder).
+        QVERIFY(f.store->setAllRules({activeLayoutAssignmentRule(
+            PWR::MatchExpression::makeLeaf(PWR::Field::ActiveLayout, PWR::Operator::Equals, someLayout))}));
+        QCOMPARE(f.registry->assignmentEntryForScreen(QStringLiteral("DP-1"), 0, QString()).mode,
+                 PhosphorZones::AssignmentEntry::Snapping);
+
+        // Negated ActiveLayout predicate — the regression case. Without the
+        // referencesAnyField guard this None{} matches the empty placeholder and
+        // forces Autotile; with it, the rule is excluded and Snapping stands.
+        QVERIFY(f.store->setAllRules({activeLayoutAssignmentRule(PWR::MatchExpression::makeNone(
+            {PWR::MatchExpression::makeLeaf(PWR::Field::ActiveLayout, PWR::Operator::Equals, someLayout)}))}));
+        const PhosphorZones::AssignmentEntry negatedEntry =
+            f.registry->assignmentEntryForScreen(QStringLiteral("DP-1"), 0, QString());
+        QCOMPARE(negatedEntry.mode, PhosphorZones::AssignmentEntry::Snapping);
+        QCOMPARE(negatedEntry.snappingLayout, QStringLiteral("{provider-snap-default}"));
+    }
+
+    // ─── ActiveLayout exclusion on the SECOND no-stamp resolver ──────────────
+    // resolveContextDefaultAssignment is the other assignment-cascade resolver
+    // that leaves ActiveLayout unstamped, so it applies the same referencesAnyField
+    // exclusion. A DefaultLayoutAssignment rule matched by None{ActiveLayout Equals
+    // X} would, without the guard, match the empty placeholder and force the default
+    // through (defeating the global suppress); with the guard it is excluded.
+    void testActiveLayoutRuleExcludedFromDefaultAssignment()
+    {
+        RegistryFixture f = makeRegistryFixture();
+        // Global default: suppress the synthesized default assignment everywhere.
+        f.registry->setDefaultAssignmentSuppressedProvider([]() {
+            return true;
+        });
+
+        const auto defaultAssignmentRule = [](const PWR::MatchExpression& match, bool allow) {
+            PWR::Rule r;
+            r.id = QUuid::createUuid();
+            r.name = QStringLiteral("default-assignment");
+            r.enabled = true;
+            r.priority = 500;
+            r.match = match;
+            PWR::RuleAction action;
+            action.type = QString(PWR::ActionType::DefaultLayoutAssignment);
+            action.params.insert(QString(PWR::ActionParam::Value), allow);
+            r.actions.append(action);
+            return r;
+        };
+
+        // Positive control: a ScreenId-pinned allow rule DOES override the global
+        // suppress (proves the harness observes default-assignment overrides, so the
+        // negatives below are meaningful rather than vacuously always-suppressed).
+        QVERIFY(f.store->setAllRules({defaultAssignmentRule(
+            PWR::MatchExpression::makeLeaf(PWR::Field::ScreenId, PWR::Operator::Equals, QStringLiteral("DP-1")),
+            true)}));
+        QVERIFY(!f.registry->isDefaultAssignmentSuppressedForContext(QStringLiteral("DP-1"), 0, QString()));
+
+        const QString someLayout = QStringLiteral("{11111111-1111-1111-1111-111111111111}");
+
+        // Negated ActiveLayout predicate — the regression case. Without the guard the
+        // None{} matches the empty placeholder and forces the default through
+        // (isSuppressed → false); with it, the rule is excluded and the global
+        // suppress stands (isSuppressed → true).
+        QVERIFY(f.store->setAllRules(
+            {defaultAssignmentRule(PWR::MatchExpression::makeNone({PWR::MatchExpression::makeLeaf(
+                                       PWR::Field::ActiveLayout, PWR::Operator::Equals, someLayout)}),
+                                   true)}));
+        QVERIFY(f.registry->isDefaultAssignmentSuppressedForContext(QStringLiteral("DP-1"), 0, QString()));
+
+        // Positive ActiveLayout leaf — also excluded (and never matched the placeholder).
+        QVERIFY(f.store->setAllRules({defaultAssignmentRule(
+            PWR::MatchExpression::makeLeaf(PWR::Field::ActiveLayout, PWR::Operator::Equals, someLayout), true)}));
+        QVERIFY(f.registry->isDefaultAssignmentSuppressedForContext(QStringLiteral("DP-1"), 0, QString()));
+    }
+
     // ─── Context autotile-parameter resolution (max / split / master) ────────
     // resolveContextTilingParams is a per-slot read: independent
     // SetMaxWindows / SetSplitRatio / SetMasterCount rules compose, and an

--- a/tests/unit/core/test_rule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_rule_cascade_fidelity.cpp
@@ -1003,7 +1003,11 @@ private Q_SLOTS:
         const PWR::Rule ob = tilingRule(
             QStringLiteral("ob"), 50, QStringLiteral("DP-1"),
             {valueAction(PWR::ActionType::SetOverflowBehavior, QString(PWR::OverflowBehaviorToken::Unlimited))});
-        QVERIFY(f.store->setAllRules({mw, sr, mc, ip, ob}));
+        // Drag behavior carries a wire token → AutotileDragBehavior int.
+        const PWR::Rule db =
+            tilingRule(QStringLiteral("db"), 25, QStringLiteral("DP-1"),
+                       {valueAction(PWR::ActionType::SetDragBehavior, QString(PWR::DragBehaviorToken::Reorder))});
+        QVERIFY(f.store->setAllRules({mw, sr, mc, ip, ob, db}));
 
         const PhosphorZones::ContextTilingParams p =
             f.registry->resolveContextTilingParams(QStringLiteral("DP-1"), 0, QString());
@@ -1017,6 +1021,8 @@ private Q_SLOTS:
         QCOMPARE(*p.insertPosition, 2); // "asMaster" → AutotileInsertPosition::AsMaster (2)
         QVERIFY(p.overflowBehavior.has_value());
         QCOMPARE(*p.overflowBehavior, 1); // "unlimited" → AutotileOverflowBehavior::Unlimited (1)
+        QVERIFY(p.dragBehavior.has_value());
+        QCOMPARE(*p.dragBehavior, 1); // "reorder" → AutotileDragBehavior::Reorder (1)
 
         // A screen the rules do not pin → all-unset (the daemon then leaves the
         // config-derived override map untouched for that screen).

--- a/tests/unit/core/test_rule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_rule_cascade_fidelity.cpp
@@ -919,6 +919,50 @@ private Q_SLOTS:
         QVERIFY(f.registry->resolveContextGaps(QStringLiteral("DP-3"), 0, QString()).isEmpty());
     }
 
+    // ─── ActiveLayout is stamped onto the non-assignment resolvers, gates rules,
+    //     and does NOT recurse ──────────────────────────────────────────────────
+    // The gap/lock/overlay resolvers stamp the screen's resolved active-layout id
+    // (via assignmentIdForScreen). A rule matching Field::ActiveLayout must fire
+    // only when that id matches — and the resolver must NOT recurse (reaching
+    // assignmentIdForScreen must never re-enter the gap resolver). The test
+    // completing at all proves the no-recursion contract.
+    void testContextActiveLayout_stampedAndGatesRule()
+    {
+        RegistryFixture f = makeRegistryFixture();
+        // No per-screen assignment rule; the active layout comes from the global
+        // default provider (exercising the non-rule-set input path that the cache
+        // key must fold in).
+        const QString layoutId = QStringLiteral("{11111111-1111-1111-1111-111111111111}");
+        f.registry->setDefaultLayoutIdProvider([layoutId]() {
+            return layoutId;
+        });
+
+        const auto gapRuleForLayout = [](const QString& id) {
+            PWR::RuleAction gapAction;
+            gapAction.type = QString(PWR::ActionType::SetInnerGap);
+            gapAction.params.insert(QString(PWR::ActionParam::Value), 15);
+            PWR::Rule r;
+            r.id = QUuid::createUuid();
+            r.name = QStringLiteral("active-layout gap");
+            r.enabled = true;
+            r.priority = 400;
+            r.match = PWR::MatchExpression::makeLeaf(PWR::Field::ActiveLayout, PWR::Operator::Equals, id);
+            r.actions = {gapAction};
+            return r;
+        };
+
+        // The screen's active layout (from the default provider) matches → gap fires.
+        QVERIFY(f.store->setAllRules({gapRuleForLayout(layoutId)}));
+        const PhosphorZones::ContextGapOverride resolved =
+            f.registry->resolveContextGaps(QStringLiteral("DP-1"), 0, QString());
+        QVERIFY(resolved.innerGap.has_value());
+        QCOMPARE(*resolved.innerGap, 15);
+
+        // A rule pinned to a DIFFERENT layout id is inert on this screen.
+        QVERIFY(f.store->setAllRules({gapRuleForLayout(QStringLiteral("{22222222-2222-2222-2222-222222222222}"))}));
+        QVERIFY(f.registry->resolveContextGaps(QStringLiteral("DP-1"), 0, QString()).isEmpty());
+    }
+
     // ─── Per-monitor gap rule overrides the baseline for that screen only ────
     // A per-monitor gap override is authored by the Appearance page as a NORMAL
     // (non-managed) screen-scoped rule: match `ScreenId == screen`, carrying the

--- a/tests/unit/core/test_rule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_rule_cascade_fidelity.cpp
@@ -875,6 +875,50 @@ private Q_SLOTS:
         QVERIFY(f.registry->resolveContextGaps(QStringLiteral("DP-2"), 0, QString()).isEmpty());
     }
 
+    // ─── ScreenOrientation is stamped onto context queries and gates rules ────
+    // The orientation provider feeds "portrait" / "landscape" per screen; a rule
+    // matching Field::ScreenOrientation must fire only on the screens the provider
+    // reports that orientation for, proving the stamp reaches a non-assignment
+    // (gap) resolver.
+    void testContextOrientation_stampedAndGatesRule()
+    {
+        RegistryFixture f = makeRegistryFixture();
+        // DP-1 is portrait, DP-2 is landscape; DP-3 has unknown geometry (nullopt).
+        f.registry->setScreenOrientationProvider([](const QString& screenId) -> std::optional<QString> {
+            if (screenId == QLatin1String("DP-1")) {
+                return QStringLiteral("portrait");
+            }
+            if (screenId == QLatin1String("DP-2")) {
+                return QStringLiteral("landscape");
+            }
+            return std::nullopt;
+        });
+
+        PWR::RuleAction gapAction;
+        gapAction.type = QString(PWR::ActionType::SetInnerGap);
+        gapAction.params.insert(QString(PWR::ActionParam::Value), 20);
+        PWR::Rule r;
+        r.id = QUuid::createUuid();
+        r.name = QStringLiteral("portrait gap");
+        r.enabled = true;
+        r.priority = 400;
+        r.match = PWR::MatchExpression::makeLeaf(PWR::Field::ScreenOrientation, PWR::Operator::Equals,
+                                                 QStringLiteral("portrait"));
+        r.actions = {gapAction};
+        QVERIFY(f.store->setAllRules({r}));
+
+        // Portrait screen → the orientation stamp matches → gap applies.
+        const PhosphorZones::ContextGapOverride portrait =
+            f.registry->resolveContextGaps(QStringLiteral("DP-1"), 0, QString());
+        QVERIFY(portrait.innerGap.has_value());
+        QCOMPARE(*portrait.innerGap, 20);
+
+        // Landscape screen → orientation token differs → rule inert.
+        QVERIFY(f.registry->resolveContextGaps(QStringLiteral("DP-2"), 0, QString()).isEmpty());
+        // Unknown geometry → orientation empty → rule inert (no false match).
+        QVERIFY(f.registry->resolveContextGaps(QStringLiteral("DP-3"), 0, QString()).isEmpty());
+    }
+
     // ─── Per-monitor gap rule overrides the baseline for that screen only ────
     // A per-monitor gap override is authored by the Appearance page as a NORMAL
     // (non-managed) screen-scoped rule: match `ScreenId == screen`, carrying the
@@ -1017,6 +1061,62 @@ private Q_SLOTS:
         QVERIFY(r3.shaderId.has_value());
         QCOMPARE(*r3.shaderId, QStringLiteral("plasma-glow"));
         QCOMPARE(r3.shaderParams.value(QStringLiteral("intensity")).toDouble(), 0.5);
+    }
+
+    // ─── Context overlay-APPEARANCE resolution (SetOverlay* colours / opacities
+    //     / border dimensions / zone-number visibility) ────────────────────────
+    // The appearance actions layer over the global Snapping.Zones.* config: each
+    // fills its own optional on ContextOverlayOverride, and an unmatched context
+    // leaves them all unset so the consumer falls through to config.
+    void testContextOverlay_appearanceOverrides()
+    {
+        const auto valueAction = [](QLatin1StringView type, const QVariant& value) {
+            PWR::RuleAction a;
+            a.type = QString(type);
+            a.params.insert(QString(PWR::ActionParam::Value), QJsonValue::fromVariant(value));
+            return a;
+        };
+        PWR::Rule r;
+        r.id = QUuid::createUuid();
+        r.name = QStringLiteral("overlay appearance");
+        r.enabled = true;
+        r.priority = 400;
+        r.match = PWR::MatchExpression::makeLeaf(PWR::Field::ScreenId, PWR::Operator::Equals, QStringLiteral("DP-1"));
+        r.actions = {
+            valueAction(PWR::ActionType::SetOverlayHighlightColor, QStringLiteral("#FF112233")),
+            valueAction(PWR::ActionType::SetOverlayInactiveColor, QStringLiteral("#80445566")),
+            valueAction(PWR::ActionType::SetOverlayBorderColor, QStringLiteral("#FFEEDDCC")),
+            valueAction(PWR::ActionType::SetOverlayActiveOpacity, 0.5),
+            valueAction(PWR::ActionType::SetOverlayInactiveOpacity, 0.25),
+            valueAction(PWR::ActionType::SetOverlayBorderWidth, 3),
+            valueAction(PWR::ActionType::SetOverlayBorderRadius, 12),
+            valueAction(PWR::ActionType::SetOverlayShowZoneNumbers, false),
+        };
+
+        RegistryFixture f = makeRegistryFixture();
+        QVERIFY(f.store->setAllRules({r}));
+
+        const PhosphorZones::ContextOverlayOverride resolved =
+            f.registry->resolveContextOverlay(QStringLiteral("DP-1"), 0, QString());
+        QVERIFY(resolved.highlightColor.has_value());
+        QCOMPARE(*resolved.highlightColor, QColor(QStringLiteral("#FF112233")));
+        QVERIFY(resolved.inactiveColor.has_value());
+        QCOMPARE(*resolved.inactiveColor, QColor(QStringLiteral("#80445566")));
+        QVERIFY(resolved.borderColor.has_value());
+        QCOMPARE(*resolved.borderColor, QColor(QStringLiteral("#FFEEDDCC")));
+        QVERIFY(resolved.activeOpacity.has_value());
+        QCOMPARE(*resolved.activeOpacity, 0.5);
+        QVERIFY(resolved.inactiveOpacity.has_value());
+        QCOMPARE(*resolved.inactiveOpacity, 0.25);
+        QVERIFY(resolved.borderWidth.has_value());
+        QCOMPARE(*resolved.borderWidth, 3);
+        QVERIFY(resolved.borderRadius.has_value());
+        QCOMPARE(*resolved.borderRadius, 12);
+        QVERIFY(resolved.showZoneNumbers.has_value());
+        QCOMPARE(*resolved.showZoneNumbers, false);
+
+        // An unpinned context leaves every appearance field unset (config wins).
+        QVERIFY(f.registry->resolveContextOverlay(QStringLiteral("DP-2"), 0, QString()).isEmpty());
     }
 
     // ─── Context lock resolution (ActionSlot::Locked) ─────────────────────

--- a/tests/unit/core/test_rule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_rule_cascade_fidelity.cpp
@@ -963,6 +963,54 @@ private Q_SLOTS:
         QVERIFY(f.registry->resolveContextGaps(QStringLiteral("DP-1"), 0, QString()).isEmpty());
     }
 
+    // ─── Context autotile-parameter resolution (max / split / master) ────────
+    // resolveContextTilingParams is a per-slot read: independent
+    // SetMaxWindows / SetSplitRatio / SetMasterCount rules compose, and an
+    // unpinned screen resolves to an all-unset (empty) params struct.
+    void testContextTilingParams_perSlotComposition()
+    {
+        const auto valueAction = [](QLatin1StringView type, const QVariant& value) {
+            PWR::RuleAction a;
+            a.type = QString(type);
+            a.params.insert(QString(PWR::ActionParam::Value), QJsonValue::fromVariant(value));
+            return a;
+        };
+        const auto tilingRule = [&](const QString& name, int priority, const QString& screenId,
+                                    const QList<PWR::RuleAction>& actions) {
+            PWR::Rule r;
+            r.id = QUuid::createUuid();
+            r.name = name;
+            r.enabled = true;
+            r.priority = priority;
+            r.match = PWR::MatchExpression::makeLeaf(PWR::Field::ScreenId, PWR::Operator::Equals, screenId);
+            r.actions = actions;
+            return r;
+        };
+
+        RegistryFixture f = makeRegistryFixture();
+        // Separate rules fill separate slots — all compose (per-slot read).
+        const PWR::Rule mw = tilingRule(QStringLiteral("mw"), 400, QStringLiteral("DP-1"),
+                                        {valueAction(PWR::ActionType::SetMaxWindows, 3)});
+        const PWR::Rule sr = tilingRule(QStringLiteral("sr"), 300, QStringLiteral("DP-1"),
+                                        {valueAction(PWR::ActionType::SetSplitRatio, 0.6)});
+        const PWR::Rule mc = tilingRule(QStringLiteral("mc"), 200, QStringLiteral("DP-1"),
+                                        {valueAction(PWR::ActionType::SetMasterCount, 2)});
+        QVERIFY(f.store->setAllRules({mw, sr, mc}));
+
+        const PhosphorZones::ContextTilingParams p =
+            f.registry->resolveContextTilingParams(QStringLiteral("DP-1"), 0, QString());
+        QVERIFY(p.maxWindows.has_value());
+        QCOMPARE(*p.maxWindows, 3);
+        QVERIFY(p.splitRatio.has_value());
+        QCOMPARE(*p.splitRatio, 0.6);
+        QVERIFY(p.masterCount.has_value());
+        QCOMPARE(*p.masterCount, 2);
+
+        // A screen the rules do not pin → all-unset (the daemon then leaves the
+        // config-derived override map untouched for that screen).
+        QVERIFY(f.registry->resolveContextTilingParams(QStringLiteral("DP-2"), 0, QString()).isEmpty());
+    }
+
     // ─── Per-monitor gap rule overrides the baseline for that screen only ────
     // A per-monitor gap override is authored by the Appearance page as a NORMAL
     // (non-managed) screen-scoped rule: match `ScreenId == screen`, carrying the

--- a/tests/unit/core/test_rule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_rule_cascade_fidelity.cpp
@@ -999,7 +999,11 @@ private Q_SLOTS:
         const PWR::Rule ip =
             tilingRule(QStringLiteral("ip"), 100, QStringLiteral("DP-1"),
                        {valueAction(PWR::ActionType::SetInsertPosition, QString(PWR::InsertPositionToken::AsMaster))});
-        QVERIFY(f.store->setAllRules({mw, sr, mc, ip}));
+        // Overflow behavior carries a wire token → AutotileOverflowBehavior int.
+        const PWR::Rule ob = tilingRule(
+            QStringLiteral("ob"), 50, QStringLiteral("DP-1"),
+            {valueAction(PWR::ActionType::SetOverflowBehavior, QString(PWR::OverflowBehaviorToken::Unlimited))});
+        QVERIFY(f.store->setAllRules({mw, sr, mc, ip, ob}));
 
         const PhosphorZones::ContextTilingParams p =
             f.registry->resolveContextTilingParams(QStringLiteral("DP-1"), 0, QString());
@@ -1011,6 +1015,8 @@ private Q_SLOTS:
         QCOMPARE(*p.masterCount, 2);
         QVERIFY(p.insertPosition.has_value());
         QCOMPARE(*p.insertPosition, 2); // "asMaster" → AutotileInsertPosition::AsMaster (2)
+        QVERIFY(p.overflowBehavior.has_value());
+        QCOMPARE(*p.overflowBehavior, 1); // "unlimited" → AutotileOverflowBehavior::Unlimited (1)
 
         // A screen the rules do not pin → all-unset (the daemon then leaves the
         // config-derived override map untouched for that screen).

--- a/tests/unit/core/test_rule_cascade_fidelity.cpp
+++ b/tests/unit/core/test_rule_cascade_fidelity.cpp
@@ -995,7 +995,11 @@ private Q_SLOTS:
                                         {valueAction(PWR::ActionType::SetSplitRatio, 0.6)});
         const PWR::Rule mc = tilingRule(QStringLiteral("mc"), 200, QStringLiteral("DP-1"),
                                         {valueAction(PWR::ActionType::SetMasterCount, 2)});
-        QVERIFY(f.store->setAllRules({mw, sr, mc}));
+        // Insert position carries a wire token → resolves to the AutotileInsertPosition int.
+        const PWR::Rule ip =
+            tilingRule(QStringLiteral("ip"), 100, QStringLiteral("DP-1"),
+                       {valueAction(PWR::ActionType::SetInsertPosition, QString(PWR::InsertPositionToken::AsMaster))});
+        QVERIFY(f.store->setAllRules({mw, sr, mc, ip}));
 
         const PhosphorZones::ContextTilingParams p =
             f.registry->resolveContextTilingParams(QStringLiteral("DP-1"), 0, QString());
@@ -1005,6 +1009,8 @@ private Q_SLOTS:
         QCOMPARE(*p.splitRatio, 0.6);
         QVERIFY(p.masterCount.has_value());
         QCOMPARE(*p.masterCount, 2);
+        QVERIFY(p.insertPosition.has_value());
+        QCOMPARE(*p.insertPosition, 2); // "asMaster" → AutotileInsertPosition::AsMaster (2)
 
         // A screen the rules do not pin → all-unset (the daemon then leaves the
         // config-derived override map untouched for that screen).

--- a/tests/unit/dbus/test_drag_policy.cpp
+++ b/tests/unit/dbus/test_drag_policy.cpp
@@ -127,10 +127,10 @@ public:
 /// isAutotileScreen() returns the desired answer. The engine is constructed
 /// with null dependencies — computeDragPolicy only reads isAutotileScreen
 /// and isWindowTracked, neither of which touches layoutManager / tracker /
-/// screenManager. The fresh engine reports `isWindowTracked = false` for
-/// every windowId; the isTracked branch is covered by separate fixtures
-/// below that seed the engine state through the standard windowOpened
-/// path with a real LayoutManager.
+/// screenManager. A fresh engine reports `isWindowTracked = false` for every
+/// windowId; tests that need the tracked branch seed a window through the
+/// standard windowOpened lifecycle via seedTrackedWindow() below (the same
+/// null-dep pattern test_autotile_drag_insert uses).
 std::unique_ptr<AutotileEngine> makeEngine(bool screenIsAutotile, const QString& screenId)
 {
     auto engine = std::make_unique<AutotileEngine>(nullptr, nullptr, nullptr, PlasmaZones::TestHelpers::testRegistry());
@@ -138,6 +138,17 @@ std::unique_ptr<AutotileEngine> makeEngine(bool screenIsAutotile, const QString&
         engine->setAutotileScreens(QSet<QString>{screenId});
     }
     return engine;
+}
+
+/// Register @p windowId through the standard windowOpened lifecycle so
+/// isWindowTracked() returns true for it — the tracked branch that
+/// computeDragPolicy's immediateFloatOnStart logic keys on. Mirrors the
+/// null-dep seeding pattern in test_autotile_drag_insert (windowOpened +
+/// processEvents populates m_states without needing a real LayoutManager).
+void seedTrackedWindow(AutotileEngine& engine, const QString& windowId, const QString& screenId)
+{
+    engine.windowOpened(windowId, screenId);
+    QCoreApplication::processEvents();
 }
 
 } // namespace
@@ -370,14 +381,20 @@ private Q_SLOTS:
         settings.m_snapEnabled = true;
         settings.m_dragBehavior = AutotileDragBehavior::Reorder;
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
+        // Seed the dragged window as tracked so this test is not vacuous: in Float
+        // mode a tracked window flips immediateFloatOnStart TRUE (see the paired
+        // floatMode test), so asserting it stays FALSE here genuinely exercises the
+        // Reorder-mode clear rather than the always-false untracked default.
+        seedTrackedWindow(*engine, QStringLiteral("win-1"), QStringLiteral("HP-1"));
+        QVERIFY(engine->isWindowTracked(QStringLiteral("win-1")));
 
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
             &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver,
             settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::AutotileScreen);
-        // Even though the engine would normally flip this on for tracked
-        // windows, Reorder mode must leave it cleared.
+        // The window IS tracked, yet Reorder mode must leave immediateFloatOnStart
+        // cleared.
         QVERIFY(!p.immediateFloatOnStart);
         QVERIFY(p.captureGeometry);
         QVERIFY(p.validationError().isEmpty());
@@ -395,17 +412,20 @@ private Q_SLOTS:
         settings.m_snapEnabled = true;
         settings.m_dragBehavior = AutotileDragBehavior::Float;
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
+        // Same tracked seed as the reorder test — this is the positive baseline
+        // proving the reorder test above catches a real difference: a tracked
+        // window in Float mode DOES set immediateFloatOnStart.
+        seedTrackedWindow(*engine, QStringLiteral("win-1"), QStringLiteral("HP-1"));
+        QVERIFY(engine->isWindowTracked(QStringLiteral("win-1")));
 
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
             &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver,
             settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::AutotileScreen);
-        // No windowOpened flowed through the engine so isWindowTracked
-        // returns false — immediateFloatOnStart stays false either way.
-        // The useful assertion here is that the reorder test above isn't
-        // masking a broken computeDragPolicy: the bypass path still
-        // returns the same bypassReason in Float mode.
+        // Float mode + tracked window → immediateFloatOnStart set. This is the
+        // behavior the paired reorder test proves is suppressed under Reorder.
+        QVERIFY(p.immediateFloatOnStart);
         QVERIFY(p.captureGeometry);
         QVERIFY(p.validationError().isEmpty());
     }

--- a/tests/unit/dbus/test_drag_policy.cpp
+++ b/tests/unit/dbus/test_drag_policy.cpp
@@ -161,7 +161,8 @@ private Q_SLOTS:
         auto engine = makeEngine(/*screenIsAutotile=*/false, QStringLiteral("DP-1"));
 
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
-            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("DP-1"), &resolver);
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("DP-1"), &resolver,
+            settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::None);
         QVERIFY(p.streamDragMoved);
@@ -190,7 +191,8 @@ private Q_SLOTS:
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
-            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver);
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver,
+            settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::AutotileScreen);
         QVERIFY(!p.streamDragMoved);
@@ -219,7 +221,8 @@ private Q_SLOTS:
         auto engine = makeEngine(/*screenIsAutotile=*/false, QStringLiteral("DP-1"));
 
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
-            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("DP-1"), &resolver);
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("DP-1"), &resolver,
+            settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::SnappingDisabled);
         QVERIFY(!p.streamDragMoved);
@@ -247,7 +250,8 @@ private Q_SLOTS:
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
-            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver);
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver,
+            settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::AutotileScreen);
         QVERIFY(p.captureGeometry);
@@ -274,7 +278,8 @@ private Q_SLOTS:
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
-            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver);
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver,
+            settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::ContextDisabled);
         QVERIFY(!p.streamDragMoved);
@@ -297,7 +302,8 @@ private Q_SLOTS:
         auto engine = makeEngine(/*screenIsAutotile=*/false, QStringLiteral("DP-1"));
 
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
-            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("DP-1"), &resolver);
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("DP-1"), &resolver,
+            settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         // Context-disabled is checked before snapping_disabled — the reason
         // is stable at ContextDisabled even though either would produce
@@ -318,7 +324,7 @@ private Q_SLOTS:
         // resolver. computeDragPolicy must still produce a canonical
         // snap policy without crashing.
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(nullptr, nullptr, QStringLiteral("win-1"),
-                                                                              QStringLiteral("DP-1"), nullptr);
+                                                                              QStringLiteral("DP-1"), nullptr, false);
 
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::None);
         QVERIFY(p.streamDragMoved);
@@ -337,8 +343,9 @@ private Q_SLOTS:
         settings.m_snapEnabled = false;
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
-        PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
-            &settings, engine.get(), QStringLiteral("win-1"), QString(), &resolver);
+        PhosphorProtocol::DragPolicy p =
+            WindowDragAdaptor::computeDragPolicy(&settings, engine.get(), QStringLiteral("win-1"), QString(), &resolver,
+                                                 settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         // Autotile check is skipped for empty screenId, so snapping_disabled wins.
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::SnappingDisabled);
@@ -365,7 +372,8 @@ private Q_SLOTS:
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
-            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver);
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver,
+            settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::AutotileScreen);
         // Even though the engine would normally flip this on for tracked
@@ -389,7 +397,8 @@ private Q_SLOTS:
         auto engine = makeEngine(/*screenIsAutotile=*/true, QStringLiteral("HP-1"));
 
         PhosphorProtocol::DragPolicy p = WindowDragAdaptor::computeDragPolicy(
-            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver);
+            &settings, engine.get(), QStringLiteral("win-1"), QStringLiteral("HP-1"), &resolver,
+            settings.m_dragBehavior == AutotileDragBehavior::Reorder);
 
         QCOMPARE(p.bypassReason, PhosphorProtocol::DragBypassReason::AutotileScreen);
         // No windowOpened flowed through the engine so isWindowTracked

--- a/tests/unit/dbus/test_wta_reactive_metadata.cpp
+++ b/tests/unit/dbus/test_wta_reactive_metadata.cpp
@@ -406,6 +406,30 @@ private Q_SLOTS:
                  "an unmatched window falls back to the global restoreWindowsToZonesOnLogin = true");
         QVERIFY2(m_wta->shouldRestoreSizeOnUnsnap(konsoleId),
                  "an unmatched window falls back to the global restoreOriginalSizeOnUnsnap = true");
+
+        // Slot independence: a rule setting ONLY SetRestoreToZoneOnLogin(false) must
+        // leave shouldRestoreSizeOnUnsnap on its own global (true). Both globals are
+        // ON and the dolphin rule above set both actions to the same value, so a
+        // cross-wired resolver (one reading the other's slot) would pass every
+        // assertion so far; this single-action rule is what catches a slot swap.
+        PhosphorRules::Rule zoneOnlyRule;
+        zoneOnlyRule.id = QUuid::createUuid();
+        zoneOnlyRule.name = QStringLiteral("no-zone-restore-gwenview");
+        zoneOnlyRule.enabled = true;
+        zoneOnlyRule.priority = 100;
+        zoneOnlyRule.match = PhosphorRules::MatchExpression::makeLeaf(
+            PhosphorRules::Field::AppId, PhosphorRules::Operator::Equals, QStringLiteral("org.kde.gwenview"));
+        zoneOnlyRule.actions.append(boolAction(PhosphorRules::ActionType::SetRestoreToZoneOnLogin, false));
+        QVERIFY(store.addRule(zoneOnlyRule));
+
+        const QString gwenInstance = QStringLiteral("gwenview-uuid-1");
+        m_registry->upsert(gwenInstance, {QStringLiteral("org.kde.gwenview"), QString(), QString()});
+        const QString gwenId =
+            PhosphorIdentity::WindowId::buildCompositeId(QStringLiteral("org.kde.gwenview"), gwenInstance);
+        QVERIFY2(!m_wta->shouldRestoreToZoneOnLogin(gwenId), "the zone-only rule overrides restore-to-zone to false");
+        QVERIFY2(m_wta->shouldRestoreSizeOnUnsnap(gwenId),
+                 "restore-size-on-unsnap must fall back to its own global (true) with no SizeOnUnsnap "
+                 "action present — proving the two resolvers read distinct slots");
     }
 
     // ────────────────────────────────────────────────────────────────────
@@ -537,6 +561,84 @@ private Q_SLOTS:
         // Absent keys → both fields disengaged → predicate inert → no float.
         QVERIFY2(!floatVerdict(QStringLiteral("no-props-1"), QVariantMap()),
                  "with the extended props absent, an IsModal/Width rule stays inert (engage-only-when-known)");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // End-to-end plumb for the IsMovable / IsMaximizable capability match fields:
+    // effect a{sv} → setWindowMetadata unpack → WindowRegistry snapshot →
+    // buildRuleQueryForWindow → evaluation. A dropped key mapping or missing parse
+    // anywhere in that chain would leave the field silently always-disengaged, so
+    // this exercises the same full path as the IsModal/Width test above.
+    // ────────────────────────────────────────────────────────────────────
+    void floatRule_matchesExtendedProperty_isMovableAndMaximizable()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        PhosphorRules::RuleStore store(dir.filePath(QStringLiteral("rules.json")));
+
+        // "Float any movable, non-maximizable window" — both new capability fields,
+        // carried only via the extended a{sv}, combined under All.
+        PhosphorRules::Rule rule;
+        rule.id = QUuid::createUuid();
+        rule.name = QStringLiteral("float-movable-nonmaximizable");
+        rule.enabled = true;
+        rule.priority = 100;
+        rule.match = PhosphorRules::MatchExpression::makeAll(
+            {PhosphorRules::MatchExpression::makeLeaf(PhosphorRules::Field::IsMovable, PhosphorRules::Operator::Equals,
+                                                      true),
+             PhosphorRules::MatchExpression::makeLeaf(PhosphorRules::Field::IsMaximizable,
+                                                      PhosphorRules::Operator::Equals, false)});
+        PhosphorRules::RuleAction action;
+        action.type = QString(PhosphorRules::ActionType::Float);
+        rule.actions.append(action);
+        QVERIFY(store.addRule(rule));
+
+        m_wta->setRuleStore(&store);
+        const auto detach = qScopeGuard([this] {
+            m_wta->setRuleStore(nullptr);
+        });
+
+        namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
+        const QString appId = QStringLiteral("org.kde.someapp");
+        const int normalType = static_cast<int>(PhosphorProtocol::WindowType::Normal);
+        const auto floatVerdict = [&](const QString& instance, const QVariantMap& extended) {
+            m_wta->setWindowMetadata(instance, appId, QString(), QString(), QString(), 0, 0, QString(), normalType,
+                                     extended);
+            return m_wta->shouldFloatByRule(PhosphorIdentity::WindowId::buildCompositeId(appId, instance));
+        };
+
+        // Movable + not maximizable → both leaves match → float.
+        QVariantMap movableNonMax;
+        movableNonMax.insert(Key::IsMovable, true);
+        movableNonMax.insert(Key::IsMaximizable, false);
+        QVERIFY2(floatVerdict(QStringLiteral("movable-nonmax-1"), movableNonMax),
+                 "a movable, non-maximizable window must float (both capability props matched end-to-end)");
+
+        // Movable + maximizable → IsMaximizable leaf fails → no float.
+        QVariantMap movableMax;
+        movableMax.insert(Key::IsMovable, true);
+        movableMax.insert(Key::IsMaximizable, true);
+        QVERIFY2(!floatVerdict(QStringLiteral("movable-max-1"), movableMax),
+                 "a maximizable window must not float (IsMaximizable == false fails the All)");
+
+        // Not movable + not maximizable → IsMovable leaf fails → no float.
+        QVariantMap nonMovableNonMax;
+        nonMovableNonMax.insert(Key::IsMovable, false);
+        nonMovableNonMax.insert(Key::IsMaximizable, false);
+        QVERIFY2(!floatVerdict(QStringLiteral("nonmovable-nonmax-1"), nonMovableNonMax),
+                 "a non-movable window must not float (IsMovable == true fails)");
+
+        // Not movable + maximizable → both leaves fail → no float (fourth corner).
+        QVariantMap nonMovableMax;
+        nonMovableMax.insert(Key::IsMovable, false);
+        nonMovableMax.insert(Key::IsMaximizable, true);
+        QVERIFY2(!floatVerdict(QStringLiteral("nonmovable-max-1"), nonMovableMax),
+                 "a non-movable maximizable window must not float (both leaves fail)");
+
+        // Absent keys → both capability fields disengaged → predicate inert → no float.
+        QVERIFY2(
+            !floatVerdict(QStringLiteral("no-caps-1"), QVariantMap()),
+            "with the capability props absent, an IsMovable/IsMaximizable rule stays inert (engage-only-when-known)");
     }
 
     // ────────────────────────────────────────────────────────────────────

--- a/tests/unit/dbus/test_wta_reactive_metadata.cpp
+++ b/tests/unit/dbus/test_wta_reactive_metadata.cpp
@@ -353,6 +353,62 @@ private Q_SLOTS:
     }
 
     // ────────────────────────────────────────────────────────────────────
+    // SetRestoreToZoneOnLogin / SetRestoreSizeOnUnsnap rules override their
+    // respective global settings per window, mirroring RestorePosition. An
+    // unmatched window falls back to the global setting.
+    // ────────────────────────────────────────────────────────────────────
+    void restoreToZoneAndUnsnapSizeRules_overrideGlobalSettings()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        PhosphorRules::RuleStore store(dir.filePath(QStringLiteral("rules.json")));
+
+        const auto boolAction = [](QLatin1StringView type, bool value) {
+            PhosphorRules::RuleAction a;
+            a.type = QString(type);
+            a.params.insert(QString(PhosphorRules::ActionParam::Value), value);
+            return a;
+        };
+        PhosphorRules::Rule rule;
+        rule.id = QUuid::createUuid();
+        rule.name = QStringLiteral("no-restore-dolphin");
+        rule.enabled = true;
+        rule.priority = 100;
+        rule.match = PhosphorRules::MatchExpression::makeLeaf(
+            PhosphorRules::Field::AppId, PhosphorRules::Operator::Equals, QStringLiteral("org.kde.dolphin"));
+        rule.actions.append(boolAction(PhosphorRules::ActionType::SetRestoreToZoneOnLogin, false));
+        rule.actions.append(boolAction(PhosphorRules::ActionType::SetRestoreSizeOnUnsnap, false));
+        QVERIFY(store.addRule(rule));
+
+        m_wta->setRuleStore(&store);
+        const auto detach = qScopeGuard([this] {
+            m_wta->setRuleStore(nullptr);
+        });
+        m_settings->setRestoreWindowsToZonesOnLogin(true); // global default ON
+        m_settings->setRestoreOriginalSizeOnUnsnap(true); // global default ON
+
+        const QString dolphinInstance = QStringLiteral("dolphin-uuid-1");
+        m_registry->upsert(dolphinInstance, {QStringLiteral("org.kde.dolphin"), QString(), QString()});
+        const QString dolphinId =
+            PhosphorIdentity::WindowId::buildCompositeId(QStringLiteral("org.kde.dolphin"), dolphinInstance);
+
+        QVERIFY2(!m_wta->shouldRestoreToZoneOnLogin(dolphinId),
+                 "a matched SetRestoreToZoneOnLogin(false) rule must override the global ON setting");
+        QVERIFY2(!m_wta->shouldRestoreSizeOnUnsnap(dolphinId),
+                 "a matched SetRestoreSizeOnUnsnap(false) rule must override the global ON setting");
+
+        // An unmatched window falls back to the global settings (ON).
+        const QString konsoleInstance = QStringLiteral("konsole-uuid-1");
+        m_registry->upsert(konsoleInstance, {QStringLiteral("org.kde.konsole"), QString(), QString()});
+        const QString konsoleId =
+            PhosphorIdentity::WindowId::buildCompositeId(QStringLiteral("org.kde.konsole"), konsoleInstance);
+        QVERIFY2(m_wta->shouldRestoreToZoneOnLogin(konsoleId),
+                 "an unmatched window falls back to the global restoreWindowsToZonesOnLogin = true");
+        QVERIFY2(m_wta->shouldRestoreSizeOnUnsnap(konsoleId),
+                 "an unmatched window falls back to the global restoreOriginalSizeOnUnsnap = true");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
     // Float rule resolves through the composite windowId. shouldFloatByRule is
     // purely rule-driven (no global default): the verdict is the presence of a
     // matched Float slot, resolved through the same bare-instance-id extraction

--- a/tests/unit/settings/test_rule_controller.cpp
+++ b/tests/unit/settings/test_rule_controller.cpp
@@ -811,6 +811,8 @@ void TestRuleController::authoringMetadata()
     bool sawActivityKind = false;
     bool sawWindowTypeKind = false;
     bool sawModeKind = false;
+    bool sawOrientationKind = false;
+    bool sawLayoutKind = false;
     for (const QVariant& v : fields) {
         const QVariantMap f = v.toMap();
         QVERIFY(f.contains(QStringLiteral("value")));
@@ -827,14 +829,22 @@ void TestRuleController::authoringMetadata()
         if (kind == QLatin1String("activity")) {
             sawActivityKind = true;
         }
-        if (kind == QLatin1String("windowType") || kind == QLatin1String("mode")) {
+        if (kind == QLatin1String("layout")) {
+            sawLayoutKind = true;
+        }
+        // Closed-vocab dropdown fields must carry an `options` array of {value, wire,
+        // label} triples so the editor can render the dropdown. ScreenOrientation
+        // (orientation) is one of these — it mirrors mode — so it is validated here
+        // too, guarding against a regression that reverts it to a bare string field.
+        if (kind == QLatin1String("windowType") || kind == QLatin1String("mode")
+            || kind == QLatin1String("orientation")) {
             if (kind == QLatin1String("windowType")) {
                 sawWindowTypeKind = true;
-            } else {
+            } else if (kind == QLatin1String("mode")) {
                 sawModeKind = true;
+            } else {
+                sawOrientationKind = true;
             }
-            // Enum-style fields must carry an `options` array of {value, wire,
-            // label} triples so the editor can render the dropdown.
             const QVariantList options = f.value(QStringLiteral("options")).toList();
             QVERIFY2(!options.isEmpty(), "enum valueKind must expose options for the dropdown");
             for (const QVariant& opt : options) {
@@ -849,6 +859,11 @@ void TestRuleController::authoringMetadata()
     QVERIFY(sawActivityKind);
     QVERIFY(sawWindowTypeKind);
     QVERIFY(sawModeKind);
+    // The two match fields this expansion adds must keep their editor-driving kinds:
+    // ScreenOrientation → "orientation" dropdown, ActiveLayout → "layout" picker. A
+    // regression reverting either to "string" would silently break the editor.
+    QVERIFY(sawOrientationKind);
+    QVERIFY(sawLayoutKind);
 
     // Picker categories drive the fly-out submenu grouping. Every field carries
     // a non-empty category label + a categoryOrder int. The Field enum

--- a/tests/unit/settings/test_rule_controller.cpp
+++ b/tests/unit/settings/test_rule_controller.cpp
@@ -819,7 +819,8 @@ void TestRuleController::authoringMetadata()
         QVERIFY(kind == QLatin1String("string") || kind == QLatin1String("number") || kind == QLatin1String("bool")
                 || kind == QLatin1String("screen") || kind == QLatin1String("activity")
                 || kind == QLatin1String("windowType") || kind == QLatin1String("virtualDesktop")
-                || kind == QLatin1String("mode") || kind == QLatin1String("orientation"));
+                || kind == QLatin1String("mode") || kind == QLatin1String("orientation")
+                || kind == QLatin1String("layout"));
         if (kind == QLatin1String("screen")) {
             sawScreenKind = true;
         }

--- a/tests/unit/settings/test_rule_controller.cpp
+++ b/tests/unit/settings/test_rule_controller.cpp
@@ -813,6 +813,7 @@ void TestRuleController::authoringMetadata()
     bool sawModeKind = false;
     bool sawOrientationKind = false;
     bool sawLayoutKind = false;
+    bool sawVirtualDesktopKind = false;
     for (const QVariant& v : fields) {
         const QVariantMap f = v.toMap();
         QVERIFY(f.contains(QStringLiteral("value")));
@@ -831,6 +832,9 @@ void TestRuleController::authoringMetadata()
         }
         if (kind == QLatin1String("layout")) {
             sawLayoutKind = true;
+        }
+        if (kind == QLatin1String("virtualDesktop")) {
+            sawVirtualDesktopKind = true;
         }
         // Closed-vocab dropdown fields must carry an `options` array of {value, wire,
         // label} triples so the editor can render the dropdown. ScreenOrientation
@@ -864,6 +868,9 @@ void TestRuleController::authoringMetadata()
     // regression reverting either to "string" would silently break the editor.
     QVERIFY(sawOrientationKind);
     QVERIFY(sawLayoutKind);
+    // VirtualDesktop keeps its dedicated "virtualDesktop" kind, which drives the
+    // desktop-name picker in the editor and the name resolution in the summaries.
+    QVERIFY(sawVirtualDesktopKind);
 
     // Picker categories drive the fly-out submenu grouping. Every field carries
     // a non-empty category label + a categoryOrder int. The Field enum

--- a/tests/unit/settings/test_rule_controller.cpp
+++ b/tests/unit/settings/test_rule_controller.cpp
@@ -819,7 +819,7 @@ void TestRuleController::authoringMetadata()
         QVERIFY(kind == QLatin1String("string") || kind == QLatin1String("number") || kind == QLatin1String("bool")
                 || kind == QLatin1String("screen") || kind == QLatin1String("activity")
                 || kind == QLatin1String("windowType") || kind == QLatin1String("virtualDesktop")
-                || kind == QLatin1String("mode"));
+                || kind == QLatin1String("mode") || kind == QLatin1String("orientation"));
         if (kind == QLatin1String("screen")) {
             sawScreenKind = true;
         }


### PR DESCRIPTION
## Summary

Expands the window-rules vocabulary with new **actions** and **match fields**, layered additively on top of config. This lets power users author per-window and per-context rules for a much wider set of behaviors, without turning config into a purely rule-backed store.

### Core invariant

Every consumer reads **`rule-slot ?? config-getter`**. Config stays authoritative for the global default (and for the existing per-screen config stores); a rule is an optional top layer that wins only where present. Consequences:

- No config group is retired. No config schema migration. `RuleSet::SchemaVersion` is untouched (new match fields drop unknown tokens on load; new actions that do not retire config cost nothing).
- Per-screen behavior is expressed as a `WHEN ScreenId` rule over the global config default, rather than growing new per-screen config plumbing.

This is deliberately the opposite of the earlier `feat/config-rules-fold-v5` approach, which made config purely rule-backed.

## What's added

**Overlay appearance (Context actions)** — `SetOverlayHighlightColor`, `SetOverlayInactiveColor`, `SetOverlayBorderColor`, `SetOverlayActiveOpacity`, `SetOverlayInactiveOpacity`, `SetOverlayBorderWidth`, `SetOverlayBorderRadius`, `SetOverlayShowZoneNumbers`. Extend `ContextOverlayOverride` and layer over config at the main overlay, snap assist, and layout picker.

**Match fields (WHEN side)** — `IsMovable`, `IsMaximizable` (window capability, full effect-to-daemon plumb), `ScreenOrientation` (portrait/landscape, from a screen-geometry provider), `ActiveLayout` (the layout resolved for a screen, recursion-safe: stamped only in the non-assignment resolvers with the active layout folded into the cache key).

**Restore policy (Window actions)** — `SetRestoreToZoneOnLogin`, `SetRestoreSizeOnUnsnap`, mirroring the existing `RestorePosition` resolver.

**Autotile parameters (Context actions)** — `SetMaxWindows`, `SetSplitRatio`, `SetMasterCount`, `SetInsertPosition`, `SetOverflowBehavior`, `SetDragBehavior`, resolved through a new `resolveContextTilingParams` and layered onto the per-screen override map (drag behavior via the drag adaptor). Several of these also revive previously-inert per-screen config for the same settings.

**`SetAlgorithmParam`** — overrides an autotile algorithm's Luau-declared custom parameters per context, mirroring the shader-uniform override pattern (target algorithm token plus a free-form params blob, with a dedicated dynamic params editor in the rule editor).

## How it's structured

Eight atomic commits, one per phase, each building and passing the full suite:

1. Overlay appearance actions + `IsMovable`/`IsMaximizable`/`ScreenOrientation`
2. `ActiveLayout` match field
3. Restore-policy actions
4. Autotile max/split/master
5. Autotile insert position
6. Autotile overflow behavior
7. Autotile drag behavior
8. `SetAlgorithmParam`

## Testing

- `251/251` unit tests pass.
- Clean rebuild (`--clean-first`, 1503 targets) with **zero warnings**.
- New coverage: action registration + domain canaries, per-action validation (ranges, enum vocab, strict allowed-keys), and resolver tests for every new context resolver and match field.

## Not covered here

- **Runtime verification in-app is still pending.** Everything is unit-tested and compiles (QML via qmlcachegen), but the rules have not yet been authored and observed applying in a live session. That is the recommended next step before this is relied on.
- **Deferred tail** (each needs a net-new seam, out of scope here): OSD suppression, a `ColorScheme` match field (needs a system color-scheme watcher), and `UnfloatFallbackToZone` (engine-internal, no daemon evaluator seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
