### PR TITLE
fix(settings): preserve SVG image size when loading a shader preset

### DIFF
--- a/src/settings/qml/ShaderBrowserDetailDialog.qml
+++ b/src/settings/qml/ShaderBrowserDetailDialog.qml
@@ -750,6 +750,21 @@ Kirigami.Dialog {
                     continue;
                 next[p.id] = (r.shaderParams[p.id] !== undefined) ? r.shaderParams[p.id] : (p.default !== undefined ? p.default : root._liveParams[p.id]);
             }
+            // Carry SVG image params' `<id>_svgSize` companion (not a schema
+            // param, so the loop above skips it): preset value where present,
+            // else the current size. Without this, loading a preset would
+            // revert a custom SVG render size to the default, unlike the editor
+            // dialog and the randomize path which preserve it.
+            for (var j = 0; j < params.length; j++) {
+                var ip = params[j];
+                if (!ip || ip.id === undefined || ip.type !== "image")
+                    continue;
+                var svgKey = ip.id + "_svgSize";
+                if (r.shaderParams[svgKey] !== undefined)
+                    next[svgKey] = r.shaderParams[svgKey];
+                else if (root._liveParams[svgKey] !== undefined)
+                    next[svgKey] = root._liveParams[svgKey];
+            }
             root._liveParams = next;
             root._recompute();
         }


### PR DESCRIPTION
## Why

`ShaderBrowserDetailDialog`'s shader-preset load handler rebuilt the live parameter map by iterating the schema param ids only. An SVG image param's `<id>_svgSize` companion (a non-schema key `ParameterRow` writes for SVG render resolution) was therefore dropped from a loaded preset, so a preset saved with a custom SVG size reverted that size to the default.

This surfaced during the PR #737 audit as a pre-existing inconsistency: the editor dialog (`ShaderSettingsDialog`) preserves the companion on load (full-map replace), and PR #737 made the randomize path preserve it too, but this preset-load path still dropped it.

## What

After the schema loop, carry the `<id>_svgSize` companion for `image`-typed params: the preset's value where present, else the current size. Matches the editor dialog and the randomize path.

## Testing

- `cmake --build build` clean.
- `ctest`: 260/260 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)