### PR TITLE
feat(settings): reorganize the rule action picker's Layout & engine group

### DIFF
--- a/src/settings/qml/ActionRow.qml
+++ b/src/settings/qml/ActionRow.qml
@@ -392,9 +392,10 @@ ColumnLayout {
         }
 
         // Categorized action-type picker — the shared cascading category-menu
-        // button (PZCommon.CategoryMenuButton). Grouped into Layout & engine /
-        // Gaps / Window / Appearance / Animation. Context-domain actions that
-        // can't fire against a window-property match render dimmed with a
+        // button (PZCommon.CategoryMenuButton). Grouped into Gaps / Engine /
+        // Snapping / Tiling / Overlay / Animation / Appearance / Window, with
+        // Tiling nesting Algorithm and Behavior submenus. Context-domain actions
+        // that can't fire against a window-property match render dimmed with a
         // warning tooltip (the picker's `dimmed` item flag); the per-row chip
         // below + the sheet's InlineMessage reinforce it for an action that's
         // already selected.

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -205,9 +205,12 @@ QString fieldDescription(Field f)
     return QString();
 }
 
-/// Group an action type into a picker category. Derives from the
-/// descriptor's `category` field — adding a new action to an existing
-/// category requires zero changes here.
+/// Group an action type into a picker category. Most categories derive
+/// straight from the descriptor's `category` field, so a new action in an
+/// existing category needs no change here. The exception is `layoutEngine`,
+/// which is split by action type into Engine, Snapping, and Tiling (the last
+/// with Algorithm and Behavior submenus via a `/` in the label); a new
+/// layoutEngine action lands in Engine unless added to the dispatch below.
 PickerCategory actionCategory(const QString& type)
 {
     const auto desc = PhosphorRules::ActionRegistry::instance().descriptor(type);
@@ -216,26 +219,43 @@ PickerCategory actionCategory(const QString& type)
     }
     const QString& cat = desc->category;
     // Two groups, alphabetised within each: the context-domain categories
-    // (resolved per screen/desktop/activity/mode) come first (orders 0-2), then
-    // the window-domain categories (orders 3-5). Keep these orders in lockstep
+    // (resolved per screen/desktop/activity/mode) come first (orders 0-4), then
+    // the window-domain categories (orders 5-7). Keep these orders in lockstep
     // with each category's action domains in RuleAction.cpp.
     if (cat == QLatin1String("gap")) {
         return {PhosphorI18n::tr("Gaps"), 0};
     }
     if (cat == QLatin1String("layoutEngine")) {
-        return {PhosphorI18n::tr("Layout & engine"), 1};
+        // The old flat "Layout & engine" list is split by what each action
+        // drives. The engine controls stand alone; the two arrangement engines
+        // (snapping and tiling) each get their own category, and tiling is
+        // further split into Algorithm and Behavior submenus (a `/` in the
+        // label, which CategoryMenuButton renders as a nested submenu).
+        if (type == ActionType::SetSnappingLayout || type == ActionType::DefaultLayoutAssignment) {
+            return {PhosphorI18n::tr("Snapping"), 2};
+        }
+        if (type == ActionType::SetTilingAlgorithm || type == ActionType::SetAlgorithmParam) {
+            return {PhosphorI18n::tr("Tiling") + QStringLiteral("/") + PhosphorI18n::tr("Algorithm"), 3};
+        }
+        if (type == ActionType::SetMaxWindows || type == ActionType::SetSplitRatio || type == ActionType::SetMasterCount
+            || type == ActionType::SetInsertPosition || type == ActionType::SetOverflowBehavior
+            || type == ActionType::SetDragBehavior) {
+            return {PhosphorI18n::tr("Tiling") + QStringLiteral("/") + PhosphorI18n::tr("Behavior"), 3};
+        }
+        // Cross-cutting engine controls: SetEngineMode / DisableEngine / LockContext.
+        return {PhosphorI18n::tr("Engine"), 1};
     }
     if (cat == QLatin1String("overlay")) {
-        return {PhosphorI18n::tr("Overlay"), 2};
+        return {PhosphorI18n::tr("Overlay"), 4};
     }
     if (cat == QLatin1String("animation")) {
-        return {PhosphorI18n::tr("Animation"), 3};
+        return {PhosphorI18n::tr("Animation"), 5};
     }
     if (cat == QLatin1String("appearance") || cat == QLatin1String("borderAppearance")) {
-        return {PhosphorI18n::tr("Appearance"), 4};
+        return {PhosphorI18n::tr("Appearance"), 6};
     }
     if (cat == QLatin1String("windowManagement")) {
-        return {PhosphorI18n::tr("Window"), 5};
+        return {PhosphorI18n::tr("Window"), 7};
     }
     return {PhosphorI18n::tr("Other"), 99};
 }

