### PR TITLE
feat(settings): add window filtering to decorations

### DIFF
--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -364,6 +364,21 @@ private:
     bool shouldAnimateWindow(KWin::EffectWindow* w) const;
 
     /**
+     * @brief Per-window gate for the border / decoration pass.
+     *
+     * Modeled on shouldAnimateWindow rather than shouldHandleWindow so the
+     * transient family is a real toggle (m_decorationExcludeTransientWindows):
+     * with it off the effect draws borders onto dialogs / popups. Rejects the
+     * always-wrong surfaces (own overlay / editor, xdg-portal, plasma-shell,
+     * special / desktop / dock / fullscreen / skipSwitcher, notification / OSD),
+     * honours the same user Exclude rule slice shouldHandleWindow uses (so an
+     * excluded app stays undecorated), then applies the transient toggle and the
+     * min-size threshold. Defaults preserve the prior behavior (transient on,
+     * size off), so a default config decorates exactly what it did before.
+     */
+    bool shouldDecorateWindow(KWin::EffectWindow* w) const;
+
+    /**
      * @brief Reject Plasma shell layer-shell surfaces by window class.
      *
      * On Wayland, KDE notification popups, system tray overlays, the emoji
@@ -1413,6 +1428,18 @@ private:
     bool m_animationExcludeNotificationsAndOsd = true;
     int m_animationMinWindowWidth = 0;
     int m_animationMinWindowHeight = 0;
+
+    // Decoration window filtering — gates the border / decoration pass,
+    // populated over D-Bus from the `Decorations.WindowFiltering` config group
+    // (loadCachedSettings). Initialised to the config defaults so a pre-D-Bus
+    // decoration pass matches the prior behavior: transients were already never
+    // decorated (exclude-transient on), and no size threshold was ever applied
+    // (min-size 0). The transient/min-size filters here reuse the snapping
+    // exclusion rule set (m_snappingExclusionEvaluator) rather than a dedicated
+    // decoration rule slice, so no new rule action is involved.
+    bool m_decorationExcludeTransientWindows = true;
+    int m_decorationMinWindowWidth = 0;
+    int m_decorationMinWindowHeight = 0;
 
     // Animation exclusion rule set — the `ExcludeAnimations`-action slice
     // of the unified Rule store the effect mirrors over D-Bus.

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -791,6 +791,45 @@ void PlasmaZonesEffect::loadCachedSettings()
     loadSettingAsync(QStringLiteral("animationMinimumWindowHeight"), [this](const QVariant& v) {
         m_animationMinWindowHeight = qBound(0, v.toInt(), 2000);
     });
+
+    // Decoration window filtering — independent of the snapping/tiling and
+    // animation filters cached above. Used by `shouldDecorateWindow()` to gate
+    // the border / decoration pass. Re-fetched on every settingsChanged, and a
+    // value change schedules a full border sweep so a Decorations page edit
+    // adds/removes borders on open windows live (mirroring the appearance
+    // loaders below) — unlike the animation filter, decorations are persistent
+    // state and won't self-correct on the next window event.
+    // Default true (exclude transients). Guard on isValid() so a failed reply
+    // leaves the member at its `true` init rather than `toBool()`'s
+    // false-on-invalid — otherwise a missed fetch would start drawing borders
+    // onto dialogs/popups until the next successful settings load.
+    loadSettingAsync(QStringLiteral("decorationExcludeTransientWindows"), [this](const QVariant& v) {
+        if (!v.isValid()) {
+            return;
+        }
+        const bool b = v.toBool();
+        if (m_decorationExcludeTransientWindows != b) {
+            m_decorationExcludeTransientWindows = b;
+            scheduleBorderSweep();
+        }
+    });
+    // Clamp on the effect side as defence-in-depth, symmetric with the
+    // animation min-size fetches above — the daemon schema already bounds
+    // these to [0, 2000].
+    loadSettingAsync(QStringLiteral("decorationMinimumWindowWidth"), [this](const QVariant& v) {
+        const int i = qBound(0, v.toInt(), 2000);
+        if (m_decorationMinWindowWidth != i) {
+            m_decorationMinWindowWidth = i;
+            scheduleBorderSweep();
+        }
+    });
+    loadSettingAsync(QStringLiteral("decorationMinimumWindowHeight"), [this](const QVariant& v) {
+        const int i = qBound(0, v.toInt(), 2000);
+        if (m_decorationMinWindowHeight != i) {
+            m_decorationMinWindowHeight = i;
+            scheduleBorderSweep();
+        }
+    });
     // animationExcludedApplications / animationExcludedWindowClasses are
     // GONE — the v4 migration folded those lists into the unified
     // Rule store as `ExcludeAnimations`-action rules, and

--- a/kwin-effect/plasmazoneseffect/decorations.cpp
+++ b/kwin-effect/plasmazoneseffect/decorations.cpp
@@ -341,13 +341,15 @@ void PlasmaZonesEffect::updateWindowDecoration(const QString& windowId, KWin::Ef
         return;
     }
 
-    // APP-WINDOW GATE: decoration applies to application windows only. Reuse the
-    // same structural app-window filter that snapping / zone management already
-    // use (shouldHandleWindow) — exactly as the animation path reuses it via
-    // shouldAnimateWindow — so no border is ever painted onto a non-window surface
-    // (docks, panels, the desktop, popups, dialogs, OSDs, tooltips, notifications,
-    // portal / plasma-shell surfaces, our own overlays).
-    if (!shouldHandleWindow(w)) {
+    // APP-WINDOW GATE: decoration-specific filter (shouldDecorateWindow), NOT
+    // the snapping shouldHandleWindow. It rejects the always-wrong surfaces
+    // (docks, panels, desktop, OSDs, notifications, portal / plasma-shell,
+    // our own overlays) and honours the user Exclude rules, but the
+    // transient family and a minimum-size threshold are user-tunable via the
+    // Decorations.WindowFiltering settings (m_decorationExcludeTransientWindows /
+    // m_decorationMinWindow{Width,Height}). Defaults preserve the prior
+    // shouldHandleWindow behavior (transients skipped, no size threshold).
+    if (!shouldDecorateWindow(w)) {
         return;
     }
 

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -393,6 +393,80 @@ bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
     return true;
 }
 
+bool PlasmaZonesEffect::shouldDecorateWindow(KWin::EffectWindow* w) const
+{
+    if (!w) {
+        return false;
+    }
+
+    const QString windowClass = w->windowClass();
+
+    // Always-wrong surfaces — never draw a border here regardless of any
+    // toggle. Our own overlay/editor windows and xdg-portal surfaces mirror the
+    // structural rejects in shouldHandleWindow; plasma-shell + the special/
+    // desktop/dock/fullscreen/skipSwitcher set is the structural clause shared
+    // with shouldAnimateWindow. (fullscreen is also rejected earlier in
+    // updateWindowDecoration, but keep it here so the gate stands alone.)
+    if (isOwnOverlayClass(windowClass) || isXdgDesktopPortalSurface(windowClass) || isPlasmaShellSurface(windowClass)) {
+        return false;
+    }
+    if (w->isSpecialWindow() || w->isDesktop() || w->isDock() || w->isFullScreen() || w->isSkipSwitcher()) {
+        return false;
+    }
+
+    // Notification / OSD surfaces — hard-excluded with no toggle. A border on a
+    // notification popup or a volume OSD is never sensible, so these are split
+    // off from the transient family below (which IS toggleable) and always
+    // rejected. There is no decoration NotificationsAndOsd knob.
+    if (w->isNotification() || w->isCriticalNotification() || w->isOnScreenDisplay()) {
+        return false;
+    }
+
+    // User Exclude rules — reuse the SAME snapping exclusion slice
+    // shouldHandleWindow gates on, so a window the user excluded from
+    // management is not decorated either (preserves prior behavior, since the
+    // decoration path used to run through shouldHandleWindow). No dedicated
+    // decoration rule slice, so no new rule action. The `!isEmpty()` fast path
+    // keeps a no-exclusions user at two pointer reads.
+    if (!m_snappingExclusionRuleSet.isEmpty()) {
+        if (m_snappingExclusionEvaluator.resolve(ruleQuery(w)).isExcluded()) {
+            return false;
+        }
+    }
+
+    // Keep-above overlays (Spectacle, colour pickers, screen rulers) — same
+    // rejection shouldHandleWindow applies, preserved so upgrading doesn't
+    // start bordering these lingering utility windows.
+    if (w->keepAbove()) {
+        return false;
+    }
+
+    // Transient-window filter — dialogs / popups / tooltips / dropdowns /
+    // menus / utility / splash windows, plus any window with a transient
+    // parent. Unlike shouldHandleWindow (which rejects these unconditionally),
+    // this is a user toggle: with it off the effect draws borders onto
+    // transients. Defaults on, so today's behavior (no borders on transients)
+    // is preserved.
+    if (m_decorationExcludeTransientWindows
+        && (w->isDialog() || w->isUtility() || w->isSplash() || w->isModal() || w->isPopupWindow() || w->isPopupMenu()
+            || w->isDropdownMenu() || w->isMenu() || w->isTooltip() || w->transientFor())) {
+        return false;
+    }
+
+    // Min-size filter — windows narrower or shorter than the threshold are not
+    // decorated. Zero (the default) disables each axis independently. Frame
+    // geometry is read live, consistent with the animation min-size gate.
+    const QRectF frame = w->frameGeometry();
+    if (m_decorationMinWindowWidth > 0 && frame.width() < m_decorationMinWindowWidth) {
+        return false;
+    }
+    if (m_decorationMinWindowHeight > 0 && frame.height() < m_decorationMinWindowHeight) {
+        return false;
+    }
+
+    return true;
+}
+
 bool PlasmaZonesEffect::isTileableWindow(KWin::EffectWindow* w, QString* rejectReason) const
 {
     if (rejectReason) {

--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -668,6 +668,48 @@ public:
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
+    // Decoration Window Filtering Settings
+    //
+    // Mirrors the Animation Window Filtering settings but lives in its own
+    // `Decorations.WindowFiltering` group so a user can tune which windows get a
+    // border independently of which windows snap or animate. The defaults
+    // preserve the pre-existing decoration behavior: transients were already
+    // never decorated (the effect's app-window gate rejected them structurally),
+    // so exclude-transient defaults on; no size threshold was ever applied, so
+    // the min-size axes default off (0). On upgrade nothing changes until the
+    // user opts into decorating transients or into a size threshold.
+    // ═══════════════════════════════════════════════════════════════════════════
+
+    static bool decorationExcludeTransientWindows()
+    {
+        return true;
+    }
+    static int decorationMinimumWindowWidth()
+    {
+        return 0;
+    }
+    static constexpr int decorationMinimumWindowWidthMin()
+    {
+        return 0;
+    }
+    static constexpr int decorationMinimumWindowWidthMax()
+    {
+        return 2000;
+    }
+    static int decorationMinimumWindowHeight()
+    {
+        return 0;
+    }
+    static constexpr int decorationMinimumWindowHeightMin()
+    {
+        return 0;
+    }
+    static constexpr int decorationMinimumWindowHeightMax()
+    {
+        return 2000;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════════
     // PhosphorZones::Zone Selector Settings
     // ═══════════════════════════════════════════════════════════════════════════
 

--- a/src/config/configkeys.h
+++ b/src/config/configkeys.h
@@ -109,6 +109,13 @@ public:
     // Animations sub-groups
     P_CONFIG_GROUP(animationsWindowFilteringGroup, "Animations.WindowFiltering")
 
+    // Decorations sub-groups — window filtering for the KWin effect's border /
+    // decoration pass. Independent of the Animations and Exclusions groups so a
+    // user can tune which windows get a border separately from which windows
+    // snap or animate. Reuses the shared leaf keys (transientWindowsKey,
+    // minimumWindowWidthKey, minimumWindowHeightKey); only the group differs.
+    P_CONFIG_GROUP(decorationsWindowFilteringGroup, "Decorations.WindowFiltering")
+
     // Tiling sub-groups
     P_CONFIG_GROUP(tilingAlgorithmGroup, "Tiling.Algorithm")
     P_CONFIG_GROUP(tilingBehaviorGroup, "Tiling.Behavior")

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -2017,6 +2017,26 @@ P_STORE_GET(int, animationMinimumWindowHeight, animationsWindowFilteringGroup, m
 P_STORE_SET_INT(setAnimationMinimumWindowHeight, animationsWindowFilteringGroup, minimumWindowHeightKey,
                 animationMinimumWindowHeightChanged)
 
+// ── Decoration Window Filtering (PhosphorConfig::Store-backed) ─────────────
+//
+// Three global decoration-filtering knobs in `Decorations.WindowFiltering`:
+// `decorationExcludeTransientWindows`, `decorationMinimumWindowWidth`,
+// `decorationMinimumWindowHeight`. Mirrors the Exclusions block, stored
+// independently so the KWin effect's border pass can be tuned separately
+// from snapping and animation filtering. Reuses the shared leaf keys; only
+// the group differs. Consumed effect-side via the generic settingsChanged
+// D-Bus broadcast (see kwin-effect loadCachedSettings).
+
+P_STORE_GET(bool, decorationExcludeTransientWindows, decorationsWindowFilteringGroup, transientWindowsKey, bool)
+P_STORE_SET_BOOL(setDecorationExcludeTransientWindows, decorationsWindowFilteringGroup, transientWindowsKey,
+                 decorationExcludeTransientWindowsChanged)
+P_STORE_GET(int, decorationMinimumWindowWidth, decorationsWindowFilteringGroup, minimumWindowWidthKey, int)
+P_STORE_SET_INT(setDecorationMinimumWindowWidth, decorationsWindowFilteringGroup, minimumWindowWidthKey,
+                decorationMinimumWindowWidthChanged)
+P_STORE_GET(int, decorationMinimumWindowHeight, decorationsWindowFilteringGroup, minimumWindowHeightKey, int)
+P_STORE_SET_INT(setDecorationMinimumWindowHeight, decorationsWindowFilteringGroup, minimumWindowHeightKey,
+                decorationMinimumWindowHeightChanged)
+
 // animationExcludedApplications / animationExcludedWindowClasses (+ their
 // add*/remove* convenience methods) retired in v4 — the v4 migration drains
 // the Animations.WindowFiltering group's Applications / WindowClasses leaves

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -323,6 +323,7 @@ QStringList Settings::managedGroupNames()
         ConfigDefaults::editorGroup(), // "Editor" — covers Editor.Shortcuts + Editor.Snapping + Editor.FillOnDrop
         ConfigDefaults::orderingGroup(), // "Ordering"
         ConfigDefaults::windowsAppearanceGroup(), // "Windows" — window border + title bar decoration
