### PR TITLE
refactor(settings): generalize ShaderParameterEditor into ParameterEditor, reuse for algorithm params

### DIFF
--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -745,7 +745,7 @@ void ActionRegistry::registerBuiltins()
             },
         .terminal = false,
         // Params carries the optional shader-uniform overrides, mirroring
-        // OverrideAnimationShader; the inline ShaderParameterEditor writes it.
+        // OverrideAnimationShader; the inline ParameterEditor writes it.
         .allowedKeys = {QString(ActionParam::EffectId), QString(ActionParam::Params)},
         .domain = ActionDomain::Context,
         .params = {P{.key = QString(ActionParam::EffectId), .kind = QStringLiteral("overlayShader")}},

--- a/src/editor/qml/ShaderSettingsDialog.qml
+++ b/src/editor/qml/ShaderSettingsDialog.qml
@@ -17,7 +17,7 @@ import org.plasmazones.common as PZCommon
  *
  * The picker, parameter rows, accordion sections and lock/randomize
  * toolbar live in `org.plasmazones.common` (PZCommon.CategoryMenuButton /
- * ShaderParameterEditor) so the animation-settings page can reuse them.
+ * ParameterEditor) so the animation-settings page can reuse them.
  * This dialog owns the editor-specific bits: the live preview pane, the
  * shader-preset load/save flow, color/image platform dialogs, and the
  * pending-state buffering until "Apply" is clicked.
@@ -516,7 +516,7 @@ Kirigami.Dialog {
             }
 
             // ── Parameters editor (toolbar + flat/grouped rows) ───────
