### PR TITLE
fix(effect): give the decoration focus fade its own duration setting

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -44,6 +44,7 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -851,7 +852,14 @@ private:
     QRect m_resizeStartGeometry;
     void notifyWindowResized(KWin::EffectWindow* w, const QRect& oldGeometry);
 
-    void updateWindowDecoration(const QString& windowId, KWin::EffectWindow* w);
+    /// wasDecoratedHint: whether @p windowId was decorated BEFORE this
+    /// reconcile cycle began. Per-window callers omit it (the internal
+    /// m_windowDecorations lookup is authoritative); updateAllDecorations MUST
+    /// supply it because it clears the whole decoration map before re-adding,
+    /// which would make every window look freshly decorated and scrub its
+    /// in-flight focus cross-fade (the fade would snap on every focus change).
+    void updateWindowDecoration(const QString& windowId, KWin::EffectWindow* w,
+                                std::optional<bool> wasDecoratedHint = std::nullopt);
     /// windowHint: the EffectWindow when the caller still holds it and the
     /// window is already deleted (close / delete paths) — findWindowById
     /// cannot resolve a deleted id, and without the pointer the GL release

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -697,7 +697,7 @@ private:
     // sentinel (first decorate snaps to the current state, no fade on
     // appearance); `lastMs` dedupes the per-frame advance across the chain's
     // packs. windowSurfaceAnimates keeps the window repainting while a value
-    // is strictly between 0 and 1, so the ramp runs to completion.
+    // is inside its near-0/near-1 thresholds, so the ramp runs to completion.
     struct FocusFadeState
     {
         float value = -1.0f;

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -703,26 +703,19 @@ private:
         qint64 lastMs = -1;
     };
     QHash<QString, FocusFadeState> m_focusFade;
-    // Default focus ramp duration (ms) — the fallback before the animation
-    // settings / motion-profile tree land. The live value is m_focusFadeDurationMs.
-    static constexpr qreal kFocusFadeMs = 160.0;
     // Live focus cross-fade duration (ms) for the uSurfaceFocused ramp (border
-    // colour mix + the focus-fade content pack). NOT a standalone setting: it
-    // tracks the window.focus animation timing via refreshFocusFadeDuration()
-    // (resolved window.focus duration, or 0 when animations are disabled — an
-    // instant switch). Seeded to the constant default until the first refresh.
-    int m_focusFadeDurationMs = static_cast<int>(kFocusFadeMs);
-    // Recompute m_focusFadeDurationMs from the animation system: 0 when
-    // animations are disabled, else the resolved window.focus event duration
-    // (motion-tree per-event override → global animationDuration). Called when
-    // animationsEnabled / animationDuration / the motion profile tree change.
-    void refreshFocusFadeDuration();
+    // colour mix + the focus-fade content pack). A STANDALONE decoration
+    // setting ("focusFadeDuration", loaded in loadCachedSettings), deliberately
+    // independent of the window animation system: the fade is a decoration
+    // cross-fade, not a window animation, so disabling animations or retuning
+    // the window.focus event no longer snaps or retimes it. 0 = instant.
+    // Seeded to the shared default until the async settings load lands.
+    int m_focusFadeDurationMs = PhosphorCompositor::DecorationDefaults::FocusFadeMs;
     // Resolve a per-event base duration (ms) from the motion profile tree: a
     // motion-tree override anywhere up @p profilePath's ancestor chain replaces
     // @p fallbackMs with the node's resolved effectiveDuration(), else the
-    // fallback stands. Shared by tryBeginShaderForEvent (per-event transition
-    // timing) and refreshFocusFadeDuration (the decoration focus fade), so the
-    // two never drift out of sync.
+    // fallback stands. Used by tryBeginShaderForEvent (per-event transition
+    // timing).
     int resolveMotionTreeBaseDuration(const QString& profilePath, int fallbackMs) const;
     // Cap on the per-frame ramp delta. A window at rest (value pinned at 0 or 1)
     // stops being force-repainted by windowSurfaceAnimates, so its FocusFadeState

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -695,8 +695,9 @@ void PlasmaZonesEffect::loadCachedSettings()
     // decoration setting, deliberately independent of animationsEnabled /
     // animationDuration / the window.focus motion node: the fade is a
     // decoration cross-fade, not a window animation. 0 = instant switch.
-    // No repaint needed on change — the new duration applies from the next
-    // focus change; in-flight ramps keep their pace via the step divisor.
+    // No repaint needed on change — an idle window picks the new duration up
+    // on its next focus change, and an in-flight ramp re-times to it on its
+    // next frame (the step divisor reads the live value).
     // Reject a non-numeric reply instead of coercing it: getSetting answers an
     // UNKNOWN key with a valid empty-string variant (an older daemon without
     // this key), and toInt() would silently turn that into 0 — forcing instant

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -697,9 +697,17 @@ void PlasmaZonesEffect::loadCachedSettings()
     // decoration cross-fade, not a window animation. 0 = instant switch.
     // No repaint needed on change — the new duration applies from the next
     // focus change; in-flight ramps keep their pace via the step divisor.
+    // Reject a non-numeric reply instead of coercing it: getSetting answers an
+    // UNKNOWN key with a valid empty-string variant (an older daemon without
+    // this key), and toInt() would silently turn that into 0 — forcing instant
+    // mode on version skew. Keeping the seeded default is the safe fallback.
     loadSettingAsync(QStringLiteral("focusFadeDuration"), [this](const QVariant& v) {
-        m_focusFadeDurationMs = qBound(PhosphorCompositor::DecorationDefaults::FocusFadeMsMin, v.toInt(),
-                                       PhosphorCompositor::DecorationDefaults::FocusFadeMsMax);
+        bool ok = false;
+        const int ms = v.toInt(&ok);
+        if (ok) {
+            m_focusFadeDurationMs = qBound(PhosphorCompositor::DecorationDefaults::FocusFadeMsMin, ms,
+                                           PhosphorCompositor::DecorationDefaults::FocusFadeMsMax);
+        }
     });
     loadSettingAsync(QStringLiteral("snapAssistEnabled"), [this](const QVariant& v) {
         m_snapAssistHandler->setEnabled(v.toBool());

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -691,6 +691,16 @@ void PlasmaZonesEffect::loadCachedSettings()
             scheduleBorderSweep();
         }
     });
