### PR TITLE
feat(rules): SetWindowLayer action for Krohnkite-style window layers

### DIFF
--- a/kwin-effect/kwin_compositor_bridge.cpp
+++ b/kwin-effect/kwin_compositor_bridge.cpp
@@ -177,9 +177,10 @@ WindowInfo KWinCompositorBridge::windowInfo(WindowHandle w) const
     info.isOnCurrentActivity = ew->isOnCurrentActivity();
     info.isNormalWindow = ew->isNormalWindow();
     // The window's OWN keep-above — pre-rule snapshot while a SetWindowLayer
-    // rule holds the pair. Every keep-above export shares the own-flag
-    // invariant (see applyOwnLayerFlags): an engine consumer gating on this
-    // must never read a rule's own output back as user state.
+    // rule holds the pair. No in-tree WindowInfo consumer reads this field
+    // today; it is kept own-flag-correct so a future engine gate cannot read
+    // a rule's own output back as user state (the applyOwnLayerFlags
+    // invariant every keep-above export shares).
     info.keepAbove = m_effect.windowOwnKeepAbove(ew);
     info.pid = ew->pid();
 

--- a/kwin-effect/kwin_compositor_bridge.cpp
+++ b/kwin-effect/kwin_compositor_bridge.cpp
@@ -176,7 +176,11 @@ WindowInfo KWinCompositorBridge::windowInfo(WindowHandle w) const
     info.isOnCurrentDesktop = ew->isOnCurrentDesktop();
     info.isOnCurrentActivity = ew->isOnCurrentActivity();
     info.isNormalWindow = ew->isNormalWindow();
-    info.keepAbove = ew->keepAbove();
+    // The window's OWN keep-above — pre-rule snapshot while a SetWindowLayer
+    // rule holds the pair. Every keep-above export shares the own-flag
+    // invariant (see applyOwnLayerFlags): an engine consumer gating on this
+    // must never read a rule's own output back as user state.
+    info.keepAbove = m_effect.windowOwnKeepAbove(ew);
     info.pid = ew->pid();
 
     info.hasDecoration = ew->hasDecoration();

--- a/kwin-effect/navigationhandler.cpp
+++ b/kwin-effect/navigationhandler.cpp
@@ -94,6 +94,13 @@ void NavigationHandler::syncZonesFromDaemon()
         QDBusPendingReply<PhosphorProtocol::WindowStateList> reply = *w;
         if (!reply.isValid()) {
             qCDebug(lcEffect) << "Failed to get window states from daemon";
+            // The unconditional clear above still changed the IsSnapped / Zone
+            // match inputs, so the stale placement-scoped verdicts must drop
+            // (and zone-scoped layer rules release via the sweep inside) on
+            // the failure path too — mirrors the getFloatingWindows reply
+            // handler in daemon_bringup.cpp, which documents the same
+            // invalid-reply reasoning.
+            m_effect->invalidateAllRuleCaches();
             return;
         }
 

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1286,9 +1286,14 @@ private:
     /// Rides a superset of reconcileRuleHiddenTitleBar's triggers
     /// (placement-state flush, rule edits / focus via updateAllDecorations)
     /// plus an eager window-added apply — so a layer rule takes effect before
-    /// the window's first reconcile-triggering event — and the bulk-placement
+    /// the window's first reconcile-triggering event — the class-swap
+    /// re-drive in the identity-change handler, and the bulk-placement
     /// sweep in invalidateAllRuleCaches (daemon loss and the daemon-ready
-    /// re-seeds).
+    /// re-seeds). Deliberately NOT triggered by keepAboveChanged /
+    /// keepBelowChanged: an instant re-assert would fight the user's own
+    /// toggle (the Krohnkite failure mode this feature exists to avoid), so
+    /// a manual toggle under an active rule stands until the next natural
+    /// reconcile.
     void reconcileRuleWindowLayer(const QString& windowId, KWin::EffectWindow* w);
 
     /// The window's OWN keep-above flag — the app/user-set state, with
@@ -1784,9 +1789,9 @@ private Q_SLOTS:
     void slotMotionProfileTreeChanged();
 
     /// Fetch the unified Rule store via `org.plasmazones.Rules.
-    /// getAllRules`, filter to rules carrying an OverrideAnimation* action,
-    /// and forward them to the shader manager — the sole source of per-window
-    /// animation overrides. Called once at bringup; the bringup also
+    /// getAllRules`, filter to rules carrying any effect-consumed
+    /// (Tag::Effect) action, and forward them to the shader manager — the
+    /// sole source of per-window effect overrides. Called once at bringup; the bringup also
     /// subscribes to the interface's `rulesChanged` signal (via a debounce
     /// timer — see m_animationRulesRefreshDebounce) so a settings-UI edit
     /// takes effect without restarting the effect.

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1295,7 +1295,8 @@ private:
     /// rule-written values substituted from the pre-rule snapshot while a
     /// SetWindowLayer rule owns the window's layer. Consulted by the
     /// keep-above overlay-tool gates (shouldHandleWindow / shouldDecorateWindow
-    /// / isTileableWindow); applyOwnLayerFlags is the query-side counterpart.
+    /// / isTileableWindow) and the engine-facing KWinCompositorBridge::windowInfo
+    /// export; applyOwnLayerFlags is the query-side counterpart.
     bool windowOwnKeepAbove(KWin::EffectWindow* w) const;
 
     /// Substitute the pre-rule snapshot's keepAbove/keepBelow pair into

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1276,6 +1276,32 @@ private:
     /// (unset = mode decides, true = rule hides, false = force-show veto).
     void reconcileRuleHiddenTitleBar(const QString& windowId, KWin::EffectWindow* w);
 
+    /// Resolve the per-window-rule SetWindowLayer override for @p windowId and
+    /// apply it to KWin's keepAbove/keepBelow pair. First application snapshots
+    /// the window's pre-rule flags into m_ruleWindowLayerSnapshots; a resolve
+    /// with no owning rule restores that snapshot once and forgets the window.
+    /// Rides the same triggers as reconcileRuleHiddenTitleBar (window added,
+    /// placement-state flush, rule edits / focus via updateAllDecorations).
+    void reconcileRuleWindowLayer(const QString& windowId, KWin::EffectWindow* w);
+
+    /// Restore every rule-applied window layer to its snapshotted pre-rule
+    /// flags and clear the snapshot map. Teardown counterpart of
+    /// reconcileRuleWindowLayer, called from the destructor next to
+    /// DecorationManager::restoreAll so an effect unload doesn't strand
+    /// rule-set keepAbove/keepBelow state on live windows.
+    void restoreAllRuleWindowLayers();
+
+    /// Pre-rule keepAbove/keepBelow pair captured the first time a
+    /// SetWindowLayer rule is applied to a window. Deliberately NOT re-captured
+    /// while a rule owns the layer, so the restore returns the window to the
+    /// user's own state, not to an intermediate rule state.
+    struct WindowLayerSnapshot
+    {
+        bool keepAbove = false;
+        bool keepBelow = false;
+    };
+    QHash<QString, WindowLayerSnapshot> m_ruleWindowLayerSnapshots;
+
     std::unique_ptr<NavigationHandler> m_navigationHandler;
     std::unique_ptr<ScreenChangeHandler> m_screenChangeHandler;
     std::unique_ptr<SnapAssistHandler> m_snapAssistHandler;

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1290,9 +1290,16 @@ private:
     /// rule-written values substituted from the pre-rule snapshot while a
     /// SetWindowLayer rule owns the window's layer. Consulted by the
     /// keep-above overlay-tool gates (shouldHandleWindow / shouldDecorateWindow
-    /// / isTileableWindow) and mirrored into ruleQuery's KeepAbove/KeepBelow
-    /// fields so rule output never feeds back into rule input.
+    /// / isTileableWindow); applyOwnLayerFlags is the query-side counterpart.
     bool windowOwnKeepAbove(KWin::EffectWindow* w) const;
+
+    /// Substitute the pre-rule snapshot's keepAbove/keepBelow pair into
+    /// @p query while a SetWindowLayer rule owns @p windowId's layer, so rule
+    /// output never feeds back into rule input. Shared by ruleQuery (the
+    /// effect's live evaluation path) and pushWindowMetadata (the daemon's
+    /// KeepAbove/KeepBelow match inputs) — the one invariant lives in one
+    /// place. No-op with no snapshots (the no-rules case pays one isEmpty).
+    void applyOwnLayerFlags(PhosphorRules::WindowQuery& query, const QString& windowId) const;
 
     /// Restore every rule-applied window layer to its snapshotted pre-rule
     /// flags and clear the snapshot map. Teardown counterpart of

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1280,9 +1280,19 @@ private:
     /// apply it to KWin's keepAbove/keepBelow pair. First application snapshots
     /// the window's pre-rule flags into m_ruleWindowLayerSnapshots; a resolve
     /// with no owning rule restores that snapshot once and forgets the window.
-    /// Rides the same triggers as reconcileRuleHiddenTitleBar (window added,
-    /// placement-state flush, rule edits / focus via updateAllDecorations).
+    /// Rides a superset of reconcileRuleHiddenTitleBar's triggers
+    /// (placement-state flush, rule edits / focus via updateAllDecorations)
+    /// plus an eager window-added apply, so a layer rule takes effect before
+    /// the window's first reconcile-triggering event.
     void reconcileRuleWindowLayer(const QString& windowId, KWin::EffectWindow* w);
+
+    /// The window's OWN keep-above flag — the app/user-set state, with
+    /// rule-written values substituted from the pre-rule snapshot while a
+    /// SetWindowLayer rule owns the window's layer. Consulted by the
+    /// keep-above overlay-tool gates (shouldHandleWindow / shouldDecorateWindow
+    /// / isTileableWindow) and mirrored into ruleQuery's KeepAbove/KeepBelow
+    /// fields so rule output never feeds back into rule input.
+    bool windowOwnKeepAbove(KWin::EffectWindow* w) const;
 
     /// Restore every rule-applied window layer to its snapshotted pre-rule
     /// flags and clear the snapshot map. Teardown counterpart of

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -355,7 +355,7 @@ private:
      * `Animations.WindowFiltering` cache so the two filter sets can
      * diverge.
      *
-     * A Rule carrying any OverrideAnimation* or SetOpacity
+     * A Rule carrying any effect-consumed (Tag::Effect)
      * action whose match expression resolves for the window OVERRIDES
      * the filter — the existence of even one targeted rule signals
      * deliberate user intent to animate this app, regardless of

--- a/kwin-effect/plasmazoneseffect.h
+++ b/kwin-effect/plasmazoneseffect.h
@@ -1259,8 +1259,11 @@ private:
     /// stay cached (e.g. a `WHEN isSnapped` SetOpacity window staying dimmed after
     /// the cache that made it "snapped" was cleared). Drops the whole match cache
     /// and forces a full repaint so opacity rules re-resolve against the current
-    /// IsSnapped / IsFloating / Zone state. Borders recover via their own
-    /// restore / rebuild path. No-op when there are no animation rules.
+    /// IsSnapped / IsFloating / Zone state, then re-reconciles every window's
+    /// rule layer — keepAbove/keepBelow is event-driven, so the cache clear
+    /// alone would leave it stale on both the loss and re-seed edges. Borders
+    /// recover via their own restore / rebuild path. No-op when there are no
+    /// animation rules and no rule-held layer snapshots.
     void invalidateAllRuleCaches();
 
     /// Flush coalesced per-rule-cache invalidations queued by
@@ -1282,8 +1285,10 @@ private:
     /// with no owning rule restores that snapshot once and forgets the window.
     /// Rides a superset of reconcileRuleHiddenTitleBar's triggers
     /// (placement-state flush, rule edits / focus via updateAllDecorations)
