### PR TITLE
fix(animations): extended-FBO halo clip and phosphor-peek drain duration

### DIFF
--- a/data/animations/bounce/effect.frag
+++ b/data/animations/bounce/effect.frag
@@ -49,7 +49,9 @@ vec4 pTransition(vec2 uv, float t) {
 
     // Map the surface-UV into the window's ("anchor") own [0,1] space.
     // Fragments outside the window map outside [0,1] and are cropped by
-    // boundaryMaskAA below.
+    // boundaryMaskAA below, widened by the decoration chain's outer margin
+    // so a bouncing window carries its halo instead of clipping it at the
+    // frame edge.
     vec2 auv = anchorRemap(uv);
 
     // Decaying bounce: one window-height above the frame at t=0, settling
@@ -62,5 +64,5 @@ vec4 pTransition(vec2 uv, float t) {
     // with the bounce and settles to 0 (identity sampling) at rest.
     vec2 sample_uv = auv;
     sample_uv.y = auv.y + offset;
-    return surfaceColor(sample_uv) * boundaryMaskAA(sample_uv);
+    return surfaceColor(sample_uv) * boundaryMaskAA(sample_uv, surfacePadRel());
 }

--- a/data/animations/flow/effect.frag
+++ b/data/animations/flow/effect.frag
@@ -31,9 +31,14 @@ vec4 pTransition(vec2 uv, float t) {
     float e = clamp(vFlow.z, 0.0, 1.0);
 
     // Feathered window mask in card space — the grid spans the whole
-    // output, so only cells inside [0, 1] carry window content.
+    // output, so only cells inside the card carry window content. The card
+    // runs past [0, 1] by the decoration chain's outer margin: that band is
+    // the halo the compositor composited into the padded canvas, which
+    // surfaceColor() resolves through its layer remap, so the mask includes
+    // it and the halo flows with the window. Zero pad reduces to [0, 1].
+    vec2 pad = surfacePadRel();
     vec2 fw = max(fwidth(cuv), vec2(1.0e-4));
-    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv), smoothstep(vec2(0.0), fw, 1.0 - cuv));
+    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv + pad), smoothstep(vec2(0.0), fw, 1.0 + pad - cuv));
     float mask = edge.x * edge.y;
     if (mask <= 0.0) {
         return vec4(0.0);

--- a/data/animations/fly-in/effect.frag
+++ b/data/animations/fly-in/effect.frag
@@ -47,7 +47,9 @@ vec4 pTransition(vec2 uv, float t) {
 
     // Surface-spanning UV → the window's own ("anchor") [0,1] space.
     // Fragments outside the window map outside [0,1] and are cropped by
-    // boundaryMaskAA below.
+    // boundaryMaskAA below, widened by the decoration chain's outer margin
+    // so a flying window carries its halo instead of clipping it at the
+    // frame edge.
     vec2 auv = anchorRemap(uv);
 
     // Decide the fly-in edge from the window's position within its
@@ -87,5 +89,5 @@ vec4 pTransition(vec2 uv, float t) {
     // is sampled further toward -x in its own texture.
     vec2 sample_uv = auv;
     sample_uv.x = auv.x - offsetUv;
-    return surfaceColor(sample_uv) * boundaryMaskAA(sample_uv);
+    return surfaceColor(sample_uv) * boundaryMaskAA(sample_uv, surfacePadRel());
 }

--- a/data/animations/fold/effect.frag
+++ b/data/animations/fold/effect.frag
@@ -26,9 +26,13 @@ vec4 pTransition(vec2 uv, float t) {
     float shade = clamp(vFold.z, 0.0, 1.0);
     float fade = clamp(vFold.w, 0.0, 1.0);
 
-    // Feathered window mask in card space.
+    // Feathered window mask in card space, widened past [0, 1] by the
+    // decoration chain's outer margin so the halo the compositor composited
+    // into the padded canvas folds with the window instead of being cropped
+    // at the frame edge. Zero pad reduces to the bare card edge.
+    vec2 pad = surfacePadRel();
     vec2 fw = max(fwidth(cuv), vec2(1.0e-4));
-    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv), smoothstep(vec2(0.0), fw, 1.0 - cuv));
+    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv + pad), smoothstep(vec2(0.0), fw, 1.0 + pad - cuv));
     float mask = edge.x * edge.y;
     if (mask <= 0.0) {
         return vec4(0.0);

--- a/data/animations/genie/effect.frag
+++ b/data/animations/genie/effect.frag
@@ -26,11 +26,15 @@ vec4 pTransition(vec2 uv, float t) {
     vec2 cuv = vGenie.xy;
     float p = clamp(vGenie.z, 0.0, 1.0);
 
-    // Feathered card-edge mask in card space — same construction as flow
-    // (the grid sits on the window's frame rect, or its padded decoration
-    // canvas, so this feathers the edges and crops any halo band).
+    // Feathered card-edge mask in card space — same construction as flow.
+    // Widened by the decoration chain's outer margin so the halo the
+    // compositor composited into the padded canvas travels with the card
+    // instead of being cropped at the frame edge; surfaceColor() resolves
+    // the out-of-range cuv into the band. Zero pad reduces to the bare
+    // [0, 1] card edge.
+    vec2 pad = surfacePadRel();
     vec2 fw = max(fwidth(cuv), vec2(1.0e-4));
-    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv), smoothstep(vec2(0.0), fw, 1.0 - cuv));
+    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv + pad), smoothstep(vec2(0.0), fw, 1.0 + pad - cuv));
     float mask = edge.x * edge.y;
     if (mask <= 0.0) {
         return vec4(0.0);

--- a/data/animations/morph/effect.frag
+++ b/data/animations/morph/effect.frag
@@ -66,13 +66,23 @@ vec4 pTransition(vec2 uv, float t)
     // endpoints (start / end of the leg) where `strength == 0` would
     // otherwise collapse the smoothstep to a step at the anchor edge
     // and lose sub-pixel AA on the silhouette.
+    // Both masks below run over the card range WIDENED by the decoration
+    // chain's outer margin. Within that band the sample is not the
+    // CLAMP_TO_EDGE smear concern (1) describes: it is the halo the
+    // compositor composited into the padded canvas, which surfaceColor()
+    // resolves through its layer remap. Cropping at the bare [0, 1] card
+    // edge threw that halo away. PAST the band the clamp reasoning stands
+    // unchanged, so the hard mask still lands there — just displaced
+    // outward. An unpadded window has zero pad and both masks reduce
+    // exactly to their previous form.
+    vec2 pad = surfacePadRel();
     vec2 sampleUv = anchorUv - warp;
-    vec2 sampleInside = step(vec2(0.0), sampleUv) * step(sampleUv, vec2(1.0));
+    vec2 sampleInside = step(-pad, sampleUv) * step(sampleUv, vec2(1.0) + pad);
     vec4 warpedSample = surfaceColor(sampleUv) * sampleInside.x * sampleInside.y;
 
     float feather = max(strength, 0.005);
-    vec2 lo = smoothstep(vec2(-feather), vec2(0.0), anchorUv);
-    vec2 hi = vec2(1.0) - smoothstep(vec2(1.0), vec2(1.0) + vec2(feather), anchorUv);
+    vec2 lo = smoothstep(-pad - vec2(feather), -pad, anchorUv);
+    vec2 hi = vec2(1.0) - smoothstep(vec2(1.0) + pad, vec2(1.0) + pad + vec2(feather), anchorUv);
     float mask = lo.x * lo.y * hi.x * hi.y;
     return warpedSample * mask;
 }

