### PR TITLE
fix(kwin): convert window-animation output to the display colour space on HDR

### DIFF
--- a/data/animations/shared/animation_uniforms.glsl
+++ b/data/animations/shared/animation_uniforms.glsl
@@ -463,4 +463,28 @@ vec2 resolutionSafe() {
     return max(iResolution, vec2(1.0));
 }
 
+// ─── Final-colour hook (HDR colour management) ─────────────────────────
+// Every final `fragColor` write in the animation pipeline routes through
+// `PZ_FINALIZE_COLOR(...)`: the entry scaffold's generated main()s
+// (animationshaderregistry.cpp) and bmw_compat's `setOutputColor()`. The
+// guarded default below is identity.
+//
+// The kwin-effect WINDOW-animation path overrides it before this header
+// is included: shader_transitions.cpp splices KWin's colormanagement.glsl
+// plus `#define PZ_FINALIZE_COLOR(c) pzFinalizeColor(c)` right after
+// `#version`, converting the shader's sRGB output into the output's
+// blending space. Installing a shader via OffscreenEffect::setShader
+// REPLACES KWin's present shader (which normally carries that
+// conversion), so without the override HDR outputs render every window
+// animation dim and desaturated.
+//
+// Everything else keeps identity: the daemon RHI runtime (Qt colour-
+// manages the scene graph output), shadervalidate, the bake tests, and
+// the desktop-switch path (its capture FBOs inherit the output's
+// colorDescription, so its inputs already live in the blending space and
+// converting again would be wrong).
+#ifndef PZ_FINALIZE_COLOR
+#define PZ_FINALIZE_COLOR(c) (c)
+#endif
+
 #endif // PLASMAZONES_ANIMATION_UNIFORMS_GLSL

--- a/data/animations/shared/animation_uniforms.glsl
+++ b/data/animations/shared/animation_uniforms.glsl
@@ -152,9 +152,9 @@ uniform vec2 iAnchorPosInFbo;
 
 // Window's effective rule-resolved opacity in [0, 1] — compositor path
 // only. A `SetOpacity` rule must dim the window for the whole
-// transition, but the custom transition shader is compiled
-// `MapTexture`-only (no `Modulate` trait), so KWin never applies
-// `data.opacity()` to it. `surfaceColor()` below multiplies the
+// transition, but the custom transition shader is compiled without the
+// `Modulate` trait, so KWin never applies `data.opacity()` to it.
+// `surfaceColor()` below multiplies the
 // premultiplied surface sample by this uniform so the dim holds across
 // the animation instead of snapping in only after it ends. The
 // kwin-effect pushes 1.0 for windows with no matching rule, so the
