### PR TITLE
fix(settings): keep filter menus open across checkbox toggles

### DIFF
--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -364,6 +364,7 @@ qt_add_qml_module(plasmazones-settings
         qml/ShaderBrowserPage.qml
         qml/ShaderBrowserCard.qml
         qml/FilterMenuButton.qml
+        qml/StayOpenMenuItem.qml
         qml/ShaderBrowserDetailDialog.qml
         qml/CurveEditorDialog.qml
         qml/CurvePresets.qml

--- a/src/settings/CMakeLists.txt
+++ b/src/settings/CMakeLists.txt
@@ -364,6 +364,9 @@ qt_add_qml_module(plasmazones-settings
         qml/ShaderBrowserPage.qml
         qml/ShaderBrowserCard.qml
         qml/FilterMenuButton.qml
+        # Stay-open checkable menu item shared by every filter menu
+        # (Layouts via LayoutFilterBar, Rules + shader browser via
+        # FilterMenuButton).
         qml/StayOpenMenuItem.qml
         qml/ShaderBrowserDetailDialog.qml
         qml/CurveEditorDialog.qml

--- a/src/settings/qml/FilterMenuButton.qml
+++ b/src/settings/qml/FilterMenuButton.qml
@@ -18,7 +18,8 @@ import org.kde.kirigami as Kirigami
  * `excluded` holds the keys the user has unchecked (empty = everything shown),
  * so options default to checked and a newly-appearing option shows up checked
  * rather than silently hidden. The button reflects an active state while any
- * option is unchecked.
+ * option is unchecked. Toggling an option keeps the menu open
+ * (StayOpenMenuItem); it closes on Escape, click-outside, or Reset.
  *
  * Every row (item, separator, reset) flows through one Repeater + a
  * DelegateChooser so the menu order is purely model-driven — mixing a Repeater
@@ -120,17 +121,17 @@ ToolButton {
             delegate: DelegateChooser {
                 role: "type"
 
-                // Checkable filter item. `checked` is held by a Binding so it
+                // Checkable filter item that keeps the menu open on toggle
+                // (StayOpenMenuItem). `checked` is held by a Binding so it
                 // survives the imperative toggle (checkable otherwise breaks the
                 // declarative binding on user click — same idiom as
                 // LayoutFilterBar.FilterMenuItem).
                 DelegateChoice {
                     roleValue: "item"
 
-                    MenuItem {
+                    StayOpenMenuItem {
                         required property var modelData
 
-                        checkable: true
                         text: (modelData.count !== undefined) ? i18nc("@option:check filter item with item count", "%1 (%2)", modelData.label, modelData.count) : modelData.label
                         Accessible.name: modelData.label
                         onToggled: root._setIncluded(modelData.key, checked)

--- a/src/settings/qml/LayoutFilterBar.qml
+++ b/src/settings/qml/LayoutFilterBar.qml
@@ -475,13 +475,13 @@ RowLayout {
         category: "LayoutsPageFilterBar"
     }
 
-    // Checkable menu item that writes back to a named root filter property.
-    // Uses an explicit Binding so the checked state survives imperative
-    // toggles (checkable breaks declarative bindings on user click).
-    component FilterMenuItem: MenuItem {
+    // Checkable menu item that writes back to a named root filter property
+    // and keeps the menu open on toggle (StayOpenMenuItem). Uses an explicit
+    // Binding so the checked state survives imperative toggles (checkable
+    // breaks declarative bindings on user click).
+    component FilterMenuItem: StayOpenMenuItem {
         required property string filterProperty
 
-        checkable: true
         onToggled: {
             if (root._resetting)
                 return;

--- a/src/settings/qml/StayOpenMenuItem.qml
+++ b/src/settings/qml/StayOpenMenuItem.qml
@@ -27,9 +27,10 @@ MenuItem {
         return key === Qt.Key_Space || key === Qt.Key_Return || key === Qt.Key_Enter || key === Qt.Key_Select;
     }
     // Programmatic setChecked() does not emit toggled(), so emit it manually —
-    // exactly once — after flipping.
+    // exactly once — after flipping. The checkable guard keeps a consumer
+    // that overrides `checkable: false` from getting phantom toggles.
     function _toggleWithoutDismiss() {
-        if (!enabled)
+        if (!enabled || !checkable)
             return;
         checked = !checked;
         toggled();

--- a/src/settings/qml/StayOpenMenuItem.qml
+++ b/src/settings/qml/StayOpenMenuItem.qml
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import QtQuick
+import QtQuick.Controls
+
+/**
+ * @brief Checkable MenuItem that keeps its Menu open when toggled.
+ *
+ * A stock MenuItem emits triggered() on activation and Menu dismisses on any
+ * item trigger, with no opt-out in QtQuick Controls (as of Qt 6.11). Filter
+ * menus made of multi-select checkboxes need to survive a toggle, so this
+ * item intercepts both activation paths — the mouse click via an overlay
+ * MouseArea, the keyboard via Keys — before they reach the AbstractButton
+ * internals, flips `checked` itself, and emits toggled(). Consumers keep the
+ * stock `onToggled` contract; the menu only closes on Escape, click-outside,
+ * or an explicit close.
+ */
+MenuItem {
+    id: root
+
+    checkable: true
+
+    function _isActivationKey(key) {
+        // Space is AbstractButton's press key; Return/Enter activate menu
+        // items; Select is the activation key on some platform themes.
+        return key === Qt.Key_Space || key === Qt.Key_Return || key === Qt.Key_Enter || key === Qt.Key_Select;
+    }
+    // Programmatic setChecked() does not emit toggled(), so emit it manually —
+    // exactly once — after flipping.
+    function _toggleWithoutDismiss() {
+        if (!enabled)
+            return;
+        checked = !checked;
+        toggled();
+    }
+
+    // Swallow the activation keys on press AND release so AbstractButton's
+    // internal trigger (which emits triggered() → menu dismiss) never runs.
+    // The highlighted item holds active focus inside the Menu, so these
+    // handlers see the keys first.
+    Keys.onPressed: event => {
+        if (_isActivationKey(event.key)) {
+            if (!event.isAutoRepeat)
+                _toggleWithoutDismiss();
+            event.accepted = true;
+        }
+    }
+    Keys.onReleased: event => {
+        if (_isActivationKey(event.key))
+            event.accepted = true;
+    }
+
+    // Sits on top of the item and consumes the click before the MenuItem sees
+    // it. Hover is untouched (hoverEnabled off), so the menu's highlight-
+    // follows-mouse behavior is unaffected.
+    MouseArea {
+        anchors.fill: parent
+        onClicked: root._toggleWithoutDismiss()
+    }
+}


### PR DESCRIPTION
## Summary
The filter buttons on the Layouts, Rules, and shader browser pages popped a menu of multi-select checkboxes that closed on the first select/unselect. QtQuick Controls `Menu` dismisses whenever a `MenuItem` emits `triggered()`, and there is no opt-out property even in Qt 6.11.

## Fix
- New shared `StayOpenMenuItem.qml`: a checkable `MenuItem` that intercepts both activation paths before the `AbstractButton` internals run. An overlay `MouseArea` consumes the click, and `Keys` handlers swallow Space/Return/Enter/Select on press and release. It then flips `checked` itself and emits `toggled()` manually, so `triggered()` never fires and the menu stays open until Escape, click-outside, or an explicit close.
- `FilterMenuButton`'s item delegate (Rules + shader browser pages) and `LayoutFilterBar`'s inline `FilterMenuItem` (Layouts page) now derive from it. The existing `Binding on checked` idiom and `onToggled` contracts are unchanged.
- Hover highlighting still tracks the mouse (the overlay does not take hover events), and the "Reset Filters" action keeps stock close-on-trigger behavior.

## Testing
- Full build with `BUILD_TESTING=ON` links clean; qmlcachegen accepts the new file.
- `ctest`: 100% of 262 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)