### PR TITLE
fix(editor): commit fixed-zone resizes in pixels and re-sync the panel on selection change

### DIFF
--- a/src/editor/qml/PropertyPanel.qml
+++ b/src/editor/qml/PropertyPanel.qml
@@ -501,10 +501,14 @@ Rectangle {
                     }
                 }
 
-                // Sync spinbox values when zone data changes (undo/redo, external updates)
+                // Sync geometry controls when zone data changes (undo/redo, external
+                // updates). Includes the mode checkbox: its `checked` binding dies on
+                // the first manual toggle, so an undone/redone mode toggle must be
+                // reflected imperatively. Not gated on fixedGeometryCheck.checked for
+                // the same reason.
                 Connections {
                     function onZonesChanged() {
-                        if (!selectedZone || !fixedGeometryCheck.checked)
+                        if (!selectedZone)
                             return;
 
                         // Use Qt.callLater to avoid binding loops
@@ -512,6 +516,7 @@ Rectangle {
                             if (!selectedZone)
                                 return;
 
+                            fixedGeometryCheck.checked = selectedZone.geometryMode === 1;
                             fixedXSpin.value = selectedZone.fixedX !== undefined ? selectedZone.fixedX : 0;
                             fixedYSpin.value = selectedZone.fixedY !== undefined ? selectedZone.fixedY : 0;
                             fixedWidthSpin.value = selectedZone.fixedWidth !== undefined ? selectedZone.fixedWidth : 50;
@@ -520,7 +525,7 @@ Rectangle {
                     }
 
                     target: editorController
-                    enabled: panelMode === "single" && fixedGeometryCheck.checked && editorController !== null
+                    enabled: panelMode === "single" && editorController !== null
                 }
 
                 // ═══════════════════════════════════════════════════════════════
@@ -774,11 +779,23 @@ Rectangle {
                 // Handle validation errors and selection changes
                 Connections {
                     function onSelectedZoneIdChanged() {
+                        // Re-sync every editable control imperatively: their
+                        // declarative bindings die on the first user edit (QQC2)
+                        // or imperative sync, after which a selection change
+                        // would keep showing the previous zone's values and any
+                        // edit would stamp those stale values onto the new zone.
+                        if (selectedZone) {
+                            zoneNameField.text = selectedZone.name || "";
+                            zoneNumberSpinBox.value = selectedZone.zoneNumber || 1;
+                            fixedGeometryCheck.checked = selectedZone.geometryMode === 1;
+                            fixedXSpin.value = selectedZone.fixedX !== undefined ? selectedZone.fixedX : 0;
+                            fixedYSpin.value = selectedZone.fixedY !== undefined ? selectedZone.fixedY : 0;
+                            fixedWidthSpin.value = selectedZone.fixedWidth !== undefined ? selectedZone.fixedWidth : 50;
+                            fixedHeightSpin.value = selectedZone.fixedHeight !== undefined ? selectedZone.fixedHeight : 50;
+                        }
                         zoneNameField.updateTimer.stop();
                         zoneNameField.validationError = "";
                         zoneNumberSpinBox.validationError = "";
-                        if (selectedZone)
-                            zoneNumberSpinBox.value = selectedZone.zoneNumber || 1;
                     }
 
                     function onZoneNameValidationError(zoneId, error) {

--- a/src/editor/qml/PropertyPanel.qml
+++ b/src/editor/qml/PropertyPanel.qml
@@ -61,6 +61,20 @@ Rectangle {
         return ColorUtils.extractZoneColor(selectedZone, propertyName, Qt.transparent);
     }
 
+    // Imperative sync for the geometry controls. Their declarative bindings
+    // die on the first user edit (QQC2) or imperative write, so both the
+    // selection-change and zonesChanged paths re-apply the model state here.
+    function syncGeometryControls() {
+        if (!selectedZone)
+            return;
+
+        fixedGeometryCheck.checked = selectedZone.geometryMode === 1;
+        fixedXSpin.value = selectedZone.fixedX !== undefined ? selectedZone.fixedX : 0;
+        fixedYSpin.value = selectedZone.fixedY !== undefined ? selectedZone.fixedY : 0;
+        fixedWidthSpin.value = selectedZone.fixedWidth !== undefined ? selectedZone.fixedWidth : 50;
+        fixedHeightSpin.value = selectedZone.fixedHeight !== undefined ? selectedZone.fixedHeight : 50;
+    }
+
     // Layout properties
     Layout.preferredWidth: visible ? 280 : 0
     Layout.maximumWidth: visible ? 280 : 0
@@ -508,20 +522,9 @@ Rectangle {
                 // the same reason.
                 Connections {
                     function onZonesChanged() {
-                        if (!selectedZone)
-                            return;
-
-                        // Use Qt.callLater to avoid binding loops
-                        Qt.callLater(function () {
-                            if (!selectedZone)
-                                return;
-
-                            fixedGeometryCheck.checked = selectedZone.geometryMode === 1;
-                            fixedXSpin.value = selectedZone.fixedX !== undefined ? selectedZone.fixedX : 0;
-                            fixedYSpin.value = selectedZone.fixedY !== undefined ? selectedZone.fixedY : 0;
-                            fixedWidthSpin.value = selectedZone.fixedWidth !== undefined ? selectedZone.fixedWidth : 50;
-                            fixedHeightSpin.value = selectedZone.fixedHeight !== undefined ? selectedZone.fixedHeight : 50;
-                        });
+                        // Qt.callLater avoids binding loops, and the stable function
+                        // reference lets it coalesce bursts of zonesChanged into one sync.
+                        Qt.callLater(propertyPanel.syncGeometryControls);
                     }
 
                     target: editorController
@@ -787,12 +790,8 @@ Rectangle {
                         if (selectedZone) {
                             zoneNameField.text = selectedZone.name || "";
                             zoneNumberSpinBox.value = selectedZone.zoneNumber || 1;
-                            fixedGeometryCheck.checked = selectedZone.geometryMode === 1;
-                            fixedXSpin.value = selectedZone.fixedX !== undefined ? selectedZone.fixedX : 0;
-                            fixedYSpin.value = selectedZone.fixedY !== undefined ? selectedZone.fixedY : 0;
-                            fixedWidthSpin.value = selectedZone.fixedWidth !== undefined ? selectedZone.fixedWidth : 50;
-                            fixedHeightSpin.value = selectedZone.fixedHeight !== undefined ? selectedZone.fixedHeight : 50;
                         }
+                        propertyPanel.syncGeometryControls();
                         zoneNameField.updateTimer.stop();
                         zoneNameField.validationError = "";
                         zoneNumberSpinBox.validationError = "";

--- a/src/editor/qml/ResizeHandles.qml
+++ b/src/editor/qml/ResizeHandles.qml
@@ -60,47 +60,56 @@ Item {
 
     // Handle positions: nw, n, ne, e, se, s, sw, w
     Repeater {
-        model: [{
-            "id": "nw",
-            "ax": 0,
-            "ay": 0,
-            "cursor": Qt.SizeFDiagCursor
-        }, {
-            "id": "n",
-            "ax": 0.5,
-            "ay": 0,
-            "cursor": Qt.SizeVerCursor
-        }, {
-            "id": "ne",
-            "ax": 1,
-            "ay": 0,
-            "cursor": Qt.SizeBDiagCursor
-        }, {
-            "id": "e",
-            "ax": 1,
-            "ay": 0.5,
-            "cursor": Qt.SizeHorCursor
-        }, {
-            "id": "se",
-            "ax": 1,
-            "ay": 1,
-            "cursor": Qt.SizeFDiagCursor
-        }, {
-            "id": "s",
-            "ax": 0.5,
-            "ay": 1,
-            "cursor": Qt.SizeVerCursor
-        }, {
-            "id": "sw",
-            "ax": 0,
-            "ay": 1,
-            "cursor": Qt.SizeBDiagCursor
-        }, {
-            "id": "w",
-            "ax": 0,
-            "ay": 0.5,
-            "cursor": Qt.SizeHorCursor
-        }]
+        model: [
+            {
+                "id": "nw",
+                "ax": 0,
+                "ay": 0,
+                "cursor": Qt.SizeFDiagCursor
+            },
+            {
+                "id": "n",
+                "ax": 0.5,
+                "ay": 0,
+                "cursor": Qt.SizeVerCursor
+            },
+            {
+                "id": "ne",
+                "ax": 1,
+                "ay": 0,
+                "cursor": Qt.SizeBDiagCursor
+            },
+            {
+                "id": "e",
+                "ax": 1,
+                "ay": 0.5,
+                "cursor": Qt.SizeHorCursor
+            },
+            {
+                "id": "se",
+                "ax": 1,
+                "ay": 1,
+                "cursor": Qt.SizeFDiagCursor
+            },
+            {
+                "id": "s",
+                "ax": 0.5,
+                "ay": 1,
+                "cursor": Qt.SizeVerCursor
+            },
+            {
+                "id": "sw",
+                "ax": 0,
+                "ay": 1,
+                "cursor": Qt.SizeBDiagCursor
+            },
+            {
+                "id": "w",
+                "ax": 0,
+                "ay": 0.5,
+                "cursor": Qt.SizeHorCursor
+            }
+        ]
 
         Rectangle {
             id: handle
@@ -258,20 +267,19 @@ Item {
                     // Clear hover state when starting resize to avoid conflicts
                     if (pressed)
                         resizeHandles.root.anyHandleHovered = true;
-
                 }
-                onPressed: function(mouse) {
+                onPressed: function (mouse) {
                     var actualCanvasW = resizeHandles.actualCanvasWidth;
                     var actualCanvasH = resizeHandles.actualCanvasHeight;
                     // Validate dimensions before proceeding
                     if (!resizeHandles.root || !isFinite(actualCanvasW) || !isFinite(actualCanvasH) || actualCanvasW <= 0 || actualCanvasH <= 0) {
                         mouse.accepted = false;
-                        return ;
+                        return;
                     }
                     // Check if handle is visible and positioned correctly
                     if (!handle.visible || handle.x < -1000 || handle.y < -1000) {
                         mouse.accepted = false;
-                        return ;
+                        return;
                     }
                     mouse.accepted = true;
                     // State values: 0=Idle, 1=Dragging, 2=Resizing
@@ -296,7 +304,7 @@ Item {
                         var canvasItem = resizeHandles.root.parent;
                         if (!canvasItem) {
                             resizeHandles.root.operationState = 0;
-                            return ;
+                            return;
                         }
                         var mouseInCanvas = handleMouse.mapToItem(canvasItem, mouse.x, mouse.y);
                         startMouseCanvasX = isFinite(mouseInCanvas.x) ? mouseInCanvas.x : 0;
@@ -305,11 +313,11 @@ Item {
                         resizeHandles.root.operationStarted(resizeHandles.root.zoneId, startZoneX, startZoneY, startZoneW, startZoneH);
                     }
                 }
-                onPositionChanged: function(mouse) {
+                onPositionChanged: function (mouse) {
                     // South handles move bottom edge
                     // State 2 = Resizing
                     if (!pressed || resizeHandles.root.operationState !== 2)
-                        return ;
+                        return;
 
                     handleMouse.lastModifiers = mouse.modifiers;
                     var actualW = resizeHandles.actualCanvasWidth;
@@ -321,13 +329,13 @@ Item {
                     }
                     // Validate dimensions before proceeding
                     if (!isFinite(actualW) || !isFinite(actualH) || actualW <= 0 || actualH <= 0)
-                        return ;
+                        return;
 
                     mouse.accepted = true;
                     // Map current mouse position to canvas coordinates
                     var canvasItem = resizeHandles.root.parent;
                     if (!canvasItem)
-                        return ;
+                        return;
 
                     var currentMouseInCanvas = handleMouse.mapToItem(canvasItem, mouse.x, mouse.y);
                     // Calculate delta from initial mouse position (both in canvas coordinates)
@@ -419,13 +427,11 @@ Item {
                         newW = resizeHandles.minSize;
                         if (isWest && newX + newW > actualW)
                             newX = actualW - resizeHandles.minSize;
-
                     }
                     if (newH < resizeHandles.minSize) {
                         newH = resizeHandles.minSize;
                         if (isNorth && newY + newH > actualH)
                             newY = actualH - resizeHandles.minSize;
-
                     }
                     // Apply snapping after clamping
                     // Only snap the edges being moved by this handle
@@ -554,13 +560,11 @@ Item {
                                 newW = resizeHandles.minSize;
                                 if (newX + newW > actualW)
                                     newX = actualW - resizeHandles.minSize;
-
                             }
                             if (newH < resizeHandles.minSize) {
                                 newH = resizeHandles.minSize;
                                 if (newY + newH > actualH)
                                     newY = actualH - resizeHandles.minSize;
-
                             }
                         }
                     }
@@ -590,7 +594,7 @@ Item {
                     // Store references early to avoid scope issues
                     var rootItem = resizeHandles.root;
                     if (!rootItem || rootItem.operationState !== 2)
-                        return ;
+                        return;
 
                     // Clear snap lines before committing
                     if (resizeHandles.snapIndicator)
@@ -602,13 +606,17 @@ Item {
                     if (actualW <= 0 || actualH <= 0) {
                         rootItem.operationState = 0;
                         rootItem.operationEnded(rootItem.zoneId);
-                        return ;
+                        return;
                     }
-                    // Convert to relative coordinates for C++ update
-                    var relX = (actualW > 0 && isFinite(rootItem.visualX)) ? rootItem.visualX / actualW : 0;
-                    var relY = (actualH > 0 && isFinite(rootItem.visualY)) ? rootItem.visualY / actualH : 0;
-                    var relW = (actualW > 0 && isFinite(rootItem.visualWidth) && rootItem.visualWidth > 0) ? rootItem.visualWidth / actualW : 0.25;
-                    var relH = (actualH > 0 && isFinite(rootItem.visualHeight) && rootItem.visualHeight > 0) ? rootItem.visualHeight / actualH : 0.25;
+                    // Convert to model coordinates for the C++ update via the
+                    // zone's fixed-geometry-aware helpers (same as ZoneDragHandler):
+                    // fixed zones must commit screen pixels or updateZoneGeometry
+                    // rejects the value against MinFixedZoneSize; relative zones
+                    // commit 0-1 normalized values.
+                    var relX = rootItem.toRelativeX(rootItem.visualX);
+                    var relY = rootItem.toRelativeY(rootItem.visualY);
+                    var relW = rootItem.toRelativeW(rootItem.visualWidth);
+                    var relH = rootItem.toRelativeH(rootItem.visualHeight);
                     // Set state to Idle BEFORE committing so onZoneGeometryChanged can process
                     rootItem.operationState = 0;
                     // Check if snap override modifier was held — skip C++ re-snapping if so
@@ -621,10 +629,9 @@ Item {
                     // Signal operation ended (state is already Idle)
                     var rootRef = rootItem;
                     var zoneIdRef = rootItem.zoneId;
-                    Qt.callLater(function() {
+                    Qt.callLater(function () {
                         if (rootRef)
                             rootRef.operationEnded(zoneIdRef);
-
                     });
                 }
                 onCanceled: {
@@ -653,25 +660,19 @@ Item {
                 PhosphorMotionAnimation {
                     profile: "widget.hover"
                 }
-
             }
 
             Behavior on color {
                 PhosphorMotionAnimation {
                     profile: "widget.hover"
                 }
-
             }
 
             Behavior on border.color {
                 PhosphorMotionAnimation {
                     profile: "widget.hover"
                 }
-
             }
-
         }
-
     }
-
 }


### PR DESCRIPTION
Fixes the two remaining editor bugs from discussion #696 (third round, reported 2026-07-02).

## Bug 1: fixed-pixel zone resize snaps back on release

`ResizeHandles.qml` committed plain canvas-relative 0-1 values on release. For a zone with "Fixed pixel size" enabled, `EditorController::updateZoneGeometry` takes the fixed branch and rejects those values against `MinFixedZoneSize` (50 px), so the model never updated. Since the v3.1.2 reconcile fix (b8c040914), that rejection shows as the zone snapping back to its old geometry on release; before it, the same rejection was the original #696 silent desync.

The commit now converts through the zone's fixed-geometry-aware `toRelativeX/Y/W/H` helpers, exactly like the move path in `ZoneDragHandler.qml`: fixed zones commit screen pixels, relative zones commit 0-1 values. Every other geometry writer (move, dividers, keyboard nav, panel spinboxes) was already fixed-aware; the resize handles were the one missed path.

## Bug 2: property panel keeps the previous zone's values after switching selection

The name field, zone number, mode checkbox, and fixed X/Y/W/H spinboxes in `PropertyPanel.qml` use declarative bindings that die permanently on the first user edit (standard QQC2 behavior) or imperative sync. After that, selecting Zone B kept showing Zone A's values, and touching any input stamped Zone A's geometry onto Zone B (the "Zone B is now in the same position as Zone A" report).

- `onSelectedZoneIdChanged` now imperatively re-syncs all of those controls.
- The `onZonesChanged` sync also refreshes the mode checkbox and is no longer gated on the checkbox's own (breakable) checked state, so undo/redo of a mode toggle is reflected too.

## Notes

- The `ResizeHandles.qml` diff includes formatting churn from qmlformat 6.11.1 (the pre-commit hook's binary) reflowing the handle-position array; it would land with any QML commit to this file.
- Build clean, all 263 tests pass. The interaction itself needs a live session to verify: check "Fixed pixel size", resize a zone by an edge handle, release; it should stay and the JSON/panel should update. Then select another zone and confirm the geometry inputs refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)