### PR TITLE
feat(i18n): add complete Dutch translation

### DIFF
--- a/translations/plasmazones_nl.ts
+++ b/translations/plasmazones_nl.ts
@@ -1,0 +1,5569 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
+<context>
+    <name>plasmazones</name>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="52"/>
+        <source>A zone with this name already exists</source>
+        <translation>Er bestaat al een zone met deze naam</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/AddZoneCommand.cpp" line="16"/>
+        <source>Add Zone</source>
+        <comment>@action</comment>
+        <translation>Zone toevoegen</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/shortcutmanager.cpp" line="592"/>
+        <source>Apply Layout %1</source>
+        <translation>Indeling %1 toepassen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ApplyTemplateCommand.cpp" line="14"/>
+        <source>Apply Template: %1</source>
+        <comment>@action</comment>
+        <translation>Sjabloon toepassen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="185"/>
+        <source>Bring Forward</source>
+        <comment>@action</comment>
+        <translation>Naar voren halen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="175"/>
+        <source>Bring to Front</source>
+        <comment>@action</comment>
+        <translation>Naar voorgrond brengen</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="357"/>
+        <source>Cancel Zone Overlay</source>
+        <translation>Zone-overlay annuleren</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="412"/>
+        <source>Layout Picker: Move Left</source>
+        <translation>Indelingskiezer: naar links</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="416"/>
+        <source>Layout Picker: Move Right</source>
+        <translation>Indelingskiezer: naar rechts</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="420"/>
+        <source>Layout Picker: Move Up</source>
+        <translation>Indelingskiezer: omhoog</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="424"/>
+        <source>Layout Picker: Move Down</source>
+        <translation>Indelingskiezer: omlaag</translation>
+    </message>
+    <message>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="428"/>
+        <location filename="../src/dbus/windowdragadaptor.cpp" line="430"/>
+        <source>Layout Picker: Confirm</source>
+        <translation>Indelingskiezer: bevestigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="21"/>
+        <source>Change Edge Gap</source>
+        <comment>@action</comment>
+        <translation>Randtussenruimte wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="20"/>
+        <source>Change Overlay Style</source>
+        <comment>@action</comment>
+        <translation>Overlay-stijl wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ChangeSelectionCommand.cpp" line="14"/>
+        <source>Change Selection</source>
+        <comment>@action</comment>
+        <translation>Selectie wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderIdCommand.cpp" line="15"/>
+        <source>Change Shader Effect</source>
+        <comment>@action</comment>
+        <translation>Shadereffect wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderParamsCommand.cpp" line="17"/>
+        <source>Change Shader Parameter</source>
+        <comment>@action</comment>
+        <translation>Shaderparameter wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateShaderParamsCommand.cpp" line="29"/>
+        <source>Change Shader Parameters</source>
+        <comment>@action</comment>
+        <translation>Shaderparameters wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ChangeZOrderCommand.cpp" line="13"/>
+        <source>Change Z-Order</source>
+        <comment>@action</comment>
+        <translation>Z-volgorde wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneAppearanceCommand.cpp" line="15"/>
+        <source>Change Zone Appearance</source>
+        <comment>@action</comment>
+        <translation>Uiterlijk van zone wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateFixedGeometryCommand.cpp" line="15"/>
+        <source>Change Zone Dimensions</source>
+        <comment>@action</comment>
+        <translation>Afmetingen van zone wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneNumberCommand.cpp" line="16"/>
+        <source>Change Zone Number</source>
+        <comment>@action</comment>
+        <translation>Zonenummer wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="16"/>
+        <source>Change Zone Padding</source>
+        <comment>@action</comment>
+        <translation>Opvulling van zone wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateVisibilityCommand.cpp" line="17"/>
+        <source>Change Zone Visibility</source>
+        <comment>@action</comment>
+        <translation>Zichtbaarheid van zone wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ClearAllZonesCommand.cpp" line="12"/>
+        <source>Clear All Zones</source>
+        <comment>@action</comment>
+        <translation>Alle zones wissen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/gaps.cpp" line="327"/>
+        <source>Clear Edge Gap Override</source>
+        <comment>@action</comment>
+        <translation>Overschrijving van randtussenruimte wissen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="151"/>
+        <source>Create new layout</source>
+        <translation>Nieuwe indeling maken</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="96"/>
+        <source>Cut %1 Zones</source>
+        <comment>@action</comment>
+        <translation>%1 zones knippen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="34"/>
+        <source>Delete %1 Zones</source>
+        <comment>@action</comment>
+        <translation>%1 zones verwijderen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DeleteZoneCommand.cpp" line="14"/>
+        <location filename="../src/editor/undo/commands/DeleteZoneWithFillCommand.cpp" line="14"/>
+        <source>Delete Zone</source>
+        <comment>@action</comment>
+        <translation>Zone verwijderen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="62"/>
+        <source>Duplicate %1 Zones</source>
+        <comment>@action</comment>
+        <translation>%1 zones dupliceren</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DuplicateZoneCommand.cpp" line="15"/>
+        <source>Duplicate Zone</source>
+        <comment>@action</comment>
+        <translation>Zone dupliceren</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/FillZoneCommand.cpp" line="13"/>
+        <source>Fill Zone</source>
+        <comment>@action</comment>
+        <translation>Zone vullen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="528"/>
+        <source>Invalid layout data format</source>
+        <translation>Ongeldig gegevensformaat voor indeling</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1041"/>
+        <location filename="../src/editor/controller/layout.cpp" line="1079"/>
+        <source>File path cannot be empty</source>
+        <translation>Bestandspad mag niet leeg zijn</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1048"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="334"/>
+        <source>Failed to import layout: %1</source>
+        <translation>Importeren van indeling mislukt: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1059"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="341"/>
+        <source>That file is not a layout this app can read.</source>
+        <translation>Dat bestand is geen indeling die deze app kan lezen.</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1102"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="386"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="545"/>
+        <source>Could not write the export. Check that the folder is writable.</source>
+        <translation>De export kon niet worden weggeschreven. Controleer of naar de map geschreven kan worden.</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1084"/>
+        <source>No layout loaded to export</source>
+        <translation>Geen indeling geladen om te exporteren</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="1091"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="377"/>
+        <source>Failed to export layout: %1</source>
+        <translation>Exporteren van indeling mislukt: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="493"/>
+        <source>Layout ID cannot be empty</source>
+        <translation>Indelings-ID mag niet leeg zijn</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="147"/>
+        <source>Layout ID to edit</source>
+        <translation>Te bewerken indelings-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="165"/>
+        <source>Layout Locked</source>
+        <translation>Indeling vergrendeld</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="214"/>
+        <source>Disabled on this monitor</source>
+        <translation>Uitgeschakeld op dit scherm</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="225"/>
+        <source>Desktop %1</source>
+        <translation>Bureaublad %1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="227"/>
+        <location filename="../src/daemon/daemon/osd.cpp" line="238"/>
+        <source>Disabled on %1</source>
+        <translation>Uitgeschakeld op %1</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="236"/>
+        <source>Disabled on this activity</source>
+        <translation>Uitgeschakeld op deze activiteit</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="266"/>
+        <source>No layout assigned</source>
+        <translation>Geen indeling toegewezen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="498"/>
+        <source>Layout service not initialized</source>
+        <translation>Indelingsdienst niet geïnitialiseerd</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="138"/>
+        <source>Layout: %1</source>
+        <translation>Indeling: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="106"/>
+        <location filename="../src/editor/controller/multiselect.cpp" line="361"/>
+        <source>Move %1 Zones</source>
+        <comment>@action</comment>
+        <translation>%1 zones verplaatsen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneGeometryCommand.cpp" line="14"/>
+        <source>Move Zone</source>
+        <comment>@action</comment>
+        <translation>Zone verplaatsen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="433"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="184"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="192"/>
+        <source>New Layout</source>
+        <translation>Nieuwe indeling</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="152"/>
+        <source>Open in read-only preview mode</source>
+        <translation>Openen in alleen-lezen voorbeeldmodus</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="196"/>
+        <location filename="../src/editor/undo/commands/PasteZonesCommand.cpp" line="14"/>
+        <source>Paste %1 Zones</source>
+        <comment>@action</comment>
+        <translation>%1 zones plakken</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateLayoutNameCommand.cpp" line="13"/>
+        <source>Rename Layout</source>
+        <comment>@action</comment>
+        <translation>Indeling hernoemen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateZoneNameCommand.cpp" line="14"/>
+        <source>Rename Zone</source>
+        <comment>@action</comment>
+        <translation>Zone hernoemen</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="215"/>
+        <source>Window tiling and zone management</source>
+        <translation>Vensters tegelen en zones beheren</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="220"/>
+        <source>Replace existing daemon instance</source>
+        <translation>Bestaande daemon-instantie vervangen</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="224"/>
+        <source>Enable debug logging for all PlasmaZones categories</source>
+        <translation>Foutopsporingslogboek inschakelen voor alle PlasmaZones-categorieën</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="228"/>
+        <source>Write log output to &lt;file&gt; instead of stderr</source>
+        <translation>Loguitvoer naar &lt;file&gt; schrijven in plaats van stderr</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/main.cpp" line="229"/>
+        <source>file</source>
+        <translation>bestand</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/shader.cpp" line="271"/>
+        <source>Reset Shader Parameters</source>
+        <comment>@action</comment>
+        <translation>Shaderparameters herstellen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/multiselect.cpp" line="189"/>
+        <source>Resize %1 Zones</source>
+        <comment>@action</comment>
+        <translation>%1 zones vergroten of verkleinen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/DividerResizeCommand.cpp" line="15"/>
+        <source>Resize Zones</source>
+        <comment>@action</comment>
+        <translation>Zones vergroten of verkleinen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="190"/>
+        <source>Send Backward</source>
+        <comment>@action</comment>
+        <translation>Naar achteren sturen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zoneops.cpp" line="180"/>
+        <source>Send to Back</source>
+        <comment>@action</comment>
+        <translation>Naar achtergrond brengen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/layout.cpp" line="843"/>
+        <source>Services not initialized</source>
+        <translation>Diensten niet geïnitialiseerd</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zones.cpp" line="197"/>
+        <location filename="../src/editor/controller/zones.cpp" line="233"/>
+        <source>Services not initialized</source>
+        <comment>@info</comment>
+        <translation>Diensten niet geïnitialiseerd</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/shortcutmanager.cpp" line="610"/>
+        <source>Snap to Zone %1</source>
+        <translation>Vastklikken in zone %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/SplitZoneCommand.cpp" line="16"/>
+        <source>Split Zone</source>
+        <comment>@action</comment>
+        <translation>Zone splitsen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/shader.cpp" line="287"/>
+        <source>Switch Shader Effect</source>
+        <comment>@action</comment>
+        <translation>Shadereffect omschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="149"/>
+        <source>Target screen name</source>
+        <translation>Naam van doelscherm</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon/osd.cpp" line="295"/>
+        <location filename="../src/settings/rulemodel.cpp" line="285"/>
+        <source>Tiling: %1</source>
+        <translation>Tegelen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateGapOverrideCommand.cpp" line="18"/>
+        <source>Toggle Per-Side Edge Gap</source>
+        <comment>@action</comment>
+        <translation>Randtussenruimte per zijde omschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/ToggleGeometryModeCommand.cpp" line="17"/>
+        <source>Toggle Relative/Fixed Size</source>
+        <comment>@action</comment>
+        <translation>Relatieve/vaste grootte omschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/UpdateFullScreenGeometryCommand.cpp" line="15"/>
+        <source>Toggle Use Full Screen Area</source>
+        <comment>@action</comment>
+        <translation>Volledig schermgebied gebruiken omschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/BatchUpdateAppearanceCommand.cpp" line="21"/>
+        <source>Update Appearance for %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Uiterlijk bijwerken voor %1 zones</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/undo/commands/BatchUpdateAppearanceCommand.cpp" line="73"/>
+        <source>Update Color for %1 Zones</source>
+        <comment>@action</comment>
+        <translation>Kleur bijwerken voor %1 zones</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/main.cpp" line="142"/>
+        <source>Visual layout editor for PlasmaZones</source>
+        <translation>Visuele indelingseditor voor PlasmaZones</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/clipboard.cpp" line="34"/>
+        <location filename="../src/editor/controller/clipboard.cpp" line="107"/>
+        <source>Zone manager not initialized</source>
+        <comment>@info</comment>
+        <translation>Zonebeheerder niet geïnitialiseerd</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="40"/>
+        <source>Zone name contains invalid characters: &lt; &gt; &quot; &apos; \</source>
+        <translation>Zonenaam bevat ongeldige tekens: &lt; &gt; &quot; &apos; \</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/zones.cpp" line="106"/>
+        <location filename="../src/editor/controller/zones.cpp" line="212"/>
+        <location filename="../src/editor/controller/zones.cpp" line="248"/>
+        <location filename="../src/editor/controller/zones.cpp" line="327"/>
+        <source>Zone not found</source>
+        <comment>@info</comment>
+        <translation>Zone niet gevonden</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="94"/>
+        <source>Zone number %1 is already in use</source>
+        <translation>Zonenummer %1 is al in gebruik</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="74"/>
+        <source>Zone number cannot exceed 99</source>
+        <translation>Zonenummer mag niet groter zijn dan 99</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="31"/>
+        <source>Zone name cannot exceed %1 characters</source>
+        <translation>Zonenaam mag niet langer zijn dan %1 tekens</translation>
+    </message>
+    <message>
+        <location filename="../src/editor/controller/settings.cpp" line="71"/>
+        <source>Zone number must be at least 1</source>
+        <translation>Zonenummer moet ten minste 1 zijn</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2159"/>
+        <source>The PlasmaZones KWin effect plugin is not installed where KWin can find it. Reinstall PlasmaZones.</source>
+        <translation>De PlasmaZones KWin-effectplug-in is niet geïnstalleerd op een plek waar KWin die kan vinden. Installeer PlasmaZones opnieuw.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2198"/>
+        <source>The PlasmaZones KWin effect was built for KWin %1 but KWin %2 is running, so KWin will not load it. Rebuild and reinstall PlasmaZones against the running KWin.</source>
+        <translation>Het PlasmaZones KWin-effect is gebouwd voor KWin %1, maar KWin %2 draait, dus KWin laadt het niet. Bouw en installeer PlasmaZones opnieuw voor de draaiende KWin.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2225"/>
+        <source>The PlasmaZones KWin effect has not registered with the daemon, so window dragging and shortcuts will not work. Make sure it is enabled in System Settings &gt; Desktop Effects, then restart the Plasma session.</source>
+        <translation>Het PlasmaZones KWin-effect heeft zich niet bij de daemon geregistreerd, dus vensters slepen en sneltoetsen werken niet. Zorg dat het is ingeschakeld in Systeeminstellingen &gt; Bureaubladeffecten en start de Plasma-sessie opnieuw.</translation>
+    </message>
+    <message>
+        <location filename="../src/daemon/daemon.cpp" line="2244"/>
+        <source>PlasmaZones: window manager integration inactive</source>
+        <translation>PlasmaZones: integratie met vensterbeheerder inactief</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="70"/>
+        <source> (Copy)</source>
+        <extracomment>Suffix appended to the name of a duplicated algorithm. Keep the leading space.</extracomment>
+        <translation> (kopie)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="329"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="401"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="413"/>
+        <source>Could not read the algorithm file. Check that it still exists and is readable.</source>
+        <translation>Het algoritmebestand kon niet worden gelezen. Controleer of het nog bestaat en leesbaar is.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="338"/>
+        <source>Only Luau algorithm files (.luau) can be imported.</source>
+        <translation>Alleen Luau-algoritmebestanden (.luau) kunnen worden geïmporteerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="343"/>
+        <source>Algorithm file names may contain only letters, digits, hyphens, and underscores.</source>
+        <translation>Namen van algoritmebestanden mogen alleen letters, cijfers, koppeltekens en onderstrepingstekens bevatten.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="356"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="418"/>
+        <source>That algorithm file is too large to load. Algorithms are limited to 1 MB.</source>
+        <translation>Dat algoritmebestand is te groot om te laden. Algoritmen zijn beperkt tot 1 MB.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="387"/>
+        <source>Too many algorithms share this name. Remove some and try again.</source>
+        <translation>Te veel algoritmen delen deze naam. Verwijder er enkele en probeer het opnieuw.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="426"/>
+        <source>Could not copy the algorithm file. Check available disk space and permissions.</source>
+        <translation>Het algoritmebestand kon niet worden gekopieerd. Controleer de beschikbare schijfruimte en de rechten.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="492"/>
+        <source>Algorithm was created but not picked up by the registry. Try refreshing or restarting the application.</source>
+        <translation>Het algoritme is gemaakt maar niet opgepikt door het register. Probeer te vernieuwen of de toepassing opnieuw te starten.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="552"/>
+        <source>No algorithm is selected to delete.</source>
+        <translation>Er is geen algoritme geselecteerd om te verwijderen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="559"/>
+        <source>Only user-created algorithms can be deleted.</source>
+        <translation>Alleen zelfgemaakte algoritmen kunnen worden verwijderd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="566"/>
+        <source>Algorithm file not found.</source>
+        <translation>Algoritmebestand niet gevonden.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="580"/>
+        <source>The user algorithms directory does not exist.</source>
+        <translation>De map met gebruikersalgoritmen bestaat niet.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="581"/>
+        <source>That file is outside the user algorithms directory.</source>
+        <translation>Dat bestand bevindt zich buiten de map met gebruikersalgoritmen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="594"/>
+        <source>Could not delete algorithm file. Check file permissions.</source>
+        <translation>Het algoritmebestand kon niet worden verwijderd. Controleer de bestandsrechten.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="604"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="720"/>
+        <source>The algorithm file could not be found.</source>
+        <translation>Het algoritmebestand kon niet worden gevonden.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="610"/>
+        <source>That algorithm is no longer registered.</source>
+        <translation>Dat algoritme is niet langer geregistreerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="628"/>
+        <source>Too many copies of this algorithm already exist. Rename or delete some before duplicating.</source>
+        <translation>Er bestaan al te veel kopieën van dit algoritme. Hernoem of verwijder er enkele voordat je dupliceert.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="636"/>
+        <source>The algorithm file path could not be resolved.</source>
+        <translation>Het pad van het algoritmebestand kon niet worden herleid.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="643"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="654"/>
+        <source>Could not read source algorithm file.</source>
+        <translation>Het bronalgoritmebestand kon niet worden gelezen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="695"/>
+        <source>Could not duplicate the algorithm. Its metadata table is not in a shape this app can rewrite.</source>
+        <translation>Het algoritme kon niet worden gedupliceerd. De metagegevenstabel heeft geen vorm die deze app kan herschrijven.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="730"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="739"/>
+        <source>Could not read the algorithm file for export.</source>
+        <translation>Het algoritmebestand kon niet worden gelezen voor export.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="702"/>
+        <source>Could not write duplicate algorithm file. Check disk space and permissions.</source>
+        <translation>Het gedupliceerde algoritmebestand kon niet worden weggeschreven. Controleer de schijfruimte en de rechten.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="714"/>
+        <source>No export destination specified.</source>
+        <translation>Geen exportbestemming opgegeven.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="745"/>
+        <source>Could not write to export destination.</source>
+        <translation>Er kon niet naar de exportbestemming worden geschreven.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="782"/>
+        <source>Too many algorithms already share this name. Rename or delete some before creating another.</source>
+        <translation>Te veel algoritmen delen al deze naam. Hernoem of verwijder er enkele voordat je een nieuwe maakt.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="816"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="859"/>
+        <source>The selected template could not be used. Pick another template or start blank.</source>
+        <translation>Het geselecteerde sjabloon kon niet worden gebruikt. Kies een ander sjabloon of begin blanco.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="833"/>
+        <source>The selected template could not be found. Pick another template or start blank.</source>
+        <translation>Het geselecteerde sjabloon kon niet worden gevonden. Kies een ander sjabloon of begin blanco.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="841"/>
+        <location filename="../src/settings/algorithmservice.cpp" line="849"/>
+        <source>The selected template could not be read. Pick another template or start blank.</source>
+        <translation>Het geselecteerde sjabloon kon niet worden gelezen. Kies een ander sjabloon of begin blanco.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/algorithmservice.cpp" line="878"/>
+        <source>Could not write algorithm file. Check disk space and permissions.</source>
+        <translation>Het algoritmebestand kon niet worden weggeschreven. Controleer de schijfruimte en de rechten.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="131"/>
+        <source>Cannot modify sets while a discard is in progress.</source>
+        <translation>Sets kunnen niet worden gewijzigd terwijl een verwerping bezig is.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="342"/>
+        <source>Cannot save while a discard is in progress.</source>
+        <translation>Opslaan kan niet terwijl een verwerping bezig is.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="507"/>
+        <location filename="../src/settings/rulecontroller.cpp" line="150"/>
+        <source>Discard already in flight.</source>
+        <translation>Er is al een verwerping onderweg.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/animationspagecontroller.cpp" line="575"/>
+        <source>Could not restore %n profile file(s). They remain pending.</source>
+        <translation>
+            <numerusform>Kon %n profielbestand niet herstellen. Het blijft in behandeling.</numerusform>
+            <numerusform>Kon %n profielbestanden niet herstellen. Ze blijven in behandeling.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="709"/>
+        <location filename="../src/settings/animationspagecontroller.cpp" line="719"/>
+        <source>Cannot modify presets while a discard is in progress.</source>
+        <translation>Voorinstellingen kunnen niet worden gewijzigd terwijl een verwerping bezig is.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="165"/>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="98"/>
+        <source>Could not create the user shader directory.</source>
+        <translation>De map voor gebruikersshaders kon niet worden gemaakt.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="62"/>
+        <source>No KZones configuration found in kwinrc</source>
+        <translation>Geen KZones-configuratie gevonden in kwinrc</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="68"/>
+        <source>Failed to parse KZones layoutsJson: %1</source>
+        <translation>Ontleden van KZones layoutsJson mislukt: %1</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="73"/>
+        <source>Imported %n layout(s) from KZones</source>
+        <translation>
+            <numerusform>%n indeling geïmporteerd uit KZones</numerusform>
+            <numerusform>%n indelingen geïmporteerd uit KZones</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="75"/>
+        <source>No layouts found in KZones configuration</source>
+        <translation>Geen indelingen gevonden in KZones-configuratie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="83"/>
+        <source>No file path specified</source>
+        <translation>Geen bestandspad opgegeven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="88"/>
+        <source>Could not open file: %1</source>
+        <translation>Kon bestand niet openen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="101"/>
+        <source>Failed to parse KZones JSON: %1</source>
+        <translation>Ontleden van KZones-JSON is mislukt: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="111"/>
+        <source>KZones file does not contain a JSON array or object</source>
+        <translation>KZones-bestand bevat geen JSON-array of -object</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/kzonesimporter.cpp" line="116"/>
+        <source>Imported %n layout(s) from KZones file</source>
+        <translation>
+            <numerusform>%n indeling geïmporteerd uit KZones-bestand</numerusform>
+            <numerusform>%n indelingen geïmporteerd uit KZones-bestand</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/kzonesimporter.cpp" line="118"/>
+        <source>No valid layouts found in file</source>
+        <translation>Geen geldige indelingen gevonden in bestand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="108"/>
+        <source>PlasmaZones Settings</source>
+        <translation>PlasmaZones-instellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="113"/>
+        <source>Open a specific settings page</source>
+        <translation>Een specifieke instellingenpagina openen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="116"/>
+        <source>Reveal a specific setting on the page (deep link)</source>
+        <translation>Een specifieke instelling op de pagina tonen (deeplink)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/main.cpp" line="120"/>
+        <source>Reveal a specific section on the page (deep link)</source>
+        <translation>Een specifieke sectie op de pagina tonen (deeplink)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="60"/>
+        <source>Identity</source>
+        <translation>Identiteit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="66"/>
+        <source>Type</source>
+        <translation>Type</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="79"/>
+        <source>State</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="85"/>
+        <source>Taskbar &amp; switcher</source>
+        <translation>Taakbalk &amp; wisselaar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="91"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="238"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="243"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="788"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="147"/>
+        <source>Tiling</source>
+        <translation>Tegelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="96"/>
+        <source>Size</source>
+        <translation>Grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="104"/>
+        <source>Context</source>
+        <translation>Context</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="106"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="218"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="260"/>
+        <source>Other</source>
+        <translation>Overig</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="117"/>
+        <source>The application&apos;s ID (Wayland app_id / desktop entry), e.g. org.kde.konsole.</source>
+        <translation>De ID van de toepassing (Wayland app_id / desktopvermelding), bijv. org.kde.konsole.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="119"/>
+        <source>The window&apos;s class (WM_CLASS resource class), e.g. konsole.</source>
+        <translation>De klasse van het venster (WM_CLASS resource class), bijv. konsole.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="121"/>
+        <source>The application&apos;s desktop entry file name.</source>
+        <translation>De bestandsnaam van de desktopvermelding van de toepassing.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="123"/>
+        <source>The window&apos;s X11 role (WM_WINDOW_ROLE). Empty for Wayland-native windows.</source>
+        <translation>De X11-rol van het venster (WM_WINDOW_ROLE). Leeg voor Wayland-eigen vensters.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="125"/>
+        <source>The window&apos;s process ID.</source>
+        <translation>De proces-ID van het venster.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="127"/>
+        <source>The window&apos;s title-bar text.</source>
+        <translation>De tekst in de titelbalk van het venster.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="129"/>
+        <source>The window&apos;s type (Normal, Dialog, Utility, Notification, …).</source>
+        <translation>Het type venster (Normaal, Dialoogvenster, Hulpmiddel, Melding, …).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="131"/>
+        <source>Whether the window is shown on all virtual desktops.</source>
+        <translation>Of het venster op alle virtuele bureaubladen wordt getoond.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="133"/>
+        <source>Whether the window is fullscreen.</source>
+        <translation>Of het venster op volledig scherm staat.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="135"/>
+        <source>Whether the window is minimized.</source>
+        <translation>Of het venster geminimaliseerd is.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="137"/>
+        <source>Whether the window is maximized.</source>
+        <translation>Of het venster gemaximaliseerd is.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="139"/>
+        <source>Whether the window currently has keyboard focus.</source>
+        <translation>Of het venster op dit moment toetsenbordfocus heeft.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="141"/>
+        <source>Whether the window is a transient (a dialog or popup owned by another window).</source>
+        <translation>Of het venster tijdelijk is (een dialoogvenster of pop-up die bij een ander venster hoort).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="143"/>
+        <source>Whether the window is a notification or on-screen display.</source>
+        <translation>Of het venster een melding of on-screen display is.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="145"/>
+        <source>The window&apos;s width in pixels.</source>
+        <translation>De breedte van het venster in pixels.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="147"/>
+        <source>The window&apos;s height in pixels.</source>
+        <translation>De hoogte van het venster in pixels.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="149"/>
+        <source>Whether the window is set to stay above other windows (always on top).</source>
+        <translation>Of het venster is ingesteld om boven andere vensters te blijven (altijd bovenop).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="151"/>
+        <source>Whether the window is set to stay below other windows.</source>
+        <translation>Of het venster is ingesteld om onder andere vensters te blijven.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="153"/>
+        <source>Whether the window is hidden from the taskbar.</source>
+        <translation>Of het venster verborgen is voor de taakbalk.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="155"/>
+        <source>Whether the window is hidden from the pager.</source>
+        <translation>Of het venster verborgen is voor de pager.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="157"/>
+        <source>Whether the window is hidden from the window switcher (Alt+Tab).</source>
+        <translation>Of het venster verborgen is voor de vensterwisselaar (Alt+Tab).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="159"/>
+        <source>Whether the window is a modal dialog.</source>
+        <translation>Of het venster een modaal dialoogvenster is.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="161"/>
+        <source>Whether the window has a server-side title-bar and border.</source>
+        <translation>Of het venster een titelbalk en rand aan de serverzijde heeft.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="163"/>
+        <source>Whether the window can be resized.</source>
+        <translation>Of het venster van grootte kan worden veranderd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="169"/>
+        <source>The window&apos;s left-edge X position in pixels.</source>
+        <translation>De X-positie van de linkerrand van het venster in pixels.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="171"/>
+        <source>The window&apos;s top-edge Y position in pixels.</source>
+        <translation>De Y-positie van de bovenrand van het venster in pixels.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="173"/>
+        <source>The window&apos;s title without the application-name suffix the window manager adds.</source>
+        <translation>De titel van het venster zonder het achtervoegsel met de toepassingsnaam dat de vensterbeheerder toevoegt.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="175"/>
+        <source>Whether the window has been floated out of tiling (snap or autotile).</source>
+        <translation>Of het venster uit het tegelen is losgemaakt (vastklikken of automatisch tegelen).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="177"/>
+        <source>Whether the window is snapped into a zone (manual-zone mode, where tiled windows are not snapped).</source>
+        <translation>Of het venster in een zone is vastgeklikt (handmatige-zonemodus, waar getegelde vensters niet worden vastgeklikt).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="180"/>
+        <source>Whether the window is managed by the autotile engine.</source>
+        <translation>Of het venster wordt beheerd door de engine voor automatisch tegelen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="182"/>
+        <source>The zone the window is snapped into (manual-zone mode only).</source>
+        <translation>De zone waarin het venster is vastgeklikt (alleen handmatige-zonemodus).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="184"/>
+        <source>The monitor the window is on.</source>
+        <translation>Het scherm waarop het venster zich bevindt.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="186"/>
+        <source>The virtual desktop the window is on.</source>
+        <translation>Het virtuele bureaublad waarop het venster zich bevindt.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="188"/>
+        <source>The KDE Activity the window is on.</source>
+        <translation>De KDE-activiteit waarop het venster zich bevindt.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="190"/>
+        <source>The engine mode the window is placed by (snapping or tiling).</source>
+        <translation>De enginemodus waarmee het venster wordt geplaatst (vastklikken of tegelen).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="192"/>
+        <source>How many windows are tiled on this monitor and desktop. Lets a rule switch the tiling algorithm as windows open and close, for example a centered single-window layout that gives way once a second window opens.</source>
+        <translation>Hoeveel vensters er op dit scherm en bureaublad zijn getegeld. Hiermee kan een regel het tegelalgoritme wisselen naarmate vensters worden geopend en gesloten, bijvoorbeeld een gecentreerde indeling met één venster die plaatsmaakt zodra een tweede venster wordt geopend.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="226"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="402"/>
+        <source>Gaps</source>
+        <translation>Tussenruimten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="249"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="168"/>
+        <source>Overlay</source>
+        <translation>Overlay</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="252"/>
+        <source>Animation</source>
+        <translation>Animatie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="255"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="97"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="174"/>
+        <source>Appearance</source>
+        <translation>Uiterlijk</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="258"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="188"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="212"/>
+        <source>Window</source>
+        <translation>Venster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="274"/>
+        <source>Engine mode</source>
+        <translation>Enginemodus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="277"/>
+        <location filename="../src/settings/rulemodel.cpp" line="276"/>
+        <source>Snapping layout</source>
+        <translation>Vastklikindeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="280"/>
+        <source>Tiling algorithm</source>
+        <translation>Tegelalgoritme</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="304"/>
+        <source>Engine to disable</source>
+        <translation>Uit te schakelen engine</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="307"/>
+        <source>Opacity (%)</source>
+        <translation>Dekking (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="310"/>
+        <source>Zones</source>
+        <translation>Zones</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="317"/>
+        <source>Restore position on login (off = don&apos;t restore)</source>
+        <translation>Positie herstellen bij aanmelden (uit = niet herstellen)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="333"/>
+        <source>Hide title bars (off = force visible)</source>
+        <translation>Titelbalken verbergen (uit = zichtbaar afdwingen)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="336"/>
+        <source>Show border (off = hide)</source>
+        <translation>Rand tonen (uit = verbergen)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="339"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="420"/>
+        <source>Border width (px)</source>
+        <translation>Randbreedte (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="342"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="423"/>
+        <source>Corner radius (px)</source>
+        <translation>Hoekradius (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="348"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="411"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <source>Border color</source>
+        <translation>Randkleur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="361"/>
+        <source>Inner gap (px)</source>
+        <translation>Binnenste tussenruimte (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="364"/>
+        <source>Outer gap (px)</source>
+        <translation>Buitenste tussenruimte (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="367"/>
+        <source>Use per-side outer gaps (off = one uniform gap)</source>
+        <translation>Buitenste tussenruimten per zijde gebruiken (uit = één uniforme tussenruimte)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="374"/>
+        <source>Lock the layout (off = don&apos;t lock)</source>
+        <translation>Indeling vergrendelen (uit = niet vergrendelen)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="381"/>
+        <source>Assign a default layout (off = leave unassigned)</source>
+        <translation>Een standaardindeling toewijzen (uit = niet toegewezen laten)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="384"/>
+        <source>Top gap (px)</source>
+        <translation>Tussenruimte boven (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="387"/>
+        <source>Bottom gap (px)</source>
+        <translation>Tussenruimte onder (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="390"/>
+        <source>Left gap (px)</source>
+        <translation>Tussenruimte links (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="393"/>
+        <source>Right gap (px)</source>
+        <translation>Tussenruimte rechts (px)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="398"/>
+        <location filename="../src/settings/rulemodel.cpp" line="394"/>
+        <source>Overlay shader</source>
+        <translation>Overlay-shader</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="401"/>
+        <location filename="../src/settings/rulemodel.cpp" line="400"/>
+        <source>Overlay style</source>
+        <translation>Overlay-stijl</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="429"/>
+        <location filename="../src/settings/rulemodel.cpp" line="900"/>
+        <source>Monitor</source>
+        <translation>Scherm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="432"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="764"/>
+        <location filename="../src/settings/rulemodel.cpp" line="902"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="260"/>
+        <source>Desktop</source>
+        <translation>Bureaublad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="435"/>
+        <source>Event</source>
+        <translation>Gebeurtenis</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="441"/>
+        <source>Shader effect</source>
+        <translation>Shader-effect</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="444"/>
+        <source>Duration (ms)</source>
+        <translation>Duur (ms)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="447"/>
+        <source>Curve</source>
+        <translation>Curve</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="462"/>
+        <source>Zone numbers like “1, 2”, or a range like “1-3”. Multiple zones snap the window to their combined area.</source>
+        <translation>Zonenummers zoals “1, 2”, of een reeks zoals “1-3”. Meerdere zones klikken het venster vast in hun gecombineerde gebied.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="235"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="787"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="834"/>
+        <location filename="../src/settings/rulemodel.cpp" line="241"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="145"/>
+        <source>Snapping</source>
+        <translation>Vastklikken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="837"/>
+        <location filename="../src/settings/rulemodel.cpp" line="243"/>
+        <source>Autotile</source>
+        <translation>Automatisch tegelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="840"/>
+        <location filename="../src/settings/rulemodel.cpp" line="245"/>
+        <source>Scrolling</source>
+        <translation>Scrollen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="845"/>
+        <source>Zone rectangles</source>
+        <translation>Zonerechthoeken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="848"/>
+        <source>Layout preview</source>
+        <translation>Voorbeeld van indeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="539"/>
+        <source>Set engine mode</source>
+        <translation>Enginemodus instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="165"/>
+        <source>Whether the window can be moved.</source>
+        <translation>Of het venster kan worden verplaatst.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="167"/>
+        <source>Whether the window can be maximized.</source>
+        <translation>Of het venster kan worden gemaximaliseerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="197"/>
+        <source>Whether the monitor is in portrait or landscape orientation. Lets a rule pick a different layout or algorithm on a rotated screen.</source>
+        <translation>Of het scherm in staande of liggende oriëntatie staat. Hiermee kan een regel een andere indeling of algoritme kiezen op een gedraaid scherm.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="201"/>
+        <source>The layout currently active on the monitor. Lets a rule change gaps, the overlay or the lock state for the screen showing a given layout. It cannot change which layout is assigned (that would be circular).</source>
+        <translation>De indeling die op dit moment actief is op het scherm. Hiermee kan een regel de tussenruimten, de overlay of de vergrendelstatus wijzigen voor het scherm dat een bepaalde indeling toont. De toegewezen indeling kan hiermee niet worden gewijzigd (dat zou circulair zijn).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="246"/>
+        <source>Engine</source>
+        <translation>Engine</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="286"/>
+        <source>Max tiled windows</source>
+        <translation>Max. getegelde vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="289"/>
+        <source>Split ratio (%)</source>
+        <translation>Splitsverhouding (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="295"/>
+        <source>Insert position</source>
+        <translation>Invoegpositie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="320"/>
+        <source>Restore to zone on login (off = don&apos;t restore)</source>
+        <translation>Herstellen naar zone bij aanmelden (uit = niet herstellen)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="323"/>
+        <source>Restore size on unsnap (off = keep zone size)</source>
+        <translation>Grootte herstellen bij losklikken (uit = zonegrootte behouden)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="326"/>
+        <source>Layer</source>
+        <translation>Laag</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="351"/>
+        <source>Show opacity and tint (off = hide)</source>
+        <translation>Dekking en tint tonen (uit = verbergen)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="354"/>
+        <source>Tint strength (%)</source>
+        <translation>Tintsterkte (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="357"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="353"/>
+        <source>Tint color</source>
+        <translation>Tintkleur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="408"/>
+        <source>Inactive zone color</source>
+        <translation>Kleur van inactieve zone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="414"/>
+        <source>Active opacity (%)</source>
+        <translation>Actieve dekking (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="417"/>
+        <source>Inactive opacity (%)</source>
+        <translation>Inactieve dekking (%)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="426"/>
+        <source>Show zone numbers (off = hide)</source>
+        <translation>Zonenummers tonen (uit = verbergen)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="438"/>
+        <source>Decoration packs</source>
+        <translation>Decoratiepakketten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="542"/>
+        <source>Set snapping layout</source>
+        <translation>Vastklikindeling instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="545"/>
+        <source>Set tiling algorithm</source>
+        <translation>Tegelalgoritme instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="548"/>
+        <source>Set max tiled windows</source>
+        <translation>Max. getegelde vensters instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="551"/>
+        <source>Set split ratio</source>
+        <translation>Splitsverhouding instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="554"/>
+        <source>Set master count</source>
+        <translation>Aantal hoofdvensters instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="557"/>
+        <source>Set insert position</source>
+        <translation>Invoegpositie instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="560"/>
+        <source>Set overflow behavior</source>
+        <translation>Overloopgedrag instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="563"/>
+        <source>Set drag behavior</source>
+        <translation>Sleepgedrag instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="566"/>
+        <source>Set algorithm parameter</source>
+        <translation>Algoritmeparameter instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="569"/>
+        <source>Disable engine</source>
+        <translation>Engine uitschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="572"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="908"/>
+        <source>Lock layout</source>
+        <translation>Indeling vergrendelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="575"/>
+        <source>Default layout assignment</source>
+        <translation>Standaardindelingstoewijzing</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="578"/>
+        <source>Exclude window</source>
+        <translation>Venster uitsluiten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="581"/>
+        <source>Float window</source>
+        <translation>Venster laten zweven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="584"/>
+        <source>Snap to zone(s)</source>
+        <translation>Vastklikken in zone(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="587"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="896"/>
+        <source>Restore position on login</source>
+        <translation>Positie herstellen bij aanmelden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="590"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="899"/>
+        <source>Restore to zone on login</source>
+        <translation>Herstellen naar zone bij aanmelden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="596"/>
+        <source>Set window layer</source>
+        <translation>Vensterlaag instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="599"/>
+        <source>Override animation shader</source>
+        <translation>Animatieshader overschrijven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="602"/>
+        <source>Override decoration packs</source>
+        <translation>Decoratiepakketten overschrijven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="605"/>
+        <source>Override animation duration</source>
+        <translation>Animatieduur overschrijven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="608"/>
+        <source>Override animation curve</source>
+        <translation>Animatiecurve overschrijven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="611"/>
+        <source>Set opacity</source>
+        <translation>Dekking instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="614"/>
+        <source>Set overlay shader</source>
+        <translation>Overlay-shader instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="617"/>
+        <source>Set overlay style</source>
+        <translation>Overlay-stijl instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="620"/>
+        <source>Set overlay highlight color</source>
+        <translation>Overlay-markeringskleur instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="623"/>
+        <source>Set overlay inactive color</source>
+        <translation>Inactieve overlay-kleur instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="626"/>
+        <source>Set overlay border color</source>
+        <translation>Overlay-randkleur instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="629"/>
+        <source>Set overlay active opacity</source>
+        <translation>Actieve overlay-dekking instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="632"/>
+        <source>Set overlay inactive opacity</source>
+        <translation>Inactieve overlay-dekking instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="635"/>
+        <source>Set overlay border width</source>
+        <translation>Overlay-randbreedte instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="638"/>
+        <source>Set overlay corner radius</source>
+        <translation>Overlay-hoekradius instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="641"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="923"/>
+        <source>Show zone numbers</source>
+        <translation>Zonenummers tonen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="644"/>
+        <source>Exclude from animations</source>
+        <translation>Uitsluiten van animaties</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="652"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="905"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="356"/>
+        <source>Hide title bars</source>
+        <translation>Titelbalken verbergen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="655"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="914"/>
+        <source>Show border</source>
+        <translation>Rand tonen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="658"/>
+        <source>Set border width</source>
+        <translation>Randbreedte instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="661"/>
+        <source>Set corner radius</source>
+        <translation>Hoekradius instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="664"/>
+        <source>Set focused border color</source>
+        <translation>Randkleur bij focus instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="667"/>
+        <source>Set unfocused border color</source>
+        <translation>Randkleur zonder focus instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="670"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="917"/>
+        <source>Show opacity and tint</source>
+        <translation>Dekking en tint tonen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="673"/>
+        <source>Set tint strength</source>
+        <translation>Tintsterkte instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="676"/>
+        <source>Set tint color</source>
+        <translation>Tintkleur instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="679"/>
+        <source>Set inner gap</source>
+        <translation>Binnenste tussenruimte instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="682"/>
+        <source>Set outer gap</source>
+        <translation>Buitenste tussenruimte instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="685"/>
+        <source>Use per-side outer gaps</source>
+        <translation>Buitenste tussenruimten per zijde gebruiken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="688"/>
+        <source>Set top gap</source>
+        <translation>Bovenste tussenruimte instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="691"/>
+        <source>Set bottom gap</source>
+        <translation>Onderste tussenruimte instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="694"/>
+        <source>Set left gap</source>
+        <translation>Linkertussenruimte instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="697"/>
+        <source>Set right gap</source>
+        <translation>Rechtertussenruimte instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="700"/>
+        <location filename="../src/settings/rulemodel.cpp" line="331"/>
+        <source>Open on monitor</source>
+        <translation>Openen op scherm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="703"/>
+        <location filename="../src/settings/rulemodel.cpp" line="336"/>
+        <source>Open on desktop</source>
+        <translation>Openen op bureaublad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="712"/>
+        <source>is</source>
+        <translation>is</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="714"/>
+        <source>contains</source>
+        <translation>bevat</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="716"/>
+        <source>starts with</source>
+        <translation>begint met</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="718"/>
+        <source>ends with</source>
+        <translation>eindigt met</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="720"/>
+        <source>matches regex</source>
+        <translation>komt overeen met regex</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="722"/>
+        <source>matches app-id</source>
+        <translation>komt overeen met app-id</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="724"/>
+        <source>greater than</source>
+        <translation>groter dan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="726"/>
+        <source>less than</source>
+        <translation>kleiner dan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="754"/>
+        <source>Unknown</source>
+        <translation>Onbekend</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="755"/>
+        <source>Normal window</source>
+        <translation>Normaal venster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="756"/>
+        <source>Dialog</source>
+        <translation>Dialoogvenster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="757"/>
+        <source>Utility</source>
+        <translation>Hulpprogramma</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="758"/>
+        <source>Toolbar</source>
+        <translation>Werkbalk</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="759"/>
+        <source>Splash screen</source>
+        <translation>Opstartscherm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="760"/>
+        <source>Menu</source>
+        <translation>Menu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="761"/>
+        <source>Tooltip</source>
+        <translation>Knopinfo</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="762"/>
+        <location filename="../src/settings/rulemodel.cpp" line="908"/>
+        <source>Notification</source>
+        <translation>Melding</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="763"/>
+        <source>Dock / panel</source>
+        <translation>Dock / paneel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="765"/>
+        <source>On-screen display</source>
+        <translation>Schermweergave</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="766"/>
+        <source>Popup</source>
+        <translation>Pop-up</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="792"/>
+        <source>Landscape</source>
+        <translation>Liggend</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="793"/>
+        <source>Portrait</source>
+        <translation>Staand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="853"/>
+        <source>End of stack</source>
+        <translation>Einde van de stapel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="856"/>
+        <source>After focused window</source>
+        <translation>Na venster met focus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="859"/>
+        <source>As master</source>
+        <translation>Als hoofdvenster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="864"/>
+        <source>Float overflow windows</source>
+        <translation>Overtollige vensters laten zweven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="867"/>
+        <source>Unlimited (no cap)</source>
+        <translation>Onbeperkt (geen limiet)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="872"/>
+        <source>Float on drag</source>
+        <translation>Laten zweven bij slepen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="875"/>
+        <source>Reorder in stack</source>
+        <translation>Opnieuw ordenen in stapel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="880"/>
+        <source>Above other windows</source>
+        <translation>Boven andere vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="883"/>
+        <source>Normal stacking</source>
+        <translation>Normale stapeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="886"/>
+        <source>Below other windows</source>
+        <translation>Onder andere vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="899"/>
+        <source>Don&apos;t restore to zone on login</source>
+        <translation>Niet herstellen naar zone bij aanmelden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="902"/>
+        <source>Keep zone size on unsnap</source>
+        <translation>Zonegrootte behouden bij losklikken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="917"/>
+        <source>Hide opacity and tint</source>
+        <translation>Dekking en tint verbergen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="923"/>
+        <source>Hide zone numbers</source>
+        <translation>Zonenummers verbergen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="1110"/>
+        <source>Regular expression, e.g. ^(firefox|chromium)$</source>
+        <translation>Reguliere expressie, bijv. ^(firefox|chromium)$</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="1113"/>
+        <source>Matches by reverse-DNS segments, so “firefox” also matches “org.mozilla.firefox”.</source>
+        <translation>Komt overeen op reverse-DNS-segmenten, dus “firefox” komt ook overeen met “org.mozilla.firefox”.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="165"/>
+        <source>Failed to fetch the daemon&apos;s rule set.</source>
+        <translation>Kan de regelset van de daemon niet ophalen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="247"/>
+        <source>The daemon rejected one or more rules.</source>
+        <translation>De daemon heeft een of meer regels afgewezen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="375"/>
+        <source>A save is already in flight.</source>
+        <translation>Er wordt al een opslagbewerking uitgevoerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="386"/>
+        <source>The daemon&apos;s rules changed while you were editing. Review or use Save anyway to overwrite.</source>
+        <translation>De regels van de daemon zijn gewijzigd terwijl je aan het bewerken was. Controleer ze of gebruik Toch opslaan om te overschrijven.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="397"/>
+        <source>One or more rules failed validation and could not be saved. See the log for details.</source>
+        <translation>Een of meer regels zijn afgekeurd bij de validatie en konden niet worden opgeslagen. Zie het logboek voor details.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulecontroller.cpp" line="657"/>
+        <source>%1 (copy)</source>
+        <translation>%1 (kopie)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="164"/>
+        <location filename="../src/settings/rulemodel.cpp" line="171"/>
+        <location filename="../src/settings/rulemodel.cpp" line="179"/>
+        <location filename="../src/settings/rulemodel.cpp" line="206"/>
+        <location filename="../src/settings/rulemodel.cpp" line="214"/>
+        <location filename="../src/settings/rulemodel.cpp" line="219"/>
+        <source>%1: %2</source>
+        <translation>%1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="215"/>
+        <source>On</source>
+        <translation>Aan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="216"/>
+        <source>Off</source>
+        <translation>Uit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="272"/>
+        <source>Engine: %1</source>
+        <translation>Engine: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="277"/>
+        <source>Snapping: %1</source>
+        <translation>Vastklikken: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="296"/>
+        <source>Disabled</source>
+        <translation>Uitgeschakeld</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="298"/>
+        <source>Disable: %1</source>
+        <translation>Uitschakelen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="301"/>
+        <source>Excluded</source>
+        <translation>Uitgesloten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="305"/>
+        <source>No animations</source>
+        <translation>Geen animaties</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="308"/>
+        <source>Float</source>
+        <translation>Laten zweven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="318"/>
+        <source>Snap to zone</source>
+        <translation>Vastklikken in zone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="321"/>
+        <source>Snap to zone %1</source>
+        <translation>Vastklikken in zone %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="323"/>
+        <source>Snap to zones %1</source>
+        <translation>Vastklikken in zones %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="332"/>
+        <source>Open on monitor: %1</source>
+        <translation>Openen op scherm: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="336"/>
+        <source>Open on desktop %1</source>
+        <translation>Openen op bureaublad %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="345"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="276"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="345"/>
+        <source>Opacity</source>
+        <translation>Dekking</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="349"/>
+        <location filename="../src/settings/rulemodel.cpp" line="354"/>
+        <source>Opacity (invalid)</source>
+        <translation>Dekking (ongeldig)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="356"/>
+        <source>Opacity: %1%</source>
+        <translation>Dekking: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="360"/>
+        <source>Block animation shader</source>
+        <translation>Animatieshader blokkeren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="361"/>
+        <source>Shader: %1</source>
+        <translation>Shader: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="366"/>
+        <location filename="../src/settings/rulemodel.cpp" line="379"/>
+        <source>Block decoration</source>
+        <translation>Decoratie blokkeren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="381"/>
+        <source>Decoration: %1</source>
+        <translation>Decoratie: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="385"/>
+        <source>Duration: %1 ms</source>
+        <translation>Duur: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="385"/>
+        <source>Animation duration</source>
+        <translation>Animatieduur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="389"/>
+        <source>Animation curve</source>
+        <translation>Animatiecurve</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="390"/>
+        <source>Curve: %1</source>
+        <translation>Curve: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="395"/>
+        <source>Overlay shader: %1</source>
+        <translation>Overlay-shader: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="896"/>
+        <source>Don&apos;t restore position on login</source>
+        <translation>Positie niet herstellen bij aanmelden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="905"/>
+        <source>Show title bars</source>
+        <translation>Titelbalken tonen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="908"/>
+        <source>Don&apos;t lock layout</source>
+        <translation>Indeling niet vergrendelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="911"/>
+        <source>Assign default layout</source>
+        <translation>Standaardindeling toewijzen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="911"/>
+        <source>Don&apos;t assign default layout</source>
+        <translation>Standaardindeling niet toewijzen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="914"/>
+        <source>Hide border</source>
+        <translation>Rand verbergen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="429"/>
+        <source>Border width: %1 px</source>
+        <translation>Randbreedte: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="432"/>
+        <source>Corner radius: %1 px</source>
+        <translation>Hoekradius: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="439"/>
+        <location filename="../src/settings/rulemodel.cpp" line="467"/>
+        <source>Accent</source>
+        <translation>Accent</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="441"/>
+        <source>Focused border: %1</source>
+        <translation>Rand bij focus: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="443"/>
+        <source>Unfocused border: %1</source>
+        <translation>Rand zonder focus: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="535"/>
+        <source>Gap: %1 px</source>
+        <translation>Tussenruimte: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="538"/>
+        <source>Outer gap: %1 px</source>
+        <translation>Buitenste tussenruimte: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="920"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="411"/>
+        <source>Per-side outer gaps</source>
+        <translation>Aparte buitenste tussenruimte per zijde</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="920"/>
+        <source>Uniform outer gap</source>
+        <translation>Uniforme buitenste tussenruimte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="405"/>
+        <source>Overlay style: %1</source>
+        <translation>Overlay-stijl: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="412"/>
+        <source>Algorithm parameter</source>
+        <translation>Algoritmeparameter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="413"/>
+        <source>Algorithm: %1</source>
+        <translation>Algoritme: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="454"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="348"/>
+        <source>Tint strength</source>
+        <translation>Tintsterkte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="460"/>
+        <source>Tint strength (invalid)</source>
+        <translation>Tintsterkte (ongeldig)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="462"/>
+        <source>Tint strength: %1%</source>
+        <translation>Tintsterkte: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="468"/>
+        <source>Tint color: %1</source>
+        <translation>Tintkleur: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="472"/>
+        <source>Max tiled windows: %1</source>
+        <translation>Max. getegelde vensters: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="475"/>
+        <source>Master count: %1</source>
+        <translation>Aantal hoofdvensters: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="479"/>
+        <source>Split ratio: %1%</source>
+        <translation>Splitsverhouding: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="482"/>
+        <source>Insert: %1</source>
+        <translation>Invoegen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="486"/>
+        <source>Overflow: %1</source>
+        <translation>Overloop: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="490"/>
+        <source>Drag: %1</source>
+        <translation>Slepen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="497"/>
+        <source>Window layer</source>
+        <translation>Vensterlaag</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="505"/>
+        <source>Window layer (invalid)</source>
+        <translation>Vensterlaag (ongeldig)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="507"/>
+        <source>Layer: %1</source>
+        <translation>Laag: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="513"/>
+        <source>Highlight color: %1</source>
+        <translation>Markeringskleur: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="516"/>
+        <source>Inactive zone color: %1</source>
+        <translation>Kleur van inactieve zone: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="519"/>
+        <source>Overlay border color: %1</source>
+        <translation>Randkleur van overlay: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="522"/>
+        <source>Active opacity: %1%</source>
+        <translation>Actieve dekking: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="525"/>
+        <source>Inactive opacity: %1%</source>
+        <translation>Inactieve dekking: %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="528"/>
+        <source>Overlay border width: %1 px</source>
+        <translation>Randbreedte van overlay: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="531"/>
+        <source>Overlay corner radius: %1 px</source>
+        <translation>Hoekradius van overlay: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="541"/>
+        <source>Top gap: %1 px</source>
+        <translation>Bovenste tussenruimte: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="544"/>
+        <source>Bottom gap: %1 px</source>
+        <translation>Onderste tussenruimte: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="547"/>
+        <source>Left gap: %1 px</source>
+        <translation>Linkertussenruimte: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="550"/>
+        <source>Right gap: %1 px</source>
+        <translation>Rechtertussenruimte: %1 px</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="625"/>
+        <source>Everywhere</source>
+        <translation>Overal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="857"/>
+        <source>Monitor &amp; Layout</source>
+        <translation>Scherm &amp; indeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="859"/>
+        <source>Applications</source>
+        <translation>Toepassingen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="861"/>
+        <source>Activities</source>
+        <translation>Activiteiten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="863"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="107"/>
+        <source>Animations</source>
+        <translation>Animaties</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="865"/>
+        <source>Advanced / Custom</source>
+        <translation>Geavanceerd / aangepast</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="867"/>
+        <source>System</source>
+        <translation>Systeem</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="876"/>
+        <source>Application</source>
+        <translation>Toepassing</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="878"/>
+        <source>Window class</source>
+        <translation>Vensterklasse</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="880"/>
+        <source>Desktop file</source>
+        <translation>Desktopbestand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="882"/>
+        <source>Window role</source>
+        <translation>Vensterrol</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="884"/>
+        <source>Process ID</source>
+        <translation>Proces-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="886"/>
+        <source>Title</source>
+        <translation>Titel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="888"/>
+        <source>Window type</source>
+        <translation>Venstertype</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="890"/>
+        <source>Sticky</source>
+        <translation>Plakkerig</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="892"/>
+        <source>Fullscreen</source>
+        <translation>Volledig scherm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="894"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="629"/>
+        <source>Maximized</source>
+        <translation>Gemaximaliseerd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="896"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="620"/>
+        <source>Minimized</source>
+        <translation>Geminimaliseerd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="898"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="622"/>
+        <source>Focused</source>
+        <translation>Gefocust</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="904"/>
+        <source>Activity</source>
+        <translation>Activiteit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="906"/>
+        <source>Transient</source>
+        <translation>Tijdelijk</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="910"/>
+        <source>Width</source>
+        <translation>Breedte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="912"/>
+        <source>Height</source>
+        <translation>Hoogte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="914"/>
+        <source>Keep above</source>
+        <translation>Boven houden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="916"/>
+        <source>Keep below</source>
+        <translation>Onder houden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="918"/>
+        <source>Skip taskbar</source>
+        <translation>Taakbalk overslaan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="920"/>
+        <source>Skip pager</source>
+        <translation>Pager overslaan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="922"/>
+        <source>Skip switcher</source>
+        <translation>Wisselaar overslaan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="924"/>
+        <source>Modal</source>
+        <translation>Modaal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="926"/>
+        <source>Decorated</source>
+        <translation>Voorzien van decoratie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="928"/>
+        <source>Resizable</source>
+        <translation>Van grootte veranderbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="930"/>
+        <source>Movable</source>
+        <translation>Verplaatsbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="932"/>
+        <source>Maximizable</source>
+        <translation>Maximaliseerbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="934"/>
+        <source>Position X</source>
+        <translation>Positie X</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="936"/>
+        <source>Position Y</source>
+        <translation>Positie Y</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="938"/>
+        <source>Title (no suffix)</source>
+        <translation>Titel (zonder achtervoegsel)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="46"/>
+        <location filename="../src/settings/rulemodel.cpp" line="940"/>
+        <source>Floating</source>
+        <translation>Zwevend</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="44"/>
+        <location filename="../src/settings/rulemodel.cpp" line="942"/>
+        <source>Snapped</source>
+        <translation>Vastgeklikt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="42"/>
+        <location filename="../src/settings/rulemodel.cpp" line="944"/>
+        <source>Tiled</source>
+        <translation>Getegeld</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="50"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="315"/>
+        <source>Popups</source>
+        <translation>Pop-ups</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="56"/>
+        <source>Layout Picker</source>
+        <translation>Indelingskiezer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="119"/>
+        <source>Global default</source>
+        <translation>Globale standaard</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="946"/>
+        <source>Zone</source>
+        <translation>Zone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="948"/>
+        <source>Mode</source>
+        <translation>Modus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="950"/>
+        <source>Tiled window count</source>
+        <translation>Aantal getegelde vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="952"/>
+        <source>Screen orientation</source>
+        <translation>Schermoriëntatie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="954"/>
+        <source>Active layout</source>
+        <translation>Actieve indeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="962"/>
+        <source>Any window</source>
+        <translation>Elk venster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="976"/>
+        <source>(condition group)</source>
+        <translation>(voorwaardengroep)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/settings/rulemodel.cpp" line="983"/>
+        <source>%n condition(s)</source>
+        <translation>
+            <numerusform>%n voorwaarde</numerusform>
+            <numerusform>%n voorwaarden</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/settings/rulemodel.cpp" line="989"/>
+        <source>No action</source>
+        <translation>Geen actie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="58"/>
+        <source>New monitor rule</source>
+        <translation>Nieuwe schermregel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="62"/>
+        <source>New desktop rule</source>
+        <translation>Nieuwe bureaubladregel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="70"/>
+        <source>New application rule</source>
+        <translation>Nieuwe toepassingsregel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="74"/>
+        <source>New activity rule</source>
+        <translation>Nieuwe activiteitsregel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="78"/>
+        <source>New animation rule</source>
+        <translation>Nieuwe animatieregel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="88"/>
+        <source>New custom rule</source>
+        <translation>Nieuwe aangepaste regel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="121"/>
+        <source>Set a layout on a monitor</source>
+        <translation>Een indeling instellen op een scherm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="122"/>
+        <source>Pick a snapping layout to use on one monitor.</source>
+        <translation>Kies een vastklikindeling voor één scherm.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="123"/>
+        <source>Set a tiling algorithm on a monitor</source>
+        <translation>Een tegelalgoritme instellen op een scherm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="124"/>
+        <source>Pick an autotile algorithm to use on one monitor.</source>
+        <translation>Kies een autotegel-algoritme voor één scherm.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="126"/>
+        <source>Lock the layout on a monitor</source>
+        <translation>De indeling op een scherm vergrendelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="127"/>
+        <source>Pin the active layout on one monitor so it can&apos;t be switched. This is the rule-driven version of the lock-layout shortcut.</source>
+        <translation>Maak de actieve indeling op één scherm vast zodat er niet gewisseld kan worden. Dit is de regelgestuurde versie van de sneltoets om de indeling te vergrendelen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="130"/>
+        <source>Set a layout on a virtual desktop</source>
+        <translation>Een indeling instellen op een virtueel bureaublad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="131"/>
+        <source>Pick a snapping layout to use on one virtual desktop.</source>
+        <translation>Kies een vastklikindeling voor één virtueel bureaublad.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="133"/>
+        <source>Set a layout for portrait monitors</source>
+        <translation>Een indeling instellen voor staande schermen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="134"/>
+        <source>Pick a snapping layout to use whenever a monitor is in portrait orientation. Handy for rotating screens.</source>
+        <translation>Kies een vastklikindeling die wordt gebruikt zodra een scherm in staande oriëntatie staat. Handig voor draaiende schermen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="137"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="215"/>
+        <source>Open an app in a zone</source>
+        <translation>Een app in een zone openen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="138"/>
+        <source>Snap one application&apos;s windows into a chosen zone when they open.</source>
+        <translation>Klik de vensters van één toepassing in een gekozen zone vast wanneer ze openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="140"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="226"/>
+        <source>Open an app on a monitor</source>
+        <translation>Een app op een scherm openen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="141"/>
+        <source>Send one application&apos;s windows to a chosen monitor when they open.</source>
+        <translation>Stuur de vensters van één toepassing naar een gekozen scherm wanneer ze openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="143"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="234"/>
+        <source>Float an app</source>
+        <translation>Een app laten zweven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="144"/>
+        <source>Keep one application&apos;s windows floating instead of tiled. The windows stay managed, unlike a full exclusion.</source>
+        <translation>Houd de vensters van één toepassing zwevend in plaats van getegeld. De vensters blijven beheerd, anders dan bij een volledige uitsluiting.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="147"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="244"/>
+        <source>Exclude an app from tiling</source>
+        <translation>Een app uitsluiten van tegelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="148"/>
+        <source>Keep one application&apos;s windows out of the snap and autotile engines entirely.</source>
+        <translation>Houd de vensters van één toepassing volledig buiten de vastklik- en autotegel-engines.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="150"/>
+        <location filename="../src/settings/ruletemplates.cpp" line="251"/>
+        <source>Don&apos;t animate small windows</source>
+        <translation>Kleine vensters niet animeren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="151"/>
+        <source>Skip open and close animations for windows narrower than a chosen width. Handy for tiny popups and tool windows.</source>
+        <translation>Sla open- en sluitanimaties over voor vensters die smaller zijn dan een gekozen breedte. Handig voor kleine pop-ups en hulpvensters.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="164"/>
+        <source>Snapping layout on monitor</source>
+        <translation>Vastklikindeling op scherm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="171"/>
+        <source>Tiling algorithm on monitor</source>
+        <translation>Tegelalgoritme op scherm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="186"/>
+        <source>Lock layout on monitor</source>
+        <translation>Indeling op scherm vergrendelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="197"/>
+        <source>Snapping layout on virtual desktop</source>
+        <translation>Vastklikindeling op virtueel bureaublad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruletemplates.cpp" line="207"/>
+        <source>Layout for portrait monitors</source>
+        <translation>Indeling voor staande schermen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="64"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <source>monitor</source>
+        <translation>scherm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="447"/>
+        <source>display</source>
+        <translation>beeldscherm</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="56"/>
+        <source>mode</source>
+        <translation>modus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="57"/>
+        <source>active layout</source>
+        <translation>actieve indeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>rendering</source>
+        <translation>weergave</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <source>backend</source>
+        <translation>backend</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="59"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>opengl</source>
+        <translation>opengl</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>vulkan</source>
+        <translation>vulkan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <source>backup</source>
+        <translation>reservekopie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="60"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <source>export</source>
+        <translation>exporteren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>import</source>
+        <translation>importeren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="61"/>
+        <source>reset</source>
+        <translation>herstellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="482"/>
+        <source>split</source>
+        <translation>splitsen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>subdivide</source>
+        <translation>onderverdelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="63"/>
+        <source>region</source>
+        <translation>gebied</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>layout</source>
+        <translation>indeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <source>zone</source>
+        <translation>zone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="66"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>grid</source>
+        <translation>raster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>preset</source>
+        <translation>voorinstelling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="67"/>
+        <source>template</source>
+        <translation>sjabloon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="68"/>
+        <source>aspect ratio</source>
+        <translation>beeldverhouding</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>overlay</source>
+        <translation>overlay</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>trigger</source>
+        <translation>trigger</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="75"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="409"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>edge</source>
+        <translation>rand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <source>magnet</source>
+        <translation>magneet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="76"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>snap</source>
+        <translation>vastklikken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <source>color</source>
+        <translation>kleur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>colour</source>
+        <translation>kleur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="78"/>
+        <source>opacity</source>
+        <translation>dekking</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <source>transparency</source>
+        <translation>transparantie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <source>theme</source>
+        <translation>thema</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="79"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="392"/>
+        <source>border</source>
+        <translation>rand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>zone selector</source>
+        <translation>zonekiezer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="442"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>picker</source>
+        <translation>kiezer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="81"/>
+        <source>chooser</source>
+        <translation>kiezer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="82"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>popup</source>
+        <translation>pop-up</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="164"/>
+        <source>window</source>
+        <translation>venster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="84"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <source>drag</source>
+        <translation>slepen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="85"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="497"/>
+        <source>modifier</source>
+        <translation>modificatietoets</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="85"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="90"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="105"/>
+        <source>key</source>
+        <translation>toets</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <source>priority</source>
+        <translation>prioriteit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <source>order</source>
+        <translation>volgorde</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="87"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="102"/>
+        <source>precedence</source>
+        <translation>voorrang</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>shortcut</source>
+        <translation>sneltoets</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>hotkey</source>
+        <translation>sneltoets</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="89"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="104"/>
+        <source>keybind</source>
+        <translation>sneltoets</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="90"/>
+        <source>keyboard</source>
+        <translation>toetsenbord</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="143"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>shader</source>
+        <translation>shader</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="143"/>
+        <source>effect</source>
+        <translation>effect</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="92"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>glow</source>
+        <translation>gloed</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>tile</source>
+        <translation>tegel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="235"/>
+        <source>tiling</source>
+        <translation>tegelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="96"/>
+        <source>auto</source>
+        <translation>automatisch</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <source>gap</source>
+        <translation>tussenruimte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="97"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <source>spacing</source>
+        <translation>spatiëring</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>algorithm</source>
+        <translation>algoritme</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>bsp</source>
+        <translation>bsp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="99"/>
+        <source>binary</source>
+        <translation>binair</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <source>spiral</source>
+        <translation>spiraal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <source>master</source>
+        <translation>hoofd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="100"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="497"/>
+        <source>stack</source>
+        <translation>stapel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="125"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>animation</source>
+        <translation>animatie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <source>duration</source>
+        <translation>duur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="109"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>easing</source>
+        <translation>versoepeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="138"/>
+        <source>curve</source>
+        <translation>curve</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <source>spring</source>
+        <translation>veer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="110"/>
+        <source>speed</source>
+        <translation>snelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>open</source>
+        <translation>openen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>close</source>
+        <translation>sluiten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="113"/>
+        <source>minimize</source>
+        <translation>minimaliseren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <source>movement</source>
+        <translation>beweging</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="117"/>
+        <source>maximize</source>
+        <translation>maximaliseren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="119"/>
+        <source>dragging</source>
+        <translation>slepen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>move</source>
+        <translation>verplaatsen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>wobble</source>
+        <translation>wiebelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="120"/>
+        <source>physics</source>
+        <translation>fysica</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <source>osd</source>
+        <translation>osd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <source>notification</source>
+        <translation>melding</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="123"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>on-screen display</source>
+        <translation>on-screen display</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>desktop</source>
+        <translation>bureaublad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="127"/>
+        <source>virtual desktop</source>
+        <translation>virtueel bureaublad</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <source>workspace</source>
+        <translation>werkruimte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <source>switch</source>
+        <translation>wisselen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="128"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>peek</source>
+        <translation>gluren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="129"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>show desktop</source>
+        <translation>bureaublad tonen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>side panel</source>
+        <translation>zijpaneel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>panel</source>
+        <translation>paneel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="131"/>
+        <source>drawer</source>
+        <translation>lade</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="133"/>
+        <source>widget</source>
+        <translation>widget</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>editor</source>
+        <translation>bewerker</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="136"/>
+        <source>layout editor</source>
+        <translation>indelingsbewerker</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="139"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="156"/>
+        <source>profile</source>
+        <translation>profiel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>motion set</source>
+        <translation>bewegingsset</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="116"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="141"/>
+        <source>motion</source>
+        <translation>beweging</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="165"/>
+        <source>title bar</source>
+        <translation>titelbalk</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="147"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="151"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="165"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>decoration</source>
+        <translation>decoratie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="112"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="148"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <source>appearance</source>
+        <translation>uiterlijk</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="166"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="404"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="407"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="412"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="417"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>gaps</source>
+        <translation>tussenruimtes</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <source>padding</source>
+        <translation>opvulling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="167"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="413"/>
+        <source>margin</source>
+        <translation>marge</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <source>rule</source>
+        <translation>regel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <source>exclude</source>
+        <translation>uitsluiten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="169"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>float</source>
+        <translation>zweven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="170"/>
+        <source>activity</source>
+        <translation>activiteit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="172"/>
+        <source>design</source>
+        <translation>ontwerp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="173"/>
+        <source>zones</source>
+        <translation>zones</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>about</source>
+        <translation>over</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>version</source>
+        <translation>versie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="175"/>
+        <source>license</source>
+        <translation>licentie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="176"/>
+        <source>credits</source>
+        <translation>met dank aan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="182"/>
+        <source>Rendering</source>
+        <translation>Weergave</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="184"/>
+        <source>Rendering backend</source>
+        <translation>Weergave-backend</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="185"/>
+        <source>graphics</source>
+        <translation>grafische weergave</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="237"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="388"/>
+        <source>Window filtering</source>
+        <translation>Vensterfiltering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="239"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="390"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="533"/>
+        <source>Exclude transient windows</source>
+        <translation>Tijdelijke vensters uitsluiten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>dialog</source>
+        <translation>dialoogvenster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="153"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="240"/>
+        <source>tooltip</source>
+        <translation>tekstballon</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="247"/>
+        <source>Reset</source>
+        <translation>Herstellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <source>reset to defaults</source>
+        <translation>standaardwaarden herstellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <source>defaults</source>
+        <translation>standaardwaarden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="248"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="459"/>
+        <source>restore</source>
+        <translation>herstellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="254"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="266"/>
+        <source>Triggers</source>
+        <translation>Triggers</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="256"/>
+        <source>Zone Span</source>
+        <translation>Zonespanning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="258"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="85"/>
+        <source>Display</source>
+        <translation>Weergave</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="52"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="261"/>
+        <source>Snap Assist</source>
+        <translation>Vastklikhulp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="263"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="268"/>
+        <source>Window Handling</source>
+        <translation>Vensterbehandeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="264"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="269"/>
+        <source>Focus</source>
+        <translation>Focus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="274"/>
+        <source>Colors</source>
+        <translation>Kleuren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="278"/>
+        <source>Border</source>
+        <translation>Rand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="280"/>
+        <source>Zone Labels</source>
+        <translation>Zonelabels</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="282"/>
+        <source>Effects</source>
+        <translation>Effecten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="186"/>
+        <source>Shader Effects</source>
+        <translation>Shader-effecten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="284"/>
+        <source>System accent color</source>
+        <translation>Systeemaccentkleur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="285"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="332"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="352"/>
+        <source>scheme</source>
+        <translation>schema</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="405"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="287"/>
+        <source>Highlight color</source>
+        <translation>Markeringskleur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <source>active</source>
+        <translation>actief</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="288"/>
+        <source>hover</source>
+        <translation>zweven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <source>Inactive color</source>
+        <translation>Inactieve kleur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="290"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>unfocused</source>
+        <translation>niet gefocust</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="338"/>
+        <source>outline</source>
+        <translation>omtrek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="295"/>
+        <source>Import colors</source>
+        <translation>Kleuren importeren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>pywal</source>
+        <translation>pywal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <source>json</source>
+        <translation>json</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="296"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>load</source>
+        <translation>laden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <source>Active opacity</source>
+        <translation>Actieve dekking</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>alpha</source>
+        <translation>alfa</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="300"/>
+        <source>Inactive opacity</source>
+        <translation>Inactieve dekking</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>Border width</source>
+        <translation>Randbreedte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <source>thickness</source>
+        <translation>dikte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="302"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="324"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>size</source>
+        <translation>grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <source>Border radius</source>
+        <translation>Randradius</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <source>rounding</source>
+        <translation>afronding</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="304"/>
+        <source>corner</source>
+        <translation>hoek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="306"/>
+        <source>Label color</source>
+        <translation>Labelkleur</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>text</source>
+        <translation>tekst</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="307"/>
+        <source>font</source>
+        <translation>lettertype</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="308"/>
+        <source>Font</source>
+        <translation>Lettertype</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>typeface</source>
+        <translation>letterbeeld</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>family</source>
+        <translation>familie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="309"/>
+        <source>style</source>
+        <translation>stijl</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="311"/>
+        <source>Label scale</source>
+        <translation>Labelschaal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="312"/>
+        <source>multiplier</source>
+        <translation>vermenigvuldiger</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="314"/>
+        <source>Zone numbers</source>
+        <translation>Zonenummers</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>index</source>
+        <translation>index</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>digit</source>
+        <translation>cijfer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="315"/>
+        <source>label</source>
+        <translation>label</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>Flash on layout switch</source>
+        <translation>Knipperen bij wisselen van indeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="317"/>
+        <source>blink</source>
+        <translation>knipperen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="187"/>
+        <source>Frame rate</source>
+        <translation>Framesnelheid</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="71"/>
+        <source>User layouts</source>
+        <translation>Gebruikersindelingen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="148"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>surface</source>
+        <translation>oppervlak</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>decoration set</source>
+        <translation>decoratieset</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="155"/>
+        <source>set</source>
+        <translation>set</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="156"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="158"/>
+        <source>pack</source>
+        <translation>pakket</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="159"/>
+        <source>glass</source>
+        <translation>glas</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="160"/>
+        <source>blur</source>
+        <translation>vervaging</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <source>fps</source>
+        <translation>fps</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="188"/>
+        <source>refresh</source>
+        <translation>verversen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="189"/>
+        <source>Audio Spectrum</source>
+        <translation>Audiospectrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="191"/>
+        <source>Audio spectrum</source>
+        <translation>Audiospectrum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="206"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <source>cava</source>
+        <translation>cava</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <source>music</source>
+        <translation>muziek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="192"/>
+        <source>visualizer</source>
+        <translation>visualisatie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="193"/>
+        <source>sound</source>
+        <translation>geluid</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="194"/>
+        <source>Spectrum bars</source>
+        <translation>Spectrumbalken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <source>bands</source>
+        <translation>banden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="195"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <source>frequency</source>
+        <translation>frequentie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="197"/>
+        <source>Noise reduction</source>
+        <translation>Ruisonderdrukking</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <source>smoothing</source>
+        <translation>afvlakken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="198"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="201"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <source>smooth</source>
+        <translation>vloeiend</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="200"/>
+        <source>Extra smoothing</source>
+        <translation>Extra afvlakking</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="202"/>
+        <source>Automatic gain</source>
+        <translation>Automatische versterking</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>autosens</source>
+        <translation>autosens</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="203"/>
+        <source>sensitivity</source>
+        <translation>gevoeligheid</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="204"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="206"/>
+        <source>gain</source>
+        <translation>versterking</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="205"/>
+        <source>Sensitivity</source>
+        <translation>Gevoeligheid</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="208"/>
+        <source>Lowest frequency</source>
+        <translation>Laagste frequentie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="209"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="213"/>
+        <source>cutoff</source>
+        <translation>afkappunt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="210"/>
+        <source>bass</source>
+        <translation>bas</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="212"/>
+        <source>Highest frequency</source>
+        <translation>Hoogste frequentie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="214"/>
+        <source>treble</source>
+        <translation>hoge tonen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="215"/>
+        <source>Channels</source>
+        <translation>Kanalen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <source>stereo</source>
+        <translation>stereo</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="216"/>
+        <source>mono</source>
+        <translation>mono</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="217"/>
+        <source>Reverse bar order</source>
+        <translation>Balkvolgorde omkeren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <source>flip</source>
+        <translation>omdraaien</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="218"/>
+        <source>mirror</source>
+        <translation>spiegelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="220"/>
+        <source>Monstercat filter</source>
+        <translation>Monstercat-filter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="221"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <source>filter</source>
+        <translation>filter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="222"/>
+        <source>Wave filter</source>
+        <translation>Golffilter</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="223"/>
+        <source>wave</source>
+        <translation>golf</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="224"/>
+        <source>Audio backend</source>
+        <translation>Audio-backend</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <source>pipewire</source>
+        <translation>pipewire</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="225"/>
+        <source>pulseaudio</source>
+        <translation>pulseaudio</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="226"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="229"/>
+        <source>capture</source>
+        <translation>opname</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="227"/>
+        <source>Audio source</source>
+        <translation>Audiobron</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="228"/>
+        <source>device</source>
+        <translation>apparaat</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="231"/>
+        <source>Layout assignment</source>
+        <translation>Indelingstoewijzing</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="233"/>
+        <source>Don&apos;t assign a layout by default</source>
+        <translation>Standaard geen indeling toewijzen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>default</source>
+        <translation>standaard</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>assign</source>
+        <translation>toewijzen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="234"/>
+        <source>snapping</source>
+        <translation>vastklikken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="320"/>
+        <source>Borders</source>
+        <translation>Randen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="322"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="123"/>
+        <source>Decorations</source>
+        <translation>Decoraties</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="326"/>
+        <source>Corner radius</source>
+        <translation>Hoekradius</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="328"/>
+        <source>Apply borders to</source>
+        <translation>Randen toepassen op</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>scope</source>
+        <translation>bereik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="329"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="343"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>which windows</source>
+        <translation>welke vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="331"/>
+        <source>Use system accent color</source>
+        <translation>Systeemaccentkleur gebruiken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="334"/>
+        <source>Active border color</source>
+        <translation>Kleur van actieve rand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="335"/>
+        <source>focused</source>
+        <translation>gefocust</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="337"/>
+        <source>Inactive border color</source>
+        <translation>Kleur van inactieve rand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="340"/>
+        <source>Opacity and tint</source>
+        <translation>Dekking en tint</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="342"/>
+        <source>Apply opacity and tint to</source>
+        <translation>Dekking en tint toepassen op</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <source>translucent</source>
+        <translation>doorschijnend</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>wash</source>
+        <translation>waas</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="349"/>
+        <source>blend</source>
+        <translation>mengen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="351"/>
+        <source>Use system accent color for the tint</source>
+        <translation>Systeemaccentkleur voor de tint gebruiken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="354"/>
+        <source>accent</source>
+        <translation>accent</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="360"/>
+        <source>titlebar</source>
+        <translation>titelbalk</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="357"/>
+        <source>header</source>
+        <translation>kop</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="359"/>
+        <source>Hide title bars on</source>
+        <translation>Titelbalken verbergen op</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="362"/>
+        <source>Focus fade duration</source>
+        <translation>Duur van focusovergang</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="346"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>fade</source>
+        <translation>vervagen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="363"/>
+        <source>dim</source>
+        <translation>dimmen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="364"/>
+        <source>cross-fade</source>
+        <translation>kruisovergang</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="370"/>
+        <source>Performance</source>
+        <translation>Prestaties</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="372"/>
+        <source>Animate only the active window</source>
+        <translation>Alleen het actieve venster animeren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <source>performance</source>
+        <translation>prestaties</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>power</source>
+        <translation>energie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="373"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="377"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="382"/>
+        <source>battery</source>
+        <translation>accu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>gpu</source>
+        <translation>gpu</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <source>heat</source>
+        <translation>warmte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="376"/>
+        <source>Pause while you are away</source>
+        <translation>Pauzeren wanneer je weg bent</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="378"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>idle</source>
+        <translation>inactief</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="380"/>
+        <source>Idle after</source>
+        <translation>Inactief na</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="381"/>
+        <source>timeout</source>
+        <translation>time-out</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="403"/>
+        <source>Inner gap</source>
+        <translation>Binnenste tussenruimte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="405"/>
+        <source>inner</source>
+        <translation>binnenste</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="406"/>
+        <source>Outer gap</source>
+        <translation>Buitenste tussenruimte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="408"/>
+        <source>outer</source>
+        <translation>buitenste</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="414"/>
+        <source>side</source>
+        <translation>zijde</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="416"/>
+        <source>Smart gaps</source>
+        <translation>Slimme tussenruimtes</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>smart</source>
+        <translation>slim</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="418"/>
+        <source>single</source>
+        <translation>enkel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="422"/>
+        <source>Activate on every drag</source>
+        <translation>Activeren bij elke sleepbeweging</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <source>Hold to activate</source>
+        <translation>Ingedrukt houden om te activeren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="424"/>
+        <source>deactivate</source>
+        <translation>deactiveren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>Toggle mode</source>
+        <translation>Schakelmodus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>tap</source>
+        <translation>tikken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="426"/>
+        <source>activation</source>
+        <translation>activering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>Span modifier</source>
+        <translation>Overspanningstoets</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>zone span</source>
+        <translation>zonespanning</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="428"/>
+        <source>paint</source>
+        <translation>tekenen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="430"/>
+        <source>span</source>
+        <translation>overspannen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <source>Edge threshold</source>
+        <translation>Randdrempel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>distance</source>
+        <translation>afstand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="432"/>
+        <source>multi-zone</source>
+        <translation>meerdere zones</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="434"/>
+        <source>Show zones on all monitors</source>
+        <translation>Zones op alle schermen tonen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="435"/>
+        <source>screens</source>
+        <translation>schermen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <source>Filter by aspect ratio</source>
+        <translation>Filteren op beeldverhouding</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="437"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="453"/>
+        <source>layouts</source>
+        <translation>indelingen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="441"/>
+        <source>Always show after snapping</source>
+        <translation>Altijd tonen na vastklikken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="442"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <source>snap assist</source>
+        <translation>vastklikhulp</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="444"/>
+        <source>Hold to enable</source>
+        <translation>Ingedrukt houden om in te schakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="446"/>
+        <source>Re-snap on resolution change</source>
+        <translation>Opnieuw vastklikken bij resolutiewijziging</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="447"/>
+        <source>resolution</source>
+        <translation>resolutie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="449"/>
+        <source>Open new windows in the last-used zone</source>
+        <translation>Nieuwe vensters openen in de laatst gebruikte zone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="450"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <source>new window</source>
+        <translation>nieuw venster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="450"/>
+        <source>last zone</source>
+        <translation>laatste zone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="452"/>
+        <source>Auto-assign new windows for all layouts</source>
+        <translation>Nieuwe vensters automatisch toewijzen voor alle indelingen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="453"/>
+        <source>auto-assign</source>
+        <translation>automatisch toewijzen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="603"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="609"/>
+        <source>User sets</source>
+        <translation>Gebruiker stelt in</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="616"/>
+        <source>Opened</source>
+        <translation>Geopend</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="618"/>
+        <source>Closed</source>
+        <translation>Gesloten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="626"/>
+        <source>Dragged</source>
+        <translation>Gesleept</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="631"/>
+        <source>Snapped Into Zone</source>
+        <translation>Vastgeklikt in zone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="633"/>
+        <source>Snapped Out of Zone</source>
+        <translation>Losgeklikt uit zone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="635"/>
+        <source>Layout Switched</source>
+        <translation>Indeling gewisseld</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="637"/>
+        <source>Shown</source>
+        <translation>Getoond</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="638"/>
+        <source>Hidden</source>
+        <translation>Verborgen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="639"/>
+        <source>Emphasized</source>
+        <translation>Benadrukt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="642"/>
+        <source>Zone Selector Shown</source>
+        <translation>Zonekiezer getoond</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="644"/>
+        <source>Zone Selector Hidden</source>
+        <translation>Zonekiezer verborgen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="646"/>
+        <source>Layout Picker Shown</source>
+        <translation>Indelingskiezer getoond</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="648"/>
+        <source>Layout Picker Hidden</source>
+        <translation>Indelingskiezer verborgen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="650"/>
+        <source>Snap Assist Shown</source>
+        <translation>Vastklikhulp getoond</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="652"/>
+        <source>Snap Assist Hidden</source>
+        <translation>Vastklikhulp verborgen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="655"/>
+        <source>Desktop Switched</source>
+        <translation>Bureaublad gewisseld</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="593"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="902"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="455"/>
+        <source>Restore size on unsnap</source>
+        <translation>Grootte herstellen bij losklikken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="456"/>
+        <source>unsnap</source>
+        <translation>losklikken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="456"/>
+        <source>original size</source>
+        <translation>oorspronkelijke grootte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="458"/>
+        <source>Restore windows to their previous zone</source>
+        <translation>Vensters herstellen naar hun vorige zone</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="459"/>
+        <source>login</source>
+        <translation>aanmelden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="461"/>
+        <source>Restore unsnapped windows to their previous position</source>
+        <translation>Losgeklikte vensters herstellen naar hun vorige positie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="462"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="506"/>
+        <source>floated</source>
+        <translation>zwevend gemaakt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="462"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="506"/>
+        <source>position</source>
+        <translation>positie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="464"/>
+        <source>Unfloat to a zone when there is no previous zone</source>
+        <translation>Naar een zone terugbrengen als er geen vorige zone is</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="465"/>
+        <source>unfloat</source>
+        <translation>niet meer laten zweven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="465"/>
+        <source>fallback</source>
+        <translation>terugval</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>Sticky windows</source>
+        <translation>Plakkerige vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>all desktops</source>
+        <translation>alle bureaubladen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="467"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="508"/>
+        <source>sticky</source>
+        <translation>plakkerig</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <source>Focus new windows</source>
+        <translation>Nieuwe vensters focussen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="114"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="374"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="469"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="514"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>focus</source>
+        <translation>focus</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>Focus follows mouse</source>
+        <translation>Focus volgt muis</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="471"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="516"/>
+        <source>pointer</source>
+        <translation>aanwijzer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="238"/>
+        <location filename="../src/settings/ruleauthoring.cpp" line="283"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="474"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="219"/>
+        <source>Algorithm</source>
+        <translation>Algoritme</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="476"/>
+        <source>Max windows</source>
+        <translation>Max. vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <source>windows</source>
+        <translation>vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <source>maximum</source>
+        <translation>maximum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="477"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>count</source>
+        <translation>aantal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="478"/>
+        <source>limit</source>
+        <translation>limiet</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="480"/>
+        <source>Master ratio</source>
+        <translation>Hoofdverhouding</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="489"/>
+        <source>center</source>
+        <translation>midden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="481"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>ratio</source>
+        <translation>verhouding</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="482"/>
+        <source>proportion</source>
+        <translation>proportie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="485"/>
+        <source>Ratio step size</source>
+        <translation>Stapgrootte verhouding</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>step</source>
+        <translation>stap</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="486"/>
+        <source>increment</source>
+        <translation>verhoging</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="292"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="488"/>
+        <source>Master count</source>
+        <translation>Aantal hoofdvensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="490"/>
+        <source>number</source>
+        <translation>getal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <source>Always re-insert on drag</source>
+        <translation>Altijd opnieuw invoegen bij slepen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="494"/>
+        <source>insert</source>
+        <translation>invoegen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="496"/>
+        <source>Hold to re-insert into stack</source>
+        <translation>Ingedrukt houden om opnieuw in de stapel in te voegen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="499"/>
+        <source>stack preview</source>
+        <translation>stapelvoorbeeld</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="501"/>
+        <source>New window placement</source>
+        <translation>Plaatsing van nieuw venster</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>Respect minimum size</source>
+        <translation>Minimumgrootte respecteren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="503"/>
+        <source>minimum</source>
+        <translation>minimum</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="505"/>
+        <source>Restore untiled windows to their previous position</source>
+        <translation>Niet-getegelde vensters herstellen naar hun vorige positie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="301"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>Drag behavior</source>
+        <translation>Sleepgedrag</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="510"/>
+        <source>reorder</source>
+        <translation>herordenen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="298"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>Overflow behavior</source>
+        <translation>Overloopgedrag</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>max windows</source>
+        <translation>max. vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="512"/>
+        <source>unlimited</source>
+        <translation>onbeperkt</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="520"/>
+        <source>Global animation defaults</source>
+        <translation>Globale animatiestandaarden</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="522"/>
+        <source>Multiple windows</source>
+        <translation>Meerdere vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>sequence</source>
+        <translation>reeks</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>simultaneous</source>
+        <translation>gelijktijdig</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="523"/>
+        <source>one by one</source>
+        <translation>een voor een</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="525"/>
+        <source>Stagger delay</source>
+        <translation>Gespreide vertraging</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>pause</source>
+        <translation>pauze</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>interval</source>
+        <translation>interval</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="526"/>
+        <source>delay</source>
+        <translation>vertraging</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="528"/>
+        <source>Minimum distance</source>
+        <translation>Minimumafstand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>threshold</source>
+        <translation>drempel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <source>skip</source>
+        <translation>overslaan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="529"/>
+        <source>geometry</source>
+        <translation>geometrie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="531"/>
+        <source>Window Filtering</source>
+        <translation>Vensterfiltering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>dialogs</source>
+        <translation>dialoogvensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>popups</source>
+        <translation>pop-ups</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="534"/>
+        <source>tooltips</source>
+        <translation>tekstballonnen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="391"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="535"/>
+        <source>menus</source>
+        <translation>menu's</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="537"/>
+        <source>Exclude notifications and OSDs</source>
+        <translation>Meldingen en OSD's uitsluiten</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>volume</source>
+        <translation>volume</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="538"/>
+        <source>brightness</source>
+        <translation>helderheid</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="242"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="394"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="540"/>
+        <source>Minimum window width</source>
+        <translation>Minimale vensterbreedte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="243"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="395"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="541"/>
+        <source>narrow</source>
+        <translation>smal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="245"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="397"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="543"/>
+        <source>Minimum window height</source>
+        <translation>Minimale vensterhoogte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="246"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="398"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="544"/>
+        <source>short</source>
+        <translation>kort</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="548"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="192"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="223"/>
+        <source>Configuration</source>
+        <translation>Configuratie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="549"/>
+        <source>Backup</source>
+        <translation>Reservekopie</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <source>save</source>
+        <translation>opslaan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="550"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="552"/>
+        <source>data</source>
+        <translation>gegevens</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="551"/>
+        <source>Restore</source>
+        <translation>Herstellen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="556"/>
+        <source>Zone selector popup</source>
+        <translation>Zonekiezer-pop-up</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>enable</source>
+        <translation>inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="557"/>
+        <source>toggle</source>
+        <translation>omschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="559"/>
+        <source>Position &amp; Trigger</source>
+        <translation>Positie &amp; trigger</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="561"/>
+        <source>Trigger distance</source>
+        <translation>Triggerafstand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="562"/>
+        <source>proximity</source>
+        <translation>nabijheid</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="564"/>
+        <source>Layout Arrangement</source>
+        <translation>Indelingsschikking</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="566"/>
+        <source>Arrangement</source>
+        <translation>Schikking</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>horizontal</source>
+        <translation>horizontaal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="567"/>
+        <source>vertical</source>
+        <translation>verticaal</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="569"/>
+        <source>Grid columns</source>
+        <translation>Rasterkolommen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>columns</source>
+        <translation>kolommen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="570"/>
+        <source>per row</source>
+        <translation>per rij</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="572"/>
+        <source>Max visible rows</source>
+        <translation>Max. zichtbare rijen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>rows</source>
+        <translation>rijen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>scroll</source>
+        <translation>scrollen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="573"/>
+        <source>visible</source>
+        <translation>zichtbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="575"/>
+        <source>Preview Size</source>
+        <translation>Voorbeeldgrootte</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="579"/>
+        <source>Snapping Layout Priority</source>
+        <translation>Prioriteit vastklik-indeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="581"/>
+        <source>Tiling Algorithm Priority</source>
+        <translation>Prioriteit tegel-algoritme</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="583"/>
+        <source>Snapping Quick Shortcuts</source>
+        <translation>Snelle sneltoetsen voor vastklikken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="585"/>
+        <source>Tiling Quick Shortcuts</source>
+        <translation>Snelle sneltoetsen voor tegelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="591"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="593"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="595"/>
+        <source>User shaders</source>
+        <translation>Gebruikersshaders</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="597"/>
+        <source>Easing Presets</source>
+        <translation>Voorinstellingen voor versoepeling</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="599"/>
+        <source>Spring Presets</source>
+        <translation>Voorinstellingen voor veren</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="601"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="607"/>
+        <source>Save current state</source>
+        <translation>Huidige status opslaan</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="605"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="611"/>
+        <source>Saved sets</source>
+        <translation>Opgeslagen sets</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="663"/>
+        <source>Peeked at Desktop</source>
+        <translation>Naar bureaublad gegluurd</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="713"/>
+        <source>Snap Out of Zone</source>
+        <translation>Uit zone losklikken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="665"/>
+        <source>Slide In</source>
+        <translation>Inschuiven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="667"/>
+        <source>Slide Out</source>
+        <translation>Uitschuiven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="669"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="687"/>
+        <source>Fade In</source>
+        <translation>Invagen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="671"/>
+        <location filename="../src/settings/searchcatalog.cpp" line="689"/>
+        <source>Fade Out</source>
+        <translation>Uitvagen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="672"/>
+        <source>Hover</source>
+        <translation>Zweven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="673"/>
+        <source>Press</source>
+        <translation>Indrukken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="675"/>
+        <source>Toggle On</source>
+        <translation>Inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="677"/>
+        <source>Toggle Off</source>
+        <translation>Uitschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="679"/>
+        <source>Show (badge)</source>
+        <translation>Tonen (badge)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="681"/>
+        <source>Hide (badge)</source>
+        <translation>Verbergen (badge)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="683"/>
+        <source>Pulse (badge)</source>
+        <translation>Pulseren (badge)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="684"/>
+        <source>Tint</source>
+        <translation>Tint</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="685"/>
+        <source>Dim</source>
+        <translation>Dimmen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="691"/>
+        <source>Reorder</source>
+        <translation>Herordenen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="693"/>
+        <source>Expand (accordion)</source>
+        <translation>Uitklappen (accordeon)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="695"/>
+        <source>Collapse (accordion)</source>
+        <translation>Inklappen (accordeon)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="697"/>
+        <source>Progress</source>
+        <translation>Voortgang</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="699"/>
+        <source>Zone Highlight</source>
+        <translation>Zone-markering</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="701"/>
+        <source>Zone Highlight: Pop</source>
+        <translation>Zone-markering: pop</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="703"/>
+        <source>Zone Highlight: Border</source>
+        <translation>Zone-markering: rand</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="705"/>
+        <source>Zone Overlay: Layout-Switch Flash</source>
+        <translation>Zone-overlay: flits bij indelingswissel</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="707"/>
+        <source>Cursor Hover</source>
+        <translation>Cursor zweven</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="709"/>
+        <source>Cursor Click</source>
+        <translation>Cursorklik</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="711"/>
+        <source>Snap Into Zone (Fill Preview)</source>
+        <translation>In zone vastklikken (voorbeeld van vulling)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/searchcatalog.cpp" line="715"/>
+        <source>Snap Resize (Drag Preview)</source>
+        <translation>Vastklikken bij formaat wijzigen (sleepvoorbeeld)</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="661"/>
+        <source>Zone %1</source>
+        <translation>Zone %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller.cpp" line="663"/>
+        <source>%1 — %2</source>
+        <translation>%1 — %2</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="216"/>
+        <source>Layout created, but aspect-ratio class could not be applied: %1</source>
+        <translation>Indeling aangemaakt, maar de klasse voor beeldverhouding kon niet worden toegepast: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="230"/>
+        <source>Could not create the layout. The daemon returned an empty layout ID.</source>
+        <translation>Kan de indeling niet aanmaken. De daemon gaf een lege indelings-ID terug.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="238"/>
+        <source>Could not create the layout. The daemon may not be running.</source>
+        <translation>Kan de indeling niet aanmaken. Mogelijk draait de daemon niet.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="257"/>
+        <source>Could not delete layout: %1</source>
+        <translation>Kan indeling niet verwijderen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="273"/>
+        <source>Could not duplicate layout: %1</source>
+        <translation>Kan indeling niet dupliceren: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="323"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="472"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="565"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="929"/>
+        <source>That file path is not allowed.</source>
+        <translation>Dat bestandspad is niet toegestaan.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="355"/>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="530"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="497"/>
+        <source>That export path is not allowed.</source>
+        <translation>Dat exportpad is niet toegestaan.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="400"/>
+        <source>Failed to update layout visibility: %1</source>
+        <translation>Bijwerken van zichtbaarheid van indeling is mislukt: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="413"/>
+        <source>Failed to update auto-assign: %1</source>
+        <translation>Bijwerken van automatisch toewijzen is mislukt: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_layouts.cpp" line="427"/>
+        <source>Failed to update aspect ratio: %1</source>
+        <translation>Bijwerken van beeldverhouding is mislukt: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_lifecycle.cpp" line="187"/>
+        <source>Failed to apply assignment changes: %1</source>
+        <translation>Toepassen van toewijzingswijzigingen is mislukt: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="77"/>
+        <source>Overview</source>
+        <translation>Overzicht</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="81"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="232"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="302"/>
+        <source>General</source>
+        <translation>Algemeen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="91"/>
+        <source>Placement</source>
+        <translation>Plaatsing</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="40"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="253"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="312"/>
+        <source>Windows</source>
+        <translation>Vensters</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="132"/>
+        <source>Rules</source>
+        <translation>Regels</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="136"/>
+        <source>Editor</source>
+        <translation>Editor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="138"/>
+        <source>About</source>
+        <translation>Over</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="151"/>
+        <source>Virtual Screens</source>
+        <translation>Virtuele schermen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="153"/>
+        <source>Layouts</source>
+        <translation>Indelingen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/ruleauthoring.cpp" line="243"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="171"/>
+        <source>Behavior</source>
+        <translation>Gedrag</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="54"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="181"/>
+        <source>Zone Selector</source>
+        <translation>Zonekiezer</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="194"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="225"/>
+        <source>Priority</source>
+        <translation>Prioriteit</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="197"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="228"/>
+        <source>Quick Shortcuts</source>
+        <translation>Snelle sneltoetsen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="199"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="287"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="322"/>
+        <source>Shaders</source>
+        <translation>Shaders</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="239"/>
+        <source>Transitions</source>
+        <translation>Overgangen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="247"/>
+        <source>Motion</source>
+        <translation>Beweging</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="264"/>
+        <source>Window Motion</source>
+        <translation>Vensterbeweging</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="271"/>
+        <source>Window Dragging</source>
+        <translation>Venster slepen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="306"/>
+        <source>Surfaces</source>
+        <translation>Oppervlakken</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="319"/>
+        <source>Decoration Sets</source>
+        <translation>Decoratiesets</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="249"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="308"/>
+        <source>Library</source>
+        <translation>Bibliotheek</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/decorationpagecontroller_browser.cpp" line="48"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="254"/>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="313"/>
+        <source>OSDs</source>
+        <translation>OSD's</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="257"/>
+        <source>Overlays</source>
+        <translation>Overlays</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="274"/>
+        <source>Side Panels</source>
+        <translation>Zijpanelen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="276"/>
+        <source>Widgets</source>
+        <translation>Widgets</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="279"/>
+        <source>Layout Editor</source>
+        <translation>Indelingseditor</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="282"/>
+        <source>Presets</source>
+        <translation>Voorinstellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_pageregistration.cpp" line="285"/>
+        <source>Motion Sets</source>
+        <translation>Bewegingssets</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="303"/>
+        <source>Shader pack installed.</source>
+        <translation>Shaderpakket geïnstalleerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="305"/>
+        <source>The dropped path is not a valid shader pack directory.</source>
+        <translation>Het neergezette pad is geen geldige shaderpakketmap.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="307"/>
+        <source>The shader pack is missing metadata.json (or it is a symlink).</source>
+        <translation>Het shaderpakket mist metadata.json (of het is een symbolische koppeling).</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="309"/>
+        <source>The user shader directory could not be created.</source>
+        <translation>De gebruikers-shadermap kon niet worden aangemaakt.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="311"/>
+        <source>A shader pack with this name is already installed.</source>
+        <translation>Er is al een shaderpakket met deze naam geïnstalleerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="313"/>
+        <source>The shader pack exceeds the maximum allowed size or file count.</source>
+        <translation>Het shaderpakket overschrijdt de maximaal toegestane grootte of het aantal bestanden.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="315"/>
+        <source>Copying the shader pack failed. The partial install was rolled back.</source>
+        <translation>Kopiëren van het shaderpakket is mislukt. De gedeeltelijke installatie is teruggedraaid.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shaderpackinstaller.cpp" line="317"/>
+        <source>Unknown shader pack installer error.</source>
+        <translation>Onbekende fout bij shaderpakketinstallatie.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="78"/>
+        <source>Color import file does not exist: %1</source>
+        <translation>Kleurimportbestand bestaat niet: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="96"/>
+        <source>Color import file does not resolve to a regular file: %1</source>
+        <translation>Kleurimportbestand verwijst niet naar een gewoon bestand: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/snappingzonescontroller.cpp" line="101"/>
+        <source>Color import file must be a .json file: %1</source>
+        <translation>Kleurimportbestand moet een .json-bestand zijn: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="449"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="545"/>
+        <source>A set named &quot;%1&quot; already exists.</source>
+        <translation>Er bestaat al een set met de naam &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="355"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="540"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="551"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="617"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="622"/>
+        <source>Could not read the set &quot;%1&quot;.</source>
+        <translation>Kan de set &quot;%1&quot; niet lezen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="169"/>
+        <source>Could not back up the existing set, so it was left untouched.</source>
+        <translation>Kan geen reservekopie maken van de bestaande set, dus deze is ongewijzigd gelaten.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="234"/>
+        <source>Could not write the set to disk.</source>
+        <translation>Kan de set niet naar schijf schrijven.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="359"/>
+        <source>&quot;%1&quot; was written by a newer version of PlasmaZones.</source>
+        <translation>&quot;%1&quot; is geschreven door een nieuwere versie van PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="367"/>
+        <source>&quot;%1&quot; does not match this page.</source>
+        <translation>&quot;%1&quot; komt niet overeen met deze pagina.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="371"/>
+        <source>Could not apply &quot;%1&quot;.</source>
+        <translation>Kan &quot;%1&quot; niet toepassen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="439"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="533"/>
+        <source>That name cannot be used. Try one with letters or numbers in it.</source>
+        <translation>Die naam kan niet worden gebruikt. Probeer er een met letters of cijfers.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="459"/>
+        <source>There is nothing to capture yet.</source>
+        <translation>Er is nog niets om vast te leggen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="500"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="508"/>
+        <source>Could not delete &quot;%1&quot;.</source>
+        <translation>Kan &quot;%1&quot; niet verwijderen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="432"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="526"/>
+        <source>A set needs a name.</source>
+        <translation>Een set heeft een naam nodig.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="589"/>
+        <source>Renamed the set, but the old file could not be removed. Delete it by hand from the sets folder.</source>
+        <translation>De set is hernoemd, maar het oude bestand kon niet worden verwijderd. Verwijder het handmatig uit de map met sets.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="605"/>
+        <source>Could not write to that location.</source>
+        <translation>Kan niet naar die locatie schrijven.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="631"/>
+        <source>Could not write to %1.</source>
+        <translation>Kan niet naar %1 schrijven.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="652"/>
+        <source>That file is not a readable set.</source>
+        <translation>Dat bestand is geen leesbare set.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="656"/>
+        <source>That set was written by a newer version of PlasmaZones.</source>
+        <translation>Die set is geschreven door een nieuwere versie van PlasmaZones.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="663"/>
+        <source>That set is empty.</source>
+        <translation>Die set is leeg.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="670"/>
+        <source>That set does not match this page.</source>
+        <translation>Die set komt niet overeen met deze pagina.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="681"/>
+        <source>That set has no usable name.</source>
+        <translation>Die set heeft geen bruikbare naam.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="466"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="688"/>
+        <location filename="../src/settings/shadersetstore.cpp" line="710"/>
+        <source>Could not create the sets folder.</source>
+        <translation>Kan de map met sets niet aanmaken.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/shadersetstore.cpp" line="715"/>
+        <source>Could not open the sets folder.</source>
+        <translation>Kan de map met sets niet openen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="130"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="199"/>
+        <source>A preset needs a name.</source>
+        <translation>Een voorinstelling heeft een naam nodig.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="140"/>
+        <source>That name cannot be used for a preset.</source>
+        <translation>Die naam kan niet worden gebruikt voor een voorinstelling.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="150"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="159"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="178"/>
+        <source>Could not save the preset &quot;%1&quot;.</source>
+        <translation>Kan de voorinstelling &quot;%1&quot; niet opslaan.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="253"/>
+        <source>Could not find the preset &quot;%1&quot;.</source>
+        <translation>Kan de voorinstelling &quot;%1&quot; niet vinden.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="261"/>
+        <location filename="../src/settings/animationpresetlibrary.cpp" line="271"/>
+        <source>Could not delete the preset &quot;%1&quot;.</source>
+        <translation>Kan de voorinstelling &quot;%1&quot; niet verwijderen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_overrides.cpp" line="260"/>
+        <location filename="../src/settings/animationspagecontroller_shaders.cpp" line="407"/>
+        <source>Cannot reset while a discard is in progress.</source>
+        <translation>Kan niet herstellen terwijl er wordt verworpen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/animationspagecontroller_overrides.cpp" line="282"/>
+        <source>Some animation overrides could not be reset.</source>
+        <translation>Sommige animatie-overschrijvingen konden niet worden hersteld.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="488"/>
+        <source>Settings can only be exported to a local file.</source>
+        <translation>Instellingen kunnen alleen naar een lokaal bestand worden geëxporteerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="529"/>
+        <source>That is the settings file this app is using. Export to a different file.</source>
+        <translation>Dat is het instellingenbestand dat deze app gebruikt. Exporteer naar een ander bestand.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="556"/>
+        <source>Settings can only be imported from a local file.</source>
+        <translation>Instellingen kunnen alleen uit een lokaal bestand worden geïmporteerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="570"/>
+        <source>That settings file is no longer there.</source>
+        <translation>Dat instellingenbestand is er niet meer.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="584"/>
+        <source>Those are the settings this app is already using. Pick a different file to import.</source>
+        <translation>Dat zijn de instellingen die deze app al gebruikt. Kies een ander bestand om te importeren.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="607"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="612"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="617"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="641"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="685"/>
+        <source>That is not a settings file this app can read.</source>
+        <translation>Dat is geen instellingenbestand dat deze app kan lezen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="657"/>
+        <source>Could not back up your current settings, so nothing was imported.</source>
+        <translation>Kan geen reservekopie maken van uw huidige instellingen, dus er is niets geïmporteerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="670"/>
+        <source>Could not read that older settings file.</source>
+        <translation>Kan dat oudere instellingenbestand niet lezen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="677"/>
+        <source>Could not read that settings file.</source>
+        <translation>Kan dat instellingenbestand niet lezen.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="697"/>
+        <source>Could not replace your settings with that file.</source>
+        <translation>Kan uw instellingen niet vervangen door dat bestand.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="725"/>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="730"/>
+        <source>Your settings could not be put back. A copy is saved at %1.</source>
+        <translation>Uw instellingen konden niet worden teruggezet. Er is een kopie opgeslagen op %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/settings/settingscontroller_session.cpp" line="770"/>
+        <source>Your settings were imported, but the animation pages still show the old ones. Reopen the settings window to see the imported values.</source>
+        <translation>Uw instellingen zijn geïmporteerd, maar de animatiepagina's tonen nog steeds de oude. Open het instellingenvenster opnieuw om de geïmporteerde waarden te zien.</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Summary
Adds a full **Dutch (`nl`)** translation — all **1022 strings** translated. Next language after German, Georgian, and Swedish, following the community footprint (the Netherlands is one of the larger non-English clusters among discussion participants).

- Generated `translations/plasmazones_nl.ts` against current sources with `lupdate` (single `plasmazones` context).
- Terminology follows KDE Plasma's Dutch conventions: `venster`=window, `scherm`=screen, `zone`=zone, `indeling`=layout, `tegelen`=tiling, `vastklikken`=snap, `titelbalk`=title bar, `markering`=highlight, `tussenruimte`=gap, `uitsluiten`=exclude.
- Dutch **sentence case** (not English title case), correct de/het gender and compound linking-s, 2 plural forms for the four `%n` strings.

## Review
Ran a **4-pass native-Dutch review** (14 → 3 → 5 → **0 findings**, converged clean). Fixed a mistranslation (`Peeked at Desktop` word order), spelling errors (`vastkliphulp`→vastklikhulp, `Venstersfiltering`→Vensterfiltering), a term mix-up (`highlight` was rendered as *accent* — corrected to *markering*, keeping *accent* only for the real system accent color), compound linking-s, and overlay-compound hyphenation.

## Verification
- Placeholders (`%1`/`%2`/`%n`) and XML entities preserved (0 mismatches).
- Technical proper nouns (OpenGL, Vulkan, pywal, cava, ...) kept in Latin.
- Well-formed XML; CMake picks it up via the `plasmazones_*.ts` glob.
- `lrelease` compiles: **1022 finished / 0 unfinished**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)