### PR TITLE
refactor(config): Decorations group for shader tree + native-JSON session state

### DIFF
--- a/src/config/configdefaults.h
+++ b/src/config/configdefaults.h
@@ -1008,16 +1008,16 @@ public:
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // Surface shader Settings
+    // Decoration shader Settings
     //
-    // The group/key accessors (surfaceGroup / surfaceDecorationTreeKey) are
+    // The group/key accessors (decorationsGroup / decorationProfileTreeKey) are
     // inherited from ConfigKeys — no forwarding accessors needed here (same as
     // every other group: ConfigDefaults derives from ConfigKeys).
     // ═══════════════════════════════════════════════════════════════════════════
 
     /// Default DecorationProfileTree — the fallback the typed
-    /// `Settings::decorationProfileTree()` returns when the Surface group holds
-    /// no `DecorationProfileTree` entry.
+    /// `Settings::decorationProfileTree()` returns when the Decorations group
+    /// holds no `DecorationProfileTree` entry.
     ///
     /// The decoration tree is the user-applied surface-shader pack stack. Window
     /// border and title-bar appearance are owned by the window rules, not by this

--- a/src/config/configkeys.h
+++ b/src/config/configkeys.h
@@ -122,13 +122,13 @@ public:
     P_CONFIG_GROUP(tilingBehaviorTriggersGroup, "Tiling.Behavior.Triggers")
     P_CONFIG_GROUP(tilingGapsGroup, "Tiling.Gaps")
 
-    // Surface — per-surface decoration tree (DecorationProfileTree: shader-pack
-    // chain + per-pack parameters, keyed on a dot-path surface namespace; any
-    // border appearance rides as the border pack's parameters). A flat
-    // top-level group rather than a per-mode sub-group of Tiling/Snapping
-    // because decoration is product-wide, not bound to a tiling/snapping
-    // appearance axis.
-    P_CONFIG_GROUP(surfaceGroup, "Surface")
+    // Decorations — per-surface decoration tree (DecorationProfileTree:
+    // shader-pack chain + per-pack parameters, keyed on a dot-path surface
+    // namespace; any border appearance rides as the border pack's parameters).
+    // The DecorationProfileTree blob is a leaf key directly under this group,
+    // mirroring how the animation ShaderProfileTree sits under Animations; the
+    // Decorations.WindowFiltering sub-group is the border-pass window filter.
+    P_CONFIG_GROUP(decorationsGroup, "Decorations")
 
     // Parent groups (for purge enumeration — covers all sub-groups)
     P_CONFIG_GROUP(shortcutsGroup, "Shortcuts")
@@ -382,16 +382,16 @@ public:
     P_CONFIG_KEY(lockedScreensKey, "LockedScreens")
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // Config Keys — Surface
+    // Config Keys — Decorations
     // ═══════════════════════════════════════════════════════════════════════════
 
     // DecorationProfileTree JSON blob — the user-applied per-surface decoration
     // (shader-pack chain). Mirrors the animation ShaderProfileTree blob under
-    // Animations, persisted as a nested JSON object under the Surface group —
-    // with one materialization difference: the surface schema default is the
+    // Animations, persisted as a nested JSON object under the Decorations group —
+    // with one materialization difference: the decoration schema default is the
     // serialized empty tree ({"baseline":…,"overrides":[]}, non-empty as a
     // map), whereas the animation default is a bare {}.
-    P_CONFIG_KEY(surfaceDecorationTreeKey, "DecorationProfileTree")
+    P_CONFIG_KEY(decorationProfileTreeKey, "DecorationProfileTree")
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Config Keys — Tiling.Gaps

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -325,7 +325,8 @@ QStringList Settings::managedGroupNames()
         ConfigDefaults::windowsAppearanceGroup(), // "Windows" — window border + title bar decoration
         ConfigDefaults::decorationsWindowFilteringGroup(), // "Decorations.WindowFiltering" — border-pass window filter
         ConfigDefaults::gapsGroup(), // "Gaps" — shared inner/outer gap model