+    // Decoration focus cross-fade (uSurfaceFocused ramp). A standalone
+    // decoration setting, deliberately independent of animationsEnabled /
+    // animationDuration / the window.focus motion node: the fade is a
+    // decoration cross-fade, not a window animation. 0 = instant switch.
+    // No repaint needed on change — the new duration applies from the next
+    // focus change; in-flight ramps keep their pace via the step divisor.
+    loadSettingAsync(QStringLiteral("focusFadeDuration"), [this](const QVariant& v) {
+        m_focusFadeDurationMs = qBound(PhosphorCompositor::DecorationDefaults::FocusFadeMsMin, v.toInt(),
+                                       PhosphorCompositor::DecorationDefaults::FocusFadeMsMax);
+    });
     loadSettingAsync(QStringLiteral("snapAssistEnabled"), [this](const QVariant& v) {
         m_snapAssistHandler->setEnabled(v.toBool());
     });
@@ -714,9 +724,6 @@ void PlasmaZonesEffect::loadCachedSettings()
     });
     loadSettingAsync(QStringLiteral("animationsEnabled"), [this](const QVariant& v) {
         m_windowAnimator->setEnabled(v.toBool());
-        // The decoration focus fade shares the window.focus timing: animations
-        // off means an instant active/inactive switch (option B).
-        refreshFocusFadeDuration();
     });
     loadSettingAsync(QStringLiteral("animationDuration"), [this](const QVariant& v) {
         // Clamp against the canonical settings-UI bounds. The earlier
@@ -728,9 +735,6 @@ void PlasmaZonesEffect::loadCachedSettings()
                              PhosphorAnimation::Limits::MaxAnimationDurationMs);
         m_windowAnimator->setDuration(d);
         m_cachedAnimationDuration = d;
-        // Keep the focus fade in lockstep with the global animation duration
-        // (unless a window.focus motion-tree node overrides it).
-        refreshFocusFadeDuration();
     });
     loadSettingAsync(QStringLiteral("animationEasingCurve"), [this](const QVariant& v) {
         // Polymorphic curve parse — handles bare bezier, named easing,

--- a/kwin-effect/plasmazoneseffect/decoration_render.cpp
+++ b/kwin-effect/plasmazoneseffect/decoration_render.cpp
@@ -104,9 +104,10 @@ void PlasmaZonesEffect::reconcileDecorationShader(const QString& windowId, KWin:
 float PlasmaZonesEffect::advanceFocusFade(const QString& windowId, bool focused)
 {
     // Ramp the smoothed focus value toward the hard 0/1 target over
-    // kFocusFadeMs so a focus change fades rather than snaps. Called from
-    // pushBorderUniforms only for a pack that reads focus, with @p windowId
-    // threaded from the fold so getWindowId(w) is not recomputed per pack.
+    // m_focusFadeDurationMs (the standalone focusFadeDuration setting) so a
+    // focus change fades rather than snaps. Called from pushBorderUniforms
+    // only for a pack that reads focus, with @p windowId threaded from the
+    // fold so getWindowId(w) is not recomputed per pack.
     // Uses the PINNED per-frame clock: a second call within the same frame (a
     // chain with several focus-reading packs) reads now == lastMs and is an
     // exact no-op, so the ramp advances at most once per frame and the step
@@ -118,10 +119,9 @@ float PlasmaZonesEffect::advanceFocusFade(const QString& windowId, bool focused)
     if (now < 0) {
         now = ShaderInternal::shaderClockNowMs();
     }
-    // Instant mode: the resolved window.focus duration is 0 (animations
-    // disabled, or a window.focus node set to 0 — see refreshFocusFadeDuration),
-    // so snap to the hard target with no ramp. windowSurfaceAnimates then never
-    // sees an in-flight value and forces no repaints — the switch is immediate.
+    // Instant mode: the user set focusFadeDuration to 0, so snap to the hard
+    // target with no ramp. windowSurfaceAnimates then never sees an in-flight
+    // value and forces no repaints — the switch is immediate.
     if (m_focusFadeDurationMs <= 0) {
         fs.value = target;
         fs.lastMs = now;

--- a/kwin-effect/plasmazoneseffect/decoration_render.cpp
+++ b/kwin-effect/plasmazoneseffect/decoration_render.cpp
@@ -134,8 +134,13 @@ float PlasmaZonesEffect::advanceFocusFade(const QString& windowId, bool focused)
         // windowSurfaceAnimates) so lastMs goes stale, and an uncapped
         // now - lastMs would jump the whole ramp on the first frame after a
         // focus change — the instant-snap bug. A live window's real frame delta
-        // is far below the cap, so normal ramps are unaffected.
-        const qint64 dt = qMin(now - fs.lastMs, kFocusFadeMaxStepMs);
+        // is far below the cap, so normal ramps are unaffected. The cap is
+        // additionally bounded to half the configured duration so a short
+        // duration (≤ 2 × kFocusFadeMaxStepMs) still spans at least two frames
+        // instead of completing inside the single 50 ms resume step; the
+        // qBound floor of 1 keeps dt non-zero for a 1 ms duration.
+        const qint64 maxStep = qBound(qint64(1), qint64(m_focusFadeDurationMs) / 2, kFocusFadeMaxStepMs);
+        const qint64 dt = qMin(now - fs.lastMs, maxStep);
         const float step = static_cast<float>(dt) / static_cast<float>(m_focusFadeDurationMs);
         if (fs.value < target) {
             fs.value = qMin(target, fs.value + step);

--- a/kwin-effect/plasmazoneseffect/decorations.cpp
+++ b/kwin-effect/plasmazoneseffect/decorations.cpp
@@ -212,7 +212,10 @@ void PlasmaZonesEffect::reconcileDecorationOnPlacementFlip(const QString& window
     if (w && getWindowId(w) == windowId && w->isOnCurrentDesktop()) {
         updateWindowDecoration(windowId, w);
     } else {
-        removeWindowDecoration(windowId, w);
+        // Same exact-id discipline for the remove hint: a fuzzy same-app
+        // sibling must not stand in for the dead window's GL release, so only
+        // pass w through when it really is windowId (e.g. merely off-desktop).
+        removeWindowDecoration(windowId, (w && getWindowId(w) == windowId) ? w : nullptr);
     }
 }
 

--- a/kwin-effect/plasmazoneseffect/decorations.cpp
+++ b/kwin-effect/plasmazoneseffect/decorations.cpp
@@ -319,14 +319,18 @@ ResolvedWindowAppearance PlasmaZonesEffect::resolveEffectiveWindowAppearance(KWi
     return out;
 }
 
-void PlasmaZonesEffect::updateWindowDecoration(const QString& windowId, KWin::EffectWindow* w)
+void PlasmaZonesEffect::updateWindowDecoration(const QString& windowId, KWin::EffectWindow* w,
+                                               std::optional<bool> wasDecoratedHint)
 {
     // Did this window already have a decoration? Captured BEFORE the remove-first
     // below so the focus cross-fade can tell a genuine undecorated→decorated
     // transition (must SNAP to the current focus) from a plain refresh (focus
     // change / snap flip / rule edit — all of which remove-then-readd and must
     // keep easing). See the m_focusFade reconcile after the insert.
-    const bool wasDecorated = m_windowDecorations.contains(windowId);
+    // updateAllDecorations supplies the hint: it clears the whole decoration map
+    // before re-adding, so the local lookup would report false for EVERY window
+    // and scrub every in-flight ramp — the fade would snap on each focus change.
+    const bool wasDecorated = wasDecoratedHint.value_or(m_windowDecorations.contains(windowId));
     // Remove existing border for this window first
     removeWindowDecoration(windowId);
 
@@ -578,6 +582,16 @@ void PlasmaZonesEffect::updateWindowDecoration(const QString& windowId, KWin::Ef
 
 void PlasmaZonesEffect::updateAllDecorations()
 {
+    // Snapshot which windows were decorated BEFORE the bulk clear: the hint
+    // passed to updateWindowDecoration below is what lets the focus cross-fade
+    // survive this reconcile (a post-clear contains() lookup would report every
+    // window as freshly decorated and snap its ramp).
+    QSet<QString> previouslyDecorated;
+    previouslyDecorated.reserve(m_windowDecorations.size());
+    for (auto it = m_windowDecorations.constBegin(); it != m_windowDecorations.constEnd(); ++it) {
+        previouslyDecorated.insert(it.key());
+    }
+
     clearAllDecorations();
 
     // Iterate all effect windows and reconcile each window's border + title-bar
@@ -612,7 +626,7 @@ void PlasmaZonesEffect::updateAllDecorations()
         // a hide (rule or config default) applying to a window on another
         // virtual desktop would not take effect until next activation.
         if (w->isOnCurrentDesktop()) {
-            updateWindowDecoration(wid, w);
+            updateWindowDecoration(wid, w, previouslyDecorated.contains(wid));
         }
         reconcileRuleHiddenTitleBar(wid, w);
     }

--- a/kwin-effect/plasmazoneseffect/decorations.cpp
+++ b/kwin-effect/plasmazoneseffect/decorations.cpp
@@ -586,11 +586,7 @@ void PlasmaZonesEffect::updateAllDecorations()
     // passed to updateWindowDecoration below is what lets the focus cross-fade
     // survive this reconcile (a post-clear contains() lookup would report every
     // window as freshly decorated and snap its ramp).
-    QSet<QString> previouslyDecorated;
-    previouslyDecorated.reserve(m_windowDecorations.size());
-    for (auto it = m_windowDecorations.constBegin(); it != m_windowDecorations.constEnd(); ++it) {
-        previouslyDecorated.insert(it.key());
-    }
+    const QSet<QString> previouslyDecorated(m_windowDecorations.keyBegin(), m_windowDecorations.keyEnd());
 
     clearAllDecorations();
 

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -1646,9 +1646,7 @@ void PlasmaZonesEffect::tryBeginShaderForEvent(KWin::EffectWindow* window, const
     // (150 ms). The resolved value is then handed to the combined resolver as its
     // `defaultDurationMs`, so the per-window-class Rule timing cascade
     // (`OverrideAnimationTiming`) still layers on top (rule wins → per-event base
-    // → global), matching the resolver's documented contract. The resolve is
-    // shared with refreshFocusFadeDuration so the focus fade tracks the same
-    // per-event timing.
+    // → global), matching the resolver's documented contract.
     const int baseDurationMs = resolveMotionTreeBaseDuration(profilePath, durationMs);
     // Combined cascade: ONE cached evaluator walk feeds BOTH the shader-slot
     // and timing-slot reads. The pre-refactor pair of `resolveAnimationShader
@@ -1912,9 +1910,6 @@ void PlasmaZonesEffect::loadMotionProfileTreeFromDbus()
                                 qCDebug(lcEffect) << "loadMotionProfileTreeFromDbus: tree loaded with"
                                                   << tree.overriddenPaths().size()
                                                   << "per-event overrides — paths=" << tree.overriddenPaths();
-                                // A window.focus per-event duration override may have
-                                // changed; keep the decoration focus fade in sync.
-                                refreshFocusFadeDuration();
                             },
                             /*arraySink=*/{});
     });
@@ -1941,23 +1936,6 @@ int PlasmaZonesEffect::resolveMotionTreeBaseDuration(const QString& profilePath,
         cursor = parent;
     }
     return fallbackMs;
-}
-
-void PlasmaZonesEffect::refreshFocusFadeDuration()
-{
-    // The decoration focus fade (uSurfaceFocused ramp, read by the border colour
-    // mix and the focus-fade content pack) shares the window.focus event's
-    // timing rather than carrying its own clock. Option B: with animations
-    // disabled the fade is instant (0) — "animations off = everything snaps".
-    if (!m_windowAnimator || !m_windowAnimator->isEnabled()) {
-        m_focusFadeDurationMs = 0;
-        return;
-    }
-    // Resolve the window.focus base duration the same way tryBeginShaderForEvent
-    // does (shared helper). Per-window Rule timing overrides are intentionally
-    // NOT applied — the fade tracks the per-event node, not per-window rules.
-    const QString profilePath = PhosphorAnimation::ProfilePaths::WindowFocus;
-    m_focusFadeDurationMs = qMax(0, resolveMotionTreeBaseDuration(profilePath, animationDurationMs()));
 }
 
 void PlasmaZonesEffect::slotMotionProfileTreeChanged()

--- a/libs/phosphor-compositor/include/PhosphorCompositor/DecorationDefaults.h
+++ b/libs/phosphor-compositor/include/PhosphorCompositor/DecorationDefaults.h
@@ -32,12 +32,23 @@ inline constexpr int BorderRadius = 8;
 inline constexpr int BorderRadiusMin = 0;
 inline constexpr int BorderRadiusMax = 20;
 
+// How long uSurfaceFocused ramps between 0 and 1 when a window gains or
+// loses focus (ms) — the cross-fade every decoration pack that mixes by
+// focus (focus-fade wash, border dims, glow, shadow) renders with. A
+// standalone decoration setting, deliberately independent of the window
+// animation system: 0 means switch instantly.
+inline constexpr int FocusFadeMs = 160;
+inline constexpr int FocusFadeMsMin = 0;
+inline constexpr int FocusFadeMsMax = 1000;
+
 // A retuned default outside its own declared slider range would clamp
 // differently on every consumer — make that a compile error instead.
 static_assert(BorderWidth >= BorderWidthMin && BorderWidth <= BorderWidthMax,
               "BorderWidth default must lie within its declared bounds");
 static_assert(BorderRadius >= BorderRadiusMin && BorderRadius <= BorderRadiusMax,
               "BorderRadius default must lie within its declared bounds");
+static_assert(FocusFadeMs >= FocusFadeMsMin && FocusFadeMs <= FocusFadeMsMax,
+              "FocusFadeMs default must lie within its declared bounds");
 
 } // namespace DecorationDefaults
 

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -327,6 +327,21 @@ public:
     {
         return ::PhosphorCompositor::DecorationDefaults::BorderRadiusMax;
     }
+    // Decoration focus cross-fade (uSurfaceFocused ramp) duration, ms. A
+    // standalone decoration setting, independent of the window animation
+    // system; 0 switches instantly.
+    static constexpr int focusFadeDuration()
+    {
+        return ::PhosphorCompositor::DecorationDefaults::FocusFadeMs;
+    }
+    static constexpr int focusFadeDurationMin()
+    {
+        return ::PhosphorCompositor::DecorationDefaults::FocusFadeMsMin;
+    }
+    static constexpr int focusFadeDurationMax()
+    {
+        return ::PhosphorCompositor::DecorationDefaults::FocusFadeMsMax;
+    }
     static bool hideWindowTitleBars()
     {
         return ::PhosphorCompositor::DecorationDefaults::HideTitleBars;
@@ -1607,6 +1622,9 @@ private:
 static_assert(ConfigDefaults::animationDuration() >= ConfigDefaults::animationDurationMin()
                   && ConfigDefaults::animationDuration() <= ConfigDefaults::animationDurationMax(),
               "ConfigDefaults::animationDuration() outside declared [min, max] slider range");
+static_assert(ConfigDefaults::focusFadeDuration() >= ConfigDefaults::focusFadeDurationMin()
+                  && ConfigDefaults::focusFadeDuration() <= ConfigDefaults::focusFadeDurationMax(),
+              "ConfigDefaults::focusFadeDuration() outside declared [min, max] slider range");
 static_assert(ConfigDefaults::animationStaggerInterval() >= ConfigDefaults::animationStaggerIntervalMin()
                   && ConfigDefaults::animationStaggerInterval() <= ConfigDefaults::animationStaggerIntervalMax(),
               "ConfigDefaults::animationStaggerInterval() outside declared [min, max] slider range");

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -1612,8 +1612,9 @@ private:
     ConfigDefaults() = delete;
 };
 
-// Compile-time bound checks for retuned animation defaults so a future
-// bump can never silently exceed the declared slider range. Mirrors the
+// Compile-time bound checks for retuned defaults that declare min/max
+// accessors, so a future bump can never silently exceed the declared
+// slider range. Mirrors the
 // pattern in AnimationLimits.h where library defaults assert against
 // their own min/max. Mirrored at runtime by QVERIFY in
 // tests/unit/config/test_configdefaults.cpp; the compile-time form

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -1612,9 +1612,9 @@ private:
     ConfigDefaults() = delete;
 };
 
-// Compile-time bound checks for retuned defaults that declare min/max
-// accessors, so a future bump can never silently exceed the declared
-// slider range. Mirrors the
+// Compile-time bound checks for defaults that declare min/max accessors,
+// so a future bump can never silently exceed the declared slider range.
+// Mirrors the
 // pattern in AnimationLimits.h where library defaults assert against
 // their own min/max. Mirrored at runtime by QVERIFY in
 // tests/unit/config/test_configdefaults.cpp; the compile-time form

--- a/src/config/configkeys.h
+++ b/src/config/configkeys.h
@@ -330,6 +330,7 @@ public:
     P_CONFIG_KEY(titleBarScopeKey, "TitleBarScope")
     P_CONFIG_KEY(borderColorActiveKey, "BorderColorActive")
     P_CONFIG_KEY(borderColorInactiveKey, "BorderColorInactive")
+    P_CONFIG_KEY(focusFadeDurationKey, "FocusFadeDuration")
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Config Keys — Gaps (shared inner/outer gap model)

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -1438,6 +1438,8 @@ P_STORE_GET(bool, hideWindowTitleBars, windowsAppearanceGroup, hideTitleBarsKey,
 P_STORE_SET_BOOL(setHideWindowTitleBars, windowsAppearanceGroup, hideTitleBarsKey, hideWindowTitleBarsChanged)
 P_STORE_GET(QString, windowTitleBarScope, windowsAppearanceGroup, titleBarScopeKey, QString)
 P_STORE_SET_STRING(setWindowTitleBarScope, windowsAppearanceGroup, titleBarScopeKey, windowTitleBarScopeChanged)
+P_STORE_GET(int, focusFadeDuration, windowsAppearanceGroup, focusFadeDurationKey, int)
+P_STORE_SET_INT(setFocusFadeDuration, windowsAppearanceGroup, focusFadeDurationKey, focusFadeDurationChanged)
 
 void Settings::connectRuleStoreGapReactivity()
 {

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -487,7 +487,9 @@ public:
     Q_PROPERTY(QString toggleLayoutLockShortcut READ toggleLayoutLockShortcut WRITE setToggleLayoutLockShortcut NOTIFY
                    toggleLayoutLockShortcutChanged)
 
-    // Virtual Screen Swap / Rotate (Meta+Ctrl+Shift+Arrow, Meta+Ctrl+Shift+[/])
+    // Virtual Screen Swap / Rotate (Meta+Ctrl+Alt+Shift+Arrow, Meta+Ctrl+Alt+[/]
+    // — the Alt is mandatory: the Alt-less chords are KWin built-ins, see
+    // configdefaults.h)
     Q_PROPERTY(QString swapVirtualScreenLeftShortcut READ swapVirtualScreenLeftShortcut WRITE
                    setSwapVirtualScreenLeftShortcut NOTIFY swapVirtualScreenLeftShortcutChanged)
     Q_PROPERTY(QString swapVirtualScreenRightShortcut READ swapVirtualScreenRightShortcut WRITE

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -181,6 +181,7 @@ public:
                    hideWindowTitleBarsChanged)
     Q_PROPERTY(QString windowTitleBarScope READ windowTitleBarScope WRITE setWindowTitleBarScope NOTIFY
                    windowTitleBarScopeChanged)
+    Q_PROPERTY(int focusFadeDuration READ focusFadeDuration WRITE setFocusFadeDuration NOTIFY focusFadeDurationChanged)
 
     // Performance and behavior (configurable constants)
     Q_PROPERTY(int pollIntervalMs READ pollIntervalMs WRITE setPollIntervalMs NOTIFY pollIntervalMsChanged)
@@ -661,6 +662,8 @@ public:
     void setHideWindowTitleBars(bool hide) override;
     QString windowTitleBarScope() const override;
     void setWindowTitleBarScope(const QString& scope) override;
+    int focusFadeDuration() const override;
+    void setFocusFadeDuration(int ms) override;
 
     // Performance — PhosphorConfig::Store-backed (see settingsschema.cpp).
     int pollIntervalMs() const override;

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -840,6 +840,8 @@ void appendAutotilingSchema(PhosphorConfig::Schema& schema)
 // the effect agree on, snapped to the default on an unknown on-disk value.
 // Width/radius are clamped ints reusing the generic Width/Radius keys (the Windows
 // group disambiguates them from the Snapping.Zones.Border keys of the same spelling).
+// FocusFadeDuration is a clamped int: the decoration focus cross-fade in ms
+// (uSurfaceFocused ramp), 0 = instant.
 
 void appendWindowsSchema(PhosphorConfig::Schema& schema)
 {

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -884,6 +884,11 @@ void appendWindowsSchema(PhosphorConfig::Schema& schema)
          QMetaType::QString,
          {},
          scopeValidator(CD::windowTitleBarScope())},
+        {CD::focusFadeDurationKey(),
+         CD::focusFadeDuration(),
+         QMetaType::Int,
+         {},
+         clampInt(CD::focusFadeDurationMin(), CD::focusFadeDurationMax())},
     };
 }
 

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -834,10 +834,12 @@ void appendAutotilingSchema(PhosphorConfig::Schema& schema)
 }
 
 // ─── Windows (window decoration appearance) ─────────────────────────────────
-// Mode-neutral window border + title bar. Border colours are the "accent"
-// sentinel (or a hex string) so no colour validator applies. The border/title-bar
-// scope is a closed-set token ("tiled" / "normal" / "all") the Appearance page and
-// the effect agree on, snapped to the default on an unknown on-disk value.
+// Mode-neutral window border + title bar. Border colours are strings (the
+// "accent" sentinel, or a hex/named colour) validated by the string-form
+// validBorderColorOr rather than the QColor-coercing validColorOr. The
+// border/title-bar scope is a closed-set token ("tiled" / "normal" / "all")
+// the Appearance page and the effect agree on, snapped to the default on an
+// unknown on-disk value.
 // Width/radius are clamped ints reusing the generic Width/Radius keys (the Windows
 // group disambiguates them from the Snapping.Zones.Border keys of the same spelling).
 // FocusFadeDuration is a clamped int: the decoration focus cross-fade in ms

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -225,6 +225,11 @@ public:
     virtual void setHideWindowTitleBars(bool hide) = 0;
     virtual QString windowTitleBarScope() const = 0;
     virtual void setWindowTitleBarScope(const QString& scope) = 0;
+    // Decoration focus cross-fade duration (ms): how long uSurfaceFocused
+    // ramps between focused and unfocused for the decoration packs that mix
+    // by focus. Independent of the window animation system; 0 = instant.
+    virtual int focusFadeDuration() const = 0;
+    virtual void setFocusFadeDuration(int ms) = 0;
 
     // Editor settings — used by EditorPageController. Editor-scope rather
     // than Snapping/Tiling-scope, so they don't fit any sub-interface.
@@ -441,6 +446,7 @@ Q_SIGNALS:
     void windowBorderColorInactiveChanged();
     void hideWindowTitleBarsChanged();
     void windowTitleBarScopeChanged();
+    void focusFadeDurationChanged();
     // Editor
     void editorDuplicateShortcutChanged();
     void editorSplitHorizontalShortcutChanged();

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -434,6 +434,7 @@ void SettingsAdaptor::initializeRegistry()
     REGISTER_STRING_SETTING("windowBorderColorInactive", windowBorderColorInactive, setWindowBorderColorInactive)
     REGISTER_BOOL_SETTING("hideWindowTitleBars", hideWindowTitleBars, setHideWindowTitleBars)
     REGISTER_STRING_SETTING("windowTitleBarScope", windowTitleBarScope, setWindowTitleBarScope)
+    REGISTER_INT_SETTING("focusFadeDuration", focusFadeDuration, setFocusFadeDuration)
     REGISTER_STRING_SETTING("labelFontFamily", labelFontFamily, setLabelFontFamily)
     // Custom setter with range validation (0.25-3.0) instead of REGISTER_DOUBLE_SETTING
     m_getters[QStringLiteral("labelFontSizeScale")] = [this]() {

--- a/src/settings/qml/WindowAppearancePage.qml
+++ b/src/settings/qml/WindowAppearancePage.qml
@@ -369,6 +369,27 @@ SettingsFlickable {
                         onActivated: index => root.ctl.titleBarScope = root.scopeOptions[index].scope
                     }
                 }
+
+                SettingsSeparator {}
+
+                SettingsRow {
+                    title: i18n("Focus fade duration")
+                    searchAnchor: "focusFadeDuration"
+                    description: i18n("How long decorations take to fade between focused and unfocused. Zero switches instantly.")
+
+                    SettingsSlider {
+                        Accessible.name: i18n("Focus fade duration")
+                        from: root.ctl.focusFadeDurationMin
+                        to: root.ctl.focusFadeDurationMax
+                        stepSize: 10
+                        value: root.ctl.focusFadeDuration
+                        valueSuffix: " ms"
+                        labelWidth: Kirigami.Units.gridUnit * 4
+                        onMoved: value => {
+                            root.ctl.focusFadeDuration = Math.round(value);
+                        }
+                    }
+                }
             }
         }
 

