### PR TITLE
fix(effect): re-push work area for non-dock layer-shell panels, restore minimized windows after daemon restart

### DIFF
--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -669,7 +669,7 @@ void PlasmaZonesEffect::slotWindowMinimizedChanged(KWin::EffectWindow* w)
 
     // Snap-mode-only minimize→float bookkeeping is owned by SnapHandler (mirrors
     // AutotileHandler running its own minimize→float machine for autotile screens).
-    m_snapHandler->handleMinimizeChanged(windowId, screenId, minimized);
+    m_snapHandler->handleMinimizeChanged(w, windowId, screenId, minimized);
 }
 
 void PlasmaZonesEffect::slotRunningWindowsRequested()

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -512,16 +512,18 @@ PlasmaZonesEffect::PlasmaZonesEffect()
     connect(KWin::effects, &KWin::EffectsHandler::windowAdded, this, &PlasmaZonesEffect::slotWindowAdded);
     connect(KWin::effects, &KWin::EffectsHandler::windowClosed, this, &PlasmaZonesEffect::slotWindowClosed);
 
-    // Panel (dock) lifecycle drives KWin's work area: a panel added, removed,
-    // or resized changes the strut-excluded clientArea. Route dock windows to
+    // Panel lifecycle drives KWin's work area: a panel added, removed, or
+    // resized changes the strut-excluded clientArea. Route panel windows to
     // the screen-change handler so it re-pushes the authoritative work area
-    // to the daemon. trackDockWindow / onWindowClosed no-op for non-docks.
+    // to the daemon. Covers docks AND unmovable layer-shell surfaces (a
+    // third-party shell's exclusive-zone panel is not isDock() to KWin);
+    // trackDockWindow / onWindowClosed no-op for every other window.
     connect(KWin::effects, &KWin::EffectsHandler::windowAdded, m_screenChangeHandler.get(),
             &ScreenChangeHandler::trackDockWindow);
     connect(KWin::effects, &KWin::EffectsHandler::windowClosed, m_screenChangeHandler.get(),
             &ScreenChangeHandler::onWindowClosed);
     // Panels mapped before the effect loaded never fire windowAdded — hook the
