### PR TITLE
feat(settings): back/forward navigation history in the settings app

### DIFF
--- a/libs/phosphor-control/include/PhosphorControl/ApplicationController.h
+++ b/libs/phosphor-control/include/PhosphorControl/ApplicationController.h
@@ -44,6 +44,8 @@ class PHOSPHORCONTROL_EXPORT ApplicationController : public QObject
     Q_PROPERTY(PhosphorControl::PageRegistry* registry READ registry CONSTANT)
     Q_PROPERTY(bool dirty READ isDirty NOTIFY dirtyChanged)
     Q_PROPERTY(QString currentPageId READ currentPageId WRITE setCurrentPageId NOTIFY currentPageIdChanged)
+    Q_PROPERTY(bool canGoBack READ canGoBack NOTIFY historyChanged)
+    Q_PROPERTY(bool canGoForward READ canGoForward NOTIFY historyChanged)
     Q_PROPERTY(bool applying READ isApplying NOTIFY applyingChanged)
     Q_PROPERTY(bool discarding READ isDiscarding NOTIFY discardingChanged)
     QML_NAMED_ELEMENT(ApplicationController)
@@ -67,6 +69,22 @@ public:
 
     QString currentPageId() const;
     void setCurrentPageId(const QString& id);
+
+    /** Browser-style navigation history over `currentPageId`.
+     *
+     *  Every ORDINARY page change (sidebar click, deep link, CLI --page,
+     *  gotoPrevious/NextPage, …) pushes the page it left onto the back
+     *  stack and clears the forward stack — exactly the browser model.
+     *  `goBack()` / `goForward()` move along the recorded trail without
+     *  re-recording (they shuffle entries between the two stacks instead).
+     *  Both return the page id landed on, or an empty string when there
+     *  was nowhere to go. Stale entries (pages unregistered after being
+     *  visited) are skipped and dropped. History depth is capped at
+     *  kMaxHistoryEntries; the oldest entry falls off first. */
+    bool canGoBack() const;
+    bool canGoForward() const;
+    Q_INVOKABLE QString goBack();
+    Q_INVOKABLE QString goForward();
 
     /** Deep-link reveal latch (generic — every settings app built on this
      *  shell gets deep-link-to-anchor for free).
@@ -160,6 +178,10 @@ public:
 Q_SIGNALS:
     void dirtyChanged();
     void currentPageIdChanged();
+    /// Emitted when canGoBack / canGoForward may have flipped (shared
+    /// NOTIFY for both properties — they always change together or not
+    /// at all from the QML binding system's perspective).
+    void historyChanged();
     /// Emitted when the deep-link pending anchor is set or cleared. PageHost
     /// listens so an already-current page reveals immediately.
     void pendingAnchorChanged();
@@ -198,6 +220,17 @@ private:
     PageRegistry* m_registry = nullptr;
     QList<QPointer<StagingDomain>> m_domains;
     QString m_currentPageId;
+    // Back/forward navigation history (see canGoBack/goBack). The back
+    // stack's last entry is the page goBack() lands on; symmetric for
+    // the forward stack. m_navigatingHistory suppresses recording while
+    // goBack/goForward drive setCurrentPageId, so history moves don't
+    // re-record themselves.
+    QStringList m_backHistory;
+    QStringList m_forwardHistory;
+    bool m_navigatingHistory = false;
+    /// History depth cap — plenty for a settings session while bounding
+    /// worst-case memory for a long-lived window.
+    static constexpr int kMaxHistoryEntries = 64;
     // Deep-link reveal latch (see setPendingAnchor). Transient; not page identity.
     QString m_pendingAnchor;
     QString m_pendingAnchorPage;

--- a/libs/phosphor-control/qml/SettingsAppWindow.qml
+++ b/libs/phosphor-control/qml/SettingsAppWindow.qml
@@ -64,14 +64,16 @@ Kirigami.ApplicationWindow {
      *  can override this binding (e.g. for tests or to force a
      *  collapsed rail) by reassigning the property. */
     property bool sidebarCompact: width < Kirigami.Units.gridUnit * 50