--- a/src/settings/searchcatalog.cpp
+++ b/src/settings/searchcatalog.cpp
@@ -256,7 +256,7 @@ void seedSearchCatalog(PhosphorControl::SearchController* search)
     addSetting(search, QStringLiteral("snapping-overlay-appearance"), QStringLiteral("flashOnLayoutSwitch"),
                PhosphorI18n::tr("Flash on layout switch"), {PhosphorI18n::tr("blink"), PhosphorI18n::tr("animation")});
 
-    // Window Appearance (shared baseline-rule editor)
+    // Window Appearance (config-backed Windows.* / Gaps.* page)
     addSection(search, QStringLiteral("window-appearance"), QStringLiteral("borders"), PhosphorI18n::tr("Borders"));
     addSection(search, QStringLiteral("window-appearance"), QStringLiteral("colors"), PhosphorI18n::tr("Colors"));
     addSection(search, QStringLiteral("window-appearance"), QStringLiteral("decorations"),
@@ -283,7 +283,7 @@ void seedSearchCatalog(PhosphorControl::SearchController* search)
                 PhosphorI18n::tr("cross-fade")});
 
     // Gaps (shared inner/outer gap model) — folded onto the Window Appearance
-    // page, which edits the same rule-backed model.
+    // page, which edits the same config-backed model.
     addSection(search, QStringLiteral("window-appearance"), QStringLiteral("gaps"), PhosphorI18n::tr("Gaps"));
     addSetting(search, QStringLiteral("window-appearance"), QStringLiteral("primaryGap"), PhosphorI18n::tr("Inner gap"),
                {PhosphorI18n::tr("gap"), PhosphorI18n::tr("gaps"), PhosphorI18n::tr("spacing"),

--- a/src/settings/searchcatalog.cpp
+++ b/src/settings/searchcatalog.cpp
@@ -277,6 +277,10 @@ void seedSearchCatalog(PhosphorControl::SearchController* search)
     addSetting(search, QStringLiteral("window-appearance"), QStringLiteral("hideTitleBars"),
                PhosphorI18n::tr("Hide title bars"),
                {PhosphorI18n::tr("titlebar"), PhosphorI18n::tr("decoration"), PhosphorI18n::tr("header")});
+    addSetting(search, QStringLiteral("window-appearance"), QStringLiteral("focusFadeDuration"),
+               PhosphorI18n::tr("Focus fade duration"),
+               {PhosphorI18n::tr("fade"), PhosphorI18n::tr("unfocused"), PhosphorI18n::tr("dim"),
+                PhosphorI18n::tr("cross-fade")});
 
     // Gaps (shared inner/outer gap model) — folded onto the Window Appearance
     // page, which edits the same rule-backed model.

--- a/src/settings/settingscontroller_pageregistration.cpp
+++ b/src/settings/settingscontroller_pageregistration.cpp
@@ -705,6 +705,7 @@ const QHash<QString, Settings::ConfigKeyList>& SettingsController::pageOwnedConf
              {CD::windowsAppearanceGroup(), CD::borderColorInactiveKey()},
              {CD::windowsAppearanceGroup(), CD::hideTitleBarsKey()},
              {CD::windowsAppearanceGroup(), CD::titleBarScopeKey()},
+             {CD::windowsAppearanceGroup(), CD::focusFadeDurationKey()},
              {CD::gapsGroup(), CD::innerGapKey()},
              {CD::gapsGroup(), CD::outerGapKey()},
              {CD::gapsGroup(), CD::usePerSideOuterGapKey()},

--- a/src/settings/windowappearancecontroller.cpp
+++ b/src/settings/windowappearancecontroller.cpp
@@ -75,6 +75,8 @@ WindowAppearanceController::WindowAppearanceController(ISettings& settings, QObj
             &WindowAppearanceController::hideWindowTitleBarsChanged);
     connect(m_settings, &ISettings::windowTitleBarScopeChanged, this,
             &WindowAppearanceController::windowTitleBarScopeChanged);
+    connect(m_settings, &ISettings::focusFadeDurationChanged, this,
+            &WindowAppearanceController::focusFadeDurationChanged);
     connect(m_settings, &ISettings::innerGapChanged, this, &WindowAppearanceController::innerGapChanged);
     connect(m_settings, &ISettings::outerGapChanged, this, &WindowAppearanceController::outerGapChanged);
     connect(m_settings, &ISettings::usePerSideOuterGapChanged, this,
@@ -119,6 +121,10 @@ QString WindowAppearanceController::windowTitleBarScope() const
 {
     return m_settings->windowTitleBarScope();
 }
+int WindowAppearanceController::focusFadeDuration() const
+{
+    return m_settings->focusFadeDuration();
+}
 
 void WindowAppearanceController::setShowWindowBorder(bool show)
 {
@@ -151,6 +157,10 @@ void WindowAppearanceController::setHideWindowTitleBars(bool hide)
 void WindowAppearanceController::setWindowTitleBarScope(const QString& scope)
 {
     m_settings->setWindowTitleBarScope(scope);
+}
+void WindowAppearanceController::setFocusFadeDuration(int ms)
+{
+    m_settings->setFocusFadeDuration(ms);
 }
 
 // ── Shared inner/outer gaps ──────────────────────────────────────────────────

--- a/src/settings/windowappearancecontroller.h
+++ b/src/settings/windowappearancecontroller.h
@@ -23,8 +23,9 @@ class ISettings;
 /// plain config settings on ISettings (Windows.* and Gaps.*), so this controller
 /// forwards each value's READ/WRITE to the matching ISettings getter/setter and
 /// re-emits the ISettings::*Changed NOTIFY to QML. It also carries the CONSTANT
-/// slider bounds (border width/radius + the shared gap range) sourced from the
-/// same defaults the schema clamps against so the UI range can never drift.
+/// slider bounds (border width/radius, focus fade duration, and the shared gap
+/// range) sourced from the same defaults the schema clamps against so the UI
+/// range can never drift.
 ///
 /// Dirty tracking: the underlying values ARE Q_PROPERTY on Settings, so
 /// SettingsController's meta-object loop already wires their NOTIFY to

--- a/src/settings/windowappearancecontroller.h
+++ b/src/settings/windowappearancecontroller.h
@@ -53,6 +53,8 @@ class WindowAppearanceController : public PhosphorControl::PageController
                    hideWindowTitleBarsChanged)
     Q_PROPERTY(
         QString titleBarScope READ windowTitleBarScope WRITE setWindowTitleBarScope NOTIFY windowTitleBarScopeChanged)
+    // Decoration focus cross-fade duration (ms); 0 switches instantly.
+    Q_PROPERTY(int focusFadeDuration READ focusFadeDuration WRITE setFocusFadeDuration NOTIFY focusFadeDurationChanged)
 
     // ── Shared inner/outer gap model (Gaps.*) ─────────────────────────────────
     Q_PROPERTY(int innerGap READ innerGap WRITE setInnerGap NOTIFY innerGapChanged)
@@ -83,6 +85,8 @@ class WindowAppearanceController : public PhosphorControl::PageController
     Q_PROPERTY(int borderWidthMax READ borderWidthMax CONSTANT)
     Q_PROPERTY(int borderRadiusMin READ borderRadiusMin CONSTANT)
     Q_PROPERTY(int borderRadiusMax READ borderRadiusMax CONSTANT)
+    Q_PROPERTY(int focusFadeDurationMin READ focusFadeDurationMin CONSTANT)
+    Q_PROPERTY(int focusFadeDurationMax READ focusFadeDurationMax CONSTANT)
     Q_PROPERTY(int innerGapMin READ innerGapMin CONSTANT)
     Q_PROPERTY(int innerGapMax READ innerGapMax CONSTANT)
     Q_PROPERTY(int outerGapMin READ outerGapMin CONSTANT)
@@ -111,6 +115,7 @@ public:
     QString windowBorderColorInactive() const;
     bool hideWindowTitleBars() const;
     QString windowTitleBarScope() const;
+    int focusFadeDuration() const;
 
     void setShowWindowBorder(bool show);
     void setWindowBorderScope(const QString& scope);
@@ -120,6 +125,7 @@ public:
     void setWindowBorderColorInactive(const QString& color);
     void setHideWindowTitleBars(bool hide);
     void setWindowTitleBarScope(const QString& scope);
+    void setFocusFadeDuration(int ms);
 
     // Shared inner/outer gaps — forward to ISettings.
     int innerGap() const;
@@ -188,6 +194,14 @@ public:
     {
         return ::PhosphorCompositor::DecorationDefaults::BorderRadiusMax;
     }
+    int focusFadeDurationMin() const
+    {
+        return ::PhosphorCompositor::DecorationDefaults::FocusFadeMsMin;
+    }
+    int focusFadeDurationMax() const
+    {
+        return ::PhosphorCompositor::DecorationDefaults::FocusFadeMsMax;
+    }
     int innerGapMin() const
     {
         return ConfigDefaults::innerGapMin();
@@ -214,6 +228,7 @@ Q_SIGNALS:
     void windowBorderColorInactiveChanged();
     void hideWindowTitleBarsChanged();
     void windowTitleBarScopeChanged();
+    void focusFadeDurationChanged();
     void innerGapChanged();
     void outerGapChanged();
     void usePerSideOuterGapChanged();

--- a/tests/unit/config/test_configdefaults.cpp
+++ b/tests/unit/config/test_configdefaults.cpp
@@ -149,16 +149,16 @@ private Q_SLOTS:
         // Animations
         QVERIFY(ConfigDefaults::animationDuration() >= ConfigDefaults::animationDurationMin());
         QVERIFY(ConfigDefaults::animationDuration() <= ConfigDefaults::animationDurationMax());
-
-        // Window decoration focus cross-fade
-        QVERIFY(ConfigDefaults::focusFadeDuration() >= ConfigDefaults::focusFadeDurationMin());
-        QVERIFY(ConfigDefaults::focusFadeDuration() <= ConfigDefaults::focusFadeDurationMax());
         QVERIFY(ConfigDefaults::animationMinDistance() >= ConfigDefaults::animationMinDistanceMin());
         QVERIFY(ConfigDefaults::animationMinDistance() <= ConfigDefaults::animationMinDistanceMax());
         QVERIFY(ConfigDefaults::animationSequenceMode() >= ConfigDefaults::animationSequenceModeMin());
         QVERIFY(ConfigDefaults::animationSequenceMode() <= ConfigDefaults::animationSequenceModeMax());
         QVERIFY(ConfigDefaults::animationStaggerInterval() >= ConfigDefaults::animationStaggerIntervalMin());
         QVERIFY(ConfigDefaults::animationStaggerInterval() <= ConfigDefaults::animationStaggerIntervalMax());
+
+        // Window decoration focus cross-fade
+        QVERIFY(ConfigDefaults::focusFadeDuration() >= ConfigDefaults::focusFadeDurationMin());
+        QVERIFY(ConfigDefaults::focusFadeDuration() <= ConfigDefaults::focusFadeDurationMax());
     }
 
     /**

--- a/tests/unit/config/test_configdefaults.cpp
+++ b/tests/unit/config/test_configdefaults.cpp
@@ -149,6 +149,10 @@ private Q_SLOTS:
         // Animations
         QVERIFY(ConfigDefaults::animationDuration() >= ConfigDefaults::animationDurationMin());
         QVERIFY(ConfigDefaults::animationDuration() <= ConfigDefaults::animationDurationMax());
+
+        // Window decoration focus cross-fade
+        QVERIFY(ConfigDefaults::focusFadeDuration() >= ConfigDefaults::focusFadeDurationMin());
+        QVERIFY(ConfigDefaults::focusFadeDuration() <= ConfigDefaults::focusFadeDurationMax());
         QVERIFY(ConfigDefaults::animationMinDistance() >= ConfigDefaults::animationMinDistanceMin());
         QVERIFY(ConfigDefaults::animationMinDistance() <= ConfigDefaults::animationMinDistanceMax());
         QVERIFY(ConfigDefaults::animationSequenceMode() >= ConfigDefaults::animationSequenceModeMin());

--- a/tests/unit/config/test_settings_validation.cpp
+++ b/tests/unit/config/test_settings_validation.cpp
@@ -8,7 +8,7 @@
  * The tests here seed the backing JSON config with deliberately-invalid or
  * out-of-range values, then construct a Settings object and verify that the
  * schema validator coerces the value on read. Covers:
- *  1. clampInt validator -- out-of-range int snaps to the schema default.
+ *  1. clampInt validator -- out-of-range int snaps to the violated clamp bound.
  *  2. validColorOr validator -- invalid color string falls back to default.
  *  3. Trigger list JSON parse -- invalid JSON drops back to the default,
  *     max-size cap at MaxTriggersPerAction is enforced.

--- a/tests/unit/config/test_settings_validation.cpp
+++ b/tests/unit/config/test_settings_validation.cpp
@@ -69,6 +69,27 @@ private Q_SLOTS:
         QCOMPARE(settings.adjacentThreshold(), ConfigDefaults::adjacentThresholdMax());
     }
 
+    /**
+     * Same clampInt contract on the decoration focus cross-fade duration
+     * (Windows/FocusFadeDuration): a hand-written out-of-range value snaps to
+     * the declared max rather than reaching the effect raw.
+     */
+    void testReadValidatedFocusFadeDuration_outOfRange_clampsToMax()
+    {
+        IsolatedConfigGuard guard;
+
+        {
+            auto backend = PlasmaZones::createDefaultConfigBackend();
+            auto windows = backend->group(ConfigDefaults::windowsAppearanceGroup());
+            windows->writeInt(ConfigDefaults::focusFadeDurationKey(), 999999);
+            windows.reset();
+            backend->sync();
+        }
+
+        Settings settings;
+        QCOMPARE(settings.focusFadeDuration(), ConfigDefaults::focusFadeDurationMax());
+    }
+
     // =========================================================================
     // Schema validColorOr validator (invalid color string)
     // =========================================================================

--- a/tests/unit/config/test_settings_validation.cpp
+++ b/tests/unit/config/test_settings_validation.cpp
@@ -90,6 +90,28 @@ private Q_SLOTS:
         QCOMPARE(settings.focusFadeDuration(), ConfigDefaults::focusFadeDurationMax());
     }
 
+    /**
+     * The min side of the same clamp: a negative on-disk value snaps up to the
+     * declared minimum (0 = instant), so the effect never divides by a negative
+     * duration. Without this case a validator that only clamps the upper bound
+     * would pass the suite.
+     */
+    void testReadValidatedFocusFadeDuration_belowMin_clampsToMin()
+    {
+        IsolatedConfigGuard guard;
+
+        {
+            auto backend = PlasmaZones::createDefaultConfigBackend();
+            auto windows = backend->group(ConfigDefaults::windowsAppearanceGroup());
+            windows->writeInt(ConfigDefaults::focusFadeDurationKey(), -50);
+            windows.reset();
+            backend->sync();
+        }
+
+        Settings settings;
+        QCOMPARE(settings.focusFadeDuration(), ConfigDefaults::focusFadeDurationMin());
+    }
+
     // =========================================================================
     // Schema validColorOr validator (invalid color string)
     // =========================================================================

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -484,6 +484,14 @@ public:
     {
         m_windowTitleBarScope = v;
     }
+    int focusFadeDuration() const override
+    {
+        return m_focusFadeDuration;
+    }
+    void setFocusFadeDuration(int ms) override
+    {
+        m_focusFadeDuration = ms;
+    }
     int adjacentThreshold() const override
     {
         return 20;
@@ -1260,6 +1268,7 @@ private:
     QString m_windowBorderColorInactive = ConfigDefaults::windowBorderColorInactive();
     bool m_hideWindowTitleBars = ConfigDefaults::hideWindowTitleBars();
     QString m_windowTitleBarScope = ConfigDefaults::windowTitleBarScope();
+    int m_focusFadeDuration = ConfigDefaults::focusFadeDuration();
 };
 
 } // namespace PlasmaZones

--- a/tests/unit/settings/test_window_appearance_controller.cpp
+++ b/tests/unit/settings/test_window_appearance_controller.cpp
@@ -48,6 +48,10 @@ private Q_SLOTS:
         controller.setHideWindowTitleBars(true);
         QCOMPARE(settings.hideWindowTitleBars(), true);
         QCOMPARE(controller.hideWindowTitleBars(), true);
+
+        controller.setFocusFadeDuration(320);
+        QCOMPARE(settings.focusFadeDuration(), 320);
+        QCOMPARE(controller.focusFadeDuration(), 320);
     }
 
     void gapPropertiesForwardToSettings()