-    /// plus an eager window-added apply, so a layer rule takes effect before
-    /// the window's first reconcile-triggering event.
+    /// plus an eager window-added apply — so a layer rule takes effect before
+    /// the window's first reconcile-triggering event — and the bulk-placement
+    /// sweep in invalidateAllRuleCaches (daemon loss and the daemon-ready
+    /// re-seeds).
     void reconcileRuleWindowLayer(const QString& windowId, KWin::EffectWindow* w);
 
     /// The window's OWN keep-above flag — the app/user-set state, with

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -599,6 +599,11 @@ void PlasmaZonesEffect::flushPendingRuleInvalidations()
         // decoration state survives desktop switches, so reconcile it for the
         // window regardless of which desktop it sits on (as updateAllDecorations does).
         reconcileRuleHiddenTitleBar(windowId, w);
+        // Same for the stacking layer: a SetWindowLayer rule scoped on a
+        // placement field (IsFloating / IsTiled / IsSnapped / Zone / Mode) must
+        // re-apply on a float/snap flip — this is the trigger that makes
+        // "floating windows above tiled windows" follow the float toggle.
+        reconcileRuleWindowLayer(windowId, w);
         // An opacity-only (borderless) window needs an explicit repaint for its
         // re-resolved opacity to reach the screen (mirrors slotWindowActivated).
         if (hasOpacity) {

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -650,8 +650,9 @@ void PlasmaZonesEffect::invalidateAllRuleCaches()
         KWin::effects->addRepaintFull();
     }
     // Window-layer rules need the same placement-scoped re-resolve, but they
-    // are EVENT-driven (only reconcileRuleWindowLayer writes
-    // keepAbove/keepBelow), so the cache clear above does nothing for them on
+    // are EVENT-driven (during normal operation only reconcileRuleWindowLayer
+    // writes keepAbove/keepBelow; restoreAllRuleWindowLayers is
+    // destructor-only), so the cache clear above does nothing for them on
     // its own — opacity revives per-frame in paintWindow, layer does not.
     // Re-reconcile every window right here at the bulk-placement chokepoint so
     // BOTH edges are covered: on daemon loss a `WHEN IsFloating` layer rule
@@ -664,8 +665,10 @@ void PlasmaZonesEffect::invalidateAllRuleCaches()
     // restoreAllRuleWindowLayers(): that unconditionally drops all snapshots,
     // which would strand windows held by an unconditional (placement-free)
     // layer rule — the rule sets deliberately survive daemon loss, so those
