### PR TITLE
feat(animations): de-duplicate the Phosphor set and add open/close variety

### DIFF
--- a/data/animations/desktop-phosphor/effect.frag
+++ b/data/animations/desktop-phosphor/effect.frag
@@ -3,11 +3,20 @@
 //
 // Desktop Phosphor — the official Phosphor brand desktop switch, the
 // desktop leg of the phosphor-flux / phosphor-bloom / border-phosphor set.
-// A wide band of the brand accent gradient (cyan #22D3EE → blue #3B82F6 →
-// purple #A855F7 → rose #F43F5E) sweeps diagonally across the screen: ahead
-// of it the outgoing desktop, behind it the incoming one, and on the front
-// the image bends softly through the light like refraction. `t` is forward
-// switch progress in [0,1].
+// Where phosphor-bloom keeps the diagonal light sweep as the per-window
+// signature, the desktop switch borrows phosphor-flux's signal-graph motif
+// instead: a sparse circuit of nodes lights up across the screen in the
+// switch direction, a bright pulse races each trace and its arrival
+// activates the destination node, and the incoming desktop floods outward
+// from every lit node behind a thin front carrying the brand gradient
+// (cyan #22D3EE → blue #3B82F6 → purple #A855F7 → rose #F43F5E). `t` is
+// forward switch progress in [0,1].
+//
+// Causality is real, not faked: each graph cell owns an activation time
+// (directional projection plus per-cell stagger), every edge's pulse
+// departs its earlier-activated endpoint and lands exactly at the later
+// endpoint's activation, and that same activation clock starts the cell's
+// reveal flood. So the circuit visibly carries the switch.
 //
 // Colour is a real tunable here: the p_color* slots resolve to the
 // customColors pool, which the desktop-transition pass binds at parity with
@@ -28,52 +37,172 @@ vec3 fluxGradient(float t) {
     return c;
 }
 