+        ConfigDefaults::decorationsWindowFilteringGroup(), // "Decorations.WindowFiltering" — border-pass window filter
         ConfigDefaults::gapsGroup(), // "Gaps" — shared inner/outer gap model
         ConfigDefaults::surfaceGroup(), // "Surface" — per-surface decoration tree (DecorationProfileTree blob)
     };

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -252,6 +252,15 @@ public:
                    NOTIFY animationMinimumWindowWidthChanged)
     Q_PROPERTY(int animationMinimumWindowHeight READ animationMinimumWindowHeight WRITE setAnimationMinimumWindowHeight
                    NOTIFY animationMinimumWindowHeightChanged)
+
+    // Decoration window filtering — separate group from snapping/tiling and
+    // animation filtering so the border pass can be tuned independently.
+    Q_PROPERTY(bool decorationExcludeTransientWindows READ decorationExcludeTransientWindows WRITE
+                   setDecorationExcludeTransientWindows NOTIFY decorationExcludeTransientWindowsChanged)
+    Q_PROPERTY(int decorationMinimumWindowWidth READ decorationMinimumWindowWidth WRITE setDecorationMinimumWindowWidth
+                   NOTIFY decorationMinimumWindowWidthChanged)
+    Q_PROPERTY(int decorationMinimumWindowHeight READ decorationMinimumWindowHeight WRITE
+                   setDecorationMinimumWindowHeight NOTIFY decorationMinimumWindowHeightChanged)
     // The animationExcludedApplications / animationExcludedWindowClasses
     // Q_PROPERTYs retired in v4 — the lists folded into `ExcludeAnimations`
     // Rules and the effect's `shouldAnimateWindow` gate now resolves