@@ -399,7 +399,7 @@ vec4 surfaceColor(vec2 uv) {
     // window-rule opacity: uTexture0 is premultiplied, so multiplying the
     // whole sample by the [0, 1] `iWindowOpacity` is the correct
     // premultiplied-alpha dim. This is what makes a `SetOpacity` rule hold
-    // throughout a transition (the MapTexture-only shader can't see
+    // throughout a transition (with no `Modulate` trait the shader can't see
     // `data.opacity()`); the effect feeds 1.0 when no rule matches, so the
     // common case is unchanged. Every window-content shader reads the
     // surface through this helper (directly or via bmw_compat's

--- a/data/animations/shared/bmw_compat.glsl
+++ b/data/animations/shared/bmw_compat.glsl
@@ -99,8 +99,14 @@ vec4 getInputColor(vec2 coords) {
     return color;
 }
 
+// Routes through PZ_FINALIZE_COLOR (identity by default; the kwin-effect
+// window-animation path overrides it with the sRGB → output-colorspace
+// conversion) so BMW packs with a hand-written main() — which bypass the
+// entry scaffold's generated fragColor write — still get colour-managed
+// on HDR. The macro comes from animation_uniforms.glsl, which the caller
+// contract above already requires be included before this header.
 void setOutputColor(vec4 outColor) {
-    fragColor = vec4(outColor.rgb * outColor.a, outColor.a);
+    fragColor = PZ_FINALIZE_COLOR(vec4(outColor.rgb * outColor.a, outColor.a));
 }
 
 // ── Composition: BMW common.glsl:189 verbatim ───────────────────────

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -803,6 +803,63 @@ bool PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
         expanded = PhosphorShaders::spliceAfterVersion(
             expanded, PhosphorAnimationShaders::AnimationShaderRegistry::paramPreamble(eff));
 
+        // HDR colour management. Installing this shader via
+        // OffscreenEffect::setShader REPLACES KWin's present shader, which
+        // normally carries the sRGB → output-colorspace conversion
+        // (ShaderTrait::TransformColorspace in KWin's own base.frag). Without
+        // it the transition writes sRGB verbatim into KWin's blending space —
+        // on an HDR output that space is gamma2.2 in the display's container
+        // colorimetry with 1.0 = peak luminance, so every window animation
+        // rendered dim and desaturated. Same bug class as the decoration
+        // present shader fix in decoration_render.cpp (kPresentFragment); the
+        // conversion below mirrors it, and KWin's base.frag, step for step:
+        // encoding → nits, colorimetry transform, tonemap, destination
+        // encoding.
+        //
+        // Deliberately NOT sourceEncodingToNitsInDestinationColorspace(): it
+        // folds doTonemapping() in at the end, which would tonemap twice — a
+        // double compression on HDR, precisely the case this exists for. No
+        // opacity modulate either: unlike the present shader, this path's
+        // window-rule opacity is folded into the sample by surfaceColor()
+        // (animation_uniforms.glsl), and KWin's TRAIT_MODULATE slot is unused
+        // on a MapTexture custom shader.
+        //
+        // The override must be spliced AFTER expandIncludes ran above:
+        // colormanagement.glsl lives in KWin's `:/opengl/` resource, which
+        // KWin's GLShader::preprocess resolves for every source it compiles
+        // (custom ones included) — the phosphor include resolver would fail
+        // the whole expansion on it. The `#define` lands before the expanded
+        // animation_uniforms.glsl text, whose `#ifndef PZ_FINALIZE_COLOR`
+        // identity default then yields to this override; the generated entry
+        // main()s and bmw_compat's setOutputColor route their fragColor
+        // writes through the macro.
+        //
+        // The colorspace uniforms come free: KWin's OffscreenData::paint
+        // calls setColorspaceUniforms(sRGB, renderTarget.colorDescription(),
+        // Perceptual) on whatever shader setShader() installed. Do not push
+        // them from drawWindow — that is a redundant write KWin overwrites.
+        //
+        // On SDR this whole block is an exact no-op (identity colorimetry,
+        // round-tripping transfer functions, tonemap degrades to a clamp that
+        // cannot bite), so "SDR pixel-identical" is the regression test.
+        //
+        // The desktop-switch path (desktoptransitionmanager.cpp) deliberately
+        // does NOT get this splice: its capture FBOs inherit the output's
+        // colorDescription, so both blend inputs already live in the blending
+        // space and converting again would double-transform. It keeps the
+        // identity default.
+        static const QString kFinalizeColorBlock = QStringLiteral(
+            "#include \"colormanagement.glsl\"\n"
+            "vec4 pzFinalizeColor(vec4 c) {\n"
+            "    c = encodingToNits(c, sourceNamedTransferFunction,\n"
+            "                       sourceTransferFunctionParams.x, sourceTransferFunctionParams.y);\n"
+            "    c.rgb = (colorimetryTransform * vec4(c.rgb, 1.0)).rgb;\n"
+            "    c.rgb = doTonemapping(c.rgb);\n"
+            "    return nitsToDestinationEncoding(c);\n"
+            "}\n"
+            "#define PZ_FINALIZE_COLOR(c) pzFinalizeColor(c)\n");
+        expanded = PhosphorShaders::spliceAfterVersion(expanded, kFinalizeColorBlock);
+
         // Selects the default-block branch in `animation_uniforms.glsl`.
         // KWin's `KWin::GLShader` API addresses default-block uniforms only
         // (no UBO bind path), so the canonical header's `#ifdef
@@ -854,8 +911,16 @@ bool PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
             }
         }
 
-        auto shader = KWin::ShaderManager::instance()->generateCustomShader(KWin::ShaderTrait::MapTexture,
-                                                                            vertWithKwinDefine, fragWithKwinDefine);
+        // TransformColorspace is DECLARATIVE ONLY here, exactly as on the
+        // decoration present shader (decoration_render.cpp): with a custom
+        // fragment source generateCustomShader uses the traits for nothing
+        // but listDefines, and colormanagement.glsl never reads
+        // TRAIT_TRANSFORM_COLORSPACE. The conversion is the explicit
+        // pzFinalizeColor splice above and runs with or without this flag; it
+        // is declared so the shader's traits describe what it actually does.
+        auto shader = KWin::ShaderManager::instance()->generateCustomShader(
+            KWin::ShaderTrait::MapTexture | KWin::ShaderTrait::TransformColorspace, vertWithKwinDefine,
+            fragWithKwinDefine);
         // KWin 6.7 removed GLShader::isValid(); generateCustomShader now returns
         // nullptr when compilation or linking fails, so a null check is the
         // validity test.

