### PR TITLE
feat(settings): make shader-page and per-event cards collapsible

### DIFF
--- a/src/settings/qml/AnimationEventCard.qml
+++ b/src/settings/qml/AnimationEventCard.qml
@@ -43,6 +43,10 @@ Item {
     property bool isParentNode: false
     property bool alwaysEnabled: false
     property bool collapsible: false
+    /// The card's hosting SettingsCard. The virtualized card list re-registers
+    /// its search anchor against this once the card builds, so a deep-link
+    /// reveal can expand the card when it's collapsed.
+    readonly property Item settingsCard: card
     // ── Internal state — one source of truth per UX axis ────────────
     // The on-disk schema is `Profile::toJson()` — a single `curve`
     // string that's either an easing wire format ("x1,y1,x2,y2",

--- a/src/settings/qml/AnimationEventCardList.qml
+++ b/src/settings/qml/AnimationEventCardList.qml
@@ -178,6 +178,19 @@ SettingsFlickable {
                     if (pg)
                         pg.unregisterSearchAnchor(cardLoader.searchAnchor);
                 }
+                // Once the card is built, re-register the anchor WITH its
+                // SettingsCard so revealAnchor can expand a collapsed card
+                // before scrolling (the initial registration passes a null
+                // card because the card doesn't exist until it scrolls in).
+                onLoaded: {
+                    if (!cardLoader.searchable)
+                        return;
+
+                    var pg = SearchAnchors.pageFor(cardLoader);
+                    var built = cardLoader.item as AnimationEventCard;
+                    if (pg && built)
+                        pg.registerSearchAnchor(cardLoader.searchAnchor, cardLoader, built.settingsCard);
+                }
 
                 Connections {
                     target: page
@@ -196,6 +209,7 @@ SettingsFlickable {
                     eventPath: cardLoader.modelData.eventPath
                     eventLabel: cardLoader.modelData.eventLabel
                     isParentNode: cardLoader.modelData.isParentNode === true
+                    collapsible: true
                 }
             }
         }

--- a/src/settings/qml/DecorationSurfaceCard.qml
+++ b/src/settings/qml/DecorationSurfaceCard.qml
@@ -148,6 +148,7 @@ Item {
 
         anchors.fill: parent
         headerText: root.cardLabel
+        collapsible: true
         // alwaysEnabled roots have nothing to inherit, so no override toggle —
         // mirrors AnimationEventCard's alwaysEnabled global root.
         showToggle: !root.alwaysEnabled

--- a/src/settings/qml/ShaderBrowserPage.qml
+++ b/src/settings/qml/ShaderBrowserPage.qml
@@ -419,6 +419,7 @@ SettingsFlickable {
         SettingsCard {
             Layout.fillWidth: true
             headerText: i18n("User shaders")
+            collapsible: true
             searchAnchor: "userShaders"
 
             contentItem: ColumnLayout {


### PR DESCRIPTION
## Summary
- The **User shaders** install card on the shared shader browser page (Animations / Snapping / Decoration → Shaders) is now collapsible; the grouped catalogue sections already were.
- Every **AnimationEventCard** (Transitions → Windows / OSDs / Overlays / Desktop, Motion → Window Motion / Window Dragging / Side Panels / Widgets, Layout Editor) is now collapsible via one `collapsible: true` at the single instantiation site in `AnimationEventCardList`.
- **DecorationSurfaceCard** (Decoration → Windows / OSDs / Popups) gets the same treatment.
- All cards use the standard `SettingsCard` collapse affordance: header chevron, click-to-collapse, default expanded, no persisted state (matching every other collapsible card).

## Reveal fix that came with it
Settings-search deep links to an event card register their anchor before the lazily-built card exists, passing a null card, so a reveal could not expand a collapsed card. `AnimationEventCard` now exposes its inner `SettingsCard` (`settingsCard`), and the list's Loader re-registers the anchor with it in `onLoaded` (typed via `as AnimationEventCard`), so a search jump expands a collapsed card before scrolling to it. The decoration list registers no search anchors, so nothing was needed there.

## Testing
- `qmllint` on all four files: no new warnings (remaining output is the pre-existing unqualified-access noise from the C++ `settingsController` context property).
- `qmlformat` parse checks pass; lefthook qmlformat pre-commit hook passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)