### PR TITLE
fix(settings): tighten slider label gap and register missing search anchors

### DIFF
--- a/src/settings/qml/GeneralPage.qml
+++ b/src/settings/qml/GeneralPage.qml
@@ -126,7 +126,7 @@ SettingsFlickable {
                         to: root.effectsBridge.shaderFrameRateMax
                         value: appSettings.shaderFrameRate
                         valueSuffix: " fps"
-                        labelWidth: Kirigami.Units.gridUnit * 5
+                        labelWidth: Kirigami.Units.gridUnit * 4
                         onMoved: value => {
                             return appSettings.shaderFrameRate = Math.round(value);
                         }
@@ -199,7 +199,7 @@ SettingsFlickable {
                             stepSize: 2
                             value: appSettings.audioSpectrumBarCount
                             valueSuffix: ""
-                            labelWidth: Kirigami.Units.gridUnit * 5
+                            labelWidth: Kirigami.Units.gridUnit * 4
                             onMoved: value => {
                                 return appSettings.audioSpectrumBarCount = Math.round(value);
                             }
@@ -218,7 +218,7 @@ SettingsFlickable {
                             to: root.effectsBridge.audioNoiseReductionMax
                             value: appSettings.audioNoiseReduction
                             valueSuffix: ""
-                            labelWidth: Kirigami.Units.gridUnit * 5
+                            labelWidth: Kirigami.Units.gridUnit * 4
                             onMoved: value => {
                                 return appSettings.audioNoiseReduction = Math.round(value);
                             }
@@ -235,7 +235,7 @@ SettingsFlickable {
                             to: root.effectsBridge.audioExtraSmoothingMax
                             value: appSettings.audioExtraSmoothing
                             valueSuffix: "%"
-                            labelWidth: Kirigami.Units.gridUnit * 5
+                            labelWidth: Kirigami.Units.gridUnit * 4
                             onMoved: value => {
                                 return appSettings.audioExtraSmoothing = Math.round(value);
                             }
@@ -270,7 +270,7 @@ SettingsFlickable {
                             to: root.effectsBridge.audioSensitivityMax
                             value: appSettings.audioSensitivity
                             valueSuffix: "%"
-                            labelWidth: Kirigami.Units.gridUnit * 5
+                            labelWidth: Kirigami.Units.gridUnit * 4
                             onMoved: value => {
                                 return appSettings.audioSensitivity = Math.round(value);
                             }
@@ -289,7 +289,7 @@ SettingsFlickable {
                             to: root.effectsBridge.audioLowerCutoffHzMax
                             value: appSettings.audioLowerCutoffHz
                             valueSuffix: " Hz"
-                            labelWidth: Kirigami.Units.gridUnit * 5
+                            labelWidth: Kirigami.Units.gridUnit * 4
                             onMoved: value => {
                                 return appSettings.audioLowerCutoffHz = Math.round(value);
                             }
@@ -306,7 +306,7 @@ SettingsFlickable {
                             to: root.effectsBridge.audioHigherCutoffHzMax
                             value: appSettings.audioHigherCutoffHz
                             valueSuffix: " Hz"
-                            labelWidth: Kirigami.Units.gridUnit * 5
+                            labelWidth: Kirigami.Units.gridUnit * 4
                             onMoved: value => {
                                 return appSettings.audioHigherCutoffHz = Math.round(value);
                             }

--- a/src/settings/searchcatalog.cpp
+++ b/src/settings/searchcatalog.cpp
@@ -240,11 +240,6 @@ void seedSearchCatalog(PhosphorControl::SearchController* search)
     addSetting(search, QStringLiteral("general"), QStringLiteral("minimumWindowHeight"),
                PhosphorI18n::tr("Minimum window height"),
                {PhosphorI18n::tr("threshold"), PhosphorI18n::tr("short"), PhosphorI18n::tr("size")});
-    addSection(search, QStringLiteral("general"), QStringLiteral("configuration"), PhosphorI18n::tr("Configuration"));
-    addSetting(search, QStringLiteral("general"), QStringLiteral("backup"), PhosphorI18n::tr("Backup"),
-               {PhosphorI18n::tr("export"), PhosphorI18n::tr("save"), PhosphorI18n::tr("config")});
-    addSetting(search, QStringLiteral("general"), QStringLiteral("restore"), PhosphorI18n::tr("Restore"),
-               {PhosphorI18n::tr("import"), PhosphorI18n::tr("load"), PhosphorI18n::tr("config")});
     addSetting(search, QStringLiteral("general"), QStringLiteral("resetDefaults"), PhosphorI18n::tr("Reset"),
                {PhosphorI18n::tr("reset to defaults"), PhosphorI18n::tr("defaults"), PhosphorI18n::tr("restore")});
 

--- a/src/settings/searchcatalog.cpp
+++ b/src/settings/searchcatalog.cpp
@@ -182,11 +182,53 @@ void seedSearchCatalog(PhosphorControl::SearchController* search)
     addSection(search, QStringLiteral("general"), QStringLiteral("shaderEffects"), PhosphorI18n::tr("Shader Effects"));
     addSetting(search, QStringLiteral("general"), QStringLiteral("frameRate"), PhosphorI18n::tr("Frame rate"),
                {PhosphorI18n::tr("fps"), PhosphorI18n::tr("refresh"), PhosphorI18n::tr("animation")});
-    addSetting(search, QStringLiteral("general"), QStringLiteral("audioSpectrum"), PhosphorI18n::tr("Audio spectrum"),
+    addSection(search, QStringLiteral("general"), QStringLiteral("audioSpectrum"), PhosphorI18n::tr("Audio Spectrum"));
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioSpectrumEnabled"),
+               PhosphorI18n::tr("Audio spectrum"),
                {PhosphorI18n::tr("cava"), PhosphorI18n::tr("music"), PhosphorI18n::tr("visualizer"),
                 PhosphorI18n::tr("sound")});
     addSetting(search, QStringLiteral("general"), QStringLiteral("spectrumBars"), PhosphorI18n::tr("Spectrum bars"),
                {PhosphorI18n::tr("cava"), PhosphorI18n::tr("bands"), PhosphorI18n::tr("frequency")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioNoiseReduction"),
+               PhosphorI18n::tr("Noise reduction"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("smoothing"), PhosphorI18n::tr("smooth")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioExtraSmoothing"),
+               PhosphorI18n::tr("Extra smoothing"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("smoothing"), PhosphorI18n::tr("smooth")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioAutosens"), PhosphorI18n::tr("Automatic gain"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("autosens"), PhosphorI18n::tr("sensitivity"),
+                PhosphorI18n::tr("gain")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioSensitivity"), PhosphorI18n::tr("Sensitivity"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("gain")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioLowerCutoff"),
+               PhosphorI18n::tr("Lowest frequency"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("cutoff"), PhosphorI18n::tr("frequency"),
+                PhosphorI18n::tr("bass")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioHigherCutoff"),
+               PhosphorI18n::tr("Highest frequency"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("cutoff"), PhosphorI18n::tr("frequency"),
+                PhosphorI18n::tr("treble")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioChannelMode"), PhosphorI18n::tr("Channels"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("stereo"), PhosphorI18n::tr("mono")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioReverse"), PhosphorI18n::tr("Reverse bar order"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("flip"), PhosphorI18n::tr("mirror")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioMonstercat"),
+               PhosphorI18n::tr("Monstercat filter"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("filter"), PhosphorI18n::tr("smooth")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioWaves"), PhosphorI18n::tr("Wave filter"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("filter"), PhosphorI18n::tr("wave")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioInputMethod"), PhosphorI18n::tr("Audio backend"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("pipewire"), PhosphorI18n::tr("pulseaudio"),
+                PhosphorI18n::tr("capture")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("audioInputSource"), PhosphorI18n::tr("Audio source"),
+               {PhosphorI18n::tr("cava"), PhosphorI18n::tr("device"), PhosphorI18n::tr("monitor"),
+                PhosphorI18n::tr("capture")});
+    addSection(search, QStringLiteral("general"), QStringLiteral("layoutAssignment"),
+               PhosphorI18n::tr("Layout assignment"));
+    addSetting(search, QStringLiteral("general"), QStringLiteral("suppressDefaultLayoutAssignment"),
+               PhosphorI18n::tr("Don't assign a layout by default"),
+               {PhosphorI18n::tr("default"), PhosphorI18n::tr("assign"), PhosphorI18n::tr("snapping"),
+                PhosphorI18n::tr("tiling")});
     addSection(search, QStringLiteral("general"), QStringLiteral("windowFiltering"),
                PhosphorI18n::tr("Window filtering"));
     addSetting(search, QStringLiteral("general"), QStringLiteral("excludeTransient"),
@@ -198,6 +240,11 @@ void seedSearchCatalog(PhosphorControl::SearchController* search)
     addSetting(search, QStringLiteral("general"), QStringLiteral("minimumWindowHeight"),
                PhosphorI18n::tr("Minimum window height"),
                {PhosphorI18n::tr("threshold"), PhosphorI18n::tr("short"), PhosphorI18n::tr("size")});
+    addSection(search, QStringLiteral("general"), QStringLiteral("configuration"), PhosphorI18n::tr("Configuration"));
+    addSetting(search, QStringLiteral("general"), QStringLiteral("backup"), PhosphorI18n::tr("Backup"),
+               {PhosphorI18n::tr("export"), PhosphorI18n::tr("save"), PhosphorI18n::tr("config")});
+    addSetting(search, QStringLiteral("general"), QStringLiteral("restore"), PhosphorI18n::tr("Restore"),
+               {PhosphorI18n::tr("import"), PhosphorI18n::tr("load"), PhosphorI18n::tr("config")});
     addSetting(search, QStringLiteral("general"), QStringLiteral("resetDefaults"), PhosphorI18n::tr("Reset"),
                {PhosphorI18n::tr("reset to defaults"), PhosphorI18n::tr("defaults"), PhosphorI18n::tr("restore")});
 


### PR DESCRIPTION
## Summary

Two small General-page settings fixes.

### Slider value-label spacing
The audio/CAVA sliders and the frame-rate slider reserved `Kirigami.Units.gridUnit * 5` for their value label, leaving an oversized gap between each slider and its value (the labels floated far to the right and looked cramped). Reverted to `* 4`, which still fits the widest label (`10000 Hz`).

### Missing search-catalog anchors
Only `audioSpectrum` and `spectrumBars` had catalog entries, so most of the General page's `searchAnchor` tags matched nothing. Searching for "sensitivity", "monstercat", "stereo", "audio source", "backup", etc. returned no results and those rows never deep-linked or pulse-highlighted.

Registered the full set:
- **Audio Spectrum card** — `audioSpectrum` (now a Section, matching the `rendering`/`shaderEffects` cards it was inconsistent with), plus `audioSpectrumEnabled`, `audioNoiseReduction`, `audioExtraSmoothing`, `audioAutosens`, `audioSensitivity`, `audioLowerCutoff`, `audioHigherCutoff`, `audioChannelMode`, `audioReverse`, `audioMonstercat`, `audioWaves`, `audioInputMethod`, `audioInputSource`
- **Layout assignment card** — `layoutAssignment`, `suppressDefaultLayoutAssignment`
- **Configuration card** — `configuration`, `backup`, `restore`

Each entry carries a title matching its QML row plus relevant search keywords.

## Test plan
- `plasmazones-settings` builds and links cleanly.
- QML label-width change is data-only; no rebuild needed to observe.
- Search catalog is static seed data with no dedicated test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)