--- a/tests/unit/settings/test_window_appearance_controller.cpp
+++ b/tests/unit/settings/test_window_appearance_controller.cpp
@@ -15,7 +15,6 @@
  *      per-monitor override, falling back to the global value when absent.
  */
 
-#include <QSignalSpy>
 #include <QTest>
 
 #include "settings/windowappearancecontroller.h"

--- a/tests/unit/settings/test_window_appearance_controller.cpp
+++ b/tests/unit/settings/test_window_appearance_controller.cpp
@@ -5,11 +5,13 @@
  * @file test_window_appearance_controller.cpp
  * @brief Tests for the config-backed @c WindowAppearanceController.
  *
- * The controller is a thin Q_PROPERTY surface over ISettings: border / title-bar
- * and the shared inner/outer gap values forward to the matching ISettings
- * getter/setter. On top of that it exposes the scope-aware gapValue()/writeGap()
- * invokables the Gaps card's monitor scope chip drives. These tests pin:
- *   1. Border / title-bar / gap properties round-trip through ISettings.
+ * The controller is a thin Q_PROPERTY surface over ISettings: border / title-bar,
+ * the focus fade duration, and the shared inner/outer gap values forward to the
+ * matching ISettings getter/setter. On top of that it exposes the scope-aware
+ * gapValue()/writeGap() invokables the Gaps card's monitor scope chip drives.
+ * These tests pin:
+ *   1. Border / title-bar / focus-fade / gap properties round-trip through
+ *      ISettings.
  *   2. gapValue("", key) / writeGap("", key, v) read and write the GLOBAL config.
  *   3. gapValue(monitor, key) / writeGap(monitor, key, v) read and write the
  *      per-monitor override, falling back to the global value when absent.