+#ifdef PLASMAZONES_KWIN
+
+// Distance from p to segment ab.
+float sdSegment(vec2 p, vec2 a, vec2 b) {
+    vec2 pa = p - a;
+    vec2 ba = b - a;
+    float h = clamp(dot(pa, ba) / max(dot(ba, ba), 1.0e-6), 0.0, 1.0);
+    return length(pa - ba * h);
+}
+
+// Jittered node position for a graph cell, in graph units. Static (no
+// orbit): activation times and pulse arrivals are derived from these
+// positions, and a transition is too short for drift to read anyway.
+vec2 graphNodePos(vec2 cell) {
+    return cell + 0.2 + 0.6 * hash22(cell);
+}
+
+// Per-cell activation time in (0, ~0.65]: a directional ramp (the circuit
+// lights up along the switch direction) plus a per-cell stagger so the
+// front reads as signal propagation, not a straight wipe. `extent` is the
+// graph-space screen extent, so the projection is normalized to [0,1]
+// regardless of resolution or density.
+float nodeActivation(vec2 nodePos, vec2 dir, vec2 extent) {
+    vec2 nodeUV = nodePos / max(extent, vec2(1.0e-4));
+    float proj = clamp(dot(nodeUV - 0.5, dir) * 0.7071 + 0.5, 0.0, 1.0);
+    float stagger = classicHash(floor(nodePos * 7.3));
+    return 0.06 + proj * 0.44 + stagger * 0.14;
+}
+
+#endif // PLASMAZONES_KWIN
+
 vec4 pTransition(vec2 uv, float t) {
 #ifdef PLASMAZONES_KWIN
-    const float kPi = 3.14159265359;
+    // ── Graph space: aspect-corrected uv scaled by circuit density, same
+    // construction as phosphor-flux's signal-graph layer. ──
+    vec2 res = resolutionSafe();
+    float aspect = res.x / max(res.y, 1.0);
+    float scale = max(p_graphScale, 2.0);
+    vec2 extent = vec2(aspect, 1.0) * scale;
+    vec2 q = uv * extent;
+    vec2 cell = floor(q);
 
-    // ── Diagonal sweep coordinate with a gentle static ripple across the
-    // perpendicular axis, matching the phosphor-bloom window front. ──
-    float band = clamp(p_bandWidth, 0.05, 0.6);
-    float grad = (uv.x + uv.y) * 0.5;   // 0 top-left .. 1 bottom-right
-    float perp = uv.x - uv.y;
-    float ripple = sin(perp * 6.0) * 0.5 + sin(perp * 15.0 + 1.9) * 0.3;
-    float rippleAmp = clamp(p_ripple, 0.0, 1.0) * 0.05;
-    float threshold = grad + ripple * rippleAmp;
+    // Direction: follow the actual switch (iSwitchDelta via switchDirection)
+    // when p_followSwitch is on; the configured direction params are the
+    // fallback and the forced direction when it is off. The default (1, 1)
+    // keeps the brand's top-left-to-bottom-right diagonal.
+    vec2 cfg = vec2(p_dirX, p_dirY);
+    vec2 dir = normalize(((p_followSwitch > 0.5) ? switchDirection(cfg) : cfg)
+                         + vec2(1.0e-6, 0.0));
 
-    // Expand progress past [0,1] by the band plus the worst-case ripple
-    // offset (|ripple| <= 0.8) so the first / last pixels fully clear their
-    // threshold band at t=0 and t=1 (clean endpoints) even when the ripple
-    // pushes a threshold outside [0,1].
-    float slack = band + 0.8 * rippleAmp;
-    float p = t * (1.0 + 2.0 * slack) - slack;
+    // Feature sizes in graph units, derived from pixels so traces stay
+    // hairline and pulses stay compact at any resolution.
+    float pxInGraph = scale / max(res.y, 1.0);
+    float lineW  = 1.5 * pxInGraph;
+    float nodeR  = 3.0 * pxInGraph;
+    float pulseR = 5.0 * pxInGraph;
 
-    // reveal: 0 = still outgoing desktop .. 1 = incoming desktop.
-    float reveal = smoothstep(threshold - band, threshold + band, p);
+    // Global envelope for the additive circuit: exactly 0 at both endpoints
+    // so the settled desktops carry no residue, full through the middle.
+    float env = smoothstep(0.0, 0.06, t) * (1.0 - smoothstep(0.86, 0.97, t));
 
-    // Proximity to the light front (1 = on the leading edge).
-    float edge = clamp(1.0 - abs((p - threshold) / band), 0.0, 1.0);
+    // Flood speed in graph units per unit progress. The latest activation is
+    // ~0.64 and a pixel's own-cell node is at most ~1.14 units away, so by
+    // t = 1 the slowest front has travelled (1 - 0.64) * 6 = 2.16 units and
+    // every pixel has cleared its reveal smoothstep with margin.
+    const float floodSpeed = 6.0;
 
-    // ── Refraction: pixels near the front bend along the sweep direction, a
-    // full sine cycle across the band so the offset is zero at the band
-    // centre and at both band edges (no seams where the effect hands back the
-    // untouched desktops). ──
-    vec2 dir = normalize(vec2(1.0, 1.0));
-    float bend = sin(clamp((p - threshold) / band, -1.0, 1.0) * kPi);
-    vec2 offset = dir * bend * edge * clamp(p_warp, 0.0, 1.0) * 0.02;
+    // m: signed distance of the furthest-advanced reveal front past this
+    // fragment, maximized over the 3x3 node neighbourhood. Positive =
+    // incoming desktop has reached this pixel.
+    float m = -1.0e3;
+    vec3 circuit = vec3(0.0);
 
-    vec3 col = crossFade(uv + offset, reveal).rgb;
+    // 3x3 neighbourhood: each visited cell contributes its node, its reveal
+    // flood, and its edges toward the right and downward neighbours, so
+    // every edge is drawn exactly once and any fragment near a node, edge,
+    // or front is covered.
+    for (int dy = -1; dy <= 1; dy++) {
+        for (int dx = -1; dx <= 1; dx++) {
+            vec2 cA = cell + vec2(float(dx), float(dy));
+            vec2 posA = graphNodePos(cA);
+            float aA = nodeActivation(posA, dir, extent);
 
-    // ── Gradient light front: the full brand gradient rides the band, cyan
-    // on the leading edge and rose trailing into the incoming desktop, with
-    // a fine per-frame grain so the light shimmers as it passes. iFrame is
-    // bound on the desktop pass at contract parity, independent of the eased
-    // switch progress. ──
-    float q = clamp((p - threshold) / band * 0.5 + 0.5, 0.0, 1.0);
-    vec3 fluxC = fluxGradient(q);
-    float sparkle = 0.9 + 0.2 * classicHash(floor(uv * resolutionSafe() / 2.0)
+            // ── Reveal flood: the incoming desktop grows radially out of
+            // the node from the moment it activates. ──
+            float dNode = length(q - posA);
+            m = max(m, (t - aA) * floodSpeed - dNode);
+
+            // ── Node dot: flares as its activation lands, holds a dimmer
+            // core while its flood is still local, gone under env at the
+            // endpoints. ──
+            float flare = exp(-pow((t - aA) / 0.05, 2.0));
+            float hold  = smoothstep(aA - 0.02, aA + 0.02, t)
+                        * (1.0 - smoothstep(aA + 0.12, aA + 0.30, t));
+            float node = exp(-dNode * dNode / (nodeR * nodeR));
+            vec3 nodeCol = fluxGradient(clamp(aA * 1.6 - 0.1, 0.0, 1.0));
+            circuit += nodeCol * node * (2.2 * flare + 0.5 * hold);
+
+            // ── Edges to the right / downward neighbours, sparsely gated so
+            // the mesh reads as circuitry, not a grid. ──
+            for (int e = 0; e < 2; e++) {
+                vec2 cB = cA + (e == 0 ? vec2(1.0, 0.0) : vec2(0.0, 1.0));
+                float gate = classicHash(cA * 3.7 + float(e) * 13.1);
+                if (gate < 0.45) continue;
+
+                vec2 posB = graphNodePos(cB);
+                float aB = nodeActivation(posB, dir, extent);
+
+                // Order the endpoints by activation: the pulse departs the
+                // earlier node and arrives exactly at the later node's
+                // activation, so signal and reveal share one clock.
+                vec2 pFrom = aA <= aB ? posA : posB;
+                vec2 pTo   = aA <= aB ? posB : posA;
+                float a0 = min(aA, aB);
+                float a1 = max(aA, aB);
+
+                // Trace lights when its source activates and fades shortly
+                // after the pulse lands.
+                float lit = smoothstep(a0 - 0.02, a0 + 0.03, t)
+                          * (1.0 - smoothstep(a1 + 0.08, a1 + 0.25, t));
+                if (lit <= 0.001) continue;
+
+                float dEdge = sdSegment(q, pFrom, pTo);
+                float line = smoothstep(lineW, lineW * 0.3, dEdge);
+                vec3 edgeCol = fluxGradient(clamp(a0 * 1.6 - 0.1 + gate * 0.2, 0.0, 1.0));
+                circuit += edgeCol * line * 0.35 * lit;
+
+                // ── Travelling pulse with a short fading tail. ──
+                float ph = clamp((t - a0) / max(a1 - a0, 0.04), 0.0, 1.0);
+                float travelling = step(a0, t) * (1.0 - step(a1 + 0.02, t));
+                vec2 pulsePos = mix(pFrom, pTo, ph);
+                float dPulse = length(q - pulsePos);
+                float pulse = exp(-dPulse * dPulse / (pulseR * pulseR));
+                vec2 tailPos = mix(pFrom, pTo, max(ph - 0.15, 0.0));
+                float dTail = length(q - tailPos);
+                pulse += 0.35 * exp(-dTail * dTail / (pulseR * pulseR * 2.0));
+
+                vec3 pulseCol = fluxGradient(clamp(mix(a0, a1, ph) * 1.6 - 0.1, 0.0, 1.0));
+                circuit += pulseCol * pulse * 1.4 * travelling;
+            }
+        }
+    }
+
+    // reveal: 0 = still outgoing desktop .. 1 = incoming desktop. The
+    // completion floor guarantees a clean t = 1 endpoint even for a pixel
+    // pathologically far from every gated node.
+    float reveal = smoothstep(0.0, 0.12, m);
+    reveal = max(reveal, smoothstep(0.92, 1.0, t));
+
+    vec3 col = crossFade(uv, reveal).rgb;
+
+    // ── Gradient front: a thin rim of brand light rides the flood boundary,
+    // cyan-through-rose by how late the local front is, with a fine
+    // per-frame grain so the light shimmers as it passes. iFrame is bound on
+    // the desktop pass at contract parity, independent of the eased switch
+    // progress. ──
+    float front = smoothstep(-0.30, 0.0, m) * (1.0 - smoothstep(0.0, 0.30, m));
+    float sparkle = 0.9 + 0.2 * classicHash(floor(uv * res / 2.0)
                                             + floor(float(iFrame) * 0.2));
-    col += fluxC * edge * edge * clamp(p_glow, 0.0, 2.0) * 0.55 * sparkle;
+    vec3 frontCol = fluxGradient(clamp(t * 1.5 - 0.15, 0.0, 1.0));
+    col += frontCol * front * front * clamp(p_glow, 0.0, 2.0) * 0.5 * sparkle;
+
+    // Additive circuit, gated by the global envelope and dimmed where the
+    // incoming desktop has already settled so it never lingers as residue.
+    col += circuit * env * clamp(p_traceOpacity, 0.0, 1.0)
+                  * mix(1.0, 0.25, reveal) * clamp(p_glow * 0.5 + 0.5, 0.0, 1.5);
 
     // Two opaque desktops blended stay opaque — the pass draws with blending
     // off and replaces the screen, so alpha is a constant 1.

--- a/data/animations/desktop-phosphor/effect.frag
+++ b/data/animations/desktop-phosphor/effect.frag
@@ -127,8 +127,11 @@ vec4 pTransition(vec2 uv, float t) {
 
             // ── Node dot: flares as its activation lands, holds a dimmer
             // core while its flood is still local, gone under env at the
-            // endpoints. ──
-            float flare = exp(-pow((t - aA) / 0.05, 2.0));
+            // endpoints. Squared via multiply — pow(x, 2.0) is undefined
+            // for x < 0 per the GLSL spec (see phosphor-stream) and this
+            // argument is negative before every activation. ──
+            float fl = (t - aA) / 0.05;
+            float flare = exp(-fl * fl);
             float hold  = smoothstep(aA - 0.02, aA + 0.02, t)
                         * (1.0 - smoothstep(aA + 0.12, aA + 0.30, t));
             float node = exp(-dNode * dNode / (nodeR * nodeR));
@@ -159,14 +162,19 @@ vec4 pTransition(vec2 uv, float t) {
                           * (1.0 - smoothstep(a1 + 0.08, a1 + 0.25, t));
                 if (lit <= 0.001) continue;
 
+                // Inverted form rather than swapped arguments: smoothstep
+                // is undefined when edge0 >= edge1 per the GLSL spec.
                 float dEdge = sdSegment(q, pFrom, pTo);
-                float line = smoothstep(lineW, lineW * 0.3, dEdge);
+                float line = 1.0 - smoothstep(lineW * 0.3, lineW, dEdge);
                 vec3 edgeCol = fluxGradient(clamp(a0 * 1.6 - 0.1 + gate * 0.2, 0.0, 1.0));
                 circuit += edgeCol * line * 0.35 * lit;
 
-                // ── Travelling pulse with a short fading tail. ──
+                // ── Travelling pulse with a short fading tail. The pulse
+                // fades out over a short window after landing instead of
+                // cutting — a step() kill at arrival would drop the full
+                // gaussian brightness in one frame. ──
                 float ph = clamp((t - a0) / max(a1 - a0, 0.04), 0.0, 1.0);
-                float travelling = step(a0, t) * (1.0 - step(a1 + 0.02, t));
+                float travelling = step(a0, t) * (1.0 - smoothstep(a1, a1 + 0.06, t));
                 vec2 pulsePos = mix(pFrom, pTo, ph);
                 float dPulse = length(q - pulsePos);
                 float pulse = exp(-dPulse * dPulse / (pulseR * pulseR));

--- a/data/animations/desktop-phosphor/metadata.json
+++ b/data/animations/desktop-phosphor/metadata.json
@@ -1,7 +1,7 @@
 {
     "id": "desktop-phosphor",
     "name": "Desktop Phosphor",
-    "description": "Switches desktops behind a diagonal band of light in the official Phosphor style. The front carries the brand gradient from cyan to rose, and the image bends softly through it like refraction.",
+    "description": "Switches desktops over a circuit of light in the official Phosphor style. Signal pulses race along glowing traces in the switch direction, nodes flare as each pulse arrives, and the new desktop floods outward from every lit node behind a thin front carrying the brand gradient.",
     "author": "PlasmaZones",
     "version": "1.0",
     "category": "Reveal",
@@ -9,26 +9,40 @@
     "fragmentShader": "effect.frag",
     "parameters": [
         {
-            "id": "bandWidth",
-            "name": "Front Width",
-            "type": "float",
-            "default": 0.28,
-            "min": 0.05,
-            "max": 0.6
+            "id": "followSwitch",
+            "name": "Follow Switch Direction",
+            "type": "bool",
+            "default": true
         },
         {
-            "id": "ripple",
-            "name": "Front Ripple",
+            "id": "dirX",
+            "name": "Direction X",
             "type": "float",
-            "default": 0.3,
-            "min": 0.0,
+            "default": 1.0,
+            "min": -1.0,
             "max": 1.0
         },
         {
-            "id": "warp",
-            "name": "Refraction",
+            "id": "dirY",
+            "name": "Direction Y",
             "type": "float",
-            "default": 0.5,
+            "default": 1.0,
+            "min": -1.0,
+            "max": 1.0
+        },
+        {
+            "id": "graphScale",
+            "name": "Circuit Density",
+            "type": "float",
+            "default": 5.0,
+            "min": 2.0,
+            "max": 12.0
+        },
+        {
+            "id": "traceOpacity",
+            "name": "Trace Brightness",
+            "type": "float",
+            "default": 0.7,
             "min": 0.0,
             "max": 1.0
         },

--- a/data/animations/phosphor-condense/effect.frag
+++ b/data/animations/phosphor-condense/effect.frag
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Phosphor Condense — a Phosphor-set open/close candidate built on the
+// ember motif (phosphor-motes, and the ember layers of phosphor-flux and
+// phosphor-stream): the window condenses out of rising luminous dust. A
+// noisy frontier climbs the surface from the bottom; below it the image
+// has settled, above it there is nothing yet but ember sparks drifting
+// upward, thickest right at the frontier where they are visibly feeding
+// the picture. The embers and the frontier rim carry the brand accent
+// gradient (cyan #22D3EE → blue #3B82F6 → purple #A855F7 → rose #F43F5E).
+// Symmetric — the runtime flips iTime on the close leg, so open condenses
+// the window out of the dust and close disperses it back through the same
+// pass.
+//
+// Output is premultiplied alpha (phosphor-bloom's contract): rgb is
+// already scaled by alpha, and the ember sparks add their own small
+// coverage so they read over whatever is behind the window.
+
+#include <animation_uniforms.glsl>
+#include <noise.glsl>
+
+// Four-stop brand gradient, t in [0, 1]: cyan → blue → purple → rose.
+vec3 fluxGradient(float t) {
+    vec3 cyan   = length(p_colorCyan.rgb)   > 0.01 ? p_colorCyan.rgb   : vec3(0.133, 0.827, 0.933);
+    vec3 blue   = length(p_colorBlue.rgb)   > 0.01 ? p_colorBlue.rgb   : vec3(0.231, 0.510, 0.965);
+    vec3 purple = length(p_colorPurple.rgb) > 0.01 ? p_colorPurple.rgb : vec3(0.659, 0.333, 0.969);
+    vec3 rose   = length(p_colorRose.rgb)   > 0.01 ? p_colorRose.rgb   : vec3(0.957, 0.247, 0.369);
+    t = clamp(t, 0.0, 1.0) * 3.0;
+    vec3 c = mix(cyan, blue, clamp(t, 0.0, 1.0));
+    c = mix(c, purple, clamp(t - 1.0, 0.0, 1.0));
+    c = mix(c, rose, clamp(t - 2.0, 0.0, 1.0));
+    return c;
+}
+
+vec4 pTransition(vec2 uv, float t)
+{
+    // Amount of the window that has condensed. iTime is per-leg [0,1]
+    // progress; the runtime runs it 1->0 on the close leg.
+    float presence = clamp(iTime, 0.0, 1.0);
+
+    if (presence <= 0.0) return vec4(0.0);
+    if (presence >= 1.0) return surfaceColor(uv);
+
+    vec2 anchor = max(iAnchorSize, vec2(1.0));
+    float aspect = anchor.x / anchor.y;
+
+    // ── Condensation frontier: mostly height (the picture settles bottom
+    // to top, condensing out of the rising dust) roughened by fBm so the
+    // edge reads as dust thickening, not a ruled line. threshold stays in
+    // ~[0,1]; presence is expanded past it by the softness so every pixel
+    // fully clears its smoothstep at the leg endpoints. ──
+    float soft = clamp(p_softness, 0.05, 0.4);
+    float grain = clamp(p_grain, 0.2, 3.0);
+    float n = fbm(uv * vec2(aspect, 1.0) * grain * 4.0 + 3.1, 4, 2.0);
+    float threshold = (1.0 - uv.y) * 0.45 + n * 0.55;
+
+    float slack = soft;
+    float pp = presence * (1.0 + 2.0 * slack) - slack;
+
+    // reveal: 0 = still dust, 1 = condensed picture.
+    float reveal = smoothstep(-soft, soft, pp - threshold);
+
+    // Mid-leg envelope: exactly zero at both endpoints so the settled and
+    // the fully-dispersed window carry no live sparks into the early-outs.
+    float mid = clamp(presence * (1.0 - presence) * 4.0, 0.0, 1.0);
+
+    vec4 s = surfaceColor(uv);   // premultiplied
+    vec4 col = s * reveal;
+
+    // Height sample of the gradient shared by rim and embers: cyan low,
+    // rose at the top, so the whole condensation reads in brand order.
+    float yUp = 1.0 - uv.y;
+
+    // ── Frontier rim: the dust glows where it is actively condensing.
+    // Coverage-weighted so the light stays inside the window silhouette. ──
+    // Squared via multiply: pow(x, 2.0) is undefined for x < 0 per the GLSL
+    // spec (see phosphor-stream), and this argument is signed.
+    float rimD = (pp - threshold) / (soft * 0.6);
+    float rim = exp(-rimD * rimD);
+    vec3 rimCol = fluxGradient(clamp(yUp * 0.8 + n * 0.2, 0.0, 1.0));
+    float sparkle = 0.85 + 0.30 * niriHash(floor(uv * anchor / 2.0)
+                                           + floor(float(iFrame) * 0.2));
+    col.rgb += rimCol * rim * mid * s.a * clamp(p_glow, 0.0, 2.0) * 0.8 * sparkle;
+
+    // ── Ember columns above the frontier: one comet-tailed spark per
+    // column (the motes life cycle — fade in low, burn out at altitude),
+    // rising through the un-condensed region. Progress drives the clock,
+    // so the close leg plays the dust in reverse. Emissive with a small
+    // coverage bump of its own: the un-condensed region has no surface
+    // alpha to ride, and without it the sparks could not composite. ──
+    float emberAmt = clamp(p_embers, 0.0, 1.0);
+    if (emberAmt > 0.001) {
+        float density = clamp(p_density, 8.0, 60.0);
+        float colW = 1.0 / density;
+        float colIdx = floor(uv.x / colW);
+        float cx = (colIdx + 0.5) * colW;
+        float seed = niriHash(vec2(colIdx * 7.13 + 0.37, 1.7));
+
+        float rate = 0.5 + 0.7 * seed;
+        float altitude = fract(seed * 7.0 - presence * rate);
+
+        // Motes-style wander, kept inside the column.
+        float sway = sin(yUp * 7.0 + seed * 6.2831853 + presence * 3.0) * colW * 0.30;
+        float dx = (uv.x - (cx + sway)) * aspect;
+        float dy = yUp - altitude;   // > 0 above the head
+
+        float cw = colW * aspect;
+        float tailLen = 0.06 + 0.06 * seed;
+        float head = exp(-dx * dx / (cw * cw * 0.05)) * exp(-dy * dy / 0.0002);
+        float tailE = exp(-dx * dx / (cw * cw * 0.02))
+                    * (dy < 0.0 ? exp(dy / tailLen) : 0.0);
+
+        // Life envelope plus locality: sparks live in the dust, thickest
+        // just above the frontier that is consuming them.
+        float life = smoothstep(0.0, 0.12, altitude)
+                   * (1.0 - smoothstep(0.70, 0.95, altitude));
+        float dust = (1.0 - reveal) * (0.35 + 0.65 * exp(-max(threshold - pp, 0.0) / (soft * 2.0)));
+
+        vec3 emberCol = fluxGradient(clamp(altitude * 0.85 + seed * 0.15, 0.0, 1.0));
+        float ember = (head + tailE * 0.5) * life * dust * mid * emberAmt;
+
+        col.rgb += emberCol * ember;
+        col.a = min(col.a + ember * 0.5, 1.0);
+    }
+
+    col.rgb = clamp(col.rgb, 0.0, 1.0);
+    col.a = clamp(col.a, 0.0, 1.0);
+    return col;
+}

--- a/data/animations/phosphor-condense/metadata.json
+++ b/data/animations/phosphor-condense/metadata.json
@@ -1,0 +1,75 @@
+{
+    "id": "phosphor-condense",
+    "name": "Phosphor Condense",
+    "description": "The window condenses out of rising ember dust in the Phosphor style. Sparks drift upward and thicken along a noisy frontier that climbs the surface, each region locking into the image as the light reaches it, with the brand gradient from cyan to rose riding the embers. Closing disperses the window back into embers that burn out as they rise.",
+    "author": "PlasmaZones",
+    "version": "1.0",
+    "category": "Particle",
+    "fragmentShader": "effect.frag",
+    "parameters": [
+        {
+            "id": "grain",
+            "name": "Frontier Grain",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.2,
+            "max": 3.0
+        },
+        {
+            "id": "softness",
+            "name": "Frontier Softness",
+            "type": "float",
+            "default": 0.15,
+            "min": 0.05,
+            "max": 0.4
+        },
+        {
+            "id": "density",
+            "name": "Ember Density",
+            "type": "float",
+            "default": 26.0,
+            "min": 8.0,
+            "max": 60.0
+        },
+        {
+            "id": "embers",
+            "name": "Ember Intensity",
+            "type": "float",
+            "default": 0.8,
+            "min": 0.0,
+            "max": 1.0
+        },
+        {
+            "id": "glow",
+            "name": "Frontier Glow",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.0,
+            "max": 2.0
+        },
+        {
+            "id": "colorCyan",
+            "name": "Gradient Cyan",
+            "type": "color",
+            "default": "#22D3EE"
+        },
+        {
+            "id": "colorBlue",
+            "name": "Gradient Blue",
+            "type": "color",
+            "default": "#3B82F6"
+        },
+        {
+            "id": "colorPurple",
+            "name": "Gradient Purple",
+            "type": "color",
+            "default": "#A855F7"
+        },
+        {
+            "id": "colorRose",
+            "name": "Gradient Rose",
+            "type": "color",
+            "default": "#F43F5E"
+        }
+    ]
+}

--- a/data/animations/phosphor-ignite/effect.frag
+++ b/data/animations/phosphor-ignite/effect.frag
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Phosphor Ignition — a Phosphor-set open/close candidate built on the
+// plasma motif (phosphor-vortex's element, minus the vortex): the window
+// ignites from its centre. A plasma bloom expands radially behind a
+// turbulent, noise-eaten rim of brand light with soft tendrils reaching
+// ahead of it, the freshly-passed region shimmers briefly with heat, and
+// the rim carries the brand accent gradient (cyan #22D3EE → blue #3B82F6
+// → purple #A855F7 → rose #F43F5E) from cyan at the core to rose at the
+// corners. Outside the bloom there is nothing yet — the window literally
+// grows out of the ignition.
+// Symmetric — the runtime flips iTime on the close leg, so open ignites
+// outward and close collapses the plasma back into the centre through the
+// same pass.
+//
+// Output is premultiplied alpha (phosphor-bloom's contract): rgb is
+// already scaled by alpha, plus an additive rim glow bounded by the
+// surface coverage.
+
+#include <animation_uniforms.glsl>
+#include <noise.glsl>
+
+// Four-stop brand gradient, t in [0, 1]: cyan → blue → purple → rose.
+vec3 fluxGradient(float t) {
+    vec3 cyan   = length(p_colorCyan.rgb)   > 0.01 ? p_colorCyan.rgb   : vec3(0.133, 0.827, 0.933);
+    vec3 blue   = length(p_colorBlue.rgb)   > 0.01 ? p_colorBlue.rgb   : vec3(0.231, 0.510, 0.965);
+    vec3 purple = length(p_colorPurple.rgb) > 0.01 ? p_colorPurple.rgb : vec3(0.659, 0.333, 0.969);
+    vec3 rose   = length(p_colorRose.rgb)   > 0.01 ? p_colorRose.rgb   : vec3(0.957, 0.247, 0.369);
+    t = clamp(t, 0.0, 1.0) * 3.0;
+    vec3 c = mix(cyan, blue, clamp(t, 0.0, 1.0));
+    c = mix(c, purple, clamp(t - 1.0, 0.0, 1.0));
+    c = mix(c, rose, clamp(t - 2.0, 0.0, 1.0));
+    return c;
+}
+
+vec4 pTransition(vec2 uv, float t)
+{
+    // Radius of the ignition. iTime is per-leg [0,1] progress; the runtime
+    // runs it 1->0 on the close leg, collapsing the plasma back in.
+    float presence = clamp(iTime, 0.0, 1.0);
+
+    if (presence <= 0.0) return vec4(0.0);
+    if (presence >= 1.0) return surfaceColor(uv);
+
+    vec2 anchor = max(iAnchorSize, vec2(1.0));
+    float aspect = anchor.x / anchor.y;
+
+    // ── Aspect-corrected radial coordinate: rr is 0 at the window centre
+    // and 1 at the corners, so a square bloom covers any window shape. ──
+    vec2 pos = (uv - 0.5) * vec2(aspect, 1.0);
+    float maxR = 0.5 * length(vec2(aspect, 1.0));
+    float rr = length(pos) / maxR;
+
+    // ── Local ignition threshold: the radius roughened by fBm (the rim is
+    // eaten by turbulence, never a compass circle) and by angular tendrils
+    // reaching ahead of the bloom. Both distortions are bounded so the
+    // slack below can guarantee clean endpoints. ──
+    float soft = clamp(p_softness, 0.04, 0.3);
+    float turb = clamp(p_turbulence, 0.0, 1.0);
+    float arms = clamp(p_arms, 0.0, 9.0);
+
+    float n = fbm(pos * 4.0 / max(maxR, 1.0e-4) * 0.5 + 7.3, 4, 2.0);
+    float tendril = 0.0;
+    if (arms >= 0.5) {
+        float ang = atan(pos.y, pos.x);
+        // floor(arms + 0.5) keeps the petal count integral so the tendril
+        // field is continuous across the atan seam at ±π.
+        float armN = floor(arms + 0.5);
+        tendril = (0.5 + 0.5 * sin(ang * armN + rr * 5.0 + presence * 3.0)) * 0.5;
+    }
+    float wobble = (n - 0.5) * turb * 0.30 + tendril * turb * 0.12;
+    float threshold = rr + wobble;
+
+    // Expand presence past [0,1] by the softness plus the worst-case
+    // wobble, with the same 3x gaussian margin as phosphor-lock so the rim
+    // glow (not just the reveal smoothstep) is fully off at both leg
+    // endpoints.
+    float slack = 3.0 * soft + 0.21 * turb;
+    float front = presence * (1.0 + 2.0 * slack) - slack;
+
+    // m > 0: the bloom has passed this pixel.
+    float m = front - threshold;
+
+    // reveal: 0 outside the plasma, 1 behind it.
+    float reveal = smoothstep(0.0, soft, m);
+
+    // ── Heat shimmer: the freshly-ignited region refracts outward for a
+    // moment, strongest just behind the rim. Boundary-masked so the
+    // displaced sample never smears the clamped edge texel. Squared via
+    // multiply — pow(x, 2) is undefined for x < 0 per the GLSL spec and m
+    // is signed. ──
+    float md = m / soft;
+    float rim = exp(-md * md);
+    vec2 outward = length(pos) > 1.0e-4 ? pos / length(pos) : vec2(0.0);
+    vec2 bend = outward * rim * clamp(p_shimmer, 0.0, 1.0) * 0.015 / vec2(aspect, 1.0);
+    vec2 suv = uv - bend;
+    vec4 s = surfaceColor(suv) * boundaryMask(suv);   // premultiplied
+
+    vec4 col = s * reveal;
+
+    // ── Plasma rim: the gradient rides the radius (cyan at the core, rose
+    // at the corners), lifted by the tendrils and a fine per-frame grain.
+    // Coverage-weighted so the light stays inside the window silhouette. ──
+    vec3 rimCol = fluxGradient(clamp(rr * 1.1, 0.0, 1.0));
+    float sparkle = 0.85 + 0.30 * niriHash(floor(uv * anchor / 2.0)
+                                           + floor(float(iFrame) * 0.2));
+    float lift = 0.7 + 0.6 * tendril;
+    col.rgb += rimCol * rim * lift * s.a * clamp(p_glow, 0.0, 2.0) * sparkle;
+
+    // Same bounds as phosphor-bloom: bound the additive emissive here, and
+    // never let a pixel be more opaque than the window is at that point.
+    col.rgb = clamp(col.rgb, 0.0, 1.0);
+    col.a = clamp(col.a + rim * s.a * 0.4, 0.0, s.a);
+
+    return col;
+}

--- a/data/animations/phosphor-ignite/metadata.json
+++ b/data/animations/phosphor-ignite/metadata.json
@@ -1,0 +1,75 @@
+{
+    "id": "phosphor-ignite",
+    "name": "Phosphor Ignition",
+    "description": "The window ignites from its centre in the Phosphor style. A plasma bloom expands outward behind a turbulent rim of brand light with soft tendrils reaching ahead of it, the image shimmers briefly where the heat has just passed, and the rim carries the gradient from cyan at the core to rose at the corners. Closing collapses the plasma back into the centre.",
+    "author": "PlasmaZones",
+    "version": "1.0",
+    "category": "Reveal",
+    "fragmentShader": "effect.frag",
+    "parameters": [
+        {
+            "id": "softness",
+            "name": "Rim Softness",
+            "type": "float",
+            "default": 0.12,
+            "min": 0.04,
+            "max": 0.3
+        },
+        {
+            "id": "turbulence",
+            "name": "Rim Turbulence",
+            "type": "float",
+            "default": 0.6,
+            "min": 0.0,
+            "max": 1.0
+        },
+        {
+            "id": "arms",
+            "name": "Tendril Count",
+            "type": "float",
+            "default": 5.0,
+            "min": 0.0,
+            "max": 9.0
+        },
+        {
+            "id": "shimmer",
+            "name": "Heat Shimmer",
+            "type": "float",
+            "default": 0.5,
+            "min": 0.0,
+            "max": 1.0
+        },
+        {
+            "id": "glow",
+            "name": "Rim Glow",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.0,
+            "max": 2.0
+        },
+        {
+            "id": "colorCyan",
+            "name": "Gradient Cyan",
+            "type": "color",
+            "default": "#22D3EE"
+        },
+        {
+            "id": "colorBlue",
+            "name": "Gradient Blue",
+            "type": "color",
+            "default": "#3B82F6"
+        },
+        {
+            "id": "colorPurple",
+            "name": "Gradient Purple",
+            "type": "color",
+            "default": "#A855F7"
+        },
+        {
+            "id": "colorRose",
+            "name": "Gradient Rose",
+            "type": "color",
+            "default": "#F43F5E"
+        }
+    ]
+}

--- a/data/animations/phosphor-scan/effect.frag
+++ b/data/animations/phosphor-scan/effect.frag
@@ -58,7 +58,9 @@ vec4 pTransition(vec2 uv, float t)
     float bd = clamp(1.0 - abs(uv.y - yB) / beamH, 0.0, 1.0);
 
     // lit: 1 above the beam (already scanned), 0 below (still dark).
-    float lit = smoothstep(yB + beamH * 0.5, yB - beamH * 0.5, uv.y);
+    // Inverted form rather than swapped arguments: smoothstep is undefined
+    // when edge0 >= edge1 per the GLSL spec.
+    float lit = 1.0 - smoothstep(yB - beamH * 0.5, yB + beamH * 0.5, uv.y);
 
     // Mid-leg envelope: peaks mid-flight, exactly zero at both endpoints.
     // Gates the persistence trail, scanlines, and jitter so a settled
@@ -92,8 +94,8 @@ vec4 pTransition(vec2 uv, float t)
 
     // ── Scanlines on the lit picture, fading out as it stabilises: fine
     // alternating rows in device pixels, mid-gated so the settled image is
-    // untouched. Multiplicative on the premultiplied pair, so coverage dims
-    // in step with the body. ──
+    // untouched. Deliberately dims rgb only, leaving alpha untouched: CRT
+    // scanlines are dark rows on the picture, not transparent slits in it. ──
     float scanAmt = clamp(p_scanlines, 0.0, 1.0) * mid;
     float scan = 0.5 + 0.5 * sin(px.y * 3.14159265);
     float scanDim = 1.0 - scanAmt * 0.35 * (1.0 - scan) * lit;

--- a/data/animations/phosphor-scan/effect.frag
+++ b/data/animations/phosphor-scan/effect.frag
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2026 fuddlesworth
+// SPDX-License-Identifier: LGPL-2.1-or-later
+//
+// Phosphor Scan — a Phosphor-set open/close candidate that leans into the
+// name itself: the window powers on like a phosphor screen. A bright beam
+// scans top to bottom, the rows it has passed glow with a decaying
+// persistence trail before settling into the image, faint scanlines fade
+// as the picture stabilises, and the beam carries the brand accent
+// gradient (cyan #22D3EE → blue #3B82F6 → purple #A855F7 → rose #F43F5E).
+// Below the beam the surface waits as a dark navy silhouette.
+// Symmetric — the runtime flips iTime on the close leg, so open scans the
+// picture in and close powers it back down through the same pass.
+//
+// Output is premultiplied alpha (phosphor-bloom's contract): the runtime
+// hands pTransition's return straight to the compositor, so rgb is already
+// scaled by alpha, plus an additive beam glow bounded by the surface
+// coverage.
+
+#include <animation_uniforms.glsl>
+#include <noise.glsl>
+
+// Four-stop brand gradient, t in [0, 1]: cyan → blue → purple → rose.
+vec3 fluxGradient(float t) {
+    vec3 cyan   = length(p_colorCyan.rgb)   > 0.01 ? p_colorCyan.rgb   : vec3(0.133, 0.827, 0.933);
+    vec3 blue   = length(p_colorBlue.rgb)   > 0.01 ? p_colorBlue.rgb   : vec3(0.231, 0.510, 0.965);
+    vec3 purple = length(p_colorPurple.rgb) > 0.01 ? p_colorPurple.rgb : vec3(0.659, 0.333, 0.969);
+    vec3 rose   = length(p_colorRose.rgb)   > 0.01 ? p_colorRose.rgb   : vec3(0.957, 0.247, 0.369);
+    t = clamp(t, 0.0, 1.0) * 3.0;
+    vec3 c = mix(cyan, blue, clamp(t, 0.0, 1.0));
+    c = mix(c, purple, clamp(t - 1.0, 0.0, 1.0));
+    c = mix(c, rose, clamp(t - 2.0, 0.0, 1.0));
+    return c;
+}
+
+vec4 pTransition(vec2 uv, float t)
+{
+    // Power of the screen. iTime is per-leg [0,1] progress; use it directly
+    // so the effect is symmetric — the runtime runs iTime 1->0 on the close
+    // leg, scanning the picture back out through the same pass.
+    float presence = clamp(iTime, 0.0, 1.0);
+
+    // Endpoint early-outs: fully gone draws nothing; fully present hands
+    // back the clean surface. Every transient below is beam-, mid-, or
+    // dim-weighted, so both early-outs stay continuous.
+    if (presence <= 0.0) return vec4(0.0);
+    if (presence >= 1.0) return surfaceColor(uv);
+
+    vec2 anchor = max(iAnchorSize, vec2(1.0));
+    vec2 px = uv * anchor;
+
+    // ── Beam position: sweeps top (0) to bottom (1), expanded past [0,1]
+    // by its own half-height so the first and last rows fully clear the
+    // beam band at the leg endpoints. ──
+    float beamH = clamp(p_beamWidth, 0.03, 0.3);
+    float yB = presence * (1.0 + 2.0 * beamH) - beamH;
+
+    // Proximity to the beam centre (1 = on the beam).
+    float bd = clamp(1.0 - abs(uv.y - yB) / beamH, 0.0, 1.0);
+
+    // lit: 1 above the beam (already scanned), 0 below (still dark).
+    float lit = smoothstep(yB + beamH * 0.5, yB - beamH * 0.5, uv.y);
+
+    // Mid-leg envelope: peaks mid-flight, exactly zero at both endpoints.
+    // Gates the persistence trail, scanlines, and jitter so a settled
+    // screen is the plain surface with no residue.
+    float mid = clamp(presence * (1.0 - presence) * 4.0, 0.0, 1.0);
+
+    // ── Horizontal row jitter near the beam: the picture wobbles for a few
+    // rows while the beam writes them, settling as it moves on. Per-row,
+    // per-frame hash; boundary-masked so the displaced sample never smears
+    // the clamped edge texel. ──
+    float jitterAmp = clamp(p_jitter, 0.0, 1.0) * bd * mid * 4.0;
+    float jx = (niriHash(vec2(floor(px.y), float(iFrame))) * 2.0 - 1.0)
+             * jitterAmp / anchor.x;
+    vec2 suv = vec2(uv.x + jx, uv.y);
+    vec4 s = surfaceColor(suv) * boundaryMask(suv);   // premultiplied
+
+    // ── Unlit silhouette below the beam: the dark screen, the window's own
+    // luminance faintly showing through (phosphor-bloom's containment
+    // shell). Fades in with presence so the open leg starts from nothing
+    // and the close leg ends at nothing. ──
+    vec3 tint = length(p_colorTint.rgb) > 0.01 ? p_colorTint.rgb : vec3(0.043, 0.090, 0.188);
+    float lum  = dot(s.rgb, vec3(0.299, 0.587, 0.114));
+    float lumN = (s.a > 0.001) ? lum / s.a : 0.0;
+    float dim  = clamp(p_unlitDim, 0.0, 1.0) * smoothstep(0.0, 0.3, presence);
+
+    float aheadA   = s.a * dim;
+    vec3  aheadRGB = tint * (0.5 + 1.6 * lumN) * aheadA;
+
+    vec3  rgb = mix(aheadRGB, s.rgb, lit);
+    float a   = mix(aheadA, s.a, lit);
+
+    // ── Scanlines on the lit picture, fading out as it stabilises: fine
+    // alternating rows in device pixels, mid-gated so the settled image is
+    // untouched. Multiplicative on the premultiplied pair, so coverage dims
+    // in step with the body. ──
+    float scanAmt = clamp(p_scanlines, 0.0, 1.0) * mid;
+    float scan = 0.5 + 0.5 * sin(px.y * 3.14159265);
+    float scanDim = 1.0 - scanAmt * 0.35 * (1.0 - scan) * lit;
+    rgb *= scanDim;
+
+    // ── Persistence trail: rows the beam has just written glow with the
+    // gradient and decay toward the plain picture — the phosphor afterglow
+    // that names the set. Coverage-weighted and mid-gated. ──
+    float tail = 0.04 + clamp(p_persistence, 0.0, 1.0) * 0.30;
+    float above = max(yB - uv.y, 0.0);
+    float ag = (uv.y < yB) ? exp(-above / tail) : 0.0;
+    vec3 agCol = fluxGradient(clamp(1.0 - ag * 0.5, 0.0, 1.0));
+    rgb += agCol * ag * mid * s.a * 0.35;
+
+    // ── The beam itself: a hot bar carrying the full gradient, cyan on the
+    // leading (lower) edge and rose trailing into the written rows, with a
+    // fine per-frame grain so it shimmers. Coverage-weighted so the light
+    // stays inside the window silhouette. ──
+    float q = clamp((uv.y - yB) / beamH * 0.5 + 0.5, 0.0, 1.0);
+    vec3 beamCol = fluxGradient(1.0 - q);
+    float sparkle = 0.85 + 0.30 * niriHash(floor(px / 2.0) + floor(float(iFrame) * 0.2));
+    float beam = bd * bd * s.a * clamp(p_glow, 0.0, 2.0);
+    rgb += beamCol * beam * sparkle * 0.9;
+
+    // Same bounds as phosphor-bloom: bound the additive emissive here, and
+    // never let a pixel be more opaque than the window is at that point.
+    rgb = clamp(rgb, 0.0, 1.0);
+    float outA = clamp(a + beam * 0.4, 0.0, s.a);
+
+    return vec4(rgb, outA);
+}

--- a/data/animations/phosphor-scan/metadata.json
+++ b/data/animations/phosphor-scan/metadata.json
@@ -1,0 +1,89 @@
+{
+    "id": "phosphor-scan",
+    "name": "Phosphor Scan",
+    "description": "The window powers on like a phosphor screen. A bright beam scans down the surface leaving a glowing persistence trail that settles into the image, faint scanlines fade as the picture stabilises, and the beam carries the brand gradient from cyan to rose. Closing powers the screen back down through the same scan.",
+    "author": "PlasmaZones",
+    "version": "1.0",
+    "category": "Reveal",
+    "fragmentShader": "effect.frag",
+    "parameters": [
+        {
+            "id": "beamWidth",
+            "name": "Beam Width",
+            "type": "float",
+            "default": 0.12,
+            "min": 0.03,
+            "max": 0.3
+        },
+        {
+            "id": "persistence",
+            "name": "Persistence",
+            "type": "float",
+            "default": 0.5,
+            "min": 0.0,
+            "max": 1.0
+        },
+        {
+            "id": "scanlines",
+            "name": "Scanlines",
+            "type": "float",
+            "default": 0.5,
+            "min": 0.0,
+            "max": 1.0
+        },
+        {
+            "id": "jitter",
+            "name": "Beam Jitter",
+            "type": "float",
+            "default": 0.4,
+            "min": 0.0,
+            "max": 1.0
+        },
+        {
+            "id": "unlitDim",
+            "name": "Silhouette Strength",
+            "type": "float",
+            "default": 0.15,
+            "min": 0.0,
+            "max": 0.8
+        },
+        {
+            "id": "glow",
+            "name": "Beam Glow",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.0,
+            "max": 2.0
+        },
+        {
+            "id": "colorCyan",
+            "name": "Gradient Cyan",
+            "type": "color",
+            "default": "#22D3EE"
+        },
+        {
+            "id": "colorBlue",
+            "name": "Gradient Blue",
+            "type": "color",
+            "default": "#3B82F6"
+        },
+        {
+            "id": "colorPurple",
+            "name": "Gradient Purple",
+            "type": "color",
+            "default": "#A855F7"
+        },
+        {
+            "id": "colorRose",
+            "name": "Gradient Rose",
+            "type": "color",
+            "default": "#F43F5E"
+        },
+        {
+            "id": "colorTint",
+            "name": "Silhouette Tint",
+            "type": "color",
+            "default": "#0B1730"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

The Phosphor set's open/close (phosphor-bloom) and desktop switch (desktop-phosphor) were near-clones: the same diagonal light sweep, gradient band, ripple front, and sparkle at two scales. This PR gives each event class its own mechanic while keeping the shared brand language (the four-stop cyan/blue/purple/rose gradient, all colour-tunable), and adds three new open/close looks.

### desktop-phosphor: reworked into a signal-graph circuit
Borrows phosphor-flux's signal-graph motif. A sparse node circuit lights up across the screen in the actual switch direction (`iSwitchDelta` via `switchDirection()`, with a `followSwitch` toggle and a configurable fallback defaulting to the brand diagonal). Causality is real: each cell owns an activation time, every edge's pulse departs its earlier-activated node and lands exactly at the later node's activation, and that same clock starts the cell's reveal flood, so the incoming desktop grows outward from every lit node behind a thin gradient front. Activations floor above zero, flood speed covers the worst-case pixel before t=1 with a completion floor behind it, and a global envelope zeroes the additive circuit at both endpoints. Old `bandWidth`/`ripple`/`warp` params are dropped per the no-ad-hoc-migration rule; new params are `followSwitch`, `dirX`/`dirY`, `graphScale`, `traceOpacity`.

### Three new open/close packs
All symmetric via the runtime's `iTime` flip, premultiplied-alpha on phosphor-bloom's contract, and endpoint-clean (transient layers are edge- or mid-envelope gated, gaussian layers get 3x softness travel margins so nothing pops against the early-outs).

- **phosphor-scan** (Reveal): the window powers on like a phosphor screen. A hot gradient beam scans top to bottom leaving a decaying persistence trail, fine scanlines fade as the picture stabilises, and rows jitter briefly while the beam writes them.
- **phosphor-ignite** (Reveal): a plasma bloom expands from the centre behind a turbulence-eaten rim with tendrils reaching ahead of it and a heat shimmer just behind the front, cyan at the core shading to rose at the corners.
- **phosphor-condense** (Particle): the window condenses out of rising ember dust. A noise-roughened frontier climbs from the bottom while comet-tailed sparks rise through the un-condensed region, thickest where the frontier is consuming them.

phosphor-bloom itself is untouched. The set now reads as phosphor-flux's layers pulled apart by event: sweep for open/close (plus the three new alternates), the signal circuit for desktop switch, streams for snap, the vortex for drag.

## Testing
- `plasmazones-shader-validate --animation`: all 76 packs OK (both compile targets)
- Full ctest suite: 264/264 passing
- Not verified live: desktop transitions only run in the kwin-effect and a rebuilt .so needs a session restart, so tuning constants (flood speed, trace/beam/rim intensities) may want a follow-up pass after visual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)