-        ConfigDefaults::surfaceGroup(), // "Surface" — per-surface decoration tree (DecorationProfileTree blob)
+        ConfigDefaults::decorationsGroup(), // "Decorations" — per-surface decoration tree (DecorationProfileTree blob)
+                                            // + WindowFiltering sub-group
     };
 }
 
@@ -1309,7 +1310,7 @@ void Settings::setShaderProfileTreeJson(const QString& json)
     setShaderProfileTree(PhosphorAnimationShaders::ShaderProfileTree::fromJson(doc.object()));
 }
 
-// ── Surface decoration tree (PhosphorConfig::Store-backed) ──────────────────
+// ── Decorations tree (PhosphorConfig::Store-backed) ─────────────────────────
 // Persisted as one nested JSON entry under Surface/DecorationProfileTree,
 // mirroring how the animation shaderProfileTree persists under
 // Animations/ShaderProfileTree. The read-side falls back to the
@@ -1321,8 +1322,8 @@ void Settings::setShaderProfileTreeJson(const QString& json)
 PhosphorSurfaceShaders::DecorationProfileTree Settings::decorationProfileTree() const
 {
     const QVariantMap map =
-        m_store->read<QVariantMap>(ConfigDefaults::surfaceGroup(), ConfigDefaults::surfaceDecorationTreeKey());
-    // The Surface schema registers a NON-empty default for this key (the
+        m_store->read<QVariantMap>(ConfigDefaults::decorationsGroup(), ConfigDefaults::decorationProfileTreeKey());
+    // The Decorations schema registers a NON-empty default for this key (the
     // serialized ConfigDefaults::decorationProfileTree), so a store built with
     // the schema never returns empty here. The guard covers a store constructed
     // WITHOUT the schema default (e.g. a bare test stub): fall back to the same
@@ -1348,7 +1349,7 @@ void Settings::setDecorationProfileTree(const PhosphorSurfaceShaders::Decoration
     // back over an empty store is correctly a no-op.
     if (pruned == decorationProfileTree())
         return;
-    m_store->write(ConfigDefaults::surfaceGroup(), ConfigDefaults::surfaceDecorationTreeKey(),
+    m_store->write(ConfigDefaults::decorationsGroup(), ConfigDefaults::decorationProfileTreeKey(),
                    pruned.toJson().toVariantMap());
     Q_EMIT decorationProfileTreeChanged();
     Q_EMIT settingsChanged();

--- a/src/config/settings.cpp
+++ b/src/config/settings.cpp
@@ -1311,7 +1311,7 @@ void Settings::setShaderProfileTreeJson(const QString& json)
 }
 
 // ── Decorations tree (PhosphorConfig::Store-backed) ─────────────────────────
-// Persisted as one nested JSON entry under Surface/DecorationProfileTree,
+// Persisted as one nested JSON entry under Decorations/DecorationProfileTree,
 // mirroring how the animation shaderProfileTree persists under
 // Animations/ShaderProfileTree. The read-side falls back to the
 // ConfigDefaults tree (EMPTY / neutral: no baseline chain, no overrides —

--- a/src/config/settings.h
+++ b/src/config/settings.h
@@ -964,7 +964,7 @@ public:
     void setShaderProfileTreeJson(const QString& json);
 
     // Per-surface decoration tree (DecorationProfile: shader-pack chain + its
-    // per-pack parameters), persisted under the Surface group. Typed accessors
+    // per-pack parameters), persisted under the Decorations group. Typed accessors
     // mirror shaderProfileTree; the JSON-string facade backs the Q_PROPERTY
     // above.
     PhosphorSurfaceShaders::DecorationProfileTree decorationProfileTree() const override;

--- a/src/config/settingsschema.cpp
+++ b/src/config/settingsschema.cpp
@@ -37,7 +37,7 @@ PhosphorConfig::Schema buildSettingsSchema()
     appendAutotilingSchema(s);
     appendWindowsSchema(s);
     appendGapsSchema(s);
-    appendSurfaceSchema(s);
+    appendDecorationsSchema(s);
 
     return s;
 }
@@ -950,21 +950,23 @@ void appendGapsSchema(PhosphorConfig::Schema& schema)
     };
 }
 
