### PR TITLE
feat(shaders): opacity-and-tint surface shader + surface metadata validation

### DIFF
--- a/data/schemas/surface-metadata.schema.json
+++ b/data/schemas/surface-metadata.schema.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "urn:plasmazones:schema:surface-metadata",
+    "title": "PlasmaZones Surface Shader Metadata",
+    "description": "metadata.json for a bundled or user surface (decoration) shader pack. Core identity and the parameter contract are enforced. Optional compositing and multipass keys (handlesOpacity, needsBackdrop, multipass, bufferShaders, bufferScale, animated, audio, paddingParam, vertexShader) and descriptive metadata (description, author, version, category) are allowed through.",
+    "type": "object",
+    "required": ["id", "name", "fragmentShader", "parameters"],
+    "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "author": { "type": "string" },
+        "version": { "type": "string" },
+        "category": { "type": "string" },
+        "fragmentShader": { "type": "string", "minLength": 1 },
+        "vertexShader": { "type": "string" },
+        "animated": { "type": "boolean" },
+        "audio": { "type": "boolean" },
+        "handlesOpacity": { "type": "boolean" },
+        "needsBackdrop": { "type": "boolean" },
+        "multipass": { "type": "boolean" },
+        "bufferShaders": {
+            "type": "array",
+            "items": { "type": "string" }
+        },
+        "bufferScale": { "type": "number" },
+        "paddingParam": { "type": "string" },
+        "parameters": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/parameter" }
+        }
+    },
+    "definitions": {
+        "parameter": {
+            "type": "object",
+            "required": ["id", "name", "type", "default"],
+            "properties": {
+                "id": { "type": "string", "minLength": 1 },
+                "name": { "type": "string", "minLength": 1 },
+                "description": { "type": "string" },
+                "group": { "type": "string" },
+                "type": {
+                    "type": "string",
+                    "enum": ["float", "int", "bool", "color", "image"],
+                    "description": "Marshalling type of the uniform (image binds a texture slot). An unknown type cannot be bound, so it is rejected."
+                },
+                "default": {
+                    "type": ["number", "string", "boolean"],
+                    "description": "Default value. Use a string for color (#aarrggbb), a number for float or int, and a boolean for bool."
+                },
+                "min": { "type": "number" },
+                "max": { "type": "number" },
+                "slot": { "type": "integer" }
+            }
+        }
+    }
+}

--- a/data/surface/opacity-tint/effect.frag
+++ b/data/surface/opacity-tint/effect.frag
@@ -1,0 +1,29 @@
+#version 450
+
+// Opacity and tint. Fades the surface and optionally washes it with a colour.
+// Works in premultiplied-alpha space (surfaceTexel is premultiplied): the tint
+// is scaled by the source coverage and the opacity scales rgb and alpha
+// together, so the output stays a valid premultiplied texel.
+#include <surface_uniforms.glsl>
+
+layout(location = 0) in vec2 vTexCoord;
+layout(location = 0) out vec4 fragColor;
+
+void main() {
+    vec4 c = surfaceTexel(vTexCoord);
+
+    // The tint colour's own alpha scales the wash alongside the strength param,
+    // so a translucent tint colour tints more gently.
+    float tint = clamp(p_tintStrength, 0.0, 1.0) * clamp(p_tintColor.a, 0.0, 1.0);
+    if (tint > 0.001) {
+        // Premultiply the tint by the surface's coverage so it only lands where
+        // the surface is opaque and the mix stays premultiplied.
+        vec3 washed = p_tintColor.rgb * c.a;
+        c.rgb = mix(c.rgb, washed, tint);
+    }
+
+    // Dim the whole premultiplied texel.
+    c *= clamp(p_opacity, 0.0, 1.0);
+
+    fragColor = c;
+}

