### PR TITLE
feat(settings): add orientation banner to animation override pages

### DIFF
--- a/src/settings/qml/AnimationEventCardList.qml
+++ b/src/settings/qml/AnimationEventCardList.qml
@@ -26,6 +26,7 @@ import "SearchAnchorHelpers.js" as SearchAnchors
  *
  *   AnimationEventCardList {
  *       Accessible.name: i18n("Window animation events")
+ *       headerText: i18n("…optional orientation banner…")
  *       eventModel: [ { eventPath, eventLabel, isParentNode }, ... ]
  *   }
  */
@@ -35,6 +36,10 @@ SettingsFlickable {
     /// Ordered list of `{ eventPath: string, eventLabel: string,
     /// isParentNode: bool }` — one AnimationEventCard per entry, in order.
     property var eventModel: []
+    /// Optional orientation banner rendered above the cards. Empty = none.
+    /// Pages with an "All" cascade parent use it for a short inheritance
+    /// explainer, mirroring the decoration surface pages.
+    property string headerText: ""
 
     // Build-ahead margin above/below the visible viewport so a card is
     // built slightly before it scrolls into view — keeps a fast flick from
@@ -54,6 +59,18 @@ SettingsFlickable {
 
         width: page.width
         spacing: Kirigami.Units.smallSpacing
+
+        // Optional page-level orientation banner, mirroring the decoration
+        // surface pages. Pages with an "All" cascade parent set `headerText`
+        // to a short inheritance explainer; pages without one leave it empty
+        // and rely on the per-card banners alone.
+        Kirigami.InlineMessage {
+            Layout.fillWidth: true
+            Layout.bottomMargin: Kirigami.Units.smallSpacing
+            type: Kirigami.MessageType.Information
+            visible: page.headerText.length > 0
+            text: page.headerText
+        }
 
         Repeater {
             model: page.eventModel

--- a/src/settings/qml/AnimationsEditorPage.qml
+++ b/src/settings/qml/AnimationsEditorPage.qml
@@ -10,6 +10,7 @@ import QtQuick
 // Card list is viewport-virtualized by AnimationEventCardList.
 AnimationEventCardList {
     Accessible.name: i18n("Layout editor animation events")
+    headerText: i18n("Animations inside the layout editor. \"All Editor Events\" is the default. Each event can override it.")
     eventModel: [
         {
             "eventPath": "editor",

--- a/src/settings/qml/AnimationsOsdsPage.qml
+++ b/src/settings/qml/AnimationsOsdsPage.qml
@@ -13,6 +13,7 @@ import QtQuick
 // Card list is viewport-virtualized by AnimationEventCardList.
 AnimationEventCardList {
     Accessible.name: i18n("OSD animation events")
+    headerText: i18n("Animations for on-screen displays. \"All OSDs\" is the default. Each event can override it.")
     eventModel: [
         {
             "eventPath": "osd",

--- a/src/settings/qml/AnimationsOverlaysPage.qml
+++ b/src/settings/qml/AnimationsOverlaysPage.qml
@@ -10,6 +10,7 @@ import QtQuick
 // Card list is viewport-virtualized by AnimationEventCardList.
 AnimationEventCardList {
     Accessible.name: i18n("Overlay animation events")
+    headerText: i18n("Animations for overlays like the zone selector and snap assist. \"All Overlays\" is the default. Each event can override it.")
     eventModel: [
         {
             "eventPath": "popup",

--- a/src/settings/qml/AnimationsSidePanelsPage.qml
+++ b/src/settings/qml/AnimationsSidePanelsPage.qml
@@ -13,6 +13,7 @@ import QtQuick
 // Card list is viewport-virtualized by AnimationEventCardList.
 AnimationEventCardList {
     Accessible.name: i18n("Side panel animation events")
+    headerText: i18n("Animations for side panels that slide in from an edge. \"All Side Panels\" is the default. Each event can override it.")
     eventModel: [
         {
             "eventPath": "panel",

--- a/src/settings/qml/AnimationsWidgetsPage.qml
+++ b/src/settings/qml/AnimationsWidgetsPage.qml
@@ -6,6 +6,7 @@ import QtQuick
 // (only visible AnimationEventCards build) — see that component.
 AnimationEventCardList {
     Accessible.name: i18n("Widget animation events")
+    headerText: i18n("Animations for widget interactions. \"All Widget Events\" is the default. Each event can override it.")
     eventModel: [
         {
             "eventPath": "widget",

--- a/src/settings/qml/AnimationsWindowMotionPage.qml
+++ b/src/settings/qml/AnimationsWindowMotionPage.qml
@@ -16,7 +16,7 @@ import QtQuick
 // Card list is viewport-virtualized by AnimationEventCardList.
 AnimationEventCardList {
     Accessible.name: i18n("Window movement animation events")
-    headerText: i18n("Animations for windows as they move, resize, and snap. \"All Windows\" is the default. Each event can override it.")
+    headerText: i18n("Animations for windows moving and snapping. \"All Windows\" is the default. Each event can override it.")
     eventModel: [
         {
             "eventPath": "window.movement",

--- a/src/settings/qml/AnimationsWindowMotionPage.qml
+++ b/src/settings/qml/AnimationsWindowMotionPage.qml
@@ -16,6 +16,7 @@ import QtQuick
 // Card list is viewport-virtualized by AnimationEventCardList.
 AnimationEventCardList {
     Accessible.name: i18n("Window movement animation events")
+    headerText: i18n("Animations for windows as they move, resize, and snap. \"All Windows\" is the default. Each event can override it.")
     eventModel: [
         {
             "eventPath": "window.movement",

--- a/src/settings/qml/AnimationsWindowsPage.qml
+++ b/src/settings/qml/AnimationsWindowsPage.qml
@@ -14,6 +14,7 @@ import QtQuick
 // Card list is viewport-virtualized by AnimationEventCardList.
 AnimationEventCardList {
     Accessible.name: i18n("Window appearance animation events")
+    headerText: i18n("Animations for windows opening, closing, and focusing. \"All Windows\" is the default. Each event can override it.")
     eventModel: [
         {
             "eventPath": "window.appearance",

--- a/src/settings/qml/AnimationsWindowsPage.qml
+++ b/src/settings/qml/AnimationsWindowsPage.qml
@@ -14,7 +14,7 @@ import QtQuick
 // Card list is viewport-virtualized by AnimationEventCardList.
 AnimationEventCardList {
     Accessible.name: i18n("Window appearance animation events")
-    headerText: i18n("Animations for windows opening, closing, and focusing. \"All Windows\" is the default. Each event can override it.")
+    headerText: i18n("Animations for windows opening and closing. \"All Windows\" is the default. Each event can override it.")
     eventModel: [
         {
             "eventPath": "window.appearance",


### PR DESCRIPTION
## Summary

The per-category animation override pages (Windows, OSDs, Overlays, etc.) were missing the page-level orientation banner that the decoration shader pages already have.

The decoration override pages render an inheritance-model explainer through `DecorationSurfaceCardList`'s optional `headerText` → `Kirigami.InlineMessage` slot. The animation-side mirror, `AnimationEventCardList`, never had that slot, so every animation page with an "All" cascade parent showed no banner.

## Changes

- **`AnimationEventCardList.qml`** — add the optional `headerText` property and an `InlineMessage` banner above the card list, mirroring `DecorationSurfaceCardList`. Empty by default, so pages without an "All" parent are unchanged.
- Set `headerText` on the seven pages with an "All" cascade parent, each with a short inheritance explainer matching the decoration copy's tone: **Windows**, **Window Motion**, **OSDs**, **Overlays**, **Side Panels**, **Widgets**, **Editor**.
- **Desktops** is left alone — `desktop.switch` is a lone leaf with no "All" parent.

## Testing

- All eight changed QML files parse cleanly under `qmllint`/`qmlformat` and are format-clean (no pre-commit churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)