### PR TITLE
fix: settings/rules layout polish + cross-desktop resnap leak

### DIFF
--- a/libs/phosphor-placement/src/WindowTrackingService.cpp
+++ b/libs/phosphor-placement/src/WindowTrackingService.cpp
@@ -785,6 +785,25 @@ void WindowTrackingService::forEachZoneAssignedWindow(
         const QHash<QString, QString>& screens = state->screenAssignments();
         const QHash<QString, int>& desktops = state->desktopAssignments();
         for (auto it = zones.constBegin(); it != zones.constEnd(); ++it) {
+            // Single-owner guard: a window's authoritative store is the one the
+            // reverse map points at (snapForWindow). Re-keying a window to a new
+            // per-(screen,desktop,activity) store only moves that pointer — it does
+            // NOT evict the window's zone/desktop data from the old store (see
+            // PerScreenStates::setKeyForWindow / removeWindow, which "do not touch
+            // state objects"). Iterating the raw stores therefore sees a re-keyed
+            // window twice, once per store, with each store's own (possibly stale)
+            // desktop value — the cross-desktop resnap leak (a VD1 window read as
+            // VD2 from a leftover store, then resnapped off its real desktop). The
+            // autotile engine never hits this because it resolves windows through
+            // the same reverse map instead of scanning raw stores. Match that here:
+            // report a window only from its owning store, skipping stale leftovers.
+            // A window untracked by the reverse map (owner == nullptr, e.g. the
+            // global holder's screenless entries) is left to the callback's own
+            // screen/desktop guards, preserving prior behaviour.
+            const PhosphorSnapEngine::SnapState* owner = snapForWindow(it.key());
+            if (owner && owner != state) {
+                continue;
+            }
             fn(it.key(), it.value(), screens.value(it.key()), desktops.value(it.key(), 0));
         }
     }

--- a/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
+++ b/libs/phosphor-snap-engine/include/PhosphorSnapEngine/SnapState.h
@@ -185,6 +185,17 @@ public:
     /// No-op when @p target is null/this or the window has no entry in this store.
     void migrateWindowTo(SnapState* target, const QString& windowId, const QString& newScreenId);
 
+    /// Remove ALL of @p windowId's per-window data from this store (zone/screen/
+    /// desktop assignment, floating bit, pre-float zone/screen, auto-snap flag),
+    /// returning true if anything was removed. Emits NO signal: this is the snap
+    /// engine's single-owner enforcement primitive — it evicts a window from every
+    /// store EXCEPT the one the reverse map owns it in, so a re-keyed window never
+    /// leaves a phantom copy behind (see SnapEngine::stateForWindowOnScreen). An
+    /// evicted phantom was never a legitimate resident here, so firing
+    /// windowUnassigned/stateChanged for it would be wrong. windowClosed() is the
+    /// signalling wrapper for the genuine "this window went away" case.
+    bool removeWindowData(const QString& windowId);
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Last-Used Zone Tracking
     //
@@ -298,8 +309,6 @@ private:
     /// bare-appId alias writes (addPreFloat*/clearPreFloatZone) safe. See the
     /// .cpp header comment.
     QString canonicalizeForLookup(const QString& rawWindowId) const;
-
-    bool removeWindowData(const QString& windowId);
 
     /// Shared body of unassignWindow / unsnapForFloat. Removes the window's
     /// zone assignment and (optionally) its screen+desktop assignment, clears

