### PR TITLE
feat(i18n): add complete Swedish translation

### DIFF
--- a/translations/plasmazones_sv.ts
+++ b/translations/plasmazones_sv.ts
@@ -1,0 +1,5569 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
+<context>
+    <name>plasmazones</name>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="52"/>
+        <source>A zone with this name already exists</source>
+        <translation>En zon med det här namnet finns redan</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/AddZoneCommand.cpp" line="16"/>
+        <source>Add Zone</source>
+        <comment>@action</comment>
+        <translation>Lägg till zon</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/shortcutmanager.cpp" line="592"/>
+        <source>Apply Layout %1</source>
+        <translation>Verkställ layout %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ApplyTemplateCommand.cpp" line="14"/>
+        <source>Apply Template: %1</source>
+        <comment>@action</comment>
+        <translation>Verkställ mall: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="185"/>
+        <source>Bring Forward</source>
+        <comment>@action</comment>
+        <translation>Flytta framåt</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="175"/>
+        <source>Bring to Front</source>
+        <comment>@action</comment>
+        <translation>Flytta längst fram</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="357"/>
+        <source>Cancel Zone Overlay</source>
+        <translation>Avbryt zonöverlägg</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="412"/>
+        <source>Layout Picker: Move Left</source>
+        <translation>Layoutväljare: flytta vänster</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="416"/>
+        <source>Layout Picker: Move Right</source>
+        <translation>Layoutväljare: flytta höger</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="420"/>
+        <source>Layout Picker: Move Up</source>
+        <translation>Layoutväljare: flytta upp</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="424"/>
+        <source>Layout Picker: Move Down</source>
+        <translation>Layoutväljare: flytta ner</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="428"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="430"/>
+        <source>Layout Picker: Confirm</source>
+        <translation>Layoutväljare: bekräfta</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="21"/>
+        <source>Change Edge Gap</source>
+        <comment>@action</comment>
+        <translation>Ändra kantmellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="20"/>
+        <source>Change Overlay Style</source>
+        <comment>@action</comment>
+        <translation>Ändra överläggsstil</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ChangeSelectionCommand.cpp" line="14"/>
+        <source>Change Selection</source>
+        <comment>@action</comment>
+        <translation>Ändra markering</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderIdCommand.cpp" line="15"/>
+        <source>Change Shader Effect</source>
+        <comment>@action</comment>
+        <translation>Ändra shadereffekt</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderParamsCommand.cpp" line="17"/>
+        <source>Change Shader Parameter</source>
+        <comment>@action</comment>
+        <translation>Ändra shaderparameter</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderParamsCommand.cpp" line="29"/>
+        <source>Change Shader Parameters</source>
+        <comment>@action</comment>
+        <translation>Ändra shaderparametrar</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ChangeZOrderCommand.cpp" line="13"/>
+        <source>Change Z-Order</source>
+        <comment>@action</comment>
+        <translation>Ändra Z-ordning</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneAppearanceCommand.cpp" line="15"/>
+        <source>Change Zone Appearance</source>
+        <comment>@action</comment>
+        <translation>Ändra zonens utseende</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateFixedGeometryCommand.cpp" line="15"/>
+        <source>Change Zone Dimensions</source>
+        <comment>@action</comment>
+        <translation>Ändra zonens dimensioner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneNumberCommand.cpp" line="16"/>
+        <source>Change Zone Number</source>
+        <comment>@action</comment>
+        <translation>Ändra zonnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="16"/>
+        <source>Change Zone Padding</source>
+        <comment>@action</comment>
+        <translation>Ändra zonens utfyllnad</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateVisibilityCommand.cpp" line="17"/>
+        <source>Change Zone Visibility</source>
+        <comment>@action</comment>
+        <translation>Ändra zonens synlighet</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ClearAllZonesCommand.cpp" line="12"/>
+        <source>Clear All Zones</source>
+        <comment>@action</comment>
+        <translation>Rensa alla zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/gaps.cpp" line="327"/>
+        <source>Clear Edge Gap Override</source>
+        <comment>@action</comment>
+        <translation>Rensa åsidosättning av kantmellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="151"/>
+        <source>Create new layout</source>
+        <translation>Skapa ny layout</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="96"/>
+        <source>Cut %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Klipp ut %1 zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="34"/>
+        <source>Delete %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Ta bort %1 zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DeleteZoneCommand.cpp" line="14"/>
+        <location filename="../src/editor/undo/commands/DeleteZoneWithFillCommand.cpp" line="14"/>
+        <source>Delete Zone</source>
+        <comment>@action</comment>
+        <translation>Ta bort zon</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="62"/>
+        <source>Duplicate %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Duplicera %1 zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DuplicateZoneCommand.cpp" line="15"/>
+        <source>Duplicate Zone</source>
+        <comment>@action</comment>
+        <translation>Duplicera zon</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/FillZoneCommand.cpp" line="13"/>
+        <source>Fill Zone</source>
+        <comment>@action</comment>
+        <translation>Fyll zon</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="528"/>
+        <source>Invalid layout data format</source>
+        <translation>Ogiltigt format på layoutdata</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1041"/>
+        <location filename="../src/editor/controller/layout.cpp" line="1079"/>
+        <source>File path cannot be empty</source>
+        <translation>Filsökvägen får inte vara tom</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1048"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="334"/>
+        <source>Failed to import layout: %1</source>
+        <translation>Kunde inte importera layout: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1059"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="341"/>
+        <source>That file is not a layout this app can read.</source>
+        <translation>Den filen är inte en layout som appen kan läsa.</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1102"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="386"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="545"/>
+        <source>Could not write the export. Check that the folder is writable.</source>
+        <translation>Kunde inte skriva exporten. Kontrollera att mappen är skrivbar.</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1084"/>
+        <source>No layout loaded to export</source>
+        <translation>Ingen layout inläst att exportera</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1091"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="377"/>
+        <source>Failed to export layout: %1</source>
+        <translation>Kunde inte exportera layout: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="493"/>
+        <source>Layout ID cannot be empty</source>
+        <translation>Layout-ID får inte vara tomt</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="147"/>
+        <source>Layout ID to edit</source>
+        <translation>Layout-ID att redigera</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="165"/>
+        <source>Layout Locked</source>
+        <translation>Layout låst</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="214"/>
+        <source>Disabled on this monitor</source>
+        <translation>Inaktiverad på den här skärmen</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="225"/>
+        <source>Desktop %1</source>
+        <translation>Skrivbord %1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="227"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="238"/>
+        <source>Disabled on %1</source>
+        <translation>Inaktiverad på %1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="236"/>
+        <source>Disabled on this activity</source>
+        <translation>Inaktiverad på den här aktiviteten</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="266"/>
+        <source>No layout assigned</source>
+        <translation>Ingen layout tilldelad</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="498"/>
+        <source>Layout service not initialized</source>
+        <translation>Layouttjänsten är inte initierad</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="138"/>
+        <source>Layout: %1</source>
+        <translation>Layout: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="106"/>
+        <location filename="../src/editor/controller/multiselect.cpp" line="361"/>
+        <source>Move %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Flytta %1 zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneGeometryCommand.cpp" line="14"/>
+        <source>Move Zone</source>
+        <comment>@action</comment>
+        <translation>Flytta zon</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="433"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="184"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="192"/>
+        <source>New Layout</source>
+        <translation>Ny layout</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="152"/>
+        <source>Open in read-only preview mode</source>
+        <translation>Öppna i skrivskyddat förhandsgranskningsläge</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="196"/>
+        <location filename="../src/editor/undo/commands/PasteZonesCommand.cpp" line="14"/>
+        <source>Paste %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Klistra in %1 zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateLayoutNameCommand.cpp" line="13"/>
+        <source>Rename Layout</source>
+        <comment>@action</comment>
+        <translation>Byt namn på layout</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneNameCommand.cpp" line="14"/>
+        <source>Rename Zone</source>
+        <comment>@action</comment>
+        <translation>Byt namn på zon</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="215"/>
+        <source>Window tiling and zone management</source>
+        <translation>Panelindelning av fönster och zonhantering</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="220"/>
+        <source>Replace existing daemon instance</source>
+        <translation>Ersätt befintlig demoninstans</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="224"/>
+        <source>Enable debug logging for all PlasmaZones categories</source>
+        <translation>Aktivera felsökningsloggning för alla PlasmaZones-kategorier</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="228"/>
+        <source>Write log output to &lt;file&gt; instead of stderr</source>
+        <translation>Skriv loggutdata till &lt;file&gt; i stället för stderr</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="229"/>
+        <source>file</source>
+        <translation>file</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/shader.cpp" line="271"/>
+        <source>Reset Shader Parameters</source>
+        <comment>@action</comment>
+        <translation>Återställ shaderparametrar</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="189"/>
+        <source>Resize %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Ändra storlek på %1 zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DividerResizeCommand.cpp" line="15"/>
+        <source>Resize Zones</source>
+        <comment>@action</comment>
+        <translation>Ändra storlek på zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="190"/>
+        <source>Send Backward</source>
+        <comment>@action</comment>
+        <translation>Skicka bakåt</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="180"/>
+        <source>Send to Back</source>
+        <comment>@action</comment>
+        <translation>Skicka längst bak</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="843"/>
+        <source>Services not initialized</source>
+        <translation>Tjänsterna är inte initierade</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zones.cpp" line="197"/>
+        <location filename="../src/editor/controller/zones.cpp" line="233"/>
+        <source>Services not initialized</source>
+        <comment>@info</comment>
+        <translation>Tjänsterna är inte initierade</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/shortcutmanager.cpp" line="610"/>
+        <source>Snap to Zone %1</source>
+        <translation>Fäst i zon %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/SplitZoneCommand.cpp" line="16"/>
+        <source>Split Zone</source>
+        <comment>@action</comment>
+        <translation>Dela zon</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/shader.cpp" line="287"/>
+        <source>Switch Shader Effect</source>
+        <comment>@action</comment>
+        <translation>Byt shadereffekt</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="149"/>
+        <source>Target screen name</source>
+        <translation>Namn på målskärm</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="295"/>
+        <location filename="../src/settings/rulemodel.cpp" line="285"/>
+        <source>Tiling: %1</source>
+        <translation>Panelindelning: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="18"/>
+        <source>Toggle Per-Side Edge Gap</source>
+        <comment>@action</comment>
+        <translation>Växla kantmellanrum per sida</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ToggleGeometryModeCommand.cpp" line="17"/>
+        <source>Toggle Relative/Fixed Size</source>
+        <comment>@action</comment>
+        <translation>Växla mellan relativ och fast storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateFullScreenGeometryCommand.cpp" line="15"/>
+        <source>Toggle Use Full Screen Area</source>
+        <comment>@action</comment>
+        <translation>Växla användning av hela skärmytan</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/BatchUpdateAppearanceCommand.cpp" line="21"/>
+        <source>Update Appearance for %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Uppdatera utseende för %1 zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/BatchUpdateAppearanceCommand.cpp" line="73"/>
+        <source>Update Color for %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Uppdatera färg för %1 zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="142"/>
+        <source>Visual layout editor for PlasmaZones</source>
+        <translation>Visuell layouteditor för PlasmaZones</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="34"/>
+        <location filename="../src/editor/controller/clipboard.cpp" line="107"/>
+        <source>Zone manager not initialized</source>
+        <comment>@info</comment>
+        <translation>Zonhanteraren är inte initierad</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="40"/>
+        <source>Zone name contains invalid characters: &lt; &gt; &quot; &apos; \</source>
+        <translation>Zonnamnet innehåller ogiltiga tecken: &lt; &gt; &quot; &apos; \</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zones.cpp" line="106"/>
+        <location filename="../src/editor/controller/zones.cpp" line="212"/>
+        <location filename="../src/editor/controller/zones.cpp" line="248"/>
+        <location filename="../src/editor/controller/zones.cpp" line="327"/>
+        <source>Zone not found</source>
+        <comment>@info</comment>
+        <translation>Zonen hittades inte</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="94"/>
+        <source>Zone number %1 is already in use</source>
+        <translation>Zonnummer %1 används redan</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="74"/>
+        <source>Zone number cannot exceed 99</source>
+        <translation>Zonnumret får inte överstiga 99</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="31"/>
+        <source>Zone name cannot exceed %1 characters</source>
+        <translation>Zonnamnet får inte överstiga %1 tecken</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="71"/>
+        <source>Zone number must be at least 1</source>
+        <translation>Zonnumret måste vara minst 1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2159"/>
+        <source>The PlasmaZones KWin effect plugin is not installed where KWin can find it. Reinstall PlasmaZones.</source>
+        <translation>Insticksmodulen för PlasmaZones KWin-effekt är inte installerad där KWin kan hitta den. Installera om PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2198"/>
+        <source>The PlasmaZones KWin effect was built for KWin %1 but KWin %2 is running, so KWin will not load it. Rebuild and reinstall PlasmaZones against the running KWin.</source>
+        <translation>PlasmaZones KWin-effekt byggdes för KWin %1 men KWin %2 körs, så KWin läser inte in den. Bygg om och installera om PlasmaZones mot den KWin som körs.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2225"/>
+        <source>The PlasmaZones KWin effect has not registered with the daemon, so window dragging and shortcuts will not work. Make sure it is enabled in System Settings &gt; Desktop Effects, then restart the Plasma session.</source>
+        <translation>PlasmaZones KWin-effekt har inte registrerats hos demonen, så fönsterdragning och genvägar fungerar inte. Se till att den är aktiverad i Systeminställningar &gt; Skrivbordseffekter och starta sedan om Plasma-sessionen.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2244"/>
+        <source>PlasmaZones: window manager integration inactive</source>
+        <translation>PlasmaZones: integration med fönsterhanteraren inaktiv</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="70"/>
+        <source> (Copy)</source>
+        <extracomment>Suffix appended to the name of a duplicated algorithm. Keep the leading space.</extracomment>
+        <translation> (kopia)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="329"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="401"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="413"/>
+        <source>Could not read the algorithm file. Check that it still exists and is readable.</source>
+        <translation>Kunde inte läsa algoritmfilen. Kontrollera att den fortfarande finns och är läsbar.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="338"/>
+        <source>Only Luau algorithm files (.luau) can be imported.</source>
+        <translation>Endast Luau-algoritmfiler (.luau) kan importeras.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="343"/>
+        <source>Algorithm file names may contain only letters, digits, hyphens, and underscores.</source>
+        <translation>Namn på algoritmfiler får endast innehålla bokstäver, siffror, bindestreck och understreck.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="356"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="418"/>
+        <source>That algorithm file is too large to load. Algorithms are limited to 1 MB.</source>
+        <translation>Den algoritmfilen är för stor för att läsa in. Algoritmer är begränsade till 1 MB.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="387"/>
+        <source>Too many algorithms share this name. Remove some and try again.</source>
+        <translation>För många algoritmer delar det här namnet. Ta bort några och försök igen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="426"/>
+        <source>Could not copy the algorithm file. Check available disk space and permissions.</source>
+        <translation>Kunde inte kopiera algoritmfilen. Kontrollera tillgängligt diskutrymme och behörigheter.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="492"/>
+        <source>Algorithm was created but not picked up by the registry. Try refreshing or restarting the application.</source>
+        <translation>Algoritmen skapades men registret upptäckte den inte. Försök att uppdatera eller starta om programmet.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="552"/>
+        <source>No algorithm is selected to delete.</source>
+        <translation>Ingen algoritm är vald att ta bort.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="559"/>
+        <source>Only user-created algorithms can be deleted.</source>
+        <translation>Endast användarskapade algoritmer kan tas bort.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="566"/>
+        <source>Algorithm file not found.</source>
+        <translation>Algoritmfilen hittades inte.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="580"/>
+        <source>The user algorithms directory does not exist.</source>
+        <translation>Katalogen för användaralgoritmer finns inte.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="581"/>
+        <source>That file is outside the user algorithms directory.</source>
+        <translation>Den filen ligger utanför katalogen för användaralgoritmer.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="594"/>
+        <source>Could not delete algorithm file. Check file permissions.</source>
+        <translation>Kunde inte ta bort algoritmfilen. Kontrollera filbehörigheterna.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="604"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="720"/>
+        <source>The algorithm file could not be found.</source>
+        <translation>Algoritmfilen kunde inte hittas.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="610"/>
+        <source>That algorithm is no longer registered.</source>
+        <translation>Den algoritmen är inte längre registrerad.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="628"/>
+        <source>Too many copies of this algorithm already exist. Rename or delete some before duplicating.</source>
+        <translation>För många kopior av den här algoritmen finns redan. Byt namn på eller ta bort några innan du duplicerar.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="636"/>
+        <source>The algorithm file path could not be resolved.</source>
+        <translation>Sökvägen till algoritmfilen kunde inte lösas upp.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="643"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="654"/>
+        <source>Could not read source algorithm file.</source>
+        <translation>Kunde inte läsa käll-algoritmfilen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="695"/>
+        <source>Could not duplicate the algorithm. Its metadata table is not in a shape this app can rewrite.</source>
+        <translation>Kunde inte duplicera algoritmen. Dess metadatatabell har inte en form som appen kan skriva om.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="730"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="739"/>
+        <source>Could not read the algorithm file for export.</source>
+        <translation>Kunde inte läsa algoritmfilen för export.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="702"/>
+        <source>Could not write duplicate algorithm file. Check disk space and permissions.</source>
+        <translation>Kunde inte skriva duplicerad algoritmfil. Kontrollera diskutrymme och behörigheter.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="714"/>
+        <source>No export destination specified.</source>
+        <translation>Ingen exportdestination angiven.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="745"/>
+        <source>Could not write to export destination.</source>
+        <translation>Kunde inte skriva till exportdestinationen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="782"/>
+        <source>Too many algorithms already share this name. Rename or delete some before creating another.</source>
+        <translation>För många algoritmer delar redan det här namnet. Byt namn på eller ta bort några innan du skapar en ny.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="816"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="859"/>
+        <source>The selected template could not be used. Pick another template or start blank.</source>
+        <translation>Den valda mallen kunde inte användas. Välj en annan mall eller börja tom.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="833"/>
+        <source>The selected template could not be found. Pick another template or start blank.</source>
+        <translation>Den valda mallen kunde inte hittas. Välj en annan mall eller börja tom.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="841"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="849"/>
+        <source>The selected template could not be read. Pick another template or start blank.</source>
+        <translation>Den valda mallen kunde inte läsas. Välj en annan mall eller börja tom.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="878"/>
+        <source>Could not write algorithm file. Check disk space and permissions.</source>
+        <translation>Kunde inte skriva algoritmfil. Kontrollera diskutrymme och behörigheter.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="131"/>
+        <source>Cannot modify sets while a discard is in progress.</source>
+        <translation>Det går inte att ändra uppsättningar medan en förkastning pågår.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="342"/>
+        <source>Cannot save while a discard is in progress.</source>
+        <translation>Det går inte att spara medan en förkastning pågår.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="507"/>
+        <location filename="../src/settings/rulecontroller.cpp" line="150"/>
+        <source>Discard already in flight.</source>
+        <translation>En förkastning pågår redan.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/animationspagecontroller.cpp" line="575"/>
+        <source>Could not restore %n profile file(s). They remain pending.</source>
+        <translation>
+            <numerusform>Kunde inte återställa %n profilfil. Den är fortfarande väntande.</numerusform>
+            <numerusform>Kunde inte återställa %n profilfiler. De är fortfarande väntande.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="709"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="719"/>
+        <source>Cannot modify presets while a discard is in progress.</source>
+        <translation>Det går inte att ändra förinställningar medan en förkastning pågår.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="165"/>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="98"/>
+        <source>Could not create the user shader directory.</source>
+        <translation>Kunde inte skapa användarkatalogen för shaders.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="62"/>
+        <source>No KZones configuration found in kwinrc</source>
+        <translation>Ingen KZones-konfiguration hittades i kwinrc</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="68"/>
+        <source>Failed to parse KZones layoutsJson: %1</source>
+        <translation>Kunde inte tolka KZones layoutsJson: %1</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="73"/>
+        <source>Imported %n layout(s) from KZones</source>
+        <translation>
+            <numerusform>Importerade %n layout från KZones</numerusform>
+            <numerusform>Importerade %n layouter från KZones</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="75"/>
+        <source>No layouts found in KZones configuration</source>
+        <translation>Inga layouter hittades i KZones-konfigurationen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="83"/>
+        <source>No file path specified</source>
+        <translation>Ingen filsökväg angiven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="88"/>
+        <source>Could not open file: %1</source>
+        <translation>Kunde inte öppna filen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="101"/>
+        <source>Failed to parse KZones JSON: %1</source>
+        <translation>Kunde inte tolka KZones-JSON: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="111"/>
+        <source>KZones file does not contain a JSON array or object</source>
+        <translation>KZones-filen innehåller inte en JSON-array eller ett JSON-objekt</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="116"/>
+        <source>Imported %n layout(s) from KZones file</source>
+        <translation>
+            <numerusform>Importerade %n layout från KZones-fil</numerusform>
+            <numerusform>Importerade %n layouter från KZones-fil</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="118"/>
+        <source>No valid layouts found in file</source>
+        <translation>Inga giltiga layouter hittades i filen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="108"/>
+        <source>PlasmaZones Settings</source>
+        <translation>PlasmaZones-inställningar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="113"/>
+        <source>Open a specific settings page</source>
+        <translation>Öppna en specifik inställningssida</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="116"/>
+        <source>Reveal a specific setting on the page (deep link)</source>
+        <translation>Visa en specifik inställning på sidan (djuplänk)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="120"/>
+        <source>Reveal a specific section on the page (deep link)</source>
+        <translation>Visa ett specifikt avsnitt på sidan (djuplänk)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="60"/>
+        <source>Identity</source>
+        <translation>Identitet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="66"/>
+        <source>Type</source>
+        <translation>Typ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="79"/>
+        <source>State</source>
+        <translation>Tillstånd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="85"/>
+        <source>Taskbar &amp; switcher</source>
+        <translation>Aktivitetsfält &amp; växlare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="91"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="238"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="243"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="788"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="147"/>
+        <source>Tiling</source>
+        <translation>Panelindelning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="96"/>
+        <source>Size</source>
+        <translation>Storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="104"/>
+        <source>Context</source>
+        <translation>Sammanhang</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="106"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="218"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="260"/>
+        <source>Other</source>
+        <translation>Övrigt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="117"/>
+        <source>The application&apos;s ID (Wayland app_id / desktop entry), e.g. org.kde.konsole.</source>
+        <translation>Programmets ID (Wayland app_id / desktop-post), t.ex. org.kde.konsole.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="119"/>
+        <source>The window&apos;s class (WM_CLASS resource class), e.g. konsole.</source>
+        <translation>Fönstrets klass (WM_CLASS resursklass), t.ex. konsole.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="121"/>
+        <source>The application&apos;s desktop entry file name.</source>
+        <translation>Filnamnet på programmets desktop-post.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="123"/>
+        <source>The window&apos;s X11 role (WM_WINDOW_ROLE). Empty for Wayland-native windows.</source>
+        <translation>Fönstrets X11-roll (WM_WINDOW_ROLE). Tom för Wayland-inbyggda fönster.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="125"/>
+        <source>The window&apos;s process ID.</source>
+        <translation>Fönstrets process-ID.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="127"/>
+        <source>The window&apos;s title-bar text.</source>
+        <translation>Texten i fönstrets namnlist.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="129"/>
+        <source>The window&apos;s type (Normal, Dialog, Utility, Notification, …).</source>
+        <translation>Fönstrets typ (Normalt, Dialog, Verktyg, Avisering, …).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="131"/>
+        <source>Whether the window is shown on all virtual desktops.</source>
+        <translation>Om fönstret visas på alla virtuella skrivbord.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="133"/>
+        <source>Whether the window is fullscreen.</source>
+        <translation>Om fönstret är i helskärm.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="135"/>
+        <source>Whether the window is minimized.</source>
+        <translation>Om fönstret är minimerat.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="137"/>
+        <source>Whether the window is maximized.</source>
+        <translation>Om fönstret är maximerat.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="139"/>
+        <source>Whether the window currently has keyboard focus.</source>
+        <translation>Om fönstret för närvarande har tangentbordsfokus.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="141"/>
+        <source>Whether the window is a transient (a dialog or popup owned by another window).</source>
+        <translation>Om fönstret är transient (en dialog eller popup som ägs av ett annat fönster).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="143"/>
+        <source>Whether the window is a notification or on-screen display.</source>
+        <translation>Om fönstret är en avisering eller en skärmvisning.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="145"/>
+        <source>The window&apos;s width in pixels.</source>
+        <translation>Fönstrets bredd i bildpunkter.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="147"/>
+        <source>The window&apos;s height in pixels.</source>
+        <translation>Fönstrets höjd i bildpunkter.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="149"/>
+        <source>Whether the window is set to stay above other windows (always on top).</source>
+        <translation>Om fönstret är inställt att ligga ovanför andra fönster (alltid överst).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="151"/>
+        <source>Whether the window is set to stay below other windows.</source>
+        <translation>Om fönstret är inställt att ligga under andra fönster.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="153"/>
+        <source>Whether the window is hidden from the taskbar.</source>
+        <translation>Om fönstret är dolt från aktivitetsfältet.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="155"/>
+        <source>Whether the window is hidden from the pager.</source>
+        <translation>Om fönstret är dolt från skrivbordsvisaren.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="157"/>
+        <source>Whether the window is hidden from the window switcher (Alt+Tab).</source>
+        <translation>Om fönstret är dolt från fönsterväxlaren (Alt+Tab).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="159"/>
+        <source>Whether the window is a modal dialog.</source>
+        <translation>Om fönstret är en modal dialog.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="161"/>
+        <source>Whether the window has a server-side title-bar and border.</source>
+        <translation>Om fönstret har en serverbaserad namnlist och kant.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="163"/>
+        <source>Whether the window can be resized.</source>
+        <translation>Om fönstret kan storleksändras.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="169"/>
+        <source>The window&apos;s left-edge X position in pixels.</source>
+        <translation>X-positionen för fönstrets vänsterkant i bildpunkter.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="171"/>
+        <source>The window&apos;s top-edge Y position in pixels.</source>
+        <translation>Y-positionen för fönstrets överkant i bildpunkter.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="173"/>
+        <source>The window&apos;s title without the application-name suffix the window manager adds.</source>
+        <translation>Fönstrets titel utan det programnamnssuffix som fönsterhanteraren lägger till.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="175"/>
+        <source>Whether the window has been floated out of tiling (snap or autotile).</source>
+        <translation>Om fönstret har gjorts flytande ut ur panelindelningen (fästning eller autopanelindelning).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="177"/>
+        <source>Whether the window is snapped into a zone (manual-zone mode, where tiled windows are not snapped).</source>
+        <translation>Om fönstret är fäst i en zon (manuellt zonläge, där panelindelade fönster inte är fästa).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="180"/>
+        <source>Whether the window is managed by the autotile engine.</source>
+        <translation>Om fönstret hanteras av autopanelindelningsmotorn.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="182"/>
+        <source>The zone the window is snapped into (manual-zone mode only).</source>
+        <translation>Zonen som fönstret är fäst i (endast manuellt zonläge).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="184"/>
+        <source>The monitor the window is on.</source>
+        <translation>Skärmen som fönstret finns på.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="186"/>
+        <source>The virtual desktop the window is on.</source>
+        <translation>Det virtuella skrivbord som fönstret finns på.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="188"/>
+        <source>The KDE Activity the window is on.</source>
+        <translation>KDE-aktiviteten som fönstret finns på.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="190"/>
+        <source>The engine mode the window is placed by (snapping or tiling).</source>
+        <translation>Motorläget som fönstret placeras av (fästning eller panelindelning).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="192"/>
+        <source>How many windows are tiled on this monitor and desktop. Lets a rule switch the tiling algorithm as windows open and close, for example a centered single-window layout that gives way once a second window opens.</source>
+        <translation>Hur många fönster som är panelindelade på denna skärm och detta skrivbord. Låter en regel byta panelindelningsalgoritm när fönster öppnas och stängs, till exempel en centrerad layout med ett enda fönster som ger vika när ett andra fönster öppnas.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="226"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="402"/>
+        <source>Gaps</source>
+        <translation>Mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="249"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="168"/>
+        <source>Overlay</source>
+        <translation>Överlägg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="252"/>
+        <source>Animation</source>
+        <translation>Animering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="255"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="97"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="174"/>
+        <source>Appearance</source>
+        <translation>Utseende</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="258"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="188"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="212"/>
+        <source>Window</source>
+        <translation>Fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="274"/>
+        <source>Engine mode</source>
+        <translation>Motorläge</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="277"/>
+        <location filename="../src/settings/rulemodel.cpp" line="276"/>
+        <source>Snapping layout</source>
+        <translation>Fästningslayout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="280"/>
+        <source>Tiling algorithm</source>
+        <translation>Panelindelningsalgoritm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="304"/>
+        <source>Engine to disable</source>
+        <translation>Motor att inaktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="307"/>
+        <source>Opacity (%)</source>
+        <translation>Opacitet (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="310"/>
+        <source>Zones</source>
+        <translation>Zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="317"/>
+        <source>Restore position on login (off = don&apos;t restore)</source>
+        <translation>Återställ position vid inloggning (av = återställ inte)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="333"/>
+        <source>Hide title bars (off = force visible)</source>
+        <translation>Dölj namnlister (av = tvinga fram synlighet)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="336"/>
+        <source>Show border (off = hide)</source>
+        <translation>Visa kant (av = dölj)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="339"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="420"/>
+        <source>Border width (px)</source>
+        <translation>Kantbredd (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="342"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="423"/>
+        <source>Corner radius (px)</source>
+        <translation>Hörnradie (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="348"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="411"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <source>Border color</source>
+        <translation>Kantfärg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="361"/>
+        <source>Inner gap (px)</source>
+        <translation>Inre mellanrum (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="364"/>
+        <source>Outer gap (px)</source>
+        <translation>Yttre mellanrum (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="367"/>
+        <source>Use per-side outer gaps (off = one uniform gap)</source>
+        <translation>Använd yttre mellanrum per sida (av = ett enhetligt mellanrum)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="374"/>
+        <source>Lock the layout (off = don&apos;t lock)</source>
+        <translation>Lås layouten (av = lås inte)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="381"/>
+        <source>Assign a default layout (off = leave unassigned)</source>
+        <translation>Tilldela en standardlayout (av = lämna otilldelad)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="384"/>
+        <source>Top gap (px)</source>
+        <translation>Övre mellanrum (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="387"/>
+        <source>Bottom gap (px)</source>
+        <translation>Nedre mellanrum (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="390"/>
+        <source>Left gap (px)</source>
+        <translation>Vänster mellanrum (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="393"/>
+        <source>Right gap (px)</source>
+        <translation>Höger mellanrum (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="398"/>
+        <location filename="../src/settings/rulemodel.cpp" line="394"/>
+        <source>Overlay shader</source>
+        <translation>Överläggsshader</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="401"/>
+        <location filename="../src/settings/rulemodel.cpp" line="400"/>
+        <source>Overlay style</source>
+        <translation>Överläggsstil</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="429"/>
+        <location filename="../src/settings/rulemodel.cpp" line="900"/>
+        <source>Monitor</source>
+        <translation>Skärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="432"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="764"/>
+        <location filename="../src/settings/rulemodel.cpp" line="902"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="260"/>
+        <source>Desktop</source>
+        <translation>Skrivbord</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="435"/>
+        <source>Event</source>
+        <translation>Händelse</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="441"/>
+        <source>Shader effect</source>
+        <translation>Shadereffekt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="444"/>
+        <source>Duration (ms)</source>
+        <translation>Varaktighet (ms)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="447"/>
+        <source>Curve</source>
+        <translation>Kurva</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="462"/>
+        <source>Zone numbers like “1, 2”, or a range like “1-3”. Multiple zones snap the window to their combined area.</source>
+        <translation>Zonnummer som ”1, 2”, eller ett intervall som ”1-3”. Flera zoner fäster fönstret i deras kombinerade yta.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="235"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="787"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="834"/>
+        <location filename="../src/settings/rulemodel.cpp" line="241"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="145"/>
+        <source>Snapping</source>
+        <translation>Fästning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="837"/>
+        <location filename="../src/settings/rulemodel.cpp" line="243"/>
+        <source>Autotile</source>
+        <translation>Autopanelindelning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="840"/>
+        <location filename="../src/settings/rulemodel.cpp" line="245"/>
+        <source>Scrolling</source>
+        <translation>Rullning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="845"/>
+        <source>Zone rectangles</source>
+        <translation>Zonrektanglar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="848"/>
+        <source>Layout preview</source>
+        <translation>Förhandsgranskning av layout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="539"/>
+        <source>Set engine mode</source>
+        <translation>Ange motorläge</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="165"/>
+        <source>Whether the window can be moved.</source>
+        <translation>Om fönstret kan flyttas.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="167"/>
+        <source>Whether the window can be maximized.</source>
+        <translation>Om fönstret kan maximeras.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="197"/>
+        <source>Whether the monitor is in portrait or landscape orientation. Lets a rule pick a different layout or algorithm on a rotated screen.</source>
+        <translation>Om skärmen är i stående eller liggande orientering. Låter en regel välja en annan layout eller algoritm på en roterad skärm.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="201"/>
+        <source>The layout currently active on the monitor. Lets a rule change gaps, the overlay or the lock state for the screen showing a given layout. It cannot change which layout is assigned (that would be circular).</source>
+        <translation>Layouten som för närvarande är aktiv på skärmen. Låter en regel ändra mellanrum, överlägget eller låstillståndet för skärmen som visar en given layout. Den kan inte ändra vilken layout som är tilldelad (det skulle bli cirkulärt).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="246"/>
+        <source>Engine</source>
+        <translation>Motor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="286"/>
+        <source>Max tiled windows</source>
+        <translation>Max antal panelindelade fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="289"/>
+        <source>Split ratio (%)</source>
+        <translation>Delningsförhållande (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="295"/>
+        <source>Insert position</source>
+        <translation>Infogningsposition</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="320"/>
+        <source>Restore to zone on login (off = don&apos;t restore)</source>
+        <translation>Återställ till zon vid inloggning (av = återställ inte)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="323"/>
+        <source>Restore size on unsnap (off = keep zone size)</source>
+        <translation>Återställ storlek vid lossning (av = behåll zonstorleken)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="326"/>
+        <source>Layer</source>
+        <translation>Lager</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="351"/>
+        <source>Show opacity and tint (off = hide)</source>
+        <translation>Visa opacitet och färgton (av = dölj)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="354"/>
+        <source>Tint strength (%)</source>
+        <translation>Färgtonsstyrka (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="357"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="353"/>
+        <source>Tint color</source>
+        <translation>Färgtonens färg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="408"/>
+        <source>Inactive zone color</source>
+        <translation>Färg för inaktiv zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="414"/>
+        <source>Active opacity (%)</source>
+        <translation>Aktiv opacitet (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="417"/>
+        <source>Inactive opacity (%)</source>
+        <translation>Inaktiv opacitet (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="426"/>
+        <source>Show zone numbers (off = hide)</source>
+        <translation>Visa zonnummer (av = dölj)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="438"/>
+        <source>Decoration packs</source>
+        <translation>Dekorationspaket</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="542"/>
+        <source>Set snapping layout</source>
+        <translation>Ange fästningslayout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="545"/>
+        <source>Set tiling algorithm</source>
+        <translation>Ange panelindelningsalgoritm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="548"/>
+        <source>Set max tiled windows</source>
+        <translation>Ange max antal panelindelade fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="551"/>
+        <source>Set split ratio</source>
+        <translation>Ange delningsförhållande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="554"/>
+        <source>Set master count</source>
+        <translation>Ange antal huvudfönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="557"/>
+        <source>Set insert position</source>
+        <translation>Ange infogningsposition</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="560"/>
+        <source>Set overflow behavior</source>
+        <translation>Ange överflödesbeteende</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="563"/>
+        <source>Set drag behavior</source>
+        <translation>Ange dragbeteende</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="566"/>
+        <source>Set algorithm parameter</source>
+        <translation>Ange algoritmparameter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="569"/>
+        <source>Disable engine</source>
+        <translation>Inaktivera motor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="572"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="908"/>
+        <source>Lock layout</source>
+        <translation>Lås layout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="575"/>
+        <source>Default layout assignment</source>
+        <translation>Tilldelning av standardlayout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="578"/>
+        <source>Exclude window</source>
+        <translation>Uteslut fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="581"/>
+        <source>Float window</source>
+        <translation>Gör fönster flytande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="584"/>
+        <source>Snap to zone(s)</source>
+        <translation>Fäst i zon(er)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="587"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="896"/>
+        <source>Restore position on login</source>
+        <translation>Återställ position vid inloggning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="590"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="899"/>
+        <source>Restore to zone on login</source>
+        <translation>Återställ till zon vid inloggning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="596"/>
+        <source>Set window layer</source>
+        <translation>Ange fönsterlager</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="599"/>
+        <source>Override animation shader</source>
+        <translation>Åsidosätt animeringsshader</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="602"/>
+        <source>Override decoration packs</source>
+        <translation>Åsidosätt dekorationspaket</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="605"/>
+        <source>Override animation duration</source>
+        <translation>Åsidosätt animeringslängd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="608"/>
+        <source>Override animation curve</source>
+        <translation>Åsidosätt animeringskurva</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="611"/>
+        <source>Set opacity</source>
+        <translation>Ange opacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="614"/>
+        <source>Set overlay shader</source>
+        <translation>Ange överläggsshader</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="617"/>
+        <source>Set overlay style</source>
+        <translation>Ange överläggsstil</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="620"/>
+        <source>Set overlay highlight color</source>
+        <translation>Ange överläggets markeringsfärg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="623"/>
+        <source>Set overlay inactive color</source>
+        <translation>Ange överläggets inaktiva färg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="626"/>
+        <source>Set overlay border color</source>
+        <translation>Ange överläggets kantfärg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="629"/>
+        <source>Set overlay active opacity</source>
+        <translation>Ange överläggets aktiva opacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="632"/>
+        <source>Set overlay inactive opacity</source>
+        <translation>Ange överläggets inaktiva opacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="635"/>
+        <source>Set overlay border width</source>
+        <translation>Ange överläggets kantbredd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="638"/>
+        <source>Set overlay corner radius</source>
+        <translation>Ange överläggets hörnradie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="641"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="923"/>
+        <source>Show zone numbers</source>
+        <translation>Visa zonnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="644"/>
+        <source>Exclude from animations</source>
+        <translation>Uteslut från animeringar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="652"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="905"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="356"/>
+        <source>Hide title bars</source>
+        <translation>Dölj namnlister</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="655"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="914"/>
+        <source>Show border</source>
+        <translation>Visa kant</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="658"/>
+        <source>Set border width</source>
+        <translation>Ange kantbredd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="661"/>
+        <source>Set corner radius</source>
+        <translation>Ange hörnradie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="664"/>
+        <source>Set focused border color</source>
+        <translation>Ange kantfärg för fokuserad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="667"/>
+        <source>Set unfocused border color</source>
+        <translation>Ange kantfärg för ofokuserad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="670"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="917"/>
+        <source>Show opacity and tint</source>
+        <translation>Visa opacitet och färgton</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="673"/>
+        <source>Set tint strength</source>
+        <translation>Ange färgtonens styrka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="676"/>
+        <source>Set tint color</source>
+        <translation>Ange färgtonens färg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="679"/>
+        <source>Set inner gap</source>
+        <translation>Ange inre mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="682"/>
+        <source>Set outer gap</source>
+        <translation>Ange yttre mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="685"/>
+        <source>Use per-side outer gaps</source>
+        <translation>Använd yttre mellanrum per sida</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="688"/>
+        <source>Set top gap</source>
+        <translation>Ange övre mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="691"/>
+        <source>Set bottom gap</source>
+        <translation>Ange nedre mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="694"/>
+        <source>Set left gap</source>
+        <translation>Ange vänster mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="697"/>
+        <source>Set right gap</source>
+        <translation>Ange höger mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="700"/>
+        <location filename="../src/settings/rulemodel.cpp" line="331"/>
+        <source>Open on monitor</source>
+        <translation>Öppna på skärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="703"/>
+        <location filename="../src/settings/rulemodel.cpp" line="336"/>
+        <source>Open on desktop</source>
+        <translation>Öppna på skrivbord</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="712"/>
+        <source>is</source>
+        <translation>är</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="714"/>
+        <source>contains</source>
+        <translation>innehåller</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="716"/>
+        <source>starts with</source>
+        <translation>börjar med</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="718"/>
+        <source>ends with</source>
+        <translation>slutar med</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="720"/>
+        <source>matches regex</source>
+        <translation>matchar reguljärt uttryck</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="722"/>
+        <source>matches app-id</source>
+        <translation>matchar app-id</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="724"/>
+        <source>greater than</source>
+        <translation>större än</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="726"/>
+        <source>less than</source>
+        <translation>mindre än</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="754"/>
+        <source>Unknown</source>
+        <translation>Okänt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="755"/>
+        <source>Normal window</source>
+        <translation>Normalt fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="756"/>
+        <source>Dialog</source>
+        <translation>Dialogruta</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="757"/>
+        <source>Utility</source>
+        <translation>Verktyg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="758"/>
+        <source>Toolbar</source>
+        <translation>Verktygsrad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="759"/>
+        <source>Splash screen</source>
+        <translation>Startskärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="760"/>
+        <source>Menu</source>
+        <translation>Meny</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="761"/>
+        <source>Tooltip</source>
+        <translation>Verktygstips</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="762"/>
+        <location filename="../src/settings/rulemodel.cpp" line="908"/>
+        <source>Notification</source>
+        <translation>Avisering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="763"/>
+        <source>Dock / panel</source>
+        <translation>Docka / panel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="765"/>
+        <source>On-screen display</source>
+        <translation>Skärmvisning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="766"/>
+        <source>Popup</source>
+        <translation>Popup</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="792"/>
+        <source>Landscape</source>
+        <translation>Liggande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="793"/>
+        <source>Portrait</source>
+        <translation>Stående</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="853"/>
+        <source>End of stack</source>
+        <translation>Sist i stacken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="856"/>
+        <source>After focused window</source>
+        <translation>Efter fokuserat fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="859"/>
+        <source>As master</source>
+        <translation>Som huvudfönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="864"/>
+        <source>Float overflow windows</source>
+        <translation>Gör överflödiga fönster flytande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="867"/>
+        <source>Unlimited (no cap)</source>
+        <translation>Obegränsat (ingen gräns)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="872"/>
+        <source>Float on drag</source>
+        <translation>Gör flytande vid dragning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="875"/>
+        <source>Reorder in stack</source>
+        <translation>Ändra ordning i stacken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="880"/>
+        <source>Above other windows</source>
+        <translation>Över andra fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="883"/>
+        <source>Normal stacking</source>
+        <translation>Normal stapling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="886"/>
+        <source>Below other windows</source>
+        <translation>Under andra fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="899"/>
+        <source>Don&apos;t restore to zone on login</source>
+        <translation>Återställ inte till zon vid inloggning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="902"/>
+        <source>Keep zone size on unsnap</source>
+        <translation>Behåll zonstorlek vid lossning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="917"/>
+        <source>Hide opacity and tint</source>
+        <translation>Dölj opacitet och färgton</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="923"/>
+        <source>Hide zone numbers</source>
+        <translation>Dölj zonnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="1110"/>
+        <source>Regular expression, e.g. ^(firefox|chromium)$</source>
+        <translation>Reguljärt uttryck, t.ex. ^(firefox|chromium)$</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="1113"/>
+        <source>Matches by reverse-DNS segments, so “firefox” also matches “org.mozilla.firefox”.</source>
+        <translation>Matchar efter omvända DNS-segment, så ”firefox” matchar även ”org.mozilla.firefox”.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="165"/>
+        <source>Failed to fetch the daemon&apos;s rule set.</source>
+        <translation>Kunde inte hämta demonens regeluppsättning.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="247"/>
+        <source>The daemon rejected one or more rules.</source>
+        <translation>Demonen avvisade en eller flera regler.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="375"/>
+        <source>A save is already in flight.</source>
+        <translation>En sparning pågår redan.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="386"/>
+        <source>The daemon&apos;s rules changed while you were editing. Review or use Save anyway to overwrite.</source>
+        <translation>Demonens regler ändrades medan du redigerade. Granska eller använd Spara ändå för att skriva över.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="397"/>
+        <source>One or more rules failed validation and could not be saved. See the log for details.</source>
+        <translation>En eller flera regler klarade inte valideringen och kunde inte sparas. Se loggen för mer information.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="657"/>
+        <source>%1 (copy)</source>
+        <translation>%1 (kopia)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="164"/>
+        <location filename="../src/settings/rulemodel.cpp" line="171"/>
+        <location filename="../src/settings/rulemodel.cpp" line="179"/>
+        <location filename="../src/settings/rulemodel.cpp" line="206"/>
+        <location filename="../src/settings/rulemodel.cpp" line="214"/>
+        <location filename="../src/settings/rulemodel.cpp" line="219"/>
+        <source>%1: %2</source>
+        <translation>%1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="215"/>
+        <source>On</source>
+        <translation>På</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="216"/>
+        <source>Off</source>
+        <translation>Av</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="272"/>
+        <source>Engine: %1</source>
+        <translation>Motor: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="277"/>
+        <source>Snapping: %1</source>
+        <translation>Fästning: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="296"/>
+        <source>Disabled</source>
+        <translation>Inaktiverad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="298"/>
+        <source>Disable: %1</source>
+        <translation>Inaktivera: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="301"/>
+        <source>Excluded</source>
+        <translation>Utesluten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="305"/>
+        <source>No animations</source>
+        <translation>Inga animeringar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="308"/>
+        <source>Float</source>
+        <translation>Gör flytande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="318"/>
+        <source>Snap to zone</source>
+        <translation>Fäst i zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="321"/>
+        <source>Snap to zone %1</source>
+        <translation>Fäst i zon %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="323"/>
+        <source>Snap to zones %1</source>
+        <translation>Fäst i zoner %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="332"/>
+        <source>Open on monitor: %1</source>
+        <translation>Öppna på skärm: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="336"/>
+        <source>Open on desktop %1</source>
+        <translation>Öppna på skrivbord %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="345"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="276"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="345"/>
+        <source>Opacity</source>
+        <translation>Opacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="349"/>
+        <location filename="../src/settings/rulemodel.cpp" line="354"/>
+        <source>Opacity (invalid)</source>
+        <translation>Opacitet (ogiltig)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="356"/>
+        <source>Opacity: %1%</source>
+        <translation>Opacitet: %1 %</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="360"/>
+        <source>Block animation shader</source>
+        <translation>Blockera animeringsshader</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="361"/>
+        <source>Shader: %1</source>
+        <translation>Shader: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="366"/>
+        <location filename="../src/settings/rulemodel.cpp" line="379"/>
+        <source>Block decoration</source>
+        <translation>Blockera dekoration</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="381"/>
+        <source>Decoration: %1</source>
+        <translation>Dekoration: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="385"/>
+        <source>Duration: %1 ms</source>
+        <translation>Längd: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="385"/>
+        <source>Animation duration</source>
+        <translation>Animeringslängd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="389"/>
+        <source>Animation curve</source>
+        <translation>Animeringskurva</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="390"/>
+        <source>Curve: %1</source>
+        <translation>Kurva: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="395"/>
+        <source>Overlay shader: %1</source>
+        <translation>Överläggsshader: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="896"/>
+        <source>Don&apos;t restore position on login</source>
+        <translation>Återställ inte position vid inloggning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="905"/>
+        <source>Show title bars</source>
+        <translation>Visa namnlister</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="908"/>
+        <source>Don&apos;t lock layout</source>
+        <translation>Lås inte layout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="911"/>
+        <source>Assign default layout</source>
+        <translation>Tilldela standardlayout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="911"/>
+        <source>Don&apos;t assign default layout</source>
+        <translation>Tilldela inte standardlayout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="914"/>
+        <source>Hide border</source>
+        <translation>Dölj kant</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="429"/>
+        <source>Border width: %1 px</source>
+        <translation>Kantbredd: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="432"/>
+        <source>Corner radius: %1 px</source>
+        <translation>Hörnradie: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="439"/>
+        <location filename="../src/settings/rulemodel.cpp" line="467"/>
+        <source>Accent</source>
+        <translation>Accent</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="441"/>
+        <source>Focused border: %1</source>
+        <translation>Fokuserad kant: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="443"/>
+        <source>Unfocused border: %1</source>
+        <translation>Ofokuserad kant: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="535"/>
+        <source>Gap: %1 px</source>
+        <translation>Mellanrum: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="538"/>
+        <source>Outer gap: %1 px</source>
+        <translation>Yttre mellanrum: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="920"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="411"/>
+        <source>Per-side outer gaps</source>
+        <translation>Yttre mellanrum per sida</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="920"/>
+        <source>Uniform outer gap</source>
+        <translation>Enhetligt yttre mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="405"/>
+        <source>Overlay style: %1</source>
+        <translation>Överläggsstil: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="412"/>
+        <source>Algorithm parameter</source>
+        <translation>Algoritmparameter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="413"/>
+        <source>Algorithm: %1</source>
+        <translation>Algoritm: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="454"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="348"/>
+        <source>Tint strength</source>
+        <translation>Färgtonens styrka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="460"/>
+        <source>Tint strength (invalid)</source>
+        <translation>Färgtonens styrka (ogiltig)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="462"/>
+        <source>Tint strength: %1%</source>
+        <translation>Färgtonens styrka: %1 %</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="468"/>
+        <source>Tint color: %1</source>
+        <translation>Färgtonens färg: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="472"/>
+        <source>Max tiled windows: %1</source>
+        <translation>Max antal panelindelade fönster: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="475"/>
+        <source>Master count: %1</source>
+        <translation>Antal huvudfönster: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="479"/>
+        <source>Split ratio: %1%</source>
+        <translation>Delningsförhållande: %1 %</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="482"/>
+        <source>Insert: %1</source>
+        <translation>Infoga: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="486"/>
+        <source>Overflow: %1</source>
+        <translation>Överflöde: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="490"/>
+        <source>Drag: %1</source>
+        <translation>Dra: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="497"/>
+        <source>Window layer</source>
+        <translation>Fönsterlager</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="505"/>
+        <source>Window layer (invalid)</source>
+        <translation>Fönsterlager (ogiltigt)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="507"/>
+        <source>Layer: %1</source>
+        <translation>Lager: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="513"/>
+        <source>Highlight color: %1</source>
+        <translation>Markeringsfärg: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="516"/>
+        <source>Inactive zone color: %1</source>
+        <translation>Färg på inaktiv zon: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="519"/>
+        <source>Overlay border color: %1</source>
+        <translation>Kantfärg för överlägg: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="522"/>
+        <source>Active opacity: %1%</source>
+        <translation>Aktiv opacitet: %1 %</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="525"/>
+        <source>Inactive opacity: %1%</source>
+        <translation>Inaktiv opacitet: %1 %</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="528"/>
+        <source>Overlay border width: %1 px</source>
+        <translation>Kantbredd för överlägg: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="531"/>
+        <source>Overlay corner radius: %1 px</source>
+        <translation>Hörnradie för överlägg: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="541"/>
+        <source>Top gap: %1 px</source>
+        <translation>Övre mellanrum: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="544"/>
+        <source>Bottom gap: %1 px</source>
+        <translation>Nedre mellanrum: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="547"/>
+        <source>Left gap: %1 px</source>
+        <translation>Vänster mellanrum: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="550"/>
+        <source>Right gap: %1 px</source>
+        <translation>Höger mellanrum: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="625"/>
+        <source>Everywhere</source>
+        <translation>Överallt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="857"/>
+        <source>Monitor &amp; Layout</source>
+        <translation>Skärm &amp; layout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="859"/>
+        <source>Applications</source>
+        <translation>Program</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="861"/>
+        <source>Activities</source>
+        <translation>Aktiviteter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="863"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="107"/>
+        <source>Animations</source>
+        <translation>Animeringar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="865"/>
+        <source>Advanced / Custom</source>
+        <translation>Avancerat/anpassat</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="867"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="876"/>
+        <source>Application</source>
+        <translation>Program</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="878"/>
+        <source>Window class</source>
+        <translation>Fönsterklass</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="880"/>
+        <source>Desktop file</source>
+        <translation>Skrivbordsfil</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="882"/>
+        <source>Window role</source>
+        <translation>Fönsterroll</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="884"/>
+        <source>Process ID</source>
+        <translation>Process-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="886"/>
+        <source>Title</source>
+        <translation>Titel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="888"/>
+        <source>Window type</source>
+        <translation>Fönstertyp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="890"/>
+        <source>Sticky</source>
+        <translation>Klistrig</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="892"/>
+        <source>Fullscreen</source>
+        <translation>Helskärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="894"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="629"/>
+        <source>Maximized</source>
+        <translation>Maximerad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="896"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="620"/>
+        <source>Minimized</source>
+        <translation>Minimerad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="898"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="622"/>
+        <source>Focused</source>
+        <translation>Fokuserad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="904"/>
+        <source>Activity</source>
+        <translation>Aktivitet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="906"/>
+        <source>Transient</source>
+        <translation>Transient</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="910"/>
+        <source>Width</source>
+        <translation>Bredd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="912"/>
+        <source>Height</source>
+        <translation>Höjd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="914"/>
+        <source>Keep above</source>
+        <translation>Behåll överst</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="916"/>
+        <source>Keep below</source>
+        <translation>Behåll underst</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="918"/>
+        <source>Skip taskbar</source>
+        <translation>Hoppa över aktivitetsfält</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="920"/>
+        <source>Skip pager</source>
+        <translation>Hoppa över skrivbordsväljare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="922"/>
+        <source>Skip switcher</source>
+        <translation>Hoppa över fönsterbytare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="924"/>
+        <source>Modal</source>
+        <translation>Modal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="926"/>
+        <source>Decorated</source>
+        <translation>Dekorerad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="928"/>
+        <source>Resizable</source>
+        <translation>Storleksändringsbar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="930"/>
+        <source>Movable</source>
+        <translation>Flyttbar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="932"/>
+        <source>Maximizable</source>
+        <translation>Maximerbar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="934"/>
+        <source>Position X</source>
+        <translation>Position X</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="936"/>
+        <source>Position Y</source>
+        <translation>Position Y</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="938"/>
+        <source>Title (no suffix)</source>
+        <translation>Titel (utan suffix)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="46"/>
+        <location filename="../src/settings/rulemodel.cpp" line="940"/>
+        <source>Floating</source>
+        <translation>Flytande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="44"/>
+        <location filename="../src/settings/rulemodel.cpp" line="942"/>
+        <source>Snapped</source>
+        <translation>Fäst</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="42"/>
+        <location filename="../src/settings/rulemodel.cpp" line="944"/>
+        <source>Tiled</source>
+        <translation>Panelindelad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="50"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="315"/>
+        <source>Popups</source>
+        <translation>Popup-fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="56"/>
+        <source>Layout Picker</source>
+        <translation>Layoutväljare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="119"/>
+        <source>Global default</source>
+        <translation>Global standard</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="946"/>
+        <source>Zone</source>
+        <translation>Zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="948"/>
+        <source>Mode</source>
+        <translation>Läge</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="950"/>
+        <source>Tiled window count</source>
+        <translation>Antal panelindelade fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="952"/>
+        <source>Screen orientation</source>
+        <translation>Skärmorientering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="954"/>
+        <source>Active layout</source>
+        <translation>Aktiv layout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="962"/>
+        <source>Any window</source>
+        <translation>Valfritt fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="976"/>
+        <source>(condition group)</source>
+        <translation>(villkorsgrupp)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/rulemodel.cpp" line="983"/>
+        <source>%n condition(s)</source>
+        <translation>
+            <numerusform>%n villkor</numerusform>
+            <numerusform>%n villkor</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="989"/>
+        <source>No action</source>
+        <translation>Ingen åtgärd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="58"/>
+        <source>New monitor rule</source>
+        <translation>Ny skärmregel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="62"/>
+        <source>New desktop rule</source>
+        <translation>Ny skrivbordsregel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="70"/>
+        <source>New application rule</source>
+        <translation>Ny programregel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="74"/>
+        <source>New activity rule</source>
+        <translation>Ny aktivitetsregel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="78"/>
+        <source>New animation rule</source>
+        <translation>Ny animeringsregel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="88"/>
+        <source>New custom rule</source>
+        <translation>Ny anpassad regel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="121"/>
+        <source>Set a layout on a monitor</source>
+        <translation>Ange en layout på en skärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="122"/>
+        <source>Pick a snapping layout to use on one monitor.</source>
+        <translation>Välj en fästlayout att använda på en skärm.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="123"/>
+        <source>Set a tiling algorithm on a monitor</source>
+        <translation>Ange en panelindelningsalgoritm på en skärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="124"/>
+        <source>Pick an autotile algorithm to use on one monitor.</source>
+        <translation>Välj en algoritm för automatisk panelindelning att använda på en skärm.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="126"/>
+        <source>Lock the layout on a monitor</source>
+        <translation>Lås layouten på en skärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="127"/>
+        <source>Pin the active layout on one monitor so it can&apos;t be switched. This is the rule-driven version of the lock-layout shortcut.</source>
+        <translation>Fäst den aktiva layouten på en skärm så att den inte kan bytas. Detta är den regelstyrda versionen av genvägen för att låsa layout.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="130"/>
+        <source>Set a layout on a virtual desktop</source>
+        <translation>Ange en layout på ett virtuellt skrivbord</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="131"/>
+        <source>Pick a snapping layout to use on one virtual desktop.</source>
+        <translation>Välj en fästlayout att använda på ett virtuellt skrivbord.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="133"/>
+        <source>Set a layout for portrait monitors</source>
+        <translation>Ange en layout för stående skärmar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="134"/>
+        <source>Pick a snapping layout to use whenever a monitor is in portrait orientation. Handy for rotating screens.</source>
+        <translation>Välj en fästlayout att använda när en skärm är i stående orientering. Praktiskt för roterande skärmar.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="137"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="215"/>
+        <source>Open an app in a zone</source>
+        <translation>Öppna ett program i en zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="138"/>
+        <source>Snap one application&apos;s windows into a chosen zone when they open.</source>
+        <translation>Fäst ett programs fönster i en vald zon när de öppnas.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="140"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="226"/>
+        <source>Open an app on a monitor</source>
+        <translation>Öppna ett program på en skärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="141"/>
+        <source>Send one application&apos;s windows to a chosen monitor when they open.</source>
+        <translation>Skicka ett programs fönster till en vald skärm när de öppnas.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="143"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="234"/>
+        <source>Float an app</source>
+        <translation>Gör ett program flytande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="144"/>
+        <source>Keep one application&apos;s windows floating instead of tiled. The windows stay managed, unlike a full exclusion.</source>
+        <translation>Håll ett programs fönster flytande i stället för panelindelade. Fönstren förblir hanterade, till skillnad från ett fullständigt undantag.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="147"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="244"/>
+        <source>Exclude an app from tiling</source>
+        <translation>Uteslut ett program från panelindelning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="148"/>
+        <source>Keep one application&apos;s windows out of the snap and autotile engines entirely.</source>
+        <translation>Håll ett programs fönster helt utanför fäst- och autopanelindelningsmotorerna.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="150"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="251"/>
+        <source>Don&apos;t animate small windows</source>
+        <translation>Animera inte små fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="151"/>
+        <source>Skip open and close animations for windows narrower than a chosen width. Handy for tiny popups and tool windows.</source>
+        <translation>Hoppa över öppnings- och stängningsanimeringar för fönster som är smalare än en vald bredd. Praktiskt för små popup-fönster och verktygsfönster.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="164"/>
+        <source>Snapping layout on monitor</source>
+        <translation>Fästlayout på skärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="171"/>
+        <source>Tiling algorithm on monitor</source>
+        <translation>Panelindelningsalgoritm på skärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="186"/>
+        <source>Lock layout on monitor</source>
+        <translation>Lås layout på skärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="197"/>
+        <source>Snapping layout on virtual desktop</source>
+        <translation>Fästlayout på virtuellt skrivbord</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="207"/>
+        <source>Layout for portrait monitors</source>
+        <translation>Layout för stående skärmar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="64"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <source>monitor</source>
+        <translation>skärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="447"/>
+        <source>display</source>
+        <translation>bildskärm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <source>mode</source>
+        <translation>läge</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="57"/>
+        <source>active layout</source>
+        <translation>aktiv layout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>rendering</source>
+        <translation>rendering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>backend</source>
+        <translation>bakände</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>opengl</source>
+        <translation>opengl</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>vulkan</source>
+        <translation>vulkan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <source>backup</source>
+        <translation>säkerhetskopiering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <source>export</source>
+        <translation>export</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>import</source>
+        <translation>import</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <source>reset</source>
+        <translation>återställ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="482"/>
+        <source>split</source>
+        <translation>dela</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>subdivide</source>
+        <translation>underindela</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>region</source>
+        <translation>region</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>layout</source>
+        <translation>layout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <source>zone</source>
+        <translation>zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>grid</source>
+        <translation>rutnät</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>preset</source>
+        <translation>förinställning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <source>template</source>
+        <translation>mall</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="68"/>
+        <source>aspect ratio</source>
+        <translation>bildförhållande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>overlay</source>
+        <translation>överlägg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>trigger</source>
+        <translation>utlösare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="409"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>edge</source>
+        <translation>kant</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <source>magnet</source>
+        <translation>magnet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>snap</source>
+        <translation>fästa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <source>color</source>
+        <translation>färg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>colour</source>
+        <translation>färg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <source>opacity</source>
+        <translation>opacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <source>transparency</source>
+        <translation>transparens</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <source>theme</source>
+        <translation>tema</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="392"/>
+        <source>border</source>
+        <translation>kant</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>zone selector</source>
+        <translation>zonväljare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="442"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>picker</source>
+        <translation>väljare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>chooser</source>
+        <translation>väljare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="82"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>popup</source>
+        <translation>popup</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <source>window</source>
+        <translation>fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <source>drag</source>
+        <translation>dra</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="85"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="497"/>
+        <source>modifier</source>
+        <translation>modifierare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="85"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="90"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="105"/>
+        <source>key</source>
+        <translation>tangent</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <source>priority</source>
+        <translation>prioritet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <source>order</source>
+        <translation>ordning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <source>precedence</source>
+        <translation>företräde</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>shortcut</source>
+        <translation>genväg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>hotkey</source>
+        <translation>snabbtangent</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>keybind</source>
+        <translation>tangentbindning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="90"/>
+        <source>keyboard</source>
+        <translation>tangentbord</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="143"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>shader</source>
+        <translation>shader</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="143"/>
+        <source>effect</source>
+        <translation>effekt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>glow</source>
+        <translation>sken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>tile</source>
+        <translation>panel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="235"/>
+        <source>tiling</source>
+        <translation>panelindelning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>auto</source>
+        <translation>auto</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <source>gap</source>
+        <translation>mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <source>spacing</source>
+        <translation>avstånd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>algorithm</source>
+        <translation>algoritm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>bsp</source>
+        <translation>bsp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>binary</source>
+        <translation>binär</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <source>spiral</source>
+        <translation>spiral</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <source>master</source>
+        <translation>huvud</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="497"/>
+        <source>stack</source>
+        <translation>stapel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>animation</source>
+        <translation>animering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <source>duration</source>
+        <translation>varaktighet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>easing</source>
+        <translation>utjämning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>curve</source>
+        <translation>kurva</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <source>spring</source>
+        <translation>fjäder</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <source>speed</source>
+        <translation>hastighet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>open</source>
+        <translation>öppna</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>close</source>
+        <translation>stäng</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>minimize</source>
+        <translation>minimera</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <source>movement</source>
+        <translation>rörelse</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>maximize</source>
+        <translation>maximera</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <source>dragging</source>
+        <translation>dragning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>move</source>
+        <translation>flytta</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>wobble</source>
+        <translation>vaja</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>physics</source>
+        <translation>fysik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <source>osd</source>
+        <translation>osd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <source>notification</source>
+        <translation>avisering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>on-screen display</source>
+        <translation>skärmvisning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>desktop</source>
+        <translation>skrivbord</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>virtual desktop</source>
+        <translation>virtuellt skrivbord</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <source>workspace</source>
+        <translation>arbetsyta</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <source>switch</source>
+        <translation>byt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>peek</source>
+        <translation>kika</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="129"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>show desktop</source>
+        <translation>visa skrivbord</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>side panel</source>
+        <translation>sidopanel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>panel</source>
+        <translation>panel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>drawer</source>
+        <translation>låda</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <source>widget</source>
+        <translation>widget</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>editor</source>
+        <translation>redigerare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <source>layout editor</source>
+        <translation>layoutredigerare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="139"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="156"/>
+        <source>profile</source>
+        <translation>profil</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>motion set</source>
+        <translation>rörelseuppsättning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>motion</source>
+        <translation>rörelse</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="165"/>
+        <source>title bar</source>
+        <translation>namnlist</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="165"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>decoration</source>
+        <translation>dekoration</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="148"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <source>appearance</source>
+        <translation>utseende</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>gaps</source>
+        <translation>mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <source>padding</source>
+        <translation>utfyllnad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <source>margin</source>
+        <translation>marginal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <source>rule</source>
+        <translation>regel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <source>exclude</source>
+        <translation>uteslut</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>float</source>
+        <translation>flytande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <source>activity</source>
+        <translation>aktivitet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>design</source>
+        <translation>design</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="173"/>
+        <source>zones</source>
+        <translation>zoner</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>about</source>
+        <translation>om</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>version</source>
+        <translation>version</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>license</source>
+        <translation>licens</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="176"/>
+        <source>credits</source>
+        <translation>medverkande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="182"/>
+        <source>Rendering</source>
+        <translation>Rendering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="184"/>
+        <source>Rendering backend</source>
+        <translation>Renderingsbakände</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>graphics</source>
+        <translation>grafik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="237"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="388"/>
+        <source>Window filtering</source>
+        <translation>Fönsterfiltrering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="239"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="390"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="533"/>
+        <source>Exclude transient windows</source>
+        <translation>Uteslut transienta fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>dialog</source>
+        <translation>dialogruta</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>tooltip</source>
+        <translation>verktygstips</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="247"/>
+        <source>Reset</source>
+        <translation>Återställ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <source>reset to defaults</source>
+        <translation>återställ till standard</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <source>defaults</source>
+        <translation>standardvärden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="459"/>
+        <source>restore</source>
+        <translation>återställ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="254"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="266"/>
+        <source>Triggers</source>
+        <translation>Utlösare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="256"/>
+        <source>Zone Span</source>
+        <translation>Zonspann</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="258"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="85"/>
+        <source>Display</source>
+        <translation>Visning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="52"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="261"/>
+        <source>Snap Assist</source>
+        <translation>Fästhjälp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="263"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="268"/>
+        <source>Window Handling</source>
+        <translation>Fönsterhantering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="264"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="269"/>
+        <source>Focus</source>
+        <translation>Fokus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="274"/>
+        <source>Colors</source>
+        <translation>Färger</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="278"/>
+        <source>Border</source>
+        <translation>Kant</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="280"/>
+        <source>Zone Labels</source>
+        <translation>Zonetiketter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="282"/>
+        <source>Effects</source>
+        <translation>Effekter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="186"/>
+        <source>Shader Effects</source>
+        <translation>Shadereffekter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="284"/>
+        <source>System accent color</source>
+        <translation>Systemets accentfärg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <source>scheme</source>
+        <translation>schema</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="287"/>
+        <source>Highlight color</source>
+        <translation>Markeringsfärg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <source>active</source>
+        <translation>aktiv</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <source>hover</source>
+        <translation>hovra</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <source>Inactive color</source>
+        <translation>Inaktiv färg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>unfocused</source>
+        <translation>ofokuserad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <source>outline</source>
+        <translation>kontur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="295"/>
+        <source>Import colors</source>
+        <translation>Importera färger</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>pywal</source>
+        <translation>pywal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>json</source>
+        <translation>json</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>load</source>
+        <translation>läs in</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <source>Active opacity</source>
+        <translation>Aktiv opacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>alpha</source>
+        <translation>alfa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>Inactive opacity</source>
+        <translation>Inaktiv opacitet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>Border width</source>
+        <translation>Kantbredd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>thickness</source>
+        <translation>tjocklek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>size</source>
+        <translation>storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <source>Border radius</source>
+        <translation>Kantradie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <source>rounding</source>
+        <translation>avrundning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <source>corner</source>
+        <translation>hörn</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="306"/>
+        <source>Label color</source>
+        <translation>Etikettfärg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>text</source>
+        <translation>text</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <source>font</source>
+        <translation>typsnitt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="308"/>
+        <source>Font</source>
+        <translation>Typsnitt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>typeface</source>
+        <translation>typsnitt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>family</source>
+        <translation>familj</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>style</source>
+        <translation>stil</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="311"/>
+        <source>Label scale</source>
+        <translation>Etikettskala</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>multiplier</source>
+        <translation>multiplikator</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="314"/>
+        <source>Zone numbers</source>
+        <translation>Zonnummer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>index</source>
+        <translation>index</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>digit</source>
+        <translation>siffra</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>label</source>
+        <translation>etikett</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>Flash on layout switch</source>
+        <translation>Blinka vid layoutbyte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>blink</source>
+        <translation>blinka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="187"/>
+        <source>Frame rate</source>
+        <translation>Bildfrekvens</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="71"/>
+        <source>User layouts</source>
+        <translation>Användarlayouter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="148"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>surface</source>
+        <translation>yta</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>decoration set</source>
+        <translation>dekorationsuppsättning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>set</source>
+        <translation>uppsättning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="156"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>pack</source>
+        <translation>paket</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>glass</source>
+        <translation>glas</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="160"/>
+        <source>blur</source>
+        <translation>oskärpa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <source>fps</source>
+        <translation>fps</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <source>refresh</source>
+        <translation>uppdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="189"/>
+        <source>Audio Spectrum</source>
+        <translation>Ljudspektrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="191"/>
+        <source>Audio spectrum</source>
+        <translation>Ljudspektrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="206"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <source>cava</source>
+        <translation>cava</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <source>music</source>
+        <translation>musik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <source>visualizer</source>
+        <translation>visualiserare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="193"/>
+        <source>sound</source>
+        <translation>ljud</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="194"/>
+        <source>Spectrum bars</source>
+        <translation>Spektrumstaplar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <source>bands</source>
+        <translation>band</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <source>frequency</source>
+        <translation>frekvens</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="197"/>
+        <source>Noise reduction</source>
+        <translation>Brusreducering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <source>smoothing</source>
+        <translation>utjämning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <source>smooth</source>
+        <translation>jämna ut</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="200"/>
+        <source>Extra smoothing</source>
+        <translation>Extra utjämning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="202"/>
+        <source>Automatic gain</source>
+        <translation>Automatisk förstärkning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>autosens</source>
+        <translation>autokänslighet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>sensitivity</source>
+        <translation>känslighet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="204"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="206"/>
+        <source>gain</source>
+        <translation>förstärkning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="205"/>
+        <source>Sensitivity</source>
+        <translation>Känslighet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="208"/>
+        <source>Lowest frequency</source>
+        <translation>Lägsta frekvens</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <source>cutoff</source>
+        <translation>gränsvärde</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="210"/>
+        <source>bass</source>
+        <translation>bas</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="212"/>
+        <source>Highest frequency</source>
+        <translation>Högsta frekvens</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="214"/>
+        <source>treble</source>
+        <translation>diskant</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="215"/>
+        <source>Channels</source>
+        <translation>Kanaler</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <source>stereo</source>
+        <translation>stereo</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <source>mono</source>
+        <translation>mono</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="217"/>
+        <source>Reverse bar order</source>
+        <translation>Omvänd stapelordning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <source>flip</source>
+        <translation>vänd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <source>mirror</source>
+        <translation>spegla</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="220"/>
+        <source>Monstercat filter</source>
+        <translation>Monstercat-filter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <source>filter</source>
+        <translation>filter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="222"/>
+        <source>Wave filter</source>
+        <translation>Vågfilter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <source>wave</source>
+        <translation>våg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="224"/>
+        <source>Audio backend</source>
+        <translation>Ljudbakände</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <source>pipewire</source>
+        <translation>pipewire</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <source>pulseaudio</source>
+        <translation>pulseaudio</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="226"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="229"/>
+        <source>capture</source>
+        <translation>infångning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="227"/>
+        <source>Audio source</source>
+        <translation>Ljudkälla</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <source>device</source>
+        <translation>enhet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="231"/>
+        <source>Layout assignment</source>
+        <translation>Layouttilldelning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="233"/>
+        <source>Don&apos;t assign a layout by default</source>
+        <translation>Tilldela ingen layout som standard</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>default</source>
+        <translation>standard</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>assign</source>
+        <translation>tilldela</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>snapping</source>
+        <translation>fästning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="320"/>
+        <source>Borders</source>
+        <translation>Kanter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="322"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="123"/>
+        <source>Decorations</source>
+        <translation>Dekorationer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <source>Corner radius</source>
+        <translation>Hörnradie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="328"/>
+        <source>Apply borders to</source>
+        <translation>Tillämpa kanter på</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>scope</source>
+        <translation>omfattning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>which windows</source>
+        <translation>vilka fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="331"/>
+        <source>Use system accent color</source>
+        <translation>Använd systemets dekorfärg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="334"/>
+        <source>Active border color</source>
+        <translation>Aktiv kantfärg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <source>focused</source>
+        <translation>fokuserad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="337"/>
+        <source>Inactive border color</source>
+        <translation>Inaktiv kantfärg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="340"/>
+        <source>Opacity and tint</source>
+        <translation>Opacitet och färgton</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="342"/>
+        <source>Apply opacity and tint to</source>
+        <translation>Tillämpa opacitet och färgton på</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <source>translucent</source>
+        <translation>genomskinlig</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>wash</source>
+        <translation>lasyr</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <source>blend</source>
+        <translation>blanda</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="351"/>
+        <source>Use system accent color for the tint</source>
+        <translation>Använd systemets dekorfärg för färgtonen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>accent</source>
+        <translation>dekorfärg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>titlebar</source>
+        <translation>namnlist</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>header</source>
+        <translation>sidhuvud</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="359"/>
+        <source>Hide title bars on</source>
+        <translation>Dölj namnlister på</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="362"/>
+        <source>Focus fade duration</source>
+        <translation>Fokustoningens varaktighet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>fade</source>
+        <translation>toning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>dim</source>
+        <translation>dämpa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="364"/>
+        <source>cross-fade</source>
+        <translation>korstoning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="370"/>
+        <source>Performance</source>
+        <translation>Prestanda</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="372"/>
+        <source>Animate only the active window</source>
+        <translation>Animera endast det aktiva fönstret</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <source>performance</source>
+        <translation>prestanda</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>power</source>
+        <translation>ström</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="382"/>
+        <source>battery</source>
+        <translation>batteri</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>gpu</source>
+        <translation>gpu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>heat</source>
+        <translation>värme</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="376"/>
+        <source>Pause while you are away</source>
+        <translation>Pausa medan du är borta</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>idle</source>
+        <translation>inaktiv</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="380"/>
+        <source>Idle after</source>
+        <translation>Inaktiv efter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>timeout</source>
+        <translation>tidsgräns</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="403"/>
+        <source>Inner gap</source>
+        <translation>Inre mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <source>inner</source>
+        <translation>inre</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="406"/>
+        <source>Outer gap</source>
+        <translation>Yttre mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <source>outer</source>
+        <translation>yttre</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="414"/>
+        <source>side</source>
+        <translation>sida</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="416"/>
+        <source>Smart gaps</source>
+        <translation>Smarta mellanrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>smart</source>
+        <translation>smart</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>single</source>
+        <translation>enkel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>Activate on every drag</source>
+        <translation>Aktivera vid varje dragning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <source>Hold to activate</source>
+        <translation>Håll för att aktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <source>deactivate</source>
+        <translation>inaktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>Toggle mode</source>
+        <translation>Växlingsläge</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>tap</source>
+        <translation>tryck</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <source>activation</source>
+        <translation>aktivering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>Span modifier</source>
+        <translation>Utsträckningsmodifierare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>zone span</source>
+        <translation>zonutsträckning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>paint</source>
+        <translation>måla</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <source>span</source>
+        <translation>utsträckning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <source>Edge threshold</source>
+        <translation>Kanttröskel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>distance</source>
+        <translation>avstånd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <source>multi-zone</source>
+        <translation>flerzon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="434"/>
+        <source>Show zones on all monitors</source>
+        <translation>Visa zoner på alla skärmar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <source>screens</source>
+        <translation>skärmar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <source>Filter by aspect ratio</source>
+        <translation>Filtrera efter proportioner</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="453"/>
+        <source>layouts</source>
+        <translation>layouter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="441"/>
+        <source>Always show after snapping</source>
+        <translation>Visa alltid efter fästning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="442"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <source>snap assist</source>
+        <translation>fästhjälp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <source>Hold to enable</source>
+        <translation>Håll för att aktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="446"/>
+        <source>Re-snap on resolution change</source>
+        <translation>Fäst om vid upplösningsändring</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="447"/>
+        <source>resolution</source>
+        <translation>upplösning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="449"/>
+        <source>Open new windows in the last-used zone</source>
+        <translation>Öppna nya fönster i den senast använda zonen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="450"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <source>new window</source>
+        <translation>nytt fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="450"/>
+        <source>last zone</source>
+        <translation>senaste zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="452"/>
+        <source>Auto-assign new windows for all layouts</source>
+        <translation>Tilldela nya fönster automatiskt för alla layouter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="453"/>
+        <source>auto-assign</source>
+        <translation>tilldela automatiskt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="603"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="609"/>
+        <source>User sets</source>
+        <translation>Användaren anger</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="616"/>
+        <source>Opened</source>
+        <translation>Öppnat</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="618"/>
+        <source>Closed</source>
+        <translation>Stängt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="626"/>
+        <source>Dragged</source>
+        <translation>Draget</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="631"/>
+        <source>Snapped Into Zone</source>
+        <translation>Fäst i zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="633"/>
+        <source>Snapped Out of Zone</source>
+        <translation>Löst från zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="635"/>
+        <source>Layout Switched</source>
+        <translation>Layout bytt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="637"/>
+        <source>Shown</source>
+        <translation>Visat</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="638"/>
+        <source>Hidden</source>
+        <translation>Dolt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="639"/>
+        <source>Emphasized</source>
+        <translation>Framhävt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="642"/>
+        <source>Zone Selector Shown</source>
+        <translation>Zonväljare visad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="644"/>
+        <source>Zone Selector Hidden</source>
+        <translation>Zonväljare dold</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="646"/>
+        <source>Layout Picker Shown</source>
+        <translation>Layoutväljare visad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="648"/>
+        <source>Layout Picker Hidden</source>
+        <translation>Layoutväljare dold</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="650"/>
+        <source>Snap Assist Shown</source>
+        <translation>Fästhjälp visad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="652"/>
+        <source>Snap Assist Hidden</source>
+        <translation>Fästhjälp dold</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="655"/>
+        <source>Desktop Switched</source>
+        <translation>Skrivbord bytt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="593"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="902"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="455"/>
+        <source>Restore size on unsnap</source>
+        <translation>Återställ storlek vid lossning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="456"/>
+        <source>unsnap</source>
+        <translation>lossning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="456"/>
+        <source>original size</source>
+        <translation>ursprunglig storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="458"/>
+        <source>Restore windows to their previous zone</source>
+        <translation>Återställ fönster till deras föregående zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="459"/>
+        <source>login</source>
+        <translation>inloggning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="461"/>
+        <source>Restore unsnapped windows to their previous position</source>
+        <translation>Återställ fönster med borttagen fästning till deras föregående position</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="462"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="506"/>
+        <source>floated</source>
+        <translation>gjort flytande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="462"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="506"/>
+        <source>position</source>
+        <translation>position</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="464"/>
+        <source>Unfloat to a zone when there is no previous zone</source>
+        <translation>Gör icke-flytande till en zon när det inte finns någon föregående zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="465"/>
+        <source>unfloat</source>
+        <translation>gör icke-flytande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="465"/>
+        <source>fallback</source>
+        <translation>reserv</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>Sticky windows</source>
+        <translation>Klistriga fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>all desktops</source>
+        <translation>alla skrivbord</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>sticky</source>
+        <translation>klistrig</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <source>Focus new windows</source>
+        <translation>Fokusera nya fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="114"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>focus</source>
+        <translation>fokus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>Focus follows mouse</source>
+        <translation>Fokus följer musen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>pointer</source>
+        <translation>pekare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="238"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="283"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="474"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="219"/>
+        <source>Algorithm</source>
+        <translation>Algoritm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="476"/>
+        <source>Max windows</source>
+        <translation>Max antal fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <source>windows</source>
+        <translation>fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <source>maximum</source>
+        <translation>maximum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>count</source>
+        <translation>antal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="478"/>
+        <source>limit</source>
+        <translation>gräns</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="480"/>
+        <source>Master ratio</source>
+        <translation>Huvudförhållande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <source>center</source>
+        <translation>mitten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>ratio</source>
+        <translation>förhållande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="482"/>
+        <source>proportion</source>
+        <translation>proportion</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="485"/>
+        <source>Ratio step size</source>
+        <translation>Stegstorlek för förhållande</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>step</source>
+        <translation>steg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>increment</source>
+        <translation>ökning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="488"/>
+        <source>Master count</source>
+        <translation>Huvudantal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="490"/>
+        <source>number</source>
+        <translation>nummer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <source>Always re-insert on drag</source>
+        <translation>Återinsätt alltid vid dragning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <source>insert</source>
+        <translation>insättning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="496"/>
+        <source>Hold to re-insert into stack</source>
+        <translation>Håll för att återinsätta i stacken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>stack preview</source>
+        <translation>stackförhandsgranskning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <source>New window placement</source>
+        <translation>Placering av nya fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>Respect minimum size</source>
+        <translation>Respektera minsta storlek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>minimum</source>
+        <translation>minimum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="505"/>
+        <source>Restore untiled windows to their previous position</source>
+        <translation>Återställ opanelindelade fönster till deras föregående position</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="301"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>Drag behavior</source>
+        <translation>Dragbeteende</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>reorder</source>
+        <translation>ändra ordning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>Overflow behavior</source>
+        <translation>Överskottsbeteende</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>max windows</source>
+        <translation>max antal fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>unlimited</source>
+        <translation>obegränsat</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="520"/>
+        <source>Global animation defaults</source>
+        <translation>Globala animeringsstandarder</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="522"/>
+        <source>Multiple windows</source>
+        <translation>Flera fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>sequence</source>
+        <translation>sekvens</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>simultaneous</source>
+        <translation>samtidigt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>one by one</source>
+        <translation>en i taget</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="525"/>
+        <source>Stagger delay</source>
+        <translation>Förskjutningsfördröjning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>pause</source>
+        <translation>paus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>interval</source>
+        <translation>intervall</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>delay</source>
+        <translation>fördröjning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="528"/>
+        <source>Minimum distance</source>
+        <translation>Minsta avstånd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>threshold</source>
+        <translation>tröskel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <source>skip</source>
+        <translation>hoppa över</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <source>geometry</source>
+        <translation>geometri</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="531"/>
+        <source>Window Filtering</source>
+        <translation>Fönsterfiltrering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>dialogs</source>
+        <translation>dialogrutor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>popups</source>
+        <translation>popupfönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>tooltips</source>
+        <translation>verktygstips</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="535"/>
+        <source>menus</source>
+        <translation>menyer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="537"/>
+        <source>Exclude notifications and OSDs</source>
+        <translation>Uteslut aviseringar och OSD:er</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>volume</source>
+        <translation>volym</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>brightness</source>
+        <translation>ljusstyrka</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="242"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="394"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="540"/>
+        <source>Minimum window width</source>
+        <translation>Minsta fönsterbredd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <source>narrow</source>
+        <translation>smal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="245"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="397"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="543"/>
+        <source>Minimum window height</source>
+        <translation>Minsta fönsterhöjd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>short</source>
+        <translation>låg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="548"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="192"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="223"/>
+        <source>Configuration</source>
+        <translation>Konfiguration</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="549"/>
+        <source>Backup</source>
+        <translation>Säkerhetskopiering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <source>save</source>
+        <translation>spara</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>data</source>
+        <translation>data</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="551"/>
+        <source>Restore</source>
+        <translation>Återställ</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="556"/>
+        <source>Zone selector popup</source>
+        <translation>Popup för zonväljare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>enable</source>
+        <translation>aktivera</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>toggle</source>
+        <translation>växla</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="559"/>
+        <source>Position &amp; Trigger</source>
+        <translation>Position &amp; utlösare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="561"/>
+        <source>Trigger distance</source>
+        <translation>Utlösaravstånd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>proximity</source>
+        <translation>närhet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="564"/>
+        <source>Layout Arrangement</source>
+        <translation>Layoutarrangemang</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="566"/>
+        <source>Arrangement</source>
+        <translation>Arrangemang</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>horizontal</source>
+        <translation>horisontell</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>vertical</source>
+        <translation>vertikal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="569"/>
+        <source>Grid columns</source>
+        <translation>Rutnätskolumner</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>columns</source>
+        <translation>kolumner</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>per row</source>
+        <translation>per rad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="572"/>
+        <source>Max visible rows</source>
+        <translation>Max synliga rader</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>rows</source>
+        <translation>rader</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>scroll</source>
+        <translation>rulla</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>visible</source>
+        <translation>synlig</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="575"/>
+        <source>Preview Size</source>
+        <translation>Förhandsgranskningsstorlek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="579"/>
+        <source>Snapping Layout Priority</source>
+        <translation>Prioritet för fästlayout</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="581"/>
+        <source>Tiling Algorithm Priority</source>
+        <translation>Prioritet för panelindelningsalgoritm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="583"/>
+        <source>Snapping Quick Shortcuts</source>
+        <translation>Snabbgenvägar för fästning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="585"/>
+        <source>Tiling Quick Shortcuts</source>
+        <translation>Snabbgenvägar för panelindelning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="591"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="593"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="595"/>
+        <source>User shaders</source>
+        <translation>Användarshaders</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="597"/>
+        <source>Easing Presets</source>
+        <translation>Förinställningar för mjukövergång</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="599"/>
+        <source>Spring Presets</source>
+        <translation>Fjäderförinställningar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="601"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="607"/>
+        <source>Save current state</source>
+        <translation>Spara aktuellt tillstånd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="605"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="611"/>
+        <source>Saved sets</source>
+        <translation>Sparade uppsättningar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>Peeked at Desktop</source>
+        <translation>Kikade på skrivbordet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="713"/>
+        <source>Snap Out of Zone</source>
+        <translation>Fäst ut ur zon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="665"/>
+        <source>Slide In</source>
+        <translation>Glid in</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="667"/>
+        <source>Slide Out</source>
+        <translation>Glid ut</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="669"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="687"/>
+        <source>Fade In</source>
+        <translation>Tona in</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="671"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="689"/>
+        <source>Fade Out</source>
+        <translation>Tona ut</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="672"/>
+        <source>Hover</source>
+        <translation>Hovra</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="673"/>
+        <source>Press</source>
+        <translation>Tryck</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="675"/>
+        <source>Toggle On</source>
+        <translation>Slå på</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="677"/>
+        <source>Toggle Off</source>
+        <translation>Slå av</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="679"/>
+        <source>Show (badge)</source>
+        <translation>Visa (bricka)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="681"/>
+        <source>Hide (badge)</source>
+        <translation>Dölj (bricka)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="683"/>
+        <source>Pulse (badge)</source>
+        <translation>Pulsera (bricka)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="684"/>
+        <source>Tint</source>
+        <translation>Färgton</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="685"/>
+        <source>Dim</source>
+        <translation>Dämpa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="691"/>
+        <source>Reorder</source>
+        <translation>Ändra ordning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="693"/>
+        <source>Expand (accordion)</source>
+        <translation>Expandera (dragspel)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="695"/>
+        <source>Collapse (accordion)</source>
+        <translation>Fäll ihop (dragspel)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="697"/>
+        <source>Progress</source>
+        <translation>Förlopp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="699"/>
+        <source>Zone Highlight</source>
+        <translation>Zonmarkering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="701"/>
+        <source>Zone Highlight: Pop</source>
+        <translation>Zonmarkering: pop</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="703"/>
+        <source>Zone Highlight: Border</source>
+        <translation>Zonmarkering: kant</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="705"/>
+        <source>Zone Overlay: Layout-Switch Flash</source>
+        <translation>Zonöverlägg: blixt vid layoutbyte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="707"/>
+        <source>Cursor Hover</source>
+        <translation>Markörhovring</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="709"/>
+        <source>Cursor Click</source>
+        <translation>Markörklick</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="711"/>
+        <source>Snap Into Zone (Fill Preview)</source>
+        <translation>Fäst in i zon (förhandsgranskning av fyllning)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="715"/>
+        <source>Snap Resize (Drag Preview)</source>
+        <translation>Fäst storleksändring (förhandsgranskning av drag)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="661"/>
+        <source>Zone %1</source>
+        <translation>Zon %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="663"/>
+        <source>%1 — %2</source>
+        <translation>%1 — %2</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="216"/>
+        <source>Layout created, but aspect-ratio class could not be applied: %1</source>
+        <translation>Layouten skapades, men bildförhållandeklassen kunde inte tillämpas: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="230"/>
+        <source>Could not create the layout. The daemon returned an empty layout ID.</source>
+        <translation>Kunde inte skapa layouten. Bakgrundstjänsten returnerade ett tomt layout-ID.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="238"/>
+        <source>Could not create the layout. The daemon may not be running.</source>
+        <translation>Kunde inte skapa layouten. Bakgrundstjänsten kanske inte körs.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="257"/>
+        <source>Could not delete layout: %1</source>
+        <translation>Kunde inte ta bort layout: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="273"/>
+        <source>Could not duplicate layout: %1</source>
+        <translation>Kunde inte duplicera layout: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="323"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="472"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="565"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="929"/>
+        <source>That file path is not allowed.</source>
+        <translation>Den filsökvägen är inte tillåten.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="355"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="530"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="497"/>
+        <source>That export path is not allowed.</source>
+        <translation>Den exportsökvägen är inte tillåten.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="400"/>
+        <source>Failed to update layout visibility: %1</source>
+        <translation>Kunde inte uppdatera layoutens synlighet: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="413"/>
+        <source>Failed to update auto-assign: %1</source>
+        <translation>Kunde inte uppdatera automatisk tilldelning: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="427"/>
+        <source>Failed to update aspect ratio: %1</source>
+        <translation>Kunde inte uppdatera bildförhållande: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_lifecycle.cpp" line="187"/>
+        <source>Failed to apply assignment changes: %1</source>
+        <translation>Kunde inte tillämpa tilldelningsändringar: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="77"/>
+        <source>Overview</source>
+        <translation>Översikt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="81"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="232"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="302"/>
+        <source>General</source>
+        <translation>Allmänt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="91"/>
+        <source>Placement</source>
+        <translation>Placering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="40"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="253"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="312"/>
+        <source>Windows</source>
+        <translation>Fönster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="132"/>
+        <source>Rules</source>
+        <translation>Regler</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="136"/>
+        <source>Editor</source>
+        <translation>Redigerare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="138"/>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="151"/>
+        <source>Virtual Screens</source>
+        <translation>Virtuella skärmar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="153"/>
+        <source>Layouts</source>
+        <translation>Layouter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="243"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="171"/>
+        <source>Behavior</source>
+        <translation>Beteende</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="54"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="181"/>
+        <source>Zone Selector</source>
+        <translation>Zonväljare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="194"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="225"/>
+        <source>Priority</source>
+        <translation>Prioritet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="197"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="228"/>
+        <source>Quick Shortcuts</source>
+        <translation>Snabbgenvägar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="199"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="287"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="322"/>
+        <source>Shaders</source>
+        <translation>Shaders</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="239"/>
+        <source>Transitions</source>
+        <translation>Övergångar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="247"/>
+        <source>Motion</source>
+        <translation>Rörelse</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="264"/>
+        <source>Window Motion</source>
+        <translation>Fönsterrörelse</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="271"/>
+        <source>Window Dragging</source>
+        <translation>Fönsterdragning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="306"/>
+        <source>Surfaces</source>
+        <translation>Ytor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="319"/>
+        <source>Decoration Sets</source>
+        <translation>Dekorationsuppsättningar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="249"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="308"/>
+        <source>Library</source>
+        <translation>Bibliotek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="48"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="254"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="313"/>
+        <source>OSDs</source>
+        <translation>OSD:er</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="257"/>
+        <source>Overlays</source>
+        <translation>Överlägg</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="274"/>
+        <source>Side Panels</source>
+        <translation>Sidopaneler</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="276"/>
+        <source>Widgets</source>
+        <translation>Widgetar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="279"/>
+        <source>Layout Editor</source>
+        <translation>Layoutredigerare</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="282"/>
+        <source>Presets</source>
+        <translation>Förinställningar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="285"/>
+        <source>Motion Sets</source>
+        <translation>Rörelseuppsättningar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="303"/>
+        <source>Shader pack installed.</source>
+        <translation>Shader-paket installerat.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="305"/>
+        <source>The dropped path is not a valid shader pack directory.</source>
+        <translation>Den släppta sökvägen är inte en giltig shader-paketkatalog.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="307"/>
+        <source>The shader pack is missing metadata.json (or it is a symlink).</source>
+        <translation>Shader-paketet saknar metadata.json (eller så är det en symbolisk länk).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="309"/>
+        <source>The user shader directory could not be created.</source>
+        <translation>Användarens shader-katalog kunde inte skapas.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="311"/>
+        <source>A shader pack with this name is already installed.</source>
+        <translation>Ett shader-paket med detta namn är redan installerat.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="313"/>
+        <source>The shader pack exceeds the maximum allowed size or file count.</source>
+        <translation>Shader-paketet överskrider den högsta tillåtna storleken eller filantalet.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="315"/>
+        <source>Copying the shader pack failed. The partial install was rolled back.</source>
+        <translation>Kopieringen av shader-paketet misslyckades. Den ofullständiga installationen ångrades.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="317"/>
+        <source>Unknown shader pack installer error.</source>
+        <translation>Okänt fel i shader-paketinstalleraren.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="78"/>
+        <source>Color import file does not exist: %1</source>
+        <translation>Färgimportfilen finns inte: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="96"/>
+        <source>Color import file does not resolve to a regular file: %1</source>
+        <translation>Färgimportfilen pekar inte på en vanlig fil: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="101"/>
+        <source>Color import file must be a .json file: %1</source>
+        <translation>Färgimportfilen måste vara en .json-fil: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="449"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="545"/>
+        <source>A set named &quot;%1&quot; already exists.</source>
+        <translation>En uppsättning med namnet &quot;%1&quot; finns redan.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="355"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="540"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="551"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="617"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="622"/>
+        <source>Could not read the set &quot;%1&quot;.</source>
+        <translation>Kunde inte läsa uppsättningen &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="169"/>
+        <source>Could not back up the existing set, so it was left untouched.</source>
+        <translation>Kunde inte säkerhetskopiera den befintliga uppsättningen, så den lämnades orörd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="234"/>
+        <source>Could not write the set to disk.</source>
+        <translation>Kunde inte skriva uppsättningen till disk.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="359"/>
+        <source>&quot;%1&quot; was written by a newer version of PlasmaZones.</source>
+        <translation>&quot;%1&quot; skrevs av en nyare version av PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="367"/>
+        <source>&quot;%1&quot; does not match this page.</source>
+        <translation>&quot;%1&quot; matchar inte den här sidan.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="371"/>
+        <source>Could not apply &quot;%1&quot;.</source>
+        <translation>Kunde inte tillämpa &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="439"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="533"/>
+        <source>That name cannot be used. Try one with letters or numbers in it.</source>
+        <translation>Det namnet kan inte användas. Prova ett med bokstäver eller siffror i.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="459"/>
+        <source>There is nothing to capture yet.</source>
+        <translation>Det finns inget att fånga ännu.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="500"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="508"/>
+        <source>Could not delete &quot;%1&quot;.</source>
+        <translation>Kunde inte ta bort &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="432"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="526"/>
+        <source>A set needs a name.</source>
+        <translation>En uppsättning behöver ett namn.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="589"/>
+        <source>Renamed the set, but the old file could not be removed. Delete it by hand from the sets folder.</source>
+        <translation>Uppsättningen bytte namn, men den gamla filen kunde inte tas bort. Ta bort den manuellt från uppsättningsmappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="605"/>
+        <source>Could not write to that location.</source>
+        <translation>Kunde inte skriva till den platsen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="631"/>
+        <source>Could not write to %1.</source>
+        <translation>Kunde inte skriva till %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="652"/>
+        <source>That file is not a readable set.</source>
+        <translation>Den filen är inte en läsbar uppsättning.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="656"/>
+        <source>That set was written by a newer version of PlasmaZones.</source>
+        <translation>Den uppsättningen skrevs av en nyare version av PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="663"/>
+        <source>That set is empty.</source>
+        <translation>Den uppsättningen är tom.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="670"/>
+        <source>That set does not match this page.</source>
+        <translation>Den uppsättningen matchar inte den här sidan.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="681"/>
+        <source>That set has no usable name.</source>
+        <translation>Den uppsättningen har inget användbart namn.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="466"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="688"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="710"/>
+        <source>Could not create the sets folder.</source>
+        <translation>Kunde inte skapa uppsättningsmappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="715"/>
+        <source>Could not open the sets folder.</source>
+        <translation>Kunde inte öppna uppsättningsmappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="130"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="199"/>
+        <source>A preset needs a name.</source>
+        <translation>En förinställning behöver ett namn.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="140"/>
+        <source>That name cannot be used for a preset.</source>
+        <translation>Det namnet kan inte användas för en förinställning.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="150"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="159"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="178"/>
+        <source>Could not save the preset &quot;%1&quot;.</source>
+        <translation>Kunde inte spara förinställningen &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="253"/>
+        <source>Could not find the preset &quot;%1&quot;.</source>
+        <translation>Kunde inte hitta förinställningen &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="261"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="271"/>
+        <source>Could not delete the preset &quot;%1&quot;.</source>
+        <translation>Kunde inte ta bort förinställningen &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_overrides.cpp" line="260"/>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="407"/>
+        <source>Cannot reset while a discard is in progress.</source>
+        <translation>Kan inte återställa medan ett förkastande pågår.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_overrides.cpp" line="282"/>
+        <source>Some animation overrides could not be reset.</source>
+        <translation>Vissa animationsöverstyrningar kunde inte återställas.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="488"/>
+        <source>Settings can only be exported to a local file.</source>
+        <translation>Inställningar kan bara exporteras till en lokal fil.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="529"/>
+        <source>That is the settings file this app is using. Export to a different file.</source>
+        <translation>Det är inställningsfilen som den här appen använder. Exportera till en annan fil.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="556"/>
+        <source>Settings can only be imported from a local file.</source>
+        <translation>Inställningar kan bara importeras från en lokal fil.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="570"/>
+        <source>That settings file is no longer there.</source>
+        <translation>Den inställningsfilen finns inte längre.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="584"/>
+        <source>Those are the settings this app is already using. Pick a different file to import.</source>
+        <translation>Det är inställningarna som den här appen redan använder. Välj en annan fil att importera.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="607"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="612"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="617"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="641"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="685"/>
+        <source>That is not a settings file this app can read.</source>
+        <translation>Det är inte en inställningsfil som den här appen kan läsa.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="657"/>
+        <source>Could not back up your current settings, so nothing was imported.</source>
+        <translation>Kunde inte säkerhetskopiera dina nuvarande inställningar, så inget importerades.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="670"/>
+        <source>Could not read that older settings file.</source>
+        <translation>Kunde inte läsa den äldre inställningsfilen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="677"/>
+        <source>Could not read that settings file.</source>
+        <translation>Kunde inte läsa den inställningsfilen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="697"/>
+        <source>Could not replace your settings with that file.</source>
+        <translation>Kunde inte ersätta dina inställningar med den filen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="725"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="730"/>
+        <source>Your settings could not be put back. A copy is saved at %1.</source>
+        <translation>Dina inställningar kunde inte återställas. En kopia är sparad på %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="770"/>
+        <source>Your settings were imported, but the animation pages still show the old ones. Reopen the settings window to see the imported values.</source>
+        <translation>Dina inställningar importerades, men animationssidorna visar fortfarande de gamla. Öppna inställningsfönstret igen för att se de importerade värdena.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Summary
Adds a full **Swedish (`sv`)** translation — all **1022 strings** translated. This is the next language after German and Georgian, chosen from the community footprint (Sweden was the largest non-English cluster among discussion participants).

- Generated `translations/plasmazones_sv.ts` against current sources with `lupdate` (single `plasmazones` context).
- Terminology follows KDE Plasma's Swedish conventions: `fönster`=window, `skärm`=screen, `zon`=zone, `panelindelning`=tiling, `fästa`=snap, `namnlist`=title bar, `mellanrum`=gap, `överlägg`=overlay, `förhandsgranskning`=preview, `utesluta`=exclude.
- Swedish **sentence case** (not English title case), 2 plural forms for the four `%n` strings.

## Review
Ran a **3-pass native-Swedish review** (7 → 3 → **0 findings**, converged clean). Fixed terminology consistency (title bar, unsnap, exclude, preview) and a couple of idiom issues (`wash`→lasyr, `credits`→medverkande).

## Verification
- Placeholders (`%1`/`%2`/`%n`) and XML entities preserved (0 mismatches).
- Technical proper nouns (OpenGL, Vulkan, pywal, cava, ...) kept in Latin.
- Well-formed XML; CMake picks it up via the `plasmazones_*.ts` glob.
- `lrelease` compiles: **1022 finished / 0 unfinished**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)