### PR TITLE
fix(daemon): decouple extended-FBO surfaces from card coordinates in transitions

### DIFF
--- a/libs/phosphor-animation/src/surfaceanimator.cpp
+++ b/libs/phosphor-animation/src/surfaceanimator.cpp
@@ -289,9 +289,16 @@ inline void syncShaderGeometryNow(QQuickItem* anchor, PhosphorRendering::ShaderE
             fieldH = parent->height();
         }
         if (fieldW > 0.0 && fieldH > 0.0) {
-            ext->setISurfaceScreenPos(QVector4D(static_cast<float>(anchorScene.x()),
-                                                static_cast<float>(anchorScene.y()), static_cast<float>(fieldW),
-                                                static_cast<float>(fieldH)));
+            // .xy is the CARD's top-left in the field, not the captured anchor's.
+            // The anchor can be larger than the card (PopupFrame glow margin,
+            // decoration outer padding), so add the card's in-anchor offset
+            // (contentRect) to report the ORIGINAL card origin — matching the
+            // compositor (paint_pipeline.cpp uses frameGeometry) so screen-centred
+            // and position-seeded transitions land at the card, not the padded
+            // canvas corner.
+            ext->setISurfaceScreenPos(QVector4D(static_cast<float>(anchorScene.x() + contentRect.x()),
+                                                static_cast<float>(anchorScene.y() + contentRect.y()),
+                                                static_cast<float>(fieldW), static_cast<float>(fieldH)));
         }
     }
 }

--- a/src/ui/SurfaceDecoration.qml
+++ b/src/ui/SurfaceDecoration.qml
@@ -295,20 +295,29 @@ Item {
                 // resolution — the ordering class behind "the border draws
                 // statically at final size while the card animates in".
                 //
-                // Card rect for the animator's card-space remap: with an outer
-                // margin the WHOLE padded canvas is published as the card. The
-                // margin band carries drawn decoration (the glow halo), and a
-                // sub-canvas card rect would leave that band OUTSIDE the
-                // animation shader's card space, where transition shaders
-                // resolve to a static 1:1 passthrough — the halo then sits at
-                // full final size while the card animates (the glow flavour of
-                // the detachment bug). Publishing the full canvas makes the
-                // transition sweep the halo together with the card. Margin-less
-                // chains keep mirroring the raw card's frame rect, the geometry
-                // the border-detachment fix shipped with.
+                // Card rect for the animator's card-space remap, in this stage
+                // item's local coords. It is the VISIBLE FRAME sub-rect within
+                // the (possibly padded) canvas, NOT the whole canvas. Publishing
+                // the frame DECOUPLES the transition's card geometry (iResolution
+                // / iAnchorSize / iSurfaceScreenPos, which the animator derives
+                // from this rect — all then card-sized) from the extended FBO, so
+                // a padded surface animates and centres at its ORIGINAL size and
+                // position rather than the inflated canvas. animation.vert maps
+                // the frame to card-space [0,1] and the surrounding band (glow
+                // margin + outer decoration padding) to the extended range, which
+                // surfaceColor still samples from uTexture0 — the daemon analogue
+                // of the compositor's extended-texcoord + iLayerRectInTexture path
+                // (kwin-effect/plasmazoneseffect/paint_pipeline.cpp). Clip
+                // transitions (boundaryMask) crop that band outside [0,1] exactly
+                // as the compositor does with the same effect.frag; the halo
+                // returns once the transition ends and the static decoration draws
+                // the full canvas. When padded, the frame sits at outerPad + its
+                // in-anchor offset; root-as-anchor content (no shaderContentRect,
+                // e.g. snap-assist) treats the whole anchor as the frame.
                 property bool shaderAnchor: root.decorationActive && stage.isLast
                 property bool shaderAnchorOverride: root.decorationActive && stage.isLast
-                property rect shaderContentRect: root.outerPad > 0 ? Qt.rect(0, 0, width, height) : ((root.shaderAnchorItem && root.shaderAnchorItem.shaderContentRect !== undefined) ? root.shaderAnchorItem.shaderContentRect : Qt.rect(0, 0, width, height))
+                readonly property rect _anchorFrameRect: (root.shaderAnchorItem && root.shaderAnchorItem.shaderContentRect !== undefined) ? root.shaderAnchorItem.shaderContentRect : Qt.rect(0, 0, (root.shaderAnchorItem ? root.shaderAnchorItem.width : 0), (root.shaderAnchorItem ? root.shaderAnchorItem.height : 0))
+                property rect shaderContentRect: root.outerPad > 0 ? Qt.rect(root.outerPad + _anchorFrameRect.x, root.outerPad + _anchorFrameRect.y, _anchorFrameRect.width, _anchorFrameRect.height) : _anchorFrameRect
 
                 // Every stage stays VISIBLE while active: an explicitly
                 // invisible item generates no scene-graph nodes, so the next


### PR DESCRIPTION
## The bug

When a daemon overlay (OSD / snap-assist / layout picker / zone selector) runs a decoration pack that **extends the FBO** (drop-shadow / glow outer padding), the surface's show/hide **transition** rendered at the wrong location and size. The extended FBO is bigger than the card, and the transition was positioned/sized off the inflated canvas instead of the original card.

## Root cause

The composited stage published the **whole padded canvas** as its animator card rect (`SurfaceDecoration.qml:311` returned `Qt.rect(0,0,width,height)` when padded). `SurfaceAnimator` derives the transition geometry from that rect, so it fed the transition:
- `iResolution` / `iAnchorSize` = the **extended canvas** (not the card)
- `iSurfaceScreenPos.xy` = the **padded top-left** (`anchorScene`, i.e. `anchorOrigin - outerPad`)

So animated + screen-centred surfaces were off by the padding.

## Fix — decouple, mirroring the compositor

Publish the visible **frame** sub-rect (within the padded stage) instead of the whole canvas. The daemon already has the compositor's decouple machinery — `animation.vert` maps the frame to card-space `[0,1]` and the surrounding band (glow margin + outer padding) to the extended range, and `surfaceColor` samples that band from the padded `uTexture0` via `iAnchorRectInTexture` (the analogue of the compositor's extended-texcoord + `iLayerRectInTexture` path in `paint_pipeline.cpp`). So publishing the frame flips the whole path to the decoupled model automatically: `iResolution` / `iAnchorSize` / `iAnchorRectInTexture` become card-sized.

Plus one line in the animator: add the card's in-anchor offset to `iSurfaceScreenPos.xy` so it reports the **original card origin** (matching the compositor's `frameGeometry`), fixing screen-centred and position-seeded transitions.

## Behavior / tradeoff

- Static decoration render is **unchanged** — it reads the *anchor's* `shaderContentRect`, not the stage's, so the border/halo still draw correctly at rest.
- During a **clip** transition (`boundaryMask` — popin/fade/slide/fly-in), the outer band is now cropped, **exactly as the compositor already does with the same `effect.frag`**. The halo returns the moment the transition ends and the static decoration draws the full canvas. Non-clip transitions still sweep the band.
- Left the symmetric `-outerPad` stage placement as-is (the decouple is the fix); happy to also switch to top-left growth if you want to avoid the negative-Y overhang.

## Testing

- `cmake --build build` clean; `ctest` 260/260 (incl. the phosphor-animation / surface suites).
- **Needs a visual check** (I can't render daemon overlays here): trigger a padded OSD / layout picker with a drop-shadow or glow decoration pack and confirm it animates in and rests at the correct centred position and size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)