--- a/libs/phosphor-snap-engine/src/SnapEngine.cpp
+++ b/libs/phosphor-snap-engine/src/SnapEngine.cpp
@@ -108,20 +108,40 @@ SnapState* SnapEngine::stateForWindowOnScreen(const QString& windowId, const QSt
     // An already-tracked window keeps its existing owning store — a screen-carrying
     // write only updates the per-window screen VALUE in place, it does not re-home
     // the window (cross-monitor re-homing is an explicit migrateWindowToScreen).
+    SnapState* owner = nullptr;
     if (const auto existing = m_states.windowKey(canonical)) {
-        if (SnapState* state = m_states.stateForKey(*existing)) {
-            return state;
+        owner = m_states.stateForKey(*existing);
+    }
+    if (!owner) {
+        // First placement (or the reverse-map key pointed at a since-pruned store):
+        // derive the key from the screen, lazily create the store, and record the
+        // reverse-map entry. A screenless call resolves to the global holder and is
+        // NOT recorded in the reverse map (untracked stays untracked).
+        const PhosphorEngine::PlacementStateKey key = currentKeyForScreen(screenId);
+        owner = ensureStateForKey(key);
+        if (owner && !key.screenId.isEmpty()) {
+            m_states.setKeyForWindow(canonical, key);
         }
     }
-    // First placement: derive the key from the screen, lazily create the store, and
-    // record the reverse-map entry. A screenless call resolves to the global holder
-    // and is NOT recorded in the reverse map (untracked stays untracked).
-    const PhosphorEngine::PlacementStateKey key = currentKeyForScreen(screenId);
-    SnapState* state = ensureStateForKey(key);
-    if (state && !key.screenId.isEmpty()) {
-        m_states.setKeyForWindow(canonical, key);
+    // Single-owner invariant: a window's zone/screen/desktop data must live in
+    // exactly ONE store. Re-keying a window moves only the reverse-map pointer —
+    // PerScreenStates::migrate / setKeyForWindow deliberately "do not touch state
+    // objects" — so a former owner store can retain stale data for the window. That
+    // phantom is invisible to owner-map reads (like the autotile engine's) but the
+    // snap resnap's forEachZoneAssignedWindow raw-scans every store and would read
+    // the phantom's stale desktop, resnapping a window off its real desktop (the
+    // cross-desktop leak). Since every write path resolves its store through here
+    // first, evicting the window from every non-owner store at resolution time keeps
+    // the phantom from ever forming. removeWindowData is a no-op where absent, so the
+    // common single-store case costs only a handful of empty hash lookups.
+    if (owner) {
+        for (SnapState* state : m_states.states()) {
+            if (state && state != owner) {
+                state->removeWindowData(canonical);
+            }
+        }
     }
-    return state;
+    return owner;
 }
 
 bool SnapEngine::migrateWindowToScreen(const QString& windowId, const QString& newScreenId)

--- a/src/settings/qml/AnimationProfileEditor.qml
+++ b/src/settings/qml/AnimationProfileEditor.qml
@@ -388,6 +388,12 @@ ColumnLayout {
         }
 
         Layout.fillWidth: true
+        // SettingsRow insets its content by largeSpacing on both sides
+        // via internal anchors; this editor lays out directly in the
+        // ColumnLayout, so match that inset explicitly or the Parameters
+        // header and rows hug the card's left edge.
+        Layout.leftMargin: Kirigami.Units.largeSpacing
+        Layout.rightMargin: Kirigami.Units.largeSpacing
         visible: root.shaderLegSupported && root.showShaderSection && root.shaderEffectId.length > 0 && _paramSchema.length > 0
         parameters: _paramSchema
         currentValues: root.shaderParams

--- a/src/settings/qml/MatchLeafEditor.qml
+++ b/src/settings/qml/MatchLeafEditor.qml
@@ -330,6 +330,22 @@ RowLayout {
         }
     }
 
+    // Slack absorber for the field-less state. Before a field is chosen the
+    // operator combo and value editor are both hidden, so the row's only
+    // fillWidth item (the value Loader above) is invisible and absorbs no
+    // stretch. QtQuick.Layouts then hands the leftover width to the remaining
+    // cells that carry a Layout.alignment (the info icon, field picker and
+    // trash), inflating each cell and left-aligning its item inside — which
+    // pushes the field picker rightward (the "Choose…" inset) and un-pins the
+    // trash. This empty fillWidth item soaks up that slack instead, so the
+    // picker stays at its natural left position and the trash stays hard right.
+    // Once a field is chosen the value Loader becomes the fillWidth item, so
+    // this collapses out of the layout.
+    Item {
+        Layout.fillWidth: true
+        visible: !leaf._hasField
+    }
+
     ToolButton {
         icon.name: "edit-delete"
         Layout.alignment: Qt.AlignTop


### PR DESCRIPTION
## Summary

Four bug fixes for v3.2, split one commit per bug.

### Bug 1 — shader Parameters block margin (`settings`)
The animation-profile shader Parameters editor hugged the left edge while every SettingsRow above it was inset. Gives the `ShaderParameterEditor` matching left/right `largeSpacing` margins so it lines up.

### Bug 2 — "Choose…" field placeholder stretched the row (`rules`)
When adding a rule condition, before a field is picked there is no value slot, so QtQuick.Layouts had no `fillWidth` item and inflated the "Choose…" field cell while the trash button drifted off the right edge (it self-corrected once a field was chosen). Adds an invisible `fillWidth` slack-absorber shown only while no field is selected.

### Bug 3 — cross-desktop resnap leak
Snap on VD2, change VD2's layout, and a VD1 window (firefox, settings, vesktop) got moved and un-snapped. Root cause: a window's snap record existed in two per-(screen, desktop, activity) SnapStates at once. Re-keying a window to a new store only moved the reverse-map pointer (`PerScreenStates::setKeyForWindow` does not touch state objects), leaving a phantom in the old store; the phantom survived the resnap desktop filter and dragged the real window along.

Two commits, belt-and-suspenders:
- **Root fix** (`snap`): `stateForWindowOnScreen` now evicts the window's data from every non-owning store, so each window's record lives in exactly one SnapState. `SnapState::removeWindowData` promoted to public.
- **Defense in depth** (`placement`): `forEachZoneAssignedWindow` raw-scans the union of all SnapStates (unlike autotile, which reads through the reverse map), so it now guards each entry with `snapForWindow()` and reports a window only from its owning store.

### Bug 4 — #648 flicker: not reproducible
Investigated the suspected per-output virtual-desktop cursor-follow flicker. A live test (two monitors on different desktops, cursor moved between them) produced **zero** `Switching autotile context` events during pure cursor movement, matching every historical session where each switch correlated with a real user action. Per-output `screenDesktopChanged` is authoritative and correctly ignores cursor motion. No code change.

## Testing
- `cmake --build build` clean
- `ctest`: 251/251 pass
- Bug 3 confirmed in-session: vesktop stays put after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)