@@ -747,6 +756,15 @@ public:
     void setAnimationMinimumWindowWidth(int width) override;
     int animationMinimumWindowHeight() const override;
     void setAnimationMinimumWindowHeight(int height) override;
+
+    // Decoration window filtering — same shape as the animation filter but
+    // stored under `Decorations.WindowFiltering`.
+    bool decorationExcludeTransientWindows() const override;
+    void setDecorationExcludeTransientWindows(bool exclude) override;
+    int decorationMinimumWindowWidth() const override;
+    void setDecorationMinimumWindowWidth(int width) override;
+    int decorationMinimumWindowHeight() const override;
+    void setDecorationMinimumWindowHeight(int height) override;
     // animationExcludedApplications / animationExcludedWindowClasses
     // (+ their add*/remove* convenience methods) retired in v4 — see the
     // Q_PROPERTY block above for the migration notes.

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -525,15 +525,16 @@ void appendEditorSchema(PhosphorConfig::Schema& schema)
     };
 }
 
-// ─── Exclusions + Animation Window Filtering ────────────────────────────────
-// Two distinct schema groups declared together:
+// ─── Exclusions + Animation + Decoration Window Filtering ───────────────────
+// Three distinct schema groups declared together:
 //   1. `Exclusions` — snapping/tiling minimum-size + transient-window
 //      globals.
 //   2. `Animations.WindowFiltering` — animation-side equivalents plus a
 //      NotificationsAndOsd knob.
-// Both retired their per-app / per-class string lists in v4 (folded into
-// Application-subject Rules); only the global behavioural knobs
-// survive. Ints are clamped via schema validators.
+//   3. `Decorations.WindowFiltering` — border/decoration-side equivalents.
+// The first two retired their per-app / per-class string lists in v4 (folded
+// into Application-subject Rules); only the global behavioural knobs survive.
+// Ints are clamped via schema validators.
 
 void appendExclusionsSchema(PhosphorConfig::Schema& schema)
 {
@@ -578,6 +579,24 @@ void appendExclusionsSchema(PhosphorConfig::Schema& schema)
          QMetaType::Int,
          {},
          clampInt(CD::animationMinimumWindowHeightMin(), CD::animationMinimumWindowHeightMax())},
+    };
+
+    // Decoration window filtering — same shape as the Exclusions group,
+    // stored independently so the KWin effect's border pass can be tuned
+    // separately from snapping and animation filtering. Reuses the shared
+    // leaf keys; only the group differs.
+    schema.groups[CD::decorationsWindowFilteringGroup()] = {
+        {CD::transientWindowsKey(), CD::decorationExcludeTransientWindows(), QMetaType::Bool},
+        {CD::minimumWindowWidthKey(),
+         CD::decorationMinimumWindowWidth(),
+         QMetaType::Int,
+         {},
+         clampInt(CD::decorationMinimumWindowWidthMin(), CD::decorationMinimumWindowWidthMax())},
+        {CD::minimumWindowHeightKey(),
+         CD::decorationMinimumWindowHeight(),
+         QMetaType::Int,
+         {},
+         clampInt(CD::decorationMinimumWindowHeightMin(), CD::decorationMinimumWindowHeightMax())},
     };
 }
 

--- a/src/core/isettings.h
+++ b/src/core/isettings.h
@@ -411,6 +411,12 @@ Q_SIGNALS:
     void excludeTransientWindowsChanged();
     void minimumWindowWidthChanged();
     void minimumWindowHeightChanged();
+    // Decoration window filtering — paired with the IWindowExclusionSettings
+    // decoration virtuals. Consumed by the kwin-effect (via the generic
+    // settingsChanged D-Bus broadcast) and the decorations settings page.
+    void decorationExcludeTransientWindowsChanged();
+    void decorationMinimumWindowWidthChanged();
+    void decorationMinimumWindowHeightChanged();
     // Animation window filtering — paired with the IAnimationSettings
     // virtuals. Same shape as the snapping/tiling exclusion signals; lives
     // in its own change-set so animation-only consumers (the kwin-effect,