-// ─── Surface ────────────────────────────────────────────────────────────────
+// ─── Decorations ──────────────────────────────────────────────────────────────
 // Per-surface decoration tree: a DecorationProfileTree (the user-applied surface
 // shader-pack chain) keyed on a dot-path surface namespace, persisted as a nested
 // JSON object — same QVariantMap storage shape as the autotile PerAlgorithmSettings
 // entry above and the animation ShaderProfileTree blob, with no sanitizer because
-// the per-pack override schema is not known to the config layer.
+// the per-pack override schema is not known to the config layer. The blob is a
+// leaf key under Decorations, mirroring ShaderProfileTree under Animations; the
+// Decorations.WindowFiltering sub-group is registered separately.
 
-void appendSurfaceSchema(PhosphorConfig::Schema& schema)
+void appendDecorationsSchema(PhosphorConfig::Schema& schema)
 {
     using CD = ConfigDefaults;
-    schema.groups[CD::surfaceGroup()] = {
+    schema.groups[CD::decorationsGroup()] = {
         // Per-surface decoration tree. The default is the (empty) ConfigDefaults
         // baseline serialized to a map; a user engages packs from the Decoration
         // pages.
-        {CD::surfaceDecorationTreeKey(), CD::decorationProfileTree().toJson().toVariantMap(), QMetaType::QVariantMap},
+        {CD::decorationProfileTreeKey(), CD::decorationProfileTree().toJson().toVariantMap(), QMetaType::QVariantMap},
     };
 }
 

--- a/src/config/settingsschema.h
+++ b/src/config/settingsschema.h
@@ -45,6 +45,6 @@ void appendBehaviorSchema(PhosphorConfig::Schema& schema);
 void appendAutotilingSchema(PhosphorConfig::Schema& schema);
 void appendWindowsSchema(PhosphorConfig::Schema& schema);
 void appendGapsSchema(PhosphorConfig::Schema& schema);
-void appendSurfaceSchema(PhosphorConfig::Schema& schema);
+void appendDecorationsSchema(PhosphorConfig::Schema& schema);
 
 } // namespace PlasmaZones

--- a/src/dbus/windowtrackingadaptor/saveload.cpp
+++ b/src/dbus/windowtrackingadaptor/saveload.cpp
@@ -152,8 +152,7 @@ void WindowTrackingAdaptor::saveState()
         for (const QString& windowClass : m_service->userSnappedClasses()) {
             userSnappedArray.append(windowClass);
         }
-        tracking->writeString(ConfigKeys::userSnappedClassesKey(),
-                              QString::fromUtf8(QJsonDocument(userSnappedArray).toJson(QJsonDocument::Compact)));
+        tracking->writeJson(ConfigKeys::userSnappedClassesKey(), userSnappedArray);
     }
 
     // Autotile window orders and pending restores are no longer persisted as
@@ -185,8 +184,7 @@ void WindowTrackingAdaptor::saveState()
                     && !isPersistedContextDisabled(p.screenId, p.virtualDesktop, p.activity);
             });
         if (!placements.isEmpty()) {
-            tracking->writeString(ConfigKeys::windowPlacementsKey(),
-                                  QString::fromUtf8(QJsonDocument(placements).toJson(QJsonDocument::Compact)));
+            tracking->writeJson(ConfigKeys::windowPlacementsKey(), placements);
         } else {
             tracking->deleteKey(ConfigKeys::windowPlacementsKey());
         }
