### PR TITLE
fix(settings): decouple global shader settings from overlay toggle

### DIFF
--- a/src/settings/qml/GeneralPage.qml
+++ b/src/settings/qml/GeneralPage.qml
@@ -105,21 +105,38 @@ SettingsFlickable {
         // SHADER EFFECTS CARD
         // =====================================================================
         // Frame rate + audio spectrum apply to all shader categories, so this
-        // card is global (moved here from Snapping → Overlay Appearance).
+        // card is global (moved here from Snapping → Overlay Appearance). The
+        // card deliberately has no master toggle: enableShaderEffects only
+        // governs the zone-overlay window shaders, whereas frame rate and the
+        // audio spectrum feed every shader category (overlay, animation,
+        // surface decoration). Gating those global rows behind the overlay
+        // switch would wrongly disable audio for animations and decorations,
+        // so "Overlay shaders" is just a normal row that gates nothing else.
         SettingsCard {
             id: shaderCard
 
             headerText: i18n("Shader Effects")
             searchAnchor: "shaderEffects"
-            showToggle: true
-            toggleChecked: appSettings.enableShaderEffects
             collapsible: true
-            onToggleClicked: checked => {
-                return appSettings.enableShaderEffects = checked;
-            }
 
             contentItem: ColumnLayout {
                 spacing: Kirigami.Units.smallSpacing
+
+                SettingsRow {
+                    title: i18n("Overlay shaders")
+                    searchAnchor: "overlayShaders"
+                    description: i18n("Render the zone overlay using GLSL shaders")
+
+                    SettingsSwitch {
+                        checked: appSettings.enableShaderEffects
+                        accessibleName: i18n("Enable overlay shaders")
+                        onToggled: function (newValue) {
+                            appSettings.enableShaderEffects = newValue;
+                        }
+                    }
+                }
+
+                SettingsSeparator {}
 
                 SettingsRow {
                     title: i18n("Frame rate")
@@ -163,7 +180,7 @@ SettingsFlickable {
                     Layout.rightMargin: Kirigami.Units.largeSpacing
                     type: Kirigami.MessageType.Warning
                     text: i18n("CAVA is not installed. Install the <b>cava</b> package to enable audio-reactive shader effects.")
-                    visible: !root.effectsBridge.cavaAvailable && shaderCard.toggleChecked
+                    visible: !root.effectsBridge.cavaAvailable
                 }
 
                 SettingsSeparator {}

--- a/src/settings/searchcatalog.cpp
+++ b/src/settings/searchcatalog.cpp
@@ -180,6 +180,8 @@ void seedSearchCatalog(PhosphorControl::SearchController* search)
                PhosphorI18n::tr("Rendering backend"),
                {PhosphorI18n::tr("opengl"), PhosphorI18n::tr("vulkan"), PhosphorI18n::tr("graphics")});
     addSection(search, QStringLiteral("general"), QStringLiteral("shaderEffects"), PhosphorI18n::tr("Shader Effects"));
+    addSetting(search, QStringLiteral("general"), QStringLiteral("overlayShaders"), PhosphorI18n::tr("Overlay shaders"),
+               {PhosphorI18n::tr("glsl"), PhosphorI18n::tr("zone"), PhosphorI18n::tr("overlay")});
     addSetting(search, QStringLiteral("general"), QStringLiteral("frameRate"), PhosphorI18n::tr("Frame rate"),
                {PhosphorI18n::tr("fps"), PhosphorI18n::tr("refresh"), PhosphorI18n::tr("animation")});
     addSetting(search, QStringLiteral("general"), QStringLiteral("audioSpectrum"), PhosphorI18n::tr("Audio spectrum"),


### PR DESCRIPTION
## Problem

The **Shader Effects** card's header toggle wrote `enableShaderEffects`, which at runtime only gates the **zone-overlay window shaders**. Its sibling rows, **Frame rate** and **Audio spectrum**, are global: they feed every shader category (overlay, animation, and surface decoration).

Because `SettingsCard` disables all of its content when the header toggle is off (`SettingsCard.qml:308-309`), turning off overlay shaders wrongly greyed out the global audio-spectrum and frame-rate controls, even though animations and decorations still consume that data.

## Fix

One card, no master toggle:

- Drop the card's header toggle. The overlay enable is now a plain **"Overlay shaders"** switch row (still bound to `enableShaderEffects`), sitting alongside Frame rate, Audio spectrum, and Spectrum bars.
- Every row is now independently editable; toggling overlay shaders no longer gates the global settings.
- Fixed the CAVA "not installed" warning banner, which referenced the removed `toggleChecked` (now shows whenever CAVA is missing).
- Registered the new "Overlay shaders" row in the settings search catalog (`searchcatalog.cpp`).

No C++ config/settings changes were needed; all four backing keys (`enableShaderEffects`, `shaderFrameRate`, `enableAudioVisualizer`, `audioSpectrumBarCount`) are unchanged, so the per-page reset manifest stays valid.

## Testing

- `make` build clean (settings app + daemon)
- `ctest`: 263/263 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)