-    /** Gate for the built-in back/forward navigation inputs (Alt+Left /
-     *  Alt+Right shortcuts and the mouse back/forward buttons — the
-     *  breadcrumb-row buttons are ordinary click targets and stay
-     *  active). Modal popups don't block window-context Shortcuts, so
-     *  apps with their own confirm dialogs bind this to their
-     *  shortcut-guard expression (the same one gating any page-step
-     *  shortcuts) to keep history navigation from firing under a modal.
-     *  Defaults true. */
+    /** Gate for the built-in back/forward navigation inputs (the
+     *  Alt+Left / Alt+Right key handling on the chrome page and the
+     *  mouse back/forward buttons — the breadcrumb-row buttons are
+     *  ordinary click targets and stay active). Modal popups block
+     *  both inputs on their own (focus moves into the popup and mouse
+     *  input outside it is grabbed), but non-modal surfaces — a search
+     *  dropdown, a help overlay, a native child window — do not, so
+     *  apps bind this to their shortcut-guard expression (the same one
+     *  gating any page-step shortcuts) to keep history navigation from
+     *  firing under those. Defaults true. */
     property bool navigationShortcutsEnabled: true
 
     /** Emitted when the user picked Apply in the close-confirmation
@@ -287,18 +289,26 @@ Kirigami.ApplicationWindow {
         // keys in the ShortcutOverride pass (which preempts the whole
         // shortcut map) and handle them as ordinary key presses bubbling
         // up from the focused item.
+        // Claim a key only when the matching history direction has
+        // somewhere to go — an unusable Back/Forward key falls through
+        // to the shortcut map (Kirigami's no-op) instead of being
+        // silently consumed here, mirroring the enabled-gating the
+        // replaced Shortcut items had.
         Keys.onShortcutOverride: event => {
-            if (root.navigationShortcutsEnabled && (event.matches(StandardKey.Back) || event.matches(StandardKey.Forward)))
+            if (!root.navigationShortcutsEnabled)
+                return;
+
+            if ((event.matches(StandardKey.Back) && root.controller.canGoBack) || (event.matches(StandardKey.Forward) && root.controller.canGoForward))
                 event.accepted = true;
         }
         Keys.onPressed: event => {
             if (!root.navigationShortcutsEnabled)
                 return;
 
-            if (event.matches(StandardKey.Back)) {
+            if (event.matches(StandardKey.Back) && root.controller.canGoBack) {
                 root.controller.goBack();
                 event.accepted = true;
-            } else if (event.matches(StandardKey.Forward)) {
+            } else if (event.matches(StandardKey.Forward) && root.controller.canGoForward) {
                 root.controller.goForward();
                 event.accepted = true;
             }

--- a/libs/phosphor-control/qml/SettingsAppWindow.qml
+++ b/libs/phosphor-control/qml/SettingsAppWindow.qml
@@ -195,23 +195,6 @@ Kirigami.ApplicationWindow {
         property bool forceClosing: false
     }
 
-    // ── Back / Forward history shortcuts ────────────────────────────
-    // StandardKey.Back / Forward resolve to Alt+Left / Alt+Right (plus
-    // the dedicated XF86Back/Forward keys on keyboards that have them).
-    // Gated on navigationShortcutsEnabled so consumers can suppress
-    // history moves while their own modals are open.
-    Shortcut {
-        sequences: [StandardKey.Back]
-        enabled: root.navigationShortcutsEnabled && root.controller.canGoBack
-        onActivated: root.controller.goBack()
-    }
-
-    Shortcut {
-        sequences: [StandardKey.Forward]
-        enabled: root.navigationShortcutsEnabled && root.controller.canGoForward
-        onActivated: root.controller.goForward()
-    }
-
     DiscardChangesDialog {
         id: discardDialog
 
@@ -287,19 +270,60 @@ Kirigami.ApplicationWindow {
     pageStack.initialPage: Kirigami.Page {
         padding: 0
         title: root.title
+        // Rest keyboard focus inside the page so key events (and the
+        // ShortcutOverride pass below) route through it even before any
+        // control has taken focus.
+        focus: true
+
+        // ── Back / Forward history keys (Alt+Left / Alt+Right + the
+        // dedicated XF86Back/Forward keys) ──────────────────────────────
+        // NOT implemented as Shortcut items: Kirigami's PageRow installs
+        // its own always-enabled StandardKey.Back/Forward Shortcuts in
+        // this window (column/layer navigation, a no-op for this
+        // single-column chrome). A second Shortcut on the same sequence
+        // makes the pair AMBIGUOUS — Qt then activates neither, it only
+        // rotates activatedAmbiguously between them — so a competing
+        // Shortcut here would simply never fire. Instead, accept the
+        // keys in the ShortcutOverride pass (which preempts the whole
+        // shortcut map) and handle them as ordinary key presses bubbling
+        // up from the focused item.
+        Keys.onShortcutOverride: event => {
+            if (root.navigationShortcutsEnabled && (event.matches(StandardKey.Back) || event.matches(StandardKey.Forward)))
+                event.accepted = true;
+        }
+        Keys.onPressed: event => {
+            if (!root.navigationShortcutsEnabled)
+                return;
+
+            if (event.matches(StandardKey.Back)) {
+                root.controller.goBack();
+                event.accepted = true;
+            } else if (event.matches(StandardKey.Forward)) {
+                root.controller.goForward();
+                event.accepted = true;
+            }
+        }
 
         // Mouse back/forward buttons drive the page history, matching
-        // the Alt+Left / Alt+Right shortcuts. Declared before (so
-        // stacked underneath) the content column: the area accepts ONLY
-        // the two navigation buttons, and receives them only when no
-        // content item claimed the press first — left-button
-        // interaction everywhere is untouched. Modal popups block
-        // outside mouse input on their own, but the shortcut gate is
-        // honoured anyway for consistency with the keyboard path.
+        // the Alt+Left / Alt+Right keys. Declared before (so stacked
+        // underneath) the content column: the area accepts ONLY the two
+        // navigation buttons, and receives them only when no content
+        // item claimed the press first — left-button interaction
+        // everywhere is untouched. Modal popups block outside mouse
+        // input on their own, but the shortcut gate is honoured anyway
+        // for consistency with the keyboard path.
+        //
+        // Navigation happens on PRESS, not click: Kirigami's ColumnView
+        // (the PageRow's C++ container, which filters every descendant's
+        // mouse events) consumes the ForwardButton RELEASE outright —
+        // and the BackButton release too once its column index moves —
+        // so a clicked handler never fires for forward. The press is
+        // the only edge guaranteed to arrive; it also matches browser
+        // behaviour, where side-button navigation triggers on press.
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.BackButton | Qt.ForwardButton
-            onClicked: function (mouse) {
+            onPressed: function (mouse) {
                 if (!root.navigationShortcutsEnabled)
                     return;
 

--- a/libs/phosphor-control/qml/SettingsAppWindow.qml
+++ b/libs/phosphor-control/qml/SettingsAppWindow.qml
@@ -64,6 +64,15 @@ Kirigami.ApplicationWindow {
      *  can override this binding (e.g. for tests or to force a
      *  collapsed rail) by reassigning the property. */
     property bool sidebarCompact: width < Kirigami.Units.gridUnit * 50