-            PZCommon.ShaderParameterEditor {
+            PZCommon.ParameterEditor {
                 id: paramEditor
 
                 Layout.fillWidth: true

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -420,9 +420,9 @@ qt_add_resources(plasmazones-settings "shared_common_qml"
         ${CMAKE_SOURCE_DIR}/src/shared/ZonePreview.qml
         ${CMAKE_SOURCE_DIR}/src/shared/CategoryBadge.qml
         ${CMAKE_SOURCE_DIR}/src/shared/CategoryMenuButton.qml
-        ${CMAKE_SOURCE_DIR}/src/shared/ShaderParameterRow.qml
-        ${CMAKE_SOURCE_DIR}/src/shared/ShaderParameterSection.qml
-        ${CMAKE_SOURCE_DIR}/src/shared/ShaderParameterEditor.qml
+        ${CMAKE_SOURCE_DIR}/src/shared/ParameterRow.qml
+        ${CMAKE_SOURCE_DIR}/src/shared/ParameterSection.qml
+        ${CMAKE_SOURCE_DIR}/src/shared/ParameterEditor.qml
         ${CMAKE_SOURCE_DIR}/src/shared/ShaderParamsEditor.qml
         ${CMAKE_SOURCE_DIR}/src/shared/ShaderCompileErrorBanner.qml
         ${CMAKE_SOURCE_DIR}/src/shared/ZoneShaderRenderer.qml

--- a/src/settings/org_plasmazones_common/qmldir
+++ b/src/settings/org_plasmazones_common/qmldir
@@ -4,9 +4,9 @@ CapabilityBadgeRow 1.0 CapabilityBadgeRow.qml
 ZonePreview 1.0 ZonePreview.qml
 CategoryBadge 1.0 CategoryBadge.qml
 CategoryMenuButton 1.0 CategoryMenuButton.qml
-ShaderParameterRow 1.0 ShaderParameterRow.qml
-ShaderParameterSection 1.0 ShaderParameterSection.qml
-ShaderParameterEditor 1.0 ShaderParameterEditor.qml
+ParameterRow 1.0 ParameterRow.qml
+ParameterSection 1.0 ParameterSection.qml
+ParameterEditor 1.0 ParameterEditor.qml
 ShaderParamsEditor 1.0 ShaderParamsEditor.qml
 ShaderCompileErrorBanner 1.0 ShaderCompileErrorBanner.qml
 ZoneShaderRenderer 1.0 ZoneShaderRenderer.qml

--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -145,6 +145,48 @@ ColumnLayout {
             return row.appSettings.tilingAlgorithmPage.customParamsForAlgorithm(row._algorithmParamAlgoId);
         return [];
     }
+    /// The algorithm schema adapted to the shared ParameterEditor's descriptor
+    /// shape: the algorithm's `name` is a code identifier so it becomes the
+    /// `id` (value key), and its human `description` becomes the display
+    /// `name`; `minValue`/`maxValue`/`defaultValue` map to `min`/`max`/
+    /// `default`. Depends only on the value-stable schema, so it rebuilds on
+    /// algorithm change, not on every param write.
+    readonly property var _adaptedAlgorithmParamSchema: {
+        var schema = row._activeAlgorithmParamSchema || [];
+        var out = [];
+        for (var i = 0; i < schema.length; i++) {
+            var p = schema[i];
+            if (!p || p.name === undefined)
+                continue;
+
+            out.push({
+                "id": p.name,
+                "name": (p.description && p.description.length > 0) ? p.description : p.name,
+                "type": p.type,
+                "default": p.defaultValue,
+                "min": p.minValue,
+                "max": p.maxValue,
+                "enumOptions": p.enumOptions
+            });
+        }
+        return out;
+    }
+    /// The live id→value map ParameterEditor renders: the rule's stored
+    /// override wins, else the algorithm's saved value, else its default.
+    /// Reassigned (fresh identity) on every write so the editor re-syncs.
+    readonly property var _algorithmParamValues: {
+        var vals = {};
+        var schema = row._activeAlgorithmParamSchema || [];
+        var overrides = (row.action && row.action.params) ? row.action.params : {};
+        for (var i = 0; i < schema.length; i++) {
+            var p = schema[i];
+            if (!p || p.name === undefined)
+                continue;
+
+            vals[p.name] = overrides[p.name] !== undefined ? overrides[p.name] : (p.value !== undefined ? p.value : p.defaultValue);
+        }
+        return vals;
+    }
     /// Write one custom-param value into the action's nested `params` object
     /// (shallow-cloned so the binding re-triggers), mirroring the shader editor's
     /// per-uniform write via _withParam("params", …).
@@ -540,10 +582,9 @@ ColumnLayout {
 
     // ── Bottom: custom-parameter editor for SetAlgorithmParam ────────────────
     // Surfaces when the action is `setAlgorithmParam`, the user has picked an
-    // algorithm, and that algorithm declares custom params. The autotile analogue
-    // of the shader-params editor above; a dedicated editor rather than the
-    // shader one because the schema shape (name / type / minValue / maxValue) and
-    // the number/bool/enum vocabulary differ.
+    // algorithm, and that algorithm declares custom params. Reuses the shared
+    // ParameterEditor (as the shader-params editor above does); the algorithm
+    // schema is adapted to the descriptor shape by row._adaptedAlgorithmParamSchema.
     Loader {
         Layout.fillWidth: true
         Layout.leftMargin: Kirigami.Units.iconSizes.small + Kirigami.Units.smallSpacing
@@ -1199,92 +1240,21 @@ ColumnLayout {
     }
 
     _algorithmParamsEditor: Component {
-        ColumnLayout {
-            spacing: Kirigami.Units.smallSpacing
-
-            Repeater {
-                model: row._activeAlgorithmParamSchema
-
-                delegate: RowLayout {
-                    required property var modelData
-
-                    // Current value: the rule's stored override, else the
-                    // algorithm's saved/default value from the schema.
-                    readonly property var _pValue: {
-                        if (row.action.params && row.action.params[modelData.name] !== undefined)
-                            return row.action.params[modelData.name];
-                        return modelData.value !== undefined ? modelData.value : modelData.defaultValue;
-                    }
-                    readonly property real _pMin: modelData.minValue !== undefined ? modelData.minValue : 0
-                    readonly property real _pMax: {
-                        var mx = modelData.maxValue !== undefined ? modelData.maxValue : 1;
-                        return mx > _pMin ? mx : _pMin + 1; // guard degenerate range
-                    }
-                    readonly property real _pRange: _pMax - _pMin
-
-                    Layout.fillWidth: true
-                    spacing: Kirigami.Units.smallSpacing
-
-                    Label {
-                        text: modelData.description ? modelData.description : modelData.name
-                        Layout.fillWidth: true
-                        elide: Text.ElideRight
-                    }
-
-                    // Number → slider (fractional-range aware, mirroring the
-                    // per-algorithm editor on the tiling settings page).
-                    SettingsSlider {
-                        visible: modelData.type === "number"
-                        Layout.preferredWidth: Kirigami.Units.gridUnit * 8
-                        Accessible.name: modelData.description ? modelData.description : modelData.name
-                        from: parent._pMin
-                        to: parent._pMax
-                        stepSize: parent._pRange <= 1 ? 0.01 : (parent._pRange <= 10 ? 0.1 : 1)
-                        // A number param that declares neither value nor
-                        // defaultValue yields undefined → NaN into the slider;
-                        // fall back to the min so from/to stay finite.
-                        value: Number.isFinite(parent._pValue) ? parent._pValue : parent._pMin
-                        formatValue: function (v) {
-                            if (parent._pRange <= 1)
-                                return Math.round(v * 100) + "%";
-                            if (parent._pRange <= 10)
-                                return v.toFixed(1);
-                            return Math.round(v).toString();
-                        }
-                        onMoved: value => row._writeAlgorithmParam(modelData.name, value)
-                    }
-
-                    SettingsSwitch {
-                        visible: modelData.type === "bool"
-                        accessibleName: modelData.description ? modelData.description : modelData.name
-                        checked: parent._pValue === true
-                        onToggled: function (newValue) {
-                            row._writeAlgorithmParam(modelData.name, newValue);
-                        }
-                    }
-
-                    WideComboBox {
-                        visible: modelData.type === "enum"
-                        Layout.preferredWidth: Kirigami.Units.gridUnit * 8
-                        Accessible.name: modelData.description ? modelData.description : modelData.name
-                        model: modelData.enumOptions || []
-                        currentIndex: {
-                            // -1 (not 0) when the stored value is out of vocabulary
-                            // (e.g. the algorithm's schema changed and dropped an
-                            // option), matching the sibling pickers (screen/activity/
-                            // layout/mode). Falling back to 0 would silently display a
-                            // different option than the rule holds until the user
-                            // touches the control.
-                            var opts = modelData.enumOptions || [];
-                            return opts.indexOf(parent._pValue);
-                        }
-                        // On an out-of-vocab miss (currentIndex -1) surface the stored
-                        // raw value rather than a blank combo, matching the sibling
-                        // pickers' dangling-value fallback.
-                        displayText: currentIndex >= 0 ? currentText : (parent._pValue !== undefined ? String(parent._pValue) : "")
-                        onActivated: row._writeAlgorithmParam(modelData.name, currentText)
-                    }
-                }
+        // The shared parameter editor, same as the shader / decoration-pack
+        // param UIs, minus the lock / randomize affordances. The algorithm
+        // schema is adapted to the descriptor shape via row._adapted*.
+        PZCommon.ParameterEditor {
+            Layout.fillWidth: true
+            parameters: row._adaptedAlgorithmParamSchema
+            currentValues: row._algorithmParamValues
+            compact: true
+            enableLocking: false
+            enableRandomize: false
+            enableImage: false
+            enableGroups: false
+            showParametersHeader: true
+            onValueChanged: function (paramId, value) {
+                row._writeAlgorithmParam(paramId, value);
             }
         }
     }

--- a/src/settings/qml/ShaderBrowserDetailDialog.qml
+++ b/src/settings/qml/ShaderBrowserDetailDialog.qml
@@ -22,7 +22,7 @@ import org.plasmazones.common as PZCommon
  * When the bridge also exposes a `previewController` (zone/overlay browser
  * only — see SnappingShadersPageController), the right pane is a LIVE
  * ZoneShaderItem preview and the left column an editable
- * ShaderParameterEditor whose changes are transient (never persisted). The
+ * ParameterEditor whose changes are transient (never persisted). The
  * animation browser has no previewController, so it shows no preview pane —
  * just a read-only parameter list.
  *
@@ -394,7 +394,7 @@ Kirigami.Dialog {
                         Layout.fillWidth: true
                         active: root._livePreview && root._hasParameters
 
-                        sourceComponent: PZCommon.ShaderParameterEditor {
+                        sourceComponent: PZCommon.ParameterEditor {
                             id: paramEditor
 
                             compact: false

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -42,10 +42,10 @@ qt_add_qml_module(plasmazones_shared_qml
         LayoutCard.qml
         PopupFrame.qml
         ShaderCompileErrorBanner.qml
-        ShaderParameterEditor.qml
+        ParameterEditor.qml
         ShaderParamsEditor.qml
-        ShaderParameterRow.qml
-        ShaderParameterSection.qml
+        ParameterRow.qml
+        ParameterSection.qml
         CategoryMenuButton.qml
         ZonePreview.qml
         ZoneShaderRenderer.qml

--- a/src/shared/ParameterEditor.qml
+++ b/src/shared/ParameterEditor.qml
@@ -7,12 +7,17 @@ import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
 
 /**
- * @brief Reusable parameter editor for a shader.
+ * @brief Reusable parameter editor for a schema-described parameter set.
  *
- * Wraps the Lock-all / Randomize toolbar plus the flat-or-grouped row
- * rendering. Both the editor's `ShaderSettingsDialog` and the settings
- * app's `AnimationEventCard` consume it; each toggles the affordances
- * it wants via the `enable*` flags below.
+ * Renders a labelled control per parameter (slider / spinbox / switch /
+ * combo / colour / image) from a descriptor list, with an optional
+ * Lock-all / Randomize toolbar and flat-or-grouped rows. Shader effects,
+ * decoration packs, and autotile algorithm params all feed it; each host
+ * toggles the affordances it wants via the `enable*` flags below.
+ *
+ * The descriptor shape is `{ id, name, type, default?, min?, max?, step?,
+ * description?, group?, enumOptions? }`. `type` is one of `number`/`float`
+ * (interchangeable), `int`, `bool`, `enum`, `color`, `image`.
  *
  * The component is fully props-and-signals — it does not own state.
  * The host:
@@ -31,7 +36,7 @@ import org.kde.kirigami as Kirigami
  * live in one place.
  *
  * Accordion behavior: when `enableGroups: true` and the parameter list
- * declares any `group` field, rows are split into ShaderParameterSection
+ * declares any `group` field, rows are split into ParameterSection
  * accordions. Exactly one group is expanded at a time;
  * `expandedGroupIndex` is read/write so the host can choose "first
  * open" (default 0), open a specific group (any non-negative index), or
@@ -52,7 +57,7 @@ ColumnLayout {
     /// Default (false) keeps the editor's wide-slider aesthetic.
     property bool compact: false
     property int expandedGroupIndex: 0
-    // Visual size hints forwarded to ShaderParameterRow. Defaults shift in
+    // Visual size hints forwarded to ParameterRow. Defaults shift in
     // compact mode to match the settings-app SettingsSlider sizing.
     property int sliderValueLabelWidth: compact ? Kirigami.Units.gridUnit * 3 : Kirigami.Units.gridUnit * 4
     property int colorButtonSize: compact ? Kirigami.Units.gridUnit * 2 : Kirigami.Units.gridUnit * 3
@@ -61,6 +66,11 @@ ColumnLayout {
     /// The toolbar row (Lock-all / Randomize) is on by default but can
     /// be hidden when neither button is wanted (animation settings).
     readonly property bool _showToolbar: enableLocking || enableRandomize || toolbarTrailing !== null
+    /// Show the "Parameters" heading independently of the lock / randomize
+    /// buttons. Defaults to the toolbar's own visibility so existing
+    /// consumers are unchanged; a host with both buttons disabled (e.g. the
+    /// rule-action algorithm-param editor) sets this true to keep the heading.
+    property bool showParametersHeader: _showToolbar
     /// Optional trailing item for the toolbar row, instantiated after the
     /// Lock-all / Randomize buttons. The editor dialog uses it for its
     /// metadata-driven preset menu so the affordance stays in line with
@@ -170,7 +180,7 @@ ColumnLayout {
     }
 
     /// Coerce @p v to a finite number, falling back to @p fallback for
-    /// undefined / non-numeric / NaN / Infinity. Mirrors ShaderParameterRow's
+    /// undefined / non-numeric / NaN / Infinity. Mirrors ParameterRow's
     /// `_numberOr` boundary defence: raw JSON metadata bounds can be strings
     /// or NaN and must not leak into computed values.
     function _finiteOr(v, fallback) {
@@ -208,6 +218,7 @@ ColumnLayout {
             }
             var value;
             switch (param.type) {
+            case "number":
             case "float":
                 // Coerce bounds/step to finite numbers: raw JSON metadata can
                 // carry strings/NaN, which would otherwise yield string
@@ -235,6 +246,12 @@ ColumnLayout {
             case "bool":
                 value = Math.random() < 0.5;
                 break;
+            case "enum":
+                var opts = param.enumOptions || [];
+                // Preserve the current value when the vocabulary is empty
+                // rather than writing undefined into the rolled map.
+                value = opts.length > 0 ? opts[Math.floor(Math.random() * opts.length)] : param.default;
+                break;
             case "color":
                 var r = Math.floor(Math.random() * 256);
                 var g = Math.floor(Math.random() * 256);
@@ -256,13 +273,14 @@ ColumnLayout {
     // ── Toolbar (Lock-all / Randomize) ───────────────────────────────
     RowLayout {
         Layout.fillWidth: true
-        visible: root._showToolbar && root.parameters && root.parameters.length > 0
+        visible: (root.showParametersHeader || root._showToolbar) && root.parameters && root.parameters.length > 0
         spacing: Kirigami.Units.smallSpacing
 
         Label {
             Layout.fillWidth: true
             text: i18nc("@title:group", "Parameters")
             font.weight: Font.DemiBold
+            visible: root.showParametersHeader
         }
 
         ToolButton {
@@ -314,7 +332,7 @@ ColumnLayout {
 
             model: root._parameterGroups
 
-            delegate: ShaderParameterSection {
+            delegate: ParameterSection {
                 id: paramSection
 
                 required property var modelData
@@ -386,7 +404,7 @@ ColumnLayout {
                 elide: Text.ElideRight
             }
 
-            ShaderParameterRow {
+            ParameterRow {
                 Layout.fillWidth: true
                 Kirigami.Theme.inherit: true
                 compact: false
@@ -454,7 +472,7 @@ ColumnLayout {
                 }
             }
 
-            ShaderParameterRow {
+            ParameterRow {
                 Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
                 Kirigami.Theme.inherit: true
                 compact: true

--- a/src/shared/ParameterRow.qml
+++ b/src/shared/ParameterRow.qml
@@ -7,11 +7,13 @@ import QtQuick.Layouts
 import org.kde.kirigami as Kirigami
 
 /**
- * @brief One parameter editor row for a shader (props in, signals out).
+ * @brief One parameter editor row (props in, signals out).
  *
- * Handles every shader parameter type (float / int / bool / color / image)
- * with visibility-based switching — avoids the Loader/onLoaded timing
- * issues that bit the dialog-coupled predecessor.
+ * Handles every parameter type (float / number / int / bool / enum /
+ * color / image) with visibility-based switching — avoids the
+ * Loader/onLoaded timing issues that bit the dialog-coupled predecessor.
+ * `number` and `float` are interchangeable numeric types (shader effects
+ * emit `float`, autotile algorithms emit `number`).
  *
  * The host owns the parameter map. Bind `paramData` to the parameter
  * schema, `currentValues` to the live value map, and react to
@@ -60,6 +62,9 @@ Item {
     // Sized for the 9-char #AARRGGBB hex the swatch label shows (alpha-first).
     property int colorLabelWidth: compact ? Kirigami.Units.gridUnit * 6 : Kirigami.Units.gridUnit * 8
     readonly property string paramType: paramData ? (paramData.type || "") : ""
+    /// `number` and `float` render identically (a slider + value readout);
+    /// shader effects declare `float`, autotile algorithms declare `number`.
+    readonly property bool _isNumber: paramType === "float" || paramType === "number"
     readonly property bool isSvgImage: paramType === "image" && imagePickerButton.currentPath.length > 0 && (imagePickerButton.currentPath.toLowerCase().endsWith(".svg") || imagePickerButton.currentPath.toLowerCase().endsWith(".svgz"))
 
     signal valueChanged(string paramId, var value)
@@ -112,7 +117,7 @@ Item {
         Slider {
             id: floatSlider
 
-            visible: paramDelegate.paramType === "float"
+            visible: paramDelegate._isNumber
             Layout.fillWidth: !paramDelegate.compact
             Layout.preferredWidth: paramDelegate.compact ? paramDelegate.sliderControlWidth : -1
             Accessible.name: paramDelegate.paramData ? (paramDelegate.paramData.name || paramDelegate.paramData.id || "") : ""
@@ -151,7 +156,7 @@ Item {
         }
 
         Label {
-            visible: paramDelegate.paramType === "float"
+            visible: paramDelegate._isNumber
             text: floatSlider.value.toFixed(2)
             Layout.preferredWidth: paramDelegate.sliderValueLabelWidth
             horizontalAlignment: Text.AlignRight
@@ -231,6 +236,46 @@ Item {
         Item {
             visible: paramDelegate.paramType === "bool" && !paramDelegate.compact
             Layout.fillWidth: true
+        }
+
+        // ── ENUM ─────────────────────────────────────────────────────
+        ComboBox {
+            id: enumCombo
+
+            visible: paramDelegate.paramType === "enum"
+            // Fill the row in wide mode; take the fixed slider-column width in
+            // compact mode so it lines up with the numeric rows above/below.
+            Layout.fillWidth: !paramDelegate.compact
+            Layout.preferredWidth: paramDelegate.compact ? paramDelegate.sliderControlWidth : -1
+            Accessible.name: paramDelegate.paramData ? (paramDelegate.paramData.name || paramDelegate.paramData.id || "") : ""
+            model: paramDelegate.paramData ? (paramDelegate.paramData.enumOptions || []) : []
+            // -1 (not 0) when the stored value is out of vocabulary (e.g. the
+            // schema changed and dropped an option) so the combo doesn't
+            // silently display a different option than the value holds.
+            currentIndex: {
+                if (!paramDelegate.paramData)
+                    return -1;
+
+                var opts = paramDelegate.paramData.enumOptions || [];
+                var fallback = paramDelegate.paramData.default !== undefined ? paramDelegate.paramData.default : (opts.length > 0 ? opts[0] : "");
+                return opts.indexOf(paramDelegate._value(fallback));
+            }
+            // On an out-of-vocab miss (currentIndex -1) surface the stored raw
+            // value rather than a blank combo.
+            displayText: {
+                if (currentIndex >= 0)
+                    return currentText;
+
+                var v = paramDelegate.paramData ? paramDelegate._value(undefined) : undefined;
+                return v !== undefined ? String(v) : "";
+            }
+            ToolTip.text: paramDelegate.paramData ? (paramDelegate.paramData.description || "") : ""
+            ToolTip.visible: hovered && paramDelegate.paramData && paramDelegate.paramData.description !== undefined && paramDelegate.paramData.description !== ""
+            ToolTip.delay: Kirigami.Units.toolTipDelay
+            onActivated: {
+                if (paramDelegate.paramData)
+                    paramDelegate.valueChanged(paramDelegate.paramData.id, currentText);
+            }
         }
 
         // ── COLOR ────────────────────────────────────────────────────

--- a/src/shared/ParameterRow.qml
+++ b/src/shared/ParameterRow.qml
@@ -24,8 +24,9 @@ import org.kde.kirigami as Kirigami
  *
  * Required:
  *   - `paramData`: var — `{ id, name, type, default?, min?, max?, step?,
- *      description?, group? }` (canonical shape, matches both
- *      ShaderRegistry and AnimationsPageController output)
+ *      description?, group?, enumOptions? }` (canonical shape, matches
+ *      ShaderRegistry, AnimationsPageController, and the ActionRow
+ *      algorithm-param adapter output)
  *   - `currentValues`: var — full parameter map; tracking the whole map
  *      keeps reactivity consistent across multi-param resets (preset
  *      load, randomize) without per-row rebinds. **The host must

--- a/src/shared/ParameterSection.qml
+++ b/src/shared/ParameterSection.qml
@@ -8,13 +8,13 @@ import org.kde.kirigami as Kirigami
 import org.phosphor.animation
 
 /**
- * @brief Collapsible accordion section for a group of shader parameters.
+ * @brief Collapsible accordion section for a group of parameters.
  *
  * Header shows the group title, a parameter-count badge, and an optional
  * group-level lock toggle. Bind `expanded` to a shared index and react to
  * `toggled()` for accordion behavior:
  *
- *   ShaderParameterSection {
+ *   ParameterSection {
  *       title: groupName
  *       groupParams: paramsForGroup
  *       expanded: sharedIndex === myIndex

--- a/src/shared/ShaderParamsEditor.qml
+++ b/src/shared/ShaderParamsEditor.qml
@@ -11,7 +11,7 @@ import org.kde.kirigami as Kirigami
  * @brief Shader parameter editor bundled with its colour-picker dialog
  *        and lock / randomize working state.
  *
- * Wraps ShaderParameterEditor and hosts the QtQuick.Dialogs.ColorDialog
+ * Wraps ParameterEditor and hosts the QtQuick.Dialogs.ColorDialog
  * that every consumer previously hand-wired (the animation profile editor,
  * the App-Rules action row, and the decoration chain editor). Owns the
  * session-only lock map internally and rolls randomized values via the
@@ -62,7 +62,7 @@ ColumnLayout {
 
     spacing: Kirigami.Units.smallSpacing
 
-    ShaderParameterEditor {
+    ParameterEditor {
         id: editor
 
         Layout.fillWidth: true


### PR DESCRIPTION
## Why

The **Set algorithm parameter** rule action rendered its custom-param sliders with a hand-rolled editor, and the numeric value readout was clipped (the `SettingsSlider` was width-constrained below its internal slider). Rather than keep patching a bespoke editor, this folds algorithm params onto the shared parameter UI that shaders and decoration packs already use, so the action now shows a **Parameters** header followed by indented rows, minus the lock/randomize affordances.

## What

The shader parameter components were never shader-specific in behavior, so they're renamed to reflect their generic role and reused.

- **Rename** `ShaderParameterEditor` / `ShaderParameterRow` / `ShaderParameterSection` → `ParameterEditor` / `ParameterRow` / `ParameterSection` (files, `qmldir`, both `CMakeLists.txt`, and every consumer). `ShaderParamsEditor` (the colour-dialog wrapper) keeps its name.
- **`ParameterRow`** treats `number` as an alias of `float` (shaders emit `float`, autotile algorithms emit `number`) and gains an `enum`/combo case with the same out-of-vocabulary handling the old ActionRow editor had, so custom algorithms with enum params don't regress.
- **`ParameterEditor`** gains `showParametersHeader` so the heading shows with lock/randomize disabled; it defaults to the prior behavior, so shader/animation consumers are unchanged. `computeRandomized` handles `number` and `enum` too.
- **`ActionRow`** feeds the shared editor through a thin adapter: `_adaptedAlgorithmParamSchema` maps the algorithm schema onto the descriptor shape (`name`→`id`, `description`→display `name`, `minValue`/`maxValue`/`defaultValue`→`min`/`max`/`default`) and `_algorithmParamValues` builds the live id→value map (rule override → saved value → default). The ~90-line inline editor is replaced by a configured `ParameterEditor` (compact, no lock/random).

Numeric values read out as `0.60` (shader style), consistent with the rest of the shared editor.

## Testing

- `cmake --build build` clean (settings, editor, shared qml module).
- `ctest`: 260/260 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)