--- a/data/animations/phosphor-peek/effect.frag
+++ b/data/animations/phosphor-peek/effect.frag
@@ -67,11 +67,21 @@ vec4 pTransition(vec2 uv, float t) {
     float jitter = (fbm(uv * density * vec2(aspect, 1.0), 4, 2.0) - 0.5) * 0.18;
     float p = proj + jitter;
 
-    // The front sweeps from well before 0 to well past 1 so that t = 0 is
+    // The front sweeps just past the fragment extent on each side so t = 0 is
     // exactly the windows scene and t = 1 is exactly the desktop, whatever the
-    // softness and jitter do in between.
+    // softness and jitter do in between. proj is clamped to [0, 1] and jitter is
+    // bounded to [-0.09, +0.079] (fbm over the [0, 1) niriNoise), so p lands in
+    // [-0.09, 1.079]. Tying the endpoints to `soft` (rather than the old fixed
+    // [-0.6, 1.6] sized for the WORST-CASE soft = 0.4) makes the front reveal the
+    // first fragment at tt ≈ 0 and the last at tt ≈ 1 for ANY softness, so the
+    // drain uses the whole [0, 1] domain. The old fixed range finished the sweep
+    // at tt ≈ 0.85 (and started it at ≈ 0.15) at the default softness, leaving
+    // the rest of the timeline a static fully-drained frame — which an ease-out
+    // progress curve then stretched into a visible hang before the peek settled.
+    // The 0.02 margin past p ± soft plus the tt ≥ 0.96 backstop below keep both
+    // endpoints clean against the jitter bound.
     float soft = mix(0.05, 0.4, clamp(p_softness, 0.0, 1.0));
-    float front = mix(-0.6, 1.6, tt);
+    float front = mix(-0.11 - soft, 1.10 + soft, tt);
 
     // reveal: 0 = windows still here .. 1 = desktop drained through.
     float reveal = smoothstep(p - soft, p + soft, front);

--- a/data/animations/phosphor-siphon/effect.frag
+++ b/data/animations/phosphor-siphon/effect.frag
@@ -46,11 +46,14 @@ vec4 pTransition(vec2 uv, float t) {
     float e = clamp(vSiphon.z, 0.0, 1.0);
     float lane = vSiphon.w;
 
-    // Feathered card-edge mask in card space — the grid sits on the
-    // window's frame rect (or its padded decoration canvas), so this
-    // feathers the edges and crops any halo band past [0, 1].
+    // Feathered card-edge mask in card space, widened by the decoration
+    // chain's outer margin so the halo the compositor composited into the
+    // padded canvas siphons along with the card instead of being cropped at
+    // the frame edge; surfaceColor() resolves the out-of-range cuv into the
+    // band. Zero pad reduces to the bare [0, 1] card edge.
+    vec2 pad = surfacePadRel();
     vec2 fw = max(fwidth(cuv), vec2(1.0e-4));
-    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv), smoothstep(vec2(0.0), fw, 1.0 - cuv));
+    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv + pad), smoothstep(vec2(0.0), fw, 1.0 + pad - cuv));
     float mask = edge.x * edge.y;
     if (mask <= 0.0) {
         return vec4(0.0);

--- a/data/animations/phosphor-stream/effect.frag
+++ b/data/animations/phosphor-stream/effect.frag
@@ -46,9 +46,14 @@ vec4 pTransition(vec2 uv, float t) {
     float lane = vFlow.w;
 
     // Feathered window mask in card space — the grid spans the whole
-    // output, so only cells inside [0, 1] carry window content.
+    // output, so only cells inside the card carry window content. The card
+    // runs past [0, 1] by the decoration chain's outer margin: that band is
+    // the halo the compositor composited into the padded canvas, which
+    // surfaceColor() resolves through its layer remap, so the mask includes
+    // it and the halo streams with the window. Zero pad reduces to [0, 1].
+    vec2 pad = surfacePadRel();
     vec2 fw = max(fwidth(cuv), vec2(1.0e-4));
-    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv), smoothstep(vec2(0.0), fw, 1.0 - cuv));
+    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv + pad), smoothstep(vec2(0.0), fw, 1.0 + pad - cuv));
     float mask = edge.x * edge.y;
     if (mask <= 0.0) {
         return vec4(0.0);

--- a/data/animations/ripple-snap/effect.frag
+++ b/data/animations/ripple-snap/effect.frag
@@ -26,9 +26,13 @@ vec4 pTransition(vec2 uv, float t) {
     float shade = clamp(vRip.z, 0.0, 1.0);
     float fade = clamp(vRip.w, 0.0, 1.0);
 
-    // Feathered window mask in card space.
+    // Feathered window mask in card space, widened past [0, 1] by the
+    // decoration chain's outer margin so the halo the compositor composited
+    // into the padded canvas ripples with the window instead of being
+    // cropped at the frame edge. Zero pad reduces to the bare card edge.
+    vec2 pad = surfacePadRel();
     vec2 fw = max(fwidth(cuv), vec2(1.0e-4));
-    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv), smoothstep(vec2(0.0), fw, 1.0 - cuv));
+    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv + pad), smoothstep(vec2(0.0), fw, 1.0 + pad - cuv));
     float mask = edge.x * edge.y;
     if (mask <= 0.0) {
         return vec4(0.0);

--- a/data/animations/shared/animation_uniforms.glsl
+++ b/data/animations/shared/animation_uniforms.glsl
@@ -446,6 +446,13 @@ vec4 surfaceColor(vec2 uv) {
 // common to both cancels, leaving the padding alone. An unpadded window
 // carries canvas == expanded, hence equal rects and an exact zero, which
 // keeps its mask bit-identical to the un-widened form.
+//
+// Valid only for SURFACE-EXTENT packs, whose card space is the frame: there
+// both rects share the frame as inner rect, so the result is pad/frame in
+// the card units their masks use. An anchor-extent pack carries
+// `iAnchorRectInTexture == (0, 0, 1, 1)` (inner == expanded), so this would
+// return pad/expanded instead — a different unit that would under-widen its
+// mask. No anchor-extent pack calls this.
 vec2 surfacePadRel() {
 #ifdef PLASMAZONES_KWIN
     // No layer means no composited canvas, so `iLayerRectInTexture` carries

--- a/data/animations/shared/animation_uniforms.glsl
+++ b/data/animations/shared/animation_uniforms.glsl
@@ -428,6 +428,43 @@ vec4 surfaceColor(vec2 uv) {
 #endif
 }
 
+// The decoration chain's outer margin, expressed in the SAME card-space
+// units `surfaceColor()`'s `uv` takes — half-width per axis, so the halo
+// band spans `uv` in [-surfacePadRel(), 1 + surfacePadRel()].
+//
+// A card-space mask built on the bare [0, 1] range clips the halo at the
+// frame edge, discarding the margin the compositor composited into
+// `uSurfaceLayer`. Widening the mask by this value lets it through, and
+// `surfaceColor()`'s unclamped `iLayerRectInTexture` remap resolves the
+// out-of-range `uv` into the band.
+//
+// Derived from the two rect uniforms rather than pushed separately: both
+// describe the SAME inner rect, `iAnchorRectInTexture` within uTexture0's
+// expanded capture and `iLayerRectInTexture` within the layer canvas the
+// compositor padded by the margin. So `inner / rect.zw` recovers each
+// outer extent, and their difference is the two margins — the shadow inset
+// common to both cancels, leaving the padding alone. An unpadded window
+// carries canvas == expanded, hence equal rects and an exact zero, which
+// keeps its mask bit-identical to the un-widened form.
+vec2 surfacePadRel() {
+#ifdef PLASMAZONES_KWIN
+    // No layer means no composited canvas, so `iLayerRectInTexture` carries
+    // nothing to difference against.
+    if (iHasSurfaceLayer == 0) {
+        return vec2(0.0);
+    }
+    vec2 layerSpan = max(iLayerRectInTexture.zw, vec2(1.0e-6));
+    vec2 anchorSpan = max(iAnchorRectInTexture.zw, vec2(1.0e-6));
+    // max() against 0: a capture-scale clamp on a huge window can shrink the
+    // canvas below the expanded rect, and a negative pad would eat INTO the
+    // card rather than extend past it.
+    return max(0.5 * (1.0 / layerSpan - 1.0 / anchorSpan), vec2(0.0));
+#else
+    // Daemon path: the padded decoration chain is a compositor-side fold.
+    return vec2(0.0);
+#endif
+}
+
 // ─── Direction helpers (T1.5) ──────────────────────────────────────────
 // A transition plays forward (in: window.open / snapIn / show) or reverse
 // (out: window.close / snapOut / hide). The runtime exposes that as

--- a/data/animations/shared/noise.glsl
+++ b/data/animations/shared/noise.glsl
@@ -188,10 +188,18 @@ float boundaryMask(vec2 uv) {
 // antialiased crop: fully-covered interior pixels stay at 1.0 (no
 // inner-edge fade), the edge pixel gets its real fractional coverage,
 // and the sub-pixel outside half is ordinary edge AA, not a halo.
-float boundaryMaskAA(vec2 uv) {
+//
+// `pad` widens the accepted range to [-pad, 1 + pad] per axis so a
+// surface-extent pack keeps the decoration chain's outer margin — the halo
+// the compositor composited into the padded uSurfaceLayer canvas, which
+// surfaceColor() resolves for uv outside [0, 1] — instead of cropping it at
+// the frame edge. Pass surfacePadRel() (card-space, frame-anchored, so it
+// pairs with the anchor-space uv here); an unpadded window carries vec2(0)
+// and the crop is bit-identical to the bare [0, 1] form.
+float boundaryMaskAA(vec2 uv, vec2 pad) {
     vec2 fw = max(fwidth(uv), vec2(1.0e-5));
-    vec2 lo = smoothstep(-0.5 * fw, 0.5 * fw, uv);
-    vec2 hi = smoothstep(-0.5 * fw, 0.5 * fw, vec2(1.0) - uv);
+    vec2 lo = smoothstep(-0.5 * fw, 0.5 * fw, uv + pad);
+    vec2 hi = smoothstep(-0.5 * fw, 0.5 * fw, vec2(1.0) + pad - uv);
     return lo.x * lo.y * hi.x * hi.y;
 }
 

--- a/data/animations/stretch/effect.frag
+++ b/data/animations/stretch/effect.frag
@@ -25,9 +25,13 @@ vec4 pTransition(vec2 uv, float t) {
     vec2 cuv = vStretch.xy;
     float fade = clamp(vStretch.z, 0.0, 1.0);
 
-    // Feathered window mask in card space.
+    // Feathered window mask in card space, widened past [0, 1] by the
+    // decoration chain's outer margin so the halo the compositor composited
+    // into the padded canvas stretches with the window instead of being
+    // cropped at the frame edge. Zero pad reduces to the bare card edge.
+    vec2 pad = surfacePadRel();
     vec2 fw = max(fwidth(cuv), vec2(1.0e-4));
-    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv), smoothstep(vec2(0.0), fw, 1.0 - cuv));
+    vec2 edge = min(smoothstep(vec2(0.0), fw, cuv + pad), smoothstep(vec2(0.0), fw, 1.0 + pad - cuv));
     float mask = edge.x * edge.y;
     if (mask <= 0.0) {
         return vec4(0.0);

--- a/data/animations/window-morph/effect.frag
+++ b/data/animations/window-morph/effect.frag
@@ -72,8 +72,18 @@ vec4 pTransition(vec2 uv, float t) {
 
     // Outside the morphing rect: nothing to draw. Small feather to avoid a
     // hard edge as the rect sweeps.
+    //
+    // The rect is the window FRAME, and ruv is frame-relative, so the bare
+    // [0, 1] range cropped the decoration chain's halo at the frame edge for
+    // the whole morph. Widen by the chain's outer margin: oldColor() and
+    // surfaceColor() are both frame-anchored, so the same out-of-range ruv
+    // resolves into the padded canvas's margin band on either side of the
+    // cross-fade. The pad rides the rect lerp, so the halo scales with the
+    // window as it morphs rather than sitting at a fixed screen width. Zero
+    // pad reduces to the previous frame-edge mask.
+    vec2 pad = surfacePadRel();
     vec2 fw = max(fwidth(ruv), vec2(1.0e-4));
-    vec2 edge = min(smoothstep(vec2(0.0), fw, ruv), smoothstep(vec2(0.0), fw, 1.0 - ruv));
+    vec2 edge = min(smoothstep(vec2(0.0), fw, ruv + pad), smoothstep(vec2(0.0), fw, 1.0 + pad - ruv));
     float mask = edge.x * edge.y;
     if (mask <= 0.0) {
         return vec4(0.0);


### PR DESCRIPTION
Two independent animation-pack bugs, one commit each.

## 1. Minimize/maximize/move packs clip the extended-FBO halo

When a decoration pack requires an extended FBO (glow, shadow, fireflies, phosphor-motes bleed past the window frame), the minimize/maximize/move animations cropped that halo at the frame edge for the whole transition. The compositor already composites the padded margin into `uSurfaceLayer` and `surfaceColor()` remaps into it unclamped — the packs were just masking themselves to card space `[0,1]` (the frame) and throwing the band away.

Fix: `surfacePadRel()` in `animation_uniforms.glsl` derives the chain's outer margin in card-space units from the two existing rect uniforms (the shadow inset common to both cancels, so their difference is the padding). Unpadded windows yield exact zero, so their masks stay bit-identical. The card mask is then widened by that pad in nine packs:

- **minimize:** genie, phosphor-siphon
- **maximize/geometry:** morph, window-morph
- **move/snap:** flow, fold, phosphor-stream, ripple-snap, stretch

`morph` keeps its hard `CLAMP_TO_EDGE` guard, displaced outward by the pad rather than removed (the band is real content, past it is still smear).

## 2. phosphor-peek freezes for the tail of the leg

The reveal front was `mix(-0.6, 1.6, tt)`, over-provisioned for the worst-case softness. At the default softness the drain finished at `tt ≈ 0.85` and didn't start until `tt ≈ 0.15`, so only ~70% of the pack's domain did visible work. An ease-out progress curve stretched the leftover tail into a static fully-drained frame held until the leg settled — measured at roughly half the leg on a 680ms peek.

Fix: tie the front's endpoints to the actual softness, `mix(-0.11 - soft, 1.10 + soft, tt)`. Jitter is bounded to `[-0.09, +0.079]` (fbm over the `[0,1)` noise) so `p ∈ [-0.09, 1.079]`, and these endpoints reveal the first fragment at `tt ≈ 0` and the last at `tt ≈ 0.99` for any softness. The `tt ≥ 0.96` backstop still guarantees a clean endpoint. peek-recede and peek-blinds already spanned their full domain and are unchanged.

## Testing

`test_animation_shader_bake`, `test_animation_shader_kwin_bake`, and `test_shader_include_resolver` pass. Bake-test coverage of the edited packs was mutation-verified (a deliberate break fails the KWin bake test, including for the desktop-contract phosphor-peek pack). Both fixes were confirmed on a live session; the visual behaviour is compositor-only and not exercisable by the daemon-side preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)