-    // must keep their applied layer.
-    if (KWin::effects) {
+    // must keep their applied layer. Gated on hasWindowLayerRules so a
+    // session whose rules never touch the layer skips the cache-cold
+    // per-window resolution (a lingering snapshot still sweeps to drain).
+    if (KWin::effects && (m_shaderManager.hasWindowLayerRules() || !m_ruleWindowLayerSnapshots.isEmpty())) {
         const auto layerWindows = KWin::effects->stackingOrder();
         for (KWin::EffectWindow* lw : layerWindows) {
             if (lw && !lw->isDeleted()) {

--- a/kwin-effect/plasmazoneseffect/daemon_apply.cpp
+++ b/kwin-effect/plasmazoneseffect/daemon_apply.cpp
@@ -584,13 +584,21 @@ void PlasmaZonesEffect::flushPendingRuleInvalidations()
         if (!w) {
             continue;
         }
+        // findWindowById's unambiguous-appId fallback can resolve a window whose
+        // live id differs from the daemon-supplied one (stale uuid after a
+        // cross-session restore). Key ALL downstream tracking by the LIVE id —
+        // matching slotApplyGeometryRequested — or the layer reconcile below
+        // would insert its pre-rule snapshot under a key no teardown path ever
+        // removes and no live-id lookup (windowOwnKeepAbove / applyOwnLayerFlags
+        // / the next reconcile) ever finds.
+        const QString liveId = getWindowId(w);
         // Recreate this window's border so a state-scoped border colour
         // re-applies. Border overlays are visual-only, so build them only for a
         // window on the current desktop — matching updateAllDecorations, which gates
         // the same call this way to avoid building an invisible off-desktop item
         // that the next desktop switch tears down.
         if (w->isOnCurrentDesktop()) {
-            updateWindowDecoration(windowId, w);
+            updateWindowDecoration(liveId, w);
         }
         // Re-resolve the hide-title-bar override too: a SetHideTitleBar rule
         // scoped on a placement field (IsSnapped / IsFloating / Zone / Mode) must
@@ -598,12 +606,12 @@ void PlasmaZonesEffect::flushPendingRuleInvalidations()
         // stays hidden after unsnap until the next updateAllDecorations. The
         // decoration state survives desktop switches, so reconcile it for the
         // window regardless of which desktop it sits on (as updateAllDecorations does).
-        reconcileRuleHiddenTitleBar(windowId, w);
+        reconcileRuleHiddenTitleBar(liveId, w);
         // Same for the stacking layer: a SetWindowLayer rule scoped on a
         // placement field (IsFloating / IsTiled / IsSnapped / Zone / Mode) must
         // re-apply on a float/snap flip — this is the trigger that makes
         // "floating windows above tiled windows" follow the float toggle.
-        reconcileRuleWindowLayer(windowId, w);
+        reconcileRuleWindowLayer(liveId, w);
         // An opacity-only (borderless) window needs an explicit repaint for its
         // re-resolved opacity to reach the screen (mirrors slotWindowActivated).
         if (hasOpacity) {
@@ -628,11 +636,11 @@ void PlasmaZonesEffect::scheduleBorderSweep()
 
 void PlasmaZonesEffect::invalidateAllRuleCaches()
 {
-    if (m_shaderManager.animationRuleSet().isEmpty()) {
+    if (m_shaderManager.animationRuleSet().isEmpty() && m_ruleWindowLayerSnapshots.isEmpty()) {
         return;
     }
     // A bulk placement change (daemon loss clears the zone/floating caches; the
-    // daemon-ready re-seed repopulates them) moves neither the windowId nor the
+    // daemon-ready re-seeds repopulate them) moves neither the windowId nor the
     // ruleSet revision the match cache is keyed on, so every placement-scoped
     // verdict would survive stale. Drop the whole cache; the full repaint makes
     // every opacity-only window re-resolve against the current placement on the
@@ -640,6 +648,30 @@ void PlasmaZonesEffect::invalidateAllRuleCaches()
     m_shaderManager.animationRuleEvaluator().clearCache();
     if (KWin::effects && m_shaderManager.hasOpacityRules()) {
         KWin::effects->addRepaintFull();
+    }
+    // Window-layer rules need the same placement-scoped re-resolve, but they
+    // are EVENT-driven (only reconcileRuleWindowLayer writes
+    // keepAbove/keepBelow), so the cache clear above does nothing for them on
+    // its own — opacity revives per-frame in paintWindow, layer does not.
+    // Re-reconcile every window right here at the bulk-placement chokepoint so
+    // BOTH edges are covered: on daemon loss a `WHEN IsFloating` layer rule
+    // releases its keep-above against the cleared placement (snapshot restore)
+    // instead of stranding it for the daemon-down interval, and on the
+    // daemon-ready re-seeds (getFloatingWindows / syncZonesFromDaemon replies)
+    // it re-applies against the fresh placement even when the getAllRules
+    // refresh fails (loadRuleAnimationsFromDbus early-returns on a D-Bus or
+    // parse error without reconciling anything). NOT
+    // restoreAllRuleWindowLayers(): that unconditionally drops all snapshots,
+    // which would strand windows held by an unconditional (placement-free)
+    // layer rule — the rule sets deliberately survive daemon loss, so those
+    // must keep their applied layer.
+    if (KWin::effects) {
+        const auto layerWindows = KWin::effects->stackingOrder();
+        for (KWin::EffectWindow* lw : layerWindows) {
+            if (lw && !lw->isDeleted()) {
+                reconcileRuleWindowLayer(getWindowId(lw), lw);
+            }
+        }
     }
 }
 

--- a/kwin-effect/plasmazoneseffect/decorations.cpp
+++ b/kwin-effect/plasmazoneseffect/decorations.cpp
@@ -36,6 +36,7 @@
 #include <QVector4D>
 
 #include <optional>
+#include <utility>
 
 namespace PlasmaZones {
 
@@ -662,6 +663,16 @@ void PlasmaZonesEffect::reconcileRuleWindowLayer(const QString& windowId, KWin::
     if (!w || w->isDeleted() || windowId.isEmpty()) {
         return;
     }
+    // No-rules fast path: with an empty rule set and no snapshot to drain,
+    // there is nothing to resolve or restore. Keeps the "no-rules case pays
+    // nothing" invariant (see shouldAnimateWindow) on the focus-driven
+    // updateAllDecorations path — without this, the layer reconcile would be
+    // the one consumer building the ~30-accessor rule query for rule-less
+    // sessions. A lingering snapshot with an empty rule set still falls
+    // through so the restore below drains it.
+    if (m_shaderManager.animationRuleSet().isEmpty() && !m_ruleWindowLayerSnapshots.contains(windowId)) {
+        return;
+    }
     KWin::Window* kw = w->window();
     if (!kw) {
         return;
@@ -670,11 +681,15 @@ void PlasmaZonesEffect::reconcileRuleWindowLayer(const QString& windowId, KWin::
     const auto it = m_ruleWindowLayerSnapshots.find(windowId);
     if (!layer) {
         // No rule owns the layer. If one did before, put the user's own flags
-        // back exactly once and forget the window.
+        // back exactly once and forget the window. Erase BEFORE the setters:
+        // they emit KWin signals, and holding a QHash iterator across code
+        // that could re-enter this map would be undefined if a future
+        // connection routes a keep-above change back into a reconcile.
         if (it != m_ruleWindowLayerSnapshots.end()) {
-            kw->setKeepAbove(it->keepAbove);
-            kw->setKeepBelow(it->keepBelow);
+            const WindowLayerSnapshot snapshot = *it;
             m_ruleWindowLayerSnapshots.erase(it);
+            kw->setKeepAbove(snapshot.keepAbove);
+            kw->setKeepBelow(snapshot.keepBelow);
         }
         return;
     }
@@ -702,7 +717,11 @@ void PlasmaZonesEffect::restoreAllRuleWindowLayers()
     const QHash<QString, WindowLayerSnapshot> snapshots = std::exchange(m_ruleWindowLayerSnapshots, {});
     for (auto it = snapshots.cbegin(); it != snapshots.cend(); ++it) {
         KWin::EffectWindow* w = findWindowById(it.key());
-        if (!w || w->isDeleted()) {
+        // Exact-id re-check, matching every other findWindowById consumer in
+        // this file: the fuzzy appId fallback can resolve a same-app SIBLING
+        // for a gone windowId, and restoring one window's snapshot onto
+        // another would clobber the sibling's own flags.
+        if (!w || w->isDeleted() || getWindowId(w) != it.key()) {
             continue;
         }
         if (KWin::Window* kw = w->window()) {

--- a/kwin-effect/plasmazoneseffect/decorations.cpp
+++ b/kwin-effect/plasmazoneseffect/decorations.cpp
@@ -9,6 +9,7 @@
 #include <opengl/glshader.h>
 #include <opengl/glshadermanager.h>
 #include <opengl/gltexture.h>
+#include <window.h>
 
 #include <epoxy/gl.h>
 
@@ -630,6 +631,11 @@ void PlasmaZonesEffect::updateAllDecorations()
             updateWindowDecoration(wid, w, previouslyDecorated.contains(wid));
         }
         reconcileRuleHiddenTitleBar(wid, w);
+        // Stacking layer is persistent window state like the title bar, so it
+        // reconciles for ALL windows regardless of desktop too — and the
+        // reconcile-to-unset restores a window whose SetWindowLayer rule was
+        // just removed, mirroring the title-bar note above.
+        reconcileRuleWindowLayer(wid, w);
     }
 }
 
@@ -649,6 +655,61 @@ void PlasmaZonesEffect::reconcileRuleHiddenTitleBar(const QString& windowId, KWi
     // veto-driven decoration flips.
     const ResolvedWindowAppearance ovr = resolveEffectiveWindowAppearance(w, windowId);
     m_decorationManager->setRuleOverride(windowId, ovr.hideTitleBar);
+}
+
+void PlasmaZonesEffect::reconcileRuleWindowLayer(const QString& windowId, KWin::EffectWindow* w)
+{
+    if (!w || w->isDeleted() || windowId.isEmpty()) {
+        return;
+    }
+    KWin::Window* kw = w->window();
+    if (!kw) {
+        return;
+    }
+    const std::optional<QString> layer = resolveWindowLayer(resolveRuleActions(w, windowId));
+    const auto it = m_ruleWindowLayerSnapshots.find(windowId);
+    if (!layer) {
+        // No rule owns the layer. If one did before, put the user's own flags
+        // back exactly once and forget the window.
+        if (it != m_ruleWindowLayerSnapshots.end()) {
+            kw->setKeepAbove(it->keepAbove);
+            kw->setKeepBelow(it->keepBelow);
+            m_ruleWindowLayerSnapshots.erase(it);
+        }
+        return;
+    }
+    // First application snapshots the pre-rule flags so the restore above
+    // returns the window to the USER's state. Deliberately not re-captured
+    // while a rule owns the layer: a manual keepAbove toggle under an active
+    // rule is re-asserted away on the next reconcile (the rule owns the
+    // property while it matches, same as the DecorationManager rule override),
+    // and capturing it would corrupt the restore target.
+    if (it == m_ruleWindowLayerSnapshots.end()) {
+        m_ruleWindowLayerSnapshots.insert(windowId, {kw->keepAbove(), kw->keepBelow()});
+    }
+    // Always write the fully-specified pair. Writing only the token's "own"
+    // flag leaves the opposite one stale on an above→below rule flip (the
+    // Krohnkite asymmetry bug); KWin's setters are change-gated, so the
+    // re-asserts are free in the steady state.
+    const bool above = (*layer == PhosphorRules::WindowLayerToken::Above);
+    const bool below = (*layer == PhosphorRules::WindowLayerToken::Below);
+    kw->setKeepAbove(above);
+    kw->setKeepBelow(below);
+}
+
+void PlasmaZonesEffect::restoreAllRuleWindowLayers()
+{
+    const QHash<QString, WindowLayerSnapshot> snapshots = std::exchange(m_ruleWindowLayerSnapshots, {});
+    for (auto it = snapshots.cbegin(); it != snapshots.cend(); ++it) {
+        KWin::EffectWindow* w = findWindowById(it.key());
+        if (!w || w->isDeleted()) {
+            continue;
+        }
+        if (KWin::Window* kw = w->window()) {
+            kw->setKeepAbove(it->keepAbove);
+            kw->setKeepBelow(it->keepBelow);
+        }
+    }
 }
 
 bool PlasmaZonesEffect::isWindowMarkedSnapped(const QString& windowId) const

--- a/kwin-effect/plasmazoneseffect/decorations.cpp
+++ b/kwin-effect/plasmazoneseffect/decorations.cpp
@@ -674,23 +674,33 @@ void PlasmaZonesEffect::reconcileRuleWindowLayer(const QString& windowId, KWin::
     if (!m_shaderManager.hasWindowLayerRules() && !m_ruleWindowLayerSnapshots.contains(windowId)) {
         return;
     }
-    // Structural / own-surface shield, mirroring the SetOpacity paint gate
-    // (paint_pipeline.cpp): a layer write is a raw KWin window-state
-    // mutation, so a broad match expression must never demote a dock, pin a
-    // notification, or strip the daemon overlay's own keep-above. Sits
-    // before the snapshot capture below, so a shielded window never enters
-    // the map and no restore path needs the same list.
-    const QString winClass = w->windowClass();
-    if (isOwnOverlayClass(winClass) || isPlasmaShellSurface(winClass) || isXdgDesktopPortalSurface(winClass)
-        || w->isDesktop() || w->isDock() || w->isNotification() || w->isCriticalNotification()
-        || w->isOnScreenDisplay()) {
-        return;
-    }
     KWin::Window* kw = w->window();
     if (!kw) {
         return;
     }
-    const std::optional<QString> layer = resolveWindowLayer(resolveRuleActions(w, windowId));
+    // Structural / own-surface shield, extending the SetOpacity paint gate
+    // (paint_pipeline.cpp shields only the overlay / plasmashell classes;
+    // the portal and structural entries here are deliberate hardening for a
+    // raw window-state write): a broad match expression must never demote a
+    // dock, pin a notification, or strip the daemon overlay's own
+    // keep-above. Transients / popups are deliberately NOT shielded:
+    // transient utility surfaces are legitimate layer-rule targets, and
+    // transient exclusion is per-feature user opt-in in this project (the
+    // IsTransient match field), never hardcoded policy. A shielded window
+    // resolves as rule-free rather than early-returning — window
+    // classification can mutate mid-session (the Electron/CEF class swap,
+    // an X11 type change), and a window that was rule-held BEFORE mutating
+    // into a shielded class must drain its snapshot through the restore
+    // branch below instead of stranding the rule's flags. Fresh shielded
+    // windows skip the resolve entirely and never enter the map.
+    const QString winClass = w->windowClass();
+    const bool shielded = isOwnOverlayClass(winClass) || isPlasmaShellSurface(winClass)
+        || isXdgDesktopPortalSurface(winClass) || w->isDesktop() || w->isDock() || w->isNotification()
+        || w->isCriticalNotification() || w->isOnScreenDisplay();
+    std::optional<QString> layer;
+    if (!shielded) {
+        layer = resolveWindowLayer(resolveRuleActions(w, windowId));
+    }
     const auto it = m_ruleWindowLayerSnapshots.find(windowId);
     if (!layer) {
         // No rule owns the layer. If one did before, put the user's own flags

--- a/kwin-effect/plasmazoneseffect/decorations.cpp
+++ b/kwin-effect/plasmazoneseffect/decorations.cpp
@@ -663,14 +663,27 @@ void PlasmaZonesEffect::reconcileRuleWindowLayer(const QString& windowId, KWin::
     if (!w || w->isDeleted() || windowId.isEmpty()) {
         return;
     }
-    // No-rules fast path: with an empty rule set and no snapshot to drain,
-    // there is nothing to resolve or restore. Keeps the "no-rules case pays
-    // nothing" invariant (see shouldAnimateWindow) on the focus-driven
-    // updateAllDecorations path — without this, the layer reconcile would be
-    // the one consumer building the ~30-accessor rule query for rule-less
-    // sessions. A lingering snapshot with an empty rule set still falls
-    // through so the restore below drains it.
-    if (m_shaderManager.animationRuleSet().isEmpty() && !m_ruleWindowLayerSnapshots.contains(windowId)) {
+    // No-layer-rules fast path: with no enabled SetWindowLayer rule and no
+    // snapshot to drain, the resolve below can neither apply nor restore
+    // anything. Keeps the "no-rules case pays nothing" invariant (see
+    // shouldAnimateWindow) on the focus-driven updateAllDecorations path —
+    // without this, the layer reconcile would be the one consumer building
+    // the ~30-accessor rule query for sessions whose rules never touch the
+    // layer (opacity/border-only rule sets included). A lingering snapshot
+    // still falls through so the restore below drains it.
+    if (!m_shaderManager.hasWindowLayerRules() && !m_ruleWindowLayerSnapshots.contains(windowId)) {
+        return;
+    }
+    // Structural / own-surface shield, mirroring the SetOpacity paint gate
+    // (paint_pipeline.cpp): a layer write is a raw KWin window-state
+    // mutation, so a broad match expression must never demote a dock, pin a
+    // notification, or strip the daemon overlay's own keep-above. Sits
+    // before the snapshot capture below, so a shielded window never enters
+    // the map and no restore path needs the same list.
+    const QString winClass = w->windowClass();
+    if (isOwnOverlayClass(winClass) || isPlasmaShellSurface(winClass) || isXdgDesktopPortalSurface(winClass)
+        || w->isDesktop() || w->isDock() || w->isNotification() || w->isCriticalNotification()
+        || w->isOnScreenDisplay()) {
         return;
     }
     KWin::Window* kw = w->window();

--- a/kwin-effect/plasmazoneseffect/drag_snap.cpp
+++ b/kwin-effect/plasmazoneseffect/drag_snap.cpp
@@ -254,8 +254,8 @@ void PlasmaZonesEffect::applyWindowGeometry(KWin::EffectWindow* window, const QR
     //
     // `shouldAnimateWindow` adds the user's per-animation Window
     // Filtering gate (transient / min-size / app / class) and lets a
-    // Rule carrying any OverrideAnimation* action override the
-    // filter when the rule's class matcher matches. Falling through to
+    // Rule carrying any effect-consumed (Tag::Effect) action override
+    // the filter when the rule's match expression resolves. Falling through to
     // the non-animated path just runs the moveResize without the snap
     // motion / shader.
     //

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -668,6 +668,11 @@ PlasmaZonesEffect::PlasmaZonesEffect()
             // the slotWindowClosed removal alone is not enough; drop it here too
             // (keyed by the frozen cachedId) or the entry leaks for the session.
             m_focusFade.remove(cachedId);
+            // Same delete-without-close defence for the layer snapshot: the
+            // normal removal lives in slotWindowClosed, which a window deleted
+            // without a preceding close never reaches. No restore is possible
+            // (the window is gone); this only keeps the map bounded.
+            m_ruleWindowLayerSnapshots.remove(cachedId);
         }
         m_trackedScreenPerWindow.remove(w);
         m_restoreSuppress.remove(w);
@@ -937,6 +942,26 @@ PlasmaZonesEffect::PlasmaZonesEffect()
         // clearAllDecorations below, but opacity would not). Re-resolve every opacity
         // window against the now-cleared placement, matching the border teardown.
         invalidateAllRuleCaches();
+        // Window-layer rules need the same placement-scoped re-resolve, but
+        // they are EVENT-driven (only reconcileRuleWindowLayer writes
+        // keepAbove/keepBelow), so the cache clear above does nothing for
+        // them on its own — opacity revives per-frame in paintWindow, layer
+        // does not. Re-reconcile every window against the now-cleared
+        // placement: a `WHEN IsFloating` layer rule releases its keep-above
+        // here (snapshot restore) instead of stranding it for the whole
+        // daemon-down interval. NOT restoreAllRuleWindowLayers(): that
+        // unconditionally drops all snapshots, which would strand windows
+        // held by an unconditional (placement-free) layer rule — the rule
+        // sets deliberately survive daemon loss (see below), so those must
+        // keep their applied layer.
+        if (KWin::effects) {
+            const auto layerWindows = KWin::effects->stackingOrder();
+            for (KWin::EffectWindow* lw : layerWindows) {
+                if (lw && !lw->isDeleted()) {
+                    reconcileRuleWindowLayer(getWindowId(lw), lw);
+                }
+            }
+        }
         m_decorationManager->restoreAll();
         m_autotileHandler->restoreAllMonocleMaximized();
         clearAllDecorations();

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -941,27 +941,10 @@ PlasmaZonesEffect::PlasmaZonesEffect()
         // the window keeps its stale opacity (borders revert via restoreAll /
         // clearAllDecorations below, but opacity would not). Re-resolve every opacity
         // window against the now-cleared placement, matching the border teardown.
+        // Also carries the window-layer sweep (see invalidateAllRuleCaches): a
+        // `WHEN IsFloating` layer rule releases its keep-above here (snapshot
+        // restore) instead of stranding it for the daemon-down interval.
         invalidateAllRuleCaches();
-        // Window-layer rules need the same placement-scoped re-resolve, but
-        // they are EVENT-driven (only reconcileRuleWindowLayer writes
-        // keepAbove/keepBelow), so the cache clear above does nothing for
-        // them on its own — opacity revives per-frame in paintWindow, layer
-        // does not. Re-reconcile every window against the now-cleared
-        // placement: a `WHEN IsFloating` layer rule releases its keep-above
-        // here (snapshot restore) instead of stranding it for the whole
-        // daemon-down interval. NOT restoreAllRuleWindowLayers(): that
-        // unconditionally drops all snapshots, which would strand windows
-        // held by an unconditional (placement-free) layer rule — the rule
-        // sets deliberately survive daemon loss (see below), so those must
-        // keep their applied layer.
-        if (KWin::effects) {
-            const auto layerWindows = KWin::effects->stackingOrder();
-            for (KWin::EffectWindow* lw : layerWindows) {
-                if (lw && !lw->isDeleted()) {
-                    reconcileRuleWindowLayer(getWindowId(lw), lw);
-                }
-            }
-        }
         m_decorationManager->restoreAll();
         m_autotileHandler->restoreAllMonocleMaximized();
         clearAllDecorations();

--- a/kwin-effect/plasmazoneseffect/lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/lifecycle.cpp
@@ -1087,6 +1087,7 @@ PlasmaZonesEffect::~PlasmaZonesEffect()
         m_snapHandler->clearSnapTracking();
         m_decorationManager->restoreAll();
         m_autotileHandler->restoreAllMonocleMaximized();
+        restoreAllRuleWindowLayers();
         clearAllDecorations();
     }
 

--- a/kwin-effect/plasmazoneseffect/shader_resolve.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.cpp
@@ -345,4 +345,30 @@ std::optional<ResolvedDecorationChain> resolveDecorationChain(const PhosphorRule
     return out;
 }
 
+std::optional<QString> resolveWindowLayer(const PhosphorRules::ResolvedActions& resolved)
+{
+    // Constant slot id — same static-hoist rationale as resolveWindowOpacity.
+    static const QString kLayerSlot = QString(PhosphorRules::ActionSlot::WindowLayer);
+    const auto action = resolved.slot(kLayerSlot);
+    if (!action) {
+        return std::nullopt;
+    }
+    // Re-validate against the closed vocabulary even though the load-time
+    // descriptor validator already did — defence in depth against a
+    // programmatically-built / hand-edited payload that bypassed the parser
+    // (see the equivalent rationale in resolveWindowOpacity). An unknown token
+    // must resolve to "no override", never to an implicit Normal (which would
+    // clear a user's own keepAbove).
+    const QJsonValue v = action->params.value(PhosphorRules::ActionParam::Value);
+    if (!v.isString()) {
+        return std::nullopt;
+    }
+    const QString token = v.toString();
+    if (token != PhosphorRules::WindowLayerToken::Above && token != PhosphorRules::WindowLayerToken::Normal
+        && token != PhosphorRules::WindowLayerToken::Below) {
+        return std::nullopt;
+    }
+    return token;
+}
+
 } // namespace PlasmaZones

--- a/kwin-effect/plasmazoneseffect/shader_resolve.h
+++ b/kwin-effect/plasmazoneseffect/shader_resolve.h
@@ -209,4 +209,18 @@ struct ResolvedDecorationChain
 
 std::optional<ResolvedDecorationChain> resolveDecorationChain(const PhosphorRules::ResolvedActions& resolved);
 
+/**
+ * @brief Per-window stacking-layer override — the runtime consumer for the
+ *        SetWindowLayer rule.
+ *
+ * Returns the validated layer token (`WindowLayerToken::Above` / `Normal` /
+ * `Below`) when an enabled rule fills the `window-layer` slot of @p resolved,
+ * or `std::nullopt` when no rule fills it or the value is outside the closed
+ * vocabulary (defence in depth against a hand-edited payload that bypassed the
+ * load-time validator, mirroring the other consumers). The caller
+ * (reconcileRuleWindowLayer) maps the token onto KWin's keepAbove/keepBelow
+ * pair, always writing both flags.
+ */
+std::optional<QString> resolveWindowLayer(const PhosphorRules::ResolvedActions& resolved);
+
 } // namespace PlasmaZones

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -1845,8 +1845,8 @@ void PlasmaZonesEffect::loadRuleAnimationsFromDbus()
 {
     // Fetch the unified Rule store via getAllRules (returns a JSON
     // string of a v4 RuleSet), deserialise, filter to rules whose
-    // action list contains any OverrideAnimation* action, and hand them to
-    // the shader manager. The shader manager mirrors them into
+    // action list contains any effect-consumed (Tag::Effect) action, and
+    // hand them to the shader manager. The shader manager mirrors them into
     // m_animationRuleSet so the per-event slot lookup in shader_resolve.cpp
     // resolves the cascade against the unified rule store directly.
     const QDBusMessage msg = QDBusMessage::createMethodCall(

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -1904,9 +1904,12 @@ void PlasmaZonesEffect::loadRuleAnimationsFromDbus()
                 // rule-set size minimal and the priority-order index smaller.)
                 continue;
             }
-            // Admit the rule to the evaluator if ANY action is effect-consumed
-            // (the OverrideAnimation* triple, SetOpacity, or a SetBorder* /
-            // SetHideTitleBar appearance action — Tag::Effect via hasTag below).
+            // Admit the rule to the evaluator if ANY action is effect-consumed,
+            // i.e. carries Tag::Effect (hasTag below). The authoritative
+            // membership list is the descriptor tag assignments in
+            // ruleaction.cpp — animation overrides, SetOpacity, the appearance
+            // family (SetBorder*, SetHideTitleBar, OverrideDecorationChain),
+            // and SetWindowLayer.
             bool admitted = false;
             for (const PhosphorRules::RuleAction& action : rule.actions) {
                 if (PhosphorRules::ActionRegistry::instance().hasTag(action.type, PhosphorRules::Tag::Effect)) {

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -1659,8 +1659,8 @@ void PlasmaZonesEffect::tryBeginShaderForEvent(KWin::EffectWindow* window, const
     }
     // Window-filtering gate. `shouldAnimateWindow` honours the user's
     // Animations.WindowFiltering exclusions (transient / min-size /
-    // app / class) AND lets a Rule carrying any OverrideAnimation*
-    // or SetOpacity action override the filter when the rule's match
+    // app / class) AND lets a Rule carrying any effect-consumed
+    // (Tag::Effect) action override the filter when the rule's match
     // expression resolves for the window's full WindowQuery (AppId /
     // WindowClass / Title / WindowRole / DesktopFile / WindowType / Pid /
     // state flags). Skipping this for shader transitions only would leave

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -569,8 +569,8 @@ void PlasmaZonesEffect::logWindowDiagnostics(KWin::EffectWindow* w, const char* 
     qCDebug(lcEffectDiag) << "[window-diag]   state — managed:" << w->isManaged() << "x11:" << w->isX11Client()
                           << "wayland:" << w->isWaylandClient() << "fullScreen:" << w->isFullScreen()
                           << "minimized:" << w->isMinimized() << "skipSwitcher:" << w->isSkipSwitcher()
-                          << "keepAbove:" << w->keepAbove() << "hasDecoration:" << w->hasDecoration()
-                          << "onCurrentDesktop:" << w->isOnCurrentDesktop()
+                          << "keepAbove:" << w->keepAbove() << "ownKeepAbove:" << windowOwnKeepAbove(w)
+                          << "hasDecoration:" << w->hasDecoration() << "onCurrentDesktop:" << w->isOnCurrentDesktop()
                           << "onCurrentActivity:" << w->isOnCurrentActivity()
                           << "onAllDesktops:" << w->isOnAllDesktops();
     qCDebug(lcEffectDiag) << "[window-diag]   geometry — frame:" << w->frameGeometry()

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -126,6 +126,12 @@ PhosphorRules::WindowQuery PlasmaZonesEffect::ruleQuery(KWin::EffectWindow* w) c
     PhosphorRules::WindowQuery query =
         ruleQueryFor(w, getWindowScreenId(w), isWindowFloating(windowId), isWindowSnapped(windowId),
                      m_autotileHandler->isTiledWindow(windowId), zoneForWindow(windowId));
+    applyOwnLayerFlags(query, windowId);
+    return query;
+}
+
+void PlasmaZonesEffect::applyOwnLayerFlags(PhosphorRules::WindowQuery& query, const QString& windowId) const
+{
     // KeepAbove / KeepBelow must report the window's OWN flags, not
     // rule-written state. SetWindowLayer is the one action that mutates a
     // matchable field: while a layer rule owns the pair, the live KWin flags
@@ -133,12 +139,16 @@ PhosphorRules::WindowQuery PlasmaZonesEffect::ruleQuery(KWin::EffectWindow* w) c
     // a `WHEN KeepAbove` predicate read its own effect — a self-feeding match
     // that flips on every cache flush and thrashes the snapshot restore. The
     // pre-rule snapshot holds the app/user-set values, so substitute those
-    // while the rule owns the layer.
+    // while the rule owns the layer. Applied to BOTH rule-input boundaries:
+    // ruleQuery (effect-side evaluation) and pushWindowMetadata (the daemon's
+    // KeepAbove/KeepBelow match inputs).
+    if (m_ruleWindowLayerSnapshots.isEmpty()) {
+        return;
+    }
     if (const auto it = m_ruleWindowLayerSnapshots.constFind(windowId); it != m_ruleWindowLayerSnapshots.cend()) {
         query.keepAbove = it->keepAbove;
         query.keepBelow = it->keepBelow;
     }
-    return query;
 }
 
 bool PlasmaZonesEffect::windowOwnKeepAbove(KWin::EffectWindow* w) const

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -123,8 +123,37 @@ void PlasmaZonesEffect::clearWindowZone(const QString& windowId)
 PhosphorRules::WindowQuery PlasmaZonesEffect::ruleQuery(KWin::EffectWindow* w) const
 {
     const QString windowId = getWindowId(w);
-    return ruleQueryFor(w, getWindowScreenId(w), isWindowFloating(windowId), isWindowSnapped(windowId),
-                        m_autotileHandler->isTiledWindow(windowId), zoneForWindow(windowId));
+    PhosphorRules::WindowQuery query =
+        ruleQueryFor(w, getWindowScreenId(w), isWindowFloating(windowId), isWindowSnapped(windowId),
+                     m_autotileHandler->isTiledWindow(windowId), zoneForWindow(windowId));
+    // KeepAbove / KeepBelow must report the window's OWN flags, not
+    // rule-written state. SetWindowLayer is the one action that mutates a
+    // matchable field: while a layer rule owns the pair, the live KWin flags
+    // are the rule's output, and feeding them back into the query would make
+    // a `WHEN KeepAbove` predicate read its own effect — a self-feeding match
+    // that flips on every cache flush and thrashes the snapshot restore. The
+    // pre-rule snapshot holds the app/user-set values, so substitute those
+    // while the rule owns the layer.
+    if (const auto it = m_ruleWindowLayerSnapshots.constFind(windowId); it != m_ruleWindowLayerSnapshots.cend()) {
+        query.keepAbove = it->keepAbove;
+        query.keepBelow = it->keepBelow;
+    }
+    return query;
+}
+
+bool PlasmaZonesEffect::windowOwnKeepAbove(KWin::EffectWindow* w) const
+{
+    // The window's OWN keep-above flag — the app/user-set state, excluding
+    // rule-written values. The keep-above overlay gates (shouldHandleWindow /
+    // shouldDecorateWindow / isTileableWindow) exist to reject external
+    // overlay tools (Spectacle, colour pickers) that set keep-above on
+    // themselves; a window raised by a SetWindowLayer rule must NOT be
+    // misclassified as one of those, or the headline "floating windows above
+    // tiled windows" rule would silently strip the matched window's
+    // decoration and drop it from snap/tile management. While a layer rule
+    // owns the pair, the pre-rule snapshot holds the window's own flag.
+    const auto it = m_ruleWindowLayerSnapshots.constFind(getWindowId(w));
+    return it != m_ruleWindowLayerSnapshots.cend() ? it->keepAbove : w->keepAbove();
 }
 
 PhosphorRules::ResolvedActions PlasmaZonesEffect::resolveRuleActions(KWin::EffectWindow* w,
@@ -257,8 +286,10 @@ bool PlasmaZonesEffect::shouldHandleWindow(KWin::EffectWindow* w, QString* rejec
 
     // Keep-above overlays (Spectacle, color pickers, screen rulers, screenshot
     // tools that linger after capture) shouldn't be snapped to a zone — same
-    // rationale as isTileableWindow's keep-above gate.
-    if (w->keepAbove()) {
+    // rationale as isTileableWindow's keep-above gate. Consults the window's
+    // OWN flag (see windowOwnKeepAbove) so a SetWindowLayer-raised window
+    // stays manageable.
+    if (windowOwnKeepAbove(w)) {
         return rejectedBecause(rejectReason, "keep-above window");
     }
 
@@ -352,9 +383,13 @@ bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
     // it — the user's act of authoring a matching rule is the opt-in signal.
     // (Type exclusions are handled above and are NOT bypassable here.)
     //
-    // `m_shaderManager.animationRuleSet()` is filtered to OverrideAnimation* /
-    // SetOpacity rules at admission (shader_transitions.cpp's
-    // `hasTag(type, Tag::Effect)` loop), so `hasAnyMatch` never surfaces a rule whose
+    // `m_shaderManager.animationRuleSet()` admits every rule carrying a
+    // Tag::Effect action (shader_transitions.cpp's `hasTag(type, Tag::Effect)`
+    // loop) — the OverrideAnimation* triple, SetOpacity, and the appearance /
+    // stacking family (SetBorder*, SetHideTitleBar, SetWindowLayer). So a rule
+    // whose only action is an appearance or layer override also force-animates
+    // its matches here — deliberate, consistent opt-in semantics across every
+    // effect-consumed action. `hasAnyMatch` never surfaces a rule whose
     // actions are EXCLUSIVELY `ExcludeAnimations` — those route through the
     // exclusion gate below.
     if (haveAnimationRules && animationEvaluator.hasAnyMatch(query())) {
@@ -436,8 +471,10 @@ bool PlasmaZonesEffect::shouldDecorateWindow(KWin::EffectWindow* w) const
 
     // Keep-above overlays (Spectacle, colour pickers, screen rulers) — same
     // rejection shouldHandleWindow applies, preserved so upgrading doesn't
-    // start bordering these lingering utility windows.
-    if (w->keepAbove()) {
+    // start bordering these lingering utility windows. Consults the window's
+    // OWN flag (see windowOwnKeepAbove) so a SetWindowLayer-raised window
+    // keeps its decoration.
+    if (windowOwnKeepAbove(w)) {
         return false;
     }
 
@@ -490,7 +527,9 @@ bool PlasmaZonesEffect::isTileableWindow(KWin::EffectWindow* w, QString* rejectR
     // pickers, screen rulers, etc.) set keep-above and should not enter the
     // autotile tree or receive auto-focus. Without this guard, opening
     // Spectacle while focusNewWindows is enabled disrupts the tiled layout.
-    if (w->keepAbove()) {
+    // Consults the window's OWN flag (see windowOwnKeepAbove) so a
+    // SetWindowLayer-raised window stays tileable.
+    if (windowOwnKeepAbove(w)) {
         return rejectedBecause(rejectReason, "keep-above window");
     }
     return true;

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -168,12 +168,18 @@ bool PlasmaZonesEffect::windowOwnKeepAbove(KWin::EffectWindow* w) const
     //
     // Empty-map fast path: with no window rule-raised, the own flag IS the
     // live flag. Keeps the gates getWindowId-free for the common no-layer-rule
-    // session (the "no-rules case pays nothing" invariant) and avoids
-    // re-polluting the id caches for close-grabbed deleted windows — several
-    // gate callers don't pre-check isDeleted(), and getWindowId on a dying
-    // window would re-insert the reverse-map entry buildWindowMap deliberately
-    // skips.
+    // session (the "no-rules case pays nothing" invariant).
     if (m_ruleWindowLayerSnapshots.isEmpty()) {
+        return w->keepAbove();
+    }
+    // Close-grabbed corpse: its flags are frozen and slotWindowClosed already
+    // dropped any snapshot it had, so answer from the live flag WITHOUT
+    // getWindowId — several gate callers don't pre-check isDeleted(), and
+    // getWindowId on a dying window would re-insert the reverse-map entry
+    // buildWindowMap deliberately skips. Unconditional (not folded into the
+    // fast path above) so the no-repollution guarantee holds even while a
+    // layer rule owns some other window.
+    if (w->isDeleted()) {
         return w->keepAbove();
     }
     const auto it = m_ruleWindowLayerSnapshots.constFind(getWindowId(w));
@@ -410,7 +416,8 @@ bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
     // `m_shaderManager.animationRuleSet()` admits every rule carrying a
     // Tag::Effect action (shader_transitions.cpp's `hasTag(type, Tag::Effect)`
     // loop) — the OverrideAnimation* triple, SetOpacity, and the appearance /
-    // stacking family (SetBorder*, SetHideTitleBar, SetWindowLayer). So a rule
+    // stacking family (SetBorder*, SetHideTitleBar, OverrideDecorationChain,
+    // SetWindowLayer). So a rule
     // whose only action is an appearance or layer override also force-animates
     // its matches here — deliberate, consistent opt-in semantics across every
     // effect-consumed action. `hasAnyMatch` never surfaces a rule whose

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -143,6 +143,9 @@ PhosphorRules::WindowQuery PlasmaZonesEffect::ruleQuery(KWin::EffectWindow* w) c
 
 bool PlasmaZonesEffect::windowOwnKeepAbove(KWin::EffectWindow* w) const
 {
+    if (!w) {
+        return false;
+    }
     // The window's OWN keep-above flag — the app/user-set state, excluding
     // rule-written values. The keep-above overlay gates (shouldHandleWindow /
     // shouldDecorateWindow / isTileableWindow) exist to reject external

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -415,9 +415,8 @@ bool PlasmaZonesEffect::shouldAnimateWindow(KWin::EffectWindow* w) const
     //
     // `m_shaderManager.animationRuleSet()` admits every rule carrying a
     // Tag::Effect action (shader_transitions.cpp's `hasTag(type, Tag::Effect)`
-    // loop) — the OverrideAnimation* triple, SetOpacity, and the appearance /
-    // stacking family (SetBorder*, SetHideTitleBar, OverrideDecorationChain,
-    // SetWindowLayer). So a rule
+    // loop; the tag assignments in ruleaction.cpp are the authoritative
+    // membership list). So a rule
     // whose only action is an appearance or layer override also force-animates
     // its matches here — deliberate, consistent opt-in semantics across every
     // effect-consumed action. `hasAnyMatch` never surfaces a rule whose

--- a/kwin-effect/plasmazoneseffect/window_filtering.cpp
+++ b/kwin-effect/plasmazoneseffect/window_filtering.cpp
@@ -152,6 +152,17 @@ bool PlasmaZonesEffect::windowOwnKeepAbove(KWin::EffectWindow* w) const
     // tiled windows" rule would silently strip the matched window's
     // decoration and drop it from snap/tile management. While a layer rule
     // owns the pair, the pre-rule snapshot holds the window's own flag.
+    //
+    // Empty-map fast path: with no window rule-raised, the own flag IS the
+    // live flag. Keeps the gates getWindowId-free for the common no-layer-rule
+    // session (the "no-rules case pays nothing" invariant) and avoids
+    // re-polluting the id caches for close-grabbed deleted windows — several
+    // gate callers don't pre-check isDeleted(), and getWindowId on a dying
+    // window would re-insert the reverse-map entry buildWindowMap deliberately
+    // skips.
+    if (m_ruleWindowLayerSnapshots.isEmpty()) {
+        return w->keepAbove();
+    }
     const auto it = m_ruleWindowLayerSnapshots.constFind(getWindowId(w));
     return it != m_ruleWindowLayerSnapshots.cend() ? it->keepAbove : w->keepAbove();
 }

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -145,7 +145,18 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w, bool includeEx
     // avoiding a per-frame query build + a{sv} marshal for chatty-title windows.
     QVariantMap extended;
     if (includeExtended) {
-        const PhosphorRules::WindowQuery props = ruleQueryFor(w, QString(), false, false, false, QString());
+        PhosphorRules::WindowQuery props = ruleQueryFor(w, QString(), false, false, false, QString());
+        // Same substitution ruleQuery applies (see windowOwnKeepAbove): while
+        // a SetWindowLayer rule owns the window's keepAbove/keepBelow pair,
+        // the live flags are rule output. The daemon matches its own
+        // KeepAbove/KeepBelow predicates against this metadata, so report the
+        // window's own (pre-rule) flags to keep rule output out of rule input
+        // on that side of the boundary too.
+        if (const auto layerIt = m_ruleWindowLayerSnapshots.constFind(getWindowId(w));
+            layerIt != m_ruleWindowLayerSnapshots.cend()) {
+            props.keepAbove = layerIt->keepAbove;
+            props.keepBelow = layerIt->keepBelow;
+        }
         namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
         if (props.isMinimized) {
             extended.insert(Key::IsMinimized, *props.isMinimized);

--- a/kwin-effect/plasmazoneseffect/window_identity.cpp
+++ b/kwin-effect/plasmazoneseffect/window_identity.cpp
@@ -146,17 +146,11 @@ void PlasmaZonesEffect::pushWindowMetadata(KWin::EffectWindow* w, bool includeEx
     QVariantMap extended;
     if (includeExtended) {
         PhosphorRules::WindowQuery props = ruleQueryFor(w, QString(), false, false, false, QString());
-        // Same substitution ruleQuery applies (see windowOwnKeepAbove): while
-        // a SetWindowLayer rule owns the window's keepAbove/keepBelow pair,
-        // the live flags are rule output. The daemon matches its own
-        // KeepAbove/KeepBelow predicates against this metadata, so report the
-        // window's own (pre-rule) flags to keep rule output out of rule input
-        // on that side of the boundary too.
-        if (const auto layerIt = m_ruleWindowLayerSnapshots.constFind(getWindowId(w));
-            layerIt != m_ruleWindowLayerSnapshots.cend()) {
-            props.keepAbove = layerIt->keepAbove;
-            props.keepBelow = layerIt->keepBelow;
-        }
+        // Report the window's OWN (pre-rule) keepAbove/keepBelow — the daemon
+        // matches its KeepAbove/KeepBelow predicates against this metadata,
+        // and rule output must not feed rule input on that side of the
+        // boundary either. Shared invariant; see applyOwnLayerFlags.
+        applyOwnLayerFlags(props, getWindowId(w));
         namespace Key = PhosphorProtocol::Service::WindowMetadataKey;
         if (props.isMinimized) {
             extended.insert(Key::IsMinimized, *props.isMinimized);

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -149,6 +149,11 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
     if (w->isOnCurrentDesktop()) {
         updateWindowDecoration(windowId, w);
     }
+    // Apply any SetWindowLayer rule to the new window right away (persistent
+    // window state, so NOT desktop-gated — matching updateAllDecorations'
+    // title-bar/layer handling). Placement-scoped layer rules re-reconcile
+    // when the async float/zone syncs land, via the placement-state flush.
+    reconcileRuleWindowLayer(windowId, w);
 
     bool onAutotileScreen = m_autotileHandler->isAutotileScreen(getWindowScreenId(w));
 
@@ -357,6 +362,10 @@ void PlasmaZonesEffect::slotWindowClosed(KWin::EffectWindow* w)
     // force-show veto). forgetWindow makes zero compositor calls — the
     // decoration dies with the window.
     m_decorationManager->forgetWindow(closedWindowId);
+    // Drop the window's pre-rule layer snapshot the same way — no restore, the
+    // keepAbove/keepBelow flags die with the window, and a reused windowId
+    // must not inherit a stale snapshot.
+    m_ruleWindowLayerSnapshots.remove(closedWindowId);
 
     // Drop the window's border entry and release its border-shader redirect —
     // UNLESS a close transition was just installed above: renderSurfaceChain

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -151,8 +151,11 @@ void PlasmaZonesEffect::slotWindowAdded(KWin::EffectWindow* w)
     }
     // Apply any SetWindowLayer rule to the new window right away (persistent
     // window state, so NOT desktop-gated — matching updateAllDecorations'
-    // title-bar/layer handling). Placement-scoped layer rules re-reconcile
-    // when the async float/zone syncs land, via the placement-state flush.
+    // title-bar/layer handling). This eager add-time apply is a layer-only
+    // extra trigger on top of the shared reconcile paths (the title-bar
+    // reconcile has no window-added call). Placement-scoped layer rules
+    // re-reconcile when the async float/zone syncs land, via the
+    // placement-state flush.
     reconcileRuleWindowLayer(windowId, w);
 
     bool onAutotileScreen = m_autotileHandler->isAutotileScreen(getWindowScreenId(w));

--- a/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
+++ b/kwin-effect/plasmazoneseffect/window_lifecycle.cpp
@@ -681,8 +681,18 @@ void PlasmaZonesEffect::setupWindowConnections(KWin::EffectWindow* w)
         // refresh on the effect's local resolver cache. Caption /
         // desktops / activities / role changes don't feed the
         // WindowClass matcher so they don't need the cache drop.
-        auto invalidateRuleCache = [this]() {
+        auto invalidateRuleCache = [this, safeW]() {
             m_shaderManager.animationRuleEvaluator().clearCache();
+            // The cache drop alone only helps per-frame consumers (opacity
+            // re-resolves in paintWindow). The stacking layer is EVENT-driven
+            // and the eager window-added apply ran against the pre-swap
+            // placeholder class — re-drive it so a layer rule keyed to the
+            // real class applies (and one keyed to the placeholder releases)
+            // without waiting for an incidental sweep. The hasWindowLayerRules
+            // fast path keeps this free for sessions with no layer rules.
+            if (safeW && !safeW->isDeleted()) {
+                reconcileRuleWindowLayer(getWindowId(safeW), safeW);
+            }
         };
         connect(kw, &KWin::Window::windowClassChanged, this, pushLatest);
         connect(kw, &KWin::Window::windowClassChanged, this, invalidateRuleCache);

--- a/kwin-effect/shadertransitionmanager.cpp
+++ b/kwin-effect/shadertransitionmanager.cpp
@@ -22,11 +22,13 @@ void ShaderTransitionManager::rebuildAnimationRuleSet()
     // entries on next access.
     m_animationRuleSet.setRules(m_ruleAnimationRules);
 
-    // Recompute the SetOpacity-presence gate for the per-frame opacity resolve
-    // (see hasOpacityRules()). Only enabled rules count — a disabled opacity
-    // rule resolves to no override, so it must not force the per-window query
-    // build every frame.
+    // Recompute the action-presence gates: SetOpacity for the per-frame
+    // opacity resolve (see hasOpacityRules()) and SetWindowLayer for the
+    // layer reconcile / bulk sweep (see hasWindowLayerRules()). Only enabled
+    // rules count — a disabled rule resolves to no override, so it must not
+    // force the per-window query build.
     m_hasOpacityRules = false;
+    m_hasWindowLayerRules = false;
     for (const PhosphorRules::Rule& rule : m_ruleAnimationRules) {
         if (!rule.enabled) {
             continue;
@@ -34,10 +36,11 @@ void ShaderTransitionManager::rebuildAnimationRuleSet()
         for (const PhosphorRules::RuleAction& action : rule.actions) {
             if (action.type == PhosphorRules::ActionType::SetOpacity) {
                 m_hasOpacityRules = true;
-                break;
+            } else if (action.type == PhosphorRules::ActionType::SetWindowLayer) {
+                m_hasWindowLayerRules = true;
             }
         }
-        if (m_hasOpacityRules) {
+        if (m_hasOpacityRules && m_hasWindowLayerRules) {
             break;
         }
     }

--- a/kwin-effect/shadertransitionmanager.h
+++ b/kwin-effect/shadertransitionmanager.h
@@ -133,6 +133,18 @@ public:
         return m_hasOpacityRules;
     }
 
+    /// True when at least one enabled rule carries a `SetWindowLayer` action.
+    /// Gates the per-window layer reconcile (`reconcileRuleWindowLayer`'s fast
+    /// path) and the bulk-placement sweep in `invalidateAllRuleCaches` —
+    /// without it, a session whose rules never touch the layer (opacity or
+    /// border only) would still pay a cache-cold per-window rule resolution
+    /// across the whole stacking order on every daemon loss / bringup re-seed.
+    /// Recomputed by `rebuildAnimationRuleSet()` on every rule-set change.
+    bool hasWindowLayerRules() const
+    {
+        return m_hasWindowLayerRules;
+    }
+
     /// Per-event motion-profile tree mirrored from the daemon's
     /// PhosphorProfileRegistry over D-Bus (`motionProfileTree`). Holds
     /// the per-event base durations (window.open, window.close, …) that
@@ -340,6 +352,8 @@ private:
     // rebuildAnimationRuleSet() so the per-frame opacity resolve can skip the
     // WindowQuery build entirely when no opacity rule exists. See hasOpacityRules().
     bool m_hasOpacityRules = false;
+    // Same shape for SetWindowLayer. See hasWindowLayerRules().
+    bool m_hasWindowLayerRules = false;
 
     // ═══════════════════════════════════════════════════════════════════════════
     // Texture Cache

--- a/kwin-effect/shadertransitionmanager.h
+++ b/kwin-effect/shadertransitionmanager.h
@@ -91,15 +91,16 @@ public:
 
     /// Rebuild the effect-rule `RuleSet` from `m_ruleAnimationRules`
     /// — the rules from `rules.json` that carry any effect-consumed
-    /// action (the `OverrideAnimation*` triple plus `SetOpacity`; admitted
-    /// via `ActionRegistry::hasTag(type, Tag::Effect)`). Call after
-    /// every mutation of that list. The bound `RuleEvaluator` picks up
-    /// the new revision transparently and its match cache is invalidated.
+    /// action (admitted via `ActionRegistry::hasTag(type, Tag::Effect)`;
+    /// the authoritative membership list is the descriptor tag
+    /// assignments in ruleaction.cpp). Call after every mutation of that
+    /// list. The bound `RuleEvaluator` picks up the new revision
+    /// transparently and its match cache is invalidated.
     void rebuildAnimationRuleSet();
 
     /// Replace the set of `rules.json` rules that carry any
-    /// effect-consumed action (`OverrideAnimation*` or `SetOpacity` —
-    /// admitted via `ActionRegistry::hasTag(type, Tag::Effect)`). The effect refreshes this on the
+    /// effect-consumed action (admitted via
+    /// `ActionRegistry::hasTag(type, Tag::Effect)`). The effect refreshes this on the
     /// `org.plasmazones.Rules.rulesChanged` D-Bus signal so a new
     /// effect rule authored in the settings UI fires without a restart.
     /// Triggers `rebuildAnimationRuleSet()` only when the list actually
@@ -107,9 +108,8 @@ public:
     void setRuleAnimationRules(QList<PhosphorRules::Rule> rules);
 
     /// The evaluator bound to the effect-rule set. Resolution of the
-    /// per-window cascade for every effect-consumed action (the
-    /// `OverrideAnimation*` triple plus `SetOpacity`) routes through
-    /// this evaluator.
+    /// per-window cascade for every effect-consumed (`Tag::Effect`)
+    /// action routes through this evaluator.
     const PhosphorRules::RuleEvaluator& animationRuleEvaluator() const
     {
         return m_animationRuleEvaluator;
@@ -330,8 +330,8 @@ private:
     PhosphorAnimationShaders::ShaderProfileTree m_shaderProfileTree;
     PhosphorAnimation::ProfileTree m_motionProfileTree;
     // Rules from rules.json that carry any effect-consumed action
-    // (`OverrideAnimation*` triple OR `SetOpacity` — admitted via
-    // `ActionRegistry::hasTag(type, Tag::Effect)`). Refreshed
+    // (admitted via `ActionRegistry::hasTag(type, Tag::Effect)`;
+    // authoritative list in ruleaction.cpp). Refreshed
     // from the daemon's org.plasmazones.Rules interface on every
     // `rulesChanged` signal; mirrored into `m_animationRuleSet` so the
     // bound RuleEvaluator picks up the new revision.

--- a/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
+++ b/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
@@ -409,6 +409,18 @@ inline constexpr QLatin1StringView SetRestoreToZoneOnLogin{"setRestoreToZoneOnLo
 /// the drag-out / drop / cursor-left-zones unsnap paths. Domain Window.
 inline constexpr QLatin1StringView SetRestoreSizeOnUnsnap{"setRestoreSizeOnUnsnap"};
 
+/// Per-window stacking-layer override. Carries a closed enum token
+/// (`ActionParam::Value`, WindowLayerToken): `above` keeps the matched window
+/// above normal windows, `below` keeps it below, `normal` pins both flags off.
+/// Effect-consumed (reconcileRuleWindowLayer): the token maps onto KWin's
+/// keepAbove/keepBelow pair, BOTH flags are always written from the token (so
+/// a layer flip can never leave a stale opposite flag), the window's pre-rule
+/// flags are snapshotted on first application, and they are restored when no
+/// rule owns the layer any more. Combined with the IsFloating / IsTiled match
+/// fields this yields Krohnkite-style window layers ("floating windows above
+/// tiled windows"). Domain Window.
+inline constexpr QLatin1StringView SetWindowLayer{"setWindowLayer"};
+
 // ── Per-window border / title-bar appearance overrides (domain Window) ──
 // Effect-side per-window overrides of the global snap appearance. Each is its
 // own slot so independent rules cascade per-property (a width rule and a
@@ -575,6 +587,17 @@ inline constexpr QLatin1StringView Float{"float"}; ///< AutotileDragBehavior::Fl
 inline constexpr QLatin1StringView Reorder{"reorder"}; ///< Reorder (1)
 } // namespace DragBehaviorToken
 
+/// Wire tokens for SetWindowLayer's `value` param — the closed vocabulary the
+/// descriptor validator, the KWin-effect consumer (resolveWindowLayer), and the
+/// settings label layers all read from this single source. The tokens map onto
+/// KWin's keepAbove/keepBelow pair: above = keepAbove, below = keepBelow,
+/// normal = both off.
+namespace WindowLayerToken {
+inline constexpr QLatin1StringView Above{"above"};
+inline constexpr QLatin1StringView Normal{"normal"};
+inline constexpr QLatin1StringView Below{"below"};
+} // namespace WindowLayerToken
+
 /// Sentinel value a `SetBorderColorActive` / `SetBorderColorInactive` `value`
 /// param may carry instead of a hex string, meaning "track the live system
 /// accent colour". The
@@ -619,6 +642,9 @@ inline constexpr QLatin1StringView RestorePosition{"restore-position"};
 // SetRestoreToZoneOnLogin / SetRestoreSizeOnUnsnap, read daemon-side.
 inline constexpr QLatin1StringView RestoreToZoneOnLogin{"restore-to-zone-on-login"};
 inline constexpr QLatin1StringView RestoreSizeOnUnsnap{"restore-size-on-unsnap"};
+/// Window-scoped stacking-layer slot — filled by `ActionType::SetWindowLayer`,
+/// read by the KWin effect's reconcileRuleWindowLayer.
+inline constexpr QLatin1StringView WindowLayer{"window-layer"};
 // Per-window border / title-bar appearance slots (one per property so
 // independent rules cascade per-property).
 inline constexpr QLatin1StringView HideTitleBar{"hide-title-bar"};

--- a/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
+++ b/libs/phosphor-rules/include/PhosphorRules/RuleAction.h
@@ -130,7 +130,8 @@ struct PHOSPHORRULES_EXPORT ParamSchema
 // ExcludeAnimations) are exactly Tag::Animation ∩ Tag::Effect.
 namespace Tag {
 /// Actions consumed by the KWin effect's rule set (shader manager +
-/// border appearance). ExcludeAnimations deliberately omits this tag.
+/// border appearance + window stacking layer). ExcludeAnimations
+/// deliberately omits this tag.
 inline constexpr QLatin1StringView Effect{"effect"};
 inline constexpr QLatin1StringView Border{"border"};
 inline constexpr QLatin1StringView Animation{"animation"};

--- a/libs/phosphor-rules/src/ruleaction.cpp
+++ b/libs/phosphor-rules/src/ruleaction.cpp
@@ -968,6 +968,32 @@ void ActionRegistry::registerBuiltins()
         });
     }
 
+    // Per-window stacking-layer override. Effect-consumed (Tag::Effect admits it
+    // into the effect's rule set): reconcileRuleWindowLayer maps the token onto
+    // KWin's keepAbove/keepBelow pair, snapshotting the pre-rule flags so a rule
+    // that stops matching restores the user's own layer state. `above` is listed
+    // first so a fresh rule seeds the headline use case (floating windows above
+    // tiled windows, paired with an IsFloating match).
+    registerAction(ActionDescriptor{
+        .type = QString(ActionType::SetWindowLayer),
+        .slotFor = constantSlot(ActionSlot::WindowLayer),
+        .validate =
+            [](const QJsonObject& p) {
+                const QString v = p.value(ActionParam::Value).toString();
+                return v == WindowLayerToken::Above || v == WindowLayerToken::Normal || v == WindowLayerToken::Below;
+            },
+        .terminal = false,
+        .allowedKeys = {QString(ActionParam::Value)},
+        .domain = ActionDomain::Window,
+        .params = {P{.key = QString(ActionParam::Value),
+                     .kind = QStringLiteral("enum"),
+                     .enumWireValues = {QString(WindowLayerToken::Above), QString(WindowLayerToken::Normal),
+                                        QString(WindowLayerToken::Below)}}},
+        .category = QStringLiteral("windowManagement"),
+        .displayOrder = 8,
+        .tags = {QString(Tag::Effect)},
+    });
+
     // ── per-window border / title-bar appearance slots (domain Window) ──
     // One slot per property so independent rules cascade per-property. The
     // effect (resolveWindowAppearance) reads these slots and merges them over

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -773,6 +773,8 @@ private Q_SLOTS:
         rejectsStray(ActionType::DefaultLayoutAssignment, QJsonValue(true));
         // OverrideOverlayStyle also declares allowedKeys = {Value}.
         rejectsStray(ActionType::OverrideOverlayStyle, QJsonValue(QString(OverlayStyleToken::Preview)));
+        // SetWindowLayer is the same Value-keyed closed-enum shape.
+        rejectsStray(ActionType::SetWindowLayer, QJsonValue(QString(WindowLayerToken::Above)));
     }
 
     void testOverrideOverlay_fromJson()

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -598,6 +598,13 @@ private Q_SLOTS:
             QCOMPARE(*roundTripped, *loaded);
         }
 
+        // Tag::Effect is the SOLE admission gate into the KWin effect's rule
+        // set (the `hasTag(type, Tag::Effect)` loop in shader_transitions.cpp):
+        // a descriptor regression that drops the tag compiles and passes every
+        // vocabulary test above while silently never delivering the action.
+        // Pin the delivery contract.
+        QVERIFY(ActionRegistry::instance().hasTag(QString(ActionType::SetWindowLayer), Tag::Effect));
+
         // Outside the closed vocabulary — rejected at load. The effect-side
         // consumer maps an unknown token to "no override", so the load
         // boundary must be the strict one: missing value, an unknown token,

--- a/libs/phosphor-rules/tests/test_ruleaction.cpp
+++ b/libs/phosphor-rules/tests/test_ruleaction.cpp
@@ -99,6 +99,9 @@ const QList<QLatin1StringView> kWindowDomainTypes = {
     // (managed-restore predicate / drag-out unsnap paths), like RestorePosition.
     ActionType::SetRestoreToZoneOnLogin,
     ActionType::SetRestoreSizeOnUnsnap,
+    // Stacking-layer override — window-domain, effect-consumed
+    // (reconcileRuleWindowLayer maps the token onto keepAbove/keepBelow).
+    ActionType::SetWindowLayer,
 };
 } // namespace
 
@@ -574,6 +577,40 @@ private Q_SLOTS:
             o.insert(QStringLiteral("value"), false);
             QVERIFY2(RuleAction::fromJson(o).has_value(), type.data());
         }
+    }
+
+    void testSetWindowLayer_tokenVocabularyAndSlot()
+    {
+        // Pin the complete recognised layer vocabulary (the DisableEngine
+        // token-pinning precedent — a future token addition must update this
+        // test). All three tokens validate, round-trip stably, and resolve
+        // the window-layer slot.
+        for (const QLatin1StringView token :
+             {WindowLayerToken::Above, WindowLayerToken::Normal, WindowLayerToken::Below}) {
+            QJsonObject o;
+            o.insert(QStringLiteral("type"), QString(ActionType::SetWindowLayer));
+            o.insert(QStringLiteral("value"), QString::fromLatin1(token.data(), token.size()));
+            const auto loaded = RuleAction::fromJson(o);
+            QVERIFY2(loaded.has_value(), token.data());
+            QCOMPARE(ActionRegistry::instance().slotFor(*loaded), QString(ActionSlot::WindowLayer));
+            const auto roundTripped = RuleAction::fromJson(loaded->toJson());
+            QVERIFY2(roundTripped.has_value(), token.data());
+            QCOMPARE(*roundTripped, *loaded);
+        }
+
+        // Outside the closed vocabulary — rejected at load. The effect-side
+        // consumer maps an unknown token to "no override", so the load
+        // boundary must be the strict one: missing value, an unknown token,
+        // and non-string payloads all fail the descriptor validator.
+        QJsonObject bad;
+        bad.insert(QStringLiteral("type"), QString(ActionType::SetWindowLayer));
+        QVERIFY(!RuleAction::fromJson(bad).has_value()); // missing value
+        bad.insert(QStringLiteral("value"), QStringLiteral("topmost"));
+        QVERIFY(!RuleAction::fromJson(bad).has_value());
+        bad.insert(QStringLiteral("value"), true);
+        QVERIFY(!RuleAction::fromJson(bad).has_value());
+        bad.insert(QStringLiteral("value"), 2);
+        QVERIFY(!RuleAction::fromJson(bad).has_value());
     }
 
     // ── autotile parameter actions (context-domain) ──

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -322,6 +322,9 @@ QString paramLabel(const QString& type, const QString& key)
     if (type == ActionType::SetRestoreSizeOnUnsnap && key == ActionParam::Value) {
         return PhosphorI18n::tr("Restore size on unsnap (off = keep zone size)");
     }
+    if (type == ActionType::SetWindowLayer && key == ActionParam::Value) {
+        return PhosphorI18n::tr("Layer");
+    }
     // Border / title-bar overrides (all single-value, keyed ActionParam::Value).
     // SetHideTitleBar is tri-state at the effect: rule absent = mode decides,
     // ON = hide, OFF = force the title bar visible even where the mode hides
@@ -579,6 +582,9 @@ QString actionTypeLabelImpl(const QString& type)
     }
     if (type == ActionType::SetRestoreSizeOnUnsnap) {
         return PhosphorI18n::tr("Restore size on unsnap");
+    }
+    if (type == ActionType::SetWindowLayer) {
+        return PhosphorI18n::tr("Set window layer");
     }
     if (type == ActionType::OverrideAnimationShader) {
         return PhosphorI18n::tr("Override animation shader");
@@ -849,6 +855,17 @@ QString enumOptionLabel(const QString& type, const QString& key, const QString& 
         }
         if (wireValue == PhosphorRules::DragBehaviorToken::Reorder) {
             return PhosphorI18n::tr("Reorder in stack");
+        }
+    }
+    if (type == ActionType::SetWindowLayer && key == ActionParam::Value) {
+        if (wireValue == PhosphorRules::WindowLayerToken::Above) {
+            return PhosphorI18n::tr("Above other windows");
+        }
+        if (wireValue == PhosphorRules::WindowLayerToken::Normal) {
+            return PhosphorI18n::tr("Normal");
+        }
+        if (wireValue == PhosphorRules::WindowLayerToken::Below) {
+            return PhosphorI18n::tr("Below other windows");
         }
     }
     return wireValue;

--- a/src/settings/ruleauthoring.cpp
+++ b/src/settings/ruleauthoring.cpp
@@ -862,7 +862,7 @@ QString enumOptionLabel(const QString& type, const QString& key, const QString& 
             return PhosphorI18n::tr("Above other windows");
         }
         if (wireValue == PhosphorRules::WindowLayerToken::Normal) {
-            return PhosphorI18n::tr("Normal");
+            return PhosphorI18n::tr("Normal stacking");
         }
         if (wireValue == PhosphorRules::WindowLayerToken::Below) {
             return PhosphorI18n::tr("Below other windows");

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -413,7 +413,8 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
                               : PhosphorI18n::tr("Algorithm: %1").arg(resolveWith(algo, tilingAlgorithmLookup));
     }
     // ── single-value actions keyed on ActionParam::Value (restore-position,
-    //    border / title-bar overrides, per-context gap overrides) ──
+    //    border / title-bar, autotile, window-management, and overlay-appearance
+    //    overrides, per-context gap overrides) ──
     {
         const QJsonValue raw = action.params.value(PhosphorRules::ActionParam::Value);
         // Boolean actions render their polarity-aware phrase ("Show border" /

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -464,6 +464,10 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
             return PhosphorI18n::tr("Drag: %1")
                 .arg(RuleAuthoring::enumOptionLabel(action.type, PhosphorRules::ActionParam::Value, raw.toString()));
         }
+        if (action.type == ActionType::SetWindowLayer) {
+            return PhosphorI18n::tr("Layer: %1")
+                .arg(RuleAuthoring::enumOptionLabel(action.type, PhosphorRules::ActionParam::Value, raw.toString()));
+        }
         // ── overlay-appearance overrides (colours upper-cased hex; opacities
         //    are [0,1] on the wire, shown as a percent to match the editor) ──
         if (action.type == ActionType::SetOverlayHighlightColor) {

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -464,9 +464,14 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
             return PhosphorI18n::tr("Drag: %1")
                 .arg(RuleAuthoring::enumOptionLabel(action.type, PhosphorRules::ActionParam::Value, raw.toString()));
         }
+        // ── window-management overrides ──
         if (action.type == ActionType::SetWindowLayer) {
+            const QString v = raw.toString();
+            if (v.isEmpty()) {
+                return PhosphorI18n::tr("Window layer");
+            }
             return PhosphorI18n::tr("Layer: %1")
-                .arg(RuleAuthoring::enumOptionLabel(action.type, PhosphorRules::ActionParam::Value, raw.toString()));
+                .arg(RuleAuthoring::enumOptionLabel(action.type, PhosphorRules::ActionParam::Value, v));
         }
         // ── overlay-appearance overrides (colours upper-cased hex; opacities
         //    are [0,1] on the wire, shown as a percent to match the editor) ──

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -412,9 +412,9 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
         return algo.isEmpty() ? PhosphorI18n::tr("Algorithm parameter")
                               : PhosphorI18n::tr("Algorithm: %1").arg(resolveWith(algo, tilingAlgorithmLookup));
     }
-    // ── single-value actions keyed on ActionParam::Value (restore-position,
-    //    border / title-bar, autotile, window-management, and overlay-appearance
-    //    overrides, per-context gap overrides) ──
+    // ── single-value actions keyed on ActionParam::Value: bool actions
+    //    resolve through boolActionStateLabel first, everything else through
+    //    the per-type value formatting below ──
     {
         const QJsonValue raw = action.params.value(PhosphorRules::ActionParam::Value);
         // Boolean actions render their polarity-aware phrase ("Show border" /

--- a/src/settings/rulemodel.cpp
+++ b/src/settings/rulemodel.cpp
@@ -471,6 +471,14 @@ QString actionLabel(const RuleAction& action, const RuleModel::LabelLookup& snap
             if (v.isEmpty()) {
                 return PhosphorI18n::tr("Window layer");
             }
+            // Mirror the resolver's closed vocabulary (shader_resolve.cpp's
+            // resolveWindowLayer): an unknown token produces no runtime
+            // override, so the label must not claim one — same contract as
+            // the SetOpacity "(invalid)" guard above.
+            namespace LayerToken = PhosphorRules::WindowLayerToken;
+            if (v != LayerToken::Above && v != LayerToken::Normal && v != LayerToken::Below) {
+                return PhosphorI18n::tr("Window layer (invalid)");
+            }
             return PhosphorI18n::tr("Layer: %1")
                 .arg(RuleAuthoring::enumOptionLabel(action.type, PhosphorRules::ActionParam::Value, v));
         }

--- a/tests/unit/settings/test_rule_model.cpp
+++ b/tests/unit/settings/test_rule_model.cpp
@@ -111,7 +111,7 @@ private Q_SLOTS:
     void actionSummaryRendersAllEngineModes();
     void disableEngineNamesTheModeBeingDisabled();
     void setOpacityRendersValidValuesAndGuardsRejectPaths();
-    void setWindowLayerRendersTokenAndGuardsEmptyValue();
+    void setWindowLayerRendersTokenAndGuardsBadValues();
     void restorePositionRendersValueAwareLabel();
     void boolMatchConditionRendersOnOff();
     void shaderAndCurveLabelsResolveThroughLookups();
@@ -462,7 +462,7 @@ void TestRuleModel::setOpacityRendersValidValuesAndGuardsRejectPaths()
     QVERIFY2(labelAt(4).contains(QStringLiteral("invalid")), qPrintable(labelAt(4)));
 }
 
-void TestRuleModel::setWindowLayerRendersTokenAndGuardsEmptyValue()
+void TestRuleModel::setWindowLayerRendersTokenAndGuardsBadValues()
 {
     // Pin that the SetWindowLayer actionLabel resolves the wire token through
     // the shared enumOptionLabel (never leaking the raw lowercase token) and
@@ -493,6 +493,9 @@ void TestRuleModel::setWindowLayerRendersTokenAndGuardsEmptyValue()
             a.params.insert(ActionParam::Value, QStringLiteral("below"));
         }),
         buildRule([](RuleAction&) { }),
+        buildRule([](RuleAction& a) {
+            a.params.insert(ActionParam::Value, QStringLiteral("topmost"));
+        }),
     });
 
     const auto labelAt = [&](int row) {
@@ -506,6 +509,11 @@ void TestRuleModel::setWindowLayerRendersTokenAndGuardsEmptyValue()
     QVERIFY2(!labelAt(2).contains(QStringLiteral("below")), qPrintable(labelAt(2)));
     // Missing Value: bare placeholder, no dangling "Layer:" prefix.
     QCOMPARE(labelAt(3), QStringLiteral("Window layer"));
+    // Out-of-vocabulary token: "(invalid)" marker, never the raw token —
+    // the resolver ignores unknown tokens, so the label must not claim
+    // a layer override (mirrors the SetOpacity reject-path guard).
+    QVERIFY2(labelAt(4).contains(QStringLiteral("invalid")), qPrintable(labelAt(4)));
+    QVERIFY2(!labelAt(4).contains(QStringLiteral("topmost")), qPrintable(labelAt(4)));
 }
 
 void TestRuleModel::restorePositionRendersValueAwareLabel()

--- a/tests/unit/settings/test_rule_model.cpp
+++ b/tests/unit/settings/test_rule_model.cpp
@@ -111,6 +111,7 @@ private Q_SLOTS:
     void actionSummaryRendersAllEngineModes();
     void disableEngineNamesTheModeBeingDisabled();
     void setOpacityRendersValidValuesAndGuardsRejectPaths();
+    void setWindowLayerRendersTokenAndGuardsEmptyValue();
     void restorePositionRendersValueAwareLabel();
     void boolMatchConditionRendersOnOff();
     void shaderAndCurveLabelsResolveThroughLookups();
@@ -459,6 +460,52 @@ void TestRuleModel::setOpacityRendersValidValuesAndGuardsRejectPaths()
     QVERIFY2(labelAt(3).contains(QStringLiteral("invalid")), qPrintable(labelAt(3)));
     // Out-of-range: same marker
     QVERIFY2(labelAt(4).contains(QStringLiteral("invalid")), qPrintable(labelAt(4)));
+}
+
+void TestRuleModel::setWindowLayerRendersTokenAndGuardsEmptyValue()
+{
+    // Pin that the SetWindowLayer actionLabel resolves the wire token through
+    // the shared enumOptionLabel (never leaking the raw lowercase token) and
+    // degrades to the bare "Window layer" placeholder when Value is absent —
+    // reachable because setRules skips the isValid() gate addRule enforces,
+    // matching the SetOpacity guard test above.
+    const auto buildRule = [](std::function<void(RuleAction&)> tweakAction) {
+        Rule rule;
+        rule.id = QUuid::createUuid();
+        rule.priority = 200;
+        rule.match = MatchExpression::makeLeaf(Field::AppId, Operator::Equals, QStringLiteral("firefox"));
+        RuleAction action;
+        action.type = QString(ActionType::SetWindowLayer);
+        tweakAction(action);
+        rule.actions = {action};
+        return rule;
+    };
+
+    RuleModel model;
+    model.setRules({
+        buildRule([](RuleAction& a) {
+            a.params.insert(ActionParam::Value, QStringLiteral("above"));
+        }),
+        buildRule([](RuleAction& a) {
+            a.params.insert(ActionParam::Value, QStringLiteral("normal"));
+        }),
+        buildRule([](RuleAction& a) {
+            a.params.insert(ActionParam::Value, QStringLiteral("below"));
+        }),
+        buildRule([](RuleAction&) { }),
+    });
+
+    const auto labelAt = [&](int row) {
+        return model.data(model.index(row, 0), RuleModel::ActionSummaryRole).toString();
+    };
+    QVERIFY2(labelAt(0).contains(QStringLiteral("Above other windows")), qPrintable(labelAt(0)));
+    QVERIFY2(labelAt(1).contains(QStringLiteral("Normal")), qPrintable(labelAt(1)));
+    QVERIFY2(labelAt(2).contains(QStringLiteral("Below other windows")), qPrintable(labelAt(2)));
+    // Never the raw lowercase wire token.
+    QVERIFY2(!labelAt(0).contains(QStringLiteral("above")), qPrintable(labelAt(0)));
+    QVERIFY2(!labelAt(2).contains(QStringLiteral("below")), qPrintable(labelAt(2)));
+    // Missing Value: bare placeholder, no dangling "Layer:" prefix.
+    QCOMPARE(labelAt(3), QStringLiteral("Window layer"));
 }
 
 void TestRuleModel::restorePositionRendersValueAwareLabel()


### PR DESCRIPTION
## Summary

Implements the request from discussion #745 (reply thread): a window-layer option so floating windows can always stay above tiled windows, like Krohnkite's Window Layer setting.

Adds a new window-domain rule action **SetWindowLayer** carrying a closed `above` / `normal` / `below` enum token. Combined with the existing `IsFloating` / `IsTiled` match fields, the requested behavior is one rule:

> WHEN IsFloating THEN Set window layer: Above other windows

and the Krohnkite fork's default (push tiled windows down instead) is the inverse rule with `IsTiled` and Below.

## How it works

The action is consumed entirely effect-side. `reconcileRuleWindowLayer` resolves the new `window-layer` slot through the existing live rule query (which already carries the floating/tiled/snapped placement facts) and maps the token onto KWin's `keepAbove`/`keepBelow` pair. It rides the same triggers as the title-bar reconcile: window added, the placement-state flush on float/snap flips, and `updateAllDecorations` on rule edits and focus changes. No daemon change, no D-Bus change, and the action is purely additive (no schema migration, older builds drop the unknown action on load).

## Divergences from Krohnkite (deliberate)

Krohnkite's implementation has three lifecycle problems this avoids:

- **It never restores flags.** Disable the script or unmanage a window and the last-committed `keepBelow` sticks forever. Here the pre-rule flag pair is snapshotted on first application and restored when no rule owns the layer any more, with a destructor restore-all so an effect unload can't strand flags on live windows.
- **Stale opposite flag.** Its Above path sets `keepAbove` without clearing `keepBelow` (and vice versa), so an above-to-below transition leaves both set. Here the fully-specified pair is always written from the token.
- **It fights the user.** It re-asserts flags on every layout commit. Here re-asserts happen only on real triggers, and the snapshot is never re-captured under an active rule, so restore always returns the window to the user's own state.

## Scope note

`IsFloating` means explicitly floated (float toggle, Float rule, overflow float), which matches what Krohnkite's option covers. A window PlasmaZones has never managed is not "floating" and will not match.

## Settings UI

Picker label, param label, enum option labels, and the rule-list summary ("Layer: Above other windows"). Enum params render data-driven in ActionRow.qml, so no QML change. A fresh rule seeds Above, the headline use case.

## Testing

- New `testSetWindowLayer_tokenVocabularyAndSlot`: vocabulary pinning, round-trip stability, slot mapping, and rejection of unknown/missing/non-string payloads.
- Registered in the domain-completeness canary (`kWindowDomainTypes`).
- Full suite: 263/263 pass. clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)