### PR DESCRIPTION
## The bug

The focus-fade decoration pack (and every pack that mixes by focus: border dims, glow, shadow) snapped between focused and unfocused instead of fading, and the mechanism interfered with the focus animation knob. Two independent defects stacked up to make it instant:

### 1. The ramp's clock was slaved to the animation system

`refreshFocusFadeDuration()` derived the ramp duration from the animation system: 0 (instant) when animations were disabled, else the resolved `window.focus` event duration. Retiming the focus animation silently retimed the decoration fade, and animations-off killed it entirely.

### 2. The ramp state was scrubbed on every focus change (why it was *always* instant)

Every focus change routes through `slotWindowActivated → updateAllDecorations()`, which clears the whole decoration map before re-adding each window. Inside `updateWindowDecoration`, the `wasDecorated` check reads that just-cleared map, so it reported false for every window on every focus change and took the "genuine undecorated→decorated transition" branch — scrubbing the window's `m_focusFade` entry. `advanceFocusFade` then re-seeded its `-1` sentinel, whose documented behavior is snap-to-target. The ramp never ran a single step regardless of duration.

## The fix

**New `focusFadeDuration` setting** (int ms, default 160, clamp 0-1000, `Windows` config group), single-sourced in `PhosphorCompositor::DecorationDefaults`. Full plumbing: config key + schema clamp, `ISettings`/`Settings`, D-Bus adaptor, `WindowAppearanceController`, a slider on the window appearance page's Decorations card (0 = instant), search catalog entry, per-page reset manifest.

**Effect decoupled**: loads the key in `loadCachedSettings` and writes `m_focusFadeDurationMs` directly. `refreshFocusFadeDuration()` and its three call sites removed; `resolveMotionTreeBaseDuration` stays (still used by per-event transition timing). Disabling animations no longer snaps the fade; the `window.focus` event is purely the transition-shader knob again.

**Ramp survives the bulk reconcile**: `updateAllDecorations` snapshots the decorated ids before `clearAllDecorations()` and passes each window's previous state as a `wasDecoratedHint`; `updateWindowDecoration` prefers the hint over the post-clear (always-false) local lookup. Per-window callers unchanged.

**Loader hardened against version skew**: `getSetting` answers an unknown key with a valid empty-string variant, which `toInt()` coerced to 0 — locking instant mode when the running daemon predates the key. Non-numeric replies are now rejected (ok-guarded `toInt`) so the seeded 160 ms default survives.

## Testing

- Build clean; `ctest` 260/260.
- New coverage: controller round-trip, schema clamp (out-of-range snaps to max), default-within-bounds (runtime + compile-time asserts).
- Visually verified: smooth cross-fade on focus change, slider retimes it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)