--- a/data/surface/opacity-tint/metadata.json
+++ b/data/surface/opacity-tint/metadata.json
@@ -1,0 +1,36 @@
+{
+    "id": "opacity-tint",
+    "name": "Opacity and Tint",
+    "description": "Fades the window's surface and can wash it with a colour of your choice. Opacity dims the whole surface, while the tint blends it toward the tint colour by the amount you set. Leave the tint strength at zero for a plain fade.",
+    "author": "PlasmaZones",
+    "version": "1.0",
+    "category": "Ambience",
+    "fragmentShader": "effect.frag",
+    "parameters": [
+        {
+            "id": "opacity",
+            "name": "Opacity",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.0,
+            "max": 1.0,
+            "description": "How visible the surface stays, where 1.0 is fully opaque and 0.0 is invisible"
+        },
+        {
+            "id": "tintStrength",
+            "name": "Tint strength",
+            "type": "float",
+            "default": 0.0,
+            "min": 0.0,
+            "max": 1.0,
+            "description": "How strongly the tint colour blends over the surface, where 0 keeps it untinted"
+        },
+        {
+            "id": "tintColor",
+            "name": "Tint colour",
+            "type": "color",
+            "default": "#ff3daee9",
+            "description": "Colour the surface is washed with when the tint strength is above zero"
+        }
+    ]
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -36,6 +36,7 @@ pre-commit:
         - "data/curves/*.json"
         - "data/animations/*/metadata.json"
         - "data/shaders/*/metadata.json"
+        - "data/surface/*/metadata.json"
         - "data/schemas/*.json"
         - "data/whatsnew.json"
       # Hard gate: when a schema-governed data file or a schema itself is
@@ -60,6 +61,16 @@ pre-commit:
         sh -c 'bin=build/bin/plasmazones-shader-validate;
         if [ -x "$bin" ]; then exec "$bin" --quiet data/shaders;
         else echo "plasmazones-shader-validate not built (build/bin/) — skipping shader validation; build the target to enable this local gate" >&2; fi'
+    shader-validate-surface:
+      glob: "data/surface/**/*.{frag,vert,glsl,json}"
+      # Surface (decoration) packs use a distinct authoring model, so validate
+      # them with --surface separately from the overlay packs above. Same
+      # best-effort skip when the binary isn't built; CI's
+      # shader_validate_surface is the hard gate.
+      run: >
+        sh -c 'bin=build/bin/plasmazones-shader-validate;
+        if [ -x "$bin" ]; then exec "$bin" --quiet --surface data/surface;
+        else echo "plasmazones-shader-validate not built (build/bin/) — skipping surface shader validation; build the target to enable this local gate" >&2; fi'
 
 commit-msg:
   commands:

--- a/scripts/validate-json-schemas.py
+++ b/scripts/validate-json-schemas.py
@@ -42,6 +42,7 @@ SCHEMA_MAP: dict[str, list[str]] = {
     "data/schemas/curve.schema.json": ["data/curves/*.json"],
     "data/schemas/animation-metadata.schema.json": ["data/animations/*/metadata.json"],
     "data/schemas/shader-metadata.schema.json": ["data/shaders/*/metadata.json"],
+    "data/schemas/surface-metadata.schema.json": ["data/surface/*/metadata.json"],
     "data/schemas/whatsnew.schema.json": ["data/whatsnew.json"],
 }
 

--- a/scripts/validate-json-schemas.py
+++ b/scripts/validate-json-schemas.py
@@ -3,12 +3,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """Validate bundled data JSON against the committed JSON Schemas.
 
-The schemas under data/schemas/ are the single source of truth shared
+Most schemas under data/schemas/ are the single source of truth shared
 with runtime validation: phosphor-fsloader's SchemaValidator (valijson)
-compiles the same schema files at load time. This script is the
-author-time gate — run from lefthook on commit and from CI — so a
-malformed bundled data file fails review rather than shipping and being
-skipped at runtime.
+compiles the same schema files at load time. A few (surface-metadata) are
+an author-time-only contract, because that document type validates its
+metadata directly in C++ rather than through a runtime schema. Either way
+this script is the author-time gate — run from lefthook on commit and from
+CI — so a malformed bundled data file fails review rather than shipping and
+being skipped at runtime.
 
 The schema dialect is Draft 7 (what valijson supports), validated here
 with the `jsonschema` package's Draft7Validator so the two engines agree.
@@ -36,7 +38,9 @@ _BOOTSTRAP_ENV = "PZ_JSONSCHEMA_BOOTSTRAPPED"
 
 # Maps a schema (relative to the source root) to the glob(s) of data
 # files it governs. Add an entry here when a new document type gets a
-# schema; the runtime side embeds the same schema file via RCC.
+# schema. Most schemas are also embedded via RCC and compiled by the
+# runtime SchemaValidator; a few (surface-metadata) are validated only
+# here, where the runtime checks that document type in C++ directly.
 SCHEMA_MAP: dict[str, list[str]] = {
     "data/schemas/layout.schema.json": ["data/layouts/*.json"],
     "data/schemas/curve.schema.json": ["data/curves/*.json"],


### PR DESCRIPTION
## What

Two related things for surface (decoration) shaders:

1. **New `opacity-tint` surface pack** (`data/surface/opacity-tint/`) — fades a window's decoration surface and can wash it with a colour. Three params: opacity (dims the whole premultiplied texel), tint strength, and tint colour (blends the surface toward the colour, scaled by strength and the colour's own alpha). Single pass, no backdrop/multipass, so it's cheap and static. The `install(DIRECTORY data/surface/)` glob bundles it and `SurfaceShaderRegistry` discovers it by folder, so it appears in the decoration chain editor keyed by `id`.

2. **Surface metadata validation coverage** — surface packs had no pre-commit gate (the `json-schema` and `shader-validate` lefthook stages only covered `data/shaders` and `data/animations`), so a malformed `metadata.json` or a shader that fails to compile was caught only later by CI's `shader_validate_surface` ctest.
   - New `data/schemas/surface-metadata.schema.json` (modeled on `animation-metadata`: `group` optional per param, `image` type allowed, surface pack keys like `handlesOpacity` / `needsBackdrop` / `multipass` / `bufferShaders` declared).
   - Mapped it in `validate-json-schemas.py` and added `data/surface` to the `json-schema` lefthook glob.
   - Added a `shader-validate-surface` lefthook stage that runs the validator with `--surface`.

## Testing

- `plasmazones-shader-validate --surface data/surface`: all 21 packs OK (new pack included).
- `validate-json-schemas.py`: 139 files OK — the new schema accepts all existing surface packs plus the new one.
- ctest `shader_validate_surface`, `shader_validate_bundled`, `shader_validate_animations`, json backends: pass.
- Both new pre-commit gates fired and passed on the commits (`shader-validate-surface` + `json-schema`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)