--- a/kwin-effect/plasmazoneseffect/shader_transitions.cpp
+++ b/kwin-effect/plasmazoneseffect/shader_transitions.cpp
@@ -821,8 +821,8 @@ bool PlasmaZonesEffect::beginShaderTransition(KWin::EffectWindow* window,
         // double compression on HDR, precisely the case this exists for. No
         // opacity modulate either: unlike the present shader, this path's
         // window-rule opacity is folded into the sample by surfaceColor()
-        // (animation_uniforms.glsl), and KWin's TRAIT_MODULATE slot is unused
-        // on a MapTexture custom shader.
+        // (animation_uniforms.glsl), and this shader is compiled without the
+        // Modulate trait so KWin's TRAIT_MODULATE slot never applies.
         //
         // The override must be spliced AFTER expandIncludes ran above:
         // colormanagement.glsl lives in KWin's `:/opengl/` resource, which

--- a/libs/phosphor-animation/src/animationshaderregistry.cpp
+++ b/libs/phosphor-animation/src/animationshaderregistry.cpp
@@ -769,11 +769,18 @@ QString AnimationShaderRegistry::animationEntryPrologue()
 
 QList<PhosphorShaders::EntryCandidate> AnimationShaderRegistry::animationEntryCandidates()
 {
+    // Both generated mains route the final colour through PZ_FINALIZE_COLOR
+    // (declared with an identity default in animation_uniforms.glsl, which the
+    // prologue includes). The kwin-effect window-animation path overrides it
+    // with the sRGB → output-colorspace conversion HDR needs; every other
+    // consumer compiles the identity form. See the hook's doc block in
+    // animation_uniforms.glsl.
+    //
     // Symmetric: one function, `t` is raw iTime (the runtime still flips it on
     // reverse legs, so the shader auto-mirrors with no direction code).
     static const QString transitionMain = QStringLiteral(
         "void main() {\n"
-        "    fragColor = pTransition(vTexCoord, iTime);\n"
+        "    fragColor = PZ_FINALIZE_COLOR(pTransition(vTexCoord, iTime));\n"
         "}\n");
     // Asymmetric: the harness un-flips iTime (legProgress → forward 0→1) and
     // dispatches by direction, so the author never touches iIsReversed/iTime
@@ -781,7 +788,7 @@ QList<PhosphorShaders::EntryCandidate> AnimationShaderRegistry::animationEntryCa
     static const QString inOutMain = QStringLiteral(
         "void main() {\n"
         "    float p_t = legProgress();\n"
-        "    fragColor = p_reversed ? pOut(vTexCoord, p_t) : pIn(vTexCoord, p_t);\n"
+        "    fragColor = PZ_FINALIZE_COLOR(p_reversed ? pOut(vTexCoord, p_t) : pIn(vTexCoord, p_t));\n"
         "}\n");
 
     PhosphorShaders::EntryCandidate transition;


### PR DESCRIPTION
## Problem

Installing the transition shader via `OffscreenEffect::setShader` replaces KWin's present shader, which normally carries the sRGB → output-colorspace conversion (`ShaderTrait::TransformColorspace`). The window-animation path omitted it, so on HDR outputs every window animation wrote sRGB verbatim into KWin's blending space (gamma2.2 in the display's container colorimetry, 1.0 = peak luminance) and rendered dim and desaturated. Same bug class as the decoration present shader fixed in #766.

## Fix

Adds a `PZ_FINALIZE_COLOR(c)` colour hook to the shared animation pack contract, since the shared shader assembly is compiled by both the KWin GL path and the daemon's Qt-RHI path (which cannot resolve KWin's `:/opengl/` includes):

- `animation_uniforms.glsl` declares an `#ifndef`-guarded identity default. The daemon RHI runtime, `shadervalidate`, the bake tests, and the desktop-switch path compile unchanged.
- The entry scaffold's two generated `main()`s (`animationshaderregistry.cpp`) and `bmw_compat.glsl`'s `setOutputColor()` (the only pack-side direct `fragColor` write) route through the hook.
- `shader_transitions.cpp` splices the KWin override after `#version`: KWin's `colormanagement.glsl` plus a `pzFinalizeColor` helper mirroring `base.frag` / `kPresentFragment` step for step (`encodingToNits` → `colorimetryTransform` → `doTonemapping` → `nitsToDestinationEncoding`). The splice happens after `expandIncludes` on purpose: the phosphor include resolver errors on the KWin-resource include, while KWin's `GLShader::preprocess` resolves it at compile time. No opacity modulate: `surfaceColor()` already folds `iWindowOpacity` into the sample.
- The animation compile gains the declarative `TransformColorspace` trait for parity with the present shader (declarative only; the conversion is the explicit GLSL).

No C++ uniform pushes: KWin's `OffscreenData::paint` calls `setColorspaceUniforms(sRGB, renderTarget.colorDescription(), Perceptual)` on whatever shader `setShader()` installed.

## Paths audited

- Geometry morph reuses the same cached transition shader (covered for free).
- Mid-transition surface-chain restore hands the present slot to the animation shader (converts); rest path uses `surfacePresentShader` (already converts).
- Desktop-switch stays identity by design: its capture FBOs inherit the output's `colorDescription`, so converting again would double-transform.
- Surface chain / buffer / gaussian passes are working-space intermediates presented through a converting shader — exactly one conversion everywhere.
- Deliberately `sourceEncodingToNitsInDestinationColorspace()`-free (it folds `doTonemapping()` in and would double-compress HDR).

## Testing

- Full suite: 273/273 pass, including the animation bake tests that compile every bundled pack through glslang with the new hook (identity and `PLASMAZONES_KWIN` variants).
- On SDR the conversion is an exact no-op (identity colorimetry, round-tripping transfer functions, tonemap degrades to a clamp that cannot bite), so SDR pixel-identity is the regression contract.
- HDR itself is unverified locally (no HDR display available); the conversion mirrors the verified decoration present shader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)