### PR TITLE
feat(shaders): fill the contract gaps across the shader families

### DIFF
--- a/data/animations/desktop-slide/effect.frag
+++ b/data/animations/desktop-slide/effect.frag
@@ -10,12 +10,17 @@
 
 vec4 pTransition(vec2 uv, float t) {
 #ifdef PLASMAZONES_KWIN
-    // Push both desktops along the sign of the direction vector. Guard the
+    // Direction: follow the actual switch (iSwitchDelta via switchDirection)
+    // when p_followSwitch is on, so switching left slides left and switching
+    // down slides down; the configured p_dirX / p_dirY vector is the fallback
+    // when no grid delta resolved, and the forced direction when the toggle is
+    // off. Push both desktops along the sign of that vector. Guard the
     // degenerate all-zero case (both sliders at 0) so the switch still moves
     // instead of holding the outgoing desktop and cutting; a zero direction
     // falls back to a horizontal push. Non-zero directions (including pure
     // vertical) are unaffected — only sign() of an exact zero is redirected.
-    vec2 s = sign(vec2(p_dirX, p_dirY));
+    vec2 cfg = vec2(p_dirX, p_dirY);
+    vec2 s = sign((p_followSwitch > 0.5) ? switchDirection(cfg) : cfg);
     if (s == vec2(0.0)) {
         s = vec2(1.0, 0.0);
     }

--- a/data/animations/desktop-slide/metadata.json
+++ b/data/animations/desktop-slide/metadata.json
@@ -9,6 +9,12 @@
     "fragmentShader": "effect.frag",
     "parameters": [
         {
+            "id": "followSwitch",
+            "name": "Follow Switch Direction",
+            "type": "bool",
+            "default": true
+        },
+        {
             "id": "dirX",
             "name": "Direction X",
             "type": "float",

--- a/data/animations/desktop-slidefade/effect.frag
+++ b/data/animations/desktop-slidefade/effect.frag
@@ -10,7 +10,10 @@
 
 vec4 pTransition(vec2 uv, float t) {
 #ifdef PLASMAZONES_KWIN
-    vec2 off = sign(vec2(p_dirX, p_dirY)) * p_travel;
+    // Slide axis follows the actual switch direction when p_followSwitch is
+    // on; the configured p_dirX / p_dirY vector is the fallback / override.
+    vec2 cfg = vec2(p_dirX, p_dirY);
+    vec2 off = sign((p_followSwitch > 0.5) ? switchDirection(cfg) : cfg) * p_travel;
     vec4 fromC = getFromColor(uv + t * off);         // slides toward its exit
     vec4 toC = getToColor(uv - (1.0 - t) * off);     // slides in from the far side
     return mix(fromC, toC, smoothstep(0.0, 1.0, t)); // crossfade over the slide

--- a/data/animations/desktop-slidefade/metadata.json
+++ b/data/animations/desktop-slidefade/metadata.json
@@ -9,6 +9,12 @@
     "fragmentShader": "effect.frag",
     "parameters": [
         {
+            "id": "followSwitch",
+            "name": "Follow Switch Direction",
+            "type": "bool",
+            "default": true
+        },
+        {
             "id": "dirX",
             "name": "Direction X",
             "type": "float",

--- a/data/animations/desktop-wipe/effect.frag
+++ b/data/animations/desktop-wipe/effect.frag
@@ -9,7 +9,10 @@
 
 vec4 pTransition(vec2 uv, float t) {
 #ifdef PLASMAZONES_KWIN
-    vec2 dir = normalize(vec2(p_dirX, p_dirY) + vec2(1.0e-6, 0.0));
+    // Sweep direction follows the actual switch when p_followSwitch is on; the
+    // configured p_dirX / p_dirY vector is the fallback / override.
+    vec2 cfg = vec2(p_dirX, p_dirY);
+    vec2 dir = normalize(((p_followSwitch > 0.5) ? switchDirection(cfg) : cfg) + vec2(1.0e-6, 0.0));
     // Project onto the sweep direction, normalised by the direction's L1 extent
     // so proj spans exactly [0,1] corner-to-corner for ANY direction. A plain
     // dot()+0.5 overshoots [0,1] on diagonals (a unit diagonal reaches ±0.707),

--- a/data/animations/desktop-wipe/metadata.json
+++ b/data/animations/desktop-wipe/metadata.json
@@ -9,6 +9,12 @@
     "fragmentShader": "effect.frag",
     "parameters": [
         {
+            "id": "followSwitch",
+            "name": "Follow Switch Direction",
+            "type": "bool",
+            "default": true
+        },
+        {
             "id": "dirX",
             "name": "Direction X",
             "type": "float",

--- a/data/animations/shared/animation_uniforms.glsl
+++ b/data/animations/shared/animation_uniforms.glsl
@@ -53,7 +53,7 @@
 // `static_assert(offsetof(...))` in `<PhosphorShaders/BaseUniforms.h>`
 // for every BASE field declared below (through iIsReversed at 660); the
 // anchor-extension tail (iSurfaceScreenPos .. iAnchorRectInTexture,
-// bytes 672-720) is supplied by AnimationUniformExtension and pinned by
+// bytes 672-719, 720 total) is supplied by AnimationUniformExtension and pinned by
 // the size static_asserts in `<PhosphorAnimation/AnimationUniformExtension.h>`.
 // If any assert fails after a C++-side change, this header has to move
 // in lockstep. The bake test in

--- a/data/animations/shared/animation_uniforms.glsl
+++ b/data/animations/shared/animation_uniforms.glsl
@@ -90,15 +90,20 @@ uniform vec4 iMouse;
 uniform vec4 iDate;
 uniform vec4 customParams[8];
 uniform vec4 customColors[16];
-// `iChannelResolution[4]` and `iAudioSpectrumSize` from the UBO branch
-// are intentionally absent here: kwin-effect/plasmazoneseffect.cpp
-// never calls `setUniform` for either, and no animation shader in
-// `data/animations/` references them. Adding default-block declarations
-// would compile but read garbage at runtime — better to surface the
-// gap as a compile error if a future shader reaches for them on the
-// kwin path. (The UBO branch keeps both fields for std140 layout
-// parity with `PhosphorShaders::BaseUniforms`; see static_asserts in
-// `<PhosphorShaders/BaseUniforms.h>`.)
+// `iChannelResolution[4]` from the UBO branch is intentionally absent
+// here: the kwin-effect never calls `setUniform` for it (single-pass, no
+// buffer FBOs), and no animation shader references it. Adding a
+// default-block declaration would compile but read garbage at runtime —
+// better to surface the gap as a compile error if a future shader
+// reaches for it on the kwin path. (The UBO branch keeps the field for
+// std140 layout parity with `PhosphorShaders::BaseUniforms`; see
+// static_asserts in `<PhosphorShaders/BaseUniforms.h>`.)
+// `iAudioSpectrumSize` is likewise absent from THIS header on the kwin
+// branch, but it is not a dead end: the opt-in audio module
+// (data/animations/shared/audio.glsl) declares it as a default-block
+// uniform alongside the `uAudioSpectrum` sampler, and paint_pipeline.cpp
+// pushes both per frame for packs that include the module. A pack that
+// reaches for it WITHOUT the module still gets the compile error.
 // `iTextureResolution[4]` IS populated on the kwin path: the per-effect
 // uTexture<N> setter loop in `paint_pipeline.cpp::paintWindow` writes the
 // pixel size of each user texture into this uniform array before

--- a/data/animations/shared/animation_uniforms.glsl
+++ b/data/animations/shared/animation_uniforms.glsl
@@ -440,9 +440,10 @@ vec4 surfaceColor(vec2 uv) {
 // equality test (branching on `!= 0` was the documented footgun).
 #define p_reversed (iIsReversed == 1)
 
-// Un-flipped, always-forward 0→1 leg progress. 24 of the bundled shaders
+// Un-flipped, always-forward 0→1 leg progress. Bundled shaders used to
 // hand-roll exactly this `(iIsReversed == 1) ? (1.0 - iTime) : iTime` to
-// recover direction-independent progress; call this instead.
+// recover direction-independent progress; the T1.5 migration replaced
+// every hand-rolled copy with this helper — new packs call it directly.
 float legProgress() {
     return p_reversed ? (1.0 - iTime) : iTime;
 }

--- a/data/animations/shared/audio.glsl
+++ b/data/animations/shared/audio.glsl
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Opt-in audio-spectrum helpers for ANIMATION shader packs — the transition
+// cousin of surface_audio.glsl (surface family) and data/shaders/shared/
+// audio.glsl (overlay family). `#include <audio.glsl>` AFTER
+// animation_uniforms.glsl in a pack that reacts to the CAVA spectrum, declare
+// `"audio": true` in the pack's metadata.json, and guard on the helpers (they
+// return 0 when audio is off).
+//
+// Unlike the overlay family, where audio is implicit/session-global, animation
+// packs must declare the metadata flag: the kwin-effect keys its CAVA run-gate
+// on it, keeping the provider warm while an audio pack is assigned anywhere in
+// the shader profile tree so a transition's FIRST frame already has a spectrum
+// (cava spawn latency would otherwise eat a whole open/close leg). The daemon
+// path needs no flag — SurfaceAnimator::setAudioSpectrum feeds every attached
+// animation shader.
+//
+// iAudioSpectrumSize is the bar count, 0 when the visualizer is off or cava is
+// unavailable. On the daemon it lives in the AnimationUniforms UBO (declared by
+// animation_uniforms.glsl); on the kwin path it is a default-block uniform
+// declared HERE, pushed per frame alongside the sampler bind — packs that never
+// include this module keep the canonical header's compile-error guard against
+// reaching for it.
+
+#ifndef PLASMAZONES_ANIMATION_AUDIO_GLSL
+#define PLASMAZONES_ANIMATION_AUDIO_GLSL
+
+// Audio spectrum texture (binding 6 on the daemon's RHI pipeline, shared with
+// the overlay convention; a plain named sampler on the compositor's classic-GL
+// pipeline, bound to a texture unit at draw time). Never sampled while
+// iAudioSpectrumSize is 0. 1D: bar index = x, y = 0; R = bar value in 0..1.
+#ifdef PLASMAZONES_KWIN
+uniform sampler2D uAudioSpectrum;
+uniform int iAudioSpectrumSize;
+#else
+layout(binding = 6) uniform sampler2D uAudioSpectrum;
+// iAudioSpectrumSize comes from the AnimationUniforms UBO.
+#endif
+
+// Sample bar value (0..1). Returns 0 if audio is disabled or the index is out
+// of range.
+float audioBar(int barIndex) {
+    if (iAudioSpectrumSize <= 0 || barIndex < 0 || barIndex >= iAudioSpectrumSize) {
+        return 0.0;
+    }
+    return texelFetch(uAudioSpectrum, ivec2(barIndex, 0), 0).r;
+}
+
+// Normalized bar index 0..1 for smooth UV sampling.
+float audioBarSmooth(float u) {
+    if (iAudioSpectrumSize <= 0)
+        return 0.0;
+    return texture(uAudioSpectrum, vec2(u, 0.5)).r;
+}
+
+// ── Frequency-band helpers ───────────────────────────────────────────────────
+
+float getBass() {
+    if (iAudioSpectrumSize <= 0)
+        return 0.0;
+    float sum = 0.0;
+    int n = min(iAudioSpectrumSize, 8);
+    for (int i = 0; i < n; i++)
+        sum += audioBar(i);
+    return sum / float(n);
+}
+
+float getMids() {
+    if (iAudioSpectrumSize <= 0)
+        return 0.0;
+    float sum = 0.0;
+    int lo = iAudioSpectrumSize / 4;
+    int hi = iAudioSpectrumSize * 3 / 4;
+    for (int i = lo; i < hi && i < iAudioSpectrumSize; i++)
+        sum += audioBar(i);
+    return sum / float(max(hi - lo, 1));
+}
+
+float getTreble() {
+    if (iAudioSpectrumSize <= 0)
+        return 0.0;
+    float sum = 0.0;
+    int lo = iAudioSpectrumSize * 3 / 4;
+    for (int i = lo; i < iAudioSpectrumSize; i++)
+        sum += audioBar(i);
+    return sum / float(max(iAudioSpectrumSize - lo, 1));
+}
+
+float getOverall() {
+    if (iAudioSpectrumSize <= 0)
+        return 0.0;
+    float sum = 0.0;
+    for (int i = 0; i < iAudioSpectrumSize; i++)
+        sum += audioBar(i);
+    return sum / float(iAudioSpectrumSize);
+}
+
+// ── Dampened band helpers ────────────────────────────────────────────────────
+// A noise-floor gate + soft curve so a weak signal doesn't jitter the visual
+// while strong hits stay punchy. Use these where audio is an enhancement.
+
+float getBassSoft() {
+    float v = getBass();
+    return v * smoothstep(0.04, 0.25, v);
+}
+float getMidsSoft() {
+    float v = getMids();
+    return v * smoothstep(0.03, 0.20, v);
+}
+float getTrebleSoft() {
+    float v = getTreble();
+    return v * smoothstep(0.03, 0.20, v);
+}
+float getOverallSoft() {
+    float v = getOverall();
+    return v * smoothstep(0.03, 0.20, v);
+}
+
+#endif // PLASMAZONES_ANIMATION_AUDIO_GLSL

--- a/data/animations/shared/desktop_transition.glsl
+++ b/data/animations/shared/desktop_transition.glsl
@@ -40,7 +40,10 @@ uniform vec4 iSwitchDelta;
 // The switch direction as a unit vector, falling back to `fallback` (a pack's
 // configured direction params, passed through un-normalized) when the runtime
 // supplied no usable delta. +x is right, +y is down, matching the top-down uv
-// space pTransition receives.
+// space pTransition receives. Only .zw is consumed here; the .xy cell delta
+// is contract surface for packs that scale travel by the switch DISTANCE
+// (e.g. a two-desktop jump travelling twice as far) — no bundled pack reads
+// it yet.
 vec2 switchDirection(vec2 fallback) {
     return dot(iSwitchDelta.zw, iSwitchDelta.zw) > 1.0e-6 ? iSwitchDelta.zw : fallback;
 }

--- a/data/animations/shared/desktop_transition.glsl
+++ b/data/animations/shared/desktop_transition.glsl
@@ -25,6 +25,26 @@
 uniform sampler2D uFromDesktop;
 uniform sampler2D uToDesktop;
 
+// vec4 iSwitchDelta — the actual switch direction, pushed once per transition
+// by the kwin-effect (DesktopTransitionManager::begin computes it from the
+// pager grid). .xy is the wrap-corrected desktop-grid delta in cells: +x = the
+// switch moved one column right, +y = one row down, and a wrapping
+// next-desktop jump off the last column reads as +1, not a full-row jump
+// backwards. .zw is the same delta normalized to unit length. All zeros when
+// the grid positions could not be resolved. Direction-aware packs read it
+// through switchDirection() below so their configured direction params still
+// apply as the fallback (and as the forced direction when the pack's
+// followSwitch toggle is off).
+uniform vec4 iSwitchDelta;
+
+// The switch direction as a unit vector, falling back to `fallback` (a pack's
+// configured direction params, passed through un-normalized) when the runtime
+// supplied no usable delta. +x is right, +y is down, matching the top-down uv
+// space pTransition receives.
+vec2 switchDirection(vec2 fallback) {
+    return dot(iSwitchDelta.zw, iSwitchDelta.zw) > 1.0e-6 ? iSwitchDelta.zw : fallback;
+}
+
 // The captured desktop FBOs are KWin Y-up (origin bottom-left), while the
 // full-screen quad hands us a top-down uv, so flip Y on the sample — same
 // convention as surfaceColor / oldColor in the per-window path.

--- a/data/surface/shared/surface_uniforms.glsl
+++ b/data/surface/shared/surface_uniforms.glsl
@@ -102,6 +102,26 @@ uniform float uHasBackdrop;
 // the frost slab stays solid).
 uniform float uSurfaceOpacity;
 
+// Cursor position for hover-reactive packs. .xy is the cursor in the SAME
+// top-down device-px space as the geometry uniforms above (origin at the
+// padded canvas's top-left), (-1, -1) when the cursor is outside the canvas.
+// .zw is .xy normalized by uSurfaceSize (negative while .xy carries the
+// sentinel), so `iMouse.x < 0.0` is the canonical off-surface test on both
+// runtimes. A pack that reads iMouse should also declare `"animated": true`
+// in its metadata — the host repaints on its vsync loop while a pack
+// animates, and there is no per-cursor-move damage path for static packs.
+uniform vec4 iMouse;
+
+// User-declared image textures (metadata `textures` — logo, mask, pattern).
+// Bound to dedicated units at draw time; iTextureResolution[N].xy carries
+// each bound texture's pixel size (slot N feeds uTexture<N+1>, mirroring the
+// animation contract's slot layout). A slot with no loadable file reads
+// transparent black.
+uniform sampler2D uTexture1;
+uniform sampler2D uTexture2;
+uniform sampler2D uTexture3;
+uniform vec4 iTextureResolution[4];
+
 #else
 
 // ── Daemon branch — std140 UBO at binding 0 ─────────────────────────────────
@@ -124,9 +144,22 @@ layout(std140, binding = 0) uniform SurfaceUniforms {
     vec4 customColors[16];       // offset 240 (256)
     vec4 iChannelResolution[4];  // offset 496 (64) — multipass buffer sizes (.xy)
     int iAudioSpectrumSize;      // offset 560 (4) — CAVA bar count (0 = audio off)
-};                               // total 576 bytes (std140 rounds the block up from 564)
+    // implicit 12-byte std140 pad here — vec4 iMouse below is 16-aligned.
+    vec4 iMouse;                 // offset 576 (16) — cursor in the surface texture's
+                                 //   top-down device-px space (.xy; negative when
+                                 //   off-surface / no hover source), .zw = .xy
+                                 //   normalized by uSurfaceSize
+    vec4 iTextureResolution[4];  // offset 592 (64) — user texture sizes (.xy;
+                                 //   slot N feeds uTexture<N+1>)
+};                               // total 656 bytes, no trailing pad
 
 layout(binding = 7) uniform sampler2D uTexture0;
+// User-declared image textures (metadata `textures`), bindings 8-10 — the
+// same sampler-name and binding-point dialect the animation and overlay
+// categories use, provided by the base ShaderEffect's user-texture plumbing.
+layout(binding = 8) uniform sampler2D uTexture1;
+layout(binding = 9) uniform sampler2D uTexture2;
+layout(binding = 10) uniform sampler2D uTexture3;
 
 // The multipass iChannel sampler bindings (2-5) live in surface_multipass.glsl,
 // which a multipass pack includes; the border and other single-pass packs bind

--- a/docs/architecture/shader-api-usability-design.md
+++ b/docs/architecture/shader-api-usability-design.md
@@ -628,10 +628,13 @@ Consequences for Tier 1:
   both; there is already `tests/unit/ui/test_animation_shader_bake.cpp` baking every
   built-in animation shader through `qsb` — extend that harness rather than
   duplicating it, and have the CLI share its code.
-- **Multipass / audio / wallpaper are daemon-only** on this path (the kwin
+- **Multipass / wallpaper are daemon-only** on this path (the kwin
   `OffscreenEffect` is single-pass). The validator should *warn*, not error, when an
   animation shader uses daemon-only features — they degrade to single-pass on the
-  compositor by design.
+  compositor by design. Audio is NOT in that set: animation packs opt in via
+  `data/animations/shared/audio.glsl` plus the `audio` metadata flag, and the
+  kwin-effect feeds the spectrum from its own CAVA provider, so audio-reactive
+  transitions run on both runtimes.
 
 ### A3 — Direction (the in/out toggle) — `T1.5`
 

--- a/docs/architecture/shader-api-usability-design.md
+++ b/docs/architecture/shader-api-usability-design.md
@@ -5,9 +5,14 @@
 
 ## Status
 
-**Tier 1 implemented** (T1.1–T1.5 + T1.2; all 53 animation + 26 zone packs migrated,
+**Tier 1 implemented** (T1.1–T1.5 + T1.2; all bundled animation + zone packs migrated,
 offline validator + CI gate landed). Tiers 2–3 remain proposed. This document covers
 the full scope across all tiers; the Tier-2/3 sections are the forward design.
+
+Pack counts throughout this document reflect the v3.1 tree at design time (53
+animation + 26 zone packs); the animation tree has since grown (69 packs as of
+v3.2) and every pack added after the T1.5 migration follows the migrated
+conventions from day one.
 
 ## Motivation
 

--- a/kwin-effect/desktoptransitionmanager.cpp
+++ b/kwin-effect/desktoptransitionmanager.cpp
@@ -34,6 +34,7 @@
 #include <QVector2D>
 
 #include <array>
+#include <cmath>
 
 namespace PlasmaZones {
 
@@ -169,6 +170,33 @@ void DesktopTransitionManager::begin(KWin::VirtualDesktop* from, KWin::VirtualDe
         }
     }
 
+    // Actual switch direction for direction-aware packs (uploaded as
+    // iSwitchDelta): the pager-grid delta from -> to, wrap-corrected to the
+    // shortest path so a "next desktop" wrap off the last column reads as one
+    // step forward, not a full-row jump backwards. Grid coords are (col, row)
+    // with row increasing downward, matching the +y-down uv space the packs
+    // sample in. Stays zero when either desktop has no grid position.
+    QVector4D switchDelta;
+    {
+        const QPoint fromCoords = KWin::effects->desktopGridCoords(from);
+        const QPoint toCoords = KWin::effects->desktopGridCoords(to);
+        const QSize grid = KWin::effects->desktopGridSize();
+        if (fromCoords.x() >= 0 && fromCoords.y() >= 0 && toCoords.x() >= 0 && toCoords.y() >= 0) {
+            float dx = float(toCoords.x() - fromCoords.x());
+            float dy = float(toCoords.y() - fromCoords.y());
+            if (grid.width() > 1 && std::abs(dx) > float(grid.width()) / 2.0f) {
+                dx -= std::copysign(float(grid.width()), dx);
+            }
+            if (grid.height() > 1 && std::abs(dy) > float(grid.height()) / 2.0f) {
+                dy -= std::copysign(float(grid.height()), dy);
+            }
+            const float len = std::hypot(dx, dy);
+            if (len > 0.0f) {
+                switchDelta = QVector4D(dx, dy, dx / len, dy / len);
+            }
+        }
+    }
+
     // Resolve the affected outputs: a specific output for a per-output switch
     // (Plasma 6.7 per-output desktops, #648), otherwise every output for a
     // global all-output switch.
@@ -195,6 +223,7 @@ void DesktopTransitionManager::begin(KWin::VirtualDesktop* from, KWin::VirtualDe
         tr.effectId = effectId;
         tr.customParams = customParams;
         tr.customColors = customColors;
+        tr.switchDelta = switchDelta;
         tr.startTimeMs = nowMs;
         tr.durationMs = effectiveDurationMs;
         tr.captured = false; // capture is deferred to the first paintOutput (live GL context)
@@ -381,6 +410,7 @@ DesktopTransitionManager::CompiledDesktopShader* DesktopTransitionManager::compi
         compiled.iTimeLoc = shader->uniformLocation("iTime");
         compiled.iResolutionLoc = shader->uniformLocation("iResolution");
         compiled.iFrameLoc = shader->uniformLocation("iFrame");
+        compiled.iSwitchDeltaLoc = shader->uniformLocation("iSwitchDelta");
         for (int slot = 0; slot < PhosphorAnimationShaders::AnimationShaderContract::kMaxCustomParams; ++slot) {
             compiled.customParamsLoc[slot] = shader->uniformLocation(ShaderInternal::kCustomParamsElementNames[slot]);
         }
@@ -465,6 +495,11 @@ bool DesktopTransitionManager::paintOutput(const KWin::RenderTarget& renderTarge
         cs->shader->setUniform(cs->iFrameLoc, tr.frameCount);
     }
     ++tr.frameCount;
+    // Actual switch direction (grid delta + unit vector) for packs that follow
+    // the navigation instead of a fixed configured direction.
+    if (cs->iSwitchDeltaLoc >= 0) {
+        cs->shader->setUniform(cs->iSwitchDeltaLoc, tr.switchDelta);
+    }
     // The p_<name> pack parameters (slide direction, dissolve scale, etc.).
     for (int slot = 0; slot < PhosphorAnimationShaders::AnimationShaderContract::kMaxCustomParams; ++slot) {
         if (cs->customParamsLoc[slot] >= 0) {

--- a/kwin-effect/desktoptransitionmanager.cpp
+++ b/kwin-effect/desktoptransitionmanager.cpp
@@ -184,6 +184,10 @@ void DesktopTransitionManager::begin(KWin::VirtualDesktop* from, KWin::VirtualDe
         if (fromCoords.x() >= 0 && fromCoords.y() >= 0 && toCoords.x() >= 0 && toCoords.y() >= 0) {
             float dx = float(toCoords.x() - fromCoords.x());
             float dy = float(toCoords.y() - fromCoords.y());
+            // Strict `>`: a delta of EXACTLY half the grid (even grids, e.g.
+            // col0 -> col2 on a 4-wide pager) is ambiguous — both directions
+            // are equally short — and the tie deliberately keeps the literal
+            // (non-wrapped) delta.
             if (grid.width() > 1 && std::abs(dx) > float(grid.width()) / 2.0f) {
                 dx -= std::copysign(float(grid.width()), dx);
             }

--- a/kwin-effect/desktoptransitionmanager.h
+++ b/kwin-effect/desktoptransitionmanager.h
@@ -143,6 +143,12 @@ private:
         // `p_<name>` define resolves to `customColors[N]`, so without this a
         // desktop pack's colors read transparent black.
         std::array<QVector4D, PhosphorAnimationShaders::AnimationShaderContract::kMaxCustomColors> customColors{};
+        // Actual switch direction for direction-aware packs: wrap-corrected
+        // desktop-grid delta in cells (.xy, +x = one column right, +y = one
+        // row down) and the same delta normalized (.zw). Zeros when the grid
+        // positions could not be resolved. Computed once in begin(), uploaded
+        // as `iSwitchDelta` (declared in desktop_transition.glsl).
+        QVector4D switchDelta;
         qint64 startTimeMs = 0;
         int durationMs = 0;
         // Monotonic paint counter uploaded as iFrame, so glitch-style desktop
@@ -162,6 +168,7 @@ private:
         int iTimeLoc = -1;
         int iResolutionLoc = -1;
         int iFrameLoc = -1;
+        int iSwitchDeltaLoc = -1;
         // customParams[slot] / customColors[slot] uniform locations (-1 when the
         // shader omits the slot — the GLSL compiler prunes unreferenced ones).
         std::array<int, PhosphorAnimationShaders::AnimationShaderContract::kMaxCustomParams> customParamsLoc{};

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1101,9 +1101,12 @@ private:
     // every audio-reactive decoration pass, mirroring the daemon's RGBA8
     // R-channel layout. A pack opts in purely by including surface_audio.glsl and
     // reading getBass/audioBar (its compiled iAudioSpectrumSizeLoc then resolves
-    // >= 0). Cava is gated by syncEffectAudioState on `enableAudioVisualizer` AND
-    // at least one decorated window carrying an audio pack, so capture only spins
-    // up when a border can actually react.
+    // >= 0). Animation packs share the same texture through their own opt-in
+    // module (data/animations/shared/audio.glsl) plus an `audio` metadata flag.
+    // Cava is gated by syncEffectAudioState on `enableAudioVisualizer` AND at
+    // least one audio consumer being present — a decorated window carrying an
+    // audio pack, or an audio animation pack assigned where transitions can
+    // resolve it — so capture only spins up when something can actually react.
 
     /// The effect's own CAVA spectrum source. Constructed lazily on first need
     /// (syncEffectAudioState) so a session that never uses an audio decoration
@@ -1115,6 +1118,17 @@ private:
     /// (m_audioSpectrumDirty), reused across every audio-reactive window that
     /// frame. Lives on the GL thread (allocated/uploaded only inside paint).
     std::unique_ptr<KWin::GLTexture> m_audioSpectrumTex;
+
+    /// Shared 1x1 transparent texture bound in place of a referenced but
+    /// unsupplied user-texture sampler (surface fold + animation paths), so
+    /// the contract's "reads transparent black" holds instead of the sampler
+    /// defaulting to unit 0 (live window content). Lazily created by
+    /// transparentFallbackTexture() on a paint path; freed with the effect.
+    std::unique_ptr<KWin::GLTexture> m_transparentFallbackTex;
+
+    /// Lazily create + return the shared transparent fallback texture; null
+    /// only when GL allocation fails (callers then skip the bind).
+    KWin::GLTexture* transparentFallbackTexture();
 
     /// Latest spectrum delivered by the provider signal (values 0..1). Copied on
     /// the compositor thread; consumed (uploaded) during the next paint.
@@ -1129,7 +1143,8 @@ private:
 
     /// The daemon's audio-viz master toggle + bar count, pulled via getSetting in
     /// loadCachedSettings exactly like snapAssistEnabled. The effect's cava run
-    /// gate ANDs the toggle with an audio decoration being present.
+    /// gate ANDs the toggle with an audio decoration or an audio animation pack
+    /// being present.
     bool m_enableAudioVisualizer = false;
     int m_audioSpectrumBarCount = PhosphorAudio::Defaults::DefaultBarCount;
     /// Coalescing latch for scheduleEffectAudioSync: many decoration/settings
@@ -1148,9 +1163,10 @@ private:
     void onEffectAudioSpectrum(const QVector<float>& spectrum);
 
     /// Start/stop/reconfigure the effect's cava instance to match the run gate
-    /// (m_enableAudioVisualizer && hasAudioReactiveDecoration()). Lazily creates
-    /// m_audioProvider on first run. Prefer scheduleEffectAudioSync from
-    /// high-frequency callers (decoration refresh, settings replies).
+    /// (m_enableAudioVisualizer && (hasAudioReactiveDecoration() ||
+    /// hasAudioReactiveAnimation())). Lazily creates m_audioProvider on first
+    /// run. Prefer scheduleEffectAudioSync from high-frequency callers
+    /// (decoration refresh, settings replies).
     void syncEffectAudioState();
 
     /// Coalesced, deferred syncEffectAudioState: sets a pending latch and posts a

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1110,7 +1110,8 @@ private:
 
     /// The effect's own CAVA spectrum source. Constructed lazily on first need
     /// (syncEffectAudioState) so a session that never uses an audio decoration
-    /// pays nothing. Owns a `cava` child process while running.
+    /// or animation pack pays nothing. Owns a `cava` child process while
+    /// running.
     std::unique_ptr<PhosphorAudio::IAudioSpectrumProvider> m_audioProvider;
 
     /// Session-global spectrum texture (`bars×1`, R = bar value 0..1). Uploaded

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1164,6 +1164,15 @@ private:
     /// needed) so the run gate resolves before first paint.
     bool hasAudioReactiveDecoration() const;
 
+    /// True when an audio-reactive ANIMATION pack (AnimationShaderEffect::
+    /// useAudio) is assigned anywhere transitions can resolve it from: the
+    /// shader profile tree's baseline or overrides, or an animation rule's
+    /// effectId payload. Keeps cava warm while such a pack is assigned so a
+    /// transition's FIRST frame already has a spectrum — a lazy start at
+    /// transition begin would eat the whole leg in cava spawn latency. Like
+    /// its decoration sibling, reads pack metadata only.
+    bool hasAudioReactiveAnimation() const;
+
     /// True when audio is live: the toggle is on, the provider is running, and a
     /// non-empty spectrum has arrived. Gates pushing iAudioSpectrumSize > 0 and
     /// binding the spectrum texture. NOT the repaint gate — use

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -913,6 +913,14 @@ void PlasmaZonesEffect::loadCachedSettings()
         // Per-pack param values are baked at first compile, so a tree change that
         // alters parameters[packId] requires a recompile of that pack — clear the
         // whole compiled-pack cache (it lazily recompiles on the next paint).
+        // This D-Bus reply lands between frames where the compositor GL context
+        // is not guaranteed current, and the cached packs own GLShaders plus
+        // user GLTextures whose destruction issues glDelete* — make the context
+        // current first, same discipline as the effectsChanged clear in
+        // lifecycle.cpp.
+        if (KWin::effects) {
+            KWin::effects->makeOpenGLContextCurrent();
+        }
         m_compiledPacks.clear();
         updateAllDecorations();
         if (KWin::effects) {

--- a/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_bringup.cpp
@@ -713,10 +713,11 @@ void PlasmaZonesEffect::loadCachedSettings()
     loadSettingAsync(QStringLiteral("snapAssistEnabled"), [this](const QVariant& v) {
         m_snapAssistHandler->setEnabled(v.toBool());
     });
-    // Audio-reactive surface decorations: the same daemon audio-viz toggle + bar
-    // count that gate the daemon's overlay audio also gate the effect's own cava
-    // instance (syncEffectAudioState ANDs the toggle with an audio decoration
-    // being present). scheduleEffectAudioSync (deferred + coalesced) so these two
+    // Audio-reactive surface decorations and animation packs: the same daemon
+    // audio-viz toggle + bar count that gate the daemon's overlay audio also
+    // gate the effect's own cava instance (syncEffectAudioState ANDs the toggle
+    // with an audio decoration or an audio animation pack being present).
+    // scheduleEffectAudioSync (deferred + coalesced) so these two
     // independent async replies collapse to ONE sync — otherwise an early
     // enable-reply could start cava at the default bar count and the later
     // bar-count reply would immediately restart it.

--- a/kwin-effect/plasmazoneseffect/decoration_render.cpp
+++ b/kwin-effect/plasmazoneseffect/decoration_render.cpp
@@ -183,8 +183,8 @@ void PlasmaZonesEffect::pushBorderUniforms(KWin::EffectWindow* w, const WindowDe
     // Padded composite path: the target texture's canvas is the expanded rect
     // inflated by the chain's outer margin (renderSurfaceChainComposite uses
     // the same construction), so the geometry uniforms must describe that
-    // padded space. @p texturePaddingLogical is 0 on the unpadded callers
-    // (idle blit, transition capture).
+    // padded space. @p texturePaddingLogical is 0 when the chain declares no
+    // padding pack.
     if (texturePaddingLogical > 0.0) {
         expanded.adjust(-texturePaddingLogical, -texturePaddingLogical, texturePaddingLogical, texturePaddingLogical);
     }
@@ -194,13 +194,10 @@ void PlasmaZonesEffect::pushBorderUniforms(KWin::EffectWindow* w, const WindowDe
                                  static_cast<float>((frame.top() - expanded.top()) * scale));
     const QVector2D frameSize(static_cast<float>(frame.width() * scale), static_cast<float>(frame.height() * scale));
 
-    // The caller has the border shader bound (a KWin::ShaderBinder). What
-    // carries the values into the eventual draw is PROGRAM-OBJECT persistence
-    // (uniform values survive the binder pop; OffscreenData::paint re-binds the
-    // same program) — the idle drawWindow caller's binder actually pops before
-    // its draw. Either way, setUniform writes to the currently bound program,
-    // so we must NOT bind/unbind here or the uniforms would land on the wrong
-    // (or no) program.
+    // The caller (the composite fold) has the pack shader bound via a
+    // KWin::ShaderBinder and draws inside that same scope. setUniform writes
+    // to the CURRENTLY BOUND program, so we must NOT bind/unbind here or the
+    // uniforms would land on the wrong (or no) program.
     if (pack.uSurfaceSizeLoc >= 0) {
         shader->setUniform(pack.uSurfaceSizeLoc, windowExpandedSize);
     }

--- a/kwin-effect/plasmazoneseffect/decoration_render.cpp
+++ b/kwin-effect/plasmazoneseffect/decoration_render.cpp
@@ -246,6 +246,33 @@ void PlasmaZonesEffect::pushBorderUniforms(KWin::EffectWindow* w, const WindowDe
     if (pack.uTimeLoc >= 0) {
         shader->setUniform(pack.uTimeLoc, surfaceShaderTimeSeconds());
     }
+    // Cursor position for hover-reactive packs, in the same top-down device-px
+    // space as the geometry uniforms above (origin at the padded canvas's
+    // top-left); (-1, -1) when the cursor is outside the canvas. .zw is .xy
+    // normalized by the canvas size (negative alongside the sentinel),
+    // matching the daemon branch's convention. Uses the per-frame cached
+    // cursor from prePaintScreen — same rationale as the animation path.
+    // Hover packs declare `animated: true` so the vsync repaint loop keeps
+    // this fresh; there is no per-cursor-move damage path.
+    if (pack.iMouseLoc >= 0) {
+        const QPointF cursorGlobal = m_shaderManager.m_cachedCursorGlobal;
+        float localX = -1.0f;
+        float localY = -1.0f;
+        const bool inside = cursorGlobal.x() >= expanded.left() && cursorGlobal.x() < expanded.right()
+            && cursorGlobal.y() >= expanded.top() && cursorGlobal.y() < expanded.bottom();
+        if (inside) {
+            localX = static_cast<float>((cursorGlobal.x() - expanded.left()) * scale);
+            localY = static_cast<float>((cursorGlobal.y() - expanded.top()) * scale);
+        }
+        QVector4D iMouseValue(localX, localY, 0.0f, 0.0f);
+        if (windowExpandedSize.x() > 0.0f) {
+            iMouseValue.setZ(localX / windowExpandedSize.x());
+        }
+        if (windowExpandedSize.y() > 0.0f) {
+            iMouseValue.setW(localY / windowExpandedSize.y());
+        }
+        shader->setUniform(pack.iMouseLoc, iMouseValue);
+    }
     // Pack-declared parameters (customParams / customColors). Seed from THIS
     // window's resolved values (updateWindowDecoration fills packParamValues from
     // the window's own DecorationProfile), falling back to the compiled pack's

--- a/kwin-effect/plasmazoneseffect/decoration_render.cpp
+++ b/kwin-effect/plasmazoneseffect/decoration_render.cpp
@@ -157,10 +157,12 @@ void PlasmaZonesEffect::pushBorderUniforms(KWin::EffectWindow* w, const WindowDe
                                            const QString& windowId)
 {
     // The caller (renderSurfaceChainComposite's per-pack fold) has already
-    // resolved @p pack and @p wb, confirmed the border is applied, ruled out a
-    // transition owning the slot, and bound pack.shader, so this just computes
-    // and writes the uniforms onto the bound program. The border APPEARANCE is
-    // not a
+    // resolved @p pack and @p wb, confirmed the border is applied, and bound
+    // pack.shader, so this just computes and writes the uniforms onto the
+    // bound program. The fold also runs while a TRANSITION owns the window's
+    // draw slot (it produces the layered surface the animation composites
+    // over); that is fine — this function only writes the fold's own bound
+    // pack program, never the redirect slot. The border APPEARANCE is not a
     // parameter here — it rides the pack's baked customParams/customColors,
     // pushed below (with @p wb's per-window rule override when set).
     KWin::GLShader* shader = pack.shader.get();

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -232,6 +232,10 @@ PlasmaZonesEffect::PlasmaZonesEffect()
         if (haveContext) {
             KWin::effects->addRepaintFull();
         }
+        // A pack reload can flip a decoration pack's `audio` metadata flag,
+        // which feeds the cava run gate via hasAudioReactiveDecoration() —
+        // mirror the animation registry's effectsChanged handler above.
+        scheduleEffectAudioSync();
     });
 
     // Frame-geometry shadow flush timer. Debounces per-window

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -202,6 +202,9 @@ PlasmaZonesEffect::PlasmaZonesEffect()
                 // invalidate the DesktopTransitionManager's parallel compiled-shader
                 // cache too — otherwise the next switch renders with the stale shader.
                 m_desktopTransition.invalidateShaderCache();
+                // A pack reload can flip a pack's `audio` metadata flag, which
+                // feeds the cava run gate via hasAudioReactiveAnimation().
+                scheduleEffectAudioSync();
             });
 
     // Surface shader pack hot-reload: when a data/surface pack changes on disk,

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -1215,9 +1215,15 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                         // silently composite live content where the pack
                         // expects nothing.
                         if (cached->userTextureLoc[slot] >= 0) {
+                            // Park the destination unit BEFORE the call: the
+                            // first-ever call creates the texture, and
+                            // GLTexture::upload binds it on the CURRENTLY
+                            // ACTIVE unit — the previous iteration may have
+                            // left an earlier slot's unit active. Same
+                            // discipline as the audio upload below.
+                            glActiveTexture(GL_TEXTURE1 + slot);
                             if (KWin::GLTexture* fallback = transparentFallbackTexture()) {
                                 shader->setUniform(cached->userTextureLoc[slot], 1 + slot);
-                                glActiveTexture(GL_TEXTURE1 + slot);
                                 fallback->bind();
                             }
                         }
@@ -1341,7 +1347,14 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                     // lands on the audio unit, its destination anyway.
                     glActiveTexture(GL_TEXTURE0 + ShaderInternal::kSurfaceAudioUnit);
                     ensureAudioSpectrumTexture();
-                    audioBound = bindSurfaceAudio(shader, cached->iAudioSpectrumSizeLoc, cached->uAudioSpectrumLoc);
+                    bindSurfaceAudio(shader, cached->iAudioSpectrumSizeLoc, cached->uAudioSpectrumLoc);
+                    // Unconditional, NOT bindSurfaceAudio's return: a dirty
+                    // upload above can leave the spectrum texture bound on
+                    // the parked unit even when the bind reports not-live
+                    // (size-only shader, audio toggled off mid-frame), and
+                    // unbinding a clear unit in the hygiene block is a
+                    // harmless no-op.
+                    audioBound = true;
                 }
                 // Restore TEXTURE0 as the active unit so KWin's
                 // OffscreenData::paint binds the redirected surface

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -115,12 +115,14 @@ void PlasmaZonesEffect::prePaintScreen(KWin::ScreenPrePaintData& data)
         data.mask |= PAINT_SCREEN_TRANSFORMED;
     }
 
-    // Cache cursor pos once per frame for shader-transition iMouse uniform.
-    // paintWindow runs once per active transition (and may run multiple
-    // times across outputs); reading KWin::effects->cursorPos() at every
-    // call multiplies up. Caching here also guarantees every transition
-    // this frame reads an identical iMouse, eliminating sub-frame jitter.
-    if (KWin::effects && !m_shaderManager.empty()) {
+    // Cache cursor pos once per frame for the iMouse uniforms. paintWindow
+    // runs once per active transition (and may run multiple times across
+    // outputs); reading KWin::effects->cursorPos() at every call multiplies
+    // up. Caching here also guarantees every consumer this frame reads an
+    // identical iMouse, eliminating sub-frame jitter. Decorated windows read
+    // it too (hover-reactive surface packs via pushBorderUniforms), so the
+    // refresh also runs while any decoration exists, not only mid-transition.
+    if (KWin::effects && (!m_shaderManager.empty() || !m_windowDecorations.isEmpty())) {
         m_shaderManager.m_cachedCursorGlobal = KWin::effects->cursorPos();
     }
 
@@ -1301,6 +1303,17 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                 // would otherwise leak into this draw.
                 if (cached->uTexture0Loc >= 0) {
                     shader->setUniform(cached->uTexture0Loc, retargetUTexture0 ? kSurfaceLayerUnit : 0);
+                }
+                // Audio spectrum (opt-in via the audio.glsl module + metadata
+                // `"audio": true`). Reuses the surface-decoration CAVA
+                // provider and texture: bindSurfaceAudio pushes the bar count
+                // (0 while the visualizer is off or cava is absent, so the
+                // pack's helpers render static) and binds the spectrum at
+                // kSurfaceAudioUnit, clear of this draw's units 0..5. The
+                // upload is a no-op when the texture is already current.
+                if (cached->iAudioSpectrumSizeLoc >= 0 || cached->uAudioSpectrumLoc >= 0) {
+                    ensureAudioSpectrumTexture();
+                    bindSurfaceAudio(shader, cached->iAudioSpectrumSizeLoc, cached->uAudioSpectrumLoc);
                 }
                 // Restore TEXTURE0 as the active unit so KWin's
                 // OffscreenData::paint binds the redirected surface

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -1227,6 +1227,15 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                                 fallback->bind();
                             }
                         }
+                        // The fallback is a 1x1 transparent, so this slot's
+                        // declared size is zero. Push it explicitly: this
+                        // cached program persists uniform state across
+                        // transitions, so a slot that carried a real texture
+                        // (and its size) on a prior leg would otherwise leave a
+                        // stale non-zero iTextureResolution here.
+                        if (cached->iTextureResolutionLoc[slot] >= 0) {
+                            shader->setUniform(cached->iTextureResolutionLoc[slot], QVector4D(0.0f, 0.0f, 0.0f, 0.0f));
+                        }
                         continue;
                     }
                     KWin::GLTexture* tex = entry->texture.get();

--- a/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
+++ b/kwin-effect/plasmazoneseffect/paint_pipeline.cpp
@@ -829,6 +829,10 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
             }
             const QVector4D layerRectInTexture = ShaderInternal::computeTextureSubRect(
                 transition.surfaceExtent ? anchorGeo : expandedGeo, layerCanvasGeo);
+            // Whether this draw bound the audio spectrum on kSurfaceAudioUnit —
+            // read by the post-draw hygiene block to unbind it, mirroring the
+            // fold's mainAudioBound/passAudioBound cleanup.
+            bool audioBound = false;
             {
                 KWin::ShaderBinder binder(shader);
                 if (cached->iTimeLoc >= 0) {
@@ -1202,6 +1206,21 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                      ++slot) {
                     CachedTexture* entry = transition.userTextures[slot];
                     if (!entry || !entry->texture) {
+                        // Referenced but unsupplied (declared file failed to
+                        // load, or the pack samples a slot it never declared):
+                        // bind the shared 1x1 transparent fallback so the
+                        // sampler reads the contract's transparent black. A
+                        // classic default-block sampler with no bind defaults
+                        // to unit 0 — the redirected window — which would
+                        // silently composite live content where the pack
+                        // expects nothing.
+                        if (cached->userTextureLoc[slot] >= 0) {
+                            if (KWin::GLTexture* fallback = transparentFallbackTexture()) {
+                                shader->setUniform(cached->userTextureLoc[slot], 1 + slot);
+                                glActiveTexture(GL_TEXTURE1 + slot);
+                                fallback->bind();
+                            }
+                        }
                         continue;
                     }
                     KWin::GLTexture* tex = entry->texture.get();
@@ -1309,11 +1328,20 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
                 // provider and texture: bindSurfaceAudio pushes the bar count
                 // (0 while the visualizer is off or cava is absent, so the
                 // pack's helpers render static) and binds the spectrum at
-                // kSurfaceAudioUnit, clear of this draw's units 0..5. The
-                // upload is a no-op when the texture is already current.
+                // kSurfaceAudioUnit, clear of this draw's units 0..5.
                 if (cached->iAudioSpectrumSizeLoc >= 0 || cached->uAudioSpectrumLoc >= 0) {
+                    // Park the active unit on the audio unit BEFORE the
+                    // (possibly dirty) upload: GLTexture::upload binds the
+                    // fresh texture on the CURRENTLY ACTIVE unit, and the
+                    // surface-layer bind above leaves kSurfaceLayerUnit
+                    // active — an upload there would replace the layered
+                    // surface with the tiny spectrum texture for this draw.
+                    // Same hazard the fold documents (surfacelayers.cpp),
+                    // which defends by uploading up front; here the upload
+                    // lands on the audio unit, its destination anyway.
+                    glActiveTexture(GL_TEXTURE0 + ShaderInternal::kSurfaceAudioUnit);
                     ensureAudioSpectrumTexture();
-                    bindSurfaceAudio(shader, cached->iAudioSpectrumSizeLoc, cached->uAudioSpectrumLoc);
+                    audioBound = bindSurfaceAudio(shader, cached->iAudioSpectrumSizeLoc, cached->uAudioSpectrumLoc);
                 }
                 // Restore TEXTURE0 as the active unit so KWin's
                 // OffscreenData::paint binds the redirected surface
@@ -1367,9 +1395,11 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
             // effect in the chain assumes TEXTURE0 is the only active
             // unit; leaving stale binds risks the next effect inheriting
             // a sampler that points at our matrix glyph atlas (or
-            // whatever) when it expects a default-empty unit.
+            // whatever) when it expects a default-empty unit. A slot with a
+            // resolved sampler location but no cached texture bound the
+            // transparent fallback above, so it needs the same unbind.
             for (int slot = 0; slot < PhosphorAnimationShaders::AnimationShaderContract::kMaxUserTextureSlots; ++slot) {
-                if (!transition.userTextures[slot]) {
+                if (!transition.userTextures[slot] && cached->userTextureLoc[slot] < 0) {
                     continue;
                 }
                 glActiveTexture(GL_TEXTURE1 + slot);
@@ -1393,6 +1423,14 @@ void PlasmaZonesEffect::paintWindow(const KWin::RenderTarget& renderTarget, cons
             if (surfaceLayerTex) {
                 constexpr int kSurfaceLayerUnit = ShaderInternal::kSurfaceLayerUnit;
                 glActiveTexture(GL_TEXTURE0 + kSurfaceLayerUnit);
+                glBindTexture(GL_TEXTURE_2D, 0);
+            }
+            // Same hygiene for the audio-spectrum unit — the fold unbinds its
+            // audio bind after every pass (mainAudioBound / passAudioBound);
+            // mirror that so the next effect in the chain doesn't inherit the
+            // spectrum texture on kSurfaceAudioUnit.
+            if (audioBound) {
+                glActiveTexture(GL_TEXTURE0 + ShaderInternal::kSurfaceAudioUnit);
                 glBindTexture(GL_TEXTURE_2D, 0);
             }
             glActiveTexture(GL_TEXTURE0);

--- a/kwin-effect/plasmazoneseffect/shader_internal.h
+++ b/kwin-effect/plasmazoneseffect/shader_internal.h
@@ -246,6 +246,15 @@ inline constexpr int kSurfaceAudioUnit = 6;
 static_assert(kSurfaceAudioUnit > 5,
               "kSurfaceAudioUnit must clear the fold's units 0..5 (uTexture0/iChannel/backdrop)");
 
+/// First texture unit for SURFACE pack user textures (uTexture1..3) in the
+/// composite fold's main pass: units 7..9, clear of the fold's units 0..5 and
+/// the audio unit 6. The animation paintWindow path also binds audio at unit 6
+/// (bindSurfaceAudio) in its own phase; its user textures live at units 1..3,
+/// so the two paths' maps never meet on the same draw.
+inline constexpr int kSurfaceUserTextureBaseUnit = 7;
+static_assert(kSurfaceUserTextureBaseUnit > kSurfaceAudioUnit,
+              "surface user textures must sit above the audio unit — the fold binds both in the same pass");
+
 /// Surface decoration texture units shared by the animation-layer paths in
 /// paint_pipeline.cpp and the present rebind in decoration_render.cpp. All are
 /// offset from kMaxUserTextureSlots (N, = 3 today) so the animation

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -850,6 +850,11 @@ bool PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
             shader->uniformLocation(PhosphorAnimationShaders::AnimationShaderContract::kIHasSurfaceLayer);
         cached.iHasOldWindowLoc =
             shader->uniformLocation(PhosphorAnimationShaders::AnimationShaderContract::kIHasOldWindow);
+        // Audio spectrum (opt-in audio.glsl module; -1 for non-audio packs).
+        cached.iAudioSpectrumSizeLoc =
+            shader->uniformLocation(PhosphorAnimationShaders::AnimationShaderContract::kIAudioSpectrumSize);
+        cached.uAudioSpectrumLoc =
+            shader->uniformLocation(PhosphorAnimationShaders::AnimationShaderContract::kUAudioSpectrum);
         cached.iMoveVelocityLoc =
             shader->uniformLocation(PhosphorAnimationShaders::AnimationShaderContract::kIMoveVelocity);
         cached.iMoveOffsetLoc =
@@ -1769,6 +1774,10 @@ void PlasmaZonesEffect::loadShaderProfileFromDbus()
                                 qCDebug(lcEffect)
                                     << "loadShaderProfileFromDbus: tree loaded with" << tree.overriddenPaths().size()
                                     << "overrides — paths=" << tree.overriddenPaths();
+                                // A tree edit can assign or unassign an audio-reactive
+                                // animation pack; re-evaluate the cava run gate so the
+                                // provider is warm before the first transition needs it.
+                                scheduleEffectAudioSync();
                             },
                             /*arraySink=*/{});
     });
@@ -1862,6 +1871,9 @@ void PlasmaZonesEffect::loadRuleAnimationsFromDbus()
             }
         }
         m_shaderManager.setRuleAnimationRules(std::move(animationRules));
+        // A rule edit can route transitions to (or away from) an audio-reactive
+        // animation pack via an EffectId payload — re-evaluate the cava run gate.
+        scheduleEffectAudioSync();
         // The new-state SetOpacity predicate is computed by rebuildAnimationRuleSet
         // (see ShaderTransitionManager::hasOpacityRules) — read it back rather than
         // re-scanning the rule list a second time here.

--- a/kwin-effect/plasmazoneseffect/surface_audio.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_audio.cpp
@@ -21,10 +21,12 @@
 #include <memory>
 #include <epoxy/gl.h>
 
-// Audio-reactive surface decorations (CAVA). The compositor has no daemon-style
-// audio path, so the effect runs its own CavaSpectrumProvider and feeds the
-// spectrum to audio-reactive decoration packs through surface_audio.glsl. Split
-// out of surfacelayers.cpp to keep that TU under the 800-line limit; the fold
+// Audio-reactive surface decorations and animation packs (CAVA). The
+// compositor has no daemon-style audio path, so the effect runs its own
+// CavaSpectrumProvider and feeds the spectrum to audio-reactive decoration
+// packs (surface_audio.glsl) and animation packs (the animation family's
+// audio.glsl module, bound from paint_pipeline's transition draw). Split out
+// of surfacelayers.cpp to keep that TU under the 800-line limit; the fold
 // itself (which binds the uploaded texture) still lives there. See the member
 // docs in plasmazoneseffect.h.
 
@@ -209,7 +211,8 @@ void PlasmaZonesEffect::syncEffectAudioState()
         }
         return;
     }
-    // Not wanted (toggle off or no audio decoration left): stop capture and clear
+    // Not wanted (toggle off, or no audio decoration or animation pack left):
+    // stop capture and clear
     // the spectrum so audioActive() goes false and any lingering audio border
     // falls back to static on its next paint.
     const bool wasLive = (m_audioProvider && m_audioProvider->isRunning()) || m_audioSpectrumSize > 0;
@@ -289,8 +292,11 @@ KWin::GLTexture* PlasmaZonesEffect::transparentFallbackTexture()
 
 bool PlasmaZonesEffect::bindSurfaceAudio(KWin::GLShader* shader, int iAudioSpectrumSizeLoc, int uAudioSpectrumLoc)
 {
-    // The texture was uploaded up front by renderSurfaceChainComposite (see the
-    // note there); here we only bind the ready texture — no upload mid-pass.
+    // This helper only binds the ready texture — it never uploads. The fold
+    // uploads up front (renderSurfaceChainComposite, see the note there); the
+    // animation path uploads inline just before calling, with the active unit
+    // parked on kSurfaceAudioUnit so the upload lands on its destination
+    // (paint_pipeline.cpp's audio block).
     const bool live = audioActive() && m_audioSpectrumTex != nullptr;
     // Push the bar count (0 when not live) so surface_audio.glsl's helpers gate
     // themselves off and the pack renders static without a bound sampler. Derive

--- a/kwin-effect/plasmazoneseffect/surface_audio.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_audio.cpp
@@ -11,6 +11,8 @@
 
 #include <PhosphorAudio/CavaSpectrumProvider.h>
 #include <PhosphorAudio/IAudioSpectrumProvider.h>
+#include <PhosphorRules/Rule.h>
+#include <PhosphorRules/RuleAction.h>
 #include <PhosphorSurface/SurfaceShaderEffect.h>
 
 #include <QImage>
@@ -74,6 +76,45 @@ bool PlasmaZonesEffect::hasAudioReactiveDecoration() const
     return false;
 }
 
+bool PlasmaZonesEffect::hasAudioReactiveAnimation() const
+{
+    // Metadata-only scan, mirroring hasAudioReactiveDecoration: collect every
+    // effect id a transition could resolve (tree baseline + direct overrides +
+    // animation-rule effectId payloads) and test the pack's audio flag. The
+    // scan is small (a handful of overrides and rules) and only runs from
+    // syncEffectAudioState, so no caching is needed.
+    const auto& registry = m_shaderManager.shaderRegistry();
+    const auto isAudioPack = [&registry](const QString& id) {
+        return !id.isEmpty() && registry.effect(id).useAudio;
+    };
+    const auto& tree = m_shaderManager.profileTree();
+    if (isAudioPack(tree.baseline().effectiveEffectId())) {
+        return true;
+    }
+    const QStringList paths = tree.overriddenPaths();
+    for (const QString& path : paths) {
+        if (isAudioPack(tree.directOverride(path).effectiveEffectId())) {
+            return true;
+        }
+    }
+    // Rules: any enabled rule action carrying an EffectId param can route a
+    // transition to that pack (the anim-shader slot). Reading the param off
+    // every action over-approximates slightly (a non-shader action never
+    // carries EffectId, so the extra reads are cheap misses), which errs on
+    // the safe side for a run gate.
+    for (const PhosphorRules::Rule& rule : m_shaderManager.m_ruleAnimationRules) {
+        if (!rule.enabled) {
+            continue;
+        }
+        for (const PhosphorRules::RuleAction& action : rule.actions) {
+            if (isAudioPack(action.params.value(PhosphorRules::ActionParam::EffectId).toString())) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 void PlasmaZonesEffect::onEffectAudioSpectrum(const QVector<float>& spectrum)
 {
     // Store on the compositor thread; the composite fold uploads it to the GL
@@ -125,7 +166,7 @@ void PlasmaZonesEffect::scheduleEffectAudioSync()
 
 void PlasmaZonesEffect::syncEffectAudioState()
 {
-    const bool wantRun = m_enableAudioVisualizer && hasAudioReactiveDecoration();
+    const bool wantRun = m_enableAudioVisualizer && (hasAudioReactiveDecoration() || hasAudioReactiveAnimation());
     if (wantRun) {
         if (!m_audioProvider) {
             // Lazily created on first need so a session that never uses an audio

--- a/kwin-effect/plasmazoneseffect/surface_audio.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_audio.cpp
@@ -88,6 +88,13 @@ bool PlasmaZonesEffect::hasAudioReactiveAnimation() const
         return !id.isEmpty() && registry.effect(id).useAudio;
     };
     const auto& tree = m_shaderManager.profileTree();
+    // Built-in per-event DEFAULT packs (resolveShaderWithDefault injects
+    // window-morph / fade for a truly-unset path) are deliberately NOT
+    // scanned: no built-in default pack declares `audio: true`, so an unset
+    // path can never resolve to an audio pack. If a future built-in default
+    // ever declares audio, this scan must route through
+    // resolveShaderWithDefault instead of raw overrides or cava never warms
+    // for it.
     if (isAudioPack(tree.baseline().effectiveEffectId())) {
         return true;
     }
@@ -103,6 +110,9 @@ bool PlasmaZonesEffect::hasAudioReactiveAnimation() const
     // carries EffectId, so the extra reads are cheap misses), which errs on
     // the safe side for a run gate.
     for (const PhosphorRules::Rule& rule : m_shaderManager.m_ruleAnimationRules) {
+        // Defensive only: loadRuleAnimationsFromDbus already prunes disabled
+        // rules before populating this list; the check stays so this scan
+        // remains correct if that upstream filter ever changes.
         if (!rule.enabled) {
             continue;
         }
@@ -180,10 +190,10 @@ void PlasmaZonesEffect::syncEffectAudioState()
             // Graceful fallback: the pack already renders as a plain static
             // border when iAudioSpectrumSize stays 0 (no spectrum ever arrives).
             // Warn ONCE — this path is re-entered on every sync while the audio
-            // decoration is present, so an unconditional warn would spam the log.
+            // pack is present, so an unconditional warn would spam the log.
             if (!m_audioUnavailableWarned) {
-                qCWarning(lcEffect) << "Audio-reactive decoration active but cava is not installed; "
-                                       "border renders static";
+                qCWarning(lcEffect) << "Audio-reactive pack active (decoration or animation) but cava is not "
+                                       "installed; audio-reactive visuals render static";
                 m_audioUnavailableWarned = true;
             }
             return;
@@ -254,6 +264,27 @@ bool PlasmaZonesEffect::ensureAudioSpectrumTexture()
         m_audioSpectrumDirty = false;
     }
     return m_audioSpectrumTex != nullptr;
+}
+
+KWin::GLTexture* PlasmaZonesEffect::transparentFallbackTexture()
+{
+    // Shared 1x1 transparent texture bound in place of a REFERENCED but
+    // unsupplied user-texture sampler (surface fold units 7-9, animation
+    // units 1-3). A classic default-block sampler with no bind reads unit 0
+    // — live window content — instead of the contract's documented
+    // transparent black; this fallback makes the documented behaviour real.
+    // Lazily created on a paint path (GL context current); freed with the
+    // effect. Mirrors the daemon's dummy-channel fallback in ShaderNodeRhi.
+    if (!m_transparentFallbackTex) {
+        QImage img(1, 1, QImage::Format_RGBA8888);
+        img.fill(Qt::transparent);
+        m_transparentFallbackTex = KWin::GLTexture::upload(img);
+        if (m_transparentFallbackTex) {
+            m_transparentFallbackTex->setFilter(GL_LINEAR);
+            m_transparentFallbackTex->setWrapMode(GL_CLAMP_TO_EDGE);
+        }
+    }
+    return m_transparentFallbackTex.get();
 }
 
 bool PlasmaZonesEffect::bindSurfaceAudio(KWin::GLShader* shader, int iAudioSpectrumSizeLoc, int uAudioSpectrumLoc)

--- a/kwin-effect/plasmazoneseffect/surface_compile.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_compile.cpp
@@ -20,12 +20,14 @@
 #include <effect/effecthandler.h>
 #include <opengl/glshader.h>
 #include <opengl/glshadermanager.h>
+#include <opengl/gltexture.h>
 
 #include <QByteArray>
 #include <QColor>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QImage>
 #include <QIODevice>
 #include <QLoggingCategory>
 #include <QStandardPaths>
@@ -325,6 +327,53 @@ CompiledSurfacePack* PlasmaZonesEffect::compiledPack(const QString& packId,
     // keeps them and iAudioSpectrumSizeLoc >= 0 flags the pack as audio-reactive.
     packState.iAudioSpectrumSizeLoc = shader->uniformLocation(SC::kIAudioSpectrumSize);
     packState.uAudioSpectrumLoc = shader->uniformLocation(SC::kUAudioSpectrum);
+    // iMouse (hover-reactive packs) — -1 for the common pack that never reads
+    // the cursor; pushBorderUniforms skips the push entirely then.
+    packState.iMouseLoc = shader->uniformLocation(SC::kIMouse);
+
+    // User-declared image textures (metadata `textures`): resolve the sampler +
+    // iTextureResolution[N] element locations and upload each declared file
+    // once — decorations are persistent, so the pack-lifetime cache owns the
+    // GLTextures (freed with the shader under the same GL-context discipline).
+    // Paths were made absolute + traversal-checked at registry scan time; an
+    // unloadable file warns and leaves the slot null (transparent black).
+    static const std::array<const char*, 3> kSurfaceUserTextureNames = {
+        {SC::kUTexture1, SC::kUTexture2, SC::kUTexture3}};
+    static const std::array<const char*, 3> kSurfaceTextureResNames = {
+        {"iTextureResolution[0]", "iTextureResolution[1]", "iTextureResolution[2]"}};
+    static_assert(SC::kMaxUserTextureSlots == 3, "surface user-texture name arrays must grow with the slot budget");
+    for (int slot = 0; slot < SC::kMaxUserTextureSlots; ++slot) {
+        packState.userTextureLoc[slot] = shader->uniformLocation(kSurfaceUserTextureNames[slot]);
+        packState.iTextureResolutionLoc[slot] = shader->uniformLocation(kSurfaceTextureResNames[slot]);
+    }
+    for (int slot = 0; slot < eff.textures.size() && slot < SC::kMaxUserTextureSlots; ++slot) {
+        const auto& texSlot = eff.textures.at(slot);
+        if (texSlot.path.isEmpty()) {
+            continue;
+        }
+        QImage img(texSlot.path);
+        if (img.isNull()) {
+            qCWarning(lcEffect) << "Surface pack" << packId << "texture slot" << slot << "failed to load"
+                                << texSlot.path << "— sampler reads transparent";
+            continue;
+        }
+        std::unique_ptr<KWin::GLTexture> tex = KWin::GLTexture::upload(img);
+        if (!tex) {
+            qCWarning(lcEffect) << "Surface pack" << packId << "texture slot" << slot << "GL upload failed for"
+                                << texSlot.path;
+            continue;
+        }
+        tex->setFilter(GL_LINEAR);
+        // Wrap vocabulary matches the shared contract (clamp default).
+        GLenum wrap = GL_CLAMP_TO_EDGE;
+        if (texSlot.wrap == QLatin1String("repeat")) {
+            wrap = GL_REPEAT;
+        } else if (texSlot.wrap == QLatin1String("mirror")) {
+            wrap = GL_MIRRORED_REPEAT;
+        }
+        tex->setWrapMode(wrap);
+        packState.userTextures[slot] = std::move(tex);
+    }
 
     // MAIN-pass multipass channel locations: the buffer-pass outputs are bound
     // here (idle drawWindow path) as iChannel0..3 so the main effect.frag can

--- a/kwin-effect/plasmazoneseffect/surface_compile.cpp
+++ b/kwin-effect/plasmazoneseffect/surface_compile.cpp
@@ -376,7 +376,7 @@ CompiledSurfacePack* PlasmaZonesEffect::compiledPack(const QString& packId,
     }
 
     // MAIN-pass multipass channel locations: the buffer-pass outputs are bound
-    // here (idle drawWindow path) as iChannel0..3 so the main effect.frag can
+    // in the composite fold as iChannel0..3 so the main effect.frag can
     // sample the pre-rendered buffer textures. -1 for a single-pass pack (the
     // border never references these — the linker drops them). The literal
     // element names match the surface contract declarations in
@@ -409,12 +409,12 @@ CompiledSurfacePack* PlasmaZonesEffect::compiledPack(const QString& packId,
     packState.customParamsValues = baked.params;
     packState.customColorsValues = baked.colors;
 
-    // ── Multipass buffer passes (idle drawWindow path) ──────────────────────
+    // ── Multipass buffer passes (composite fold) ────────────────────────────
     //
     // Only a multipass pack with declared buffers compiles passes here;
     // single-pass packs (the border) leave packState.bufferPasses empty and pay
-    // nothing — the cheap OffscreenData path in drawWindow is byte-for-byte
-    // unchanged for them. If ANY buffer pass fails to compile we leave the vector
+    // nothing — they skip the buffer loop and render only their main pass in
+    // the composite fold. If ANY buffer pass fails to compile we leave the vector
     // empty and warn: the pack then renders single-pass (fail closed), exactly
     // like the daemon/animation degradation. (packState.bufferPasses starts empty
     // for this freshly-inserted cache slot.)

--- a/kwin-effect/plasmazoneseffect/surfacelayers.cpp
+++ b/kwin-effect/plasmazoneseffect/surfacelayers.cpp
@@ -571,22 +571,32 @@ KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChainComposite(KWin::EffectWind
             mainAudioBound = bindSurfaceAudio(pk->shader.get(), pk->iAudioSpectrumSizeLoc, pk->uAudioSpectrumLoc);
             // User-declared image textures (metadata `textures`), units
             // kSurfaceUserTextureBaseUnit.. — loaded once at compile time onto
-            // the pack state. Push the sampler unit + the texture's pixel size
-            // (iTextureResolution[N]) only for slots the shader references AND
-            // a texture loaded; an unbound declared sampler reads transparent.
+            // the pack state. Every slot the shader REFERENCES gets a bind: a
+            // loaded texture, or the shared 1x1 transparent fallback when the
+            // metadata file failed to load (or the pack referenced a sampler
+            // it never declared). Without the fallback a referenced classic
+            // default-block sampler reads unit 0 — the running composite —
+            // instead of the contract's transparent black. iTextureResolution
+            // is pushed only for real textures (stays 0 for the fallback).
             for (int t = 0; t < PhosphorSurfaceShaders::SurfaceShaderContract::kMaxUserTextureSlots; ++t) {
-                if (!pk->userTextures[t] || pk->userTextureLoc[t] < 0) {
+                if (pk->userTextureLoc[t] < 0) {
                     continue;
+                }
+                KWin::GLTexture* userTex = pk->userTextures[t].get();
+                if (!userTex) {
+                    userTex = transparentFallbackTexture();
+                    if (!userTex) {
+                        continue; // allocation failed — keep the old omit behaviour
+                    }
+                } else if (pk->iTextureResolutionLoc[t] >= 0) {
+                    pk->shader->setUniform(pk->iTextureResolutionLoc[t],
+                                           QVector4D(static_cast<float>(userTex->width()),
+                                                     static_cast<float>(userTex->height()), 0.0f, 0.0f));
                 }
                 const int unit = ShaderInternal::kSurfaceUserTextureBaseUnit + t;
                 pk->shader->setUniform(pk->userTextureLoc[t], unit);
-                if (pk->iTextureResolutionLoc[t] >= 0) {
-                    pk->shader->setUniform(pk->iTextureResolutionLoc[t],
-                                           QVector4D(static_cast<float>(pk->userTextures[t]->width()),
-                                                     static_cast<float>(pk->userTextures[t]->height()), 0.0f, 0.0f));
-                }
                 glActiveTexture(GL_TEXTURE0 + unit);
-                pk->userTextures[t]->bind();
+                userTex->bind();
                 glActiveTexture(GL_TEXTURE0);
                 mainUserTexturesBound = true;
             }

--- a/kwin-effect/plasmazoneseffect/surfacelayers.cpp
+++ b/kwin-effect/plasmazoneseffect/surfacelayers.cpp
@@ -584,7 +584,14 @@ KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChainComposite(KWin::EffectWind
                 }
                 KWin::GLTexture* userTex = pk->userTextures[t].get();
                 if (!userTex) {
+                    // Park the destination unit BEFORE the call: the
+                    // first-ever call creates the texture, and
+                    // GLTexture::upload binds it on the CURRENTLY ACTIVE
+                    // unit — which is TEXTURE0 here, holding the running
+                    // composite this pass samples.
+                    glActiveTexture(GL_TEXTURE0 + ShaderInternal::kSurfaceUserTextureBaseUnit + t);
                     userTex = transparentFallbackTexture();
+                    glActiveTexture(GL_TEXTURE0);
                     if (!userTex) {
                         continue; // allocation failed — keep the old omit behaviour
                     }

--- a/kwin-effect/plasmazoneseffect/surfacelayers.cpp
+++ b/kwin-effect/plasmazoneseffect/surfacelayers.cpp
@@ -607,9 +607,8 @@ KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChainComposite(KWin::EffectWind
                 glActiveTexture(GL_TEXTURE0);
                 mainUserTexturesBound = true;
             }
-            // Contract uniforms + pack params (shared with the OffscreenData path).
-            // windowId threaded in so the focus-fade ramp doesn't recompute
-            // getWindowId(w) per pack.
+            // Contract uniforms + pack params. windowId threaded in so the
+            // focus-fade ramp doesn't recompute getWindowId(w) per pack.
             pushBorderUniforms(w, *bit, chain.at(k), *pk, captureScale, pad, windowId);
             drawFullscreenQuad();
         }

--- a/kwin-effect/plasmazoneseffect/surfacelayers.cpp
+++ b/kwin-effect/plasmazoneseffect/surfacelayers.cpp
@@ -523,6 +523,7 @@ KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChainComposite(KWin::EffectWind
         const bool backdropAvailable = state.backdropTex && state.backdropRect.z() > 0.0f;
         const bool mainHasBackdrop = pk->uBackdropLoc >= 0 && backdropAvailable;
         bool mainAudioBound = false;
+        bool mainUserTexturesBound = false;
         {
             KWin::ShaderBinder binder(pk->shader.get());
             // Identity MVP so the NDC fullscreen quad from drawFullscreenQuad maps
@@ -568,6 +569,27 @@ KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChainComposite(KWin::EffectWind
             // off, so getBass* reads 0 and the pack renders static) and binds
             // the spectrum texture only when live.
             mainAudioBound = bindSurfaceAudio(pk->shader.get(), pk->iAudioSpectrumSizeLoc, pk->uAudioSpectrumLoc);
+            // User-declared image textures (metadata `textures`), units
+            // kSurfaceUserTextureBaseUnit.. — loaded once at compile time onto
+            // the pack state. Push the sampler unit + the texture's pixel size
+            // (iTextureResolution[N]) only for slots the shader references AND
+            // a texture loaded; an unbound declared sampler reads transparent.
+            for (int t = 0; t < PhosphorSurfaceShaders::SurfaceShaderContract::kMaxUserTextureSlots; ++t) {
+                if (!pk->userTextures[t] || pk->userTextureLoc[t] < 0) {
+                    continue;
+                }
+                const int unit = ShaderInternal::kSurfaceUserTextureBaseUnit + t;
+                pk->shader->setUniform(pk->userTextureLoc[t], unit);
+                if (pk->iTextureResolutionLoc[t] >= 0) {
+                    pk->shader->setUniform(pk->iTextureResolutionLoc[t],
+                                           QVector4D(static_cast<float>(pk->userTextures[t]->width()),
+                                                     static_cast<float>(pk->userTextures[t]->height()), 0.0f, 0.0f));
+                }
+                glActiveTexture(GL_TEXTURE0 + unit);
+                pk->userTextures[t]->bind();
+                glActiveTexture(GL_TEXTURE0);
+                mainUserTexturesBound = true;
+            }
             // Contract uniforms + pack params (shared with the OffscreenData path).
             // windowId threaded in so the focus-fade ramp doesn't recompute
             // getWindowId(w) per pack.
@@ -585,6 +607,12 @@ KWin::GLTexture* PlasmaZonesEffect::renderSurfaceChainComposite(KWin::EffectWind
         if (mainAudioBound) {
             glActiveTexture(GL_TEXTURE0 + ShaderInternal::kSurfaceAudioUnit);
             glBindTexture(GL_TEXTURE_2D, 0);
+        }
+        if (mainUserTexturesBound) {
+            for (int t = 0; t < PhosphorSurfaceShaders::SurfaceShaderContract::kMaxUserTextureSlots; ++t) {
+                glActiveTexture(GL_TEXTURE0 + ShaderInternal::kSurfaceUserTextureBaseUnit + t);
+                glBindTexture(GL_TEXTURE_2D, 0);
+            }
         }
         glActiveTexture(GL_TEXTURE0);
         KWin::GLFramebuffer::popFramebuffer();

--- a/kwin-effect/plasmazoneseffect/types.h
+++ b/kwin-effect/plasmazoneseffect/types.h
@@ -29,9 +29,9 @@ class Item;
 
 namespace PlasmaZones {
 
-/// One compiled buffer pass of a multipass SURFACE pack (the idle drawWindow
-/// path). Each buffer.frag is a fullscreen-quad fragment that samples the
-/// captured window surface (uTexture0) plus any prior buffer outputs
+/// One compiled buffer pass of a multipass SURFACE pack (run in the
+/// composite fold). Each buffer.frag is a fullscreen-quad fragment that
+/// samples the captured window surface (uTexture0) plus any prior buffer outputs
 /// (iChannel0..N-1) and writes into its own FBO; the main effect.frag then
 /// samples the final buffer output(s) as iChannel0..3. Compiled in
 /// compiledPack() right after the main pack shader, cleared (fail-closed) if any
@@ -189,10 +189,10 @@ struct CompiledSurfacePack
     std::array<QVector4D, PhosphorSurfaceShaders::SurfaceShaderContract::kMaxCustomParams> customParamsValues{};
     std::array<QVector4D, PhosphorSurfaceShaders::SurfaceShaderContract::kMaxCustomColors> customColorsValues{};
 
-    /// Compiled multipass buffer passes (idle drawWindow path). Empty for a
-    /// single-pass pack (the border). Cleared fail-closed if any pass fails to
-    /// compile (the pack then renders single-pass). The per-window FBO targets
-    /// live in m_surfaceMultipass.
+    /// Compiled multipass buffer passes (run in the composite fold). Empty for
+    /// a single-pass pack (the border). Cleared fail-closed if any pass fails
+    /// to compile (the pack then renders single-pass). The per-window FBO
+    /// targets live in m_surfaceMultipass.
     std::vector<CompiledSurfaceBufferPass> bufferPasses;
 };
 

--- a/kwin-effect/plasmazoneseffect/types.h
+++ b/kwin-effect/plasmazoneseffect/types.h
@@ -139,11 +139,35 @@ struct CompiledSurfacePack
     /// (syncEffectAudioState) and the per-frame repaint gate (windowSurfaceAnimates).
     int iAudioSpectrumSizeLoc = -1;
     int uAudioSpectrumLoc = -1;
+    /// iMouse — cursor in the surface texture's top-down device-px space,
+    /// (-1, -1) off-canvas. -1 for packs that never read the cursor (the
+    /// common case); pushBorderUniforms then skips the push entirely.
+    int iMouseLoc = -1;
 
     /// MAIN-pass iChannel0..3 sampler + iChannelResolution[0..3] element
     /// locations. -1 when the linker dropped the uniform (single-pass pack).
     std::array<int, 4> iChannelLoc{{-1, -1, -1, -1}};
     std::array<int, 4> iChannelResolutionLoc{{-1, -1, -1, -1}};
+
+    /// User-declared image textures (metadata `textures`): sampler +
+    /// iTextureResolution[N] element locations, plus the textures themselves,
+    /// loaded once at compile time (decorations are persistent, so the
+    /// pack-lifetime cache is the natural owner — freed with the shader on
+    /// cache clear, where the GL context discipline already applies). Slot N
+    /// feeds uTexture<N+1>. A slot with no loadable file stays null and the
+    /// fold skips its bind (the sampler then reads transparent black).
+    std::array<int, PhosphorSurfaceShaders::SurfaceShaderContract::kMaxUserTextureSlots> userTextureLoc = []() {
+        std::array<int, PhosphorSurfaceShaders::SurfaceShaderContract::kMaxUserTextureSlots> a;
+        a.fill(-1);
+        return a;
+    }();
+    std::array<int, PhosphorSurfaceShaders::SurfaceShaderContract::kMaxUserTextureSlots> iTextureResolutionLoc = []() {
+        std::array<int, PhosphorSurfaceShaders::SurfaceShaderContract::kMaxUserTextureSlots> a;
+        a.fill(-1);
+        return a;
+    }();
+    std::array<std::unique_ptr<KWin::GLTexture>, PhosphorSurfaceShaders::SurfaceShaderContract::kMaxUserTextureSlots>
+        userTextures;
 
     /// Pack-declared parameter uniform locations + resolved-default values.
     /// float/int/bool params pack into customParams[N], colours into
@@ -451,6 +475,12 @@ struct CachedShader
     /// surfaceColor() for its "old" side instead of sampling the raw window
     /// through the unit-0 alias).
     int iHasOldWindowLoc = -1;
+    /// Audio-spectrum uniforms (opt-in module
+    /// `data/animations/shared/audio.glsl` + metadata `"audio": true`).
+    /// -1 when the pack doesn't include the module — paintWindow then skips
+    /// the spectrum push and bind entirely.
+    int iAudioSpectrumSizeLoc = -1;
+    int uAudioSpectrumLoc = -1;
     /// Interactive-move motion uniforms (held move/resize transitions).
     int iMoveVelocityLoc = -1;
     int iMoveOffsetLoc = -1;

--- a/kwin-effect/plasmazoneseffect/types.h
+++ b/kwin-effect/plasmazoneseffect/types.h
@@ -120,11 +120,12 @@ struct CompiledSurfacePack
     int uFocusedLoc = -1; ///< uSurfaceFocused — 1.0 focused / 0.0 unfocused
     int uOpacityLoc = -1; ///< uSurfaceOpacity — rule-resolved window opacity (handlesOpacity packs)
     int uTimeLoc = -1; ///< iTime — continuous seconds; -1 ⟺ static pack (drives the repaint gate)
-    /// uTexture0 — the input-surface sampler (unit 0). On the single-pack path
-    /// OffscreenData::paint binds the redirected surface to unit 0 automatically,
-    /// so this is unused there; the multi-pack composite (renderSurfaceChainComposite)
-    /// runs the main pass as a fullscreen FBO pass and binds the running composite
-    /// to unit 0 itself, setting this explicitly.
+    /// uTexture0 — the input-surface sampler (unit 0). Every decorated window
+    /// (one-pack chains included) folds through renderSurfaceChainComposite,
+    /// which runs the main pass as a fullscreen FBO pass, binds the running
+    /// composite to unit 0 itself, and sets this explicitly. (The only
+    /// remaining OffscreenData::paint auto-bind of unit 0 belongs to the
+    /// animation-transition path's CachedShader, a different struct.)
     int uTexture0Loc = -1;
     /// Backdrop sampling (needsBackdrop packs, main pass): sampler +
     /// valid-rect + gate locations; -1 for packs that never reference the

--- a/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
@@ -248,7 +248,9 @@ inline constexpr const char* kIDate = "iDate";
 /// Authoring rule: branch with `iIsReversed == 1` (NOT `iIsReversed != 0`
 /// or implicit-truthy). This pins the behaviour against any future
 /// runtime that elects to extend the encoding (e.g. negative for
-/// "unknown direction"). The matrix shader follows this convention.
+/// "unknown direction"). Bundled packs read direction through the
+/// `p_reversed` / `legProgress()` helpers in the canonical header, which
+/// encode this rule once.
 inline constexpr const char* kIIsReversed = "iIsReversed";
 
 /// `vec4 iSurfaceScreenPos` — the shader surface's position in screen

--- a/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
@@ -142,13 +142,18 @@ namespace PhosphorAnimationShaders {
 /// The helpers read 0 (render static) while the visualizer is off.
 ///
 /// @par Daemon-only extensions
-/// These fields receive zero values on the compositor path; shaders
-/// that need them must run on the daemon overlay path until the
-/// compositor wires the matching producers:
+/// Shaders that need these must run on the daemon overlay path until
+/// the compositor wires the matching producers — but the two fail in
+/// DIFFERENT ways on the compositor:
 ///
 ///   • `iChannelResolution[]` — auto-populated when multipass buffer
-///     shaders are bound
-///   • `iTimeHi` — auto-computed wrap counterpart of `iTime`
+///     shaders are bound. NOT declared by the canonical header's
+///     `#ifdef PLASMAZONES_KWIN` branch (the compositor is single-pass,
+///     no buffer FBOs), so reaching for it there is a COMPILE error,
+///     not a zero read.
+///   • `iTimeHi` — auto-computed wrap counterpart of `iTime`. Declared
+///     on both branches for source parity; reads zero on the
+///     compositor.
 ///
 /// @par Spatial uniforms — per-runtime capture geometry
 /// These four fields describe where the captured card sits inside the
@@ -293,12 +298,17 @@ inline constexpr const char* kIAnchorSize = "iAnchorSize";
 ///   vec2 anchorSizeUv    = iAnchorSize    / iResolution;
 ///   vec2 anchorUv        = (vTexCoord - anchorTopLeftUv) / anchorSizeUv;
 /// Daemon-side written via `AnimationUniformExtension`; kwin-effect
-/// uses classic-GL `setUniform`. On kwin the value is (0, 0) today
-/// (the OffscreenEffect FBO covers the window's frameGeometry 1:1,
-/// no actor expansion), which makes the anchor-space remap collapse
-/// to identity. Equivalent to the pre-refactor `customParams[7].x = 0`
-/// fallback that morph documented as the kwin path. A future actor-
-/// expansion PR would push (padW, padH) instead.
+/// uses classic-GL `setUniform`. On kwin the value is the anchor's
+/// top-left offset within whatever rect the FBO spans: the shadow /
+/// decoration inset within the EXPANDED window geometry for an
+/// anchor-extent transition (KWin's OffscreenEffect redirects the whole
+/// window item — see `kIAnchorRectInTexture` below), or the window's
+/// position within the output for a surface-extent transition. It
+/// collapses to (0, 0) only when the expanded geometry equals the frame
+/// (an undecorated, shadowless window). Shaders MUST apply the
+/// anchor-space remap (`anchorRemap` in anchor_remap.glsl) on both
+/// runtimes; `tests/unit/ui/test_anchor_uniforms.cpp` pins the kwin
+/// inset values.
 inline constexpr const char* kIAnchorPosInFbo = "iAnchorPosInFbo";
 
 /// `vec4 iAnchorRectInTexture` — the card's UV sub-rect within

--- a/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderContract.h
@@ -72,7 +72,7 @@ namespace PhosphorAnimationShaders {
 ///
 /// Shader authors do NOT need their own `#ifdef PLASMAZONES_KWIN` blocks
 /// — both branches expose the same identifiers (`iTime`, `iResolution`,
-/// `customParams[N]`, `iChannel0`, etc.). The macro switch describes the
+/// `customParams[N]`, `uTexture0`, etc.). The macro switch describes the
 /// uniform-binding ABI, not the runtime feature set.
 ///
 /// @par Per-effect declared parameters
@@ -122,23 +122,32 @@ namespace PhosphorAnimationShaders {
 ///     containment.
 ///   • `customParams[N]` / `customColors[N]` — per-effect declared
 ///     parameters resolved at transition begin time.
-///   • `iChannel0` — redirected surface texture. Daemon: live FBO
+///   • `uTexture0` — redirected surface texture. Daemon: live FBO
 ///     from the layer-enabled shader anchor. Kwin: KWin's
 ///     `OffscreenEffect`-managed window snapshot.
+///   • `iTextureResolution[]` — pixel sizes of the bound user textures.
+///     Daemon: node-resolved live. Kwin: pushed by paintWindow's
+///     per-effect texture loop.
+///
+/// @par Audio spectrum (opt-in module, both runtimes)
+/// `iAudioSpectrumSize` + the `uAudioSpectrum` sampler are an opt-in
+/// module: a pack includes `data/animations/shared/audio.glsl` (after the
+/// canonical header) and declares `"audio": true` in its metadata. The
+/// daemon feeds them via `SurfaceAnimator::setAudioSpectrum` (the
+/// `OverlayService` wires CAVA's `IAudioSpectrumProvider::spectrumUpdated`
+/// here); the kwin-effect reuses its surface-decoration CAVA provider and
+/// pushes both per frame from `paintWindow`. The metadata flag is what
+/// keys the kwin CAVA run-gate — an assigned audio pack keeps the
+/// provider warm so a transition's first frame already has a spectrum.
+/// The helpers read 0 (render static) while the visualizer is off.
 ///
 /// @par Daemon-only extensions
 /// These fields receive zero values on the compositor path; shaders
 /// that need them must run on the daemon overlay path until the
 /// compositor wires the matching producers:
 ///
-///   • `iAudioSpectrumSize` and the audio spectrum binding — fed by
-///     `SurfaceAnimator::setAudioSpectrum` (the daemon's
-///     `OverlayService` wires CAVA's `IAudioSpectrumProvider::spectrumUpdated`
-///     here)
 ///   • `iChannelResolution[]` — auto-populated when multipass buffer
 ///     shaders are bound
-///   • `iTextureResolution[]` — auto-populated when user textures are
-///     bound (bindings 7-10)
 ///   • `iTimeHi` — auto-computed wrap counterpart of `iTime`
 ///
 /// @par Spatial uniforms — per-runtime capture geometry
@@ -317,9 +326,12 @@ inline constexpr const char* kIAnchorRectInTexture = "iAnchorRectInTexture";
 /// (new frame) by `iTime`, cross-fading the captured old content
 /// (`uOldWindow`) into the live new content. Both default to `(0,0,0,0)`
 /// for non-morph transitions (window.open/close/etc.), which a shader can
-/// treat as "no morph". kwin-effect: pushed via classic-GL `setUniform`;
-/// daemon: reserved in the UBO contract for source parity (the morph runs
-/// compositor-side, but the shared header declares them on both branches).
+/// treat as "no morph". COMPOSITOR PATH ONLY, and deliberately NOT
+/// declared by the canonical shared header: each geometry-morph pack
+/// (flow, fold, ripple-snap, stretch, window-morph) declares the pair
+/// itself inside its own `#ifdef PLASMAZONES_KWIN` block — geometry
+/// events never run on the daemon, and the guard keeps the daemon's
+/// strict SPIR-V bake from ever seeing the loose declarations.
 inline constexpr const char* kIFromRect = "iFromRect";
 inline constexpr const char* kIToRect = "iToRect";
 
@@ -329,7 +341,11 @@ inline constexpr const char* kIToRect = "iToRect";
 /// content in `uTexture0` (alpha `iTime`), each mapped at native aspect,
 /// so an aspect-ratio-changing resize doesn't stretch the content. Bound
 /// to a dedicated texture unit on the kwin path; a transparent 1×1
-/// fallback is bound when no snapshot was captured.
+/// fallback is bound when no snapshot was captured. The sampler is NOT
+/// declared by the canonical header — only the `iHasOldWindow` gate int
+/// is; packs that sample old content opt in via
+/// `data/animations/shared/old_content.glsl`, which declares the sampler
+/// inside its own `#ifdef PLASMAZONES_KWIN` guard.
 inline constexpr const char* kUOldWindow = "uOldWindow";
 
 /// `sampler2D uSurfaceLayer` — COMPOSITOR PATH ONLY. The window's surface
@@ -426,8 +442,8 @@ inline constexpr const char* kIWindowOpacity = "iWindowOpacity";
 /// Maximum number of user-declared textures per animation effect.
 ///
 /// Each declared texture binds to one of the canonical samplers
-/// `iChannel1` / `iChannel2` / `iChannel3`. The redirected surface
-/// itself (`iChannel0`, binding 7 on the daemon, TEXTURE0 on KWin) is
+/// `uTexture1` / `uTexture2` / `uTexture3`. The redirected surface
+/// itself (`uTexture0`, binding 7 on the daemon, TEXTURE0 on KWin) is
 /// not counted here — that's a separate runtime-managed slot. The
 /// daemon's `PhosphorRendering::kMaxUserTextures = 4` includes slot 0,
 /// hence the off-by-one in the budget. Pinned to the daemon constant
@@ -438,6 +454,21 @@ inline constexpr const char* kIWindowOpacity = "iWindowOpacity";
 /// why the assert can't sit in this header (epoxy/Qt typedef collision
 /// in the kwin-effect TU).
 inline constexpr int kMaxUserTextureSlots = 3;
+
+/// `int iAudioSpectrumSize` — CAVA bar count, 0 while the audio visualizer
+/// is off or cava is unavailable. Daemon: BaseUniforms UBO member fed by
+/// `SurfaceAnimator::setAudioSpectrum`. Kwin: default-block uniform
+/// declared by the opt-in `data/animations/shared/audio.glsl` module,
+/// pushed per frame via `bindSurfaceAudio` (shared with the surface
+/// decoration path).
+inline constexpr const char* kIAudioSpectrumSize = "iAudioSpectrumSize";
+
+/// `sampler2D uAudioSpectrum` — the CAVA spectrum texture (`bars×1`,
+/// R = bar value in 0..1). Declared by the opt-in audio.glsl module:
+/// binding 6 on the daemon (the overlay convention), a named sampler
+/// bound to a dedicated unit at draw time on the kwin path. Never
+/// sampled while `iAudioSpectrumSize` is 0.
+inline constexpr const char* kUAudioSpectrum = "uAudioSpectrum";
 
 /// `vec4 iMouse` — cursor position in shader-local pixels.
 /// `.xy = (cursorX, cursorY)` relative to the shader surface's origin

--- a/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderEffect.h
+++ b/libs/phosphor-animation/include/PhosphorAnimation/AnimationShaderEffect.h
@@ -145,6 +145,17 @@ struct PHOSPHORANIMATION_EXPORT AnimationShaderEffect
     /// can sample window depth. Daemon-only.
     bool useDepthBuffer = false;
 
+    /// Audio-reactive opt-in (JSON key `audio`, matching the surface pack
+    /// vocabulary). The pack samples the CAVA spectrum via
+    /// `data/animations/shared/audio.glsl`. Unlike the overlay family, where
+    /// audio is implicit/session-global, animation packs must declare it:
+    /// the kwin-effect keys its CAVA run-gate on this flag (an assigned
+    /// audio pack keeps the provider warm so a transition's first frame has
+    /// a spectrum), and the daemon's SurfaceAnimator feeds the spectrum
+    /// unconditionally. Helpers read 0 (render static) when the visualizer
+    /// is off or cava is unavailable.
+    bool useAudio = false;
+
     /// How wide the shader effect's render target is — relative to its
     /// anchor (default), or filling the surface scene root.
     ///
@@ -227,10 +238,10 @@ struct PHOSPHORANIMATION_EXPORT AnimationShaderEffect
     QList<ParameterInfo> parameters;
 
     /// User texture slot. Each entry binds an asset file to one of the
-    /// canonical samplers `iChannel1` / `iChannel2` / `iChannel3` (slots
+    /// canonical samplers `uTexture1` / `uTexture2` / `uTexture3` (slots
     /// 0 / 1 / 2 here, which the runtimes map to texture-unit
     /// allocations 1 / 2 / 3 — slot 0 of the binding-7+ region is the
-    /// surface itself / `iChannel0`, never user-declared).
+    /// surface itself / `uTexture0`, never user-declared).
     ///
     /// `path` is resolved relative to the effect's `sourceDir`. Loading
     /// failures are non-fatal — the effect still installs and the
@@ -243,8 +254,8 @@ struct PHOSPHORANIMATION_EXPORT AnimationShaderEffect
     /// the default rather than silently re-persisting the typo. Filter
     /// mode is not exposed here — both runtimes use linear filtering
     /// for user textures today. The slot index is the 0-based position
-    /// in this list: the first entry binds to `iChannel1`, the second
-    /// to `iChannel2`, etc. Up to three textures per effect; surplus
+    /// in this list: the first entry binds to `uTexture1`, the second
+    /// to `uTexture2`, etc. Up to three textures per effect; surplus
     /// entries are silently dropped at parse time.
     struct TextureSlot
     {

--- a/libs/phosphor-animation/src/animationshadereffect.cpp
+++ b/libs/phosphor-animation/src/animationshadereffect.cpp
@@ -137,6 +137,8 @@ QJsonObject AnimationShaderEffect::toJson() const
     }
     if (useDepthBuffer)
         obj.insert(QLatin1String("depthBuffer"), true);
+    if (useAudio)
+        obj.insert(QLatin1String("audio"), true);
 
     if (!parameters.isEmpty()) {
         QJsonArray params;
@@ -254,6 +256,7 @@ AnimationShaderEffect AnimationShaderEffect::fromJson(const QJsonObject& obj)
             e.bufferFilters.append(f);
     }
     e.useDepthBuffer = obj.value(QLatin1String("depthBuffer")).toBool(false);
+    e.useAudio = obj.value(QLatin1String("audio")).toBool(false);
 
     // `fboExtent` (string). Accepted forms:
     //   "anchor"        Anchor extent — FBO == captured anchor (default)
@@ -381,7 +384,7 @@ bool AnimationShaderEffect::operator==(const AnimationShaderEffect& other) const
     if (geometryGridSubdivisions != other.geometryGridSubdivisions)
         return false;
     if (isMultipass != other.isMultipass || useWallpaper != other.useWallpaper || bufferFeedback != other.bufferFeedback
-        || useDepthBuffer != other.useDepthBuffer)
+        || useDepthBuffer != other.useDepthBuffer || useAudio != other.useAudio)
         return false;
     if (!qFuzzyCompare(bufferScale + 1.0, other.bufferScale + 1.0))
         return false;

--- a/libs/phosphor-animation/src/animationshadereffect.cpp
+++ b/libs/phosphor-animation/src/animationshadereffect.cpp
@@ -298,7 +298,7 @@ AnimationShaderEffect AnimationShaderEffect::fromJson(const QJsonObject& obj)
     }
 
     // Cap the texture list at the contract budget. Surplus entries are
-    // silently dropped — the canonical UBO only declares iChannel1..3
+    // silently dropped — the canonical UBO only declares uTexture1..3
     // and exposing more would require both runtimes to grow more
     // sampler bindings. A future contract bump (kMaxUserTextureSlots > 3)
     // would loosen this cap automatically.
@@ -335,8 +335,8 @@ AnimationShaderEffect AnimationShaderEffect::fromJson(const QJsonObject& obj)
         // slot-index field; an empty entry preceding a populated one
         // SHIFTS the populated entry's runtime slot. e.g. authoring
         // [{path:""}, {path:"foo.png"}, {path:"bar.png"}] yields
-        // textures bound at iChannel1+iChannel2 instead of iChannel2+
-        // iChannel3 as the metadata reads. Loud so authors notice the
+        // textures bound at uTexture1+uTexture2 instead of uTexture2+
+        // uTexture3 as the metadata reads. Loud so authors notice the
         // implicit re-mapping.
         if (t.path.isEmpty()) {
             ++droppedEmpty;

--- a/libs/phosphor-animation/src/contract_pins.cpp
+++ b/libs/phosphor-animation/src/contract_pins.cpp
@@ -5,7 +5,7 @@
 #include <PhosphorRendering/ShaderNodeRhi.h>
 
 // Compile-time pin: the contract's user-declarable texture budget plus the
-// reserved surface slot (iChannel0) must equal the daemon's RHI texture-array
+// reserved surface slot (uTexture0) must equal the daemon's RHI texture-array
 // capacity. If anyone resizes one without the other, the kwin/daemon contract
 // silently drifts (declared textures past slot kMaxUserTextureSlots would land
 // outside the SRB binding range on the daemon, or the daemon would reserve

--- a/libs/phosphor-animation/src/surfaceanimator.cpp
+++ b/libs/phosphor-animation/src/surfaceanimator.cpp
@@ -647,7 +647,7 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
                                          << "x" << shaderAnchor->height();
 
     // Render the anchor into a separate FBO via QQuickShaderEffectSource;
-    // the ShaderEffect samples that FBO as iChannel0. The separate FBO
+    // the ShaderEffect samples that FBO as uTexture0. The separate FBO
     // is what sidesteps the "Texture used with different accesses within
     // the same pass" Vulkan validation: the source FBO render and the
     // shader effect's read are different render passes.
@@ -655,20 +655,20 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
     // **Gated on `foundExplicitAnchor`**: only created when a descendant
     // tagged `shaderAnchor: true` was found. The fallback path (no tag,
     // anchor==target==QML root) leaves `shaderSource` null and skips the
-    // `setSourceItem` call below, so iChannel0 is unbound for the whole
+    // `setSourceItem` call below, so uTexture0 is unbound for the whole
     // leg — the shader runs without a content texture and any
-    // `texture(iChannel0, …)` call returns whatever the GL spec does for
+    // `texture(uTexture0, …)` call returns whatever the GL spec does for
     // an unbound sampler (typically transparent black). This is
     // intentional: layer-enabling a QQuickRootItem-rooted target breaks
     // scene-graph rendering for the consumer's whole window. Animation
-    // shaders that need an iChannel0 sample MUST be paired with a
+    // shaders that need an uTexture0 sample MUST be paired with a
     // `shaderAnchor: true` descendant in the consumer's QML; the
     // explicit=false case in the qCDebug above is the operator's signal
     // that a shader is running source-less.
     //
     // live=true: open animations have no prior frame to snapshot. A
     // one-shot grab (live=false) races the source's first layout/paint
-    // and captures an empty FBO, leaving iChannel0 transparent for the
+    // and captures an empty FBO, leaving uTexture0 transparent for the
     // whole animation. Re-rendering each frame also lets the shader
     // pick up content that moves during the leg.
     //
@@ -677,7 +677,7 @@ ShaderAttachResult attachShaderToAnchor(QQuickItem* target,
     //
     // Width/Height MUST be non-zero — Qt's QQuickShaderEffectSource
     // skips updatePaintNode (and the FBO render along with it) at 0×0,
-    // leaving iChannel0 unpopulated even with hideSource set.
+    // leaving uTexture0 unpopulated even with hideSource set.
     //
     // Position is parked far off-screen. QQuickShaderEffectSource is
     // itself a renderable item: its updatePaintNode returns a node that

--- a/libs/phosphor-animation/tests/test_animationshadereffect.cpp
+++ b/libs/phosphor-animation/tests/test_animationshadereffect.cpp
@@ -140,6 +140,7 @@ private Q_SLOTS:
         original.bufferFilter = QStringLiteral("linear");
         original.bufferFilters = {QStringLiteral("nearest"), QStringLiteral("linear")};
         original.useDepthBuffer = true;
+        original.useAudio = true;
         original.geometryGridSubdivisions = 40;
 
         const AnimationShaderEffect restored = AnimationShaderEffect::fromJson(original.toJson());

--- a/libs/phosphor-rendering/src/shadernoderhipipeline.cpp
+++ b/libs/phosphor-rendering/src/shadernoderhipipeline.cpp
@@ -481,6 +481,14 @@ bool ShaderNodeRhi::ensurePipeline()
             return false;
         }
     }
+    // The dummy 1x1 transparent texture also backs UNSUPPLIED user-texture
+    // slots 1-3 (appendUserTextureBindings): a shader that references
+    // uTexture<N> without a loaded texture must read the documented
+    // transparent black rather than leave the declared binding without an
+    // SRB entry (strict backends reject the mismatch; lenient ones sample
+    // undefined). Best-effort — a failed create falls back to the previous
+    // omit-the-binding behaviour.
+    ensureDummyChannelResources(rhi);
 
     if (!m_srb) {
         if (multiBufferMode) {
@@ -558,12 +566,23 @@ void ShaderNodeRhi::appendUserTextureBindings(QVector<QRhiShaderResourceBinding>
     }
 
     // Slots 1-3 always come from the QImage path; the source-provider
-    // override is slot-0-only by design.
+    // override is slot-0-only by design. An unsupplied slot binds the dummy
+    // 1x1 transparent texture instead of omitting the binding: the shared
+    // GLSL headers declare uTexture1..3 unconditionally, and a shader that
+    // references one without a loaded texture must read the documented
+    // transparent black — an absent SRB entry for a declared-and-referenced
+    // binding is rejected by strict backends and samples undefined on
+    // lenient ones. Extra SRB entries for bindings a shader never declares
+    // are ignored by QRhi, so the unconditional dummy append is safe.
     for (int t = 1; t < kMaxUserTextures; ++t) {
         if (m_userTextures[t] && m_userTextureSamplers[t]) {
             bindings.append(QRhiShaderResourceBinding::sampledTexture(
                 kUserTextureBaseBinding + t, QRhiShaderResourceBinding::FragmentStage, m_userTextures[t].get(),
                 m_userTextureSamplers[t].get()));
+        } else if (m_dummyChannelTexture && m_dummyChannelSampler) {
+            bindings.append(QRhiShaderResourceBinding::sampledTexture(
+                kUserTextureBaseBinding + t, QRhiShaderResourceBinding::FragmentStage, m_dummyChannelTexture.get(),
+                m_dummyChannelSampler.get()));
         }
     }
 }

--- a/libs/phosphor-rendering/src/shadernoderhipipeline.cpp
+++ b/libs/phosphor-rendering/src/shadernoderhipipeline.cpp
@@ -563,6 +563,16 @@ void ShaderNodeRhi::appendUserTextureBindings(QVector<QRhiShaderResourceBinding>
         bindings.append(
             QRhiShaderResourceBinding::sampledTexture(kUserTextureBaseBinding, QRhiShaderResourceBinding::FragmentStage,
                                                       m_userTextures[0].get(), m_userTextureSamplers[0].get()));
+    } else if (m_dummyChannelTexture && m_dummyChannelSampler) {
+        // Neither a provider nor a QImage at slot 0: bind the dummy 1x1
+        // transparent texture so binding 7 (uTexture0, declared by every
+        // family's shared header and referenced by most packs) always has an
+        // SRB entry — same rationale as the slots 1-3 fallback below. Hosts
+        // normally wire a source before first paint; this covers the gap on
+        // strict backends.
+        bindings.append(
+            QRhiShaderResourceBinding::sampledTexture(kUserTextureBaseBinding, QRhiShaderResourceBinding::FragmentStage,
+                                                      m_dummyChannelTexture.get(), m_dummyChannelSampler.get()));
     }
 
     // Slots 1-3 always come from the QImage path; the source-provider

--- a/libs/phosphor-shaders/src/shaderparampreamble.cpp
+++ b/libs/phosphor-shaders/src/shaderparampreamble.cpp
@@ -14,7 +14,7 @@ namespace {
 
 /// Overlay/zone image params bind to `uTexture0..3`. Animation packs never
 /// use the Image pool (their textures are a separate top-level list bound to
-/// `iChannel1..3`), so this cap only governs the zone path.
+/// `uTexture1..3`), so this cap only governs the zone path.
 constexpr int kMaxImageSlots = 4;
 
 QString imageAccessor(int slot)

--- a/libs/phosphor-surface/include/PhosphorSurface/SurfaceShaderContract.h
+++ b/libs/phosphor-surface/include/PhosphorSurface/SurfaceShaderContract.h
@@ -198,6 +198,29 @@ inline constexpr const char* kUBackdropRect = "uBackdropRect";
 /// gate (e.g. a plain translucent tint) instead of assuming the sampler.
 inline constexpr const char* kUHasBackdrop = "uHasBackdrop";
 
+/// `vec4 iMouse` — cursor position for hover-reactive packs. `.xy` is the
+/// cursor in the SAME top-down device-px space as the geometry uniforms
+/// (origin at the padded canvas's top-left), `(-1, -1)` when the cursor is
+/// outside the canvas (or, on the daemon, when the host wires no hover
+/// source — SurfaceShaderItem seeds the sentinel). `.zw` is `.xy` normalized
+/// by `uSurfaceSize`, negative alongside the sentinel, so `iMouse.x < 0.0`
+/// is the canonical off-surface test on both runtimes. A pack that reads
+/// iMouse should also declare `"animated": true`: the host repaints on its
+/// vsync loop while a pack animates, and there is no per-cursor-move damage
+/// path for static packs.
+inline constexpr const char* kIMouse = "iMouse";
+
+/// `sampler2D uTexture1..3` — user-declared image textures (metadata
+/// `textures`: logo, mask, pattern). Slot N of the metadata list feeds
+/// `uTexture<N+1>` (bindings 8-10 on the daemon; dedicated units on the
+/// compositor), and `iTextureResolution[N].xy` carries the bound texture's
+/// pixel size — the same slot layout as the animation contract, so the
+/// settings UI reuses the same editor components. A slot with no loadable
+/// file reads transparent black.
+inline constexpr const char* kUTexture1 = "uTexture1";
+inline constexpr const char* kUTexture2 = "uTexture2";
+inline constexpr const char* kUTexture3 = "uTexture3";
+
 /// `int iAudioSpectrumSize` — number of CAVA spectrum bars, or 0 when audio
 /// is off. Declared in surface_uniforms.glsl (always present) and read by the
 /// surface_audio.glsl helpers to gate every audio read: a pack that never

--- a/libs/phosphor-surface/include/PhosphorSurface/SurfaceShaderContract.h
+++ b/libs/phosphor-surface/include/PhosphorSurface/SurfaceShaderContract.h
@@ -200,11 +200,13 @@ inline constexpr const char* kUHasBackdrop = "uHasBackdrop";
 
 /// `vec4 iMouse` — cursor position for hover-reactive packs. `.xy` is the
 /// cursor in the SAME top-down device-px space as the geometry uniforms
-/// (origin at the padded canvas's top-left), `(-1, -1)` when the cursor is
-/// outside the canvas (or, on the daemon, when the host wires no hover
-/// source — SurfaceShaderItem seeds the sentinel). `.zw` is `.xy` normalized
+/// (origin at the padded canvas's top-left); negative when the cursor is
+/// off the canvas — exactly `(-1, -1)` on the compositor, and the seeded
+/// `(-1, -1)` sentinel scaled by the dpr on a daemon host that wires no
+/// hover source (SurfaceShaderItem seeds it). `.zw` is `.xy` normalized
 /// by `uSurfaceSize`, negative alongside the sentinel, so `iMouse.x < 0.0`
-/// is the canonical off-surface test on both runtimes. A pack that reads
+/// is the canonical off-surface test on both runtimes; do not test
+/// `iMouse.x == -1.0` exactly. A pack that reads
 /// iMouse should also declare `"animated": true`: the host repaints on its
 /// vsync loop while a pack animates, and there is no per-cursor-move damage
 /// path for static packs.

--- a/libs/phosphor-surface/include/PhosphorSurface/SurfaceShaderUniforms.h
+++ b/libs/phosphor-surface/include/PhosphorSurface/SurfaceShaderUniforms.h
@@ -72,10 +72,22 @@ struct alignas(16) SurfaceUniforms
     // UBO; only the size is a UBO member. A pack reads it via surface_audio.glsl
     // (audioBar / getBass).
     int iAudioSpectrumSize; // int: 4 bytes at offset 560
-    int _pad_after_audioSpectrum[3]; // pad the std140 block to a 16-byte multiple
-}; // total 576 bytes
+    int _pad_after_audioSpectrum[3]; // std140 pads to the 16-byte-aligned vec4 below
 
-static_assert(sizeof(SurfaceUniforms) == 576, "SurfaceUniforms must be exactly 576 bytes (surface UBO contract)");
+    // Cursor position for hover-reactive packs. .xy in the surface texture's
+    // top-down device-px space (negative when off-surface / no hover source),
+    // .zw = .xy normalized by uSurfaceSize. The daemon consumer defaults its
+    // inherited iMouse to (-1, -1) so an un-hovered surface carries the
+    // off-surface sentinel rather than a phantom top-left hover.
+    float iMouse[4]; // vec4: 16 bytes at offset 576
+
+    // User texture sizes: iTextureResolution[i].xy = the pixel size of the
+    // texture bound at slot i (slot N feeds uTexture<N+1>, bindings 8-10 on
+    // the daemon). The node resolves these live, same as the overlay UBO.
+    float iTextureResolution[4][4]; // vec4[4]: 64 bytes at offset 592
+}; // total 656 bytes
+
+static_assert(sizeof(SurfaceUniforms) == 656, "SurfaceUniforms must be exactly 656 bytes (surface UBO contract)");
 
 static_assert(offsetof(SurfaceUniforms, qt_Matrix) == 0, "SurfaceUniforms::qt_Matrix must remain at std140 offset 0");
 static_assert(offsetof(SurfaceUniforms, qt_Opacity) == 64,
@@ -103,5 +115,8 @@ static_assert(offsetof(SurfaceUniforms, iChannelResolution) == 496,
               "SurfaceUniforms::iChannelResolution must remain at std140 offset 496");
 static_assert(offsetof(SurfaceUniforms, iAudioSpectrumSize) == 560,
               "SurfaceUniforms::iAudioSpectrumSize must remain at std140 offset 560");
+static_assert(offsetof(SurfaceUniforms, iMouse) == 576, "SurfaceUniforms::iMouse must remain at std140 offset 576");
+static_assert(offsetof(SurfaceUniforms, iTextureResolution) == 592,
+              "SurfaceUniforms::iTextureResolution must remain at std140 offset 592");
 
 } // namespace PhosphorSurfaceShaders

--- a/libs/phosphor-surface/include/PhosphorSurface/SurfaceUniformProfile.h
+++ b/libs/phosphor-surface/include/PhosphorSurface/SurfaceUniformProfile.h
@@ -11,17 +11,18 @@
 namespace PhosphorSurfaceShaders {
 
 /// IUboProfile implementation for the surface-decoration runtime — the leaner
-/// 576-byte SurfaceUniforms layout.
+/// 656-byte SurfaceUniforms layout.
 ///
 /// Reuses the shared PhosphorRendering::ShaderNodeRhi engine with the surface
-/// UBO. The surface binding map (UBO@0, iChannel0-3@2-5, uTexture0@7) is a
-/// strict subset of the overlay map, so only the UBO concern differs — this
-/// class is that difference.
+/// UBO. The surface binding map (UBO@0, iChannel0-3@2-5, uTexture0@7,
+/// uTexture1-3@8-10) is a strict subset of the overlay map, so only the UBO
+/// concern differs — this class is that difference.
 ///
 /// fill() reads the surface-only fields of UboFrameState (qtOpacity,
 /// surfaceScale, surfaceFocused, time, surfaceSize/FrameTopLeft/FrameSize) plus
-/// the shared customParams/customColors/channelResolution; it ignores the
-/// overlay-only fields BaseUniformProfile uses.
+/// the shared customParams/customColors/channelResolution/mouse/
+/// textureResolution; it ignores the overlay-only fields BaseUniformProfile
+/// uses.
 class PHOSPHORSURFACE_EXPORT SurfaceUniformProfile : public PhosphorShaders::IUboProfile
 {
 public:

--- a/libs/phosphor-surface/src/surfaceuniformprofile.cpp
+++ b/libs/phosphor-surface/src/surfaceuniformprofile.cpp
@@ -92,8 +92,18 @@ void SurfaceUniformProfile::fill(const PhosphorShaders::UboFrameState& state)
     // Cursor position, already in device px (ShaderEffect scales its iMouse
     // property by the dpr before pushing it to the node). SurfaceShaderItem
     // seeds the inherited iMouse to (-1, -1), so a host that wires no hover
-    // source publishes the off-surface sentinel; .zw stays negative alongside
-    // it, matching the kwin branch's convention.
+    // source publishes the off-surface sentinel — which arrives here as
+    // (-dpr, -dpr) after that scale; still strictly negative, so the
+    // canonical `iMouse.x < 0.0` off-surface test holds, and .zw stays
+    // negative alongside it, matching the kwin branch's convention.
+    //
+    // Space assumption: .xy is the item-local position scaled to device px
+    // against the node's RESOLUTION, while surfaceSize is the host-pushed
+    // surface geometry. The two coincide because the decoration item covers
+    // the decorated surface 1:1; a host that wires a HoverHandler on a
+    // differently-sized item would desync .xy (and this .zw normalization)
+    // from the geometry uniforms and must map positions into surface space
+    // itself before pushing iMouse.
     m_u.iMouse[0] = state.mouseX;
     m_u.iMouse[1] = state.mouseY;
     m_u.iMouse[2] = state.surfaceSize[0] > 0.0f ? state.mouseX / state.surfaceSize[0] : 0.0f;

--- a/libs/phosphor-surface/src/surfaceuniformprofile.cpp
+++ b/libs/phosphor-surface/src/surfaceuniformprofile.cpp
@@ -86,8 +86,27 @@ void SurfaceUniformProfile::fill(const PhosphorShaders::UboFrameState& state)
 
     // Audio spectrum bar count (0 when CAVA is off). The node uploads the
     // spectrum texture (binding 6) via setAudioSpectrum; only the size crosses
-    // into the UBO. The trailing pad stays zero from the m_u{} value-init.
+    // into the UBO. The pad stays zero from the m_u{} value-init.
     m_u.iAudioSpectrumSize = state.audioSpectrumSize;
+
+    // Cursor position, already in device px (ShaderEffect scales its iMouse
+    // property by the dpr before pushing it to the node). SurfaceShaderItem
+    // seeds the inherited iMouse to (-1, -1), so a host that wires no hover
+    // source publishes the off-surface sentinel; .zw stays negative alongside
+    // it, matching the kwin branch's convention.
+    m_u.iMouse[0] = state.mouseX;
+    m_u.iMouse[1] = state.mouseY;
+    m_u.iMouse[2] = state.surfaceSize[0] > 0.0f ? state.mouseX / state.surfaceSize[0] : 0.0f;
+    m_u.iMouse[3] = state.surfaceSize[1] > 0.0f ? state.mouseY / state.surfaceSize[1] : 0.0f;
+
+    // User texture sizes (bindings 8-10) — the node resolves these live, same
+    // as the overlay profile.
+    for (std::size_t i = 0; i < std::size(m_u.iTextureResolution); ++i) {
+        m_u.iTextureResolution[i][0] = state.textureResolution[i][0];
+        m_u.iTextureResolution[i][1] = state.textureResolution[i][1];
+        m_u.iTextureResolution[i][2] = 0.0f;
+        m_u.iTextureResolution[i][3] = 0.0f;
+    }
 }
 
 PhosphorShaders::UboUploadRegionList

--- a/libs/phosphor-surface/tests/test_surfaceuniformprofile.cpp
+++ b/libs/phosphor-surface/tests/test_surfaceuniformprofile.cpp
@@ -44,6 +44,12 @@ PhosphorShaders::UboFrameState makeFixedState()
         s.channelResolution[i][1] = static_cast<float>(50 + i);
     }
     s.audioSpectrumSize = 12;
+    s.mouseX = 320.0f;
+    s.mouseY = 240.0f;
+    for (int i = 0; i < 4; ++i) {
+        s.textureResolution[i][0] = static_cast<float>(64 + i);
+        s.textureResolution[i][1] = static_cast<float>(32 + i);
+    }
     return s;
 }
 
@@ -85,6 +91,19 @@ SurfaceUniforms makeReference(const PhosphorShaders::UboFrameState& s)
         u.iChannelResolution[i][3] = 0.0f;
     }
     u.iAudioSpectrumSize = s.audioSpectrumSize;
+    // Cursor (device px) with .zw normalized by the surface size — mirrors
+    // fill()'s convention (negative passthrough carries the off-surface
+    // sentinel; the fixed state uses an in-surface position).
+    u.iMouse[0] = s.mouseX;
+    u.iMouse[1] = s.mouseY;
+    u.iMouse[2] = s.surfaceSize[0] > 0.0f ? s.mouseX / s.surfaceSize[0] : 0.0f;
+    u.iMouse[3] = s.surfaceSize[1] > 0.0f ? s.mouseY / s.surfaceSize[1] : 0.0f;
+    for (int i = 0; i < 4; ++i) {
+        u.iTextureResolution[i][0] = s.textureResolution[i][0];
+        u.iTextureResolution[i][1] = s.textureResolution[i][1];
+        u.iTextureResolution[i][2] = 0.0f;
+        u.iTextureResolution[i][3] = 0.0f;
+    }
     return u;
 }
 
@@ -95,11 +114,11 @@ class TestSurfaceUniformProfile : public QObject
     Q_OBJECT
 
 private Q_SLOTS:
-    void baseSize_is_576()
+    void baseSize_is_656()
     {
         SurfaceUniformProfile profile;
         QCOMPARE(profile.baseSize(), static_cast<int>(sizeof(SurfaceUniforms)));
-        QCOMPARE(profile.baseSize(), 576);
+        QCOMPARE(profile.baseSize(), 656);
     }
 
     void golden_bytes_match_reference()
@@ -150,7 +169,7 @@ private Q_SLOTS:
         // No flags → no regions.
         QVERIFY(profile.dirtyRegions(PhosphorShaders::UboDirtyFlags{}).empty());
 
-        // Any flag → matrix {0,64} + scene {64, 576-64}.
+        // Any flag → matrix {0,64} + scene {64, 656-64}.
         auto r = profile.dirtyRegions(PhosphorShaders::UboDirtyFlags{false, false, true, false});
         QCOMPARE(static_cast<int>(r.size()), 2);
         QCOMPARE(r[0].offset, 0);

--- a/src/daemon/rendering/surfaceshaderitem.cpp
+++ b/src/daemon/rendering/surfaceshaderitem.cpp
@@ -88,7 +88,7 @@ SurfaceShaderItem::~SurfaceShaderItem()
 PhosphorRendering::ShaderNodeRhi* SurfaceShaderItem::createShaderNode()
 {
     // The surface UBO profile is the ONLY thing that differs from the base/
-    // overlay render path — a stock ShaderNodeRhi driven by the 576-byte
+    // overlay render path — a stock ShaderNodeRhi driven by the 656-byte
     // SurfaceUniformProfile rather than a SurfaceShaderItem-specific subclass.
     return new PhosphorRendering::ShaderNodeRhi(this,
                                                 std::make_unique<PhosphorSurfaceShaders::SurfaceUniformProfile>());

--- a/src/daemon/rendering/surfaceshaderitem.cpp
+++ b/src/daemon/rendering/surfaceshaderitem.cpp
@@ -63,6 +63,13 @@ SurfaceShaderItem::SurfaceShaderItem(QQuickItem* parent)
     // ShaderEffect's setAudioSpectrum / setAudioSpectrumVariant already call
     // update() on a value change, and update() schedules this item's
     // updatePaintNode whether or not the override is present.
+
+    // Seed the inherited iMouse to the off-surface sentinel. The surface UBO
+    // publishes iMouse (hover-reactive packs), and a host that wires no hover
+    // source must read as "cursor off the surface", not as a phantom hover at
+    // the base's (0, 0) default. A host that does wire a HoverHandler simply
+    // overwrites this.
+    setIMouse(QPointF(-1.0, -1.0));
 }
 
 SurfaceShaderItem::~SurfaceShaderItem()

--- a/src/daemon/rendering/surfaceshaderitem.h
+++ b/src/daemon/rendering/surfaceshaderitem.h
@@ -34,7 +34,7 @@ namespace PlasmaZones {
  * consumer escape-hatch int slots. The ONLY thing that differs from the base
  * render path is the UBO: the node is created with a
  * PhosphorSurfaceShaders::SurfaceUniformProfile so it uploads the leaner
- * 576-byte surface UBO instead of the overlay UBO. createShaderNode() supplies
+ * 656-byte surface UBO instead of the overlay UBO. createShaderNode() supplies
  * that profile to a stock PhosphorRendering::ShaderNodeRhi — there is no
  * SurfaceShaderItem-specific node subclass.
  *
@@ -130,7 +130,7 @@ protected:
      *
      * Returns a stock PhosphorRendering::ShaderNodeRhi constructed with a
      * PhosphorSurfaceShaders::SurfaceUniformProfile, so the shared render engine
-     * uploads the 576-byte surface UBO. No node subclass — the profile is the
+     * uploads the 656-byte surface UBO. No node subclass — the profile is the
      * only difference from the base/overlay path.
      */
     PhosphorRendering::ShaderNodeRhi* createShaderNode() override;


### PR DESCRIPTION
## Summary

Implements the gaps found in the shader-contract audit, one commit per contract family.

**Desktop-switch direction (`iSwitchDelta`)** — the runtime now tells desktop transitions which way the switch went. `DesktopTransitionManager::begin()` computes the pager-grid delta (wrap-corrected to the shortest path) and uploads it as `vec4 iSwitchDelta` (.xy = cells, .zw = unit direction). `desktop_transition.glsl` gains a `switchDirection(fallback)` helper, and the slide/slidefade/wipe packs gain a `followSwitch` parameter (default on) with the configured `dirX`/`dirY` kept as fallback and manual override. Switching left now slides left.

**Audio on the compositor animation path** — new opt-in `data/animations/shared/audio.glsl` module (dual-runtime, binding 6 on the daemon, loose uniforms on KWin) plus an `audio` metadata flag on animation packs. `paintWindow` reuses the existing surface-decoration CAVA texture, and a new `hasAudioReactiveAnimation()` gate keeps cava warm whenever an audio pack is assigned in the profile tree or routed by a rule, so a transition's first frame already has a spectrum. The daemon path already worked and is unchanged.

**Surface `iMouse` + user textures** — the surface UBO grows from 576 to 656 bytes (`iMouse` at 576, `iTextureResolution[4]` at 592) with the C++ mirror, asserts, profile fill, and golden-byte test moved in lockstep. Hover-reactive decorations are now possible: `iMouse.xy` is the cursor in the geometry uniforms' top-down device-px space with a `(-1, -1)` off-canvas sentinel (seeded on the daemon so hover-less hosts read off-surface). The already-parsed `textures` metadata now actually loads and binds: bindings 8-10 on the daemon, units 7-9 in the compositor fold.

**Contract doc drift** — `AnimationShaderContract.h` fixes folded into the audio commit: user textures are `uTexture0-3` not `iChannel0-3`, `iTextureResolution` is populated on both runtimes, `iFromRect`/`iToRect` are per-pack kwin-guarded declarations, and `uOldWindow`'s sampler lives in `old_content.glsl`.

## Behavior change

The three directional desktop packs (slide, slidefade, wipe) now follow the actual switch direction by default: the new `followSwitch` parameter ships enabled, which demotes an existing user-configured `dirX`/`dirY` to a fallback. Users who want their fixed configured direction back can turn the toggle off in the pack's parameters.

## Test plan

- Full suite passes: 262/262 (`ctest`), including `shader_validate_*` and `test_animation_shader_bake` which qsb-compile every pack against the edited shared includes (daemon branch).
- The KWin-only GLSL branches (unreachable by the bake test) were assembled and validated with `glslangValidator`: the three modified desktop packs, the new audio module on both branches, and the surface contract on both branches exercising `iMouse` + `uTexture1` + `iTextureResolution`.
- `test_surfaceuniformprofile` golden-byte reference extended to cover the new UBO fields, size pin updated to 656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