@@ -271,8 +269,9 @@ void WindowTrackingAdaptor::loadState()
 {
     // Read config via the PhosphorConfig::IBackend group API (readString/readInt).
     // This correctly handles values stored as native JSON objects/arrays
-    // (e.g. PendingRestoreQueues, PreTileGeometries) — the group's readString()
-    // serializes them back to compact JSON strings.
+    // (UserSnappedClasses, WindowPlacements) — the group's readString()
+    // serializes them back to compact JSON strings, so the same fromJson parse
+    // below also reads a pre-native session.json where these were escaped strings.
     //
     // The previous approach used readJsonConfigFromDisk() which flattened the
     // entire config into a QMap. Its flattener recursed into native JSON objects

--- a/src/settings/settingscontroller_pagestate.cpp
+++ b/src/settings/settingscontroller_pagestate.cpp
@@ -100,7 +100,7 @@ const Settings::ConfigKeyList& decorationConfigKeys()
 {
     using CD = ConfigDefaults;
     static const Settings::ConfigKeyList keys{
-        {CD::surfaceGroup(), CD::surfaceDecorationTreeKey()},
+        {CD::decorationsGroup(), CD::decorationProfileTreeKey()},
     };
     return keys;
 }

--- a/tests/unit/config/test_settings_decoration_tree.cpp
+++ b/tests/unit/config/test_settings_decoration_tree.cpp
@@ -7,7 +7,7 @@
  *
  * The decoration analogue of test_settings_shader_tree.cpp. The
  * per-surface decoration tree persists as one nested JSON entry under
- * Surface/DecorationProfileTree, mirroring how the animation
+ * Decorations/DecorationProfileTree, mirroring how the animation
  * shaderProfileTree persists under Animations/ShaderProfileTree. Pinned
  * behaviour:
  *   - a fresh Settings returns the EMPTY/neutral ConfigDefaults tree
@@ -66,7 +66,7 @@ class TestSettingsDecorationTree : public QObject
 
 private Q_SLOTS:
 
-    /// A fresh config has no Surface/DecorationProfileTree entry, so
+    /// A fresh config has no Decorations/DecorationProfileTree entry, so
     /// Settings::decorationProfileTree() must fall back to the canonical
     /// ConfigDefaults default — the EMPTY/neutral tree. Border and
     /// titlebar visuals are owned by the window rules, so the tree starts
@@ -86,7 +86,7 @@ private Q_SLOTS:
     /// save() and reload through a fresh Settings instance. This is the
     /// cross-process path: the daemon's Settings reads the same disk file
     /// the settings app wrote. Regression guard mirroring the shader-tree
-    /// round-trip (a missing Surface-schema key would drop the blob at
+    /// round-trip (a missing Decorations-schema key would drop the blob at
     /// the Store gate and silently reset the picker).
     void testDecorationProfileTree_setRoundTripsThroughDisk()
     {


### PR DESCRIPTION
Two independent config-layout cleanups on `v3.2`, both new-in-3.2 so neither needs a migration.

## 1. Move the decoration tree under `Decorations`

The `DecorationProfileTree` blob (shader-pack chain + per-pack parameters) lived under a standalone `Surface` group. This moves it to `Decorations`, mirroring how the animation `ShaderProfileTree` sits under `Animations`. `Decorations` now parents both the tree leaf key and the existing `Decorations.WindowFiltering` sub-group.

Accessors renamed to match: `surfaceGroup` → `decorationsGroup`, `surfaceDecorationTreeKey` → `decorationProfileTreeKey`, `appendSurfaceSchema` → `appendDecorationsSchema`.

No migration: the tree is new in 3.2 and the stale `Surface` group is purged by `purgeStaleKeys()` on the next save.

## 2. Store window-tracking session state as native JSON

`UserSnappedClasses` and `WindowPlacements` in `session.json` were serialized to escaped JSON strings via `writeString(QJsonDocument::toJson)`. Both are already built as a `QJsonArray`/`QJsonObject`, so they now write through `writeJson`, which `JsonBackend` stores as native JSON nodes.

The load path stays on `readString` + `fromJson`, which reads both the new native form and any existing escaped-string `session.json` without loss, so no migration is needed.

**Before:**
```json
"UserSnappedClasses": "[\"firefox\",\"vesktop\"]"
```
**After:**
```json
"UserSnappedClasses": ["firefox", "vesktop"]
```

## Testing
- Full build succeeds.
- `ctest`: 260/260 pass, including `test_settings_schema`, `test_decorationpagecontroller`, `test_session_persistence`, `test_wts_session`, and the v4→v5 migration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)