--- a/tests/unit/settings/test_rule_controller.cpp
+++ b/tests/unit/settings/test_rule_controller.cpp
@@ -967,9 +967,10 @@ void TestRuleController::authoringMetadata()
     QVERIFY(!actions.isEmpty());
     bool sawFloat = false;
     // Every action carries a picker category; collect the order per wire so the
-    // grouping can be spot-checked. Context-domain categories come first,
-    // alphabetised (Gaps=0, Layout & engine=1, Overlay=2), then the window-domain
-    // categories, alphabetised (Animation=3, Appearance=4, Window=5).
+    // grouping can be spot-checked. Context-domain categories come first
+    // (Gaps=0, Engine=1, Snapping=2, Tiling=3, Overlay=4), then the
+    // window-domain categories (Animation=5, Appearance=6, Window=7). The old
+    // flat "Layout & engine" category was split into Engine / Snapping / Tiling.
     QHash<QString, int> actionCategoryOrder;
     for (const QVariant& v : actions) {
         const QVariantMap a = v.toMap();
@@ -982,10 +983,14 @@ void TestRuleController::authoringMetadata()
     }
     QVERIFY(sawFloat);
     QCOMPARE(actionCategoryOrder.value(QStringLiteral("setInnerGap")), 0); // Gaps (context)
-    QCOMPARE(actionCategoryOrder.value(QStringLiteral("setEngineMode")), 1); // Layout & engine (context)
-    QCOMPARE(actionCategoryOrder.value(QStringLiteral("excludeAnimations")), 3); // Animation (window)
-    QCOMPARE(actionCategoryOrder.value(QStringLiteral("setOpacity")), 4); // Appearance (window)
-    QCOMPARE(actionCategoryOrder.value(QStringLiteral("exclude")), 5); // Window (window)
+    QCOMPARE(actionCategoryOrder.value(QStringLiteral("setEngineMode")), 1); // Engine (context)
+    QCOMPARE(actionCategoryOrder.value(QStringLiteral("setSnappingLayout")), 2); // Snapping (context)
+    QCOMPARE(actionCategoryOrder.value(QStringLiteral("setTilingAlgorithm")), 3); // Tiling (context)
+    QCOMPARE(actionCategoryOrder.value(QStringLiteral("setAlgorithmParam")), 3); // Tiling (context)
+    QCOMPARE(actionCategoryOrder.value(QStringLiteral("overrideOverlayShader")), 4); // Overlay (context)
+    QCOMPARE(actionCategoryOrder.value(QStringLiteral("excludeAnimations")), 5); // Animation (window)
+    QCOMPARE(actionCategoryOrder.value(QStringLiteral("setOpacity")), 6); // Appearance (window)
+    QCOMPARE(actionCategoryOrder.value(QStringLiteral("exclude")), 7); // Window (window)
 }
 
 void TestRuleController::inputHints()


### PR DESCRIPTION
## Why

The THEN action picker's "Layout & engine" submenu was a flat list of 13 actions ([screenshot in the issue]). It also mixed two unlike ideas: "layout" and "engine" aren't peers — a snapping *layout* and a tiling *algorithm* are the same concept (the arrangement) for the two different engines.

## What

Split it by what each action drives, so the picker mirrors the two arrangement engines. "Layout & engine" is replaced by three top-level categories:

```
Engine ▸     Set engine mode · Disable engine · Lock layout
Snapping ▸   Set snapping layout · Default layout assignment
Tiling ▸     Algorithm ▸  Set tiling algorithm · Set algorithm parameter
             Behavior ▸   Set master count · Set split ratio · Set max tiled windows ·
                          Set insert position · Set overflow behavior · Set drag behavior
```

- **Engine** holds the cross-cutting engine controls.
- **Snapping** / **Tiling** are the two engines; each holds its own arrangement actions.
- **Tiling** is further split into **Algorithm** (which algorithm + its params) and **Behavior** (the arrangement knobs).

All 13 are context-domain actions, so the new categories stay on the context side of the picker's context/window divider. The trailing categories renumber (Overlay 4, Animation 5, Appearance 6, Window 7).

## How

Entirely in `actionCategory()` (`src/settings/ruleauthoring.cpp`): the `layoutEngine` category now dispatches on action type, and the Tiling submenus use `CategoryMenuButton`'s existing (previously unused) `/`-delimited subcategory support (`"Tiling/Algorithm"`). No QML change. `"Default layout assignment"` is grouped under Snapping (it's a layout assignment) — trivial to move if you'd prefer it elsewhere.

## Testing

- `test_rule_controller` category-order assertions updated for the new categories; passes.
- Full `ctest`: 260/260 pass. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)