--- a/src/core/settings_interfaces.h
+++ b/src/core/settings_interfaces.h
@@ -273,9 +273,13 @@ public:
 };
 
 /**
- * @brief Settings related to window exclusion rules
+ * @brief Global window-filtering knobs for the KWin effect
  *
- * Used by: KWin Effect only (not exposed in KCM visualization)
+ * Two independent filter sets, same shape: the snapping/tiling exclusion
+ * globals (excludeTransientWindows + min-size) and the decoration/border
+ * filter (decoration* + min-size). Both are consumed by the KWin effect; the
+ * decoration knobs are also surfaced in the standalone Window Appearance
+ * settings page. Not exposed in the KCM.
  */
 class PLASMAZONES_EXPORT IWindowExclusionSettings
 {
@@ -294,6 +298,20 @@ public:
     virtual void setMinimumWindowWidth(int width) = 0;
     virtual int minimumWindowHeight() const = 0;
     virtual void setMinimumWindowHeight(int height) = 0;
+
+    // Decoration window filtering — gates the KWin effect's border /
+    // decoration pass, independent of the snapping filter above so a user can
+    // tune which windows get a border separately from which windows snap.
+    // Unlike the snapping filter, exclude-transient is a real toggle here: with
+    // it off the effect draws borders onto dialogs / popups. Defaults preserve
+    // the prior behavior (transients were already never decorated; no size
+    // threshold was ever applied).
+    virtual bool decorationExcludeTransientWindows() const = 0;
+    virtual void setDecorationExcludeTransientWindows(bool exclude) = 0;
+    virtual int decorationMinimumWindowWidth() const = 0;
+    virtual void setDecorationMinimumWindowWidth(int width) = 0;
+    virtual int decorationMinimumWindowHeight() const = 0;
+    virtual void setDecorationMinimumWindowHeight(int height) = 0;
 };
 
 /**

--- a/src/dbus/settingsadaptor.cpp
+++ b/src/dbus/settingsadaptor.cpp
@@ -529,6 +529,15 @@ void SettingsAdaptor::initializeRegistry()
                           setAnimationExcludeNotificationsAndOsd)
     REGISTER_INT_SETTING("animationMinimumWindowWidth", animationMinimumWindowWidth, setAnimationMinimumWindowWidth)
     REGISTER_INT_SETTING("animationMinimumWindowHeight", animationMinimumWindowHeight, setAnimationMinimumWindowHeight)
+
+    // Decoration window filtering — same getSetting/setSetting wire, stored
+    // independently so the KWin effect's border pass can be tuned separately
+    // from snapping and animation filtering.
+    REGISTER_BOOL_SETTING("decorationExcludeTransientWindows", decorationExcludeTransientWindows,
+                          setDecorationExcludeTransientWindows)
+    REGISTER_INT_SETTING("decorationMinimumWindowWidth", decorationMinimumWindowWidth, setDecorationMinimumWindowWidth)
+    REGISTER_INT_SETTING("decorationMinimumWindowHeight", decorationMinimumWindowHeight,
+                         setDecorationMinimumWindowHeight)
     // animationExcludedApplications / animationExcludedWindowClasses
     // retired in v4 — folded into ExcludeAnimations Rules; the
     // effect derives its animation exclusion rule set from the unified

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -370,6 +370,7 @@ qt_add_qml_module(plasmazones-settings
         qml/SpringPhysics.js
         qml/SettingsCard.qml
         qml/GapsSettingsCard.qml
+        qml/WindowFilterCard.qml
         qml/OsdCard.qml
         qml/ShortcutCaptureField.qml
         qml/ModifierComboBox.qml

--- a/src/settings/generalpagecontroller.h
+++ b/src/settings/generalpagecontroller.h
@@ -66,6 +66,10 @@ class GeneralPageController : public PhosphorControl::PageController
     Q_PROPERTY(int animationMinimumWindowWidthMax READ animationMinimumWindowWidthMax CONSTANT)
     Q_PROPERTY(int animationMinimumWindowHeightMin READ animationMinimumWindowHeightMin CONSTANT)
     Q_PROPERTY(int animationMinimumWindowHeightMax READ animationMinimumWindowHeightMax CONSTANT)
+    Q_PROPERTY(int decorationMinimumWindowWidthMin READ decorationMinimumWindowWidthMin CONSTANT)
+    Q_PROPERTY(int decorationMinimumWindowWidthMax READ decorationMinimumWindowWidthMax CONSTANT)
+    Q_PROPERTY(int decorationMinimumWindowHeightMin READ decorationMinimumWindowHeightMin CONSTANT)
+    Q_PROPERTY(int decorationMinimumWindowHeightMax READ decorationMinimumWindowHeightMax CONSTANT)
 
 public:
     /// Reference parameter, not pointer: the ISettings instance is required
@@ -155,6 +159,22 @@ public:
     int animationMinimumWindowHeightMax() const
     {
         return ConfigDefaults::animationMinimumWindowHeightMax();
+    }
+    int decorationMinimumWindowWidthMin() const
+    {
+        return ConfigDefaults::decorationMinimumWindowWidthMin();
+    }
+    int decorationMinimumWindowWidthMax() const
+    {
+        return ConfigDefaults::decorationMinimumWindowWidthMax();
+    }
+    int decorationMinimumWindowHeightMin() const
+    {
+        return ConfigDefaults::decorationMinimumWindowHeightMin();
+    }
+    int decorationMinimumWindowHeightMax() const
+    {
+        return ConfigDefaults::decorationMinimumWindowHeightMax();
     }
 
 private:

--- a/src/settings/qml/AnimationsGeneralPage.qml
+++ b/src/settings/qml/AnimationsGeneralPage.qml
@@ -295,103 +295,59 @@ SettingsFlickable {
             text: i18n("Filtered windows are not animated. Use a Rule to keep a specific application animated even when a filter would exclude it.")
         }
 
-        SettingsCard {
-            id: filteringCard
-
+        WindowFilterCard {
             Layout.fillWidth: true
-            headerText: i18n("Window Filtering")
-            searchAnchor: "windowFiltering"
-            collapsible: true
 
-            contentItem: ColumnLayout {
-                spacing: Kirigami.Units.smallSpacing
+            excludeTransient: page.appSettings.animationExcludeTransientWindows
+            transientDescription: i18n("Skip animations for dialogs, popups, tooltips, and dropdown menus")
+            transientAccessibleName: i18n("Exclude transient windows from animations")
+            onExcludeTransientToggled: value => {
+                page.appSettings.animationExcludeTransientWindows = value;
+            }
 
-                SettingsRow {
-                    title: i18n("Exclude transient windows")
-                    searchAnchor: "excludeTransientWindows"
-                    description: i18n("Skip animations for dialogs, popups, tooltips, and dropdown menus")
+            // Animations-only extra row: exclude notifications / OSDs. Supplies
+            // its own leading separator so it composes under the transient row.
+            insertAfterTransient: Component {
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: Kirigami.Units.smallSpacing
 
-                    SettingsSwitch {
-                        checked: page.appSettings.animationExcludeTransientWindows
-                        accessibleName: i18n("Exclude transient windows from animations")
-                        onToggled: function (newValue) {
-                            page.appSettings.animationExcludeTransientWindows = newValue;
+                    SettingsSeparator {}
+
+                    SettingsRow {
+                        title: i18n("Exclude notifications and OSDs")
+                        searchAnchor: "excludeNotificationsAndOsds"
+                        description: i18n("Skip animations for notification popups and on-screen displays such as volume and brightness")
+
+                        SettingsSwitch {
+                            checked: page.appSettings.animationExcludeNotificationsAndOsd
+                            accessibleName: i18n("Exclude notifications and on-screen displays from animations")
+                            onToggled: function (newValue) {
+                                page.appSettings.animationExcludeNotificationsAndOsd = newValue;
+                            }
                         }
                     }
                 }
+            }
 
-                SettingsSeparator {}
+            minWidth: page.appSettings.animationMinimumWindowWidth
+            minWidthFrom: settingsController.generalPage.animationMinimumWindowWidthMin
+            minWidthTo: settingsController.generalPage.animationMinimumWindowWidthMax
+            minWidthDescription: i18n("Windows narrower than this will not animate")
+            minWidthDisabledDescription: i18n("Disabled. No width threshold.")
+            minWidthAccessibleName: i18n("Minimum window width for animations")
+            onMinWidthModified: value => {
+                page.appSettings.animationMinimumWindowWidth = value;
+            }
 
-                SettingsRow {
-                    title: i18n("Exclude notifications and OSDs")
-                    searchAnchor: "excludeNotificationsAndOsds"
-                    description: i18n("Skip animations for notification popups and on-screen displays such as volume and brightness")
-
-                    SettingsSwitch {
-                        checked: page.appSettings.animationExcludeNotificationsAndOsd
-                        accessibleName: i18n("Exclude notifications and on-screen displays from animations")
-                        onToggled: function (newValue) {
-                            page.appSettings.animationExcludeNotificationsAndOsd = newValue;
-                        }
-                    }
-                }
-
-                SettingsSeparator {}
-
-                SettingsRow {
-                    title: i18n("Minimum window width")
-                    searchAnchor: "minimumWindowWidth"
-                    description: page.appSettings.animationMinimumWindowWidth === 0 ? i18n("Disabled. No width threshold.") : i18n("Windows narrower than this will not animate")
-
-                    SettingsSpinBox {
-                        // Schema-driven bounds — see GeneralPageController's
-                        // animationMinimumWindowWidthMin/Max Q_PROPERTYs.
-                        // Literal bounds would silently truncate any saved
-                        // value outside the literal range when the SpinBox
-                        // clamped the bound `value` on render.
-                        from: settingsController.generalPage.animationMinimumWindowWidthMin
-                        to: settingsController.generalPage.animationMinimumWindowWidthMax
-                        stepSize: 10
-                        value: page.appSettings.animationMinimumWindowWidth
-                        // textFromValue already emits the localised "%1 px" suffix; suppress
-                        // SettingsSpinBox's default "px" Label so the displayed value reads
-                        // "100 px" rather than "100 px px" (and "Off" rather than "Off px").
-                        unitText: ""
-                        Accessible.name: i18n("Minimum window width for animations")
-                        onValueModified: value => {
-                            page.appSettings.animationMinimumWindowWidth = value;
-                        }
-                        textFromValue: function (value) {
-                            return value === 0 ? i18n("Off") : i18nc("pixel-unit suffix in spin box", "%1 px", value);
-                        }
-                    }
-                }
-
-                SettingsSeparator {}
-
-                SettingsRow {
-                    title: i18n("Minimum window height")
-                    searchAnchor: "minimumWindowHeight"
-                    description: page.appSettings.animationMinimumWindowHeight === 0 ? i18n("Disabled. No height threshold.") : i18n("Windows shorter than this will not animate")
-
-                    SettingsSpinBox {
-                        from: settingsController.generalPage.animationMinimumWindowHeightMin
-                        to: settingsController.generalPage.animationMinimumWindowHeightMax
-                        stepSize: 10
-                        value: page.appSettings.animationMinimumWindowHeight
-                        // textFromValue already emits the localised "%1 px" suffix; see the
-                        // width SettingsSpinBox above for rationale on suppressing
-                        // SettingsSpinBox's default "px" Label.
-                        unitText: ""
-                        Accessible.name: i18n("Minimum window height for animations")
-                        onValueModified: value => {
-                            page.appSettings.animationMinimumWindowHeight = value;
-                        }
-                        textFromValue: function (value) {
-                            return value === 0 ? i18n("Off") : i18nc("pixel-unit suffix in spin box", "%1 px", value);
-                        }
-                    }
-                }
+            minHeight: page.appSettings.animationMinimumWindowHeight
+            minHeightFrom: settingsController.generalPage.animationMinimumWindowHeightMin
+            minHeightTo: settingsController.generalPage.animationMinimumWindowHeightMax
+            minHeightDescription: i18n("Windows shorter than this will not animate")
+            minHeightDisabledDescription: i18n("Disabled. No height threshold.")
+            minHeightAccessibleName: i18n("Minimum window height for animations")
+            onMinHeightModified: value => {
+                page.appSettings.animationMinimumWindowHeight = value;
             }
         }
     }

--- a/src/settings/qml/GeneralPage.qml
+++ b/src/settings/qml/GeneralPage.qml
@@ -228,76 +228,34 @@ SettingsFlickable {
         // Exclude rules), so the page itself was deleted; these three global
         // knobs survive here because they apply to ALL windows uniformly
         // rather than matching specific applications.
-        SettingsCard {
-            headerText: i18n("Window filtering")
-            collapsible: true
-            searchAnchor: "windowFiltering"
+        WindowFilterCard {
+            Layout.fillWidth: true
 
-            contentItem: ColumnLayout {
-                spacing: Kirigami.Units.smallSpacing
+            excludeTransient: appSettings.excludeTransientWindows
+            transientDescription: i18n("Skip dialogs, popups, and toolbars for snapping and tiling")
+            transientAccessibleName: i18n("Exclude transient windows")
+            onExcludeTransientToggled: value => {
+                appSettings.excludeTransientWindows = value;
+            }
 
-                SettingsRow {
-                    title: i18n("Exclude transient windows")
-                    description: i18n("Skip dialogs, popups, and toolbars for snapping and tiling")
-                    searchAnchor: "excludeTransient"
+            minWidth: appSettings.minimumWindowWidth
+            minWidthFrom: settingsController.generalPage.minimumWindowWidthMin
+            minWidthTo: settingsController.generalPage.minimumWindowWidthMax
+            minWidthDescription: i18n("Windows narrower than this are excluded")
+            minWidthDisabledDescription: i18n("Disabled (no width threshold)")
+            minWidthAccessibleName: i18n("Minimum window width")
+            onMinWidthModified: value => {
+                appSettings.minimumWindowWidth = value;
+            }
 
-                    SettingsSwitch {
-                        checked: appSettings.excludeTransientWindows
-                        accessibleName: i18n("Exclude transient windows")
-                        onToggled: function (newValue) {
-                            appSettings.excludeTransientWindows = newValue;
-                        }
-                    }
-                }
-
-                SettingsSeparator {}
-
-                SettingsRow {
-                    title: i18n("Minimum window width")
-                    description: appSettings.minimumWindowWidth === 0 ? i18n("Disabled (no width threshold)") : i18n("Windows narrower than this are excluded")
-
-                    SettingsSpinBox {
-                        // Schema-driven bounds — see GeneralPageController's
-                        // minimumWindowWidthMin/Max Q_PROPERTYs. Literal
-                        // bounds would silently truncate any saved value
-                        // outside the literal range when the SpinBox clamped
-                        // the bound `value` on render.
-                        from: settingsController.generalPage.minimumWindowWidthMin
-                        to: settingsController.generalPage.minimumWindowWidthMax
-                        stepSize: 10
-                        value: appSettings.minimumWindowWidth
-                        unitText: ""
-                        Accessible.name: i18n("Minimum window width")
-                        onValueModified: value => {
-                            appSettings.minimumWindowWidth = value;
-                        }
-                        textFromValue: function (value) {
-                            return value === 0 ? i18n("Off") : i18nc("pixel-unit suffix in spin box", "%1 px", value);
-                        }
-                    }
-                }
-
-                SettingsSeparator {}
-
-                SettingsRow {
-                    title: i18n("Minimum window height")
-                    description: appSettings.minimumWindowHeight === 0 ? i18n("Disabled (no height threshold)") : i18n("Windows shorter than this are excluded")
-
-                    SettingsSpinBox {
-                        from: settingsController.generalPage.minimumWindowHeightMin
-                        to: settingsController.generalPage.minimumWindowHeightMax
-                        stepSize: 10
-                        value: appSettings.minimumWindowHeight
-                        unitText: ""
-                        Accessible.name: i18n("Minimum window height")
-                        onValueModified: value => {
-                            appSettings.minimumWindowHeight = value;
-                        }
-                        textFromValue: function (value) {
-                            return value === 0 ? i18n("Off") : i18nc("pixel-unit suffix in spin box", "%1 px", value);
-                        }
-                    }
-                }
+            minHeight: appSettings.minimumWindowHeight
+            minHeightFrom: settingsController.generalPage.minimumWindowHeightMin
+            minHeightTo: settingsController.generalPage.minimumWindowHeightMax
+            minHeightDescription: i18n("Windows shorter than this are excluded")
+            minHeightDisabledDescription: i18n("Disabled (no height threshold)")
+            minHeightAccessibleName: i18n("Minimum window height")
+            onMinHeightModified: value => {
+                appSettings.minimumWindowHeight = value;
             }
         }
 

--- a/src/settings/qml/WindowAppearancePage.qml
+++ b/src/settings/qml/WindowAppearancePage.qml
@@ -411,6 +411,10 @@ SettingsFlickable {
                 appSettings.decorationExcludeTransientWindows = value;
             }
 
+            // Spin-box bounds come from generalPage (the shared schema-bounds
+            // controller that also serves the animation filter card), not
+            // root.ctl — the same cross-controller sourcing AnimationsGeneralPage
+            // uses for its filter bounds.
             minWidth: appSettings.decorationMinimumWindowWidth
             minWidthFrom: settingsController.generalPage.decorationMinimumWindowWidthMin
             minWidthTo: settingsController.generalPage.decorationMinimumWindowWidthMax

--- a/src/settings/qml/WindowAppearancePage.qml
+++ b/src/settings/qml/WindowAppearancePage.qml
@@ -394,6 +394,45 @@ SettingsFlickable {
         }
 
         // =================================================================
+        // Window Filtering Card — which windows get a border at all. Shared
+        // component (also on Snapping → General and Animations), bound here to
+        // the independent Decorations.WindowFiltering group. Unlike the snapping
+        // filter, the transient toggle is real: turning it off draws borders
+        // onto dialogs / popups. Defaults preserve prior behavior (transients
+        // skipped, no size threshold).
+        // =================================================================
+        WindowFilterCard {
+            Layout.fillWidth: true
+
+            excludeTransient: appSettings.decorationExcludeTransientWindows
+            transientDescription: i18n("Skip borders for dialogs, popups, and menus")
+            transientAccessibleName: i18n("Exclude transient windows from decorations")
+            onExcludeTransientToggled: value => {
+                appSettings.decorationExcludeTransientWindows = value;
+            }
+
+            minWidth: appSettings.decorationMinimumWindowWidth
+            minWidthFrom: settingsController.generalPage.decorationMinimumWindowWidthMin
+            minWidthTo: settingsController.generalPage.decorationMinimumWindowWidthMax
+            minWidthDescription: i18n("Windows narrower than this get no border")
+            minWidthDisabledDescription: i18n("Disabled (no width threshold)")
+            minWidthAccessibleName: i18n("Minimum window width for decorations")
+            onMinWidthModified: value => {
+                appSettings.decorationMinimumWindowWidth = value;
+            }
+
+            minHeight: appSettings.decorationMinimumWindowHeight
+            minHeightFrom: settingsController.generalPage.decorationMinimumWindowHeightMin
+            minHeightTo: settingsController.generalPage.decorationMinimumWindowHeightMax
+            minHeightDescription: i18n("Windows shorter than this get no border")
+            minHeightDisabledDescription: i18n("Disabled (no height threshold)")
+            minHeightAccessibleName: i18n("Minimum window height for decorations")
+            onMinHeightModified: value => {
+                appSettings.decorationMinimumWindowHeight = value;
+            }
+        }
+
+        // =================================================================
         // Gaps Card — the unified inner/outer gap model, config-backed. Smart
         // gaps is tiling-only and lives on the Tiling → Window page, so it is
         // hidden here.

--- a/src/settings/qml/WindowFilterCard.qml
+++ b/src/settings/qml/WindowFilterCard.qml
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+
+// Reusable "Window filtering" card — the exclude-transient toggle plus the two
+// minimum-size spin boxes shared by the Snapping (General), Animations, and
+// Decorations pages. Each host binds the values to its own settings group and
+// wires the change signals, so the values stay independent per feature while
+// the UI is defined once. The animations host also supplies an extra
+// notifications/OSD row through `insertAfterTransient`.
+//
+// Host-driven: this component holds no settings state of its own. Values come in
+// as properties; edits go out as signals. Descriptions and accessible names are
+// host-provided so each feature keeps its own wording (and its translations stay
+// in the host page).
+SettingsCard {
+    id: card
+
+    headerText: i18n("Window filtering")
+    searchAnchor: "windowFiltering"
+    collapsible: true
+
+    // ── Exclude-transient toggle ──
+    property bool excludeTransient: false
+    property string transientDescription: ""
+    property string transientAccessibleName: ""
+    signal excludeTransientToggled(bool value)
+
+    // ── Optional extra row, inserted between the transient toggle and the
+    // minimum-width row (the Animations page uses it for notifications/OSD). ──
+    property Component insertAfterTransient: null
+
+    // ── Minimum width / height ──
+    property int minWidth: 0
+    property int minHeight: 0
+    property int minWidthFrom: 0
+    property int minWidthTo: 2000
+    property int minHeightFrom: 0
+    property int minHeightTo: 2000
+    // Shown when the value is > 0; the disabled variant is shown at 0 ("Off").
+    property string minWidthDescription: ""
+    property string minWidthDisabledDescription: ""
+    property string minHeightDescription: ""
+    property string minHeightDisabledDescription: ""
+    property string minWidthAccessibleName: ""
+    property string minHeightAccessibleName: ""
+    signal minWidthModified(int value)
+    signal minHeightModified(int value)
+
+    contentItem: ColumnLayout {
+        spacing: Kirigami.Units.smallSpacing
+
+        SettingsRow {
+            title: i18n("Exclude transient windows")
+            description: card.transientDescription
+            searchAnchor: "excludeTransient"
+
+            SettingsSwitch {
+                checked: card.excludeTransient
+                accessibleName: card.transientAccessibleName
+                onToggled: function (newValue) {
+                    card.excludeTransientToggled(newValue);
+                }
+            }
+        }
+
+        // Extra host-supplied content (e.g. the animations notifications/OSD
+        // toggle), inserted between the transient toggle and the size rows. The
+        // component supplies its own leading separator so it composes with the
+        // transient row above without a dangling divider.
+        Loader {
+            Layout.fillWidth: true
+            active: card.insertAfterTransient !== null
+            visible: active
+            sourceComponent: card.insertAfterTransient
+        }
+
+        SettingsSeparator {}
+
+        SettingsRow {
+            title: i18n("Minimum window width")
+            searchAnchor: "minimumWindowWidth"
+            description: card.minWidth === 0 ? card.minWidthDisabledDescription : card.minWidthDescription
+
+            SettingsSpinBox {
+                // Schema-driven bounds — literal bounds would silently truncate
+                // a saved value outside the literal range when the SpinBox
+                // clamped the bound `value` on render.
+                from: card.minWidthFrom
+                to: card.minWidthTo
+                stepSize: 10
+                value: card.minWidth
+                // textFromValue already emits the localised "%1 px" suffix;
+                // suppress SettingsSpinBox's default "px" Label so the value
+                // reads "100 px" rather than "100 px px" (and "Off" not "Off px").
+                unitText: ""
+                Accessible.name: card.minWidthAccessibleName
+                onValueModified: value => {
+                    card.minWidthModified(value);
+                }
+                textFromValue: function (value) {
+                    return value === 0 ? i18n("Off") : i18nc("pixel-unit suffix in spin box", "%1 px", value);
+                }
+            }
+        }
+
+        SettingsSeparator {}
+
+        SettingsRow {
+            title: i18n("Minimum window height")
+            searchAnchor: "minimumWindowHeight"
+            description: card.minHeight === 0 ? card.minHeightDisabledDescription : card.minHeightDescription
+
+            SettingsSpinBox {
+                from: card.minHeightFrom
+                to: card.minHeightTo
+                stepSize: 10
+                value: card.minHeight
+                unitText: ""
+                Accessible.name: card.minHeightAccessibleName
+                onValueModified: value => {
+                    card.minHeightModified(value);
+                }
+                textFromValue: function (value) {
+                    return value === 0 ? i18n("Off") : i18nc("pixel-unit suffix in spin box", "%1 px", value);
+                }
+            }
+        }
+    }
+}

--- a/src/settings/searchcatalog.cpp
+++ b/src/settings/searchcatalog.cpp
@@ -282,6 +282,22 @@ void seedSearchCatalog(PhosphorControl::SearchController* search)
                {PhosphorI18n::tr("fade"), PhosphorI18n::tr("unfocused"), PhosphorI18n::tr("dim"),
                 PhosphorI18n::tr("cross-fade")});
 
+    // Window filtering (Decorations.WindowFiltering) — the shared WindowFilterCard
+    // on the Window Appearance page. Same anchors the card emits, mirroring the
+    // General and Animations filtering entries.
+    addSection(search, QStringLiteral("window-appearance"), QStringLiteral("windowFiltering"),
+               PhosphorI18n::tr("Window filtering"));
+    addSetting(search, QStringLiteral("window-appearance"), QStringLiteral("excludeTransient"),
+               PhosphorI18n::tr("Exclude transient windows"),
+               {PhosphorI18n::tr("dialogs"), PhosphorI18n::tr("popups"), PhosphorI18n::tr("menus"),
+                PhosphorI18n::tr("border")});
+    addSetting(search, QStringLiteral("window-appearance"), QStringLiteral("minimumWindowWidth"),
+               PhosphorI18n::tr("Minimum window width"),
+               {PhosphorI18n::tr("threshold"), PhosphorI18n::tr("narrow"), PhosphorI18n::tr("size")});
+    addSetting(search, QStringLiteral("window-appearance"), QStringLiteral("minimumWindowHeight"),
+               PhosphorI18n::tr("Minimum window height"),
+               {PhosphorI18n::tr("threshold"), PhosphorI18n::tr("short"), PhosphorI18n::tr("size")});
+
     // Gaps (shared inner/outer gap model) — folded onto the Window Appearance
     // page, which edits the same config-backed model.
     addSection(search, QStringLiteral("window-appearance"), QStringLiteral("gaps"), PhosphorI18n::tr("Gaps"));
@@ -414,7 +430,7 @@ void seedSearchCatalog(PhosphorControl::SearchController* search)
                {PhosphorI18n::tr("threshold"), PhosphorI18n::tr("skip"), PhosphorI18n::tr("geometry")});
     addSection(search, QStringLiteral("animations-general"), QStringLiteral("windowFiltering"),
                PhosphorI18n::tr("Window Filtering"));
-    addSetting(search, QStringLiteral("animations-general"), QStringLiteral("excludeTransientWindows"),
+    addSetting(search, QStringLiteral("animations-general"), QStringLiteral("excludeTransient"),
                PhosphorI18n::tr("Exclude transient windows"),
                {PhosphorI18n::tr("dialogs"), PhosphorI18n::tr("popups"), PhosphorI18n::tr("tooltips"),
                 PhosphorI18n::tr("menus")});

--- a/src/settings/searchcatalog.cpp
+++ b/src/settings/searchcatalog.cpp
@@ -182,6 +182,12 @@ void seedSearchCatalog(PhosphorControl::SearchController* search)
     addSetting(search, QStringLiteral("general"), QStringLiteral("excludeTransient"),
                PhosphorI18n::tr("Exclude transient windows"),
                {PhosphorI18n::tr("dialog"), PhosphorI18n::tr("popup"), PhosphorI18n::tr("tooltip")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("minimumWindowWidth"),
+               PhosphorI18n::tr("Minimum window width"),
+               {PhosphorI18n::tr("threshold"), PhosphorI18n::tr("narrow"), PhosphorI18n::tr("size")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("minimumWindowHeight"),
+               PhosphorI18n::tr("Minimum window height"),
+               {PhosphorI18n::tr("threshold"), PhosphorI18n::tr("short"), PhosphorI18n::tr("size")});
     addSetting(search, QStringLiteral("general"), QStringLiteral("resetDefaults"), PhosphorI18n::tr("Reset"),
                {PhosphorI18n::tr("reset to defaults"), PhosphorI18n::tr("defaults"), PhosphorI18n::tr("restore")});
 

--- a/src/settings/settingscontroller_pageregistration.cpp
+++ b/src/settings/settingscontroller_pageregistration.cpp
@@ -706,6 +706,11 @@ const QHash<QString, Settings::ConfigKeyList>& SettingsController::pageOwnedConf
              {CD::windowsAppearanceGroup(), CD::hideTitleBarsKey()},
              {CD::windowsAppearanceGroup(), CD::titleBarScopeKey()},
              {CD::windowsAppearanceGroup(), CD::focusFadeDurationKey()},
+             // Window filtering — the Decorations → General page hosts the
+             // WindowFilterCard bound to the Decorations.WindowFiltering group.
+             {CD::decorationsWindowFilteringGroup(), CD::transientWindowsKey()},
+             {CD::decorationsWindowFilteringGroup(), CD::minimumWindowWidthKey()},
+             {CD::decorationsWindowFilteringGroup(), CD::minimumWindowHeightKey()},
              {CD::gapsGroup(), CD::innerGapKey()},
              {CD::gapsGroup(), CD::outerGapKey()},
              {CD::gapsGroup(), CD::usePerSideOuterGapKey()},

--- a/src/settings/settingscontroller_pageregistration.cpp
+++ b/src/settings/settingscontroller_pageregistration.cpp
@@ -706,8 +706,9 @@ const QHash<QString, Settings::ConfigKeyList>& SettingsController::pageOwnedConf
              {CD::windowsAppearanceGroup(), CD::hideTitleBarsKey()},
              {CD::windowsAppearanceGroup(), CD::titleBarScopeKey()},
              {CD::windowsAppearanceGroup(), CD::focusFadeDurationKey()},
-             // Window filtering — the Decorations → General page hosts the
-             // WindowFilterCard bound to the Decorations.WindowFiltering group.
+             // Window filtering — the Decorations → General page (this
+             // window-appearance page) hosts the WindowFilterCard bound to the
+             // Decorations.WindowFiltering group.
              {CD::decorationsWindowFilteringGroup(), CD::transientWindowsKey()},
              {CD::decorationsWindowFilteringGroup(), CD::minimumWindowWidthKey()},
              {CD::decorationsWindowFilteringGroup(), CD::minimumWindowHeightKey()},

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -92,6 +92,10 @@ bool isDecorationPage(const QString& page)
 // is entirely resetKeys/discardKeys, and the decorationProfileTreeChanged
 // re-emit drives DecorationPageController::profilesChanged so open cards
 // refresh.
+//
+// The Decorations.WindowFiltering knobs are NOT here — they live on the
+// Decorations → General (window-appearance) page and ride that page's
+// pageOwnedConfigKeys manifest entry, not this shared surface-tree domain.
 const Settings::ConfigKeyList& decorationConfigKeys()
 {
     using CD = ConfigDefaults;

--- a/tests/unit/config/test_configdefaults.cpp
+++ b/tests/unit/config/test_configdefaults.cpp
@@ -110,6 +110,12 @@ private Q_SLOTS:
         QVERIFY(ConfigDefaults::minimumWindowHeight() >= ConfigDefaults::minimumWindowHeightMin());
         QVERIFY(ConfigDefaults::minimumWindowHeight() <= ConfigDefaults::minimumWindowHeightMax());
 
+        // Decoration window filtering
+        QVERIFY(ConfigDefaults::decorationMinimumWindowWidth() >= ConfigDefaults::decorationMinimumWindowWidthMin());
+        QVERIFY(ConfigDefaults::decorationMinimumWindowWidth() <= ConfigDefaults::decorationMinimumWindowWidthMax());
+        QVERIFY(ConfigDefaults::decorationMinimumWindowHeight() >= ConfigDefaults::decorationMinimumWindowHeightMin());
+        QVERIFY(ConfigDefaults::decorationMinimumWindowHeight() <= ConfigDefaults::decorationMinimumWindowHeightMax());
+
         // PhosphorZones::Zone Selector
         QVERIFY(ConfigDefaults::triggerDistance() >= ConfigDefaults::triggerDistanceMin());
         QVERIFY(ConfigDefaults::triggerDistance() <= ConfigDefaults::triggerDistanceMax());

--- a/tests/unit/config/test_settings_core.cpp
+++ b/tests/unit/config/test_settings_core.cpp
@@ -142,6 +142,35 @@ private Q_SLOTS:
     }
 
     /**
+     * The decoration window-filtering knobs (Decorations.WindowFiltering group)
+     * must return to their defaults on reset(). Regression: the group has to be
+     * listed in managedGroupNames() or reset() leaves the user's values on disk,
+     * and the schema-claimed group is never otherwise purged, so a factory reset
+     * would silently fail to restore the three Window Appearance filter knobs.
+     */
+    void testDecorationWindowFiltering_defaultsAndReset()
+    {
+        IsolatedConfigGuard guard;
+
+        Settings settings;
+        QCOMPARE(settings.decorationExcludeTransientWindows(), ConfigDefaults::decorationExcludeTransientWindows());
+        QCOMPARE(settings.decorationMinimumWindowWidth(), ConfigDefaults::decorationMinimumWindowWidth());
+        QCOMPARE(settings.decorationMinimumWindowHeight(), ConfigDefaults::decorationMinimumWindowHeight());
+
+        settings.setDecorationExcludeTransientWindows(false);
+        settings.setDecorationMinimumWindowWidth(300);
+        settings.setDecorationMinimumWindowHeight(200);
+        QCOMPARE(settings.decorationExcludeTransientWindows(), false);
+        QCOMPARE(settings.decorationMinimumWindowWidth(), 300);
+        QCOMPARE(settings.decorationMinimumWindowHeight(), 200);
+
+        settings.reset();
+        QCOMPARE(settings.decorationExcludeTransientWindows(), ConfigDefaults::decorationExcludeTransientWindows());
+        QCOMPARE(settings.decorationMinimumWindowWidth(), ConfigDefaults::decorationMinimumWindowWidth());
+        QCOMPARE(settings.decorationMinimumWindowHeight(), ConfigDefaults::decorationMinimumWindowHeight());
+    }
+
+    /**
      * After save() then load(), every property must equal what was set.
      * This validates the full round-trip for a representative subset of settings
      * across all config groups.

--- a/tests/unit/helpers/StubSettings.h
+++ b/tests/unit/helpers/StubSettings.h
@@ -547,6 +547,45 @@ public:
         m_minimumWindowHeight = h;
     }
 
+    // Decoration window filtering — stub accessors backed by m_decoration*
+    // state, mirroring the animation-filter stubs below.
+    bool decorationExcludeTransientWindows() const override
+    {
+        return m_decorationExcludeTransientWindows;
+    }
+    void setDecorationExcludeTransientWindows(bool exclude) override
+    {
+        if (m_decorationExcludeTransientWindows == exclude) {
+            return;
+        }
+        m_decorationExcludeTransientWindows = exclude;
+        Q_EMIT decorationExcludeTransientWindowsChanged();
+    }
+    int decorationMinimumWindowWidth() const override
+    {
+        return m_decorationMinimumWindowWidth;
+    }
+    void setDecorationMinimumWindowWidth(int width) override
+    {
+        if (m_decorationMinimumWindowWidth == width) {
+            return;
+        }
+        m_decorationMinimumWindowWidth = width;
+        Q_EMIT decorationMinimumWindowWidthChanged();
+    }
+    int decorationMinimumWindowHeight() const override
+    {
+        return m_decorationMinimumWindowHeight;
+    }
+    void setDecorationMinimumWindowHeight(int height) override
+    {
+        if (m_decorationMinimumWindowHeight == height) {
+            return;
+        }
+        m_decorationMinimumWindowHeight = height;
+        Q_EMIT decorationMinimumWindowHeightChanged();
+    }
+
     // Animation window filtering — pure-stub no-op accessors backed by
     // m_animation* state so tests that exercise the filter cascade can
     // round-trip values through the stub without involving the real
@@ -1239,6 +1278,11 @@ private:
     bool m_animationExcludeNotificationsAndOsd = ConfigDefaults::animationExcludeNotificationsAndOsd();
     int m_animationMinimumWindowWidth = ConfigDefaults::animationMinimumWindowWidth();
     int m_animationMinimumWindowHeight = ConfigDefaults::animationMinimumWindowHeight();
+    // Decoration-filter defaults, routed through ConfigDefaults like the
+    // animation-filter defaults above.
+    bool m_decorationExcludeTransientWindows = ConfigDefaults::decorationExcludeTransientWindows();
+    int m_decorationMinimumWindowWidth = ConfigDefaults::decorationMinimumWindowWidth();
+    int m_decorationMinimumWindowHeight = ConfigDefaults::decorationMinimumWindowHeight();
     QVariantMap m_autotilePerAlgorithmSettings;
     QString m_editorDuplicateShortcut = ConfigDefaults::editorDuplicateShortcut();
     QString m_editorSplitHorizontalShortcut = ConfigDefaults::editorSplitHorizontalShortcut();


### PR DESCRIPTION
## What

Adds a **Window filtering** control (exclude transient windows + minimum width/height) to window **Decorations**, matching the cards that already exist on Snapping and Animations. Decorations previously had no such control: borders already skipped transients structurally, but landed on tiny windows with no way to tune either.

## How

- **New `Decorations.WindowFiltering` config group** — independent of the snapping `Exclusions` and `Animations.WindowFiltering` groups so the border pass tunes separately. Reuses the shared leaf keys; no migration (new keys just default on the already-bumped v3.2 schema).
- **New `shouldDecorateWindow` effect gate** replacing the `shouldHandleWindow` call in the decoration path. Modeled on `shouldAnimateWindow`, it **reuses the existing snapping Exclude rule slice** (so `libs/phosphor-rules` is untouched — no new rule action), hard-rejects notifications/OSDs, makes the transient family a real toggle, and adds a minimum-size filter. Filter changes call `scheduleBorderSweep` so a Decorations edit re-decorates open windows live (decorations are persistent state, unlike event-driven animations).
- **Reusable `WindowFilterCard.qml`** — the duplicated filtering UI is factored into one component now shared by the Snapping, Animations, and Decorations pages (the animations notifications/OSD row rides an `insertAfterTransient` slot). The two existing pages shrink by ~150 lines net.

## Behavior / compatibility

Defaults preserve today's behavior exactly: **exclude-transient on, size threshold off (0)**. Upgrading changes nothing until a user opts in — e.g. turning the transient toggle off to draw borders on dialogs and popups, or setting a minimum size to skip tiny windows.

## Testing

- `cmake --build` green; `ctest` 260/260 pass (added decoration default-bounds assertions).
- Multi-agent code audit run on the diff (correctness, regressions, project rules, search-catalog consistency); all findings fixed.
- End-to-end behavior (live re-decoration on toggle) needs an installed session and is not covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)