+    /** Gate for the built-in back/forward navigation inputs (Alt+Left /
+     *  Alt+Right shortcuts and the mouse back/forward buttons — the
+     *  breadcrumb-row buttons are ordinary click targets and stay
+     *  active). Modal popups don't block window-context Shortcuts, so
+     *  apps with their own confirm dialogs bind this to their
+     *  shortcut-guard expression (the same one gating any page-step
+     *  shortcuts) to keep history navigation from firing under a modal.
+     *  Defaults true. */
+    property bool navigationShortcutsEnabled: true
 
     /** Emitted when the user picked Apply in the close-confirmation
      *  prompt, applyAll() ran, and the controller is STILL dirty —
@@ -186,6 +195,23 @@ Kirigami.ApplicationWindow {
         property bool forceClosing: false
     }
 
+    // ── Back / Forward history shortcuts ────────────────────────────
+    // StandardKey.Back / Forward resolve to Alt+Left / Alt+Right (plus
+    // the dedicated XF86Back/Forward keys on keyboards that have them).
+    // Gated on navigationShortcutsEnabled so consumers can suppress
+    // history moves while their own modals are open.
+    Shortcut {
+        sequences: [StandardKey.Back]
+        enabled: root.navigationShortcutsEnabled && root.controller.canGoBack
+        onActivated: root.controller.goBack()
+    }
+
+    Shortcut {
+        sequences: [StandardKey.Forward]
+        enabled: root.navigationShortcutsEnabled && root.controller.canGoForward
+        onActivated: root.controller.goForward()
+    }
+
     DiscardChangesDialog {
         id: discardDialog
 
@@ -261,6 +287,28 @@ Kirigami.ApplicationWindow {
     pageStack.initialPage: Kirigami.Page {
         padding: 0
         title: root.title
+
+        // Mouse back/forward buttons drive the page history, matching
+        // the Alt+Left / Alt+Right shortcuts. Declared before (so
+        // stacked underneath) the content column: the area accepts ONLY
+        // the two navigation buttons, and receives them only when no
+        // content item claimed the press first — left-button
+        // interaction everywhere is untouched. Modal popups block
+        // outside mouse input on their own, but the shortcut gate is
+        // honoured anyway for consistency with the keyboard path.
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.BackButton | Qt.ForwardButton
+            onClicked: function (mouse) {
+                if (!root.navigationShortcutsEnabled)
+                    return;
+
+                if (mouse.button === Qt.BackButton)
+                    root.controller.goBack();
+                else if (mouse.button === Qt.ForwardButton)
+                    root.controller.goForward();
+            }
+        }
 
         ColumnLayout {
             anchors.fill: parent
@@ -396,6 +444,38 @@ Kirigami.ApplicationWindow {
                         Layout.topMargin: Kirigami.Units.smallSpacing
                         Layout.bottomMargin: Kirigami.Units.smallSpacing
                         spacing: Kirigami.Units.smallSpacing
+
+                        // Back / Forward history buttons. Always present
+                        // (disabled when there's nowhere to go) so the
+                        // breadcrumb row doesn't reflow as history
+                        // accumulates.
+                        QQC2.ToolButton {
+                            Layout.alignment: Qt.AlignVCenter
+                            icon.name: "go-previous"
+                            display: QQC2.AbstractButton.IconOnly
+                            text: qsTr("Back")
+                            Accessible.name: text
+                            enabled: root.controller.canGoBack
+                            onClicked: root.controller.goBack()
+
+                            QQC2.ToolTip.visible: hovered
+                            QQC2.ToolTip.delay: Kirigami.Units.toolTipDelay
+                            QQC2.ToolTip.text: text
+                        }
+
+                        QQC2.ToolButton {
+                            Layout.alignment: Qt.AlignVCenter
+                            icon.name: "go-next"
+                            display: QQC2.AbstractButton.IconOnly
+                            text: qsTr("Forward")
+                            Accessible.name: text
+                            enabled: root.controller.canGoForward
+                            onClicked: root.controller.goForward()
+
+                            QQC2.ToolTip.visible: hovered
+                            QQC2.ToolTip.delay: Kirigami.Units.toolTipDelay
+                            QQC2.ToolTip.text: text
+                        }
 
                         Breadcrumbs {
                             Layout.fillWidth: true

--- a/libs/phosphor-control/src/applicationcontroller.cpp
+++ b/libs/phosphor-control/src/applicationcontroller.cpp
@@ -54,7 +54,26 @@ void ApplicationController::setCurrentPageId(const QString& id)
         qWarning() << "ApplicationController::setCurrentPageId: unknown page" << id;
         return;
     }
+    // Record ordinary navigation in the back/forward history: push the
+    // page being left and drop the forward trail (browser model). Moves
+    // driven by goBack/goForward manage the stacks themselves and set
+    // m_navigatingHistory to skip this. The startup transition (empty →
+    // first page) records nothing — there is no page to go back to.
+    const bool couldGoBack = canGoBack();
+    const bool couldGoForward = canGoForward();
+    if (!m_navigatingHistory) {
+        if (!m_currentPageId.isEmpty()) {
+            m_backHistory.append(m_currentPageId);
+            if (m_backHistory.size() > kMaxHistoryEntries) {
+                m_backHistory.removeFirst();
+            }
+        }
+        m_forwardHistory.clear();
+    }
     m_currentPageId = id;
+    if (canGoBack() != couldGoBack || canGoForward() != couldGoForward) {
+        Q_EMIT historyChanged();
+    }
     // Discard a stale deep-link reveal anchor when navigation moves to a
     // different page than the one it targeted (discard-on-navigate-away).
     if (!m_pendingAnchor.isEmpty() && m_pendingAnchorPage != m_currentPageId) {
@@ -315,6 +334,74 @@ QString ApplicationController::gotoNextPage()
     const int next = state.currentIdx < 0 || state.currentIdx == state.ids.size() - 1 ? 0 : state.currentIdx + 1;
     setCurrentPageId(state.ids.at(next));
     return state.ids.at(next);
+}
+
+bool ApplicationController::canGoBack() const
+{
+    return !m_backHistory.isEmpty();
+}
+
+bool ApplicationController::canGoForward() const
+{
+    return !m_forwardHistory.isEmpty();
+}
+
+QString ApplicationController::goBack()
+{
+    const bool couldGoBack = canGoBack();
+    const bool couldGoForward = canGoForward();
+    QString landed;
+    while (!m_backHistory.isEmpty()) {
+        const QString target = m_backHistory.takeLast();
+        // Drop stale entries: the page was unregistered after being
+        // visited, or the entry duplicates the current page (defensive —
+        // setCurrentPageId's same-id early-return means recording never
+        // produces one, but a subclass override could).
+        if (target == m_currentPageId || !m_registry->hasPage(target)) {
+            continue;
+        }
+        if (!m_currentPageId.isEmpty()) {
+            m_forwardHistory.append(m_currentPageId);
+        }
+        // m_navigatingHistory suppresses the recording branch in
+        // setCurrentPageId — a history move must not push onto the back
+        // stack again or clear the forward trail it just extended.
+        m_navigatingHistory = true;
+        setCurrentPageId(target);
+        m_navigatingHistory = false;
+        landed = target;
+        break;
+    }
+    if (canGoBack() != couldGoBack || canGoForward() != couldGoForward) {
+        Q_EMIT historyChanged();
+    }
+    return landed;
+}
+
+QString ApplicationController::goForward()
+{
+    const bool couldGoBack = canGoBack();
+    const bool couldGoForward = canGoForward();
+    QString landed;
+    while (!m_forwardHistory.isEmpty()) {
+        const QString target = m_forwardHistory.takeLast();
+        // Same stale-entry policy as goBack.
+        if (target == m_currentPageId || !m_registry->hasPage(target)) {
+            continue;
+        }
+        if (!m_currentPageId.isEmpty()) {
+            m_backHistory.append(m_currentPageId);
+        }
+        m_navigatingHistory = true;
+        setCurrentPageId(target);
+        m_navigatingHistory = false;
+        landed = target;
+        break;
+    }
+    if (canGoBack() != couldGoBack || canGoForward() != couldGoForward) {
+        Q_EMIT historyChanged();
+    }
+    return landed;
 }
 
 QStringList ApplicationController::parentChainFor(const QString& id) const

--- a/libs/phosphor-control/tests/CMakeLists.txt
+++ b/libs/phosphor-control/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ endfunction()
 
 phosphorcontrol_add_test(test_page_registry)
 phosphorcontrol_add_test(test_application_controller)
+phosphorcontrol_add_test(test_application_controller_history)
 phosphorcontrol_add_test(test_localized_context)
 phosphorcontrol_add_test(test_dbus_bridge)
 phosphorcontrol_add_test(test_search_ranker)

--- a/libs/phosphor-control/tests/test_application_controller_history.cpp
+++ b/libs/phosphor-control/tests/test_application_controller_history.cpp
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QSignalSpy>
+#include <QTest>
+#include <QUrl>
+
+#include "PhosphorControl/ApplicationController.h"
+#include "PhosphorControl/PageController.h"
+
+using PhosphorControl::ApplicationController;
+using PhosphorControl::PageController;
+
+// Named namespace (not anonymous) for external linkage — mirrors
+// test_application_controller.cpp; each test is its own executable so
+// the name cannot collide.
+namespace ApplicationControllerHistoryTest {
+
+// Minimal always-clean page: the history tests only exercise
+// navigation, never the staging-domain surface.
+class StubPage : public PageController
+{
+    Q_OBJECT
+public:
+    explicit StubPage(QString id, QObject* parent = nullptr)
+        : PageController(std::move(id), parent)
+    {
+    }
+
+    bool isDirty() const override
+    {
+        return false;
+    }
+    void apply() override
+    {
+    }
+    void discard() override
+    {
+    }
+    void resetToDefaults() override
+    {
+    }
+};
+
+} // namespace ApplicationControllerHistoryTest
+
+using ApplicationControllerHistoryTest::StubPage;
+
+class TestApplicationControllerHistory : public QObject
+{
+    Q_OBJECT
+
+private:
+    // Registers pages "a", "b", "c" on the given controller.
+    static void registerAbc(ApplicationController& app)
+    {
+        for (const auto* id : {"a", "b", "c"}) {
+            const QString pageId = QLatin1String(id);
+            app.registerPage(new StubPage(pageId), {}, pageId.toUpper(),
+                             QUrl(QStringLiteral("qrc:/%1.qml").arg(pageId)));
+        }
+    }
+
+private Q_SLOTS:
+    void startsWithEmptyHistory()
+    {
+        ApplicationController app;
+        registerAbc(app);
+
+        QVERIFY(!app.canGoBack());
+        QVERIFY(!app.canGoForward());
+        QCOMPARE(app.goBack(), QString());
+        QCOMPARE(app.goForward(), QString());
+
+        // The startup transition (empty → first page) records nothing.
+        app.setCurrentPageId(QStringLiteral("a"));
+        QVERIFY(!app.canGoBack());
+        QVERIFY(!app.canGoForward());
+    }
+
+    void recordsNavigationAndGoesBack()
+    {
+        ApplicationController app;
+        registerAbc(app);
+
+        app.setCurrentPageId(QStringLiteral("a"));
+        app.setCurrentPageId(QStringLiteral("b"));
+        app.setCurrentPageId(QStringLiteral("c"));
+        QVERIFY(app.canGoBack());
+
+        QCOMPARE(app.goBack(), QStringLiteral("b"));
+        QCOMPARE(app.currentPageId(), QStringLiteral("b"));
+        QCOMPARE(app.goBack(), QStringLiteral("a"));
+        QCOMPARE(app.currentPageId(), QStringLiteral("a"));
+
+        QVERIFY(!app.canGoBack());
+        QCOMPARE(app.goBack(), QString());
+        QCOMPARE(app.currentPageId(), QStringLiteral("a"));
+    }
+
+    void goForwardRetracesAfterBack()
+    {
+        ApplicationController app;
+        registerAbc(app);
+
+        app.setCurrentPageId(QStringLiteral("a"));
+        app.setCurrentPageId(QStringLiteral("b"));
+        QVERIFY(!app.canGoForward());
+
+        QCOMPARE(app.goBack(), QStringLiteral("a"));
+        QVERIFY(app.canGoForward());
+
+        QCOMPARE(app.goForward(), QStringLiteral("b"));
+        QCOMPARE(app.currentPageId(), QStringLiteral("b"));
+        QVERIFY(!app.canGoForward());
+        QCOMPARE(app.goForward(), QString());
+
+        // The back/forward round trip must not have re-recorded: exactly
+        // one back entry ("a") remains, as if the user never went back.
+        QCOMPARE(app.goBack(), QStringLiteral("a"));
+        QVERIFY(!app.canGoBack());
+    }
+
+    void ordinaryNavigationClearsForwardTrail()
+    {
+        ApplicationController app;
+        registerAbc(app);
+
+        app.setCurrentPageId(QStringLiteral("a"));
+        app.setCurrentPageId(QStringLiteral("b"));
+        QCOMPARE(app.goBack(), QStringLiteral("a"));
+        QVERIFY(app.canGoForward());
+
+        // Browser model: branching off the trail drops the forward stack.
+        app.setCurrentPageId(QStringLiteral("c"));
+        QVERIFY(!app.canGoForward());
+        QCOMPARE(app.goForward(), QString());
+        QCOMPARE(app.goBack(), QStringLiteral("a"));
+    }
+
+    void gotoNextPageRecordsHistory()
+    {
+        // The wrap-around page stepper routes through setCurrentPageId,
+        // so its moves are ordinary recorded navigation.
+        ApplicationController app;
+        registerAbc(app);
+
+        app.setCurrentPageId(QStringLiteral("a"));
+        QCOMPARE(app.gotoNextPage(), QStringLiteral("b"));
+        QCOMPARE(app.goBack(), QStringLiteral("a"));
+    }
+
+    void rejectedNavigationLeavesHistoryUntouched()
+    {
+        ApplicationController app;
+        registerAbc(app);
+
+        app.setCurrentPageId(QStringLiteral("a"));
+        app.setCurrentPageId(QStringLiteral("ghost")); // refused: unknown page
+        app.setCurrentPageId(QStringLiteral("a")); // refused: same id
+
+        QVERIFY(!app.canGoBack());
+        QCOMPARE(app.currentPageId(), QStringLiteral("a"));
+    }
+
+    void historyChangedEmitsOnlyOnFlips()
+    {
+        ApplicationController app;
+        registerAbc(app);
+        QSignalSpy spy(&app, &ApplicationController::historyChanged);
+
+        app.setCurrentPageId(QStringLiteral("a")); // empty → a: no history
+        QCOMPARE(spy.count(), 0);
+        app.setCurrentPageId(QStringLiteral("b")); // canGoBack false → true
+        QCOMPARE(spy.count(), 1);
+        app.setCurrentPageId(QStringLiteral("c")); // both flags unchanged
+        QCOMPARE(spy.count(), 1);
+        app.goBack(); // canGoForward false → true
+        QCOMPARE(spy.count(), 2);
+        app.goBack(); // canGoBack true → false
+        QCOMPARE(spy.count(), 3);
+        app.goBack(); // no-op: nothing to pop
+        QCOMPARE(spy.count(), 3);
+        app.goForward(); // canGoBack false → true
+        QCOMPARE(spy.count(), 4);
+    }
+
+    void depthIsCapped()
+    {
+        ApplicationController app;
+        registerAbc(app);
+
+        // 200 alternating navigations record 199 back entries uncapped;
+        // the cap keeps only the most recent 64.
+        app.setCurrentPageId(QStringLiteral("a"));
+        for (int i = 0; i < 199; ++i) {
+            app.setCurrentPageId((i % 2 == 0) ? QStringLiteral("b") : QStringLiteral("a"));
+        }
+
+        int hops = 0;
+        while (app.canGoBack() && !app.goBack().isEmpty()) {
+            ++hops;
+        }
+        QCOMPARE(hops, 64);
+    }
+};
+
+QTEST_MAIN(TestApplicationControllerHistory)
+#include "test_application_controller_history.moc"

--- a/src/settings/qml/KeyboardShortcutOverlay.qml
+++ b/src/settings/qml/KeyboardShortcutOverlay.qml
@@ -65,6 +65,14 @@ Rectangle {
             "action": i18n("Next page")
         },
         {
+            "key": "Alt+Left",
+            "action": i18n("Back")
+        },
+        {
+            "key": "Alt+Right",
+            "action": i18n("Forward")
+        },
+        {
             "key": "?",
             "action": i18n("Toggle this overlay")
         }

--- a/src/settings/qml/Main.qml
+++ b/src/settings/qml/Main.qml
@@ -110,6 +110,13 @@ PhosphorUi.SettingsAppWindow {
     // — same UX as the legacy hand-rolled unsavedChangesDialog, but
     // the framework owns the dialog and the close orchestration.
     closePromptShowsApply: true
+    // Gate the chrome's back/forward history inputs (Alt+Left /
+    // Alt+Right, mouse back/forward buttons) behind the same guard as
+    // the Ctrl+PgUp/PgDown page-step shortcuts, so history navigation
+    // can't drag the user off the page while a confirm dialog, the
+    // shortcut overlay, a page-owned modal, or the search dropdown is
+    // open.
+    navigationShortcutsEnabled: window._navShortcutsEnabled
 
     // Global search in the header toolbar (headerExtras slot). It supersedes the
     // in-sidebar page-tree filter, which is disabled in Component.onCompleted.


### PR DESCRIPTION
## Summary

Adds browser-style back/forward navigation to the settings app.

- **`ApplicationController` (phosphor-control)** records a page history over `currentPageId`: every ordinary navigation (sidebar click, search deep link, CLI `--page`, Ctrl+PgUp/PgDown stepping) pushes the departed page onto the back stack and clears the forward trail; `goBack()`/`goForward()` retrace the trail without re-recording. New API: `canGoBack`/`canGoForward` properties (shared `historyChanged` NOTIFY, emitted only on actual flips) and `Q_INVOKABLE goBack()`/`goForward()` returning the landed page id. Depth capped at 64 entries; stale entries skipped defensively. Because `currentPageId` is the single navigation truth synced with `SettingsController::activePage`, every navigation source is recorded automatically and any app built on the shell gets the feature.
- **`SettingsAppWindow` chrome** gains Back/Forward icon buttons at the start of the breadcrumb row (always present, disabled when there is nowhere to go, tooltips + accessible names), `StandardKey.Back`/`StandardKey.Forward` shortcuts (Alt+Left / Alt+Right plus XF86 nav keys), and mouse back/forward button handling via a MouseArea that accepts only those two buttons. All gated behind a new `navigationShortcutsEnabled` property (default true).
- **Main.qml** binds `navigationShortcutsEnabled` to the existing `_navShortcutsEnabled` guard, so history moves cannot fire while a confirm dialog, page-owned modal, the shortcut overlay, or the search dropdown is open (same rule as Ctrl+PgUp/PgDown). The keyboard-shortcut overlay lists the new keys.

Going back restores the page, not scroll position: page identity is deliberately fragment-free in the framework.

## Testing

- New `test_application_controller_history` suite: empty-history startup, back/forward round trips that don't re-record, forward-trail clearing on branch navigation, `gotoNextPage` recording, rejected navigations leaving history untouched, emit-only-on-flip signal discipline, 64-entry depth cap.
- Full suite: 262/262 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)