-    // already-present docks now so a later resize of one still re-reports.
+    // already-present panels now so a later resize of one still re-reports.
     // Skip close-grabbed dying windows: other effects' close animations can
     // hold deleted windows in the stacking order across an effect (re)load.
     for (KWin::EffectWindow* existing : KWin::effects->stackingOrder()) {

--- a/kwin-effect/screenchangehandler.cpp
+++ b/kwin-effect/screenchangehandler.cpp
@@ -28,6 +28,31 @@ namespace {
 // multiple times per screen connect/disconnect/resolution change. 500ms lets
 // all signals from a single user action settle before we process.
 constexpr int ScreenChangeDebounceMs = 500;
+
+// Whether @p w can reserve screen-edge space (a strut) and so must be tracked
+// for work-area reporting. Plasma panels and X11 docks report isDock(). A
+// layer-shell panel from a third-party shell (e.g. a phosphor-shell bar with
+// an exclusive zone) does NOT — KWin classifies it as an unmovable NORMAL
+// window (isDock()=false, isNormalWindow()=true, isMovable()=false) — so an
+// isDock()-only gate leaves its strut changes unreported and the daemon's
+// compositor work-area override goes stale. Match those by "Wayland client
+// the user cannot interactively move", excluding the unmovable states that
+// cannot carry an exclusive zone: xdg popups (tooltips/menus — they churn on
+// open/close), fullscreen windows, and special windows (desktop, splash,
+// notifications, OSDs). Over-matching is cheap — a tracked window that never
+// reserves space only costs one signal connection, and every report the
+// daemon receives with an unchanged rect is deduplicated there.
+bool mayReserveScreenEdge(KWin::EffectWindow* w)
+{
+    if (!w) {
+        return false;
+    }
+    if (w->isDock()) {
+        return true;
+    }
+    return w->isWaylandClient() && !w->isMovable() && !w->isPopupWindow() && !w->isFullScreen() && !w->isSpecialWindow()
+        && !w->isDesktop();
+}
 } // namespace
 
 ScreenChangeHandler::ScreenChangeHandler(PlasmaZonesEffect* effect, QObject* parent)
@@ -266,7 +291,7 @@ void ScreenChangeHandler::applyWindowGeometries(const PhosphorProtocol::WindowGe
 
 void ScreenChangeHandler::trackDockWindow(KWin::EffectWindow* w)
 {
-    if (!w || !w->isDock()) {
+    if (!mayReserveScreenEdge(w)) {
         return;
     }
     // A panel mapped (or was already mapped at effect startup). KWin reserves
@@ -274,7 +299,7 @@ void ScreenChangeHandler::trackDockWindow(KWin::EffectWindow* w)
     // during its own lifetime (config changes, content-driven thickness).
     // Hook frame-geometry changes so every strut adjustment re-pushes the
     // work area. `this` as the connection context auto-disconnects the lambda
-    // when either the dock's EffectWindow or this handler is destroyed.
+    // when either the panel's EffectWindow or this handler is destroyed.
     connect(w, &KWin::EffectWindow::windowFrameGeometryChanged, this, [this]() {
         scheduleClientAreaReport();
     });
@@ -283,7 +308,7 @@ void ScreenChangeHandler::trackDockWindow(KWin::EffectWindow* w)
 
 void ScreenChangeHandler::onWindowClosed(KWin::EffectWindow* w)
 {
-    if (!w || !w->isDock()) {
+    if (!mayReserveScreenEdge(w)) {
         return;
     }
     // A panel closed — its strut is freed and KWin grows the work area.

--- a/kwin-effect/screenchangehandler.h
+++ b/kwin-effect/screenchangehandler.h
@@ -52,9 +52,13 @@ public:
     /// path schedules another.
     void scheduleClientAreaReport();
 
-    /// Hook @p w for work-area reporting when it is a panel (dock): connects
-    /// its geometry-changed signal and schedules a report. A no-op for
-    /// non-dock windows. Called for every `windowAdded` and once per
+    /// Hook @p w for work-area reporting when it may reserve screen-edge
+    /// space: connects its geometry-changed signal and schedules a report.
+    /// Matches docks AND unmovable layer-shell surfaces — a third-party
+    /// shell's panel (e.g. phosphor-shell) carries an exclusive zone but is
+    /// NOT isDock() to KWin, and missing it leaves the daemon's compositor
+    /// work-area override stale when that panel resizes. A no-op for every
+    /// other window. Called for every `windowAdded` and once per
     /// already-mapped window at effect startup so pre-existing panels are
     /// covered too.
     void trackDockWindow(KWin::EffectWindow* w);
@@ -83,8 +87,9 @@ public Q_SLOTS:
     void slotScreenLayoutChanged();
 
     /// Connected to `EffectsHandler::windowClosed` — schedules a work-area
-    /// report when @p w is a panel (dock) so the strut it freed reaches the
-    /// daemon. A no-op for non-dock windows.
+    /// report when @p w may have reserved screen-edge space (same match as
+    /// @ref trackDockWindow) so the strut it freed reaches the daemon. A
+    /// no-op for every other window.
     void onWindowClosed(KWin::EffectWindow* w);
 
 private:

--- a/kwin-effect/snaphandler.cpp
+++ b/kwin-effect/snaphandler.cpp
@@ -305,12 +305,54 @@ void SnapHandler::callCancelSnap()
                                                 QStringLiteral("cancelSnap"));
 }
 
-void SnapHandler::handleMinimizeChanged(const QString& windowId, const QString& screenId, bool minimized)
+void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
+                                        bool minimized)
 {
     // Snap-mode-only: the autotile handler runs its own snap-state / float-state
     // machine for autotile screens.
     if (m_effect->autotileHandler()->isAutotileScreen(screenId)) {
         return;
+    }
+
+    // Restore net for windows minimized across a daemon restart: every restore
+    // pass (slotDaemonReady's untracked sweep, slotPendingRestoresAvailable)
+    // deliberately skips minimized windows, and this unfloat path only flips a
+    // floating flag the daemon applies to windows it already tracks. A window
+    // that was minimized while the daemon restarted is therefore tracked by
+    // neither pass — it unminimizes to whatever geometry KWin restores and
+    // never rejoins its zone. Ask the daemon whether it tracks the window and
+    // run the same single-window restore the retry passes use when it does
+    // not. Tracked-ness MUST be checked first (not resolved blindly):
+    // resolveWindowRestore consumes the single-shot FIFO pending-restore entry
+    // for the window's appId, and burning it on an already-tracked window robs
+    // a sibling window's restore.
+    if (!minimized && window && m_effect->isDaemonReady("unminimize restore check")) {
+        QPointer<KWin::EffectWindow> safeWindow = window;
+        QDBusPendingCall pendingCall = PhosphorProtocol::ClientHelpers::asyncCall(
+            PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
+        auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
+        connect(watcher, &QDBusPendingCallWatcher::finished, this,
+                [this, safeWindow, windowId](QDBusPendingCallWatcher* w) {
+                    w->deleteLater();
+                    QDBusPendingReply<QStringList> reply = *w;
+                    // On a failed query do nothing — a blind restore could consume
+                    // another window's pending-restore entry (see above).
+                    if (!reply.isValid() || reply.value().contains(windowId)) {
+                        return;
+                    }
+                    // Same eligibility guards as slotPendingRestoresAvailable's
+                    // sweep, re-checked post-await: the window may have closed,
+                    // re-minimized, or left the current desktop/activity while
+                    // the query was in flight (restoring an off-desktop window
+                    // would snap it through the wrong desktop's snap state).
+                    if (!safeWindow || safeWindow->isDeleted() || safeWindow->isMinimized()
+                        || !safeWindow->isOnCurrentDesktop() || !safeWindow->isOnCurrentActivity()) {
+                        return;
+                    }
+                    qCInfo(lcEffect) << "Snap: unminimized window is untracked by daemon — retrying restore:"
+                                     << windowId;
+                    callResolveWindowRestore(safeWindow.data());
+                });
     }
 
     if (minimized) {

--- a/kwin-effect/snaphandler.cpp
+++ b/kwin-effect/snaphandler.cpp
@@ -26,6 +26,8 @@
 #include <QSet>
 #include <QStringList>
 
+#include <memory>
+
 namespace PlasmaZones {
 
 Q_DECLARE_LOGGING_CATEGORY(lcEffect)
@@ -314,47 +316,6 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
         return;
     }
 
-    // Restore net for windows minimized across a daemon restart: every restore
-    // pass (slotDaemonReady's untracked sweep, slotPendingRestoresAvailable)
-    // deliberately skips minimized windows, and this unfloat path only flips a
-    // floating flag the daemon applies to windows it already tracks. A window
-    // that was minimized while the daemon restarted is therefore tracked by
-    // neither pass — it unminimizes to whatever geometry KWin restores and
-    // never rejoins its zone. Ask the daemon whether it tracks the window and
-    // run the same single-window restore the retry passes use when it does
-    // not. Tracked-ness MUST be checked first (not resolved blindly):
-    // resolveWindowRestore consumes the single-shot FIFO pending-restore entry
-    // for the window's appId, and burning it on an already-tracked window robs
-    // a sibling window's restore.
-    if (!minimized && window && m_effect->isDaemonReady("unminimize restore check")) {
-        QPointer<KWin::EffectWindow> safeWindow = window;
-        QDBusPendingCall pendingCall = PhosphorProtocol::ClientHelpers::asyncCall(
-            PhosphorProtocol::Service::Interface::WindowTracking, QStringLiteral("getSnappedWindows"));
-        auto* watcher = new QDBusPendingCallWatcher(pendingCall, this);
-        connect(watcher, &QDBusPendingCallWatcher::finished, this,
-                [this, safeWindow, windowId](QDBusPendingCallWatcher* w) {
-                    w->deleteLater();
-                    QDBusPendingReply<QStringList> reply = *w;
-                    // On a failed query do nothing — a blind restore could consume
-                    // another window's pending-restore entry (see above).
-                    if (!reply.isValid() || reply.value().contains(windowId)) {
-                        return;
-                    }
-                    // Same eligibility guards as slotPendingRestoresAvailable's
-                    // sweep, re-checked post-await: the window may have closed,
-                    // re-minimized, or left the current desktop/activity while
-                    // the query was in flight (restoring an off-desktop window
-                    // would snap it through the wrong desktop's snap state).
-                    if (!safeWindow || safeWindow->isDeleted() || safeWindow->isMinimized()
-                        || !safeWindow->isOnCurrentDesktop() || !safeWindow->isOnCurrentActivity()) {
-                        return;
-                    }
-                    qCInfo(lcEffect) << "Snap: unminimized window is untracked by daemon — retrying restore:"
-                                     << windowId;
-                    callResolveWindowRestore(safeWindow.data());
-                });
-    }
-
     if (minimized) {
         if (m_effect->isWindowFloating(windowId)) {
             qCDebug(lcEffect) << "Snap: minimized already-floating window, skipping float:" << windowId;
@@ -365,6 +326,86 @@ void SnapHandler::handleMinimizeChanged(KWin::EffectWindow* window, const QStrin
         if (!m_minimizeFloatedWindows.remove(windowId)) {
             qCDebug(lcEffect) << "Snap: unminimized window was not minimize-floated, skipping unfloat:" << windowId;
             return;
+        }
+        // Restore net for a snap-tracked window minimized across a daemon
+        // restart: every restore pass (slotDaemonReady's untracked sweep,
+        // slotPendingRestoresAvailable) deliberately skips minimized windows,
+        // and the unfloat sent below only flips a floating flag the daemon
+        // applies to windows it already tracks — the new daemon session tracks
+        // this window as neither snapped nor floating, so the unfloat no-ops
+        // and the window never rejoins its zone.
+        //
+        // Discriminating "orphaned by a restart" from a NORMAL minimize cycle
+        // needs both daemon states: minimize-float UNSNAPS the window
+        // (SnapEngine::setWindowFloat(true) → unsnapForFloat), so in a normal
+        // cycle it is absent from getSnappedWindows too — but it IS in the
+        // daemon's floating set, and the unfloat below re-snaps it. Only a
+        // window in NEITHER set is orphaned. Both queries are dispatched HERE,
+        // before the unfloat fireAndForget below enters the same D-Bus send
+        // queue, so the daemon answers them against the pre-unfloat state.
+        //
+        // The restore-on-orphan is deliberately scoped to windows this effect
+        // session minimize-floated (the remove() above succeeded): an
+        // unconditional net would fire resolveWindowRestore on every
+        // unminimize of any never-tracked window, re-running its open-time
+        // placement routing (RouteToDesktop) and churning the placement
+        // store's per-app FIFO on a path that is not an open.
+        //
+        // Tracked-ness MUST be checked, not resolved blindly:
+        // resolveWindowRestore consumes the single-shot FIFO pending-restore
+        // entry for the window's appId, and burning it on a window the daemon
+        // still owns robs a sibling window's restore. A failed query counts
+        // as tracked for the same reason.
+        if (window && m_effect->isDaemonReady("unminimize restore check")) {
+            struct QueryJoin
+            {
+                int pending = 2;
+                bool trackedOrFailed = false;
+            };
+            auto join = std::make_shared<QueryJoin>();
+            QPointer<KWin::EffectWindow> safeWindow = window;
+            const auto onReplyDone = [this, join, safeWindow, windowId]() {
+                if (--join->pending > 0 || join->trackedOrFailed) {
+                    return;
+                }
+                // Same eligibility guards as slotPendingRestoresAvailable's
+                // sweep, re-checked post-await: the window may have closed,
+                // re-minimized, or left the current desktop/activity while
+                // the queries were in flight (restoring an off-desktop window
+                // would snap it through the wrong desktop's snap state).
+                if (!safeWindow || safeWindow->isDeleted() || safeWindow->isMinimized()
+                    || !safeWindow->isOnCurrentDesktop() || !safeWindow->isOnCurrentActivity()) {
+                    return;
+                }
+                qCInfo(lcEffect) << "Snap: unminimized window is untracked by daemon — retrying restore:" << windowId;
+                callResolveWindowRestore(safeWindow.data());
+            };
+            auto* snappedWatcher = new QDBusPendingCallWatcher(
+                PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                           QStringLiteral("getSnappedWindows")),
+                this);
+            connect(snappedWatcher, &QDBusPendingCallWatcher::finished, this,
+                    [join, windowId, onReplyDone](QDBusPendingCallWatcher* w) {
+                        w->deleteLater();
+                        QDBusPendingReply<QStringList> reply = *w;
+                        if (!reply.isValid() || reply.value().contains(windowId)) {
+                            join->trackedOrFailed = true;
+                        }
+                        onReplyDone();
+                    });
+            auto* floatingWatcher = new QDBusPendingCallWatcher(
+                PhosphorProtocol::ClientHelpers::asyncCall(PhosphorProtocol::Service::Interface::WindowTracking,
+                                                           QStringLiteral("queryWindowFloating"), {windowId}),
+                this);
+            connect(floatingWatcher, &QDBusPendingCallWatcher::finished, this,
+                    [join, onReplyDone](QDBusPendingCallWatcher* w) {
+                        w->deleteLater();
+                        QDBusPendingReply<bool> reply = *w;
+                        if (!reply.isValid() || reply.value()) {
+                            join->trackedOrFailed = true;
+                        }
+                        onReplyDone();
+                    });
         }
     }
 

--- a/kwin-effect/snaphandler.h
+++ b/kwin-effect/snaphandler.h
@@ -152,10 +152,15 @@ public:
     // ── Snap minimize-float (mirrors AutotileHandler's minimize→float machine) ──
     /// Drive the snap-mode minimize→float state machine: on a snapping-mode
     /// screen, float a window when it minimizes and unfloat it when it
-    /// unminimizes (autotile screens run AutotileHandler's own machine). Called
-    /// from PlasmaZonesEffect::slotWindowMinimizedChanged after the shared
-    /// minimize shader event.
-    void handleMinimizeChanged(const QString& windowId, const QString& screenId, bool minimized);
+    /// unminimizes (autotile screens run AutotileHandler's own machine). On
+    /// unminimize it also retries snap restore when the daemon does not track
+    /// @p window — every restore pass (daemon-ready, pendingRestoresAvailable)
+    /// skips minimized windows, so a window minimized across a daemon restart
+    /// would otherwise stay stranded at whatever geometry KWin unminimizes it
+    /// to. Called from PlasmaZonesEffect::slotWindowMinimizedChanged after the
+    /// shared minimize shader event.
+    void handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
+                               bool minimized);
     /// Drop @p windowId from the minimize-float set (window closed). Returns
     /// true if it was present.
     bool removeMinimizeFloated(const QString& windowId)

--- a/kwin-effect/snaphandler.h
+++ b/kwin-effect/snaphandler.h
@@ -152,13 +152,17 @@ public:
     // ── Snap minimize-float (mirrors AutotileHandler's minimize→float machine) ──
     /// Drive the snap-mode minimize→float state machine: on a snapping-mode
     /// screen, float a window when it minimizes and unfloat it when it
-    /// unminimizes (autotile screens run AutotileHandler's own machine). On
-    /// unminimize it also retries snap restore when the daemon does not track
-    /// @p window — every restore pass (daemon-ready, pendingRestoresAvailable)
+    /// unminimizes (autotile screens run AutotileHandler's own machine). When
+    /// unminimizing a window this session minimize-floated, it also retries
+    /// snap restore if the daemon tracks the window as neither snapped nor
+    /// floating — every restore pass (daemon-ready, pendingRestoresAvailable)
     /// skips minimized windows, so a window minimized across a daemon restart
     /// would otherwise stay stranded at whatever geometry KWin unminimizes it
-    /// to. Called from PlasmaZonesEffect::slotWindowMinimizedChanged after the
-    /// shared minimize shader event.
+    /// to. In a normal minimize cycle the daemon still holds the window in its
+    /// floating set (minimize-float unsnaps), so the neither-set check keeps
+    /// the net inert and the plain unfloat re-snaps as before. Called from
+    /// PlasmaZonesEffect::slotWindowMinimizedChanged after the shared minimize
+    /// shader event.
     void handleMinimizeChanged(KWin::EffectWindow* window, const QString& windowId, const QString& screenId,
                                bool minimized);
     /// Drop @p windowId from the minimize-float set (window closed). Returns


### PR DESCRIPTION
## Problem

Windows were positioned against a stale work area when a third-party layer-shell panel (a phosphor-shell bar) changed its exclusive zone. With a top bar present, snapped windows shifted up underneath it.

Root cause chain:

1. The daemon's highest-priority available-geometry source is the KWin effect's pushed `clientArea(MaximizeArea)` snapshot. That snapshot is refreshed only on daemon-ready, screen changes, and dock windows' frame-geometry changes, gated on `isDock()`.
2. KWin classifies a layer-shell panel with an exclusive zone as an unmovable NORMAL window (`dock=false, normal=true, movable=false`), so the panel's strut changes never triggered a re-push. The override went stale in both magnitude and direction and, being the top-priority source, suppressed the live layer-shell sensor.
3. A fresh `clientArea` query is always directionally correct (verified live: forcing a re-push via a desktop switch produced the exact right work area). The fix is keeping the push fresh, not reconciling stale data daemon-side. A daemon-side reconciliation was prototyped and rejected: the sensor knows only per-axis magnitude, so it amplifies a stale override's wrong edge.

## Fix 1: track layer-shell panels for work-area reporting

New `mayReserveScreenEdge()` predicate in `ScreenChangeHandler`: matches docks AND unmovable Wayland surfaces, excluding the unmovable states that cannot carry an exclusive zone (xdg popups, fullscreen windows, special windows, desktop). Used by `trackDockWindow` and `onWindowClosed`, so a layer-shell panel's map, resize, and close all re-push the authoritative work area. Over-matching is cheap: one signal connection per window, and the daemon dedups unchanged rects.

## Fix 2: restore windows minimized across a daemon restart

Discovered while verifying fix 1: a window minimized when the daemon restarts is skipped by every snap-restore pass (the daemon-ready untracked sweep and `slotPendingRestoresAvailable` both skip minimized windows), and the unminimize path only flipped the daemon-side floating flag, a no-op for an untracked window. The window stayed stranded at whatever geometry KWin unminimized it to.

`SnapHandler::handleMinimizeChanged` now checks daemon tracking (`getSnappedWindows`) on unminimize and runs the same single-window restore the retry passes use when the window is untracked. Tracked-ness is checked before resolving: a blind `resolveWindowRestore` would consume the per-appId FIFO pending-restore entry and rob a sibling window's restore. Eligibility (alive, unminimized, current desktop/activity) is re-checked after the async reply, mirroring `slotPendingRestoresAvailable`'s guards.

## Testing

- Full build clean; all 313 ctest tests pass.
- Live-diagnosed on a 2-screen Wayland session: confirmed the stale override via `getAvailableGeometry`, confirmed a forced re-push produces the correct top+bottom insets, confirmed the untracked-after-restart window via `getSnappedWindows`.
- KWin-side behaviour (effect reload) verified by inspection; the effect cannot be unit-tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)